### PR TITLE
Clone repos concurrently, and stop git hanging on a prompt nobody sees

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -260,32 +260,66 @@ def cmd_clone(args) -> int:
         util.err(str(e))
         return 1
 
-    from .forge import registry
+    if len(targets) > 1:
+        util.info(f"Cloning {len(targets)} repo(s) into '{ws}', "
+                  f"{min(CLONE_WORKERS, len(targets))} at a time …")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=CLONE_WORKERS) as ex:
+        results = list(ex.map(lambda r: _clone_one(r, wd), targets))
 
+    # Printed HERE, from one thread, in the order the repos were asked for. Eight workers
+    # calling util.info/ok/err directly would interleave into something no one can scan
+    # for which repo failed — and the failure list is the only part of this output that
+    # anybody reads twice.
     failures = 0
-    for r in targets:
-        dest = wd / r["name"]
-        if dest.exists():
+    for res in results:
+        r, dest = res["repo"], res["dest"]
+        if res["status"] == "exists":
             util.info(f"{r['name']}: already cloned in '{ws}'")
-            _hint_repo_docs(dest, r)
-            continue
-        forge = registry.for_repo(r)
-        util.info(f"Cloning {_clone_announcement(r)} into '{ws}' via {forge.cli} (HTTPS) …")
-        proc = _git([*_cred_flag(forge), "clone", "--branch", r["default_branch"], _https_url(r), str(dest)])
-        if proc.returncode != 0:
+        elif res["status"] == "ok":
+            util.ok(f"{r['name']} → {dest.relative_to(config.ROOT)} "
+                    f"({_clone_announcement(r)} via {res['forge'].cli}, HTTPS)")
+        else:
             failures += 1
-            util.err(
-                f"{r['name']}: clone failed — no access, network, or {forge.cli} isn't authed "
-                f"(`{forge.cli} auth status`). Skipping.\n" + (proc.stderr or "").strip()
-            )
+            cli = res["forge"].cli
+            util.err(f"{r['name']}: clone failed — no access, network, or {cli} isn't authed "
+                     f"(`{cli} auth status`). Skipping.\n" + res["stderr"])
             continue
-        # Golden rule 0: every git op from this clone uses ITS FORGE's token over HTTPS —
-        # credential helper + signing off + SSH→HTTPS rewrites (see charter/gitpolicy.py).
-        from . import gitpolicy
-        gitpolicy.apply(dest)
-        util.ok(f"{r['name']} → {dest.relative_to(config.ROOT)}")
         _hint_repo_docs(dest, r)
     return 1 if failures else 0
+
+
+#: Concurrent clones. The same number `_build_batch` uses for its API probes, so there is
+#: one concurrency figure to reason about in this file rather than two. Cloning is
+#: network-bound, so this is deliberately not derived from CPU count — a 16-core laptop
+#: would open 14 connections to one forge for no gain.
+CLONE_WORKERS = 8
+
+
+def _clone_one(r: dict, wd) -> dict:
+    """Clone ONE repo and return what happened. **Prints nothing** — `cmd_clone` renders
+    every result afterwards, in order, from a single thread.
+
+    Runs in a worker thread: `_git` shells out (releasing the GIL for the network wait,
+    which is the whole point), `registry.for_repo` builds a fresh backend per call, and
+    `gitpolicy.apply` writes only inside this clone's own `.git/config`. Nothing here is
+    shared between repos.
+    """
+    from . import gitpolicy
+    from .forge import registry
+
+    dest = wd / r["name"]
+    if dest.exists():
+        return {"repo": r, "dest": dest, "status": "exists"}
+    forge = registry.for_repo(r)
+    proc = _git([*_cred_flag(forge), "clone", "--branch", r["default_branch"],
+                 _https_url(r), str(dest)])
+    if proc.returncode != 0:
+        return {"repo": r, "dest": dest, "status": "failed", "forge": forge,
+                "stderr": (proc.stderr or "").strip()}
+    # Golden rule 0: every git op from this clone uses ITS FORGE's token over HTTPS —
+    # credential helper + signing off + SSH→HTTPS rewrites (see charter/gitpolicy.py).
+    gitpolicy.apply(dest)
+    return {"repo": r, "dest": dest, "status": "ok", "forge": forge}
 
 
 def cmd_save(args) -> int:

--- a/charter/util.py
+++ b/charter/util.py
@@ -84,9 +84,25 @@ def run(
     itself — a mutated `os.environ` would outlive the call and silently apply to the next
     vault, which is the identity confusion the whole feature exists to prevent.
     """
+    overlay = dict(env or {})
+    if cmd and cmd[0] == "git":
+        # git falls back to prompting on the TERMINAL when a credential helper produces
+        # nothing — and this function captures stdout/stderr while leaving stdin
+        # INHERITED, so that prompt is invisible and the call simply waits, forever.
+        #
+        # charter's auth design (see `planegit`) says a prompt is never the path: every
+        # git operation authenticates with its forge CLI's token over HTTPS. So this
+        # restricts nothing charter supports — it makes that intent enforceable, and turns
+        # an invisible hang into the "isn't authed (`gh auth status`)" error that already
+        # exists. It matters more now that clones run concurrently, where a stuck child
+        # is one of eight and its prompt is buffered out of sight.
+        #
+        # Covers git's own prompts only — not a GUI credential manager, and not an SSH
+        # signing agent, which is a separate way for a captured git call to hang.
+        overlay.setdefault("GIT_TERMINAL_PROMPT", "0")
     child_env = None
-    if env:
-        child_env = {**os.environ, **{k: v for k, v in env.items() if v is not None}}
+    if overlay:
+        child_env = {**os.environ, **{k: v for k, v in overlay.items() if v is not None}}
     try:
         proc = subprocess.run(
             list(cmd),

--- a/tests/test_clone_parallel.py
+++ b/tests/test_clone_parallel.py
@@ -1,0 +1,220 @@
+"""Repos clone concurrently, and a git call can no longer hang on a prompt nobody sees.
+
+`cmd_clone` ran `git clone` in a plain loop, so a nine-repo `workspace restore` waited out
+nine round trips one after another. Cloning is network-bound, so the wait was almost
+entirely idle: `_git` shells out and releases the GIL while it waits.
+
+Two things had to hold before the loop could become a pool.
+
+**Output has to stay in order.** Eight workers calling `util.info`/`ok`/`err` directly
+would interleave into something nobody can scan for which repo failed — and that failure
+list is the only part of this output anyone reads twice. Workers return records; one
+thread renders them, in the order the repos were asked for.
+
+**And a stuck clone has to fail rather than wait.** `util.run` captures stdout and stderr
+but leaves stdin INHERITED, so when git falls back to prompting for credentials the prompt
+is invisible and the call waits forever. Sequentially that is one hung child you can
+interrupt. At eight-way with buffered output it is a command that appears to have died.
+`GIT_TERMINAL_PROMPT=0` costs nothing charter supports — its auth design routes every git
+operation through a forge CLI's token over HTTPS and treats a prompt as a symptom.
+
+Observed twice while building this: a captured git child blocked on a signing agent, with
+a second run queuing behind it and looking like an unrelated regression.
+"""
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands, util
+
+
+class TestGitCallsCannotBlockOnAnInvisiblePrompt(unittest.TestCase):
+    def env_of(self, *cmd) -> dict:
+        seen = {}
+
+        def fake(cmd_, **kw):
+            seen.update(kw.get("env") or {})
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with mock.patch("subprocess.run", side_effect=fake):
+            util.run(list(cmd), check=False)
+        return seen
+
+    def test_a_git_call_disables_the_terminal_prompt(self):
+        self.assertEqual(self.env_of("git", "clone", "x").get("GIT_TERMINAL_PROMPT"), "0")
+
+    def test_it_applies_to_every_git_call_not_just_clone(self):
+        """The 70 git invocations charter makes were all equally able to hang; the ones
+        that do are not only clones."""
+        self.assertEqual(self.env_of("git", "status").get("GIT_TERMINAL_PROMPT"), "0")
+
+    def test_a_non_git_command_is_left_alone(self):
+        self.assertNotIn("GIT_TERMINAL_PROMPT", self.env_of("gh", "auth", "status"))
+
+    def test_an_explicit_setting_still_wins(self):
+        """Nothing in charter passes it today, but a caller that does means it."""
+        seen = {}
+
+        def fake(cmd_, **kw):
+            seen.update(kw.get("env") or {})
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with mock.patch("subprocess.run", side_effect=fake):
+            util.run(["git", "clone", "x"], check=False, env={"GIT_TERMINAL_PROMPT": "1"})
+        self.assertEqual(seen.get("GIT_TERMINAL_PROMPT"), "1")
+
+    def test_the_rest_of_the_environment_still_reaches_the_child(self):
+        """A child that loses PATH cannot find git at all — the overlay must stay an
+        overlay."""
+        self.assertIn("PATH", self.env_of("git", "status"))
+
+    def test_it_reaches_a_real_git_child_not_just_the_kwargs(self):
+        """End-to-end, through an actual `git` process: a shell alias inherits git's
+        environment, so it reports what git itself was given. Asserting on the kwargs
+        alone would pass even if the overlay never made it out of this process."""
+        proc = util.run(["git", "-c", "alias.envprobe=!printf %s \"$GIT_TERMINAL_PROMPT\"",
+                         "envprobe"], check=False)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "0")
+
+
+class CloneCase(unittest.TestCase):
+    """`_clone_one` is stubbed: this pins the concurrency and the rendering, not git."""
+
+    def targets(self, *names):
+        return [{"name": n, "default_branch": "main", "path_with_namespace": f"g/{n}",
+                 "forge": "github"} for n in names]
+
+    def run_clone(self, targets, clone_one):
+        out = []
+        with mock.patch.object(commands, "_clone_one", clone_one), \
+             mock.patch.object(commands.util, "info", lambda m, *a: out.append(m)), \
+             mock.patch.object(commands.util, "ok", lambda m, *a: out.append(m)), \
+             mock.patch.object(commands.util, "err", lambda m, *a: out.append(m)), \
+             mock.patch.object(commands, "_hint_repo_docs", lambda *a: None), \
+             mock.patch.object(commands.workspace, "resolve", lambda *a, **k: "ws"), \
+             mock.patch.object(commands.workspace, "banner", lambda *a, **k: None), \
+             mock.patch.object(commands.workspace, "ensure", lambda *a: commands.config.ROOT), \
+             mock.patch.object(commands.inventory, "load", lambda: {}), \
+             mock.patch.object(commands.inventory, "repos", lambda d=None: targets), \
+             mock.patch.object(commands, "_resolve_targets", lambda a, d: targets):
+            rc = commands.cmd_clone(SimpleNamespace(repos=[t["name"] for t in targets],
+                                                    workspace="ws"))
+        return rc, out
+
+
+class TestClonesRunConcurrently(CloneCase):
+    def test_eight_slow_clones_overlap_rather_than_queue(self):
+        """The point of the change. Sequentially this is 8 × 0.10s; concurrently it is
+        about one of them. The threshold is loose so a busy machine cannot flake it, but
+        it is far below the sequential floor."""
+        def slow(r, wd):
+            time.sleep(0.10)
+            return {"repo": r, "dest": commands.config.ROOT / r["name"], "status": "ok",
+                    "forge": SimpleNamespace(cli="gh")}
+
+        t0 = time.monotonic()
+        rc, _ = self.run_clone(self.targets(*"abcdefgh"), slow)
+        self.assertEqual(rc, 0)
+        self.assertLess(time.monotonic() - t0, 0.40)
+
+    def test_no_more_than_the_cap_run_at_once(self):
+        """Unbounded threads would open a connection per repo — a 50-repo restore would
+        hammer one forge."""
+        live = peak = 0
+        lock = threading.Lock()
+
+        def counted(r, wd):
+            nonlocal live, peak
+            with lock:
+                live += 1
+                peak = max(peak, live)
+            time.sleep(0.02)
+            with lock:
+                live -= 1
+            return {"repo": r, "dest": commands.config.ROOT / r["name"], "status": "ok",
+                    "forge": SimpleNamespace(cli="gh")}
+
+        self.run_clone(self.targets(*[f"r{i}" for i in range(20)]), counted)
+        self.assertLessEqual(peak, commands.CLONE_WORKERS)
+
+    def test_every_repo_is_still_cloned(self):
+        seen = []
+        lock = threading.Lock()
+
+        def rec(r, wd):
+            with lock:
+                seen.append(r["name"])
+            return {"repo": r, "dest": commands.config.ROOT / r["name"], "status": "ok",
+                    "forge": SimpleNamespace(cli="gh")}
+
+        self.run_clone(self.targets(*"abcdef"), rec)
+        self.assertEqual(sorted(seen), list("abcdef"))
+
+
+class TestOutputStaysInOrder(CloneCase):
+    def finishing_backwards(self, r, wd):
+        """Later repos finish FIRST, so completion order is the reverse of ask order."""
+        n = r["name"][1:]
+        time.sleep(0.01 * (10 - int(n)) if n.isdigit() else 0)
+        return {"repo": r, "dest": commands.config.ROOT / r["name"], "status": "ok",
+                "forge": SimpleNamespace(cli="gh")}
+
+    def test_results_print_in_the_order_the_repos_were_asked_for(self):
+        _, out = self.run_clone(self.targets(*[f"r{i}" for i in range(6)]),
+                                self.finishing_backwards)
+        names = [ln.split()[0] for ln in out if ln.startswith("r")]
+        self.assertEqual(names, [f"r{i}" for i in range(6)])
+
+    def test_a_failure_names_its_repo_and_carries_the_git_error(self):
+        def fail(r, wd):
+            return {"repo": r, "dest": commands.config.ROOT / r["name"], "status": "failed",
+                    "forge": SimpleNamespace(cli="gh"), "stderr": "fatal: not found"}
+
+        rc, out = self.run_clone(self.targets("only"), fail)
+        self.assertEqual(rc, 1)
+        joined = "\n".join(out)
+        self.assertIn("only", joined)
+        self.assertIn("fatal: not found", joined)
+        self.assertIn("gh auth status", joined)
+
+    def test_one_failure_does_not_stop_the_others(self):
+        """Partial access is normal — `restore` documents it. A pool must not turn one
+        unreachable repo into a lost batch."""
+        def mixed(r, wd):
+            st = "failed" if r["name"] == "b" else "ok"
+            return {"repo": r, "dest": commands.config.ROOT / r["name"], "status": st,
+                    "forge": SimpleNamespace(cli="gh"), "stderr": "denied"}
+
+        rc, out = self.run_clone(self.targets("a", "b", "c"), mixed)
+        self.assertEqual(rc, 1)
+        joined = "\n".join(out)
+        self.assertIn("a →", joined)
+        self.assertIn("c →", joined)
+
+    def test_an_already_cloned_repo_is_reported_not_recloned(self):
+        def exists(r, wd):
+            return {"repo": r, "dest": commands.config.ROOT / r["name"], "status": "exists"}
+
+        rc, out = self.run_clone(self.targets("a"), exists)
+        self.assertEqual(rc, 0)
+        self.assertIn("already cloned", "\n".join(out))
+
+    def test_a_batch_announces_itself_before_the_quiet_part(self):
+        """Buffering means nothing prints until the clones finish; without this line a
+        nine-repo restore looks hung."""
+        _, out = self.run_clone(self.targets("a", "b"), self.finishing_backwards)
+        self.assertIn("2 repo(s)", out[0])
+        self.assertIn("at a time", out[0])
+
+    def test_a_single_repo_does_not_get_a_batch_header(self):
+        _, out = self.run_clone(self.targets("a"), self.finishing_backwards)
+        self.assertNotIn("at a time", "\n".join(out))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`cmd_clone` is the single loop behind `charter clone`, `workspace restore` and `fork --restore`, so one change covers all three. A nine-repo restore ran nine `git clone`s in series, almost all of it idle network wait.

## The change

Bounded `ThreadPoolExecutor(max_workers=8)` — the same figure `_build_batch` already uses for its API probes, so there is one number to reason about. Deliberately not CPU-derived: cloning is network-bound, and a 16-core laptop opening 14 connections to one forge buys nothing.

`_clone_one` does the work and **prints nothing**; `cmd_clone` renders every result afterwards from a single thread, in the order the repos were asked for. Eight workers calling `util.info`/`ok`/`err` directly would interleave into output nobody can scan for which repo failed — and the failure list is the only part anyone reads twice. A batch announces itself upfront (`Cloning 9 repo(s) …, 8 at a time`) to cover the quiet period buffering creates.

Partial failure semantics are unchanged: one unreachable repo does not lose the batch, and the exit code is still 1 if any failed.

## The precondition

This is one change rather than two because parallelising without it would have made an existing hang much worse.

`util.run` captures stdout and stderr but leaves **stdin inherited**. When a credential helper produces nothing, git falls back to prompting on the terminal — invisible, because output is captured — and the call waits forever. Sequentially that is one stuck child you can Ctrl-C. At eight-way with buffered output it is a command that appears to have died.

`GIT_TERMINAL_PROMPT=0` now applies to **every** git invocation through `util.run` (70 sites), not just clones — the calls that hang are not only clones, and all 70 were equally exposed. This restricts nothing charter supports: `planegit` states the auth design outright, every git operation authenticating with its forge CLI's token over HTTPS, "no SSH keys, no 1Password agent". A prompt was never a supported path, only a symptom. The outcome is now the `isn't authed (\`gh auth status\`)` error that already existed.

It covers git's own prompts — not a GUI credential manager, and not an SSH signing agent. Worth saying because the hang I hit twice while building this was the latter, and it would still hang.

## Not done

No timeout on clones. A clone's honest duration depends on repo size and link speed, so any number is wrong for someone, and aborting a large clone at 90% is a worse failure than waiting. Bounding all 70 unbounded git calls is its own change on its own evidence — noting here that none of them has one today.

1634 tests green.