### PR TITLE
plane: a worktree is a view of a repo, not a plane of its own

### DIFF
--- a/charter/root.py
+++ b/charter/root.py
@@ -49,8 +49,65 @@ def find_root(start: Path | None = None) -> Path:
     cur = (start or Path.cwd()).resolve()
     for d in (cur, *cur.parents):
         if (d / MARKER).is_file():      # is_file, not exists: a directory is not a marker
-            return d
+            return _plane_of(d)
     raise ControlPlaneNotFound(_explain(f"in {cur} or any parent"))
+
+
+def main_worktree_of(tree: Path) -> Path | None:
+    """The MAIN working tree behind *tree*, when *tree* is a linked worktree — else ``None``.
+
+    A linked worktree's ``.git`` is a file reading ``gitdir: <main>/.git/worktrees/<name>``,
+    so the main tree is the directory holding that ``.git``. Pure path arithmetic: no
+    subprocess, because this sits on the import path of every single charter command.
+
+    ``None`` for the main tree itself (``.git`` is a directory), for a non-repo, and for a
+    gitdir with no ``.git`` component — a worktree of a BARE repo (``/srv/repo.git/
+    worktrees/x``) has no working tree to redirect to, so the caller must keep what it had.
+    """
+    g = Path(tree) / ".git"
+    try:
+        if g.is_dir():
+            return None                       # already the main tree
+        txt = g.read_text().strip()
+    except OSError:
+        return None
+    if not txt.startswith("gitdir:"):
+        return None
+    p = Path(txt[len("gitdir:"):].strip())
+    if not p.is_absolute():
+        p = Path(tree) / p
+    try:
+        p = p.resolve()
+    except (OSError, RuntimeError):
+        return None
+    for anc in p.parents:
+        if anc.name == ".git":
+            return anc.parent
+    return None
+
+
+def _plane_of(marked: Path) -> Path:
+    """The plane a found marker really belongs to.
+
+    A worktree is a *view of a repo*, not a repo — but ``charter.toml`` is a tracked file,
+    so in an **embedded** plane every worktree gets its own copy checked out and therefore
+    looks like its own control plane. Standing in one, charter used to resolve the plane to
+    the worktree: the status line went blank (``root_tree`` requires ``.git`` to be a
+    DIRECTORY, and a linked worktree's is a file), and personas, the vault and every
+    written memory resolved into a directory ``git worktree remove`` deletes. Worktrees are
+    how you are meant to work in an embedded plane, so that landed on the main path.
+
+    Identity therefore follows the main working tree. The marker must be present there too
+    — if it is not, this is not one plane seen from two directories and the found marker
+    stands.
+
+    ``$CHARTER_ROOT`` never reaches here: an explicit root wins outright, including when it
+    names a worktree, which is the escape hatch for anyone who genuinely wants one.
+    """
+    main = main_worktree_of(marked)
+    if main is not None and main != marked and (main / MARKER).is_file():
+        return main
+    return marked
 
 
 def find_root_or_cwd(start: Path | None = None) -> Path:

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -502,7 +502,7 @@ def _current(payload: dict) -> tuple[str | None, str] | None:
     return None
 
 
-def _tree_cells(lead: str, label: str, d, states, branches, gl) -> tui.Row:
+def _tree_cells(lead: str, label: str, d, states, branches, gl, branch=None) -> tui.Row:
     """One table row — ``<lead><label>`` in the name column, then branch+markers, CI, change.
 
     Shared by repo rows and nested worktree rows so the two cannot drift: a worktree's row
@@ -513,12 +513,17 @@ def _tree_cells(lead: str, label: str, d, states, branches, gl) -> tui.Row:
     The name cell's width is the same total whatever the lead costs — `tui.Cell` pads and
     truncates to it — so a longer lead spends its columns out of the label, never out of
     the branch column's starting position.
+
+    *branch* overrides the looked-up branch text — pass ``""`` to print the markers alone.
+    The markers are never part of that override: dirty and ahead/behind are true of the
+    tree whatever its branch is called, so they survive an emptied branch cell.
     """
     name = tui.Cell(f"{lead}{label}", 2 + 3 + _NAME_W)
 
     # branch + markers: truncate the *branch* so the markers always survive
     marks_plain, marks_col, is_dirty = _markers(states.get(d, {}))
-    br = tui.truncate(branches.get(d, "?"), max(1, _BRANCH_W - tui.width(marks_plain)))
+    text = branches.get(d, "?") if branch is None else branch
+    br = tui.truncate(text, max(1, _BRANCH_W - tui.width(marks_plain)))
     branch = tui.Cell(f"{_YELLOW if is_dirty else _DIM}{br}{_R}{marks_col}", _BRANCH_W)
 
     info = gl.get(d, {})
@@ -634,9 +639,17 @@ def _repo_rows(dirs, active, cur, states, branches, gl, root_dir=None,
                 # exact bug `_TREE_WT` was introduced to prevent — see its definition.
                 mark = _TREE_WT if j == len(kids) - 1 else _TREE_MID
                 emph_w = f"{_BOLD}{_UNDER}" if w.name == cur_repo else ""
+                # `charter worktree add <repo> <piece>` names the branch after the piece,
+                # so by default these two columns print the same word twice and the branch
+                # cell spends `_BRANCH_W` restating the name beside it. Empty it when they
+                # agree (the dirty/ahead/behind markers still render — they are true of the
+                # tree, not of its name), so the column comes to mean "this piece is NOT on
+                # the branch you would assume" — the only case worth 34 columns.
+                wb = branches.get(w, "?")
                 rows.append(_tree_cells(f"  {_DIM}{_TREE_PIPE}{mark}{_R}",
                                         f"{emph_w}{_DIM}{w.name}{_R}",
-                                        w, states, branches, gl))
+                                        w, states, branches, gl,
+                                        branch="" if wb == w.name else wb))
         # ONE summary line per repo, newest piece first — a fixed cost no matter how many
         # worktrees exist, so the footer can't grow with them (the ⑂N badge above carries
         # the true total, and overflow truncates with … rather than dropping pieces

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -150,6 +150,22 @@ rewriting git's own `gitdir` pointer, and `git worktree move` is the command tha
 correctly. `charter doctor` finds any that are still inside the codebase and prints that
 command with the paths filled in.
 
+### Working inside a worktree
+
+`charter.toml` is a tracked file, so an embedded plane checks a copy of it into every
+worktree — which means each worktree *looks* like its own control plane. It is not: a
+worktree is a view of a repo, not a repo.
+
+So the plane's identity follows the **main working tree**. Standing anywhere inside a
+worktree, `charter` resolves the plane to the repo the worktree belongs to, and personas,
+the vault, workspaces and memory all stay attached to it. Without that they resolved into
+the worktree itself — a directory `git worktree remove` deletes, taking any memory written
+there with it — and the status line rendered `repos 0`, because a linked worktree's `.git`
+is a file rather than a directory.
+
+`$CHARTER_ROOT` is never redirected, so pointing it at a worktree is the escape hatch if
+you genuinely want a plane of its own there.
+
 ### Nested planes
 
 `charter` takes the **innermost** `charter.toml` above your working directory. That is the

--- a/tests/test_plane_embedded.py
+++ b/tests/test_plane_embedded.py
@@ -209,6 +209,77 @@ class InitDecidesTheShape(PersonaIso):
         self.assertEqual(instance.drift(self.tmp), [])
 
 
+class PlaneIdentityFollowsTheMainTree(MonorepoIso):
+    """`charter.toml` is a TRACKED file, so an embedded plane checks a copy of it into
+    every worktree — and each one then looked like its own control plane.
+
+    Standing in one, charter resolved the plane to the worktree: the status line went
+    blank (`root_tree` requires `.git` to be a DIRECTORY and a linked worktree's is a
+    file), and personas, the vault and every written memory resolved into a directory
+    `git worktree remove` deletes. Worktrees are how you are meant to work in an embedded
+    plane, so this was the main path, not an edge.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        from charter import root as _root
+        self._root_mod = _root
+        # COMMIT charter.toml before branching off. That it is a tracked file is the whole
+        # premise: an untracked one is simply absent from the worktree and there is no bug
+        # to reproduce. `MonorepoIso` writes it after its initial commit, which is fine for
+        # every other fixture and exactly wrong for this one.
+        git(self.tmp, "add", "charter.toml")
+        git(self.tmp, "-c", "commit.gpgsign=false", "commit", "-qm", "charter.toml")
+        self.wt = self.add_worktree("piece-a")
+
+    def test_the_fixture_really_is_a_linked_worktree(self):
+        """Everything below is meaningless if `.git` here is a directory."""
+        self.assertFalse((self.wt / ".git").is_dir())
+        self.assertTrue((self.wt / "charter.toml").is_file(),
+                        "charter.toml was not checked out into the worktree")
+
+    def test_the_plane_resolves_to_the_trunk_not_the_worktree(self):
+        self.assertEqual(self._root_mod.find_root(self.wt), self.tmp.resolve())
+
+    def test_a_path_deep_inside_the_worktree_resolves_the_same(self):
+        deep = self.wt / "a" / "b"
+        deep.mkdir(parents=True)
+        self.assertEqual(self._root_mod.find_root(deep), self.tmp.resolve())
+
+    def test_the_trunk_still_resolves_to_itself(self):
+        self.assertEqual(self._root_mod.find_root(self.tmp), self.tmp.resolve())
+
+    def test_main_worktree_of_reads_the_gitdir_pointer(self):
+        self.assertEqual(self._root_mod.main_worktree_of(self.wt), self.tmp.resolve())
+
+    def test_main_worktree_of_says_none_for_a_main_tree(self):
+        self.assertIsNone(self._root_mod.main_worktree_of(self.tmp))
+
+    def test_main_worktree_of_says_none_for_a_non_repo(self):
+        plain = self.tmp / "not-a-repo"
+        plain.mkdir()
+        self.assertIsNone(self._root_mod.main_worktree_of(plain))
+
+    def test_a_worktree_whose_trunk_has_no_marker_keeps_its_own(self):
+        """Then this is not one plane seen from two directories — the found marker is the
+        only evidence there is, and redirecting would point at something that is not a
+        plane at all."""
+        (self.tmp / "charter.toml").unlink()
+        self.assertEqual(self._root_mod.find_root(self.wt), self.wt.resolve())
+
+    def test_an_explicit_charter_root_is_never_redirected(self):
+        """The escape hatch for anyone who genuinely wants a per-worktree plane."""
+        old = os.environ.get("CHARTER_ROOT")
+        os.environ["CHARTER_ROOT"] = str(self.wt)
+        try:
+            self.assertEqual(self._root_mod.find_root(self.tmp), self.wt.resolve())
+        finally:
+            if old is None:
+                os.environ.pop("CHARTER_ROOT", None)
+            else:
+                os.environ["CHARTER_ROOT"] = old
+
+
 class NestedPlanesAreVisible(PersonaIso):
     """`find_root` takes the innermost marker — the git/cargo/npm contract, and correct.
     But the embedded shape puts `charter.toml` into ordinary product repos, and a fleet

--- a/tests/test_statusline_monorepo.py
+++ b/tests/test_statusline_monorepo.py
@@ -282,10 +282,27 @@ class WorktreeRows(MonorepoIso):
         self.assertNotIn("└─", child)
 
     def test_dirty_state_of_a_worktree_reaches_its_own_row(self):
+        """The marker survives an emptied branch cell: dirty is true of the tree, not of
+        what its branch is called."""
         wt = self.add_worktree("statusline")
         (wt / "README.md").write_text("changed\n")
         row = [ln for ln in self.render() if re.search(r"─ statusline\b", ln)][0]
-        self.assertIn("statusline*", row)
+        self.assertIn("*", row.split("statusline", 1)[1])
+
+    def test_a_branch_matching_the_piece_name_is_not_printed_twice(self):
+        """`worktree add <repo> <piece>` names the branch after the piece, so the default
+        row said the same word in two columns and spent _BRANCH_W doing it."""
+        self.add_worktree("statusline")
+        row = [ln for ln in self.render() if re.search(r"─ statusline\b", ln)][0]
+        self.assertEqual(row.count("statusline"), 1, row)
+
+    def test_a_branch_that_differs_from_the_piece_name_is_shown(self):
+        """Which is the case the column is now FOR: this piece is not on the branch you
+        would assume from its name."""
+        wt = self.add_worktree("statusline")
+        git(wt, "checkout", "-q", "-b", "feat/renamed")
+        row = [ln for ln in self.render() if re.search(r"─ statusline\b", ln)][0]
+        self.assertIn("feat/renamed", row)
 
     def test_cwd_inside_a_worktree_is_not_reported_as_the_root_tree(self):
         """A worktree lives under `workspaces/`, so `_current` resolves it there and must


### PR DESCRIPTION
Found while checking whether worktree rows should carry branch/PR/CI (they already do — `_tree_cells` builds repo and worktree rows from the same four cells).

## The bug

`charter.toml` is a **tracked** file, so an embedded plane checks a copy into every worktree — and each one then resolved as its own control plane:

```
ROOT         .../charter.worktrees/default/charter/probe
STATE_DIR    .../probe/.charter      <- vaults, session pointers
PERSONAS_DIR .../probe/personas
WORKSPACES   .../probe/workspaces    <- memory
```

Two failures, both on the main path, because worktrees are *how* you work in an embedded plane:

- **The status line rendered `repos 0`.** `root_tree` requires `.git` to be a directory and a linked worktree's is a file. The exact blankness the embedded shape was built to fix, reappearing one level down.
- **Personas, the vault and every written memory resolved into a directory `git worktree remove` deletes.**

`_nested_under` doesn't catch it either — the worktree isn't under another plane's `workspaces/`, it's under the relocated worktree root.

## The fix

Identity follows the **main working tree**. A linked worktree's `.git` file reads `gitdir: <main>/.git/worktrees/<name>`, so the trunk is the directory holding that `.git` — pure path arithmetic, no subprocess, which matters because this sits on the import path of every charter command.

The marker must be present at the main tree too: without it, this is not one plane seen from two directories and the found marker stands. `$CHARTER_ROOT` is never redirected, so pointing it at a worktree remains the escape hatch for anyone who genuinely wants a plane of its own there.

Verified against the real repo — from inside a worktree, before and after:

```
before:  ▪ repos 0
after:   ▪ repos 1
         ├─ charter    worktree-plane-identity*
         │  ╰─ probe
```

## Also: the branch column stops repeating the name

`charter worktree add <repo> <piece>` names the branch after the piece, so the default row said the same word in two columns and spent `_BRANCH_W` doing it (`secrets   secrets`). It's emptied when they agree — the dirty/ahead/behind markers still render, being true of the tree rather than of its name — so the column now means *this piece is not on the branch you'd assume*, which is the only case worth 34 columns.

## Note on the fixture

`PlaneIdentityFollowsTheMainTree` commits `charter.toml` before branching off. That it is tracked is the entire premise; `MonorepoIso` writes it after its initial commit, which is right for every other test and exactly wrong here — untracked, it's simply absent from the worktree and there's no bug to reproduce.

1080 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4