### PR TITLE
0.20.0 — charter can report its own bugs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.19.0"
+__version__ = "0.20.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.19.0",
+            "command": "charter hook sessionstart --plugin-version 0.20.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.19.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.20.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.19.0",
+            "command": "charter hook pretooluse --plugin-version 0.20.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.19.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.20.0"
           }
         ]
       }
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.19.0",
+            "command": "charter hook posttooluse --plugin-version 0.20.0",
             "timeout": 5
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.19.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.20.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.19.0"
+version = "0.20.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only. Moves all four numbers together — `pyproject.toml`, `charter/__init__.py`, `.claude-plugin/plugin.json`, and every `--plugin-version` in `hooks/hooks.json` (six commands). `MIN_PLUGIN_VERSION` derives from `__version__`, so it follows.

**Minor, not patch.** #47 adds a new top-level command group (`charter report`, with `bug`/`gap`/`list`/`show`/`consent`/`send`/`comment`), a derived `REPORTS_DIR`, and two new environment variables (`CHARTER_CONFIG_HOME`, `CHARTER_UPSTREAM_REPO`).

`TestVersionsMoveInLockstep` passes, full suite green at 1338.

Tag `v0.20.0` from `main` once this merges — that push is the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCnBscCDiUN4fRvEuB7RC