### PR TITLE
feat: claiming a piece, and a loser that can tell

### DIFF
--- a/charter/commands_worktree.py
+++ b/charter/commands_worktree.py
@@ -9,8 +9,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from . import config, util, workspace, worktree
+from . import config, pieces, util, workspace, worktree
 from . import root as _root
+
+#: Exit code for "this piece is already claimed", distinct from the generic 1 every other
+#: failure returns. A worker that loses a race takes the next unclaimed name from its plan,
+#: and it must not have to parse English to know that is what happened — nor mistake an
+#: invalid piece name for a lost race.
+CLAIM_TAKEN = 2
 
 
 def clone_for(ws: str, repo: str) -> Path | None:
@@ -44,6 +50,32 @@ def _rel(p: Path) -> str:
         return str(p)
 
 
+def _claim_holder(ws: str, clone: Path, path: Path, branch: str | None) -> str | None:
+    """Who already holds this claim, or ``None`` if it is free.
+
+    Two shapes of the same collision. The piece's directory existing is the obvious one.
+    The branch being checked out by another live worktree is the same thing under a
+    different piece name — git refuses either way, since a branch can be checked out in
+    exactly one tree.
+
+    A branch that merely *exists* is deliberately not a holder: nobody is working in it, so
+    reporting it as claimed would send workers past names that were free.
+    """
+    if path.exists():
+        return f"a worktree at {_rel(path)}"
+    if branch:
+        for r in worktree.list_for(clone, ws):
+            if r["branch"] == branch and not r["prunable"]:
+                return f"piece '{r['piece']}'"
+    return None
+
+
+def _refuse_taken(piece: str, held_by: str) -> int:
+    util.err(f"'{piece}' is already claimed — held by {held_by}.")
+    util.info("Take the next unclaimed piece from the plan, or work in the existing worktree.")
+    return CLAIM_TAKEN
+
+
 def cmd_worktree_add(args) -> int:
     ws, clone = _resolve(args)
     if clone is None:
@@ -54,9 +86,10 @@ def cmd_worktree_add(args) -> int:
         return 1
 
     path = worktree.path_for(ws, args.repo, args.piece)
-    if path.exists():
-        util.err(f"'{args.piece}' already exists → {_rel(path)}")
-        return 1
+    branch = args.branch or args.piece
+    held = _claim_holder(ws, clone, path, branch)
+    if held:
+        return _refuse_taken(args.piece, held)
 
     base, detached = worktree.head_of(clone)
     if detached:
@@ -79,8 +112,21 @@ def cmd_worktree_add(args) -> int:
     path.parent.mkdir(parents=True, exist_ok=True)
     proc = util.run(["git", "-C", str(clone), *cmd], check=False)
     if proc.returncode != 0:
+        # The check above is not the mutex — git is. A worker that won between that check
+        # and git's own lock leaves this failure indistinguishable from a broken repo
+        # unless we look again, so look: if the path or the branch is now held, the cause
+        # was established by reading reality rather than by parsing git's English, which
+        # is the only kind of cause charter is allowed to name (ADR 0009).
+        held = _claim_holder(ws, clone, path, branch)
+        if held:
+            return _refuse_taken(args.piece, held)
         util.err(f"git worktree add failed:\n{proc.stderr.strip()}")
         return 1
+
+    # The worktree is the claim; this only records who took it, because git will not know
+    # that until a commit lands (ADR 0011). Best-effort by construction — a claim that
+    # git granted must not be undone by a log that could not be written.
+    pieces.record(ws, "claimed", args.repo, args.piece)
 
     util.ok(f"{args.repo} · {args.piece} → {_rel(path)}")
     util.info(f"  base:   {base}{' (detached)' if detached else ''}")
@@ -118,6 +164,10 @@ def cmd_worktree_list(args) -> int:
         # worktrees" while the status line one line above was drawing them.
         targets = workspace.repo_trees(ws)
 
+    # Rows come from git and only from git. The record is joined onto what git found, to
+    # put a name on it — it is never asked which worktrees exist (ADR 0011).
+    claims = pieces.claims(ws)
+
     total = 0
     for clone in targets:
         rows = worktree.list_for(clone, ws)
@@ -132,7 +182,8 @@ def cmd_worktree_list(args) -> int:
             else:
                 state = "dirty" if worktree.is_dirty(Path(r["path"])) else "clean"
             branch = r["branch"] or f"detached {r['path']}"
-            print(f"    {r['piece']:<24} {branch:<28} {state}")
+            who = pieces.claimant(claims.get((clone.name, r["piece"])))
+            print(f"    {r['piece']:<24} {branch:<28} {state:<8} {who}")
             total += 1
     if not total:
         util.info("No worktrees. Create one: "

--- a/charter/pieces.py
+++ b/charter/pieces.py
@@ -1,0 +1,158 @@
+"""What charter is *told* about a piece — never what it can see for itself.
+
+A piece is a worktree, and a claim is that worktree coming into existence, so git already
+arbitrates who gets it: ``git worktree add`` fails for the loser when two workers race the
+same path or branch. Nothing here participates in that. What git cannot answer is whether
+the worker considered itself finished — a branch with three commits and no further activity
+looks identical whether its worker declared done, hit a denial, or was killed — and this is
+where that answer lives (ADR 0011).
+
+**Only what git cannot know.** No branch, no path, no dirty or pushed flag ever appears in a
+line here; every one of those is read from git at read time, exactly as :mod:`charter.worktree`
+does. The moment a derivable fact is cached here for convenience, ADR 0011 has been reversed
+whether or not anyone says so.
+
+**Events, never state.** *"Piece P claimed at T by X"* is a fact about the past and cannot
+become false; *"X holds P"* becomes false the instant the worktree is removed by hand. Only
+the first form is written. The present tense is reconstructed by joining git's answer about
+what exists to this log — which is why there is no "current status" field and may never be.
+
+Shape of the store::
+
+    workspaces/<ws>/pieces/<host>.jsonl      one JSON object per line
+
+Three properties matter, and two are borrowed wholesale from :mod:`charter.dispatch`:
+
+* **Parallel-writer safe.** Lines are small and opened ``O_APPEND``, so a fan-out of eight
+  workers appends without a lock.
+* **Host in the filename**, so the pattern is unchanged if fleets ever span machines. They
+  do not today, which is why the log is not committed — it describes worktrees that exist on
+  exactly one disk, and a portable file describing a local reality is the mismatch ADR 0010
+  dissects at length.
+* **Best-effort.** A failed write returns ``None`` and never raises. The worktree *is* the
+  claim; if it exists, the claim happened, and losing the bookkeeping must not undo it.
+
+The workspace is not a field: the log lives inside the workspace directory, so writing the
+name into every line would record a fact the path already carries.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+from datetime import datetime, timezone
+from pathlib import Path
+
+from . import persona, session, workspace
+
+#: Directory under a workspace holding its piece records. Deliberately absent from
+#: ``workspace._live_block`` — see the module docstring.
+DIR_NAME = "pieces"
+
+#: Every key a line may carry. A closed set, asserted by the tests: this is where an
+#: innocent-looking extra field would quietly reverse ADR 0011.
+FIELDS = ("ts", "event", "repo", "piece", "session", "host", "persona")
+
+
+def _host() -> str:
+    """Short, filename-safe hostname — the `dispatch.py` rule, for the same reason."""
+    raw = (socket.gethostname() or "unknown").split(".")[0]
+    return re.sub(r"[^A-Za-z0-9_-]", "", raw)[:32] or "unknown"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def dir_for(ws: str) -> Path:
+    return workspace.workspace_dir(ws) / DIR_NAME
+
+
+def log_path(ws: str) -> Path:
+    return dir_for(ws) / f"{_host()}.jsonl"
+
+
+def record(ws: str, event: str, repo: str, piece: str,
+           when: datetime | None = None) -> Path | None:
+    """Append one event. Best-effort: returns ``None`` if it could not be written.
+
+    Swallowing the failure is deliberate. This is bookkeeping about a claim that git has
+    already granted — raising here would fail a command whose real work succeeded, and a
+    worker cannot un-create its worktree in response.
+    """
+    when = when or _now()
+    line = {
+        "ts": when.isoformat(timespec="seconds"),
+        "event": event,
+        "repo": repo,
+        "piece": piece,
+        "session": session.current(),
+        "host": _host(),
+        "persona": persona.resolve_active(),
+    }
+    p = log_path(ws)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        blob = (json.dumps(line, sort_keys=True) + "\n").encode()
+        # O_APPEND: concurrent workers interleave safely without a lock.
+        fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        try:
+            os.write(fd, blob)
+        finally:
+            os.close(fd)
+        return p
+    except OSError:
+        return None
+
+
+def events(ws: str) -> list[dict]:
+    """Every recorded event, oldest first.
+
+    A malformed line is skipped rather than fatal: this feeds the status line, which must
+    render whatever it finds, and a half-written line from a killed process is exactly the
+    kind of thing an append-only log collects.
+    """
+    d = dir_for(ws)
+    if not d.exists():
+        return []
+    out = []
+    for f in sorted(d.glob("*.jsonl")):
+        try:
+            text = f.read_text()
+        except OSError:
+            continue
+        for raw in text.splitlines():
+            try:
+                obj = json.loads(raw)
+            except ValueError:
+                continue
+            if isinstance(obj, dict) and obj.get("piece"):
+                out.append(obj)
+    return sorted(out, key=lambda e: e.get("ts") or "")
+
+
+def claims(ws: str) -> dict[tuple[str, str], dict]:
+    """The latest ``claimed`` event per piece, keyed ``(repo, piece)``.
+
+    Note what this is *not*: an answer to which pieces exist. A claim here for a worktree
+    that was since removed is a true statement about the past and must not put a row in any
+    listing — callers start from git and use this only to put a name on what git found.
+    """
+    out: dict[tuple[str, str], dict] = {}
+    for e in events(ws):
+        if e.get("event") == "claimed":
+            out[(e.get("repo") or "", e["piece"])] = e
+    return out
+
+
+def claim_for(ws: str, repo: str, piece: str) -> dict | None:
+    return claims(ws).get((repo, piece))
+
+
+def claimant(entry: dict | None) -> str:
+    """How a claim reads in a listing. ``unknown`` when nobody claimed it — a worktree made
+    by hand with plain git is first-class and simply has no claim event."""
+    if not entry:
+        return "unknown"
+    return entry.get("persona") or entry.get("session") or entry.get("host") or "unknown"

--- a/tests/test_piece_claim.py
+++ b/tests/test_piece_claim.py
@@ -1,0 +1,249 @@
+"""Claiming a piece — `charter worktree add` as the act that takes it (#96).
+
+Real git, per `tests/test_worktree.py`: git's own atomicity *is* the mutual exclusion here,
+so a mocked git would prove nothing about the property that matters.
+
+The record under test holds only what git cannot know. Which worktrees exist, which branch
+each is on, whether it is dirty — all of that is read from git every time, and none of it
+may appear here (ADR 0011). What is recorded is that a session took a piece.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import threading
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+
+from charter import pieces, workspace, worktree
+from charter import commands_worktree as cwt
+from tests._isolation import PersonaIso
+
+_GIT_ENV = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e"}
+
+
+class ClaimCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(redirect_stdout(io.StringIO()))
+        workspace.ensure("alpha")
+        workspace.scaffold("alpha")
+        self.clone = workspace.workspace_dir("alpha") / "svc"
+        self.clone.mkdir(parents=True, exist_ok=True)
+        env = {**os.environ, **_GIT_ENV}
+        subprocess.run(["git", "init", "-q", "-b", "main", str(self.clone)], check=True,
+                       capture_output=True, env=env)
+        (self.clone / "README").write_text("base\n")
+        subprocess.run(["git", "-C", str(self.clone), "add", "-A"], check=True,
+                       capture_output=True, env=env)
+        subprocess.run(["git", "-C", str(self.clone), "-c", "commit.gpgsign=false",
+                        "commit", "-qm", "base"], check=True, capture_output=True, env=env)
+
+    def add(self, piece: str = "slice", branch: str | None = None, repo: str = "svc"):
+        """Returns (rc, stdout + stderr)."""
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = cwt.cmd_worktree_add(SimpleNamespace(
+                repo=repo, piece=piece, branch=branch, workspace="alpha"))
+        return rc, out.getvalue() + err.getvalue()
+
+    def listing(self, repo: str | None = "svc"):
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            cwt.cmd_worktree_list(SimpleNamespace(repo=repo, workspace="alpha"))
+        return out.getvalue() + err.getvalue()
+
+
+class TestClaimingRecordsWhoTookIt(ClaimCase):
+    def test_a_claim_is_recorded(self):
+        self.add()
+        events = pieces.events("alpha")
+        self.assertEqual([e["event"] for e in events], ["claimed"])
+        self.assertEqual(events[0]["piece"], "slice")
+        self.assertEqual(events[0]["repo"], "svc")
+
+    def test_the_claim_carries_the_session_and_host(self):
+        """Visibility needs a name. A worktree's existence proves *someone* took the piece
+        and says nothing about who — git records an author only once a commit lands."""
+        os.environ["CLAUDE_CODE_SESSION_ID"] = "sess-abc"
+        self.addCleanup(os.environ.pop, "CLAUDE_CODE_SESSION_ID", None)
+        self.add()
+        claim = pieces.claim_for("alpha", "svc", "slice")
+        self.assertEqual(claim["session"], "sess-abc")
+        self.assertTrue(claim["host"])
+
+    def test_a_claim_with_no_session_is_still_recorded(self):
+        """Absence is representable — `session.current()` returns None rather than a shared
+        sentinel, and a claim made outside a Claude session is still a claim."""
+        os.environ.pop("CLAUDE_CODE_SESSION_ID", None)
+        self.add()
+        claim = pieces.claim_for("alpha", "svc", "slice")
+        self.assertIsNone(claim["session"])
+
+    def test_nothing_derivable_from_git_is_recorded(self):
+        """ADR 0011's whole discipline, asserted as a closed set. A record with one extra
+        convenient field looks like a convenience and is the reversal of that decision."""
+        self.add()
+        allowed = {"ts", "event", "repo", "piece", "session", "host", "persona"}
+        for e in pieces.events("alpha"):
+            self.assertEqual(set(e) - allowed, set())
+        text = pieces.log_path("alpha").read_text()
+        for derivable in ("branch", "path", "dirty", "pushed", "upstream", "detached"):
+            self.assertNotIn(derivable, text)
+
+
+class TestTheListingNamesTheClaimant(ClaimCase):
+    def test_the_claimant_appears_in_the_listing(self):
+        os.environ["CLAUDE_CODE_SESSION_ID"] = "sess-abc"
+        self.addCleanup(os.environ.pop, "CLAUDE_CODE_SESSION_ID", None)
+        self.add()
+        self.assertIn("sess-abc", self.listing())
+
+    def test_a_hand_made_worktree_is_listed_as_claimant_unknown(self):
+        """`worktree.py` holds that a worktree made with plain git is first-class. This
+        design does not weaken that — it has no claim event, so it has no claimant, and
+        saying so is different from refusing it."""
+        wt = worktree.path_for("alpha", "svc", "byhand")
+        wt.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "-C", str(self.clone), "worktree", "add", "-q",
+                        "-b", "byhand", str(wt)], check=True, capture_output=True,
+                       env={**os.environ, **_GIT_ENV})
+        out = self.listing()
+        self.assertIn("byhand", out)
+        self.assertIn("unknown", out)
+        self.assertEqual(pieces.claim_for("alpha", "svc", "byhand"), None)
+
+
+class TestExactlyOneClaimWins(ClaimCase):
+    def test_a_second_claim_on_the_same_piece_loses(self):
+        rc1, _ = self.add()
+        rc2, _ = self.add()
+        self.assertEqual(rc1, 0)
+        self.assertEqual(rc2, cwt.CLAIM_TAKEN)
+
+    def test_the_loser_exits_distinctly_from_every_other_failure(self):
+        """The exit code is what makes this usable by a worker moving to the next name in
+        its plan. An invalid piece name must not look like a lost race."""
+        self.add()
+        taken, _ = self.add()
+        invalid, _ = self.add(piece=".hidden")
+        missing, _ = self.add(repo="nope")
+        self.assertEqual(taken, cwt.CLAIM_TAKEN)
+        self.assertNotEqual(invalid, cwt.CLAIM_TAKEN)
+        self.assertNotEqual(missing, cwt.CLAIM_TAKEN)
+
+    def test_the_loser_names_the_recognised_cause(self):
+        self.add()
+        _, out = self.add()
+        self.assertIn("slice", out)
+        self.assertIn("claim", out.lower())
+
+    def test_a_branch_held_by_another_piece_is_a_lost_claim(self):
+        """Same collision wearing a different name: the branch is checked out by a live
+        worktree, so somebody holds it even though this piece's path is free."""
+        self.add(piece="first")
+        rc, out = self.add(piece="second", branch="first")
+        self.assertEqual(rc, cwt.CLAIM_TAKEN)
+        self.assertIn("first", out)
+
+    def test_a_branch_that_exists_but_nobody_holds_is_not_a_lost_claim(self):
+        """Specificity. A leftover branch with no worktree on it is not a claim, and
+        reporting it as one would teach workers to skip names that were free."""
+        subprocess.run(["git", "-C", str(self.clone), "branch", "leftover"], check=True,
+                       capture_output=True, env={**os.environ, **_GIT_ENV})
+        rc, _ = self.add(piece="leftover")
+        self.assertNotEqual(rc, 0)
+        self.assertNotEqual(rc, cwt.CLAIM_TAKEN)
+
+    def test_losing_the_race_inside_git_is_still_a_lost_claim(self):
+        """The pre-check is not the mutex — git is. A racer that wins between our check and
+        git's lock makes `git worktree add` fail, and that failure must classify the same
+        way, or which error a worker sees becomes a matter of timing.
+
+        The cause is established by re-reading reality, never by parsing git's English
+        (ADR 0009): after the failure, the path is there.
+        """
+        real_run = cwt.util.run
+
+        def racer(cmd, *a, **kw):
+            if "worktree" in cmd and "add" in cmd:
+                worktree.path_for("alpha", "svc", "slice").mkdir(parents=True, exist_ok=True)
+                return subprocess.CompletedProcess(cmd, 1, "", "fatal: whatever git says")
+            return real_run(cmd, *a, **kw)
+
+        cwt.util.run = racer
+        self.addCleanup(setattr, cwt.util, "run", real_run)
+        rc, out = self.add()
+        self.assertEqual(rc, cwt.CLAIM_TAKEN)
+
+    def test_concurrent_claims_leave_exactly_one_winner(self):
+        """The property the whole design rests on, exercised concurrently rather than
+        argued for. Git's lock is the arbiter; charter adds nothing to it."""
+        results, barrier = [], threading.Barrier(4)
+        lock = threading.Lock()
+
+        def claim():
+            barrier.wait()
+            rc, _ = self.add(piece="contested")
+            with lock:
+                results.append(rc)
+
+        threads = [threading.Thread(target=claim) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(results.count(0), 1, results)
+
+
+class TestTheRecordIsParallelWriterSafe(ClaimCase):
+    def test_concurrent_appends_all_survive_intact(self):
+        """Invisible from a single-process CLI test, so it gets a direct one. `O_APPEND`
+        with no lock is the `dispatch.py` pattern — small lines interleave atomically."""
+        barrier = threading.Barrier(8)
+
+        def write(i: int):
+            barrier.wait()
+            for j in range(25):
+                pieces.record("alpha", "claimed", "svc", f"p{i}-{j}")
+
+        threads = [threading.Thread(target=write, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        lines = pieces.log_path("alpha").read_text().splitlines()
+        self.assertEqual(len(lines), 200)
+        for line in lines:
+            json.loads(line)  # every line is whole — no interleaved fragments
+
+    def test_a_write_failure_never_breaks_the_caller(self):
+        """A record is bookkeeping. Claiming a piece must not fail because the log could
+        not be written — the worktree is the claim, and it already exists."""
+        d = pieces.log_path("alpha").parent
+        d.mkdir(parents=True, exist_ok=True)
+        d.chmod(0o500)
+        self.addCleanup(d.chmod, 0o700)
+        self.assertIsNone(pieces.record("alpha", "claimed", "svc", "slice"))
+
+
+class TestTheRecordIsNotShared(ClaimCase):
+    def test_the_record_is_not_in_the_live_sharing_block(self):
+        """It describes worktrees that exist on exactly one disk. Committing it recreates
+        the mismatch ADR 0010 dissects — a portable file describing a local reality."""
+        block = workspace._live_block(["alpha"])
+        self.assertNotIn(pieces.DIR_NAME, block)
+
+    def test_the_record_lives_inside_the_workspace(self):
+        self.assertEqual(pieces.log_path("alpha").parent.parent,
+                         workspace.workspace_dir("alpha"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -230,10 +230,14 @@ class TestAdd(WorktreeIso):
         self.assertEqual(worktree.head_of(p), ("taken", False))
 
     def test_add_refuses_a_duplicate_piece(self):
+        """Refused with `CLAIM_TAKEN`, not the generic 1 this asserted before #96. A
+        duplicate piece IS a lost claim, and the code is what lets a worker take the next
+        name from its plan without reading the message."""
         a = _Args(workspace=self.ws, repo="iam-service", piece="spi-schema")
         self.assertEqual(self.cw.cmd_worktree_add(a), 0)
         self.assertEqual(self.cw.cmd_worktree_add(
-            _Args(workspace=self.ws, repo="iam-service", piece="spi-schema")), 1)
+            _Args(workspace=self.ws, repo="iam-service", piece="spi-schema")),
+            self.cw.CLAIM_TAKEN)
 
     def test_add_never_writes_inside_the_clone(self):
         before = sorted(p.name for p in self.clone.iterdir())


### PR DESCRIPTION
Closes #96. Second ticket of the fleet outcome spine (#95); gates #97.

`charter worktree add` becomes the **act of claiming**. It records that this session took the piece, so `charter worktree list` can name the claimant — a worktree's existence proves *somebody* took it and says nothing about who, since git records an author only once a commit lands.

```
--- worker A claims 'parser' ---
✓ src · parser → workspaces/demo/.worktrees/src/parser
--- worker B races the same piece ---
✗ 'parser' is already claimed — held by a worktree at workspaces/demo/.worktrees/src/parser.
• Take the next unclaimed piece from the plan, or work in the existing worktree.
  → exit code: 2
--- listing ---
    lexer                    lexer                        clean    worker-B
    parser                   parser                       clean    worker-A
```

## The record

New `charter.pieces`. Holds **only what git cannot know** (ADR 0011) — no branch, no path, no dirty or pushed flag, asserted as a closed key set by a test, because a record with one extra convenient field is how that decision gets reversed without anyone saying so.

**Events, never state.** *"claimed at T by X"* cannot become false; *"X holds P"* goes false the moment the worktree is removed by hand. So listings start from git and join this on to name what git found — the record is never asked which worktrees exist.

Not committed, and not in the live-sharing block: it describes worktrees that exist on exactly one disk, which is the portable-file-describing-local-reality mismatch ADR 0010 dissects. Borrows `dispatch.py`'s `O_APPEND`-no-locks pattern and keeps the host in the filename, so nothing changes if fleets ever span machines. Writes are best-effort — the worktree *is* the claim, and losing the bookkeeping must not undo what git granted.

## Losing, made legible

Exit code **2** (`CLAIM_TAKEN`) rather than the generic 1 every other failure returns, so a worker takes the next name from its plan on the code alone and never mistakes an invalid piece name for a lost race.

Three shapes of the same collision are unified, because *which* one a worker hits is a matter of timing: the path already existing; the branch already checked out by another live piece; and `git worktree add` itself failing because a racer won between the pre-check and git's lock. That last is classified by **re-reading reality** — is the path or branch held now? — never by parsing git's stderr, since inventing a signature is what ADR 0009 forbids.

A branch that merely *exists* with no worktree on it is deliberately **not** a holder. Nobody is working in it, and calling it claimed would send workers past names that were free.

## Note for reviewers

`test_add_refuses_a_duplicate_piece` changed: it pinned exit 1, and a duplicate piece IS a lost claim. That's the one intentional behaviour change to an existing contract.

## Tests

17 new in `tests/test_piece_claim.py`, real git throughout. Covers the record's contents as a closed set, session/host/absent-session, the claimant in the listing, a hand-made worktree reported as **claimant unknown** and never refused, all three collision shapes, the branch-exists-but-unheld specificity case, a simulated lost race inside git, four threads contending for one piece with exactly one winner, 200 concurrent appends all landing whole, best-effort write failure, and the live-sharing exclusion.

Full suite: 1673 passing, up from 1656.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX