### PR TITLE
fix(#21): store a vault's file relative to the plane, so the registry travels

### DIFF
--- a/charter/commands_secrets.py
+++ b/charter/commands_secrets.py
@@ -24,18 +24,38 @@ from .secrets import base, registry
 # --------------------------------------------------------------------------- #
 # vault management                                                             #
 # --------------------------------------------------------------------------- #
+def _portable_file(p) -> str:
+    """A vault ``file`` as it should be STORED: relative to the control-plane root when it
+    lives inside it, otherwise absolute and untouched (issue #21).
+
+    The registry used to record one developer's home directory, so a team that commits its
+    reference vaults — they hold ``op://`` URIs, never values — found the vault files
+    present on a fresh clone and the index that locates them useless, and had to script
+    `charter vault add` calls to rebuild state already in git.
+
+    Absolute survives deliberately: a vault kept outside the plane has no portable form,
+    and rewriting it would silently re-point it at somewhere inside.
+    """
+    from pathlib import Path
+    p = Path(p).expanduser()
+    try:
+        return str(p.resolve().relative_to(Path(config.ROOT).resolve()))
+    except (ValueError, OSError):
+        return str(p)
+
+
 def cmd_vault_add(args) -> int:
     cfg: dict = {}
     if args.provider == "plain-file":
-        cfg["file"] = args.file or str(config.VAULTS_DIR / f"{args.name}.json")
+        cfg["file"] = _portable_file(args.file or config.VAULTS_DIR / f"{args.name}.json")
     elif args.provider == "reference":
         # A reference vault stores URIs, not values, but it still needs somewhere to
         # keep them. Defaulting this (it used to apply only to plain-file) is why
         # `vault add x --provider reference` registered and then warned that it had no
         # file configured — technically correct and useless as a first experience.
-        cfg["file"] = args.file or str(config.VAULTS_DIR / f"{args.name}.json")
+        cfg["file"] = _portable_file(args.file or config.VAULTS_DIR / f"{args.name}.json")
     elif args.file:
-        cfg["file"] = args.file
+        cfg["file"] = _portable_file(args.file)
     if args.provider == "1password":
         if not getattr(args, "op_vault", None):
             util.err("--op-vault is required for a 1password vault: which 1Password "

--- a/charter/secrets/base.py
+++ b/charter/secrets/base.py
@@ -40,6 +40,31 @@ class VaultProvider(ABC):
         self.name = name
         self.config = config or {}
 
+    @property
+    def file_path(self):
+        """Absolute path of this vault's ``file``, resolving a RELATIVE one against the
+        control-plane root. Raises when the provider needs a file and none is configured.
+
+        A relative value is how the registry becomes portable (issue #21). Reference
+        vaults hold ``op://`` URIs rather than values, so a team commits them and expects
+        a fresh clone to inherit the wiring — but the registry that finds them hard-coded
+        one developer's home directory, so the committed vault files were invisible on any
+        other machine until someone re-registered them by hand.
+
+        Absolute stays valid and untouched, for a vault deliberately kept outside the
+        plane. Resolution lives here rather than in each provider because `plain-file` and
+        `reference` had byte-identical `path` properties, and two implementations of "where
+        is this file" is how one of them quietly keeps resolving the old way.
+        """
+        from pathlib import Path
+        from .. import config as _config
+
+        p = self.config.get("file")
+        if not p:
+            raise VaultError(f"vault '{self.name}' has no 'file' configured")
+        p = Path(p).expanduser()
+        return p if p.is_absolute() else (_config.ROOT / p)
+
     @abstractmethod
     def get(self, key: str) -> str:
         """Return the secret value, or raise :class:`SecretNotFound`."""

--- a/charter/secrets/plain_file.py
+++ b/charter/secrets/plain_file.py
@@ -16,6 +16,21 @@ from pathlib import Path
 from .base import SecretNotFound, VaultError, VaultProvider
 
 
+def _short(p: Path) -> str:
+    """A path as it should be SHOWN — relative to the plane when it lives inside it.
+
+    `charter vault list` printed the absolute path in its STATUS column, which is noise
+    and leaks one developer's local layout into terminal output other people see (issue
+    #21's aside). Inside the plane the relative form is both shorter and the same string
+    everyone else would see.
+    """
+    from .. import config as _config
+    try:
+        return str(Path(p).resolve().relative_to(Path(_config.ROOT).resolve()))
+    except (ValueError, OSError):
+        return str(p)
+
+
 class PlainFileProvider(VaultProvider):
     id = "plain-file"
     label = "Plain file (JSON, 0600)"
@@ -23,10 +38,7 @@ class PlainFileProvider(VaultProvider):
 
     @property
     def path(self) -> Path:
-        p = self.config.get("file")
-        if not p:
-            raise VaultError(f"vault '{self.name}' has no 'file' configured")
-        return Path(p).expanduser()
+        return self.file_path      # shared resolution — see VaultProvider.file_path
 
     def _load(self) -> dict:
         p = self.path
@@ -129,12 +141,11 @@ class PlainFileProvider(VaultProvider):
         return sorted(self._load().keys())
 
     def health(self) -> tuple[bool, str]:
-        p = self.config.get("file")
-        if not p:
+        if not self.config.get("file"):
             return False, "no 'file' configured"
-        pp = Path(p).expanduser()
+        pp = self.file_path
         if not pp.exists():
-            return True, f"not created yet ({pp})"
+            return True, f"not created yet ({_short(pp)})"
         try:
             count = len(self._load())
         except VaultError as e:

--- a/charter/secrets/reference.py
+++ b/charter/secrets/reference.py
@@ -73,10 +73,7 @@ class ReferenceProvider(VaultProvider):
 
     @property
     def path(self) -> Path:
-        p = self.config.get("file")
-        if not p:
-            raise VaultError(f"vault '{self.name}' has no 'file' configured")
-        return Path(p).expanduser()
+        return self.file_path      # shared resolution — see VaultProvider.file_path
 
     def _load(self) -> dict:
         p = self.path

--- a/tests/test_vault_registration.py
+++ b/tests/test_vault_registration.py
@@ -89,5 +89,64 @@ class RegisteringOverAnExistingName(PersonaIso):
         self.assertIn("fresh", registry.vaults())
 
 
+class TheRegistryIsPortable(PersonaIso):
+    """Issue #21. The registry recorded one developer's home directory, so a team that
+    commits its reference vaults — they hold `op://` URIs, never values — found the vault
+    files present on a fresh clone and the index that locates them useless, and scripted
+    `charter vault add` calls to rebuild state already in git."""
+
+    def _add(self, name: str, provider: str = "plain-file", file=None):
+        with redirect_stderr(io.StringIO()):
+            return commands_secrets.cmd_vault_add(
+                _args(name, provider, file=str(file) if file else None))
+
+    def test_a_managed_path_is_stored_relative_to_the_plane(self):
+        self._add("devops")
+        self.assertEqual(registry.vaults()["devops"]["config"]["file"],
+                         ".charter/vaults/devops.json")
+
+    def test_a_path_given_inside_the_plane_is_relativised_too(self):
+        self._add("team", file=self.tmp / "secrets" / "team.json")
+        self.assertEqual(registry.vaults()["team"]["config"]["file"],
+                         "secrets/team.json")
+
+    def test_a_path_outside_the_plane_stays_absolute(self):
+        """A vault deliberately kept outside has no portable form, and rewriting it would
+        silently re-point it at somewhere inside."""
+        outside = self.tmp.parent / "elsewhere.json"
+        self._add("ext", file=outside)
+        self.assertEqual(registry.vaults()["ext"]["config"]["file"], str(outside))
+
+    def test_a_relative_entry_resolves_against_the_plane_root(self):
+        """The half that makes the stored form usable — and the half that makes the same
+        registry work on a machine whose checkout lives somewhere else."""
+        registry.add_vault("devops", "plain-file", {"file": ".charter/vaults/devops.json"})
+        prov = registry.provider_for("devops")
+        self.assertEqual(prov.path, self.tmp / ".charter" / "vaults" / "devops.json")
+
+    def test_an_absolute_entry_still_resolves_unchanged(self):
+        """Registries written before this keep working — no migration, no rewrite."""
+        abs_path = self.tmp / "legacy.json"
+        registry.add_vault("legacy", "plain-file", {"file": str(abs_path)})
+        self.assertEqual(registry.provider_for("legacy").path, abs_path)
+
+    def test_status_does_not_leak_the_local_layout(self):
+        """#21's aside: `vault list` printed the absolute path in its STATUS column, which
+        is noise and puts one developer's directory layout into output others may read."""
+        self._add("devops")
+        ok, detail = registry.provider_for("devops").health()
+        self.assertTrue(ok)
+        self.assertIn("not created yet", detail)
+        self.assertNotIn(str(self.tmp), detail)
+
+    def test_both_providers_resolve_the_same_way(self):
+        """`plain-file` and `reference` had byte-identical `path` properties; they now
+        share one, so neither can quietly keep resolving the old way."""
+        registry.add_vault("a", "plain-file", {"file": "x/a.json"})
+        registry.add_vault("b", "reference", {"file": "x/b.json"})
+        self.assertEqual(registry.provider_for("a").path, self.tmp / "x" / "a.json")
+        self.assertEqual(registry.provider_for("b").path, self.tmp / "x" / "b.json")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Addresses the core of #21.

`.charter/vaults.json` recorded an absolute path, hard-coding one developer's home directory. Reference vaults hold `op://` URIs rather than values and are therefore safe to commit — a team that does found the vault *files* present on a fresh clone and the *index* that locates them useless, and scripted `charter vault add` calls to rebuild state already in git.

## The change

A `file` inside the control plane is now **stored** relative to it and **resolved** against `ROOT` on read. Absolute survives untouched — a vault deliberately kept outside the plane has no portable form, and rewriting one would silently re-point it somewhere inside. Registries written before this keep working; nothing is migrated or rewritten.

Verified by relocation rather than by unit test alone — a plane copied to a different path, registry and all:

```
stored:  {'file': '.charter/vaults/team.json'}
at /tmp/p21a:  team  reference  no references yet
at /tmp/p21b:  team  reference  1 reference(s) via op     <- same registry, different path
outside the plane: {'file': '/private/tmp/outside.json'}  <- left alone
```

Resolution lives in `VaultProvider.file_path`, not in each provider: `plain-file` and `reference` had byte-identical `path` properties, and two implementations of "where is this file" is how one of them quietly keeps resolving the old way.

Also the issue's aside — `vault list` printed the absolute path in its STATUS column, which is noise and puts a developer's local layout into output other people read. Shown relative when inside the plane.

## What this does not settle

Whether `.charter/vaults.json` should actually be **committed**. `.charter/` is gitignored under a comment saying never to commit it because it holds credentials, and the registry also carries per-developer fields (a 1Password `account`). Making the file portable is the prerequisite either way; where the shareable half finally lives is a separate decision, so #21 stays open.

1106 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4