### PR TITLE
fix: workspace removal guards worktrees, not just clones

### DIFF
--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -245,7 +245,7 @@ def cmd_workspace_rename(args) -> int:
 
 
 def _work_at_risk(name: str) -> list[str]:
-    """Clones in the workspace with uncommitted or unpushed work.
+    """Clones **and worktrees** in the workspace with uncommitted or unpushed work.
 
     Only that. Open todos are deliberately NOT here, though `remove` reports them: this
     list is what is *unrecoverable*, and a todo is a note about the future, not work that
@@ -263,6 +263,47 @@ def _work_at_risk(name: str) -> list[str]:
             ahead = _git(["rev-list", "--count", "@{u}..HEAD"], cwd=d).stdout.strip()
             if ahead and ahead != "0":
                 out.append(f"{d.name}: {ahead} unpushed commit(s)")
+    return out + _worktrees_at_risk(name)
+
+
+def _worktrees_at_risk(name: str) -> list[str]:
+    """Worktrees of this workspace holding work that removing it would destroy (#91).
+
+    The loop above cannot see these and never could: it iterates `workspace.clones()`,
+    which filters on `is_clone` — a clone's ``.git`` is a directory, a linked worktree's is
+    a FILE. That exclusion is deliberate and correct for counting repos, and it is exactly
+    what left worktrees unguarded while `shutil.rmtree` took them anyway.
+
+    The **rule** differs from the clone rule above, not just the paths. `charter worktree
+    remove` treats a branch with NO upstream as work at risk — its commits exist nowhere
+    else — where the clone loop does not. That difference is the point rather than an
+    inconsistency: a parallel agent's piece is unpushed with no upstream almost by
+    definition, so applying the clone rule here would keep missing the very case this
+    exists for. The two guards now refuse on the same grounds.
+
+    This fires even when the worktree directory lives outside the workspace — a relocated
+    ``[plane] worktrees`` root, which `shutil.rmtree` never touches. That is not an
+    oversight: a linked worktree keeps its objects in the CLONE's object store, so removing
+    the clone destroys those commits whether or not the directory survives.
+    """
+    base = worktree.root(name)
+    try:
+        repos = sorted(d.name for d in base.iterdir() if d.is_dir())
+    except OSError:
+        return []
+
+    out = []
+    for repo in repos:
+        for wt in sorted(worktree.dirs_for(name, repo)):
+            label = f"{repo}/{wt.name}"
+            if worktree.is_dirty(wt):
+                out.append(f"{label}: uncommitted changes")
+                continue
+            ahead = worktree.unpushed(wt)
+            if ahead is None:
+                out.append(f"{label}: no upstream, so its commits exist nowhere else")
+            elif ahead:
+                out.append(f"{label}: {ahead} unpushed commit(s)")
     return out
 
 

--- a/tests/test_workspace_remove.py
+++ b/tests/test_workspace_remove.py
@@ -16,7 +16,7 @@ import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from types import SimpleNamespace
 
-from charter import todos, workspace
+from charter import todos, workspace, worktree
 from charter import commands_workspace as cw
 from tests._isolation import PersonaIso
 
@@ -48,6 +48,37 @@ class RemoveCase(PersonaIso):
                        env={**os.environ, **_GIT_ENV})
         (d / "unsaved.txt").write_text("work nobody has committed\n")
         return d
+
+    def git(self, cwd, *args: str):
+        return subprocess.run(["git", "-C", str(cwd), *args], check=True,
+                              capture_output=True, text=True,
+                              env={**os.environ, **_GIT_ENV})
+
+    def commit(self, cwd, message: str):
+        """`commit.gpgsign=false` per `tests/test_worktree.py` — a developer whose global
+        config signs commits gets an interactive signer, which hangs the suite forever."""
+        self.git(cwd, "add", "-A")
+        self.git(cwd, "-c", "commit.gpgsign=false", "commit", "-qm", message)
+
+    def make_clone_with_worktree(self, name: str = "alpha", repo: str = "svc",
+                                 piece: str = "slice"):
+        """A clone carrying one commit, plus a linked worktree on its own branch.
+
+        The worktree's ``.git`` is a FILE, which is precisely why `workspace.clones()`
+        cannot see it — and why removal used to delete it unguarded.
+        """
+        env = {**os.environ, **_GIT_ENV}
+        clone = workspace.workspace_dir(name) / repo
+        clone.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "init", "-q", "-b", "main", str(clone)], check=True,
+                       capture_output=True, env=env)
+        (clone / "README").write_text("base\n")
+        self.commit(clone, "base")
+
+        wt = worktree.path_for(name, repo, piece)
+        wt.parent.mkdir(parents=True, exist_ok=True)
+        self.git(clone, "worktree", "add", "-q", "-b", piece, str(wt))
+        return clone, wt
 
 
 class TestTodosAreReportedOnRemoval(RemoveCase):
@@ -107,6 +138,85 @@ class TestWorkAtRiskStillBlocks(RemoveCase):
 
     def test_force_still_removes_work_at_risk(self):
         self.make_dirty_clone()
+        rc, _ = self.remove(force=True)
+        self.assertEqual(rc, 0)
+        self.assertFalse(workspace.workspace_dir("alpha").exists())
+
+
+class TestWorktreesAreGuardedToo(RemoveCase):
+    """#91 — the exclusion that keeps a worktree from being *counted* as a clone also kept
+    it from being *guarded*, while `shutil.rmtree` took it anyway. `charter worktree remove`
+    refuses to lose this work; `charter workspace remove` said `✓ Removed workspace`.
+
+    The guard follows `worktree remove`'s stance rather than the clone rule beside it: for a
+    worktree, *no upstream* counts as at risk. That difference is the whole point — a
+    parallel agent's branch is unpushed with no upstream almost by definition, so the clone
+    rule would keep missing exactly the case this exists for.
+    """
+
+    def test_uncommitted_work_in_a_worktree_refuses_removal(self):
+        _, wt = self.make_clone_with_worktree()
+        (wt / "unsaved.txt").write_text("an agent's work, never committed\n")
+        rc, _ = self.remove()
+        self.assertNotEqual(rc, 0)
+        self.assertTrue(workspace.workspace_dir("alpha").exists())
+
+    def test_commits_that_exist_nowhere_else_refuse_removal(self):
+        """The fleet case. The tree is clean, so a dirt check alone passes it — but the
+        branch has no upstream, so deleting the workspace is the only copy going away."""
+        _, wt = self.make_clone_with_worktree()
+        (wt / "feature.txt").write_text("committed, pushed nowhere\n")
+        self.commit(wt, "work")
+        rc, _ = self.remove()
+        self.assertNotEqual(rc, 0)
+        self.assertTrue(workspace.workspace_dir("alpha").exists())
+
+    def test_the_piece_is_named_in_the_refusal(self):
+        """A refusal that cannot say *which* piece is holding work sends the reader to
+        check every worktree by hand — ADR 0009's complaint, in the guard rather than the
+        error classifier."""
+        _, wt = self.make_clone_with_worktree(piece="slice")
+        (wt / "unsaved.txt").write_text("work\n")
+        _, out = self.remove()
+        self.assertIn("slice", out)
+
+    def test_the_worktree_appears_in_the_work_at_risk_set(self):
+        """Asserted against the guard itself, so a future refactor that reports worktrees
+        without actually guarding them cannot pass."""
+        _, wt = self.make_clone_with_worktree()
+        (wt / "unsaved.txt").write_text("work\n")
+        self.assertTrue(any("slice" in r for r in cw._work_at_risk("alpha")))
+
+    def test_a_pushed_clean_worktree_does_not_block(self):
+        """Specificity: the guard must protect work, not merely notice worktrees. A piece
+        whose branch is clean and on a remote survives deletion of the workspace, so
+        refusing over it would teach the `--force` habit the clone guard avoids."""
+        clone, wt = self.make_clone_with_worktree()
+        # Outside the workspace, so removal cannot take the remote with it.
+        bare = workspace.workspace_dir("alpha").parent.parent / "origin.git"
+        subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=True,
+                       capture_output=True, env={**os.environ, **_GIT_ENV})
+        self.git(wt, "remote", "add", "origin", str(bare))
+        self.git(wt, "push", "-q", "-u", "origin", "slice")
+        rc, out = self.remove()
+        self.assertEqual(rc, 0, out)
+        self.assertFalse(workspace.workspace_dir("alpha").exists())
+
+    def test_a_fresh_worktree_blocks_because_it_has_no_upstream(self):
+        """Pinned deliberately rather than left to be discovered. A just-created piece has
+        nothing to lose, so refusing over it is a false positive — but it is the same false
+        positive `charter worktree remove` already has, and the two guards agreeing on what
+        "at risk" means matters more than shaving it here. Narrowing the rule to commits
+        unique to the branch changes that definition, and belongs in its own ticket.
+        """
+        self.make_clone_with_worktree()
+        rc, out = self.remove()
+        self.assertNotEqual(rc, 0)
+        self.assertIn("slice", out)
+
+    def test_force_still_removes_a_worktree_holding_work(self):
+        _, wt = self.make_clone_with_worktree()
+        (wt / "unsaved.txt").write_text("work\n")
         rc, _ = self.remove(force=True)
         self.assertEqual(rc, 0)
         self.assertFalse(workspace.workspace_dir("alpha").exists())


### PR DESCRIPTION
Closes #91. First ticket of the fleet outcome spine (#95) — it gates #96.

`charter worktree remove` refuses to lose uncommitted or unpushed work. `charter workspace remove` deleted that same work and printed `✓ Removed workspace`.

## Why the guard couldn't see it

`_work_at_risk` iterates `workspace.clones()`, which filters on `is_clone` — a clone's `.git` is a directory, a linked worktree's is a **file**. That exclusion is deliberate and correct for counting repos, and it is also exactly what kept worktrees out of the guard while `shutil.rmtree` took them anyway.

## The rule, and why it differs from the clone rule beside it

For a worktree, **no upstream counts as at risk**, matching `worktree remove` rather than the clone loop above it. That difference is load-bearing: a parallel agent's piece is unpushed with no upstream almost by definition, so reusing the clone rule would have kept missing the exact case this bug is about. The two guards now refuse on the same grounds, which is what the issue asked for.

It also fires for worktrees relocated outside the workspace by `[plane] worktrees`, which `rmtree` never touches — a linked worktree keeps its objects in the **clone's** object store, so removing the clone destroys those commits whether or not the directory survives.

## One known false positive, pinned rather than hidden

A just-created piece has no upstream and therefore blocks removal, despite having nothing to lose. It is the same false positive `charter worktree remove` already has, and there is a test asserting it so it reads as deliberate. Narrowing the rule to *commits unique to the branch* changes what "at risk" means and belongs in its own ticket — filed separately.

## Tests

7 new tests in `tests/test_workspace_remove.py`, real git throughout per that suite's stance. Covers: uncommitted work in a worktree, commits that exist nowhere else (the fleet case), the piece being named in the refusal, the guard itself rather than only its outcome, a pushed clean worktree **not** blocking (specificity), the fresh-worktree false positive, and `--force` still removing.

Full suite: 1656 passing, up from 1649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX