### PR TITLE
0.16.0 — vaults that travel, and vaults that know who reads them

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.15.1"
+__version__ = "0.16.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.15.1",
+            "command": "charter hook sessionstart --plugin-version 0.16.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.15.1",
+            "command": "charter hook userpromptsubmit --plugin-version 0.16.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.15.1",
+            "command": "charter hook pretooluse --plugin-version 0.16.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.15.1"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.16.0"
           }
         ]
       }
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.15.1",
+            "command": "charter hook posttooluse --plugin-version 0.16.0",
             "timeout": 5
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.15.1",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.16.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.15.1"
+version = "0.16.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
`0.15.1 → 0.16.0`. Minor rather than patch: three of the five changes add CLI surface.

- **#22** — `vault add` refuses a name already registered. It used to overwrite in place (different provider, no prompt, exit 0), and the registration is the only pointer to a plain-file vault's secrets, so replacing it stranded them. `--force` is the deliberate override and still doesn't migrate.
- **#21** — a vault's `file` is stored relative to the plane and resolved on read, so the registry stops hard-coding one developer's home directory.
- **#21** — `vaults.json` at the plane root is a committed registry; `.charter/` keeps the local half and wins on conflict, merged per field. `--share` publishes, local is the default (matching `[memory].share`). A fresh clone inherits the wiring instead of re-registering it by hand.
- **#13** — a vault declares the identity it's read through: `--env TARGET=SOURCE`, or `--token-env` for the 1Password case. Names only, never values. An unset source is an error rather than a fallback to an ambient token — which would read the vault as someone else and report it as an empty vault.
- **#30** — fixes tests that assumed `op` was on PATH, which turned CI red after #29.

All four version files move together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4