### PR TITLE
todos: close, fork-inherit, and report on removal

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -346,7 +346,19 @@ def _add_workspace_parser(sub) -> None:
                               "journal (what happened).")
     # Text optional, exactly like `remember`: the bare verb lists. A `list` SUBCOMMAND
     # would be indistinguishable from recording a todo whose text is "list".
-    td.add_argument("text", nargs="?", help="The todo; omit to list this workspace's todos.")
+    #
+    # `done`/`forget` are read as verbs rather than as todo text, which the same argument
+    # would seem to forbid — except that each takes a SLUG after it, and recording never
+    # has a second positional. So the two are told apart by the shape of the call, not by
+    # the word: `todo "forget the labels"` is one argument and records; `todo forget
+    # 20260101-120000-labels` is two and closes. Real subparsers can't do this — argparse
+    # matches the leading positional against `text` before any subcommand gets a look.
+    td.add_argument("text", nargs="?",
+                    help="The todo — or `done`/`forget` with a slug after it; omit to list.")
+    td.add_argument("slug", nargs="?",
+                    help="With `done` (finished — journalled) or `forget` (abandoned — "
+                         "silent): which todo to close. Closing deletes it; the journal is "
+                         "already the record of what happened.")
     td.add_argument("--workspace", "-w", help="Target workspace (default: the active one).")
     td.add_argument("--query", "-q", help="Search the todos instead of listing them all.")
     td.set_defaults(func=commands_workspace.cmd_workspace_todo)

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -748,9 +748,10 @@ def cmd_workspace_vision(args) -> int:
 def cmd_workspace_fork(args) -> int:
     """Fork a workspace: create <new> pre-loaded with <src>'s context — the living
     charter (workspace.md: vision, context, glossary), the manifest (repos+branches),
-    and the task memo — so you can branch off and continue with full context. The
-    repo clones are not copied (they're reconstructible): pass --restore to clone them
-    from the manifest, or `charter clone` on demand. Starts LOCAL unless --live."""
+    the task memo, and the open todos — so you can branch off and continue with full
+    context. The repo clones are not copied (they're reconstructible): pass --restore to
+    clone them from the manifest, or `charter clone` on demand. Starts LOCAL unless --live."""
+    from . import todos
     src, new = args.src, args.new
     if not workspace.valid_name(new):
         util.err(f"invalid workspace name '{new}' (use lowercase letters, digits, . _ -)")
@@ -773,6 +774,20 @@ def cmd_workspace_fork(args) -> int:
     src_mem = workspace.memory_dir(src)
     if src_mem.exists():
         shutil.copytree(src_mem, workspace.memory_dir(new), dirs_exist_ok=True)
+    # Open todos travel with the memory, and for the same reason: a fork exists so someone
+    # can pick the task up with full context, and what is still to be done is the most
+    # actionable part of that. Inheriting everything the task LEARNED while dropping
+    # everything it still INTENDED leaves the fork re-deriving the plan — the exact problem
+    # todos were built to end.
+    #
+    # A COPY, so the two lists diverge from here: closing one in the fork must not rewrite
+    # the source's plan. Copied wholesale (files + index) rather than re-added one by one,
+    # which would restamp every todo with today's date and hide a three-week-old intent
+    # behind a fresh one — age is the only ranking this feature has. Closed todos never
+    # arise, since finishing one deletes it.
+    src_todos = todos.todos_dir(src)
+    if src_todos.exists():
+        shutil.copytree(src_todos, todos.todos_dir(new), dirs_exist_ok=True)
     m = workspace.read_manifest(src)
     repos = list(m.get("repos") or [])
     if m:
@@ -787,6 +802,12 @@ def cmd_workspace_fork(args) -> int:
         workspace.set_live(new, True)
     util.ok(f"Forked '{src}' → '{new}' — charter + context + memo copied "
             f"({'LIVE' if getattr(args, 'live', False) else 'LOCAL'}).")
+    inherited = todos.count_open(new)
+    if inherited:
+        # Said out loud because the two lists are independent from here: whoever forked
+        # needs to know they now own a second copy of this intent, not a view of the first.
+        util.info(f"Inherited {inherited} open todo(s) from '{src}' — the fork's own list "
+                  f"now: charter ws todo --workspace {new}")
     if getattr(args, "restore", False) and repos:
         util.info(f"Cloning {len(repos)} repo(s) from the inherited manifest…")
         return cmd_workspace_restore(SimpleNamespace(name=new, on_demand=False))

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -219,6 +219,16 @@ def cmd_workspace_remove(args) -> int:
         )
         return 2
 
+    # Open todos are REPORTED, never guarded on — see `_work_at_risk` for why they are not
+    # in that list. Said here rather than above the guard so the count describes what is
+    # actually about to happen, and only when there is something to say: "0 open todos" on
+    # every removal is how a line stops being read at all, including on the removal where
+    # it mattered.
+    from . import todos
+    open_todos = todos.count_open(name)
+    if open_todos:
+        util.warn(f"Discarding {open_todos} open todo(s) with '{name}' — nothing else holds them.")
+
     shutil.rmtree(wd)
     util.ok(f"Removed workspace '{name}' and its clones.")
     if workspace.resolve() == name and workspace.source() in ("session", "active-file"):
@@ -270,7 +280,14 @@ def cmd_workspace_rename(args) -> int:
 
 
 def _work_at_risk(name: str) -> list[str]:
-    """Clones in the workspace with uncommitted or unpushed work."""
+    """Clones in the workspace with uncommitted or unpushed work.
+
+    Only that. Open todos are deliberately NOT here, though `remove` reports them: this
+    list is what is *unrecoverable*, and a todo is a note about the future, not work that
+    ceases to exist. A workspace whose todos were all abandoned is precisely the one worth
+    deleting, and making that case demand `--force` would teach the habit of reaching for
+    `--force` — which is how a guard stops protecting the commits it exists for.
+    """
     out = []
     for d in workspace.clones(name):
         if _git(["status", "--porcelain"], cwd=d).stdout.strip():

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -569,8 +569,16 @@ def cmd_workspace_note(args) -> int:
     return cmd_workspace_remember(args)
 
 
+#: The two ways a todo stops being open — `done` (finished) and `forget` (abandoned).
+#: They are safe as leading words where a `list` subcommand was not (see the docstring
+#: below) because each is followed by a SLUG: recording never has a second positional, so
+#: "did the user mean to record this?" is answered by the shape of the call, not by
+#: guessing at the word. Two states only, and neither is `in_progress` (docs/adr/0006).
+_CLOSING_VERBS = ("done", "forget")
+
+
 def cmd_workspace_todo(args) -> int:
-    """Record one **todo** — something this task still means to do — or list them.
+    """Record one **todo** — something this task still means to do — list them, or close one.
 
     Shaped like `remember`: the verb with text records, the verb bare lists. A literal
     `todo list` subcommand would be indistinguishable from recording a todo whose text is
@@ -582,7 +590,18 @@ def cmd_workspace_todo(args) -> int:
     from . import todos
     name = getattr(args, "workspace", None) or workspace.resolve()
     text = (getattr(args, "text", None) or "").strip()
+    slug = (getattr(args, "slug", None) or "").strip()
     query = getattr(args, "query", None)
+
+    if text in _CLOSING_VERBS:
+        if not slug:
+            # Falling through to the recording path here would record a todo whose text is
+            # "done" — a silent wrong action in answer to an obvious slip, and one nobody
+            # could act on later. Ask for the missing half instead.
+            util.err(f"`todo {text}` needs the slug of the todo to close.")
+            util.info(f"  The slug is the first column: charter ws todo --workspace {name}")
+            return 1
+        return _close_todo(name, slug, journal=(text == "done"))
 
     if not text:
         return _list_todos(name, query)
@@ -600,6 +619,51 @@ def cmd_workspace_todo(args) -> int:
     util.ok(f"Todo recorded in '{name}' → workspaces/{name}/todos/{p.name}")
     if not workspace.is_live(name):
         util.info(f"  '{name}' is LOCAL (private) — todos stay on disk, not committed.")
+    return 0
+
+
+def _close_todo(name: str, slug: str, *, journal: bool) -> int:
+    """Close one todo: **delete** it, leaving a journal entry (`done`) or nothing (`forget`).
+
+    Closing deletes rather than marking done because the journal is already the permanent
+    record of what happened — keeping closed todos would build a second one that every read
+    then has to filter past, and a store whose reads all begin with a filter is a store that
+    will eventually be read without it.
+
+    Which makes the journal entry the load-bearing half, not a courtesy. An agent may close
+    todos it recorded itself, so without a trace outside the list it could create and tick
+    off work unobserved and the list would always read as finished — worse than no list,
+    because it would be confidently wrong. `forget` has no trace precisely because it claims
+    nothing happened.
+
+    Journalling happens BEFORE the delete: the entry is the only surviving evidence, so it
+    is written while the todo is still there to name. Both halves resolve through the
+    workspace's own todo directory, which is what keeps one workspace from closing another's
+    work — there is no path from here to a slug that lives elsewhere.
+    """
+    from . import memstore, todos
+    d = todos.todos_dir(name)
+    p = memstore.resolve(d, slug)
+    if p is None:
+        util.err(f"no todo '{slug}' in workspace '{name}'.")
+        util.info(f"  List the real ones: charter ws todo --workspace {name}")
+        return 1
+    # Ask the store for the title rather than re-parsing the file here: `open_todos` already
+    # decides what a todo is called, and two answers to that would eventually disagree.
+    title = next((t["title"] for t in todos.open_todos(name) if t["slug"] == p.stem), p.stem)
+
+    if journal:
+        # Through the normal note path, so a LIVE workspace shares this entry exactly like
+        # every other journal entry. A trace that stays on disk while the rest of the
+        # journal is shared is a weaker trace than the argument above needs.
+        cmd_workspace_remember(SimpleNamespace(
+            workspace=name, text=f"Closed todo: {title}", title=None, no_sync=False))
+
+    memstore.forget(d, p.name)  # drops the file AND its index line — no residue either side
+    if journal:
+        util.ok(f"Closed '{title}' in '{name}' — the journal has the trace.")
+    else:
+        util.ok(f"Dropped '{title}' from '{name}' — abandoned, so nothing was journalled.")
     return 0
 
 

--- a/tests/test_todos_command.py
+++ b/tests/test_todos_command.py
@@ -1,8 +1,9 @@
-"""`charter workspace todo` — recording and reading a workspace's intent.
+"""`charter workspace todo` — recording, reading and closing a workspace's intent.
 
 Follows the shape `workspace remember` already established: the verb with text records,
 the verb bare lists. A literal `todo list` subcommand would be indistinguishable from
-recording a todo whose text is "list".
+recording a todo whose text is "list"; `done`/`forget` escape that trap only because they
+take a slug after them, which recording never does.
 """
 from __future__ import annotations
 
@@ -19,6 +20,7 @@ def _args(**kw):
     kw.setdefault("text", None)
     kw.setdefault("workspace", None)
     kw.setdefault("query", None)
+    kw.setdefault("slug", None)
     return SimpleNamespace(**kw)
 
 
@@ -144,6 +146,168 @@ class TestScoping(TodoCommandCase):
         with redirect_stdout(buf):
             commands_workspace.cmd_workspace_todo(_args(workspace="beta"))
         self.assertNotIn("alpha work", buf.getvalue())
+
+
+class ClosingCase(TodoCommandCase):
+    """A todo is closed by slug — the handle the list already prints beside each one."""
+
+    def record(self, text: str) -> str:
+        """Record one todo and return the slug that addresses it.
+
+        By difference, not by position: todos recorded in the same second sort
+        alphabetically among themselves, so "the last one listed" is not "the one just
+        added" — which made a test close the wrong todo and still pass its own assertion.
+        """
+        before = {t["slug"] for t in todos.open_todos("alpha")}
+        self.run_todo(text=text)
+        new = [t["slug"] for t in todos.open_todos("alpha") if t["slug"] not in before]
+        self.assertEqual(len(new), 1, "the todo under test was not recorded")
+        return new[0]
+
+    def journal(self, name: str = "alpha") -> str:
+        return "\n".join(p.read_text() for p in workspace.memories(name))
+
+
+class TestFinishingATodo(ClosingCase):
+    """`done` — finished, so the list drops it and the journal keeps the trace.
+
+    The trace is the load-bearing half. An agent may close its own todos, so without a
+    record in the journal it could create and tick off work unobserved and the list would
+    always read as finished — which is worse than having no list.
+    """
+
+    def test_a_finished_todo_leaves_the_list(self):
+        slug = self.record("prove the live gh path")
+        rc, _ = self.run_todo_all(text="done", slug=slug)
+        self.assertEqual(rc, 0)
+        self.assertEqual(todos.open_todos("alpha"), [])
+
+    def test_finishing_writes_a_journal_entry_naming_the_todo(self):
+        self.assertEqual(self.journal(), "")  # nothing in the journal to mistake for the trace
+        slug = self.record("prove the live gh path")
+        self.run_todo_all(text="done", slug=slug)
+        self.assertIn("prove the live gh path", self.journal())
+
+    def test_finishing_reports_what_it_closed(self):
+        """The slug is a truncated stamp+title; echoing the todo back is how the developer
+        confirms the right one went, not the one recorded in the same second."""
+        slug = self.record("prove the live gh path")
+        _, out = self.run_todo_all(text="done", slug=slug)
+        self.assertIn("prove the live gh path", out)
+
+    def test_a_finished_todo_leaves_no_file_behind(self):
+        """Closing DELETES. The journal is already the permanent record of what happened,
+        so a kept-but-marked todo would build a second one that every later read has to
+        filter past."""
+        slug = self.record("prove the live gh path")
+        self.run_todo_all(text="done", slug=slug)
+        left = [p.name for p in todos.todos_dir("alpha").glob("*.md") if p.name != "MEMORY.md"]
+        self.assertEqual(left, [])
+
+    def test_a_finished_todo_leaves_the_index(self):
+        slug = self.record("prove the live gh path")
+        self.run_todo_all(text="done", slug=slug)
+        self.assertNotIn(slug, todos.index("alpha").read_text())
+
+    def test_the_closing_verb_is_not_itself_recorded_as_a_todo(self):
+        """`todo done <slug>` must never fall through to the recording path — a todo
+        called "done" is the one entry nobody could act on."""
+        slug = self.record("prove the live gh path")
+        self.run_todo_all(text="done", slug=slug)
+        self.assertNotIn("done", [t["title"] for t in todos.open_todos("alpha")])
+
+    def test_finishing_leaves_the_other_todos_alone(self):
+        keep = self.record("keep this one")
+        slug = self.record("close this one")
+        self.run_todo_all(text="done", slug=slug)
+        self.assertEqual([t["slug"] for t in todos.open_todos("alpha")], [keep])
+
+
+class TestAbandoningATodo(ClosingCase):
+    """`forget` — given up on, so it goes silently: nothing happened worth journalling."""
+
+    def test_an_abandoned_todo_leaves_the_list(self):
+        slug = self.record("prove the live gh path")
+        rc, _ = self.run_todo_all(text="forget", slug=slug)
+        self.assertEqual(rc, 0)
+        self.assertEqual(todos.open_todos("alpha"), [])
+
+    def test_abandoning_writes_no_journal_entry(self):
+        """The distinction from `done` is the entire point of having two verbs: a journal
+        full of work that was never done is a journal nobody trusts."""
+        slug = self.record("prove the live gh path")
+        self.run_todo_all(text="forget", slug=slug)
+        self.assertNotIn("prove the live gh path", self.journal())
+
+    def test_abandoning_leaves_no_file_behind(self):
+        slug = self.record("prove the live gh path")
+        self.run_todo_all(text="forget", slug=slug)
+        left = [p.name for p in todos.todos_dir("alpha").glob("*.md") if p.name != "MEMORY.md"]
+        self.assertEqual(left, [])
+
+
+class TestClosingWhatIsNotThere(ClosingCase):
+    def test_an_unknown_slug_fails(self):
+        self.record("prove the live gh path")
+        rc, _ = self.run_todo_all(text="done", slug="no-such-todo")
+        self.assertNotEqual(rc, 0)
+
+    def test_an_unknown_slug_says_how_to_list_the_real_ones(self):
+        """Slugs are typed by hand from a listing, so a typo is the normal failure — and
+        the answer to "what are the real ones?" is one command away."""
+        self.record("prove the live gh path")
+        _, out = self.run_todo_all(text="done", slug="no-such-todo")
+        self.assertIn("charter ws todo", out)
+
+    def test_an_unknown_slug_closes_nothing(self):
+        self.record("prove the live gh path")
+        self.run_todo_all(text="done", slug="no-such-todo")
+        self.assertEqual(len(todos.open_todos("alpha")), 1)
+
+    def test_an_unknown_slug_writes_no_journal_entry(self):
+        """A trace of finishing something that was never there is a lie in the one record
+        the list's trustworthiness rests on."""
+        self.record("prove the live gh path")
+        self.run_todo_all(text="done", slug="no-such-todo")
+        self.assertEqual(self.journal(), "")
+
+    def test_abandoning_an_unknown_slug_fails(self):
+        self.record("prove the live gh path")
+        rc, _ = self.run_todo_all(text="forget", slug="no-such-todo")
+        self.assertNotEqual(rc, 0)
+
+    def test_a_closing_verb_without_a_slug_asks_for_one(self):
+        """`todo done` with nothing after it is a forgotten argument, not a request to
+        record a todo whose text is "done" — recording it would be a silent wrong action."""
+        rc, out = self.run_todo_all(text="done")
+        self.assertNotEqual(rc, 0)
+        self.assertEqual(todos.open_todos("alpha"), [])
+        self.assertIn("slug", out)
+
+
+class TestClosingIsWorkspaceScoped(ClosingCase):
+    """A todo belongs to exactly one workspace, and so does the command that closes it —
+    otherwise one task could quietly tick off another's work."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("beta")
+
+    def _close(self, ws: str, verb: str, slug: str) -> int:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            return commands_workspace.cmd_workspace_todo(
+                _args(workspace=ws, text=verb, slug=slug))
+
+    def test_done_cannot_reach_another_workspaces_todo(self):
+        slug = self.record("alpha work")
+        self.assertNotEqual(self._close("beta", "done", slug), 0)
+        self.assertEqual(len(todos.open_todos("alpha")), 1)
+
+    def test_forget_cannot_reach_another_workspaces_todo(self):
+        slug = self.record("alpha work")
+        self.assertNotEqual(self._close("beta", "forget", slug), 0)
+        self.assertEqual(len(todos.open_todos("alpha")), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_workspace_charter.py
+++ b/tests/test_workspace_charter.py
@@ -4,10 +4,11 @@ can continue with full context."""
 
 from __future__ import annotations
 
+import datetime
 import unittest
 from types import SimpleNamespace
 
-from charter import config, workspace
+from charter import config, todos, workspace
 from charter import commands_workspace as cw
 from tests._isolation import PersonaIso
 
@@ -115,6 +116,76 @@ class CharterCase(PersonaIso):
         self.assertEqual(cw.cmd_workspace_fork(self._fork_args("src", "taken")), 1)
         self.assertEqual(cw.cmd_workspace_fork(self._fork_args("ghost", "new")), 1)
         self.assertEqual(cw.cmd_workspace_fork(self._fork_args("src", "src")), 1)
+
+    # --- fork inherits open todos ---
+    #
+    # Fork exists so someone can pick a task up with full context, and what is still to be
+    # done is the most actionable part of it. Inheriting everything the task LEARNED while
+    # dropping everything it still INTENDED leaves the fork re-deriving the plan — the exact
+    # problem todos were built to end.
+
+    def test_a_fork_starts_with_the_sources_open_todos(self):
+        self._mk("src", vision="g")
+        todos.add("src", "prove the live gh path")
+        todos.add("src", "rewrite the status line frame")
+        self.assertEqual(cw.cmd_workspace_fork(self._fork_args("src", "fork1")), 0)
+        self.assertEqual([t["title"] for t in todos.open_todos("fork1")],
+                         ["prove the live gh path", "rewrite the status line frame"])
+
+    def test_forking_leaves_the_sources_list_untouched(self):
+        self._mk("src", vision="g")
+        todos.add("src", "prove the live gh path")
+        cw.cmd_workspace_fork(self._fork_args("src", "fork1"))
+        self.assertEqual([t["title"] for t in todos.open_todos("src")],
+                         ["prove the live gh path"])
+
+    def test_closing_in_the_fork_does_not_close_it_in_the_source(self):
+        """A fork is a copy, so the two lists diverge from that moment. Sharing them would
+        make finishing work in one workspace silently rewrite another's plan."""
+        self._mk("src", vision="g")
+        todos.add("src", "prove the live gh path")
+        cw.cmd_workspace_fork(self._fork_args("src", "fork1"))
+        slug = todos.open_todos("fork1")[0]["slug"]
+        cw.cmd_workspace_todo(SimpleNamespace(workspace="fork1", text="done", slug=slug,
+                                              query=None))
+        self.assertEqual(todos.open_todos("fork1"), [])
+        self.assertEqual(len(todos.open_todos("src")), 1)
+
+    def test_closing_in_the_source_does_not_close_it_in_the_fork(self):
+        self._mk("src", vision="g")
+        todos.add("src", "prove the live gh path")
+        cw.cmd_workspace_fork(self._fork_args("src", "fork1"))
+        slug = todos.open_todos("src")[0]["slug"]
+        cw.cmd_workspace_todo(SimpleNamespace(workspace="src", text="done", slug=slug,
+                                              query=None))
+        self.assertEqual(todos.open_todos("src"), [])
+        self.assertEqual(len(todos.open_todos("fork1")), 1)
+
+    def test_forking_a_workspace_with_no_todos_succeeds_with_none(self):
+        """Most workspaces have no todos at all, so the empty case is the common one — it
+        must not be an error, and must not leave the fork with a phantom list."""
+        self._mk("src", vision="g")
+        self.assertEqual(cw.cmd_workspace_fork(self._fork_args("src", "fork1")), 0)
+        self.assertEqual(todos.open_todos("fork1"), [])
+
+    def test_an_inherited_todo_keeps_its_original_age(self):
+        """Age is the only ranking the feature has, and it is what makes a stale intent
+        visible. Resetting it at the fork would hide a three-week-old todo behind a fresh
+        date — precisely the todo most worth surfacing."""
+        self._mk("src", vision="g")
+        todos.add("src", "an old one",
+                  stamp=datetime.datetime.now() - datetime.timedelta(days=30))
+        cw.cmd_workspace_fork(self._fork_args("src", "fork1"))
+        self.assertEqual(todos.open_todos("fork1")[0]["age_days"], 30)
+
+    def test_an_inherited_todo_can_be_closed_by_the_slug_the_fork_lists(self):
+        """Inheriting the files but not their index lines would leave todos that list but
+        cannot be addressed — the store's index is how a slug resolves."""
+        self._mk("src", vision="g")
+        todos.add("src", "prove the live gh path")
+        cw.cmd_workspace_fork(self._fork_args("src", "fork1"))
+        slug = todos.open_todos("fork1")[0]["slug"]
+        self.assertIn(slug, todos.index("fork1").read_text())
 
     # --- committed for LIVE ---
     def test_charter_committed_for_live(self):

--- a/tests/test_workspace_remove.py
+++ b/tests/test_workspace_remove.py
@@ -1,0 +1,116 @@
+"""`charter workspace remove` — what it warns about, and what it refuses over.
+
+The two are deliberately different sets. Removal refuses to discard **work at risk** —
+uncommitted or unpushed commits, which nothing can recover. Open todos are reported and
+never block: a workspace whose todos are all abandoned is precisely the one worth deleting,
+and making that case need `--force` teaches the habit of reaching for `--force`, which is
+how a guard stops protecting the commits it exists for.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+
+from charter import todos, workspace
+from charter import commands_workspace as cw
+from tests._isolation import PersonaIso
+
+#: `git init` has to work regardless of who runs the suite, so identity comes from the
+#: call rather than from the developer's ~/.gitconfig.
+_GIT_ENV = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e"}
+
+
+class RemoveCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+        workspace.scaffold("alpha")
+
+    def remove(self, name: str = "alpha", force: bool = False):
+        """Returns (rc, stdout + stderr) — util.err/warn write to stderr."""
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = cw.cmd_workspace_remove(SimpleNamespace(name=name, force=force))
+        return rc, out.getvalue() + err.getvalue()
+
+    def make_dirty_clone(self, name: str = "alpha", repo: str = "svc"):
+        """A real clone inside the workspace with an uncommitted file — genuine work at
+        risk, the thing removal exists to guard."""
+        d = workspace.workspace_dir(name) / repo
+        d.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "init", "-q", str(d)], check=True, capture_output=True,
+                       env={**os.environ, **_GIT_ENV})
+        (d / "unsaved.txt").write_text("work nobody has committed\n")
+        return d
+
+
+class TestTodosAreReportedOnRemoval(RemoveCase):
+    def test_removal_says_how_many_open_todos_it_discards(self):
+        """Todos are deleted with the workspace and nothing else holds them, so a silent
+        removal is the one case where the developer learns what was lost afterwards."""
+        todos.add("alpha", "prove the live gh path")
+        todos.add("alpha", "rewrite the status line frame")
+        rc, out = self.remove()
+        self.assertEqual(rc, 0)
+        self.assertIn("2", out)
+        self.assertIn("todo", out)
+
+    def test_removing_a_workspace_with_no_todos_reports_nothing_extra(self):
+        """An empty list is not news. Reporting "0 open todos" on every removal is how a
+        message stops being read at all, including on the removal that mattered."""
+        _, out = self.remove()
+        self.assertNotIn("todo", out)
+
+
+class TestTodosDoNotBlockRemoval(RemoveCase):
+    def test_todos_alone_do_not_require_force(self):
+        todos.add("alpha", "prove the live gh path")
+        rc, _ = self.remove()
+        self.assertEqual(rc, 0)
+
+    def test_the_workspace_is_actually_gone(self):
+        """Reporting the todos and then declining to remove would be the same failure as
+        blocking outright — the guard is what it does, not what it prints."""
+        todos.add("alpha", "prove the live gh path")
+        self.remove()
+        self.assertFalse(workspace.workspace_dir("alpha").exists())
+
+    def test_todos_are_not_in_the_work_at_risk_set(self):
+        """Asserted against the guard itself, not just its outcome: folding todos in here
+        is the overreach the ticket exists to prevent, and it would be invisible in a
+        workspace that has real work at risk anyway."""
+        todos.add("alpha", "prove the live gh path")
+        self.assertEqual(cw._work_at_risk("alpha"), [])
+
+
+class TestWorkAtRiskStillBlocks(RemoveCase):
+    def test_uncommitted_work_still_refuses_removal(self):
+        self.make_dirty_clone()
+        rc, _ = self.remove()
+        self.assertNotEqual(rc, 0)
+        self.assertTrue(workspace.workspace_dir("alpha").exists())
+
+    def test_uncommitted_work_refuses_even_with_todos_present(self):
+        """The todo count must not become an escape hatch: "it only had todos" is a
+        judgement about the todos, never about the commits beside them."""
+        todos.add("alpha", "prove the live gh path")
+        self.make_dirty_clone()
+        rc, _ = self.remove()
+        self.assertNotEqual(rc, 0)
+        self.assertTrue(workspace.workspace_dir("alpha").exists())
+
+    def test_force_still_removes_work_at_risk(self):
+        self.make_dirty_clone()
+        rc, _ = self.remove(force=True)
+        self.assertEqual(rc, 0)
+        self.assertFalse(workspace.workspace_dir("alpha").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three tickets on the todo lifecycle, grouped because they all touch `charter/commands_workspace.py`. One commit each, test-first.

## 02 — Close or abandon a todo

`charter ws todo done <slug>` removes the todo and writes a journal entry naming it; `charter ws todo forget <slug>` removes it silently. Closing **deletes** — the journal is already the permanent record of what happened, and keeping closed todos would build a second one that every later read has to filter past.

The journal trace is the load-bearing half rather than a courtesy: an agent may close todos it recorded itself, so with nothing outside the list to show for it, an agent could create and tick off work unobserved and the list would always read as finished — worse than no list, since it would be confidently wrong. `forget` has no trace precisely because it claims nothing happened. Still two states only; no `in_progress` (docs/adr/0006).

`done`/`forget` are read as verbs where a `list` subcommand was rejected, because each takes a slug after it and recording never has a second positional — the call is told apart by its shape, not by guessing at the word. `todo "forget the labels"` is one argument and records; `todo forget <slug>` is two and closes. `todo done` with no slug is refused rather than recorded, since a todo called "done" is the one entry nobody could act on.

Deletion goes through `memstore.forget` (file + index line), and both verbs resolve through the workspace's own todo directory — which is what keeps one workspace from closing another's work. Journalling happens through `cmd_workspace_remember`, so a LIVE workspace shares the entry exactly like every other journal entry, and before the delete, since the entry is the only surviving evidence.

## 06 — A fork inherits open todos

Fork already carries the living charter, manifest and task memo; it now carries what is still to be done, the most actionable part of the context a fork exists to hand over. Copied, not moved or shared: the source list is untouched and the two diverge from that point. Copied wholesale (files + index) rather than re-recorded one at a time, which would restamp every todo with the fork date and hide a three-week-old intent behind a fresh one — age is the only ranking the feature has. The fork reports how many it inherited, because whoever forked now owns a second copy of that intent rather than a view of the first.

## 07 — Removal reports todos without guarding on them

`workspace remove` says how many open todos go with the workspace, and does **not** block on them. Todos are deliberately not added to `_work_at_risk`: that list is what is unrecoverable, and a todo is a note about the future, not work that ceases to exist. A workspace whose todos were all abandoned is precisely the one worth deleting, and making that case demand `--force` teaches the habit of reaching for `--force`, which is how a guard stops protecting the commits it exists for. The reasoning now lives in `_work_at_risk`'s own docstring, where the next person will be standing when they consider adding them.

Removal had no tests at all, so `tests/test_workspace_remove.py` also pins the guard that does exist: uncommitted work still refuses, still refuses with todos beside it, and `--force` still overrides.

## Tests

`python3 -m unittest discover -s tests -t .` → **1415 tests, OK** (1400 before this branch).

Each ticket was seen red first. The assertions that pass trivially before their implementation (a fork not touching the source list, todos not being in the work-at-risk set) were checked by mutation — making fork `shutil.move` instead of copy, and adding todos to `_work_at_risk` — and each mutation fails exactly the test written for it.

## Not in scope, worth knowing

`todos/` is still absent from `workspace._live_block` and `_ws_meta_paths`, so a LIVE workspace's todos are invisible to git — the consequence docs/adr/0004 records. Left alone here: it is `charter/workspace.py`, which had concurrent work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145Anhzojfo151sYXYwwest
