### PR TITLE
0.22.1 — a refusal that is no longer a dead end

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.22.0"
+__version__ = "0.22.1"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.22.0",
+            "command": "charter hook sessionstart --plugin-version 0.22.1",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.22.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.22.1",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.22.0",
+            "command": "charter hook pretooluse --plugin-version 0.22.1",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.22.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.22.1"
           }
         ]
       }
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.22.0",
+            "command": "charter hook posttooluse --plugin-version 0.22.1",
             "timeout": 5
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.22.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.22.1",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.22.0"
+version = "0.22.1"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only. **Patch** — no new commands or flags; one message and one doc section.

A reference vault refuses a bare value on purpose: accepting one would turn it into a plaintext vault without saying so. That refusal offered *"use a plain-file vault"* and never mentioned that charter's `1password` provider already owns its items and stores values, with the value on stdin and never in argv.

Somebody forbidden by policy from calling `op` directly read that, concluded there was no charter-mediated route, and put a freshly generated credential in a `0600` file under `/tmp` — with the irreversible half of the operation already deployed (#70).

The docs were right all along. The error was correct and **incomplete**, and the person hit the error, not the docs. The refusal now teaches who owns what, gives the two commands, and keeps the other routes.

Suite **1521 green**. Tag `v0.22.1` from `main` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCnBscCDiUN4fRvEuB7RC