### PR TITLE
feat(#13): a vault declares the identity it is read through

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -353,6 +353,14 @@ def _add_vault_parser(sub) -> None:
     add.add_argument("--account", help="1Password account to pin to (provider: 1password); "
                                        "needed when signed into more than one.")
     add.add_argument("--persona", help="Tag this vault for a persona (e.g. devops, qa).")
+    add.add_argument("--env", action="append", metavar="TARGET=SOURCE", default=[],
+                     help="Bind the identity this vault is read through: TARGET is the "
+                          "variable the CLI reads, SOURCE the one this machine carries it "
+                          "in (e.g. OP_SERVICE_ACCOUNT_TOKEN=OP_ACME_DEVOPS_TOKEN). Only "
+                          "NAMES are stored, never values. Repeatable.")
+    add.add_argument("--token-env", metavar="SOURCE",
+                     help="Shorthand for --env OP_SERVICE_ACCOUNT_TOKEN=SOURCE, the "
+                          "1Password service-account case.")
     add.add_argument("--share", action="store_true",
                      help="Record it in the COMMITTED registry (vaults.json at the plane "
                           "root) so teammates inherit the wiring. Default is local-only: a "

--- a/charter/commands_secrets.py
+++ b/charter/commands_secrets.py
@@ -44,6 +44,37 @@ def _portable_file(p) -> str:
         return str(p)
 
 
+#: A POSIX-ish environment variable name. Validated at registration because the failure
+#: it prevents surfaces much later and in disguise: a typo'd source name is simply unset,
+#: and an unset source is (deliberately) a hard error at read time about a credential.
+_ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _env_bindings(args) -> dict | None:
+    """``{TARGET: SOURCE}`` from ``--env``/``--token-env``, or None if none were given.
+
+    ``--token-env X`` is sugar for ``--env OP_SERVICE_ACCOUNT_TOKEN=X``. The general form
+    exists because reference vaults already resolve two schemes — `op://` and `vault://` —
+    so a binding that could only ever mean "the 1Password token" would be wrong on arrival
+    for half of what charter ships.
+    """
+    pairs: dict = {}
+    token_env = getattr(args, "token_env", None)
+    if token_env:
+        pairs["OP_SERVICE_ACCOUNT_TOKEN"] = token_env
+    for raw in getattr(args, "env", None) or []:
+        target, sep, source = raw.partition("=")
+        if not sep:
+            raise ValueError(f"--env expects TARGET=SOURCE, got {raw!r}")
+        pairs[target.strip()] = source.strip()
+    for target, source in pairs.items():
+        for label, v in (("target", target), ("source", source)):
+            if not _ENV_NAME.match(v or ""):
+                raise ValueError(f"--env {label} {v!r} is not a valid environment "
+                                 f"variable name")
+    return pairs or None
+
+
 def cmd_vault_add(args) -> int:
     cfg: dict = {}
     if args.provider == "plain-file":
@@ -65,6 +96,14 @@ def cmd_vault_add(args) -> int:
         cfg["op-vault"] = args.op_vault
         if getattr(args, "account", None):
             cfg["account"] = args.account
+    try:
+        env_map = _env_bindings(args)
+    except ValueError as e:
+        util.err(str(e))
+        return 1
+    if env_map:
+        cfg["env"] = env_map
+
     force = getattr(args, "force", False)
     share = getattr(args, "share", False)
     replaced = registry.vaults().get(args.name) if force else None
@@ -121,9 +160,14 @@ def cmd_vault_list(args) -> int:
     print(fmt.format("-" * 18, "-" * 16, "-" * 12, "-" * 7, "-" * 28))
     for name in sorted(vs):
         try:
-            ok, detail = registry.provider_for(name, doc).health()
+            prov = registry.provider_for(name, doc)
+            # `env_overlay` raises when a declared identity's variable is unset, which is
+            # exactly the state a listing should show rather than let a later read
+            # discover. It reads as "no secrets" everywhere else.
+            prov.env_overlay()
+            ok, detail = prov.health()
         except base.VaultError as e:
-            detail = str(e)
+            detail = str(e).split("\n")[0]
         persona = vs[name].get("persona") or "—"
         print(fmt.format(name, vs[name].get("provider", "?"), persona,
                          registry.scope_of(name), detail))

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -281,14 +281,33 @@ def check_vaults() -> Result:
         return Result("vaults", WARN, hint=str(e))
     if not vs:
         return Result("vaults", OK, detail="none configured")
-    bad = []
+    bad, no_identity = [], []
     for name in vs:
         try:
-            healthy, _ = registry.provider_for(name).health()
-        except base.VaultError:
+            prov = registry.provider_for(name)
+            # A vault that declares the identity it is read through, whose variable is
+            # not set, is broken in a way `health()` cannot see: `op` answers with "no
+            # items" or a permission error, so it reads as an empty or misconfigured
+            # vault rather than as a missing credential. Separated from `bad` because
+            # the fix is `export`, not anything about the vault.
+            prov.env_overlay()
+            healthy, _ = prov.health()
+        except base.VaultError as e:
+            if "is unset" in str(e):
+                no_identity.append(name)
+                continue
             healthy = False
         if not healthy:
             bad.append(name)
+    if no_identity:
+        srcs = []
+        for n in no_identity:
+            srcs += [f"${s}" for s in (vs[n].get("config", {}).get("env") or {}).values()]
+        return Result("vaults", WARN, detail=f"{len(vs)} configured",
+                      hint=f"identity variable unset for: {', '.join(no_identity)} — "
+                           f"export {', '.join(sorted(set(srcs)))} (charter will not fall "
+                           f"back to an ambient token; that would read the vault as "
+                           f"someone else)")
     if bad:
         return Result("vaults", WARN, detail=f"{len(vs)} configured",
                       hint="unhealthy: " + ", ".join(bad))

--- a/charter/secrets/base.py
+++ b/charter/secrets/base.py
@@ -40,6 +40,59 @@ class VaultProvider(ABC):
         self.name = name
         self.config = config or {}
 
+    def env_overlay(self) -> dict:
+        """Environment this vault's CLI is invoked with — ``{}`` when it declares none.
+
+        A vault may bind the identity it is read through, as a mapping from the variable
+        the CLI reads to the variable this machine carries it in::
+
+            "env": {"OP_SERVICE_ACCOUNT_TOKEN": "OP_ACME_DEVOPS_SERVICE_ACCOUNT_TOKEN"}
+
+        Only NAMES are stored — never a value — so the registry stays inert if it leaks
+        and the binding is reviewable in git. Least-privilege setups issue one service
+        account per scope, and without this the mapping lives in every caller's shell:
+        `OP_SERVICE_ACCOUNT_TOKEN="$OP_ACME_DEVOPS_…" charter secret exec devops -- …`,
+        which is the property the vault abstraction otherwise removes.
+
+        A declared source that is unset or empty **raises**. Falling back to whatever
+        ambient token exists would read the vault under an identity the plane did not
+        declare, and 1Password answers that with "no items" or a permission error — the
+        wrong-identity failure this exists to eliminate, not a variant of it. Vaults that
+        declare nothing are untouched, so single-account setups see no change.
+
+        Both providers call this rather than each resolving `config["env"]`, so a second
+        implementation cannot quietly keep reading the ambient environment.
+        """
+        import os
+
+        mapping = self.config.get("env") or {}
+        if not mapping:
+            return {}
+        out = {}
+        for target, source in mapping.items():
+            val = os.environ.get(source)
+            if not val:
+                raise VaultError(
+                    f"vault '{self.name}' is read through ${source}, which is unset. "
+                    f"charter will not fall back to an ambient ${target}: that would read "
+                    f"this vault under an identity it does not declare, and the failure "
+                    f"would look like a missing secret rather than a wrong credential.\n"
+                    f"  export {source}=… , or drop the binding: "
+                    f"charter vault add {self.name} --provider {self.id} --force"
+                )
+            out[target] = val
+        return out
+
+    def identity_note(self) -> str:
+        """One clause naming where this vault's credential comes from, or ``""``.
+
+        Appended to read failures so a permission error points at the identity in play
+        instead of reading as an empty vault.
+        """
+        mapping = self.config.get("env") or {}
+        srcs = ", ".join(f"${s}" for s in mapping.values())
+        return f" (identity from {srcs})" if srcs else ""
+
     @property
     def file_path(self):
         """Absolute path of this vault's ``file``, resolving a RELATIVE one against the

--- a/charter/secrets/onepassword.py
+++ b/charter/secrets/onepassword.py
@@ -90,10 +90,9 @@ class OnePasswordProvider(VaultProvider):
             raise VaultError(
                 "the 1Password CLI ('op') is not on PATH. Install it and sign in "
                 "(https://developer.1password.com/docs/cli/), then retry.")
-        return self.runner(argv, input=stdin, check=False)
+        return self.runner(argv, input=stdin, check=False, env=self.env_overlay())
 
-    @staticmethod
-    def _fail(what: str, proc, write: bool = False) -> VaultError:
+    def _fail(self, what: str, proc, write: bool = False) -> VaultError:
         """Errors never carry the process output.
 
         ``op``'s stderr can echo the assignment it was given, and on a read path its
@@ -111,7 +110,7 @@ class OnePasswordProvider(VaultProvider):
                 if write else
                 "Check that `op` is signed in (`op whoami`) and the vault exists.")
         return VaultError(
-            f"{what} failed (op exit {proc.returncode}). {hint} "
+            f"{what} failed (op exit {proc.returncode}){self.identity_note()}. {hint} "
             "(op output withheld — it can contain the secret.)")
 
     # --- CRUD -------------------------------------------------------------- #

--- a/charter/secrets/reference.py
+++ b/charter/secrets/reference.py
@@ -135,10 +135,11 @@ class ReferenceProvider(VaultProvider):
         if not shutil.which(cli):
             raise VaultError(f"'{key}' needs the '{cli}' CLI to resolve {uri} — it is not "
                              f"on PATH. Install it and authenticate, then retry.")
-        proc = self.runner(argv, check=False)
+        proc = self.runner(argv, check=False, env=self.env_overlay())
         if proc.returncode != 0:
             raise VaultError(
-                f"resolving '{key}' via {cli} failed (exit {proc.returncode}) for {uri}. "
+                f"resolving '{key}' via {cli} failed (exit {proc.returncode}) for {uri}"
+                f"{self.identity_note()}. "
                 f"Check that you are authenticated to {cli} and the reference exists. "
                 "(Resolver output withheld — it can contain the secret.)")
         value = proc.stdout or ""

--- a/charter/util.py
+++ b/charter/util.py
@@ -5,6 +5,7 @@ Everything here is stdlib-only so the CLI runs with a bare ``python3``.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import urllib.parse
@@ -48,18 +49,29 @@ class ProcError(RuntimeError):
 
 def run(
     cmd: Sequence[str], cwd=None, check: bool = True, capture: bool = True,
-    input: str | None = None,
+    input: str | None = None, env: dict | None = None,
 ) -> subprocess.CompletedProcess:
     """Run ``cmd``. Raises :class:`ProcError` on failure when ``check``.
 
     ``input`` is written to the child's stdin. That is how a secret reaches a CLI
     without ever appearing in argv — where `ps` and the shell's history can see it.
+
+    ``env`` is an OVERLAY on this process's environment, not a replacement: the child
+    still needs PATH, HOME and the rest to find and run the CLI at all. It exists so a
+    vault can carry the credential a CLI reads (``OP_SERVICE_ACCOUNT_TOKEN``,
+    ``VAULT_TOKEN``) for the duration of one call, without charter ever setting it on
+    itself — a mutated `os.environ` would outlive the call and silently apply to the next
+    vault, which is the identity confusion the whole feature exists to prevent.
     """
+    child_env = None
+    if env:
+        child_env = {**os.environ, **{k: v for k, v in env.items() if v is not None}}
     proc = subprocess.run(
         list(cmd),
         cwd=cwd,
         text=True,
         input=input,
+        env=child_env,
         stdout=subprocess.PIPE if capture else None,
         stderr=subprocess.PIPE if capture else None,
     )

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -74,6 +74,50 @@ charter persona secret set API_TOKEN --stdin        # resolves the active person
 charter persona secret exec --env TOKEN=API_TOKEN -- some-cli
 ```
 
+### Binding the identity a vault is read through
+
+`op` authenticates from a single global `OP_SERVICE_ACCOUNT_TOKEN`, but least-privilege
+setups issue **one service account per scope**, so the tokens are named per persona. A
+vault can declare which one it is read through:
+
+```
+charter vault add devops --provider reference --file secrets/devops.json \
+  --token-env OP_ACME_DEVOPS_SERVICE_ACCOUNT_TOKEN --share
+```
+
+charter sets `OP_SERVICE_ACCOUNT_TOKEN` from that variable for the duration of that
+vault's `op` call, and for nothing else. Only **names** are stored — never a value — so
+the registry stays inert if it leaks and the binding is reviewable in git:
+
+```json
+"config": { "env": { "OP_SERVICE_ACCOUNT_TOKEN": "OP_ACME_DEVOPS_SERVICE_ACCOUNT_TOKEN" } }
+```
+
+`--token-env` is shorthand. The general form names both sides, because reference vaults
+resolve `vault://` as well as `op://` and HashiCorp reads a different variable entirely:
+
+```
+charter vault add infra --provider reference --env VAULT_TOKEN=ACME_VAULT_TOKEN
+```
+
+**A declared variable that is unset is an error, not a fallback.** charter will not reach
+for an ambient `OP_SERVICE_ACCOUNT_TOKEN`: that reads the vault under an identity it never
+declared, and 1Password answers with "no items" or a permission error — so the failure
+arrives disguised as an empty vault rather than as the wrong credential. Vaults that
+declare nothing are untouched, so single-account setups see no change.
+
+`charter vault list` and `charter doctor` report a missing identity as its own state,
+separate from an unhealthy vault, because the fix is an `export` rather than anything
+about the vault:
+
+```
+→ identity variable unset for: devops — export $OP_ACME_DEVOPS_SERVICE_ACCOUNT_TOKEN
+  (charter will not fall back to an ambient token; that would read the vault as someone else)
+```
+
+A read that fails anyway names the identity in play, so a permission error points at the
+credential rather than reading as an empty vault.
+
 ### Where a registration is recorded: two files, one view
 
 | File | Committed? | Holds |

--- a/tests/test_vault_identity.py
+++ b/tests/test_vault_identity.py
@@ -1,0 +1,169 @@
+"""Binding the identity a vault is read through (issue #13).
+
+`op` authenticates from the single global `OP_SERVICE_ACCOUNT_TOKEN`, but least-privilege
+setups issue one service account per scope, so tokens are named per persona. Without a
+binding the mapping lives in every caller's shell —
+`OP_SERVICE_ACCOUNT_TOKEN="$OP_ACME_DEVOPS_TOKEN" charter secret exec devops -- …` —
+which is the property charter's vault abstraction otherwise removes. Worse, using the
+wrong one is *silently* wrong: 1Password answers with "no items" or a permission error,
+so it reads as an empty or broken vault rather than as the wrong credential.
+
+Stored as a mapping of NAMES, `{TARGET: SOURCE}` — the variable the CLI reads, and the one
+this machine carries it in. Never a value, so the registry stays inert if it leaks and the
+binding is reviewable in git.
+"""
+from __future__ import annotations
+
+import io
+import os
+import unittest
+from contextlib import redirect_stderr
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_secrets
+from charter.secrets import base, registry
+from tests._isolation import PersonaIso
+
+_SRC = "OP_ACME_DEVOPS_TOKEN"
+_TARGET = "OP_SERVICE_ACCOUNT_TOKEN"
+
+
+class _Rec:
+    """Stands in for `util.run`, recording argv and the env overlay it was handed."""
+
+    def __init__(self, rc=0, stdout="value"):
+        self.rc, self.stdout, self.calls = rc, stdout, []
+
+    def __call__(self, argv, check=True, env=None, input=None, **kw):
+        self.calls.append({"argv": list(argv), "env": env})
+        return SimpleNamespace(returncode=self.rc, stdout=self.stdout, stderr="")
+
+
+def _args(name, provider="reference", **kw):
+    return SimpleNamespace(name=name, provider=provider, file=kw.pop("file", None),
+                           op_vault=kw.pop("op_vault", None), account=None, persona=None,
+                           force=kw.pop("force", False), share=kw.pop("share", False),
+                           env=kw.pop("env", []), token_env=kw.pop("token_env", None))
+
+
+class RecordingTheBinding(PersonaIso):
+    def _add(self, **kw):
+        with redirect_stderr(io.StringIO()):
+            return commands_secrets.cmd_vault_add(_args("devops", **kw))
+
+    def test_token_env_is_sugar_for_the_1password_variable(self):
+        self.assertEqual(self._add(token_env=_SRC), 0)
+        self.assertEqual(registry.vaults()["devops"]["config"]["env"], {_TARGET: _SRC})
+
+    def test_the_general_form_names_both_variables(self):
+        """Reference vaults already resolve `op://` AND `vault://`, so a binding that
+        could only mean "the 1Password token" would be wrong on arrival for half of what
+        charter ships."""
+        self.assertEqual(self._add(env=["VAULT_TOKEN=ACME_VAULT_TOKEN"]), 0)
+        self.assertEqual(registry.vaults()["devops"]["config"]["env"],
+                         {"VAULT_TOKEN": "ACME_VAULT_TOKEN"})
+
+    def test_only_names_are_stored_never_a_value(self):
+        with mock.patch.dict(os.environ, {_SRC: "ops_supersecret"}):
+            self._add(token_env=_SRC)
+        self.assertNotIn("supersecret", str(registry.vaults()["devops"]))
+
+    def test_a_malformed_binding_is_refused(self):
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(commands_secrets.cmd_vault_add(_args("d", env=["NOEQUALS"])), 1)
+        self.assertNotIn("d", registry.vaults())
+
+    def test_an_invalid_variable_name_is_refused_at_registration(self):
+        """The failure it prevents surfaces much later and in disguise: a typo'd source is
+        simply unset, and unset is (deliberately) a hard error about a credential."""
+        with redirect_stderr(io.StringIO()):
+            rc = commands_secrets.cmd_vault_add(_args("d", env=["OK=has-a-dash"]))
+        self.assertEqual(rc, 1)
+
+    def test_the_binding_travels_with_the_shared_half(self):
+        """A variable NAME is a team convention; only its value is private."""
+        self._add(token_env=_SRC, share=True)
+        self.assertEqual(
+            registry.load_shared()["vaults"]["devops"]["config"]["env"], {_TARGET: _SRC})
+
+
+class UsingTheBinding(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "d.json").write_text('{"API": "op://Eng/api/token"}')
+        registry.add_vault("devops", "reference",
+                           {"file": "d.json", "env": {_TARGET: _SRC}})
+        self.prov = registry.provider_for("devops")
+
+    def test_the_credential_reaches_the_child_environment(self):
+        rec = _Rec()
+        self.prov.runner = rec
+        with mock.patch.dict(os.environ, {_SRC: "ops_supersecret"}):
+            self.prov.get("API")
+        self.assertEqual(rec.calls[0]["env"][_TARGET], "ops_supersecret")
+
+    def test_it_never_reaches_argv(self):
+        """The module's standing rule — `ps` and shell history can read argv."""
+        rec = _Rec()
+        self.prov.runner = rec
+        with mock.patch.dict(os.environ, {_SRC: "ops_supersecret"}):
+            self.prov.get("API")
+        self.assertFalse([a for a in rec.calls[0]["argv"] if "supersecret" in a])
+
+    def test_charter_does_not_set_it_on_itself(self):
+        """A mutated `os.environ` would outlive the call and apply to the NEXT vault —
+        the identity confusion this feature exists to prevent."""
+        rec = _Rec()
+        self.prov.runner = rec
+        with mock.patch.dict(os.environ, {_SRC: "ops_supersecret"}):
+            self.prov.get("API")
+            self.assertNotIn(_TARGET, os.environ)
+
+    def test_an_unset_source_is_a_hard_error_not_a_fallback(self):
+        """The whole point. Falling back to an ambient token reads the vault under an
+        identity the plane never declared, and 1Password reports that as "no items"."""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(base.VaultError) as e:
+                self.prov.env_overlay()
+        msg = str(e.exception)
+        self.assertIn(_SRC, msg)
+        self.assertIn("will not fall back", msg)
+
+    def test_an_empty_source_counts_as_unset(self):
+        with mock.patch.dict(os.environ, {_SRC: ""}):
+            with self.assertRaises(base.VaultError):
+                self.prov.env_overlay()
+
+    def test_a_vault_declaring_nothing_is_untouched(self):
+        """Single-account setups see no change — no overlay, no new failure mode."""
+        registry.add_vault("plain", "reference", {"file": "d.json"})
+        self.assertEqual(registry.provider_for("plain").env_overlay(), {})
+
+    def test_a_failed_read_names_the_identity_in_play(self):
+        """Turns a silent wrong answer into a pointed question, without asking `op` who it
+        is on every read."""
+        self.prov.runner = _Rec(rc=1)
+        with mock.patch.dict(os.environ, {_SRC: "tok"}):
+            with self.assertRaises(base.VaultError) as e:
+                self.prov.get("API")
+        self.assertIn(_SRC, str(e.exception))
+
+
+class DoctorSeparatesTheTwoFailures(PersonaIso):
+    def test_a_missing_identity_is_not_reported_as_an_unhealthy_vault(self):
+        """The fix is `export`, not anything about the vault — and `health()` cannot see
+        it, because `op` reports it as an empty or misconfigured vault."""
+        from charter import doctor
+        (self.tmp / "d.json").write_text('{"API": "op://Eng/api/token"}')
+        registry.add_vault("devops", "reference",
+                           {"file": "d.json", "env": {_TARGET: _SRC}})
+        with mock.patch.dict(os.environ, {}, clear=True):
+            res = doctor.check_vaults()
+        self.assertEqual(res.status, doctor.WARN)
+        self.assertIn("identity variable unset", res.hint)
+        self.assertIn(_SRC, res.hint)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #13.

`op` authenticates from a single global `OP_SERVICE_ACCOUNT_TOKEN`, but least-privilege setups issue one service account per scope, so tokens are named per persona. charter had no way to learn that mapping, so it lived in every caller's shell — which is the property the vault abstraction otherwise removes. And bridging the wrong one is **silently** wrong: 1Password answers "no items" or a permission error, so it reads as an empty or broken vault rather than as the wrong credential.

## The binding

A vault carries `{TARGET: SOURCE}` — the variable the CLI reads, and the one this machine carries it in. **Names only, never values**, so the registry stays inert if it leaks and the binding is reviewable in git.

```
charter vault add devops --provider reference --file secrets/devops.json \
  --token-env OP_ACME_DEVOPS_SERVICE_ACCOUNT_TOKEN --share
```
```json
"config": { "env": { "OP_SERVICE_ACCOUNT_TOKEN": "OP_ACME_DEVOPS_SERVICE_ACCOUNT_TOKEN" } }
```

It travels in the shared half (#21): a variable *name* is team convention, only its value is private.

## General, not op-shaped

`--token-env X` is sugar for `--env OP_SERVICE_ACCOUNT_TOKEN=X`, but the stored form names both sides. Reference vaults already resolve `vault://` as well as `op://`, and HashiCorp reads a different variable entirely — a binding that could only mean "the 1Password token" would be wrong on arrival for half of what charter ships.

## Unset is an error, not a fallback

Reaching for an ambient token would read the vault under an identity the plane never declared, and that failure arrives disguised as an empty vault — the exact bug, not a variant of it. Vaults declaring nothing are untouched, so single-account setups see no change.

```
$ charter doctor
!  vaults   1 configured
   → identity variable unset for: devops — export $OP_ACME_DEVOPS_SERVICE_ACCOUNT_TOKEN
     (charter will not fall back to an ambient token; that would read the vault as someone else)
```

Reported as its own state, separate from "unhealthy", because the fix is an `export` rather than anything about the vault. A read that fails anyway names the identity in play. No `op whoami` on the read path.

## Verified, not assumed

```
argv : ['op', 'read', '--no-newline', 'op://Eng/api/token']
token in argv?                                  False
env passes it?                                  True
leaked into charter's own env after the call?   False
```

`util.run` grows an `env` **overlay** (not a replacement — the child still needs `PATH` to find `op`). charter never sets the variable on itself: a mutated `os.environ` outlives the call and applies to the next vault, which is the identity confusion this exists to prevent. Resolution lives in `VaultProvider.env_overlay`, shared by both providers, so a second implementation can't quietly keep reading the ambient environment.

1129 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4