### PR TITLE
0.25.0 — clones run concurrently, git stops hanging on unseen prompts

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.24.0"
+__version__ = "0.25.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.24.0",
+            "command": "charter hook sessionstart --plugin-version 0.25.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.24.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.25.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.24.0",
+            "command": "charter hook pretooluse --plugin-version 0.25.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.24.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.25.0"
           }
         ]
       }
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.24.0",
+            "command": "charter hook posttooluse --plugin-version 0.25.0",
             "timeout": 5
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.24.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.25.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.24.0"
+version = "0.25.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only: 0.24.0 → 0.25.0 across `pyproject.toml`, `charter/__init__.py`, `.claude-plugin/plugin.json` and the six `--plugin-version` pins in `hooks/hooks.json`.

Minor rather than patch on two counts: `GIT_TERMINAL_PROMPT=0` changes behaviour at all 70 git call sites, and clone's per-repo `Cloning X via gh (HTTPS) …` line is gone — that detail now rides on the success line instead.

Ships #86.

1634 tests green.