### PR TITLE
audit: four more — the unheard warning, a typo trap, a false alarm, a dirty tree

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -230,6 +230,10 @@ def _add_workspace_parser(sub) -> None:
     use.add_argument("name")
     use.add_argument("--force", action="store_true",
                      help="Override the session lock and switch to another workspace mid-session.")
+    use.add_argument("--create", action="store_true",
+                     help="Create the workspace if it does not exist. Without this an "
+                          "unknown name is an error with a did-you-mean — a typo used to "
+                          "be created AND session-locked, so the correction was refused.")
     use.set_defaults(func=commands_workspace.cmd_workspace_use)
 
     unl = wsub.add_parser("unlock",

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -105,6 +105,23 @@ def cmd_workspace_use(args) -> int:
     if not workspace.valid_name(args.name):
         util.err(f"invalid workspace name '{args.name}'")
         return 1
+
+    # A typo used to be a one-way door: the name was only validated for SHAPE, so
+    # `use fature-x` created `fature-x`, took the session lock, and the correction then
+    # hit `✗ Workspace is 🔒 locked to 'fature-x' for this session`. Creating is now
+    # deliberate (`--create`), and an unknown name is a question rather than an action.
+    existing = workspace.list_workspaces()
+    if args.name not in existing and not getattr(args, "create", False):
+        import difflib
+        close = difflib.get_close_matches(args.name, existing, n=3, cutoff=0.6)
+        util.err(f"no workspace named '{args.name}'.")
+        if close:
+            util.info(f"  Did you mean: {', '.join(close)}?")
+        elif existing:
+            util.info(f"  Existing: {', '.join(sorted(existing))}")
+        util.info(f"  Create it: charter workspace use {args.name} --create")
+        return 1
+
     workspace.ensure(args.name)
     scope = workspace.set_active(args.name, force=getattr(args, "force", False))
     if scope == "locked":

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -556,7 +556,13 @@ def check_plugin_skew() -> Result:
                       hint=f"expected a readable plugin.json at {manifest}")
     msg = hooks.skew_message(plugin_version)
     if msg:
-        return Result("plugin", WARN,
+        # FAIL, not WARN. A plugin NEWER than the CLI can dispatch `charter hook <name>`
+        # for a handler this CLI does not have, so the hook simply does not run — the
+        # guard looks installed and is not. `cmd_doctor` exits 1 only on FAIL, and that
+        # exit code is what makes the SessionStart wrapper (`out=$(charter doctor) ||
+        # printf …`) print anything at all; at WARN the message reached nobody through
+        # either surface.
+        return Result("plugin", FAIL,
                       detail=f"v{plugin_version} (CLI v{hooks.MIN_PLUGIN_VERSION})", hint=msg)
     # `skew_message` is one-directional — silent for an equal OR older plugin — so "matches"
     # was printed for a plugin many versions behind. It stays OK (an older plugin wires

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -41,7 +41,18 @@ def _read_stdin() -> dict:
         return {}
 
 
+#: Messages to surface to the USER on this hook's output. `systemMessage` is a top-level
+#: hook-output field that renders at exit 0 without blocking — which matters because the
+#: only alternatives are stderr (a zero-exit hook's stderr reaches the debug log and
+#: nobody else) and exit 2, which on `UserPromptSubmit` erases the prompt the user just
+#: typed. Folded into whatever the handler already emits, so stdout stays one JSON object.
+_pending_system: list[str] = []
+
+
 def _emit(obj: dict) -> None:
+    if _pending_system:
+        obj = {**obj, "systemMessage": "\n".join(_pending_system)}
+        _pending_system.clear()
     print(json.dumps(obj))
 
 
@@ -693,14 +704,15 @@ def sessionstart() -> int:
         if mem:
             parts.append(mem)
 
-        # Keep the README's generated roster block current — once per session, not per
-        # dispatch (the tally moves constantly; the README shouldn't). Silent + best-effort:
-        # it only rewrites when the rendered block actually differs.
-        try:
-            from .commands import refresh_readme_personas
-            refresh_readme_personas()
-        except Exception:
-            pass
+        # NOT refreshing the README's roster block here, deliberately. It splices per-
+        # persona DISPATCH COUNTS into a committed file, so opening a session dirtied the
+        # working tree — and `_uncommitted_memory_nudge` below then complained about the
+        # uncommitted file charter had just written. On a shared plane it produces
+        # recurring conflicts in a block marked "do not edit by hand", because the counts
+        # differ per developer and change on every dispatch.
+        #
+        # It belongs where the marker already points: `charter docs` / `make docs`, run
+        # deliberately, by someone about to commit the result.
 
         if parts:
             _emit({"hookSpecificOutput": {
@@ -1305,13 +1317,33 @@ def dispatch(name: str, plugin_version: str | None) -> int:
     directly the way the umbrella's inline `python3 -c "from edm.hooks import …"` does).
 
     Runs the skew check first — the one place this module speaks up rather than
-    swallowing — then the named handler, unchanged."""
+    swallowing — then the named handler, unchanged.
+
+    The skew message used to go to stderr and stop there: Claude Code routes a zero-exit
+    hook's stderr to the debug log, so neither the user nor the model ever saw it, while
+    README.md promised "a plugin newer than the CLI says so loudly at session start". It
+    now rides out as `systemMessage`, which renders at exit 0 and blocks nothing.
+
+    Surfaced on **sessionstart only**, and that is the gate. `pretooluse` fires on every
+    Bash call, so emitting there would print the same warning dozens of times a session
+    and teach people to scroll past it — which is how the guard stops working even when it
+    is finally visible. Once, at the start, is what the README already promised. Other
+    hooks keep the stderr line for the debug log.
+    """
     msg = skew_message(plugin_version)
     if msg:
-        print(msg, file=sys.stderr)
+        if name == "sessionstart":
+            _pending_system.append(msg)
+        else:
+            print(msg, file=sys.stderr)
     fn = _HANDLERS.get(name)
     if fn is None:
         print(f"charter hook: unknown hook '{name}' (known: {', '.join(sorted(_HANDLERS))})",
               file=sys.stderr)
         return 1
-    return fn()
+    rc = fn()
+    # A handler that emitted nothing would swallow the message with it — sessionstart
+    # stays silent when there is no persona, no memory and no news to inject.
+    if _pending_system:
+        _emit({})
+    return rc

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -321,7 +321,18 @@ def legacy_flat_clones() -> list[Path]:
 
 
 def ensure(name: str) -> Path:
-    """Create the workspace directory if needed; return its path."""
+    """Create the workspace directory **and its baseline structure**; return its path.
+
+    `scaffold` used to be called only by create/live/restore/fork, so a workspace born via
+    `charter clone` or `charter workspace use` got a bare directory — and then the status
+    line showed `⚠ reinit` on every turn, phrased as post-upgrade drift, for a workspace
+    that had just been created correctly. The README's own quickstart ends that way.
+
+    Scaffolding here rather than at each call site because "the directory exists" and "the
+    directory is a workspace" were two different states with nothing keeping them in step;
+    `needs_reinit` is meant to detect a plane left behind by an older charter, not one
+    charter made a moment ago.
+    """
     if not valid_name(name):
         raise ValueError(
             f"invalid workspace name '{name}' "
@@ -330,6 +341,10 @@ def ensure(name: str) -> Path:
     _ensure_layout()
     wd = workspace_dir(name)
     wd.mkdir(parents=True, exist_ok=True)
+    try:
+        scaffold(name)
+    except Exception:
+        pass          # best-effort: a workspace you can use beats one that failed to exist
     return wd
 
 

--- a/docs/audits/2026-08-10-user-experience.md
+++ b/docs/audits/2026-08-10-user-experience.md
@@ -25,6 +25,10 @@ the thing that otherwise gets re-proposed every six months.
 | 1.6 `secret set` stored `""` on empty stdin, exit 0 | fixed — refuses; `--allow-empty` is the override |
 | 1.5 plaintext vault could land in git | fixed — an unignored path is refused at `vault add` |
 | 1.8 `worktree list`/`status` blind to the root tree | fixed — both use `repo_trees` |
+| 1.9 version-skew warning reached nobody | fixed — `systemMessage` at session start; doctor FAILs |
+| 2.5 `workspace use <typo>` created and locked it | fixed — refused with a did-you-mean; `--create` to make one |
+| 2.6 permanent `⚠ reinit` chip on new workspaces | fixed — `ensure` scaffolds |
+| 2.11 SessionStart rewrote a tracked README.md | fixed — left to `charter docs` |
 | everything else | open |
 
 Numbers in sections 2 and 3 that were not adversarially re-checked are flagged in

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -6,6 +6,7 @@ installed, which is the failure this guard exists to prevent."""
 from __future__ import annotations
 
 import json
+import sys
 import unittest
 from pathlib import Path
 
@@ -252,3 +253,60 @@ class TestVersionSkew(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestSkewReachesTheUser(unittest.TestCase):
+    """`README.md` promises "a plugin newer than the CLI says so loudly at session start".
+    It did not. `dispatch` printed to stderr and returned 0, and Claude Code routes a
+    zero-exit hook's stderr to the debug log only — so neither the user nor the model ever
+    saw it. The second surface was no better: `check_plugin_skew` returned WARN, and
+    `cmd_doctor` exits 0 on WARN, so the `||` in hooks.json never fired either."""
+
+    def _dispatch(self, name, version):
+        import io as _io, json as _json
+        from contextlib import redirect_stdout
+        from tests._isolation import run_hook  # noqa: F401  (stdin plumbing)
+        buf = _io.StringIO()
+        old = sys.stdin
+        sys.stdin = _io.StringIO("{}")
+        try:
+            with redirect_stdout(buf):
+                hooks.dispatch(name, version)
+        finally:
+            sys.stdin = old
+        out = buf.getvalue().strip()
+        return _json.loads(out) if out else None
+
+    def test_session_start_surfaces_it_as_a_system_message(self):
+        got = self._dispatch("sessionstart", "99.0.0")
+        self.assertIsNotNone(got, "dispatch emitted nothing")
+        self.assertIn("systemMessage", got)
+        self.assertIn("version skew", got["systemMessage"])
+
+    def test_a_matching_version_says_nothing(self):
+        got = self._dispatch("sessionstart", __version__)
+        self.assertFalse((got or {}).get("systemMessage"))
+
+    def test_pretooluse_does_not_repeat_it_on_every_bash_call(self):
+        """Emitting there would print the same warning dozens of times a session, which is
+        how a guard stops working even once it is finally visible."""
+        got = self._dispatch("pretooluse", "99.0.0")
+        self.assertFalse((got or {}).get("systemMessage"))
+
+    def test_doctor_treats_skew_as_a_blocker(self):
+        """`cmd_doctor` exits 1 only on FAIL, and that exit code is what makes the
+        SessionStart wrapper print anything at all."""
+        import os
+        from charter import doctor
+        from unittest import mock
+        with mock.patch.dict(os.environ, {"CLAUDE_PLUGIN_ROOT": str(ROOT)}):
+            res = doctor.check_plugin_skew()
+        self.assertEqual(res.status, doctor.OK)   # this repo is in lockstep
+
+    def test_a_newer_plugin_is_a_fail_not_a_warn(self):
+        from charter import doctor
+        from unittest import mock
+        with mock.patch.object(hooks, "MIN_PLUGIN_VERSION", "0.0.1"), \
+             mock.patch.dict(__import__("os").environ, {"CLAUDE_PLUGIN_ROOT": str(ROOT)}):
+            res = doctor.check_plugin_skew()
+        self.assertEqual(res.status, doctor.FAIL)

--- a/tests/test_workspace_lock.py
+++ b/tests/test_workspace_lock.py
@@ -16,7 +16,7 @@ import shutil
 import sys
 import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -154,21 +154,23 @@ class TestCommandLayer(WorkspaceLockBase):
         return rc, buf.getvalue()
 
     def test_use_locks_then_refuses_switch(self):
-        rc, _ = self._run(commands.cmd_workspace_use, name="alpha", force=False)
+        # `--create`: `use` no longer invents a workspace from a name. A typo used to be
+        # created AND session-locked, so the correction hit "locked to 'fature-x'".
+        rc, _ = self._run(commands.cmd_workspace_use, name="alpha", force=False, create=True)
         self.assertEqual(rc, 0)
         self.assertEqual(workspace.is_locked(), "alpha")
-        rc, out = self._run(commands.cmd_workspace_use, name="beta", force=False)
+        rc, out = self._run(commands.cmd_workspace_use, name="beta", force=False, create=True)
         self.assertEqual(rc, 2)  # refused (message goes to stderr)
         self.assertEqual(workspace.is_locked(), "alpha")
 
     def test_use_force_switches(self):
-        self._run(commands.cmd_workspace_use, name="alpha", force=False)
-        rc, _ = self._run(commands.cmd_workspace_use, name="beta", force=True)
+        self._run(commands.cmd_workspace_use, name="alpha", force=False, create=True)
+        rc, _ = self._run(commands.cmd_workspace_use, name="beta", force=True, create=True)
         self.assertEqual(rc, 0)
         self.assertEqual(workspace.is_locked(), "beta")
 
     def test_create_use_respects_lock(self):
-        self._run(commands.cmd_workspace_use, name="alpha", force=False)
+        self._run(commands.cmd_workspace_use, name="alpha", force=False, create=True)
         rc, out = self._run(commands.cmd_workspace_create, name="beta", use=True, force=False, repos=[])
         self.assertEqual(rc, 2)
         # the workspace is still created even though the switch was refused
@@ -182,3 +184,58 @@ from charter import commands_workspace as commands  # noqa: E402
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class UseDoesNotInventAWorkspaceFromATypo(WorkspaceLockBase):
+    """`use` validated the name's SHAPE, then created it and took the session lock. So
+    `charter workspace use fature-x` made `fature-x`, locked to it, and the correction hit
+    `✗ Workspace is 🔒 locked to 'fature-x' for this session` — a one-way door out of a
+    single mistyped character."""
+
+    def _run(self, **kw):
+        buf, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(buf), redirect_stderr(err):
+            rc = commands.cmd_workspace_use(SimpleNamespace(force=False, create=False, **kw))
+        return rc, err.getvalue()
+
+    def test_an_unknown_name_is_refused(self):
+        rc, err = self._run(name="fature-x")
+        self.assertEqual(rc, 1)
+        self.assertIn("no workspace named", err)
+
+    def test_it_does_not_create_the_typo(self):
+        self._run(name="fature-x")
+        self.assertFalse((config.WORKSPACES_DIR / "fature-x").exists())
+
+    def test_it_does_not_take_the_session_lock(self):
+        """The half that made it unrecoverable."""
+        self._run(name="fature-x")
+        self.assertIsNone(workspace.is_locked())
+
+    def test_it_suggests_the_name_you_meant(self):
+        workspace.ensure("feature-x")
+        _rc, err = self._run(name="fature-x")
+        self.assertIn("feature-x", err)
+
+    def test_create_is_the_deliberate_path(self):
+        buf, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(buf), redirect_stderr(err):
+            rc = commands.cmd_workspace_use(
+                SimpleNamespace(name="brand-new", force=False, create=True))
+        self.assertEqual(rc, 0)
+        self.assertTrue((config.WORKSPACES_DIR / "brand-new").exists())
+
+
+class EnsureScaffoldsSoNothingAsksForReinit(WorkspaceLockBase):
+    """`scaffold` ran only from create/live/restore/fork, so a workspace born via
+    `charter clone` or `workspace use` got a bare directory — and the status line then
+    showed `⚠ reinit` every turn, phrased as post-upgrade drift, for a workspace charter
+    had just made correctly. The README's own quickstart ended that way."""
+
+    def test_a_freshly_ensured_workspace_does_not_need_reinit(self):
+        workspace.ensure("fresh")
+        self.assertFalse(workspace.needs_reinit("fresh"))
+
+    def test_it_has_its_baseline_structure(self):
+        workspace.ensure("fresh")
+        self.assertTrue((config.WORKSPACES_DIR / "fresh" / "memory").is_dir())


### PR DESCRIPTION
## 1.9 — the version-skew warning reached nobody

It printed to stderr and returned 0. Claude Code routes a zero-exit hook's stderr to the debug log, so neither the user nor the model ever saw it. The second surface was no better: `check_plugin_skew` returned WARN, `cmd_doctor` exits 0 on WARN, so the `||` in `hooks.json` never fired either. Meanwhile `README.md` promised *"a plugin newer than the CLI says so loudly at session start."*

It now rides out as `systemMessage`, which renders at exit 0 and blocks nothing — **not** `exit 2`, which on `UserPromptSubmit` erases the prompt the user just typed.

Surfaced on **sessionstart only**, and that's the gate: `pretooluse` fires on every Bash call, so emitting there would print the same warning dozens of times a session and teach people to scroll past it — which is how a guard stops working just as it becomes visible.

`check_plugin_skew` is now **FAIL**: a plugin newer than the CLI can dispatch a handler the CLI doesn't have, so the hook silently doesn't run while looking installed.

## 2.5 — `workspace use <typo>` was a one-way door

It validated the name's *shape*, then created it and took the session lock. So `use fature-x` made `fature-x`, locked to it, and the correction hit `✗ Workspace is 🔒 locked to 'fature-x' for this session`.

```
$ charter ws use fature-x
✗ no workspace named 'fature-x'.
•   Did you mean: feature-x?
•   Create it: charter workspace use fature-x --create
```

Verified: the typo isn't created, the lock isn't taken, and the correction succeeds.

## 2.6 — a permanent `⚠ reinit` chip on correctly-created workspaces

`scaffold` ran only from create/live/restore/fork, so a workspace born via `charter clone` or `workspace use` got a bare directory — and the status line then showed `⚠ reinit` every turn, phrased as post-upgrade drift, for a workspace charter had just made correctly. The README's own quickstart ended that way.

"The directory exists" and "the directory is a workspace" were two states with nothing keeping them in step; `ensure` now scaffolds.

## 2.11 — SessionStart rewrote a tracked `README.md`

It spliced per-persona *dispatch counts* into a committed file, so opening a session dirtied your working tree — and `_uncommitted_memory_nudge`, four lines later, complained about the file charter had just written. On a shared plane that produces recurring conflicts in a block marked "do not edit by hand". It belongs where the marker already points: `charter docs`, run deliberately by someone about to commit the result.

---

The workspace-lock tests now pass `create=True` — they exercise `use` on workspaces that don't exist yet, which is exactly the case that now needs saying out loud.

1200 tests pass; audit status table updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4