### PR TITLE
0.22.0 — a plane can clone itself, and doctor stops overclaiming

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.21.0"
+__version__ = "0.22.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.21.0",
+            "command": "charter hook sessionstart --plugin-version 0.22.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.21.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.22.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.21.0",
+            "command": "charter hook pretooluse --plugin-version 0.22.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.21.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.22.0"
           }
         ]
       }
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.21.0",
+            "command": "charter hook posttooluse --plugin-version 0.22.0",
             "timeout": 5
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.21.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.22.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.21.0"
+version = "0.22.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only. All four numbers move together. **Minor** — two new user-facing surfaces.

### `charter vault verify`

Resolves every reference for real and names each one that does not, exiting non-zero when any fails. `doctor`'s vault line stops saying *"all healthy"* about something it never tested:

```
✓  vaults           2 reachable (references not resolved)
      → Resolve them for real: charter vault verify
```

From #55, a live incident where `✓ vaults 6 configured, all healthy` and total resolution failure were true **minutes apart** — and the green line is what sent people to the wrong place for forty minutes.

### The plane's own repo is always clonable

Derived from the root's `origin`, so `discover` is optional rather than a prerequisite:

```
charter clone charter        # on a plane that has never run discover
```

It exists because removing the embedded shape in 0.21.0 took away how a solo user reached their own code — and the only replacement charter offered was enumerating an entire forge owner, sixty repos written to a tracked file, to surface the one they already had.

### Also

- `charter ws todo` now says how to record a todo actually called `done` (#59).
- charter's own plane enables charter's own plugin.

### Two bugs found by cloning for real, not by the suite

`cmd_clone` died with a `KeyError` on any record lacking `default_branch`, and the derived clone URL came out `…/repo.git.git`, which clones nothing — my own test had asserted only that it *started with* `https://`.

`TestVersionsMoveInLockstep` passes; suite **1512 green**. Tag `v0.22.0` from `main` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCnBscCDiUN4fRvEuB7RC