### PR TITLE
fix(#22): vault add refuses a name that is already registered

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -353,6 +353,10 @@ def _add_vault_parser(sub) -> None:
     add.add_argument("--account", help="1Password account to pin to (provider: 1password); "
                                        "needed when signed into more than one.")
     add.add_argument("--persona", help="Tag this vault for a persona (e.g. devops, qa).")
+    add.add_argument("--force", action="store_true",
+                     help="Replace an existing registration of this name. Does NOT migrate "
+                          "its secrets — the old vault's file is left where it is, with "
+                          "nothing pointing at it.")
     add.set_defaults(func=commands_secrets.cmd_vault_add)
 
     lst = vsub.add_parser("list", help="List configured vaults (names/status only, never values).")

--- a/charter/commands_secrets.py
+++ b/charter/commands_secrets.py
@@ -45,11 +45,21 @@ def cmd_vault_add(args) -> int:
         cfg["op-vault"] = args.op_vault
         if getattr(args, "account", None):
             cfg["account"] = args.account
+    force = getattr(args, "force", False)
+    replaced = registry.vaults().get(args.name) if force else None
     try:
-        registry.add_vault(args.name, args.provider, cfg, persona=args.persona)
+        registry.add_vault(args.name, args.provider, cfg, persona=args.persona, force=force)
     except base.VaultError as e:
         util.err(str(e))
         return 1
+    if replaced is not None:
+        # Say what was let go of, and where it still is. `--force` does not migrate, so
+        # the old file survives on disk with nothing pointing at it — the user needs its
+        # path to recover anything from it.
+        old_where = (replaced.get("config") or {}).get("file")
+        util.warn(f"Replaced the previous '{args.name}' registration "
+                  f"(provider: {replaced.get('provider', '?')}). Its secrets were NOT "
+                  f"migrated." + (f" They remain at {old_where}." if old_where else ""))
     tag = f", persona: {args.persona}" if args.persona else ""
     util.ok(f"Vault '{args.name}' registered (provider: {args.provider}{tag}).")
     prov = registry.provider_for(args.name)

--- a/charter/secrets/registry.py
+++ b/charter/secrets/registry.py
@@ -70,12 +70,44 @@ def provider_for(name: str, doc: dict | None = None) -> VaultProvider:
     return cls(name, vc.get("config", {}))
 
 
-def add_vault(name: str, provider: str, cfg: dict, persona: str | None = None) -> None:
+def add_vault(name: str, provider: str, cfg: dict, persona: str | None = None,
+              force: bool = False) -> None:
+    """Register a vault. Refuses to replace an existing registration unless *force*.
+
+    Registering over a name that already exists used to overwrite it in place — different
+    provider, no prompt, exit 0 (issue #22). The registration is the ONLY pointer to a
+    plain-file vault's secrets, so replacing it does not migrate anything: it strands the
+    file on disk with nothing referring to it, and `charter secret get` then reports the
+    key as missing rather than as unreachable. Observed during a real migration, where
+    three vaults were re-registered onto 1Password and accepted silently.
+
+    That also broke the rule the rest of charter states and follows — additive: never
+    delete or rename a user's thing to make room; name the blocker and refuse. `init`,
+    `reinit` and `_create_baseline_dirs` all work this way.
+
+    ``force`` is the deliberate override, the same idiom `charter persona create --force`
+    already uses. It still does not migrate: moving secrets between providers is its own
+    operation and must be typed on purpose, not ride along inside `add`.
+    """
     if provider not in PROVIDERS:
         raise VaultError(
             f"unknown provider '{provider}'. Available: {', '.join(sorted(PROVIDERS))}"
         )
     doc = load_registry()
+    existing = doc["vaults"].get(name)
+    if existing is not None and not force:
+        old = existing.get("provider", "?")
+        where = (existing.get("config") or {}).get("file")
+        detail = f" ({where})" if where else ""
+        raise VaultError(
+            f"vault '{name}' is already registered with provider '{old}'{detail}. "
+            f"charter will not replace it: the registration is the only pointer to that "
+            f"vault's secrets, so replacing it strands them with nothing referring to "
+            f"them.\n"
+            f"  keep both:     charter vault add <other-name> --provider {provider} …\n"
+            f"  inspect it:    charter vault list\n"
+            f"  replace anyway: re-run with --force (this does NOT migrate secrets)"
+        )
     doc["vaults"][name] = {"provider": provider, "persona": persona, "config": cfg}
     save_registry(doc)
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -74,6 +74,27 @@ charter persona secret set API_TOKEN --stdin        # resolves the active person
 charter persona secret exec --env TOKEN=API_TOKEN -- some-cli
 ```
 
+### Registering over a name that already exists
+
+`charter vault add` **refuses** a name that is already registered, naming the provider in
+the way and where its secrets live:
+
+```
+✗ vault 'devops' is already registered with provider 'plain-file' (.charter/vaults/devops.json).
+  charter will not replace it: the registration is the only pointer to that vault's
+  secrets, so replacing it strands them with nothing referring to them.
+```
+
+That pointer is the whole reason. A plain-file vault's secrets are found *only* through
+its registration, so overwriting it does not move anything — the file stays on disk with
+nothing referring to it, and `charter secret get` then reports the key as missing rather
+than as unreachable. Same additive rule `charter init` and `reinit` follow: name the
+blocker, refuse, never delete or rename to make room.
+
+`--force` overrides it, warns, and tells you where the old vault's file remains. It does
+**not** migrate secrets — moving them between providers is a deliberate operation, not
+something that rides along inside `add`.
+
 ## Provider status
 
 | Provider | id | Status |

--- a/tests/test_vault_registration.py
+++ b/tests/test_vault_registration.py
@@ -1,0 +1,93 @@
+"""Registering a vault over a name that already exists (issue #22).
+
+`charter vault add <name>` used to overwrite the registration in place — different
+provider, no prompt, exit 0. The registration is the ONLY pointer to a plain-file vault's
+secrets, so replacing it migrates nothing: it strands the file on disk with nothing
+referring to it, and `charter secret get` then reports the key as *missing* rather than as
+unreachable. Observed during a real migration, where three vaults were re-registered onto
+1Password and every one was accepted silently.
+
+It also broke the rule the rest of charter states and follows — additive: never delete or
+rename a user's thing to make room; name the blocker and refuse. `init`, `reinit` and
+`_create_baseline_dirs` all work that way.
+"""
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr
+from types import SimpleNamespace
+
+from charter import commands_secrets
+from charter.secrets import base, registry
+from tests._isolation import PersonaIso
+
+
+def _args(name: str, provider: str = "plain-file", **kw) -> SimpleNamespace:
+    return SimpleNamespace(name=name, provider=provider, file=kw.pop("file", None),
+                           op_vault=kw.pop("op_vault", None), account=None,
+                           persona=kw.pop("persona", None), force=kw.pop("force", False))
+
+
+class RegisteringOverAnExistingName(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        registry.add_vault("devops", "plain-file", {"file": str(self.tmp / "devops.json")})
+
+    def test_a_collision_is_refused(self):
+        with self.assertRaises(base.VaultError):
+            registry.add_vault("devops", "1password", {"op-vault": "Eng"})
+
+    def test_the_original_registration_survives_the_refusal(self):
+        """The point of refusing: what was there must still be there afterwards."""
+        with self.assertRaises(base.VaultError):
+            registry.add_vault("devops", "1password", {"op-vault": "Eng"})
+        got = registry.vaults()["devops"]
+        self.assertEqual(got["provider"], "plain-file")
+        self.assertEqual(got["config"]["file"], str(self.tmp / "devops.json"))
+
+    def test_the_refusal_names_what_is_in_the_way_and_how_to_proceed(self):
+        """A blocker the user cannot act on is only half a refusal."""
+        with self.assertRaises(base.VaultError) as e:
+            registry.add_vault("devops", "1password", {"op-vault": "Eng"})
+        msg = str(e.exception)
+        self.assertIn("plain-file", msg)              # what is registered
+        self.assertIn("devops.json", msg)             # and where its secrets are
+        self.assertIn("--force", msg)                 # how to override
+
+    def test_force_replaces(self):
+        registry.add_vault("devops", "1password", {"op-vault": "Eng"}, force=True)
+        self.assertEqual(registry.vaults()["devops"]["provider"], "1password")
+
+    def test_force_does_not_migrate_and_says_so(self):
+        """`--force` is an override, not a migration. Moving secrets between providers is
+        its own operation and must be typed on purpose — burying it inside `add` is how
+        the original bug orphaned things."""
+        err = io.StringIO()
+        with redirect_stderr(err):
+            commands_secrets.cmd_vault_add(
+                _args("devops", "1password", op_vault="Eng", force=True))
+        out = err.getvalue()
+        self.assertIn("NOT migrated", out)
+        self.assertIn(str(self.tmp / "devops.json"), out)   # where they still are
+
+    def test_a_different_name_is_unaffected(self):
+        registry.add_vault("qa", "plain-file", {"file": str(self.tmp / "qa.json")})
+        self.assertEqual(sorted(registry.vaults()), ["devops", "qa"])
+
+    def test_the_command_exits_non_zero_on_a_refusal(self):
+        """Scripted callers must be able to tell from the exit code alone that the vault
+        they asked for is not the vault that is registered."""
+        with redirect_stderr(io.StringIO()):
+            rc = commands_secrets.cmd_vault_add(_args("devops", "1password", op_vault="Eng"))
+        self.assertEqual(rc, 1)
+
+    def test_a_first_registration_still_just_works(self):
+        with redirect_stderr(io.StringIO()):
+            rc = commands_secrets.cmd_vault_add(_args("fresh"))
+        self.assertEqual(rc, 0)
+        self.assertIn("fresh", registry.vaults())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #22.

`charter vault add <name>` overwrote an existing registration in place — different provider, no prompt, exit 0. The issue observed it during a real migration: three vaults re-registered onto 1Password, all accepted silently.

## Why it loses secrets

The registration is the **only** pointer to a plain-file vault's secrets. Replacing it migrates nothing — it strands the file on disk with nothing referring to it, and `charter secret get` then reports the key as *missing* rather than as unreachable. That's the failure mode that hides the loss instead of reporting it.

It also broke the rule the rest of charter states and follows: `init`, `reinit` and `_create_baseline_dirs` are all additive — never delete or rename a user's thing to make room, name the blocker and refuse.

## Now

```
$ charter vault add devops --provider 1password --op-vault Eng
✗ vault 'devops' is already registered with provider 'plain-file' (…/vaults/devops.json).
  charter will not replace it: the registration is the only pointer to that vault's
  secrets, so replacing it strands them with nothing referring to them.
  keep both:      charter vault add <other-name> --provider 1password …
  inspect it:     charter vault list
  replace anyway: re-run with --force (this does NOT migrate secrets)
$ echo $?
1
```

Exit 1, so a scripted caller can tell from the code alone that the vault it asked for isn't the vault that's registered.

`--force` is the deliberate override — the idiom `persona create --force` already establishes here. It still doesn't migrate (that's its own operation, and burying it inside `add` is how the original bug orphaned things), and it names where the old file remains:

```
! Replaced the previous 'devops' registration (provider: plain-file). Its secrets were
  NOT migrated. They remain at …/vaults/devops.json.
```

Verified end to end against a scratch control plane, not only in unit tests. 1099 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4