### PR TITLE
0.26.0 — recall answers "when", not only "what"

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.25.0"
+__version__ = "0.26.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.25.0",
+            "command": "charter hook sessionstart --plugin-version 0.26.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.25.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.26.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.25.0",
+            "command": "charter hook pretooluse --plugin-version 0.26.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.25.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.26.0"
           }
         ]
       }
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.25.0",
+            "command": "charter hook posttooluse --plugin-version 0.26.0",
             "timeout": 5
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.25.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.26.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.25.0"
+version = "0.26.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only. Ships [#88](https://github.com/diazoxide/charter/pull/88): `charter recall --since` and `--all-workspaces`.

All four version sites move together, per the release charter:

- `pyproject.toml`
- `charter/__init__.py`
- `.claude-plugin/plugin.json`
- the six `--plugin-version` flags in `hooks/hooks.json`

`tests/test_plugin.py::TestVersionsMoveInLockstep` green (26 tests), full suite 1649 passing.

Tag `v0.26.0` follows once this is merged — that push is the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)