### PR TITLE
statusline: warn when the plane root is being worked in

### DIFF
--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1097,9 +1097,33 @@ def _default_branch(gitdir: Path) -> str | None:
     return None
 
 
+def _head_detached(gitdir: Path) -> bool:
+    """True when HEAD names a commit rather than a branch.
+
+    Its own read rather than an inference from :func:`_branch`, which collapses the two:
+    a detached HEAD reads back from there as a short sha, and a short sha is not
+    distinguishable from a branch someone named after one. The distinction has to be
+    made where git makes it — HEAD is a symref (``ref: refs/heads/…``) or it is not.
+
+    Reads the gitdir it is GIVEN, never the common dir — the opposite of
+    :func:`_default_branch`. HEAD is per-worktree (that is the whole point of a linked
+    worktree), while refs are shared, so following ``commondir`` here would report the
+    main tree's branch for a worktree standing on its own.
+
+    ``False`` when HEAD cannot be read at all. "Unknown" is not "detached", and
+    manufacturing the most alarming of the three states out of a failed read is exactly
+    the false alarm this element cannot afford.
+    """
+    try:
+        txt = (gitdir / "HEAD").read_text().strip()
+    except OSError:
+        return False
+    return bool(txt) and not txt.startswith("ref:")
+
+
 def _plane_root_alert() -> str | None:
-    """One line when the **plane root** is being worked in — dirty, or off its default
-    branch. ``None`` otherwise, which is the ordinary case.
+    """One line when the **plane root** is being worked in — dirty, detached, or off its
+    default branch. ``None`` otherwise, which is the ordinary case.
 
     The root is the directory holding ``charter.toml``: the control plane itself, and
     since ADR 0007 not a repo row at all — a plane's `repo_trees` is its clones and
@@ -1115,7 +1139,7 @@ def _plane_root_alert() -> str | None:
     nothing — the row has no right-hand neighbour, so unlike a row in the repo column it
     cannot shear a column by being one cell wider than `tui.width` believes.
 
-    Both findings share ONE line. A row is spent on every single turn, and "dirty AND off
+    All findings share ONE line. A row is spent on every single turn, and "dirty AND off
     main" is one situation with two symptoms.
 
     "Dirty" here means ``tracked_dirty`` — untracked files excluded, which is exactly
@@ -1159,11 +1183,20 @@ def _plane_root_alert() -> str | None:
             # The word, not the repo table's `*`. A marker reads as a marker beside a
             # column of them; this line has no siblings to be read against.
             bits.append(f"{_YELLOW}dirty{_R}")
+        if _head_detached(gitdir):
+            # Reported on its own terms and WITHOUT a default to compare against, unlike
+            # the branch case below. Detachment is a fact about HEAD alone, it is the
+            # most alarming of these states rather than the least — a commit made here is
+            # unreachable the moment anything else is checked out — and staying silent
+            # about it on a plane whose default cannot be discovered would be the wrong
+            # way round. `doctor`'s `check_plane_root` reports it the same way and on the
+            # same terms; the words match so the two cannot be read as different findings.
+            bits.append(f"{_YELLOW}detached HEAD{_R}")
         # `?` is `_branch`'s "HEAD unreadable" — nothing to compare, so nothing to claim.
-        # A detached HEAD is not `?`: it reads as a short sha, which differs from any
-        # default, and a detached HEAD in the plane root is the same accident wearing a
-        # different hat.
-        if default and branch not in ("?", default):
+        # A detached HEAD never reaches here: it is already said above, and saying it
+        # again as "on 1a2b3c4, not main" would dress the worst state up as an ordinary
+        # branch you happened to be on.
+        elif default and branch not in ("?", default):
             bits.append(f"{_DIM}on{_R} {branch}{_DIM}, not{_R} {default}")
         if not bits:
             return None

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -380,15 +380,37 @@ def _repo_states(dirs: list[Path]) -> dict:
 
 
 def _run_state(d: Path) -> dict:
-    """One `git status --porcelain --branch` → dirty flag + ahead/behind counts."""
+    """One `git status --porcelain --branch` → dirty flags + ahead/behind counts.
+
+    TWO notions of dirt, from the one command, because two callers legitimately want
+    different ones:
+
+    * ``dirty`` — anything at all, untracked files included. What a repo row's ``*``
+      means, and right for a tree you are actually working in: a new file you have not
+      added yet is still work in progress.
+    * ``tracked_dirty`` — the same minus untracked (``??``) entries, i.e. exactly what
+      ``git status --untracked-files=no`` reports. What :func:`_plane_root_alert` uses,
+      and it is `doctor`'s `check_plane_root` that makes it necessary rather than merely
+      nicer: that check asks git the ``-uno`` question, so a plane-root warning built on
+      the wider notion would have the status line calling the root dirty every turn
+      while `doctor` called it clean — two answers to one question, which is worse than
+      either answer alone. The reason `doctor` narrowed it applies here identically:
+      memory defaults to ``share = "local"``, so ``personas/*/memory/`` accumulates
+      untracked files on any plane a few days old, and a warning that is permanently on
+      is furniture.
+
+    Computed here, in the one place that already reads git's answer, rather than by a
+    second `git status` in the caller: the plane root's state would otherwise cost a
+    subprocess on every render, since only this path is behind `_repo_states`' TTL cache.
+    """
     try:
         r = subprocess.run(
             ["git", "-C", str(d), "status", "--porcelain=v1", "--branch"],
             stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=3,
         )
     except Exception:
-        return {"dirty": False, "ahead": 0, "behind": 0}
-    dirty, ahead, behind = False, 0, 0
+        return {"dirty": False, "tracked_dirty": False, "ahead": 0, "behind": 0}
+    dirty, tracked_dirty, ahead, behind = False, False, 0, 0
     for ln in r.stdout.splitlines():
         if ln.startswith("## "):
             m = re.search(r"\[([^\]]*)\]", ln)
@@ -401,7 +423,12 @@ def _run_state(d: Path) -> dict:
                         behind = _int(part[7:])
         elif ln.strip():
             dirty = True
-    return {"dirty": dirty, "ahead": ahead, "behind": behind}
+            # `??` is the only untracked form in porcelain v1 (`!!` needs --ignored,
+            # which is not asked for). Everything else — modified, staged, renamed,
+            # unmerged — is a tracked path, and is what `-uno` would have printed.
+            if not ln.startswith("??"):
+                tracked_dirty = True
+    return {"dirty": dirty, "tracked_dirty": tracked_dirty, "ahead": ahead, "behind": behind}
 
 
 def _int(s: str) -> int:
@@ -1091,11 +1118,14 @@ def _plane_root_alert() -> str | None:
     Both findings share ONE line. A row is spent on every single turn, and "dirty AND off
     main" is one situation with two symptoms.
 
-    A dirty root also covers the milder case of uncommitted control-plane edits — a
-    persona, or a memory written under the default ``share = "local"`` posture, which is
-    never committed for you. That is still something to act on (`charter save`), so the
-    line stays honest; if it ever becomes furniture on a real plane, the fix is a
-    narrower notion of "dirty", not a quieter warning.
+    "Dirty" here means ``tracked_dirty`` — untracked files excluded, which is exactly
+    what `doctor`'s `check_plane_root` asks git for (``--untracked-files=no``). Both the
+    reason and the agreement matter. The reason: memory defaults to ``share = "local"``,
+    written to disk and never committed for you, so ``personas/*/memory/`` fills with
+    untracked files on any plane a few days old and the wider notion would put this line
+    on screen permanently — furniture, which is the one thing this element must not
+    become. The agreement: `doctor` and the status line answer the same question about
+    the same tree, and two answers to one question is worse than either alone.
     """
     try:
         if not config.HAS_CONTROL_PLANE:
@@ -1121,7 +1151,11 @@ def _plane_root_alert() -> str | None:
         default = _default_branch(gitdir)
 
         bits = []
-        if state.get("dirty"):
+        # `tracked_dirty`, never `dirty` — see this function's docstring and `_run_state`.
+        # `.get` defaults to False rather than to `dirty`: a cache entry written seconds
+        # ago by an older charter has no such key, and a few silent seconds is a better
+        # failure than a warning derived from the notion `doctor` disagrees with.
+        if state.get("tracked_dirty"):
             # The word, not the repo table's `*`. A marker reads as a marker beside a
             # column of them; this line has no siblings to be read against.
             bits.append(f"{_YELLOW}dirty{_R}")

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -957,12 +957,18 @@ def _session_news(sid: str | None) -> list[str]:
 
 
 def _alerts(active: str) -> list[str]:
-    """Full-width alert lines — a pinned-version mismatch, workspaces needing reinit.
+    """Full-width alert lines — a pinned-version mismatch, workspaces needing reinit,
+    a nested plane, a plane root being worked in.
 
     Kept off the session strip and out of both columns: these are not telemetry but
     *actionable* problems that carry the command that fixes them, and they are about
     the control plane rather than this session's activity. They render only when real,
     so they cost no rows on a healthy control plane.
+
+    The plane-root check goes LAST because this function has ONE guard: an exception
+    anywhere below leaves the alerts already appended in `out` and drops everything
+    after it. The two above it carry commands that fix problems of their own, so the
+    newest addition is the one that pays if something here goes wrong.
     """
     out: list[str] = []
     try:
@@ -980,9 +986,166 @@ def _alerts(active: str) -> list[str]:
             out.append(f"{_RED}⚠{_R} {_DIM}nested plane{_R} — {_DIM}memory and vault go to"
                        f"{_R} {config.ROOT.name}{_DIM}, not{_R} {outer.name}"
                        f"{_DIM} · export CHARTER_ROOT={outer}{_R}")
+        root_line = _plane_root_alert()
+        if root_line:
+            out.append(root_line)
     except Exception:
         pass
     return out
+
+
+#: Fallback names for "the branch this tree is meant to sit on", tried in order and only
+#: when the repository itself does not say. Convention, not guesswork: a name counts only
+#: when a ref by that name actually exists in this repo.
+_ROOT_DEFAULTS = ("main", "master")
+
+
+def _common_git_dir(gitdir: Path) -> Path:
+    """The git directory holding the SHARED refs behind *gitdir*.
+
+    A linked worktree's git dir (``<main>/.git/worktrees/<name>``) holds only what is
+    per-worktree — HEAD, the index — while every ref, including ``origin/HEAD`` and the
+    branches, lives in the common directory its ``commondir`` file names. ``$CHARTER_ROOT``
+    may legitimately point at a worktree (``root._plane_of`` documents that escape hatch),
+    and reading refs from the per-worktree directory there finds none of them: the plane
+    would look like a repo with no default branch rather than one being worked in.
+    """
+    try:
+        txt = (gitdir / "commondir").read_text().strip()
+    except OSError:
+        return gitdir                      # a clone's git dir IS the common dir
+    if not txt:
+        return gitdir
+    p = Path(txt)
+    return p if p.is_absolute() else (gitdir / p)
+
+
+def _ref_exists(common: Path, ref: str) -> bool:
+    """Whether *ref* (e.g. ``refs/heads/main``) exists — loose file **or** packed.
+
+    Both forms are normal and either can be the only one: a fresh ``git init`` writes
+    loose refs, while anything that has been ``gc``'d keeps them in ``packed-refs``.
+    Checking only the loose form reports an established repo as having no ``main`` at
+    all, which here would silently disable the branch half of the warning on exactly the
+    long-lived planes it is for.
+    """
+    if (common / ref).is_file():
+        return True
+    try:
+        packed = (common / "packed-refs").read_text()
+    except OSError:
+        return False
+    # `<sha> refs/heads/main`, one per line; `^<sha>` peel lines never carry a ref name.
+    return any(ln.rstrip().endswith(f" {ref}") for ln in packed.splitlines())
+
+
+def _default_branch(gitdir: Path) -> str | None:
+    """The branch this tree is meant to sit on, or ``None`` when nothing says.
+
+    ``origin/HEAD`` is the repository's own answer — ``git clone`` writes it and
+    ``git remote set-head`` maintains it — so it wins outright: a plane living on
+    ``trunk`` must never be told every turn that it is off ``main``.
+
+    ``None`` is a real answer, and it is what lets the branch half of the warning go
+    quiet. A plane with no remote and a hand-named branch has no default to be off, and a
+    warning manufactured from a guess would fire forever on a tree nobody is misusing —
+    which is precisely the furniture this element is designed not to become. Dirtiness
+    still speaks; only the branch claim is withheld.
+
+    Filesystem-only, like :func:`charter.util.branch_of`, because this runs on every
+    render: two small reads answer it exactly, where a ``git`` fork would be paid over
+    and over for the same constant.
+    """
+    common = _common_git_dir(gitdir)
+    try:
+        head = (common / "refs" / "remotes" / "origin" / "HEAD").read_text().strip()
+    except OSError:
+        head = ""
+    prefix = "ref: refs/remotes/origin/"
+    if head.startswith(prefix):
+        return head[len(prefix):].strip() or None
+    for name in _ROOT_DEFAULTS:
+        if _ref_exists(common, f"refs/heads/{name}"):
+            return name
+    return None
+
+
+def _plane_root_alert() -> str | None:
+    """One line when the **plane root** is being worked in — dirty, or off its default
+    branch. ``None`` otherwise, which is the ordinary case.
+
+    The root is the directory holding ``charter.toml``: the control plane itself, and
+    since ADR 0007 not a repo row at all — a plane's `repo_trees` is its clones and
+    nothing else. That absence is exactly why this line exists (docs/adr/0008). Two
+    sessions that both sit in the root share one working tree and one HEAD and thrash
+    each other's branches, while charter reports two different workspaces and lists no
+    tree that would hint at why. **Not presenting a tree is not the same as preventing
+    work in it**, and the failure is invisible in the one surface a user would check.
+
+    An *alert* rather than a row, and deliberately: this is not a property of the active
+    workspace (the top line) nor of this session (the bottom strip), so it sits with the
+    other actionable control-plane problems, full width. Full width also costs the layout
+    nothing — the row has no right-hand neighbour, so unlike a row in the repo column it
+    cannot shear a column by being one cell wider than `tui.width` believes.
+
+    Both findings share ONE line. A row is spent on every single turn, and "dirty AND off
+    main" is one situation with two symptoms.
+
+    A dirty root also covers the milder case of uncommitted control-plane edits — a
+    persona, or a memory written under the default ``share = "local"`` posture, which is
+    never committed for you. That is still something to act on (`charter save`), so the
+    line stays honest; if it ever becomes furniture on a real plane, the fix is a
+    narrower notion of "dirty", not a quieter warning.
+    """
+    try:
+        if not config.HAS_CONTROL_PLANE:
+            return None                    # `charter --version` outside a plane, etc.
+        from . import util
+        root = config.ROOT
+        gitdir = util.git_dir(root)
+        if gitdir is None:
+            # Two cases, one answer. `charter init` in a fresh directory does not run
+            # `git init` (that is the README's 60-second path), and a plane created in a
+            # SUBDIRECTORY of some other repo has no `.git` of its own either. Asking git
+            # about the directory anyway would answer for the surrounding repo, and
+            # reporting a tree the user never named as "the plane root" is worse than
+            # saying nothing.
+            return None
+        # Its own `_repo_states` call rather than joining `render`'s scan list, because
+        # that list also feeds `glstate.read_for`/`maybe_spawn`: a directory in it has
+        # forge state fetched for it in the background. The root has no row, so that
+        # would be network work for something nothing can display. The TTL cache is
+        # shared, so the cost here is one `git status` per few seconds, not per render.
+        state = _repo_states([root]).get(root) or {}
+        branch = _branch(root)
+        default = _default_branch(gitdir)
+
+        bits = []
+        if state.get("dirty"):
+            # The word, not the repo table's `*`. A marker reads as a marker beside a
+            # column of them; this line has no siblings to be read against.
+            bits.append(f"{_YELLOW}dirty{_R}")
+        # `?` is `_branch`'s "HEAD unreadable" — nothing to compare, so nothing to claim.
+        # A detached HEAD is not `?`: it reads as a short sha, which differs from any
+        # default, and a detached HEAD in the plane root is the same accident wearing a
+        # different hat.
+        if default and branch not in ("?", default):
+            bits.append(f"{_DIM}on{_R} {branch}{_DIM}, not{_R} {default}")
+        if not bits:
+            return None
+
+        # Order IS truncation order, and the words that must survive a narrow pane are
+        # the ones naming what the line is about: `plane root` first, then which root.
+        # Nothing but ASCII and `⚠` — the same glyph the alerts above already use, so
+        # this adds no character whose width some font gets to disagree about.
+        sep = f"{_DIM} · {_R}"
+        return (f"{_YELLOW}⚠{_R} {_DIM}plane root{_R} {root.name}{sep}"
+                + sep.join(bits)
+                + f"{_DIM} · work belongs in a workspace clone{_R}")
+    except Exception:
+        # The status line's one hard contract. A root that cannot be read costs this
+        # line and nothing else.
+        return None
 
 
 def _nested_under() -> Path | None:

--- a/tests/test_statusline_plane_root_warning.py
+++ b/tests/test_statusline_plane_root_warning.py
@@ -80,7 +80,16 @@ class PlaneRootIso(PersonaIso):
     # -- the two ways a root gets worked in ------------------------------------ #
 
     def dirty(self) -> None:
+        """Dirt of the kind that counts: an edit to a file git is already tracking."""
         (self.tmp / "charter.toml").write_text("schema = 1\n# edited\n")
+
+    def leave_untracked_file(self) -> Path:
+        """A file git has never been told about — what a recorded memory looks like on
+        the default `share = "local"` posture."""
+        p = self.tmp / "personas" / "alpha" / "memory" / "zz-note.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# a memory nobody committed\n")
+        return p
 
     def switch_to(self, branch: str) -> None:
         git(self.tmp, "checkout", "-q", "-b", branch)
@@ -228,6 +237,28 @@ class ACleanRootSaysNothing(PlaneRootIso):
         self.forget_state()
         self.assertEqual(len(self.lines()), before + 1)
 
+    def test_an_untracked_file_alone_does_not_raise_the_warning(self):
+        """The regression that would make this element worthless.
+
+        Memory defaults to ``share = "local"``: written to disk and never committed for
+        you. So `personas/*/memory/` accumulates untracked files on any plane a few days
+        old, and counting them would put this line on screen every turn forever — and a
+        warning that is always on is furniture within a day, after which a real one draws
+        no more attention than a zero would.
+
+        It is also what `doctor`'s `check_plane_root` decided, by asking git the
+        `--untracked-files=no` question. Two answers to one question would be worse than
+        either answer alone."""
+        self.leave_untracked_file()
+        self.assertIsNone(statusline._plane_root_alert())
+
+    def test_a_tracked_edit_beside_untracked_files_still_speaks(self):
+        """The narrower notion must not be a mute button: untracked files sitting there
+        cannot hide an actual uncommitted change to the control plane."""
+        self.leave_untracked_file()
+        self.dirty()
+        self.assertIn("dirty", self.warning() or "")
+
     def test_a_plane_root_that_is_not_a_git_repo_is_silent(self):
         """`charter init` in a fresh directory does not run `git init`, and that is the
         README's 60-second path. A plane with no repo cannot be off a branch, and
@@ -297,6 +328,57 @@ class TheLineIsFullWidthFurniture(PlaneRootIso):
         self.dirty()
         self.switch_to("feat/some-very-long-branch-name-that-will-not-fit")
         self.assertIsNotNone(self.warning(40), self.lines(40))
+
+
+class DoctorAndTheStatusLineCannotDisagree(PlaneRootIso):
+    """Both answer "is anyone working in the plane root?", about the same tree, from the
+    same ADR — one at session start, one on every turn. They reached that question by
+    different routes: `doctor` shells out to git (it has a budget and a timeout), while
+    the status line reads the filesystem and reuses `_repo_states`' cached
+    `git status`. Different routes are fine; different answers are not, and the one that
+    already shipped and diverged was dirt — untracked files counted here and not there,
+    so on the default memory posture `doctor` said `clean on main` while the status line
+    said `dirty`, every turn.
+
+    Asserted as agreement rather than as two copies of an expected string, so whichever
+    side changes its mind next has to change the other with it.
+    """
+
+    def doctor_says_dirty(self) -> bool:
+        from charter import doctor
+        r = doctor.check_plane_root()
+        return "uncommitted" in (r.detail or "")
+
+    def statusline_says_dirty(self) -> bool:
+        return "dirty" in _plain(statusline._plane_root_alert() or "")
+
+    def test_they_agree_that_an_untracked_file_is_not_dirt(self):
+        self.leave_untracked_file()
+        self.assertEqual(self.statusline_says_dirty(), self.doctor_says_dirty())
+        self.assertFalse(self.doctor_says_dirty(), "fixture proves nothing if doctor warns")
+
+    def test_they_agree_that_a_tracked_edit_is_dirt(self):
+        self.dirty()
+        self.assertEqual(self.statusline_says_dirty(), self.doctor_says_dirty())
+        self.assertTrue(self.doctor_says_dirty(), "fixture proves nothing if doctor is quiet")
+
+    def test_they_agree_on_which_branch_is_the_default(self):
+        """`origin/HEAD` first, then a `main`/`master` that actually exists, then no
+        claim at all — reached by reading refs on one side and by asking git on the
+        other, which is exactly the kind of pair that drifts unwatched."""
+        from charter import doctor
+        head = self.tmp / ".git" / "refs" / "remotes" / "origin"
+        head.mkdir(parents=True, exist_ok=True)
+        (head / "HEAD").write_text("ref: refs/remotes/origin/trunk\n")
+        self.assertEqual(statusline._default_branch(self.tmp / ".git"),
+                         doctor._plane_default_branch(self.tmp))
+
+    def test_they_agree_when_nothing_says_what_the_default_is(self):
+        from charter import doctor
+        git(self.tmp, "branch", "-m", "main", "trunk")
+        self.assertEqual(statusline._default_branch(self.tmp / ".git"),
+                         doctor._plane_default_branch(self.tmp))
+        self.assertIsNone(doctor._plane_default_branch(self.tmp))
 
 
 class ItNeverBreaksTheStatusLine(PlaneRootIso):

--- a/tests/test_statusline_plane_root_warning.py
+++ b/tests/test_statusline_plane_root_warning.py
@@ -188,10 +188,25 @@ class AnOffDefaultRootSpeaks(PlaneRootIso):
         self.assertIn("feat/x", line)
         self.assertIn("main", line)
 
-    def test_a_detached_head_counts_as_off_the_default(self):
-        """A detached HEAD in the plane root is the same accident wearing a sha."""
+    def test_a_detached_head_is_reported_as_detachment_not_as_a_branch(self):
+        """The most alarming of these states, and it must read as itself. `_branch`
+        answers a detached HEAD with a short sha, so comparing that against the default
+        would print `on 1a2b3c4, not main` — which dresses "whatever you commit here
+        becomes unreachable" up as an ordinary branch you happened to be on."""
         git(self.tmp, "checkout", "-q", "--detach")
-        self.assertIsNotNone(self.warning(), self.lines())
+        line = self.warning()
+        self.assertIsNotNone(line, self.lines())
+        self.assertIn("detached", line)
+        self.assertNotIn("not main", line)
+
+    def test_a_detached_head_speaks_even_when_no_default_is_discoverable(self):
+        """Detachment is a fact about HEAD alone. Requiring a default to compare against
+        would silence the worst state on exactly the planes charter knows least about —
+        the wrong way round, and a disagreement with `doctor`, which reports it
+        independently of the default."""
+        git(self.tmp, "branch", "-m", "main", "trunk")     # no main/master to fall back on
+        git(self.tmp, "checkout", "-q", "--detach")
+        self.assertIn("detached", self.warning() or "", self.lines())
 
     def test_origin_head_decides_what_the_default_is(self):
         """Not a hardcoded `main`: the repo already states its own default, and a plane
@@ -352,6 +367,13 @@ class DoctorAndTheStatusLineCannotDisagree(PlaneRootIso):
     def statusline_says_dirty(self) -> bool:
         return "dirty" in _plain(statusline._plane_root_alert() or "")
 
+    def doctor_says_detached(self) -> bool:
+        from charter import doctor
+        return "detached" in (doctor.check_plane_root().detail or "")
+
+    def statusline_says_detached(self) -> bool:
+        return "detached" in _plain(statusline._plane_root_alert() or "")
+
     def test_they_agree_that_an_untracked_file_is_not_dirt(self):
         self.leave_untracked_file()
         self.assertEqual(self.statusline_says_dirty(), self.doctor_says_dirty())
@@ -361,6 +383,22 @@ class DoctorAndTheStatusLineCannotDisagree(PlaneRootIso):
         self.dirty()
         self.assertEqual(self.statusline_says_dirty(), self.doctor_says_dirty())
         self.assertTrue(self.doctor_says_dirty(), "fixture proves nothing if doctor is quiet")
+
+    def test_they_agree_that_a_detached_head_speaks_with_no_default_to_compare(self):
+        """The case that would have caught the divergence this class is named for.
+
+        The status line's branch clause needs a default to compare against; `doctor`'s
+        detached-HEAD finding never did. So a plane with no `origin/HEAD`, no `main` and
+        no `master`, standing on a detached HEAD, had `doctor` warning and the status
+        line silent — a known exception to an invariant this class asserts, which is
+        worse than either behaviour, because the next reader believes the name."""
+        from charter import doctor
+        git(self.tmp, "branch", "-m", "main", "trunk")
+        git(self.tmp, "checkout", "-q", "--detach")
+        self.assertIsNone(doctor._plane_default_branch(self.tmp),
+                          "fixture proves nothing if a default is still discoverable")
+        self.assertEqual(self.statusline_says_detached(), self.doctor_says_detached())
+        self.assertTrue(self.doctor_says_detached(), "fixture proves nothing if both are quiet")
 
     def test_they_agree_on_which_branch_is_the_default(self):
         """`origin/HEAD` first, then a `main`/`master` that actually exists, then no

--- a/tests/test_statusline_plane_root_warning.py
+++ b/tests/test_statusline_plane_root_warning.py
@@ -1,0 +1,338 @@
+"""The status line says so when the plane root is being worked in.
+
+The directory holding `charter.toml` is the control plane — personas, inventory,
+workspaces, config — and nothing anyone is meant to edit. Work happens in a workspace's
+clones. Since ADR 0007 the root is not drawn as a repo at all, and ADR 0008 is about the
+gap that leaves: **not presenting a tree is not the same as preventing work in it**. Two
+sessions that both sit in the plane root share one working tree and one HEAD and thrash
+each other's branches, while charter reports two different workspaces and lists no tree
+that would hint at why. The failure is invisible in exactly the surface a user checks.
+
+So the root gets ONE full-width line, and only when it is dirty or off its default
+branch. Silence is the whole point of the design: a warning that renders every turn is
+furniture within a day, and then a real one draws no more attention than a zero would.
+
+Real git in a temp dir throughout (the tests/test_statusline_worktree_rows.py pattern).
+Every fact under test here — HEAD, `origin/HEAD`, the ref store, dirtiness — is a fact
+about a real repository on disk, and a mocked git would prove nothing about any of them.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import config, statusline, update
+from tests._isolation import PersonaIso
+
+
+def git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", str(repo), *args],
+                          check=True, capture_output=True, text=True)
+
+
+def _plain(s: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+def init_repo(path: Path, branch: str = "main") -> Path:
+    """A real git repo whose working tree is CLEAN: everything already there is
+    committed, so a later `git status` reports only what a test itself changed."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", branch, str(path)],
+                   check=True, capture_output=True)
+    git(path, "config", "user.email", "t@example.com")
+    git(path, "config", "user.name", "t")
+    # Guarantees there is something to commit: an empty first commit leaves no
+    # `refs/heads/<branch>`, and half of what is under test here is read from the ref
+    # store. A repo with no content is not the fixture any of these tests mean.
+    (path / "README.md").write_text("hello\n")
+    git(path, "add", "-A")
+    git(path, "-c", "commit.gpgsign=false", "commit", "-qm", "init")
+    return path
+
+
+class PlaneRootIso(PersonaIso):
+    """A control plane whose root is a real git repo — clean, on `main`."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.HAS_CONTROL_PLANE = True
+        # The ignore rules `charter init` writes. Without them this fixture would be
+        # dirty for reasons no real plane is: rendering writes its own caches under
+        # `.charter/`, and a workspace's clones live under `workspaces/`. Both are
+        # ignored in every real plane, so ignoring them here keeps "clean" meaning in
+        # the test what it means in the field.
+        (self.tmp / ".gitignore").write_text("/workspaces/*/*\n/.charter/\n")
+        # Personas exist before the first commit, so the roster the two-column layout
+        # needs does not itself leave the root dirty.
+        for n in ("alpha", "beta"):
+            self.make_persona(n, role=n.title(), **{"delegate-when": f"{n} work"})
+        init_repo(self.tmp)
+        # `_brand` forks a detached version check. A suite that quietly reaches the
+        # network is not hermetic.
+        self.enterContext(mock.patch.object(update, "maybe_spawn", lambda: None))
+
+    # -- the two ways a root gets worked in ------------------------------------ #
+
+    def dirty(self) -> None:
+        (self.tmp / "charter.toml").write_text("schema = 1\n# edited\n")
+
+    def switch_to(self, branch: str) -> None:
+        git(self.tmp, "checkout", "-q", "-b", branch)
+
+    def forget_state(self) -> None:
+        """Drop the cached `git status` answers.
+
+        `_repo_states` trusts an entry for `_STATE_TTL` seconds so the status line forks
+        at most one `git status` per repo per few seconds however often it renders. That
+        is right in the field and a trap in a test: a tree dirtied between two renders
+        inside the window would still be reported clean, and the test would be measuring
+        the cache rather than the code."""
+        (config.STATE_DIR / "cache" / "repostate.json").unlink(missing_ok=True)
+
+    # -- rendering -------------------------------------------------------------- #
+
+    def alerts(self) -> list[str]:
+        return [_plain(a) for a in statusline._alerts(config.DEFAULT_WORKSPACE)]
+
+    def raw(self, width: int = 200) -> list[str]:
+        """Rendered lines exactly as emitted, frame included, ANSI stripped."""
+        old = os.environ.get("COLUMNS")
+        os.environ["COLUMNS"] = str(width)
+        try:
+            return [_plain(ln) for ln in statusline.render({"session_id": "t"}).split("\n")]
+        finally:
+            if old is None:
+                os.environ.pop("COLUMNS", None)
+            else:
+                os.environ["COLUMNS"] = old
+
+    def lines(self, width: int = 200) -> list[str]:
+        """Content lines with the frame stripped — most of these tests are about which
+        rows exist and what they say, not about the box drawn around them."""
+        out = []
+        for ln in self.raw(width):
+            if not ln.strip() or set(ln.strip()) <= set("┌─┐└┘├┤"):
+                continue                      # border, or a zone divider
+            if ln.startswith("│ ") and ln.rstrip().endswith("│"):
+                ln = ln[2:].rstrip()[:-1].rstrip()
+            out.append(ln)
+        return out
+
+    def warning(self, width: int = 200) -> str | None:
+        found = [ln for ln in self.lines(width) if "plane root" in ln]
+        return found[0] if found else None
+
+
+class ADirtyRootSpeaks(PlaneRootIso):
+    def test_a_dirty_plane_root_is_warned_about_in_the_status_line(self):
+        """The observed failure: work happening in the one tree charter does not draw."""
+        self.dirty()
+        self.assertIsNotNone(self.warning(), self.lines())
+
+    def test_the_warning_says_dirty_in_words(self):
+        """`*` is the repo table's dirty marker and reads as a marker only next to a
+        column of them. This line has no siblings, so it says the word."""
+        self.dirty()
+        self.assertIn("dirty", self.warning())
+
+    def test_the_warning_names_the_plane_root(self):
+        """It cannot be mistaken for a workspace repo: the root is the one tree that is
+        never a row, so a line about it with no subject would name nothing on screen."""
+        self.dirty()
+        line = self.warning()
+        self.assertIn("plane root", line)
+        self.assertIn(config.ROOT.name, line)
+
+    def test_the_root_is_still_not_counted_as_one_of_your_repos(self):
+        """Warning about it must not smuggle it back into `repo_trees`: a plane's repos
+        are its clones and nothing else (ADR 0007), and the whole reason this warning
+        exists is that the root is NOT among them."""
+        clone = config.WORKSPACES_DIR / config.DEFAULT_WORKSPACE / "demo"
+        init_repo(clone)
+        self.dirty()
+        joined = "\n".join(self.lines())
+        self.assertIn("repos 1", joined)
+        self.assertIsNotNone(self.warning())
+        self.assertFalse([ln for ln in self.lines()
+                          if re.search(rf"[├└╰]─ {re.escape(config.ROOT.name)}\b", ln)],
+                         "the plane root was drawn as a repo row")
+
+
+class AnOffDefaultRootSpeaks(PlaneRootIso):
+    def test_a_non_default_branch_produces_a_warning_on_a_clean_tree(self):
+        """The sharpest form of the observed failure — six branches cut in the root,
+        and a `git checkout main` that reverted in-flight work out of the tree."""
+        self.switch_to("feat/x")
+        self.assertIsNotNone(self.warning(), self.lines())
+
+    def test_the_warning_names_both_the_branch_and_the_default(self):
+        """"Off default" is unactionable without both halves: which branch you are on,
+        and which one this tree is supposed to sit on."""
+        self.switch_to("feat/x")
+        line = self.warning()
+        self.assertIn("feat/x", line)
+        self.assertIn("main", line)
+
+    def test_a_detached_head_counts_as_off_the_default(self):
+        """A detached HEAD in the plane root is the same accident wearing a sha."""
+        git(self.tmp, "checkout", "-q", "--detach")
+        self.assertIsNotNone(self.warning(), self.lines())
+
+    def test_origin_head_decides_what_the_default_is(self):
+        """Not a hardcoded `main`: the repo already states its own default, and a plane
+        living on `trunk` must not be told every turn that it is off `main`."""
+        head = Path(self.tmp / ".git" / "refs" / "remotes" / "origin")
+        head.mkdir(parents=True, exist_ok=True)
+        (head / "HEAD").write_text("ref: refs/remotes/origin/trunk\n")
+        line = self.warning()               # still on `main`, which is now NOT the default
+        self.assertIsNotNone(line, self.lines())
+        self.assertIn("trunk", line)
+
+    def test_no_branch_claim_when_the_repo_never_says_what_its_default_is(self):
+        """No `origin/HEAD`, no `main`, no `master` — nothing here knows which branch is
+        home, and a warning invented from a guess is worse than the silence it replaced.
+        Dirtiness still speaks; only the branch half goes quiet."""
+        git(self.tmp, "branch", "-m", "main", "trunk")
+        git(self.tmp, "checkout", "-q", "-b", "other")
+        self.assertIsNone(statusline._plane_root_alert())
+
+    def test_both_findings_share_one_line(self):
+        """One line, not two rows. Every row is spent on every turn, and "dirty AND off
+        main" is one situation with two symptoms."""
+        self.dirty()
+        self.switch_to("feat/x")
+        self.assertEqual(len([ln for ln in self.lines() if "plane root" in ln]), 1)
+        line = self.warning()
+        self.assertIn("dirty", line)
+        self.assertIn("feat/x", line)
+
+
+class ACleanRootSaysNothing(PlaneRootIso):
+    def test_a_clean_root_on_its_default_branch_renders_nothing_at_all(self):
+        """No row, no zero, no badge. Presence IS the signal — the same discipline
+        `_session_news` and the todo count keep."""
+        self.assertIsNone(statusline._plane_root_alert())
+        self.assertIsNone(self.warning(), self.lines())
+
+    def test_a_clean_root_costs_the_layout_no_row(self):
+        """Not merely an empty string: an all-clean plane must render the same number of
+        rows it rendered before this warning existed."""
+        before = len(self.lines())
+        self.dirty()
+        self.forget_state()
+        self.assertEqual(len(self.lines()), before + 1)
+
+    def test_a_plane_root_that_is_not_a_git_repo_is_silent(self):
+        """`charter init` in a fresh directory does not run `git init`, and that is the
+        README's 60-second path. A plane with no repo cannot be off a branch, and
+        warning it about one would be the first thing a new user ever saw."""
+        import shutil
+        shutil.rmtree(self.tmp / ".git")
+        self.assertIsNone(statusline._plane_root_alert())
+
+    def test_a_dirty_tree_around_a_plane_that_is_not_a_repo_is_not_borrowed(self):
+        """`charter init` inside a subdirectory of some other repo leaves ROOT without a
+        `.git` of its own. Reporting the surrounding repo's dirtiness as the plane
+        root's would be a warning about a tree the user never named."""
+        import shutil
+        outer, inner = self.tmp, self.tmp / "plane"
+        shutil.rmtree(outer / ".git")
+        init_repo(outer)
+        inner.mkdir()
+        (inner / "charter.toml").write_text("schema = 1\n")
+        (outer / "scratch.txt").write_text("uncommitted\n")   # the OUTER tree is dirty
+        self._orig_root = config.ROOT
+        config.use(inner)
+        self.addCleanup(config.use, outer)
+        self.assertIsNone(statusline._plane_root_alert())
+
+
+class TheLineIsFullWidthFurniture(PlaneRootIso):
+    """It sits with the other control-plane alerts: not a property of the active
+    workspace (the top line) and not a property of this session (the bottom strip), but
+    an actionable problem about the plane itself, on its own full-width row."""
+
+    def test_the_warning_is_not_inside_the_width_critical_repo_column(self):
+        """The left column is padded to `_LEFT_W` with `tui.width`; anything drawn
+        inside it that a font renders wider than the Unicode tables claim shifts the
+        divider on that row alone. A full-width row has nothing to its right to shear."""
+        self.dirty()
+        self.switch_to("feat/x")
+        line = self.warning()
+        self.assertNotIn("│", line, "the warning was laid out inside the two columns")
+
+    def test_column_alignment_holds_at_every_pane_width(self):
+        """The frame is the ruler: a row that renders wider than counted pushes its own
+        `│` past the others, so drift is visible rather than mysterious."""
+        self.dirty()
+        self.switch_to("feat/x")
+        for w in (40, 60, 80, 120, 200):
+            with self.subTest(width=w):
+                rows = [ln for ln in self.raw(w) if ln.strip()]
+                self.assertEqual(len({statusline.tui.width(ln) for ln in rows}), 1,
+                                 f"ragged frame at {w}: {rows}")
+
+    def test_the_divider_still_sits_in_one_column_with_the_warning_present(self):
+        self.dirty()
+        cols = {ln.find("│", 40) for ln in self.lines() if ln.find("│", 40) > 0}
+        self.assertEqual(len(cols), 1, f"divider wanders between columns: {sorted(cols)}")
+
+    def test_no_line_exceeds_a_narrow_pane(self):
+        self.dirty()
+        self.switch_to("feat/some-very-long-branch-name-that-will-not-fit")
+        for w in (24, 30, 40, 80):
+            with self.subTest(width=w):
+                for ln in self.raw(w):
+                    self.assertLessEqual(statusline.tui.width(ln), w)
+
+    def test_the_identity_survives_truncation_on_a_narrow_pane(self):
+        """This row's order is its truncation order: on a pane with room for a few words
+        the ones that must survive are the ones naming what the line is about."""
+        self.dirty()
+        self.switch_to("feat/some-very-long-branch-name-that-will-not-fit")
+        self.assertIsNotNone(self.warning(40), self.lines(40))
+
+
+class ItNeverBreaksTheStatusLine(PlaneRootIso):
+    """The module's one hard contract: `render` must never raise, and everything added
+    to it must fall back to silence rather than take the footer down."""
+
+    def test_an_unreadable_root_yields_no_line_and_no_exception(self):
+        config.use(Path("/nonexistent-control-plane-xyz"))
+        self.addCleanup(config.use, self.tmp)
+        # Forced past the "is there a plane at all" guard, so this exercises the
+        # filesystem probe itself against a directory that cannot be read.
+        config.HAS_CONTROL_PLANE = True
+        self.assertIsNone(statusline._plane_root_alert())
+
+    def test_a_failing_git_status_yields_no_line_and_no_exception(self):
+        """`git` missing, a corrupt index, a timeout — the state probe is the one part
+        of this that shells out, so it is the part that can fail in the field."""
+        self.dirty()
+        with mock.patch.object(statusline, "_repo_states", side_effect=RuntimeError("boom")):
+            self.assertIsNone(statusline._plane_root_alert())
+
+    def test_render_survives_the_warning_exploding(self):
+        with mock.patch.object(statusline, "_plane_root_alert",
+                               side_effect=RuntimeError("boom")):
+            self.assertTrue(statusline.render({"session_id": "t"}).strip())
+
+    def test_the_other_alerts_survive_the_warning_exploding(self):
+        """It is checked LAST inside `_alerts`, whose guard returns what it has already
+        collected — so a failure here costs its own line and not the pinned-version
+        warning above it, which carries the command that fixes a different problem."""
+        from charter import instance
+        instance.set_locked_version(config.ROOT, "99.0.0")
+        with mock.patch.object(statusline, "_plane_root_alert",
+                               side_effect=RuntimeError("boom")):
+            self.assertTrue(any("pinned" in a for a in self.alerts()), self.alerts())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The plane root — the directory holding `charter.toml` — is the control plane, and since
[ADR 0007](docs/adr/0007-one-plane-shape.md) it is not drawn as a repo at all. [ADR
0008](docs/adr/0008-the-plane-root-is-not-a-work-tree.md) is about the gap that leaves:
**not presenting a tree is not the same as preventing work in it.** Two sessions that both
sit in the plane root share one working tree and one HEAD and thrash each other's branches,
while charter reports two different workspaces and lists no tree that would hint at why.

So the root gets **one line, only when it is dirty or off its default branch**:

```
┌──────────────────────────────────────────────────────────────────────────────────┐
│ ⬢ default · ws 1                                                                 │
├──────────────────────────────────────────────────────────────────────────────────┤
│ ▪ repos 1                                                    │ ▪ personas 1      │
│   └─ iam-service            main                             │ ▫ steward ·       │
│ ⚠ plane root acme · dirty · on hotfix/thing, not main · work belongs in a … clone │
├──────────────────────────────────────────────────────────────────────────────────┤
│ ctx 22% · ⚡97%                                                  ⬢ charter 0.20.0 │
└──────────────────────────────────────────────────────────────────────────────────┘
```

### Where it goes, and why

`_alerts` — the full-width lines between the table and the session strip. The warning is a
property of neither the active workspace (the top line) nor this session (the bottom
strip), but of the plane itself: the same scope as the nested-plane and pinned-version
warnings it now sits with, and the same discipline — it renders only when real, so a
healthy plane spends no row on it.

Full width also happens to be the safe width. The row has no right-hand neighbour, so
unlike a row in the repo column it cannot shear a column by being one cell wider than
`tui.width` believes, and the only glyph it adds is the `⚠` those alerts already use.

It is checked **last** inside `_alerts`, whose single guard returns what it has already
collected — so a failure here costs its own line rather than the warnings above it that
carry commands of their own. There is a test for that ordering.

### What "default branch" means

`origin/HEAD` is the repository's own answer and wins outright; then the conventional
names, and only when a ref by that name actually exists here (loose *or* packed). When
nothing says, **nothing is claimed** — a plane with no remote and a hand-named branch has
no default to be off, and a warning manufactured from a guess would fire forever on a tree
nobody is misusing. Dirtiness still speaks there.

Read from the filesystem, like `util.branch_of`: this runs on every render. Dirtiness
reuses `_repo_states`, so it shares the existing TTL cache — one `git status` per few
seconds, not per render. The root deliberately does **not** join `render`'s scan list,
because that list also feeds `glstate`'s background forge fetches, and a repo with no row
must not spawn network work for itself.

### Silence

- clean root on its default branch → no row, no zero, no badge;
- plane root that is not a git repo (`charter init` in a fresh directory — the README's
  60-second path) → silent;
- plane created *inside* another repo → silent, because asking git about a directory with
  no `.git` of its own answers for the surrounding tree, and reporting a tree the user
  never named as "the plane root" is worse than saying nothing;
- the root is still not counted among your repos, and still gets no tree row.

### Tests

23 new, `tests/test_statusline_plane_root_warning.py`, real git in a temp dir throughout —
every fact under test (HEAD, `origin/HEAD`, the ref store, dirtiness) is a fact about a
repository on disk, and a mocked git would prove nothing about any of them. Each was seen
to fail before the implementation existed, and the load-bearing ones were mutation-checked
afterwards (hardcoding `main` as the default, dropping the "has its own `.git`" guard, and
moving the call to the front of `_alerts` each break a specific test).

`python3 -m unittest discover -s tests -t .` → **1424 tests, OK** (1401 on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145Anhzojfo151sYXYwwest
