### PR TITLE
report: charter's users can report charter's bugs, without leaving the session

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -9,6 +9,7 @@ from . import (
     __version__,
     commands,
     commands_persona,
+    commands_report,
     commands_secrets,
     commands_workspace,
     commands_worktree,
@@ -188,8 +189,24 @@ def build_parser() -> argparse.ArgumentParser:
     _add_vault_parser(sub)
     _add_secret_parser(sub)
     _add_persona_parser(sub)
+    _add_report_parser(sub)
 
     return p
+
+
+def _add_report_parser(sub) -> None:
+    r = sub.add_parser("report",
+                       help="Report a charter bug or missing capability upstream (drafts "
+                            "locally; nothing is published without a second command).")
+    rsub = r.add_subparsers(dest="report_cmd", required=True)
+
+    bug = rsub.add_parser("bug", help="Charter did something wrong.")
+    bug.add_argument("text", help="What went wrong, in your own words.")
+    bug.set_defaults(func=commands_report.cmd_report_bug)
+
+    gap = rsub.add_parser("gap", help="Charter cannot do something it should.")
+    gap.add_argument("text", help="What is missing, in your own words.")
+    gap.set_defaults(func=commands_report.cmd_report_gap)
 
 
 def _add_workspace_parser(sub) -> None:
@@ -710,6 +727,26 @@ def _split_exec_command(argv: list[str]) -> tuple[list[str], list[str] | None]:
     return argv, None
 
 
+def _record_crash(exc: BaseException, subcommand: str) -> None:
+    """Draft a report for a crash, locally. Never raises.
+
+    Wrapped defensively because a bug in the bug reporter is the worst possible thing to
+    surface in place of the real error: whatever happens here, the caller re-raises the
+    original exception and the developer still sees what actually broke.
+
+    Nothing is published. This only writes to the Reporter's own disk, which is what lets
+    detection default to on without charter reading as telemetry (docs/adr/0003).
+    """
+    try:
+        from . import report
+        rid = report.record_bug(exc, subcommand)
+        if rid:
+            util.err(f"↳ this is a charter bug, drafted locally as {rid} — nothing sent. "
+                     f"Review and report it: charter report --help")
+    except Exception:  # noqa: BLE001 - see the docstring; this must never win over `exc`
+        pass
+
+
 def main(argv=None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     argv = _hoist_persona_memory(argv)
@@ -728,3 +765,12 @@ def main(argv=None) -> int:
         # called failing to answer.
         util.err(str(e))
         return 1
+    except Exception as e:
+        # Anything reaching here IS a charter bug — the two clauses above are exactly the
+        # conditions, and that distinction predates this feature. charter is the only thing
+        # that reliably observes its own crash (no hook does: PostToolUse matches only
+        # Write|Edit|MultiEdit and Task|Agent, and PreToolUse runs *before* the command),
+        # and it already holds the exception, the subcommand and the version that a hook
+        # would have to reconstruct from a string.
+        _record_crash(e, argv[0] if argv else "?")
+        raise  # Recording is not handling. The developer still gets their traceback.

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -208,6 +208,37 @@ def _add_report_parser(sub) -> None:
     gap.add_argument("text", help="What is missing, in your own words.")
     gap.set_defaults(func=commands_report.cmd_report_gap)
 
+    ls = rsub.add_parser("list", help="Reports drafted on this machine, and what was sent.")
+    ls.set_defaults(func=commands_report.cmd_report_list)
+
+    sh = rsub.add_parser("show", help="Print one report exactly as it would be published.")
+    sh.add_argument("id")
+    sh.set_defaults(func=commands_report.cmd_report_show)
+
+    # Its own command, not a flag on `send`: a flag an agent can pass is a flag it will
+    # pass every time, where a one-off command has a single auditable purpose (ADR 0003).
+    cs = rsub.add_parser("consent",
+                         help="Agree, once, that reports may be published under your own "
+                              "GitHub identity. Nothing sends until you do.")
+    cs.set_defaults(func=commands_report.cmd_report_consent)
+
+    sd = rsub.add_parser("send",
+                         help="Publish a drafted report. THIS is the approval step — the "
+                              "only reporting command that touches the network.")
+    sd.add_argument("id")
+    sd.add_argument("--new", action="store_true",
+                    help="File even though charter found a possible duplicate.")
+    sd.add_argument("--dry-run", action="store_true",
+                    help="Show exactly what would be published, and send nothing.")
+    sd.set_defaults(func=commands_report.cmd_report_send)
+
+    cm = rsub.add_parser("comment",
+                         help="Add your details to an existing upstream issue — the right "
+                              "answer to a duplicate, since it keeps your reproduction.")
+    cm.add_argument("id")
+    cm.add_argument("--on", required=True, help="Upstream issue number to comment on.")
+    cm.set_defaults(func=commands_report.cmd_report_comment)
+
 
 def _add_workspace_parser(sub) -> None:
     w = sub.add_parser("workspace", aliases=["ws"],
@@ -727,6 +758,38 @@ def _split_exec_command(argv: list[str]) -> tuple[list[str], list[str] | None]:
     return argv, None
 
 
+def _subcommand_names(parser: argparse.ArgumentParser) -> set[str]:
+    """Every top-level subcommand the parser accepts.
+
+    Reads the subparsers action directly. ``_SubParsersAction`` is nominally private but
+    has been stable for the life of argparse, and the alternative — keeping a hand-written
+    list of command names in sync with :func:`build_parser` — is the kind of duplication
+    that goes wrong silently.
+    """
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return set(action.choices)
+    return set()
+
+
+def _hint_gap_if_unknown_command(parser: argparse.ArgumentParser, argv: list[str]) -> None:
+    """Offer gap reporting when someone reached for a command charter does not have.
+
+    This is the *only* mechanical signal charter gets that a capability is missing. The
+    reporting feature is advertised on failure and nowhere else — which costs no prompt
+    budget and is perfectly targeted — but a gap prints nothing on its own, so without this
+    it would have no delivery mechanism at all.
+
+    Narrow on purpose. A bad flag or a missing argument is a typo, not a missing
+    capability, and offering to open an upstream issue every time someone mistypes would
+    turn the prompt into noise — which is how a feature like this gets switched off.
+    """
+    if not argv or argv[0].startswith("-") or argv[0] in _subcommand_names(parser):
+        return
+    util.err(f"↳ charter has no `{argv[0]}` command. If that is something charter should "
+             f'do, say so: charter report gap "<what you were trying to do>"')
+
+
 def _record_crash(exc: BaseException, subcommand: str) -> None:
     """Draft a report for a crash, locally. Never raises.
 
@@ -740,9 +803,16 @@ def _record_crash(exc: BaseException, subcommand: str) -> None:
     try:
         from . import report
         rid = report.record_bug(exc, subcommand)
-        if rid:
+        if not rid:
+            return
+        rec = report.load(rid) or {}
+        if rec.get("issue_url"):
+            # Already filed from this machine. Pointing at the existing issue is the whole
+            # reason a sent report is kept rather than deleted — local dedupe, no API call.
+            util.err(f"↳ this is a charter bug you already reported → {rec['issue_url']}")
+        else:
             util.err(f"↳ this is a charter bug, drafted locally as {rid} — nothing sent. "
-                     f"Review and report it: charter report --help")
+                     f"Review it: charter report show {rid}")
     except Exception:  # noqa: BLE001 - see the docstring; this must never win over `exc`
         pass
 
@@ -751,7 +821,14 @@ def main(argv=None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     argv = _hoist_persona_memory(argv)
     argv, exec_command = _split_exec_command(argv)
-    args = build_parser().parse_args(argv)
+    parser = build_parser()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit:
+        # `parse_args` exits from inside itself, above the crash handler below — so the
+        # gap signal needs catching here rather than a third `except` down there.
+        _hint_gap_if_unknown_command(parser, argv)
+        raise
     if exec_command is not None:
         args.command = exec_command
     try:

--- a/charter/commands_report.py
+++ b/charter/commands_report.py
@@ -11,7 +11,7 @@ approval could not be a y/n prompt; it is a second command instead.
 
 from __future__ import annotations
 
-from . import report, util
+from . import __version__, report, util
 
 
 def _draft(kind: str, text: str) -> int:
@@ -46,3 +46,162 @@ def cmd_report_bug(args) -> int:
 def cmd_report_gap(args) -> int:
     """Draft a **gap** — charter cannot do something it should."""
     return _draft("gap", getattr(args, "text", None))
+
+
+def cmd_report_consent(args) -> int:
+    """Record, once, that this human agrees to publish under their own GitHub identity.
+
+    Its own command rather than a flag on `send`: ADR 0003 rejects flags that collapse
+    approval into the sending call, because a flag an agent can pass is a flag it will
+    pass every time. A one-off command has a single, auditable purpose.
+    """
+    report.grant_consent()
+    util.ok(f"Consent recorded → {report.consent_path()}")
+    util.info("`charter report send` may now open issues on "
+              f"{report.upstream_repo()} as you. Delete that file to withdraw.")
+    return 0
+
+
+def cmd_report_send(args) -> int:
+    """Publish a drafted report. **This is the consent step** — the only command here
+    that touches the network."""
+    rid = getattr(args, "id", None)
+    rec = report.load(rid) if rid else None
+    if not rec:
+        util.err(f"no drafted report '{rid}'. List them: charter report list")
+        return 1
+
+    if rec.get("issue_url"):
+        util.info(f"Already reported → {rec['issue_url']}")
+        return 0
+
+    if not report.has_consent():
+        util.err("publishing sends this to a PUBLIC tracker under your own GitHub "
+                 "identity, and that has not been agreed yet.")
+        util.info("Read the draft first:  charter report show " + rid)
+        util.info("Then agree once with:  charter report consent")
+        return 1
+
+    _warn_if_stale()
+
+    # Before any network call, deliberately. A dry run is the offline affordance — it is
+    # how this feature was developed without spamming a real tracker — so it must not
+    # depend on `gh`, and a duplicate must not short-circuit it before it has shown the
+    # Reporter the payload they asked to see.
+    if getattr(args, "dry_run", False):
+        util.ok("dry run — nothing sent, no network touched. This would open:")
+        print(f"  {report.upstream_repo()}: {report.title(rec)}")
+        print(report.issue_body(rec))
+        return 0
+
+    try:
+        if not report.gh_available():
+            # Not an error: a GitLab-only Reporter has no `gh` identity, and a broken or
+            # rate-limited `gh` should never lose the report either.
+            util.warn("no usable `gh` — open this prefilled issue instead:")
+            print(report.fallback_url(rec))
+            return 0
+
+        if not getattr(args, "new", False):
+            dups = report.search_duplicates(rec)
+            if dups:
+                return _report_duplicates(dups, rid)
+
+        url = report.create_issue(rec)
+    except report.ReportingError as e:
+        # Loud, never swallowed: a silent failure here means the Reporter believes they
+        # reported something they did not (docs/adr/0002).
+        util.err(f"could not open the issue: {e}")
+        util.info("Your draft is safe. Retry, or use: charter report send "
+                  f"{rid} --dry-run to see exactly what it would send.")
+        return 1
+
+    report.mark_sent(rid, url)
+    util.ok(f"Reported → {url}")
+    return 0
+
+
+def cmd_report_list(args) -> int:
+    """Every report on this machine — drafts awaiting approval, and what was already sent."""
+    recs = report.all_reports()
+    if not recs:
+        util.info("No reports drafted. charter records one automatically when it crashes; "
+                  "describe one yourself with: charter report bug|gap \"<what>\"")
+        return 0
+    for r in recs:
+        state = r["issue_url"] if r.get("issue_url") else "not sent"
+        hits = f" ×{r['occurrences']}" if r.get("occurrences", 1) > 1 else ""
+        print(f"  {r['id']}  {r.get('kind', '?'):4}{hits:5}  {report.title(r)}\n      {state}")
+    return 0
+
+
+def cmd_report_show(args) -> int:
+    """Print one report exactly as it would be published."""
+    rec = report.load(getattr(args, "id", None))
+    if not rec:
+        util.err(f"no report '{getattr(args, 'id', None)}'. List them: charter report list")
+        return 1
+    print(report.render(rec))
+    if rec.get("issue_url"):
+        util.info(f"Already reported → {rec['issue_url']}")
+    else:
+        util.info(f"Not sent. Send it with: charter report send {rec['id']}")
+    return 0
+
+
+def cmd_report_comment(args) -> int:
+    """Add this Reporter's details to an existing upstream issue.
+
+    The default answer to a confirmed duplicate: a repeat carries a second environment
+    where the problem reproduces, which is the most useful thing about it — dropping it
+    silently is the one outcome that wastes it.
+    """
+    rid = getattr(args, "id", None)
+    rec = report.load(rid) if rid else None
+    if not rec:
+        util.err(f"no drafted report '{rid}'. List them: charter report list")
+        return 1
+    if not report.has_consent():
+        util.err("commenting publishes under your own GitHub identity, which has not "
+                 "been agreed yet. Agree once with: charter report consent")
+        return 1
+
+    issue = str(getattr(args, "on", "") or "").lstrip("#")
+    try:
+        report.comment_on(issue, rec)
+    except report.ReportingError as e:
+        util.err(f"could not comment on #{issue}: {e}")
+        return 1
+
+    url = f"https://github.com/{report.upstream_repo()}/issues/{issue}"
+    report.mark_sent(rid, url)
+    util.ok(f"Added your details to → {url}")
+    return 0
+
+
+def _report_duplicates(dups: list[dict], rid: str) -> int:
+    """Stop and hand the candidates to whoever can judge them.
+
+    Not a verdict: a keyword score cannot tell "clone fails on a private repo" from
+    "clone fails on a submodule". And not a silent drop — a duplicate carries a second
+    environment where the bug reproduces, which is the most useful thing about it.
+    """
+    util.warn("this may already be reported:")
+    for d in dups:
+        print(f"  #{d.get('number')}  {d.get('title')}\n      {d.get('url')}")
+    util.info(f"Add your details to one:  charter report comment {rid} --on <number>")
+    util.info(f"Or file anyway:           charter report send {rid} --new")
+    return 2
+
+
+def _warn_if_stale() -> None:
+    """Warn, never block. A bug that survives on an old charter is still worth having, and
+    "upgrade first, then report" is a reliable way to never get the report at all."""
+    try:
+        from . import update
+        latest = update.newer_than(__version__)
+        if latest:
+            util.warn(f"you are on charter {__version__}; {latest} is out — this may "
+                      "already be fixed. Reporting anyway is fine.")
+    except Exception:  # noqa: BLE001 - a staleness check must never block a report
+        pass

--- a/charter/commands_report.py
+++ b/charter/commands_report.py
@@ -1,0 +1,48 @@
+"""`charter report` — handlers for drafting a report about charter itself.
+
+Two commands, because the second one **is** the consent (docs/adr/0003). These are the
+first: they draft, scrub, store and *show*. Nothing here touches the network — that is
+what lets detection default to on without charter reading as telemetry.
+
+charter has no interactive prompt anywhere (`util.py` carries only info/ok/warn/err),
+because it runs inside hooks and agent sessions where blocking on stdin would hang. So
+approval could not be a y/n prompt; it is a second command instead.
+"""
+
+from __future__ import annotations
+
+from . import report, util
+
+
+def _draft(kind: str, text: str) -> int:
+    if not (text or "").strip():
+        util.err(f"nothing to report — describe the {kind}: charter report {kind} \"<what>\"")
+        return 1
+
+    rid = report.record_described(kind, text)
+    if rid is None:
+        util.err(f"too many undrafted reports ({report.MAX_PENDING}); send or discard some first.")
+        return 1
+
+    rec = report.load(rid)
+    # To stdout, and in full: the Reporter is being asked to approve this exact text, and
+    # approving something they were never shown would make the approval meaningless.
+    print(report.render(rec))
+    print()
+    print(f"id: {rid}")
+
+    util.info("Nothing has been sent. Read the text above — it is exactly what would be "
+              "published, on a PUBLIC tracker, under your own GitHub identity.")
+    util.info(f"Send it with: charter report send {rid}")
+    return 0
+
+
+def cmd_report_bug(args) -> int:
+    """Draft a **bug** the Reporter describes by hand. The automatic path (a real crash,
+    with a traceback) records itself; this is for "it did the wrong thing"."""
+    return _draft("bug", getattr(args, "text", None))
+
+
+def cmd_report_gap(args) -> int:
+    """Draft a **gap** — charter cannot do something it should."""
+    return _draft("gap", getattr(args, "text", None))

--- a/charter/config.py
+++ b/charter/config.py
@@ -294,6 +294,12 @@ def derive(root: Path) -> dict:
     #: ``$CHARTER_PERSONA`` and by a command's ``--persona``. Gitignored (in STATE_DIR).
     d["ACTIVE_PERSONA_FILE"] = state / "active-persona"
 
+    #: Drafted upstream **reports** — charter's own bugs and gaps, awaiting the Reporter's
+    #: approval before anything is published (see charter/report.py, docs/adr/0003).
+    #: Under STATE_DIR because it is per-developer and gitignored: a draft may quote an
+    #: exception message that has not been redacted yet, so it must never be committable.
+    d["REPORTS_DIR"] = state / "reports"
+
     return d
 
 

--- a/charter/report.py
+++ b/charter/report.py
@@ -23,17 +23,24 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import platform
 import re
+import time
 import traceback
 from pathlib import Path
 
-from . import __version__, config
+from . import __version__, config, util
 
 #: Ceiling on **distinct** pending reports. A broken config makes every invocation fail,
 #: and a Reporter who walks away should not return to a full disk. Repeats of a report
 #: already on disk are unaffected — they collapse onto it, which is the whole point.
 MAX_PENDING = 25
+
+#: How long an **unsent** draft survives. A report nobody approved in a month is one
+#: nobody is going to; sent reports are never aged out, since they are what a later
+#: identical crash points at.
+MAX_DRAFT_AGE_DAYS = 30
 
 #: The installed charter package. A frame is ours if it lives under here — resolved, so a
 #: symlinked install (``uv tool install`` makes several) still matches its own frames.
@@ -214,10 +221,33 @@ def pending() -> list[dict]:
     return [r for r in _all() if not r.get("issue_url")]
 
 
+def all_reports() -> list[dict]:
+    """Every report on this machine, sent or not."""
+    return _all()
+
+
 def _write(rec: dict) -> str:
     config.REPORTS_DIR.mkdir(parents=True, exist_ok=True)
     _path(rec["id"]).write_text(json.dumps(rec, indent=2))
     return rec["id"]
+
+
+def prune() -> int:
+    """Drop unsent drafts older than :data:`MAX_DRAFT_AGE_DAYS`. Returns how many went.
+
+    Only *unsent* ones: a sent report is kept forever, because it is what lets a later
+    identical crash point at the existing upstream issue.
+
+    Runs on write rather than from a hook, so it works on a CLI-only install with no
+    plugin — the same reason crash detection lives in `cli.main` rather than in a hook.
+    """
+    cutoff = time.time() - (MAX_DRAFT_AGE_DAYS * 86400)
+    gone = 0
+    for r in pending():
+        if r.get("first_seen", 0) < cutoff:
+            _path(r["id"]).unlink(missing_ok=True)
+            gone += 1
+    return gone
 
 
 def _record(rid: str, kind: str, payload: dict) -> str | None:
@@ -229,18 +259,24 @@ def _record(rid: str, kind: str, payload: dict) -> str | None:
     existing = load(rid)
     if existing:
         existing["occurrences"] = existing.get("occurrences", 1) + 1
+        existing["last_seen"] = time.time()
         return _write(existing)
+
+    prune()
 
     # Checked only for a genuinely new report, so a crash loop sitting at the cap keeps
     # counting the very bug that is looping.
     if len(pending()) >= MAX_PENDING:
         return None
 
+    now = time.time()
     return _write({
         "id": rid,
         "kind": kind,
         "payload": payload,
         "occurrences": 1,
+        "first_seen": now,
+        "last_seen": now,
         "issue_url": None,
     })
 
@@ -301,6 +337,139 @@ def render(rec: dict) -> str:
         f"charter {p.get('charter_version')} · Python {p.get('python_version')} "
         f"· {p.get('os')}")
     return "\n".join(lines)
+
+
+# --- consent ------------------------------------------------------------------------
+
+class ReportingError(RuntimeError):
+    """A reporting operation failed in a way the Reporter must be told about.
+
+    Deliberately loud. The forge adapter's ``_api`` is documented as best-effort and
+    returns None on any failure so the status line can never crash — correct there, and
+    catastrophic here: applied to publishing, "swallow it and return None" means the
+    Reporter's report vanishes while they are told it worked (docs/adr/0002).
+    """
+
+
+def consent_path() -> Path:
+    """Where consent-to-publish is remembered — under the **human's** config home.
+
+    Not STATE_DIR: that is per control plane, so a Reporter with several planes would be
+    asked repeatedly until the safeguard became a reflex. Not charter.toml: that is
+    committed, and would enrol a whole team on one person's say-so (docs/adr/0003).
+
+    ``$CHARTER_CONFIG_HOME`` overrides it. That exists rather than relying on
+    ``$XDG_CONFIG_HOME`` alone for a concrete reason: **`gh` keeps its own auth under
+    XDG_CONFIG_HOME**, so anything redirecting that variable to isolate charter's consent
+    also logs `gh` out — which silently turns a publish into the no-`gh` fallback path.
+    """
+    base = (os.environ.get("CHARTER_CONFIG_HOME")
+            or os.environ.get("XDG_CONFIG_HOME")
+            or (Path.home() / ".config"))
+    return Path(base) / "charter" / "reporting-consent"
+
+
+def has_consent() -> bool:
+    return consent_path().exists()
+
+
+def grant_consent() -> None:
+    p = consent_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        "The Reporter agreed that `charter report send` may open issues on the upstream "
+        "tracker under their own GitHub identity. Delete this file to withdraw.\n")
+
+
+# --- the forge ----------------------------------------------------------------------
+# The ONLY network boundary in reporting, and the only place charter writes to a forge.
+# Concentrated into one function on purpose: it is the single seam tests stub, which is
+# what lets the whole feature be developed and verified without touching a real tracker.
+
+#: Where reports go. Configuration rather than a constant so a fork can point its users at
+#: its own tracker, and an internal deployment can keep reports off a public one.
+DEFAULT_UPSTREAM = "diazoxide/charter"
+
+
+def upstream_repo() -> str:
+    return os.environ.get("CHARTER_UPSTREAM_REPO") or DEFAULT_UPSTREAM
+
+
+def gh(args: list[str]) -> str:
+    """Run one `gh` command and return its stdout. Raises :class:`ReportingError`.
+
+    A flat call rather than a `Forge` method (docs/adr/0002): reporting always targets one
+    specific repo on github.com, so it is not polymorphic over the Reporter's forges, and
+    putting ``create_issue`` on that protocol would imply a GitLab implementation nobody
+    will ever need.
+    """
+    p = util.run(["gh", *args], check=False)
+    if p.returncode != 0:
+        raise ReportingError((p.stderr or p.stdout or "gh failed").strip())
+    return (p.stdout or "").strip()
+
+
+def gh_available() -> bool:
+    """Whether this Reporter can publish directly. False for a GitLab-only Reporter, and
+    whenever `gh` is missing, logged out, or rate-limited — all of which fall back to the
+    prefilled URL rather than losing the report."""
+    p = util.run(["gh", "auth", "status"], check=False)
+    return p.returncode == 0
+
+
+def title(rec: dict) -> str:
+    """The upstream issue title. Crashes lead with exception type and subcommand so
+    duplicates collide visually in the issue list."""
+    p = rec["payload"]
+    if p.get("exception_type"):
+        return f"{p['exception_type']} in `charter {p.get('subcommand', '?')}`"
+    first = (p.get("text") or "").strip().splitlines()[0]
+    return first[:72] + ("…" if len(first) > 72 else "")
+
+
+def search_duplicates(rec: dict) -> list[dict]:
+    """Candidate upstream issues that may already cover *rec*.
+
+    Returns candidates for a human or the reporting agent to **judge** — deliberately not
+    a verdict. A keyword score cannot separate "clone fails on a private repo" from "clone
+    fails on a submodule", which is a distinction that needs the issue read.
+    """
+    out = gh(["issue", "list", "--repo", upstream_repo(), "--search", title(rec),
+              "--state", "all", "--limit", "5", "--json", "number,title,url"])
+    try:
+        return json.loads(out) if out else []
+    except ValueError:
+        return []
+
+
+def issue_body(rec: dict) -> str:
+    return render(rec)
+
+
+def create_issue(rec: dict) -> str:
+    """Open the upstream issue and return its URL."""
+    return gh(["issue", "create", "--repo", upstream_repo(),
+               "--title", title(rec), "--body", issue_body(rec),
+               "--label", "via-charter-report", "--label", rec.get("kind", "bug")])
+
+
+def comment_on(issue: str, rec: dict) -> str:
+    """Add this Reporter's reproduction to an existing upstream issue.
+
+    The default on a confirmed duplicate: silently dropping a repeat throws away the most
+    valuable thing it carries — a second environment where the bug reproduces.
+    """
+    return gh(["issue", "comment", issue, "--repo", upstream_repo(), "--body", issue_body(rec)])
+
+
+def fallback_url(rec: dict) -> str:
+    """A prefilled `issues/new` link, for a Reporter with no usable `gh`.
+
+    charter supports GitLab forges, so "no GitHub identity" is a real population rather
+    than an edge case — and this doubles as the escape hatch when `gh` is broken.
+    """
+    return (f"https://github.com/{upstream_repo()}/issues/new"
+            f"?title={util.urlenc(title(rec))}&body={util.urlenc(issue_body(rec))}")
 
 
 def mark_sent(report_id: str, issue_url: str) -> None:

--- a/charter/report.py
+++ b/charter/report.py
@@ -1,0 +1,312 @@
+"""Upstream reporting — turning a charter failure into an issue on charter's own tracker.
+
+charter is installed by strangers (`uv tool install charter-cp`), so when it breaks in
+someone's session the maintainer never hears about it: the Reporter is mid-task on their
+own work, and opening a browser to write up a reproduction is enough friction that nobody
+does. The reporting agent is already sitting there holding the traceback, the version and
+what was being attempted — this module turns that into something publishable.
+
+Vocabulary (see ``workspaces/user-reporting/workspace.md``):
+
+* **Reporter** — the human who installed charter and in whose session this surfaced.
+* **report** — the *private* draft. It is not public and may never become public.
+* **upstream issue** — the public artifact. Qualified deliberately: charter also works
+  with issues in the Reporter's *own* repos, so a bare "issue" is ambiguous here.
+* **bug** — charter did something wrong. Structured, fingerprintable.
+* **gap** — charter cannot do something it should. Free prose, no fingerprint.
+* **condition** — a failure that is *not* a bug (a timeout, an interrupt). Never reported.
+
+The governing decisions live in ``docs/adr/`` 0001-0003.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import re
+import traceback
+from pathlib import Path
+
+from . import __version__, config
+
+#: Ceiling on **distinct** pending reports. A broken config makes every invocation fail,
+#: and a Reporter who walks away should not return to a full disk. Repeats of a report
+#: already on disk are unaffected — they collapse onto it, which is the whole point.
+MAX_PENDING = 25
+
+#: The installed charter package. A frame is ours if it lives under here — resolved, so a
+#: symlinked install (``uv tool install`` makes several) still matches its own frames.
+_PKG = Path(__file__).resolve().parent
+
+#: Every key a bug payload may carry. A **closed allowlist**: a public tracker is the
+#: wrong place to discover that some field quietly carried a client's repo name, so
+#: nothing travels unless it was decided to be safe. Note the deliberate absence of
+#: ``argv`` — the subcommand *name* is safe, its *arguments* carry workspace and repo
+#: names — and of anything derived from the session transcript.
+BUG_FIELDS = (
+    "charter_version",
+    "python_version",
+    "os",
+    "subcommand",
+    "exception_type",
+    "frames",
+    #: The one field that cannot be made safe mechanically: messages routinely embed the
+    #: very names we are stripping (``no workspace 'acme-migration'``). Treated as free
+    #: text the Reporter must read before sending, never as a field we vouch for.
+    "message",
+)
+
+
+def safe_frames(frames) -> list[str]:
+    """Charter's own stack frames, rendered package-relative. Everything else is dropped.
+
+    Two different leaks are closed here, and only one of them is about paths. Relativizing
+    ``/Users/someone/.local/.../charter/cli.py`` to ``charter/cli.py`` strips the
+    Reporter's username. Dropping non-charter frames strips something we could not sanitize
+    even if we wanted to: *their* filenames and *their* function names, which on a bug hit
+    inside their own tooling would describe code they never agreed to publish.
+
+    A frame that is not a real path (``<string>``, ``<stdin>``) simply fails the check and
+    is dropped, which is the correct answer for it too.
+    """
+    out: list[str] = []
+    for f in frames:
+        p = Path(f.filename).resolve()
+        if not p.is_relative_to(_PKG):
+            continue
+        # Prefixed with the package directory's own name rather than a literal "charter/",
+        # so the rendering stays honest if the package is ever vendored under another name.
+        out.append(f"{_PKG.name}/{p.relative_to(_PKG)}:{f.lineno} in {f.name}")
+    return out
+
+
+def fingerprint(payload: dict) -> str:
+    """A stable identifier for *the same bug*, from the exception type and the deepest
+    charter frame — the place it actually broke.
+
+    Deliberately built **without the message**. The message is where the variable part
+    lives: ``no workspace 'alpha'`` and ``no workspace 'beta'`` are one bug, and folding
+    the message in would defeat the collapse this exists for — as well as baking a
+    Reporter-specific name into a key that gets stored and compared.
+
+    Line numbers are included, so the same bug fingerprints differently across a charter
+    release that moved the code. That is the right trade: within a version (where collapse
+    matters) it is exact, and across versions the upstream duplicate search is what catches
+    the repeat.
+    """
+    frames = payload.get("frames") or []
+    # Deepest charter frame — the innermost is where it broke; the outer ones are just
+    # how we got there, and they are identical across unrelated failures in `main`.
+    site = frames[-1] if frames else "<no charter frame>"
+    return hashlib.sha256(
+        f"{payload.get('exception_type')}\n{site}".encode()).hexdigest()[:16]
+
+
+def bug_payload(exc: BaseException, subcommand: str) -> dict:
+    """The publishable part of a **bug** report, built from a caught exception.
+
+    Returns only :data:`BUG_FIELDS`. Callers must not add to the result — the closed set
+    *is* the privacy guarantee.
+    """
+    return {
+        "charter_version": __version__,
+        "python_version": platform.python_version(),
+        "os": platform.platform(),
+        "subcommand": subcommand,
+        "exception_type": type(exc).__name__,
+        "frames": safe_frames(traceback.extract_tb(exc.__traceback__)),
+        "message": str(exc),
+    }
+
+
+# --- gaps ---------------------------------------------------------------------------
+# A gap is prose, so it cannot be allowlisted field-by-field the way a crash can. What it
+# gets instead is a scrub of the things charter can positively identify, plus the human
+# read that docs/adr/0003 makes mandatory. The scrub is the careless half; the Reporter is
+# the rest, because nothing mechanical catches "our billing service can't do X".
+
+#: Left in place of anything removed. Visible on purpose — a silent redaction reads as
+#: charter having published the original.
+REDACTED = "[redacted]"
+
+#: Absolute paths rooted at a user's home. These carry the Reporter's username in the
+#: second segment and their project names in the rest, so the whole token goes, not just
+#: the prefix.
+_HOME_PATH_RE = re.compile(r"(?:/Users|/home)/\S*")
+
+
+def scrub(text: str) -> str:
+    """Remove from *text* what charter can positively identify as the Reporter's.
+
+    The advantage over a generic scrubber is that charter knows its own **workspace** and
+    **persona** names — which are routinely named after the client or the project. That is
+    also the trade-off: a workspace named after a common word will redact that word out of
+    ordinary prose. Preferring a mangled sentence to a leaked client name is deliberate,
+    and the Reporter reads the result before it is sent either way.
+    """
+    # Lazy imports: this is the only place report.py needs them, and keeping them out of
+    # module scope means importing `report` (which `cli` does on every invocation) does not
+    # drag the workspace and persona machinery in.
+    from . import persona, workspace
+
+    out = _HOME_PATH_RE.sub(REDACTED, text)
+
+    names = set(workspace.list_workspaces()) | set(persona.list_personas())
+    # `default` exists on every install, so it identifies nobody — and redacting it would
+    # mangle ordinary English in most reports.
+    names.discard(config.DEFAULT_WORKSPACE)
+    # Longest first, so `acme-migration` is removed whole rather than being half-eaten by
+    # a shorter `acme` and leaving `[redacted]-migration` behind.
+    for name in sorted(names, key=len, reverse=True):
+        out = re.sub(rf"\b{re.escape(name)}\b", REDACTED, out)
+    return out
+
+
+def gap_payload(text: str) -> dict:
+    """The publishable part of a **gap** report. No exception type and no frames — a gap
+    is not a crash — but the same version context, which is what tells the maintainer
+    whether the capability landed since."""
+    return {
+        "charter_version": __version__,
+        "python_version": platform.python_version(),
+        "os": platform.platform(),
+        "text": scrub(text),
+    }
+
+
+# --- local storage ------------------------------------------------------------------
+# A report outlives the invocation that found it: detection is automatic, approval is not
+# (docs/adr/0003), so the two can be hours apart. Reports are also kept AFTER sending,
+# stamped with their issue URL, so the next identical crash can point at the existing
+# upstream issue instead of re-drafting — local dedupe at zero API cost.
+
+def _path(report_id: str) -> Path:
+    return config.REPORTS_DIR / f"{report_id}.json"
+
+
+def load(report_id: str) -> dict | None:
+    """One report by id, or None if there is no such report."""
+    p = _path(report_id)
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except ValueError:
+        # A truncated draft (killed mid-write) is not worth crashing a CLI over; the
+        # Reporter loses a draft, which is recoverable, where a crash is not.
+        return None
+
+
+def _all() -> list[dict]:
+    if not config.REPORTS_DIR.exists():
+        return []
+    out = []
+    for p in sorted(config.REPORTS_DIR.glob("*.json")):
+        r = load(p.stem)
+        if r:
+            out.append(r)
+    return out
+
+
+def pending() -> list[dict]:
+    """Reports awaiting the Reporter's approval — drafted but never published."""
+    return [r for r in _all() if not r.get("issue_url")]
+
+
+def _write(rec: dict) -> str:
+    config.REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    _path(rec["id"]).write_text(json.dumps(rec, indent=2))
+    return rec["id"]
+
+
+def _record(rid: str, kind: str, payload: dict) -> str | None:
+    """Store a report under *rid*, collapsing onto an existing one with the same id.
+
+    Nothing here touches the network — recording is not reporting. That separation is what
+    lets detection default to on: it only ever writes to the Reporter's own disk.
+    """
+    existing = load(rid)
+    if existing:
+        existing["occurrences"] = existing.get("occurrences", 1) + 1
+        return _write(existing)
+
+    # Checked only for a genuinely new report, so a crash loop sitting at the cap keeps
+    # counting the very bug that is looping.
+    if len(pending()) >= MAX_PENDING:
+        return None
+
+    return _write({
+        "id": rid,
+        "kind": kind,
+        "payload": payload,
+        "occurrences": 1,
+        "issue_url": None,
+    })
+
+
+def record_bug(exc: BaseException, subcommand: str) -> str | None:
+    """Record a **bug** locally. Returns its id, or None if the cap refused it.
+
+    The id *is* the fingerprint, so collapse falls out of the storage layout rather than
+    needing a search: the same bug twice is the same filename twice.
+    """
+    payload = bug_payload(exc, subcommand)
+    return _record(fingerprint(payload), "bug", payload)
+
+
+def record_described(kind: str, text: str) -> str | None:
+    """Record a report the Reporter **described in prose**, scrubbed. Returns its id, or
+    None if the cap refused it.
+
+    Covers both a gap and a bug the Reporter reports by hand — the latter has no exception
+    object, so it gets the same prose treatment rather than a traceback payload.
+
+    Scrubbed on the way *in*, not on the way out: a draft sitting on disk unredacted is a
+    draft that can be published without the scrub having run. Identical text collapses the
+    way a repeated crash does — prose has no stack frame to fingerprint, but an agent
+    re-raising the same request every session should not accumulate.
+    """
+    payload = gap_payload(text)
+    rid = hashlib.sha256(f"{kind}\n{payload['text']}".encode()).hexdigest()[:16]
+    return _record(rid, kind, payload)
+
+
+def record_gap(text: str) -> str | None:
+    """Record a **gap** locally, scrubbed. See :func:`record_described`."""
+    return record_described("gap", text)
+
+
+def render(rec: dict) -> str:
+    """The report as the Reporter will see it — and, later, as the upstream issue body.
+
+    One renderer for both, deliberately: if what is shown and what is sent could drift,
+    the Reporter's approval would stop meaning anything (docs/adr/0003).
+    """
+    p = rec["payload"]
+    lines = []
+    if p.get("text"):
+        lines += [p["text"], ""]
+    if p.get("exception_type"):
+        lines.append(f"**{p['exception_type']}** in `charter {p.get('subcommand', '?')}`")
+        if p.get("message"):
+            # Flagged, not vouched for: this is the one field no allowlist could make safe.
+            lines.append(f"> {p['message']}   ← free text, check before sending")
+        if p.get("frames"):
+            lines += ["", "```", *p["frames"], "```"]
+        lines.append("")
+    if rec.get("occurrences", 1) > 1:
+        lines.append(f"Hit {rec['occurrences']} times on this machine.")
+    lines.append(
+        f"charter {p.get('charter_version')} · Python {p.get('python_version')} "
+        f"· {p.get('os')}")
+    return "\n".join(lines)
+
+
+def mark_sent(report_id: str, issue_url: str) -> None:
+    """Stamp a report with the upstream issue it became. Kept rather than deleted: a later
+    identical crash points the Reporter at their own issue instead of drafting again."""
+    rec = load(report_id)
+    if rec:
+        rec["issue_url"] = issue_url
+        _write(rec)

--- a/docs/adr/0001-reports-filed-under-the-reporters-own-identity.md
+++ b/docs/adr/0001-reports-filed-under-the-reporters-own-identity.md
@@ -1,0 +1,22 @@
+# Upstream reports are filed under the Reporter's own GitHub identity
+
+charter lets a Reporter file bugs and feature gaps against `diazoxide/charter` from inside
+a running session. Those issues are created with the Reporter's own `gh` credentials, so
+they appear under their name — charter operates no service and holds no credentials of its
+own for this.
+
+The alternative was a charter-owned relay: charter POSTs a report to a hosted endpoint,
+which files under a machine account. That was rejected because it makes the maintainer the
+operator of an anonymous write endpoint into their own issue tracker, with the moderation
+and abuse burden that implies, in exchange for infrastructure that must be paid for and
+kept alive. Filing as the Reporter costs nothing to run, inherits GitHub's own spam
+controls for free, and — the part that actually matters — produces an attributed issue the
+maintainer can ask follow-up questions on.
+
+## Consequences
+
+A Reporter with no GitHub identity cannot file directly. charter supports GitLab forges,
+so this is a real population, not an edge case. They get a prefilled
+`issues/new?title=…&body=…` URL to click instead, which needs no service and reuses the
+existing `util.urlenc`. That fallback doubles as the escape hatch when `gh` is missing,
+broken, or rate-limited.

--- a/docs/adr/0002-issue-filing-bypasses-the-forge-protocol.md
+++ b/docs/adr/0002-issue-filing-bypasses-the-forge-protocol.md
@@ -1,0 +1,26 @@
+# Upstream issue filing bypasses the Forge protocol
+
+Filing and searching upstream issues is done with a flat `gh` call inside the reporting
+module, **not** by adding `create_issue`/`search_issues` to the `Forge` protocol in
+`charter/forge/`. This looks wrong at a glance — a raw `gh` invocation sitting beside a
+full forge abstraction — so it is written down to stop someone "fixing" it.
+
+The `Forge` protocol exists to abstract over *the Reporter's own* forges: their GitHub
+Enterprise, their GitLab, whatever they clone from. Upstream reporting has no such
+variation. It always targets one specific repo on github.com, so it is not polymorphic and
+gains nothing from the abstraction. Putting `create_issue` on the protocol would instead
+imply GitLab needs an implementation, which it never will: nobody files charter bugs on
+GitLab.
+
+The second reason is `_api`'s contract. It is documented as *"Best-effort JSON GET.
+Returns None on any failure"* precisely so the status line — which renders every turn —
+can never crash. Those semantics are correct there and catastrophic here: applied to
+filing an issue, "swallow the failure and return None" means the Reporter's report
+vanishes while they are told nothing. A write needs to fail loudly, which means it needs a
+path that is not `_api`.
+
+## Consequences
+
+The reporting module is the only place in charter that writes to a forge, and the only
+place that shells out to `gh` outside `charter/forge/`. That concentration is deliberate:
+it is a single seam, which is what makes the feature testable without touching the network.

--- a/docs/adr/0003-no-unattended-publish.md
+++ b/docs/adr/0003-no-unattended-publish.md
@@ -1,0 +1,28 @@
+# Nothing publishes without a human "yes" — and there is no `--yes` flag
+
+Detection and drafting of a report are automatic. Publishing never is. `charter report
+bug|gap` drafts, redacts and prints the payload; `charter report send <id>` publishes.
+The second command *is* the consent — there is deliberately no flag that collapses the two
+into one, and adding one would defeat the entire design.
+
+charter has no interactive prompt anywhere: `util.py` carries only `info/ok/warn/err`,
+because charter runs inside hooks and agent sessions where blocking on stdin would hang.
+So consent could not be a y/n prompt, and the two-command split turns that constraint into
+the mechanism: the reporting agent drafts, shows the Reporter the payload in conversation,
+and can only publish after the Reporter answers. An upstream issue is public, attributed to
+a real person, and awkward to retract; an agent filing them unattended under the Reporter's
+name is the kind of thing that gets a tool uninstalled once.
+
+## Considered Options
+
+A `--yes` flag on a single command was rejected: a flag the agent can pass is a flag the
+agent will pass unprompted, which is exactly the failure being prevented. An interactive
+path gated on `isatty()` was rejected too — it would put the safeguard only in front of
+humans at a terminal, which is almost never the case, leaving the agent path ungated.
+
+## Consequences
+
+The automation on offer relieves the Reporter of *writing* a report, not of *approving*
+one. That is the intended trade. Filing consent is additionally asked once per human and
+stored in user-level config — never in `charter.toml`, which is committed and would enrol
+a whole team on one person's say-so.

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -10,12 +10,14 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import shutil
 import sys
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from unittest import mock
 
 from charter import config, instance, persona, root
 
@@ -82,6 +84,33 @@ def run_hook(fn, payload: dict):
         sys.stdin = old
     out = buf.getvalue().strip()
     return json.loads(out) if out else None
+
+
+class ReportIso(PersonaIso):
+    """`PersonaIso` plus the two isolations upstream reporting needs.
+
+    1. **Consent home.** Reporting consent is stored per-*human*, outside the plane, so
+       `PersonaIso` alone does not isolate it — without this a test would read (or write!)
+       the developer's real consent. Redirected via ``$CHARTER_CONFIG_HOME`` and
+       deliberately NOT ``$XDG_CONFIG_HOME``: **`gh` keeps its own auth under
+       XDG_CONFIG_HOME**, so hijacking that logs `gh` out mid-test and silently pushes
+       `send` down its no-`gh` fallback path instead of the branch under test.
+
+    2. **`gh` availability.** Stubbed true, so no test depends on whether whoever is
+       running the suite happens to be logged in — the flakiness `test_forge_github.py`
+       exists to avoid. A test covering the *unavailable* path re-patches it false.
+
+    Nothing here stubs :func:`charter.report.gh` itself; each test does that, so a test
+    that forgets cannot silently reach the network — it fails on a real `gh` call instead.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        home = Path(tempfile.mkdtemp(prefix="charter-consent-"))
+        self.addCleanup(shutil.rmtree, home, True)
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_CONFIG_HOME": str(home)}))
+        self.enterContext(mock.patch("charter.report.gh_available", return_value=True))
+        self.consent_home = home
 
 
 def isolate_state_dir(case) -> Path:

--- a/tests/test_report_command.py
+++ b/tests/test_report_command.py
@@ -1,0 +1,82 @@
+"""The `charter report` surface — the drafting half.
+
+Two commands exist because the second one *is* the consent (docs/adr/0003): `report
+bug|gap` drafts and shows, `report send` publishes. This module covers drafting, and its
+central claim is a negative one — **drafting touches no network**. That is what lets
+detection default to on without charter reading as telemetry.
+"""
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_report, report, workspace
+from tests._isolation import PersonaIso
+
+
+class TestDraftingABug(PersonaIso):
+    def _run(self, text):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = commands_report.cmd_report_bug(SimpleNamespace(text=text))
+        return rc, buf.getvalue()
+
+    def test_it_records_a_report_and_succeeds(self):
+        rc, _ = self._run("charter clone crashes on a private repo")
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(report.pending()), 1)
+
+    def test_it_prints_the_id_the_reporter_needs_to_send(self):
+        """The id is the handle for the second command. Without it printed, the two-step
+        flow is unusable and the Reporter cannot approve anything."""
+        _, out = self._run("charter clone crashes on a private repo")
+        self.assertIn(report.pending()[0]["id"], out)
+
+    def test_it_prints_the_exact_text_that_would_be_published(self):
+        """Shown, not summarised. The Reporter is being asked to approve a payload, so
+        approving something they were never shown would make the approval meaningless."""
+        _, out = self._run("charter clone crashes on a private repo")
+        self.assertIn("charter clone crashes on a private repo", out)
+
+    def test_it_shows_the_scrubbed_text_not_the_original(self):
+        """What is displayed must be what would be sent. Showing the original while
+        sending the scrubbed version is a confusing lie; the reverse is a dangerous one."""
+        workspace.ensure("acme-migration")
+        _, out = self._run("clone fails in acme-migration")
+        self.assertNotIn("acme-migration", out)
+        self.assertIn(report.REDACTED, out)
+
+
+class TestDraftingTouchesNoNetwork(PersonaIso):
+    """The load-bearing test of the whole phase. Drafting must not reach the network under
+    any circumstance — that is the difference between a local draft and telemetry."""
+
+    def test_drafting_a_bug_runs_no_subprocess(self):
+        with mock.patch("charter.util.run") as run:
+            commands_report.cmd_report_bug(SimpleNamespace(text="something broke"))
+        run.assert_not_called()
+
+    def test_drafting_a_gap_runs_no_subprocess(self):
+        with mock.patch("charter.util.run") as run:
+            commands_report.cmd_report_gap(SimpleNamespace(text="no archive command"))
+        run.assert_not_called()
+
+
+class TestDraftingAGap(PersonaIso):
+    def test_it_records_a_gap_not_a_bug(self):
+        rc = commands_report.cmd_report_gap(SimpleNamespace(text="no way to archive"))
+        self.assertEqual(rc, 0)
+        self.assertEqual(report.pending()[0]["kind"], "gap")
+
+
+class TestNothingIsSentByDrafting(PersonaIso):
+    def test_a_drafted_report_is_not_marked_sent(self):
+        commands_report.cmd_report_bug(SimpleNamespace(text="something broke"))
+        self.assertIsNone(report.pending()[0]["issue_url"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_report_consent.py
+++ b/tests/test_report_consent.py
@@ -1,0 +1,102 @@
+"""Consent to publish — asked once, remembered per **human**.
+
+Consenting to file issues under your own GitHub identity is a property of the person, not
+of a directory (docs/adr/0003). So it cannot live in STATE_DIR, which is per control plane
+— a Reporter running several planes would be asked repeatedly, which trains them to click
+through it — and emphatically not in charter.toml, which is committed and would enrol a
+whole team on one person's say-so.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_report, config, report
+from tests._isolation import PersonaIso
+
+
+class ConsentIso(PersonaIso):
+    """PersonaIso isolates the plane; this also isolates the per-human config home, so a
+    test never reads or writes the developer's real consent."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.home = Path(tempfile.mkdtemp(prefix="charter-consent-"))
+        # CHARTER_CONFIG_HOME, deliberately NOT XDG_CONFIG_HOME: `gh` keeps its own auth
+        # under XDG_CONFIG_HOME, so redirecting that to isolate consent logs `gh` out and
+        # silently pushes `send` down the no-`gh` fallback path. Found the hard way.
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_CONFIG_HOME": str(self.home)}))
+        # No test may depend on whether the developer running it happens to be logged in
+        # to `gh` — that is the flakiness tests/test_forge_github.py exists to avoid.
+        self.enterContext(mock.patch("charter.report.gh_available", return_value=True))
+
+
+class TestConsentIsPerHuman(ConsentIso):
+    def test_consent_is_absent_by_default(self):
+        """Installing charter must never imply agreeing to publish anything."""
+        self.assertFalse(report.has_consent())
+
+    def test_granting_consent_persists_it(self):
+        report.grant_consent()
+        self.assertTrue(report.has_consent())
+
+    def test_consent_is_not_stored_under_the_plane(self):
+        """The load-bearing one: stored per-plane, a Reporter with several planes gets
+        asked again and again, and the safeguard degrades into a reflex."""
+        report.grant_consent()
+        self.assertFalse(report.consent_path().is_relative_to(config.STATE_DIR))
+        self.assertTrue(report.consent_path().is_relative_to(self.home))
+
+    def test_consent_survives_a_different_control_plane(self):
+        """Same human, different plane — already consented, so not asked again."""
+        report.grant_consent()
+        other = Path(tempfile.mkdtemp(prefix="other-plane-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(other, ignore_errors=True))
+        orig = config.use(other)
+        try:
+            self.assertTrue(report.has_consent())
+        finally:
+            config.restore(orig)
+
+
+class TestSendRefusesWithoutConsent(ConsentIso):
+    def _draft(self):
+        commands_report.cmd_report_gap(SimpleNamespace(text="no archive command"))
+        return report.pending()[0]["id"]
+
+    def test_send_without_consent_does_not_publish(self):
+        rid = self._draft()
+        with mock.patch("charter.report.gh") as gh:
+            rc = commands_report.cmd_report_send(SimpleNamespace(id=rid, new=False, dry_run=False))
+        self.assertNotEqual(rc, 0)
+        gh.assert_not_called()
+        self.assertIsNone(report.load(rid)["issue_url"])
+
+    def test_send_after_consent_reaches_the_forge(self):
+        report.grant_consent()
+        rid = self._draft()
+        with mock.patch("charter.report.gh") as gh:
+            gh.return_value = "https://github.com/diazoxide/charter/issues/7"
+            with mock.patch("charter.report.search_duplicates", return_value=[]):
+                rc = commands_report.cmd_report_send(
+                    SimpleNamespace(id=rid, new=False, dry_run=False))
+        self.assertEqual(rc, 0)
+        self.assertTrue(gh.called)
+
+
+class TestGrantingConsentIsItsOwnCommand(ConsentIso):
+    def test_the_consent_command_records_it(self):
+        """A separate command rather than a flag on `send`. ADR 0003 rejects flags that
+        collapse approval into the sending call — a flag an agent can pass is a flag it
+        will pass every time, where a one-off command has a single, auditable purpose."""
+        rc = commands_report.cmd_report_consent(SimpleNamespace())
+        self.assertEqual(rc, 0)
+        self.assertTrue(report.has_consent())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_report_detection.py
+++ b/tests/test_report_detection.py
@@ -10,7 +10,9 @@ docs/adr/0003 for why publishing is a separate, human-gated step.
 """
 from __future__ import annotations
 
+import io
 import unittest
+from contextlib import redirect_stderr
 from unittest import mock
 
 from charter import cli, report, util
@@ -70,6 +72,26 @@ class TestUncaughtExceptionsAreRecorded(PersonaIso):
                     cli.main(["doctor"])
         self.assertEqual(len(report.pending()), 1)
         self.assertEqual(report.pending()[0]["occurrences"], 3)
+
+
+class TestARepeatOfSomethingAlreadyFiled(PersonaIso):
+    def test_it_points_at_the_existing_issue_instead_of_re_drafting(self):
+        """The whole reason a sent report is kept rather than deleted: local dedupe at
+        zero API cost. Telling the Reporter it was 'drafted, nothing sent' when they
+        already filed it would send them round the loop a second time."""
+        with mock.patch("charter.commands.cmd_doctor", side_effect=ValueError("boom")):
+            with self.assertRaises(ValueError):
+                cli.main(["doctor"])
+        rid = report.pending()[0]["id"]
+        report.mark_sent(rid, "https://github.com/diazoxide/charter/issues/7")
+
+        err = io.StringIO()
+        with redirect_stderr(err):
+            with mock.patch("charter.commands.cmd_doctor", side_effect=ValueError("boom")):
+                with self.assertRaises(ValueError):
+                    cli.main(["doctor"])
+        self.assertIn("issues/7", err.getvalue())
+        self.assertNotIn("nothing sent", err.getvalue())
 
 
 class TestDetectionNeverBreaksTheCli(PersonaIso):

--- a/tests/test_report_detection.py
+++ b/tests/test_report_detection.py
@@ -1,0 +1,86 @@
+"""Automatic crash detection — the third `except` in `cli.main`.
+
+`main` already caught exactly `KeyboardInterrupt` and `util.ProcTimeout`, the latter with
+the comment *"A child that outlived its budget is a **condition, not a bug**"*. That line
+predates upstream reporting and defines its rule for free: a **condition** never produces a
+report, an uncaught exception always does.
+
+Detection is on by default because it only ever writes to the Reporter's own disk — see
+docs/adr/0003 for why publishing is a separate, human-gated step.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import cli, report, util
+from tests._isolation import PersonaIso
+
+
+class TestConditionsAreNotBugs(PersonaIso):
+    """The distinction charter already drew, now load-bearing. A Reporter's Ctrl-C must
+    never become an upstream issue, and a slow child process is not charter's bug."""
+
+    def test_a_keyboard_interrupt_records_nothing(self):
+        with mock.patch("charter.commands.cmd_doctor", side_effect=KeyboardInterrupt):
+            rc = cli.main(["doctor"])
+        self.assertEqual(rc, 130)
+        self.assertEqual(report.pending(), [])
+
+    def test_a_process_timeout_records_nothing(self):
+        with mock.patch("charter.commands.cmd_doctor",
+                        side_effect=util.ProcTimeout(["git", "fetch"], 5)):
+            rc = cli.main(["doctor"])
+        self.assertEqual(rc, 1)
+        self.assertEqual(report.pending(), [])
+
+
+class TestUncaughtExceptionsAreRecorded(PersonaIso):
+    def test_a_crash_records_exactly_one_report(self):
+        with mock.patch("charter.commands.cmd_doctor", side_effect=ValueError("boom")):
+            with self.assertRaises(ValueError):
+                cli.main(["doctor"])
+        self.assertEqual(len(report.pending()), 1)
+
+    def test_the_crash_still_reaches_the_developer(self):
+        """Recording must not swallow the failure. A charter that quietly files a report
+        and exits 0 would hide the very breakage it is reporting."""
+        with mock.patch("charter.commands.cmd_doctor", side_effect=ValueError("boom")):
+            with self.assertRaises(ValueError):
+                cli.main(["doctor"])
+
+    def test_the_report_names_the_subcommand_that_failed(self):
+        with mock.patch("charter.commands.cmd_doctor", side_effect=ValueError("boom")):
+            with self.assertRaises(ValueError):
+                cli.main(["doctor"])
+        self.assertEqual(report.pending()[0]["payload"]["subcommand"], "doctor")
+
+    def test_the_report_carries_charters_own_frames(self):
+        """Proves the traceback survived far enough to be useful — a report with no frames
+        would tell the maintainer nothing about where it broke."""
+        with mock.patch("charter.commands.cmd_doctor", side_effect=ValueError("boom")):
+            with self.assertRaises(ValueError):
+                cli.main(["doctor"])
+        self.assertTrue(report.pending()[0]["payload"]["frames"])
+
+    def test_a_repeated_crash_collapses(self):
+        for _ in range(3):
+            with mock.patch("charter.commands.cmd_doctor", side_effect=ValueError("boom")):
+                with self.assertRaises(ValueError):
+                    cli.main(["doctor"])
+        self.assertEqual(len(report.pending()), 1)
+        self.assertEqual(report.pending()[0]["occurrences"], 3)
+
+
+class TestDetectionNeverBreaksTheCli(PersonaIso):
+    def test_a_failure_to_record_does_not_mask_the_original_crash(self):
+        """If reporting itself breaks, the Reporter must still see the real error. A
+        bug in the bug reporter is the worst possible thing to surface instead."""
+        with mock.patch("charter.report.record_bug", side_effect=OSError("disk full")), \
+             mock.patch("charter.commands.cmd_doctor", side_effect=ValueError("boom")):
+            with self.assertRaises(ValueError):
+                cli.main(["doctor"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_report_gap.py
+++ b/tests/test_report_gap.py
@@ -1,0 +1,98 @@
+"""A **gap** — charter cannot do something it should — and the scrubbing it needs.
+
+A bug payload is structured, so it can be allowlisted field by field. A gap is free prose
+composed by the reporting agent while it holds the Reporter's private repo names, workspace
+names, and whatever they were actually trying to do. Mechanical scrubbing catches the
+careless half; the human read (docs/adr/0003) catches the rest, because nothing mechanical
+catches "we need this because our billing service can't do X".
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from charter import config, report, workspace
+from tests._isolation import PersonaIso
+
+
+class TestScrubbingProse(PersonaIso):
+    def test_an_absolute_home_path_does_not_survive(self):
+        """Absolute paths carry the Reporter's username in the second segment."""
+        out = report.scrub(f"it broke at {Path.home()}/code/billing/app.py")
+        self.assertNotIn(str(Path.home()), out)
+
+    def test_a_workspace_name_is_replaced(self):
+        """charter knows its own workspace names, which a generic scrubber never would.
+        A workspace is usually named after the client or the project."""
+        workspace.ensure("acme-migration")
+        out = report.scrub("charter clone fails inside acme-migration every time")
+        self.assertNotIn("acme-migration", out)
+
+    def test_a_persona_name_is_replaced(self):
+        self.make_persona("client-billing-reviewer")
+        out = report.scrub("the client-billing-reviewer persona cannot do this")
+        self.assertNotIn("client-billing-reviewer", out)
+
+    def test_the_surrounding_prose_survives(self):
+        """Scrubbing must not shred the report — what remains has to still describe the
+        gap, or the Reporter is left approving something useless."""
+        workspace.ensure("acme")
+        out = report.scrub("charter clone fails inside acme every time")
+        self.assertIn("charter clone fails inside", out)
+        self.assertIn("every time", out)
+
+    def test_scrubbing_is_visible_not_silent(self):
+        """A redaction the Reporter cannot see reads as charter having sent the original.
+        The placeholder is the signal that something was removed."""
+        workspace.ensure("acme-migration")
+        self.assertIn(report.REDACTED, report.scrub("broken in acme-migration"))
+
+    def test_text_with_nothing_sensitive_is_returned_unchanged(self):
+        text = "charter has no way to archive a workspace"
+        self.assertEqual(report.scrub(text), text)
+
+    def test_the_default_workspace_name_is_not_scrubbed(self):
+        """`default` exists on every install, so it identifies nobody — and redacting it
+        would mangle ordinary English in most reports."""
+        workspace.ensure(config.DEFAULT_WORKSPACE)
+        text = f"the {config.DEFAULT_WORKSPACE} workspace behaves differently"
+        self.assertEqual(report.scrub(text), text)
+
+
+class TestRecordingAGap(PersonaIso):
+    def test_a_gap_is_recorded_and_readable(self):
+        rid = report.record_gap("charter has no way to archive a workspace")
+        rec = report.load(rid)
+        self.assertEqual(rec["kind"], "gap")
+        self.assertEqual(rec["issue_url"], None)
+
+    def test_a_gaps_text_is_scrubbed_on_the_way_in(self):
+        """Scrubbed at record time, not at send time. A draft sitting on disk unredacted
+        is a draft someone can publish without the scrub ever having run."""
+        workspace.ensure("acme-migration")
+        rec = report.load(report.record_gap("no archive command for acme-migration"))
+        self.assertNotIn("acme-migration", rec["payload"]["text"])
+
+    def test_two_different_gaps_are_two_reports(self):
+        report.record_gap("no way to archive a workspace")
+        report.record_gap("no way to rename a persona")
+        self.assertEqual(len(report.pending()), 2)
+
+    def test_the_same_gap_text_twice_is_one_report(self):
+        """Gaps have no stack frame to fingerprint, but identical text is still the same
+        request — an agent re-reporting on every session should not accumulate."""
+        first = report.record_gap("no way to archive a workspace")
+        second = report.record_gap("no way to archive a workspace")
+        self.assertEqual(first, second)
+        self.assertEqual(len(report.pending()), 1)
+
+    def test_a_gap_carries_the_version_but_no_traceback_fields(self):
+        """A gap is not a crash: there is no exception type and no frame to report."""
+        rec = report.load(report.record_gap("no way to archive a workspace"))
+        self.assertIn("charter_version", rec["payload"])
+        self.assertNotIn("exception_type", rec["payload"])
+        self.assertNotIn("frames", rec["payload"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_report_gap_signal.py
+++ b/tests/test_report_gap_signal.py
@@ -1,0 +1,58 @@
+"""Typing a command charter doesn't have is a **gap** signal.
+
+The reporting capability is advertised only when something fails — that costs no prompt
+budget and is perfectly targeted. But a gap prints nothing on its own, so it would have no
+delivery mechanism at all. An unknown subcommand closes that: someone reaching for
+`charter workspace archive` has mechanically expressed a missing capability.
+
+This path exits via ``SystemExit`` from inside ``parse_args``, which runs *above* the
+``try`` that catches crashes — so it needs its own handling, not a third ``except``.
+"""
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+
+from charter import cli
+
+
+def _run(argv) -> str:
+    err = io.StringIO()
+    with redirect_stderr(err), redirect_stdout(io.StringIO()):
+        try:
+            cli.main(argv)
+        except SystemExit:
+            pass
+    return err.getvalue()
+
+
+class TestUnknownSubcommandOffersToReportAGap(unittest.TestCase):
+    def test_an_unknown_command_points_at_gap_reporting(self):
+        self.assertIn("charter report gap", _run(["frobnicate"]))
+
+    def test_it_names_the_command_that_was_missing(self):
+        self.assertIn("frobnicate", _run(["frobnicate"]))
+
+
+class TestItDoesNotFireOnOrdinaryUsageErrors(unittest.TestCase):
+    """A gap is 'charter cannot do this', not 'you typed it wrong'. Offering to file an
+    upstream issue every time someone fat-fingers a flag would make the prompt noise, and
+    noise is what gets a feature like this switched off."""
+
+    def test_a_bad_flag_on_a_real_command_is_not_a_gap(self):
+        self.assertNotIn("charter report gap", _run(["doctor", "--nonexistent-flag"]))
+
+    def test_a_missing_required_argument_is_not_a_gap(self):
+        self.assertNotIn("charter report gap", _run(["report", "show"]))
+
+    def test_help_is_not_a_gap(self):
+        self.assertNotIn("charter report gap", _run(["--help"]))
+
+    def test_an_unknown_flag_is_not_a_gap(self):
+        """`--frobnicate` is a typo, not a missing capability."""
+        self.assertNotIn("charter report gap", _run(["--frobnicate"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_report_payload.py
+++ b/tests/test_report_payload.py
@@ -1,0 +1,150 @@
+"""What travels upstream in a **bug** report, and what must never.
+
+The payload is a **closed allowlist** — nothing reaches a public issue unless it was
+explicitly decided to be safe. A blocklist leaks eventually; an allowlist fails closed.
+The Reporter's session holds absolute paths carrying their username, private repo and org
+names, workspace and persona names; a public tracker is the wrong place to discover any of
+them (see docs/adr/0001, and `workspaces/user-reporting/workspace.md` for the glossary).
+"""
+from __future__ import annotations
+
+import traceback
+import unittest
+from pathlib import Path
+
+import charter
+from charter import report
+
+
+def _caught(exc: Exception) -> Exception:
+    """An exception with a real ``__traceback__``, the way `cli.main` would see it."""
+    try:
+        raise exc
+    except Exception as e:  # noqa: BLE001 - the point is to capture whatever was raised
+        return e
+
+
+class TestBugPayloadIsAClosedAllowlist(unittest.TestCase):
+    def test_payload_carries_exactly_the_allowlisted_fields(self):
+        """Six mechanical fields plus `message`, the one free-text field the Reporter
+        must read. Asserted as an exact set, not a subset: a field added without a
+        decision should fail here rather than surface on a public issue."""
+        p = report.bug_payload(_caught(ValueError("boom")), subcommand="clone")
+        self.assertEqual(
+            set(p),
+            {"charter_version", "python_version", "os", "subcommand",
+             "exception_type", "frames", "message"},
+        )
+
+    def test_argv_never_appears_in_a_payload(self):
+        """The subcommand name is safe; its ARGUMENTS are not — they carry workspace,
+        repo and org names. Excluded deliberately, so this is a named guard rather than
+        a consequence of the set above."""
+        p = report.bug_payload(_caught(ValueError("boom")), subcommand="clone")
+        self.assertNotIn("argv", p)
+        self.assertEqual(p["subcommand"], "clone")
+
+    def test_exception_type_is_recorded_by_name(self):
+        p = report.bug_payload(_caught(KeyError("k")), subcommand="doctor")
+        self.assertEqual(p["exception_type"], "KeyError")
+
+
+class TestFramesAreCharterOnlyAndRelativized(unittest.TestCase):
+    """A traceback is the leakiest thing charter captures. Absolute paths carry the
+    Reporter's username; frames from *their* code carry their filenames and function
+    names. Only charter's own frames survive, and only as package-relative paths."""
+
+    def setUp(self) -> None:
+        self.pkg = Path(charter.__file__).parent
+
+    def test_a_charter_frame_survives_as_a_package_relative_path(self):
+        f = traceback.FrameSummary(str(self.pkg / "cli.py"), 713, "main")
+        self.assertEqual(report.safe_frames([f]), ["charter/cli.py:713 in main"])
+
+    def test_the_reporters_own_frames_are_dropped_entirely(self):
+        """Not relativized — dropped. Their filenames and function names are theirs."""
+        mine = traceback.FrameSummary(str(Path.home() / "code/billing/app.py"), 3, "charge")
+        ours = traceback.FrameSummary(str(self.pkg / "workspace.py"), 42, "ensure")
+        self.assertEqual(report.safe_frames([mine, ours]), ["charter/workspace.py:42 in ensure"])
+
+    def test_stdlib_frames_are_dropped(self):
+        std = traceback.FrameSummary("/usr/lib/python3.14/subprocess.py", 1, "run")
+        self.assertEqual(report.safe_frames([std]), [])
+
+    def test_a_nested_charter_module_keeps_its_subpath(self):
+        """`charter/forge/github.py`, not `github.py` — the subpackage is the useful part."""
+        f = traceback.FrameSummary(str(self.pkg / "forge" / "github.py"), 66, "_api")
+        self.assertEqual(report.safe_frames([f]), ["charter/forge/github.py:66 in _api"])
+
+    def test_no_absolute_path_survives(self):
+        """The guard that matters: whatever the rule, nothing leaves with a leading `/`."""
+        frames = [
+            traceback.FrameSummary(str(Path.home() / "secret/thing.py"), 1, "f"),
+            traceback.FrameSummary(str(self.pkg / "cli.py"), 713, "main"),
+        ]
+        for rendered in report.safe_frames(frames):
+            self.assertFalse(rendered.startswith("/"), rendered)
+            self.assertNotIn(str(Path.home()), rendered)
+
+
+class TestPayloadUsesSafeFrames(unittest.TestCase):
+    def test_frames_in_a_payload_are_rendered_strings(self):
+        """The payload is what gets published, so its frames must already be safe —
+        not FrameSummary objects a later caller has to remember to sanitize."""
+        p = report.bug_payload(_caught(ValueError("boom")), subcommand="clone")
+        for f in p["frames"]:
+            self.assertIsInstance(f, str)
+
+
+class TestFingerprintIdentifiesTheSameBug(unittest.TestCase):
+    """The fingerprint is what collapses a crash loop into one report with a counter, and
+    what lets an already-filed bug point at its own upstream issue without an API call."""
+
+    def setUp(self) -> None:
+        self.pkg = Path(charter.__file__).parent
+
+    def _payload(self, exc_type="ValueError", message="boom", line=713):
+        return {
+            "charter_version": "0.19.0", "python_version": "3.11.0", "os": "macOS",
+            "subcommand": "clone", "exception_type": exc_type, "message": message,
+            "frames": report.safe_frames(
+                [traceback.FrameSummary(str(self.pkg / "cli.py"), line, "main")]),
+        }
+
+    def test_the_same_failure_fingerprints_the_same(self):
+        self.assertEqual(report.fingerprint(self._payload()),
+                         report.fingerprint(self._payload()))
+
+    def test_a_different_exception_type_is_a_different_bug(self):
+        self.assertNotEqual(report.fingerprint(self._payload(exc_type="ValueError")),
+                            report.fingerprint(self._payload(exc_type="KeyError")))
+
+    def test_a_different_frame_is_a_different_bug(self):
+        self.assertNotEqual(report.fingerprint(self._payload(line=713)),
+                            report.fingerprint(self._payload(line=42)))
+
+    def test_the_message_does_not_change_the_fingerprint(self):
+        """The load-bearing one. Messages carry the variable part — `no workspace 'a'`
+        versus `no workspace 'b'` is ONE bug. Folding the message in would defeat
+        collapse entirely, and would put Reporter-specific names into a stored key."""
+        self.assertEqual(report.fingerprint(self._payload(message="no workspace 'alpha'")),
+                         report.fingerprint(self._payload(message="no workspace 'beta'")))
+
+    def test_a_crash_with_no_charter_frames_still_fingerprints(self):
+        """Every frame can be filtered out; that must not raise. It is still a real bug
+        and still needs to collapse against its own repeats."""
+        p = self._payload()
+        p["frames"] = []
+        self.assertTrue(report.fingerprint(p))
+        self.assertEqual(report.fingerprint(p), report.fingerprint(p))
+
+    def test_a_fingerprint_leaks_nothing_readable(self):
+        """It is stored and compared, so it must not become a side channel for the
+        message it was deliberately built without."""
+        fp = report.fingerprint(self._payload(message="/Users/someone/private-repo"))
+        self.assertNotIn("someone", fp)
+        self.assertNotIn("private-repo", fp)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_report_send.py
+++ b/tests/test_report_send.py
@@ -1,0 +1,208 @@
+"""`charter report send` — the only command here that touches the network.
+
+Every test stubs :func:`charter.report.gh`, the single seam through which reporting reaches
+a forge (docs/adr/0002). Nothing in this module may reach a real tracker.
+"""
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_report, report
+from tests._isolation import ReportIso
+
+_ISSUE = "https://github.com/diazoxide/charter/issues/7"
+
+
+class SendCase(ReportIso):
+    def setUp(self) -> None:
+        super().setUp()
+        report.grant_consent()
+
+    def draft(self, text="charter cannot archive a workspace") -> str:
+        commands_report.cmd_report_gap(SimpleNamespace(text=text))
+        return report.pending()[0]["id"]
+
+    def send(self, rid, *, new=False, dry_run=False, dups=None, gh_result=_ISSUE):
+        buf = io.StringIO()
+        with mock.patch("charter.report.gh", return_value=gh_result) as gh, \
+             mock.patch("charter.report.search_duplicates", return_value=dups or []):
+            with redirect_stdout(buf):
+                rc = commands_report.cmd_report_send(
+                    SimpleNamespace(id=rid, new=new, dry_run=dry_run))
+        return rc, buf.getvalue(), gh
+
+
+class TestASuccessfulSend(SendCase):
+    def test_it_records_the_issue_url_against_the_report(self):
+        rid = self.draft()
+        rc, _, _ = self.send(rid)
+        self.assertEqual(rc, 0)
+        self.assertEqual(report.load(rid)["issue_url"], _ISSUE)
+
+    def test_a_sent_report_is_kept_not_deleted(self):
+        """Kept so the next identical failure can point at the existing upstream issue
+        instead of drafting again — local dedupe at zero API cost."""
+        rid = self.draft()
+        self.send(rid)
+        self.assertIsNotNone(report.load(rid))
+
+    def test_sending_twice_does_not_open_a_second_issue(self):
+        rid = self.draft()
+        self.send(rid)
+        rc, out, gh = self.send(rid)
+        self.assertEqual(rc, 0)
+        gh.assert_not_called()
+
+    def test_the_issue_is_labelled_at_creation(self):
+        """`via-charter-report` is what separates machine-drafted reports from
+        hand-written ones — and how you measure whether this feature works at all."""
+        rid = self.draft()
+        _, _, gh = self.send(rid)
+        args = gh.call_args[0][0]
+        self.assertIn("via-charter-report", args)
+        self.assertIn("gap", args)
+
+    def test_the_body_sent_is_the_body_shown(self):
+        """One renderer for both. If they could drift, the Reporter's approval would stop
+        meaning anything."""
+        rid = self.draft()
+        _, _, gh = self.send(rid)
+        args = gh.call_args[0][0]
+        self.assertIn(report.issue_body(report.load(rid)), args)
+
+
+class TestDuplicateHandling(SendCase):
+    _DUP = [{"number": 12, "title": "cannot archive a workspace",
+             "url": "https://github.com/diazoxide/charter/issues/12"}]
+
+    def test_a_candidate_duplicate_stops_the_send(self):
+        rid = self.draft()
+        rc, out, gh = self.send(rid, dups=self._DUP)
+        self.assertEqual(rc, 2)
+        gh.assert_not_called()
+        self.assertIsNone(report.load(rid)["issue_url"])
+
+    def test_the_candidates_are_shown_so_someone_can_judge_them(self):
+        """Candidates, not a verdict — a keyword score cannot tell 'clone fails on a
+        private repo' from 'clone fails on a submodule'."""
+        rid = self.draft()
+        _, out, _ = self.send(rid, dups=self._DUP)
+        self.assertIn("12", out)
+        self.assertIn("https://github.com/diazoxide/charter/issues/12", out)
+
+    def test_new_overrides_the_duplicate_check(self):
+        """The Reporter believing their case is different must be able to say so — an
+        over-eager duplicate check cannot be allowed to silence a real bug."""
+        rid = self.draft()
+        rc, _, gh = self.send(rid, new=True, dups=self._DUP)
+        self.assertEqual(rc, 0)
+        self.assertTrue(gh.called)
+
+
+class TestDryRun(SendCase):
+    def test_dry_run_sends_nothing(self):
+        rid = self.draft()
+        rc, _, gh = self.send(rid, dry_run=True)
+        self.assertEqual(rc, 0)
+        gh.assert_not_called()
+        self.assertIsNone(report.load(rid)["issue_url"])
+
+    def test_dry_run_shows_what_would_be_sent(self):
+        rid = self.draft()
+        _, out, _ = self.send(rid, dry_run=True)
+        self.assertIn("charter cannot archive a workspace", out)
+
+    def test_dry_run_touches_no_network_at_all(self):
+        """Not even the duplicate search or the `gh auth` probe. This is the offline
+        affordance the feature was developed against — it must not need a forge."""
+        rid = self.draft()
+        buf = io.StringIO()
+        with mock.patch("charter.report.gh") as gh, \
+             mock.patch("charter.report.gh_available") as avail, \
+             mock.patch("charter.report.search_duplicates") as search:
+            with redirect_stdout(buf):
+                rc = commands_report.cmd_report_send(
+                    SimpleNamespace(id=rid, new=False, dry_run=True))
+        self.assertEqual(rc, 0)
+        gh.assert_not_called()
+        avail.assert_not_called()
+        search.assert_not_called()
+
+    def test_a_duplicate_does_not_short_circuit_a_dry_run(self):
+        """A dry run asked to see the payload. Returning 'this may be a duplicate' without
+        ever showing it would answer a question the Reporter did not ask."""
+        rid = self.draft()
+        _, out, _ = self.send(rid, dry_run=True, dups=TestDuplicateHandling._DUP)
+        self.assertIn("charter cannot archive a workspace", out)
+
+
+class TestFailureIsLoud(SendCase):
+    def test_a_forge_failure_does_not_report_success(self):
+        """The `_api` contract — swallow everything, return None — would mean the
+        Reporter believes they reported something they did not (docs/adr/0002)."""
+        rid = self.draft()
+        buf = io.StringIO()
+        with mock.patch("charter.report.gh",
+                        side_effect=report.ReportingError("label not found")), \
+             mock.patch("charter.report.search_duplicates", return_value=[]):
+            with redirect_stdout(buf):
+                rc = commands_report.cmd_report_send(
+                    SimpleNamespace(id=rid, new=False, dry_run=False))
+        self.assertEqual(rc, 1)
+
+    def test_the_draft_survives_a_failed_send(self):
+        rid = self.draft()
+        with mock.patch("charter.report.gh", side_effect=report.ReportingError("boom")), \
+             mock.patch("charter.report.search_duplicates", return_value=[]):
+            commands_report.cmd_report_send(SimpleNamespace(id=rid, new=False, dry_run=False))
+        self.assertIsNone(report.load(rid)["issue_url"])
+        self.assertEqual(len(report.pending()), 1)
+
+
+class TestNoGithubIdentity(SendCase):
+    """charter supports GitLab forges, so a Reporter with no `gh` is a real population —
+    and this is also the escape hatch when `gh` is broken or rate-limited."""
+
+    def test_it_offers_a_prefilled_url_instead_of_failing(self):
+        rid = self.draft()
+        buf = io.StringIO()
+        with mock.patch("charter.report.gh_available", return_value=False), \
+             mock.patch("charter.report.gh") as gh:
+            with redirect_stdout(buf):
+                rc = commands_report.cmd_report_send(
+                    SimpleNamespace(id=rid, new=False, dry_run=False))
+        self.assertEqual(rc, 0)
+        gh.assert_not_called()
+        self.assertIn("/issues/new", buf.getvalue())
+
+    def test_the_prefilled_url_is_encoded(self):
+        rid = self.draft("clone fails & breaks")
+        url = report.fallback_url(report.load(rid))
+        self.assertNotIn(" ", url)
+        self.assertIn("title=", url)
+        self.assertIn("body=", url)
+
+
+class TestUnknownReport(SendCase):
+    def test_sending_an_unknown_id_fails_cleanly(self):
+        rc, _, gh = self.send("nosuchid")
+        self.assertEqual(rc, 1)
+        gh.assert_not_called()
+
+
+class TestCrashTitles(ReportIso):
+    def test_a_crash_title_leads_with_exception_type_and_subcommand(self):
+        """So duplicates collide visually in the maintainer's issue list."""
+        try:
+            raise ValueError("boom")
+        except ValueError as e:
+            rid = report.record_bug(e, subcommand="clone")
+        self.assertEqual(report.title(report.load(rid)), "ValueError in `charter clone`")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_report_store.py
+++ b/tests/test_report_store.py
@@ -6,6 +6,8 @@ and a Reporter who walks away from a crash loop must not come back to a full dis
 """
 from __future__ import annotations
 
+import json
+import time
 import unittest
 
 from charter import config, report
@@ -100,6 +102,42 @@ class TestCrashLoopCollapse(PersonaIso):
             report.record_bug(_distinct(i), subcommand=f"cmd{i}")
         self.assertEqual(report.load(self._same_bug())["occurrences"], 2)
         self.assertEqual(first, self._same_bug())
+
+
+class TestDraftsAgeOut(PersonaIso):
+    """A draft nobody approved in a month is one nobody is going to. Pruned on write
+    rather than from a hook, so a CLI-only install with no plugin still gets it."""
+
+    def _age(self, rid, days):
+        rec = report.load(rid)
+        rec["first_seen"] = time.time() - days * 86400
+        (config.REPORTS_DIR / f"{rid}.json").write_text(json.dumps(rec))
+
+    def test_an_old_unsent_draft_is_dropped(self):
+        rid = report.record_bug(_caught(ValueError("boom")), subcommand="clone")
+        self._age(rid, report.MAX_DRAFT_AGE_DAYS + 1)
+        report.prune()
+        self.assertIsNone(report.load(rid))
+
+    def test_a_recent_draft_survives(self):
+        rid = report.record_bug(_caught(ValueError("boom")), subcommand="clone")
+        self._age(rid, report.MAX_DRAFT_AGE_DAYS - 1)
+        report.prune()
+        self.assertIsNotNone(report.load(rid))
+
+    def test_a_sent_report_is_never_aged_out(self):
+        """It is what a later identical crash points at, so it outlives every timer."""
+        rid = report.record_bug(_caught(ValueError("boom")), subcommand="clone")
+        report.mark_sent(rid, "https://github.com/diazoxide/charter/issues/7")
+        self._age(rid, report.MAX_DRAFT_AGE_DAYS * 10)
+        report.prune()
+        self.assertIsNotNone(report.load(rid))
+
+    def test_an_old_draft_does_not_consume_a_slot_in_the_cap(self):
+        rid = report.record_bug(_caught(ValueError("boom")), subcommand="clone")
+        self._age(rid, report.MAX_DRAFT_AGE_DAYS + 1)
+        for i in range(report.MAX_PENDING):
+            self.assertIsNotNone(report.record_bug(_distinct(i), subcommand=f"cmd{i}"))
 
 
 class TestPendingListing(PersonaIso):

--- a/tests/test_report_store.py
+++ b/tests/test_report_store.py
@@ -1,0 +1,120 @@
+"""Where a **report** lives between being detected and being sent.
+
+Detection is automatic and local; publishing never is (docs/adr/0003). So a report drafted
+when charter crashed at 2pm has to still be there when the Reporter approves it at 4pm —
+and a Reporter who walks away from a crash loop must not come back to a full disk.
+"""
+from __future__ import annotations
+
+import unittest
+
+from charter import config, report
+from tests._isolation import PersonaIso
+
+
+def _caught(exc: Exception) -> Exception:
+    try:
+        raise exc
+    except Exception as e:  # noqa: BLE001
+        return e
+
+
+def _distinct(i: int) -> Exception:
+    """A genuinely different bug.
+
+    Note what does NOT make one: a different message or a different subcommand. The
+    fingerprint is exception type plus failure site, so `clone` and `doctor` both dying
+    with ValueError at the same charter line are ONE bug — correctly, since one fix closes
+    both. Varying the exception type is what actually produces distinct reports.
+    """
+    return _caught(type(f"SynthError{i}", (Exception,), {})("boom"))
+
+
+class TestRecordingABug(PersonaIso):
+    def test_a_recorded_bug_can_be_read_back(self):
+        rid = report.record_bug(_caught(ValueError("boom")), subcommand="clone")
+        loaded = report.load(rid)
+        self.assertEqual(loaded["payload"]["exception_type"], "ValueError")
+        self.assertEqual(loaded["payload"]["subcommand"], "clone")
+
+    def test_a_new_report_starts_unsent(self):
+        """`sent` is what separates a draft from something already public — and what the
+        Reporter's approval flips. It must never start true."""
+        loaded = report.load(report.record_bug(_caught(ValueError("boom")), subcommand="clone"))
+        self.assertIsNone(loaded["issue_url"])
+        self.assertEqual(loaded["occurrences"], 1)
+
+    def test_reports_are_written_under_the_state_dir(self):
+        """Gitignored, per-developer, beside the other per-session state — never inside a
+        workspace and never anywhere committed."""
+        report.record_bug(_caught(ValueError("boom")), subcommand="clone")
+        self.assertTrue(config.REPORTS_DIR.is_relative_to(config.STATE_DIR))
+        self.assertTrue(any(config.REPORTS_DIR.iterdir()))
+
+
+class TestCrashLoopCollapse(PersonaIso):
+    """A broken config makes every invocation fail identically. That is one report with a
+    count, not a hundred files — and the count is useful signal upstream ('hit 47 times')."""
+
+    def _same_bug(self):
+        return report.record_bug(_caught(ValueError("boom")), subcommand="clone")
+
+    def test_the_same_bug_twice_is_one_report(self):
+        first, second = self._same_bug(), self._same_bug()
+        self.assertEqual(first, second)
+        self.assertEqual(len(report.pending()), 1)
+
+    def test_repeats_increment_the_occurrence_counter(self):
+        for _ in range(5):
+            rid = self._same_bug()
+        self.assertEqual(report.load(rid)["occurrences"], 5)
+
+    def test_a_different_bug_is_its_own_report(self):
+        self._same_bug()
+        report.record_bug(_caught(KeyError("other")), subcommand="doctor")
+        self.assertEqual(len(report.pending()), 2)
+
+    def test_the_subcommand_does_not_split_one_bug_into_two(self):
+        """`clone` and `doctor` failing the same way at the same place is one bug — one
+        fix closes both. Pinned because it is the surprising half of the fingerprint rule."""
+        report.record_bug(_caught(ValueError("boom")), subcommand="clone")
+        report.record_bug(_caught(ValueError("boom")), subcommand="doctor")
+        self.assertEqual(len(report.pending()), 1)
+
+    def test_distinct_pending_reports_are_capped(self):
+        """Past the cap, recording stops rather than filling the disk. Returns None so a
+        caller can tell it was refused instead of silently believing it recorded."""
+        for i in range(report.MAX_PENDING):
+            report.record_bug(_distinct(i), subcommand=f"cmd{i}")
+        self.assertEqual(len(report.pending()), report.MAX_PENDING)
+
+        refused = report.record_bug(_distinct(9999), subcommand="zzz")
+        self.assertIsNone(refused)
+        self.assertEqual(len(report.pending()), report.MAX_PENDING)
+
+    def test_the_cap_still_lets_an_existing_report_collapse(self):
+        """The cap bounds DISTINCT reports. A repeat of one already on disk must still
+        count, or a crash loop at the cap would stop counting the very thing looping."""
+        first = self._same_bug()
+        for i in range(report.MAX_PENDING):
+            report.record_bug(_distinct(i), subcommand=f"cmd{i}")
+        self.assertEqual(report.load(self._same_bug())["occurrences"], 2)
+        self.assertEqual(first, self._same_bug())
+
+
+class TestPendingListing(PersonaIso):
+    def test_nothing_recorded_means_nothing_pending(self):
+        self.assertEqual(report.pending(), [])
+
+    def test_a_sent_report_is_no_longer_pending(self):
+        """Sent reports are kept (they carry the issue URL a later repeat points at), but
+        they are not drafts awaiting approval."""
+        rid = report.record_bug(_caught(ValueError("boom")), subcommand="clone")
+        report.mark_sent(rid, "https://github.com/diazoxide/charter/issues/7")
+        self.assertEqual(report.pending(), [])
+        self.assertEqual(report.load(rid)["issue_url"],
+                         "https://github.com/diazoxide/charter/issues/7")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
charter is installed by strangers via `uv tool install charter-cp`. When it breaks in their session the maintainer never hears about it — the Reporter is mid-task on their own work, and opening a browser to write up a reproduction is enough friction that nobody does. Meanwhile the agent sitting right there already holds the traceback, the version, and what was being attempted.

This adds `charter report`, so that information stops dying in a terminal scrollback.

## The shape

**Detection is automatic and local. Publishing is neither.**

```
charter report gap "no way to archive a workspace"   # drafts, scrubs, shows the exact payload
charter report send <id>                             # refuses: consent not given
charter report consent                               # once, per human
charter report send <id> --dry-run                   # shows what would go, touches no network
```

Two commands rather than one is not ceremony. charter has no interactive prompt anywhere — `util.py` is `info/ok/warn/err` by design, because it runs inside hooks and agent sessions where blocking on stdin would hang. So approval could not be a y/n prompt. Splitting draft from send makes a human the only thing that can publish, and there is deliberately no `--yes`.

Crash detection attaches as a third `except` in `cli.main`, which is where the rule already existed: `KeyboardInterrupt` and `ProcTimeout` were caught as *"a condition, not a bug"*, so everything else is by definition worth recording. No hook could do this — `PostToolUse` never matches Bash, `PreToolUse` runs before the command, and charter already holds what a hook would reconstruct from a string. It also means CLI-only installs get it.

## What travels

A closed allowlist: version, Python, OS, subcommand, exception type, and charter-only frames with paths relativized. `argv` is excluded — the subcommand *name* is safe, its *arguments* carry workspace and repo names. Non-charter frames are dropped entirely rather than relativized, because they carry the Reporter's own filenames and function names.

The exception message is the one field no allowlist can make safe (`no workspace 'acme-migration'`), so it is shown as free text the Reporter must read rather than a field we vouch for. Gap prose gets the same treatment plus a scrub of workspace and persona names — which charter can enumerate from its own state, and a generic scrubber never could.

## Decisions recorded as ADRs

Three things a future reader would otherwise undo:

- **0001** — no hosted relay. Reports go under the Reporter's own `gh` identity; a relay would make the maintainer the operator of an anonymous write endpoint into their own tracker.
- **0002** — filing bypasses the `Forge` protocol. It looks like a mistake next to a whole forge abstraction, so it is written down: reporting always targets one repo on github.com, so it is not polymorphic, and `_api`'s "best-effort, return None" contract applied to publishing loses the report while telling the Reporter it worked.
- **0003** — no `--yes` flag, ever.

## Two findings worth knowing

**`gh` stores its own auth under `$XDG_CONFIG_HOME`.** Isolating consent by redirecting that variable logs `gh` out and silently reroutes `send` down the no-`gh` fallback. Hence `$CHARTER_CONFIG_HOME`, and hence `ReportIso` stubbing `gh_available` so no test depends on whoever runs the suite being logged in.

**The fingerprint ignores subcommand as well as message.** `clone` and `doctor` dying at the same charter line is one bug — one fix closes both.

## Also here

Duplicate search before filing (candidates for a human to judge, not a verdict — a keyword score cannot separate "clone fails on a private repo" from "clone fails on a submodule"), `--new` to override it, comment-on-duplicate as the default since a repeat carries a second reproducing environment, a prefilled `issues/new` URL for GitLab-only Reporters, a staleness warning that never blocks, a configurable target repo so a fork can retarget, and draft GC on write.

## Testing

90 new tests across 8 modules; full suite **1338 green**. The `gh` call is a single stubbed seam, so nothing in the suite can reach a tracker. Prior art followed: handler functions called directly (per `test_cli_smoke.py`'s stated convention), `PersonaIso` for state isolation, and `test_forge_github.py`'s fake completed-process objects.

The `via-charter-report` and `gap` labels have been created on this repo — `create_issue` applies them, so the first real send needed them to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCnBscCDiUN4fRvEuB7RC