### PR TITLE
todos: a workspace can record what it still means to do

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -340,6 +340,17 @@ def _add_workspace_parser(sub) -> None:
     fg.add_argument("--workspace", "-w", help="Target workspace (default: the active one).")
     fg.set_defaults(func=commands_workspace.cmd_workspace_forget)
 
+    td = wsub.add_parser("todo",
+                         help="Record what this task still means to do — or list them. "
+                              "Intent, kept apart from memory (what it learned) and the "
+                              "journal (what happened).")
+    # Text optional, exactly like `remember`: the bare verb lists. A `list` SUBCOMMAND
+    # would be indistinguishable from recording a todo whose text is "list".
+    td.add_argument("text", nargs="?", help="The todo; omit to list this workspace's todos.")
+    td.add_argument("--workspace", "-w", help="Target workspace (default: the active one).")
+    td.add_argument("--query", "-q", help="Search the todos instead of listing them all.")
+    td.set_defaults(func=commands_workspace.cmd_workspace_todo)
+
     nt = wsub.add_parser("note", help="Alias for `remember` — record a workspace memory (or list them).")
     nt.add_argument("message", nargs="?", help="Memory text; omit to list the workspace's memories.")
     nt.add_argument("--workspace", "-w", help="Target workspace (default: the active one).")

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -569,6 +569,63 @@ def cmd_workspace_note(args) -> int:
     return cmd_workspace_remember(args)
 
 
+def cmd_workspace_todo(args) -> int:
+    """Record one **todo** — something this task still means to do — or list them.
+
+    Shaped like `remember`: the verb with text records, the verb bare lists. A literal
+    `todo list` subcommand would be indistinguishable from recording a todo whose text is
+    "list", which is a real thing somebody will eventually try to write down.
+
+    Intent is not memory (docs/adr/0004): a todo stops being true the moment it is done,
+    so it lives in its own store and never surfaces from `charter recall`.
+    """
+    from . import todos
+    name = getattr(args, "workspace", None) or workspace.resolve()
+    text = (getattr(args, "text", None) or "").strip()
+    query = getattr(args, "query", None)
+
+    if not text:
+        return _list_todos(name, query)
+
+    # Duplicate intent is worse than duplicate memory: closing one of a near-identical
+    # pair leaves its twin looking outstanding, so the list starts lying about what is
+    # left. Warn and skip rather than merge, so the writer learns it is already there.
+    dup = todos.duplicate_of(name, text)
+    if dup:
+        util.err(f"already on the list: {dup}")
+        util.info(f"  See it: charter ws todo --workspace {name}")
+        return 1
+
+    p = todos.add(name, text)
+    util.ok(f"Todo recorded in '{name}' → workspaces/{name}/todos/{p.name}")
+    if not workspace.is_live(name):
+        util.info(f"  '{name}' is LOCAL (private) — todos stay on disk, not committed.")
+    return 0
+
+
+def _list_todos(name: str, query: str | None) -> int:
+    """Open todos, oldest first — the ranking the whole feature uses."""
+    from . import todos
+    if query:
+        hits = todos.search(name, query)
+        if not hits:
+            util.info(f"No todos in '{name}' match {query!r}.")
+            return 0
+        for p, title, _score in hits:
+            print(f"  {p.stem}  {title}")
+        return 0
+
+    open_ = todos.open_todos(name)
+    if not open_:
+        # Silence is indistinguishable from a broken command, so say it plainly.
+        util.info(f"No open todos in '{name}'. Record one: charter ws todo \"<what>\"")
+        return 0
+
+    for t in open_:
+        print(f"  {t['slug']}  {t['age_days']}d  {t['title']}")
+    return 0
+
+
 def cmd_workspace_recall(args) -> int:
     """Search this workspace's memories (--query) or list them all chronologically."""
     name = getattr(args, "workspace", None) or workspace.resolve()

--- a/charter/memstore.py
+++ b/charter/memstore.py
@@ -216,7 +216,14 @@ def search(dirs, query: str, limit: int = 8) -> list[tuple[Path, str, int]]:
     return [(p, title, score) for score, _s, p, title in scored[:limit]]
 
 
-def _wordset(text: str) -> set[str]:
+def wordset(text: str) -> set[str]:
+    """The comparable words in *text* — the tokenizer :func:`duplicates` scores with.
+
+    Public because near-duplicate detection has a second caller (the todo store, which asks
+    "would this new text duplicate an existing one?" rather than "which stored pairs
+    duplicate each other?"). Both must tokenize identically or the shared threshold means
+    two different things.
+    """
     return {w for w in re.split(r"\W+", text.lower()) if len(w) > 3}
 
 
@@ -225,7 +232,7 @@ def duplicates(dirs, threshold: float = 0.5) -> list[tuple[float, Path, str, Pat
     ents = []
     for d in dirs:
         ents += entries(d)
-    sets = [(p, title, _wordset(text)) for p, title, text in ents]
+    sets = [(p, title, wordset(text)) for p, title, text in ents]
     dupes = []
     for i in range(len(sets)):
         pa, ta, sa = sets[i]

--- a/charter/todos.py
+++ b/charter/todos.py
@@ -1,0 +1,133 @@
+"""A workspace's **todos** — its intent, as against what it learned or what happened.
+
+charter already records two things about a task: durable facts (**memory**) and a
+chronological record of what was done (the **journal**). Neither can hold what the task
+still *means* to do. That gap is why every session on a long-running task re-derives its
+own plan: work consciously deferred leaves no trace, so it is indistinguishable from work
+nobody ever thought of.
+
+A todo is the third category, and it differs from the other two in one way that decides
+the whole design: **it expires.** A memory is true indefinitely; a todo stops being true
+the moment it is done or abandoned. So todos get their own store beside ``memory/`` rather
+than a state flag inside it — a ``charter recall`` hit on something finished last month
+would read with exactly the authority of a fact, which is worse than no hit at all
+(docs/adr/0004).
+
+Two states only, open and done, and done *deletes* — the journal is already the permanent
+record of what happened. ``in_progress`` is deliberately absent: it is a session concept,
+correctly owned by Claude Code's own ephemeral task list, and a durable list claiming
+something has been in progress for three weeks is simply lying (docs/adr/0006).
+
+Workspace-scoped only. A persona is a role, not a worker with a queue (docs/adr/0005).
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+from . import memstore, workspace
+
+_HEADER = (
+    "# Todos — workspace `{name}`\n\n"
+    "One line per todo; each links a file holding one thing this task still means to do.\n"
+    "Open or done — and done removes it, leaving its trace in the journal instead.\n"
+)
+
+#: Word-overlap above which two todos are "the same intent". Borrowed from the memory
+#: store's own duplicate detection rather than tuned separately: the failure it prevents
+#: is identical in kind, and one threshold is easier to reason about than two.
+_DUPLICATE_THRESHOLD = 0.5
+
+
+def todos_dir(name: str) -> Path:
+    """``workspaces/<name>/todos/`` — a *sibling* of ``memory/``, never a child."""
+    return workspace.workspace_dir(name) / "todos"
+
+
+def index(name: str) -> Path:
+    return memstore.index_path(todos_dir(name))
+
+
+def scaffold(name: str) -> Path:
+    """Ensure the todo directory and its index exist. Returns the index path."""
+    return memstore.ensure_index(todos_dir(name), _HEADER.format(name=name))
+
+
+def add(name: str, text: str, *, stamp: datetime.datetime | None = None) -> Path:
+    """Record one todo as its own timestamp-prefixed file, and index it.
+
+    Timestamped for a reason beyond tidiness: oldest-first is the only ranking this feature
+    has, and taking it from the filename means the directory listing *is* the order. No
+    priority field, so nothing to leave blank and nothing to disagree with age.
+
+    That ordering is only as fine as the stamp, which is **whole seconds**: several todos
+    recorded in the same second sort by name among themselves, not by which came first.
+    Harmless for a human, and worth knowing for an agent recording a burst — "the three
+    oldest" is then arbitrary within that second.
+
+    *stamp* overrides the recorded time, passed straight through to the store. It exists so
+    ordering can be tested across real time gaps rather than within one second, where
+    alphabetical tie-breaking would make any such test pass for the wrong reason.
+    """
+    scaffold(name)
+    return memstore.write(todos_dir(name), text, timestamped=True, index=True, stamp=stamp)
+
+
+def duplicate_of(name: str, text: str) -> str | None:
+    """The title of an existing todo that already says this, or None.
+
+    Deliberately a query rather than something :func:`add` enforces: the *policy* — warn
+    and skip — belongs to the command, so the store stays a store. Scoped to one workspace,
+    since an identical todo in another is a different task's business.
+    """
+    existing = memstore.entries(todos_dir(name))
+    if not existing:
+        return None
+    words = _words(text)
+    if not words:
+        return None
+    for _p, title, body in existing:
+        other = _words(f"{title} {memstore.body(body)}")
+        if not other:
+            continue
+        # Jaccard — intersection over UNION, the same metric `memstore.duplicates` uses.
+        # Dividing by max(len) instead looks equivalent and is not: on text this short a
+        # single shared word is half the content, so "first thing" and "second thing"
+        # scored 0.5 and the second was refused as a duplicate of the first.
+        if len(words & other) / len(words | other) >= _DUPLICATE_THRESHOLD:
+            return title
+    return None
+
+
+def _words(text: str) -> set[str]:
+    return memstore.wordset(text or "")
+
+
+def open_todos(name: str) -> list[dict]:
+    """Every open todo, **oldest first**, each with its age in days.
+
+    Oldest-first makes the session reminder self-correcting: what surfaces is what is being
+    avoided, rather than what you already have in mind. Age is reported and never enforced —
+    an open todo is a commitment a human made, so nothing here deletes one on a timer.
+    """
+    today = datetime.date.today()
+    out = []
+    for p, title, text in memstore.entries(todos_dir(name)):
+        recorded = memstore.memory_date(text, p.name)
+        out.append({
+            "slug": p.stem,
+            "title": title,
+            "text": memstore.body(text),
+            "age_days": (today - recorded).days if recorded else 0,
+        })
+    return out
+
+
+def search(name: str, query: str, limit: int = 8) -> list[tuple[Path, str, int]]:
+    """Keyword search across this workspace's todos."""
+    return memstore.search([todos_dir(name)], query, limit=limit)
+
+
+def count_open(name: str) -> int:
+    return len(memstore.files(todos_dir(name)))

--- a/tests/test_todos_command.py
+++ b/tests/test_todos_command.py
@@ -1,0 +1,150 @@
+"""`charter workspace todo` — recording and reading a workspace's intent.
+
+Follows the shape `workspace remember` already established: the verb with text records,
+the verb bare lists. A literal `todo list` subcommand would be indistinguishable from
+recording a todo whose text is "list".
+"""
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+
+from charter import commands_workspace, todos, workspace
+from tests._isolation import PersonaIso
+
+
+def _args(**kw):
+    kw.setdefault("text", None)
+    kw.setdefault("workspace", None)
+    kw.setdefault("query", None)
+    return SimpleNamespace(**kw)
+
+
+class TodoCommandCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+
+    def run_todo(self, **kw):
+        """Returns (rc, stdout). Progress messages go to stderr via util.ok/info —
+        `run_todo_all` is for the tests that care what the user was told."""
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = commands_workspace.cmd_workspace_todo(_args(workspace="alpha", **kw))
+        return rc, buf.getvalue()
+
+    def run_todo_all(self, **kw):
+        """Returns (rc, stdout + stderr) — for assertions about what was reported."""
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = commands_workspace.cmd_workspace_todo(_args(workspace="alpha", **kw))
+        return rc, out.getvalue() + err.getvalue()
+
+
+class TestRecording(TodoCommandCase):
+    def test_recording_a_todo_succeeds_and_stores_it(self):
+        rc, _ = self.run_todo(text="prove the live gh path")
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(todos.open_todos("alpha")), 1)
+
+    def test_recording_reports_where_it_went(self):
+        """Naming the workspace matters — todos are scoped, so 'recorded' without saying
+        where is exactly the ambiguity the scoping exists to remove."""
+        _, out = self.run_todo_all(text="prove the live gh path")
+        self.assertIn("alpha", out)
+
+    def test_whitespace_only_text_lists_rather_than_recording(self):
+        """Consistent with the bare verb, and with `workspace remember`: no text means
+        no todo to record, so the useful answer is to show what is already there."""
+        rc, _ = self.run_todo(text="   ")
+        self.assertEqual(rc, 0)
+        self.assertEqual(todos.open_todos("alpha"), [])
+
+
+class TestListing(TodoCommandCase):
+    def test_the_bare_verb_lists(self):
+        self.run_todo(text="first thing")
+        self.run_todo(text="second thing")
+        rc, out = self.run_todo()
+        self.assertEqual(rc, 0)
+        self.assertIn("first thing", out)
+        self.assertIn("second thing", out)
+
+    def test_an_empty_list_says_so_rather_than_printing_nothing(self):
+        """Silence is indistinguishable from a broken command, so an empty list has to
+        say it is empty — and say how to add the first one."""
+        rc, out = self.run_todo_all()
+        self.assertEqual(rc, 0)
+        self.assertIn("No open todos", out)
+        self.assertIn("charter ws todo", out)
+
+    def test_listing_shows_age(self):
+        self.run_todo(text="something")
+        _, out = self.run_todo()
+        self.assertIn("0d", out)
+
+    def test_listing_is_oldest_first(self):
+        for t in ("aaa first", "bbb second", "ccc third"):
+            self.run_todo(text=t)
+        _, out = self.run_todo()
+        self.assertLess(out.index("aaa first"), out.index("bbb second"))
+        self.assertLess(out.index("bbb second"), out.index("ccc third"))
+
+    def test_listing_shows_a_slug_to_address_each_todo(self):
+        self.run_todo(text="prove the live path")
+        _, out = self.run_todo()
+        self.assertIn(todos.open_todos("alpha")[0]["slug"], out)
+
+
+class TestDuplicates(TodoCommandCase):
+    def test_a_near_duplicate_is_refused(self):
+        self.run_todo(text="prove the live gh issue create path works")
+        rc, _ = self.run_todo(text="prove the live gh issue create path works")
+        self.assertNotEqual(rc, 0)
+
+    def test_a_near_duplicate_does_not_grow_the_list(self):
+        self.run_todo(text="prove the live gh issue create path works")
+        self.run_todo(text="prove the live gh issue create path works")
+        self.assertEqual(len(todos.open_todos("alpha")), 1)
+
+    def test_the_original_survives_untouched(self):
+        self.run_todo(text="prove the live gh issue create path works")
+        before = todos.open_todos("alpha")[0]
+        self.run_todo(text="prove the live gh issue create path works")
+        self.assertEqual(todos.open_todos("alpha")[0]["slug"], before["slug"])
+
+    def test_an_unrelated_todo_is_still_accepted(self):
+        self.run_todo(text="prove the live gh issue create path works")
+        rc, _ = self.run_todo(text="rewrite the status line frame")
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(todos.open_todos("alpha")), 2)
+
+
+class TestSearching(TodoCommandCase):
+    def test_query_finds_a_matching_todo(self):
+        self.run_todo(text="prove the live gh issue path")
+        self.run_todo(text="rewrite the status line frame")
+        _, out = self.run_todo(query="statusline status frame")
+        self.assertIn("status line frame", out)
+
+    def test_query_excludes_non_matches(self):
+        self.run_todo(text="prove the live gh issue path")
+        self.run_todo(text="rewrite the status line frame")
+        _, out = self.run_todo(query="statusline status frame")
+        self.assertNotIn("live gh issue path", out)
+
+
+class TestScoping(TodoCommandCase):
+    def test_the_command_targets_the_named_workspace(self):
+        workspace.ensure("beta")
+        self.run_todo(text="alpha work")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            commands_workspace.cmd_workspace_todo(_args(workspace="beta"))
+        self.assertNotIn("alpha work", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_todos_store.py
+++ b/tests/test_todos_store.py
@@ -1,0 +1,152 @@
+"""The todo store — a workspace's **intent**, kept apart from its memory.
+
+charter records what a task learned (memory) and what happened (the journal). A **todo** is
+neither: it is a claim about the future, and the only one of the three that stops being true
+by being acted on. It therefore gets its own store rather than a flag on memory — see
+docs/adr/0004, and `workspaces/todos/workspace.md` for the glossary.
+"""
+from __future__ import annotations
+
+import datetime
+import unittest
+
+from charter import memstore, todos, workspace
+from tests._isolation import PersonaIso
+
+
+class TestRecordingATodo(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+
+    def test_a_recorded_todo_is_listed(self):
+        todos.add("alpha", "prove the live gh issue create path")
+        self.assertEqual([t["title"] for t in todos.open_todos("alpha")],
+                         ["prove the live gh issue create path"])
+
+    def test_nothing_recorded_means_an_empty_list(self):
+        self.assertEqual(todos.open_todos("alpha"), [])
+
+    def test_a_todo_survives_a_separate_read(self):
+        """Persistence is the entire point — the harness's own list already covers the
+        within-session case."""
+        todos.add("alpha", "come back to the labels")
+        self.assertEqual(len(todos.open_todos("alpha")), 1)
+        self.assertEqual(len(todos.open_todos("alpha")), 1)
+
+    def test_each_todo_carries_an_age_in_days(self):
+        todos.add("alpha", "something")
+        self.assertEqual(todos.open_todos("alpha")[0]["age_days"], 0)
+
+    def test_a_todo_is_addressable_by_slug(self):
+        todos.add("alpha", "prove the live path")
+        self.assertTrue(todos.open_todos("alpha")[0]["slug"])
+
+
+class TestIntentIsNotMemory(PersonaIso):
+    """ADR 0004. A `charter recall` hit on a todo somebody finished last month would read
+    with the same authority as a durable fact — worse than no hit at all."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+
+    def test_todos_live_beside_memory_not_inside_it(self):
+        todos.add("alpha", "a todo")
+        self.assertFalse(
+            todos.todos_dir("alpha").is_relative_to(workspace.memory_dir("alpha")))
+        self.assertEqual(todos.todos_dir("alpha").parent,
+                         workspace.memory_dir("alpha").parent)
+
+    def test_a_todo_never_appears_among_the_workspace_memories(self):
+        todos.add("alpha", "a todo about migrations")
+        workspace.remember("alpha", "a memory about migrations")
+        titles = [t for _, t, _ in memstore.entries(workspace.memory_dir("alpha"))]
+        self.assertNotIn("a todo about migrations", titles)
+
+    def test_a_memory_never_appears_among_the_todos(self):
+        workspace.remember("alpha", "a memory about migrations")
+        todos.add("alpha", "a todo about migrations")
+        self.assertEqual([t["title"] for t in todos.open_todos("alpha")],
+                         ["a todo about migrations"])
+
+
+class TestWorkspaceIsolation(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+        workspace.ensure("beta")
+
+    def test_a_todo_belongs_to_exactly_one_workspace(self):
+        todos.add("alpha", "alpha work")
+        todos.add("beta", "beta work")
+        self.assertEqual([t["title"] for t in todos.open_todos("alpha")], ["alpha work"])
+        self.assertEqual([t["title"] for t in todos.open_todos("beta")], ["beta work"])
+
+    def test_one_workspaces_list_is_empty_while_anothers_is_not(self):
+        todos.add("alpha", "alpha work")
+        self.assertEqual(todos.open_todos("beta"), [])
+
+
+class TestOldestFirst(PersonaIso):
+    """The only ranking in the feature. Oldest-first makes the session reminder
+    self-correcting: what surfaces is what is being avoided."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+
+    def test_todos_come_back_oldest_first(self):
+        """Titles chosen to sort alphabetically *against* insertion order, and stamped
+        days apart. Recorded in the same second with ascending names, this test would pass
+        on alphabetical ordering alone and prove nothing about time."""
+        base = datetime.datetime(2026, 1, 1, 12, 0, 0)
+        todos.add("alpha", "zzz recorded first", stamp=base)
+        todos.add("alpha", "mmm recorded second", stamp=base + datetime.timedelta(days=1))
+        todos.add("alpha", "aaa recorded last", stamp=base + datetime.timedelta(days=2))
+        self.assertEqual([t["title"] for t in todos.open_todos("alpha")],
+                         ["zzz recorded first", "mmm recorded second", "aaa recorded last"])
+
+    def test_age_reflects_when_it_was_recorded(self):
+        todos.add("alpha", "an old one",
+                  stamp=datetime.datetime.now() - datetime.timedelta(days=30))
+        self.assertEqual(todos.open_todos("alpha")[0]["age_days"], 30)
+
+    def test_todos_in_the_same_second_are_all_kept(self):
+        """Second granularity must never cost a todo — ties sort by name, but nothing
+        is overwritten."""
+        base = datetime.datetime(2026, 1, 1, 12, 0, 0)
+        for t in ("one", "two", "three"):
+            todos.add("alpha", t, stamp=base)
+        self.assertEqual(len(todos.open_todos("alpha")), 3)
+
+
+class TestNearDuplicates(PersonaIso):
+    """Duplicate intent is worse than duplicate memory: closing one of a near-identical
+    pair leaves its twin looking outstanding, so the list starts lying about what is left."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+
+    def test_an_almost_identical_todo_is_reported(self):
+        todos.add("alpha", "prove the live gh issue create path works")
+        self.assertIsNotNone(
+            todos.duplicate_of("alpha", "prove the live gh issue create path works"))
+
+    def test_an_unrelated_todo_is_not_reported(self):
+        todos.add("alpha", "prove the live gh issue create path works")
+        self.assertIsNone(todos.duplicate_of("alpha", "rewrite the status line frame"))
+
+    def test_the_first_todo_in_an_empty_list_is_never_a_duplicate(self):
+        self.assertIsNone(todos.duplicate_of("alpha", "anything at all"))
+
+    def test_a_duplicate_in_another_workspace_does_not_count(self):
+        """Scoping is the point — an identical todo elsewhere is a different task's."""
+        workspace.ensure("beta")
+        todos.add("beta", "prove the live path")
+        self.assertIsNone(todos.duplicate_of("alpha", "prove the live path"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ticket 01 of the todos spec (ADRs 0004–0006 in #50).

charter records what a task **learned** (memory) and what **happened** (the journal), but nothing holds what it still **intends**. So every session on a long-running task re-derives its own plan, and work consciously deferred is indistinguishable from work nobody ever thought of.

```
charter ws todo "prove the live gh issue create path"
charter ws todo                    # oldest first, with age
charter ws todo --query "…"
```

## Shape

Its own store beside `memory/`, never inside it. A todo **expires** and a memory does not, so a `charter recall` hit on something finished last month would read with exactly the authority of a fact — worse than no hit at all (ADR 0004).

Shaped like `workspace remember`: the verb with text records, the verb bare lists. A `list` subcommand would be indistinguishable from recording a todo whose text is "list", which someone will eventually try to write down.

`memstore` gains a public `wordset`. Near-duplicate detection now has a second caller asking a different question — *"would this new text duplicate an existing one?"* rather than *"which stored pairs duplicate each other?"* — and both must tokenize identically or the shared threshold means two different things.

## Two bugs, both found by running the real CLI rather than only the suite

**Duplicate scoring wasn't Jaccard.** It divided by `max(len(a), len(b))` instead of the union. That looks equivalent and isn't: on text this short a single shared word is half the content, so *"first thing"* and *"second thing"* scored 0.5 and the second was refused as a duplicate of the first. Now uses the metric `memstore.duplicates` documents.

**The ordering test passed for the wrong reason.** Todos written within one second sort by *name* among themselves, and the test recorded `aaa`/`bbb`/`ccc` in a single second — so alphabetical order and insertion order agreed and nothing was proven. It now stamps days apart with titles sorting *against* insertion order.

That second-granularity tie is real, so it is documented rather than hidden: for an agent recording a burst, "the three oldest" is arbitrary within that second.

## Tests

32 new, full suite **1370 green**. No new seams — this feature has no external boundary at all, so `PersonaIso` and direct handler calls cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCnBscCDiUN4fRvEuB7RC