### PR TITLE
audit: three more — the leak guard, a lying save, and the repo table

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -20,8 +20,27 @@ from .forge.registry import KINDS as _FORGE_KINDS
 from .secrets.registry import PROVIDERS
 
 
+class _NoAbbrev(argparse.ArgumentParser):
+    """An ArgumentParser that refuses prefix abbreviations, for the whole command tree.
+
+    argparse expands any unambiguous prefix by default, so `charter secret get X Y --rev`
+    ran as `--reveal` — and the PreToolUse leak guard, which looks for the flag the user
+    would have to type, saw nothing to deny. A guard that a three-character abbreviation
+    walks past is not a guard.
+
+    Applied by making the ROOT parser this class: `add_subparsers` defaults its
+    `parser_class` to `type(self)`, so every subcommand and sub-subcommand inherits it
+    without each one having to remember. Setting `allow_abbrev=False` on the root alone
+    would have covered only the top level, which is the level with nothing to protect.
+    """
+
+    def __init__(self, *a, **kw):
+        kw.setdefault("allow_abbrev", False)
+        super().__init__(*a, **kw)
+
+
 def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(
+    p = _NoAbbrev(
         prog="charter",
         description="charter — discover, clone, and track org repos on demand.",
     )

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -367,6 +367,21 @@ def commit_push(root, add_cmd: list, message: str | None,
     if add_cmd and add_cmd[0] == "git":
         raise ValueError(f"commit_push(add_cmd=…) takes git's arguments, not a command "
                          f"line — drop the leading 'git' from {add_cmd!r}")
+
+    # A plane is not always a git repo: `charter init` in a fresh directory does not run
+    # `git init`, and that is exactly the README's 60-second path. Every git call below
+    # runs with check=False (this is reached from hooks and background paths that must
+    # never break a turn), so without this the add failed silently, `diff --cached
+    # --quiet` returned 128 rather than 0 so the "Nothing to save" branch was skipped,
+    # the commit failed too, and `rev-parse --short HEAD` came back empty — printing
+    # `✓ Committed : charter save: 0 file(s)` and exiting 0. The personas and memory
+    # charter had just told the user to commit had no history at all.
+    if _git(["rev-parse", "--git-dir"], cwd=root).returncode != 0:
+        util.err(f"{root} is not a git repository, so there is nothing to commit to.")
+        util.info("  charter init does not create one. Run: git init && git remote add "
+                  "origin <url>  — personas and memory are meant to be committed and shared.")
+        return 1
+
     _git(add_cmd, cwd=root)
     if _git(["diff", "--cached", "--quiet"], cwd=root).returncode == 0:
         util.info("Nothing to save — the control-plane working tree is clean.")
@@ -397,6 +412,14 @@ def commit_push(root, add_cmd: list, message: str | None,
     _git([*signcfg, "commit", "-q", "-m", msg], cwd=root)
     if _git(["diff", "--cached", "--quiet"], cwd=root).returncode != 0:  # signed commit failed
         _git(["commit", "--no-gpg-sign", "-q", "-m", msg], cwd=root)
+    # Still staged after both attempts = nothing was committed. Reporting success here is
+    # how a failed commit became `✓ Committed :` with an empty sha — the sha was empty
+    # precisely BECAUSE there was no commit, and that was the only visible symptom.
+    if _git(["diff", "--cached", "--quiet"], cwd=root).returncode != 0:
+        util.err(f"git commit failed — {len(staged)} file(s) are staged but not committed.")
+        util.info("  Run `git -C {} status` to see why; charter has left them staged."
+                  .format(root))
+        return 1
     short = _git(["rev-parse", "--short", "HEAD"], cwd=root).stdout.strip()
     util.ok(f"Committed {short}: {msg}  ({len(staged)} file(s))")
 

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -85,18 +85,65 @@ def _secret_kind(text: str) -> str | None:
 # --------------------------------------------------------------------------- #
 # A: secret-leak guard — deny commands that would print a secret value          #
 # --------------------------------------------------------------------------- #
-_READERS = r"cat|less|more|head|tail|bat|nl|tac|xxd|od|strings|grep|rg|ag|awk|sed"
-_REVEAL_RE = re.compile(r"(?:^|\s)--reveal(?:[\s=]|$)")
-_VAULT_READ_RE = re.compile(rf"\b(?:{_READERS})\b[^|;&]*\.charter/(?:vaults|browser|active-)", re.IGNORECASE)
+_READERS = frozenset("cat less more head tail bat nl tac xxd od strings grep rg ag awk "
+                     "sed".split())
+#: The vault FILES — note the trailing slash. `.charter/vaults.json` is the registry and
+#: holds provider config and paths, never values, so `grep -rn vaults .charter/vaults.json`
+#: is an ordinary read and was being hard-denied.
+_VAULT_PATH_RE = re.compile(r"\.charter/(?:vaults/|browser|active-)")
+
+
+#: `edm` is charter's pre-rename name. Kept because this is a security guard and the cost
+#: of an extra alternative is one string, while the cost of dropping it is a silent
+#: denial that stops happening on a machine where the old binary is still installed.
+#: `config._LEGACY_ENV_VARS` keeps the same posture for the renamed env vars.
+_CHARTER_PROGS = ("charter", "edm")
+
+
+def _is_charter(prog: str, args: list[str]) -> bool:
+    """True when this invocation is charter itself, including `python3 -m charter`."""
+    base = os.path.basename(prog)
+    if base in _CHARTER_PROGS:
+        return True
+    if base.startswith("python") and "-m" in args:
+        i = args.index("-m")
+        return i + 1 < len(args) and args[i + 1] in _CHARTER_PROGS
+    return False
 
 
 def _leak_reason(cmd: str) -> str | None:
-    if _REVEAL_RE.search(cmd):
-        return ("would reveal a secret value into the conversation (--reveal). "
-                "Use `charter … secret exec`/`cp` — never --reveal for an agent")
-    if _VAULT_READ_RE.search(cmd):
-        return ("reads a vault/secret file directly (would print plaintext). "
-                "Use `charter … secret exec`/`cp` instead of catting `.charter/`")
+    """Deny a command that would print a secret into the transcript.
+
+    Inspects real INVOCATIONS, not the raw string. Both patterns used to be substring
+    scans over the whole command line, so a command that merely *mentioned* the words was
+    hard-denied with a reason that misdescribed what it had done:
+
+        git commit -m "docs: document the --reveal flag"
+        rg -n -- --reveal charter/
+        grep -rn "vaults" .charter/vaults.json
+
+    The sibling SSH guard already solved exactly this, and its docstring says why — "a
+    commit message may legitimately *mention* an SSH URL". `_segments` + `_invocation`
+    give shlex-accurate argv, so a quoted commit message stays ONE token and can never be
+    read as a flag.
+
+    Deliberately not consulting the vault registry for paths outside `.charter/`: this
+    runs on every Bash tool call, and a registry read per invocation is a real cost. A
+    vault registered elsewhere is therefore still unguarded here — a separate finding,
+    not something to half-fix on the hot path.
+    """
+    for seg in _segments(cmd):
+        prog, _env, args = _invocation(seg)
+        if not prog:
+            continue
+        if _is_charter(prog, args) and any(
+                a == "--reveal" or a.startswith("--reveal=") for a in args):
+            return ("would reveal a secret value into the conversation (--reveal). "
+                    "Use `charter … secret exec`/`cp` — never --reveal for an agent")
+        if os.path.basename(prog).lower() in _READERS and any(
+                _VAULT_PATH_RE.search(a) for a in args):
+            return ("reads a vault/secret file directly (would print plaintext). "
+                    "Use `charter … secret exec`/`cp` instead of catting `.charter/`")
     return None
 
 

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -535,6 +535,42 @@ def _tree_cells(lead: str, label: str, d, states, branches, gl, branch=None) -> 
     return tui.Row(name, branch, ci, mr_cell, gap=_GAP)
 
 
+def _pick_rows(dirs, budget: int, cur_repo, root_dir, states, gl) -> list[Path]:
+    """Which repos get a row when there are more repos than rows.
+
+    The cap was a bare positional slice, so with the list in directory order the rows went
+    to whatever sorted first and `…(+N more)` swallowed the rest. Observed with 18 clones:
+    thirteen rows of clean `aaa-svc-NN` on main, and the hidden five held every dirty
+    repo, the only off-main branch and both failing pipelines. The table was showing the
+    repos with nothing to say. Worse, the repo you were standing in could be among the
+    hidden, so the bold you-are-here marker attached to nothing on screen.
+
+    Selection is ranked; **display order is not**. The chosen set is re-sorted back into
+    the original order before drawing, because a row that moves as its state changes stops
+    being a place you can look — you would re-read the whole table every turn to find the
+    repo you were just in. Same reason `_repo_rows` colours by position in the FULL list
+    rather than by position among the shown: a repo keeps its colour and its row whether
+    or not its neighbour went dirty.
+    """
+    order = {d: i for i, d in enumerate(dirs)}
+
+    def rank(d):
+        st = states.get(d) or {}
+        info = gl.get(d) or {}
+        return (
+            0 if d.name == cur_repo else 1,        # where you are, always
+            0 if d == root_dir else 1,             # the plane's own tree
+            0 if st.get("dirty") else 1,
+            0 if (st.get("ahead") or st.get("behind")) else 1,
+            0 if info.get("ci") in ("failed", "running") else 1,
+            0 if info.get("change") else 1,
+            order[d],                              # stable: original order breaks ties
+        )
+
+    chosen = sorted(dirs, key=rank)[:budget]
+    return sorted(chosen, key=lambda d: order[d])
+
+
 def _detail_worktrees(ws: str, dirs) -> list[Path]:
     """The worktrees to draw as full rows, or ``[]`` to keep the one-line summary.
 
@@ -592,20 +628,28 @@ def _repo_rows(dirs, active, cur, states, branches, gl, root_dir=None,
     cur_repo = cur[1] if (cur and (cur[0] is None or cur[0] == active)) else None
     n = len(dirs)
     capped = n > _MAX_REPO_LINES
-    show = dirs[: _MAX_REPO_LINES - 1] if capped else dirs
+    show = _pick_rows(dirs, _MAX_REPO_LINES - 1, cur_repo, root_dir, states, gl) if capped else dirs
     # What's left of the total-row budget after every shown repo gets its own row (and,
     # if capped, the trailing "…(+N more)" line) — spent on nested worktree rows below.
     wt_budget = _MAX_REPO_LINES - len(show) - (1 if capped else 0)
 
+    # Palette index by position in the FULL list, not among the shown. Counting within
+    # `show` meant a repo changed colour whenever a neighbour entered or left the cap —
+    # and with ranked selection that happens the moment anything goes dirty, so the one
+    # channel carrying "this row is that repo" would churn turn to turn.
+    palette_ix, _k = {}, 0
+    for d in dirs:
+        if root_dir is not None and d == root_dir:
+            continue
+        palette_ix[d] = _k
+        _k += 1
+
     rows: list[tui.Node] = []
-    clone_i = 0            # palette index — counts CLONES only, so a repo keeps its
-                           # colour whether or not a root row sits above it
     for i, d in enumerate(show):
         if root_dir is not None and d == root_dir:
             color = _CYAN
         else:
-            color = _PALETTE[clone_i % len(_PALETTE)]
-            clone_i += 1
+            color = _PALETTE[palette_ix.get(d, i) % len(_PALETTE)]
         emph = f"{_BOLD}{_UNDER}" if d.name == cur_repo else ""
 
         # worktrees: a ⑂N badge here, plus either full nested rows (`_detail_worktrees`)
@@ -665,7 +709,18 @@ def _repo_rows(dirs, active, cur, states, branches, gl, root_dir=None,
             rows.append(tui.Text(f"{lead}{_DIM}{pieces}{_R}"))
 
     if capped:
-        rows.append(tui.Text(f"  {_DIM}{_TREE_END}…(+{n - len(show)} more){_R}"))
+        # Say whether the hidden ones matter. Selection is ranked, so anything with a
+        # dirty tree, an unpushed commit, a failing pipeline or an open change is already
+        # on screen — which makes "all clean" a claim the code can actually back, and
+        # turns the overflow line from a worry into an answer.
+        hidden = [d for d in dirs if d not in set(show)]
+        quiet = not any((states.get(d) or {}).get("dirty")
+                        or (states.get(d) or {}).get("ahead")
+                        or (states.get(d) or {}).get("behind")
+                        or (gl.get(d) or {}).get("ci") in ("failed", "running")
+                        or (gl.get(d) or {}).get("change") for d in hidden)
+        note = ", all clean" if quiet else ""
+        rows.append(tui.Text(f"  {_DIM}{_TREE_END}…(+{len(hidden)} more{note}){_R}"))
     return rows
 
 

--- a/docs/audits/2026-08-10-user-experience.md
+++ b/docs/audits/2026-08-10-user-experience.md
@@ -19,6 +19,9 @@ the thing that otherwise gets re-proposed every six months.
 | 2.1 `op` called once per persona per render | fixed — TTL cache off the render path |
 | 2.2 credential guard fired outside any plane | fixed — gated on `HAS_CONTROL_PLANE` |
 | 1.7 `recall` dropped tokens of ≤2 characters | fixed — floor of 2, stopwords, word-boundary matching |
+| 2.3 leak guard substring-matched prose | fixed — inspects argv; `--rev` abbreviation closed |
+| 1.3 `charter save` claimed success in a non-git plane | fixed — refuses, and a failed commit is a failure |
+| 1.4 repo table dropped rows alphabetically | fixed — ranked selection, stable display order |
 | everything else | open |
 
 Numbers in sections 2 and 3 that were not adversarially re-checked are flagged in

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -397,3 +397,53 @@ class TestGuardsAreScopedToAPlane(PersonaIso):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestLeakGuardInspectsInvocationsNotProse(PersonaIso):
+    """Both patterns were substring scans over the whole command line, so a command that
+    merely MENTIONED the words was hard-denied with a reason misdescribing what it did.
+    The sibling SSH guard already solved this and its docstring says why — "a commit
+    message may legitimately *mention* an SSH URL"."""
+
+    def test_a_commit_message_mentioning_the_flag_is_allowed(self):
+        self.assertIsNone(hooks._leak_reason(
+            'git commit -m "docs: document the --reveal flag"'))
+
+    def test_searching_the_source_for_the_flag_is_allowed(self):
+        self.assertIsNone(hooks._leak_reason("rg -n -- --reveal charter/"))
+
+    def test_reading_the_registry_is_allowed(self):
+        """`.charter/vaults.json` is the registry — provider config and paths, never
+        values. Only `.charter/vaults/` holds secrets."""
+        self.assertIsNone(hooks._leak_reason('grep -rn "vaults" .charter/vaults.json'))
+
+    def test_the_real_thing_is_still_denied(self):
+        for cmd in ("charter secret get devops API --reveal",
+                    "python3 -m charter secret get d k --reveal",
+                    "cat .charter/vaults/devops.json",
+                    "edm persona secret get k --reveal"):
+            with self.subTest(cmd=cmd):
+                self.assertIsNotNone(hooks._leak_reason(cmd), cmd)
+
+    def test_a_second_segment_is_inspected_too(self):
+        self.assertIsNotNone(hooks._leak_reason("echo hi && charter secret get d k --reveal"))
+
+    def test_the_flag_must_belong_to_charter(self):
+        """A non-charter program's `--reveal` reveals nothing of ours."""
+        self.assertIsNone(hooks._leak_reason("some-other-tool --reveal"))
+
+
+class TestAbbreviationsCannotWalkPastTheGuard(unittest.TestCase):
+    """argparse expands any unambiguous prefix, so `--rev` ran as `--reveal` while the
+    guard — which looks for the flag a user would have to type — saw nothing to deny."""
+
+    def test_reveal_cannot_be_abbreviated(self):
+        from charter import cli
+        p = cli.build_parser()
+        with self.assertRaises(SystemExit):
+            p.parse_args(["secret", "get", "v", "k", "--rev"])
+
+    def test_the_full_flag_still_parses(self):
+        from charter import cli
+        ns = cli.build_parser().parse_args(["secret", "get", "v", "k", "--reveal"])
+        self.assertTrue(ns.reveal)

--- a/tests/test_statusline_layout_scope.py
+++ b/tests/test_statusline_layout_scope.py
@@ -448,3 +448,76 @@ class Framed(PersonaIso):
             starts.add(m.start())
         self.assertEqual(len(starts), 1,
                          f"right-column text starts at differing columns: {sorted(starts)}")
+
+
+class OverflowKeepsTheReposWithSomethingToSay(unittest.TestCase):
+    """The cap was a bare positional slice, so with the list in directory order the rows
+    went to whatever sorted first. Observed with 18 clones: thirteen rows of clean
+    `aaa-svc-NN` on main, while `…(+5 more)` swallowed every dirty repo, the only off-main
+    branch and both failing pipelines — the table was showing the repos with nothing to
+    say. The repo you were standing in could be hidden too, so the bold you-are-here
+    marker attached to nothing on screen."""
+
+    def setUp(self):
+        from pathlib import Path
+        self.dirs = [Path(f"/w/aaa-{i:02d}") for i in range(1, 16)] + [
+            Path("/w/zzz-dirty"), Path("/w/zzz-ahead"), Path("/w/mmm-ci")]
+        self.states = {d: {"dirty": False, "ahead": 0, "behind": 0} for d in self.dirs}
+        self.gl = {d: {} for d in self.dirs}
+        self.states[Path("/w/zzz-dirty")] = {"dirty": True, "ahead": 0, "behind": 0}
+        self.states[Path("/w/zzz-ahead")] = {"dirty": False, "ahead": 2, "behind": 0}
+        self.gl[Path("/w/mmm-ci")] = {"ci": "failed", "change": 412, "sigil": "#"}
+
+    def _pick(self, cur=None, root=None):
+        budget = statusline._MAX_REPO_LINES - 1
+        return [d.name for d in
+                statusline._pick_rows(self.dirs, budget, cur, root, self.states, self.gl)]
+
+    def test_a_dirty_repo_survives_the_cap(self):
+        self.assertIn("zzz-dirty", self._pick())
+
+    def test_an_unpushed_repo_survives_the_cap(self):
+        self.assertIn("zzz-ahead", self._pick())
+
+    def test_a_failing_pipeline_survives_the_cap(self):
+        self.assertIn("mmm-ci", self._pick())
+
+    def test_the_repo_you_are_standing_in_always_survives(self):
+        """Otherwise the bold you-are-here marker attaches to nothing on screen."""
+        self.assertIn("aaa-09", self._pick(cur="aaa-09"))
+
+    def test_display_order_is_not_the_ranking(self):
+        """Ranking decides WHICH rows; it must not decide where they sit. A row that
+        moves as its state changes stops being a place you can look — you would re-read
+        the table every turn to find the repo you were just in."""
+        names = self._pick()
+        order = [d.name for d in self.dirs]
+        self.assertEqual(names, sorted(names, key=order.index))
+
+    def test_nothing_is_dropped_when_it_fits(self):
+        from pathlib import Path
+        few = [Path("/w/a"), Path("/w/b")]
+        st = {d: {} for d in few}
+        self.assertEqual(statusline._pick_rows(few, 13, None, None, st, {}),
+                         few)
+
+    def test_a_repo_keeps_its_colour_when_a_neighbour_enters_the_cap(self):
+        from pathlib import Path
+        """Palette was indexed by position among the SHOWN rows, so a repo changed colour
+        whenever a neighbour entered or left — which, with ranked selection, happens the
+        moment anything goes dirty."""
+        rows_a = statusline._repo_rows(self.dirs, "ws", None, self.states,
+                                       {d: "main" for d in self.dirs}, self.gl)
+        self.states[Path("/w/aaa-14")] = {"dirty": True, "ahead": 0, "behind": 0}
+        rows_b = statusline._repo_rows(self.dirs, "ws", None, self.states,
+                                       {d: "main" for d in self.dirs}, self.gl)
+
+        def colour_of(rows, name):
+            for r in rows:
+                line = r.render(statusline._LEFT_W)[0]
+                if re.search(rf"\b{name}\b", _plain(line)):
+                    m = re.search(r"\x1b\[(\d+)m" + r"[^\x1b]*" + name, line)
+                    return m.group(1) if m else None
+            return None
+
+        self.assertEqual(colour_of(rows_a, "aaa-02"), colour_of(rows_b, "aaa-02"))

--- a/tests/test_version_lock.py
+++ b/tests/test_version_lock.py
@@ -11,10 +11,13 @@ during development this feature really did downgrade the running charter.
 
 from __future__ import annotations
 
+import io
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from tests._isolation import PersonaIso
 from charter import commands, config, hooks, instance
 
 
@@ -187,3 +190,36 @@ class CommitPushTakesGitsArgumentsNotACommandLine(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class CommitPushRefusesToClaimSuccessItDidNotHave(PersonaIso):
+    """`charter save` printed `✓ Committed : charter save: 0 file(s)` and exited 0 in a
+    plane that is not a git repo — which `charter init` in a fresh directory produces, and
+    which is exactly the README's 60-second path. Every git call here runs `check=False`
+    (this is reached from hooks and background paths that must never break a turn), so the
+    add failed silently, `diff --cached --quiet` returned 128 rather than 0 so the
+    "Nothing to save" branch was skipped, the commit failed too, and `rev-parse` came back
+    empty. The personas and memory charter had just told the user to commit had no
+    history."""
+
+    def test_a_plane_that_is_not_a_repo_is_refused(self):
+        err = io.StringIO()
+        with redirect_stderr(err):
+            rc = commands.commit_push(self.tmp, ["add", "-A"], "m")
+        self.assertEqual(rc, 1)
+        self.assertIn("not a git repository", err.getvalue())
+
+    def test_the_refusal_says_what_to_do(self):
+        err = io.StringIO()
+        with redirect_stderr(err):
+            commands.commit_push(self.tmp, ["add", "-A"], "m")
+        self.assertIn("git init", err.getvalue())
+
+    def test_a_real_repo_with_nothing_staged_still_reports_nothing_to_save(self):
+        import subprocess
+        subprocess.run(["git", "init", "-q", str(self.tmp)], check=True, capture_output=True)
+        err = io.StringIO()
+        with redirect_stderr(err):
+            rc = commands.commit_push(self.tmp, ["add", "-A"], "m")
+        self.assertEqual(rc, 0)
+        self.assertIn("Nothing to save", err.getvalue())


### PR DESCRIPTION
## 2.3 — the leak guard inspects invocations, not prose

Both patterns were substring scans over the whole command line, so commands that merely *mentioned* the words were hard-denied with a reason misdescribing what they'd done:

```
git commit -m "docs: document the --reveal flag"      → was DENIED
rg -n -- --reveal charter/                            → was DENIED
grep -rn "vaults" .charter/vaults.json                → was DENIED
```

Now routed through `_segments`/`_invocation` — the machinery the sibling SSH guard already uses, for the reason its own docstring gives: *"a commit message may legitimately mention an SSH URL."* shlex keeps a quoted message as one token, so it can never be read as a flag. `--reveal` denies only as a real argv token of a charter invocation; a reader denies only with a real vault path in argv. The vault pattern gained a trailing slash, since `.charter/vaults.json` is the *registry* — paths, never values.

**And the hole that made the guard optional:** argparse expands any unambiguous prefix, so `--rev` ran as `--reveal` while the guard saw nothing to deny. The root parser now refuses abbreviation, and since `add_subparsers` defaults `parser_class` to `type(self)`, the whole command tree inherits it — `allow_abbrev=False` on the root alone would have covered only the level with nothing to protect.

`edm`, the pre-rename name, stays covered: an extra alternative costs one string; dropping it costs a denial that silently stops happening.

## 1.3 — `commit_push` stops claiming success it didn't have

A plane isn't always a git repo — `charter init` in a fresh directory doesn't run `git init`, which is the README's own 60-second path. Every git call here is `check=False` (hooks and background paths must never break a turn), so the add failed silently, `diff --cached --quiet` returned 128 so "Nothing to save" was skipped, the commit failed, `rev-parse` came back empty, and it printed:

```
✓ Committed : charter save: 0 file(s)
```

exit 0. The personas and memory charter had just told you to commit had no history. It now refuses up front with the reason, and treats still-staged-after-commit as the failure it is.

## 1.4 — the repo table keeps the repos with something to say

The cap was a bare positional slice, so rows went to whatever sorted first. With 18 clones: thirteen rows of clean `aaa-svc-NN`, while `…(+5 more)` swallowed every dirty repo, the only off-main branch and both failing pipelines. The repo you were standing in could be hidden, leaving the bold you-are-here marker attached to nothing.

Verified at that scale:

```
shown: 13 of 18
  ✓ zzz-payments (dirty)   ✓ zzz-web (ahead 2)   ✓ mmm-api (CI failed, #412)   ✓ aaa-svc-03 (current)
display order preserved: True
```

Selection is ranked; **display order is not**. The chosen set re-sorts back into the original order, and the palette indexes by position in the *full* list rather than among the shown — otherwise a repo moves and changes colour the moment a neighbour goes dirty, and the one channel carrying "this row is that repo" churns every turn. `…(+N more, all clean)` is now a claim the ranking can back.

1177 tests pass. The audit's status table is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4