### PR TITLE
secrets: point a reference vault's refusal at the provider that does own items (#70)

### DIFF
--- a/charter/secrets/reference.py
+++ b/charter/secrets/reference.py
@@ -105,8 +105,14 @@ class ReferenceProvider(VaultProvider):
         if not scheme_of(value):
             raise VaultError(
                 f"'{key}': a reference vault stores a URI, not a value — expected one of "
-                f"{', '.join(s + '://' for s in sorted(_RESOLVERS))}. "
-                "Use a plain-file vault to store the value itself.")
+                f"{', '.join(s + '://' for s in sorted(_RESOLVERS))}.\n"
+                f"  A reference vault POINTS AT items somebody else owns, which is why it "
+                f"declines to create one. To have charter own the item — creating it and "
+                f"storing the value, with the value on stdin and never in argv:\n"
+                f"      charter vault add <name> --provider 1password --op-vault <VAULT>\n"
+                f"      charter secret set <name> {key} --from-file <path>\n"
+                f"  To keep the value on this machine instead: --provider plain-file.\n"
+                f"  To register an item you created elsewhere: pass its URI here.")
         _RESOLVERS[scheme_of(value)](value)  # validate shape now, not at read time
         data = self._load()
         data[key] = value

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -252,6 +252,20 @@ charter vault add team --provider reference --file .charter/vaults/team.json
 charter secret set team DEPLOY_TOKEN --value 'op://Eng/deploy/token'
 ```
 
+`secret set` on a reference vault takes a **URI**, never a value — accepting one would
+turn it into a plaintext vault without saying so. If what you have is the secret itself
+and you want charter to store it, you want the other shape: a `1password` vault owns its
+items and `secret set` creates them, with the value arriving on stdin and never in argv.
+
+```bash
+charter vault add team-owned --provider 1password --op-vault Engineering
+… | charter secret set team-owned DEPLOY_TOKEN
+```
+
+The distinction is who owns the item, not which CLI is involved — both end up in
+1Password. Reach for `reference` when a human or another system should stay in charge of
+rotating the credential, and for `1password` when charter should.
+
 Every consuming path works unchanged — the value is resolved only when something
 actually needs it:
 

--- a/tests/test_reference_write_signpost.py
+++ b/tests/test_reference_write_signpost.py
@@ -1,0 +1,89 @@
+"""A reference vault's refusal names the provider that *does* store values (issue #70).
+
+`ReferenceProvider.set` refuses a bare value on purpose — accepting one would turn a
+reference vault into a plaintext vault without saying so. That refusal was correct and a
+dead end: it offered only "use a plain-file vault", never mentioning that charter already
+has a provider which creates the item AND owns it — `1password`, whose `set()` writes the
+value to a new or existing item with the value on stdin.
+
+So the reporter, forbidden by policy from calling `op` directly, concluded there was no
+charter-mediated route and put a freshly generated credential in a 0600 file under /tmp,
+with the irreversible half of the operation already deployed. There was a route. Nothing
+pointed at it.
+
+The distinction the message has to teach, because it is the whole reason there are two
+providers:
+
+* a **reference** vault POINTS AT items somebody else owns — it stores `op://` URIs and is
+  safe to commit;
+* a **1password** vault OWNS its items — charter creates, edits and deletes them.
+
+Choosing `reference` is a statement that charter does not own these items. That is why it
+declines to create one, and why the fix is a signpost rather than a write path.
+"""
+from __future__ import annotations
+
+import unittest
+
+from charter.secrets import base, reference
+from tests._isolation import PersonaIso
+
+
+class RefusalCase(PersonaIso):
+    def provider(self):
+        return reference.ReferenceProvider("refs", {"file": str(self.tmp / "refs.json")})
+
+    def refusal(self) -> str:
+        with self.assertRaises(base.VaultError) as e:
+            self.provider().set("DEPLOY_KEY", "an-actual-secret-value")
+        return str(e.exception)
+
+
+class TestTheRefusalIsNotADeadEnd(RefusalCase):
+    def test_it_names_the_provider_that_stores_values(self):
+        self.assertIn("1password", self.refusal())
+
+    def test_it_gives_the_command_to_create_such_a_vault(self):
+        """Naming the provider without the invocation leaves the reader to guess at
+        `--op-vault`, which is required and has no default."""
+        r = self.refusal()
+        self.assertIn("charter vault add", r)
+        self.assertIn("--op-vault", r)
+
+    def test_it_still_offers_the_plain_file_route(self):
+        self.assertIn("plain-file", self.refusal())
+
+    def test_it_still_says_what_a_reference_vault_stores(self):
+        """The refusal has to keep teaching the model, not just list escape routes."""
+        self.assertIn("URI", self.refusal())
+
+    def test_it_names_the_key_that_was_refused(self):
+        self.assertIn("DEPLOY_KEY", self.refusal())
+
+    def test_the_value_is_never_echoed_back(self):
+        """The refusal is printed. Echoing the rejected value would put a live secret in
+        a terminal and any log scraping it — the failure this whole area exists to avoid.
+        """
+        self.assertNotIn("an-actual-secret-value", self.refusal())
+
+
+class TestAValidReferenceIsStillAccepted(RefusalCase):
+    """The signpost must not narrow what the provider takes."""
+
+    def test_an_op_uri_is_stored(self):
+        p = self.provider()
+        p.set("K", "op://Private/item/password")
+        self.assertEqual(p.reference_for("K"), "op://Private/item/password")
+
+    def test_a_vault_uri_is_stored(self):
+        p = self.provider()
+        p.set("K", "vault://secret/data/app#FIELD")
+        self.assertEqual(p.reference_for("K"), "vault://secret/data/app#FIELD")
+
+    def test_a_malformed_uri_of_a_known_scheme_is_still_refused(self):
+        with self.assertRaises(base.VaultError):
+            self.provider().set("K", "op://only-one-part")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #70.

## What actually happened

The reporter was forbidden by policy from calling `op` directly, hit `secret set`'s refusal on a reference vault, read *"use a plain-file vault to store the value itself"*, and concluded there was no charter-mediated route. A freshly generated credential went into a `0600` file under `/tmp` with the irreversible half of the operation already deployed.

**There was a route.** charter's `1password` provider owns its items — `set()` creates or edits them with the value on **stdin**, never in argv, and has done for a long time. The refusal simply never mentioned it.

## Why this is a signpost and not a write path

I designed, built and threw away a `secret create` for reference vaults — 29 tests and an ADR — before checking whether the capability already existed. It did.

Choosing `reference` **is** the statement that charter does not own these items; a reference vault that creates them is a contradiction. And it would have given charter two ways to make a 1Password item with two different URI conventions.

Worth being precise about where the failure was, because it decides the fix: **the docs are not wrong.** `docs/secrets.md` already draws the distinction well, under *"the difference is who owns the item"*. The person hit the **error**, not the docs, and the error offered one escape route and omitted the one they wanted. A message that is correct and incomplete at the moment of refusal is how someone ends up doing the unsafe thing while holding the safe tool.

## The new refusal

```
'DEPLOY_KEY': a reference vault stores a URI, not a value — expected one of op://, vault://.
  A reference vault POINTS AT items somebody else owns, which is why it declines to create one.
  To have charter own the item — creating it and storing the value, with the value on stdin
  and never in argv:
      charter vault add <name> --provider 1password --op-vault <VAULT>
      charter secret set <name> DEPLOY_KEY --from-file <path>
  To keep the value on this machine instead: --provider plain-file.
  To register an item you created elsewhere: pass its URI here.
```

It teaches the model rather than listing escapes, and never echoes the rejected value — the refusal is printed. `docs/secrets.md` gains the same cross-reference in the reference-vault section, where somebody reaching for the wrong shape is standing.

## Found while implementing the opposite

`OnePasswordProvider.get` addresses items by **title** — `op://<vault>/<title>/password`. A title is mutable from the 1Password UI by someone who has never heard of charter, and a rename silently turns a working credential into a dangling reference: the failure class #55 exists to expose. **Not touched here** — it is shipped behaviour and deserves its own change with its own migration thinking.

9 new tests, suite **1521 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCnBscCDiUN4fRvEuB7RC