### PR TITLE
fix: identity tests assumed `op` was installed, so CI went red

### DIFF
--- a/tests/test_vault_identity.py
+++ b/tests/test_vault_identity.py
@@ -91,6 +91,14 @@ class RecordingTheBinding(PersonaIso):
 class UsingTheBinding(PersonaIso):
     def setUp(self) -> None:
         super().setUp()
+        # `reference` refuses to resolve when the CLI is absent from PATH, so without this
+        # these tests pass on a laptop with `op` installed and fail on a bare CI runner —
+        # which is exactly what happened. Same stub `test_secret_reference.py` uses.
+        from charter.secrets import reference
+        self._which = reference.shutil.which
+        reference.shutil.which = lambda c: f"/usr/local/bin/{c}"
+        self.addCleanup(lambda: setattr(reference.shutil, "which", self._which))
+
         (self.tmp / "d.json").write_text('{"API": "op://Eng/api/token"}')
         registry.add_vault("devops", "reference",
                            {"file": "d.json", "env": {_TARGET: _SRC}})


### PR DESCRIPTION
`reference` refuses to resolve when the CLI is absent from PATH, and the new tests in #29 stubbed the *runner* but not `shutil.which`. They passed on a laptop with 1Password installed and failed on a bare runner — the machine-dependence `test_secret_onepassword.py`'s own docstring warns about.

Same stub `test_secret_reference.py` already uses.

Reproduced locally by running the suite with `op` removed from `PATH`, rather than reading the CI log and assuming:

```
op absent — CI condition
Ran 1129 tests   OK
```

## How #29 got merged red

`gh pr checks --watch | tail -3` reports the exit status of `tail`, not of the checks, so the `&&` chain that performed the merge proceeded over four failing jobs. Second time today a pipe swallowed an exit code I was relying on — the first was a `head` in an issue-reproduction check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4