### PR TITLE
session: one answer to "which session is this", and the leak from having three

### DIFF
--- a/charter/persona.py
+++ b/charter/persona.py
@@ -85,7 +85,9 @@ def refs_dir(name: str, shared: bool = False) -> Path:
 
 
 def _session_id(session: str | None = None) -> str:
-    return (session or os.environ.get("CLAUDE_CODE_SESSION_ID") or "nosession").strip() or "nosession"
+    """This session's bucket name — see :mod:`charter.session`, which owns the question."""
+    from . import session as _session
+    return _session.bucket(session)
 
 
 def ephemeral_dir(name: str, shared: bool = False, session: str | None = None) -> Path:
@@ -748,11 +750,18 @@ def gc_ephemeral(current: str | None = None, max_age_hours: float = 6.0) -> int:
     root = config.PERSONA_STATE_DIR / "ephemeral"
     if not root.exists():
         return 0
-    cur = _session_id(current)
+    # `current()`, not `_session_id()`. The latter falls back to the shared NO_SESSION
+    # bucket, so when the GC itself ran without a session id — which is most of the time,
+    # since it runs from a hook — that bucket compared equal to "the live session" and was
+    # skipped every single time. Ephemeral scratch from every id-less session accumulated
+    # there forever, which is the opposite of ephemeral. There is nothing to preserve when
+    # there is no current session, so nothing is exempt.
+    from . import session as _session
+    cur = _session.current(current)
     now = time.time()
     removed = 0
     for sd in root.iterdir():
-        if not sd.is_dir() or sd.name == cur:
+        if not sd.is_dir() or (cur is not None and sd.name == cur):
             continue
         try:
             newest = max([sd.stat().st_mtime] + [p.stat().st_mtime for p in sd.rglob("*")])

--- a/charter/session.py
+++ b/charter/session.py
@@ -1,0 +1,51 @@
+"""Who "this session" is — one answer, for everything that keys state by it.
+
+There were three implementations of this, and they disagreed about the case that matters:
+what absence means. `workspace._session_id` returned ``None``; `persona._session_id`
+returned the string ``"nosession"``. That sentinel is a *shared key*, so every invocation
+without a session id wrote into one bucket — and `persona.gc_ephemeral` compared it
+against the id of the session it was told to preserve, so when the GC itself ran without
+one, ``nosession`` looked like the live session and was skipped. It accumulated forever,
+which is the opposite of what "ephemeral" promises.
+
+Absence is now representable: :func:`current` returns ``None`` and callers decide. The
+sentinel survives only as :data:`NO_SESSION`, for the one place that genuinely needs a
+directory name, and the GC no longer protects it.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+#: Bucket name for state written with no session to attribute it to. A shared key by
+#: construction, so it is prunable like any other stale bucket and never treated as live.
+NO_SESSION = "nosession"
+
+_SAFE = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def current(explicit: str | None = None) -> str | None:
+    """This Claude session's id, or ``None`` when there is not one.
+
+    ``explicit`` first — the status line receives the id in its stdin payload rather than
+    its environment, which Claude Code scrubs. Then ``$CLAUDE_CODE_SESSION_ID``, which is
+    present for Bash-tool commands and hooks.
+
+    Sanitised, because the value becomes a filename.
+    """
+    raw = explicit or os.environ.get("CLAUDE_CODE_SESSION_ID")
+    if not raw:
+        return None
+    sid = _SAFE.sub("", raw.strip())
+    return sid or None
+
+
+def bucket(explicit: str | None = None) -> str:
+    """A directory name for this session's state — :data:`NO_SESSION` when there is none.
+
+    Use this only where a name is unavoidable. Prefer :func:`current` and handling
+    ``None``: a shared bucket mixes two concurrent sessions' scratch, which is the failure
+    the per-session split exists to prevent.
+    """
+    return current(explicit) or NO_SESSION

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -48,13 +48,9 @@ def _ensure_layout() -> None:
 
 
 def _session_id(explicit: str | None = None) -> str | None:
-    """The current Claude session id: an explicit one (e.g. from the status-line
-    payload) or ``$CLAUDE_CODE_SESSION_ID`` (present for Bash tool commands)."""
-    sid = explicit or os.environ.get("CLAUDE_CODE_SESSION_ID")
-    if not sid:
-        return None
-    sid = re.sub(r"[^A-Za-z0-9._-]", "", sid.strip())
-    return sid or None
+    """This session's id, or ``None`` — see :mod:`charter.session`, which owns it."""
+    from . import session as _session
+    return _session.current(explicit)
 
 
 def _session_file(sid: str) -> Path:

--- a/docs/audits/2026-08-10-user-experience.md
+++ b/docs/audits/2026-08-10-user-experience.md
@@ -32,7 +32,8 @@ the thing that otherwise gets re-proposed every six months.
 | 3.1 a second committer pushing over SSH | fixed — `charter/planegit.py` is the one committer |
 | (not in the audit) two sessions in one window shared a workspace | fixed — `WINDOWID` is not a pane id |
 | 3.4 no timeout on `util.run`; doctor printed nothing on a stall | fixed — `ProcTimeout`, per-check budgets, streamed results |
-| everything else | open |
+| 3.5 three `_session_id`s; the shared bucket never collected | fixed — `charter/session.py`; GC no longer protects it |
+| everything else | open (3.2 guards.py, 3.3 config derive seam) |
 
 Numbers in sections 2 and 3 that were not adversarially re-checked are flagged in
 "Evidence caveats" at the end. Two of the report's own claims are discounted there.

--- a/tests/test_session_identity.py
+++ b/tests/test_session_identity.py
@@ -1,0 +1,98 @@
+"""One answer to "which session is this", and the leak that came from having three.
+
+`workspace._session_id` returned ``None`` when there was no session; `persona._session_id`
+returned the string ``"nosession"``. That sentinel is a SHARED KEY, and
+`persona.gc_ephemeral` compared it against the id of the session it was told to preserve —
+so when the GC itself ran without one, which is most of the time since it runs from a
+hook, ``nosession`` compared equal to "the live session" and was skipped on every pass.
+Ephemeral scratch from every id-less session accumulated there forever, which is the
+opposite of what "ephemeral" promises.
+"""
+from __future__ import annotations
+
+import os
+import time
+import unittest
+from unittest import mock
+
+from charter import config, persona, session, workspace
+from tests._isolation import PersonaIso
+
+
+class AbsenceIsRepresentable(unittest.TestCase):
+    def test_current_is_none_when_there_is_no_session(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(session.current())
+
+    def test_current_reads_the_environment(self):
+        with mock.patch.dict(os.environ, {"CLAUDE_CODE_SESSION_ID": "abc-123"}):
+            self.assertEqual(session.current(), "abc-123")
+
+    def test_an_explicit_id_wins(self):
+        """The status line receives the id in its stdin payload — Claude Code scrubs its
+        environment."""
+        with mock.patch.dict(os.environ, {"CLAUDE_CODE_SESSION_ID": "env"}):
+            self.assertEqual(session.current("explicit"), "explicit")
+
+    def test_the_id_is_sanitised_because_it_becomes_a_filename(self):
+        self.assertEqual(session.current("../../etc/passwd"), "....etcpasswd")
+
+    def test_bucket_falls_back_to_the_shared_name(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(session.bucket(), session.NO_SESSION)
+
+    def test_both_readers_now_agree(self):
+        """They disagreed about the case that matters — what absence means."""
+        with mock.patch.dict(os.environ, {"CLAUDE_CODE_SESSION_ID": "s-1"}):
+            self.assertEqual(workspace._session_id(), "s-1")
+            self.assertEqual(persona._session_id(), "s-1")
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(workspace._session_id())
+            self.assertEqual(persona._session_id(), session.NO_SESSION)
+
+
+class TheSharedBucketIsCollectable(PersonaIso):
+    """The leak. `gc_ephemeral` must never treat the shared bucket as the live session."""
+
+    def _bucket(self, name: str, age_hours: float = 0.0):
+        d = config.PERSONA_STATE_DIR / "ephemeral" / name / "p"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "note.md").write_text("scratch")
+        if age_hours:
+            when = time.time() - age_hours * 3600
+            for p in (config.PERSONA_STATE_DIR / "ephemeral" / name).rglob("*"):
+                os.utime(p, (when, when))
+            os.utime(config.PERSONA_STATE_DIR / "ephemeral" / name, (when, when))
+        return d
+
+    def _names(self):
+        root = config.PERSONA_STATE_DIR / "ephemeral"
+        return sorted(p.name for p in root.iterdir()) if root.exists() else []
+
+    def test_a_stale_shared_bucket_is_pruned_when_there_is_no_current_session(self):
+        """The exact case that never fired: the GC runs from a hook, usually with no id."""
+        self._bucket(session.NO_SESSION, age_hours=24)
+        self.assertEqual(persona.gc_ephemeral(current=None), 1)
+        self.assertNotIn(session.NO_SESSION, self._names())
+
+    def test_a_recently_touched_bucket_survives_on_AGE_not_on_being_current(self):
+        """Age is the guard when there is no session to preserve — concurrent live
+        sessions are still never clobbered."""
+        self._bucket(session.NO_SESSION, age_hours=0)
+        persona.gc_ephemeral(current=None)
+        self.assertIn(session.NO_SESSION, self._names())
+
+    def test_the_current_session_is_still_exempt(self):
+        self._bucket("live-1", age_hours=24)
+        persona.gc_ephemeral(current="live-1")
+        self.assertIn("live-1", self._names())
+
+    def test_other_stale_sessions_are_still_pruned(self):
+        self._bucket("old-1", age_hours=24)
+        self._bucket("live-1", age_hours=0)
+        persona.gc_ephemeral(current="live-1")
+        self.assertEqual(self._names(), ["live-1"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Audit 3.5.

`workspace._session_id` returned `None` when there was no session; `persona._session_id` returned the string `"nosession"`. They disagreed about the only case that matters — what absence means — and that sentinel is a **shared key**.

## The leak

`gc_ephemeral` compared the sentinel against the id of the session it was told to preserve. When the GC itself ran without one — which is most of the time, since it runs from the SessionStart hook — `"nosession"` compared equal to *"the live session"* and was skipped on every pass. Ephemeral scratch from every id-less invocation accumulated there forever.

Reproduced, then fixed:

```
before: ['live-abc', 'nosession', 'old-xyz']
gc_ephemeral(current=None) → 2 removed
after : ['live-abc']
```

## The fix

`charter/session.py` owns the question. `current()` returns `None` when there is no session, so absence is representable and callers decide; `bucket()` keeps the sentinel for the one place that genuinely needs a directory name. The GC uses `current()` and exempts **nothing** when there is no current session — age is the guard there, so concurrent live sessions are still never clobbered.

Both readers delegate, so they can't drift again.

## Deliberately not addressed

Two id-less sessions still share the bucket. The alternative is refusing ephemeral memory outside Claude Code, which breaks using charter from a plain shell to prevent a failure that needs two concurrent id-less sessions to bite.

`hooks.py` also has four hand-rolled per-session counters with two different sanitisation policies — real duplication, but no bug attached, so it isn't smuggled into this change.

1248 tests pass (10 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4