### PR TITLE
0.21.0 — one plane shape, and a workspace that remembers what it means to do

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.20.0",
+            "command": "charter hook sessionstart --plugin-version 0.21.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.20.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.21.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.20.0",
+            "command": "charter hook pretooluse --plugin-version 0.21.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.20.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.21.0"
           }
         ]
       }
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.20.0",
+            "command": "charter hook posttooluse --plugin-version 0.21.0",
             "timeout": 5
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.20.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.21.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.20.0"
+version = "0.21.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only. All four numbers move together — `pyproject.toml`, `charter/__init__.py`, `.claude-plugin/plugin.json`, and every `--plugin-version` in `hooks/hooks.json` (six commands). `MIN_PLUGIN_VERSION` derives from `__version__`.

**Minor, and breaking under 0.x.** Since 0.20.0:

### `charter ws todo`

A workspace records what it still means to do — **intent**, a third category beside memory (what it learned) and the journal (what happened), and the only one of the three that stops being true by being acted on. Recorded, closed with a journal trace, inherited by a fork, shared with a LIVE workspace, surfaced at session start and in the status line. ADRs 0004–0006.

### The embedded plane shape is gone

`[plane].shape`, `PLANE_SHAPE`, `SHAPES`, `shape_of`, `own_tree`, `root_tree`, `--shape` and `--branch` deleted; `repo_trees` is a workspace's clones and nothing else. A `charter.toml` still declaring `shape = "embedded"` loads with the key **ignored** — no migration, by decision, and no materialised worktree touched. ADR 0007.

### The plane root is not a place to work

The status line warns when it is dirty or off its default branch, `doctor` checks the same at SessionStart, and `charter init` inside a repo offers to clone it into the first workspace rather than leaving you editing the plane. ADR 0008.

Worth stating plainly: removing the shape did **not** by itself fix the branch-thrashing that prompted it — a fleet plane never listed the plane root, so the removal closed that hole outright, and what survived was that nothing *prevents* working there. These two signals are the part that addresses it.

### Fixes

- `charter … | head` no longer crashes charter — a reader closing a pipe is a condition, not a bug. Found by charter's own crash detector, unprompted.
- Eighteen status-line tests that were never running now run: three classes were defined twice, so 47 written test methods collected as 29.
- A LIVE workspace's todos are actually committed rather than merely un-ignored.

Plus status-line zone dividers.

`TestVersionsMoveInLockstep` passes; full suite **1468 green**. Tag `v0.21.0` from `main` once this merges — that push is the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCnBscCDiUN4fRvEuB7RC