### PR TITLE
Three places where two sources of truth disagreed (#81, #82, #83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,128 @@
 # charter
 
-**charter** is a control plane for Claude Code agents working across many repos on
-GitHub or GitLab. It gives an agent durable **personas** (specialist role identities,
-each with its own committed memory and a scoped credential vault), isolated per-task
-**workspaces** for cloning and working several repos in parallel without mixing them up,
-and a **vault** that keeps credentials out of the model's context — so an agent (or a
-whole team of them) can move between repos and tasks without losing what it has learned
-or leaking a secret into a transcript.
+**charter** is a control plane for Claude Code agents working across many repos on GitHub
+or GitLab: durable **personas**, isolated per-task **workspaces**, and a credential
+**vault** the model never reads from.
+
+## What it solves
+
+Each of these is something that went wrong often enough to get built around.
+
+### Dozens of repos, and several tasks in flight at once
+
+A team's work doesn't sit in one repository, and an engineer rarely has one task open.
+Two features and a hotfix means three sets of branches across a shifting set of repos, and
+if they share a checkout you spend the day stashing. A **workspace** is one directory of
+clones per task (`workspaces/<task>/<repo>`), each repo on its own branch, so moving
+between tasks is `charter workspace use <name>` and nothing follows you across. The
+status line shows which one is active and what state every clone in it is in.
+`charter discover` keeps the map of every repo in the org — including the ones nobody has
+cloned yet — so an agent can find a repo before it exists locally.
+
+### Two sub-agents that need the same repo
+
+Splitting a task across parallel sub-agents falls apart the moment both want the same
+repository on different branches. Cloning it twice wastes the disk and they still collide.
+A **worktree** splits one clone into several checkouts (`.worktrees/<repo>/<piece>`), a
+branch each, so the pieces genuinely run at the same time. `charter worktree remove`
+refuses if it would drop uncommitted or unpushed work.
+
+### You are always teaching the agent the same things
+
+`CLAUDE.md` holds what you sat down and wrote. It doesn't hold what the agent worked out
+at 2am — that the flaky checkout test is a DNS timeout rather than the code, that billing
+deploys gate on the e2e suite and not the unit ones. That knowledge dies with the session,
+so next week you explain it again or watch it get rediscovered the slow way.
+`charter persona remember` and `charter workspace remember` write one fact per markdown
+file; `charter recall` searches the workspace's notes, the active role's own notes and the
+shared ones in a single pass. They're ordinary committed files, so a teammate's agent can
+start where yours left off.
+
+### One agent that holds every credential and every context
+
+A single agent carrying every token, every convention and every repo's history is both a
+security problem and a quality one — it has access it doesn't need for the task in front
+of it, and a context full of things that don't apply. A **persona** is a small named scope
+(`devops`, `qa`, `reviewer`) with its own charter, its own committed memory, its own vault,
+and a `delegate-when` line saying what should be handed to it. `charter persona
+sync-agents` turns each one into a real Claude Code sub-agent, so dispatching a role is
+ordinary delegation rather than a prompt trick. They compose the way people do: `extends:`
+inherits a parent's charter, `uses:` says this role routes work to that one, and
+`agent-tools` narrows what the generated sub-agent is allowed to touch.
+
+### Credentials that end up in the transcript
+
+The moment an agent reads a token, that token is in the context window — and from there in
+the transcript, the logs, and any summary fed into a later prompt. A **vault** holds the
+value and hands it to a *command* rather than to the model:
+
+```
+charter secret exec devops --env TOKEN=API_TOKEN -- some-tool
+```
+
+charter resolves the secret in its own process, puts it in the child's environment, and
+redacts every occurrence of it from whatever that command prints. Reads are masked by
+default, `--reveal` refuses a non-interactive stdout, and the plugin's guard denies both
+that flag and `cat`-ing a vault file outright. Read [docs/secrets.md](docs/secrets.md)
+before storing anything real: the default provider is plaintext at 0600, so what this buys
+you is the model never seeing the value — not encryption at rest.
+
+### An unattended run that stops to ask a question
+
+An SSH key passphrase or a GPG signing prompt hangs an autonomous agent until it times
+out, because there is nobody at the keyboard to answer it. Every git operation charter
+performs authenticates with that repo's own forge CLI token over HTTPS — `gh` or `glab`,
+never a key, never signing. `charter git-policy --apply` writes that into a repo's local
+git config, and `charter clone` applies it to everything it clones. The plugin denies the
+commands that would route around it, which is why a denial there is the rule working
+rather than a bug.
+
+### What the task still means to do
+
+Claude Code's task list is per-session: close the terminal and the intent is gone. That's
+fine for "run the tests" and useless for "we still owe the billing team a migration".
+`charter ws todo "<what>"` records intent against the **workspace**, so it outlives the
+session that noticed it — finishing one journals it, abandoning one goes quietly. Each
+workspace also carries a **Vision**, one line saying what the whole task is for, which a
+fork inherits.
+
+### Coming back to a task cold, or handing it to someone else
+
+Two weeks later a workspace is a pile of repos on branches whose names you no longer
+trust. `charter workspace snapshot` writes the repos and their branches into a committed
+manifest and `charter workspace restore` rebuilds the whole thing from it, on your machine
+or a colleague's. `charter workspace fork` copies a workspace's charter, manifest and
+memory so you can branch a task off with its context intact. Workspaces stay private until
+you decide otherwise; `charter workspace live` is what makes one shareable.
+
+### Everyone on the team running a slightly different charter
+
+Once a control plane is shared, the version each engineer happens to have installed stops
+being a private detail: hooks fire differently, a guard denies on one machine and not the
+next, and bug reports stop lining up. It's opt-in — with no pin, charter tracks whatever
+you have — but `[charter].version` in `charter.toml` pins one version the way a lockfile
+does, and the `SessionStart` hook conforms each machine to it once per session, never
+mid-turn. The pin is exact rather than a floor, so it downgrades too; putting a team back
+on a known-good release is precisely the case worth automating. `charter version bump`
+installs and verifies the target *before* writing the lock, so you can't pin colleagues to
+a build you haven't run yourself, and charter only ever shows you that command — it never
+moves the pin on its own. A conform that fails (offline, no `uv`) warns and gets out of
+the way instead of blocking you, and the drift stays visible in `charter doctor` until
+someone deals with it.
+
+### Not being able to see what any of it is doing
+
+Across four repos and three roles, "is anything broken" shouldn't take six commands to
+answer. The status line carries the active workspace and its open todos, every clone with
+its branch, dirty and ahead/behind markers, CI and open PRs, beside the personas, their
+vault health and how much each has remembered — all read from disk, with no git subprocess
+and no network on the render path. `charter doctor` preflights the environment before an
+agent discovers the problem halfway through a task. `charter trace` shows what actually
+happened in a session: guard denials, tool approvals, secret warnings, memory writes. And
+`charter persona stats` says whether a role is being dispatched at all, or whether that
+work is quietly routing to a generic agent instead.
+
+---
 
 If you've never seen it before, you can go from `uv tool install charter-cp` to a working
 control plane in about a minute — see [60 seconds](#60-seconds-from-nothing-to-a-working-control-plane) below.

--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -709,6 +709,16 @@ def cmd_persona_forget(args) -> int:
     if persona.forget(name, args.slug, shared=args.shared, ephemeral=args.ephemeral):
         util.ok(f"Forgot '{args.slug}' from {name}'s "
                 f"{'ephemeral' if args.ephemeral else 'persistent'} memory.")
+        if args.ephemeral:
+            return 0  # session scratch, gitignored — nothing to commit
+        # Symmetric with `remember`: a removal that stays on one machine is not a
+        # removal. Staging the memory DIRECTORY rather than the deleted file is
+        # deliberate — `git add` on a path that no longer exists and was never tracked
+        # fails the whole call, taking the index update down with it (#82).
+        from .commands import commit_memory_reactive
+        d = persona.memory_dir(name, args.shared)
+        commit_memory_reactive([str(d.relative_to(config.ROOT))],
+                               f"persona({name}): forget {args.slug}")
         return 0
     util.err(f"no memory '{args.slug}' in that store")
     return 1
@@ -896,6 +906,16 @@ def cmd_persona_stats(args) -> int:
     else:
         util.info("No dispatches recorded yet — the tally starts filling as sub-agents are "
                   "dispatched (`charter persona dispatch-backfill` seeds it from past sessions).")
+    # How complete this tally is, stated rather than implied. `PostToolUse(Task|Agent)`
+    # does not fire for every background dispatch, so DISP, ⚑ and the routing ratio are
+    # all floors, not counts — three real dispatches were missing from one plane's store
+    # while `stats` reported `0 / never dispatched` (#83). A count that silently omits
+    # them reads exactly like one that includes them, and personas get retired on it.
+    last = dispatch.last_backfill()
+    when = f"last reconciled {last:%Y-%m-%d}" if last else "never reconciled"
+    util.info(f"Tallied live from a PostToolUse hook, which can miss background "
+              f"dispatches — treat DISP and ⚑ as a FLOOR ({when}). Reconcile against "
+              f"this project's transcripts: charter persona dispatch-backfill.")
     if unused:
         util.warn(f"{unused} persona(s) NEVER dispatched — they exist, lint green, and are "
                   f"unused. Check whether their work is routing to a generic agent instead.")

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -717,6 +717,10 @@ def cmd_workspace_forget(args) -> int:
     name = getattr(args, "workspace", None) or workspace.resolve()
     if workspace.forget_memory(name, args.slug):
         util.ok(f"Forgot '{args.slug}' from workspace '{name}'.")
+        # Symmetric with `remember` — see `cmd_persona_forget` for why the directory,
+        # not the deleted file, is what gets staged (#82).
+        commit_memory_reactive([str(workspace.memory_dir(name).relative_to(config.ROOT))],
+                               f"workspace({name}): forget {args.slug}")
         return 0
     util.err(f"no memory '{args.slug}' in workspace '{name}' (list them: charter workspace recall).")
     return 1
@@ -790,11 +794,17 @@ def cmd_workspace_fork(args) -> int:
     src_todos = todos.todos_dir(src)
     if src_todos.exists():
         shutil.copytree(src_todos, todos.todos_dir(new), dirs_exist_ok=True)
+    # Membership comes from BOTH sources — see `workspace.merge_repo_rows`. Reading the
+    # manifest alone made a fork of an un-snapshotted workspace inherit nothing while
+    # `status` cheerfully reported its clones (#81).
     m = workspace.read_manifest(src)
-    repos = list(m.get("repos") or [])
-    if m:
+    disk = [{"name": d.name, "branch": _repo_branch(d)} for d in workspace.clones(src)]
+    repos, disk_only = workspace.merge_repo_rows(m.get("repos") or [], disk)
+    if repos or m:
         m["name"] = new
         m["forked_from"] = src
+        m["repos"] = repos
+        m.setdefault("description", "")
         m["updated_at"] = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
         m["updated_by"] = _git_user()
         workspace.write_manifest(new, m)
@@ -810,14 +820,25 @@ def cmd_workspace_fork(args) -> int:
         # needs to know they now own a second copy of this intent, not a view of the first.
         util.info(f"Inherited {inherited} open todo(s) from '{src}' — the fork's own list "
                   f"now: charter ws todo --workspace {new}")
+    # Say which source each repo came from. A snapshot promises its branch was pushed;
+    # a clone found on disk promises only that it is checked out here right now, and
+    # `restore` on another machine will fail on a branch that was never pushed. Reporting
+    # it at the moment of use beats a drift warning that would fire on every workspace
+    # nobody has snapshotted — which is most of them, by design.
+    if disk_only:
+        util.info(f"  {len(disk_only)} of them come from clones on disk, not from a "
+                  f"snapshot ({', '.join(disk_only)}) — their branch is whatever is "
+                  f"checked out now, which may not be pushed. `charter workspace "
+                  f"snapshot {src}` records them properly.")
     if getattr(args, "restore", False) and repos:
-        util.info(f"Cloning {len(repos)} repo(s) from the inherited manifest…")
+        util.info(f"Cloning {len(repos)} inherited repo(s)…")
         return cmd_workspace_restore(SimpleNamespace(name=new, on_demand=False))
     if repos:
-        util.info(f"Clone its {len(repos)} recorded repo(s): charter workspace restore {new}  "
+        util.info(f"Clone its {len(repos)} inherited repo(s): charter workspace restore {new}  "
                   f"(or re-run fork with --restore).")
     else:
-        util.info(f"No repos recorded on '{src}' yet — clone into the fork: charter clone <repo> -w {new}")
+        util.info(f"No repos on '{src}' — neither a snapshot nor clones on disk. "
+                  f"Clone into the fork: charter clone <repo> -w {new}")
     if getattr(args, "live", False):
         util.info(f"Share the fork: charter workspace save {new}")
     return 0

--- a/charter/dispatch.py
+++ b/charter/dispatch.py
@@ -155,24 +155,50 @@ def _transcript_dir() -> Path:
     return Path.home() / ".claude" / "projects" / slug
 
 
-def _earliest_live() -> datetime | None:
-    """Start of the live-tallied period. Backfill must not import anything at or after
-    it, or a session that was both live-recorded and transcribed would count twice."""
-    best = None
+def _live_keys() -> set[tuple[str, str]]:
+    """Every dispatch the live hook actually recorded, by identity — (timestamp, agent).
+
+    This replaced a single global cutoff: the earliest live record, with everything at or
+    after it skipped. That prevented double-counting on one assumption — that once live
+    recording had started it was **complete** — and #83 is the report that it is not. A
+    `PostToolUse(Task|Agent)` hook does not fire for every background dispatch, so three
+    real dispatches on 2026-08-10 were missing from a store whose earliest record was
+    2026-08-07, and the cutoff put them permanently out of backfill's reach. One early
+    live record disabled reconciliation for all later history.
+
+    Identity expresses the same guarantee without the assumption, and it self-heals: a
+    window the hook missed is imported the next time backfill runs, whenever that is,
+    without anyone having to know which window it was.
+    """
+    keys: set[tuple[str, str]] = set()
     d = _dir()
     if not d.exists():
-        return None
+        return keys
     for f in d.glob("*.jsonl"):
         if f.name.endswith(BACKFILL_SUFFIX):
             continue
         for ln in f.read_text(errors="replace").splitlines():
             try:
-                t = _ts(json.loads(ln))
+                o = json.loads(ln)
+                t = _ts(o)
             except ValueError:
                 continue
-            if t and (best is None or t < best):
-                best = t
-    return best
+            if t:
+                keys.add((t.isoformat(timespec="seconds"), str(o.get("agent") or "")))
+    return keys
+
+
+def last_backfill() -> datetime | None:
+    """When transcripts were last reconciled into the tally, or None if never.
+
+    `stats` reports this because the tally is only as complete as its last reconciliation,
+    and a count that silently omits every background dispatch reads exactly like a count
+    that includes them (#83)."""
+    d = _dir()
+    if not d.exists():
+        return None
+    stamps = [f.stat().st_mtime for f in d.glob(f"*{BACKFILL_SUFFIX}")]
+    return datetime.fromtimestamp(max(stamps)) if stamps else None
 
 
 def scan_transcripts() -> list[dict]:
@@ -211,20 +237,24 @@ def scan_transcripts() -> list[dict]:
 def backfill() -> tuple[int, int]:
     """Seed the tally from transcripts. Returns (imported, skipped-as-already-live).
     Idempotent: rewrites only the backfill files it owns."""
-    cutoff = _earliest_live()
-    keep: dict[str, list[str]] = {}
+    live = _live_keys()
+    keep: dict[str, set[str]] = {}
+    seen: set[tuple[str, str]] = set()
     imported = skipped = 0
     for row in scan_transcripts():
         t = _ts(row)
         if not t:
             continue
-        if cutoff and t >= cutoff:
+        key = (t.isoformat(timespec="seconds"), str(row.get("agent") or ""))
+        if key in live or key in seen:
+            # Already tallied — by the live hook, or by an earlier line of this same run
+            # (one dispatch can appear in more than one transcript file).
             skipped += 1
             continue
+        seen.add(key)
         name = f"{t:%Y-%m}.{_host()}{BACKFILL_SUFFIX}"
-        keep.setdefault(name, []).append(
-            json.dumps({"ts": t.isoformat(timespec="seconds"), "agent": row["agent"]},
-                       sort_keys=True))
+        keep.setdefault(name, set()).add(
+            json.dumps({"ts": key[0], "agent": row["agent"]}, sort_keys=True))
         imported += 1
     d = _dir()
     d.mkdir(parents=True, exist_ok=True)

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -538,17 +538,40 @@ def pretooluse() -> int:
 # C: SessionStart — inject the active persona's memory index as context          #
 # --------------------------------------------------------------------------- #
 def _uncommitted_memory_nudge() -> str:
-    """One-line reminder if persona memory/refs are sitting uncommitted (knowledge not
-    yet shared). Fires independent of the active persona; best-effort, never raises."""
+    """One-line reminder if memory/refs are sitting uncommitted (knowledge not yet shared).
+
+    Scans **both** stores. It used to scan `personas` alone, so a workspace memory could
+    sit uncommitted indefinitely with nothing to say so — while `_mem_cadence_nudge` was
+    telling the agent that workspace memory was committed and shared. One hook claimed it
+    was shared and the other could not see that it wasn't (#82).
+
+    Silent under the ``local`` posture, where uncommitted memory is not a backlog but the
+    declared design: nothing is meant to reach a remote without a human between writing
+    and disclosure. A nudge that fired on the intended state would be a new false alarm,
+    and telling someone to run a sync command charter deliberately did not run is worse
+    than saying nothing.
+
+    Best-effort; never raises.
+    """
     try:
+        from . import instance as _instance
+        if _instance.clamp_share(config.MEMORY_SHARE) == "local":
+            return ""
         import subprocess
-        r = subprocess.run(["git", "-C", str(config.ROOT), "status", "--porcelain", "--", "personas"],
+        r = subprocess.run(["git", "-C", str(config.ROOT), "status", "--porcelain", "--",
+                            "personas", "workspaces"],
                            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=3)
-        n = sum(1 for ln in r.stdout.splitlines()
-                if ln.strip() and ("/memory/" in ln or "/refs/" in ln))
-        if n:
-            return (f"⬤ {n} persona memory/ref file(s) are **uncommitted** — durable knowledge "
-                    f"not yet shared. Commit + push it with `charter persona memory-sync`.")
+        rows = [ln for ln in r.stdout.splitlines()
+                if ln.strip() and ("/memory/" in ln or "/refs/" in ln)]
+        if not rows:
+            return ""
+        ws = sum(1 for ln in rows if "workspaces/" in ln)
+        where = ("persona" if not ws else "workspace" if ws == len(rows) else "persona + workspace")
+        how = ("`charter persona memory-sync`" if not ws else
+               "`charter workspace save`" if ws == len(rows) else
+               "`charter persona memory-sync` and `charter workspace save`")
+        return (f"⬤ {len(rows)} {where} memory/ref file(s) are **uncommitted** — durable "
+                f"knowledge not yet shared. Commit + push it with {how}.")
     except Exception:
         pass
     return ""
@@ -884,18 +907,44 @@ def _mem_cadence_nudge(sid: str | None, count: int) -> str:
     except Exception:
         pass
     if live:
-        how = f"`charter workspace remember \"<fact>\"` (workspace **{ws}** — committed + shared)"
+        how = f"`charter workspace remember \"<fact>\"` (workspace **{ws}**)"
     elif active:
-        how = f"`charter persona remember {active} \"<fact>\"` (committed + shared)"
+        how = f"`charter persona remember {active} \"<fact>\"`"
     else:
         how = ("`charter workspace remember \"<fact>\"` (make the workspace LIVE to share) or "
                "`charter persona remember <p> \"<fact>\"`")
     return (f"⬢ Memory check — ~{count} file changes since your last recorded memory. Recording "
             f"durable memory is a standing part of the flow, and it fades on long sessions. If this "
             f"work produced something durable — a decision, a gotcha, a verified fact, a *why* — "
-            f"record it now so it survives this session and reaches the team: {how}. It's reactive "
-            f"(commits + pushes immediately). If nothing here is worth keeping, carry on — don't "
-            f"record filler.")
+            f"record it now so it survives this session: {how}. {memory_share_note()} If nothing "
+            f"here is worth keeping, carry on — don't record filler.")
+
+
+def memory_share_note() -> str:
+    """What recording a memory will ACTUALLY do on this plane.
+
+    This used to be the fixed sentence *"committed + shared … reactive (commits + pushes
+    immediately)"*, chosen on workspace LIVENESS. Whether anything is committed is decided
+    somewhere else entirely — ``config.MEMORY_SHARE`` — which defaults to ``local``, where
+    `commit_memory_reactive` returns before touching git. Both underlying facts were true
+    and the sentence built by reading one off the other was false, on the default posture,
+    which is the one chosen so that nothing reaches a remote without a human in between.
+
+    A memory recorded under that promise sat on one laptop while the agent reported it had
+    reached the team (#82). Saying what the posture will actually do costs one lookup.
+    """
+    try:
+        from . import instance as _instance
+        share = _instance.clamp_share(config.MEMORY_SHARE)
+    except Exception:
+        return ""
+    return {
+        "local": "It stays on THIS MACHINE — this plane's `share` is `local`, so charter "
+                 "commits nothing; commit and push it yourself if the team needs it.",
+        "commit": "It is committed locally straight away, but NOT pushed — this plane's "
+                  "`share` is `commit`.",
+        "push": "It is committed and pushed immediately, so it reaches the team.",
+    }.get(share, "")
 
 
 def posttooluse() -> int:

--- a/charter/memstore.py
+++ b/charter/memstore.py
@@ -258,14 +258,24 @@ def resolve(mem_dir: Path, ident: str) -> Path | None:
     return hits[0] if hits else None
 
 
-def forget(mem_dir: Path, ident: str) -> bool:
-    """Delete one memory (by filename or slug) and drop its index line. True if removed."""
+def forget(mem_dir: Path, ident: str) -> Path | None:
+    """Delete one memory (by filename or slug) and drop its index line.
+
+    Returns the path that was removed, so the caller can stage the deletion — `remember`
+    is reactive and `forget` was not, which meant a purge stayed on the machine that ran
+    it while the memory it removed lived on in the remote and came back with the next
+    pull. Removal is the operation that most needs to propagate: it is how a poisoned or
+    secret-bearing memory is taken out of circulation (#82).
+
+    Falsy when nothing matched, as before — a `Path` is truthy, so callers testing the
+    result still read correctly.
+    """
     p = resolve(mem_dir, ident)
     if not p or not p.exists():
-        return False
+        return None
     p.unlink()
     _drop_index_line(mem_dir, p.name)
-    return True
+    return p
 
 
 def _drop_index_line(mem_dir: Path, filename: str) -> None:

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -658,8 +658,11 @@ def find_duplicates(name: str, threshold: float = 0.5,
 
 
 def forget(name: str, slug: str, *, shared: bool = False, ephemeral: bool = False,
-           session: str | None = None) -> bool:
-    """Delete one memory file (by slug/filename) and drop its index line."""
+           session: str | None = None):
+    """Delete one memory file (by slug/filename) and drop its index line.
+
+    Returns the removed path (falsy when nothing matched) so the caller can stage the
+    deletion — see `memstore.forget`."""
     from . import memstore
     d = ephemeral_dir(name, shared, session) if ephemeral else memory_dir(name, shared)
     return memstore.forget(d, slug)

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -547,6 +547,47 @@ def write_manifest(name: str, data: dict) -> None:
     manifest_path(name).write_text(json.dumps(data, indent=2) + "\n")
 
 
+def merge_repo_rows(manifest_rows, disk_rows) -> tuple[list[dict], list[str]]:
+    """Union of what a workspace RECORDED and what it actually HAS.
+
+    charter has two answers to "which repos are in this workspace" and they are both
+    right about different questions. `status` and `workspace list` scan the directory:
+    always current, never portable. The manifest is a **snapshot**: portable and
+    committed, but written only by `charter workspace snapshot`, which deliberately
+    refuses while a repo has unpushed work so a recorded branch can actually be restored.
+
+    Nothing reconciled them, and `fork` read the manifest alone. So a workspace with nine
+    clones and no snapshot reported nine repos everywhere a human looked and inherited
+    zero — issue #81, observed live with the whole point of forking a task environment
+    silently defeated.
+
+    Taking the union rather than picking a winner is what keeps both cases working: a
+    workspace nobody snapshotted still forks its clones, and a teammate who has just
+    cloned the plane — with no repos on disk at all — still inherits from the snapshot.
+
+    Where both know a repo, the **manifest's** branch wins: it was recorded under
+    `snapshot`'s guarantee that the branch was pushed, where the disk only knows whatever
+    happens to be checked out now.
+
+    Returns ``(rows, disk_only)`` — rows sorted by name, and the names no snapshot
+    recorded, which the caller reports rather than silently passing off as snapshotted.
+    """
+    by_name: dict[str, dict] = {}
+    for r in disk_rows or []:
+        n = str(r.get("name") or "").strip()
+        if n:
+            by_name[n] = {"name": n, "branch": r.get("branch") or "HEAD"}
+    disk_only = set(by_name)
+    for r in manifest_rows or []:
+        n = str(r.get("name") or "").strip()
+        if not n:
+            continue
+        disk_only.discard(n)
+        by_name[n] = {"name": n,
+                      "branch": r.get("branch") or by_name.get(n, {}).get("branch") or "HEAD"}
+    return [by_name[n] for n in sorted(by_name)], sorted(disk_only)
+
+
 def memory_dir(name: str) -> Path:
     return workspace_dir(name) / "memory"
 
@@ -621,8 +662,11 @@ def recall(name: str, query: str | None = None, limit: int = 8) -> list[tuple[Pa
     return [(p, t, 0) for p, t, _tx in memstore.entries(memory_dir(name))]
 
 
-def forget_memory(name: str, ident: str) -> bool:
-    """Delete one workspace memory (by slug or filename) and drop its index line."""
+def forget_memory(name: str, ident: str):
+    """Delete one workspace memory (by slug or filename) and drop its index line.
+
+    Returns the removed path (falsy when nothing matched) so the caller can stage the
+    deletion — see `memstore.forget`."""
     from . import memstore
     return memstore.forget(memory_dir(name), ident)
 

--- a/docs/adr/0010-the-manifest-is-a-snapshot-not-an-inventory.md
+++ b/docs/adr/0010-the-manifest-is-a-snapshot-not-an-inventory.md
@@ -1,0 +1,55 @@
+# The manifest is a snapshot, not an inventory
+
+`workspaces/<name>/workspace.json` records **restorable state**: which repos, on which
+branches, captured at a moment somebody chose. It is not the answer to "which repos are in
+this workspace right now". That answer comes from scanning the directory.
+
+Both questions are legitimate and neither source can answer the other's. The directory is
+always current and never portable — a teammate who has just cloned the plane has no repos
+on disk at all. The manifest is portable and always stale — it is written only by
+`charter workspace snapshot`, which *refuses* while a repo has unpushed work, precisely so
+that a recorded branch is one `restore` can actually check out.
+
+## Why it matters
+
+`status` and `workspace list` scanned the directory. `fork` and `fork --restore` read the
+manifest. Nothing reconciled them, and nothing said they were answering different
+questions.
+
+So a workspace with nine clones and no snapshot reported `(9 cloned)` everywhere a human
+looked, and forked to a workspace with nothing in it — reporting *"No repos recorded"*,
+which was true of the manifest and read as true of the workspace. Nine of ten workspaces on
+that machine had no manifest at all, so divergence was the ordinary state, hidden
+everywhere by the scan (#81).
+
+The tempting fix is to make the manifest self-heal: write it on `clone`, or reconcile it on
+every workspace-touching command. That is worse than it looks. It makes read commands mutate
+a committed, shared file, and it fills the manifest with branches recorded outside
+`snapshot`'s guarantee — so `restore` starts failing on branches that were never pushed,
+which is the one thing the manifest exists to prevent. The guard would still be there,
+and everything would route around it.
+
+## What this means in practice
+
+`workspace.merge_repo_rows(manifest_rows, disk_rows)` returns the **union**, with the
+manifest's branch winning where both know a repo — it was recorded under a promise the
+working tree cannot make. `fork` uses it, so an un-snapshotted workspace forks its clones
+and a freshly cloned plane still forks from the snapshot.
+
+It also returns which repos came from disk alone, and `fork` says so: their branch is
+whatever is checked out and may not be pushed. That reporting is the alternative to a
+`doctor` drift check, which was considered and rejected — a manifest only exists once
+somebody snapshots, so drift is the *intended* state for most workspaces, and a warning
+that fires on the intended state teaches people to ignore warnings.
+
+## Consequences
+
+`snapshot` stays the only writer, and its enforce-push guard keeps meaning what it says.
+
+The union is not a merge of equals and must not become one. If a future change starts
+writing the manifest automatically, the guard is gone whether or not the code still calls
+it — and `restore` will fail on someone else's machine, which is the failure that is
+hardest to attribute back here.
+
+Where two sources answer a question, name which question each answers. Both were right;
+only the code that read one and reported the other was wrong.

--- a/tests/test_dispatch_backfill_dedupe.py
+++ b/tests/test_dispatch_backfill_dedupe.py
@@ -1,0 +1,145 @@
+"""Backfill reconciles by identity, so a window the live hook missed is still reachable
+(issue #83).
+
+`PostToolUse(Task|Agent)` does not fire for every dispatch — background sub-agents in
+particular return immediately and complete later, and charter never sees them. On the
+reporting plane, three real dispatches on 2026-08-10 were absent from a trace store whose
+last record was 2026-08-07, and `charter persona stats` showed `DISP 0 / never dispatched`
+for personas that had just done the work.
+
+Backfill existed and could have found them: transcripts record every dispatch, and
+`scan_transcripts` already reads them. It was the double-count guard that put them out of
+reach — everything at or after `_earliest_live()` was skipped, on one global timestamp.
+The guard's job is "do not count the same dispatch twice"; expressing that as a cutoff
+also asserted that live recording was complete from the first live record onward, which is
+exactly what this issue disproves. One early record disabled reconciliation for good.
+
+Identity — (timestamp, agent) — is the same guarantee without the assumption, and it
+self-heals: whenever backfill next runs it picks up whatever the hook missed, without
+anyone having to work out which window that was.
+
+Verified on this plane while diagnosing: six dispatches in the transcripts, zero in the
+tally, and `personas/_dispatch` never created at all.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import dispatch
+
+
+class BackfillCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="edm-backfill-"))
+        self.d = self.tmp / "_dispatch"
+        self.d.mkdir(parents=True)
+        p = mock.patch.object(dispatch, "_dir", lambda: self.d)
+        p.start()
+        self.addCleanup(p.stop)
+        self.addCleanup(lambda: shutil.rmtree(self.tmp, ignore_errors=True))
+
+    def live(self, *rows):
+        """Dispatches the live hook did record."""
+        (self.d / "2026-08.host.jsonl").write_text(
+            "".join(json.dumps({"ts": ts, "agent": a}) + "\n" for ts, a in rows))
+
+    def transcripts(self, *rows):
+        return mock.patch.object(dispatch, "scan_transcripts",
+                                 lambda: [{"ts": ts, "agent": a} for ts, a in rows])
+
+    def rows(self) -> list[tuple[str, str]]:
+        """Timestamps are normalised through `_ts` on both the live and backfill sides,
+        so compare the way the code does rather than against a literal."""
+        out = []
+        for f in sorted(self.d.glob("*.jsonl")):
+            for ln in f.read_text().splitlines():
+                o = json.loads(ln)
+                out.append((dispatch._ts(o).isoformat(), o["agent"]))
+        return sorted(out)
+
+
+class TestTheGapTheCutoffCouldNotReach(BackfillCase):
+    """The report, reduced: live records from the 7th, a hook-missed dispatch on the
+    10th. Under the cutoff this was skipped forever."""
+
+    def test_a_dispatch_after_the_earliest_live_record_is_imported(self):
+        self.live(("2026-08-07T16:45:04", "datadog-master"))
+        with self.transcripts(("2026-08-07T16:45:04", "datadog-master"),
+                              ("2026-08-10T09:00:00", "datadog-master")):
+            imported, skipped = dispatch.backfill()
+        self.assertEqual((imported, skipped), (1, 1))
+
+    def test_the_missed_dispatch_reaches_the_tally(self):
+        self.live(("2026-08-07T16:45:04", "datadog-master"))
+        with self.transcripts(("2026-08-10T09:00:00", "datadog-master")):
+            dispatch.backfill()
+        self.assertIn(("2026-08-10T09:00:00+00:00", "datadog-master"), self.rows())
+
+    def test_a_persona_stops_reading_as_never_dispatched(self):
+        self.live(("2026-08-07T16:45:04", "someone-else"))
+        with self.transcripts(("2026-08-10T09:00:00", "datadog-master"),
+                              ("2026-08-10T09:05:00", "psa-integrations-master")):
+            dispatch.backfill()
+        self.assertEqual(dispatch.tally().get("datadog-master"), 1)
+
+
+class TestNothingIsCountedTwice(BackfillCase):
+    """The guard still has to do its actual job."""
+
+    def test_a_dispatch_the_hook_already_recorded_is_skipped(self):
+        self.live(("2026-08-07T16:45:04", "datadog-master"))
+        with self.transcripts(("2026-08-07T16:45:04", "datadog-master")):
+            imported, skipped = dispatch.backfill()
+        self.assertEqual((imported, skipped), (0, 1))
+        self.assertEqual(len(self.rows()), 1)
+
+    def test_the_same_dispatch_in_two_transcripts_lands_once(self):
+        with self.transcripts(("2026-08-10T09:00:00", "a"), ("2026-08-10T09:00:00", "a")):
+            imported, _ = dispatch.backfill()
+        self.assertEqual(imported, 1)
+
+    def test_two_agents_at_the_same_instant_are_both_kept(self):
+        """A fan-out dispatches several sub-agents in the same second. Deduping on the
+        timestamp alone would silently drop every one but the first."""
+        with self.transcripts(("2026-08-10T09:00:00", "a"), ("2026-08-10T09:00:00", "b")):
+            imported, _ = dispatch.backfill()
+        self.assertEqual(imported, 2)
+
+    def test_rerunning_is_idempotent(self):
+        with self.transcripts(("2026-08-10T09:00:00", "a")):
+            dispatch.backfill()
+            dispatch.backfill()
+        self.assertEqual(len(self.rows()), 1)
+
+    def test_an_empty_tally_imports_everything(self):
+        """This plane, when the gap was found: six in the transcripts, nothing recorded,
+        `_dispatch` not even created."""
+        with self.transcripts(*[(f"2026-08-12T09:0{i}:00", "general-purpose")
+                                for i in range(6)]):
+            imported, skipped = dispatch.backfill()
+        self.assertEqual((imported, skipped), (6, 0))
+
+
+class TestReportingHowCompleteTheTallyIs(BackfillCase):
+    def test_never_reconciled_when_nothing_was_backfilled(self):
+        self.assertIsNone(dispatch.last_backfill())
+
+    def test_a_reconciliation_is_dated(self):
+        with self.transcripts(("2026-08-10T09:00:00", "a")):
+            dispatch.backfill()
+        self.assertIsNotNone(dispatch.last_backfill())
+
+    def test_live_records_alone_do_not_count_as_a_reconciliation(self):
+        """The live store being non-empty says nothing about whether transcripts were
+        ever checked — which is the whole failure."""
+        self.live(("2026-08-07T16:45:04", "a"))
+        self.assertIsNone(dispatch.last_backfill())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_forget_is_reactive.py
+++ b/tests/test_forget_is_reactive.py
@@ -1,0 +1,216 @@
+"""Removing a memory propagates as far as adding one, and the hooks stop guessing how
+far that is (issue #82).
+
+Two halves of one defect.
+
+**Removal was not symmetric with addition.** `remember` routes through
+`commit_memory_reactive`; `forget` only unlinked the file. A purge therefore stayed on
+the machine that ran it while the memory it removed lived on in the remote and returned
+with the next pull. That is backwards: removal is the operation that most needs to
+propagate, because it is how a poisoned or secret-bearing memory is taken out of
+circulation. The incident behind the report was a classifier-bypass note that had to be
+purged, and the workaround was a manual commit and push.
+
+**And the hooks described a propagation they never checked.** `_mem_cadence_nudge` chose
+its wording from workspace LIVENESS and announced "committed + shared … reactive (commits
++ pushes immediately)". What actually commits is `config.MEMORY_SHARE`, which defaults to
+`local` — where nothing is committed at all, deliberately, so that nothing reaches a
+remote without a human between writing and disclosure. Meanwhile `_uncommitted_memory_nudge`
+scanned `personas/` only, so the one mechanism that could have contradicted the claim was
+blind to the store the other hook was recommending.
+
+One hook said it was shared; the other could not see that it wasn't. Under `local` — the
+default — both were wrong at once.
+"""
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_persona as cp
+from charter import commands_workspace as cw
+from charter import config, hooks, memstore, persona, workspace
+from tests._isolation import PersonaIso
+
+
+class ForgetCase(PersonaIso):
+    def calls(self):
+        """Records what was handed to the reactive committer, without running git."""
+        return mock.patch("charter.commands.commit_memory_reactive")
+
+    def _persona(self, name="steward"):
+        """`forget` refuses on a persona that does not exist, so the memory store alone
+        is not enough of a fixture."""
+        d = config.PERSONAS_DIR / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "persona.md").write_text(f"---\nname: {name}\n---\n\nCharter.\n")
+        persona.scaffold_memory(name)
+
+
+class TestMemstoreReportsWhatItRemoved(PersonaIso):
+    """The commands can only stage a deletion they are told about."""
+
+    def test_it_returns_the_removed_path(self):
+        d = self.tmp / "mem"
+        d.mkdir()
+        (d / "a-fact.md").write_text("x")
+        self.assertEqual(memstore.forget(d, "a-fact.md"), d / "a-fact.md")
+
+    def test_a_miss_is_still_falsy(self):
+        """Callers test the result for truthiness; a Path is truthy and None is not, so
+        the change of type must not change the branch anyone takes."""
+        d = self.tmp / "mem"
+        d.mkdir()
+        self.assertFalse(memstore.forget(d, "nope"))
+
+    def test_the_file_is_actually_gone(self):
+        d = self.tmp / "mem"
+        d.mkdir()
+        (d / "a-fact.md").write_text("x")
+        memstore.forget(d, "a-fact.md")
+        self.assertFalse((d / "a-fact.md").exists())
+
+
+class TestPersonaForgetIsReactive(ForgetCase):
+    def forget(self, **kw):
+        args = SimpleNamespace(name="steward", slug="a-fact", shared=False,
+                               ephemeral=False, **kw)
+        with self.calls() as m:
+            rc = cp.cmd_persona_forget(args)
+        return rc, m
+
+    def setUp(self):
+        super().setUp()
+        self._persona()
+        persona.remember("steward", "a durable fact", title="a fact")
+
+    def test_the_deletion_is_handed_to_the_reactive_committer(self):
+        rc, m = self.forget()
+        self.assertEqual(rc, 0)
+        self.assertTrue(m.called)
+
+    def test_it_stages_the_memory_directory_not_the_deleted_file(self):
+        """`git add` on a path that no longer exists and was never tracked fails the
+        whole call — which would take the index update down with it. The directory
+        always exists, and `git add <dir>` stages deletions inside it."""
+        _, m = self.forget()
+        staged = m.call_args[0][0]
+        self.assertTrue(any(s.endswith("memory") for s in staged), staged)
+
+    def test_the_commit_message_names_the_removal(self):
+        _, m = self.forget()
+        self.assertIn("forget", m.call_args[0][1])
+
+    def test_an_ephemeral_forget_commits_nothing(self):
+        """Ephemeral memory is session scratch and gitignored — `remember` skips the
+        commit for it, and so must `forget`."""
+        persona.remember("steward", "scratch", title="scratch", ephemeral=True)
+        args = SimpleNamespace(name="steward", slug="scratch", shared=False, ephemeral=True)
+        with self.calls() as m:
+            cp.cmd_persona_forget(args)
+        self.assertFalse(m.called)
+
+    def test_a_forget_that_matched_nothing_commits_nothing(self):
+        args = SimpleNamespace(name="steward", slug="never-existed", shared=False,
+                               ephemeral=False)
+        with self.calls() as m:
+            rc = cp.cmd_persona_forget(args)
+        self.assertEqual(rc, 1)
+        self.assertFalse(m.called)
+
+
+class TestWorkspaceForgetIsReactive(ForgetCase):
+    def setUp(self):
+        super().setUp()
+        workspace.ensure("ws")
+        workspace.remember("ws", "a durable fact", title="a fact")
+
+    def test_the_deletion_is_handed_to_the_reactive_committer(self):
+        with mock.patch("charter.commands_workspace.commit_memory_reactive") as m:
+            rc = cw.cmd_workspace_forget(SimpleNamespace(workspace="ws", slug="a-fact"))
+        self.assertEqual(rc, 0)
+        self.assertTrue(m.called)
+
+    def test_a_forget_that_matched_nothing_commits_nothing(self):
+        with mock.patch("charter.commands_workspace.commit_memory_reactive") as m:
+            rc = cw.cmd_workspace_forget(SimpleNamespace(workspace="ws", slug="nope"))
+        self.assertEqual(rc, 1)
+        self.assertFalse(m.called)
+
+
+class ShareCase(PersonaIso):
+    def note(self, share: str) -> str:
+        with mock.patch.object(config, "MEMORY_SHARE", share):
+            return hooks.memory_share_note()
+
+    def cadence(self, share: str) -> str:
+        with mock.patch.object(config, "MEMORY_SHARE", share):
+            return hooks._mem_cadence_nudge(None, 12)
+
+
+class TestTheNudgeStatesTheRealPosture(ShareCase):
+    def test_local_says_it_stays_on_this_machine(self):
+        self.assertIn("THIS MACHINE", self.note("local"))
+
+    def test_local_does_not_claim_it_is_shared(self):
+        """The exact false claim: a memory recorded under `local` reached nobody while
+        the agent was told it had reached the team."""
+        n = self.cadence("local").lower()
+        self.assertNotIn("committed + shared", n)
+        self.assertNotIn("pushes immediately", n)
+
+    def test_local_says_what_to_do_instead(self):
+        self.assertIn("yourself", self.note("local"))
+
+    def test_commit_says_committed_but_not_pushed(self):
+        n = self.note("commit")
+        self.assertIn("NOT pushed", n)
+
+    def test_push_says_it_reaches_the_team(self):
+        self.assertIn("pushed", self.note("push"))
+
+    def test_the_cadence_nudge_carries_the_posture(self):
+        self.assertIn("THIS MACHINE", self.cadence("local"))
+
+    def test_an_unreadable_posture_says_nothing_rather_than_guessing(self):
+        with mock.patch("charter.instance.clamp_share", side_effect=RuntimeError):
+            self.assertEqual(hooks.memory_share_note(), "")
+
+
+class TestTheUncommittedNetSeesBothStores(ShareCase):
+    def scan(self, share: str, porcelain: str) -> str:
+        with mock.patch.object(config, "MEMORY_SHARE", share), \
+             mock.patch("subprocess.run",
+                        return_value=SimpleNamespace(stdout=porcelain, returncode=0)):
+            return hooks._uncommitted_memory_nudge()
+
+    WS = "?? workspaces/plane-shape/memory/20260813-a-fact.md\n"
+    PERSONA = "?? personas/steward/memory/a-fact.md\n"
+
+    def test_an_uncommitted_workspace_memory_is_now_reported(self):
+        """The file this whole issue was found through was invisible here."""
+        self.assertIn("workspace", self.scan("push", self.WS))
+
+    def test_an_uncommitted_persona_memory_is_still_reported(self):
+        self.assertIn("persona", self.scan("push", self.PERSONA))
+
+    def test_both_stores_are_counted_together(self):
+        self.assertIn("2", self.scan("push", self.WS + self.PERSONA))
+
+    def test_it_names_the_command_that_fits_the_store(self):
+        self.assertIn("workspace save", self.scan("push", self.WS))
+        self.assertIn("memory-sync", self.scan("push", self.PERSONA))
+
+    def test_it_is_silent_under_local(self):
+        """Under `local`, uncommitted memory is the design, not a backlog. Nagging about
+        the intended state — and naming a sync command charter deliberately did not run —
+        would be a new false alarm in a change made to remove one."""
+        self.assertEqual(self.scan("local", self.WS + self.PERSONA), "")
+
+    def test_nothing_uncommitted_says_nothing(self):
+        self.assertEqual(self.scan("push", ""), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fork_inherits_repos.py
+++ b/tests/test_fork_inherits_repos.py
@@ -1,0 +1,229 @@
+"""A fork inherits the repos the workspace actually has, not only the ones it recorded
+(issue #81).
+
+charter has two answers to "which repos are in this workspace":
+
+* `status` and `workspace list` **scan the directory** — always current, never portable;
+* `workspace.json` is a **snapshot** — portable and committed, but written only by
+  `charter workspace snapshot`, which refuses while a repo has unpushed work so that a
+  recorded branch can actually be restored.
+
+Nothing reconciled them and `fork` read the manifest alone. Reported live: a workspace
+with nine clones on disk and no snapshot, where `status` and `list` both said `(9 cloned)`
+and `fork` said *"No repos recorded"* and inherited nothing. Nine of ten workspaces on
+that machine had no manifest at all, so the divergence was the normal case, hidden
+everywhere a human looked by the directory scan.
+
+The fix takes the union rather than picking a winner, because each source is the only one
+that works in a case the other cannot reach — and the manifest wins on branch, since only
+it was written under a guarantee that the branch was pushed.
+"""
+from __future__ import annotations
+
+import io
+import shutil
+import subprocess
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import commands_workspace as cw
+from charter import config, workspace
+
+# `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` are neutralised, not just the identity: a
+# developer with `commit.gpgsign = true` and `gpg.format = ssh` would otherwise have every
+# fixture commit block on the signing agent — the test hangs rather than fails, which is
+# the worst way for a fixture to be wrong. Same reason CI needs the identity: a fixture
+# must not depend on the machine's git config.
+_ENV = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e", "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@e",
+        "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"}
+
+
+def _git(*a, cwd):
+    import os
+    subprocess.run(["git", *a], cwd=cwd, check=True, capture_output=True,
+                   env={**os.environ, **_ENV})
+
+
+class TestTheMerge(unittest.TestCase):
+    """The pure half — no git, no filesystem."""
+
+    def merge(self, manifest, disk):
+        return workspace.merge_repo_rows(manifest, disk)
+
+    def test_clones_with_no_snapshot_are_inherited(self):
+        """The reported bug, reduced: nine on disk, nothing recorded."""
+        rows, disk_only = self.merge([], [{"name": "a", "branch": "main"}])
+        self.assertEqual(rows, [{"name": "a", "branch": "main"}])
+        self.assertEqual(disk_only, ["a"])
+
+    def test_a_snapshot_with_no_clones_is_inherited(self):
+        """The portable case, and why the disk cannot simply become the source of truth:
+        a teammate who has just cloned the plane has no repos on disk at all."""
+        rows, disk_only = self.merge([{"name": "a", "branch": "release"}], [])
+        self.assertEqual(rows, [{"name": "a", "branch": "release"}])
+        self.assertEqual(disk_only, [])
+
+    def test_a_repo_known_to_both_appears_once(self):
+        rows, _ = self.merge([{"name": "a", "branch": "release"}],
+                             [{"name": "a", "branch": "scratch"}])
+        self.assertEqual(len(rows), 1)
+
+    def test_the_snapshot_branch_wins_over_whatever_is_checked_out(self):
+        """`snapshot` refuses to record an unpushed branch, so its answer is restorable.
+        The working tree's current branch carries no such promise."""
+        rows, _ = self.merge([{"name": "a", "branch": "release"}],
+                             [{"name": "a", "branch": "scratch"}])
+        self.assertEqual(rows[0]["branch"], "release")
+
+    def test_disjoint_sources_are_unioned_and_sorted(self):
+        rows, disk_only = self.merge([{"name": "b", "branch": "main"}],
+                                     [{"name": "a", "branch": "main"}])
+        self.assertEqual([r["name"] for r in rows], ["a", "b"])
+        self.assertEqual(disk_only, ["a"])
+
+    def test_nothing_anywhere_is_empty(self):
+        self.assertEqual(self.merge([], []), ([], []))
+
+    def test_a_row_without_a_branch_still_produces_one(self):
+        """`restore` clones by branch; a row with none would fail there instead of here."""
+        rows, _ = self.merge([{"name": "a"}], [])
+        self.assertEqual(rows[0]["branch"], "HEAD")
+
+    def test_nameless_rows_are_dropped(self):
+        rows, _ = self.merge([{"branch": "main"}, {"name": "  "}], [])
+        self.assertEqual(rows, [])
+
+
+class ForkCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="edm-fork-"))
+        self._orig = {k: getattr(config, k) for k in ("WORKSPACES_DIR", "ROOT")}
+        config.WORKSPACES_DIR = self.tmp / "workspaces"
+        config.ROOT = self.tmp
+        config.WORKSPACES_DIR.mkdir(parents=True, exist_ok=True)
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        for k, v in self._orig.items():
+            setattr(config, k, v)
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _clone(self, ws: str, name: str, branch: str = "main"):
+        """A real clone on disk — what `status` counts and what `fork` used to miss."""
+        wd = workspace.workspace_dir(ws)
+        wd.mkdir(parents=True, exist_ok=True)
+        c = wd / name
+        c.mkdir()
+        _git("init", "-q", "-b", branch, ".", cwd=c)
+        (c / "f.txt").write_text("x")
+        _git("add", "-A", cwd=c)
+        _git("commit", "-q", "-m", "init", cwd=c)
+        return c
+
+    def fork(self, src, new, **kw):
+        out = io.StringIO()
+        args = SimpleNamespace(src=src, new=new, restore=False, live=False, **kw)
+        with redirect_stdout(out), redirect_stderr(out):
+            rc = cw.cmd_workspace_fork(args)
+        return rc, out.getvalue()
+
+
+class TestForkingAnUnsnapshottedWorkspace(ForkCase):
+    """The live report: nine clones, no manifest, `fork` inherits nothing."""
+
+    def setUp(self):
+        super().setUp()
+        workspace.ensure("src")
+        self._clone("src", "repoA")
+        self._clone("src", "repoB")
+
+    def test_the_premise_holds_there_is_no_manifest(self):
+        self.assertEqual(workspace.read_manifest("src"), {})
+        self.assertEqual(len(workspace.clones("src")), 2)
+
+    def test_the_fork_inherits_the_clones(self):
+        rc, _ = self.fork("src", "dst")
+        self.assertEqual(rc, 0)
+        self.assertEqual([r["name"] for r in workspace.read_manifest("dst")["repos"]],
+                         ["repoA", "repoB"])
+
+    def test_it_no_longer_claims_no_repos_are_recorded(self):
+        _, out = self.fork("src", "dst")
+        self.assertNotIn("No repos", out)
+
+    def test_it_says_they_came_from_disk_rather_than_a_snapshot(self):
+        """Their branch is whatever is checked out, which `restore` on another machine
+        may not find. Saying so at the point of use is the whole of the honesty here."""
+        _, out = self.fork("src", "dst")
+        self.assertIn("not from a snapshot", out)
+        self.assertIn("snapshot src", out)
+
+
+class TestForkingASnapshotWithNothingOnDisk(ForkCase):
+    """A teammate who has just cloned the plane. The manifest is all they have."""
+
+    def test_the_fork_inherits_the_snapshot(self):
+        workspace.ensure("src")
+        workspace.write_manifest("src", {"name": "src",
+                                         "repos": [{"name": "repoA", "branch": "release"}]})
+        rc, _ = self.fork("src", "dst")
+        self.assertEqual(rc, 0)
+        self.assertEqual(workspace.read_manifest("dst")["repos"],
+                         [{"name": "repoA", "branch": "release"}])
+
+    def test_nothing_is_attributed_to_disk(self):
+        workspace.ensure("src")
+        workspace.write_manifest("src", {"name": "src",
+                                         "repos": [{"name": "repoA", "branch": "release"}]})
+        _, out = self.fork("src", "dst")
+        self.assertNotIn("not from a snapshot", out)
+
+
+class TestForkingWithBothSources(ForkCase):
+    def setUp(self):
+        super().setUp()
+        workspace.ensure("src")
+        self._clone("src", "repoA", branch="scratch")
+        self._clone("src", "repoB")
+        workspace.write_manifest("src", {"name": "src",
+                                         "repos": [{"name": "repoA", "branch": "release"},
+                                                   {"name": "repoC", "branch": "main"}]})
+
+    def test_every_repo_from_either_source_is_inherited(self):
+        self.fork("src", "dst")
+        self.assertEqual([r["name"] for r in workspace.read_manifest("dst")["repos"]],
+                         ["repoA", "repoB", "repoC"])
+
+    def test_the_snapshot_branch_wins_for_a_repo_in_both(self):
+        self.fork("src", "dst")
+        rows = {r["name"]: r["branch"] for r in workspace.read_manifest("dst")["repos"]}
+        self.assertEqual(rows["repoA"], "release")
+
+    def test_only_the_unsnapshotted_one_is_attributed_to_disk(self):
+        _, out = self.fork("src", "dst")
+        self.assertIn("repoB", out.split("come from clones on disk")[1])
+        self.assertNotIn("repoC", out.split("come from clones on disk")[1].split("\n")[0])
+
+
+class TestForkingATrulyEmptyWorkspace(ForkCase):
+    def test_it_still_says_there_is_nothing(self):
+        workspace.ensure("src")
+        rc, out = self.fork("src", "dst")
+        self.assertEqual(rc, 0)
+        self.assertIn("No repos", out)
+
+    def test_it_names_both_sources_it_checked(self):
+        """The old message said 'No repos recorded', which was true of the manifest and
+        read as true of the workspace. It has to name what it actually looked at."""
+        workspace.ensure("src")
+        _, out = self.fork("src", "dst")
+        self.assertIn("snapshot", out)
+        self.assertIn("disk", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
All three reports are confirmed. Two are not quite what they say, and both differences changed the fix.

## #81 — `fork` inherits what the workspace has

`write_manifest` has three callers: `snapshot` and two fork paths. `clone` is not one of them. So `status`/`list` (directory scan) and `fork` (manifest) answered different questions and nobody said so.

The manifest is a **snapshot**, not an inventory — `snapshot` refuses while a repo has unpushed work, so a recorded branch is one `restore` can check out. Self-healing it on `clone`/`status` (proposal 1) was rejected: read commands would mutate a committed shared file, and the manifest would fill with branches recorded outside that guard, so `restore` starts failing on another machine. `merge_repo_rows` takes the union instead, manifest branch winning, and `fork` reports which repos came from disk alone. No `doctor` drift check: drift is the intended state until someone snapshots, and a warning that fires on the intended state trains people to ignore warnings. ADR 0010.

## #82 — confirmed, but its premise is half wrong

Neither forget path called `commit_memory_reactive`; the asymmetry is real and now fixed (staging the memory *directory*, since `git add` on a deleted-and-untracked path fails the whole call and would take the index update with it).

But "`remember` commits and pushes immediately" is only true under `share = commit|push`. The default is `local`, where nothing commits. So on a default plane **neither** operation was reactive, while `_mem_cadence_nudge` — choosing its wording from workspace liveness — announced that both were. And `_uncommitted_memory_nudge` scanned `personas/` only, so the mechanism that could have contradicted it was blind to workspace memory. Both now read `MEMORY_SHARE`; the scan covers both stores and stays silent under `local`, where uncommitted memory is the design rather than a backlog.

Correcting something I said earlier in review: `charter workspace save` **does** commit workspace memory (`_ws_meta_paths` includes `memory`), as does the Stop-hook autosave. No new sync command was needed.

## #83 — the proposed fix already exists; the guard is what blocks it

`dispatch.backfill()` already sweeps transcripts. Its guard skipped everything at or after `_earliest_live()` — one global timestamp — so with live records from 2026-08-07 the 2026-08-10 gap was unreachable forever. The guard prevents double-counting on the assumption that live recording is complete from the first record onward, which is precisely what this issue disproves.

Dedupe on `(ts, agent)` is the same guarantee without the assumption, and it self-heals: a missed window is picked up whenever backfill next runs, with nobody needing to know which window it was. Two agents dispatched in the same second are both kept — deduping on timestamp alone would silently drop a fan-out.

Backfill stays manual (transcript scanning grows with history and SessionStart already carries a preflight budget), but `stats` now says DISP and ⚑ are a **floor** and when it was last reconciled.

Verified on this plane while diagnosing: six dispatches in the transcripts, zero tallied, `personas/_dispatch` never created.

1619 tests green.

Closes #81, closes #82, closes #83