### PR TITLE
fix: don't break every pipe to stop an empty secret

### DIFF
--- a/charter/commands_secrets.py
+++ b/charter/commands_secrets.py
@@ -250,15 +250,15 @@ def _provider(name: str):
 def _read_value(args) -> str:
     """Obtain a secret value without exposing it on the command line.
 
-    A non-tty stdin is NOT on its own a request to read a secret from it. An agent's Bash
-    tool, a CI step and `< /dev/null` all present one, so `charter secret set devops
-    API_TOKEN` typed without a value read EOF, stored ``""``, and exited 0 — after which
-    `get` says the key is present, `vault list` counts it and `doctor` calls the vault
-    healthy. The failure surfaces hours later as a 401 from something unrelated.
+    A non-tty stdin is still read — `… | charter secret set <vault> <key>` is the ordinary
+    way to do this and predates `--stdin`. What is refused is the RESULT being empty (see
+    `cmd_secret_set`), which is the actual failure: an agent's Bash tool, a CI step and
+    `< /dev/null` all present a non-tty stdin with nothing behind it, so the read returned
+    "" and overwrote the credential.
 
-    So an explicit source is required whenever stdin is not a terminal: one of `--stdin`,
-    `--from-file` or `--value`. With a terminal, the interactive prompt still applies and
-    needs no flag.
+    Requiring an explicit `--stdin` for every pipe was the first fix here and it was worse
+    than the bug in one direction: it broke every working pipeline to stop a mistake the
+    empty check already catches. Narrow the refusal to the thing that is wrong.
     """
     if args.from_file:
         return Path(args.from_file).expanduser().read_text()
@@ -266,18 +266,9 @@ def _read_value(args) -> str:
         util.warn("Value passed via --value is visible in shell history / process list; "
                   "prefer --stdin or --from-file.")
         return args.value
-    if args.stdin:
+    if args.stdin or not sys.stdin.isatty():
         data = sys.stdin.read()
         return data[:-1] if data.endswith("\n") else data  # strip one trailing newline
-    if not sys.stdin.isatty():
-        raise base.VaultError(
-            "no value given, and stdin is not a terminal — refusing to guess.\n"
-            "  An agent's shell, a CI step and `< /dev/null` all look like this, and\n"
-            "  reading EOF here would overwrite the secret with an empty string.\n"
-            "  Say where the value comes from:\n"
-            "    … | charter secret set <vault> <key> --stdin\n"
-            "    charter secret set <vault> <key> --from-file <path>\n"
-            "    charter secret set <vault> <key> --value <value>   (visible in history)")
     import getpass
     return getpass.getpass(f"Value for '{args.key}' (hidden): ")
 
@@ -292,9 +283,12 @@ def cmd_secret_set(args) -> int:
         # it, `doctor` says healthy. A warning is not enough for something that can only be
         # detected later, by a 401.
         if value == "" and not getattr(args, "allow_empty", False):
+            how = ("" if sys.stdin.isatty() else
+                   "\n  Nothing arrived on stdin. An agent's shell, a CI step and "
+                   "`< /dev/null` all\n  look like a pipe with no data behind them.")
             raise base.VaultError(
                 f"refusing to store an empty value for '{args.key}' — it would read as a "
-                f"present, healthy secret everywhere charter looks.\n"
+                f"present, healthy secret everywhere charter looks.{how}\n"
                 f"  If that is genuinely what you want: --allow-empty")
         prov.set(args.key, value)
     except base.VaultError as e:

--- a/tests/test_secret_dotenv.py
+++ b/tests/test_secret_dotenv.py
@@ -559,17 +559,26 @@ class AnEmptySecretIsRefused(PersonaIso):
             rc = commands_secrets.cmd_secret_set(args)
         return rc, err.getvalue()
 
-    def test_no_source_with_a_non_tty_stdin_is_refused(self):
+    def test_an_empty_non_tty_stdin_is_refused(self):
         with mock.patch.object(sys, "stdin", io.StringIO("")):
             rc, err = self._set()
         self.assertEqual(rc, 1)
-        self.assertIn("refusing to guess", err)
+        self.assertIn("empty value", err)
 
-    def test_the_refusal_names_all_three_ways_to_supply_a_value(self):
+    def test_the_refusal_explains_where_the_nothing_came_from(self):
         with mock.patch.object(sys, "stdin", io.StringIO("")):
             _rc, err = self._set()
-        for flag in ("--stdin", "--from-file", "--value"):
-            self.assertIn(flag, err)
+        self.assertIn("Nothing arrived on stdin", err)
+
+    def test_an_ordinary_pipe_still_works_without_a_flag(self):
+        """`… | charter secret set <vault> <key>` predates `--stdin` and is how people
+        actually do this. Requiring the flag was the first fix here, and it broke every
+        working pipeline to stop a mistake the empty check already catches."""
+        with mock.patch.object(sys, "stdin", io.StringIO("s3cret")):
+            rc, _ = self._set()
+        self.assertEqual(rc, 0)
+        from charter.secrets import registry
+        self.assertEqual(registry.provider_for("dev").get("API_TOKEN"), "s3cret")
 
     def test_an_explicit_empty_stdin_is_still_refused(self):
         """`--stdin` says where the value comes from, not that empty is intended."""


### PR DESCRIPTION
`… | charter secret set <vault> <key>` is the ordinary way to set a secret and predates `--stdin`. Requiring the flag for any non-tty stdin — my first fix for the empty-overwrite bug in #36 — broke every working pipeline to stop a mistake the empty-value check already catches. It would have shipped in the next release.

Non-tty stdin is read again. What stays refused is the **result being empty**, which is the actual failure: an agent's Bash tool, a CI step and `< /dev/null` all present a pipe with nothing behind it.

```
echo -n s3cret | charter secret set dev K   → ✓ Set 'K' in vault 'dev' (6 bytes)
charter secret set dev K < /dev/null        → ✗ refusing to store an empty value …
                                                Nothing arrived on stdin. An agent's
                                                shell, a CI step and `< /dev/null` all
                                                look like a pipe with no data behind them.
```

The message distinguishes the two cases, since "you gave me nothing" and "nothing arrived" want different fixes.

Caught while assembling the release notes — by reading the change back as a user of the old behaviour rather than as its author.

1212 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4