### PR TITLE
0.15.1 — the credential command sub-agents are handed actually runs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.15.0",
+            "command": "charter hook sessionstart --plugin-version 0.15.1",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.15.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.15.1",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.15.0",
+            "command": "charter hook pretooluse --plugin-version 0.15.1",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.15.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.15.1"
           }
         ]
       }
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.15.0",
+            "command": "charter hook posttooluse --plugin-version 0.15.1",
             "timeout": 5
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.15.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.15.1",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.15.0"
+version = "0.15.1"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Patch release: fixes only, no new surface.

- **fix(#18)** — `sync-agents` wrote `charter persona secret --persona <name> <list|exec|cp>`, which argparse rejects. It's the only credential instruction a generated sub-agent carries, so an agent following it may reach for `op` directly — exactly what the vault abstraction exists to prevent. 0.15.0 shipped it.
- **tests** — the suite overwrote the developer's real `.charter/vaults.json`, orphaning registered vaults. Contributor-only (shipped code resolves consistently at import), but real.

All four version files move together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4