### PR TITLE
tests: the suite was overwriting the developer's real vault registry

### DIFF
--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -22,7 +22,15 @@ from charter import config, instance, persona, root
 _PATCH = ("ROOT", "PERSONAS_DIR", "PERSONA_STATE_DIR", "STATE_DIR", "ACTIVE_PERSONA_FILE",
           "WORKSPACES_DIR", "SESSIONS_DIR", "TERMINALS_DIR", "HAS_CONTROL_PLANE",
           "CONFIG_ERROR", "GROUP", "EXCLUDE", "DEFAULT_WORKSPACE", "INVENTORY",
-          "MEMORY_SHARE", "PLANE_SHAPE", "WORKTREES_ROOT")
+          "MEMORY_SHARE", "PLANE_SHAPE", "WORKTREES_ROOT",
+          # Every one of these was missing, and each is a path a test can WRITE to in the
+          # developer's real checkout. `VAULTS_REGISTRY` is the worst: the suite replaced a
+          # real registry with its own fixture data, orphaning every vault registered on
+          # the machine — the exact harm issue #22 describes, delivered by the test suite
+          # instead of by `vault add`. `DOCS_DIR` lets a doc-generating test write into the
+          # real `docs/`. See `EveryRootDerivedPathIsIsolated`, which now fails if another
+          # one is ever added to config.py without landing here.
+          "VAULTS_REGISTRY", "VAULTS_DIR", "ACTIVE_WORKSPACE_FILE", "DOCS_DIR")
 
 
 class PersonaIso(unittest.TestCase):
@@ -48,6 +56,11 @@ class PersonaIso(unittest.TestCase):
         config.WORKSPACES_DIR = self.tmp / "workspaces"
         config.SESSIONS_DIR = config.STATE_DIR / "sessions"
         config.TERMINALS_DIR = config.STATE_DIR / "terminals"
+        # Derived exactly as config.py derives them, against the temp ROOT.
+        config.VAULTS_REGISTRY = config.STATE_DIR / "vaults.json"
+        config.VAULTS_DIR = config.STATE_DIR / "vaults"
+        config.ACTIVE_WORKSPACE_FILE = config.STATE_DIR / "active-workspace"
+        config.DOCS_DIR = config.ROOT / "docs"
         # Task 1's fix round found a test that wrote a fake inventory/repos.json into the
         # REAL checkout because this tuple omitted INVENTORY — every other well-known path
         # was redirected into the tmp tree, but inventory.load()/save() kept resolving

--- a/tests/test_isolation_harness.py
+++ b/tests/test_isolation_harness.py
@@ -86,5 +86,58 @@ class TestIsolationHarnessInventory(unittest.TestCase):
             self.assertEqual(config.INVENTORY, original)  # restored on cleanup
 
 
+class EveryRootDerivedPathIsIsolated(PersonaIso):
+    """The class of bug, closed — rather than one more test per attribute.
+
+    Every case above pins ONE attribute, which is exactly why four went missing at once:
+    `VAULTS_REGISTRY`, `VAULTS_DIR`, `ACTIVE_WORKSPACE_FILE` and `DOCS_DIR` were all
+    derived from `STATE_DIR`/`ROOT` at import and none was patched, so the suite wrote
+    into the developer's real checkout. The registry was the sharp one — a run replaced a
+    real `vaults.json` with fixture data, orphaning every vault registered on that
+    machine, which is issue #22's harm arriving by a different road.
+
+    Enumerating `config` instead of listing names means a constant added later is covered
+    the day it appears, without anyone remembering this file exists.
+    """
+
+    @staticmethod
+    def _under(p: Path, base: Path) -> bool:
+        try:
+            p.relative_to(base)
+            return True
+        except ValueError:
+            return False
+
+    def _path_constants(self) -> list[tuple[str, Path]]:
+        out = []
+        for name in sorted(dir(config)):
+            if name.startswith("_") or name != name.upper():
+                continue
+            val = getattr(config, name)
+            if isinstance(val, Path):
+                out.append((name, val))
+        return out
+
+    def test_no_config_path_escapes_the_sandbox(self):
+        """`relative_to(tmp)`, not "differs from the real value" — an embedded plane's
+        worktree root is a SIBLING of ROOT, so a leaked one is outside the real plane too
+        and a not-equal check would wave it through."""
+        sandbox = [self.tmp.resolve(),
+                   (self.tmp.parent / f"{self.tmp.name}.worktrees").resolve()]
+        escaped = [f"{n} → {v}" for n, v in self._path_constants()
+                   if not any(self._under(Path(v).resolve(), s) for s in sandbox)]
+        self.assertEqual(escaped, [], "config paths still pointing outside the test "
+                                      "sandbox — a test writing to one of these edits the "
+                                      "developer's real checkout: " + "; ".join(escaped))
+
+    def test_every_path_constant_is_named_in_the_patch_tuple(self):
+        """Belt and braces: a constant could coincidentally resolve inside the sandbox
+        while still being ambient. `_PATCH` is also what `_restore` reads, so a name
+        missing here is a value never put back after the test."""
+        missing = [n for n, _ in self._path_constants() if n not in _PATCH]
+        self.assertEqual(missing, [], f"config path constants absent from _PATCH (add "
+                                      f"them there AND derive them in setUp): {missing}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`VAULTS_REGISTRY`, `VAULTS_DIR`, `ACTIVE_WORKSPACE_FILE` and `DOCS_DIR` are derived from `ROOT`/`STATE_DIR` at import and **none was in `_PATCH`**, so a test that patched `config.ROOT` left all four pointing at the real checkout.

Demonstrated rather than argued — sentinel into `.charter/vaults.json`, run the suite:

```
before:  {"vaults":{"SENTINEL": ...}}
after:   {"vaults": {"alpha": {"provider": "plain-file", "config": {"file": "/x"}}}}
```

That is fixture data. It's also why a vault registered earlier in this session had silently vanished. On a contributor's machine this orphans every vault they have registered — **issue #22's harm, arriving by a different road than #22 describes**. `DOCS_DIR` is the same shape with a smaller blade: a doc-generating test writes into the real `docs/`.

**Shipped code is unaffected.** Everything resolves consistently at import there; only tests re-point `ROOT` afterwards. Blast radius is contributors.

## Why four went missing at once

`test_isolation_harness.py` pinned one attribute per case, so a new constant is covered only if someone remembers the file exists. `EveryRootDerivedPathIsIsolated` enumerates `config` instead and fails on any `Path` resolving outside the sandbox, plus any absent from `_PATCH` (which `_restore` also reads — a missing name is a value never put back).

Verified by un-patching one and watching it name the offender:

```
AssertionError: ['VAULTS_REGISTRY → /Users/aharon/IdeaProjects/charter/.charter/vaults.json'] != []
```

`relative_to(tmp)` rather than "differs from the real value" deliberately: an embedded plane's worktree root is a *sibling* of ROOT, so a leaked one is outside the real plane too and a not-equal check would wave it through.

## How it was found

While gathering facts for a review of the open issues — not by the suite. It is the same bug as `WORKTREES_ROOT`, fixed hours earlier today, whose siblings were never checked. Closing the class is the actual fix.

1091 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4