### PR TITLE
0.17.0 — the audit release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.16.0"
+__version__ = "0.17.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.16.0",
+            "command": "charter hook sessionstart --plugin-version 0.17.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.16.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.17.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.16.0",
+            "command": "charter hook pretooluse --plugin-version 0.17.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.16.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.17.0"
           }
         ]
       }
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.16.0",
+            "command": "charter hook posttooluse --plugin-version 0.17.0",
             "timeout": 5
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.16.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.17.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.16.0"
+version = "0.17.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
`0.16.0 → 0.17.0`. Minor: new flags, and several behaviours that were wrong now behave differently.

## Silent or misleading failures, fixed

- **A worktree with no committed `charter.toml` resolved to itself** — so charter's own `enter:` line opened a session with no personas, no vault, and memory written where `git worktree remove --force` deletes it, while `doctor` reported green.
- **Two Claude sessions in one terminal *window* shared a workspace.** `_terminal_id` keyed on `WINDOWID`, which identifies a window, not a pane. Parallel workspaces are the feature; sharing one behind the user's back is what they exist to prevent.
- **`persona memory-sync` pushed over SSH** (`push origin HEAD`), violating the one-credential rule on the one memory path the SessionStart hook tells agents to use — and blamed git auth while `gh auth status` was fine.
- **`charter version bump --push` ran `git git add`** and had never committed anything, while printing `✓ committed + pushed`.
- **`charter save` printed `✓ Committed`** in a plane that isn't a git repo.
- **`secret set` stored `""`** when nothing arrived on stdin; everything downstream then reported a present, healthy secret.
- **A plain-file vault could be pointed at a path git tracks**, committing plaintext.
- **The version-skew warning reached nobody** — stderr from a zero-exit hook goes to the debug log, and `doctor` exited 0 on WARN so the hook wrapper never printed it either.
- **`doctor` reported a missing control plane as `ok`**, which is what let several of the above read as healthy.
- **The status line dropped repo rows alphabetically**, hiding exactly the dirty repos, off-main branches and failing pipelines it exists to show.
- **`recall` discarded every two-character token**, so `"S3"`, `"CI"` and `"PR"` returned confident negatives against a corpus containing them.

## Repeated friction, fixed

- Vault health shelled out to `op` **once per persona per render** — 96% of status-line render time. Now cached with a TTL off the render path.
- The one-credential guard denied SSH git in **every repo on the machine**, plane or not. Now scoped to a plane; the secret-leak guard stays unconditional.
- That leak guard matched prose, so `git commit -m "document the --reveal flag"` was denied. It inspects real invocations now, and `--rev` no longer abbreviates past it.
- `workspace use <typo>` created the typo and locked the session to it.
- Workspaces born via `clone`/`use` were never scaffolded, so a correct setup showed `⚠ reinit` every turn.
- SessionStart rewrote a tracked `README.md`, dirtying your tree every session.
- `worktree list` and `status` were blind to an embedded plane's own repo.

## New

`charter secret set --allow-empty`, `charter workspace use --create`, and a paste-into-Claude-Code install prompt in the README.

## Internal

`charter/planegit.py` is now the one committer for the control plane. `docs/audits/2026-08-10-user-experience.md` records the audit these came from — including what was considered and deliberately **not** done.

All four version files move together. 1212 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4