### PR TITLE
inventory: the plane's own repo is always clonable, so discover is optional

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -18,6 +18,19 @@ from .forge import ForgeError
 from .forge.gitlab import GitLabForge
 
 
+def _clone_announcement(r: dict) -> str:
+    """``name (branch)``, or just ``name`` when the branch is unknown.
+
+    Read straight off the record as ``r['default_branch']`` until a record turned up
+    without one — the plane repo, the first record charter builds by hand rather than from
+    a forge query — and the KeyError took down the whole command instead of cloning. Any
+    hand-built or older record could do the same; the branch is a nicety, not a
+    precondition for cloning.
+    """
+    branch = r.get("default_branch")
+    return f"{r['name']} ({branch})" if branch else r["name"]
+
+
 def _https_url(r: dict) -> str:
     """HTTPS clone URL for a repo (so cloning uses that repo's own forge's token, never
     SSH) — rewritten via THAT forge's own SSH forms (`registry.for_repo`, from the
@@ -224,8 +237,13 @@ def refresh_readme_personas() -> bool:
 # --------------------------------------------------------------------------- #
 def cmd_clone(args) -> int:
     doc = inventory.load()
-    if not doc.get("repos"):
-        util.err("Inventory is empty — run `charter discover` first.")
+    # `inventory.repos()`, not the raw document: the plane's own repo is clonable whether
+    # or not `discover` has ever run (see `inventory.plane_repo`), so refusing on an empty
+    # FILE would turn the one repo a fresh plane definitely has into the one it cannot get.
+    if not inventory.repos(doc):
+        util.err("Nothing to clone: this plane has no inventory, and its own repo could "
+                 "not be derived (no origin, or a forge it does not declare).")
+        util.info("  Build one: charter discover")
         return 1
 
     targets = _resolve_targets(args, doc)
@@ -252,7 +270,7 @@ def cmd_clone(args) -> int:
             _hint_repo_docs(dest, r)
             continue
         forge = registry.for_repo(r)
-        util.info(f"Cloning {r['name']} ({r['default_branch']}) into '{ws}' via {forge.cli} (HTTPS) …")
+        util.info(f"Cloning {_clone_announcement(r)} into '{ws}' via {forge.cli} (HTTPS) …")
         proc = _git([*_cred_flag(forge), "clone", "--branch", r["default_branch"], _https_url(r), str(dest)])
         if proc.returncode != 0:
             failures += 1
@@ -340,7 +358,10 @@ def _sync_one(d: Path, ws: str) -> None:
 # --------------------------------------------------------------------------- #
 def cmd_status(args) -> int:
     doc = inventory.load()
-    inv_by_name = {r["name"]: r for r in doc.get("repos", [])}
+    # `inventory.repos(doc)`, not the raw document: the plane's own repo is clonable
+    # without `discover` (see `inventory.plane_repo`), so counting only what is on disk
+    # would report "0 repos available to clone" beside a `charter clone` that works.
+    inv_by_name = {r["name"]: r for r in inventory.repos(doc)}
     all_ws = workspace.list_workspaces()
     explicit = getattr(args, "workspace", None)
     active = workspace.resolve(explicit)

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -412,11 +412,28 @@ def check_plane_root() -> Result:
 
 
 def check_inventory() -> Result:
-    from . import config as _config
+    """Can this plane clone anything?
+
+    Asked of `inventory.repos()` rather than the file's own count, because a plane can
+    clone its own repo without ever running `discover` — the root's `origin` says what it
+    is (`inventory.plane_repo`). `discover` is therefore optional, and a plane that can
+    reach the repo it was made for is not missing anything.
+
+    Warning regardless would be the permanently-yellow preflight `check_memory_indexes`
+    records the case against — and the nag is expensive in its own right: on a personal
+    account `discover` enumerates every repo the owner has, and writes that listing into
+    a tracked `inventory/repos.json`. Telling someone to publish sixty repos to silence a
+    row about the one they already have is worse advice than saying nothing.
+    """
     n = inventory.load().get("count", 0)
     if n:
         return Result("inventory", OK, detail=f"{n} repos mapped")
-    return Result("inventory", WARN, hint="Run: charter discover  (builds inventory/repos.json).")
+    if inventory.repos():
+        return Result("inventory", OK,
+                      detail="not built — this plane's own repo is clonable without it")
+    return Result("inventory", WARN,
+                  detail="empty, and this plane's own repo could not be derived",
+                  hint="Run: charter discover  (builds inventory/repos.json).")
 
 
 def check_vaults() -> Result:

--- a/charter/inventory.py
+++ b/charter/inventory.py
@@ -13,6 +13,7 @@ resolves to a backend.
 from __future__ import annotations
 
 import json
+import re
 
 from . import config
 
@@ -74,8 +75,126 @@ def load() -> dict:
     return json.loads(config.INVENTORY.read_text())
 
 
+#: Marks a record charter derived rather than discovered. Its presence is what keeps a
+#: synthetic entry out of the file `save` writes, and what lets a listing say "known
+#: without discover" instead of implying a forge query found it.
+PLANE_SOURCE = "plane"
+
+
+def _root_default_branch() -> str:
+    """The plane root's default branch as best charter can tell, or ``""``."""
+    from . import util
+    ref = util.run(["git", "-C", str(config.ROOT), "symbolic-ref", "--quiet", "--short",
+                    "refs/remotes/origin/HEAD"], check=False)
+    head = (ref.stdout or "").strip()
+    if ref.returncode == 0 and head:
+        return head.split("/", 1)[1] if head.startswith("origin/") else head
+    cur = util.run(["git", "-C", str(config.ROOT), "symbolic-ref", "--quiet", "--short",
+                    "HEAD"], check=False)
+    return (cur.stdout or "").strip() if cur.returncode == 0 else ""
+
+
+def plane_repo() -> dict | None:
+    """The **plane repo** — the forge repo the plane root is a checkout of — or None.
+
+    Not the **root tree**, which is the same code seen from the other end: the local
+    directory nobody works in (docs/adr/0008). This is the remote you clone *from*.
+
+    It exists because removing the embedded plane shape took away how a solo user reached
+    their own code. The plane root used to BE the working tree; now work happens in a
+    workspace clone, and the only route charter offered to one was an inventory built by
+    enumerating a whole forge owner — on a personal account, dozens of repos queried and
+    written to a tracked file to surface the one that mattered. The root's own ``origin``
+    already knows the answer, so ``discover`` becomes optional rather than a prerequisite.
+
+    ``None`` whenever charter cannot answer honestly, and each case is a deliberate
+    silence rather than a fallback:
+
+    * the root is not a git repo — ``charter init`` in an empty directory, the README's
+      own 60-second path;
+    * it has no ``origin`` — a repo with no remote cannot be cloned *from* in any useful
+      sense, and a workspace clone of it would have no upstream to push to;
+    * ``origin``'s host matches no declared forge — guessing the first one would build a
+      plausible, wrong clone URL and fail later with a confusing error, where silence
+      fails here with an honest one.
+
+    Carries no ``stack`` or ``kind``: those come from probing a repo's file list, and
+    faking them would put a wrong answer in a column that renders a missing one as ``?``.
+    """
+    try:
+        from . import util
+        from .forge import registry
+
+        p = util.run(["git", "-C", str(config.ROOT), "remote", "get-url", "origin"],
+                     check=False)
+        origin = (p.stdout or "").strip()
+        if p.returncode != 0 or not origin:
+            return None
+
+        forge = registry.resolve_host(origin, config.ROOT)
+        if forge is None:
+            return None
+
+        # `<owner>/<name>`, from either URL form. Trailing `.git` and any `scheme://host`
+        # or `git@host:` prefix removed; what is left is the path the forge names it by.
+        path = re.sub(r"^[a-z+]+://[^/]+/", "", origin)
+        path = re.sub(r"^[^@]+@[^:]+:", "", path)
+        path = path.rstrip("/").removesuffix(".git")
+        if not path or "/" not in path:
+            return None
+
+        return {
+            "name": path.rsplit("/", 1)[1],
+            # Knowable, unlike stack — and `cmd_clone` announces it. `origin/HEAD` is the
+            # remote's own answer where it exists; a plane `git init`-ed and given a
+            # remote by hand never has one, so the checked-out branch stands in.
+            "default_branch": _root_default_branch(),
+            "path_with_namespace": path,
+            "forge": forge.kind,
+            # One of these is what `commands._https_url` needs. Recording the origin as
+            # given lets that function apply THIS forge's own ssh→https rewrite, rather
+            # than this module second-guessing a rule that already exists.
+            # WITHOUT the `.git` suffix: a forge's `web_url` is its HTML page, and
+            # `commands._https_url` appends `.git` itself. Passing the origin through
+            # verbatim produced `…/charter.git.git`, which clones nothing.
+            "web_url": origin.removesuffix(".git") if origin.startswith("https://") else "",
+            "ssh_url": "" if origin.startswith("https://") else origin,
+            "description": "",
+            "topics": [],
+            "source": PLANE_SOURCE,
+        }
+    except Exception:
+        # Never raises: this sits under `repos()`, which the status line, `clone` and
+        # `doctor` all call. A plane whose git is broken should lose this convenience,
+        # not every listing that depends on it.
+        return None
+
+
 def repos(doc: dict | None = None) -> list:
-    return (doc or load()).get("repos", [])
+    """Every repo this plane can clone — the inventory, plus the plane repo.
+
+    The plane repo is contributed here rather than in `clone` so that `clone`, `status`
+    and the status line cannot disagree about what is available. Splitting that decision
+    is what once left the root tree rendered from one list and refreshed from another.
+
+    A discovered record always wins a duplicate: it carries ``stack``, ``kind``,
+    ``description`` and an ``id`` that a derived one cannot know. Matched on
+    ``path_with_namespace``, never the bare name — two repos called ``api`` under
+    different owners are different repos, which is the distinction that field exists for.
+
+    An explicit ``exclude`` still wins. It is something the user wrote down about their
+    own plane, and overriding a written instruction to be helpful is worse than the
+    inconvenience it saves.
+    """
+    listed = (doc or load()).get("repos", [])
+    own = plane_repo()
+    if own is None:
+        return listed
+    if own["name"] in config.EXCLUDE or own["path_with_namespace"] in config.EXCLUDE:
+        return listed
+    if any(r.get("path_with_namespace") == own["path_with_namespace"] for r in listed):
+        return listed
+    return [own, *listed]
 
 
 def merge(batches: list[list[dict]]) -> list[dict]:
@@ -163,6 +282,12 @@ def save(repo_list: list) -> dict:
     Deliberately carries no generated-at timestamp: this file is tracked, and a
     volatile timestamp would churn git history on every discover.
     """
+    # A derived record must never land here. This file's own note tells the next reader
+    # to regenerate it with `discover` and not to hand-edit it, so a synthetic entry
+    # written into it becomes a permanent fake that no `discover` removes. Today no
+    # caller does `save(repos())` — the strip makes that safe by design rather than by
+    # nobody having tried it yet.
+    repo_list = [r for r in repo_list if r.get("source") != PLANE_SOURCE]
     repo_list = sorted(repo_list, key=lambda r: r["name"])
     doc = {
         "group": config.GROUP,

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -320,8 +320,17 @@ def _repo_trees(ws: str) -> list[Path]:
 
 
 def _available() -> int:
+    """The denominator in `repos N/M` — how many repos this plane could clone.
+
+    Asked of `inventory.repos()` rather than the file's own `count`, because the plane's
+    own repo is clonable whether or not `discover` has run. Reading the count alone
+    rendered `repos 0/0` on a plane where `charter clone <its own repo>` works — the
+    status line contradicting the CLI about the same question, which is the split this
+    layout has paid for before.
+    """
     try:
-        return json.loads(config.INVENTORY.read_text()).get("count", 0)
+        from . import inventory
+        return len(inventory.repos())
     except Exception:
         return 0
 

--- a/tests/test_plane_repo.py
+++ b/tests/test_plane_repo.py
@@ -33,6 +33,11 @@ class PlaneRepoCase(PersonaIso):
         """The plane root as a real git repo with an origin — the ordinary case."""
         subprocess.run(["git", "init", "-q", str(config.ROOT)], check=True,
                        capture_output=True)
+        # Set per-repo, not inherited: a CI runner has no global git identity, so a
+        # fixture that commits fails there with exit 128 while passing on any developer
+        # machine. `tests/test_statusline_worktree_rows.py::init_repo` does the same.
+        _git(config.ROOT, "config", "user.email", "t@example.com")
+        _git(config.ROOT, "config", "user.name", "t")
         if origin:
             _git(config.ROOT, "remote", "add", "origin", origin)
         (config.ROOT / "charter.toml").write_text(

--- a/tests/test_plane_repo.py
+++ b/tests/test_plane_repo.py
@@ -1,0 +1,233 @@
+"""The **plane repo** — the forge repo the plane root is a checkout of — is always a
+clone target, without `charter discover`.
+
+Not to be confused with the **root tree**, which is the same code seen from the other end:
+the local directory you must not work in (docs/adr/0008). One is a remote you clone *from*,
+the other a checkout you leave alone.
+
+This exists because removing the embedded plane shape (docs/adr/0007) took away the way a
+solo user reached their own code. Before, the plane root *was* the working tree. Now work
+happens in a workspace clone, and the only route charter offered to one was an inventory
+built by enumerating an entire forge owner — 63 repos queried to surface the one that
+mattered, written to a file that is not gitignored. The root's own `origin` already knows
+the answer, so `discover` becomes optional rather than a prerequisite.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+from charter import config, inventory
+from tests._isolation import PersonaIso
+
+
+def _git(path: Path, *args: str):
+    return subprocess.run(["git", "-C", str(path), *args],
+                          check=True, capture_output=True, text=True)
+
+
+class PlaneRepoCase(PersonaIso):
+    def make_root_repo(self, origin: str = "https://github.com/acme/api.git") -> None:
+        """The plane root as a real git repo with an origin — the ordinary case."""
+        subprocess.run(["git", "init", "-q", str(config.ROOT)], check=True,
+                       capture_output=True)
+        if origin:
+            _git(config.ROOT, "remote", "add", "origin", origin)
+        (config.ROOT / "charter.toml").write_text(
+            'schema = 1\n\n[[forge]]\nkind = "github"\nowner = "acme"\n')
+        config.use(config.ROOT)
+
+
+class TestDerivingThePlaneRepo(PlaneRepoCase):
+    def test_it_is_named_from_the_origin_not_the_directory(self):
+        """A plane in ~/work/api-checkout whose origin is …/acme/api must produce `api`,
+        or a later `charter clone api` lands beside it instead of on it."""
+        self.make_root_repo("https://github.com/acme/api.git")
+        self.assertEqual(inventory.plane_repo()["name"], "api")
+
+    def test_it_carries_the_owner_path(self):
+        self.make_root_repo("https://github.com/acme/api.git")
+        self.assertEqual(inventory.plane_repo()["path_with_namespace"], "acme/api")
+
+    def test_it_is_clonable_over_https(self):
+        """The exact URL, not merely that it looks https-ish. Asserting the prefix alone
+        let `…/api.git.git` through — `_https_url` appends `.git` to a `web_url`, and an
+        origin passed through verbatim already ends in one."""
+        from charter.commands import _https_url
+        self.make_root_repo("https://github.com/acme/api.git")
+        self.assertEqual(_https_url(inventory.plane_repo()),
+                         "https://github.com/acme/api.git")
+
+    def test_an_origin_without_a_git_suffix_still_yields_one(self):
+        from charter.commands import _https_url
+        self.make_root_repo("https://github.com/acme/api")
+        self.assertEqual(_https_url(inventory.plane_repo()),
+                         "https://github.com/acme/api.git")
+
+    def test_an_ssh_origin_still_yields_an_https_clone_url(self):
+        """Golden rule: one credential, HTTPS token, never SSH."""
+        from charter.commands import _https_url
+        self.make_root_repo("git@github.com:acme/api.git")
+        self.assertEqual(_https_url(inventory.plane_repo()),
+                         "https://github.com/acme/api.git")
+
+    def test_it_is_stamped_with_the_forge_it_belongs_to(self):
+        self.make_root_repo("https://github.com/acme/api.git")
+        self.assertEqual(inventory.plane_repo()["forge"], "github")
+
+    def test_it_is_marked_as_not_coming_from_discover(self):
+        self.make_root_repo()
+        self.assertEqual(inventory.plane_repo()["source"], "plane")
+
+    def test_it_carries_the_default_branch(self):
+        """Unlike stack, this IS knowable from the root — and `cmd_clone` reads it to
+        announce what it is cloning."""
+        self.make_root_repo()
+        _git(config.ROOT, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/trunk")
+        self.assertEqual(inventory.plane_repo()["default_branch"], "trunk")
+
+    def test_the_default_branch_falls_back_to_the_checked_out_branch(self):
+        """A plane `git init`-ed and given a remote by hand never gets origin/HEAD."""
+        self.make_root_repo()
+        (config.ROOT / "f.txt").write_text("x")
+        _git(config.ROOT, "add", "f.txt")
+        _git(config.ROOT, "-c", "commit.gpgsign=false", "commit", "-qm", "c")
+        self.assertTrue(inventory.plane_repo()["default_branch"])
+
+    def test_it_claims_no_stack_it_cannot_know(self):
+        """Faking a stack would put a wrong answer in the STACK column; absent renders
+        as `?`, which is true."""
+        self.make_root_repo()
+        self.assertNotIn("stack", inventory.plane_repo())
+
+
+class TestWhenThereIsNothingToDerive(PlaneRepoCase):
+    def test_a_root_that_is_not_a_git_repo_contributes_nothing(self):
+        """`charter init` in an empty directory is the README's own 60-second path."""
+        (config.ROOT / "charter.toml").write_text("schema = 1\n")
+        self.assertIsNone(inventory.plane_repo())
+
+    def test_a_root_with_no_origin_contributes_nothing(self):
+        """A repo with no remote cannot be cloned *from* in any useful sense — a
+        workspace clone of it would have no upstream to push to."""
+        self.make_root_repo(origin="")
+        self.assertIsNone(inventory.plane_repo())
+
+    def test_an_origin_on_an_undeclared_forge_contributes_nothing(self):
+        """Guessing the first declared forge would build a plausible, wrong clone URL —
+        failing later with a confusing error instead of here with an honest silence."""
+        self.make_root_repo("https://svn.example.invalid/acme/api.git")
+        self.assertIsNone(inventory.plane_repo())
+
+    def test_it_never_raises(self):
+        self.assertIsNone(inventory.plane_repo())
+
+
+class TestItReachesEveryConsumer(PlaneRepoCase):
+    def test_repos_includes_it_with_no_inventory_on_disk(self):
+        self.make_root_repo()
+        self.assertEqual([r["name"] for r in inventory.repos()], ["api"])
+
+    def test_it_is_findable_by_name(self):
+        self.make_root_repo()
+        self.assertIsNotNone(inventory.find(inventory.repos(), "api"))
+
+    def test_it_is_findable_by_path(self):
+        self.make_root_repo()
+        self.assertIsNotNone(inventory.find(inventory.repos(), "acme/api"))
+
+    def test_a_plane_with_nothing_derivable_still_lists_nothing(self):
+        (config.ROOT / "charter.toml").write_text("schema = 1\n")
+        self.assertEqual(inventory.repos(), [])
+
+
+class TestAgainstARealInventory(PlaneRepoCase):
+    def _write_inventory(self, repos):
+        config.INVENTORY.parent.mkdir(parents=True, exist_ok=True)
+        config.INVENTORY.write_text(json.dumps(
+            {"group": "acme", "count": len(repos), "repos": repos}) + "\n")
+
+    def test_the_discovered_record_wins_a_duplicate(self):
+        """It carries stack, kind, description and an id — everything the synthetic one
+        cannot know."""
+        self.make_root_repo()
+        self._write_inventory([{"name": "api", "path_with_namespace": "acme/api",
+                                "forge": "github", "stack": "python", "id": 7}])
+        found = inventory.find(inventory.repos(), "api")
+        self.assertEqual(found.get("stack"), "python")
+        self.assertNotIn("source", found)
+
+    def test_a_duplicate_is_not_listed_twice(self):
+        self.make_root_repo()
+        self._write_inventory([{"name": "api", "path_with_namespace": "acme/api",
+                                "forge": "github"}])
+        self.assertEqual([r["name"] for r in inventory.repos()], ["api"])
+
+    def test_deduping_is_by_path_not_bare_name(self):
+        """Two repos called `api` under different owners are different repos — which is
+        what path_with_namespace exists to disambiguate."""
+        self.make_root_repo("https://github.com/acme/api.git")
+        self._write_inventory([{"name": "api", "path_with_namespace": "other/api",
+                                "forge": "github"}])
+        self.assertEqual(len(inventory.repos()), 2)
+
+    def test_other_repos_are_untouched(self):
+        self.make_root_repo()
+        self._write_inventory([{"name": "web", "path_with_namespace": "acme/web",
+                                "forge": "github"}])
+        self.assertEqual(sorted(r["name"] for r in inventory.repos()), ["api", "web"])
+
+
+class TestAnExplicitExcludeWins(PlaneRepoCase):
+    def test_excluding_the_plane_repo_by_name_removes_it(self):
+        """A written instruction about your own plane beats charter being helpful."""
+        self.make_root_repo()
+        (config.ROOT / "charter.toml").write_text(
+            'schema = 1\n\n[[forge]]\nkind = "github"\nowner = "acme"\n'
+            'exclude = ["api"]\n')
+        config.use(config.ROOT)
+        self.assertEqual(inventory.repos(), [])
+
+
+class TestItNeverReachesDisk(PlaneRepoCase):
+    def test_save_strips_the_synthetic_entry(self):
+        """inventory/repos.json says "regenerate with `charter discover`; do not
+        hand-edit". A synthetic record landing there becomes a permanent fake that no
+        discover removes — a hazard currently avoided by accident, pinned here by design.
+        """
+        self.make_root_repo()
+        inventory.save(inventory.repos())
+        on_disk = json.loads(config.INVENTORY.read_text())["repos"]
+        self.assertEqual(on_disk, [])
+
+    def test_save_keeps_real_records(self):
+        self.make_root_repo()
+        inventory.save(inventory.repos() + [{"name": "web",
+                                             "path_with_namespace": "acme/web",
+                                             "forge": "github"}])
+        on_disk = json.loads(config.INVENTORY.read_text())["repos"]
+        self.assertEqual([r["name"] for r in on_disk], ["web"])
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestCloneToleratesAThinRecord(PlaneRepoCase):
+    """`cmd_clone` read `r['default_branch']` directly, so ANY record without it took the
+    whole command down with a KeyError rather than cloning. Found by cloning the plane
+    repo — the first record charter ever built by hand rather than from a forge query."""
+
+    def test_a_record_without_a_default_branch_does_not_crash_the_announcement(self):
+        from charter import commands
+        thin = {"name": "api", "path_with_namespace": "acme/api", "forge": "github",
+                "web_url": "https://github.com/acme/api"}
+        self.assertIsInstance(commands._clone_announcement(thin), str)
+
+    def test_the_announcement_names_the_branch_when_there_is_one(self):
+        from charter import commands
+        rec = {"name": "api", "path_with_namespace": "acme/api", "forge": "github",
+               "default_branch": "trunk"}
+        self.assertIn("trunk", commands._clone_announcement(rec))

--- a/tests/test_statusline_worktree_rows.py
+++ b/tests/test_statusline_worktree_rows.py
@@ -222,8 +222,15 @@ class CountDenominator(ClonedRepoIso):
         self.assertNotIn("repos 1/0", joined)
 
     def test_denominator_returns_once_there_is_an_inventory(self):
+        """Records, not a bare count. `inventory.save` always writes
+        ``count == len(repos)``, so a document claiming 38 with none listed is a state
+        charter cannot produce — and the denominator is now what is actually clonable
+        (`inventory.repos()`), which includes the plane repo and so cannot be read off
+        `count` alone."""
         config.INVENTORY.parent.mkdir(parents=True, exist_ok=True)
-        config.INVENTORY.write_text(json.dumps({"count": 38, "repos": []}))
+        records = [{"name": f"r{i}", "path_with_namespace": f"acme/r{i}",
+                    "forge": "github"} for i in range(38)]
+        config.INVENTORY.write_text(json.dumps({"count": len(records), "repos": records}))
         self.assertIn("repos 1/38", "\n".join(self.render()))
 
 


### PR DESCRIPTION
Removing the embedded plane shape (#62) took away how a solo user reached their own code. The plane root used to **be** the working tree; now work happens in a workspace clone, and the only route charter offered to one was an inventory built by enumerating an entire forge owner.

On a personal account that is **sixty repos queried**, and written into a tracked `inventory/repos.json`, to surface the one that mattered — a large disclosure and a network round trip to learn something the root's own `origin` already says.

```
charter clone charter        # on a plane that has never run discover
✓ charter → workspaces/<ws>/charter
```

## The plane repo

`inventory.repos()` contributes the **plane repo**: the forge repo the plane root is a checkout of. Not the **root tree**, which is the same code seen from the other end — the local directory nobody works in (ADR 0008). One is a remote you clone *from*; the other a checkout you leave alone.

Contributed in `repos()` rather than in `clone`, so `clone`, `status` and the status line cannot disagree about what is available — splitting that decision is what once left a tree rendered from one list and refreshed from another. Both counts now read the live list: `charter status` said *"0 repos available to clone"* beside a `charter clone` that worked, and the status line rendered `repos 0/0` on a plane with something to clone.

**Silent rather than guessing**, in each case deliberately: no git repo, no `origin` (a repo with no remote cannot be cloned *from*, and the clone would have no upstream to push to), or an origin on a forge the plane does not declare (guessing the first would build a plausible, wrong URL that fails later with a confusing error).

A discovered record **wins** a duplicate — it knows `stack`, `kind` and `id`, which a derived one cannot — matched on `path_with_namespace`, never the bare name. An explicit `exclude` still wins: overriding something the user wrote about their own plane is worse than the inconvenience it saves. And a synthetic record can never reach disk; `save` strips it, pinned by a test, because that file's own note says *"do not hand-edit"* and a fake landing there is one no `discover` removes.

`doctor` stops nagging for `discover` when the plane repo resolves. Telling someone to publish sixty repos to silence a row about the one they already have is worse advice than saying nothing.

## Two bugs found by cloning for real, not by the suite

**`cmd_clone` read `r['default_branch']` directly**, so *any* record lacking it took the command down with a `KeyError` instead of cloning. The plane repo is the first record charter builds by hand rather than from a forge query, so it found this — any older or hand-built record could have. The branch is a nicety, not a precondition. It is also knowable here, unlike stack, so the record carries it.

**The clone URL came out `…/charter.git.git`.** `_https_url` appends `.git` to a `web_url`, and the origin passed through verbatim already ended in one. **My own test let it through** by asserting only that the URL started with `https://`; it now asserts the exact URL, with and without a `.git` origin.

One test fixture changed rather than the code: it wrote `{"count": 38, "repos": []}`, a document `inventory.save` cannot produce, and only passed while the denominator read `count` blindly.

27 new tests, suite **1495 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCnBscCDiUN4fRvEuB7RC