### PR TITLE
doctor: the plane root is not a place to work, and the preflight now says so

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -274,6 +274,143 @@ def check_control_plane_schema() -> Result:
     )
 
 
+def _git_in(root: Path, *args: str):
+    """One read-only git question about ``root``, never raising on a non-zero exit.
+
+    Timed out like every other check: the plane root is normally a small local repo, but
+    a plane on a stalled network mount makes `git status` hang, and the SessionStart hook
+    has a budget — a check that eats it prints nothing at all (see `CHECK_TIMEOUT`)."""
+    return util.run(["git", "-C", str(root), *args], check=False, timeout=CHECK_TIMEOUT)
+
+
+def _plane_default_branch(root: Path) -> str | None:
+    """This repo's default branch, or ``None`` when charter cannot honestly say.
+
+    Asked in order of decreasing authority:
+
+    1. ``refs/remotes/origin/HEAD`` — the *remote's own* answer, recorded by `git clone`.
+       It is the only source that is a fact rather than a guess, so it is consulted
+       first: a plane whose default is `trunk` can easily still carry a stale local
+       `main`, and guessing before asking would warn about the correct branch.
+    2. A local ``main`` or ``master``, in that order. Needed because a plane is very often
+       `git init`-ed and then given a remote by hand (`charter init` does not clone), and
+       that never writes ``origin/HEAD`` — without this fallback the branch half of the
+       check would be silent on most real planes.
+
+    ``None`` when neither answers, and the caller must then say nothing about branches.
+    Naming a default charter has not discovered would fire a warning at every session of
+    a plane whose only sin is calling its branch something else, and a preflight that is
+    permanently yellow is one people stop reading (`check_memory_indexes` records the
+    same concern for the same reason)."""
+    ref = _git_in(root, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")
+    remote_head = ref.stdout.strip()
+    if ref.returncode == 0 and remote_head:
+        # `--short` renders it as `origin/main`, not `main`.
+        return remote_head.split("/", 1)[1] if remote_head.startswith("origin/") else remote_head
+    for guess in ("main", "master"):
+        if _git_in(root, "rev-parse", "--verify", "--quiet",
+                   f"refs/heads/{guess}").returncode == 0:
+            return guess
+    return None
+
+
+def check_plane_root() -> Result:
+    """Is anyone working in the plane root?
+
+    The plane root — the directory holding ``charter.toml`` — holds the control plane:
+    personas, inventory, workspaces, config, and nothing anyone is meant to edit or
+    switch branches in. Work happens in a workspace's clones. Nothing in the filesystem
+    enforces that (ADR 0008), and the failure it invites is invisible in exactly the
+    surface a user would check: two sessions both sitting in the root share one working
+    tree and one HEAD and thrash each other's branches, while charter reports two
+    different workspaces and lists no tree that would hint at why. Observed rather than
+    theorised — six branches in one session, and a `git checkout main` in the root that
+    silently reverted in-flight work out of the tree.
+
+    This is the replacement for `check_embedded_worktrees`, which went with the embedded
+    plane shape (ADR 0007). That check guarded a hazard specific to a shape that no
+    longer exists; deleting it without a successor would leave the *new* failure mode
+    unwatched in the file built to watch for failure modes.
+
+    WARN, never FAIL. FAIL is doctor's "you cannot work" list — it is what makes
+    `charter doctor` exit non-zero, which is what makes the SessionStart wrapper print
+    the preflight-failed banner — and a root being worked in is a smell that gets
+    expensive later, not a broken plane. ADR 0008 chose signal over refusal on purpose,
+    and this is that signal at the moment acting on it is still cheap.
+
+    Never raises: this runs from the SessionStart hook, and is the command you run
+    *because* something is wrong. The exceptions caught are narrow (a missing/unusable
+    git, a root that cannot be read, git not answering in time) rather than a bare
+    ``except``, for the reason `check_memory_indexes` records: a broad catch there once
+    swallowed a `NameError` and reported OK, and a check that silently does nothing is
+    worse than no check.
+    """
+    from . import config as _config
+
+    name = "plane root"
+    if not _config.HAS_CONTROL_PLANE:
+        # No plane, no plane root. `check_control_plane_config` already says so loudly;
+        # a second row repeating it is noise.
+        return Result(name, OK, detail="no control plane found")
+
+    root = Path(_config.ROOT)
+    try:
+        top = _git_in(root, "rev-parse", "--show-toplevel")
+        toplevel = top.stdout.strip()
+        if top.returncode != 0 or not toplevel:
+            # `charter init` in a fresh directory does not run `git init` — that is the
+            # README's own 60-second path. No history, no branch to be on, no dirt.
+            return Result(name, OK, detail="not a git repository")
+        # `.resolve()` on both sides or this comparison lies: macOS hands out temp and
+        # home paths through symlinks (`/var` → `/private/var`), and git always answers
+        # with the physical path.
+        if Path(toplevel).resolve() != root.resolve():
+            # A `charter.toml` in a subdirectory of some larger repo: that repo is not
+            # the plane's. Its branch is whatever that project is working on and its dirt
+            # is that project's work in progress, so reporting on it would warn every
+            # session about a state that is entirely correct.
+            return Result(name, OK, detail=f"not its own repository (inside {toplevel})")
+
+        head = _git_in(root, "symbolic-ref", "--quiet", "--short", "HEAD")
+        # Non-zero means detached — asked this way rather than `rev-parse --abbrev-ref`,
+        # which answers the literal string "HEAD" and so reads as an ordinary branch name
+        # right up until it is compared against the default.
+        branch = head.stdout.strip() if head.returncode == 0 else None
+        default = _plane_default_branch(root)
+        # `--untracked-files=no` deliberately. Memory defaults to `share = "local"` —
+        # written to disk and never committed — so every plane a few days old carries
+        # untracked files under `personas/*/memory/`. Counting those would put this row
+        # permanently in the yellow, which costs the two findings that do matter.
+        status = _git_in(root, "status", "--porcelain", "--untracked-files=no")
+        dirty = [ln for ln in status.stdout.splitlines() if ln.strip()]
+    except (util.ProcTimeout, OSError) as e:
+        return Result(name, OK, detail=f"not checked ({e})")
+
+    findings, actions = [], []
+    if branch is None:
+        findings.append("detached HEAD")
+        actions.append(f"Put the root back on a branch: git -C {root} checkout "
+                       f"{default or '<your default branch>'}.")
+    elif default and branch != default:
+        findings.append(f"on {branch}, not {default}")
+        actions.append(f"Put the root back: git -C {root} checkout {default}.")
+    if dirty:
+        findings.append(f"{len(dirty)} uncommitted file(s)")
+        actions.append("Commit control-plane content with `charter save`.")
+    if not findings:
+        return Result(name, OK, detail=f"clean on {branch}")
+    # Where the work belongs is said ONCE, after the per-finding actions. Saying it per
+    # finding printed the same "move it into a workspace clone" clause twice in a row
+    # that fires with both findings at once — which is the common case, since whoever
+    # branched in the root is also editing in it.
+    return Result(
+        name, WARN, detail=", ".join(findings),
+        hint=" ".join(actions) + " Anything that is not control plane belongs in a "
+             "workspace clone — charter workspace create <task>, then charter clone "
+             "<repo>; the plane root is one working tree every session shares.",
+    )
+
+
 def check_inventory() -> Result:
     from . import config as _config
     n = inventory.load().get("count", 0)
@@ -568,6 +705,7 @@ def _checks():
         results.append(check_forge_cli(forge))
         results.append(check_forge_auth(forge))
     results += [check_ssh(), check_control_plane_config(), check_control_plane_schema(),
+                check_plane_root(),
                 check_inventory(), check_vaults(), check_version_lock(),
                 check_memory_indexes(), check_personas(),
                 check_plugin_skew()]

--- a/tests/test_doctor_plane_root.py
+++ b/tests/test_doctor_plane_root.py
@@ -1,0 +1,218 @@
+"""`charter doctor` reports when the plane root is being worked in.
+
+The plane root — the directory holding `charter.toml` — holds the control plane:
+personas, inventory, workspaces, config, and nothing anyone is meant to edit or switch
+branches in. Work happens in a workspace's clones. Nothing in the filesystem makes that
+true (ADR 0008), and the failure it invites is invisible in exactly the surface a user
+would check: two sessions both sitting in the plane root share one working tree and one
+HEAD and thrash each other's branches, while charter reports two different workspaces and
+lists no tree that would hint at why. In the session that produced the ADR that was six
+branches and a `git checkout main` that silently reverted in-flight work out of the tree.
+
+This is the preflight half of that signal, and the replacement for the deleted
+`check_embedded_worktrees` — the check that guarded the shape ADR 0007 removed. Removing a
+guard is fine; leaving the *new* failure mode unwatched in the file built to watch for
+failure modes is not.
+
+Real git in a temp dir throughout (the `tests/test_worktree.py` pattern): "is this tree
+dirty" and "which branch is this repo's default" are answers only git has, and against a
+mocked git these tests would prove nothing about how that answer is read.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import config, doctor, util
+from tests._isolation import PersonaIso
+
+
+def git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", str(repo), *args],
+                          check=True, capture_output=True, text=True)
+
+
+def init_repo(path: Path, branch: str = "main") -> Path:
+    """A real git repo with one commit, so HEAD and `git status` both have answers.
+
+    Identity and signing are set locally rather than inherited: whoever runs the suite
+    may have `commit.gpgsign = true` globally, and a signer that waits on a hardware
+    prompt would hang the test rather than fail it.
+    """
+    subprocess.run(["git", "init", "-q", "-b", branch, str(path)],
+                   check=True, capture_output=True)
+    git(path, "config", "user.email", "t@example.com")
+    git(path, "config", "user.name", "t")
+    git(path, "config", "commit.gpgsign", "false")
+    git(path, "add", "-A")
+    git(path, "commit", "-qm", "init")
+    return path
+
+
+class PlaneRootCheck(PersonaIso):
+    """A plane root that is its own git repo, on `main`, with everything committed."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.HAS_CONTROL_PLANE = True
+        init_repo(self.tmp)
+
+    # ------------------------------------------------------------------ healthy
+    def test_a_clean_plane_root_on_its_default_branch_is_healthy(self):
+        """The whole point of the row: when nobody is working in the root it must say
+        so in green. A check that is yellow in the normal case is a check people stop
+        reading — the same reason `check_memory_indexes` refuses to nag."""
+        r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIn("main", r.detail)
+
+    def test_untracked_files_in_the_plane_root_are_not_work_in_progress(self):
+        """Memory defaults to `share = "local"` — written to disk and deliberately never
+        committed — so a long-lived plane always carries untracked files under
+        `personas/*/memory/`. Counting those as dirt would make this row permanently
+        yellow within a day of use, which teaches people to ignore the preflight and
+        costs the two findings that actually matter."""
+        (self.tmp / "personas" / "note.md").write_text("a memory nobody committed\n")
+        self.assertEqual(doctor.check_plane_root().status, doctor.OK)
+
+    # ------------------------------------------------------------------- dirty
+    def test_an_edit_to_a_tracked_file_in_the_plane_root_needs_attention(self):
+        """An edit here is product work in the one directory that isolates nothing."""
+        (self.tmp / "charter.toml").write_text("schema = 1\n# edited in the root\n")
+        r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("uncommitted", r.detail)
+
+    def test_a_staged_change_is_still_work_in_the_plane_root(self):
+        """`git add` is not a fix for it, so staging must not make the row go green."""
+        (self.tmp / "feature.py").write_text("print('product work')\n")
+        git(self.tmp, "add", "feature.py")
+        self.assertEqual(doctor.check_plane_root().status, doctor.WARN)
+
+    def test_the_dirty_message_says_where_the_work_belongs_instead(self):
+        """"Your root is dirty" is a statement; a preflight has to be an instruction.
+        Both routes out are named because both are legitimate: control-plane content
+        gets committed, product work moves to a clone."""
+        (self.tmp / "charter.toml").write_text("schema = 1\n# edited\n")
+        hint = doctor.check_plane_root().hint
+        self.assertIn("charter save", hint)
+        self.assertIn("charter workspace create", hint)
+
+    # ------------------------------------------------------------------ branch
+    def test_a_plane_root_on_a_non_default_branch_needs_attention(self):
+        git(self.tmp, "checkout", "-q", "-b", "feature/x")
+        r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("feature/x", r.detail)
+        self.assertIn("main", r.detail)
+
+    def test_the_branch_message_says_how_to_put_the_root_back(self):
+        """The observed harm was a `git checkout main` in the root that reverted
+        in-flight work; the hint has to name the branch to return to and the place the
+        branch work should have happened."""
+        git(self.tmp, "checkout", "-q", "-b", "feature/x")
+        hint = doctor.check_plane_root().hint
+        self.assertIn("checkout main", hint)
+        self.assertIn("charter workspace create", hint)
+
+    def test_a_detached_head_in_the_plane_root_needs_attention(self):
+        """Detached is not a branch, so the branch comparison would call it "on HEAD" —
+        true only in the sense that a wrong answer is a string. It is also unambiguously
+        someone doing git surgery in the root, which is the thing being watched for."""
+        git(self.tmp, "checkout", "-q", "--detach")
+        r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("detached", r.detail)
+
+    def test_the_remotes_own_default_beats_the_main_master_guess(self):
+        """`origin/HEAD` is the remote's own answer to "what is default here", recorded
+        by clone. A repo whose default is `trunk` can still have a stale `main` lying
+        around, so guessing before asking would warn about the correct branch."""
+        git(self.tmp, "checkout", "-q", "-b", "trunk")
+        git(self.tmp, "update-ref", "refs/remotes/origin/trunk", "HEAD")
+        git(self.tmp, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/trunk")
+        r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.OK, r.detail)
+        self.assertIn("trunk", r.detail)
+
+    def test_a_root_with_no_discoverable_default_is_never_warned_about(self):
+        """No `origin/HEAD`, no `main`, no `master`: charter has no idea what this
+        repo's default is, and inventing one would fire a warning at every session of a
+        plane whose only sin is naming its branch something else. Silence beats a
+        confident wrong answer — the dirt half of the check still applies."""
+        git(self.tmp, "branch", "-m", "main", "wip")
+        r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.OK, r.detail)
+
+    # -------------------------------------------------------------- degradation
+    def test_a_plane_root_that_is_not_a_git_repository_is_not_a_finding(self):
+        """`charter init` in a fresh directory does not run `git init`, and that is the
+        README's own 60-second path. A plane with no history has no branch to be on and
+        no dirt to carry."""
+        shutil.rmtree(self.tmp / ".git")
+        self.assertEqual(doctor.check_plane_root().status, doctor.OK)
+
+    def test_a_plane_nested_inside_another_repo_is_not_judged_by_that_repo(self):
+        """A `charter.toml` in a subdirectory of some larger repo means the enclosing
+        repo is not the plane's — its branch is whatever that project is working on and
+        its dirt is that project's work in progress. Reporting on it would produce a
+        warning about a repo the plane does not own, every session, for a state that is
+        correct."""
+        nested = self.tmp / "plane"
+        nested.mkdir()
+        (nested / "charter.toml").write_text("schema = 1\n")
+        config.ROOT = nested
+        (self.tmp / "charter.toml").write_text("schema = 1\n# the outer project's work\n")
+        git(self.tmp, "checkout", "-q", "-b", "their-feature")
+        self.assertEqual(doctor.check_plane_root().status, doctor.OK)
+
+    def test_no_control_plane_at_all_is_not_a_finding(self):
+        """With no plane there is no plane root; `check_control_plane_config` already
+        says that loudly, and a second row saying it again is noise."""
+        config.HAS_CONTROL_PLANE = False
+        self.assertEqual(doctor.check_plane_root().status, doctor.OK)
+
+    def test_an_unreadable_root_degrades_to_a_report_rather_than_raising(self):
+        """doctor runs from the SessionStart hook and is the command you run *because*
+        something is wrong. It may not be the thing that breaks."""
+        with mock.patch("charter.doctor.util.run", side_effect=OSError("no git here")):
+            r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIn("not checked", r.detail)
+
+    def test_a_git_that_never_answers_degrades_to_a_report(self):
+        """A plane root on a stalled network mount hangs `git status`, and the preflight
+        has a hook timeout: the check must come back with something rather than eat the
+        whole budget and print nothing."""
+        with mock.patch("charter.doctor.util.run",
+                        side_effect=util.ProcTimeout(["git", "status"], 5.0)):
+            r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIn("not checked", r.detail)
+
+    # -------------------------------------------------------------- integration
+    def test_it_warns_and_never_fails(self):
+        """FAIL is doctor's "you cannot work" list — it is what makes `charter doctor`
+        exit 1, which is what makes the SessionStart wrapper print the preflight-failed
+        banner. A root being worked in is a smell that gets expensive later, not a
+        broken plane, and ADR 0008 chose signal over refusal deliberately."""
+        (self.tmp / "charter.toml").write_text("schema = 1\n# edited\n")
+        git(self.tmp, "checkout", "-q", "-b", "feature/x")
+        r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("uncommitted", r.detail)
+        self.assertIn("feature/x", r.detail)
+
+    def test_it_is_registered_in_the_preflight(self):
+        """An unregistered check reports drift only to someone who already suspected
+        drift — the exact way `persona lint` sat unrun for months."""
+        self.assertIn("plane root", [r.name for r in doctor.run_all()])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`check_embedded_worktrees` was deleted with the embedded plane shape (ADR 0007) — it
guarded worktrees nesting inside the codebase where nx/jest/maven recurse into them, a
hazard specific to a shape that no longer exists. This is its successor, guarding the
failure mode the new shape actually has.

The **plane root** — the directory holding `charter.toml` — holds personas, inventory,
workspaces and config, and nothing anyone is meant to edit or switch branches in. A dirty
root, or a root off its default branch, means someone is doing product work in the one
directory that isolates nothing, and the damage is invisible in the surface a user would
check: two sessions both sitting there share one working tree and one HEAD and thrash each
other's branches while charter reports two different workspaces
([ADR 0008](https://github.com/diazoxide/charter/blob/main/docs/adr/0008-the-plane-root-is-not-a-work-tree.md)).
`doctor` runs at SessionStart, which is exactly when acting on it is still cheap.
`docs/control-plane.md` already promised this check existed; it now does.

```
  ✓  plane root       clean on main

  !  plane root       on feature/x, not main, 1 uncommitted file(s)
        → Put the root back: git -C /path/to/plane checkout main. Commit control-plane
          content with `charter save`. Anything that is not control plane belongs in a
          workspace clone — charter workspace create <task>, then charter clone <repo>;
          the plane root is one working tree every session shares.
```

### Judgement calls

**The default branch is asked for, then guessed.** `refs/remotes/origin/HEAD` first — the
remote's own answer, recorded by clone, and the only source that is a fact rather than a
guess; a plane whose default is `trunk` can still carry a stale local `main`, and guessing
first would warn about the correct branch. Local `main`/`master` second, because a plane is
usually `git init`-ed and given a remote by hand, which never writes `origin/HEAD` —
without the fallback the branch half would be silent on most real planes. When neither
answers, charter says nothing about branches rather than inventing a default.

**WARN, never FAIL.** FAIL is doctor's "you cannot work" list — it is what makes `charter
doctor` exit non-zero and the SessionStart wrapper print the preflight-failed banner. A
root being worked in is a smell that gets expensive later, not a broken plane, and ADR 0008
chose signal over refusal deliberately.

**Untracked files are not dirt.** Memory defaults to `share = "local"` — written to disk
and never committed — so every plane a few days old carries untracked files under
`personas/*/memory/`. Counting them would put this row permanently in the yellow, and a
permanently-yellow preflight is one people stop reading.

**Degrades, never raises.** No plane, no git repo, a `charter.toml` nested inside somebody
else's repo (whose branch and dirt are that project's, not the plane's), an unreadable root,
or a git that does not answer within `CHECK_TIMEOUT` all report instead of blowing up. The
catches are narrow (`ProcTimeout`, `OSError`) rather than a bare `except`, for the reason
`check_memory_indexes` records: a broad catch there once swallowed a `NameError` and
reported OK.

### Tests

17 new tests, real git in a temp dir throughout — dirtiness and "which branch is default"
are answers only git has, and a mocked git would prove nothing about how the answer is read.
Each test was verified against a mutated implementation (untracked counted as dirt, guess
before asking, invent a default, drop the nested-repo guard, ignore detached HEAD, ignore
dirt, FAIL instead of WARN, drop the hint, skip registration) — every mutation is caught by
exactly the test that claims it. Full suite: **1418 green** (baseline 1401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145Anhzojfo151sYXYwwest
