### PR TITLE
feat: SessionStart tells a worker which piece it holds and what it owes

### DIFF
--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -499,6 +499,65 @@ def _touch_piece(data: dict) -> None:
         return
 
 
+#: SessionStart `source` values that mean "this is the same work continuing", not a second
+#: worker arriving. A resumed session gets a NEW session id, so an id check alone would warn
+#: on every resume — which is the fastest way to teach people to ignore the warning.
+_CONTINUATIONS = ("resume", "clear", "compact")
+
+
+def _piece_announcement(data: dict) -> str | None:
+    """Tell a session which piece it holds and what it owes — the whole reason declarations
+    ever get made, since a worker is otherwise just a session sitting in a directory.
+
+    MUST be computed before :func:`_touch_piece` writes this session's liveness, or a
+    visitor overwrites the holder's mark with its own and the collision can never be seen.
+
+    A collision is reported, never refused: ADR 0008 faced the identical choice for the
+    plane root, chose signal over refusal because which cases count is a judgement wanting
+    evidence, and recorded that the warning would be worked through at first. There are
+    legitimate second sessions — a human reading a worker's tree among them.
+    """
+    try:
+        cwd = data.get("cwd") or ""
+        if not cwd:
+            return None
+        from pathlib import Path as _Path
+        from . import pieces, worktree
+        here = worktree.locate(_Path(cwd))
+        if here is None:
+            return None
+        ws, repo, piece = here
+
+        lines = []
+        declared = pieces.declaration_for(ws, repo, piece)
+        if declared:
+            lines.append(f"⬢ You are in piece **{piece}** of `{repo}` (workspace `{ws}`), "
+                         f"already declared **{declared['event']}**.")
+        else:
+            lines.append(
+                f"⬢ You hold piece **{piece}** of `{repo}` (workspace `{ws}`). "
+                f"When you finish, declare it — nothing else will: "
+                f"`charter worktree done`, or "
+                f"`charter worktree abandon \"<why you stopped>\"` if you cannot. "
+                f"A piece that declares nothing is reported as silent, which is how a fleet "
+                f"that finished 7 of 8 stops reading as success.")
+
+        sid = data.get("session_id")
+        claim = pieces.claim_for(ws, repo, piece)
+        holder = (claim or {}).get("session")
+        if (holder and holder != sid
+                and (data.get("source") or "") not in _CONTINUATIONS):
+            age = pieces.seen_age(ws, repo, piece)
+            lines.append(
+                f"⚠ This piece was already claimed by `{holder}`, last seen {age} ago. "
+                f"Two sessions in one worktree share a working tree and a HEAD. Nothing "
+                f"stops you — this is a signal, not a refusal — but if that session is "
+                f"live, you will thrash each other's branches.")
+        return "\n".join(lines)
+    except Exception:
+        return None
+
+
 def pretooluse() -> int:
     data = _read_stdin()
     _touch_piece(data)
@@ -780,6 +839,9 @@ def _autosync_version_lock() -> str | None:
 
 def sessionstart() -> int:
     data = _read_stdin()
+    # Read the piece's existing state BEFORE recording this session as alive — the write
+    # below would otherwise replace the holder's mark with ours and hide the collision.
+    _piece_note = _piece_announcement(data)
     _touch_piece(data)
     sid = data.get("session_id")
     try:
@@ -826,6 +888,11 @@ def sessionstart() -> int:
         todo = _todo_digest(sid)
         if todo:
             parts.append(todo)
+
+        # The piece this session is standing in, last: it is the most specific thing here
+        # and the one an agent acts on immediately, so it reads closest to the work.
+        if _piece_note:
+            parts.append(_piece_note)
 
         # NOT refreshing the README's roster block here, deliberately. It splices per-
         # persona DISPATCH COUNTS into a committed file, so opening a session dirtied the

--- a/charter/pieces.py
+++ b/charter/pieces.py
@@ -252,6 +252,18 @@ def since(when: datetime | None, now: datetime | None = None) -> str:
     return f"{secs // 86400}d"
 
 
+def seen_age(ws: str, repo: str, piece: str) -> str:
+    """How long since this piece's worker was observed, falling back to its claim.
+
+    Unlike :func:`silence` this answers even for a piece that has declared an outcome — it
+    is "how long ago", not "how long has it said nothing", and the collision warning needs
+    the first question.
+    """
+    mark = last_seen(ws, repo, piece)
+    claim = claim_for(ws, repo, piece)
+    return since(_parse((mark or {}).get("ts")) or _parse((claim or {}).get("ts")))
+
+
 def silence(ws: str, repo: str, piece: str) -> str | None:
     """How long this piece has said nothing, or ``None`` if it declared an outcome.
 

--- a/tests/test_piece_session_announce.py
+++ b/tests/test_piece_session_announce.py
@@ -1,0 +1,142 @@
+"""SessionStart tells a worker which piece it holds and what it owes (#99).
+
+Nothing in this design works if workers do not declare, and a worker is just a session that
+happens to be sitting in a worktree — it has no reason to know charter wants anything from
+it. So it is told, by the mechanism that already announces workspace, persona and todos.
+
+The verbs are stated literally, because an obligation that is not spelled out is one that
+will not be met.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from charter import hooks, pieces, workspace, worktree
+from charter import commands_worktree as cwt
+from tests._isolation import PersonaIso, run_hook
+
+_GIT_ENV = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e"}
+
+
+def _context(r) -> str:
+    return (r or {}).get("hookSpecificOutput", {}).get("additionalContext", "")
+
+
+class AnnounceCase(PersonaIso):
+    """Workspace pinned through the env var, as `test_todos_session_injection.py` does, so
+    the confirm nudge's several hundred words are not most of the text every assertion
+    here has to search."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(redirect_stdout(io.StringIO()))
+        os.environ["CHARTER_WORKSPACE"] = "alpha"
+        self.addCleanup(os.environ.pop, "CHARTER_WORKSPACE", None)
+        workspace.ensure("alpha")
+        workspace.scaffold("alpha")
+        self.clone = workspace.workspace_dir("alpha") / "svc"
+        self.clone.mkdir(parents=True, exist_ok=True)
+        env = {**os.environ, **_GIT_ENV}
+        subprocess.run(["git", "init", "-q", "-b", "main", str(self.clone)], check=True,
+                       capture_output=True, env=env)
+        (self.clone / "README").write_text("base\n")
+        subprocess.run(["git", "-C", str(self.clone), "add", "-A"], check=True,
+                       capture_output=True, env=env)
+        subprocess.run(["git", "-C", str(self.clone), "-c", "commit.gpgsign=false",
+                        "commit", "-qm", "base"], check=True, capture_output=True, env=env)
+        os.environ["CLAUDE_CODE_SESSION_ID"] = "worker-A"
+        self.addCleanup(os.environ.pop, "CLAUDE_CODE_SESSION_ID", None)
+        with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            cwt.cmd_worktree_add(SimpleNamespace(repo="svc", piece="slice", branch=None,
+                                                 workspace="alpha"))
+        self.wt = worktree.path_for("alpha", "svc", "slice")
+
+    def start(self, cwd=None, sid="worker-A", source="startup") -> str:
+        return _context(run_hook(hooks.sessionstart, {
+            "cwd": str(cwd if cwd is not None else self.wt),
+            "session_id": sid, "source": source}))
+
+
+class TestTheWorkerIsToldWhatItHolds(AnnounceCase):
+    def test_a_session_inside_a_worktree_is_told_its_piece(self):
+        out = self.start()
+        self.assertIn("slice", out)
+        self.assertIn("svc", out)
+
+    def test_the_verbs_are_stated_literally(self):
+        """Naming the obligation without naming the commands is how it goes unmet."""
+        out = self.start()
+        self.assertIn("charter worktree done", out)
+        self.assertIn("charter worktree abandon", out)
+
+    def test_a_session_outside_a_worktree_hears_nothing_about_pieces(self):
+        out = self.start(cwd=self.clone)
+        self.assertNotIn("slice", out)
+        self.assertNotIn("charter worktree done", out)
+
+    def test_a_declared_piece_is_not_asked_to_declare_again(self):
+        """The obligation is discharged. Repeating it is how a reminder becomes noise."""
+        pieces.record("alpha", "done", "svc", "slice")
+        out = self.start()
+        self.assertNotIn("charter worktree done", out)
+
+
+class TestCollisionIsReportedNotRefused(AnnounceCase):
+    def test_entering_a_piece_another_session_holds_says_so(self):
+        out = self.start(sid="worker-B")
+        self.assertIn("worker-A", out)
+
+    def test_the_collision_carries_the_holders_last_seen_age(self):
+        pieces.seen("alpha", "svc", "slice", session="worker-A",
+                    when=datetime.now(timezone.utc) - timedelta(minutes=20))
+        out = self.start(sid="worker-B")
+        self.assertIn("20m", out)
+
+    def test_the_session_is_not_refused(self):
+        """ADR 0008's trade, knowingly repeated: signal, not refusal. There are legitimate
+        second sessions — a human inspecting a worker's tree among them."""
+        rc = run_hook(hooks.sessionstart,
+                      {"cwd": str(self.wt), "session_id": "worker-B", "source": "startup"})
+        self.assertIsNotNone(rc)  # emitted context, exited normally
+
+    def test_my_own_claim_does_not_warn_me(self):
+        out = self.start(sid="worker-A")
+        self.assertNotIn("already", out.lower())
+
+    def test_a_resumed_session_is_not_warned_about_itself(self):
+        """A resumed session gets a new id, so the id check alone would fire on every
+        resume — which is the fastest way to make the signal ignored."""
+        for source in ("resume", "clear", "compact"):
+            out = self.start(sid="worker-A-resumed", source=source)
+            self.assertNotIn("worker-A", out, source)
+
+    def test_the_holders_liveness_is_not_clobbered_by_the_visitor(self):
+        """The ordering trap: liveness is written at the top of the handler, so a naive
+        implementation overwrites the holder's mark with the visitor's before reading it —
+        and the warning could then never fire twice."""
+        pieces.seen("alpha", "svc", "slice", session="worker-A",
+                    when=datetime.now(timezone.utc) - timedelta(minutes=20))
+        self.start(sid="worker-B")
+        self.assertIn("worker-A", self.start(sid="worker-C"))
+
+
+class TestNoTurnEndNagging(AnnounceCase):
+    def test_the_reminder_does_not_repeat_every_turn(self):
+        """Liveness is already automatic, so a per-turn reminder adds nothing but noise —
+        and ADR 0008 records what becomes of a warning you can work through."""
+        out = _context(run_hook(hooks.userpromptsubmit,
+                                {"cwd": str(self.wt), "session_id": "worker-A",
+                                 "prompt": "carry on"}))
+        self.assertNotIn("charter worktree done", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #99. Sixth ticket of the fleet outcome spine (#95).

A worker is just a session sitting in a worktree — it has no reason to know charter wants anything from it. So it is told, by the mechanism that already announces workspace, persona and todos, **with the verbs spelled out**: an obligation that is not stated is one that will not be met.

## The ordering trap

`_touch_piece` (from #98) runs at the top of the handler. The announcement therefore has to be computed **before** it — otherwise a visiting session overwrites the holder's liveness mark with its own, and the collision can never be seen.

There's a test for exactly that: after worker B visits, worker C arrives and must still be told worker A holds it.

## Reported, never refused

ADR 0008 faced the identical choice for the plane root, chose signal over refusal because which cases count is a judgement wanting evidence, and recorded that the warning would be worked through at first. Same trade, knowingly repeated — there are legitimate second sessions, a human reading a worker's tree among them.

## Resume needs more than an id check

A resumed session gets a **new** session id, so comparing ids alone would warn on every resume — the fastest way to teach people to ignore the signal. `source` in `(resume, clear, compact)` is the same work continuing, not a second worker arriving.

## Two smaller calls

A piece that has already declared is told so and **not** asked to declare again — repeating a discharged obligation is how a reminder becomes noise. And there is no turn-end nagging: liveness is already automatic, so a per-turn reminder adds only the thing ADR 0008 warns about. A test pins that `userpromptsubmit` says nothing about pieces.

## Tests

11 new in `tests/test_piece_session_announce.py`, driven through the hook entry point. Covers the announcement and its literal verbs, silence outside a worktree, a declared piece not being re-asked, the collision with its holder and last-seen age, the session not being refused, own-claim and resumed-session exemptions, the liveness-clobber ordering trap, and no turn-end repeat.

Full suite: 1718 passing, up from 1707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX