### PR TITLE
fix: unreadable record directory no longer blanks the status line

### DIFF
--- a/charter/pieces.py
+++ b/charter/pieces.py
@@ -137,8 +137,17 @@ def events(ws: str) -> list[dict]:
     d = dir_for(ws)
     if not d.exists():
         return []
+    try:
+        # Listing an unreadable directory RAISES on Linux and yields nothing on macOS.
+        # The divergence is why this needs a guard rather than a comment: a suite green on
+        # a developer's Mac went red on CI over exactly this line, and the failure it
+        # produced was the status line falling back to `⬢ charter` — the blank footer this
+        # module promises never to show.
+        files = sorted(d.glob("*.jsonl"))
+    except OSError:
+        return []
     out = []
-    for f in sorted(d.glob("*.jsonl")):
+    for f in files:
         try:
             text = f.read_text()
         except OSError:

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -4,10 +4,26 @@ Wired via ``.claude/settings.json`` → ``statusLine``. Claude Code pipes a JSON
 payload on stdin (session/model/workspace context) and renders this command's
 stdout in the footer on every turn.
 
-Contract we honor (see docs/workspaces.md): read *all* of stdin, stay fast (no
-git subprocess, no network — branches are read straight from ``.git/HEAD``),
-never raise (fall back to a minimal string), and exit 0. ANSI colour and
-multiple lines are supported.
+Contract we honor (see docs/workspaces.md): read *all* of stdin, stay fast, no
+network, never raise (fall back to a minimal string), and exit 0. ANSI colour
+and multiple lines are supported.
+
+**On subprocesses.** This used to claim "no git subprocess", which was never true
+of the module as a whole and misled at least one change into asserting it: dirt
+and ahead/behind come from :func:`_run_state`, one ``git status --porcelain
+--branch`` per tree, and origin's URL costs another. What *is* true is narrower
+and still worth stating, because it is the rule new work has to follow:
+
+* **Branches never fork.** They are read straight from ``.git/HEAD`` — see
+  :func:`_branch` — because a branch is needed for every row and a subprocess per
+  row is what the cheap read exists to avoid.
+* **Nothing new may add one per row.** :func:`_piece_state` and
+  :func:`_piece_summary` are file reads for exactly this reason, and
+  :func:`charter.worktree.dirs_for` exists so that listing pieces does not become
+  a ``git worktree list`` per clone on every turn.
+
+So: a bounded number of subprocesses proportional to *repos*, none proportional
+to rows, and none at all for anything that can be read off the filesystem.
 
 This module only *gathers* content (repos, branches, CI, personas) and
 declares the layout; all width math lives in :mod:`charter.tui`, whose nodes

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -122,22 +122,41 @@ def valid_name(name: str) -> bool:
     return bool(name) and name not in (".", "..") and _NAME_RE.match(name) is not None
 
 
+def _unreadable(fn) -> bool:
+    """Run a filesystem predicate, treating "I am not allowed to look" as "no".
+
+    ``pathlib`` does NOT count ``EACCES`` among the errors it swallows — only ENOENT,
+    ENOTDIR, EBADF and ELOOP — so ``(d / ".git").is_dir()`` *raises* on a directory the
+    process cannot enter. It raises on Linux and returns False on macOS, which is how a
+    suite green on a laptop goes red on CI.
+
+    Every caller here is asking "is there a checkout at this path", and the honest answer
+    for a directory we cannot read is no. Raising instead means one unreadable directory
+    anywhere under ``workspaces/`` takes down every caller that scans it — including the
+    status line, whose failure mode is a blank footer on every turn.
+    """
+    try:
+        return fn()
+    except OSError:
+        return False
+
+
 def is_git_repo(path: Path) -> bool:
-    return (path / ".git").exists()
+    return _unreadable(lambda: (path / ".git").exists())
 
 
 def is_tree(path: Path) -> bool:
     """A working tree of either provenance — a clone (``.git`` is a directory) or a
     linked worktree (``.git`` is a file). :func:`is_clone` deliberately excludes the
     second; this is for callers that only need "is there a checkout here"."""
-    return (Path(path) / ".git").exists()
+    return _unreadable(lambda: (Path(path) / ".git").exists())
 
 
 def is_clone(path: Path) -> bool:
     """A real clone, not a worktree. Git itself draws the line: a clone's ``.git`` is a
     DIRECTORY, a linked worktree's ``.git`` is a FILE pointing at the shared gitdir. So a
     worktree can never be miscounted as a cloned repo — no bookkeeping required."""
-    return (path / ".git").is_dir()
+    return _unreadable(lambda: (path / ".git").is_dir())
 
 
 def workspace_dir(name: str) -> Path:

--- a/tests/test_statusline_pieces.py
+++ b/tests/test_statusline_pieces.py
@@ -166,6 +166,40 @@ class TestItNeverBlanksTheFooter(PieceStatusCase):
         self.addCleanup(d.chmod, 0o700)
         self.assertIn("parser", self.render())
 
+    def test_an_unreadable_record_directory_still_renders_with_linux_semantics(self):
+        """`chmod 000` does not reproduce this everywhere: listing an unreadable directory
+        RAISES on Linux and yields nothing on macOS. That divergence is exactly why the
+        test above passed locally and went red on CI, with the footer collapsing to
+        `⬢ charter` — the blank this module promises never to show.
+
+        So the raising behaviour is patched in explicitly, and the platform that happens to
+        run the suite stops deciding whether this case is covered.
+        """
+        self.add_piece("parser")
+        blocked = pieces.dir_for(self.ws)
+        real_glob, real_is_dir = Path.glob, Path.is_dir
+
+        def denied(p) -> bool:
+            return p == blocked or blocked in p.parents
+
+        def strict_glob(self_, pattern, *a, **kw):
+            if denied(self_):
+                raise PermissionError(13, "Permission denied", str(self_))
+            return real_glob(self_, pattern, *a, **kw)
+
+        def strict_is_dir(self_, *a, **kw):
+            # pathlib swallows ENOENT/ENOTDIR/EBADF/ELOOP but NOT EACCES, so this raises
+            # on Linux where macOS quietly answers False.
+            if denied(self_):
+                raise PermissionError(13, "Permission denied", str(self_))
+            return real_is_dir(self_, *a, **kw)
+
+        Path.glob, Path.is_dir = strict_glob, strict_is_dir
+        self.addCleanup(setattr, Path, "is_dir", real_is_dir)
+        self.addCleanup(setattr, Path, "glob", real_glob)
+        self.assertEqual(pieces.events(self.ws), [])
+        self.assertIn("parser", self.render())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_workspace_structure.py
+++ b/tests/test_workspace_structure.py
@@ -165,5 +165,47 @@ class StructureCase(PersonaIso):
         self.assertEqual(cw.cmd_workspace_reinit(SimpleNamespace(name="ghost", all=False)), 1)
 
 
+class UnreadableDirectoriesAnswerNo(PersonaIso):
+    """`is_clone` and friends answer "is there a checkout here". For a directory the
+    process cannot enter, the honest answer is no — not an exception.
+
+    `pathlib` does not count EACCES among the errors it swallows (only ENOENT, ENOTDIR,
+    EBADF and ELOOP), so `(d / ".git").is_dir()` RAISES on Linux and returns False on
+    macOS. That divergence took CI red once already: one unreadable directory under
+    `workspaces/` took down every caller that scans it, including the status line, whose
+    failure mode is a blank footer on every turn.
+    """
+
+    def _denying(self, path):
+        from pathlib import Path
+        real = Path.is_dir
+
+        def strict(self_, *a, **kw):
+            if self_ == path or path in self_.parents:
+                raise PermissionError(13, "Permission denied", str(self_))
+            return real(self_, *a, **kw)
+
+        Path.is_dir = strict
+        self.addCleanup(setattr, Path, "is_dir", real)
+
+    def test_is_clone_answers_no_rather_than_raising(self):
+        workspace.ensure("alpha")
+        workspace.scaffold("alpha")
+        d = workspace.workspace_dir("alpha") / "locked"
+        d.mkdir(parents=True, exist_ok=True)
+        self._denying(d)
+        self.assertFalse(workspace.is_clone(d))
+
+    def test_scanning_a_workspace_survives_one_unreadable_directory(self):
+        """The case that actually bit: the scan, not the predicate. One directory nobody
+        can enter must not make the whole workspace unlistable."""
+        workspace.ensure("alpha")
+        workspace.scaffold("alpha")
+        d = workspace.workspace_dir("alpha") / "locked"
+        d.mkdir(parents=True, exist_ok=True)
+        self._denying(d)
+        self.assertEqual(workspace.clones("alpha"), [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**CI is red on `main`** after #110. This fixes it, and corrects the docstring that caused the mistake.

## The bug

`pieces.events` listed its directory with `sorted(d.glob(...))` outside any guard. Listing an unreadable directory **raises on Linux and yields nothing on macOS** — so the suite was green locally and red on CI, and the failure was the status line falling back to `⬢ charter`: the blank footer this module promises never to show.

The test that caught it was correct; the platform I ran it on was not. So the fix ships with a second test that patches the raising behaviour in explicitly, and the platform that happens to run the suite no longer decides whether the case is covered.

## The docstring

It claimed **"no git subprocess"**. That was never true of the module — `_run_state` runs `git status --porcelain --branch` per tree, and origin's URL costs another — and it is what misled #110 into asserting the whole render forks nothing.

Replaced with what is actually true, framed as the rule new work must follow:

- **Branches never fork** — read straight from `.git/HEAD`, because a branch is needed per row.
- **Nothing new may add a subprocess per row** — which is why `_piece_state`/`_piece_summary` are file reads and `worktree.dirs_for` exists.

Net: a bounded number of subprocesses proportional to *repos*, none proportional to rows.

Full suite: 1729 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX