### PR TITLE
recall: find a memory by when, not only by wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ deploys gate on the e2e suite and not the unit ones. That knowledge dies with th
 so next week you explain it again or watch it get rediscovered the slow way.
 `charter persona remember` and `charter workspace remember` write one fact per markdown
 file; `charter recall` searches the workspace's notes, the active role's own notes and the
-shared ones in a single pass. They're ordinary committed files, so a teammate's agent can
-start where yours left off.
+shared ones in a single pass — by keyword, or by `--since 2w` and `--all-workspaces` for
+the case where you remember roughly when a thing was decided but not where or in what
+words. They're ordinary committed files, so a teammate's agent can start where yours left
+off.
 
 ### One agent that holds every credential and every context
 
@@ -266,6 +268,9 @@ charter clone some-repo
   (`charter persona remember` / `charter workspace remember`). How far a note travels —
   disk only, committed locally, or pushed to the team — is one setting,
   `[memory].share`, and it **defaults to `local`**: see `docs/control-plane.md`.
+  `charter recall` reads them back: with keywords to search, without to browse newest-first,
+  `--since 2w` when you remember *when* but not the wording, and `--all-workspaces` when you
+  no longer remember which task it belonged to.
 - **Vault** — where a persona's credentials live: plaintext JSON at file mode 0600, with
   **no encryption at rest**. What it protects against is different and real — keeping a
   secret value out of an agent's context and transcript. Read `docs/secrets.md` before

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -126,7 +126,16 @@ def build_parser() -> argparse.ArgumentParser:
                                      "default workspace,persona,shared.")
     rcl.add_argument("--ephemeral", action="store_true", help="Also include the persona's session scratch.")
     rcl.add_argument("--persona", help="Search this persona instead of the active one.")
-    rcl.add_argument("--workspace", "-w", help="Search this workspace instead of the active one.")
+    # One workspace or every workspace — never both. `-w beta --all-workspaces` has no
+    # coherent reading, and argparse refusing it beats silently honouring one of them.
+    _ws = rcl.add_mutually_exclusive_group()
+    _ws.add_argument("--workspace", "-w", help="Search this workspace instead of the active one.")
+    _ws.add_argument("--all-workspaces", action="store_true",
+                     help="Search EVERY workspace's journal (persona + shared appear once). "
+                          "For 'it was two weeks ago and I forget which task'.")
+    rcl.add_argument("--since", metavar="WHEN",
+                     help="Only memories recorded on/after this: an age (14d, 2w, 3m) or a "
+                          "date (2026-07-01). Undated memories are excluded and counted.")
     rcl.add_argument("--limit", type=int, default=8, help="Max results (0 = no cap).")
     rcl.set_defaults(func=commands.cmd_recall)
 

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1034,9 +1034,23 @@ def cmd_recall(args) -> int:
             return 1
     if getattr(args, "ephemeral", False) and "ephemeral" not in scopes:
         scopes.append("ephemeral")
-    results = rc.recall(query=getattr(args, "query", None), limit=getattr(args, "limit", 8),
-                        persona_name=getattr(args, "persona", None),
-                        workspace_name=getattr(args, "workspace", None), scopes=scopes)
+    since = None
+    if getattr(args, "since", None):
+        try:
+            since = rc.parse_since(args.since)
+        except ValueError as e:
+            util.err(str(e))
+            return 2
+    limit = getattr(args, "limit", 8)
+    all_ws = getattr(args, "all_workspaces", False)
+    # Ask for one more than we will show, so "8 of ?" can say whether anything was cut
+    # without a second pass over every base.
+    got = rc.recall(query=getattr(args, "query", None), limit=(limit + 1) if limit else 0,
+                    persona_name=getattr(args, "persona", None),
+                    workspace_name=getattr(args, "workspace", None), scopes=scopes,
+                    since=since, all_workspaces=all_ws)
+    truncated = bool(limit) and len(got.hits) > limit
+    results = got.hits[:limit] if limit else got.hits
     if not results:
         q = getattr(args, "query", None)
         # "No memories match X" and "none of X was searchable" are different answers, and
@@ -1050,14 +1064,26 @@ def cmd_recall(args) -> int:
                           f"{'is' if len(_ms.dropped_terms(q)) == 1 else 'are'} too short "
                           f"or too common to rank. Try a distinctive word.")
                 return 0
-        util.info(f"No memories {'match ' + repr(q) if q else 'yet'} across {', '.join(scopes)}.")
+        where = "every workspace" if all_ws else ", ".join(scopes)
+        when = f" recorded since {since}" if since else ""
+        util.info(f"No memories {'match ' + repr(q) if q else 'yet'} across {where}{when}.")
+        if got.undated:
+            util.info(f"{got.undated} undated memory(ies) skipped — no recorded date to compare.")
         return 0
-    width = max((len(s) for s, _p, _t, _sc in results), default=8)
-    for source, path, title, score in results:
-        tag = f"  ({score})" if score else ""
-        print(f"  {source:<{width}}  {title}{tag}")
-    util.info(f"{len(results)} memory(ies) across {', '.join(scopes)}. "
+    width = max((len(h.label) for h in results), default=8)
+    for h in results:
+        tag = f"  ({h.score})" if h.score else ""
+        # The date leads because when listing it IS the sort key — and the column order
+        # stays identical under a query (where score orders instead), since a layout that
+        # rearranges itself per mode is harder to read than one that never moves.
+        print(f"  {h.date.isoformat() if h.date else '—':<10}  {h.label:<{width}}  {h.title}{tag}")
+    where = "every workspace" if all_ws else ", ".join(scopes)
+    util.info(f"{len(results)} memory(ies) across {where}. "
               f"Read one: find the file under its base (workspaces/… or personas/…).")
+    if truncated:
+        util.info(f"Showing {len(results)} — pass --limit 0 for all.")
+    if got.undated:
+        util.info(f"{got.undated} undated memory(ies) skipped by --since — no recorded date.")
     return 0
 
 

--- a/charter/recall.py
+++ b/charter/recall.py
@@ -13,7 +13,10 @@ assembly of *which* dirs are in scope and tags each result with where it came fr
 
 from __future__ import annotations
 
+import datetime
+import re
 from pathlib import Path
+from typing import NamedTuple
 
 from . import config, memstore
 
@@ -22,16 +25,74 @@ SCOPES = ("workspace", "persona", "shared", "ephemeral")
 DEFAULT_SCOPES = ("workspace", "persona", "shared")  # the committed bases; ephemeral is opt-in
 
 
+class Hit(NamedTuple):
+    """One recalled memory. A NamedTuple rather than a bare tuple because this grew a field
+    once (``date``) and every positional unpack in the codebase broke at the same time —
+    the next field should not cost that again."""
+    label: str
+    path: Path
+    title: str
+    score: int
+    date: datetime.date | None
+
+
+class Recalled(NamedTuple):
+    """Hits, plus what was *withheld*. ``undated`` counts memories a ``since`` filter could
+    not place in time (no in-body stamp, no date-prefixed filename) and therefore dropped.
+    Reported rather than silently discarded: a filter that hides what it excluded is a
+    filter you cannot trust — and 0 undated is the common case, so it costs nothing."""
+    hits: list[Hit]
+    undated: int
+
+
+#: `14d` / `2w` / `3m`. Months are 30 days — predictable beats calendar-correct for a
+#: filter whose whole job is "roughly two weeks ago".
+_REL_RE = re.compile(r"^(\d+)([dwm])$")
+_REL_DAYS = {"d": 1, "w": 7, "m": 30}
+
+
+def parse_since(value: str, today: datetime.date | None = None) -> datetime.date:
+    """The earliest date a ``--since`` filter accepts. Takes a relative age (``14d``,
+    ``2w``, ``3m``) or an ISO date (``2026-07-01``).
+
+    Raises ``ValueError`` on anything else — deliberately, rather than falling back to no
+    filter. A silently-ignored ``--since`` returns MORE than was asked for, and a reader
+    then takes a full corpus as proof that nothing was recorded recently. A future date is
+    accepted and simply matches nothing; that is a real answer, not an error."""
+    s = (value or "").strip()
+    m = _REL_RE.match(s)
+    if m:
+        return (today or datetime.date.today()) - datetime.timedelta(
+            days=int(m.group(1)) * _REL_DAYS[m.group(2)])
+    try:
+        return datetime.date.fromisoformat(s)
+    except ValueError:
+        raise ValueError(
+            f"unrecognised --since {value!r} — use an age (14d, 2w, 3m) or a date (2026-07-01)"
+        ) from None
+
+
 def sources(session_id: str | None = None, persona_name: str | None = None,
-            workspace_name: str | None = None, scopes=DEFAULT_SCOPES) -> list[tuple[str, Path]]:
+            workspace_name: str | None = None, scopes=DEFAULT_SCOPES,
+            all_workspaces: bool = False) -> list[tuple[str, Path]]:
     """``[(source_label, memory_dir)]`` for the requested scopes in the current context.
     Resolves the active workspace/persona unless overridden. Skips a scope with no owner
-    (e.g. no active persona → no persona/ephemeral rows)."""
+    (e.g. no active persona → no persona/ephemeral rows).
+
+    ``all_workspaces`` widens the WORKSPACE axis only — one base per workspace, LOCAL and
+    LIVE alike (that setting governs what is committed, not what you may search on your own
+    machine). Persona and shared memory are not workspace-scoped, so they stay single rows;
+    emitting them once per workspace would multiply every role fact by the workspace count.
+    """
     from . import workspace as ws_mod, persona as p_mod
     out: list[tuple[str, Path]] = []
     if "workspace" in scopes:
-        ws = workspace_name or ws_mod.resolve(session_id=session_id)
-        out.append((f"workspace:{ws}", ws_mod.memory_dir(ws)))
+        if all_workspaces:
+            for ws in ws_mod.list_workspaces():
+                out.append((f"workspace:{ws}", ws_mod.memory_dir(ws)))
+        else:
+            ws = workspace_name or ws_mod.resolve(session_id=session_id)
+            out.append((f"workspace:{ws}", ws_mod.memory_dir(ws)))
     name = persona_name or p_mod.resolve_active()
     if "persona" in scopes and name:
         out.append((f"persona:{name}", p_mod.memory_dir(name)))
@@ -54,23 +115,48 @@ def _label_of(path: Path, srcs: list[tuple[str, Path]]) -> str:
 
 def recall(query: str | None = None, session_id: str | None = None, limit: int = 8,
            persona_name: str | None = None, workspace_name: str | None = None,
-           scopes=DEFAULT_SCOPES) -> list[tuple[str, Path, str, int]]:
+           scopes=DEFAULT_SCOPES, since: datetime.date | None = None,
+           all_workspaces: bool = False) -> Recalled:
     """THE memory fetch gate. With a ``query`` → keyword-ranked hits across all in-scope
     bases (title hits weigh 3×, via the memstore engine). Without → every in-scope memory,
-    newest-first. Returns ``[(source_label, path, title, score)]`` best-first (score 0 when
-    listing). ``limit`` caps the results (``0`` = no cap)."""
+    newest-first by recorded date. ``limit`` caps the results (``0`` = no cap).
+
+    ``since`` drops anything recorded earlier, on the same ``memstore.memory_date`` key the
+    no-query listing already sorts by — so the filter and the order can never disagree. It
+    **narrows, it never re-ranks**: with a query the survivors stay in score order, because
+    someone who typed a keyword asked for relevance, and quietly re-sorting by date would
+    change what "best match" means without saying so.
+    """
     srcs = sources(session_id=session_id, persona_name=persona_name,
-                   workspace_name=workspace_name, scopes=scopes)
+                   workspace_name=workspace_name, scopes=scopes,
+                   all_workspaces=all_workspaces)
     dirs = [d for _lbl, d in srcs]
+    undated = 0
+
+    def _dated(p: Path) -> datetime.date | None:
+        try:
+            return memstore.memory_date(p.read_text(), p.name)
+        except OSError:
+            return None
+
     if query:
-        hits = memstore.search(dirs, query, limit or 10_000)
-        return [(_label_of(p, srcs), p, title, score) for p, title, score in hits]
-    # no query → list everything in scope, newest-first by recorded date
-    import datetime
-    items = []
+        rows = []
+        for p, title, score in memstore.search(dirs, query, 0 or 10_000):
+            d = _dated(p)
+            if since is not None and (d is None or d < since):
+                undated += d is None
+                continue
+            rows.append(Hit(_label_of(p, srcs), p, title, score, d))
+        return Recalled(rows[:limit] if limit else rows, undated)
+
+    items: list[tuple[datetime.date, Hit]] = []
     for lbl, d in srcs:
         for p, title, text in memstore.entries(d):
-            items.append((memstore.memory_date(text, p.name) or datetime.date.min, lbl, p, title))
+            dt = memstore.memory_date(text, p.name)
+            if since is not None and (dt is None or dt < since):
+                undated += dt is None
+                continue
+            items.append((dt or datetime.date.min, Hit(lbl, p, title, 0, dt)))
     items.sort(key=lambda x: x[0], reverse=True)
-    rows = [(lbl, p, title, 0) for _dt, lbl, p, title in items]
-    return rows[:limit] if limit else rows
+    rows = [h for _dt, h in items]
+    return Recalled(rows[:limit] if limit else rows, undated)

--- a/tests/test_recall.py
+++ b/tests/test_recall.py
@@ -23,11 +23,11 @@ class RecallGateCase(PersonaIso):
         persona.remember("dev", "shared org keycloak convention", shared=True)  # shared
 
     def _labels(self, results):
-        return sorted({src for src, _p, _t, _s in results})
+        return sorted({h.label for h in results.hits})
 
     def test_searches_across_all_bases_with_source_labels(self):
         r = recall.recall("keycloak", workspace_name="w", persona_name="dev")
-        self.assertEqual(len(r), 3)
+        self.assertEqual(len(r.hits), 3)
         self.assertEqual(self._labels(r), ["persona:dev", "shared", "workspace:w"])
 
     def test_scope_filter_narrows_bases(self):
@@ -49,7 +49,7 @@ class RecallGateCase(PersonaIso):
         memstore.write(workspace.memory_dir("t"), "newer", "newer", timestamped=True,
                        stamp=datetime.datetime(2026, 7, 20, 9, 0))
         r = recall.recall(None, workspace_name="t", scopes=("workspace",))
-        titles = [t for _s, _p, t, _sc in r]
+        titles = [h.title for h in r.hits]
         self.assertEqual(titles[:2], ["newer", "older"])
 
     def test_sources_skips_persona_when_none_active(self):
@@ -65,13 +65,156 @@ class RecallGateCase(PersonaIso):
         r = recall.recall("keycloak", workspace_name="w", persona_name="dev",
                           scopes=("ephemeral",))
         # ephemeral resolves per-session; with no session it targets 'nosession' — just assert no crash
-        self.assertIsInstance(r, list)
+        self.assertIsInstance(r.hits, list)
 
     def test_limit_caps_results(self):
         for i in range(5):
             persona.remember("dev", f"keycloak item {i}", shared=True)
         r = recall.recall("keycloak", workspace_name="w", persona_name="dev", limit=2)
-        self.assertEqual(len(r), 2)
+        self.assertEqual(len(r.hits), 2)
+
+
+class ParseSinceCase(unittest.TestCase):
+    """`--since` accepts what you type when you are remembering (`14d`) and what you type
+    when you know (`2026-07-01`). Anything else is an error, never a silent no-filter:
+    degrading to 'no filter' returns MORE than asked for, and a full corpus then reads as
+    'nothing was recorded that recently'."""
+
+    TODAY = datetime.date(2026, 7, 20)
+
+    def test_relative_days_weeks_months(self):
+        self.assertEqual(recall.parse_since("14d", today=self.TODAY), datetime.date(2026, 7, 6))
+        self.assertEqual(recall.parse_since("2w", today=self.TODAY), datetime.date(2026, 7, 6))
+        self.assertEqual(recall.parse_since("1m", today=self.TODAY), datetime.date(2026, 6, 20))
+
+    def test_iso_date_passes_through(self):
+        self.assertEqual(recall.parse_since("2026-07-01", today=self.TODAY),
+                         datetime.date(2026, 7, 1))
+
+    def test_zero_days_is_today(self):
+        self.assertEqual(recall.parse_since("0d", today=self.TODAY), self.TODAY)
+
+    def test_future_date_is_valid_and_simply_matches_nothing(self):
+        self.assertEqual(recall.parse_since("2027-01-01", today=self.TODAY),
+                         datetime.date(2027, 1, 1))
+
+    def test_garbage_raises(self):
+        for bad in ("banana", "14", "d14", "2026-13-01", "", "-3d"):
+            with self.assertRaises(ValueError, msg=bad):
+                recall.parse_since(bad, today=self.TODAY)
+
+
+class RecallSinceCase(PersonaIso):
+    """`--since` filters on the RECORDED date (memstore.memory_date) — the same key the
+    no-query listing already sorts by, so the filter and the order agree."""
+
+    def setUp(self):
+        super().setUp()
+        workspace.ensure("w")
+        workspace.scaffold("w")
+        self.make_persona("dev", role="Dev", vault="d")
+
+    def _note(self, day, title, text="keycloak note"):
+        return memstore.write(workspace.memory_dir("w"), text, title, timestamped=True,
+                              stamp=datetime.datetime(2026, 7, day, 9, 0))
+
+    def _undated(self, title):
+        """A memory with no in-body stamp and no date prefix — hand-written, or predating
+        the stamp. `memory_date` returns None for these."""
+        p = workspace.memory_dir("w") / f"{title}.md"
+        p.write_text(f"# {title}\n\nkeycloak note with no stamp\n")
+        return p
+
+    def test_excludes_older_and_includes_the_boundary_day(self):
+        self._note(1, "older")
+        self._note(6, "boundary")
+        self._note(19, "newer")
+        got = recall.recall(None, workspace_name="w", scopes=("workspace",),
+                            since=datetime.date(2026, 7, 6))
+        self.assertEqual(sorted(h.title for h in got.hits), ["boundary", "newer"])
+
+    def test_excludes_undated_but_reports_how_many(self):
+        self._note(19, "dated")
+        self._undated("nostamp-one")
+        self._undated("nostamp-two")
+        got = recall.recall(None, workspace_name="w", scopes=("workspace",),
+                            since=datetime.date(2026, 7, 1))
+        self.assertEqual([h.title for h in got.hits], ["dated"])
+        self.assertEqual(got.undated, 2)
+
+    def test_undated_are_not_counted_when_no_since_filter(self):
+        self._note(19, "dated")
+        self._undated("nostamp")
+        got = recall.recall(None, workspace_name="w", scopes=("workspace",))
+        self.assertEqual(len(got.hits), 2)
+        self.assertEqual(got.undated, 0)
+
+    def test_query_plus_since_keeps_score_order_not_date_order(self):
+        # 'keycloak' in the TITLE scores 3x a body hit, so the older title-match must
+        # outrank the newer body-match. --since narrows the field; it never re-ranks.
+        self._note(2, "keycloak rotation", text="rotation detail")
+        self._note(19, "unrelated title", text="a keycloak mention in the body")
+        got = recall.recall("keycloak", workspace_name="w", scopes=("workspace",),
+                            since=datetime.date(2026, 7, 1))
+        self.assertEqual([h.title for h in got.hits], ["keycloak rotation", "unrelated title"])
+
+    def test_hit_fields_are_reachable_by_name(self):
+        self._note(19, "named")
+        h = recall.recall(None, workspace_name="w", scopes=("workspace",)).hits[0]
+        self.assertEqual(h.title, "named")
+        self.assertEqual(h.label, "workspace:w")
+        self.assertEqual(h.date, datetime.date(2026, 7, 19))
+        self.assertEqual(h.score, 0)
+        self.assertTrue(h.path.name.endswith("named.md"))
+
+
+class AllWorkspacesCase(PersonaIso):
+    """`--all-workspaces` widens the workspace axis only: persona and shared are not
+    workspace-scoped, so they must appear exactly once, not once per workspace."""
+
+    def setUp(self):
+        super().setUp()
+        for w in ("alpha", "beta"):
+            workspace.ensure(w)
+            workspace.scaffold(w)
+            workspace.remember(w, f"keycloak note in {w}")
+        self.make_persona("dev", role="Dev", vault="d")
+        persona.remember("dev", "keycloak fact owned by dev")
+        persona.remember("dev", "keycloak convention shared org-wide", shared=True)
+
+    def test_surfaces_every_workspace_with_distinct_labels(self):
+        got = recall.recall("keycloak", persona_name="dev", all_workspaces=True)
+        labels = {h.label for h in got.hits}
+        self.assertIn("workspace:alpha", labels)
+        self.assertIn("workspace:beta", labels)
+
+    def test_persona_and_shared_appear_exactly_once(self):
+        got = recall.recall("keycloak", persona_name="dev", all_workspaces=True, limit=0)
+        labels = [h.label for h in got.hits]
+        self.assertEqual(labels.count("persona:dev"), 1)
+        self.assertEqual(labels.count("shared"), 1)
+
+    def test_sources_lists_one_base_per_workspace(self):
+        srcs = recall.sources(persona_name="dev", all_workspaces=True)
+        ws_labels = sorted(lbl for lbl, _d in srcs if lbl.startswith("workspace:"))
+        self.assertEqual(ws_labels, ["workspace:alpha", "workspace:beta"])
+
+
+class RecallCliCase(unittest.TestCase):
+    """Through the REAL parser — a handler tested only via SimpleNamespace never proves
+    the flag exists or that two flags refuse each other."""
+
+    def test_since_and_all_workspaces_flags_parse(self):
+        from charter import cli
+        args = cli.build_parser().parse_args(["recall", "tokens", "--since", "14d",
+                                              "--all-workspaces"])
+        self.assertEqual(args.since, "14d")
+        self.assertTrue(args.all_workspaces)
+
+    def test_all_workspaces_and_workspace_are_mutually_exclusive(self):
+        from charter import cli
+        with self.assertRaises(SystemExit):
+            cli.build_parser().parse_args(["recall", "--all-workspaces", "-w", "alpha"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`charter recall` could search by keyword and list newest-first. It could not answer the
question two people asked this week: *"a decision was made about two weeks ago, I don't
remember the wording or which workspace."* Keyword recall needs the wording; the listing
needs you to scroll.

## What's new

```
charter recall --since 2w                     # recorded in the last fortnight
charter recall "migration" --since 2026-07-01 # keyword, narrowed by date
charter recall --all-workspaces --since 14d   # ...and I forget which task it was
```

**`--since`** takes an age (`14d`, `2w`, `3m`) or an ISO date. It filters on
`memstore.memory_date` — the same recorded-date key the no-query listing already sorts by,
so the filter and the ordering can never disagree. It **narrows, it never re-ranks**: with
a query the survivors stay in score order, because someone who typed a keyword asked for
relevance.

**`--all-workspaces`** widens the workspace axis only. Persona and shared memory aren't
workspace-scoped, so they stay single rows instead of multiplying by the workspace count.
Mutually exclusive with `-w` — `-w beta --all-workspaces` has no coherent reading.

## Neither flag lies about what it withheld

- An unparseable `--since` **exits 2** rather than degrading to no filter. A silently
  ignored filter returns *more* than was asked for, and a full corpus then reads as
  "nothing was recorded recently" — the exact wrong conclusion.
- Memories with no recorded date are excluded and **counted**: `1 undated memory(ies)
  skipped by --since`.
- A capped result says so: `Showing 8 — pass --limit 0 for all`.

## Output

The date leads, because when listing it *is* the sort key. Column order stays identical
under a query (where score orders instead) — a layout that rearranges per mode is harder
to read than one that never moves.

```
  2026-08-13  workspace:default  a dated note about tokens
  —           workspace:default  handwritten with no stamp
```

## API change

`recall()` now returns `Recalled(hits, undated)` over `Hit(label, path, title, score,
date)` NamedTuples. Adding `date` broke every positional unpack at once; named access
means the next field won't.

## Testing

`tests/test_recall.py` grows 15 cases: date boundary include/exclude, undated excluded
*and* counted, undated *not* counted without `--since`, relative and ISO parsing, six
malformed inputs, score order preserved under `--since`, per-workspace labels, persona and
shared appearing exactly once, and both flags through the real parser rather than a
`SimpleNamespace` — including the mutual exclusion.

Full suite: **1649 passing**.

Scoped to the unified `charter recall` deliberately. `charter workspace recall` and
`charter persona recall` are separate code paths, and the scoped question is already
expressible here: `charter recall --scope persona --persona steward --since 14d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
