### PR TITLE
docs: one plane shape, and a plane root nobody works in

### DIFF
--- a/docs/adr/0007-one-plane-shape.md
+++ b/docs/adr/0007-one-plane-shape.md
@@ -1,0 +1,45 @@
+# One plane shape — and the obvious reason for it is the wrong one
+
+charter had two plane shapes. **fleet**: the plane is its own directory and a workspace
+holds clones. **embedded**: charter serves the codebase it sits inside, and a workspace
+holds worktrees of it. The embedded shape is removed; fleet is the only shape, and the
+`[plane]` section and its `shape` key are deleted rather than kept and validated.
+
+The justification is **one code path instead of two**. Every function that asked "which
+shape am I?" was a place the two could drift, and only one of them was ever exercised by
+any given plane — so the other was carried on trust.
+
+## What this decision is NOT
+
+It is not a fix for workspaces thrashing each other's git branches, which is the symptom
+that prompted it. Recording that plainly, because the next person to hit branch-thrashing
+in a fleet plane will otherwise conclude this removal failed, or was never done.
+
+Embedded workspaces already had their own worktrees — see the `own_tree` docstring, which
+records that exact bug and that exact fix, predating this decision. What remained were two
+holes underneath it:
+
+1. the `default` workspace owned the plane root outright, so it isolated nothing; and
+2. selecting a workspace never moved the session into its tree — charter printed
+   `cd … && claude` and trusted the caller.
+
+**Fleet has both holes.** `repo_trees` returned `root_tree() + clones(ws)` in either shape,
+so a session that stays in the plane root edits the plane root regardless of which workspace
+it claims and regardless of which shape the plane is. The removal changes nothing about
+that, which is why it ships alongside ADR 0008.
+
+## Consequences
+
+charter develops itself through a clone of itself: the self-exclude in its own
+`charter.toml` existed only because "the repo is already here, as the plane's root tree",
+which stops being true.
+
+The solo-user path gains a step. `own_tree` promised that one person with one repo could
+`charter init` and carry on working in that repo; now they must clone it into a workspace.
+`charter init` inside a git repo offers to make that clone immediately, so the step is met
+once at setup rather than discovered later as "where did my code go?".
+
+No backward compatibility: `shape = "embedded"` in an existing `charter.toml` becomes an
+ignored unknown key. There is no migration, no refusal, and no deprecation window, and
+materialised worktrees are left exactly where they are — they remain valid git worktrees
+whether or not charter manages them.

--- a/docs/adr/0008-the-plane-root-is-not-a-work-tree.md
+++ b/docs/adr/0008-the-plane-root-is-not-a-work-tree.md
@@ -1,0 +1,43 @@
+# The plane root is not a work tree
+
+The directory holding `charter.toml` is the **plane root**. It holds the control plane —
+personas, inventory, workspaces, config — and nothing anyone is meant to edit or switch
+branches in. Work happens in a **workspace tree**: a clone a workspace owns.
+
+This needs writing down because nothing in the code makes it true. The plane root *is* a
+git repo, `charter init` is documented as something you run inside your existing repo, and
+the status line lists the root tree alongside the repos you work in. Every signal says
+"this is a place to work". Only a warning says otherwise.
+
+## Why it matters
+
+Two sessions in two workspaces are perfectly isolated right up until both of them are
+actually sitting in the plane root — at which point they share one working tree and one
+HEAD, and they thrash each other's branches while charter reports two different workspaces.
+That is the failure this constraint exists to prevent, and removing the embedded plane
+shape (ADR 0007) does not prevent it: `repo_trees` lists the root tree in every shape.
+
+Observed rather than theorised. In the session that produced this decision the agent was
+nominally in two different workspaces in turn while doing every git operation in the plane
+root — six branches, and at one point a `git checkout main` that silently reverted
+in-flight work out of the tree.
+
+## Considered options
+
+Preventing it outright — refusing commands that would operate in the root — is the real
+answer and is deliberately not what ships first. Which commands count is a judgement that
+wants evidence: `charter` itself must obviously work there, and so must whatever a user
+does to configure their plane. Shipping a refusal built on a guess would either block
+legitimate work or be so narrow it protects nothing.
+
+So the first step is signal, in the two places already designed to carry it: the status
+line marks the root row as infrastructure rather than drawing it as a peer of the clones,
+and `doctor` — which runs at SessionStart, while acting on it is still cheap — checks the
+root is clean and on its default branch.
+
+## Consequences
+
+A warning you can work through is a warning you learn to work through, and this one is
+expected to be ignored at first. That is accepted for now, and it is the reason this ADR
+exists: so that when someone later proposes making it an error, the note explaining why it
+was not one on day one is already here.


### PR DESCRIPTION
Design-only. Two ADRs, no implementation.

charter carries **two plane shapes** and every plane exercises exactly one, so the other is dead code carried on trust — `repo_trees`, `doctor`, `init`, the status line and `workspace` all branch on shape with nothing forcing the halves to agree. Embedded goes; fleet is the only shape.

## 0007 — one plane shape, and the obvious reason is the wrong one

The symptom that prompted this was two workspaces thrashing each other's git branches. **The shape is not the cause**, and the ADR says so at length, because the next person to hit branch-thrashing in a fleet plane would otherwise conclude the removal failed.

Embedded workspaces already owned their own worktrees — `own_tree`'s docstring records that exact bug and that exact fix, predating this. What actually breaks isolation is that the `default` workspace owns the plane root outright, and that selecting a workspace never moves the session into its tree; charter prints `cd … && claude` and trusts the caller. **Fleet has both holes**: `repo_trees` returns `root_tree() + clones` in either shape.

So the removal is justified by *one code path instead of two*, and not by fixing the bug — which it does not do on its own.

## 0008 — the plane root is not a work tree

The other half, and the reason the removal is worth anything to the person who asked for it. Nothing in the code makes this true: the plane root **is** a git repo, `charter init` is documented as something you run inside your existing repo, and the status line lists it beside the clones you edit. Every signal says "work here".

So the status line marks it as infrastructure, and `doctor` checks it is clean and on its default branch — at SessionStart, while acting on it is still cheap.

Observed rather than theorised: in the session that produced this, the agent was nominally in two different workspaces in turn while doing every git operation in the plane root — six branches, and one `git checkout main` that silently reverted in-flight work out of the tree.

**Warning, not refusal, deliberately.** Which commands may operate in the root wants evidence; a refusal built on a guess either blocks legitimate work or is too narrow to protect anything. 0008 exists so that when someone later proposes tightening it, the note explaining why it was loose on day one is already there.

## Not here

No code. No backward compatibility by decision — `shape = "embedded"` becomes an ignored unknown key, with no migration and no worktree touched. This plane is itself embedded, so the first cost lands here.

Four tracer-bullet tickets live in the `plane-shape` workspace, which is LOCAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCnBscCDiUN4fRvEuB7RC