### PR TITLE
0.14.0 — the embedded shape

### DIFF
--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.13.1"
+__version__ = "0.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.13.1"
+version = "0.14.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump for the release. Ships #14.

`0.13.1 → 0.14.0`, minor rather than patch because this adds config and CLI surface:

- `[plane] shape` — `fleet` (default, unchanged) or `embedded`
- `[plane] worktrees` — where worktrees live, with `$CHARTER_WORKTREES` override
- `charter init --shape` — overrides the detection
- `charter init` now decides the shape by detecting whether it is running inside an existing git repo
- an embedded plane's worktrees default to a sibling of the repo rather than `workspaces/<ws>/.worktrees/`

A fleet plane sees no behaviour change: the shape defaults to fleet, and an unrecognised value falls back to it.

Merging this and tagging `v0.14.0` triggers the release workflow, which publishes to PyPI via Trusted Publishing. The `guard` job cross-checks the tag against `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4