### PR TITLE
todos: a LIVE workspace shares its todo list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist/
 # working-tree status line lives (`python3 -m charter statusline`) — the committed
 # settings.json keeps `charter statusline`, which is what an actual user runs.
 /.claude/settings.local.json
+
+# Agent worktrees created by the harness for isolated sub-agent runs.
+.claude/worktrees/

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -507,21 +507,25 @@ def is_live(name: str) -> bool:
 
 
 def _live_block(names) -> str:
+    """The managed .gitignore block un-ignoring every LIVE workspace's shareable paths.
+
+    Each path is listed twice — the directory and its contents — because un-ignoring
+    ``…/memory`` alone re-includes the directory entry and none of the files inside it.
+    ``todos`` needs the same pair: a shared task list is one of the better reasons to make
+    a workspace LIVE at all, and without a line here the list would simply never travel,
+    which is the quietest way this could fail.
+    """
     lines = [_LIVE_BEGIN]
     for n in sorted(names):
         lines += [f"!/workspaces/{n}/workspace.json", f"!/workspaces/{n}/workspace.md",
-                  f"!/workspaces/{n}/memory", f"!/workspaces/{n}/memory/**"]
+                  f"!/workspaces/{n}/memory", f"!/workspaces/{n}/memory/**",
+                  f"!/workspaces/{n}/todos", f"!/workspaces/{n}/todos/**"]
     lines.append(_LIVE_END)
     return "\n".join(lines)
 
 
-def set_live(name: str, live: bool) -> bool:
-    """Mark a workspace LIVE (un-ignore its manifest+memory) or LOCAL (re-ignore).
-    Returns True if the liveness changed. Rewrites the managed .gitignore block."""
-    names = live_workspaces()
-    if (name in names) == live:
-        return False
-    names = names | {name} if live else names - {name}
+def _write_live_block(names) -> None:
+    """Rewrite the managed block for exactly *names*, creating it if absent."""
     gi = _gitignore()
     text = gi.read_text() if gi.exists() else ""
     block = _live_block(names)
@@ -533,6 +537,28 @@ def set_live(name: str, live: bool) -> bool:
     else:
         text = text.rstrip("\n") + "\n" + block + "\n"
     gi.write_text(text)
+
+
+def refresh_live_block() -> None:
+    """Regenerate the managed block from the workspaces that are already LIVE.
+
+    Idempotent, and it changes no workspace's liveness — it only brings the block up to
+    the paths this version of charter shares. A plane made LIVE before `todos/` existed
+    has a block listing four paths per workspace and nothing re-runs `set_live` on its
+    own, so without this the list silently never travels for exactly the people who
+    adopted the feature earliest.
+    """
+    _write_live_block(live_workspaces())
+
+
+def set_live(name: str, live: bool) -> bool:
+    """Mark a workspace LIVE (un-ignore its manifest+memory) or LOCAL (re-ignore).
+    Returns True if the liveness changed. Rewrites the managed .gitignore block."""
+    names = live_workspaces()
+    if (name in names) == live:
+        return False
+    names = names | {name} if live else names - {name}
+    _write_live_block(names)
     return True
 
 
@@ -857,6 +883,11 @@ def reinit(name: str) -> dict:
     content. Returns the pre-reinit status (what was missing / the old version)."""
     before = structure_status(name)
     scaffold(name)  # creates memory/refs/workspace.md if missing + stamps the marker
+    # Structure is not only what lives inside the workspace directory: which of its paths
+    # are SHARED is part of the layout too, and that lives in the managed .gitignore block.
+    # A plane made LIVE before `todos/` existed lists four paths per workspace and nothing
+    # re-runs `set_live` unprompted — so the upgrade command is where it gets repaired.
+    refresh_live_block()
     return before
 
 

--- a/tests/test_todos_live_sharing.py
+++ b/tests/test_todos_live_sharing.py
@@ -1,0 +1,103 @@
+"""Todos travel with a LIVE workspace.
+
+A shared todo list is one of the better arguments for making a workspace LIVE at all: a
+team picking up a task gets what is left to do, not only what was learned. The mechanism
+already exists — marking a workspace LIVE rewrites a managed `.gitignore` block that
+un-ignores its shareable paths — and the todo directory has to join the four already there.
+
+This is the quietest possible failure if missed. Everything else about todos keeps working
+and the list simply never travels, noticed only by the person who most needed it.
+"""
+from __future__ import annotations
+
+import unittest
+
+from charter import config, todos, workspace
+from tests._isolation import PersonaIso
+
+
+def _gitignore() -> str:
+    p = config.ROOT / ".gitignore"
+    return p.read_text() if p.exists() else ""
+
+
+class TestLiveWorkspacesShareTheirTodos(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+
+    def test_a_live_workspace_un_ignores_its_todos(self):
+        workspace.set_live("alpha", True)
+        self.assertIn("!/workspaces/alpha/todos", _gitignore())
+
+    def test_the_contents_are_un_ignored_too_not_just_the_directory(self):
+        """`!/workspaces/alpha/todos` alone un-ignores the directory entry and none of
+        the files in it — the same reason `memory` is paired with `memory/**`."""
+        workspace.set_live("alpha", True)
+        self.assertIn("!/workspaces/alpha/todos/**", _gitignore())
+
+    def test_a_local_workspace_keeps_its_todos_private(self):
+        todos.add("alpha", "something private")
+        self.assertNotIn("!/workspaces/alpha/todos", _gitignore())
+
+    def test_going_local_again_re_ignores_them(self):
+        workspace.set_live("alpha", True)
+        workspace.set_live("alpha", False)
+        self.assertNotIn("!/workspaces/alpha/todos", _gitignore())
+
+    def test_several_live_workspaces_each_get_their_own_line(self):
+        workspace.ensure("beta")
+        workspace.set_live("alpha", True)
+        workspace.set_live("beta", True)
+        gi = _gitignore()
+        self.assertIn("!/workspaces/alpha/todos/**", gi)
+        self.assertIn("!/workspaces/beta/todos/**", gi)
+
+    def test_making_one_live_does_not_share_anothers_todos(self):
+        workspace.ensure("beta")
+        workspace.set_live("alpha", True)
+        self.assertNotIn("!/workspaces/beta/todos", _gitignore())
+
+    def test_the_existing_shared_paths_are_untouched(self):
+        """Adding todos must not disturb what LIVE already shared."""
+        workspace.set_live("alpha", True)
+        gi = _gitignore()
+        for path in ("workspace.json", "workspace.md", "memory", "memory/**"):
+            self.assertIn(f"!/workspaces/alpha/{path}", gi)
+
+
+class TestUpgradingAPlaneThatPredatesTodos(PersonaIso):
+    """A plane made LIVE before todos existed has a managed block with four paths and no
+    todo line, and nothing re-runs `set_live` on its own. `reinit` is the documented
+    upgrade path — "after a charter upgrade" — so it is what repairs the block."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+
+    def _stale_block(self) -> None:
+        """Recreate the pre-todos block: LIVE, then strip the todo lines back out."""
+        workspace.set_live("alpha", True)
+        gi = config.ROOT / ".gitignore"
+        gi.write_text("\n".join(ln for ln in gi.read_text().splitlines()
+                                if "/todos" not in ln) + "\n")
+
+    def test_the_stale_block_really_is_missing_the_todo_path(self):
+        """Guards the guard: if this ever stops being true the upgrade test below would
+        pass without proving anything."""
+        self._stale_block()
+        self.assertNotIn("!/workspaces/alpha/todos", _gitignore())
+
+    def test_reinit_restores_the_todo_path(self):
+        self._stale_block()
+        workspace.reinit("alpha")
+        self.assertIn("!/workspaces/alpha/todos/**", _gitignore())
+
+    def test_reinit_leaves_a_local_workspace_local(self):
+        """Repairing the block must never quietly promote a private workspace."""
+        workspace.reinit("alpha")
+        self.assertNotIn("!/workspaces/alpha/todos", _gitignore())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ticket 05 of the todos spec.

A shared todo list is one of the better arguments for making a workspace LIVE at all — a team picking up a task gets what is left to do, not only what was learned. The managed `.gitignore` block now un-ignores `todos/` alongside `workspace.json`, `workspace.md` and `memory/`.

Listed as a **pair** — directory and contents — for the same reason `memory` is: un-ignoring the directory alone re-includes its entry and none of the files inside it.

## Why this is more than one line

Block-writing is extracted from `set_live` into `_write_live_block`, and a new `refresh_live_block` regenerates it from whichever workspaces are *already* LIVE, changing no workspace's liveness. `reinit` calls it.

A plane made LIVE **before** todos existed carries a block listing four paths per workspace, and nothing re-runs `set_live` on its own. Without the refresh, the list would silently never travel — for exactly the people who adopted the feature earliest, with no symptom to notice. Which of a workspace's paths are shared is part of its structure, so the command that upgrades structure after a charter release is where it gets repaired.

## On the tests

The upgrade test is itself guarded: a second test asserts the simulated stale block really is missing the todo line, so the upgrade test cannot start passing for free if that setup ever drifts.

10 new tests, full suite **1392 green**.

Also gitignores `.claude/worktrees/` — the harness creates agent worktrees there, and they are not repo content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCnBscCDiUN4fRvEuB7RC