### PR TITLE
0.19.0 — the structural round

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.18.0",
+            "command": "charter hook sessionstart --plugin-version 0.19.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.18.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.19.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.18.0",
+            "command": "charter hook pretooluse --plugin-version 0.19.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.18.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.19.0"
           }
         ]
       }
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.18.0",
+            "command": "charter hook posttooluse --plugin-version 0.19.0",
             "timeout": 5
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.18.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.19.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.18.0"
+version = "0.19.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
`0.18.0 → 0.19.0`. Minor: `util.run` grows a `timeout`, `doctor` streams, and ephemeral scratch that never got collected now does.

- **`util.run` takes `timeout=`** and raises `util.ProcTimeout` — a *charter* error rather than `subprocess.TimeoutExpired`. `cli.main` caught only `KeyboardInterrupt`, so a timeout reached the user as a traceback from inside charter instead of as "the tool I called didn't answer". Six call sites had been bypassing `util.run` entirely just to pass their own literal; everything else could hang indefinitely.
- **`charter doctor` prints each check as it lands.** It collected them all first, so a preflight killed by its 20s SessionStart budget emitted **nothing** — not even the checks that had passed — and a hang looked exactly like a crash. The two checks that reach outside (forge auth, vault health) get a 5s budget, and a timed-out vault is reported as its own state rather than an unhealthy one.
- **Ephemeral persona scratch is collected again.** Two `_session_id` implementations disagreed about what absence means; the `"nosession"` sentinel is a shared key, and the GC compared it against the session it was told to preserve — so when the GC itself ran without an id (most of the time, since it runs from a hook) that bucket looked like the live session and was skipped forever. `charter/session.py` owns the question now.
- **`config.py` has one definition** of what follows from the plane root. The test harness re-implemented all twenty-five derivations by hand, and four were missing — which is how the suite once orphaned a contributor's vaults.

No user-facing surface changes. The visible differences are a preflight that says where it stopped, and errors instead of tracebacks.

All four version files move together. 1248 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkxb3oioeN8BSozaU8kQb4