### PR TITLE
docs: domain model and decisions for the fleet outcome spine

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,89 @@
+# charter
+
+charter is a control plane for agent development: it holds the personas, workspaces and
+repos a team works through, and enforces the invariants that keep parallel work from
+colliding. It has no model and makes no judgements about the *content* of work — every
+term below describes something charter can observe or enforce without understanding it.
+
+## Language
+
+### The plane
+
+**Plane**:
+The control plane — the directory holding `charter.toml`, its personas, inventory,
+workspaces and config. Not a place work happens (ADR 0008).
+_Avoid_: root, repo, home
+
+**Workspace**:
+An isolated per-task working context, owning clones of the repos that task touches. The
+task is the unit: one workspace, one task — so a workspace running N pieces in parallel is
+what "a fleet" describes, and charter stores no such thing separately.
+_Avoid_: project, session, environment, fleet
+
+**Clone**:
+A repo a workspace owns, on disk under that workspace.
+_Avoid_: checkout, copy
+
+**Worktree**:
+An additional working tree over a clone's object store, living outside every clone so that
+build tools cannot recurse into it and `git clean` inside the clone cannot destroy it.
+_Avoid_: branch dir, tree
+
+**Persona**:
+A role — Release Engineer, Forge Integration Engineer — with its own charter, memory and
+vault. A persona is *who does the work*, never a queue of work (ADR 0005).
+_Avoid_: agent, bot, owner, worker
+
+**Todo**:
+Workspace-scoped intent that expires: it stops being true the moment it is done or
+abandoned, which is why it lives beside memory rather than inside it (ADR 0004).
+_Avoid_: task, ticket, item
+
+### Parallel work
+
+**Plan**:
+The set of piece names a task was divided into, recorded as the workspace's todos. charter
+holds no other representation of it, and never judges whether it covers the task (ADR 0012).
+_Avoid_: breakdown, decomposition, backlog, assignment
+
+**Piece**:
+A unit of one task that exactly one worker owns, and the worktree that holds it. A piece
+*is* a worktree — `workspaces/<ws>/.worktrees/<repo>/<piece>` — not a separate record that
+points at one. Scoped to a single repo: a task spanning two repos is two pieces.
+_Avoid_: task, chunk, shard, work item, unit
+
+**Claim**:
+One worker's exclusive ownership of a piece, established by that worker creating the piece's
+worktree. Git is what makes it exclusive, and the claimant is always the creator — a piece
+created for somebody else is not claimed by anyone.
+_Avoid_: lock, lease, reservation, assignment
+
+**Declaration**:
+A statement only the worker can make, because it is a judgement rather than a fact on disk.
+An outcome is the only declaration there is.
+_Avoid_: report, update, signal
+
+**Observation**:
+Something charter can see without being told — that a piece's worktree exists, that a
+worker was alive at some moment. Observations are never judgements, which is why charter
+may record one about a worker that never speaks to it, and why it may not conclude anything
+from their absence (ADR 0009).
+_Avoid_: check, probe, ping
+
+**Worker**:
+One live session holding one piece. Distinct from a persona (the *role* it may be acting
+as) and from an agent (a *generated sub-agent definition*, which `charter report` counts by
+name) — three things the same word used to cover.
+_Avoid_: agent, sub-agent, runner, bot
+
+**Outcome**:
+What a worker declares became of its piece: `done`, or `abandoned` with a reason. An outcome
+is a statement git cannot make on its own — commits and branches show what a piece *left
+behind*, never whether the worker considered itself finished.
+_Avoid_: result, status, state, report
+
+**Silence**:
+A piece with a claim and no outcome. Not a third outcome but the absence of one, and the
+shape every undeclared failure takes — denial, timeout, or a killed session alike. Silence
+has an *age*, which is the only thing charter says about it: the cause is never inferred.
+_Avoid_: stuck, failed, timed-out, orphaned, dead

--- a/docs/adr/0011-the-record-holds-only-what-git-cannot-know.md
+++ b/docs/adr/0011-the-record-holds-only-what-git-cannot-know.md
@@ -1,0 +1,123 @@
+# The record holds only what git cannot know
+
+Parallel work needs two things charter does not have: a **claim**, so two workers cannot
+take the same piece, and an **outcome**, so a fleet that completes seven of eight cannot
+report success. The obvious design for both is a ledger in workspace state. `worktree.py`
+forbids exactly that, in its opening docstring, on the grounds that a marker which can
+disagree with reality is a failure mode this repo has already paid for.
+
+The decision is a split, not an exception:
+
+- **A claim is the piece's worktree existing.** A piece *is* a worktree, and `git worktree
+  add` already fails for the loser when two workers race the same path or branch. Assignment
+  is therefore atomic with no new state and no new command — git's own lock is the mutex.
+- **An outcome is written down**, because it is a fact git has no opinion on. A branch with
+  three commits and no further activity looks identical whether the worker declared itself
+  finished, hit a permission denial, or was killed. There is no reality for that record to
+  disagree with, because nothing else records it.
+
+So the rule survives in a sharper form: **git is the only registry of what exists; the
+record holds only a worker's declaration.**
+
+## The claimant is the creator, which forbids pre-assignment
+
+The atomicity above is only real if the worker that will do the work is the process that
+creates the worktree. An orchestrator that pre-creates eight worktrees and then starts eight
+workers inside them has won a race that was never run — one process, creating sequentially —
+while the race that matters, two workers entering the same tree, goes unguarded. The mutex
+would be decorative.
+
+So the plan declares piece *names* (ADR 0012) and each worker creates its own worktree,
+taking the name or losing it. An orchestrator writes the plan and starts workers; it does
+not hand out assignments. Nothing enforces this — it is a property of how fleets are driven,
+not of the code — which is exactly why it is written here rather than left as an assumption
+inside a design that silently depends on it.
+
+Two sessions entering one existing worktree remain possible and are **reported, not
+refused** — the same trade ADR 0008 made for the plane root, for the same reason, with the
+same known cost.
+
+## What this forbids
+
+The discipline is the whole value, and it is invisible in the code that follows it — a
+record with one extra field looks like a convenience, not a regression. The record must
+never store a fact that is derivable: which worktrees exist, which branch a piece is on,
+whether it is pushed, whether it is dirty. All of it is read from git at read time, every
+time, exactly as `worktree.py` already does. The moment a derivable fact is cached for
+convenience, this ADR has been reversed whether or not anyone says so.
+
+## The record is events, not state
+
+What makes the identity of a claim recordable at all is that the record is an **append-only
+log of things that happened**, never a description of how things are. *"Piece P claimed at T
+by X"* is a fact about the past and cannot become false; *"X holds P"* can, the moment the
+worktree is removed by hand. Only the first form is written.
+
+The present tense is reconstructed at read time: git answers which worktrees exist, and the
+log is joined to that answer to say who took each one and what they declared. Nothing is
+believed about a piece git no longer sees. That join is what allows a written record to
+carry identity without becoming the marker the docstring forbids, and it is the reason the
+log may never gain a "current status" field, however convenient.
+
+The corollary is that the log and git answer **different questions** and must not be made to
+answer each other's — *what is running here* comes from git, *what happened here* comes from
+the log. ADR 0010 is the same lesson learned the expensive way with the manifest and the
+directory scan.
+
+That corollary immediately splits the record in two. Declarations are rare — at most three
+lines per piece — and belong in the log forever. Liveness is not: it is written by a hook
+that fires every turn, so appending it would bury three meaningful lines per piece under
+thousands of "still alive" ones and make the log unbounded. **Liveness therefore lives in a
+small per-piece file that is overwritten, not in the log.** Overwriting does not breach the
+rule above: *"last seen at T"* is a past observation, not a cached derivable fact, and there
+is no reality it can contradict. What it discards is heartbeat history, which nothing needs.
+Two files, two questions, once again.
+
+## Considered options
+
+**A claims ledger with leases** (append-only records, reconciled against a plan) was the
+leading design until the docstring was read. It is the marker the module forbids, and it
+fails the same way: a lease outlives the worktree it describes.
+
+**Deriving everything from git**, with nothing written at all, cannot represent a
+declaration. It was rejected for the case it cannot see — a dead worker and a slow one are
+identical — which is precisely the failure the work exists to fix.
+
+**Git refs as claims** (`git update-ref refs/charter/claim/<piece>` for compare-and-swap)
+was the most promising option before the split above. It is not wrong; it is redundant.
+Once a claim *is* a worktree, refs add a second namespace to buy atomicity git already
+provided. Its real advantage — a pushed ref is visible on every machine — only pays off
+across hosts, which is out of scope for now. **If multi-host fleets are ever in scope, this
+is the option to reopen**, and it should be reopened rather than reinvented.
+
+## Consequences
+
+**A piece nobody started is invisible to charter.** Claims are worktrees, so a piece that
+was planned and never begun has nothing to observe. "Nothing will drift and be missed" is
+therefore true of *declared* pieces only; coverage of the plan is not something a program
+with no model can check, and this ADR does not pretend otherwise.
+
+**The absence of an outcome is not a state.** There is no `failed`, no `timed-out`, no
+`blocked` — a worker that dies declares nothing, and inventing a state for it would mean
+charter asserting a cause it never verified, which ADR 0009 rules out. What charter can say
+is that a claim exists and nothing was declared. Naming that condition *silence* is what
+makes it reportable instead of indistinguishable from success.
+
+That extends to elapsed time: **no threshold ever converts silence into a verdict.** charter
+reports how long a piece has been claimed and how long since its worker was last observed,
+and stops there. A piece marked `failed` that was in fact running a forty-minute test suite
+is ADR 0009's exact failure one level up — a confident wrong answer tells the reader to stop
+looking. Somebody will propose a staleness threshold; this paragraph is the answer.
+
+**An abandoned piece keeps its name.** Freeing a piece for a retry would mean removing its
+worktree, and `charter worktree remove` deliberately refuses to lose uncommitted or unpushed
+work — so an abandoning worker often *cannot* remove it, and forcing the removal would
+destroy the evidence of why it gave up, which is the most useful thing it produced. Handing
+the tree to a second worker is worse: it inherits a state nobody characterised. So an
+abandoned piece stays on disk carrying its declaration, and a retry is a new piece. The cost
+is worktree sprawl needing curation, which is issue #93 rather than a new problem.
+
+**The claim carries no identity on its own.** A worktree's existence proves someone took the
+piece and says nothing about who, since git records an author only once a commit lands.
+Visibility therefore depends on the written record covering the claim as well as the
+outcome — the same record, under the same restriction.

--- a/docs/adr/0012-the-plan-is-todos-the-lifecycle-is-the-pieces.md
+++ b/docs/adr/0012-the-plan-is-todos-the-lifecycle-is-the-pieces.md
@@ -1,0 +1,49 @@
+# The plan is todos; the lifecycle belongs to the piece
+
+A fleet needs somewhere to say *"this task is eight pieces"* before any of them exist.
+Without it charter can only see pieces that were started, so it can report seven of eight
+declared and never notice that an eighth was planned and never begun — which is one of the
+four failure modes the work exists to close.
+
+The plan is **workspace todos**, unchanged. A todo is intent that expires (ADR 0004), and
+"piece eight, not yet begun" is exactly that. A piece may record which todo it came from;
+the todo records nothing about the piece. *"Declared but claimed by nobody"* is then a query
+over what already exists — **a todo with no piece** — with no new store and no new noun.
+
+## Why not put the state on the todo
+
+The obvious cheaper design is to grow a todo an `owner`, a `state` and a `claim` and call it
+a work item. It will be proposed again, which is why this is written down.
+
+Intent and execution have different lifetimes, and merging them destroys the shorter one. A
+todo is true until somebody decides it isn't; a piece is claimed, worked, and declared
+finished or abandoned, possibly several times over for one todo. Giving the todo a state
+means the retry has nowhere to live except by overwriting the record of the first attempt —
+so the store that was supposed to guarantee nothing is missed becomes the one that forgets.
+
+It also breaks the direction of ADR 0004. Todos live outside memory because intent goes
+stale and facts do not; hanging execution state off intent puts a third lifetime in the same
+file and reintroduces the rot one level down.
+
+## The link is one-way, and nothing closes automatically
+
+A piece never closes its todo. Every piece of a todo declaring `done` does not mean the
+intent was satisfied — that is a judgement about *coverage*, and coverage is the one thing a
+program with no model cannot check. charter deciding otherwise would be asserting the plan
+was correct, which is precisely the authority the design withholds from it: the agent plans,
+charter enforces.
+
+So a todo is closed by whoever closed todos before this design existed. Nothing changes
+about that.
+
+## Consequences
+
+**The hole shrinks; it does not close.** Nothing forces an agent to write its plan down as
+todos, so a plan held only in an agent's head is still invisible, exactly as ADR 0011 states.
+This makes the gap *closable by the planner* rather than closed by charter, which is the
+most an unmodelled control plane can offer.
+
+**Todos gain a reader they did not have.** They have been a human-facing list; they now also
+answer a structural question about a fleet. That is a reason to keep them cheap to write —
+anything that makes recording a todo more ceremonious makes the plan less likely to exist,
+and the plan not existing is the failure this decision is meant to prevent.

--- a/docs/superpowers/specs/2026-08-13-fleet-orchestration-settled.md
+++ b/docs/superpowers/specs/2026-08-13-fleet-orchestration-settled.md
@@ -1,0 +1,94 @@
+# Fleet orchestration — settled ground
+
+**Date:** 2026-08-13 · **Status:** grilled, pre-spec. Input to `/to-spec`.
+**Supersedes** [`2026-08-13-fleet-orchestration-handoff.md`](./2026-08-13-fleet-orchestration-handoff.md),
+whose open questions are now answered.
+
+The vocabulary is in [`CONTEXT.md`](../../../CONTEXT.md). The decisions that were hard to
+reverse are in [ADR 0011](../../adr/0011-the-record-holds-only-what-git-cannot-know.md) and
+[ADR 0012](../../adr/0012-the-plan-is-todos-the-lifecycle-is-the-pieces.md). **Those three
+files are the authority** — this one carries only what did not belong in them, and does not
+restate their reasoning.
+
+---
+
+## The shape, in six lines
+
+A **plan** is workspace todos: piece names, nothing more. A **worker** is one session that
+claims a **piece** by creating its worktree, which is how exactly one worker gets it. It
+declares `done` or `abandoned` when finished; a hook records that it was alive, so a worker
+that dies leaves **silence** with an age rather than looking like success. charter reports
+all of it and diagnoses none of it. The agent plans; charter enforces.
+
+## What charter guarantees, and what it does not
+
+Guaranteed: no two workers hold one piece; every claim and declaration is recorded; a piece
+that declared nothing is visibly silent, with an age.
+
+**Not** guaranteed, and this is the honest edge of the design: that the plan covers the task.
+charter has no model, so it cannot know an eighth piece was needed. ADR 0012 shrinks the gap
+— a todo with no piece is computable — but only for plans that were written down. Any spec
+language promising that "nothing drifts and nothing is missed" must say *declared* pieces, or
+it is over-promising.
+
+## Settled, but not ADR material
+
+**Scope of the first cut.** The outcome spine alone: hook-recorded liveness, `done` /
+`abandoned`, the log, the read surface, the SessionStart announcement. **Issue #91 is fixed
+first, as a separate ticket** — `workspace remove` destroys worktrees silently, a fleet
+multiplies worktrees, and the bug is already real at N=1.
+
+**Second cut:** the todo↔piece linkage, then same-file overlap detection. Overlap started in
+the first cut and was moved out during grilling: it needs a merge-base per repo and shares
+nothing with the outcome spine.
+
+**Out of scope, deliberately:** fan-in (sequencing merges, rolling N branches into one PR),
+and multi-host fleets. If multi-host ever returns, reopen git-refs-as-claims — ADR 0011 says
+why it was set aside rather than rejected, so it should be reopened, not reinvented.
+
+**Verbs.** Claiming stays `charter worktree add <repo> <piece>`, which now also writes the
+claim event. Declaring is `charter worktree done` and `charter worktree abandon "<reason>"`
+with **no piece argument** — the piece comes from cwd via `worktree.locate()`, since every
+argument is a chance to name someone else's piece. Reading is the existing
+`charter worktree list` plus a history flag; no new command tree, because there is no fleet
+noun to hang one on.
+
+**Losing a claim** must be distinguishable without parsing English: a classified error (the
+cause *is* recognised — the path or branch exists — so ADR 0009 permits naming it) and a
+distinct exit code, so a worker can take the next unclaimed name from the plan.
+
+**Hand-made worktrees** keep working. A tree created with plain `git worktree add` has no
+claim event and reports **claimant unknown**. It is never refused — `worktree.py`'s stance
+that hand-made trees are first-class is not weakened by this design.
+
+**SessionStart** is where a worker learns it holds a piece and owes a declaration, by the
+same mechanism that already announces workspace, persona and todos. State the verbs
+literally. No nagging at turn end — liveness is already automatic, and ADR 0008 records what
+becomes of a warning you can work through.
+
+**Status line.** Annotate the worktree detail rows it already draws, plus one summary cell on
+the workspace line: *"8 pieces · 5 done · 1 abandoned · 2 silent (oldest 3h)"*. No fleet
+block. **The join is directory-scan × log, never `git worktree list`** — the status line's
+contract forbids a git subprocess, and the obvious implementation reaches for one. Lands on
+the `statusline` persona.
+
+**A second session entering a held worktree** is reported, not refused — ADR 0008's trade,
+knowingly repeated. A *resumed* session must not warn about itself.
+
+## Still open
+
+Nothing in the design. Two things for the spec to decide, both mechanical:
+
+- The log's file layout. `dispatch.py`'s pattern is the model (`O_APPEND`, host in the
+  filename, no locks); what is undecided is one log per workspace versus one per repo.
+- Whether the history read is `charter worktree list --history` or its own subcommand.
+
+## Route
+
+Spec for the first cut is filed as **[#95](https://github.com/diazoxide/charter/issues/95)**
+(`ready-for-agent`, `gap`), with **#91** as its prerequisite. It is the single source for the
+spec — this file is not a second copy of it, deliberately.
+
+`/to-tickets` on #95 next, then `/implement` per ticket with `/clear` between. Keep tickets in
+one context window with #95, `CONTEXT.md`, and ADRs 0011–0012 loaded; that is the whole of the
+settled ground, and it is deliberately small enough to carry.


### PR DESCRIPTION
Output of a `/grill-with-docs` session that turned [the pre-spec handoff](docs/superpowers/specs/2026-08-13-fleet-orchestration-handoff.md) into settled ground. Docs only — no code.

- **`CONTEXT.md`** (new — the repo had no glossary) carries the vocabulary the design needed: plan, piece, claim, declaration, observation, worker, outcome, silence.
- **ADR 0011** splits the problem the previous session could not get past: a claim *is* a worktree's creation, so git arbitrates it and "git is the only registry" survives; an outcome is written, because git has no opinion on whether a worker considered itself finished.
- **ADR 0012** records that the plan is workspace todos and the lifecycle stays on the piece — written to answer "why not put `owner` and `state` on the todo?", which ADR 0005 predicted would be asked again.

Writing 0011 exposed a hole in its own leading design: the atomicity is only real if the **worker** creates its own worktree. An orchestrator that pre-creates N worktrees wins a race nobody ran, while the race that matters — two workers in one tree — goes unguarded. Recorded explicitly, because nothing in the code enforces it.

Spec is #95; tickets #96–#101, gated by #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX