### PR TITLE
1password: adopted items key on labels, not 1Password's generated ids (#75)

### DIFF
--- a/charter/secrets/onepassword.py
+++ b/charter/secrets/onepassword.py
@@ -51,6 +51,23 @@ _TAG = "charter"
 _CATEGORY = "PASSWORD"
 
 
+def _field_name(f: dict) -> str:
+    """The key a field is addressable by: its **label**, falling back to its id.
+
+    Label first, and the order is the whole of issue #75. `id` was preferred, and `or`
+    only falls through when the left side is falsy — which an id never is on a real item.
+    charter-created items hid it completely, because `_write` sets id == label == key; it
+    surfaced only on an item charter adopted, where 1Password assigns a random id and
+    keeps the human text as the label. Every key then came back as a random string, while
+    `doctor` and `vault verify` both reported healthy: resolution genuinely worked, and
+    only the names were unusable.
+
+    The fallback matters too — 1Password does not require a label, and a field without one
+    stays addressable by id rather than vanishing from the vault.
+    """
+    return str(f.get("label") or f.get("id") or "")
+
+
 class OnePasswordProvider(VaultProvider):
     id = "1password"
     label = "1Password (op CLI — charter creates and manages the items)"
@@ -222,20 +239,58 @@ class OnePasswordProvider(VaultProvider):
             doc = json.loads(proc.stdout or "{}")
         except json.JSONDecodeError as e:
             raise VaultError(f"could not parse 1Password item '{self.op_item}': {e}")
+        out: dict = {}
+        for f in doc.get("fields") or []:
+            name = _field_name(f)
+            if not name or "value" not in f:
+                continue
+            if name in out:
+                # 1Password permits two fields with the same label; only the ids
+                # disambiguate them. Letting one silently win would make a secret
+                # unreachable while `list`, `doctor` and `verify` all reported healthy —
+                # invisible loss, which is the one outcome worth failing for.
+                raise VaultError(
+                    f"1Password item '{self.op_item}' has more than one field labelled "
+                    f"'{name}', so charter cannot tell which secret that key means. "
+                    f"Rename one in 1Password, then retry.")
+            out[name] = f["value"]
+        return out
+
+    def _existing_ids(self) -> dict:
+        """``{field name: 1Password's id}`` for the item as it stands.
+
+        Adoption must be non-destructive: a field charter did not create carries an id
+        1Password generated, and rewriting it to the key name on the next write would
+        mutate an identifier the user never chose on an item charter does not own.
+        """
+        proc = self._run(self._argv("item", "get", self.op_item, "--vault", self.op_vault,
+                                    "--format", "json"))
+        if proc.returncode != 0:
+            return {}
+        try:
+            doc = json.loads(proc.stdout or "{}")
+        except json.JSONDecodeError:
+            return {}
         out = {}
         for f in doc.get("fields") or []:
-            fid = f.get("id") or f.get("label")
-            if fid and "value" in f:
-                out[str(fid)] = f["value"]
+            name = _field_name(f)
+            if name and f.get("id"):
+                out[name] = str(f["id"])
         return out
 
     def _write(self, fields: dict, creating: bool) -> None:
-        """Replace the item with exactly *fields*. The template travels on stdin."""
+        """Replace the item with exactly *fields*. The template travels on stdin.
+
+        Existing ids are carried through so adopting a hand-made item does not renumber
+        its fields; only genuinely new ones take the key as their id, which is what makes
+        charter-created items round-trip identically.
+        """
+        ids = {} if creating else self._existing_ids()
         template = json.dumps({
             "title": self.op_item,
             "category": _CATEGORY,
             "tags": [_TAG, self._vault_tag()],
-            "fields": [{"id": k, "label": k, "type": "CONCEALED", "value": v}
+            "fields": [{"id": ids.get(k, k), "label": k, "type": "CONCEALED", "value": v}
                        for k, v in sorted(fields.items())],
         })
         if creating:

--- a/tests/test_onepassword_single_item.py
+++ b/tests/test_onepassword_single_item.py
@@ -38,9 +38,13 @@ from tests._isolation import PersonaIso
 class FakeOp:
     """Stands in for `op`, recording every argv and stdin."""
 
-    def __init__(self, fields=None, item_exists=True, legacy=(), fail_on=None):
+    def __init__(self, fields=None, item_exists=True, legacy=(), fail_on=None,
+                 raw_fields=None):
         self.calls: list[dict] = []
         self.fields = dict(fields or {})
+        #: Full field dicts, for items charter did not create — 1Password assigns a
+        #: random `id` and keeps the human text as `label`.
+        self.raw_fields = raw_fields
         self.item_exists = item_exists
         self.legacy = list(legacy)
         self.fail_on = fail_on
@@ -49,7 +53,8 @@ class FakeOp:
         return json.dumps({
             "id": "itm1", "title": "charter-devops",
             "category": "PASSWORD", "vault": {"name": "Eng"},
-            "fields": [{"id": k, "label": k, "type": "CONCEALED", "value": v}
+            "fields": self.raw_fields if self.raw_fields is not None else
+                      [{"id": k, "label": k, "type": "CONCEALED", "value": v}
                        for k, v in self.fields.items()],
         })
 
@@ -74,7 +79,9 @@ class FakeOp:
             return SimpleNamespace(returncode=0, stdout=self.fields[key], stderr="")
         if a[:3] in (["op", "item", "edit"], ["op", "item", "create"]):
             tpl = json.loads(input or "{}")
-            self.fields = {f["id"]: f.get("value", "") for f in tpl.get("fields", [])}
+            self.raw_fields = tpl.get("fields", [])
+            self.fields = {f.get("label") or f["id"]: f.get("value", "")
+                           for f in tpl.get("fields", [])}
             self.item_exists = True
             return SimpleNamespace(returncode=0, stdout=self._item_json(), stderr="")
         return SimpleNamespace(returncode=0, stdout="", stderr="")
@@ -370,6 +377,105 @@ class TestHealthNeverReadsAValue(OpCase):
         op, p = self.make(fields={"A": "1"})
         p.health()
         self.assertNotIn("--reveal", " ".join(" ".join(c["argv"]) for c in op.calls))
+
+
+class TestAdoptedItemsUseLabelsAsKeys(OpCase):
+    """Issue #75. `--op-item` documents itself as "point it at an item you already
+    curate" — and adopting one produced 1Password's random field IDs as key names, so
+    every consumer naming a key broke.
+
+    Invisible on charter-created items, because `_write` sets id == label == key. It
+    appears only on adopted items, which is precisely the case the flag exists for.
+    """
+
+    ADOPTED = [
+        {"id": "27r3gphb4fnsonx5ikcaw3cxwq", "label": "PROD_KUBECONFIG",
+         "type": "CONCEALED", "value": "kubeconfig-body"},
+        {"id": "6kqf7x6wchnoeucvbwwogt6bai", "label": "GITHUB_TOKEN",
+         "type": "CONCEALED", "value": "ghp_xyz"},
+    ]
+
+    def test_keys_are_the_labels_a_human_typed(self):
+        _, p = self.make(raw_fields=self.ADOPTED)
+        self.assertEqual(p.keys(), ["GITHUB_TOKEN", "PROD_KUBECONFIG"])
+
+    def test_the_generated_ids_are_not_keys(self):
+        _, p = self.make(raw_fields=self.ADOPTED)
+        self.assertNotIn("27r3gphb4fnsonx5ikcaw3cxwq", p.keys())
+
+    def test_a_field_with_no_label_still_resolves_by_id(self):
+        """1Password does not require a label. Falling back keeps such a field
+        addressable rather than dropping it silently."""
+        _, p = self.make(raw_fields=[{"id": "abc123", "type": "CONCEALED", "value": "v"}])
+        self.assertEqual(p.keys(), ["abc123"])
+
+    def test_charter_created_items_are_unaffected(self):
+        _, p = self.make(fields={"A": "1", "B": "2"})
+        self.assertEqual(p.keys(), ["A", "B"])
+
+
+class TestDuplicateLabels(OpCase):
+    """1Password permits two fields with the same label; ids disambiguate. Letting one
+    win silently would make a secret unreachable while everything reported healthy —
+    which is the #55 shape, and worse here because the loss is invisible."""
+
+    DUPES = [
+        {"id": "aaa", "label": "TOKEN", "type": "CONCEALED", "value": "s3cret-alpha"},
+        {"id": "bbb", "label": "TOKEN", "type": "CONCEALED", "value": "s3cret-beta"},
+    ]
+
+    def test_it_refuses_rather_than_picking_one(self):
+        _, p = self.make(raw_fields=self.DUPES)
+        with self.assertRaises(base.VaultError):
+            p.keys()
+
+    def test_the_error_names_the_item_and_the_label(self):
+        _, p = self.make(raw_fields=self.DUPES)
+        with self.assertRaises(base.VaultError) as e:
+            p.keys()
+        self.assertIn("TOKEN", str(e.exception))
+        self.assertIn("charter-devops", str(e.exception))
+
+    def test_the_error_does_not_echo_a_value(self):
+        """Values are distinctive on purpose: a short fixture like "one" collides with
+        ordinary prose in the message ("Rename one in 1Password") and the assertion then
+        fails on the explanation rather than on a leak."""
+        _, p = self.make(raw_fields=self.DUPES)
+        with self.assertRaises(base.VaultError) as e:
+            p.keys()
+        self.assertNotIn("s3cret", str(e.exception))
+
+    def test_health_reports_it_rather_than_raising(self):
+        _, p = self.make(raw_fields=self.DUPES)
+        ok, _ = p.health()
+        self.assertFalse(ok)
+
+
+class TestAdoptionIsNonDestructive(OpCase):
+    """A round-trip used to rewrite `id` to the key name, mutating identifiers the user
+    never chose on an item charter does not own."""
+
+    ADOPTED = [
+        {"id": "27r3gphb4fnsonx5ikcaw3cxwq", "label": "PROD_KUBECONFIG",
+         "type": "CONCEALED", "value": "body"},
+    ]
+
+    def test_an_existing_fields_id_is_preserved(self):
+        op, p = self.make(raw_fields=list(self.ADOPTED))
+        p.set("GITHUB_TOKEN", "ghp_new")
+        written = {f["label"]: f["id"] for f in op.raw_fields}
+        self.assertEqual(written["PROD_KUBECONFIG"], "27r3gphb4fnsonx5ikcaw3cxwq")
+
+    def test_a_new_field_takes_the_key_as_its_id(self):
+        op, p = self.make(raw_fields=list(self.ADOPTED))
+        p.set("GITHUB_TOKEN", "ghp_new")
+        written = {f["label"]: f["id"] for f in op.raw_fields}
+        self.assertEqual(written["GITHUB_TOKEN"], "GITHUB_TOKEN")
+
+    def test_the_adopted_value_survives_the_write(self):
+        op, p = self.make(raw_fields=list(self.ADOPTED))
+        p.set("GITHUB_TOKEN", "ghp_new")
+        self.assertEqual(op.fields["PROD_KUBECONFIG"], "body")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #75. A bug I introduced in #73, in exactly the feature `--op-item` exists to serve.

## What broke

`--op-item` says *"point it at an item you already curate"* — and adopting one produced unusable keys:

```
$ charter secret list devops
27r3gphb4fnsonx5ikcaw3cxwq
6kqf7x6wchnoeucvbwwogt6bai
```

The labels — `PROD_KUBECONFIG`, `GITHUB_TOKEN` — never appeared, so every consumer naming a key broke. The reporter's vault held prod kubeconfigs and Vault unseal shares.

## Cause

`_fields` read `f.get("id") or f.get("label")`. `or` only falls through when the left side is **falsy**, and an id is never falsy on a real item — so the label was unreachable.

charter-created items hid it completely, because `_write` sets `id == label == key`. It surfaced **only** on adopted items, where 1Password assigns a random id and keeps the human text as the label. Which is the one case the flag exists for, and the one case no test covered.

The name rule now lives in a single function with the ordering written down, so the next reader sees *why* label comes first rather than inheriting an `or` that reads as arbitrary. The id fallback stays — 1Password does not require a label, and a field without one should stay addressable rather than vanish.

## The two decisions you flagged, both taken

**Duplicate labels.** 1Password permits two fields with the same label; only ids disambiguate. Letting one win silently would make a secret unreachable while `list`, `doctor` and `verify` all reported healthy. It now refuses, naming the item and the label; `health` reports it rather than raising.

**Adoption is non-destructive.** `_write` rewrote every id to the key name, mutating identifiers the user never chose on an item charter does not own. Existing ids are carried through; only genuinely new fields take the key as their id, so charter-created items still round-trip identically.

## What did not catch it

`charter vault verify` reported `✓ 14 reference(s) resolved` throughout — **and it was right.** Resolution genuinely worked, by id. The check was honest about what it tested, and what it tested was not the thing that was broken. Same shape as #55, one layer up. Your point that a migration script would have sailed past this is the part that stings.

11 new tests, suite **1541 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCnBscCDiUN4fRvEuB7RC