### PR TITLE
feat: a worker declares done or abandoned

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -433,6 +433,15 @@ def _add_worktree_parser(sub) -> None:
     lst.add_argument("--workspace", "-w", help="Target workspace (default: the active one).")
     lst.set_defaults(func=commands_worktree.cmd_worktree_list)
 
+    # `done` and `abandon` take no piece argument on purpose: the piece is where you are
+    # standing, and an argument is an opportunity to declare someone else's finished.
+    done = wsub.add_parser("done", help="Declare the piece you are standing in finished.")
+    done.set_defaults(func=commands_worktree.cmd_worktree_done)
+
+    ab = wsub.add_parser("abandon", help="Declare the piece you are standing in given up.")
+    ab.add_argument("reason", help="Why you stopped — what whoever picks this up reads first.")
+    ab.set_defaults(func=commands_worktree.cmd_worktree_abandon)
+
     rm = wsub.add_parser("remove", help="Remove a worktree (refuses to lose uncommitted "
                                         "or unpushed work).")
     rm.add_argument("repo")

--- a/charter/commands_worktree.py
+++ b/charter/commands_worktree.py
@@ -148,6 +148,50 @@ def cmd_worktree_add(args) -> int:
     return 0
 
 
+def _declare(event: str, reason: str | None = None) -> int:
+    """Record a declaration for the piece the caller is standing in.
+
+    Neither verb takes a piece argument, and that absence is the design: a worker naming its
+    own piece is a worker that can name someone else's. `worktree.locate` answers it from
+    the working directory — path arithmetic, no subprocess, and the same triple the rest of
+    charter identifies a piece by.
+    """
+    here = worktree.locate(Path.cwd())
+    if here is None:
+        util.err("Not inside a worktree — `done` and `abandon` declare the piece you are "
+                 "standing in, so there is nothing here to declare.")
+        util.info("cd into the piece first; `charter worktree list` shows where they are.")
+        return 1
+    ws, repo, piece = here
+
+    previous = pieces.declaration_for(ws, repo, piece)
+    if previous:
+        util.warn(f"'{piece}' was already declared {previous['event']} — recording "
+                  f"{event} over it (the earlier one stays in the log).")
+
+    pieces.record(ws, event, repo, piece, reason=reason)
+    util.ok(f"{repo} · {piece} — {event}" + (f": {reason}" if reason else ""))
+    return 0
+
+
+def cmd_worktree_done(args) -> int:
+    """Declare the piece you are in finished."""
+    return _declare("done")
+
+
+def cmd_worktree_abandon(args) -> int:
+    """Declare the piece you are in given up, with a reason.
+
+    The reason is required because it is the most useful thing an abandoning worker
+    produces — the next worker reads it instead of re-deriving why this stopped.
+    """
+    reason = (getattr(args, "reason", None) or "").strip()
+    if not reason:
+        util.err("abandon needs a reason — it is what whoever picks this up reads first.")
+        return 1
+    return _declare("abandoned", reason)
+
+
 def cmd_worktree_list(args) -> int:
     ws = workspace.resolve(getattr(args, "workspace", None))
     util.info(f"workspace: {ws}")
@@ -167,6 +211,7 @@ def cmd_worktree_list(args) -> int:
     # Rows come from git and only from git. The record is joined onto what git found, to
     # put a name on it — it is never asked which worktrees exist (ADR 0011).
     claims = pieces.claims(ws)
+    declared = pieces.declarations(ws)
 
     total = 0
     for clone in targets:
@@ -183,7 +228,8 @@ def cmd_worktree_list(args) -> int:
                 state = "dirty" if worktree.is_dirty(Path(r["path"])) else "clean"
             branch = r["branch"] or f"detached {r['path']}"
             who = pieces.claimant(claims.get((clone.name, r["piece"])))
-            print(f"    {r['piece']:<24} {branch:<28} {state:<8} {who}")
+            said = pieces.outcome(declared.get((clone.name, r["piece"])))
+            print(f"    {r['piece']:<24} {branch:<28} {state:<8} {who:<16} {said}".rstrip())
             total += 1
     if not total:
         util.info("No worktrees. Create one: "

--- a/charter/pieces.py
+++ b/charter/pieces.py
@@ -52,7 +52,19 @@ DIR_NAME = "pieces"
 
 #: Every key a line may carry. A closed set, asserted by the tests: this is where an
 #: innocent-looking extra field would quietly reverse ADR 0011.
-FIELDS = ("ts", "event", "repo", "piece", "session", "host", "persona")
+FIELDS = ("ts", "event", "repo", "piece", "session", "host", "persona", "reason")
+
+#: The whole vocabulary. ``claimed`` is an observation charter makes when it creates the
+#: worktree; the other two are the worker's declarations.
+#:
+#: There is deliberately no ``failed``, ``blocked`` or ``timed-out``. charter can verify
+#: none of them, and a state nobody can verify is the marker that lies — a worker that dies
+#: declares nothing at all, and that *absence* is what gets reported, with an age. Adding a
+#: value here is how this design stops being honest.
+EVENTS = ("claimed", "done", "abandoned")
+
+#: The subset a worker declares about itself, as opposed to what charter observed.
+DECLARATIONS = ("done", "abandoned")
 
 
 def _host() -> str:
@@ -73,14 +85,21 @@ def log_path(ws: str) -> Path:
     return dir_for(ws) / f"{_host()}.jsonl"
 
 
-def record(ws: str, event: str, repo: str, piece: str,
+def record(ws: str, event: str, repo: str, piece: str, reason: str | None = None,
            when: datetime | None = None) -> Path | None:
     """Append one event. Best-effort: returns ``None`` if it could not be written.
 
-    Swallowing the failure is deliberate. This is bookkeeping about a claim that git has
-    already granted — raising here would fail a command whose real work succeeded, and a
+    Swallowing an I/O failure is deliberate. This is bookkeeping about a claim that git has
+    already granted — raising there would fail a command whose real work succeeded, and a
     worker cannot un-create its worktree in response.
+
+    An event outside :data:`EVENTS` raises instead, because it is a different kind of
+    problem: not a disk that was full, but a caller inventing vocabulary. Swallowing that
+    would let a ``failed`` state reach the log and be reported as if charter had verified
+    it, which is the whole thing this design refuses to do.
     """
+    if event not in EVENTS:
+        raise ValueError(f"unknown piece event {event!r} — the vocabulary is {EVENTS}")
     when = when or _now()
     line = {
         "ts": when.isoformat(timespec="seconds"),
@@ -91,6 +110,8 @@ def record(ws: str, event: str, repo: str, piece: str,
         "host": _host(),
         "persona": persona.resolve_active(),
     }
+    if reason:
+        line["reason"] = reason
     p = log_path(ws)
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
@@ -148,6 +169,33 @@ def claims(ws: str) -> dict[tuple[str, str], dict]:
 
 def claim_for(ws: str, repo: str, piece: str) -> dict | None:
     return claims(ws).get((repo, piece))
+
+
+def declarations(ws: str) -> dict[tuple[str, str], dict]:
+    """The latest declaration per piece, keyed ``(repo, piece)``.
+
+    Latest wins, and the earlier ones stay in the log. A worker that declared ``done`` and
+    then found it was not done must be able to say so, and the history of it having changed
+    its mind is worth more than a record that pretends the first answer never happened.
+    """
+    out: dict[tuple[str, str], dict] = {}
+    for e in events(ws):
+        if e.get("event") in DECLARATIONS:
+            out[(e.get("repo") or "", e["piece"])] = e
+    return out
+
+
+def declaration_for(ws: str, repo: str, piece: str) -> dict | None:
+    return declarations(ws).get((repo, piece))
+
+
+def outcome(entry: dict | None) -> str:
+    """How a declaration reads in a listing. Empty when there is none — which is *silence*,
+    not a third outcome, and #98 is what gives it an age."""
+    if not entry:
+        return ""
+    reason = entry.get("reason")
+    return f"{entry['event']}: {reason}" if reason else entry["event"]
 
 
 def claimant(entry: dict | None) -> str:

--- a/tests/test_piece_declare.py
+++ b/tests/test_piece_declare.py
@@ -1,0 +1,161 @@
+"""Declaring a piece done or abandoned (#97).
+
+The only two declarations there are. `failed`, `blocked` and `timed-out` are absent on
+purpose: charter can verify none of them, and a state nobody can verify is the marker that
+lies (ADR 0009, ADR 0011). A worker that dies declares nothing at all, and that absence is
+the subject of #98 — not a third value here.
+
+Neither verb takes a piece argument. The piece comes from where you are standing, because
+every argument is an opportunity to name someone else's piece.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import unittest
+from contextlib import chdir, redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+
+from charter import pieces, workspace, worktree
+from charter import commands_worktree as cwt
+from tests._isolation import PersonaIso
+
+_GIT_ENV = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e"}
+
+
+class DeclareCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(redirect_stdout(io.StringIO()))
+        workspace.ensure("alpha")
+        workspace.scaffold("alpha")
+        self.clone = workspace.workspace_dir("alpha") / "svc"
+        self.clone.mkdir(parents=True, exist_ok=True)
+        env = {**os.environ, **_GIT_ENV}
+        subprocess.run(["git", "init", "-q", "-b", "main", str(self.clone)], check=True,
+                       capture_output=True, env=env)
+        (self.clone / "README").write_text("base\n")
+        subprocess.run(["git", "-C", str(self.clone), "add", "-A"], check=True,
+                       capture_output=True, env=env)
+        subprocess.run(["git", "-C", str(self.clone), "-c", "commit.gpgsign=false",
+                        "commit", "-qm", "base"], check=True, capture_output=True, env=env)
+        with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            cwt.cmd_worktree_add(SimpleNamespace(repo="svc", piece="slice", branch=None,
+                                                 workspace="alpha"))
+        self.wt = worktree.path_for("alpha", "svc", "slice")
+
+    def declare(self, verb: str, reason: str | None = None, cwd=None):
+        """Returns (rc, stdout + stderr). Run from *cwd*, since that is what names the
+        piece — the whole point of the two verbs taking no argument."""
+        out, err = io.StringIO(), io.StringIO()
+        args = SimpleNamespace() if reason is None else SimpleNamespace(reason=reason)
+        fn = cwt.cmd_worktree_done if verb == "done" else cwt.cmd_worktree_abandon
+        with chdir(cwd or self.wt), redirect_stdout(out), redirect_stderr(err):
+            rc = fn(args)
+        return rc, out.getvalue() + err.getvalue()
+
+    def listing(self):
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            cwt.cmd_worktree_list(SimpleNamespace(repo="svc", workspace="alpha"))
+        return out.getvalue() + err.getvalue()
+
+
+class TestDeclaringDone(DeclareCase):
+    def test_done_records_a_declaration_for_the_piece_you_are_in(self):
+        rc, _ = self.declare("done")
+        self.assertEqual(rc, 0)
+        d = pieces.declaration_for("alpha", "svc", "slice")
+        self.assertEqual(d["event"], "done")
+
+    def test_done_takes_no_piece_argument(self):
+        """Asserted against the signature, because the protection is the *absence* of the
+        argument — a later refactor that adds one back would pass every other test here."""
+        import inspect
+        params = inspect.signature(cwt.cmd_worktree_done).parameters
+        self.assertEqual(list(params), ["args"])
+        rc, _ = self.declare("done")
+        self.assertEqual(rc, 0)
+
+    def test_the_declaration_shows_in_the_listing(self):
+        self.declare("done")
+        self.assertIn("done", self.listing())
+
+
+class TestDeclaringAbandoned(DeclareCase):
+    def test_abandon_records_the_reason(self):
+        rc, _ = self.declare("abandon", "the fixture needs a live forge token")
+        self.assertEqual(rc, 0)
+        d = pieces.declaration_for("alpha", "svc", "slice")
+        self.assertEqual(d["event"], "abandoned")
+        self.assertIn("forge token", d["reason"])
+
+    def test_abandon_refuses_an_empty_reason(self):
+        """The reason is the most useful thing an abandoning worker produces — it is what
+        the next worker reads instead of re-deriving why this stopped."""
+        rc, out = self.declare("abandon", "   ")
+        self.assertNotEqual(rc, 0)
+        self.assertIsNone(pieces.declaration_for("alpha", "svc", "slice"))
+        self.assertIn("reason", out.lower())
+
+    def test_the_reason_shows_in_the_listing(self):
+        self.declare("abandon", "blocked on a denial")
+        self.assertIn("blocked on a denial", self.listing())
+
+
+class TestDeclaringOutsideAWorktree(DeclareCase):
+    def test_done_outside_a_worktree_refuses(self):
+        rc, out = self.declare("done", cwd=self.clone)
+        self.assertNotEqual(rc, 0)
+        self.assertIn("worktree", out.lower())
+
+    def test_abandon_outside_a_worktree_refuses(self):
+        rc, out = self.declare("abandon", "whatever", cwd=self.clone)
+        self.assertNotEqual(rc, 0)
+        self.assertIn("worktree", out.lower())
+
+    def test_nothing_is_recorded_when_it_refuses(self):
+        self.declare("done", cwd=self.clone)
+        self.assertEqual([e["event"] for e in pieces.events("alpha")], ["claimed"])
+
+
+class TestDeclaringTwice(DeclareCase):
+    def test_the_latest_declaration_wins(self):
+        """A worker that declares done and then finds it was not done must be able to say
+        so. The log is append-only, so the first declaration survives as history."""
+        self.declare("done")
+        self.declare("abandon", "the tests only passed locally")
+        d = pieces.declaration_for("alpha", "svc", "slice")
+        self.assertEqual(d["event"], "abandoned")
+        self.assertEqual([e["event"] for e in pieces.events("alpha")],
+                         ["claimed", "done", "abandoned"])
+
+    def test_redeclaring_says_so(self):
+        """Predictable, not silent: overwriting an outcome is worth one line, because the
+        common cause is a worker that did not know the piece was already declared."""
+        self.declare("done")
+        _, out = self.declare("done")
+        self.assertIn("already", out.lower())
+
+
+class TestTheVocabularyIsClosed(DeclareCase):
+    def test_no_state_other_than_done_or_abandoned_can_be_recorded(self):
+        """`failed`, `blocked` and `timed-out` are absent because charter can verify none
+        of them. This raises rather than returning None: an unknown event is a programming
+        mistake, not the runtime condition that `record`'s best-effort contract covers."""
+        for bogus in ("failed", "blocked", "timed-out", "stuck"):
+            with self.assertRaises(ValueError):
+                pieces.record("alpha", bogus, "svc", "slice")
+
+    def test_the_record_keys_stay_a_closed_set(self):
+        self.declare("abandon", "why")
+        allowed = set(pieces.FIELDS)
+        for e in pieces.events("alpha"):
+            self.assertEqual(set(e) - allowed, set())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #97. Third ticket of the fleet outcome spine (#95); gates #98 and #101.

```
--- worker A finishes ---
✓ src · parser — done
--- worker B gives up ---
✓ src · lexer — abandoned: the grammar fixture needs a live token
--- declaring outside a worktree ---
✗ Not inside a worktree — `done` and `abandon` declare the piece you are standing in, so there is nothing here to declare.
• cd into the piece first; `charter worktree list` shows where they are.
--- listing ---
    codegen    codegen    clean    worker-C
    lexer      lexer      clean    worker-B    abandoned: the grammar fixture needs a live token
    parser     parser     clean    worker-A    done
```

`codegen` says nothing. That is **silence** — not a third outcome, and #98 is what gives it an age.

## No piece argument

That absence is the design, not an omission: a worker naming its own piece is a worker that can name someone else's. `worktree.locate` answers it from the working directory — path arithmetic, no subprocess, the same triple the rest of charter identifies a piece by. There's a test asserting the *signature*, because a later refactor that adds the argument back would pass every other test here.

## The vocabulary is closed, and enforced by raising

`EVENTS` is `claimed`/`done`/`abandoned`, and `record` **raises** on anything else — deliberately a different failure mode from the best-effort `OSError` path beside it. A full disk is a runtime condition; a caller inventing `failed` is a programming mistake, and swallowing the second would let a state charter never verified reach the log and be reported as though it had.

No `failed`, `blocked` or `timed-out`. A worker that dies declares nothing, and that absence is #98's subject.

## Declaring twice

Allowed, warned about, latest wins, both kept. A worker that declared `done` and then found it wasn't must be able to say so — this is the append-only property doing real work rather than being a slogan.

## Tests

13 new in `tests/test_piece_declare.py`: both verbs, the reason required and rendered, refusal outside a worktree with nothing recorded, the no-argument signature, redeclaration ordering and warning, and the closed vocabulary.

Full suite: 1686 passing, up from 1673.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX