### PR TITLE
plane: in an embedded plane, a workspace IS a working tree

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -216,6 +216,10 @@ def _add_workspace_parser(sub) -> None:
     cr.add_argument("--vision", "--about", dest="vision",
                     help="The goal/idea for this workspace — seeds its living charter "
                          "(workspaces/<name>/workspace.md). Ask the developer if you don't know it.")
+    cr.add_argument("--branch", help="Branch for this workspace's working tree (embedded "
+                                     "planes only; default: the workspace name). In an "
+                                     "embedded plane a workspace IS a worktree of the "
+                                     "repo, since there is nothing to clone apart.")
     cr.add_argument("repos", nargs="*", help="Repos to clone into it immediately.")
     cr.set_defaults(func=commands_workspace.cmd_workspace_create)
 

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -16,7 +16,7 @@ import sys
 import time
 from types import SimpleNamespace
 
-from . import config, gitpolicy, util, workspace
+from . import config, gitpolicy, util, workspace, worktree
 from .commands import (_cred_flag, _git, _origin_https, cmd_clone, commit_memory_reactive,
                        commit_push)
 
@@ -73,6 +73,27 @@ def cmd_workspace_create(args) -> int:
     live = getattr(args, "live", False)
     if live:
         workspace.set_live(args.name, True)
+
+    # Embedded: give the workspace the working tree that MAKES it a workspace. A fleet
+    # workspace gets its trees from `charter clone`; here there is nothing to clone, so
+    # the only way to isolate is a worktree of the one repo — and leaving that to the user
+    # is what made every embedded workspace share one checkout.
+    tree_path = None
+    if (config.PLANE_SHAPE == "embedded"
+            and args.name != config.DEFAULT_WORKSPACE
+            and workspace.own_tree(args.name) is None):
+        rt = workspace.root_tree()
+        if rt is not None:
+            branch = getattr(args, "branch", None) or args.name
+            tree_path = worktree.path_for(args.name, rt.name, args.name)
+            tree_path.parent.mkdir(parents=True, exist_ok=True)
+            add = ["worktree", "add", str(tree_path)]
+            add += (["-b", branch] if not worktree.branch_exists(rt, branch) else [branch])
+            proc = util.run(["git", "-C", str(rt), *add], check=False)
+            if proc.returncode != 0:
+                util.err(f"could not create this workspace's working tree:\n"
+                         f"{(proc.stderr or '').strip()}")
+                return 1
     mode = ("LIVE — charter + manifest + memory committed + shared + auto-saved" if live
             else "LOCAL — private (nothing committed); `charter workspace live` to share")
     util.ok(f"Workspace '{args.name}' ready ({mode}) → {wd.relative_to(config.ROOT)}/")
@@ -93,9 +114,19 @@ def cmd_workspace_create(args) -> int:
         util.ok(f"Active workspace set to '{args.name}'{_scope_note(scope)} — 🔒 locked for this session.")
         _warn_env_override(args.name)
 
+    if tree_path is not None:
+        # The path is the point: charter cannot cd your shell, so selecting the workspace
+        # is an instruction rather than an action — the same shape `worktree add` already
+        # has. Being INSIDE this directory is what makes it the active workspace
+        # (`workspace.from_path`), so no pointer has to agree with anything.
+        rel = tree_path if not str(tree_path).startswith(str(config.ROOT)) else tree_path
+        util.ok(f"Working tree → {rel}")
+        util.info(f"  enter:  cd {rel} && claude")
+        util.info(f"  Being in that directory IS this workspace — no pointer needed.")
+
     if args.repos:
         return cmd_clone(SimpleNamespace(repos=args.repos, workspace=args.name))
-    if not args.use:
+    if not args.use and tree_path is None:
         util.info(f"Select it with: charter workspace use {args.name}  "
                   f"(or --workspace {args.name} per command)")
     return 0
@@ -110,8 +141,29 @@ def cmd_workspace_use(args) -> int:
     # `use fature-x` created `fature-x`, took the session lock, and the correction then
     # hit `✗ Workspace is 🔒 locked to 'fature-x' for this session`. Creating is now
     # deliberate (`--create`), and an unknown name is a question rather than an action.
+    # In an embedded plane a workspace IS a working tree, so one without a tree isolates
+    # nothing — selecting it would put this session on the same files as every other
+    # workspace, which is the promise `workspace` exists to keep. Refused rather than
+    # warned: this is charter's own command, so it can decline without breaking any work,
+    # and a warning would leave the default path wrong.
+    if (config.PLANE_SHAPE == "embedded"
+            and args.name != config.DEFAULT_WORKSPACE
+            and args.name in workspace.list_workspaces()
+            and workspace.own_tree(args.name) is None):
+        util.err(f"workspace '{args.name}' has no working tree of its own, so selecting it "
+                 f"would leave you on the same files as every other workspace.")
+        util.info(f"  Give it one: charter workspace create {args.name}")
+        util.info(f"  (In an embedded plane a workspace is a worktree of this repo; "
+                  f"'{config.DEFAULT_WORKSPACE}' is the repo itself.)")
+        return 1
+
+    # `default` is always selectable, whether or not its directory exists yet — it is
+    # documented as "the always-present workspace used when none is selected", and
+    # `ensure` creates it on demand. The unknown-name guard below refused it in a plane
+    # that had never made one, which is every fresh plane.
     existing = workspace.list_workspaces()
-    if args.name not in existing and not getattr(args, "create", False):
+    if (args.name not in existing and args.name != config.DEFAULT_WORKSPACE
+            and not getattr(args, "create", False)):
         import difflib
         close = difflib.get_close_matches(args.name, existing, n=3, cutoff=0.6)
         util.err(f"no workspace named '{args.name}'.")

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -130,6 +130,13 @@ def is_git_repo(path: Path) -> bool:
     return (path / ".git").exists()
 
 
+def is_tree(path: Path) -> bool:
+    """A working tree of either provenance — a clone (``.git`` is a directory) or a
+    linked worktree (``.git`` is a file). :func:`is_clone` deliberately excludes the
+    second; this is for callers that only need "is there a checkout here"."""
+    return (Path(path) / ".git").exists()
+
+
 def is_clone(path: Path) -> bool:
     """A real clone, not a worktree. Git itself draws the line: a clone's ``.git`` is a
     DIRECTORY, a linked worktree's ``.git`` is a FILE pointing at the shared gitdir. So a
@@ -141,15 +148,50 @@ def workspace_dir(name: str) -> Path:
     return config.WORKSPACES_DIR / name
 
 
+def from_path(path=None) -> str | None:
+    """The workspace whose working tree *path* is inside, or ``None``.
+
+    A workspace's trees live at known places — `workspaces/<ws>/<repo>/…` for a fleet
+    clone, `<worktrees-root>/<ws>/<repo>/<piece>/…` for a worktree — so standing in one
+    IS the answer to "which workspace am I in", and it is an answer no pointer can
+    contradict. You cannot be in two directories at once, which is exactly the property
+    the pointers lacked: a session that had never chosen anything inherited another
+    session's choice through a shared terminal key.
+    """
+    from . import worktree
+    try:
+        here = Path(path or os.getcwd()).resolve()
+    except (OSError, RuntimeError):
+        return None
+
+    loc = worktree.locate(here)          # (workspace, repo, piece) — handles both roots
+    if loc:
+        return loc[0]
+    try:
+        parts = here.relative_to(Path(config.WORKSPACES_DIR).resolve()).parts
+    except (ValueError, OSError, RuntimeError):
+        return None
+    # `workspaces/<ws>` alone is the container, not a tree — only a repo inside it counts.
+    return parts[0] if len(parts) >= 2 else None
+
+
 def resolve(explicit: str | None = None, session_id: str | None = None) -> str:
-    """Active workspace by precedence: ``--workspace`` → ``$CHARTER_WORKSPACE`` →
-    per-session pointer (Claude session id) → per-terminal pointer (survives reopen)
-    → ``default``. No shared/global pointer, so one pane never affects another."""
+    """Active workspace by precedence: ``--workspace`` → ``$CHARTER_WORKSPACE`` → **the
+    tree you are standing in** → per-session pointer → per-terminal pointer → ``default``.
+
+    The cwd sits above the pointers because it cannot be wrong: a workspace's trees live
+    at paths that name the workspace, so being inside one is not a hint about which
+    workspace is active, it is the fact. The pointers remain for the case with no tree to
+    stand in — a shell at the plane root.
+    """
     if explicit:
         return explicit
     env = os.environ.get("CHARTER_WORKSPACE")
     if env:
         return env.strip()
+    here = from_path()
+    if here:
+        return here
     sid = _session_id(session_id)
     if sid:
         val = _read(_session_file(sid))
@@ -169,6 +211,9 @@ def source(explicit: str | None = None, session_id: str | None = None) -> str:
         return "--workspace"
     if os.environ.get("CHARTER_WORKSPACE"):
         return "$CHARTER_WORKSPACE"
+    if from_path():
+        return "cwd"      # must mirror `resolve`'s order, or the status line explains
+                          # the active workspace by naming a source that did not decide it
     sid = _session_id(session_id)
     if sid and _read(_session_file(sid)):
         return "session"
@@ -320,8 +365,42 @@ def root_tree() -> Path | None:
         return None
 
 
+def own_tree(ws: str) -> Path | None:
+    """The working tree that belongs to *ws* alone, in an **embedded** plane.
+
+    Embedded means the codebase cannot be cloned apart, so a workspace that materialises
+    nothing isolates nothing: `ws use alpha` then `ws use beta` changed the memory
+    namespace and not one file being edited, while charter promised "never mix
+    workspaces". Two agents in two workspaces were editing the same files on the same
+    branch.
+
+    So in an embedded plane a workspace **is** a working tree:
+
+    - ``default`` owns the root tree. A solo user's experience stays `charter init` and
+      work in your repo — charter starts materialising trees only when you ask for a
+      SECOND concurrent thing, so the simplest case is never the strangest one.
+    - every other workspace owns the worktree whose piece name equals the workspace name,
+      i.e. ``<worktrees-root>/<ws>/<repo>/<ws>``. Reusing the existing piece layout rather
+      than inventing a level: `worktree.dirs_for` keeps listing it, and a workspace's own
+      tree is simply its first piece.
+
+    ``None`` when the workspace has no tree yet — the state `workspace use` refuses.
+    Always ``None`` in a fleet plane, where a workspace holds clones instead.
+    """
+    if config.PLANE_SHAPE != "embedded":
+        return None
+    rt = root_tree()
+    if rt is None:
+        return None
+    if ws == config.DEFAULT_WORKSPACE:
+        return rt
+    from . import worktree
+    p = worktree.path_for(ws, rt.name, ws)
+    return p if is_tree(p) else None
+
+
 def repo_trees(ws: str) -> list[Path]:
-    """Every repo this workspace works in: the plane's root tree first, then its clones.
+    """Every repo this workspace works in.
 
     The one list anything asking "which repos am I on?" should use — the status line's
     rows and `gl-refresh`'s fetch targets both come from here, so a repo can never be
@@ -329,9 +408,18 @@ def repo_trees(ws: str) -> list[Path]:
     Splitting that decision in two is what left the root tree with a permanently empty
     CI column: it was rendered from one list and refreshed from another.
 
-    A fleet workspace's answer is unchanged (its clones, plus the plane's own repo, which
-    has a branch like any other). A monorepo workspace's answer is just the root tree.
+    Fleet: the plane's own repo (it has a branch like any other) plus this workspace's
+    clones. Embedded: this workspace's OWN tree — the root for `default`, its worktree
+    otherwise. Returning the root for every embedded workspace is what made them all look
+    like the same workspace, because they were.
     """
+    if config.PLANE_SHAPE == "embedded":
+        # The workspace's OWN tree stands where the shared root used to — every embedded
+        # workspace returning the same root is what made them all one workspace. Clones
+        # still count: nothing stops `charter clone` in an embedded plane, and a hybrid
+        # (the codebase plus a vendored dependency) is a reasonable thing to have.
+        own = own_tree(ws)
+        return ([own] if own is not None else []) + clones(ws)
     rt = root_tree()
     return ([rt] if rt is not None else []) + clones(ws)
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -150,6 +150,56 @@ rewriting git's own `gitdir` pointer, and `git worktree move` is the command tha
 correctly. `charter doctor` finds any that are still inside the codebase and prints that
 command with the paths filled in.
 
+### What a workspace is, in each shape
+
+A workspace is **a set of working trees** — one task's code, kept apart from every other
+task's. How it gets those trees is the only thing that differs:
+
+| | fleet | embedded |
+| --- | --- | --- |
+| a workspace's trees | clones, via `charter clone` | a **worktree** of the one repo |
+| `default` | its own clones like any other | **the repo itself** |
+| creating one | `workspace create` then `clone` | `workspace create` materialises the tree |
+
+In an embedded plane there is nothing to clone apart, so a workspace that materialised
+nothing isolated nothing: every workspace resolved to the same root tree, and `ws use
+alpha` then `ws use beta` changed the memory namespace while leaving you on exactly the
+same files. Two agents in two workspaces edited the same branch.
+
+So `charter workspace create feature-x` now creates the tree that makes it a workspace:
+
+```
+$ charter workspace create feature-x
+✓ Workspace 'feature-x' ready (LOCAL …) → workspaces/feature-x/
+✓ Working tree → ../app.worktrees/feature-x/app/feature-x
+  enter:  cd ../app.worktrees/feature-x/app/feature-x && claude
+  Being in that directory IS this workspace — no pointer needed.
+```
+
+Its branch is the workspace name unless you pass `--branch`.
+
+`default` deliberately stays the repo itself, so a solo user's path is `charter init`, work
+in your repo — charter starts materialising trees only when you ask for a *second*
+concurrent thing.
+
+**Selecting a workspace with no tree is refused**, because it would put you on the same
+files as every other workspace — the thing workspaces exist to prevent. `charter workspace
+create <name>` gives it one.
+
+### The directory you are in decides the workspace
+
+A workspace's trees live at paths that name it — `workspaces/<ws>/<repo>/` for a fleet
+clone, `<worktrees-root>/<ws>/<repo>/<piece>/` for a worktree — so **being inside one is
+the answer**, ahead of any pointer:
+
+```
+--workspace → $CHARTER_WORKSPACE → the tree you are standing in → session → terminal → default
+```
+
+You cannot be in two directories at once, which is precisely the property the pointers
+lacked: a session that had never chosen anything could inherit another session's choice.
+`charter workspace current` reports `via cwd` when the directory decided it.
+
 ### Working inside a worktree
 
 `charter.toml` is a tracked file, so an embedded plane checks a copy of it into every

--- a/tests/test_embedded_workspace_is_a_tree.py
+++ b/tests/test_embedded_workspace_is_a_tree.py
@@ -1,0 +1,202 @@
+"""In an embedded plane, a workspace IS a working tree.
+
+Embedded means the codebase cannot be cloned apart, so a workspace that materialised
+nothing isolated nothing: `repo_trees` returned the same root tree for every workspace, so
+`ws use alpha` then `ws use beta` changed the memory namespace and not one file being
+edited. Two agents in two workspaces were editing the same files on the same branch, while
+charter's central promise is "never mix workspaces".
+
+The model now reads the same in both shapes — *a workspace is a set of working trees* —
+with one repo collapsing the fleet's "set" to exactly one:
+
+    default      → the root tree (a solo user never learns a second directory)
+    <other>      → <worktrees-root>/<ws>/<repo>/<ws>, on its own branch
+"""
+from __future__ import annotations
+
+import io
+import subprocess
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import commands_workspace as cw
+from charter import config, workspace, worktree
+from tests._isolation import PersonaIso
+from tests.test_statusline_monorepo import MonorepoIso, git
+
+
+def _create(name, **kw):
+    args = SimpleNamespace(name=name, use=kw.pop("use", False), force=False,
+                           live=False, vision=None, repos=[],
+                           branch=kw.pop("branch", None))
+    with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+        return cw.cmd_workspace_create(args)
+
+
+def _use(name, **kw):
+    args = SimpleNamespace(name=name, force=kw.pop("force", False),
+                           create=kw.pop("create", False))
+    err = io.StringIO()
+    with redirect_stdout(io.StringIO()), redirect_stderr(err):
+        rc = cw.cmd_workspace_use(args)
+    return rc, err.getvalue()
+
+
+class AWorkspaceOwnsATree(MonorepoIso):
+    def setUp(self) -> None:
+        super().setUp()
+        git(self.tmp, "add", "-A")
+        git(self.tmp, "-c", "commit.gpgsign=false", "commit", "-qm", "plane")
+
+    def test_default_owns_the_root_tree(self):
+        """The simplest case must not become the strangest one: `charter init`, then work
+        in your repo, with no extra directory to learn."""
+        self.assertEqual(workspace.own_tree("default"), self.tmp)
+
+    def test_another_workspace_has_no_tree_until_it_is_created(self):
+        self.assertIsNone(workspace.own_tree("feature-a"))
+
+    def test_creating_one_materialises_its_tree(self):
+        self.assertEqual(_create("feature-a"), 0)
+        own = workspace.own_tree("feature-a")
+        self.assertIsNotNone(own)
+        self.assertTrue((own / ".git").exists())
+
+    def test_the_tree_is_on_its_own_branch(self):
+        _create("feature-a")
+        own = workspace.own_tree("feature-a")
+        self.assertEqual(
+            subprocess.run(["git", "-C", str(own), "branch", "--show-current"],
+                           capture_output=True, text=True).stdout.strip(), "feature-a")
+
+    def test_the_branch_can_be_named(self):
+        _create("feature-a", branch="feat/a")
+        own = workspace.own_tree("feature-a")
+        self.assertEqual(
+            subprocess.run(["git", "-C", str(own), "branch", "--show-current"],
+                           capture_output=True, text=True).stdout.strip(), "feat/a")
+
+    def test_two_workspaces_edit_different_files(self):
+        """The whole point, stated as the failure it replaces."""
+        _create("feature-a")
+        _create("feature-b")
+        a, b = workspace.own_tree("feature-a"), workspace.own_tree("feature-b")
+        (a / "code.txt").write_text("v-A\n")
+        (b / "code.txt").write_text("v-B\n")
+        self.assertEqual((a / "code.txt").read_text(), "v-A\n")
+        self.assertEqual((b / "code.txt").read_text(), "v-B\n")
+        self.assertNotEqual(a, b)
+
+    def test_repo_trees_differs_per_workspace(self):
+        """It returned the same root for every workspace, which is what made them all one
+        workspace."""
+        _create("feature-a")
+        self.assertNotEqual(workspace.repo_trees("default"),
+                            workspace.repo_trees("feature-a"))
+
+    def test_a_clone_in_an_embedded_workspace_still_counts(self):
+        """Nothing stops `charter clone` here, and a hybrid — the codebase plus a vendored
+        dependency — is reasonable to have."""
+        from tests.test_statusline_monorepo import init_repo
+        clone = init_repo(config.WORKSPACES_DIR / "default" / "vendored")
+        self.assertIn(clone, workspace.repo_trees("default"))
+        self.assertIn(self.tmp, workspace.repo_trees("default"))
+
+
+class SelectingAWorkspaceWithoutATreeIsRefused(MonorepoIso):
+    def setUp(self) -> None:
+        super().setUp()
+        git(self.tmp, "add", "-A")
+        git(self.tmp, "-c", "commit.gpgsign=false", "commit", "-qm", "plane")
+
+    def test_a_treeless_workspace_is_refused(self):
+        (config.WORKSPACES_DIR / "orphan" / "memory").mkdir(parents=True)
+        rc, err = _use("orphan")
+        self.assertEqual(rc, 1)
+        self.assertIn("no working tree of its own", err)
+
+    def test_the_refusal_says_how_to_fix_it(self):
+        (config.WORKSPACES_DIR / "orphan" / "memory").mkdir(parents=True)
+        _rc, err = _use("orphan")
+        self.assertIn("charter workspace create orphan", err)
+
+    def test_one_with_a_tree_selects_fine(self):
+        _create("feature-a")
+        rc, _ = _use("feature-a")
+        self.assertEqual(rc, 0)
+
+    def test_default_is_always_selectable(self):
+        """It is the always-present workspace; `ensure` creates it on demand. The
+        unknown-name guard refused it in a plane that had never made one — every fresh
+        plane."""
+        rc, err = _use("default")
+        self.assertEqual(rc, 0, err)
+
+
+class TheCwdDecidesTheWorkspace(MonorepoIso):
+    """A workspace's trees live at paths that name the workspace, so being inside one is
+    not a hint — it is the fact, and no pointer can contradict it. That also removes this
+    shape from the pointer-sharing class of bug entirely."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        git(self.tmp, "add", "-A")
+        git(self.tmp, "-c", "commit.gpgsign=false", "commit", "-qm", "plane")
+        _create("feature-a")
+        self.own = workspace.own_tree("feature-a")
+
+    def test_inside_a_workspace_tree_resolves_to_it(self):
+        self.assertEqual(workspace.from_path(self.own), "feature-a")
+
+    def test_deep_inside_resolves_too(self):
+        deep = self.own / "src" / "pkg"
+        deep.mkdir(parents=True)
+        self.assertEqual(workspace.from_path(deep), "feature-a")
+
+    def test_the_plane_root_is_not_a_workspace_tree(self):
+        self.assertIsNone(workspace.from_path(self.tmp))
+
+    def test_it_outranks_a_pointer_that_disagrees(self):
+        """The pointer-sharing bug, made unreachable for this shape: whatever any pointer
+        says, the tree you are standing in wins."""
+        import os
+        workspace.set_active("default", session_id="s1")
+        old = os.getcwd()
+        os.chdir(self.own)
+        try:
+            self.assertEqual(workspace.resolve(session_id="s1"), "feature-a")
+            self.assertEqual(workspace.source(session_id="s1"), "cwd")
+        finally:
+            os.chdir(old)
+
+    def test_an_explicit_flag_still_wins(self):
+        self.assertEqual(workspace.resolve(explicit="other"), "other")
+
+    def test_a_fleet_clone_path_resolves_too(self):
+        """Same rule, other shape: `workspaces/<ws>/<repo>` names its workspace."""
+        d = config.WORKSPACES_DIR / "alpha" / "svc"
+        d.mkdir(parents=True)
+        self.assertEqual(workspace.from_path(d), "alpha")
+
+    def test_the_workspace_container_alone_is_not_a_tree(self):
+        d = config.WORKSPACES_DIR / "alpha"
+        d.mkdir(parents=True)
+        self.assertIsNone(workspace.from_path(d))
+
+
+class FleetIsUnchanged(PersonaIso):
+    def test_own_tree_is_meaningless_in_a_fleet_plane(self):
+        config.PLANE_SHAPE = "fleet"
+        self.assertIsNone(workspace.own_tree("anything"))
+
+    def test_repo_trees_still_returns_root_plus_clones(self):
+        from tests.test_statusline_monorepo import init_repo
+        config.PLANE_SHAPE = "fleet"
+        clone = init_repo(config.WORKSPACES_DIR / "default" / "svc")
+        self.assertEqual(workspace.repo_trees("default"), [clone])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`repo_trees` returned **the same root tree for every workspace**, so `ws use alpha` then `ws use beta` changed the memory namespace and not one file being edited. Two agents in two workspaces edited the same files on the same branch — while charter's central promise is *"never mix workspaces"*. In a shape where the codebase can't be cloned apart, a workspace that materialises nothing isolates nothing.

## The model, now one sentence in both shapes

*A workspace is a set of working trees* — with one repo collapsing the fleet's "set" to exactly one:

| | fleet | embedded |
| --- | --- | --- |
| a workspace's trees | clones, via `charter clone` | a **worktree** of the one repo |
| `default` | its own clones | **the repo itself** |
| creating one | `create` then `clone` | `create` materialises the tree |

```
$ charter workspace create feature-x
✓ Working tree → ../app.worktrees/feature-x/app/feature-x
  enter:  cd ../app.worktrees/feature-x/app/feature-x && claude
  Being in that directory IS this workspace — no pointer needed.
```

Verified end to end — same file, three trees, three branches, three contents:

```
root (default) : v1   (branch main)
feature-a      : v-A  (branch feature-a)
feature-b      : v-B  (branch feature-b)
```

`default` keeps the root deliberately: a solo user's path stays `charter init`, work in your repo. Charter starts materialising trees only when you ask for a *second* concurrent thing — the simplest case must not become the strangest one.

Clones still count in an embedded plane (nothing stops `charter clone`, and a hybrid is reasonable), so the own tree stands where the shared root used to rather than excluding them.

## `use` refuses a treeless workspace

Refused, not warned: this is charter's own command, so it can decline without breaking work, and a warning would leave the default path wrong while becoming wallpaper.

Issue #12 chose *advisory* for the same class of problem, and correctly — there `isolation` is an Agent-tool parameter chosen by the caller, so charter could only advise about something it didn't control. Here it controls it.

## The directory decides the workspace

```
--workspace → $CHARTER_WORKSPACE → the tree you are standing in → session → terminal → default
```

A workspace's trees live at paths that name it, so being inside one isn't a hint — it's the fact. You cannot be in two directories at once, which is exactly the property the pointers lacked this morning, when a session that had never chosen anything inherited another's through a shared terminal key. `source()` reports `cwd`.

## Also

Fixes a regression from the `--create` guard: `ws use default` was refused in any plane whose `workspaces/default/` didn't exist yet — every fresh plane — though it's documented as the always-present workspace.

1233 tests pass (21 new). `docs/control-plane.md` documents the model, which was the thing that wasn't clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4