### PR TITLE
readme: a paste-in install prompt, pinned to the things it names

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,34 @@ charter ships as **two artifacts** — install both. A CLI-only install leaves t
 hooks inert (no session context injection, no golden-rule guard, no auto-save), since the
 plugin is what actually wires them into Claude Code.
 
+### Paste this into Claude Code
+
+Both artifacts, installed and checked, without looking anything up:
+
+```
+Install charter (https://github.com/diazoxide/charter) for me:
+
+1. CLI: run `uv tool install charter-cp`. charter needs Python 3.11+, which uv can
+   fetch for me; fall back to pipx or pip only if uv is missing.
+2. Plugin: run `claude plugin marketplace add diazoxide/charter`, then
+   `claude plugin install charter@charter`.
+3. Run `charter doctor` and show me the output.
+4. Do NOT run `charter init` — tell me what it would create and let me pick the
+   directory first.
+
+Then tell me to restart this session so the plugin's hooks load.
+```
+
+Step 4 is not caution for its own sake: `charter init` behaves differently depending on
+where it runs. Inside a directory that is already a git repo it writes
+`shape = "embedded"` and makes *that repo* a control plane (see
+[docs/control-plane.md](docs/control-plane.md)). Run from an unrelated project by
+accident, it would quietly convert it — so the prompt stops before the step that writes
+into your working directory, and hands the choice back to you.
+
+The manual steps below are the same install, written out. Reach for them when you want to
+know exactly what is happening, or when the prompt does something you did not expect.
+
 ### 1. The CLI
 
 ```
@@ -49,10 +77,22 @@ uvx --from charter-cp charter <cmd>
 ### 2. The Claude Code plugin
 
 This repo also ships as a Claude Code plugin — `.claude-plugin/plugin.json` +
-`hooks/hooks.json` — installed the way you install any Claude Code plugin from a git
-repo (inside a session: `/plugin marketplace add diazoxide/charter`, then `/plugin
-install charter@charter`; consult Claude Code's own `/plugin` help if that flow has
-moved on since this was written).
+`hooks/hooks.json` — installed the way you install any Claude Code plugin from a git repo.
+From a shell, which is also what the paste-in prompt above runs:
+
+```
+claude plugin marketplace add diazoxide/charter
+claude plugin install charter@charter
+```
+
+Or inside a session: `/plugin marketplace add diazoxide/charter`, then `/plugin install
+charter@charter`. Consult Claude Code's own `claude plugin --help` if that flow has moved
+on since this was written.
+
+The plugin loads on the **next** session, so restart after installing. Upgrading the CLI
+does not upgrade the plugin — they are two artifacts with two version numbers, pinned to
+each other, so `claude plugin update charter@charter` is its own step. A plugin *newer*
+than the CLI says so loudly at session start; an older one is quietly supported.
 
 The plugin supplies the pieces that only make sense running *inside* a Claude Code
 session: injecting the active persona's memory at session start, the `PreToolUse` guard

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -5,6 +5,7 @@ drifted: the install command, the config keys, and the two framings that protect
 (the vault is not a password manager; memory defaults to local)."""
 from __future__ import annotations
 
+import json
 import re
 import unittest
 from pathlib import Path
@@ -61,6 +62,54 @@ class TestConfigDocs(unittest.TestCase):
         body = (ROOT / "docs" / "control-plane.md").read_text()
         self.assertGreaterEqual(len(re.findall(r"\[\[forge\]\]", body)), 2,
                                 "a mixed-forge example is the non-obvious case")
+
+
+class TestPasteInInstall(unittest.TestCase):
+    """The README carries a prompt users paste into Claude Code to install charter.
+
+    Prose that drifts merely reads oddly; a prompt that drifts *fails*, in someone else's
+    session, on their first contact with the project. Every command in it is therefore
+    checked against the thing it names — the distribution on PyPI, and the plugin id built
+    from the two manifests — rather than trusted to stay true.
+    """
+
+    def _paste_block(self) -> str:
+        blocks = re.findall(r"```\n(.*?)```", README, re.S)
+        found = [b for b in blocks if "Install charter" in b]
+        self.assertTrue(found, "the paste-in install prompt is gone from the README")
+        return found[0]
+
+    def test_it_installs_the_distribution_that_actually_exists(self):
+        """`charter` is not installable — PyPI would not allow the name, so the
+        distribution carries a suffix. A prompt saying otherwise installs nothing."""
+        import tomllib
+        pkg = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]["name"]
+        self.assertIn(pkg, self._paste_block())
+
+    def test_the_plugin_id_matches_both_manifests(self):
+        """`plugin@marketplace`, built from `.claude-plugin/plugin.json` and
+        `marketplace.json`. Rename either and the prompt keeps looking right while
+        installing nothing — the same silent-rot shape as the version drift."""
+        plugin = json.loads((ROOT / ".claude-plugin" / "plugin.json").read_text())["name"]
+        market = json.loads((ROOT / ".claude-plugin" / "marketplace.json").read_text())["name"]
+        self.assertIn(f"claude plugin install {plugin}@{market}", self._paste_block())
+
+    def test_it_adds_the_marketplace_before_installing_from_it(self):
+        block = self._paste_block()
+        self.assertLess(block.index("marketplace add"), block.index("plugin install"),
+                        "installing from a marketplace that has not been added fails")
+
+    def test_it_does_not_tell_an_agent_to_run_init(self):
+        """`charter init` inside an existing git repo makes THAT repo a control plane.
+        An install prompt pasted from an unrelated project would quietly convert it, so
+        the prompt must stop before anything that writes to the working directory."""
+        block = self._paste_block()
+        self.assertIn("Do NOT run `charter init`", block)
+
+    def test_it_tells_the_user_to_restart(self):
+        """Hooks load on the next session, so an install that looks complete and does
+        nothing is the default experience without this line."""
+        self.assertIn("restart", self._paste_block().lower())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Both artifacts installed and checked from one block a user pastes into Claude Code.

```
Install charter (https://github.com/diazoxide/charter) for me:

1. CLI: run `uv tool install charter-cp`. charter needs Python 3.11+, which uv can
   fetch for me; fall back to pipx or pip only if uv is missing.
2. Plugin: run `claude plugin marketplace add diazoxide/charter`, then
   `claude plugin install charter@charter`.
3. Run `charter doctor` and show me the output.
4. Do NOT run `charter init` — tell me what it would create and let me pick the
   directory first.

Then tell me to restart this session so the plugin's hooks load.
```

It can do the **whole** install rather than half of it, because plugin management has real shell commands — `claude plugin marketplace add <owner/repo>` and `claude plugin install <plugin@marketplace>` — not just the `/plugin` slash command an agent can't type. The manual steps stay below it and now carry those commands too.

## Why it stops before `charter init`

`init` behaves differently by location: inside an existing git repo it writes `shape = "embedded"` and makes *that repo* a control plane. A prompt pasted from an unrelated project would quietly convert it. So it installs, verifies with `doctor`, and hands the directory choice back.

## Why it's tested

Prose that drifts reads oddly. A **prompt** that drifts *fails* — in someone else's session, on their first contact with the project. So every command is checked against the thing it names:

- the distribution comes from `pyproject.toml` (`charter` is not installable; PyPI wouldn't allow the name, so `uv tool install charter` installs nothing)
- the plugin id is rebuilt from `plugin.json` + `marketplace.json`, so renaming either fails here instead of silently installing nothing — the same silent-rot shape as the version drift that went twelve releases unnoticed
- the marketplace must be added before it's installed from
- `init` must not appear as something to run
- the restart line must survive

Verified by breaking each one and watching the right test name it:

```
AssertionError: 'charter-cp' not found in "…uv tool install charter…"
FAIL: test_the_plugin_id_matches_both_manifests
```

The commands themselves were confirmed to exist (`claude plugin --help`); they are **not** run in tests, since installing would mutate the developer's environment.

1134 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4