### PR TITLE
0.23.1 — adopted 1Password items key on labels

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.23.0"
+__version__ = "0.23.1"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.23.0",
+            "command": "charter hook sessionstart --plugin-version 0.23.1",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.23.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.23.1",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.23.0",
+            "command": "charter hook pretooluse --plugin-version 0.23.1",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.23.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.23.1"
           }
         ]
       }
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.23.0",
+            "command": "charter hook posttooluse --plugin-version 0.23.1",
             "timeout": 5
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.23.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.23.1",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.23.0"
+version = "0.23.1"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only. **Patch**, and worth shipping promptly.

0.23.0's `--op-item` produced 1Password's generated field **ids** as key names on any item charter did not create — `27r3gphb4fnsonx5ikcaw3cxwq` instead of `PROD_KUBECONFIG` — so every consumer naming a key broke, on vaults holding prod kubeconfigs and Vault unseal shares (#75). charter-created items were unaffected, which is exactly why it shipped: `_write` sets `id == label == key`, so the bug was invisible everywhere except the case the flag exists for.

Also in the fix: duplicate labels now refuse rather than silently making a secret unreachable, and adopting an item no longer rewrites ids the user never chose.

Suite **1541 green**. Tag `v0.23.1` from `main` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCnBscCDiUN4fRvEuB7RC