### PR TITLE
feat: a worker that dies leaves silence with an age

### DIFF
--- a/charter/commands_worktree.py
+++ b/charter/commands_worktree.py
@@ -229,6 +229,11 @@ def cmd_worktree_list(args) -> int:
             branch = r["branch"] or f"detached {r['path']}"
             who = pieces.claimant(claims.get((clone.name, r["piece"])))
             said = pieces.outcome(declared.get((clone.name, r["piece"])))
+            if not said:
+                quiet = pieces.silence(ws, clone.name, r["piece"])
+                # An age, never a verdict. Whether `silent 3d` is a problem is the reader's
+                # call — charter has not verified that the worker is gone (ADR 0009).
+                said = f"silent {quiet}" if quiet else ""
             print(f"    {r['piece']:<24} {branch:<28} {state:<8} {who:<16} {said}".rstrip())
             total += 1
     if not total:

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -473,8 +473,35 @@ def _trace(event, session, **f):
         pass
 
 
+def _touch_piece(data: dict) -> None:
+    """Record that the worker in this session's directory is alive.
+
+    Called from the handlers that already run whenever a session is doing anything, which
+    is the point: liveness must not depend on the worker remembering, because the worker we
+    most need to catch is precisely the one that did not. A session outside a worktree has
+    no piece and writes nothing.
+
+    Silent and best-effort like everything else in this module — a turn must never fail
+    over bookkeeping. It is one small overwritten file, so the cost is a write, not a grep.
+    """
+    try:
+        cwd = data.get("cwd") or ""
+        if not cwd:
+            return
+        from pathlib import Path as _Path
+        from . import pieces, worktree
+        here = worktree.locate(_Path(cwd))
+        if here is None:
+            return
+        ws, repo, piece = here
+        pieces.seen(ws, repo, piece, session=data.get("session_id"))
+    except Exception:
+        return
+
+
 def pretooluse() -> int:
     data = _read_stdin()
+    _touch_piece(data)
     ti = data.get("tool_input") or {}
     cmd = ti.get("command", "") or ""
     cwd = data.get("cwd") or ""
@@ -753,6 +780,7 @@ def _autosync_version_lock() -> str | None:
 
 def sessionstart() -> int:
     data = _read_stdin()
+    _touch_piece(data)
     sid = data.get("session_id")
     try:
         from . import persona
@@ -949,6 +977,7 @@ def memory_share_note() -> str:
 
 def posttooluse() -> int:
     data = _read_stdin()
+    _touch_piece(data)
     if (data.get("tool_name") or "") not in ("Write", "Edit", "MultiEdit"):
         return 0
     ti = data.get("tool_input") or {}
@@ -1331,6 +1360,7 @@ def _commitment_nudge(prompt: str, sid: str | None) -> str:
 
 def userpromptsubmit() -> int:
     data = _read_stdin()
+    _touch_piece(data)
     sid = data.get("session_id")
     parts = []
     try:

--- a/charter/pieces.py
+++ b/charter/pieces.py
@@ -189,6 +189,89 @@ def declaration_for(ws: str, repo: str, piece: str) -> dict | None:
     return declarations(ws).get((repo, piece))
 
 
+#: Liveness lives under here, one file per piece, OVERWRITTEN rather than appended.
+#:
+#: It is written by a hook that fires every turn. Appending it to the log would bury three
+#: meaningful lines per piece under thousands and make the log unbounded, so it is a
+#: separate store answering a separate question — the log is *what happened*, this is *the
+#: latest observation*. Overwriting breaches nothing: "last seen at T" is a past
+#: observation, not a cached derivable fact, and there is no reality it can contradict.
+#: What it discards is heartbeat history, which nothing needs.
+SEEN_DIR = "seen"
+
+
+def seen_path(ws: str, repo: str, piece: str) -> Path:
+    return dir_for(ws) / SEEN_DIR / repo / f"{piece}.json"
+
+
+def seen(ws: str, repo: str, piece: str, session: str | None = None,
+         when: datetime | None = None) -> Path | None:
+    """Mark a piece's worker alive now. Best-effort — never raises, never blocks a turn."""
+    p = seen_path(ws, repo, piece)
+    when = when or _now()
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"ts": when.isoformat(timespec="seconds"),
+                                 "session": session}, sort_keys=True) + "\n")
+        return p
+    except OSError:
+        return None
+
+
+def last_seen(ws: str, repo: str, piece: str) -> dict | None:
+    """The latest observation of this piece's worker, or ``None``.
+
+    A malformed file reads as ``None`` rather than raising. An append-only world collects
+    half-written files from killed processes, and this feeds a listing and a status line —
+    both of which must render whatever they find.
+    """
+    try:
+        obj = json.loads(seen_path(ws, repo, piece).read_text())
+    except (OSError, ValueError):
+        return None
+    return obj if isinstance(obj, dict) and obj.get("ts") else None
+
+
+def _parse(ts: str | None) -> datetime | None:
+    try:
+        return datetime.fromisoformat(ts) if ts else None
+    except (TypeError, ValueError):
+        return None
+
+
+def since(when: datetime | None, now: datetime | None = None) -> str:
+    """A coarse age — ``3m``, ``5h``, ``3d``. Coarse on purpose: the number is context for
+    a human decision, not an input to one charter is making."""
+    if when is None:
+        return "?"
+    secs = max(0, int(((now or _now()) - when).total_seconds()))
+    if secs < 3600:
+        return f"{secs // 60}m"
+    if secs < 86400:
+        return f"{secs // 3600}h"
+    return f"{secs // 86400}d"
+
+
+def silence(ws: str, repo: str, piece: str) -> str | None:
+    """How long this piece has said nothing, or ``None`` if it declared an outcome.
+
+    Measured from the last observation, falling back to the **claim** when the worker never
+    got as far as a first turn — that is precisely the case worth seeing, and answering
+    "unknown" there would lose it.
+
+    Note what is deliberately absent: any judgement. This returns an age. Whether an age is
+    a problem is the reader's call, and no threshold here may ever make it charter's
+    (ADR 0009, ADR 0011).
+    """
+    if declaration_for(ws, repo, piece):
+        return None
+    claim = claim_for(ws, repo, piece)
+    if not claim:
+        return None
+    mark = last_seen(ws, repo, piece)
+    return since(_parse((mark or {}).get("ts")) or _parse(claim.get("ts")))
+
+
 def outcome(entry: dict | None) -> str:
     """How a declaration reads in a listing. Empty when there is none — which is *silence*,
     not a third outcome, and #98 is what gives it an age."""

--- a/tests/test_piece_silence.py
+++ b/tests/test_piece_silence.py
@@ -1,0 +1,165 @@
+"""Silence — a claim with no declaration, carrying an age (#98).
+
+The case the whole spine exists for. A worker that hits a denial, times out, or is killed
+declares nothing, and a branch with three commits and no further activity looks identical
+whether its worker finished deliberately or died. Liveness is what separates them, and it
+has to be recorded *for* the worker rather than by it: the worker we most need to catch is
+precisely the one that did not remember.
+
+What charter says about silence is its age and nothing else. No threshold turns it into a
+verdict — a piece marked `failed` that was running a forty-minute test suite is ADR 0009's
+exact failure one level up, and a confident wrong answer tells the reader to stop looking.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from charter import hooks, pieces, workspace, worktree
+from charter import commands_worktree as cwt
+from tests._isolation import PersonaIso, run_hook
+
+_GIT_ENV = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e"}
+
+
+class SilenceCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(redirect_stdout(io.StringIO()))
+        workspace.ensure("alpha")
+        workspace.scaffold("alpha")
+        self.clone = workspace.workspace_dir("alpha") / "svc"
+        self.clone.mkdir(parents=True, exist_ok=True)
+        env = {**os.environ, **_GIT_ENV}
+        subprocess.run(["git", "init", "-q", "-b", "main", str(self.clone)], check=True,
+                       capture_output=True, env=env)
+        (self.clone / "README").write_text("base\n")
+        subprocess.run(["git", "-C", str(self.clone), "add", "-A"], check=True,
+                       capture_output=True, env=env)
+        subprocess.run(["git", "-C", str(self.clone), "-c", "commit.gpgsign=false",
+                        "commit", "-qm", "base"], check=True, capture_output=True, env=env)
+        with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            cwt.cmd_worktree_add(SimpleNamespace(repo="svc", piece="slice", branch=None,
+                                                 workspace="alpha"))
+        self.wt = worktree.path_for("alpha", "svc", "slice")
+
+    def touch(self, cwd=None, sid="worker-A"):
+        """A turn happening — the hook fires, the worker does nothing."""
+        return run_hook(hooks.userpromptsubmit,
+                        {"cwd": str(cwd or self.wt), "session_id": sid, "prompt": "carry on"})
+
+    def listing(self):
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            cwt.cmd_worktree_list(SimpleNamespace(repo="svc", workspace="alpha"))
+        return out.getvalue() + err.getvalue()
+
+    def backdate(self, minutes: int):
+        """Rewrite the last-seen mark into the past, since a test cannot wait an hour."""
+        when = datetime.now(timezone.utc) - timedelta(minutes=minutes)
+        pieces.seen("alpha", "svc", "slice", session="worker-A", when=when)
+
+
+class TestLivenessIsRecordedForTheWorker(SilenceCase):
+    def test_a_hook_records_liveness_with_no_action_by_the_worker(self):
+        self.assertIsNone(pieces.last_seen("alpha", "svc", "slice"))
+        self.touch()
+        self.assertIsNotNone(pieces.last_seen("alpha", "svc", "slice"))
+
+    def test_liveness_is_overwritten_rather_than_appended(self):
+        """The hook fires every turn. Appending would bury three meaningful lines per piece
+        under thousands, and make the log unbounded — so this is a different store, and
+        `last seen at T` is a past observation with no history worth keeping."""
+        for _ in range(5):
+            self.touch()
+        p = pieces.seen_path("alpha", "svc", "slice")
+        self.assertEqual(len(p.read_text().strip().splitlines()), 1)
+
+    def test_liveness_never_enters_the_declaration_log(self):
+        self.touch()
+        self.assertEqual([e["event"] for e in pieces.events("alpha")], ["claimed"])
+
+    def test_a_session_outside_a_worktree_records_nothing(self):
+        self.touch(cwd=self.clone)
+        self.assertIsNone(pieces.last_seen("alpha", "svc", "slice"))
+
+    def test_the_hook_never_fails_the_session(self):
+        """Hooks are silent-on-error by discipline. Liveness is bookkeeping; a session must
+        never die because it could not be written."""
+        d = pieces.seen_path("alpha", "svc", "slice").parent
+        d.mkdir(parents=True, exist_ok=True)
+        d.chmod(0o500)
+        self.addCleanup(d.chmod, 0o700)
+        self.touch()  # must not raise
+        self.assertIsNone(pieces.last_seen("alpha", "svc", "slice"))
+
+
+class TestSilenceIsReported(SilenceCase):
+    def test_a_claim_with_no_declaration_reads_as_silent_with_an_age(self):
+        self.backdate(12)
+        out = self.listing()
+        self.assertIn("silent", out)
+        self.assertIn("12m", out)
+
+    def test_a_declared_piece_is_not_silent(self):
+        """Silence is the absence of a declaration, so a declaration ends it. Reporting
+        both would make `done` look like a problem."""
+        self.backdate(90)
+        pieces.record("alpha", "done", "svc", "slice")
+        out = self.listing()
+        self.assertIn("done", out)
+        self.assertNotIn("silent", out)
+
+    def test_silence_is_measured_from_the_claim_when_nothing_was_ever_seen(self):
+        """A worker that died before its first turn left no liveness mark at all. The claim
+        is still a moment in the past, so the age is knowable — falling back to "no idea"
+        would lose the only case where the worker never got going."""
+        self.assertIn("silent", self.listing())
+
+
+class TestSilenceIsNeverDiagnosed(SilenceCase):
+    def test_no_verdict_wording_however_long_the_silence(self):
+        """Somebody will want a threshold here. ADR 0011 says no, and this is the test that
+        makes adding one fail rather than merely disagree with a document."""
+        for minutes in (1, 60, 60 * 24, 60 * 24 * 30):
+            self.backdate(minutes)
+            out = self.listing().lower()
+            for verdict in ("failed", "dead", "stuck", "timed out", "timed-out",
+                            "blocked", "abandoned", "orphan"):
+                self.assertNotIn(verdict, out, f"{verdict!r} at {minutes}m")
+
+    def test_the_age_grows_with_the_silence(self):
+        self.backdate(3)
+        self.assertIn("3m", self.listing())
+        self.backdate(60 * 5)
+        self.assertIn("5h", self.listing())
+        self.backdate(60 * 24 * 3)
+        self.assertIn("3d", self.listing())
+
+
+class TestTheLivenessStoreIsSeparate(SilenceCase):
+    def test_liveness_lives_beside_the_log_not_inside_it(self):
+        self.touch()
+        self.assertNotIn(".jsonl", pieces.seen_path("alpha", "svc", "slice").name)
+        self.assertEqual(pieces.events("alpha")[0]["event"], "claimed")
+
+    def test_a_malformed_liveness_mark_is_not_fatal(self):
+        """An append-only world collects half-written files from killed processes; a
+        listing that raises on one is worse than a listing that shows no age."""
+        p = pieces.seen_path("alpha", "svc", "slice")
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{not json")
+        self.assertIsNone(pieces.last_seen("alpha", "svc", "slice"))
+        self.assertIn("silent", self.listing())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #98. Fourth ticket of the fleet outcome spine (#95); gates #99 and #100.

A branch with three commits and no further activity looks identical whether its worker finished deliberately, hit a denial, or was killed. Liveness is what separates them — and it is recorded **for** the worker rather than by it, because the worker most worth catching is precisely the one that did not remember.

## Where it is written

From the handlers that already run whenever a session does anything: `sessionstart`, `userpromptsubmit`, `pretooluse`, `posttooluse`. No new hook registration, and `hooks/hooks.json` is untouched.

Worth saying why there is no `Stop` hook here: this repo's registry has six handlers and Stop is not among them. Adding one would have been a bigger change for a worse signal — an autonomous worker submits no prompts but uses tools constantly, so tool-adjacent hooks track it far better than turn-end would.

A session outside a worktree has no piece and writes nothing. Silent and best-effort, per the module's discipline: a turn must never fail over bookkeeping.

## Why it is not in the log

The hook fires every turn. Appending would bury three meaningful lines per piece under thousands and make the log unbounded. So it is a separate store answering a separate question — the log is *what happened*, this is *the latest observation*. Overwriting breaches ADR 0011 not at all: "last seen at T" is a past observation, not a cached derivable fact. What it discards is heartbeat history, which nothing needs.

## Two details worth a look

**Silence falls back to the claim** when a worker never got as far as a first turn. That is exactly the case worth seeing, and answering "unknown" there would lose it.

**No threshold, anywhere.** A test iterates a minute, an hour, a day and a month and asserts no verdict word appears in the output — so adding one fails the suite rather than merely disagreeing with a document. That is the guard on the decision most likely to be "improved" later.

## Tests

12 new in `tests/test_piece_silence.py`, driven through the hook entry point with a JSON payload. Covers liveness written with no worker action, overwritten not appended, absent from the log, nothing written outside a worktree, the hook surviving an unwritable directory, silence with an age, a declaration ending silence, the claim fallback, ages growing m→h→d, the no-verdict sweep, and a malformed mark rendering rather than raising.

Full suite: 1698 passing, up from 1686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX