### PR TITLE
init: inside a repo, offer the first clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,10 @@ charter clone some-repo
   (`personas/`, `inventory/`, `workspaces/`), a `.gitignore` tuned for the layout, and a
   Claude Code status line — additive and idempotent, so re-running it is always safe.
   `--forge` is `gitlab` (the default) or `github`; `--owner` is the GitLab group or
-  GitHub org/user whose repos this control plane tracks.
+  GitHub org/user whose repos this control plane tracks. Run inside an existing git repo
+  it also *offers* to clone that repo into your first workspace — accept with
+  `charter init --clone-this-repo`, because work happens in a workspace, never in the
+  plane root.
 - **`charter doctor`** preflights the environment (python, git, git identity, the
   forge's CLI and its auth) and tells you exactly what's missing before anything else
   tries to use it.

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -61,6 +61,13 @@ def build_parser() -> argparse.ArgumentParser:
     ini.add_argument("--owner", help="Group/org/user that owns the repos "
                                      "(GitLab group or GitHub org/user).")
     ini.add_argument("--host", help="Self-hosted forge host (default: the forge's own public host).")
+    # The acceptance half of init's one offer. charter has no interactive prompt (it runs
+    # inside hooks, where blocking on stdin hangs the turn), so the offer is a printed
+    # command and this flag is the command — nothing is ever cloned unasked.
+    ini.add_argument("--clone-this-repo", action="store_true",
+                     help="Also clone the git repo you are standing in into the first "
+                          "workspace. This is how you accept the offer `charter init` "
+                          "prints when it finds one; without it, init clones nothing.")
     ini.set_defaults(func=commands.cmd_init)
 
     doc_check = sub.add_parser(

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -587,6 +587,181 @@ def _ensure_statusline(root: Path) -> tuple[str, Path | None]:
     return "created", None
 
 
+# --------------------------------------------------------------------------- #
+# init's one offer: the repo you are standing in                               #
+#                                                                              #
+# Being inside a git repo used to decide the plane's SHAPE; there is one shape #
+# now (docs/adr/0007), so it decides nothing about what init BUILDS. It is     #
+# kept for the debt that removal created: charter used to promise a solo user  #
+# with one repo could `charter init` and carry on working in that repo,        #
+# because the `default` workspace WAS the plane root. It isn't, so init offers #
+# the first clone instead — the lesson "work happens in a workspace, not in    #
+# the plane root" met once at setup rather than later as "where did my code    #
+# go?".                                                                        #
+#                                                                              #
+# "Offers" is not a prompt, and cannot be: `util.py` carries info/ok/warn/err  #
+# and nothing that reads stdin, because charter runs inside hooks and agent    #
+# sessions where blocking on stdin hangs the turn. So the offer is a printed   #
+# command and running it (`charter init --clone-this-repo`) IS the acceptance  #
+# — the same two-step shape `charter report` uses for consent, where the       #
+# second command is the consent (docs/adr/0003, charter/commands_report.py).   #
+# Nothing is ever cloned that was not asked for by name.                       #
+# --------------------------------------------------------------------------- #
+def _is_repo_top_level(root: Path) -> bool:
+    """True when *root* is the TOP LEVEL of a git working tree.
+
+    Deliberately not "is root somewhere inside a repo". ``rev-parse --show-toplevel``
+    walks upwards, and a great many people keep ``$HOME`` under git for their dotfiles —
+    so a plane scaffolded at ``~/planes/acme`` would have init offering to clone the home
+    directory into it. The offer exists for one person standing in one project, which is
+    the equality case; anything looser turns a helpful line into an alarming one.
+
+    Asked of git rather than tested as ``(root / ".git").exists()`` so a linked worktree
+    (whose ``.git`` is a file) and a genuinely broken ``.git`` are judged by git's own
+    rules. Paths are resolved on both sides because git answers with the real path and the
+    plane root may be reached through a symlink — ``/var/…`` vs ``/private/var/…`` on
+    macOS is enough to make a true equality read as false.
+
+    A machine with no git at all gets no offer instead of a traceback: `init` is the one
+    command a stranger runs BEFORE `doctor` has told them git is missing.
+    """
+    try:
+        proc = _git(["rev-parse", "--show-toplevel"], cwd=root)
+        top = (proc.stdout or "").strip()
+        if proc.returncode != 0 or not top:
+            return False
+        return Path(top).resolve() == Path(root).resolve()
+    except OSError:
+        return False
+
+
+def _origin_url(root: Path) -> str:
+    """*root*'s ``origin`` remote as configured, or ``""`` — never raises."""
+    try:
+        return _git(["remote", "get-url", "origin"], cwd=root).stdout.strip()
+    except OSError:
+        return ""
+
+
+def _first_clone_name(root: Path) -> str:
+    """What to call the clone of the repo *root* sits in.
+
+    The basename of its ``origin`` URL when it has one, NOT the directory the plane
+    happens to live in: `cmd_clone` names a clone after its inventory record, which
+    carries the FORGE's name for the repo. A plane in ``~/work/acme-api-checkout`` whose
+    origin is ``…/acme/api.git`` must produce ``workspaces/default/api``, or a later
+    `charter clone api` lands a second copy of the same repo beside the first and neither
+    one is obviously the real one.
+
+    ``workspace.valid_name`` is reused as a sanity filter on a path segment charter is
+    about to create — a URL that ends in nothing name-shaped falls back to the directory
+    the user already calls their project."""
+    url = _origin_url(root)
+    tail = re.split(r"[/:]", url.rstrip("/"))[-1] if url else ""
+    if tail.endswith(".git"):
+        tail = tail[:-len(".git")]
+    return tail if workspace.valid_name(tail) else root.name
+
+
+def _first_clone_dest(root: Path) -> Path:
+    """Where the first clone of *root*'s repo goes — the FIRST workspace, by name.
+
+    `workspace.resolve()` is deliberately not consulted: it answers "which workspace is
+    this session on", and during `init` there is no session to have chosen one. The
+    workspace being offered is the one every plane starts with."""
+    return config.WORKSPACES_DIR / config.DEFAULT_WORKSPACE / _first_clone_name(root)
+
+
+def _offer_first_clone(root: Path) -> None:
+    """Say it once, in the terms the person is standing in (docs/adr/0008: the plane root
+    is not a work tree).
+
+    One `util.info` with embedded newlines rather than three calls, because each call
+    prefixes its own `•` bullet — and a bullet in front of the command is a character that
+    gets copied along with it. The malformed-settings warning below already prints its
+    paste-me JSON this way for the same reason."""
+    name = _first_clone_name(root)
+    util.info(f"You are standing in the git repo '{name}'. Work happens in a workspace, "
+              f"not in the plane root — clone it into the first one:\n"
+              f"      charter init --clone-this-repo\n"
+              f"  Nothing is cloned unless you run that. It lands in "
+              f"workspaces/{config.DEFAULT_WORKSPACE}/{name}/, and declining leaves this "
+              f"plane complete.")
+
+
+def _clone_first_workspace(root: Path) -> int:
+    """Accept the offer: clone the repo *root* sits in into the first workspace.
+
+    Cloned from the plane root ON DISK rather than fetched from its origin. This runs
+    during setup, before `doctor` has checked that the forge CLI is even authed, and it
+    must not be the step that stalls on an SSH passphrase or fails on a token that isn't
+    there yet. A local clone also carries commits that were never pushed — for the one
+    person standing in their own project, that is the work they were in the middle of.
+
+    Its ``origin`` is then repointed at the SOURCE's origin (rewritten to HTTPS by that
+    forge's own rule when charter recognises the host — golden rule 0 is that git talks
+    over a token, never SSH). Left pointing at the plane root it would look right and fail
+    at the first push: git refuses a push to a non-bare repo's checked-out branch.
+
+    Never touches the plane root's git state — it is read, and only read. The plane root
+    is a working tree someone is in the middle of using.
+    """
+    name = _first_clone_name(root)
+    ws = config.DEFAULT_WORKSPACE
+    try:
+        wd = workspace.ensure(ws)
+    except ValueError as e:
+        util.err(str(e))
+        return 1
+    dest = wd / name
+    if dest.exists():
+        # Additive, exactly like the rest of `init`: re-running is always safe, and never
+        # re-clones over work that is already sitting there.
+        util.info(f"{name}: already cloned in '{ws}' — left exactly as it is.")
+        return 0
+
+    util.info(f"Cloning {name} into workspace '{ws}' …")
+    proc = _git(["clone", "--quiet", str(root), str(dest)])
+    if proc.returncode != 0:
+        util.err(f"could not clone {root} into {dest} — nothing else was changed.\n"
+                 + (proc.stderr or "").strip())
+        return 1
+
+    upstream = _origin_https(root) or _origin_url(root)
+    if upstream:
+        _git(["remote", "set-url", "origin", upstream], cwd=dest)
+    else:
+        util.warn(f"{name} has no origin of its own yet, so this clone's origin is the "
+                  f"plane root — give it a real remote before you push.")
+    from . import gitpolicy
+    gitpolicy.apply(dest)     # golden rule 0, same as `charter clone` does per clone
+
+    rel = dest.relative_to(config.ROOT)
+    util.ok(f"{name} → {rel}")
+    _hint_repo_docs(dest, {"name": name})
+    util.info(f"  work there: cd {rel}   (being in that directory IS this workspace)")
+    return 0
+
+
+def _first_clone_step(root: Path, accepted: bool) -> int:
+    """The one thing being inside a git repo changes about `init`: what it OFFERS."""
+    here = _is_repo_top_level(root)
+    if not accepted:
+        # An offer already taken is noise. `init` is idempotent and gets re-run — after
+        # adding a forge, after an upgrade — and repeating a suggestion the user has
+        # already acted on is how people learn to skip init's output, which is also where
+        # its actual errors are.
+        if here and not _first_clone_dest(root).exists():
+            _offer_first_clone(root)
+        return 0
+    if not here:
+        util.err(f"--clone-this-repo: there is no repo here to clone. {root} is not the "
+                 f"top level of a git working tree, and the flag clones the repo you are "
+                 f"standing in. The control plane itself was still created.")
+        return 1
+    return _clone_first_workspace(root)
+
+
 def cmd_init(args) -> int:
     """Scaffold a control plane from nothing — the first-run command a stranger needs
     and the one `root.py`'s own "no control plane found" error already points to.
@@ -612,7 +787,7 @@ def cmd_init(args) -> int:
     # Being inside a git repo used to decide the plane's SHAPE here, and there is now only
     # one shape — so `init` produces the same plane wherever it runs. What it detects is
     # still worth knowing, but it changes only what init OFFERS (a first clone of the repo
-    # you are standing in), never what it builds.
+    # you are standing in — see `_first_clone_step`, called last), never what it builds.
     created, present, blocked = [], [], []
 
     toml_path = root / _root.MARKER
@@ -673,7 +848,11 @@ def cmd_init(args) -> int:
         util.info(f"  already present: {', '.join(present)}")
     util.info("Next: `charter doctor` to preflight, then `charter discover` to build the "
               "inventory.")
-    return 0
+    # Last, so the most specific thing init can say about THIS directory is the line the
+    # user's eye lands on. Its rc becomes init's: a clone that was asked for and did not
+    # happen is the same failure shape as a blocked baseline path — "you requested this,
+    # it did not happen" has to be visible from the exit code alone.
+    return _first_clone_step(root, bool(getattr(args, "clone_this_repo", False)))
 
 
 # --------------------------------------------------------------------------- #

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -80,7 +80,22 @@ plane exercised exactly one of the two, so the other was carried on trust. An ex
 
 `charter init` therefore produces the same plane wherever it runs. Being inside a git repo
 no longer changes what you get; it changes only what init *offers*, which is to clone that
-repo into your first workspace.
+repo into your first workspace:
+
+```
+$ charter init --forge github --owner acme
+✓ Initialized control plane (schema 1) → charter.toml, personas/, …
+• You are standing in the git repo 'myapp'. Work happens in a workspace, not in the plane
+  root — clone it into the first one:
+      charter init --clone-this-repo
+```
+
+That is an offer, not a prompt: charter never reads stdin (it runs inside hooks, where
+blocking would hang the turn), so the second command *is* the acceptance — the same shape
+`charter report` uses for consent. Run it and you get `workspaces/default/myapp/`, cloned
+from the repo you are standing in and pointed at the same `origin` it has; ignore it and
+the plane is complete as it stands. Either way the control plane itself is identical, and
+nothing is written to your repo's git state.
 
 ### The plane root is not a place to work
 
@@ -136,9 +151,10 @@ $ charter workspace create feature-x
 
 Its branch is the workspace name unless you pass `--branch`.
 
-`default` deliberately stays the repo itself, so a solo user's path is `charter init`, work
-in your repo — charter starts materialising trees only when you ask for a *second*
-concurrent thing.
+A solo user with one repo used to be able to `charter init` and carry on working in that
+repo, because `default` *was* the plane root. It no longer is (ADR 0007), so their path is
+`charter init --clone-this-repo` — the offer above — and then work in
+`workspaces/default/<repo>/`.
 
 **Selecting a workspace with no tree is refused**, because it would put you on the same
 files as every other workspace — the thing workspaces exist to prevent. `charter workspace

--- a/tests/test_init_first_clone.py
+++ b/tests/test_init_first_clone.py
@@ -1,0 +1,347 @@
+"""`charter init` inside a git repo — the one thing that changes: what it *offers*.
+
+Being inside a repo no longer decides what init PRODUCES. The embedded plane shape is gone
+(docs/adr/0007), there is one shape, and `tests/test_init.py` already pins the plane init
+builds. What is left is a debt that removal created: charter used to promise a solo user
+with one repo could `charter init` and carry on working in that repo, because the `default`
+workspace *was* the plane root. It isn't, so init offers the first clone instead — met once
+during setup rather than discovered later as "where did my code go?".
+
+**"Offers" is not a prompt.** charter has no interactive input anywhere: `util.py` carries
+info/ok/warn/err and nothing that reads stdin, because charter runs inside hooks and agent
+sessions where blocking on stdin hangs the turn. So the offer is a printed command, and
+running that command (`charter init --clone-this-repo`) IS the acceptance — the same
+two-step shape `charter report` uses for consent, where the second command is the consent
+(docs/adr/0003).
+
+Real git throughout, the `tests/test_worktree.py` pattern: what these tests are about is a
+clone's `.git`, its `origin`, and what `git status` in the plane root says afterwards. A
+mocked git would prove nothing about any of them.
+"""
+from __future__ import annotations
+
+import io
+import shutil
+import subprocess
+import tempfile
+import unittest
+from contextlib import contextmanager, redirect_stderr
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import cli, commands, config, gitpolicy, instance, workspace
+from tests._isolation import PersonaIso
+
+
+def git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", str(repo), *args],
+                          check=True, capture_output=True, text=True)
+
+
+def init_repo(path: Path, branch: str = "main") -> Path:
+    """A real git repo with one commit, so HEAD and `git status` both have answers."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", branch, str(path)],
+                   check=True, capture_output=True)
+    git(path, "config", "user.email", "t@example.com")
+    git(path, "config", "user.name", "t")
+    (path / "README.md").write_text("hello\n")
+    git(path, "add", "README.md")
+    git(path, "-c", "commit.gpgsign=false", "commit", "-qm", "init")
+    return path
+
+
+def make_repo_plane(root: Path, upstream_home: Path, name: str = "myapp") -> Path:
+    """The solo user's situation: the directory they run `charter init` in is their own
+    project — a git working tree with an origin they push to. Returns the upstream path.
+
+    The upstream is a bare repo on disk rather than a forge URL so the whole fixture is
+    offline and honest at once: `git fetch` from the clone either works or it doesn't."""
+    upstream = upstream_home / f"{name}.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(upstream)],
+                   check=True, capture_output=True)
+    init_repo(root)
+    git(root, "remote", "add", "origin", str(upstream))
+    git(root, "push", "-q", "origin", "main")
+    return upstream
+
+
+@contextmanager
+def plane_at(root: Path):
+    """Point charter's derived paths at *root* for the duration. `config.use` is the same
+    seam `tests/_isolation.py` uses, so a test can stand a second plane up without
+    re-deriving twenty-five settings by hand."""
+    previous = config.use(root)
+    try:
+        yield root
+    finally:
+        config.restore(previous)
+
+
+def run_init(**kw) -> tuple[int, str]:
+    """Call the handler directly (the suite's convention) against the active `config.ROOT`.
+
+    Returns ``(rc, stderr)`` — the offer is user-facing text and `util.info/ok/warn/err`
+    all write to **stderr**, so a test asserting on it that only captured stdout would
+    assert on an empty string and pass for the wrong reason."""
+    args = SimpleNamespace(forge=kw.get("forge", "github"),
+                           owner=kw.get("owner", "acme"),
+                           host=kw.get("host"),
+                           clone_this_repo=kw.get("clone_this_repo", False))
+    buf = io.StringIO()
+    with redirect_stderr(buf):
+        rc = commands.cmd_init(args)
+    return rc, buf.getvalue()
+
+
+def offered_command(stderr: str) -> list[str]:
+    """The argv of the command the offer printed, e.g. ``['init', '--clone-this-repo']``."""
+    line = next(ln for ln in stderr.splitlines() if "charter init --clone" in ln)
+    return line.split("charter", 1)[1].split()
+
+
+def git_state(repo: Path) -> dict:
+    """Everything about *repo*'s git that making a clone could plausibly disturb."""
+    return {name: git(repo, *cmd).stdout for name, cmd in (
+        ("head", ("rev-parse", "HEAD")),
+        ("branch", ("rev-parse", "--abbrev-ref", "HEAD")),
+        ("refs", ("show-ref",)),
+        ("remotes", ("remote", "-v")),
+        ("config", ("config", "--local", "--list")),
+        ("status", ("status", "--porcelain")),
+    )}
+
+
+def plane_surface(root: Path) -> dict:
+    """What the *control plane* is: the files init writes, and the top-level layout.
+
+    Deliberately excludes what is INSIDE `workspaces/` — that is where a task's clones
+    live, it is gitignored, and a clone landing there is precisely what accepting the offer
+    is for. The claim under test is that the plane is the same either way, not that the
+    filesystem is."""
+    return {
+        "entries": sorted(p.name + ("/" if p.is_dir() else "") for p in root.iterdir()),
+        "files": {rel: (root / rel).read_text()
+                  for rel in ("charter.toml", ".gitignore", ".claude/settings.json")},
+    }
+
+
+class RepoPlaneIso(PersonaIso):
+    """A plane root that is itself a git repo with an upstream — `charter init` run inside
+    your own project, which is the only situation the offer exists for."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        home = Path(tempfile.mkdtemp(prefix="charter-upstream-"))
+        self.addCleanup(shutil.rmtree, home, True)
+        self.upstream = make_repo_plane(config.ROOT, home)
+        self.clone = config.WORKSPACES_DIR / config.DEFAULT_WORKSPACE / "myapp"
+
+
+class TestTheOffer(RepoPlaneIso):
+    def test_init_inside_a_git_repo_offers_that_repo_as_the_first_clone(self):
+        """The whole point: a person who has just made their project a control plane is
+        told, once, where work now happens — instead of finding out when their next clone
+        lands somewhere they did not expect."""
+        rc, err = run_init()
+        self.assertEqual(rc, 0)
+        self.assertIn("myapp", err)
+        self.assertIn("--clone-this-repo", err)
+
+    def test_the_command_the_offer_prints_is_a_command_that_exists(self):
+        """An offer whose command does not parse is worse than no offer — it sends the
+        person to a `charter init: unrecognized arguments` error at their first step."""
+        _, err = run_init()
+        args = cli.build_parser().parse_args(offered_command(err))
+        self.assertIs(args.func, commands.cmd_init)
+        self.assertTrue(args.clone_this_repo)
+
+    def test_the_offer_on_its_own_clones_nothing(self):
+        """Declining is the default, and it has to cost nothing: not a clone, not even the
+        first workspace's directory."""
+        run_init()
+        self.assertEqual(list(config.WORKSPACES_DIR.iterdir()), [])
+
+    def test_declining_leaves_a_valid_plane(self):
+        """The offer is never a requirement — a plane you said no to is a finished plane."""
+        rc, _ = run_init()
+        self.assertEqual(rc, 0)
+        self.assertEqual(instance.drift(config.ROOT), [])
+        self.assertTrue((config.ROOT / "charter.toml").is_file())
+
+    def test_the_offer_stops_once_the_repo_is_cloned(self):
+        """init is idempotent and gets re-run — after adding a forge, after an upgrade.
+        Repeating an offer that has already been taken trains people to skip init's
+        output, which is where its actual errors are."""
+        run_init(clone_this_repo=True)
+        _, err = run_init()
+        self.assertNotIn("--clone-this-repo", err)
+
+
+class TestAcceptingTheOffer(RepoPlaneIso):
+    def test_accepting_leaves_the_repo_cloned_and_ready_to_work_in(self):
+        rc, _ = run_init(clone_this_repo=True)
+        self.assertEqual(rc, 0)
+        self.assertTrue((self.clone / ".git").is_dir())
+        self.assertEqual((self.clone / "README.md").read_text(), "hello\n")
+
+    def test_the_clone_carries_the_commits_you_were_standing_on(self):
+        """Cloned from the plane root on disk, not re-fetched from the forge — so work
+        that is committed but not pushed comes along, which for the one person standing in
+        their own project is the work they were in the middle of."""
+        (config.ROOT / "wip.txt").write_text("unpushed\n")
+        git(config.ROOT, "add", "wip.txt")
+        git(config.ROOT, "-c", "commit.gpgsign=false", "commit", "-qm", "wip")
+        run_init(clone_this_repo=True)
+        self.assertEqual(git(self.clone, "rev-parse", "HEAD").stdout,
+                         git(config.ROOT, "rev-parse", "HEAD").stdout)
+        self.assertTrue((self.clone / "wip.txt").exists())
+
+    def test_the_clone_talks_to_the_same_upstream_the_repo_did(self):
+        """"Ready to work in" means you can push what you write there. A clone left
+        pointing at the plane root looks right and fails on the first push — git refuses a
+        push to a non-bare repo's checked-out branch."""
+        run_init(clone_this_repo=True)
+        self.assertEqual(git(self.clone, "remote", "get-url", "origin").stdout.strip(),
+                         str(self.upstream))
+        git(self.clone, "fetch", "origin")      # raises (fails the test) if it cannot
+
+    def test_the_clone_is_named_after_the_repo_not_the_directory_the_plane_sits_in(self):
+        """`charter clone` names a clone after its inventory record — the forge's name for
+        the repo. Naming this one after the plane's directory instead would let a later
+        `charter clone myapp` land a SECOND copy beside it, with neither obviously real."""
+        run_init(clone_this_repo=True)
+        self.assertEqual([d.name for d in workspace.clones(config.DEFAULT_WORKSPACE)],
+                         ["myapp"])
+
+    def test_accepting_twice_never_reclones_over_work_already_there(self):
+        """Same additive discipline as the rest of init: re-running is always safe."""
+        run_init(clone_this_repo=True)
+        (self.clone / "LOCAL.md").write_text("mine\n")
+        rc, _ = run_init(clone_this_repo=True)
+        self.assertEqual(rc, 0)
+        self.assertEqual((self.clone / "LOCAL.md").read_text(), "mine\n")
+
+    def test_nothing_about_the_offer_writes_to_the_plane_roots_git_state(self):
+        """The plane root is a repo someone is in the middle of working in. Cloning out of
+        it must not touch its HEAD, its branch, its refs, its remotes, its local config or
+        its working tree — snapshotted around the accepted run only, so init's own writes
+        (charter.toml, .gitignore, .claude/) are on both sides and cannot mask a change."""
+        run_init()
+        before = git_state(config.ROOT)
+        rc, _ = run_init(clone_this_repo=True)
+        self.assertEqual(rc, 0)
+        self.assertEqual(git_state(config.ROOT), before)
+
+
+class TestOutsideAGitRepo(PersonaIso):
+    """`charter init` in a plain directory — the README's 60-second path — must behave
+    exactly as it did before the offer existed."""
+
+    def test_init_outside_a_git_repo_makes_no_offer(self):
+        rc, err = run_init()
+        self.assertEqual(rc, 0)
+        self.assertNotIn("--clone-this-repo", err)
+        self.assertEqual(instance.drift(config.ROOT), [])
+
+    def test_asking_for_the_clone_outside_a_git_repo_fails_loudly(self):
+        """Non-zero because a caller asked for something that did not happen — the same
+        rule `cmd_init` already applies to a blocked baseline directory and a malformed
+        settings.json. The plane is still scaffolded: the flag is an extra, not a gate."""
+        rc, err = run_init(clone_this_repo=True)
+        self.assertEqual(rc, 1)
+        self.assertIn("--clone-this-repo", err)
+        self.assertTrue((config.ROOT / "charter.toml").is_file())
+        self.assertEqual(list(config.WORKSPACES_DIR.iterdir()), [])
+
+
+class TestOnlyTheRepoYouAreActuallyStandingIn(PersonaIso):
+    """The offer keys off the plane root BEING a working tree's top level, not off git
+    finding a repo somewhere up the tree. A great many people keep $HOME under git for
+    their dotfiles; scaffolding a plane at ~/planes/acme must not offer to clone their
+    home directory into it."""
+
+    def test_a_plane_below_a_repos_top_level_gets_no_offer(self):
+        init_repo(config.ROOT)
+        sub = config.ROOT / "plane"
+        sub.mkdir()
+        with plane_at(sub):
+            rc, err = run_init()
+        self.assertEqual(rc, 0)
+        self.assertNotIn("--clone-this-repo", err)
+
+
+class TestARepoWithNoUpstreamYet(PersonaIso):
+    """A `git init`-ed project that has never been pushed is still a repo you are standing
+    in, and the offer must still land a workspace you can work in — cloned from the plane
+    root, because that copy is the only one there is."""
+
+    def test_a_repo_with_no_origin_is_still_cloned_into_the_first_workspace(self):
+        init_repo(config.ROOT)
+        rc, err = run_init(clone_this_repo=True)
+        self.assertEqual(rc, 0)
+        clone = config.WORKSPACES_DIR / config.DEFAULT_WORKSPACE / config.ROOT.name
+        self.assertTrue((clone / ".git").is_dir())
+        self.assertEqual((clone / "README.md").read_text(), "hello\n")
+        # Said out loud, because this clone's origin is the plane root and pushing to it
+        # will be refused — a silent surprise at the first push otherwise.
+        self.assertIn("no origin", err)
+
+
+class TestTheFirstCloneTalksOverATokenNotSSH(PersonaIso):
+    """Golden rule 0 — one credential per forge, over HTTPS — governs this clone like
+    every other. Plenty of people's own repos have an SSH origin, and inheriting it
+    verbatim would hand charter's very first workspace exactly what the rule exists to
+    avoid: a remote that needs an ssh-agent, in the setup step that runs before `doctor`
+    has checked anything."""
+
+    def test_an_ssh_origin_becomes_its_forges_https_form_under_that_forges_token(self):
+        init_repo(config.ROOT)
+        git(config.ROOT, "remote", "add", "origin", "git@github.com:acme/api.git")
+        rc, _ = run_init(clone_this_repo=True)
+        self.assertEqual(rc, 0)
+        clone = config.WORKSPACES_DIR / config.DEFAULT_WORKSPACE / "api"
+        self.assertEqual(git(clone, "remote", "get-url", "origin").stdout.strip(),
+                         "https://github.com/acme/api.git")
+        self.assertEqual(gitpolicy.check(clone), [])   # charter's own compliance checker
+
+
+class TestThePlaneIsTheSameEitherWay(unittest.TestCase):
+    """The acceptance criterion the whole design turns on: being inside a git repo changes
+    what init OFFERS, never what it BUILDS. Two identical repo-planes, one accepting and
+    one declining, must produce the same control plane."""
+
+    def _plane(self, accept: bool) -> Path:
+        tmp = Path(tempfile.mkdtemp(prefix="charter-either-way-")).resolve()
+        self.addCleanup(shutil.rmtree, tmp, True)
+        root, upstream_home = tmp / "plane", tmp / "upstream"
+        root.mkdir()
+        upstream_home.mkdir()
+        make_repo_plane(root, upstream_home)
+        with plane_at(root):
+            rc, _ = run_init(clone_this_repo=accept)
+            self.assertEqual(rc, 0)
+            if accept:      # the run must really have cloned, or this proves nothing
+                self.assertTrue((root / "workspaces" / config.DEFAULT_WORKSPACE
+                                 / "myapp" / ".git").is_dir())
+        return root
+
+    def test_the_plane_is_identical_whether_or_not_the_offer_was_accepted(self):
+        self.assertEqual(plane_surface(self._plane(accept=True)),
+                         plane_surface(self._plane(accept=False)))
+
+
+class TestTheFlagIsReachableFromTheCLI(unittest.TestCase):
+    """Every other test here calls the handler directly, so none of them would notice the
+    flag missing from the parser — and the command the offer prints would not exist."""
+
+    def test_init_takes_the_flag(self):
+        self.assertTrue(cli.build_parser().parse_args(["init", "--clone-this-repo"])
+                        .clone_this_repo)
+
+    def test_plain_init_does_not_ask_for_the_clone(self):
+        self.assertFalse(cli.build_parser().parse_args(["init"]).clone_this_repo)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Removing the embedded plane shape ([ADR 0007](docs/adr/0007-one-plane-shape.md)) took a promise with it: a solo user with one repo could `charter init` and carry on working in that repo, because the `default` workspace *was* the plane root. It isn't any more. This is the one genuinely new behaviour in the plane-shape change — everything else was subtraction — and it exists to pay that cost rather than pretend it was never incurred.

`charter init` inside a git repo now offers to clone that repo into the first workspace:

```
$ charter init --forge github --owner acme
✓ Initialized control plane (schema 1) → charter.toml, personas/, inventory/, workspaces/, …
• Next: `charter doctor` to preflight, then `charter discover` to build the inventory.
• You are standing in the git repo 'myapp'. Work happens in a workspace, not in the plane root — clone it into the first one:
      charter init --clone-this-repo
  Nothing is cloned unless you run that. It lands in workspaces/default/myapp/, and declining leaves this plane complete.
```

Being inside a repo still changes **nothing** about what init produces. The plane is identical either way, and a test stands two identical repo-planes up — one accepting, one declining — and compares the files init writes and the layout it creates.

## What "offers" means, and why

charter has no interactive prompt anywhere: `util.py` carries `info/ok/warn/err` and nothing that reads stdin, because charter runs inside hooks and agent sessions where blocking on stdin hangs the turn. So the offer is a **printed command**, and `charter init --clone-this-repo` is the acceptance — the same two-step shape `charter report` uses for consent, where the second command *is* the consent ([ADR 0003](docs/adr/0003-no-unattended-publish.md)).

A flag rather than a second, separate command because init is already idempotent and additive: re-running it is the documented safe thing, so "run it again, this time asking for the clone" needs no new surface. `charter clone` was the alternative home for this and was rejected — that command is defined by the inventory, and the repo you are standing in is not in it (`discover` has not run yet), so it would have grown a second contract. ADR 0003's objection to flags is about a flag that collapses *approval to publish* into the sending call; here the flag is the request itself, and absent it init clones nothing.

The offer stops printing once it has been taken — init gets re-run after adding a forge or an upgrade, and repeating a suggestion already acted on is how people learn to skip init's output, which is also where its actual errors are.

## Three decisions worth reviewing

- **The plane root must BE the repo's top level**, not merely sit somewhere inside one. `rev-parse --show-toplevel` walks upwards, and a great many people keep `$HOME` under git for dotfiles — a plane at `~/planes/acme` would otherwise offer to clone their home directory into it. Pinned by a test.
- **The clone comes from the plane root on disk**, not from a fetch of its origin. This runs before `doctor` has checked that a forge CLI is authed, so it must not be the step that stalls on an SSH passphrase or fails on a token that isn't there yet — and a local clone carries commits that were never pushed, which for one person in their own project is the work they were in the middle of. Its `origin` is then repointed at the *source's* origin, rewritten to that forge's HTTPS form so golden rule 0 still holds (an SSH origin does not become an SSH clone). Left pointing at the plane root it would look right and fail at the first push: git refuses a push to a non-bare repo's checked-out branch.
- **The clone is named after the origin URL's basename**, not the directory the plane sits in, so a later `charter clone <repo>` from the inventory lands on the same directory rather than a second copy of the same repo beside it.

## Acceptance criteria

- [x] `charter init` inside a git repo offers that repo as the first workspace clone
- [x] Accepting leaves a workspace with that repo cloned and ready to work in (same commits, same upstream, `git fetch` works, token-only git policy applied)
- [x] Declining leaves a valid, empty plane — not even the first workspace's directory is created
- [x] `charter init` outside a git repo behaves exactly as before, with no offer
- [x] The plane produced is identical whether or not the offer was accepted
- [x] Nothing about the offer writes to the plane root's git state — pinned by a test snapshotting HEAD, branch, refs, remotes, local config and `status --porcelain` around the accepted run

## Tests

19 new tests in `tests/test_init_first_clone.py`, real git throughout (a mocked git would prove nothing about a clone's `origin` or about what `git status` says in the plane root afterwards). Every test that passed before the implementation existed was re-checked by mutation — dropping the top-level equality check, dropping the already-cloned suppression, having the offer clone by itself, and writing to the plane root's config each fail exactly the test that claims to cover it.

`python3 -m unittest discover -s tests -t .` → **1420 tests, OK** (1401 on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145Anhzojfo151sYXYwwest
