### PR TITLE
0.15.0 — worktree plane identity, and personas without vaults

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.14.0",
+            "command": "charter hook sessionstart --plugin-version 0.15.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.14.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.15.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.14.0",
+            "command": "charter hook pretooluse --plugin-version 0.15.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.14.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.15.0"
           }
         ]
       }
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.14.0",
+            "command": "charter hook posttooluse --plugin-version 0.15.0",
             "timeout": 5
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.14.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.15.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.14.0"
+version = "0.15.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump for the release. `0.14.0 → 0.15.0`, minor rather than patch because `vault: none` is new config surface in persona frontmatter.

Three merged changes since 0.14.0:

- **#17 — a worktree is a view of a repo, not a plane of its own.** `charter.toml` is a tracked file, so an embedded plane checked a copy into every worktree and each resolved as its own control plane: the status line went blank inside one, and personas, the vault and every written memory resolved into a directory `git worktree remove` deletes. Identity now follows the main working tree. A worktree row also stops printing its branch when the branch *is* its name.
- **#19 — a persona may declare `vault: none`.** Plenty hold no credentials, and lint warned at them forever. Also fixes two generated-sub-agent strings that were already wrong: the description named the persona rather than its actual vault, and every sub-agent was handed a `persona secret` command regardless of whether it had a vault to open.
- **#16 — both plugin artifacts pinned to the CLI version, enforced.** They had drifted for twelve releases.

All four version files move together, as they now must — `TestVersionsMoveInLockstep` pins `pyproject.toml`, `charter/__init__.py`, `.claude-plugin/plugin.json` and every `--plugin-version` in `hooks/hooks.json`.

Merging this and tagging `v0.15.0` triggers the release workflow, which publishes to PyPI via Trusted Publishing. The `guard` job cross-checks the tag against `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4