### PR TITLE
0.23.0 — a 1Password vault is one item

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.22.1"
+__version__ = "0.23.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.22.1",
+            "command": "charter hook sessionstart --plugin-version 0.23.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.22.1",
+            "command": "charter hook userpromptsubmit --plugin-version 0.23.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.22.1",
+            "command": "charter hook pretooluse --plugin-version 0.23.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.22.1"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.23.0"
           }
         ]
       }
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.22.1",
+            "command": "charter hook posttooluse --plugin-version 0.23.0",
             "timeout": 5
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.22.1",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.23.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.22.1"
+version = "0.23.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only. All four numbers move together. **Minor, and breaking** for existing `1password` vaults.

### A vault is one item whose fields are the secrets

```
charter vault add devops --provider 1password --op-vault "Engineering" \
                         --op-item "Engineering Secrets"     # optional
```

One item per key could not describe real 1Password vaults — two keys sharing an item, or a value in `notesPlain` rather than `password` — so anyone with such a layout kept a file of `op://` URIs through the `reference` provider to work around it. Custom fields express both directly, and a vault becomes one item with one ACL. `--op-item` defaults to `charter-<vault>`.

### Upgrading

**Existing `1password` vaults need their secrets re-registered.** Nothing is lost and nothing is silently emptied: a vault whose item is absent while `charter-<vault>-<key>` items remain reports **unhealthy** and names the count, rather than reporting an empty vault as fine. Re-register with `charter secret set`, then delete the old items.

### Behaviour worth knowing

Reads fetch **one field** (`op read op://<vault>/<item>/<field>`) and never the whole item, so a read never pays the write's cost. Writes are a read-modify-write — `op` templates replace rather than merge — so `set` re-reads the field afterwards and fails loudly if a concurrent writer dropped it. 1Password keeps item history if that happens.

`keys()` and `health()` fetch **without** `--reveal`; field names are all they need. Revealing there would pull every secret in the vault into memory on every `vault list` and every `doctor` run.

`TestVersionsMoveInLockstep` passes; suite **1530 green**. Tag `v0.23.0` from `main` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCnBscCDiUN4fRvEuB7RC