### PR TITLE
fix(#18): the credential command a sub-agent is handed must actually run

### DIFF
--- a/.claude/agents/forge.md
+++ b/.claude/agents/forge.md
@@ -60,8 +60,8 @@ limits, host resolution surprises. Secrets go in the vault, never in memory.
 ## As a persona sub-agent
 - **🔑 git = the gh token over HTTPS. Never SSH, never signing.** Repos are pre-configured, so a plain `git push` works. If git ever asks for a key or passphrase, run `charter git-policy --apply` — don't reach for SSH (`gh auth status` checks the credential).
 - **Credentials** come only from this persona's vault, and are **never printed**:
-  `charter persona secret --persona forge <list|exec|cp> …` — use `exec`/`cp`, never `--reveal`.
-  Run tools through it, e.g. `… exec --file KUBECONFIG=kubeconfig -- kubectl -n <ns> get pods`
+  `charter persona secret list --persona forge` — use `exec`/`cp` to consume a secret, never `--reveal`.
+  Run tools through it, e.g. `charter persona secret exec --persona forge --file KUBECONFIG=kubeconfig -- kubectl -n <ns> get pods`
 - **Outside your domain, hand off — don't guess with partial credentials.** Delegate to the owner via the Agent tool (`subagent_type: <persona>`; it runs with *its own* vault — you never see its secrets); `charter persona list` shows who owns what. Never `charter persona use` to switch the active persona — that's user-request-only.
 - Follow the control plane's conventions (see CLAUDE.md); report results concisely to the caller.
 

--- a/.claude/agents/steward.md
+++ b/.claude/agents/steward.md
@@ -73,7 +73,7 @@ anything every persona needs.
 ## As a persona sub-agent
 - **🔑 git = the gh token over HTTPS. Never SSH, never signing.** Repos are pre-configured, so a plain `git push` works. If git ever asks for a key or passphrase, run `charter git-policy --apply` — don't reach for SSH (`gh auth status` checks the credential).
 - **This persona holds no credentials** (`vault: none`). Never read another persona's vault, and never improvise with a credential you find in the environment — if a task needs one, hand off to the persona that owns it.
-- **You may also use these personas: `statusline`, `release`, `forge`.** Read their vault (`charter persona secret --persona <name> …`), run their tools, or delegate a sub-task to their sub-agent (Agent tool, `subagent_type: <name>`).
+- **You may also use these personas: `statusline`, `release`, `forge`.** Read their vault (`charter persona secret list --persona <name>`), run their tools, or delegate a sub-task to their sub-agent (Agent tool, `subagent_type: <name>`).
 - **Outside your domain, hand off — don't guess with partial credentials.** Delegate to the owner via the Agent tool (`subagent_type: <persona>`; it runs with *its own* vault — you never see its secrets); `charter persona list` shows who owns what. Never `charter persona use` to switch the active persona — that's user-request-only.
 - Follow the control plane's conventions (see CLAUDE.md); report results concisely to the caller.
 

--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -491,7 +491,7 @@ def _render_agent(name: str, meta: dict, charter: str) -> str:
         joined = ", ".join(f"`{u}`" for u in uses)
         uses_note = (
             f"\n- **You may also use these personas: {joined}.** Read their vault "
-            f"(`charter persona secret --persona <name> …`), run their tools, or delegate a "
+            f"(`charter persona secret list --persona <name>`), run their tools, or delegate a "
             f"sub-task to their sub-agent (Agent tool, `subagent_type: <name>`)."
         )
 
@@ -517,10 +517,19 @@ def _render_agent(name: str, meta: dict, charter: str) -> str:
     # credential it found lying around.
     vault = persona.vault_of(name)
     if vault:
+        # SUBCOMMAND FIRST, then `--persona`. `charter persona secret --persona X list`
+        # is rejected by argparse ("invalid choice: 'X'"), and this is the ONLY credential
+        # instruction a generated sub-agent carries — an agent that follows a broken one
+        # may reach for `op` directly, which is what the vault abstraction exists to
+        # prevent. `test_the_generated_credential_command_actually_parses` runs what is
+        # written here through charter's real parser, because this shipped wrong twice:
+        # once originally, and once when this string was rewritten and the order carried
+        # forward unread.
         creds = (
             f"\n- **Credentials** come only from this persona's vault, and are **never "
-            f"printed**:\n  `charter persona secret --persona {name} <list|exec|cp> …` — "
-            f"use `exec`/`cp`, never `--reveal`.\n  Run tools through it, e.g. `… exec "
+            f"printed**:\n  `charter persona secret list --persona {name}` — use `exec`/`cp` "
+            f"to consume a secret, never `--reveal`.\n  Run tools through it, e.g. "
+            f"`charter persona secret exec --persona {name} "
             f"--file KUBECONFIG=kubeconfig -- kubectl -n <ns> get pods`"
         )
     else:

--- a/tests/test_persona_create_contract.py
+++ b/tests/test_persona_create_contract.py
@@ -236,6 +236,51 @@ class SyncAgentsRefusesDrafts(PersonaIso):
         self.assertIn("holds no credentials", body.lower())
         self.assertNotIn("--persona tui <list|exec|cp>", body)
 
+    def test_the_generated_credential_command_actually_parses(self):
+        """Issue #18. Every `charter …` command in a generated sub-agent is run through
+        charter's REAL parser, because the broken form (`secret --persona X list`, which
+        argparse rejects with "invalid choice: 'X'") is a perfectly plausible string and a
+        string-match test passes it happily. It shipped twice: once originally, and once
+        when the surrounding block was rewritten and the order carried forward unread.
+
+        This is the only credential instruction those agents carry, so an agent following
+        a broken one hits an argparse error and may reach for `op` directly — which is
+        precisely what the vault abstraction exists to prevent.
+        """
+        import re as _re
+        import shlex
+        from charter import cli
+
+        self.make_persona("ops", role="Ops", vault="ops", **{"delegate-when": "x"})
+        self.make_persona("dev", role="Dev", vault="dev", uses="ops",
+                          **{"delegate-when": "y"})
+        parser = cli.build_parser()
+
+        checked = 0
+        for name in ("ops", "dev"):
+            r = persona.resolve(name)
+            body = commands_persona._render_agent(name, r["meta"], r.get("charter") or "")
+            # Scoped to `persona secret`, the credential path this is about. A sweep over
+            # every backticked command would also catch prose that CITES a command rather
+            # than instructing one — the body says "Never `charter persona use` to switch
+            # the active persona", a deliberate fragment — and telling citation from
+            # instruction is guesswork this test should not be doing.
+            for cmd in _re.findall(r"`(charter persona secret [^`]+)`", body):
+                cmd = cmd.replace("…", "").strip()
+                if "<" in cmd:                      # a placeholder, not a real invocation
+                    cmd = _re.sub(r"<[^>]+>", "PLACEHOLDER", cmd)
+                argv = shlex.split(cmd)[1:]         # drop the `charter` program name
+                if not argv:
+                    continue
+                try:
+                    parser.parse_args(argv)
+                except SystemExit:
+                    self.fail(f"generated agent for '{name}' carries an invocation charter "
+                              f"itself rejects: {cmd}")
+                checked += 1
+        self.assertGreater(checked, 0, "no charter commands found to check — did the "
+                                       "generated body stop carrying them?")
+
     def test_a_hand_written_agent_is_never_removed(self):
         """Generated files are charter's to manage; hand-written ones are not."""
         self.make_persona("wip", role="WIP", vault="wip", draft="true")


### PR DESCRIPTION
Closes #18.

`sync-agents` wrote this into every generated sub-agent:

```
charter persona secret --persona <name> <list|exec|cp> …
```

argparse rejects it — the persona name lands where the subcommand is expected:

```
charter persona secret: error: argument psecret_cmd: invalid choice: 'forge'
  (choose from set, list, audit, get, rm, cp, exec)
```

The subcommand comes first. Two occurrences: the credentials block and the `uses:` note.

As the issue says, this is the *only* credential instruction those agents carry — an agent that follows it hits an argparse error and, at worst, reaches for `op` directly, which is exactly what the vault abstraction exists to prevent.

## It shipped twice

Once originally, and again in **0.15.0**: rewriting that block for `vault: none` carried the broken order forward unread. That's precisely the "running `sync-agents` after upgrading re-introduces the bug" failure the issue describes, and it means the currently published release carries it.

## So the test doesn't match strings

`test_the_generated_credential_command_actually_parses` extracts every `charter persona secret` invocation from a generated body and runs it through charter's **real** parser. The broken form is a perfectly plausible string, and a string-match test passes it happily — as it now has, twice. Verified by re-breaking the generator and watching the test fail with the exact invocation.

Scoped to `persona secret` deliberately: a sweep over every backticked command also catches prose that *cites* a command rather than instructing one (the body says "Never `charter persona use` to switch the active persona", a deliberate fragment), and telling citation from instruction is guesswork a test shouldn't do. That false positive showed up on the first run.

1089 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4