### PR TITLE
0.23.2 — errors classify, they do not guess

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.23.1"
+__version__ = "0.23.2"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.23.1",
+            "command": "charter hook sessionstart --plugin-version 0.23.2",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.23.1",
+            "command": "charter hook userpromptsubmit --plugin-version 0.23.2",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.23.1",
+            "command": "charter hook pretooluse --plugin-version 0.23.2",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.23.1"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.23.2"
           }
         ]
       }
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.23.1",
+            "command": "charter hook posttooluse --plugin-version 0.23.2",
             "timeout": 5
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.23.1",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.23.2",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.23.1"
+version = "0.23.2"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"

--- a/workspaces/plane-shape/memory/MEMORY.md
+++ b/workspaces/plane-shape/memory/MEMORY.md
@@ -4,3 +4,4 @@ One file per memory — a small, programmatically-explorable DB, not a single lo
 merge-conflict on. Files are timestamp-prefixed, so this index (and the directory) list chronologically. **Committed + shared** for LIVE workspaces. Write with `charter workspace remember "…"`, search with `charter workspace recall [--query …]`, drop one with `charter workspace forget <slug>`. Never put secrets here (vault only).
 - [Tickets 01, 03, 04 merged (#62, #63, #65); 02 in review as #64. Correcti](20260812-144109-tickets-01-03-04-merged-62-63-65-02-in-review-as.md)
 - [Decision: discover should be optional. On a personal account it enumerat](20260812-150638-decision-discover-should-be-optional-on-a-person.md)
+- [An error message may classify a failure it recognised; it must never ass](20260813-120419-an-error-message-may-classify-a-failure-it-recog.md)


### PR DESCRIPTION
Version bump only: 0.23.1 → 0.23.2 across `pyproject.toml`, `charter/__init__.py`, `.claude-plugin/plugin.json` and the six `--plugin-version` pins in `hooks/hooks.json`.

Ships #79 / closes #78: a 1Password failure names a cause only where charter recognised one. See ADR 0009 for the rule and why `reference.py` is deliberately untouched.

1566 tests green.