### PR TITLE
fix: a worktree with no charter.toml resolved to itself, and doctor called it healthy

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -356,7 +356,17 @@ def commit_push(root, add_cmd: list, message: str | None,
     """Stage (``add_cmd``) → secret-scan staged memory/refs → commit → push via the
     control plane's OWN FORGE's token (`gitpolicy.forge_for`; rebase-retry on non-ff).
     Shared by `charter save` and `charter workspace save` so the secret-guard + no-SSH
-    push path is identical everywhere, on whichever forge the control plane lives on."""
+    push path is identical everywhere, on whichever forge the control plane lives on.
+
+    ``add_cmd`` is git's ARGUMENTS, not a command line — `_git` supplies `git` itself.
+    One caller passed `["git", "add", …]`, so it ran `git git add`, which fails; the
+    staged-nothing check below then took the "Nothing to save" branch and returned 0, and
+    the caller printed `✓ committed + pushed`. `charter version bump --push` had therefore
+    never committed anything. Asserting the shape here rather than fixing the one caller,
+    because the failure was invisible at every layer above it."""
+    if add_cmd and add_cmd[0] == "git":
+        raise ValueError(f"commit_push(add_cmd=…) takes git's arguments, not a command "
+                         f"line — drop the leading 'git' from {add_cmd!r}")
     _git(add_cmd, cwd=root)
     if _git(["diff", "--cached", "--quiet"], cwd=root).returncode == 0:
         util.info("Nothing to save — the control-plane working tree is clean.")
@@ -1171,7 +1181,7 @@ def cmd_version_bump(args) -> int:
     util.ok(f"pinned this control plane to charter {target}.")
     rel = "charter.toml"
     if getattr(args, "push", False):
-        rc = commit_push(config.ROOT, ["git", "add", rel], f"charter: pin to {target}")
+        rc = commit_push(config.ROOT, ["add", "--", rel], f"charter: pin to {target}")
         if rc != 0:
             util.warn("lock written, but commit/push failed — commit charter.toml yourself.")
             return rc

--- a/charter/commands_worktree.py
+++ b/charter/commands_worktree.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from . import config, util, workspace, worktree
+from . import root as _root
 
 
 def clone_for(ws: str, repo: str) -> Path | None:
@@ -89,6 +90,18 @@ def cmd_worktree_add(args) -> int:
     util.ok(f"{args.repo} · {args.piece} → {_rel(path)}")
     util.info(f"  base:   {base}{' (detached)' if detached else ''}")
     util.info(f"  branch: {args.branch or args.piece}")
+
+    # `root.find_root` now resolves a plane-less worktree back to its main tree, so this
+    # is an invariant assertion rather than the fix — kept because it catches the same
+    # failure one step earlier, right beside the `enter:` line the user is about to run,
+    # and because an untracked charter.toml is worth knowing about on its own: nobody
+    # else on the team has the plane at all.
+    if not (path / _root.MARKER).is_file() and (config.ROOT / _root.MARKER).is_file():
+        util.warn(f"  {_root.MARKER} is not committed, so it is absent from this worktree. "
+                  f"charter resolves the plane from the repo it was cut from, but "
+                  f"teammates cloning this repo get no control plane — commit it: "
+                  f"git add {_root.MARKER}")
+
     util.info(f"  enter:  cd {_rel(path)} && claude    "
               "(or hand this path to EnterWorktree)")
     return 0

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -231,8 +231,19 @@ def check_control_plane_config() -> Result:
             hint=f"{shown} — those hosts are NOT covered by the one-credential guard or "
                  f"git-policy until fixed (other declared/default hosts still are).",
         )
-    return Result("charter.toml", OK, detail="parsed cleanly" if _config.HAS_CONTROL_PLANE
-                  else "no control plane found")
+    if not _config.HAS_CONTROL_PLANE:
+        # NOT ok. Every check below reports green against a plane that does not exist —
+        # `personas: none defined`, `vaults: none configured` — so a session with no
+        # personas, no vault and memory written into a scratch directory reads as a
+        # healthy one. This row is the only place that can say otherwise, and saying it
+        # in the OK column is what made the worktree failure invisible.
+        return Result("charter.toml", WARN, detail=f"no control plane found (cwd: {_config.ROOT})",
+                      hint="`charter init` here, or cd into a plane, or set $CHARTER_ROOT. "
+                           "Every check below is reporting on a plane that does not exist.")
+    # Name the plane unconditionally. Nothing else printed WHICH plane is bound, so a
+    # stale $CHARTER_ROOT, a nested plane and a rootless cwd all looked identical to a
+    # correct setup.
+    return Result("charter.toml", OK, detail=f"parsed cleanly ({_config.ROOT})")
 
 
 def check_control_plane_schema() -> Result:

--- a/charter/root.py
+++ b/charter/root.py
@@ -50,6 +50,30 @@ def find_root(start: Path | None = None) -> Path:
     for d in (cur, *cur.parents):
         if (d / MARKER).is_file():      # is_file, not exists: a directory is not a marker
             return _plane_of(d)
+
+    # Nothing above us. Before giving up, ask whether we are standing in a linked
+    # WORKTREE whose plane lives in the repo it was cut from.
+    #
+    # `_plane_of` handles the case where the worktree HAS a `charter.toml` — it redirects
+    # to the main tree. It cannot fire here, because the walk above found no marker to
+    # redirect from, and in the documented embedded flow there is none to find: `charter
+    # init` writes `charter.toml` and never stages it, so a worktree cut from `main` does
+    # not contain it. A worktree branched before the plane was committed has the same
+    # shape. Following charter's own `enter:` line then landed a session in a plane-less
+    # directory — no personas, no vault, memory written where `git worktree remove
+    # --force` deletes it — while `doctor` reported everything green.
+    #
+    # Walking the main tree's PARENTS too is deliberate: a worktree of a fleet clone sits
+    # at `workspaces/<ws>/<repo>/…`, so its plane is above the clone, not at it.
+    for d in (cur, *cur.parents):
+        main = main_worktree_of(d)
+        if main is None:
+            continue
+        for m in (main, *main.parents):
+            if (m / MARKER).is_file():
+                return _plane_of(m)
+        break                            # its main tree has no plane either — stop here
+
     raise ControlPlaneNotFound(_explain(f"in {cur} or any parent"))
 
 

--- a/tests/test_doctor_forge_visibility.py
+++ b/tests/test_doctor_forge_visibility.py
@@ -56,11 +56,34 @@ class TestDoctorSurfacesPartialForgeFailure(unittest.TestCase):
         result = doctor.check_control_plane_config()
         self.assertEqual(result.status, doctor.OK)
 
-    def test_no_charter_toml_at_all_still_reports_ok(self):
+    def test_no_charter_toml_at_all_is_a_warning_not_a_green_check(self):
+        """Overturns `test_no_charter_toml_at_all_still_reports_ok`, which pinned the
+        opposite.
+
+        Every other check reports green against a plane that does not exist — `personas:
+        none defined`, `vaults: none configured`, `schema: no control plane found`, all
+        OK — because each is truthfully describing nothing. So a session with no personas,
+        no vault, and memory being written into a scratch directory rendered as a
+        completely healthy plane. This row is the only one positioned to say otherwise,
+        and it was saying `ok` too.
+
+        WARN, not FAIL, deliberately: `cmd_doctor` exits 1 only on FAIL, and doctor runs
+        from the SessionStart hook — a FAIL here would print a blocker banner in every
+        session opened outside a plane, which is a normal thing to do.
+        """
         self._set(has_control_plane=False)
         result = doctor.check_control_plane_config()
-        self.assertEqual(result.status, doctor.OK)
+        self.assertEqual(result.status, doctor.WARN)
         self.assertIn("no control plane", result.detail)
+        self.assertTrue(result.hint, "a warning the user cannot act on is worse than none")
+
+    def test_a_healthy_plane_names_which_plane_is_bound(self):
+        """Nothing printed WHICH plane was bound, so a stale $CHARTER_ROOT, a nested
+        plane and a rootless cwd were indistinguishable from a correct setup."""
+        self._set()
+        result = doctor.check_control_plane_config()
+        self.assertEqual(result.status, doctor.OK)
+        self.assertIn(str(config.ROOT), result.detail)
 
     def test_whole_file_parse_failure_still_wins_as_fail_not_the_new_warn_path(self):
         """A truly malformed charter.toml (CONFIG_ERROR set at import time) must still

--- a/tests/test_plane_embedded.py
+++ b/tests/test_plane_embedded.py
@@ -280,6 +280,63 @@ class PlaneIdentityFollowsTheMainTree(MonorepoIso):
                 os.environ["CHARTER_ROOT"] = old
 
 
+class AWorktreeWithoutTheMarkerStillFindsItsPlane(MonorepoIso):
+    """The gap `PlaneIdentityFollowsTheMainTree` left open, and the one that actually
+    fires in charter's own documented flow.
+
+    That class redirects a worktree that HAS a checked-out `charter.toml` to its main
+    tree. But `charter init` writes `charter.toml` and never stages it, so a worktree cut
+    from `main` does not contain one — and with no marker anywhere above, the walk found
+    nothing to redirect FROM and fell back to the cwd. Following charter's own `enter:`
+    line then opened a session whose plane was the worktree: no personas, no vault, and
+    memory written into a directory `git worktree remove --force` deletes. `doctor`
+    reported it green.
+
+    A worktree branched before the plane was committed has exactly the same shape, so
+    committing `charter.toml` fixes today's case and not tomorrow's.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        from charter import root as _root
+        self._root_mod = _root
+        # charter.toml deliberately NOT committed — that is the whole premise.
+        self.wt = self.add_worktree("task1")
+
+    def test_the_fixture_has_no_marker(self):
+        self.assertFalse((self.wt / "charter.toml").exists(),
+                         "fixture committed the marker; there is no bug to reproduce")
+
+    def test_the_plane_resolves_to_the_repo_the_worktree_was_cut_from(self):
+        self.assertEqual(self._root_mod.find_root(self.wt), self.tmp.resolve())
+
+    def test_a_path_deep_inside_it_resolves_too(self):
+        deep = self.wt / "src" / "pkg"
+        deep.mkdir(parents=True)
+        self.assertEqual(self._root_mod.find_root(deep), self.tmp.resolve())
+
+    def test_a_plain_directory_with_no_plane_anywhere_still_raises(self):
+        """The fallback must not start inventing planes for ordinary directories."""
+        plain = self.tmp.parent / f"{self.tmp.name}-elsewhere"
+        plain.mkdir(exist_ok=True)
+        self.addCleanup(lambda: plain.rmdir())
+        with self.assertRaises(self._root_mod.ControlPlaneNotFound):
+            self._root_mod.find_root(plain)
+
+    def test_a_worktree_whose_repo_has_no_plane_still_raises(self):
+        """Being in a worktree is not itself evidence of a plane."""
+        (self.tmp / "charter.toml").unlink()
+        with self.assertRaises(self._root_mod.ControlPlaneNotFound):
+            self._root_mod.find_root(self.wt)
+
+    def test_doctor_no_longer_calls_a_missing_plane_healthy(self):
+        from charter import config as _config, doctor
+        old = _config.HAS_CONTROL_PLANE
+        _config.HAS_CONTROL_PLANE = False
+        self.addCleanup(lambda: setattr(_config, "HAS_CONTROL_PLANE", old))
+        self.assertEqual(doctor.check_control_plane_config().status, doctor.WARN)
+
+
 class NestedPlanesAreVisible(PersonaIso):
     """`find_root` takes the innermost marker — the git/cargo/npm contract, and correct.
     But the embedded shape puts `charter.toml` into ordinary product repos, and a fleet

--- a/tests/test_version_lock.py
+++ b/tests/test_version_lock.py
@@ -154,5 +154,36 @@ class SyncCommand(unittest.TestCase):
         self.assertNotIn("upgrade", commands._sync_cmd("1.2.3"))
 
 
+class CommitPushTakesGitsArgumentsNotACommandLine(unittest.TestCase):
+    """`charter version bump --push` had never committed anything.
+
+    It passed `["git", "add", rel]` to `commit_push`, whose `_git` helper supplies `git`
+    itself — so the command run was `git git add charter.toml`. That fails; the staged-
+    nothing check immediately below then took the "Nothing to save" branch and returned
+    0; and the caller printed `✓ committed + pushed — teammates conform on their next
+    session`. Seven other callers pass `["add", …]`, so the mistake was invisible by
+    comparison and invisible at runtime.
+
+    Asserted as a shape rather than fixed only at the one caller, because nothing between
+    the wrong argv and the success message could tell the difference.
+    """
+
+    def test_a_leading_git_is_refused(self):
+        with self.assertRaises(ValueError) as e:
+            commands.commit_push(Path("/tmp"), ["git", "add", "charter.toml"], "m")
+        self.assertIn("drop the leading 'git'", str(e.exception))
+
+    def test_every_caller_in_the_tree_passes_bare_arguments(self):
+        """The regression test for the fix itself: grep the callers, not the behaviour."""
+        import re
+        root = Path(__file__).resolve().parents[1] / "charter"
+        bad = []
+        for f in root.rglob("*.py"):
+            for m in re.finditer(r"commit_push\(\s*[^,]+,\s*\[([^\]]*)\]", f.read_text()):
+                if m.group(1).strip().startswith(('"git"', "'git'")):
+                    bad.append(f"{f.name}: {m.group(0)[:60]}")
+        self.assertEqual(bad, [], f"commit_push called with a command line, not arguments: {bad}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`charter init` writes `charter.toml` and **never stages it**, so in the documented embedded flow a worktree cut from `main` doesn't contain one. `_plane_of` redirects a worktree that *has* the marker to its main tree — but with no marker anywhere above, there was nothing to redirect *from*, so the walk fell back to cwd.

Reproduced end to end before touching anything:

```
$ git init && charter init --forge github --owner acme     # shape = "embedded"
$ git ls-files                                             # README.md — no charter.toml
$ charter worktree add app task1
  enter:  cd .../app.worktrees/default/app/task1 && claude
$ cd .../task1
  ROOT              : .../app.worktrees/default/app/task1
  HAS_CONTROL_PLANE : False
  doctor            : ok charter.toml | no control plane found
                      ok personas     | none defined
```

Follow charter's own `enter:` line and the session has **no personas, no vault**, and writes memory into a directory `git worktree remove --force` deletes — reported green. A worktree branched before the plane was committed has the same shape, so committing `charter.toml` fixes today's case and not tomorrow's.

After:

```
  ROOT              : .../app
  HAS_CONTROL_PLANE : True
  doctor            : ok   charter.toml  parsed cleanly (.../app)
                      warn personas      1 draft: backend
```

## The fix

`find_root` asks — only after the marker walk comes up empty — whether it's standing in a linked worktree, and restarts the walk from the main working tree. `main_worktree_of` was already there and is pure path arithmetic. This is the existing rule (*plane identity follows the main working tree*) applied where it couldn't previously reach. The main tree's **parents** are walked too: a worktree of a fleet clone sits at `workspaces/<ws>/<repo>/…`, so its plane is above the clone. `$CHARTER_ROOT` still wins outright.

**`doctor` stops reporting a missing plane as OK.** Every other check truthfully reports green against a plane that doesn't exist — personas none, vaults none, schema fine — so this row is the only one positioned to say otherwise, and it was saying `ok` too. `WARN` not `FAIL`: `cmd_doctor` exits 1 only on FAIL and doctor runs from SessionStart, where a blocker banner outside a plane would be wrong. It also **names the bound plane** unconditionally, so a stale `$CHARTER_ROOT`, a nested plane and a rootless cwd stop being indistinguishable from a correct setup.

That overturns `test_no_charter_toml_at_all_still_reports_ok`, replaced with a test whose name states the new claim and whose docstring says why the old one was wrong.

## Also: `charter version bump --push` had never committed anything

It passed `["git", "add", rel]` to `commit_push`, whose `_git` supplies `git` — so it ran `git git add`. That fails, the staged-nothing check returns 0 via "Nothing to save", and the caller prints `✓ committed + pushed — teammates conform on their next session`. Seven other callers pass `["add", …]`.

Fixed, and `commit_push` now rejects a leading `"git"` outright, plus a test that greps every caller — because nothing between the wrong argv and the success message could tell the difference.

Found by a multi-agent audit. The worktree finding survived a deliberate attempt to refute it; I reproduced both myself before changing anything.

1143 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4