### PR TITLE
0.18.0 — a workspace is a working tree, in both shapes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.17.0"
+__version__ = "0.18.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.17.0",
+            "command": "charter hook sessionstart --plugin-version 0.18.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.17.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.18.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.17.0",
+            "command": "charter hook pretooluse --plugin-version 0.18.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.17.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.18.0"
           }
         ]
       }
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.17.0",
+            "command": "charter hook posttooluse --plugin-version 0.18.0",
             "timeout": 5
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.17.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.18.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.17.0"
+version = "0.18.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
`0.17.0 → 0.18.0`. Minor: `workspace use` can now refuse, and the directory you're in outranks the workspace pointers.

An embedded plane's workspaces **all resolved to the same root tree**, so `ws use alpha` then `ws use beta` changed the memory namespace and not one file being edited. Two agents in two workspaces edited the same files on the same branch — while charter's central promise is *"never mix workspaces"*.

## What changed

- **A workspace is a set of working trees, in both shapes** — clones in fleet, a worktree of the one repo in embedded. `default` remains the repo itself, so a solo user never learns a second directory.
- **`workspace create` materialises the tree** and prints the path; `--branch` names its branch.
- **`workspace use` refuses** a workspace with no tree of its own, rather than silently putting the session on the same files as every other workspace.
- **The directory decides**: being inside a workspace's tree outranks both the session and terminal pointers (`--workspace` and `$CHARTER_WORKSPACE` still win). You can't be in two directories at once — the property the pointers lacked.

## Fix

`ws use default` was refused in any plane whose `workspaces/default/` didn't exist yet — every fresh plane — a regression from 0.17.0's unknown-name guard.

All four version files move together. 1233 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4