### PR TITLE
docs: why a workspace gets a todo list, and why a persona does not

### DIFF
--- a/docs/adr/0004-intent-is-its-own-store.md
+++ b/docs/adr/0004-intent-is-its-own-store.md
@@ -1,0 +1,24 @@
+# Intent is its own store, not a state flag on memory
+
+A workspace's todos live in `todos/`, beside `memory/` rather than inside it — a third
+category alongside **memory** (what was learned) and the **journal** (what happened). The
+obvious cheaper designs were both rejected.
+
+The distinguishing property is that intent **expires**. A memory is true indefinitely; a
+todo stops being true the moment it is done or abandoned. `memstore` exists precisely
+because durable facts are worth keeping, indexing and searching forever, and putting
+something that goes stale inside it would rot the half that must not go stale — a
+`charter recall` hit on a todo somebody completed last month is worse than no hit, because
+it reads with the same authority as a fact.
+
+Free text in `workspace.md` was rejected for the opposite reason: a markdown blob gets no
+search, no duplicate detection, and no way for an agent to close a single item without
+rewriting the whole file.
+
+## Consequences
+
+`todos/` is a third instance of the `memstore` pattern, so it inherits the index, keyword
+search, near-duplicate detection and forget-by-slug essentially free. It also needs its own
+line in `workspace._live_block`, which currently un-ignores only `workspace.json`,
+`workspace.md`, `memory` and `memory/**` — without it, todos would be invisible to git even
+in a LIVE workspace.

--- a/docs/adr/0005-no-persona-todos.md
+++ b/docs/adr/0005-no-persona-todos.md
@@ -1,0 +1,21 @@
+# Todos are workspace-scoped only — personas do not get them
+
+Personas have their own committed memory, their own vault and their own charter, so the
+symmetry is tempting: if a workspace has a todo list, why not a persona? Deliberately not,
+and this is written down because the symmetry argument will be made again.
+
+A persona is a **role** — Release Engineer, Forge Integration Engineer — not a worker with
+a queue. Work is owned by a workspace, which charter already defines as an *isolated
+per-task* workspace; a persona is *who does it*. Role-level "should get around to it" items
+are a backlog, and charter already has two homes for those: `charter report gap` and the
+issue tracker.
+
+The cost of a second scope is not disk, it is coherence. Two scopes means every write needs
+a "which one?" decision, and an agent that guesses wrong scatters intent across two stores
+that are never read together — so neither list is trustworthy, which defeats the point of
+having one.
+
+## Consequences
+
+Reversible if evidence appears: the bar is three real persona todos that are not workspace
+todos and not issues. Until then the absence is a decision, not an oversight.

--- a/docs/adr/0006-charter-todos-do-not-sync-with-the-harness-task-list.md
+++ b/docs/adr/0006-charter-todos-do-not-sync-with-the-harness-task-list.md
@@ -1,0 +1,26 @@
+# charter's todos do not sync with Claude Code's task list
+
+Claude Code ships its own per-session task list. charter's todos are a separate,
+persistent, workspace-scoped list, and the two are never synchronised in either direction.
+*"Why doesn't charter update the task list I can actually see?"* is the most natural
+question anyone will ask about this feature, so the answer is recorded rather than left to
+look like an omission.
+
+Two live task lists in one session is strictly worse than one. The agent updates whichever
+it last thought about, they drift, and both stop being trustworthy — at which point the
+durable one is worth less than no list at all, because it is confidently wrong about what
+is left. The two are kept honest by giving each exactly one job: the harness's list is
+**session scratch** and owns `in_progress`; charter's is **durable intent** across sessions
+and knows only open/done.
+
+Mirroring at session start was considered and rejected. Two stores syncing bidirectionally
+is a bug factory, and the failure is silent: an item ticked in one place and not the other
+produces a list that lies without anyone noticing.
+
+## Consequences
+
+charter's list would be write-only if nothing surfaced it, so SessionStart injects a
+**bounded** signal — an open count plus the three oldest titles — into a context budget
+that is already defended (`_memory_digest` is commented as "a BOUNDED digest, not the whole
+index"). One-way and bounded is the whole compromise. An open count also sits in status-line
+zone one, beside the workspace it belongs to.


### PR DESCRIPTION
Design-only. Three ADRs, no implementation — the tickets they came from live in a LOCAL workspace and nothing is built yet.

charter records what a task **learned** (memory) and what **happened** (the journal), but has no representation of what it still **means to do**. Intent lives nowhere durable: it sits in the agent's context until the session ends, so work that was consciously deferred is indistinguishable from work nobody ever thought of.

## The ADRs

**0004 — intent is its own store, not a flag on memory.** Intent expires; memory does not. A `charter recall` hit on a todo somebody finished last month reads with the same authority as a fact, which is worse than no hit at all. Free text in `workspace.md` fails the other way: no search, no dedupe, and no way to close one item without rewriting the file.

**0005 — no persona todos.** The symmetry is tempting and will be argued again: a persona has memory, a vault and a charter, so why not a list? Because a persona is a **role**, not a worker with a queue — work is owned by a workspace, which charter already defines as *per-task*. The cost of a second scope is coherence, not disk: every write needs a "which one?" decision, and an agent guessing wrong scatters intent across two stores nobody reads together. Reversible on evidence — the bar is three real persona todos that are neither workspace todos nor issues.

**0006 — no sync with Claude Code's own task list.** Two live lists in one session is worse than one; the agent updates whichever it last thought about and both stop being trustworthy. Each gets one job instead: the harness's is session scratch and owns `in_progress`, charter's is durable across sessions and knows only open/done.

That last one was observed live rather than reasoned about. While designing this feature, the harness's task list carried seven stale items for hours — one marked `in_progress` throughout — while entirely different work shipped, got released, and went to PyPI.

## Not here

No code. `memstore` already generalizes across two scopes, so the implementation is additive and needs no prefactor. Seven tracer-bullet tickets exist in the `todos` workspace, which is LOCAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCnBscCDiUN4fRvEuB7RC