### PR TITLE
audit: three more — an empty secret, plaintext in git, and the blind root tree

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -406,6 +406,10 @@ def _sa_set(p):
     p.add_argument("--stdin", action="store_true", help="Read the value from stdin.")
     p.add_argument("--from-file", help="Read the value verbatim from a file.")
     p.add_argument("--value", help="Inline value (discouraged: visible in shell history).")
+    p.add_argument("--allow-empty", action="store_true", dest="allow_empty",
+                   help="Permit storing an empty value. Refused by default: an empty "
+                        "secret reads as present and healthy everywhere charter looks, so "
+                        "the mistake only surfaces later as a 401.")
 
 
 def _sa_get(p):

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -564,11 +564,17 @@ def cmd_status(args) -> int:
 
 
 def _status_for_workspace(ws: str, inv_by_name: dict, active: str) -> None:
-    clones = {d.name: d for d in workspace.clones(ws)}
+    # `repo_trees` includes an embedded plane's own repo, which has no clone and never
+    # will — listing only `clones` reported it as an empty workspace and then advised
+    # `charter clone`, in a shape with nothing to clone.
+    clones = {d.name: d for d in workspace.repo_trees(ws)}
     marker = " (active)" if ws == active else ""
-    print(f"— workspace: {ws}{marker} · {len(clones)} cloned —")
+    print(f"— workspace: {ws}{marker} · {len(clones)} repo(s) —")
     if not clones:
-        print(f"  (empty; `charter clone <repo> --workspace {ws}` to populate)\n")
+        hint = (f"`charter worktree add <repo> <piece>` to start a piece"
+                if config.PLANE_SHAPE == "embedded"
+                else f"`charter clone <repo> --workspace {ws}` to populate")
+        print(f"  (empty; {hint})\n")
         return
     fmt = "  {:<38} {:<12} {}"
     print(fmt.format("REPO", "STACK", "BRANCH / NOTE"))

--- a/charter/commands_secrets.py
+++ b/charter/commands_secrets.py
@@ -75,6 +75,35 @@ def _env_bindings(args) -> dict | None:
     return pairs or None
 
 
+def _unignored_plaintext(configured: str):
+    """The path, if a plain-file vault would store plaintext somewhere git tracks.
+
+    ``None`` when it is outside the plane (git here has no say), when the plane is not a
+    git repo, or when git already ignores it. Asks `git check-ignore` rather than reading
+    `.gitignore`, so nested ignore files, negations and global excludes all count — the
+    question is only ever "would git take this file", and git is the authority on that.
+    """
+    from pathlib import Path as _P
+    p = _P(configured).expanduser()
+    if not p.is_absolute():
+        p = _P(config.ROOT) / p
+    try:
+        p.resolve().relative_to(_P(config.ROOT).resolve())
+    except (ValueError, OSError):
+        return None                                   # outside the plane
+    if util.run(["git", "-C", str(config.ROOT), "rev-parse", "--git-dir"],
+                check=False).returncode != 0:
+        return None                                   # not a repo; nothing to commit to
+    ignored = util.run(["git", "-C", str(config.ROOT), "check-ignore", "-q", str(p)],
+                       check=False).returncode == 0
+    if ignored:
+        return None
+    try:
+        return str(p.resolve().relative_to(_P(config.ROOT).resolve()))
+    except (ValueError, OSError):
+        return str(p)
+
+
 def cmd_vault_add(args) -> int:
     cfg: dict = {}
     if args.provider == "plain-file":
@@ -87,6 +116,27 @@ def cmd_vault_add(args) -> int:
         cfg["file"] = _portable_file(args.file or config.VAULTS_DIR / f"{args.name}.json")
     elif args.file:
         cfg["file"] = _portable_file(args.file)
+    # A plain-file vault holds PLAINTEXT. The default lives under `.charter/`, which
+    # `charter init` gitignores — but `--file` accepts any path, and a vault pointed at
+    # one git tracks commits the credentials on the next `charter save`. Nothing said so:
+    # `doctor` reported "all healthy", because from the vault's point of view it was.
+    #
+    # Refusing the PATH rather than refusing `--share` (which would be the obvious guess)
+    # is deliberate: a team that provisions the file out of band has a legitimate use for
+    # a shared pointer, and the unignored path is the actual defect — it also catches the
+    # far more common case where `--share` was never passed at all.
+    if args.provider == "plain-file" and cfg.get("file"):
+        unignored = _unignored_plaintext(cfg["file"])
+        if unignored:
+            util.err(f"'{unignored}' is inside the control plane and NOT gitignored — a "
+                     f"plain-file vault stores plaintext, so the next `charter save` would "
+                     f"commit these credentials.")
+            util.info("  Keep it out of git (add it to .gitignore, or use the default "
+                      f"under {config.VAULTS_DIR.name}/), or point --file outside the plane.")
+            util.info("  A `reference` vault stores op:// URIs rather than values and IS "
+                      "safe to commit: --provider reference")
+            return 1
+
     if args.provider == "1password":
         if not getattr(args, "op_vault", None):
             util.err("--op-vault is required for a 1password vault: which 1Password "
@@ -198,16 +248,36 @@ def _provider(name: str):
 
 
 def _read_value(args) -> str:
-    """Obtain a secret value without exposing it on the command line."""
+    """Obtain a secret value without exposing it on the command line.
+
+    A non-tty stdin is NOT on its own a request to read a secret from it. An agent's Bash
+    tool, a CI step and `< /dev/null` all present one, so `charter secret set devops
+    API_TOKEN` typed without a value read EOF, stored ``""``, and exited 0 — after which
+    `get` says the key is present, `vault list` counts it and `doctor` calls the vault
+    healthy. The failure surfaces hours later as a 401 from something unrelated.
+
+    So an explicit source is required whenever stdin is not a terminal: one of `--stdin`,
+    `--from-file` or `--value`. With a terminal, the interactive prompt still applies and
+    needs no flag.
+    """
     if args.from_file:
         return Path(args.from_file).expanduser().read_text()
     if args.value is not None:
         util.warn("Value passed via --value is visible in shell history / process list; "
                   "prefer --stdin or --from-file.")
         return args.value
-    if args.stdin or not sys.stdin.isatty():
+    if args.stdin:
         data = sys.stdin.read()
         return data[:-1] if data.endswith("\n") else data  # strip one trailing newline
+    if not sys.stdin.isatty():
+        raise base.VaultError(
+            "no value given, and stdin is not a terminal — refusing to guess.\n"
+            "  An agent's shell, a CI step and `< /dev/null` all look like this, and\n"
+            "  reading EOF here would overwrite the secret with an empty string.\n"
+            "  Say where the value comes from:\n"
+            "    … | charter secret set <vault> <key> --stdin\n"
+            "    charter secret set <vault> <key> --from-file <path>\n"
+            "    charter secret set <vault> <key> --value <value>   (visible in history)")
     import getpass
     return getpass.getpass(f"Value for '{args.key}' (hidden): ")
 
@@ -216,8 +286,16 @@ def cmd_secret_set(args) -> int:
     try:
         prov = _provider(args.vault)
         value = _read_value(args)
-        if value == "":
-            util.warn("Storing an empty value.")
+        # An empty value is almost always an accident — a command substitution that
+        # produced nothing, a file that was not there — and storing it is indistinguishable
+        # afterwards from storing a real secret: `get` reports present, `vault list` counts
+        # it, `doctor` says healthy. A warning is not enough for something that can only be
+        # detected later, by a 401.
+        if value == "" and not getattr(args, "allow_empty", False):
+            raise base.VaultError(
+                f"refusing to store an empty value for '{args.key}' — it would read as a "
+                f"present, healthy secret everywhere charter looks.\n"
+                f"  If that is genuinely what you want: --allow-empty")
         prov.set(args.key, value)
     except base.VaultError as e:
         util.err(str(e))

--- a/charter/commands_worktree.py
+++ b/charter/commands_worktree.py
@@ -117,7 +117,11 @@ def cmd_worktree_list(args) -> int:
             return 1
         targets = [clone]
     else:
-        targets = workspace.clones(ws)
+        # `repo_trees`, not `clones` — its own docstring calls it "the one list
+        # anything asking 'which repos am I on?' should use", and `gl-refresh`
+        # already uses it. An embedded plane has NO clones, so this said "No
+        # worktrees" while the status line one line above was drawing them.
+        targets = workspace.repo_trees(ws)
 
     total = 0
     for clone in targets:

--- a/docs/audits/2026-08-10-user-experience.md
+++ b/docs/audits/2026-08-10-user-experience.md
@@ -22,6 +22,9 @@ the thing that otherwise gets re-proposed every six months.
 | 2.3 leak guard substring-matched prose | fixed — inspects argv; `--rev` abbreviation closed |
 | 1.3 `charter save` claimed success in a non-git plane | fixed — refuses, and a failed commit is a failure |
 | 1.4 repo table dropped rows alphabetically | fixed — ranked selection, stable display order |
+| 1.6 `secret set` stored `""` on empty stdin, exit 0 | fixed — refuses; `--allow-empty` is the override |
+| 1.5 plaintext vault could land in git | fixed — an unignored path is refused at `vault add` |
+| 1.8 `worktree list`/`status` blind to the root tree | fixed — both use `repo_trees` |
 | everything else | open |
 
 Numbers in sections 2 and 3 that were not adversarially re-checked are flagged in

--- a/tests/test_secret_dotenv.py
+++ b/tests/test_secret_dotenv.py
@@ -21,11 +21,14 @@ import io
 import json
 import os
 import tempfile
+import sys
+from unittest import mock
 import unittest
 from contextlib import redirect_stderr
 from pathlib import Path
 from types import SimpleNamespace
 
+from tests._isolation import PersonaIso
 from charter import commands_secrets
 
 _GOLDEN_FIXTURE = Path(__file__).parent / "fixtures" / "dotenv_golden.json"
@@ -530,3 +533,66 @@ class DotenvExec(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class AnEmptySecretIsRefused(PersonaIso):
+    """`charter secret set devops API_TOKEN` typed without a value read EOF, stored `""`
+    and exited 0. Afterwards `get` says the key is present, `vault list` counts it and
+    `doctor` calls the vault healthy — the failure surfaces hours later as a 401 from
+    something unrelated.
+
+    A non-tty stdin is not on its own a request to read a secret from it: an agent's Bash
+    tool, a CI step and `< /dev/null` all present one.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        from charter.secrets import registry
+        registry.add_vault("dev", "plain-file", {"file": "dev.json"})
+
+    def _set(self, **kw):
+        args = SimpleNamespace(vault="dev", key="API_TOKEN", stdin=kw.pop("stdin", False),
+                               from_file=kw.pop("from_file", None),
+                               value=kw.pop("value", None),
+                               allow_empty=kw.pop("allow_empty", False))
+        with redirect_stderr(io.StringIO()) as err:
+            rc = commands_secrets.cmd_secret_set(args)
+        return rc, err.getvalue()
+
+    def test_no_source_with_a_non_tty_stdin_is_refused(self):
+        with mock.patch.object(sys, "stdin", io.StringIO("")):
+            rc, err = self._set()
+        self.assertEqual(rc, 1)
+        self.assertIn("refusing to guess", err)
+
+    def test_the_refusal_names_all_three_ways_to_supply_a_value(self):
+        with mock.patch.object(sys, "stdin", io.StringIO("")):
+            _rc, err = self._set()
+        for flag in ("--stdin", "--from-file", "--value"):
+            self.assertIn(flag, err)
+
+    def test_an_explicit_empty_stdin_is_still_refused(self):
+        """`--stdin` says where the value comes from, not that empty is intended."""
+        with mock.patch.object(sys, "stdin", io.StringIO("")):
+            rc, err = self._set(stdin=True)
+        self.assertEqual(rc, 1)
+        self.assertIn("empty", err)
+
+    def test_allow_empty_is_the_deliberate_override(self):
+        with mock.patch.object(sys, "stdin", io.StringIO("")):
+            rc, _ = self._set(stdin=True, allow_empty=True)
+        self.assertEqual(rc, 0)
+
+    def test_a_real_value_still_stores(self):
+        with mock.patch.object(sys, "stdin", io.StringIO("s3cret\n")):
+            rc, _ = self._set(stdin=True)
+        self.assertEqual(rc, 0)
+
+    def test_an_existing_secret_survives_a_refused_overwrite(self):
+        """The damage was never the error — it was the silent replacement."""
+        from charter.secrets import registry
+        with mock.patch.object(sys, "stdin", io.StringIO("real-token\n")):
+            self._set(stdin=True)
+        with mock.patch.object(sys, "stdin", io.StringIO("")):
+            self._set()
+        self.assertEqual(registry.provider_for("dev").get("API_TOKEN"), "real-token")

--- a/tests/test_vault_registration.py
+++ b/tests/test_vault_registration.py
@@ -244,3 +244,53 @@ class SharedAndLocalHalves(PersonaIso):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class PlaintextMustNotLandInGit(PersonaIso):
+    """A plain-file vault holds PLAINTEXT. The default sits under `.charter/`, which
+    `charter init` gitignores — but `--file` accepts any path, and a vault pointed at one
+    git tracks commits the credentials on the next `charter save`. Nothing said so:
+    `doctor` reported "all healthy", because from the vault's point of view it was.
+
+    The PATH is refused, not `--share`: a team that provisions the file out of band has a
+    legitimate use for a shared pointer, and the unignored path is the actual defect — it
+    also catches the far more common case where `--share` was never passed at all.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        import subprocess
+        subprocess.run(["git", "init", "-q", str(self.tmp)], check=True, capture_output=True)
+        (self.tmp / ".gitignore").write_text("/.charter/\n")
+
+    def _add(self, name, provider="plain-file", file=None):
+        with redirect_stderr(io.StringIO()) as err:
+            rc = commands_secrets.cmd_vault_add(
+                _args(name, provider, file=str(file) if file else None))
+        return rc, err.getvalue()
+
+    def test_a_tracked_path_is_refused(self):
+        rc, err = self._add("leaky", file=self.tmp / "cfg" / "leaky.json")
+        self.assertEqual(rc, 1)
+        self.assertIn("NOT gitignored", err)
+        self.assertNotIn("leaky", registry.vaults())
+
+    def test_the_gitignored_default_is_fine(self):
+        rc, _ = self._add("ok")
+        self.assertEqual(rc, 0)
+        self.assertIn("ok", registry.vaults())
+
+    def test_a_path_outside_the_plane_is_not_our_business(self):
+        rc, _ = self._add("ext", file=self.tmp.parent / "outside.json")
+        self.assertEqual(rc, 0)
+
+    def test_a_reference_vault_there_is_allowed(self):
+        """It stores op:// URIs rather than values, and committing those is the point."""
+        rc, _ = self._add("refs", provider="reference", file=self.tmp / "cfg" / "refs.json")
+        self.assertEqual(rc, 0)
+
+    def test_a_plane_that_is_not_a_repo_has_nothing_to_leak_into(self):
+        import shutil as _sh
+        _sh.rmtree(self.tmp / ".git")
+        rc, _ = self._add("anywhere", file=self.tmp / "cfg" / "v.json")
+        self.assertEqual(rc, 0)


### PR DESCRIPTION
## 1.6 — `secret set` stored `""` and exited 0

A non-tty stdin isn't on its own a request to read a secret from it: an agent's Bash tool, a CI step and `< /dev/null` all present one. So `charter secret set devops API_TOKEN` typed without a value read EOF and **overwrote the credential with an empty string**. Afterwards `get` says present, `vault list` counts it, `doctor` calls the vault healthy — the failure surfaces hours later as a 401 from something unrelated.

```
$ charter secret set dev API_TOKEN < /dev/null
✗ no value given, and stdin is not a terminal — refusing to guess.
  An agent's shell, a CI step and `< /dev/null` all look like this, and
  reading EOF here would overwrite the secret with an empty string.
  Say where the value comes from:
    … | charter secret set <vault> <key> --stdin
    charter secret set <vault> <key> --from-file <path>
    charter secret set <vault> <key> --value <value>
```

An empty value is now **refused**, not warned about, with `--allow-empty` as the deliberate override — a warning isn't enough for a mistake only detectable later. Verified that a refused overwrite leaves the existing secret intact.

## 1.5 — plaintext could land in git

A plain-file vault holds plaintext. The default sits under `.charter/`, which `init` gitignores — but `--file` takes any path, and one git tracks gets committed on the next `charter save`. Nothing said so; `doctor` reported "all healthy", because from the vault's point of view it was.

```
$ charter vault add leaky --provider plain-file --file cfg/leaky.json
✗ 'cfg/leaky.json' is inside the control plane and NOT gitignored — a plain-file vault
  stores plaintext, so the next `charter save` would commit these credentials.
```

The **path** is refused rather than `--share`, following the audit's own reading: a team that provisions the file out of band has a legitimate use for a shared pointer, and the unignored path is the actual defect — it also catches the far more common case where `--share` was never passed. `git check-ignore` is the authority, so nested ignore files, negations and global excludes all count. A `reference` vault at the same path is untouched: it stores `op://` URIs rather than values, and committing those is the point.

## 1.8 — `worktree list` and `status` were blind to the root tree

Both used `workspace.clones`, whose sibling `repo_trees` is documented as *"the one list anything asking 'which repos am I on?' should use"* — and which `gl-refresh` already uses. An embedded plane has no clones, so `worktree list` printed "No worktrees" while the status line one line above was drawing them, and `status` called the workspace empty then advised `charter clone` in a shape with nothing to clone.

```
— workspace: default (active) · 1 repo(s) —
  REPO       STACK   BRANCH / NOTE
  f3         ?       main · clean
```

The empty-state hint is now shape-aware.

All three verified end to end in a scratch plane. 1188 tests pass; audit status table updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4