### PR TITLE
feat: the status line shows the fleet at a glance

### DIFF
--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -601,6 +601,90 @@ def _detail_worktrees(ws: str, dirs) -> list[Path]:
         return []
 
 
+def _piece_state(ws: str, repo: str, piece: str) -> str:
+    """What a piece row says about itself: its declaration, or how long it has been silent.
+
+    Never a verdict. `silent 3d` is an age and whether that is a problem is the reader's
+    call — charter has not verified that the worker is gone, and ADR 0009's rule about
+    unearned diagnoses applies with more force here than anywhere, because the status line
+    is read at a glance and its wording is taken as settled.
+
+    File reads only: this is on the every-turn path and the module's contract forbids a git
+    subprocess. Returns "" rather than raising on anything unreadable — a footer that
+    blanks is worse than one that shows less.
+    """
+    try:
+        from . import pieces as _p
+        said = _p.outcome(_p.declaration_for(ws, repo, piece))
+        if said:
+            return said.split(":")[0]  # the reason belongs in `worktree list`, not here
+        quiet = _p.silence(ws, repo, piece)
+        return f"silent {quiet}" if quiet else ""
+    except Exception:
+        return ""
+
+
+def _piece_summary(ws: str) -> str | None:
+    """The workspace line's piece cell — counts, and the oldest silence.
+
+    Omitted entirely when the workspace has no pieces, exactly as the todo count is: a
+    figure that renders on every session including the ones it means nothing for is how a
+    line stops being read at all.
+
+    Existence comes from `worktree.dirs_for`, which is filesystem-only by design — its own
+    docstring records that listing those directories IS reading git's output, since
+    `git worktree add`/`remove` are what create and delete them.
+    """
+    try:
+        from . import pieces as _p
+        from . import worktree as _wt
+        base = _wt.root(ws)
+        repos = sorted(d.name for d in base.iterdir() if d.is_dir())
+    except (OSError, Exception):
+        return None
+
+    total = done = gave_up = 0
+    quiet: list[str] = []
+    for repo in repos:
+        try:
+            for wt in _wt.dirs_for(ws, repo):
+                total += 1
+                d = _p.declaration_for(ws, repo, wt.name)
+                if d and d["event"] == "done":
+                    done += 1
+                elif d:
+                    gave_up += 1
+                else:
+                    s = _p.silence(ws, repo, wt.name)
+                    if s:
+                        quiet.append(s)
+        except Exception:
+            continue
+    if not total:
+        return None
+
+    parts = [f"{_DIM}pieces{_R} {total}"]
+    if done:
+        parts.append(f"{_GREEN}{done} done{_R}")
+    if gave_up:
+        parts.append(f"{_YELLOW}{gave_up} abandoned{_R}")
+    if quiet:
+        parts.append(f"{_DIM}{len(quiet)} silent {max(quiet, key=_silence_rank)}{_R}")
+    return " ".join(parts)
+
+
+#: Order silence ages so the OLDEST is the one reported. Coarse strings ("3m", "5h", "2d")
+#: do not sort lexically — "9m" would beat "2d" — and the oldest is the whole point.
+_UNIT_SECS = {"m": 60, "h": 3600, "d": 86400}
+
+
+def _silence_rank(age: str) -> int:
+    try:
+        return int(age[:-1]) * _UNIT_SECS.get(age[-1], 0)
+    except (ValueError, IndexError):
+        return 0
+
+
 def _repo_rows(dirs, active, cur, states, branches, gl, detail_wts=()) -> list[tui.Node]:
     """One table row per clone, nested under the workspace like a tree:
 
@@ -684,10 +768,16 @@ def _repo_rows(dirs, active, cur, states, branches, gl, detail_wts=()) -> list[t
                 # tree, not of its name), so the column comes to mean "this piece is NOT on
                 # the branch you would assume" — the only case worth 34 columns.
                 wb = branches.get(w, "?")
+                # When the branch restates the piece name — the default, since `worktree
+                # add` names them alike — the column was already being emptied as 34
+                # wasted columns. Spend them on what the piece SAID instead. When the
+                # branch differs it still wins: "this piece is not on the branch you would
+                # assume" is the surprise, and a surprise outranks a status.
+                state = _piece_state(active, d.name, w.name)
                 rows.append(_tree_cells(f"  {_DIM}{_TREE_PIPE}{mark}{_R}",
                                         f"{emph_w}{_DIM}{w.name}{_R}",
                                         w, states, branches, gl,
-                                        branch="" if wb == w.name else wb))
+                                        branch=state if wb == w.name else wb))
         # ONE summary line per repo, newest piece first — a fixed cost no matter how many
         # worktrees exist, so the footer can't grow with them (the ⑂N badge above carries
         # the true total, and overflow truncates with … rather than dropping pieces
@@ -1473,6 +1563,7 @@ def render(payload: dict | None = None) -> str:
             f"{_CYAN}⬢{_R} {_BOLD}{active}{_R}{pin}",
             reinit,
             f"{_DIM}todo{_R} {ntodo}" if ntodo else None,
+            _piece_summary(active),
             f"{_DIM}ws{_R} {nws}",
         ]))
 

--- a/tests/test_statusline_pieces.py
+++ b/tests/test_statusline_pieces.py
@@ -1,0 +1,171 @@
+"""The fleet in the status line (#100).
+
+Sub-problem 2 lands here because this is the surface people actually look at: the footer
+already draws worktree rows, so a piece's declaration — or its silence, with an age — costs
+no new row and no new command.
+
+Two constraints govern everything below. The status line **may not fork a git subprocess**
+(its own contract: fast, no network, branches read straight from `.git/HEAD`), and it must
+**never raise** — a malformed record has to render, not blank the footer. The obvious
+implementation of this feature reaches straight for `git worktree list`, which is why the
+first of those gets a test rather than a comment.
+
+And no verdict, at any age. That rule is the same one ADR 0009 sets for error text, and the
+status line is where a threshold would be most tempting to add.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from charter import config, pieces, statusline, workspace
+from tests._isolation import PersonaIso
+
+
+def git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", str(repo), *args],
+                          check=True, capture_output=True, text=True)
+
+
+def _plain(s: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+class PieceStatusCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.HAS_CONTROL_PLANE = True
+        self.ws = config.DEFAULT_WORKSPACE
+        self.repo = config.WORKSPACES_DIR / self.ws / "demo"
+        self.repo.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "init", "-q", "-b", "main", str(self.repo)],
+                       check=True, capture_output=True)
+        git(self.repo, "config", "user.email", "t@example.com")
+        git(self.repo, "config", "user.name", "t")
+        (self.repo / "README.md").write_text("hello\n")
+        git(self.repo, "add", "README.md")
+        git(self.repo, "-c", "commit.gpgsign=false", "commit", "-qm", "init")
+
+    def add_piece(self, piece: str):
+        from charter import worktree
+        p = worktree.path_for(self.ws, "demo", piece)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        git(self.repo, "worktree", "add", "-q", str(p), "-b", piece)
+        pieces.record(self.ws, "claimed", "demo", piece)
+        return p
+
+    def backdate(self, piece: str, minutes: int):
+        pieces.seen(self.ws, "demo", piece, session="w",
+                    when=datetime.now(timezone.utc) - timedelta(minutes=minutes))
+
+    def render(self, width: int = 200) -> str:
+        old = os.environ.get("COLUMNS")
+        os.environ["COLUMNS"] = str(width)
+        try:
+            return _plain(statusline.render({"session_id": "t"}))
+        finally:
+            if old is None:
+                os.environ.pop("COLUMNS", None)
+            else:
+                os.environ["COLUMNS"] = old
+
+
+class TestRowsCarryTheOutcome(PieceStatusCase):
+    def test_a_declared_piece_shows_its_declaration(self):
+        self.add_piece("parser")
+        pieces.record(self.ws, "done", "demo", "parser")
+        self.assertIn("done", self.render())
+
+    def test_an_abandoned_piece_shows_that(self):
+        self.add_piece("lexer")
+        pieces.record(self.ws, "abandoned", "demo", "lexer", reason="needs a live token")
+        self.assertIn("abandoned", self.render())
+
+    def test_an_undeclared_piece_shows_its_silence_age(self):
+        self.add_piece("codegen")
+        self.backdate("codegen", 45)
+        out = self.render()
+        self.assertIn("silent", out)
+        self.assertIn("45m", out)
+
+
+class TestTheWorkspaceLineSummarises(PieceStatusCase):
+    def test_the_counts_appear_on_the_workspace_line(self):
+        for p in ("a", "b", "c"):
+            self.add_piece(p)
+        pieces.record(self.ws, "done", "demo", "a")
+        pieces.record(self.ws, "abandoned", "demo", "b", reason="x")
+        out = self.render()
+        self.assertIn("pieces", out)
+        self.assertRegex(out, r"pieces\s*3")
+
+    def test_a_workspace_with_no_pieces_says_nothing_about_them(self):
+        """An empty count is not news. `todo` is already omitted at zero for exactly this
+        reason — a line that always fires is a line nobody reads."""
+        self.assertNotIn("pieces", self.render())
+
+
+class TestNoVerdictAndNoSubprocess(PieceStatusCase):
+    def test_no_verdict_wording_at_any_age(self):
+        self.add_piece("codegen")
+        for minutes in (1, 60, 60 * 24, 60 * 24 * 40):
+            self.backdate("codegen", minutes)
+            out = self.render().lower()
+            for verdict in ("failed", "dead", "stuck", "timed out", "timed-out", "orphan"):
+                self.assertNotIn(verdict, out, f"{verdict!r} at {minutes}m")
+
+    def test_the_piece_annotation_forks_no_git_subprocess(self):
+        """The contract this feature is most likely to break, and it breaks silently — an
+        extra subprocess per piece per turn costs every render and nothing fails.
+
+        Asserted against the piece functions rather than the whole render, because the
+        render already shells out: `_run_state` runs `git status --porcelain --branch` per
+        tree. (The module docstring's "no git subprocess" is narrower than it reads — it is
+        about BRANCHES, which come from `.git/HEAD`.) Pinning the whole render at zero
+        would therefore be pinning a falsehood; what must stay true is that *this* feature
+        adds nothing, and it reaches for `git worktree list` in the obvious implementation.
+        """
+        self.add_piece("parser")
+        pieces.record(self.ws, "done", "demo", "parser")
+        calls = []
+        real = subprocess.run
+
+        def spy(cmd, *a, **kw):
+            calls.append(cmd)
+            return real(cmd, *a, **kw)
+
+        subprocess.run = spy
+        self.addCleanup(setattr, subprocess, "run", real)
+        statusline._piece_summary(self.ws)
+        statusline._piece_state(self.ws, "demo", "parser")
+        self.assertEqual(calls, [])
+
+
+class TestItNeverBlanksTheFooter(PieceStatusCase):
+    def test_a_malformed_record_still_renders(self):
+        self.add_piece("parser")
+        pieces.log_path(self.ws).write_text("{not json\n")
+        self.assertIn("parser", self.render())
+
+    def test_a_malformed_liveness_mark_still_renders(self):
+        self.add_piece("parser")
+        p = pieces.seen_path(self.ws, "demo", "parser")
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{nope")
+        self.assertIn("parser", self.render())
+
+    def test_an_unreadable_record_directory_still_renders(self):
+        self.add_piece("parser")
+        d = pieces.dir_for(self.ws)
+        d.chmod(0o000)
+        self.addCleanup(d.chmod, 0o700)
+        self.assertIn("parser", self.render())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #100. Last ticket of the fleet outcome spine (#95) — the spine is complete with this.

Worktree detail rows carry what the piece said; the workspace line gains a piece summary beside the todo count.

## The rows cost no new columns

`worktree add` names a piece's branch after the piece, so the branch cell was **already being emptied** for exactly these rows — 34 columns spent restating the name beside it. Those columns now carry the state.

When the branch *differs* from the piece name it still wins: "this piece is not on the branch you would assume" is a surprise, and a surprise outranks a status.

## A correction worth reviewers' attention

I wrote a test pinning that rendering forks **no git subprocess**, per the module docstring. It failed — because the status line already shells out: `_run_state` runs `git status --porcelain --branch` per tree, plus `git remote get-url origin`.

The docstring's "no git subprocess" is narrower than it reads: it is about **branches**, which come from `.git/HEAD`. So the test now asserts that *this feature* adds no subprocess, against `_piece_summary` and `_piece_state` directly. Pinning the whole render at zero would have pinned a falsehood.

**The docstring is misleading as written.** Not fixed here — it is unrelated to this ticket and belongs in its own change.

## Other calls

The summary is omitted entirely when a workspace has no pieces, as the todo count already is — a figure that renders on every session including the ones it means nothing for is how a line stops being read.

No verdict at any age, with a test sweeping one minute to forty days. The status line is read at a glance and its wording is taken as settled, so ADR 0009 applies here harder than anywhere.

Oldest-silence selection sorts by real duration, not lexically — "9m" would otherwise beat "2d", and the oldest is the entire point.

## Tests

10 new in `tests/test_statusline_pieces.py`: declaration and abandonment on rows, silence with its age, the workspace summary, omission at zero, the no-verdict sweep, the no-subprocess contract, and three footer-never-blanks cases (malformed log, malformed liveness mark, unreadable record directory).

Full suite: 1728 passing, up from 1718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX