### PR TITLE
statusline: draw the zones the layout already had

### DIFF
--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -87,6 +87,11 @@ _RIGHT_MIN_W = 36  # a persona column narrower than this is not worth showing
 # EVERY row against the edge, which turned one truncated word into a column of `…` down
 # the whole status line.
 _SAFETY = 4
+#: Marks a body line as a horizontal rule for :func:`_boxed` to draw as ``├───┤``.
+#: A sentinel rather than a pre-drawn string because only `_boxed` knows the frame's
+#: final width — and because a rule has to survive `tui.truncate` without being cropped
+#: into a shorter line. NUL cannot occur in real content, so it can never collide.
+_RULE_LINE = "\x00charter-rule\x00"
 _BRAND_GAP = 3  # min blank columns between content and the right-aligned brand
 # Extra headroom the brand demands beyond `width`. A real session cropped the brand to
 # `⬢ charter 0.10…` — impossible from `_with_brand`, which fits-or-drops — so the pane
@@ -1099,17 +1104,48 @@ def _boxed(body: str, width: int) -> str:
     try:
         inner = width - 4                      # "│ " + content + " │"
         if inner < 20:
-            return body
+            # Unframed: a rule has no side borders to join, so it is dropped rather than
+            # printed. The sentinel must never reach a terminal.
+            return "\n".join(ln for ln in body.split("\n") if ln != _RULE_LINE)
         top = f"{_DIM}┌{'─' * (width - 2)}┐{_R}"
         bot = f"{_DIM}└{'─' * (width - 2)}┘{_R}"
+        rule = f"{_DIM}├{'─' * (width - 2)}┤{_R}"
         out = [top]
         for ln in body.split("\n"):
+            if ln == _RULE_LINE:
+                # Drawn here, not in layout, so it is always exactly as wide as the top
+                # and bottom borders — a rule that disagreed with them would be the most
+                # visible possible defect.
+                out.append(rule)
+                continue
             ln = tui.truncate(ln, inner)
             out.append(f"{_DIM}│{_R} {ln}{' ' * max(0, inner - tui.width(ln))} {_DIM}│{_R}")
         out.append(bot)
         return "\n".join(out)
     except Exception:
         return body
+
+
+def _zone_rules(body: str, has_strip: bool) -> str:
+    """Insert the zone dividers: one under the workspace line, one above the strip.
+
+    Applied to the finished body rather than threaded through the layout branches, which
+    works because every branch lays out the same two anchors — the workspace summary is
+    always the first line, and the session strip, when there is one, is always the last.
+    Splicing here keeps a divider out of `_columns`, where it would be padded and
+    truncated as though it were content.
+
+    No divider above a strip that does not exist: an empty session (or one just past
+    `/compact`) renders no strip, and a rule there would separate the tree from nothing
+    but the bottom border.
+    """
+    lines = body.split("\n")
+    if len(lines) < 2:
+        return body                     # nothing to divide
+    out = [lines[0], _RULE_LINE, *lines[1:]]
+    if has_strip:
+        out.insert(len(out) - 1, _RULE_LINE)
+    return "\n".join(out)
 
 
 def _with_brand(body: str, width: int) -> str:
@@ -1132,6 +1168,10 @@ def _with_brand(body: str, width: int) -> str:
         if not lines:
             return body
         last = lines[-1]
+        if last == _RULE_LINE:
+            # Defensive: `_zone_rules` never leaves a divider last, but welding the brand
+            # onto one would produce a line that is part box-drawing and part text.
+            return body
         used, need = tui.width(last), tui.width(brand)
         if used + need + _BRAND_GAP + _BRAND_MARGIN > width:
             return body                      # no room: content wins
@@ -1269,6 +1309,9 @@ def render(payload: dict | None = None) -> str:
         else:
             body = _columns([summary, left_head, *repo_lines,
                              *alerts, *([strip] if strip else [])], None, width)
+        # After layout, before the frame: the dividers are furniture, and letting them
+        # through `_columns` would have them padded and cropped as content.
+        body = _zone_rules(body, has_strip=bool(strip))
     except Exception:
         # Never crash the status line if layout fails — plain truncated stack.
         plain = [summary, *repo_lines]

--- a/tests/test_statusline_gauge.py
+++ b/tests/test_statusline_gauge.py
@@ -86,8 +86,9 @@ class ContextGaugeCase(unittest.TestCase):
         out = statusline.render({"session_id": "t", **_payload(pct=42, read=900, write=100)})
         lines = [re.sub(r"\033\[[0-9;]*m", "", l) for l in out.splitlines() if l.strip()]
         # The status line is framed; the first and last rows are the box's own rules,
-        # and every other row is bounded by the frame's own verticals.
-        lines = [l.strip("│ ") for l in lines if set(l) - set("┌─┐└┘")]
+        # the zone dividers join its sides with tees, and every other row is bounded by
+        # the frame's own verticals.
+        lines = [l.strip("│ ") for l in lines if set(l) - set("┌─┐└┘├┤")]
         self.assertIn("ctx 42%", lines[-1])
         self.assertIn("⚡90%", lines[-1])
         self.assertNotIn("ctx", lines[0])

--- a/tests/test_statusline_layout_scope.py
+++ b/tests/test_statusline_layout_scope.py
@@ -48,8 +48,8 @@ def _lines(payload=None, width=200):
     the box, not the box."""
     out = []
     for ln in _raw(payload, width):
-        if not ln.strip() or set(ln.strip()) <= set("┌─┐└┘"):
-            continue                      # top/bottom rule
+        if not ln.strip() or set(ln.strip()) <= set("┌─┐└┘├┤"):
+            continue                      # top/bottom border, or a zone divider
         if ln.startswith("│ ") and ln.rstrip().endswith("│"):
             ln = ln[2:].rstrip()[:-1].rstrip()
         out.append(ln)
@@ -225,6 +225,11 @@ class Framed(PersonaIso):
     def test_every_content_row_is_bounded_on_both_sides(self):
         rows = [ln for ln in _raw(_USAGE) if ln.strip()][1:-1]
         for ln in rows:
+            if set(ln.strip()) <= set("├─┤"):
+                # A zone divider is bounded too — it joins the side borders with tees
+                # instead of carrying content between them.
+                self.assertTrue(ln.startswith("├") and ln.endswith("┤"), ln)
+                continue
             self.assertTrue(ln.startswith("│"), ln)
             self.assertTrue(ln.endswith("│"), ln)
 
@@ -393,6 +398,11 @@ class Framed(PersonaIso):
     def test_every_content_row_is_bounded_on_both_sides(self):
         rows = [ln for ln in _raw(_USAGE) if ln.strip()][1:-1]
         for ln in rows:
+            if set(ln.strip()) <= set("├─┤"):
+                # A zone divider is bounded too — it joins the side borders with tees
+                # instead of carrying content between them.
+                self.assertTrue(ln.startswith("├") and ln.endswith("┤"), ln)
+                continue
             self.assertTrue(ln.startswith("│"), ln)
             self.assertTrue(ln.endswith("│"), ln)
 

--- a/tests/test_statusline_monorepo.py
+++ b/tests/test_statusline_monorepo.py
@@ -98,8 +98,8 @@ class MonorepoIso(PersonaIso):
                 os.environ["COLUMNS"] = old
         out = []
         for ln in raw:
-            if not ln.strip() or set(ln.strip()) <= set("┌─┐└┘"):
-                continue
+            if not ln.strip() or set(ln.strip()) <= set("┌─┐└┘├┤"):
+                continue                  # top/bottom border, or a zone divider
             if ln.startswith("│ ") and ln.rstrip().endswith("│"):
                 ln = ln[2:].rstrip()[:-1].rstrip()
             out.append(ln)

--- a/tests/test_statusline_zone_rules.py
+++ b/tests/test_statusline_zone_rules.py
@@ -1,0 +1,124 @@
+"""Horizontal rules that make the status line's zones visible.
+
+The layout has always been grouped by scope — *where I am*, then *what is here*, then
+*this session* — but the three read as one undifferentiated stack of rows. A rule under
+the workspace line and another above the session strip draws the grouping that the
+layout already had.
+
+The rules are frame furniture, not content: they are inserted after layout and rendered
+by `_boxed`, so they cannot perturb the column maths that ran inside it — the same reason
+the box itself is applied last.
+"""
+from __future__ import annotations
+
+import os
+import re
+import unittest
+
+from charter import statusline
+from tests._isolation import PersonaIso
+
+
+def _plain(s: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+def _raw(payload=None, width=200):
+    old = os.environ.get("COLUMNS")
+    os.environ["COLUMNS"] = str(width)
+    try:
+        return [_plain(ln) for ln in statusline.render(payload or {}).split("\n") if ln]
+    finally:
+        if old is None:
+            os.environ.pop("COLUMNS", None)
+        else:
+            os.environ["COLUMNS"] = old
+
+
+def _is_rule(ln: str) -> bool:
+    return bool(ln.strip()) and set(ln.strip()) <= set("├─┤")
+
+
+_USAGE = {"session_id": "zone-rules",
+          "context_window": {"used_percentage": 22,
+                             "current_usage": {"cache_read_input_tokens": 100,
+                                               "cache_creation_input_tokens": 10}}}
+
+
+class TestZoneRules(PersonaIso):
+    def test_a_rule_sits_directly_under_the_workspace_line(self):
+        """The workspace line is zone one on its own; everything below it describes
+        what is *in* that workspace."""
+        rows = _raw(_USAGE)
+        self.assertTrue(_is_rule(rows[2]), rows[:4])
+
+    def test_the_workspace_line_is_still_the_first_content_row(self):
+        rows = _raw(_USAGE)
+        self.assertIn("⬢", rows[1])
+        self.assertFalse(_is_rule(rows[1]))
+
+    def test_a_rule_sits_directly_above_the_session_strip(self):
+        """The strip describes the session, not the workspace — so it gets separated
+        from the tree the same way the workspace line is."""
+        rows = _raw(_USAGE)
+        strip_at = next(i for i, ln in enumerate(rows) if "ctx" in ln)
+        self.assertTrue(_is_rule(rows[strip_at - 1]), rows[strip_at - 2:strip_at + 1])
+
+    def test_there_are_exactly_two_rules_when_a_strip_is_present(self):
+        self.assertEqual(sum(1 for ln in _raw(_USAGE) if _is_rule(ln)), 2)
+
+    def test_there_is_one_rule_when_there_is_no_session_strip(self):
+        """A fresh session has no usage yet, so no strip — and a rule above a row that
+        does not exist would be a divider separating nothing from the bottom border."""
+        self.assertEqual(sum(1 for ln in _raw({}) if _is_rule(ln)), 1)
+
+
+class TestRulesMatchTheFrame(PersonaIso):
+    def test_a_rule_is_exactly_as_wide_as_the_top_border(self):
+        """A rule narrower or wider than the box is the most visible possible defect."""
+        rows = _raw(_USAGE)
+        for ln in rows:
+            if _is_rule(ln):
+                self.assertEqual(len(ln), len(rows[0]), f"{ln!r} vs {rows[0]!r}")
+
+    def test_a_rule_uses_tee_connectors_not_corners(self):
+        """`├`/`┤` join the side borders; `┌`/`┐` would read as a second box starting."""
+        for ln in _raw(_USAGE):
+            if _is_rule(ln):
+                self.assertTrue(ln.startswith("├") and ln.rstrip().endswith("┤"), ln)
+
+    def test_the_frame_still_opens_and_closes_with_corners(self):
+        rows = _raw(_USAGE)
+        self.assertTrue(set(rows[0]) <= set("┌─┐"), rows[0])
+        self.assertTrue(set(rows[-1]) <= set("└─┘"), rows[-1])
+
+
+class TestTheSentinelNeverReachesTheTerminal(PersonaIso):
+    def test_no_marker_leaks_into_a_normal_render(self):
+        self.assertNotIn("\x00", statusline.render(_USAGE))
+
+    def test_no_marker_leaks_when_the_pane_is_too_narrow_to_frame(self):
+        """`_boxed` returns the body unframed below its minimum width. A rule has no
+        meaning without side borders to join, so it must be dropped, not printed raw."""
+        body = f"top{statusline._RULE_LINE}bottom".replace(
+            statusline._RULE_LINE, "\n" + statusline._RULE_LINE + "\n")
+        out = statusline._boxed(body, 10)
+        self.assertNotIn("\x00", out)
+
+    def test_a_rule_never_becomes_the_line_the_brand_lands_on(self):
+        """`_with_brand` appends to the last line. A brand welded onto a divider would
+        be both ugly and, since the divider is pure box-drawing, unreadable."""
+        rows = [ln for ln in _raw(_USAGE) if ln.strip()]
+        self.assertFalse(_is_rule(rows[-2]), rows[-3:])
+
+
+class TestRenderStillNeverCrashes(PersonaIso):
+    def test_narrow_panes_render_without_raising(self):
+        for w in (24, 30, 40, 60, 80, 120, 200):
+            out = statusline.render(_USAGE) if w == 200 else None
+            with self.subTest(width=w):
+                self.assertTrue(_raw(_USAGE, w))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The status line has been grouped by scope for a while — *where I am*, *what is here*, *this session* — but all three rendered as one undifferentiated stack of rows, so the grouping existed in the code and not on screen.

```
┌──────────────────────────────────────────┐
│ ⬢ default · ws 2                         │   where I am
├──────────────────────────────────────────┤
│ ▪ repos 1                                │
│   └─ charter                           … │   what is here
│ ▪ personas 4 · vaults 2                  │
│ ▸ steward · ✎4                           │
├──────────────────────────────────────────┤
│ ctx 42% · ⚡92%         ⬢ charter 0.20.0 │   this session
└──────────────────────────────────────────┘
```

## How

The dividers are **furniture, not content**. They are spliced in after layout and drawn by `_boxed`, for the same reason the box itself is applied last: a rule routed through `_columns` would be padded and cropped as though it were a row, and `_boxed` is the only place that knows the frame's final width. That is what keeps a divider exactly as wide as the top and bottom borders — a rule disagreeing with them would be the most visible possible defect.

One splice covers all three layout branches, because every branch shares two anchors: the workspace summary is always the first body line, and the session strip, when present, is always the last.

Carried as a NUL-delimited sentinel rather than a pre-drawn string, so it survives `tui.truncate` uncropped and cannot collide with real content.

## Edge cases

- **No divider above a strip that isn't there.** A fresh session, or one just past `/compact`, renders no strip — a rule there would separate the tree from nothing but the bottom border.
- **Dropped, never printed, on the unframed narrow path**, where there are no side borders for it to join.
- **`_with_brand` refuses to weld the brand onto a divider**, which would produce a line that is part box-drawing and part text.

## Tests

The three helpers that strip the frame now strip dividers too — they document themselves as being about the zones inside the box, not the box. The bounded-on-both-sides assertion was widened to accept tees *only* for divider rows, rather than loosened for everything: a divider is bounded, just with `├`/`┤` rather than `│`.

`test_every_row_is_exactly_the_same_width` — the ragged-frame ruler — needed **no** change and still passes. That is the real evidence the rules match the frame, rather than my own assertion of it.

1350 tests green, +12 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCnBscCDiUN4fRvEuB7RC