### PR TITLE
0.24.0 — two sources of truth, reconciled

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.23.2"
+__version__ = "0.24.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.23.2",
+            "command": "charter hook sessionstart --plugin-version 0.24.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.23.2",
+            "command": "charter hook userpromptsubmit --plugin-version 0.24.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.23.2",
+            "command": "charter hook pretooluse --plugin-version 0.24.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.23.2"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.24.0"
           }
         ]
       }
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.23.2",
+            "command": "charter hook posttooluse --plugin-version 0.24.0",
             "timeout": 5
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.23.2",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.24.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.23.2"
+version = "0.24.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only: 0.23.2 → 0.24.0 across `pyproject.toml`, `charter/__init__.py`, `.claude-plugin/plugin.json` and the six `--plugin-version` pins in `hooks/hooks.json`.

Minor rather than patch: `fork` changes which repos it inherits, and the memory hooks change what they tell an agent about where a memory goes.

Ships #84 — closes #81, #82, #83. See ADR 0010 (the manifest is a snapshot, not an inventory) and ADR 0009 (errors classify, they do not guess), which #82's hook fix applies.

1619 tests green.