### PR TITLE
feat(#21): a committed vault registry, so the wiring survives a clone

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -353,6 +353,12 @@ def _add_vault_parser(sub) -> None:
     add.add_argument("--account", help="1Password account to pin to (provider: 1password); "
                                        "needed when signed into more than one.")
     add.add_argument("--persona", help="Tag this vault for a persona (e.g. devops, qa).")
+    add.add_argument("--share", action="store_true",
+                     help="Record it in the COMMITTED registry (vaults.json at the plane "
+                          "root) so teammates inherit the wiring. Default is local-only: a "
+                          "registry names which personas hold credentials and where their "
+                          "files are, so it is never published by accident. The 1Password "
+                          "--account pin always stays local.")
     add.add_argument("--force", action="store_true",
                      help="Replace an existing registration of this name. Does NOT migrate "
                           "its secrets — the old vault's file is left where it is, with "

--- a/charter/commands_secrets.py
+++ b/charter/commands_secrets.py
@@ -66,9 +66,11 @@ def cmd_vault_add(args) -> int:
         if getattr(args, "account", None):
             cfg["account"] = args.account
     force = getattr(args, "force", False)
+    share = getattr(args, "share", False)
     replaced = registry.vaults().get(args.name) if force else None
     try:
-        registry.add_vault(args.name, args.provider, cfg, persona=args.persona, force=force)
+        registry.add_vault(args.name, args.provider, cfg, persona=args.persona,
+                           force=force, share=share)
     except base.VaultError as e:
         util.err(str(e))
         return 1
@@ -81,7 +83,11 @@ def cmd_vault_add(args) -> int:
                   f"(provider: {replaced.get('provider', '?')}). Its secrets were NOT "
                   f"migrated." + (f" They remain at {old_where}." if old_where else ""))
     tag = f", persona: {args.persona}" if args.persona else ""
-    util.ok(f"Vault '{args.name}' registered (provider: {args.provider}{tag}).")
+    where = "shared — commit vaults.json" if share else "local only"
+    util.ok(f"Vault '{args.name}' registered (provider: {args.provider}{tag}) [{where}].")
+    if not share:
+        util.info(f"  Teammates won't see it. Publish the wiring (never the secrets) with: "
+                  f"charter vault add {args.name} --provider {args.provider} --share")
     prov = registry.provider_for(args.name)
     ok, detail = prov.health()
     (util.info if ok else util.warn)(f"  {detail}")
@@ -107,16 +113,20 @@ def cmd_vault_list(args) -> int:
         util.info("No vaults configured. Add one: "
                   "charter vault add <name> --provider plain-file --file <path>")
         return 0
-    fmt = "{:<18} {:<16} {:<12} {}"
-    print(fmt.format("VAULT", "PROVIDER", "PERSONA", "STATUS"))
-    print(fmt.format("-" * 18, "-" * 16, "-" * 12, "-" * 28))
+    # SCOPE earns a column because a two-file registry invites exactly two questions —
+    # "why can't my teammate see this vault" and "why is this vault in git" — and both are
+    # answered by where it is registered.
+    fmt = "{:<18} {:<16} {:<12} {:<7} {}"
+    print(fmt.format("VAULT", "PROVIDER", "PERSONA", "SCOPE", "STATUS"))
+    print(fmt.format("-" * 18, "-" * 16, "-" * 12, "-" * 7, "-" * 28))
     for name in sorted(vs):
         try:
             ok, detail = registry.provider_for(name, doc).health()
         except base.VaultError as e:
             detail = str(e)
         persona = vs[name].get("persona") or "—"
-        print(fmt.format(name, vs[name].get("provider", "?"), persona, detail))
+        print(fmt.format(name, vs[name].get("provider", "?"), persona,
+                         registry.scope_of(name), detail))
     return 0
 
 

--- a/charter/config.py
+++ b/charter/config.py
@@ -94,6 +94,17 @@ def worktrees_root_for(root: "Path", shape: str, cfg: dict) -> "Path | None":
 #: Root for worktrees, or ``None`` for the per-workspace ``.worktrees/`` default.
 WORKTREES_ROOT = worktrees_root_for(ROOT, PLANE_SHAPE, _cfg)
 
+#: The SHARED half of the vault registry — committed, beside personas/ and inventory/.
+#: Holds what is identical on every machine: provider, persona, op-vault, and a `file`
+#: relative to the plane. Never a secret, and never the per-developer `account` (that
+#: stays in `.charter/vaults.json`, which keeps overriding this one).
+#:
+#: A separate file rather than a section of charter.toml because `vault add` WRITES it:
+#: charter.toml is hand-maintained, tomllib cannot write TOML, and `instance.
+#: set_locked_version` already has to edit that file as raw text to keep the comments
+#: people put in it. Machine-written config belongs somewhere a machine may rewrite whole.
+SHARED_VAULTS = ROOT / "vaults.json"
+
 #: Per-task workspaces live here: ``workspaces/<workspace>/<repo>`` (on-demand repo
 #: clones) plus the workspace's own ``memory/`` and ``refs/``. Gitignored — a
 #: workspace is a private, per-developer, per-task environment. (Renamed from the

--- a/charter/secrets/registry.py
+++ b/charter/secrets/registry.py
@@ -1,8 +1,26 @@
 """The vault registry: which vaults exist, their provider + config + persona.
 
-Persisted at ``.charter/vaults.json`` (0600, gitignored). This file may reference
-provider config such as file paths or token locations, so it is treated as
-sensitive and never committed.
+**Two files, one view.**
+
+``vaults.json`` at the plane root is the SHARED half — committed, beside ``personas/``
+and ``inventory/``. It carries what is identical on every machine: provider, persona,
+op-vault, and a ``file`` relative to the plane. That is what makes the wiring travel:
+reference vaults hold ``op://`` URIs rather than values and are meant to be committed, but
+before this the index that located them hard-coded one developer's home directory, so a
+fresh clone found the vault files present and unusable (issue #21).
+
+``.charter/vaults.json`` (0600, gitignored) is the LOCAL half — this developer's own
+vaults, plus per-machine overrides of shared ones. It wins on conflict.
+
+The split is per FIELD, not per vault, and it is small: going through them, only
+``account`` — which 1Password account this developer is signed into — genuinely differs
+between machines.
+
+**Registering is local by default.** ``--share`` publishes. That direction is deliberate
+and matches ``[memory].share``, which defaults to ``local`` so "a fresh control plane must
+never publish agent-written notes by accident". The same applies here with more force: a
+registry names which personas hold credentials and where their files are, which is a map
+worth having even without the values, and charter's own repo is public.
 """
 
 from __future__ import annotations
@@ -27,28 +45,89 @@ PROVIDERS: dict[str, type[VaultProvider]] = {
 }
 
 
-def load_registry() -> dict:
-    if not config.VAULTS_REGISTRY.exists():
+#: Config keys that never travel — see the module docstring's field-by-field pass.
+LOCAL_ONLY_KEYS = ("account",)
+
+
+def _read(path) -> dict:
+    if not path.exists():
         return {"vaults": {}}
     try:
-        doc = json.loads(config.VAULTS_REGISTRY.read_text())
+        doc = json.loads(path.read_text())
     except json.JSONDecodeError as e:
-        raise VaultError(f"vault registry {config.VAULTS_REGISTRY} is corrupt: {e}")
+        raise VaultError(f"vault registry {path} is corrupt: {e}")
     doc.setdefault("vaults", {})
     return doc
 
 
-def save_registry(doc: dict) -> None:
-    config.STATE_DIR.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(config.VAULTS_REGISTRY), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+def load_shared() -> dict:
+    return _read(config.SHARED_VAULTS)
+
+
+def load_local() -> dict:
+    return _read(config.VAULTS_REGISTRY)
+
+
+def load_registry() -> dict:
+    """The merged view every reader gets: shared as the base, local layered over it.
+
+    Merged per FIELD rather than per vault, so a developer can pin `account` on a vault
+    the team declares without having to restate the provider, the file and the persona —
+    restating them is how a local copy silently drifts from the shared one.
+    """
+    merged = {}
+    shared, local = load_shared(), load_local()
+    for name, entry in shared.get("vaults", {}).items():
+        merged[name] = json.loads(json.dumps(entry))          # deep copy, no aliasing
+    for name, entry in local.get("vaults", {}).items():
+        if name not in merged:
+            merged[name] = json.loads(json.dumps(entry))
+            continue
+        base = merged[name]
+        for k, v in entry.items():
+            if k == "config":
+                base.setdefault("config", {}).update(v or {})
+            elif v is not None:
+                base[k] = v
+    return {"vaults": merged}
+
+
+def _write(path, doc: dict, mode: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
     with os.fdopen(fd, "w") as f:
         json.dump(doc, f, indent=2, ensure_ascii=False)
         f.write("\n")
-    os.chmod(config.VAULTS_REGISTRY, 0o600)
+    os.chmod(path, mode)
+
+
+def save_registry(doc: dict) -> None:
+    """Write the LOCAL half. Kept for callers that read-modify-write the merged view.
+
+    0600 as before: this file holds per-developer paths and account pins.
+    """
+    _write(config.VAULTS_REGISTRY, doc, 0o600)
+
+
+def save_shared(doc: dict) -> None:
+    """Write the SHARED half — committed, so 0644 rather than 0600. It carries no secret
+    values by construction: `LOCAL_ONLY_KEYS` never reaches it, and a `file` is a path."""
+    _write(config.SHARED_VAULTS, doc, 0o644)
 
 
 def vaults(doc: dict | None = None) -> dict:
     return (doc or load_registry()).get("vaults", {})
+
+
+def scope_of(name: str) -> str:
+    """``"shared"``, ``"local"``, or ``"both"`` — where *name* is registered.
+
+    `vault list` shows this because "why does my teammate not see this vault" and "why is
+    this vault in git" are the two questions a two-file registry invites.
+    """
+    in_shared = name in load_shared().get("vaults", {})
+    in_local = name in load_local().get("vaults", {})
+    return "both" if (in_shared and in_local) else ("shared" if in_shared else "local")
 
 
 def get_vault_config(name: str, doc: dict | None = None) -> dict:
@@ -71,7 +150,7 @@ def provider_for(name: str, doc: dict | None = None) -> VaultProvider:
 
 
 def add_vault(name: str, provider: str, cfg: dict, persona: str | None = None,
-              force: bool = False) -> None:
+              force: bool = False, share: bool = False) -> None:
     """Register a vault. Refuses to replace an existing registration unless *force*.
 
     Registering over a name that already exists used to overwrite it in place — different
@@ -88,6 +167,12 @@ def add_vault(name: str, provider: str, cfg: dict, persona: str | None = None,
     ``force`` is the deliberate override, the same idiom `charter persona create --force`
     already uses. It still does not migrate: moving secrets between providers is its own
     operation and must be typed on purpose, not ride along inside `add`.
+
+    ``share`` writes the committed half instead of the local one. Off by default, matching
+    ``[memory].share`` — a registration must never be published by accident, because it
+    names which personas hold credentials and where their files are. Local-only keys
+    (:data:`LOCAL_ONLY_KEYS`) are split off and kept local even then, so a shared entry
+    never carries one developer's 1Password account pin.
     """
     if provider not in PROVIDERS:
         raise VaultError(
@@ -108,16 +193,44 @@ def add_vault(name: str, provider: str, cfg: dict, persona: str | None = None,
             f"  inspect it:    charter vault list\n"
             f"  replace anyway: re-run with --force (this does NOT migrate secrets)"
         )
-    doc["vaults"][name] = {"provider": provider, "persona": persona, "config": cfg}
-    save_registry(doc)
+
+    cfg = dict(cfg or {})
+    local_cfg = {k: cfg.pop(k) for k in LOCAL_ONLY_KEYS if k in cfg}
+    entry = {"provider": provider, "persona": persona, "config": cfg}
+
+    if share:
+        shared = load_shared()
+        shared["vaults"][name] = entry
+        save_shared(shared)
+        # An account pin still belongs to this machine, so it is layered on top rather
+        # than published with the rest of the entry.
+        if local_cfg:
+            local = load_local()
+            local["vaults"].setdefault(name, {}).setdefault("config", {}).update(local_cfg)
+            save_registry(local)
+    else:
+        entry["config"] = {**cfg, **local_cfg}
+        local = load_local()
+        local["vaults"][name] = entry
+        save_registry(local)
 
 
 def remove_vault(name: str) -> None:
-    doc = load_registry()
-    if name not in doc["vaults"]:
+    """Remove *name* from wherever it is registered — both halves if both carry it.
+
+    Removing from one and leaving the other is how a vault comes back from the dead after
+    the user watched charter say it was gone.
+    """
+    shared, local = load_shared(), load_local()
+    in_shared, in_local = name in shared["vaults"], name in local["vaults"]
+    if not (in_shared or in_local):
         raise VaultNotConfigured(f"no vault named '{name}'")
-    del doc["vaults"][name]
-    save_registry(doc)
+    if in_shared:
+        del shared["vaults"][name]
+        save_shared(shared)
+    if in_local:
+        del local["vaults"][name]
+        save_registry(local)
 
 
 def vaults_for_persona(persona: str, doc: dict | None = None) -> list[str]:

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -74,6 +74,45 @@ charter persona secret set API_TOKEN --stdin        # resolves the active person
 charter persona secret exec --env TOKEN=API_TOKEN -- some-cli
 ```
 
+### Where a registration is recorded: two files, one view
+
+| File | Committed? | Holds |
+| --- | --- | --- |
+| `vaults.json` (plane root) | **yes** | what is the same on every machine: provider, persona, `op-vault`, and a `file` relative to the plane |
+| `.charter/vaults.json` | no (0600) | this developer's own vaults, plus per-machine overrides — which wins on conflict |
+
+Reads see them merged, **field by field**, so you can pin an `account` on a vault the team
+declares without restating its provider and file (restating them is how a local copy
+silently drifts from the shared one).
+
+`charter vault add` writes the **local** file unless you pass `--share`:
+
+```
+charter vault add team --provider reference --file secrets/team.json --share
+```
+
+Local-by-default is deliberate, and it is the same posture as `[memory].share` — which
+defaults to `local` so a control plane never publishes by accident. It matters more here:
+a registry names which personas hold credentials and where their files live, which is a
+useful map even without the values.
+
+`--account` never travels, even with `--share`. It is the one field that genuinely differs
+per machine, so it is split off and written locally.
+
+This is what makes committed vault files usable. A **reference** vault holds `op://` URIs
+rather than values, so teams commit them — but before this the *index* that located them
+recorded one developer's home directory, so a fresh clone found the vault files present
+and unreachable, and had to re-register them by hand. Now `git clone` is enough:
+
+```
+$ charter vault list          # on a machine with no .charter/ at all
+VAULT     PROVIDER    PERSONA  SCOPE   STATUS
+team      reference   —        shared  1 reference(s) via op
+```
+
+The `SCOPE` column answers the two questions a two-file registry invites: *why can't my
+teammate see this vault*, and *why is this vault in git*.
+
 ### Registering over a name that already exists
 
 `charter vault add` **refuses** a name that is already registered, naming the provider in

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -30,7 +30,8 @@ _PATCH = ("ROOT", "PERSONAS_DIR", "PERSONA_STATE_DIR", "STATE_DIR", "ACTIVE_PERS
           # instead of by `vault add`. `DOCS_DIR` lets a doc-generating test write into the
           # real `docs/`. See `EveryRootDerivedPathIsIsolated`, which now fails if another
           # one is ever added to config.py without landing here.
-          "VAULTS_REGISTRY", "VAULTS_DIR", "ACTIVE_WORKSPACE_FILE", "DOCS_DIR")
+          "VAULTS_REGISTRY", "VAULTS_DIR", "ACTIVE_WORKSPACE_FILE", "DOCS_DIR",
+          "SHARED_VAULTS")
 
 
 class PersonaIso(unittest.TestCase):
@@ -61,6 +62,7 @@ class PersonaIso(unittest.TestCase):
         config.VAULTS_DIR = config.STATE_DIR / "vaults"
         config.ACTIVE_WORKSPACE_FILE = config.STATE_DIR / "active-workspace"
         config.DOCS_DIR = config.ROOT / "docs"
+        config.SHARED_VAULTS = config.ROOT / "vaults.json"
         # Task 1's fix round found a test that wrote a fake inventory/repos.json into the
         # REAL checkout because this tuple omitted INVENTORY — every other well-known path
         # was redirected into the tmp tree, but inventory.load()/save() kept resolving

--- a/tests/test_vault_registration.py
+++ b/tests/test_vault_registration.py
@@ -18,7 +18,7 @@ import unittest
 from contextlib import redirect_stderr
 from types import SimpleNamespace
 
-from charter import commands_secrets
+from charter import commands_secrets, config
 from charter.secrets import base, registry
 from tests._isolation import PersonaIso
 
@@ -146,6 +146,100 @@ class TheRegistryIsPortable(PersonaIso):
         registry.add_vault("b", "reference", {"file": "x/b.json"})
         self.assertEqual(registry.provider_for("a").path, self.tmp / "x" / "a.json")
         self.assertEqual(registry.provider_for("b").path, self.tmp / "x" / "b.json")
+
+
+class SharedAndLocalHalves(PersonaIso):
+    """#21's remaining half: the registry that *locates* committed vaults must travel too.
+
+    `vaults.json` at the plane root is committed; `.charter/vaults.json` stays local and
+    wins on conflict. The split is per FIELD and it is small — going through them, only
+    `account` (which 1Password account this developer signed into) genuinely differs
+    between machines.
+    """
+
+    def _add(self, name, provider="plain-file", share=False, **kw):
+        with redirect_stderr(io.StringIO()):
+            a = _args(name, provider, **kw)
+            a.share = share
+            return commands_secrets.cmd_vault_add(a)
+
+    def test_registering_is_local_by_default(self):
+        """Matching `[memory].share`, which defaults to local so a plane never publishes
+        by accident. A registry names which personas hold credentials and where their
+        files live — a map worth having even without the values."""
+        self._add("mine")
+        self.assertIn("mine", registry.load_local()["vaults"])
+        self.assertNotIn("mine", registry.load_shared()["vaults"])
+
+    def test_share_writes_the_committed_half(self):
+        self._add("team", "reference", share=True)
+        self.assertIn("team", registry.load_shared()["vaults"])
+        self.assertNotIn("team", registry.load_local()["vaults"])
+
+    def test_a_shared_vault_resolves_with_no_local_file_at_all(self):
+        """The fresh-clone case: git carried `vaults.json` and the vault file, nothing
+        else. Before this, the vault files arrived and the index that found them didn't."""
+        self._add("team", "reference", share=True)
+        config.VAULTS_REGISTRY.unlink(missing_ok=True)
+        self.assertIn("team", registry.vaults())
+        self.assertEqual(registry.provider_for("team").path,
+                         self.tmp / ".charter" / "vaults" / "team.json")
+
+    def test_the_account_pin_never_travels(self):
+        """It is the one genuinely per-developer field, so it is split off even when the
+        rest of the entry is published."""
+        self._add("ops", "1password", share=True, op_vault="Engineering")
+        registry.add_vault("ops", "1password",
+                           {"op-vault": "Engineering", "account": "me@corp.com"},
+                           force=True, share=True)
+        self.assertNotIn("account", registry.load_shared()["vaults"]["ops"]["config"])
+        self.assertEqual(
+            registry.load_local()["vaults"]["ops"]["config"]["account"], "me@corp.com")
+
+    def test_the_merged_view_carries_both(self):
+        registry.add_vault("ops", "1password",
+                           {"op-vault": "Engineering", "account": "me@corp.com"},
+                           share=True)
+        cfg = registry.vaults()["ops"]["config"]
+        self.assertEqual(cfg["op-vault"], "Engineering")
+        self.assertEqual(cfg["account"], "me@corp.com")
+
+    def test_local_overrides_shared_field_by_field(self):
+        """Per field, not per vault: pinning `account` must not require restating the
+        provider and file, which is how a local copy silently drifts from the shared one."""
+        registry.add_vault("t", "reference", {"file": "a/t.json"}, persona="qa", share=True)
+        local = registry.load_local()
+        local["vaults"]["t"] = {"config": {"account": "me"}}
+        registry.save_registry(local)
+        got = registry.vaults()["t"]
+        self.assertEqual(got["persona"], "qa")               # from shared
+        self.assertEqual(got["config"]["file"], "a/t.json")  # from shared
+        self.assertEqual(got["config"]["account"], "me")     # from local
+
+    def test_scope_is_reported(self):
+        registry.add_vault("s", "reference", {"file": "s.json"}, share=True)
+        registry.add_vault("l", "plain-file", {"file": "l.json"})
+        self.assertEqual(registry.scope_of("s"), "shared")
+        self.assertEqual(registry.scope_of("l"), "local")
+
+    def test_removing_clears_both_halves(self):
+        """Removing one and leaving the other is how a vault comes back from the dead
+        after the user watched charter say it was gone."""
+        registry.add_vault("t", "reference", {"file": "t.json"}, share=True)
+        registry.add_vault("t", "reference", {"file": "t.json"}, force=True)
+        self.assertEqual(registry.scope_of("t"), "both")
+        registry.remove_vault("t")
+        self.assertNotIn("t", registry.vaults())
+        self.assertEqual(registry.scope_of("t"), "local")   # i.e. present in neither file
+
+    def test_the_shared_file_is_world_readable_and_the_local_one_is_not(self):
+        """The committed half carries no values by construction; the local half holds
+        per-developer paths and account pins and keeps 0600."""
+        import stat as _stat
+        registry.add_vault("s", "reference", {"file": "s.json"}, share=True)
+        registry.add_vault("l", "plain-file", {"file": "l.json"})
+        self.assertEqual(_stat.S_IMODE(config.SHARED_VAULTS.stat().st_mode), 0o644)
+        self.assertEqual(_stat.S_IMODE(config.VAULTS_REGISTRY.stat().st_mode), 0o600)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #21.

Reference vaults hold `op://` URIs rather than values and are meant to be committed. Before this the **index** that located them lived only in `.charter/vaults.json`, so a fresh clone found the vault files present and unreachable, and a team scripted `charter vault add` calls to rebuild state already in git. Relative paths (#27) made that file portable; this gives it somewhere to go.

`vaults.json` at the plane root is the shared half — committed, beside `personas/` and `inventory/`. `.charter/vaults.json` keeps the local half and wins on conflict. Reads merge them **per field**, so pinning an `account` on a vault the team declares doesn't mean restating its provider and file.

## Why not commit `.charter/vaults.json`, as the issue suggested

Three things that only showed up on inspection:

- **git cannot re-include a file whose parent directory is excluded** (verified — `/.charter/` + `!/.charter/vaults.json` stays ignored; `/.charter/*` works). So committing it in place means changing the shipped baseline, spending the one line that keeps plaintext vault files out of git, in every control plane, to relocate one JSON file.
- **The registry is mixed-provider.** A reference entry is safe to share; a plain-file entry is a map to plaintext secrets — which vaults exist, which personas hold credentials, where the files are. charter's own repo is public.
- **"Never commit this, except one file" is a rule people misapply.** The next person adds `!/.charter/vaults/team.json` because reference vaults are safe, and is right until a plain-file vault matches the same pattern.

Nor a `[[vault]]` section of `charter.toml`: `vault add` *writes* this, `charter.toml` is hand-maintained, `tomllib` can't write TOML, and `instance.set_locked_version` already edits that file as raw text to preserve comments. Machine-written config belongs somewhere a machine may rewrite whole.

## Local by default

`--share` publishes. Same direction as `[memory].share`, which defaults to `local` so a plane never publishes by accident — and it matters more here, since a registry is a useful map even without the values. `--account` never travels regardless.

## Verified as a clone, not just in unit tests

A plane holding only what git would carry — `charter.toml`, `vaults.json`, the vault file — and **no `.charter/` at all**:

```
VAULT     PROVIDER    PERSONA  SCOPE   STATUS
team      reference   —        shared  1 reference(s) via op
```

The local-only vault correctly doesn't appear. `vault list` grows a SCOPE column, which answers the two questions a two-file registry invites: *why can't my teammate see this*, and *why is this in git*.

The isolation guard added earlier today caught `SHARED_VAULTS` missing from the test harness on its first run — which is what it was for.

1115 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4