### PR TITLE
1Password failures classify, they do not guess (#78)

### DIFF
--- a/charter/secrets/onepassword.py
+++ b/charter/secrets/onepassword.py
@@ -43,6 +43,48 @@ import shutil
 from .. import util
 from .base import SecretNotFound, VaultError, VaultProvider
 
+#: Failures of `op` charter recognises, each paired with the provenance that earns its
+#: place here. Matching another CLI's English is only defensible because of which way it
+#: fails: an unmatched signature costs precision, never correctness — `_fail` falls back
+#: to candidates presented as candidates. Adding an entry without a source is how #78
+#: happened, so every entry names where its wording was observed.
+_DIAGNOSES: tuple[tuple[str, str], ...] = (
+    # op 2.34.0, reproduced locally: no account configured on this machine at all.
+    ("no accounts configured",
+     "`op` has no account configured on this machine. Sign in (`op signin`), or set "
+     "this vault's service-account token, then retry."),
+    # A real incident: a service-account token that could read the vault but not write
+    # to it. 101 is 1Password's own code, carried inside the message — the process still
+    # exits 1, which is precisely why the exit status cannot classify this.
+    ("you do not have permission",
+     "1Password refused this as unauthorised. For a service-account token that usually "
+     "means it has no WRITE access to this vault — the same token reads perfectly well, "
+     "which is what makes the failure look like a charter bug."),
+    # Reported in #78 against op 2.34.0: `op` says this when it never parsed the JSON
+    # template, which DOES declare a category. The flag it asks for is a red herring,
+    # and supplying it is actively destructive, so the hint has to say so.
+    ("provide the item category",
+     "`op` did not parse the JSON template it was given on stdin — that template does "
+     "declare a category, so the flag op asks for is not the real problem. Do NOT add "
+     "--category or --title to satisfy it: op then creates the item with every custom "
+     "field silently dropped, storing nothing while reporting success (issue #78)."),
+)
+
+
+def _diagnose(stderr: str | None) -> str | None:
+    """Recognise a failure of `op`, or admit that we do not.
+
+    Returns a **fixed** string per signature. ``stderr`` is matched against and never
+    interpolated into the result, which is what makes "charter errors never carry
+    provider output" a property of this function's shape rather than of anyone
+    remembering to scrub. There is no path by which op's text can reach a message.
+    """
+    low = (stderr or "").lower()
+    for needle, hint in _DIAGNOSES:
+        if needle in low:
+            return hint
+    return None
+
 #: Every item charter creates carries this, so `keys()` can list its own without
 #: sweeping a shared 1Password vault the team also uses by hand.
 _TAG = "charter"
@@ -128,25 +170,39 @@ class OnePasswordProvider(VaultProvider):
         return self.runner(argv, input=stdin, check=False, env=self.env_overlay())
 
     def _fail(self, what: str, proc, write: bool = False) -> VaultError:
-        """Errors never carry the process output.
+        """Report what failed, and a cause only where one was actually recognised.
 
-        ``op``'s stderr can echo the assignment it was given, and on a read path its
-        stdout *is* the secret. Report the exit status and what was attempted.
+        Errors never carry the process output: ``op``'s stderr can echo the assignment
+        it was given, and on a read path its stdout *is* the secret.
 
-        Write failures name **permissions** first, from experience: against a real
-        account the first failure was ``(101) You do not have permission to perform
-        this action`` — a service-account token that could read the vault but not write
-        to it. The original message suggested checking that `op` was signed in and the
-        vault existed; both were true, so it sent the reader looking in the wrong place.
+        They also never guess. This message used to staple a fixed sentence to every
+        write failure — *check that a service-account token has WRITE access; a
+        read-only token fails here with (101)*. That was earned once, against a real
+        101, and then said unconditionally. In #78 it met a template `op` had refused to
+        parse and reported a permissions problem; the reporter went and audited tokens.
+        Naming a culprit you have not checked is worse than admitting ignorance, because
+        the vague message keeps someone looking and the confident one tells them to stop.
         """
-        hint = ("Check that `op` is signed in (`op whoami`), that the vault exists, and "
-                "— for a service-account token — that it has WRITE access to this vault; "
-                "a read-only token fails here with 1Password error (101)."
-                if write else
-                "Check that `op` is signed in (`op whoami`) and the vault exists.")
+        note = f"{what} failed (op exit {proc.returncode}){self.identity_note()}."
+        hint = _diagnose(getattr(proc, "stderr", ""))
+        if hint:
+            return VaultError(f"{note} {hint}")
+        # Nothing matched. The path is the only information left, so it shapes the
+        # order of the candidates — and they stay candidates.
+        causes = (["the token can read this vault but can not write to it — a "
+                   "service-account token fails here while every read succeeds",
+                   "another writer changed or removed the item mid-operation"]
+                  if write else
+                  ["the vault or item does not exist under this identity",
+                   "this vault's identity variable is unset, so `op` read it as "
+                   "somebody else"]) + \
+                 ["`op` is not signed in, or its session has expired"]
         return VaultError(
-            f"{what} failed (op exit {proc.returncode}){self.identity_note()}. {hint} "
-            "(op output withheld — it can contain the secret.)")
+            f"{note} charter did not recognise this failure. Causes, roughly in order "
+            f"of how often they are the real one:\n"
+            + "".join(f"    - {c}\n" for c in causes)
+            + "  Run the same `op` command yourself to see what it said — charter "
+              "withholds op's output because it can contain the secret.")
 
     # --- CRUD -------------------------------------------------------------- #
     def get(self, key: str) -> str:

--- a/docs/adr/0009-errors-classify-they-do-not-guess.md
+++ b/docs/adr/0009-errors-classify-they-do-not-guess.md
@@ -1,0 +1,78 @@
+# Errors classify, they do not guess
+
+A charter error may name a cause it **recognised**. It must not assert a cause it has not
+verified. Where nothing was recognised, it says so, offers candidates *as* candidates, and
+tells the reader how to see the underlying tool's own output.
+
+This is a rule about error text, which sounds too small for an ADR. It is here because the
+rule is invisible in the code that follows it — a well-written wrong guess and an earned
+diagnosis are the same three lines — and because removing a confident, helpful-sounding
+sentence looks like a regression to anyone who has not read the incident that produced it.
+
+## Why it matters
+
+The 1Password provider's write failure used to end with: *check that a service-account
+token has WRITE access to this vault; a read-only token fails here with 1Password error
+(101)*.
+
+That sentence was true once. It was written after a real incident where a token could read
+a vault and not write to it, and where the previous, vaguer message ("check `op` is signed
+in and the vault exists") had sent someone to check two things that were both fine. It was
+a good fix for that failure. It was then applied to **every** write failure, regardless of
+what `op` had actually said.
+
+In #78 it met a template `op` had declined to parse. charter reported a permissions
+problem. The reporter audited their tokens — and one of the two genuinely *was* read-only,
+so the wrong answer briefly looked confirmed. The two causes were only separated by testing
+each token by hand against a piped `op` call.
+
+The general shape: **a vague error keeps you looking; a confident wrong one tells you to
+stop.** That makes an unearned diagnosis worse than no diagnosis, not better — which is the
+opposite of how it feels to write one.
+
+This is the third instance of one family in this codebase. #55: `doctor` said vaults were
+"healthy" when it had tested reachability. #75: a test covered charter-created items and
+was read as covering adopted ones. Each time the statement was accurate about a narrower
+thing than the reader took it for. An error message is the sharpest version, because it
+does not merely permit the wrong inference — it supplies it.
+
+## What this means in practice
+
+`_diagnose(stderr) -> str | None` matches `op`'s stderr against signatures and returns a
+**fixed constant** per signature. Failing to match is a normal outcome.
+
+Three properties do the work:
+
+**Constants only.** stderr is matched against and never interpolated into the result. The
+rule that charter errors never carry provider output — because a resolver's stdout *is* the
+secret and its stderr can echo what it was given — therefore holds by the shape of the
+function rather than by anyone remembering to scrub. There is no path along which the text
+could reach a message.
+
+**Every signature carries provenance.** Each entry names where its wording was observed: a
+local reproduction on op 2.34.0, a real incident, a specific issue. Two signatures that
+would obviously be useful — item-not-found and session-expired — are *absent*, because
+their wording could only have been guessed. Inventing them is the same error one level down.
+
+**It degrades to silence, not to a wrong answer.** Matching another CLI's English is
+fragile: `op` may reword an error in any release. What makes that acceptable is the
+direction of the failure — an unmatched signature costs precision and can never produce a
+false diagnosis. The behaviour it replaces failed the other way, being precise and unearned.
+
+The `write` flag survives for one job: ordering the candidates when nothing matched, where
+the path is genuinely the only remaining information. Where a signature matched, it wins
+regardless of path.
+
+## Consequences
+
+Some failures now say less than they did. That is the point, and it will read as a
+regression to someone comparing messages side by side without the incident in hand.
+
+`reference.py` is deliberately **not** changed. Its resolver failure already lists causes in
+order rather than naming one — it is the model being copied here, not a defect. Extending
+the classifier to it would mean inventing signatures for HashiCorp `vault`, which nobody has
+observed, and that is precisely what this ADR forbids.
+
+The bar for adding a signature is a source, not a plausible-sounding string. A signature
+without provenance recreates the failure this ADR exists to prevent, with the added
+durability of looking deliberate.

--- a/tests/test_onepassword_single_item.py
+++ b/tests/test_onepassword_single_item.py
@@ -39,8 +39,12 @@ class FakeOp:
     """Stands in for `op`, recording every argv and stdin."""
 
     def __init__(self, fields=None, item_exists=True, legacy=(), fail_on=None,
-                 raw_fields=None):
+                 raw_fields=None, fail_stderr="denied"):
         self.calls: list[dict] = []
+        #: What `op` writes to stderr when `fail_on` trips. Tests that care which
+        #: failure this is set it to real `op` output — charter classifies on this
+        #: text, so a generic default would make every failure look unrecognised.
+        self.fail_stderr = fail_stderr
         self.fields = dict(fields or {})
         #: Full field dicts, for items charter did not create — 1Password assigns a
         #: random `id` and keeps the human text as `label`.
@@ -62,7 +66,7 @@ class FakeOp:
         self.calls.append({"argv": list(argv), "input": input})
         a = [x for x in argv if not x.startswith("--")]
         if self.fail_on and self.fail_on in " ".join(argv):
-            return SimpleNamespace(returncode=1, stdout="", stderr="denied")
+            return SimpleNamespace(returncode=1, stdout="", stderr=self.fail_stderr)
         if a[:3] == ["op", "item", "get"]:
             if not self.item_exists:
                 return SimpleNamespace(returncode=1, stdout="", stderr="not found")
@@ -333,13 +337,34 @@ class TestErrorsWithholdOutput(OpCase):
 class TestWriteFailuresNamePermissions(OpCase):
     """Against a real account the first failure was `(101) You do not have permission` —
     a service-account token that could read the vault but not write to it. The original
-    message suggested checking sign-in and vault existence; both were true."""
+    message suggested checking sign-in and vault existence; both were true.
 
-    def test_a_write_failure_mentions_permissions(self):
+    This class used to fail a write with the fake's generic stderr and assert that the
+    message named WRITE access. It passed, because the message named WRITE access on
+    every write failure whatever `op` had said — so the test asserted the diagnosis
+    without ever supplying the evidence for it, and could not have distinguished a
+    message that had learnt something from one that always says the same thing. That is
+    what #78 walked into. The assertion is kept and now earns itself: the fake emits the
+    real 101, and its opposite is pinned alongside.
+    """
+
+    def test_a_write_failure_against_a_real_101_names_permissions(self):
         op, p = self.make(fields={"A": "1"}, fail_on="item edit")
+        op.fail_stderr = "(101) You do not have permission to perform this action"
         with self.assertRaises(base.VaultError) as e:
             p.set("B", "2")
         self.assertIn("write access", str(e.exception).lower())
+
+    def test_a_write_failure_op_did_not_explain_does_not_assert_permissions(self):
+        """The other half, and the actual regression: an unrecognised failure may list
+        a read-only token among its candidates, never announce it as the cause."""
+        op, p = self.make(fields={"A": "1"}, fail_on="item edit")
+        op.fail_stderr = "ERROR: unexpected end of JSON input"
+        with self.assertRaises(base.VaultError) as e:
+            p.set("B", "2")
+        m = str(e.exception).lower()
+        self.assertIn("did not recognise", m)
+        self.assertNotIn("write access", m)
 
     def test_a_read_failure_does_not_blame_permissions(self):
         op, p = self.make(fields={})

--- a/tests/test_op_failure_diagnosis.py
+++ b/tests/test_op_failure_diagnosis.py
@@ -1,0 +1,181 @@
+"""A 1Password failure names a cause only when charter recognised one (issue #78).
+
+`_fail` used to staple a fixed sentence to every write failure: *"for a service-account
+token, check it has WRITE access; a read-only token fails here with (101)"*. That sentence
+was earned exactly once, against a real 101 during a real incident — and then applied
+unconditionally, to parse failures, missing vaults and expired sessions alike.
+
+So when `op` rejected a template for an unrelated reason, charter reported a permissions
+problem. The reporter went and checked permissions. They had two tokens, one of which
+genuinely was read-only, which made the wrong answer look confirmed; they only separated
+the two causes by testing each token by hand. The error message cost more time than the
+error.
+
+The rule this file pins: **charter may classify a failure it recognises, and must not
+assert a cause it has not verified.** An unrecognised failure gets candidates presented AS
+candidates, plus the invitation to run `op` directly — because charter withholds output the
+user is perfectly entitled to see.
+
+Matching another CLI's English is only safe because of which way it fails. An unmatched
+signature costs precision; it can never produce a wrong answer. That is the inverse of the
+behaviour it replaces, which was precise and unearned.
+"""
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from charter.secrets import base
+from charter.secrets.onepassword import _diagnose
+from tests.test_onepassword_single_item import OpCase
+
+#: Verbatim `op` stderr, each with the provenance that earns its place in `_DIAGNOSES`.
+NO_ACCOUNT = "No accounts configured for use with 1Password CLI."          # op 2.34.0, local
+FORBIDDEN = "(101) You do not have permission to perform this action"      # real incident
+NO_TEMPLATE = "ERROR: provide the item category with '--category' flag"    # #78, op 2.34.0
+UNKNOWN = "ERROR: something charter has never seen before"
+
+
+class TestRecognisedFailures(unittest.TestCase):
+    def test_a_missing_account_is_named(self):
+        self.assertIn("sign in", (_diagnose(NO_ACCOUNT) or "").lower())
+
+    def test_a_permission_refusal_is_named(self):
+        self.assertIn("write", (_diagnose(FORBIDDEN) or "").lower())
+
+    def test_an_unparsed_template_is_named(self):
+        d = (_diagnose(NO_TEMPLATE) or "").lower()
+        self.assertIn("template", d)
+
+    def test_the_unparsed_template_hint_warns_against_the_obvious_fix(self):
+        """`op` asks for `--category`. Supplying it makes op create the item and drop
+        every custom field — a credential that looks stored and is not. The message has
+        to say so, because the error itself is an invitation to do exactly that."""
+        d = (_diagnose(NO_TEMPLATE) or "")
+        self.assertIn("--category", d)
+        self.assertIn("silently", d.lower())
+
+    def test_matching_ignores_case(self):
+        self.assertIsNotNone(_diagnose(FORBIDDEN.upper()))
+
+
+class TestUnrecognisedFailures(unittest.TestCase):
+    def test_an_unknown_failure_is_not_diagnosed(self):
+        self.assertIsNone(_diagnose(UNKNOWN))
+
+    def test_empty_stderr_is_not_diagnosed(self):
+        self.assertIsNone(_diagnose(""))
+        self.assertIsNone(_diagnose(None))
+
+
+class TestTheDiagnosisCannotCarryTheSecret(unittest.TestCase):
+    """`stderr` is matched against, never interpolated. The hint per signature is a
+    fixed constant, so there is no code path by which provider output could reach a
+    message — the property holds by the shape of the code, not by anyone remembering it.
+    """
+
+    def test_no_recognised_hint_echoes_the_stderr_it_matched(self):
+        for stderr in (NO_ACCOUNT, FORBIDDEN, NO_TEMPLATE):
+            leaky = f"{stderr} while storing s3cret-alpha"
+            self.assertNotIn("s3cret-alpha", _diagnose(leaky) or "")
+
+    def test_the_hint_is_the_same_constant_whatever_surrounds_the_signature(self):
+        self.assertEqual(_diagnose(FORBIDDEN), _diagnose(f"prefix {FORBIDDEN} suffix"))
+
+
+class TestTheMessageStopsGuessing(OpCase):
+    def message(self, stderr: str, *, write: bool = True) -> str:
+        op, p = self.make(fields={"A": "1"}, fail_on="item edit")
+        op.fail_stderr = stderr
+        with self.assertRaises(base.VaultError) as e:
+            p.set("B", "s3cret-beta")
+        return str(e.exception)
+
+    def test_a_recognised_permission_failure_still_names_permissions(self):
+        """The old message was not wrong about 101 — it was wrong to say it every time.
+        Where the signature actually matches, the diagnosis must survive."""
+        self.assertIn("write", self.message(FORBIDDEN).lower())
+
+    def test_an_unparsed_template_is_not_reported_as_a_permissions_problem(self):
+        """The regression from #78, stated directly."""
+        m = self.message(NO_TEMPLATE)
+        self.assertIn("template", m.lower())
+        self.assertNotIn("read-only", m.lower())
+
+    def test_an_unrecognised_failure_admits_it(self):
+        m = self.message(UNKNOWN)
+        self.assertIn("did not recognise", m.lower())
+
+    def test_an_unrecognised_failure_offers_candidates_as_candidates(self):
+        """Listing causes is honest; naming one is not. The wording has to make the
+        difference legible to someone skimming under incident pressure."""
+        self.assertIn("roughly in order of how often", self.message(UNKNOWN))
+
+    def test_an_unrecognised_failure_says_how_to_see_the_real_error(self):
+        """charter withholds op's output for a good reason. Withholding it without
+        saying the user may go and read it themselves is a dead end — which is how #78's
+        reporter ended up debugging by hand with no idea what op had actually said."""
+        m = self.message(UNKNOWN).lower()
+        self.assertIn("yourself", m)
+
+    def test_no_failure_of_any_kind_echoes_the_value_being_written(self):
+        for stderr in (NO_ACCOUNT, FORBIDDEN, NO_TEMPLATE, UNKNOWN):
+            self.assertNotIn("s3cret-beta", self.message(stderr))
+
+    def test_no_failure_of_any_kind_echoes_op_s_output(self):
+        self.assertNotIn("something charter has never seen", self.message(UNKNOWN))
+
+
+class TestTheUnknownCaseStillDependsOnThePath(OpCase):
+    """Where nothing matched, the path is the only information left: a failed write is
+    usually a token that can read but not write; a failed read is usually a reference
+    pointing at something that moved. That is the one job the `write` flag still does."""
+
+    def failure(self, stderr: str, *, write: bool) -> str:
+        """`_fail` is the seam both paths share; the read side of it is reachable only
+        through the item-list call that `health()` wraps, so it is exercised here
+        directly rather than through a contrived route."""
+        _, p = self.make(fields={"A": "1"})
+        proc = SimpleNamespace(returncode=1, stdout="", stderr=stderr)
+        return str(p._fail("doing something", proc, write=write))
+
+    def test_an_unrecognised_write_lists_write_access_first(self):
+        self.assertIn("can not write to it", self.failure(UNKNOWN, write=True))
+
+    def test_an_unrecognised_read_does_not_lead_with_write_access(self):
+        self.assertNotIn("can not write to it", self.failure(UNKNOWN, write=False))
+
+    def test_a_recognised_failure_ignores_the_path_entirely(self):
+        """Where op told us what happened, the guess the path would have produced is
+        irrelevant — the same signature means the same thing reading or writing."""
+        self.assertEqual(self.failure(FORBIDDEN, write=True),
+                         self.failure(FORBIDDEN, write=False))
+
+
+class TestTheTemplateFlagsAreNeverPassed(OpCase):
+    """`op` responds to an unparsed template by asking for `--category`. Adding it — or
+    `--title` — makes op create the item with only `notesPlain`, dropping every custom
+    field: a write that reports success and stores nothing.
+
+    charter builds this argv from a literal, so nothing a user types can introduce the
+    flags. What this pins is the code edit: the next person to hit that error and try the
+    fix `op` itself suggests.
+    """
+
+    def test_neither_flag_reaches_a_create(self):
+        op, p = self.make(fields={}, item_exists=False)
+        p.set("A", "1")
+        for c in op.call_with("item", "create"):
+            self.assertNotIn("--category", c["argv"])
+            self.assertNotIn("--title", c["argv"])
+
+    def test_neither_flag_reaches_an_edit(self):
+        op, p = self.make(fields={"A": "1"})
+        p.set("B", "2")
+        for c in op.call_with("item", "edit"):
+            self.assertNotIn("--category", c["argv"])
+            self.assertNotIn("--title", c["argv"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_secrets_travel_by_pipe.py
+++ b/tests/test_secrets_travel_by_pipe.py
@@ -1,0 +1,62 @@
+"""A secret reaches a CLI through a pipe — never a file on disk (issue #78).
+
+`util.run(input=...)` is how every credential gets to `op`, `gh` and `vault` without
+appearing in argv, where `ps` and shell history can read it. The half that was never
+pinned is what `input=` becomes on the way: `subprocess.run` opens a pipe and writes the
+bytes into it, so the secret exists only in kernel buffers between two processes.
+
+The plausible edit this guards against is an optimisation, not a mistake. Templates get
+large — #78 reports one at 239 KB across 43 fields — and writing a large payload to a
+temp file and redirecting it in is the obvious thing to reach for. It would put every
+secret charter handles on disk, and it would break `op` besides: `op item create -`
+distinguishes a piped stdin from a redirected file and fails on the latter with an error
+naming `--category`, which points nowhere near the real cause.
+
+So the guarantee has two independent reasons to hold, and until now no test at all.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+from charter import util
+
+#: Reports what kind of file description the child was handed as stdin.
+PROBE = ("import os, stat; m = os.fstat(0).st_mode; "
+         "print('FIFO' if stat.S_ISFIFO(m) else "
+         "'REGULAR-FILE' if stat.S_ISREG(m) else 'OTHER')")
+
+
+class TestInputBecomesAPipe(unittest.TestCase):
+    def child_stdin_kind(self) -> str:
+        return util.run([sys.executable, "-c", PROBE],
+                        input='{"category":"SECURE_NOTE"}', check=False).stdout.strip()
+
+    def test_a_template_reaches_the_child_as_a_pipe(self):
+        self.assertEqual(self.child_stdin_kind(), "FIFO")
+
+    def test_it_is_still_a_pipe_when_charter_s_own_stdin_is_a_file(self):
+        """The case from the report: charter invoked as `charter secret set ... < f`.
+        The child's stdin must come from charter's `input=`, not be inherited."""
+        path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_isolation.py")
+        saved = os.dup(0)
+        fd = os.open(path, os.O_RDONLY)
+        try:
+            os.dup2(fd, 0)
+            self.assertEqual(self.child_stdin_kind(), "FIFO")
+        finally:
+            os.dup2(saved, 0)
+            os.close(saved)
+            os.close(fd)
+
+    def test_the_child_actually_receives_the_bytes(self):
+        """A pipe nothing was written to would satisfy the check above and deliver no
+        template at all."""
+        proc = util.run([sys.executable, "-c", "import sys; print(sys.stdin.read())"],
+                        input="s3cret-alpha", check=False)
+        self.assertEqual(proc.stdout.strip(), "s3cret-alpha")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The reported `op` pipe-vs-redirect behaviour **cannot reach charter** — `util.run` passes `input=` to `subprocess.run`, which always opens a pipe, verified even when charter's own stdin is a redirected file. The conditional in the report ("if it ever becomes a file object or temp file") is the accurate part.

What the report *did* find is the reason the debugging went wrong.

## The defect

`_fail` ended every write failure with a fixed sentence naming a read-only service-account token. It was written after a real incident where that was the cause, and then applied regardless of what `op` said — so a template `op` had declined to parse was reported as a permissions problem, and the reporter audited tokens instead.

The irony worth recording: that sentence exists *because* an earlier, vaguer message misdirected someone. The fix for one misdirection was to hard-code a different one.

## The change

`_diagnose(stderr) -> str | None` recognises three signatures, each carrying the provenance of its wording — a local reproduction on op 2.34.0, a real incident, and this issue. Anything else is a normal outcome and degrades to candidates presented as candidates, plus how to see op's real output.

Three properties carry it:

- **Constants only.** stderr is matched against, never interpolated. "charter errors never carry provider output" now holds by the function's shape, not by remembering to scrub.
- **Provenance required.** item-not-found and session-expired are the two I most wanted and are absent — I could only have guessed their wording, which is this bug one level down.
- **Degrades to silence.** If op rewords an error we lose precision, never correctness. The behaviour it replaces failed the other way: precise and unearned.

## The old test pinned the bug

`TestWriteFailuresNamePermissions` failed a write with generic stderr and asserted the message named WRITE access. It passed because the message said that on *every* write failure — asserting the diagnosis without supplying the evidence, unable to distinguish a message that had learnt something from one that always says the same thing. Kept, and now earns itself.

## Also

- Pin that create/edit argv never carries `--category`/`--title`. `op` asks for the flag when it fails to parse a template; supplying it makes op create the item and drop every custom field — a write that reports success and stores nothing. `set()`'s read-back already catches this, but the flags should never get near the argv.
- Pin that a secret reaches a CLI through a pipe, not a temp file. Untested until now, and the plausible edit is an optimisation — templates reach 239 KB.

ADR 0009 records the rule and why `reference.py` is deliberately untouched: its ordered-causes message is the model being copied, not a defect.

1566 tests green.

Closes #78