### PR TITLE
vaults: stop claiming health that was never tested (#55), and escape a reserved todo word (#59)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -474,6 +474,13 @@ def _add_vault_parser(sub) -> None:
     lst = vsub.add_parser("list", help="List configured vaults (names/status only, never values).")
     lst.set_defaults(func=commands_secrets.cmd_vault_list)
 
+    vfy = vsub.add_parser("verify",
+                          help="Resolve every reference for real and report what does NOT "
+                               "resolve. `list` and `doctor` only check the vault is "
+                               "reachable — a reference can be registered and still be dead.")
+    vfy.add_argument("name", nargs="?", help="One vault (default: all of them).")
+    vfy.set_defaults(func=commands_secrets.cmd_vault_verify)
+
     rm = vsub.add_parser("remove", help="Unregister a vault (leaves its file on disk).")
     rm.add_argument("name")
     rm.set_defaults(func=commands_secrets.cmd_vault_remove)

--- a/charter/commands_secrets.py
+++ b/charter/commands_secrets.py
@@ -195,6 +195,92 @@ def cmd_vault_add(args) -> int:
     return 0
 
 
+# --------------------------------------------------------------------------- #
+# verify — the check that actually resolves                                    #
+#                                                                              #
+# `health()` asks whether a vault is REACHABLE and how many items it holds. It #
+# deliberately never resolves: `vault list` and `doctor` call it routinely, and #
+# a resolve would hit 1Password every time and could prompt for re-auth. Good  #
+# reason to skip it — and no reason to then call the result "healthy".         #
+#                                                                              #
+# Issue #55, from a live incident: `doctor` said "6 configured, all healthy"   #
+# while every resolution through those vaults was failing. Both true. A        #
+# reference can point at an item that no longer exists while the vault holding #
+# it is perfectly reachable, and nothing tested that until something failed at #
+# runtime — with the green line steering people away from the cause for forty  #
+# minutes. So the expensive check gets its own command, and the cheap one      #
+# stops overclaiming.                                                          #
+# --------------------------------------------------------------------------- #
+def verify_vault(prov) -> list[dict]:
+    """Resolve every reference in *prov*, reporting whether each one worked.
+
+    Returns ``[{"key", "ok", "error"}]`` and **never the resolved value** — a verify
+    result is printed to a terminal and may end up in a log or a CI transcript.
+
+    A vault whose key list itself cannot be read reports one failing row rather than
+    raising: `verify` is the command you run when something is already wrong, so it has
+    to survive the thing being wrong.
+    """
+    try:
+        keys = prov.keys()
+    except Exception as e:  # noqa: BLE001 - see docstring
+        return [{"key": "*", "ok": False, "error": str(e)}]
+
+    rows = []
+    for key in keys:
+        try:
+            prov.get(key)
+        except Exception as e:  # noqa: BLE001 - any resolver failure is a failed verify
+            rows.append({"key": key, "ok": False, "error": str(e)})
+        else:
+            rows.append({"key": key, "ok": True, "error": ""})
+    return rows
+
+
+def _vaults_to_verify(name: str | None = None):
+    names = [name] if name else list(registry.vaults())
+    out = []
+    for n in names:
+        try:
+            out.append(registry.provider_for(n))
+        except base.VaultError as e:
+            util.err(f"{n}: {e}")
+    return out
+
+
+def cmd_vault_verify(args) -> int:
+    """Resolve every reference in every vault (or one named vault) and report failures.
+
+    Exits non-zero when anything fails to resolve, because the exit status is what a CI
+    step or a `&&` chain reads — printing a dead reference and exiting 0 would be the same
+    lie in a new place.
+    """
+    provs = _vaults_to_verify(getattr(args, "name", None))
+    if not provs:
+        util.info("No vaults to verify.")
+        return 0
+
+    failed = 0
+    for prov in provs:
+        rows = verify_vault(prov)
+        bad = [r for r in rows if not r["ok"]]
+        failed += len(bad)
+        if not rows:
+            util.info(f"{prov.name}: no references to verify")
+            continue
+        if not bad:
+            util.ok(f"{prov.name}: {len(rows)} reference(s) resolved")
+            continue
+        util.err(f"{prov.name}: {len(bad)} of {len(rows)} reference(s) did NOT resolve")
+        for r in bad:
+            print(f"    {r['key']}: {r['error']}")
+    if failed:
+        util.info("A reference can be registered and still not resolve — the vault being "
+                  "reachable says nothing about the item behind the reference.")
+        return 1
+    return 0
+
+
 def cmd_vault_list(args) -> int:
     doc = registry.load_registry()
     vs = registry.vaults(doc)

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -596,6 +596,12 @@ def cmd_workspace_todo(args) -> int:
             # could act on later. Ask for the missing half instead.
             util.err(f"`todo {text}` needs the slug of the todo to close.")
             util.info(f"  The slug is the first column: charter ws todo --workspace {name}")
+            # Issue #59: the reserved words swallow a todo you genuinely wanted to record
+            # under that name. The escape already existed — matching is exact and
+            # lowercase, so any other capitalisation records — but nothing said so, which
+            # made a recoverable slip look like a wall.
+            util.info(f"  To record a todo actually called \"{text}\", capitalise it or "
+                      f"add a word: charter ws todo \"{text.capitalize()} …\"")
             return 1
         return _close_todo(name, slug, journal=(text == "done"))
 

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -486,8 +486,21 @@ def check_vaults() -> Result:
                            f"someone else)")
     if bad:
         return Result("vaults", WARN, detail=f"{len(vs)} configured",
-                      hint="unhealthy: " + ", ".join(bad))
-    return Result("vaults", OK, detail=f"{len(vs)} configured, all healthy")
+                      hint="not reachable: " + ", ".join(bad))
+    # Says what was actually checked, and nothing more. This line used to read "all
+    # healthy", which is a claim about resolution that nothing here tests: `health()`
+    # asks whether the vault is REACHABLE and how many items it holds, and deliberately
+    # never resolves — `vault list` and `doctor` call it routinely, and resolving would
+    # hit 1Password every time and could prompt for re-auth.
+    #
+    # Issue #55: "6 configured, all healthy" printed minutes apart from every resolution
+    # through those vaults failing. Both were true. A reference can point at an item that
+    # no longer exists while the vault holding it is perfectly reachable — and `doctor` is
+    # the command you run BECAUSE something is wrong, so a green line about the broken
+    # subsystem does not merely fail to help, it steers you away from the cause. It cost
+    # the reporter forty minutes mid-incident.
+    return Result("vaults", OK, detail=f"{len(vs)} reachable (references not resolved)",
+                  hint="Resolve them for real: charter vault verify")
 
 
 #: Entry count at which a memory index is worth curating. Not a cap and not a

--- a/charter/secrets/reference.py
+++ b/charter/secrets/reference.py
@@ -139,9 +139,17 @@ class ReferenceProvider(VaultProvider):
         if proc.returncode != 0:
             raise VaultError(
                 f"resolving '{key}' via {cli} failed (exit {proc.returncode}) for {uri}"
-                f"{self.identity_note()}. "
-                f"Check that you are authenticated to {cli} and the reference exists. "
-                "(Resolver output withheld — it can contain the secret.)")
+                f"{self.identity_note()}.\n"
+                f"  Causes, roughly in order of how often they are the real one:\n"
+                f"    - the item or field behind the reference was renamed, moved or "
+                f"deleted (the vault stays healthy — `charter vault verify` tests this)\n"
+                f"    - you are not authenticated to {cli}\n"
+                f"    - the identity variable for this vault is unset, so {cli} read the "
+                f"vault as somebody else\n"
+                f"    - charter version drift: an older build may not map this vault's "
+                f"identity into {cli}'s environment (`charter version` shows the pin; "
+                f"`charter version sync` conforms this machine)\n"
+                "  (Resolver output withheld — it can contain the secret.)")
         value = proc.stdout or ""
         # `op read --no-newline` already omits it; `vault kv get -field=` appends one.
         return value[:-1] if value.endswith("\n") else value

--- a/tests/test_todos_command.py
+++ b/tests/test_todos_command.py
@@ -312,3 +312,27 @@ class TestClosingIsWorkspaceScoped(ClosingCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestTheReservedWordsAreEscapable(TodoCommandCase):
+    """Issue #59. `done` and `forget` are reserved as closing verbs, so a todo whose text
+    is exactly one of them cannot be recorded. Degenerate, but the escape existed all
+    along — matching is exact and lowercase — and nothing told you, which turned a
+    recoverable slip into a dead end."""
+
+    def test_the_exact_lowercase_word_is_still_refused(self):
+        rc, _ = self.run_todo(text="done")
+        self.assertNotEqual(rc, 0)
+
+    def test_the_refusal_says_how_to_record_it_anyway(self):
+        _, out = self.run_todo_all(text="done")
+        self.assertIn("capitalise", out.lower())
+
+    def test_any_other_capitalisation_records_normally(self):
+        rc, _ = self.run_todo(text="Done")
+        self.assertEqual(rc, 0)
+        self.assertEqual([t["title"] for t in todos.open_todos("alpha")], ["Done"])
+
+    def test_the_word_inside_a_longer_todo_is_untouched(self):
+        rc, _ = self.run_todo(text="done with the migration, write it up")
+        self.assertEqual(rc, 0)

--- a/tests/test_vault_verify.py
+++ b/tests/test_vault_verify.py
@@ -1,0 +1,154 @@
+"""`charter vault verify` — the check that actually resolves, and `doctor` no longer
+claiming health it has not tested.
+
+Reported as issue #55, from a live incident: `doctor` said `✓ vaults 6 configured, all
+healthy` at the same moment every secret resolution through those vaults was failing. Both
+statements were true. `health()` asks whether the vault is reachable and how many items it
+holds; it deliberately never resolves, because `vault list` and `doctor` call it routinely
+and a resolve would hit 1Password every time and could prompt for re-auth. That is a good
+reason to skip it — and no reason at all to then call the result "healthy".
+
+A reference can point at an item that does not exist while the vault holding it is
+perfectly reachable. Nothing tested that until something failed at runtime, and the green
+line sent people looking everywhere except at the reference. The reporter lost roughly 40
+minutes to it during an incident.
+
+Third instance of this class in this codebase: `commands_secrets` already carries two
+comments saying "`doctor` reported 'all healthy', because from the vault's point of view it
+was" — for a plaintext vault on a git-tracked path, and for an empty value stored by
+accident.
+"""
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_secrets, doctor
+from charter.secrets import base
+from tests._isolation import PersonaIso
+
+
+class _Ref:
+    """A reference vault whose resolution outcome the test decides."""
+
+    def __init__(self, name="v", refs=None, fails=()):
+        self.name = name
+        self._refs = refs or {"GOOD": "op://vault/good/password"}
+        self._fails = set(fails)
+
+    def keys(self):
+        return sorted(self._refs)
+
+    def reference_for(self, key):
+        return self._refs[key]
+
+    def health(self):
+        return True, f"{len(self._refs)} reference(s)"
+
+    def env_overlay(self):
+        # `doctor` calls this before health() — a vault declaring an identity whose
+        # variable is unset is broken in a way health() cannot see.
+        return {}
+
+    def get(self, key):
+        if key in self._fails:
+            raise base.VaultError(f"resolving '{key}' via op failed (exit 1)")
+        return "s3cret"
+
+
+class TestVerifyResolvesForReal(PersonaIso):
+    def test_a_vault_whose_references_resolve_reports_ok(self):
+        rows = commands_secrets.verify_vault(_Ref())
+        self.assertEqual([r["ok"] for r in rows], [True])
+
+    def test_a_reference_that_does_not_resolve_is_reported(self):
+        """The whole point: reachable vault, dead reference."""
+        v = _Ref(refs={"GOOD": "op://v/a/p", "DEAD": "op://v/gone/p"}, fails={"DEAD"})
+        rows = commands_secrets.verify_vault(v)
+        self.assertEqual({r["key"]: r["ok"] for r in rows}, {"GOOD": True, "DEAD": False})
+
+    def test_the_failure_reason_is_carried_back(self):
+        v = _Ref(fails={"GOOD"})
+        self.assertIn("exit 1", commands_secrets.verify_vault(v)[0]["error"])
+
+    def test_no_resolved_value_is_ever_returned(self):
+        """A verify result travels to a terminal and possibly a log. It reports whether a
+        reference resolves, never what it resolved to."""
+        rows = commands_secrets.verify_vault(_Ref())
+        self.assertNotIn("s3cret", repr(rows))
+
+    def test_a_vault_that_cannot_list_keys_does_not_crash_the_verify(self):
+        class Broken(_Ref):
+            def keys(self):
+                raise base.VaultError("registry unreadable")
+        rows = commands_secrets.verify_vault(Broken())
+        self.assertEqual([r["ok"] for r in rows], [False])
+
+
+class TestTheCommand(PersonaIso):
+    def _run(self, **kw):
+        out, err = io.StringIO(), io.StringIO()
+        kw.setdefault("name", None)
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = commands_secrets.cmd_vault_verify(SimpleNamespace(**kw))
+        return rc, out.getvalue() + err.getvalue()
+
+    def test_a_failing_reference_makes_the_command_fail(self):
+        """Exit status is what a CI step or a `&&` chain reads. Reporting a dead
+        reference on stdout and exiting 0 is the same lie in a new place."""
+        with mock.patch("charter.commands_secrets._vaults_to_verify",
+                        return_value=[_Ref(fails={"GOOD"})]):
+            rc, _ = self._run()
+        self.assertNotEqual(rc, 0)
+
+    def test_all_resolving_succeeds(self):
+        with mock.patch("charter.commands_secrets._vaults_to_verify",
+                        return_value=[_Ref()]):
+            rc, _ = self._run()
+        self.assertEqual(rc, 0)
+
+    def test_it_names_the_key_that_failed(self):
+        with mock.patch("charter.commands_secrets._vaults_to_verify",
+                        return_value=[_Ref(refs={"A": "op://v/a/p", "DEAD": "op://v/x/p"},
+                                           fails={"DEAD"})]):
+            _, out = self._run()
+        self.assertIn("DEAD", out)
+
+    def test_no_vaults_is_not_a_failure(self):
+        with mock.patch("charter.commands_secrets._vaults_to_verify", return_value=[]):
+            rc, _ = self._run()
+        self.assertEqual(rc, 0)
+
+
+class TestDoctorStopsClaimingUntestedHealth(PersonaIso):
+    """The reporter's own fallback suggestion, and the right default: if a resolution
+    probe is too expensive for every preflight, say what was actually checked."""
+
+    def _detail(self, vaults):
+        with mock.patch("charter.secrets.registry.vaults", return_value=vaults), \
+             mock.patch("charter.secrets.registry.provider_for",
+                        side_effect=lambda n: _Ref(n)):
+            return doctor.check_vaults()
+
+    def test_it_does_not_say_healthy(self):
+        r = self._detail({"a": {}, "b": {}})
+        self.assertNotIn("healthy", f"{r.detail} {r.hint or ''}".lower())
+
+    def test_it_says_what_it_actually_checked(self):
+        r = self._detail({"a": {}})
+        self.assertIn("reachable", f"{r.detail}".lower())
+
+    def test_it_points_at_the_command_that_does_resolve(self):
+        r = self._detail({"a": {}})
+        self.assertIn("vault verify", f"{r.detail} {r.hint or ''}")
+
+    def test_no_vaults_still_says_none_configured(self):
+        r = self._detail({})
+        self.assertIn("none", r.detail.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #55. Closes #59.

## #55 — `doctor` said "all healthy" while nothing resolved

Reported from a live incident: `charter doctor` printed `✓ vaults 6 configured, all healthy` **minutes apart** from every secret resolution through those vaults failing. Both statements were true, which is the problem.

`health()` asks whether a vault is **reachable** and how many items it holds. It deliberately never resolves — `vault list` and `doctor` call it routinely, and resolving would hit 1Password every time and could prompt for re-auth. That is a good reason to skip the resolve, and no reason at all to then call the result *"healthy"*: a reference can point at an item that was renamed or deleted while the vault holding it is perfectly reachable.

And `doctor` is the command you run **because** something is wrong. A green line about the broken subsystem does not merely fail to help — it steers you away from the cause, at the moment that costs most. It cost the reporter about forty minutes.

**The expensive check gets its own command:**

```
charter vault verify [name]
```

It resolves every reference for real and names each one that does not. It exits non-zero when anything fails, because the exit status is what a CI step or a `&&` chain reads — printing a dead reference and exiting 0 would be the same lie in a new place. It never returns or prints a resolved value.

**The cheap check stops overclaiming:**

```
✓  vaults           2 reachable (references not resolved)
      → Resolve them for real: charter vault verify
```

**The failure message** named two causes — `op` auth and reference existence — and in the reported case *neither was true*. It now lists four, in rough order of how often each is the real one, leading with the renamed-or-deleted item, and including the version drift a colleague traced their instance to. The reporter was careful to mark that cause reported-and-plausible rather than confirmed; the wording follows suit by listing it rather than asserting it.

**This is the third instance of the class.** `commands_secrets` already carries two comments saying *"`doctor` reported 'all healthy', because from the vault's point of view it was"* — for a plaintext vault on a git-tracked path, and for an empty value stored by accident. Same shape each time: a listing describes the registry and reads as describing the credential.

## #59 — a todo cannot be called "done"

`done` and `forget` are reserved as closing verbs, so `charter ws todo done` asks for a slug instead of recording. The escape existed all along — matching is exact and lowercase, so `"Done"` or any longer phrase records normally — but nothing said so, which turned a recoverable slip into a dead end. The refusal now says how.

17 new tests, suite **1512 green**. Verified against this machine's real 1Password vaults.

Thanks to the reporter of #55 — the write-up separated what was observed from what was inferred, which is what made it actionable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCnBscCDiUN4fRvEuB7RC