### PR TITLE
plane: the embedded shape — charter installed inside the codebase it serves

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "statusLine": {
+    "type": "command",
+    "command": "charter statusline",
+    "padding": 0
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,12 @@ dist/
 
 # SDD scratch (review packages, task briefs) — never publish
 .superpowers/
+
+# added by `charter init`
+/workspaces/*/*
+!/workspaces/.gitkeep
+
+# Per-developer Claude Code settings. charter dogfoods itself, so this is where the
+# working-tree status line lives (`python3 -m charter statusline`) — the committed
+# settings.json keeps `charter statusline`, which is what an actual user runs.
+/.claude/settings.local.json

--- a/charter.toml
+++ b/charter.toml
@@ -1,0 +1,16 @@
+schema = 1
+
+# charter is installed inside the one codebase it serves — its own. Nothing to clone:
+# the tree you edit is this directory, and a workspace holds worktrees of it.
+[plane]
+shape = "embedded"
+
+[[forge]]
+kind = "github"
+owner = "diazoxide"
+# This control plane's own repo. Excluded so `discover` never offers to clone charter
+# into charter's own workspace — the repo is already here, as the plane's root tree.
+exclude = ["charter"]
+
+[memory]
+share = "local"

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -39,6 +39,11 @@ def build_parser() -> argparse.ArgumentParser:
     ini.add_argument("--owner", help="Group/org/user that owns the repos "
                                      "(GitLab group or GitHub org/user).")
     ini.add_argument("--host", help="Self-hosted forge host (default: the forge's own public host).")
+    ini.add_argument("--shape", choices=["fleet", "embedded"],
+                     help="fleet: the plane is its own directory and workspaces hold "
+                          "clones. embedded: charter serves the codebase it sits inside, "
+                          "and workspaces hold worktrees of it. Default: embedded when "
+                          "run inside an existing git repo, otherwise fleet.")
     ini.set_defaults(func=commands.cmd_init)
 
     doc_check = sub.add_parser(

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -7,7 +7,7 @@ import json
 import re
 from pathlib import Path
 
-from . import config, doctor, inventory, render, util, workspace
+from . import config, doctor, inventory, render, util, workspace, worktree
 from . import root as _root
 from .forge import ForgeError
 from .forge.gitlab import GitLabForge
@@ -558,12 +558,20 @@ def cmd_gl_refresh(args) -> int:
     from . import glstate
 
     ws = workspace.resolve(getattr(args, "workspace", None))
-    dirs = workspace.clones(ws)
+    # `repo_trees`, not `clones`: the status line draws the plane's own root tree as a
+    # repo row, and this is what fills that row's CI and change columns. A monorepo plane
+    # has NO clones, so the old list was empty and this command returned early — the one
+    # shape where every repo it should refresh is the one it skipped.
+    dirs = workspace.repo_trees(ws)
+    # Worktrees carry their own branch, so they carry their own pipeline and their own
+    # open change; the status line gives them full rows when a workspace holds a single
+    # repo. Refreshed here so those columns have something to show.
+    dirs += [w for d in dirs for w in worktree.dirs_for(ws, d.name)]
     if not dirs:
-        util.info(f"No clones in workspace '{ws}'.")
+        util.info(f"No repos in workspace '{ws}'.")
         return 0
     cache = glstate.refresh(dirs)
-    util.ok(f"Refreshed forge state for {len(dirs)} repo(s) in '{ws}'.")
+    util.ok(f"Refreshed forge state for {len(dirs)} tree(s) in '{ws}'.")
     for d in dirs:
         ent = cache.get(str(d), {})
         bits = []

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -605,10 +605,20 @@ def _toml_str(s: str) -> str:
     return json.dumps(s)
 
 
-def _render_charter_toml(forge_kind: str, owner: str, host: str | None) -> str:
+def _render_charter_toml(forge_kind: str, owner: str, host: str | None,
+                         shape: str = "fleet") -> str:
     from . import instance as _instance
 
-    lines = [f"schema = {_instance.SCHEMA}", "", "[[forge]]", f"kind = {_toml_str(forge_kind)}"]
+    lines = [f"schema = {_instance.SCHEMA}"]
+    # Written only when it is not the default, so a fleet plane's charter.toml stays the
+    # same minimal file it has always been and nobody has to learn a key they don't need.
+    if shape == "embedded":
+        lines += ["",
+                  "# charter is installed inside the one codebase it serves. Nothing to",
+                  "# clone: the tree you edit is this directory, and a workspace holds",
+                  "# worktrees of it. See docs/control-plane.md.",
+                  "[plane]", 'shape = "embedded"']
+    lines += ["", "[[forge]]", f"kind = {_toml_str(forge_kind)}"]
     if owner:
         lines.append(f"owner = {_toml_str(owner)}")
     if host:
@@ -770,19 +780,40 @@ def cmd_init(args) -> int:
     owner = getattr(args, "owner", None) or ""
     host = getattr(args, "host", None)
 
+    # THE moment the fleet/embedded distinction is decidable. `charter init` run inside a
+    # directory that is already a git repo means the user chose to install charter into a
+    # codebase they work in — the embedded shape — and running it in an empty or non-repo
+    # directory means the plane is its own thing. Afterwards nothing can tell: a fleet
+    # plane's root is a git repo too (its personas carry committed memory), so `ROOT/.git`
+    # stops being evidence the moment init has finished. So decide here, write it down,
+    # and never sniff for it again. `--shape` overrides for scripted setups.
+    shape = getattr(args, "shape", None)
+    if shape and shape not in _instance.SHAPES:
+        util.err(f"unknown --shape {shape!r} — known shapes: "
+                 f"{', '.join(_instance.SHAPES)}")
+        return 1
+    detected = (root / ".git").is_dir()
+    shape = shape or ("embedded" if detected else "fleet")
+
     created, present, blocked = [], [], []
 
     toml_path = root / _root.MARKER
     if toml_path.exists():
         present.append(_root.MARKER)
+        shape = _instance.shape_of(_instance.load(root))   # existing file decides
     else:
-        toml_path.write_text(_render_charter_toml(forge_kind, owner, host))
+        toml_path.write_text(_render_charter_toml(forge_kind, owner, host, shape))
         created.append(_root.MARKER)
-        if not owner:
+        if shape == "embedded":
+            util.info(f"{root.name} is already a git repo, so this plane is EMBEDDED: "
+                      f"charter serves this codebase, there is nothing to clone, and "
+                      f"worktrees live outside the tree. Re-run with --shape fleet if "
+                      f"you meant a plane that clones other repos.")
+        elif not owner:
             util.warn(f"No --owner given — {_root.MARKER}'s [[forge]] block has no "
                       f"owner/group set. Add one before `charter discover`.")
 
-    d_created, d_present, d_blocked = _create_baseline_dirs(root)
+    d_created, d_present, d_blocked = _create_baseline_dirs(root, shape)
     created += d_created
     present += d_present
     blocked += d_blocked
@@ -843,8 +874,9 @@ def cmd_init(args) -> int:
 # the heal half; `doctor`'s "schema" check is where the drift is visible       #
 # without running this first.                                                  #
 # --------------------------------------------------------------------------- #
-def _create_baseline_dirs(root: Path) -> tuple[list[str], list[str], list[tuple[str, Path]]]:
-    """Create any ``instance.BASELINE_DIRS`` absent under ``root``; never touch a
+def _create_baseline_dirs(root: Path,
+                          shape: str = "fleet") -> tuple[list[str], list[str], list[tuple[str, Path]]]:
+    """Create any ``instance.baseline_dirs_for(shape)`` absent under ``root``; never touch a
     directory that's already there. Shared by ``cmd_init`` (a fresh control plane) and
     ``cmd_reinit`` (healing an existing one) so both follow the exact same additive
     discipline instead of two dialects of the same rule.
@@ -858,7 +890,7 @@ def _create_baseline_dirs(root: Path) -> tuple[list[str], list[str], list[tuple[
     from . import instance as _instance
 
     created, present, blocked = [], [], []
-    for d in _instance.BASELINE_DIRS:
+    for d in _instance.baseline_dirs_for(shape):
         p = root / d
         if p.is_dir():
             present.append(f"{d}/")
@@ -882,7 +914,13 @@ def cmd_reinit(args) -> int:
         return 1
     from . import instance as _instance
 
-    created, present, blocked = _create_baseline_dirs(config.ROOT)
+    # Read from the plane on disk, NOT `config.PLANE_SHAPE`. Both are "the shape", but the
+    # global is an import-time snapshot of whatever ROOT was then, and `instance.drift` —
+    # the detect half this command heals — reads the file every time. When those two
+    # disagree, `doctor` reports drift that `reinit` then declines to fix, which is a loop
+    # with no way out from the outside. Same source, same answer, always.
+    shape = _instance.shape_of(_instance.load(config.ROOT))
+    created, present, blocked = _create_baseline_dirs(config.ROOT, shape)
 
     if blocked:
         for d, p in blocked:

--- a/charter/commands_worktree.py
+++ b/charter/commands_worktree.py
@@ -13,10 +13,22 @@ from . import config, util, workspace, worktree
 
 
 def clone_for(ws: str, repo: str) -> Path | None:
+    """The tree named *repo* that this workspace can cut worktrees from.
+
+    The plane's own root tree is checked too, and it is the whole point in a **monorepo**
+    control plane: there, `workspaces/` holds no clones at all, so without this every
+    `charter worktree` command would answer "isn't cloned in workspace X" about the one
+    repo that is unmistakably present — the one you are standing in.
+
+    Clones win a name collision. A workspace's own clone of `foo` is the tree the user
+    selected by cloning it *into this workspace*; the root tree is ambient. Preferring
+    the ambient one would silently cut the worktree off the wrong repo.
+    """
     for d in workspace.clones(ws):
         if d.name == repo:
             return d
-    return None
+    rt = workspace.root_tree()
+    return rt if (rt is not None and rt.name == repo) else None
 
 
 def _resolve(args) -> tuple[str, Path | None]:

--- a/charter/config.py
+++ b/charter/config.py
@@ -51,6 +51,49 @@ MEMORY_SHARE = _instance.share_of(_cfg)
 #: for why this is declared rather than sniffed off the filesystem.
 PLANE_SHAPE = _instance.shape_of(_cfg)
 
+
+def worktrees_root_for(root: "Path", shape: str, cfg: dict) -> "Path | None":
+    """Where worktrees live, or ``None`` to keep them per-workspace under ``.worktrees/``.
+
+    ``$CHARTER_WORKTREES`` → ``[plane] worktrees`` → the shape's default. Relative values
+    resolve against ROOT, so ``"../charter.worktrees"`` reads as written.
+
+    The defaults differ because the shapes do. A **fleet** plane keeps the original
+    layout: ``workspaces/<ws>/.worktrees/`` is already outside every clone, which was the
+    whole point of that path. An **embedded** plane's clone IS the plane root, so the same
+    path lands the worktrees inside the codebase and every root-level glob — pytest, jest,
+    nx, tsc, an IDE indexer — sees the source several times over. There the default is a
+    SIBLING of the repo: outside the tree, but adjacent to it rather than hidden away in a
+    home directory, so it is findable with ``cd ..`` and obvious in a path.
+
+    Only the worktrees move. ``workspaces/<ws>/memory/`` and ``refs/`` stay put — they are
+    a few KB of text, and ``charter workspace live`` exists specifically to un-ignore them
+    so a team can commit them. Relocating those would break sharing to fix a problem they
+    do not have.
+
+    Takes *root*/*shape*/*cfg* rather than reading the module globals so the test harness
+    can re-derive it against a temp ROOT the way it already does for GROUP, EXCLUDE and
+    the rest. When this read the globals directly it defaulted to the REAL repo's sibling
+    in every test — which is outside the tmp tree, so the suite wrote worktrees into the
+    developer's checkout directory and accumulated them across cases.
+    """
+    declared = os.environ.get("CHARTER_WORKTREES") or _instance.worktrees_of(cfg)
+    if declared:
+        p = Path(declared).expanduser()
+        p = p if p.is_absolute() else (root / p)
+    elif shape == "embedded":
+        p = root.parent / f"{root.name}.worktrees"
+    else:
+        return None
+    try:
+        return p.resolve()
+    except (OSError, RuntimeError):
+        return p       # unresolvable (symlink loop, vanished parent) — still usable
+
+
+#: Root for worktrees, or ``None`` for the per-workspace ``.worktrees/`` default.
+WORKTREES_ROOT = worktrees_root_for(ROOT, PLANE_SHAPE, _cfg)
+
 #: Per-task workspaces live here: ``workspaces/<workspace>/<repo>`` (on-demand repo
 #: clones) plus the workspace's own ``memory/`` and ``refs/``. Gitignored — a
 #: workspace is a private, per-developer, per-task environment. (Renamed from the

--- a/charter/config.py
+++ b/charter/config.py
@@ -46,6 +46,11 @@ DEFAULT_WORKSPACE = _instance.default_workspace_of(_cfg, DEFAULT_WORKSPACE_FALLB
 #: How far a written memory travels — see charter.instance.SHARE_MODES.
 MEMORY_SHARE = _instance.share_of(_cfg)
 
+#: Which deployment this plane is — ``fleet`` (many clones per workspace) or ``embedded``
+#: (charter installed inside the single codebase it serves). See charter.instance.SHAPES
+#: for why this is declared rather than sniffed off the filesystem.
+PLANE_SHAPE = _instance.shape_of(_cfg)
+
 #: Per-task workspaces live here: ``workspaces/<workspace>/<repo>`` (on-demand repo
 #: clones) plus the workspace's own ``memory/`` and ``refs/``. Gitignored — a
 #: workspace is a private, per-developer, per-task environment. (Renamed from the

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -258,9 +258,15 @@ def check_control_plane_schema() -> Result:
 
 
 def check_inventory() -> Result:
+    from . import config as _config
     n = inventory.load().get("count", 0)
     if n:
         return Result("inventory", OK, detail=f"{n} repos mapped")
+    # An embedded plane clones nothing, so it has no clone targets to enumerate and
+    # `discover` is not a thing it will ever run. Nagging for it forever is how a
+    # permanently-yellow preflight teaches people to stop reading preflight.
+    if _config.PLANE_SHAPE == "embedded":
+        return Result("inventory", OK, detail="not used by an embedded plane")
     return Result("inventory", WARN, hint="Run: charter discover  (builds inventory/repos.json).")
 
 
@@ -445,6 +451,56 @@ def check_personas() -> Result:
                   hint="charter persona lint  (per-persona detail and how to fix each)")
 
 
+def check_embedded_worktrees() -> Result:
+    """An **embedded** plane must not keep worktrees inside its own codebase.
+
+    Worktrees default to ``workspaces/<ws>/.worktrees/`` — outside every clone, which is
+    what stops nx/jest/maven recursing into them. In an embedded plane the clone IS the
+    plane root, so that same path puts a full second copy of the source inside the tree
+    every root-level glob walks. Nothing warns you: ``.gitignore`` hides it from git, and
+    from git alone. Measured in charter's own checkout: 214 test files discoverable from
+    the root, 142 of them duplicates of the other 72.
+
+    `config.WORKTREES_ROOT` moves new worktrees out. Existing ones are NOT moved
+    automatically — relocating a worktree means rewriting git's own ``gitdir`` pointer,
+    and ``git worktree move`` is the command that does it correctly. So this reports them
+    and hands over that command rather than guessing.
+
+    Silent on a fleet plane, where the default path was never a problem.
+    """
+    from . import config as _config, workspace as _ws
+    if _config.PLANE_SHAPE != "embedded":
+        return Result("worktrees", OK, detail="fleet plane — worktrees stay per-workspace")
+
+    stray: list[Path] = []
+    try:
+        for d in sorted(_config.WORKSPACES_DIR.glob(f"*/{_worktree_dir_name()}/*/*")):
+            if d.is_dir():
+                stray.append(d)
+    except OSError:
+        pass
+
+    dest = _config.WORKTREES_ROOT
+    if not stray:
+        where = f" → {dest}" if dest else ""
+        return Result("worktrees", OK, detail=f"outside the codebase{where}")
+
+    names = ", ".join(d.name for d in stray[:3]) + (" …" if len(stray) > 3 else "")
+    return Result(
+        "worktrees",
+        WARN,
+        detail=f"{len(stray)} inside the codebase ({names}) — every root-level glob "
+               f"(pytest/jest/nx/tsc, IDE indexers) sees the source twice over",
+        hint=("Move each one with git, which rewrites its gitdir pointer: "
+              f"git worktree move <old> {dest}/<workspace>/<repo>/<piece>"),
+    )
+
+
+def _worktree_dir_name() -> str:
+    from . import worktree
+    return worktree.DIR_NAME
+
+
 def check_plugin_skew() -> Result:
     """`charter` ships as two artifacts — the CLI (pip/uv) and the Claude Code plugin
     (``.claude-plugin/plugin.json`` + ``hooks/hooks.json``) — with two version numbers.
@@ -487,6 +543,6 @@ def run_all() -> list[Result]:
         results.append(check_forge_auth(forge))
     results += [check_ssh(), check_control_plane_config(), check_control_plane_schema(),
                 check_inventory(), check_vaults(), check_version_lock(),
-                check_memory_indexes(), check_personas(),
+                check_memory_indexes(), check_personas(), check_embedded_worktrees(),
                 check_plugin_skew()]
     return results

--- a/charter/glstate.py
+++ b/charter/glstate.py
@@ -18,7 +18,7 @@ import time
 import urllib.parse
 from pathlib import Path
 
-from . import config
+from . import config, util
 
 DISPLAY_TTL = 7200    # show a cached value for up to 2h
 REFRESH_TTL = 300     # try to refresh entries older than 5 min
@@ -180,13 +180,19 @@ def _remote_url(d: Path) -> str | None:
 
 
 def _branch(d: Path) -> str:
+    """The tree's branch, clone or linked worktree alike.
+
+    Shares :func:`charter.util.branch_of` with the status line deliberately: this value
+    is written into the cache entry and the status line compares its own reading against
+    it (:func:`read_for` drops any entry whose ``branch`` differs). Two implementations
+    of "what branch is this" is exactly the kind of drift that shows up as a CI column
+    that silently never renders — as it did for worktrees, which only this side could
+    read.
+    """
     try:
-        txt = (d / ".git" / "HEAD").read_text().strip()
+        return util.branch_of(d)
     except Exception:
         return "?"
-    if txt.startswith("ref:"):
-        return txt.split("/", 2)[-1] or "?"
-    return txt[:7] if txt else "?"
 
 
 def _remote_path(d: Path):

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -168,6 +168,44 @@ def share_of(cfg: dict) -> str:
 
 
 # --------------------------------------------------------------------------- #
+# plane SHAPE — which of charter's two deployments this control plane is.      #
+#                                                                              #
+#   fleet     the plane is its own thing; a workspace holds many CLONES, each  #
+#             with its own worktrees. The original and the default.            #
+#   embedded  charter installed INSIDE the one codebase it serves (which may   #
+#             itself be a backend/frontend monorepo). Nothing to clone: the    #
+#             tree you edit is the plane's own root, and a workspace holds     #
+#             worktrees of it rather than clones.                              #
+#                                                                              #
+# DECLARED, never inferred, and the distinction matters: a fleet plane's root  #
+# is a git repo too — its personas carry committed memory and docs/control-    #
+# plane.md ships `exclude = ["this-control-plane"]` precisely because the      #
+# plane's own repo lives on the forge. So `ROOT/.git` cannot tell the two      #
+# apart. Every filesystem signal that might ("no clones anywhere", "empty      #
+# inventory") reads a FRESH FLEET PLANE — before its first `discover` or       #
+# `clone` — as embedded, which is the worst possible moment to guess wrong.    #
+#                                                                              #
+# What separates them is intent, and `charter init` is where intent exists:    #
+# running it inside an existing repo IS the choice. So init writes it down.    #
+# --------------------------------------------------------------------------- #
+
+#: The deployments a control plane can declare. `fleet` first — it is the default.
+SHAPES = ("fleet", "embedded")
+
+
+def shape_of(cfg: dict) -> str:
+    """This control plane's shape, defaulting to ``fleet``.
+
+    An unrecognised value falls back to ``fleet`` for the same reason
+    :func:`share_of` falls back to ``local``: a typo must fail toward the behaviour that
+    changes nothing. ``fleet`` is what every existing control plane already does, so a
+    misspelled shape costs a feature rather than rearranging a working status line.
+    """
+    v = (cfg.get("plane") or {}).get("shape")
+    return v if v in SHAPES else "fleet"
+
+
+# --------------------------------------------------------------------------- #
 # control-plane SCHEMA — the same stamp/detect/heal pattern `workspace.py`'s   #
 # STRUCTURE_VERSION already proves, one level up: a control plane (not just a  #
 # single workspace) can lack layout a newer charter expects (personas/,        #

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -205,6 +205,28 @@ def shape_of(cfg: dict) -> str:
     return v if v in SHAPES else "fleet"
 
 
+def worktrees_of(cfg: dict) -> str | None:
+    """Where this plane keeps worktrees, or ``None`` for the shape's default.
+
+    A relative value is resolved against the control-plane root (see
+    ``config.WORKTREES_ROOT``), so `"../charter.worktrees"` means what it looks like.
+
+    Exists because of a problem only the **embedded** shape has. Worktrees default to
+    ``workspaces/<ws>/.worktrees/`` — deliberately OUTSIDE every clone, so that (in
+    ``worktree.py``'s own words) "nx/jest/maven never recurse into them". In an embedded
+    plane the clone IS the plane root, so that path is *inside* the codebase and the rule
+    inverts: a repo with two worktrees now answers a root-level glob with three copies of
+    itself. Measured in charter's own checkout at the time this was written: 214 test
+    files discoverable from the root, 142 of them duplicates.
+
+    ``.gitignore`` hides that from git and from nothing else — pytest, jest, nx, tsc and
+    every IDE indexer glob the working tree directly. A dot-directory fixes pytest (whose
+    ``norecursedirs`` skips ``.*``) and not jest. Only leaving the tree fixes all of them.
+    """
+    v = (cfg.get("plane") or {}).get("worktrees")
+    return v.strip() if isinstance(v, str) and v.strip() else None
+
+
 # --------------------------------------------------------------------------- #
 # control-plane SCHEMA — the same stamp/detect/heal pattern `workspace.py`'s   #
 # STRUCTURE_VERSION already proves, one level up: a control plane (not just a  #
@@ -220,6 +242,23 @@ def shape_of(cfg: dict) -> str:
 BASELINE_DIRS = ("personas", "inventory", "workspaces")
 
 
+def baseline_dirs_for(shape: str) -> tuple[str, ...]:
+    """:data:`BASELINE_DIRS` filtered to what a plane of this *shape* actually uses.
+
+    An **embedded** plane has no ``inventory/``. The inventory lists a forge owner's repos
+    so ``clone`` has targets to choose from, and an embedded plane clones nothing — its one
+    repo is the plane. Creating it regardless leaves an empty directory sitting in
+    someone's application repo that no command will ever write to, and then ``drift``
+    reports it missing forever once they delete it.
+
+    ``personas/`` stays in both: shared role identities and their committed memory are
+    exactly what a team installs charter into their codebase to get.
+    """
+    if shape == "embedded":
+        return tuple(d for d in BASELINE_DIRS if d != "inventory")
+    return BASELINE_DIRS
+
+
 def drift(root: Path) -> list[str]:
     """Human-readable descriptions of what this control plane is missing.
 
@@ -231,9 +270,17 @@ def drift(root: Path) -> list[str]:
     a file or other non-directory (FINDING C1 — ``reinit`` will *refuse*, because
     deleting or renaming a user's file to make room would break the additive rule).
     ``is_dir()`` alone can't tell these apart, so this also checks ``exists()``.
+
+    Scoped to the plane's own shape, so an embedded plane is not told forever that it is
+    missing the ``inventory/`` it has no use for. An unreadable charter.toml falls back to
+    the full set — the same fail-toward-fleet rule :func:`shape_of` uses.
     """
+    try:
+        shape = shape_of(load(Path(root)))
+    except Exception:
+        shape = "fleet"
     out = []
-    for d in BASELINE_DIRS:
+    for d in baseline_dirs_for(shape):
         p = Path(root) / d
         if p.is_dir():
             continue

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -456,10 +456,17 @@ def _current(payload: dict) -> tuple[str | None, str] | None:
     A caller comparing against the active workspace must read ``None`` as "matches
     whichever workspace is active".
 
-    ``workspaces/`` is checked first and, once the cwd is known to be under it, this
-    returns without consulting the root tree even when there is no repo component (e.g.
-    the cwd is ``workspaces/<ws>`` itself). ``WORKSPACES_DIR`` lives *under* ``ROOT``, so
-    falling through would report the root tree as current while you stand in a workspace.
+    Worktrees are resolved FIRST, and to their *piece* name, which is what the nested rows
+    are labelled with. This never worked in either layout: an in-plane worktree sits at
+    ``workspaces/<ws>/.worktrees/<repo>/<piece>``, so the plain workspace arithmetic below
+    read its repo as the literal ``.worktrees`` and matched no row, leaving the cwd
+    unmarked. In an embedded plane the worktrees are the rows you move between, so an
+    unmarked one is the whole feature missing.
+
+    ``workspaces/`` is checked next and, once the cwd is known to be under it, this returns
+    without consulting the root tree even when there is no repo component (e.g. the cwd is
+    ``workspaces/<ws>`` itself). ``WORKSPACES_DIR`` lives *under* ``ROOT``, so falling
+    through would report the root tree as current while you stand in a workspace.
     """
     ws = payload.get("workspace") or {}
     cwd = ws.get("current_dir") or payload.get("cwd") or ""
@@ -469,6 +476,15 @@ def _current(payload: dict) -> tuple[str | None, str] | None:
         here = Path(cwd).resolve()
     except Exception:
         return None
+
+    try:
+        from . import worktree as _wt
+        loc = _wt.locate(here)
+    except Exception:
+        loc = None
+    if loc:
+        return (loc[0], loc[2])          # (workspace, piece)
+
     try:
         parts = here.relative_to(config.WORKSPACES_DIR.resolve()).parts
     except Exception:
@@ -859,9 +875,47 @@ def _alerts(active: str) -> list[str]:
         if stale:
             out.append(f"{_YELLOW}⚠{_R} {_DIM}reinit{_R} {len(stale)} {_DIM}ws · "
                        f"charter ws reinit --all{_R}")
+        outer = _nested_under()
+        if outer is not None:
+            out.append(f"{_RED}⚠{_R} {_DIM}nested plane{_R} — {_DIM}memory and vault go to"
+                       f"{_R} {config.ROOT.name}{_DIM}, not{_R} {outer.name}"
+                       f"{_DIM} · export CHARTER_ROOT={outer}{_R}")
     except Exception:
         pass
     return out
+
+
+def _nested_under() -> Path | None:
+    """The OUTER control plane whose ``workspaces/`` contains this one, if any.
+
+    ``root.find_root`` takes the innermost ``charter.toml`` — the git/cargo/npm contract,
+    and the right one. But the embedded shape puts a ``charter.toml`` into ordinary
+    product repos, and a fleet plane clones product repos into its workspaces. So `cd`
+    into ``workspaces/<ws>/<repo>`` and the active plane silently becomes a different one:
+    different personas, a different vault, and a memory write landing somewhere the user
+    did not choose. Nothing said so.
+
+    Only walks upward comparing paths — no config is parsed for the ancestors beyond the
+    marker's presence, because this runs on every render.
+    """
+    try:
+        here = config.ROOT.resolve()
+    except (OSError, RuntimeError):
+        return None
+    for anc in here.parents:
+        if not (anc / _root_marker()).is_file():
+            continue
+        try:                       # only a plane whose WORKSPACES holds us is the trap:
+            here.relative_to(anc / "workspaces")   # a plain parent directory is not
+        except ValueError:
+            continue
+        return anc
+    return None
+
+
+def _root_marker() -> str:
+    from . import root as _r
+    return _r.MARKER
 
 
 def _session_strip(payload: dict, sid: str | None) -> str:

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -300,6 +300,47 @@ def _clone_dirs(ws: str) -> list[Path]:
     return workspace.clones(ws)
 
 
+def _repo_trees(ws: str) -> list[Path]:
+    """Every repo the workspace works in — the plane's root tree, then its clones.
+
+    Same list `charter gl-refresh` fetches forge state for, by construction (both call
+    :func:`charter.workspace.repo_trees`), so a row can never be drawn for a repo whose
+    CI was never fetched.
+    """
+    from . import workspace
+    try:
+        return workspace.repo_trees(ws)
+    except Exception:
+        return _clone_dirs(ws)
+
+
+def _root_tree() -> Path | None:
+    """The control plane's own repo, when the plane's root is itself a git clone.
+
+    A **monorepo** control plane is `charter init` run inside the repo you already work
+    in: there is nothing to clone, `workspaces/` stays empty, and the tree you are
+    editing IS the root. Without this the status line renders `repos 0/0` in a repo with
+    a live branch, uncommitted work and an open PR — the one shape where every column it
+    draws has an answer and it showed none.
+
+    Not a new concept, and deliberately so: :func:`charter.gitpolicy.repos` has always
+    meant "the control plane itself plus every repo clone". This is the status line
+    agreeing with git policy about what counts as a repo, rather than a second opinion.
+
+    A *fleet* plane whose root happens to be a git repo (the common case — control planes
+    get committed) gets the same row, which is right: it has a branch and a dirty state
+    you care about, and it is the one repo `charter clone` will never produce. It stays
+    excluded from the *inventory* (``exclude`` in charter.toml) because that lists clone
+    targets, and cloning yourself into your own workspace is the thing to prevent — a
+    different question from whether the tree is here, which it demonstrably is.
+    """
+    from . import workspace
+    try:
+        return workspace.root_tree()
+    except Exception:
+        return None
+
+
 def _available() -> int:
     try:
         return json.loads(config.INVENTORY.read_text()).get("count", 0)
@@ -315,14 +356,16 @@ def _vaults() -> int:
 
 
 def _branch(repo_dir: Path) -> str:
-    """Current branch read straight from .git/HEAD (no git subprocess)."""
+    """Current branch read straight from HEAD (no git subprocess).
+
+    Handles a clone and a linked worktree alike — see :func:`charter.util.branch_of`,
+    which is where the two ``.git`` layouts are reconciled.
+    """
+    from . import util
     try:
-        txt = (repo_dir / ".git" / "HEAD").read_text().strip()
+        return util.branch_of(repo_dir)
     except Exception:
         return "?"
-    if txt.startswith("ref:"):
-        return txt.split("/", 2)[-1] or "?"  # refs/heads/<branch> (keeps slashes)
-    return txt[:7] if txt else "?"           # detached HEAD → short sha
 
 
 _STATE_TTL = 5.0  # seconds a cached repo-state is trusted before re-checking
@@ -405,20 +448,99 @@ def _markers(state: dict) -> tuple[str, str, bool]:
     return plain, coloured, dirty
 
 
-def _current(payload: dict) -> tuple[str, str] | None:
-    """(workspace, repo) that the session's cwd is inside, if any."""
+def _current(payload: dict) -> tuple[str | None, str] | None:
+    """``(workspace, repo)`` that the session's cwd is inside, if any.
+
+    The workspace is ``None`` when the cwd is inside the plane's own root tree
+    (:func:`_root_tree`), which belongs to no single workspace — it is in all of them.
+    A caller comparing against the active workspace must read ``None`` as "matches
+    whichever workspace is active".
+
+    ``workspaces/`` is checked first and, once the cwd is known to be under it, this
+    returns without consulting the root tree even when there is no repo component (e.g.
+    the cwd is ``workspaces/<ws>`` itself). ``WORKSPACES_DIR`` lives *under* ``ROOT``, so
+    falling through would report the root tree as current while you stand in a workspace.
+    """
     ws = payload.get("workspace") or {}
     cwd = ws.get("current_dir") or payload.get("cwd") or ""
     if not cwd:
         return None
     try:
-        parts = Path(cwd).resolve().relative_to(config.WORKSPACES_DIR.resolve()).parts
+        here = Path(cwd).resolve()
     except Exception:
         return None
-    return (parts[0], parts[1]) if len(parts) >= 2 else None
+    try:
+        parts = here.relative_to(config.WORKSPACES_DIR.resolve()).parts
+    except Exception:
+        parts = None
+    if parts is not None:
+        return (parts[0], parts[1]) if len(parts) >= 2 else None
+
+    rt = _root_tree()
+    if rt is not None:
+        try:
+            here.relative_to(rt.resolve())
+            return (None, rt.name)
+        except Exception:
+            pass
+    return None
 
 
-def _repo_rows(dirs, active, cur, states, branches, gl) -> list[tui.Node]:
+def _tree_cells(lead: str, label: str, d, states, branches, gl) -> tui.Row:
+    """One table row — ``<lead><label>`` in the name column, then branch+markers, CI, change.
+
+    Shared by repo rows and nested worktree rows so the two cannot drift: a worktree's row
+    is the *same four cells* as its repo's, differing only in the lead glyphs. Building
+    them twice is precisely how a nested row ends up a column off from the one above it,
+    which this layout has already paid for more than once.
+
+    The name cell's width is the same total whatever the lead costs — `tui.Cell` pads and
+    truncates to it — so a longer lead spends its columns out of the label, never out of
+    the branch column's starting position.
+    """
+    name = tui.Cell(f"{lead}{label}", 2 + 3 + _NAME_W)
+
+    # branch + markers: truncate the *branch* so the markers always survive
+    marks_plain, marks_col, is_dirty = _markers(states.get(d, {}))
+    br = tui.truncate(branches.get(d, "?"), max(1, _BRANCH_W - tui.width(marks_plain)))
+    branch = tui.Cell(f"{_YELLOW if is_dirty else _DIM}{br}{_R}{marks_col}", _BRANCH_W)
+
+    info = gl.get(d, {})
+    ci = tui.Cell(_ci_part(info.get("ci")), _CI_W)
+    change = info.get("change")
+    sigil = info.get("sigil") or "!"   # old caches (pre-forge-protocol) carry no sigil
+    mr_cell = tui.Cell(f"{_GREEN}{sigil}{change}{_R}" if change else "", _MR_W)
+
+    return tui.Row(name, branch, ci, mr_cell, gap=_GAP)
+
+
+def _detail_worktrees(ws: str, dirs) -> list[Path]:
+    """The worktrees to draw as full rows, or ``[]`` to keep the one-line summary.
+
+    With exactly ONE repo — the monorepo shape, and equally a fleet workspace holding a
+    single clone — `_MAX_REPO_LINES` leaves about a dozen rows unspent while the compact
+    summary crams every piece onto one line as bare names: no branch, no dirty flag, no
+    CI, no change. There is nothing to compress, so spend the rows. At two or more repos
+    the summary is still the right trade, because a repo must never lose its row to
+    another repo's worktrees.
+
+    ONE predicate, whose result is passed to everything that needs it. `render` scans
+    these directories for branch/dirty/CI and `_repo_rows` draws them; deciding it
+    separately in each is how a row gets drawn for a directory nobody scanned, which
+    renders as `?` in the branch column and blanks everywhere else — strictly worse than
+    the summary line it replaced.
+    """
+    if len(dirs) != 1:
+        return []
+    try:
+        from . import worktree as _wt
+        return _wt.dirs_for(ws, dirs[0].name)[: _MAX_REPO_LINES - 1]
+    except Exception:
+        return []
+
+
+def _repo_rows(dirs, active, cur, states, branches, gl, root_dir=None,
+               detail_wts=()) -> list[tui.Node]:
     """One table row per clone, nested under the workspace like a tree:
 
         ├─ <repo>   <branch><markers>   <ci>   <sigil><change>
@@ -434,10 +556,19 @@ def _repo_rows(dirs, active, cur, states, branches, gl) -> list[tui.Node]:
     over worktree rows (every repo gets its own row before any repo's worktrees get
     nested rows), so a repo is never dropped just because an earlier repo's worktrees
     ate the budget.
+
+    *root_dir* — the plane's own tree (:func:`_root_tree`), when it is in *dirs*. It is
+    drawn in the plane's own colour (the cyan of `⬢ <workspace>` two rows up) rather than
+    from `_PALETTE`, so "this repo IS the control plane" is carried by the one channel
+    that costs no columns. Every other repo distinction here is already colour, and a new
+    glyph in the name cell would have to earn its width against `_NAME_W` — see the
+    header comments in `render` for what a mis-measured glyph does to this layout.
     """
     if not dirs:
         return []
-    cur_repo = cur[1] if (cur and cur[0] == active) else None
+    # `cur[0] is None` = the cwd is in the root tree, which is a member of EVERY
+    # workspace, so it is current whichever one is active.
+    cur_repo = cur[1] if (cur and (cur[0] is None or cur[0] == active)) else None
     n = len(dirs)
     capped = n > _MAX_REPO_LINES
     show = dirs[: _MAX_REPO_LINES - 1] if capped else dirs
@@ -446,39 +577,50 @@ def _repo_rows(dirs, active, cur, states, branches, gl) -> list[tui.Node]:
     wt_budget = _MAX_REPO_LINES - len(show) - (1 if capped else 0)
 
     rows: list[tui.Node] = []
+    clone_i = 0            # palette index — counts CLONES only, so a repo keeps its
+                           # colour whether or not a root row sits above it
     for i, d in enumerate(show):
-        is_last = (not capped) and (i == len(show) - 1)
-        tree = _TREE_END if is_last else _TREE_MID
-        color = _PALETTE[i % len(_PALETTE)]
+        if root_dir is not None and d == root_dir:
+            color = _CYAN
+        else:
+            color = _PALETTE[clone_i % len(_PALETTE)]
+            clone_i += 1
         emph = f"{_BOLD}{_UNDER}" if d.name == cur_repo else ""
 
-        # worktrees: a ⑂N badge here, the newest few nested below (see after the row)
+        # worktrees: a ⑂N badge here, plus either full nested rows (`_detail_worktrees`)
+        # or the one-line summary below.
         try:
             from . import worktree as _wt
             wts = _wt.dirs_for(active, d.name)
         except Exception:
             wts = []
-        badge = f"{_DIM} ⑂{len(wts)}{_R}" if wts else ""
+        kids = list(detail_wts) if (len(show) == 1 and detail_wts) else []
+        kids = kids[:wt_budget]
+        # The badge is a count of what you CANNOT see. With every piece drawn as its own
+        # row below, `⑂2` above two visible rows is just noise restating them.
+        badge = f"{_DIM} ⑂{len(wts)}{_R}" if len(kids) < len(wts) else ""
+
+        # A repo with rows nested beneath it is not where the tree ends, so it keeps `├─`.
+        is_last = (not capped) and (i == len(show) - 1) and not kids
+        tree = _TREE_END if is_last else _TREE_MID
 
         # indent + tree + name (padding lands outside the style, not underlined)
-        name = tui.Cell(f"  {_DIM}{tree}{_R}{emph}{color}{d.name}{_R}{badge}",
-                        2 + 3 + _NAME_W)
+        rows.append(_tree_cells(f"  {_DIM}{tree}{_R}",
+                                f"{emph}{color}{d.name}{_R}{badge}",
+                                d, states, branches, gl))
 
-        # branch + markers: truncate the *branch* so the markers always survive
-        marks_plain, marks_col, is_dirty = _markers(states.get(d, {}))
-        br = tui.truncate(branches.get(d, "?"),
-                          max(1, _BRANCH_W - tui.width(marks_plain)))
-        branch_color = _YELLOW if is_dirty else _DIM
-        branch = tui.Cell(f"{branch_color}{br}{_R}{marks_col}", _BRANCH_W)
-
-        info = gl.get(d, {})
-        ci = tui.Cell(_ci_part(info.get("ci")), _CI_W)
-        change = info.get("change")
-        sigil = info.get("sigil") or "!"  # old caches (pre-forge-protocol) carry no sigil
-        mr_cell = tui.Cell(f"{_GREEN}{sigil}{change}{_R}" if change else "", _MR_W)
-
-        rows.append(tui.Row(name, branch, ci, mr_cell, gap=_GAP))
-
+        if kids:
+            wt_budget -= len(kids)
+            for j, w in enumerate(kids):
+                # `╰─` for the last child, NOT `└─`. `render`'s "the tree keeps going"
+                # rewrite searches backwards for the last `└─` to turn into `├─`; a child
+                # sharing that marker gets rewritten instead of its repo. That is the
+                # exact bug `_TREE_WT` was introduced to prevent — see its definition.
+                mark = _TREE_WT if j == len(kids) - 1 else _TREE_MID
+                emph_w = f"{_BOLD}{_UNDER}" if w.name == cur_repo else ""
+                rows.append(_tree_cells(f"  {_DIM}{_TREE_PIPE}{mark}{_R}",
+                                        f"{emph_w}{_DIM}{w.name}{_R}",
+                                        w, states, branches, gl))
         # ONE summary line per repo, newest piece first — a fixed cost no matter how many
         # worktrees exist, so the footer can't grow with them (the ⑂N badge above carries
         # the true total, and overflow truncates with … rather than dropping pieces
@@ -486,7 +628,7 @@ def _repo_rows(dirs, active, cur, states, branches, gl) -> list[tui.Node]:
         # whitespace-only prefix to column 0 — the same trap the persona column works
         # around below — which would drop this line to the left margin and stop it
         # reading as a child of its repo.
-        if wts and wt_budget > 0:
+        elif wts and wt_budget > 0:
             wt_budget -= 1
             lead = f"  {_DIM}{_TREE_PIPE}{_R} {_DIM}{_TREE_WT}{_R}"
             pieces = tui.truncate(" · ".join(w.name for w in wts),
@@ -838,7 +980,12 @@ def render(payload: dict | None = None) -> str:
     try:
         active, src = _active(payload.get("session_id"))
         nws = _count_workspaces()
-        dirs = _clone_dirs(active)
+        # The plane's own tree leads, then the active workspace's clones. A monorepo
+        # plane has only the former, a fleet plane usually only the latter, and both
+        # shapes render through the exact same rows — the monorepo is not a special
+        # case here, just a workspace whose clone list happens to be empty.
+        root_dir = _root_tree()
+        dirs = _repo_trees(active)
         avail = _available()
         nv = _vaults()
         cur = _current(payload)
@@ -848,11 +995,15 @@ def render(payload: dict | None = None) -> str:
         # Everything below lays out inside the frame, so it gets the pane minus the
         # box's own chrome ("| " each side). `_boxed` re-widens to `frame_w` at the end.
         width = max(24, frame_w - 4)
-        states = _repo_states(dirs)
-        branches = {d: _branch(d) for d in dirs}
+        # Worktrees drawn as full rows need the same per-directory data their repo does,
+        # so they are scanned alongside it — a row can only show what `scan` gathered.
+        detail_wts = _detail_worktrees(active, dirs)
+        scan = [*dirs, *detail_wts]
+        states = _repo_states(scan)
+        branches = {d: _branch(d) for d in scan}
         from . import glstate
-        gl = glstate.read_for(dirs, branches)
-        glstate.maybe_spawn(dirs, active)
+        gl = glstate.read_for(scan, branches)
+        glstate.maybe_spawn(scan, active)
 
         pin = f"{_YELLOW}*{_R}" if src == "$CHARTER_WORKSPACE" else ""
         # Reinit tip sits right after the name so it survives truncation on narrow panes.
@@ -868,7 +1019,9 @@ def render(payload: dict | None = None) -> str:
         ]))
 
         sid = payload.get("session_id")
-        repo_lines = [r.render(_LEFT_W)[0] for r in _repo_rows(dirs, active, cur, states, branches, gl)]
+        repo_lines = [r.render(_LEFT_W)[0]
+                      for r in _repo_rows(dirs, active, cur, states, branches, gl,
+                                          root_dir, detail_wts)]
         chips = _persona_chips(sid)
     except Exception:
         return f"{_CYAN}⬢{_R} charter"
@@ -897,7 +1050,12 @@ def render(payload: dict | None = None) -> str:
         #
         # So: labels only up here. Decoration lives on the content rows, where a
         # sibling would expose it.
-        left_head = f"{_DIM}{_HEAD_PAD}repos{_R} {len(dirs)}{_DIM}/{avail}{_R}"
+        # `/<avail>` is "of this many in the inventory", so it is only printed when there
+        # IS an inventory. A monorepo plane never runs `discover` — its one repo is
+        # already here — and rendering `repos 1/0` there states the opposite of the truth.
+        # A fleet plane before its first `discover` gets the same honest bare count.
+        left_head = f"{_DIM}{_HEAD_PAD}repos{_R} {len(dirs)}" + (
+            f"{_DIM}/{avail}{_R}" if avail else "")
         header = f"{_DIM}{_HEAD_PAD}personas{_R} {len(chips)}" + (
             f"{_DIM} · vaults{_R} {nv}" if nv else "") + (
             f"{_DIM} · shared{_R}{shared_badge}" if shared_badge else "")

--- a/charter/util.py
+++ b/charter/util.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import subprocess
 import sys
 import urllib.parse
+from pathlib import Path
 from typing import Sequence
 
 _USE_COLOR = sys.stderr.isatty()
@@ -70,3 +71,53 @@ def run(
 def urlenc(s: str) -> str:
     """URL-encode a path segment (e.g. a group path with slashes)."""
     return urllib.parse.quote(s, safe="")
+
+
+def git_dir(tree: Path) -> Path | None:
+    """The git directory backing *tree*, or ``None`` when *tree* is not a working tree.
+
+    Git stores this two different ways and both are normal. A **clone**'s ``.git`` is a
+    directory holding HEAD. A linked **worktree**'s ``.git`` is a FILE containing
+    ``gitdir: <path>``, and its HEAD — along with everything else that is per-worktree —
+    lives at that path instead. ``workspace.is_clone`` relies on exactly this difference
+    to tell the two apart without bookkeeping.
+
+    Readers that handled only the directory form reported the worktree's branch as ``?``,
+    which is the entire branch column of a monorepo control plane, where every tree below
+    the root is a worktree.
+    """
+    g = Path(tree) / ".git"
+    try:
+        if g.is_dir():
+            return g
+        txt = g.read_text().strip()
+    except OSError:
+        return None
+    if not txt.startswith("gitdir:"):
+        return None
+    p = Path(txt[len("gitdir:"):].strip())
+    # `git worktree add` writes an absolute path, but the file format permits a relative
+    # one (and `git worktree repair` can produce it) — resolve it against the tree.
+    return p if p.is_absolute() else (Path(tree) / p)
+
+
+def branch_of(tree: Path) -> str:
+    """Current branch of a working tree, read straight from HEAD — **no subprocess**.
+
+    ``?`` when unreadable, a short sha when detached, and the full ref name otherwise
+    (branch names legitimately contain slashes, so only ``refs/heads/`` is stripped).
+
+    Filesystem-only on purpose: the status line renders on every turn and calls this once
+    per tree, so a `git` fork here would be paid over and over for something two `read`s
+    answer exactly.
+    """
+    gd = git_dir(tree)
+    if gd is None:
+        return "?"
+    try:
+        txt = (gd / "HEAD").read_text().strip()
+    except OSError:
+        return "?"
+    if txt.startswith("ref:"):
+        return txt.split("/", 2)[-1] or "?"   # refs/heads/<branch> — keeps slashes
+    return txt[:7] if txt else "?"            # detached HEAD → short sha

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -269,6 +269,48 @@ def clones(name: str) -> list[Path]:
     return sorted(d for d in wd.iterdir() if is_clone(d))
 
 
+def root_tree() -> Path | None:
+    """The codebase an **embedded** plane serves — its own root — or ``None``.
+
+    In the embedded shape (`charter init` run inside the repo you already work in) there
+    is nothing to clone: ``workspaces/`` holds no repos and the tree you edit IS the root.
+    It belongs to no single workspace — it is in all of them, since there is physically
+    one of it — which is what separates it from everything :func:`clones` returns.
+
+    Two conditions, and the shape check is the load-bearing one. A **fleet** plane's root
+    is very often a git repo as well (personas carry committed memory; docs/control-
+    plane.md ships ``exclude = ["this-control-plane"]`` because the plane's own repo lives
+    on the forge) — but there it is the plane, not a repo you work in, and listing it
+    beside the workspace's real clones would be wrong. ``ROOT/.git`` cannot tell those
+    apart, so :func:`charter.instance.shape_of` is asked instead.
+
+    The ``is_clone`` half still matters: an embedded plane whose ``.git`` has been removed
+    has no tree to offer, and a *worktree* of one (``.git`` is a file) is not the trunk.
+    """
+    try:
+        if config.PLANE_SHAPE != "embedded":
+            return None
+        return config.ROOT if is_clone(config.ROOT) else None
+    except OSError:
+        return None
+
+
+def repo_trees(ws: str) -> list[Path]:
+    """Every repo this workspace works in: the plane's root tree first, then its clones.
+
+    The one list anything asking "which repos am I on?" should use — the status line's
+    rows and `gl-refresh`'s fetch targets both come from here, so a repo can never be
+    drawn without its forge state having been fetched, or fetched without being drawn.
+    Splitting that decision in two is what left the root tree with a permanently empty
+    CI column: it was rendered from one list and refreshed from another.
+
+    A fleet workspace's answer is unchanged (its clones, plus the plane's own repo, which
+    has a branch like any other). A monorepo workspace's answer is just the root tree.
+    """
+    rt = root_tree()
+    return ([rt] if rt is not None else []) + clones(ws)
+
+
 def legacy_flat_clones() -> list[Path]:
     """Git repos sitting directly under ``workspaces/`` (pre-workspace layout)."""
     _ensure_layout()

--- a/charter/worktree.py
+++ b/charter/worktree.py
@@ -10,19 +10,66 @@ Worktrees live at ``workspaces/<ws>/.worktrees/<repo>/<piece>``: OUTSIDE every c
 nx/jest/maven never recurse into them and ``mvn clean`` / ``git clean -xfd`` inside the
 clone cannot destroy live work. ``workspaces/`` is gitignored, so none of it can reach the
 control plane's history.
+
+That path assumes the clone and the control plane are different directories. In an
+**embedded** plane they are the same one, and "outside every clone" then requires leaving
+the plane too — so there the root moves to a sibling of the repo (``config.WORKTREES_ROOT``,
+overridable via ``[plane] worktrees``) and the layout below it is unchanged:
+``<root>/<ws>/<repo>/<piece>``. Same rule, followed to where it leads.
 """
 from __future__ import annotations
 
 from pathlib import Path
 
-from . import util, workspace
+from . import config, util, workspace
 
-#: Directory under a workspace holding every clone's worktrees.
+#: Directory under a workspace holding every clone's worktrees (the in-plane layout).
 DIR_NAME = ".worktrees"
 
 
 def root(ws: str) -> Path:
-    return workspace.workspace_dir(ws) / DIR_NAME
+    """This workspace's worktree root — relocated (embedded) or in-plane (fleet)."""
+    ext = config.WORKTREES_ROOT
+    return (ext / ws) if ext is not None else (workspace.workspace_dir(ws) / DIR_NAME)
+
+
+def locate(path: Path) -> tuple[str, str, str] | None:
+    """``(workspace, repo, piece)`` when *path* is inside a worktree, else ``None``.
+
+    Path arithmetic, not git: the layout is ``<root>/<ws>/<repo>/<piece>`` in both forms,
+    and this is called on every status-line render — see :func:`dirs_for` on why nothing
+    here may fork a subprocess.
+
+    Both roots are tried because both can be live at once: a plane that has just declared
+    ``[plane] worktrees`` still has yesterday's worktrees in ``workspaces/``, and the
+    status line should keep pointing at whichever one you are actually standing in.
+    """
+    try:
+        here = Path(path).resolve()
+    except (OSError, RuntimeError):
+        return None
+
+    candidates = []
+    if config.WORKTREES_ROOT is not None:
+        candidates.append((config.WORKTREES_ROOT, ()))
+    # In-plane: `workspaces/<ws>/.worktrees/<repo>/<piece>` — one extra component, and it
+    # sits AFTER the workspace name, so it is matched positionally rather than stripped.
+    candidates.append((config.WORKSPACES_DIR, (DIR_NAME,)))
+
+    for base, infix in candidates:
+        try:
+            parts = here.relative_to(Path(base).resolve()).parts
+        except (ValueError, OSError, RuntimeError):
+            continue
+        need = 3 + len(infix)
+        if len(parts) < need:
+            continue
+        ws, rest = parts[0], parts[1:]
+        if infix and tuple(rest[: len(infix)]) != infix:
+            continue
+        rest = rest[len(infix):]
+        return (ws, rest[0], rest[1])
+    return None
 
 
 def path_for(ws: str, repo: str, piece: str) -> Path:

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -26,6 +26,10 @@ share = "local"
 # problem reading an OLDER schema. Omit it and 1 is assumed.
 schema = 1
 
+# Which of charter's two deployments this plane is. See "Fleet and embedded" below.
+[plane]
+shape = "fleet"                  # "fleet" | "embedded". Default: "fleet".
+
 # One [[forge]] block per code-hosting forge this control plane tracks. A single-forge
 # control plane (the common case) declares exactly one; see "Mixed-forge" below for more
 # than one. Each block is independent — its own owner, host, and excludes.
@@ -58,6 +62,46 @@ personal **user** account). `charter` accepts either key name in a `[[forge]]` b
 `group` and `owner` mean the same thing — so you can use whichever reads naturally for
 the forge in question. If a block sets both, `group` wins. `charter init --owner <name>`
 always writes the field as `owner`, since it works for either forge kind.
+
+## Fleet and embedded: `[plane].shape`
+
+charter is deployed two ways, and a plane declares which one it is.
+
+**`fleet`** (the default, and the original) — the control plane is its own directory. A
+workspace holds many **clones**, one per repo the task touches, each of which can carry
+worktrees. This is what the rest of this document assumes.
+
+**`embedded`** — charter installed *inside* the single codebase it serves, which may
+itself be a monorepo of backend, frontend and the rest. There is nothing to clone: the
+tree you edit is the plane's own root, and a workspace holds **worktrees** of it rather
+than clones. Teams reach for this when there is one repo, not a fleet, and they still
+want personas, memory and a vault.
+
+```toml
+[plane]
+shape = "embedded"
+```
+
+The status line follows the declaration. An embedded plane shows its own repo as the
+first row — branch, dirty state, CI, open change — with each worktree on its own row
+beneath it. A fleet plane shows the workspace's clones, exactly as before.
+
+### Why this is declared rather than detected
+
+A fleet plane's root is *also* a git repo in the normal case: its personas carry
+committed memory, and the `exclude` example above exists precisely because the plane's
+own repo lives on the forge. So the presence of `.git` cannot separate the two shapes —
+in one it means "the repo I work in", in the other "the plane itself, which I do not".
+
+Every filesystem signal that might substitute has the same defect in a worse place.
+"No clones anywhere" and "empty inventory" both describe a *fresh fleet plane*, before
+its first `discover` or `clone` — the moment a new user can least afford charter to
+guess. What separates the shapes is intent, and `charter init` is where the intent
+exists: running it inside a repo you already work in is the choice. So it is written
+down, once, instead of re-derived forever.
+
+An unrecognised value falls back to `fleet`, on the same principle as `[memory].share`
+falling back to `local`: a typo should cost a feature, not rearrange something that works.
 
 ## A self-hosted example
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -29,6 +29,11 @@ schema = 1
 # Which of charter's two deployments this plane is. See "Fleet and embedded" below.
 [plane]
 shape = "fleet"                  # "fleet" | "embedded". Default: "fleet".
+worktrees = "../plane.worktrees" # Where worktrees live. A relative path resolves against
+                                  # this file's directory; $CHARTER_WORKTREES overrides it.
+                                  # Default: fleet keeps them per-workspace under
+                                  # workspaces/<ws>/.worktrees/; embedded puts them in a
+                                  # SIBLING of the repo — see "Where worktrees live" below.
 
 # One [[forge]] block per code-hosting forge this control plane tracks. A single-forge
 # control plane (the common case) declares exactly one; see "Mixed-forge" below for more
@@ -102,6 +107,61 @@ down, once, instead of re-derived forever.
 
 An unrecognised value falls back to `fleet`, on the same principle as `[memory].share`
 falling back to `local`: a typo should cost a feature, not rearrange something that works.
+
+`charter init` decides it for you, because init is the only moment it is decidable: run
+inside a directory that is already a git repo, it writes `shape = "embedded"` and says so;
+run anywhere else, it writes nothing and you get a fleet plane. Afterwards the evidence is
+gone — a fleet plane's root becomes a git repo too — which is exactly why it is recorded
+rather than re-derived. `charter init --shape fleet|embedded` overrides the detection.
+
+An embedded plane gets no `inventory/` directory: the inventory lists a forge owner's
+repos so `clone` has targets, and an embedded plane clones nothing. `doctor` and
+`reinit` both know this, so neither reports its absence as drift.
+
+### Where worktrees live
+
+Worktrees normally sit at `workspaces/<ws>/.worktrees/<repo>/<piece>` — deliberately
+**outside every clone**, so that nx, jest and maven never recurse into them and a
+`git clean -xfd` inside a clone cannot destroy live work.
+
+That path assumes the clone and the control plane are different directories. In an
+embedded plane they are the same directory, so the identical rule now requires leaving the
+plane as well — otherwise a worktree is a complete second copy of the codebase sitting
+inside the tree that every root-level glob walks. This is not hypothetical: charter's own
+checkout, with two worktrees, answered a root-level test glob with 214 files of which 142
+were duplicates. `.gitignore` hides that from git and from nothing else — pytest, jest,
+nx, tsc and every IDE indexer read the working tree directly.
+
+So an embedded plane defaults its worktrees to a **sibling of the repo**, `<root>.worktrees/`,
+keeping the layout below it identical:
+
+```
+my-app/                                 the plane, and the codebase
+my-app.worktrees/<workspace>/my-app/<piece>
+```
+
+Set `[plane].worktrees` (or `$CHARTER_WORKTREES`) to put them somewhere else. Only the
+worktrees move — `workspaces/<ws>/memory/` and `refs/` stay inside the plane, because they
+are a few KB of text and `charter workspace live` exists precisely to un-ignore them so a
+team can commit them.
+
+Worktrees created before this are **not** relocated automatically: moving one means
+rewriting git's own `gitdir` pointer, and `git worktree move` is the command that does it
+correctly. `charter doctor` finds any that are still inside the codebase and prints that
+command with the paths filled in.
+
+### Nested planes
+
+`charter` takes the **innermost** `charter.toml` above your working directory. That is the
+right rule — it is the one git, cargo and npm use — but the embedded shape puts a
+`charter.toml` into ordinary product repos, and a fleet plane clones product repos into its
+workspaces. So `cd`-ing into `workspaces/<ws>/<repo>` can land you in a *different* control
+plane: different personas, a different vault, and memories written somewhere you did not
+choose.
+
+The rule does not change; charter just stops being quiet about it. When the active plane
+sits inside another plane's `workspaces/`, the status line carries a warning naming both
+planes and the `$CHARTER_ROOT` export that pins you to the outer one.
 
 ## A self-hosted example
 

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -22,7 +22,7 @@ from charter import config, instance, persona, root
 _PATCH = ("ROOT", "PERSONAS_DIR", "PERSONA_STATE_DIR", "STATE_DIR", "ACTIVE_PERSONA_FILE",
           "WORKSPACES_DIR", "SESSIONS_DIR", "TERMINALS_DIR", "HAS_CONTROL_PLANE",
           "CONFIG_ERROR", "GROUP", "EXCLUDE", "DEFAULT_WORKSPACE", "INVENTORY",
-          "MEMORY_SHARE", "PLANE_SHAPE")
+          "MEMORY_SHARE", "PLANE_SHAPE", "WORKTREES_ROOT")
 
 
 class PersonaIso(unittest.TestCase):
@@ -76,10 +76,24 @@ class PersonaIso(unittest.TestCase):
         config.DEFAULT_WORKSPACE = instance.default_workspace_of(_cfg, config.DEFAULT_WORKSPACE_FALLBACK)
         config.MEMORY_SHARE = instance.share_of(_cfg)
         config.PLANE_SHAPE = instance.shape_of(_cfg)
+        # Re-derived through config's own resolver, not reimplemented here — an embedded
+        # plane's worktree root is a SIBLING of ROOT, so a stale value points outside the
+        # tmp tree entirely. Left unpatched it resolved against the real checkout, and the
+        # suite wrote worktrees into the developer's projects directory and carried them
+        # from one test to the next (a `⑂2` assertion failing with `⑂6`).
+        config.WORKTREES_ROOT = config.worktrees_root_for(
+            config.ROOT, config.PLANE_SHAPE, _cfg)
         config.PERSONAS_DIR.mkdir(parents=True, exist_ok=True)
         self.addCleanup(self._restore)
 
     def _restore(self) -> None:
+        # An embedded plane's worktree root is a SIBLING of ROOT, so it survives the
+        # rmtree below. Removed by name-prefix rather than by "is it outside tmp" — the
+        # only path this ever creates is `<tmp>.worktrees`, and anything else sharing the
+        # temp directory is not ours to delete.
+        wt = getattr(config, "WORKTREES_ROOT", None)
+        if wt is not None and Path(wt).name == f"{self.tmp.name}.worktrees":
+            shutil.rmtree(wt, ignore_errors=True)
         for k, v in self._orig.items():
             setattr(config, k, v)
         shutil.rmtree(self.tmp, ignore_errors=True)

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -22,7 +22,7 @@ from charter import config, instance, persona, root
 _PATCH = ("ROOT", "PERSONAS_DIR", "PERSONA_STATE_DIR", "STATE_DIR", "ACTIVE_PERSONA_FILE",
           "WORKSPACES_DIR", "SESSIONS_DIR", "TERMINALS_DIR", "HAS_CONTROL_PLANE",
           "CONFIG_ERROR", "GROUP", "EXCLUDE", "DEFAULT_WORKSPACE", "INVENTORY",
-          "MEMORY_SHARE")
+          "MEMORY_SHARE", "PLANE_SHAPE")
 
 
 class PersonaIso(unittest.TestCase):
@@ -75,6 +75,7 @@ class PersonaIso(unittest.TestCase):
         config.EXCLUDE = instance.exclude_of(_cfg)
         config.DEFAULT_WORKSPACE = instance.default_workspace_of(_cfg, config.DEFAULT_WORKSPACE_FALLBACK)
         config.MEMORY_SHARE = instance.share_of(_cfg)
+        config.PLANE_SHAPE = instance.shape_of(_cfg)
         config.PERSONAS_DIR.mkdir(parents=True, exist_ok=True)
         self.addCleanup(self._restore)
 

--- a/tests/test_plane_embedded.py
+++ b/tests/test_plane_embedded.py
@@ -1,0 +1,258 @@
+"""The embedded shape's consequences beyond the status line: where worktrees live, what
+`init` decides, and what happens when one plane ends up inside another.
+
+The worktree relocation is the load-bearing one. `worktree.py` puts worktrees at
+``workspaces/<ws>/.worktrees/`` and says why: OUTSIDE every clone, "so nx/jest/maven never
+recurse into them". That reasoning assumes the clone and the plane are different
+directories. In an embedded plane they are the same one, so the identical path lands a
+full second copy of the codebase inside the tree every root-level glob walks — measured in
+charter's own checkout at the time this was written, 214 discoverable test files of which
+142 were duplicates. ``.gitignore`` hides that from git and from nothing else.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import subprocess
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+from charter import commands, config, doctor, instance, statusline, worktree
+from tests._isolation import PersonaIso
+from tests.test_statusline_monorepo import MonorepoIso, git, init_repo
+
+
+class WorktreesLeaveTheCodebase(MonorepoIso):
+    """An embedded plane's worktrees default to a SIBLING of the repo."""
+
+    def test_default_root_is_beside_the_repo_not_inside_it(self):
+        root = config.WORKTREES_ROOT
+        self.assertIsNotNone(root, "embedded plane kept the in-tree default")
+        self.assertEqual(root.name, f"{self.tmp.name}.worktrees")
+        with self.assertRaises(ValueError):
+            root.relative_to(self.tmp.resolve())
+
+    def test_worktrees_are_created_outside_the_repo(self):
+        wt = self.add_worktree("piece-a")
+        with self.assertRaises(ValueError):
+            wt.resolve().relative_to(self.tmp.resolve())
+
+    def test_nothing_is_added_to_a_root_level_glob_of_the_repo(self):
+        """The failure this exists to prevent, stated the way a build tool sees it."""
+        (self.tmp / "test_thing.py").write_text("x = 1\n")
+        git(self.tmp, "add", "test_thing.py")
+        git(self.tmp, "-c", "commit.gpgsign=false", "commit", "-qm", "add test")
+        before = list(self.tmp.rglob("test_*.py"))
+        self.add_worktree("piece-a")
+        self.assertEqual(list(self.tmp.rglob("test_*.py")), before)
+
+    def test_the_status_line_still_finds_them(self):
+        """Relocating them must not cost the rows — `dirs_for` follows the same root."""
+        self.add_worktree("piece-a")
+        self.assertTrue([ln for ln in self.render() if re.search(r"─ piece-a\b", ln)])
+
+    def test_a_declared_path_wins_and_is_relative_to_root(self):
+        cfg = {"plane": {"shape": "embedded", "worktrees": "../elsewhere"}}
+        self.assertEqual(
+            config.worktrees_root_for(self.tmp, "embedded", cfg),
+            (self.tmp.parent / "elsewhere").resolve())
+
+    def test_an_absolute_declared_path_is_taken_verbatim(self):
+        cfg = {"plane": {"worktrees": str(self.tmp / "here")}}
+        self.assertEqual(config.worktrees_root_for(self.tmp, "embedded", cfg),
+                         (self.tmp / "here").resolve())
+
+
+class FleetKeepsTheOriginalLayout(PersonaIso):
+    """A fleet plane's worktrees were never inside a clone, so nothing moves."""
+
+    def test_no_relocation_root(self):
+        self.assertIsNone(config.worktrees_root_for(self.tmp, "fleet", {}))
+
+    def test_worktrees_stay_under_the_workspace(self):
+        config.WORKTREES_ROOT = None
+        self.assertEqual(worktree.root("demo"),
+                         config.WORKSPACES_DIR / "demo" / worktree.DIR_NAME)
+
+    def test_a_fleet_plane_may_still_declare_a_path(self):
+        cfg = {"plane": {"worktrees": "../shared-worktrees"}}
+        self.assertEqual(config.worktrees_root_for(self.tmp, "fleet", cfg),
+                         (self.tmp.parent / "shared-worktrees").resolve())
+
+
+class LocatingAWorktree(MonorepoIso):
+    """`_current` marks the row you are standing in. For worktrees it never did, in
+    either layout: an in-plane worktree sits at `workspaces/<ws>/.worktrees/<repo>/<piece>`
+    and the plain workspace arithmetic read its repo as the literal `.worktrees`."""
+
+    def test_locate_resolves_a_relocated_worktree(self):
+        wt = self.add_worktree("piece-a")
+        self.assertEqual(worktree.locate(wt), ("default", self.tmp.name, "piece-a"))
+
+    def test_locate_resolves_a_path_deep_inside_one(self):
+        wt = self.add_worktree("piece-a")
+        deep = wt / "charter" / "sub"
+        deep.mkdir(parents=True)
+        self.assertEqual(worktree.locate(deep), ("default", self.tmp.name, "piece-a"))
+
+    def test_locate_still_handles_the_in_plane_layout(self):
+        """Both roots stay live: a plane that has just declared `[plane] worktrees` still
+        has yesterday's worktrees under `workspaces/`."""
+        legacy = config.WORKSPACES_DIR / "demo" / worktree.DIR_NAME / "svc" / "piece-b"
+        legacy.mkdir(parents=True)
+        self.assertEqual(worktree.locate(legacy), ("demo", "svc", "piece-b"))
+
+    def test_locate_says_no_for_an_unrelated_path(self):
+        self.assertIsNone(worktree.locate(self.tmp))
+        self.assertIsNone(worktree.locate(self.tmp.parent))
+
+    def test_the_status_line_marks_the_worktree_you_are_in(self):
+        wt = self.add_worktree("piece-a")
+        self.assertEqual(statusline._current({"cwd": str(wt)}), ("default", "piece-a"))
+
+
+class DoctorFlagsStrandedWorktrees(MonorepoIso):
+    """Existing worktrees are NOT moved automatically — relocating one means rewriting
+    git's own gitdir pointer, and `git worktree move` is what does that correctly."""
+
+    def _check(self):
+        with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            return doctor.check_embedded_worktrees()
+
+    def test_clean_when_they_are_outside(self):
+        self.add_worktree("piece-a")
+        self.assertEqual(self._check().status, doctor.OK)
+
+    def test_warns_when_one_is_inside_the_codebase(self):
+        stranded = config.WORKSPACES_DIR / "default" / worktree.DIR_NAME / "app" / "piece-a"
+        stranded.mkdir(parents=True)
+        res = self._check()
+        self.assertEqual(res.status, doctor.WARN)
+        self.assertIn("piece-a", res.detail)
+
+    def test_the_hint_names_the_command_that_actually_works(self):
+        stranded = config.WORKSPACES_DIR / "default" / worktree.DIR_NAME / "app" / "piece-a"
+        stranded.mkdir(parents=True)
+        self.assertIn("git worktree move", self._check().hint)
+
+    def test_silent_on_a_fleet_plane(self):
+        """Where that path was never a problem — it is outside every clone by design."""
+        self.declare_shape("fleet")
+        stranded = config.WORKSPACES_DIR / "default" / worktree.DIR_NAME / "app" / "piece-a"
+        stranded.mkdir(parents=True)
+        self.assertEqual(self._check().status, doctor.OK)
+
+
+class InitDecidesTheShape(PersonaIso):
+    """`charter init` is the only moment the distinction is decidable — afterwards a fleet
+    plane's root is a git repo too, so `.git` stops being evidence."""
+
+    def _init(self, **kw):
+        args = type("A", (), {"forge": "github", "owner": "acme", "host": None,
+                              "shape": None, **kw})()
+        with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            return commands.cmd_init(args)
+
+    def test_inside_an_existing_repo_writes_embedded(self):
+        init_repo(self.tmp)
+        self.assertEqual(self._init(), 0)
+        self.assertEqual(instance.shape_of(instance.load(self.tmp)), "embedded")
+
+    def test_an_empty_directory_stays_fleet(self):
+        self.assertEqual(self._init(), 0)
+        self.assertEqual(instance.shape_of(instance.load(self.tmp)), "fleet")
+
+    def test_a_fleet_plane_gets_no_plane_block_at_all(self):
+        """The default file stays the minimal one a stranger opens — no key to learn."""
+        self._init()
+        self.assertNotIn("[plane]", (self.tmp / "charter.toml").read_text())
+
+    def test_the_flag_overrides_detection(self):
+        init_repo(self.tmp)
+        self.assertEqual(self._init(shape="fleet"), 0)
+        self.assertEqual(instance.shape_of(instance.load(self.tmp)), "fleet")
+
+    def test_an_unknown_shape_is_refused_rather_than_guessed(self):
+        self.assertEqual(self._init(shape="embeded"), 1)
+        self.assertFalse((self.tmp / "charter.toml").exists())
+
+    def test_an_embedded_plane_gets_no_inventory_directory(self):
+        """`discover` enumerates clone targets and an embedded plane clones nothing."""
+        init_repo(self.tmp)
+        self._init()
+        self.assertFalse((self.tmp / "inventory").exists())
+        self.assertTrue((self.tmp / "personas").is_dir())
+        self.assertTrue((self.tmp / "workspaces").is_dir())
+
+    def test_a_fleet_plane_still_gets_one(self):
+        self._init()
+        self.assertTrue((self.tmp / "inventory").is_dir())
+
+    def test_the_absent_inventory_is_not_reported_as_drift(self):
+        """Otherwise doctor reports drift forever and reinit declines to fix it."""
+        init_repo(self.tmp)
+        self._init()
+        self.assertEqual(instance.drift(self.tmp), [])
+
+    def test_reinit_agrees_with_drift_about_an_embedded_plane(self):
+        """The detect and heal halves must read the shape from the same place — when
+        reinit used the import-time global instead of the file, a plane whose ROOT
+        differed from the process's got drift that reinit refused to act on."""
+        init_repo(self.tmp)
+        self._init()
+        config.HAS_CONTROL_PLANE = True
+        with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            commands.cmd_reinit(type("A", (), {})())
+        self.assertFalse((self.tmp / "inventory").exists())
+        self.assertEqual(instance.drift(self.tmp), [])
+
+
+class NestedPlanesAreVisible(PersonaIso):
+    """`find_root` takes the innermost marker — the git/cargo/npm contract, and correct.
+    But the embedded shape puts `charter.toml` into ordinary product repos, and a fleet
+    plane clones product repos into its workspaces. So cd-ing into `workspaces/<ws>/<repo>`
+    silently swaps personas, vault and memory destination. Nothing said so."""
+
+    def _make_nested(self) -> tuple[Path, Path]:
+        outer = self.tmp
+        (outer / "charter.toml").write_text("schema = 1\n")
+        inner = outer / "workspaces" / "default" / "product"
+        inner.mkdir(parents=True)
+        (inner / "charter.toml").write_text('schema = 1\n\n[plane]\nshape = "embedded"\n')
+        return outer, inner
+
+    def test_detects_the_outer_plane(self):
+        outer, inner = self._make_nested()
+        config.ROOT = inner
+        self.assertEqual(statusline._nested_under(), outer.resolve())
+
+    def test_a_standalone_plane_reports_nothing(self):
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        self.assertIsNone(statusline._nested_under())
+
+    def test_a_plain_parent_directory_is_not_a_trap(self):
+        """Only a plane whose WORKSPACES holds us swaps anything. A plane that merely
+        sits above us on the filesystem is the ordinary nesting `find_root` is for."""
+        outer = self.tmp
+        (outer / "charter.toml").write_text("schema = 1\n")
+        inner = outer / "sub" / "project"
+        inner.mkdir(parents=True)
+        (inner / "charter.toml").write_text("schema = 1\n")
+        config.ROOT = inner
+        self.assertIsNone(statusline._nested_under())
+
+    def test_the_alert_names_both_planes_and_the_fix(self):
+        outer, inner = self._make_nested()
+        config.ROOT = inner
+        alerts = "\n".join(statusline._alerts("default"))
+        alerts = re.sub(r"\x1b\[[0-9;]*m", "", alerts)
+        self.assertIn("nested plane", alerts)
+        self.assertIn(inner.name, alerts)
+        self.assertIn(outer.name, alerts)
+        self.assertIn("CHARTER_ROOT", alerts)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_statusline_monorepo.py
+++ b/tests/test_statusline_monorepo.py
@@ -68,7 +68,18 @@ class MonorepoIso(PersonaIso):
         init_repo(self.tmp)
         (self.tmp / "charter.toml").write_text('schema = 1\n\n[plane]\nshape = "embedded"\n')
         config.HAS_CONTROL_PLANE = True
-        config.PLANE_SHAPE = "embedded"
+        self.declare_shape("embedded")
+
+    def declare_shape(self, shape: str) -> None:
+        """Set the shape AND everything derived from it. `PersonaIso.setUp` already ran
+        against a tmp dir with no charter.toml, so it resolved a fleet plane's paths —
+        `WORKTREES_ROOT` in particular, which is `None` for fleet and a sibling of ROOT for
+        embedded. Setting `PLANE_SHAPE` alone leaves the two disagreeing, and the fixture
+        then silently tests the layout it was written to prove had changed."""
+        from charter import instance
+        config.PLANE_SHAPE = shape
+        config.WORKTREES_ROOT = config.worktrees_root_for(
+            config.ROOT, shape, instance.load(config.ROOT))
 
     def render(self, cwd: Path | None = None, width: int = 200) -> list[str]:
         """Content lines, ANSI and frame stripped — these tests are about which rows
@@ -143,7 +154,7 @@ class FleetPlaneIsUnchanged(MonorepoIso):
 
     def setUp(self) -> None:
         super().setUp()
-        config.PLANE_SHAPE = "fleet"
+        self.declare_shape("fleet")
 
     def test_a_git_root_alone_does_not_make_a_trunk(self):
         self.assertTrue((self.tmp / ".git").is_dir(), "fixture lost its repo")

--- a/tests/test_statusline_monorepo.py
+++ b/tests/test_statusline_monorepo.py
@@ -1,0 +1,350 @@
+"""A **monorepo** control plane: `charter init` run inside the repo you already work in.
+
+There is nothing to clone, so `workspaces/` holds no repos, and before this the status
+line rendered
+
+    ⬢ default · ws 0
+    ▪ repos 0/0
+
+in a checkout with a live branch, uncommitted work and an open PR — the one shape where
+every column it draws has an answer and it showed none. Both halves of the fix are here:
+
+* the plane's own tree is a repo row (`workspace.root_tree` → `_repo_trees`), counted,
+  drawn in the plane's own cyan, and current whenever the cwd is inside it;
+* with a single repo the ~12 unspent rows of `_MAX_REPO_LINES` go to that repo's
+  worktrees as FULL rows — branch, dirty, ahead/behind — instead of one line of bare
+  names. In a monorepo those worktrees are the whole parallel-task story, so they are
+  what the left column is actually for.
+
+Real git throughout (the tests/test_worktree.py pattern): a linked worktree's `.git` is a
+FILE rather than a directory, and that difference is the thing under test in half of
+these — a mocked git would prove nothing about it.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+from charter import config, statusline, util, workspace
+from tests._isolation import PersonaIso
+
+
+def git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", str(repo), *args],
+                          check=True, capture_output=True, text=True)
+
+
+def _plain(s: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+def init_repo(path: Path, branch: str = "main") -> Path:
+    """A real git repo with one commit, so HEAD and `git status` both have answers."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", branch, str(path)],
+                   check=True, capture_output=True)
+    git(path, "config", "user.email", "t@example.com")
+    git(path, "config", "user.name", "t")
+    (path / "README.md").write_text("hello\n")
+    git(path, "add", "README.md")
+    git(path, "-c", "commit.gpgsign=false", "commit", "-qm", "init")
+    return path
+
+
+class MonorepoIso(PersonaIso):
+    """An **embedded** control plane: ROOT is itself the git repo charter serves.
+
+    Both halves are set up, because both are required — the declared shape AND the git
+    repo. A fleet plane's root is usually a git repo too, so the declaration is what
+    carries the meaning; `FleetPlaneIsUnchanged` below pins that.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        init_repo(self.tmp)
+        (self.tmp / "charter.toml").write_text('schema = 1\n\n[plane]\nshape = "embedded"\n')
+        config.HAS_CONTROL_PLANE = True
+        config.PLANE_SHAPE = "embedded"
+
+    def render(self, cwd: Path | None = None, width: int = 200) -> list[str]:
+        """Content lines, ANSI and frame stripped — these tests are about which rows
+        exist and what they say, not about the box drawn around them."""
+        payload = {"session_id": "t"}
+        if cwd is not None:
+            payload["workspace"] = {"current_dir": str(cwd)}
+        old = os.environ.get("COLUMNS")
+        os.environ["COLUMNS"] = str(width)
+        try:
+            raw = _plain(statusline.render(payload)).split("\n")
+        finally:
+            if old is None:
+                os.environ.pop("COLUMNS", None)
+            else:
+                os.environ["COLUMNS"] = old
+        out = []
+        for ln in raw:
+            if not ln.strip() or set(ln.strip()) <= set("┌─┐└┘"):
+                continue
+            if ln.startswith("│ ") and ln.rstrip().endswith("│"):
+                ln = ln[2:].rstrip()[:-1].rstrip()
+            out.append(ln)
+        return out
+
+    def add_worktree(self, piece: str, repo: Path | None = None) -> Path:
+        """A worktree at the path charter uses, created with PLAIN git — charter reads
+        git's own registry rather than keeping one, so plain git is the honest fixture."""
+        from charter import worktree
+        repo = repo or self.tmp
+        p = worktree.path_for("default", repo.name, piece)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        git(repo, "worktree", "add", "-q", str(p), "-b", piece)
+        return p
+
+
+class RootTreeIsARepo(MonorepoIso):
+    """The plane's own repo is a row, not an absence."""
+
+    def test_root_tree_is_rendered_as_a_repo_row(self):
+        lines = self.render()
+        self.assertTrue(any(self.tmp.name in ln and "main" in ln for ln in lines),
+                        f"root tree missing from rows: {lines}")
+
+    def test_root_tree_is_counted(self):
+        self.assertIn("repos 1", "\n".join(self.render()))
+
+    def test_a_plane_whose_root_is_not_a_repo_has_no_root_row(self):
+        """A fleet plane checked out as a plain directory keeps the old behaviour
+        exactly — this must add a row only where there genuinely is a tree."""
+        import shutil
+        shutil.rmtree(self.tmp / ".git")
+        self.assertIsNone(workspace.root_tree())
+        self.assertIn("repos 0", "\n".join(self.render()))
+
+    def test_dirty_state_of_the_root_tree_reaches_its_row(self):
+        (self.tmp / "README.md").write_text("changed\n")
+        row = [ln for ln in self.render() if self.tmp.name in ln][0]
+        self.assertIn("main*", row, "root tree's dirty marker missing")
+
+
+class FleetPlaneIsUnchanged(MonorepoIso):
+    """The regression this shape check exists to prevent.
+
+    A fleet plane's root is a git repo in the normal case — its personas carry committed
+    memory, and docs/control-plane.md ships `exclude = ["this-control-plane"]` because the
+    plane's own repo lives on the forge. Gating the trunk row on `ROOT/.git` alone would
+    therefore have put EVERY existing fleet user's control-plane repo into their repo
+    list, beside the clones they actually work in. Same filesystem as `MonorepoIso`; only
+    the declaration differs.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        config.PLANE_SHAPE = "fleet"
+
+    def test_a_git_root_alone_does_not_make_a_trunk(self):
+        self.assertTrue((self.tmp / ".git").is_dir(), "fixture lost its repo")
+        self.assertIsNone(workspace.root_tree())
+
+    def test_the_plane_repo_is_not_listed_among_the_workspace_clones(self):
+        clone = init_repo(config.WORKSPACES_DIR / "default" / "iam-service")
+        self.assertEqual(workspace.repo_trees("default"), [clone])
+        joined = "\n".join(self.render())
+        self.assertIn("repos 1", joined)
+        self.assertIn("iam-service", joined)
+        self.assertNotIn(self.tmp.name, joined)
+
+    def test_an_unknown_shape_falls_back_to_fleet(self):
+        """A typo must cost a feature, not rearrange a working status line — the same
+        fail-toward-no-change rule `share_of` uses."""
+        from charter import instance
+        self.assertEqual(instance.shape_of({"plane": {"shape": "embeded"}}), "fleet")
+        self.assertEqual(instance.shape_of({}), "fleet")
+
+    def test_the_shape_is_read_from_charter_toml(self):
+        from charter import instance
+        self.assertEqual(instance.shape_of(instance.load(self.tmp)), "embedded")
+
+
+class CountDenominator(MonorepoIso):
+    """`repos N/M` means "N of M in the inventory" — so `/M` needs an inventory."""
+
+    def test_no_denominator_without_an_inventory(self):
+        """`repos 1/0` states the opposite of the truth in a plane that will never run
+        `discover`, because its one repo is already here."""
+        joined = "\n".join(self.render())
+        self.assertIn("repos 1", joined)
+        self.assertNotIn("repos 1/0", joined)
+
+    def test_denominator_returns_once_there_is_an_inventory(self):
+        config.INVENTORY.parent.mkdir(parents=True, exist_ok=True)
+        config.INVENTORY.write_text(json.dumps({"count": 38, "repos": []}))
+        self.assertIn("repos 1/38", "\n".join(self.render()))
+
+
+class CurrentRepo(MonorepoIso):
+    """Which row gets the you-are-here emphasis."""
+
+    def test_cwd_inside_the_root_tree_marks_it_current(self):
+        self.assertEqual(statusline._current({"cwd": str(self.tmp / "charter")}),
+                         (None, self.tmp.name))
+
+    def test_the_root_tree_belongs_to_no_single_workspace(self):
+        """`None` for the workspace, not the active one's name: there is one root tree
+        and it is in every workspace, so it is current whichever is active."""
+        ws, repo = statusline._current({"cwd": str(self.tmp)})
+        self.assertIsNone(ws)
+        self.assertEqual(repo, self.tmp.name)
+
+    def test_cwd_in_a_workspace_dir_does_not_mark_the_root_tree_current(self):
+        """`workspaces/` lives UNDER the root, so a cwd there is also "inside" it.
+        Falling through would bold the root row while you stand in a workspace."""
+        (config.WORKSPACES_DIR / "demo").mkdir(parents=True)
+        self.assertIsNone(statusline._current({"cwd": str(config.WORKSPACES_DIR / "demo")}))
+
+    def test_cwd_outside_the_plane_entirely_is_not_current(self):
+        self.assertIsNone(statusline._current({"cwd": str(self.tmp.parent)}))
+
+
+class WorktreeBranches(MonorepoIso):
+    """A linked worktree's `.git` is a FILE — `gitdir: <path>` — and its HEAD lives at
+    that path. Readers that only handled the directory form returned `?` for every
+    worktree, which in a monorepo plane is the entire branch column."""
+
+    def test_branch_of_a_linked_worktree(self):
+        wt = self.add_worktree("piece-a")
+        self.assertFalse((wt / ".git").is_dir(), "fixture is not a linked worktree")
+        self.assertEqual(util.branch_of(wt), "piece-a")
+
+    def test_branch_of_a_clone_still_works(self):
+        self.assertEqual(util.branch_of(self.tmp), "main")
+
+    def test_branch_of_a_non_tree(self):
+        self.assertEqual(util.branch_of(self.tmp / "nope"), "?")
+
+    def test_branch_names_keep_their_slashes(self):
+        wt = self.add_worktree("feat/deep/name")
+        self.assertEqual(util.branch_of(wt), "feat/deep/name")
+
+
+class WorktreeRows(MonorepoIso):
+    """With one repo there are ~12 idle rows and nothing to compress — spend them."""
+
+    def test_each_worktree_gets_its_own_row_with_its_branch(self):
+        self.add_worktree("statusline")
+        self.add_worktree("secrets")
+        lines = self.render()
+        for piece in ("statusline", "secrets"):
+            row = [ln for ln in lines if re.search(rf"─ {piece}\b", ln)]
+            self.assertTrue(row, f"no row for worktree {piece}: {lines}")
+            self.assertIn(piece, row[0], "worktree row is missing its branch")
+
+    def test_the_compact_summary_is_not_also_emitted(self):
+        """The one-liner and the full rows say the same thing; both is duplication."""
+        self.add_worktree("statusline")
+        self.assertFalse([ln for ln in self.render() if "│   ╰─" in ln],
+                         "compact summary rendered alongside full rows")
+
+    def test_no_worktree_count_badge_when_every_piece_is_visible(self):
+        """`⑂N` counts what you cannot see. Above two visible rows it restates them."""
+        self.add_worktree("statusline")
+        self.add_worktree("secrets")
+        root_row = [ln for ln in self.render() if self.tmp.name in ln][0]
+        self.assertNotIn("⑂", root_row)
+
+    def test_a_repo_with_children_is_not_drawn_as_the_end_of_the_tree(self):
+        self.add_worktree("statusline")
+        root_row = [ln for ln in self.render() if self.tmp.name in ln][0]
+        self.assertIn("├─", root_row)
+        self.assertNotIn("└─", root_row)
+
+    def test_the_last_child_uses_a_distinct_elbow(self):
+        """NOT `└─`. `render`'s "the tree keeps going" rewrite searches backwards for the
+        last `└─` to turn into `├─` when personas outnumber repos; a child sharing that
+        marker gets rewritten instead of its repo. That bug is why `_TREE_WT` exists."""
+        self.add_worktree("statusline")
+        child = [ln for ln in self.render() if re.search(r"─ statusline\b", ln)][0]
+        self.assertIn("╰─", child)
+        self.assertNotIn("└─", child)
+
+    def test_dirty_state_of_a_worktree_reaches_its_own_row(self):
+        wt = self.add_worktree("statusline")
+        (wt / "README.md").write_text("changed\n")
+        row = [ln for ln in self.render() if re.search(r"─ statusline\b", ln)][0]
+        self.assertIn("statusline*", row)
+
+    def test_cwd_inside_a_worktree_is_not_reported_as_the_root_tree(self):
+        """A worktree lives under `workspaces/`, so `_current` resolves it there and must
+        not fall through to the root — otherwise every worktree bolds the wrong row."""
+        wt = self.add_worktree("statusline")
+        self.assertNotEqual(statusline._current({"cwd": str(wt)}), (None, self.tmp.name))
+
+
+class MultiRepoKeepsTheSummary(MonorepoIso):
+    """At two or more repos the trade flips back: a repo must never lose its row to
+    another repo's worktrees, so their pieces go back to one compact line."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.clone = init_repo(config.WORKSPACES_DIR / "default" / "iam-service")
+
+    def test_two_repos_render_two_rows(self):
+        joined = "\n".join(self.render())
+        self.assertIn("repos 2", joined)
+        self.assertIn("iam-service", joined)
+
+    def test_worktrees_collapse_back_to_the_compact_summary(self):
+        self.add_worktree("piece-a", repo=self.clone)
+        lines = self.render()
+        self.assertTrue([ln for ln in lines if "│   ╰─" in ln],
+                        f"compact summary missing with 2 repos: {lines}")
+        self.assertFalse([ln for ln in lines if re.search(r"│  [├╰]─ piece-a", ln)],
+                         "full worktree rows drawn with 2 repos")
+
+    def test_the_badge_returns_when_pieces_are_summarised(self):
+        self.add_worktree("piece-a", repo=self.clone)
+        row = [ln for ln in self.render() if "iam-service" in ln][0]
+        self.assertIn("⑂1", row)
+
+
+class RepoTreesIsOneList(MonorepoIso):
+    """`workspace.repo_trees` is the single answer to "which repos am I on?", so the
+    status line cannot draw a repo whose forge state `gl-refresh` never fetched."""
+
+    def test_root_tree_leads_the_list(self):
+        clone = init_repo(config.WORKSPACES_DIR / "default" / "iam-service")
+        self.assertEqual(workspace.repo_trees("default"), [self.tmp, clone])
+
+    def test_a_plane_without_a_root_repo_is_just_its_clones(self):
+        import shutil
+        shutil.rmtree(self.tmp / ".git")
+        clone = init_repo(config.WORKSPACES_DIR / "default" / "iam-service")
+        self.assertEqual(workspace.repo_trees("default"), [clone])
+
+
+class WorktreeCommandsReachTheRootTree(MonorepoIso):
+    """In a monorepo plane `workspaces/` holds no clones, so without this every
+    `charter worktree` command answers "isn't cloned in workspace X" about the one repo
+    that is unmistakably present — the one you are standing in."""
+
+    def test_clone_for_finds_the_root_tree(self):
+        from charter import commands_worktree
+        self.assertEqual(commands_worktree.clone_for("default", self.tmp.name), self.tmp)
+
+    def test_an_unknown_name_is_still_unknown(self):
+        from charter import commands_worktree
+        self.assertIsNone(commands_worktree.clone_for("default", "not-a-repo"))
+
+    def test_a_workspace_clone_wins_a_name_collision(self):
+        """The clone was put in THIS workspace deliberately; the root tree is ambient.
+        Preferring the ambient one would cut the worktree off the wrong repo."""
+        from charter import commands_worktree
+        clone = init_repo(config.WORKSPACES_DIR / "default" / self.tmp.name)
+        self.assertEqual(commands_worktree.clone_for("default", self.tmp.name), clone)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
charter had one deployment: the plane is its own directory, and a workspace holds many clones. Installed inside a single codebase instead, every column the status line draws had an answer and it showed none —

```
⬢ default · ws 0
▪ repos 0/0
```

— in a checkout with a live branch, uncommitted work and a passing pipeline.

This adds the second deployment as a first-class shape, and dogfoods it: charter's own repo is now an embedded plane.

## `[plane] shape`

`fleet` is the default and changes nothing. `embedded` means there is nothing to clone — the tree you edit is the plane's own root, and a workspace holds worktrees of it.

**Declared, not detected**, and that is the load-bearing decision. A fleet plane's root is a git repo too (its personas carry committed memory, and `docs/control-plane.md` already ships `exclude = ["this-control-plane"]` because the plane's own repo lives on the forge), so `ROOT/.git` means "the repo I work in" in one shape and "the plane itself, which I do not" in the other. Every filesystem signal that might substitute — "no clones anywhere", "empty inventory" — describes a *fresh fleet plane* before its first `discover`, which is the worst possible moment to guess.

`charter init` decides it, since init is the only moment it is decidable. `--shape` overrides.

## What the left column becomes

```
▪ repos 1
├─ charter        main*        ✓ passed
│  ├─ secrets     secrets
│  ╰─ statusline  statusline
```

With one repo, `_MAX_REPO_LINES` left ~12 rows unspent while the compact summary crammed every piece onto one line as bare names. Each piece now gets branch, dirty and CI. Two or more repos keep the summary — a repo must never lose its row to another repo's worktrees.

## Worktrees leave the codebase

`worktree.py` puts worktrees outside every clone and says why: "so nx/jest/maven never recurse into them". That assumes the clone and the plane are different directories. In an embedded plane they are the same one, so the identical path lands a full second copy of the source inside the tree every root-level glob walks.

Measured in this repo with two worktrees: **214 test files discoverable from the root, 142 of them duplicates** of the other 72. `.gitignore` hides that from git and from nothing else — pytest, jest, nx, tsc and every IDE indexer read the working tree directly. A dot-directory fixes pytest (whose `norecursedirs` skips `.*`) and not jest; only leaving the tree fixes all of them.

Embedded planes therefore default worktrees to a sibling, `<root>.worktrees/`. Only the worktrees move — `memory/` and `refs/` stay, because `charter workspace live` exists to un-ignore them so a team can commit them.

Existing worktrees are **not** relocated automatically: that means rewriting git's own `gitdir` pointer, so `doctor` finds strays and hands over `git worktree move` with the paths filled in.

## Nesting is now visible

`find_root` takes the innermost marker — the git/cargo/npm contract, and correct. But this shape puts `charter.toml` into ordinary product repos, and fleet planes clone product repos into their workspaces. So `cd`-ing into `workspaces/<ws>/<repo>` silently swapped personas, vault, and memory destination. The rule stands; the status line stops being quiet, naming both planes and the `CHARTER_ROOT` export.

## Pre-existing bugs this surfaced

- **`util.branch_of`** — a linked worktree's `.git` is a *file* (`gitdir: <path>`) and its HEAD lives there. Both readers handled only the directory form, so every worktree's branch read `?`. One implementation now, shared with `glstate`, whose copy *wrote* the branch the status line compares against.
- **`_current`** could never mark the worktree you were standing in, in either layout — an in-plane worktree's path made its repo read as the literal `.worktrees`.
- **`gl-refresh`** asked only for clones, so it returned early on an embedded plane and the CI column stayed permanently blank.
- **`charter worktree`** could not see the root tree, answering "isn't cloned in workspace X" about the repo you are standing in.
- **`repos 1/0`** said the opposite of the truth in a plane that will never run `discover`.

## Test isolation

`WORKTREES_ROOT` resolved at import from the real repo, so the suite wrote worktrees into the developer's projects directory and carried them between cases. It is now a pure function of `(root, shape, cfg)` that the harness re-derives like every other value, and `_restore` cleans the sibling.

`cmd_reinit` read `config.PLANE_SHAPE` while `instance.drift` read `charter.toml`, so a plane whose ROOT differed from the process's got drift that `reinit` declined to fix. Both read the file now.

---

1066 tests pass (64 new). Fleet behaviour is pinned unchanged by `FleetPlaneIsUnchanged`: same filesystem as the embedded fixture, only the declaration differs, and no trunk row may appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4