### PR TITLE
feat: charter workspace optimize, and a doctor hint that can actually fix it

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -329,6 +329,17 @@ def _add_workspace_parser(sub) -> None:
     ri.add_argument("--all", action="store_true", help="Reinit every workspace (after a charter upgrade).")
     ri.set_defaults(func=commands_workspace.cmd_workspace_reinit)
 
+    opt = wsub.add_parser("optimize",
+                          help="Curate a workspace's memory: collapse exact duplicates and "
+                               "repair the index with --apply; propose the rest.")
+    opt.add_argument("name", nargs="?", help="Workspace to optimize (default: every one).")
+    opt.add_argument("--all", action="store_true", help="Every workspace (the default).")
+    opt.add_argument("--apply", action="store_true",
+                     help="Apply the safe, reversible ops. Proposals always stay manual.")
+    opt.add_argument("--stale-days", type=int, default=90, dest="stale_days",
+                     help="Age at which a memory is proposed for review (default: 90).")
+    opt.set_defaults(func=commands_workspace.cmd_workspace_optimize)
+
     rem = wsub.add_parser("remember",
                           help="Record one workspace memory (its own file, indexed) — the task journal.")
     rem.add_argument("text", nargs="?", help="Memory text; omit to list the workspace's memories.")

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -244,6 +244,74 @@ def cmd_workspace_rename(args) -> int:
     return commit_push(config.ROOT, ["add", "-A", "--", *tracked_old, *new_rel, ".gitignore"], msg)
 
 
+def cmd_workspace_optimize(args) -> int:
+    """Optimize a workspace's memory (one, or ``--all``) — the workspace half of what
+    ``charter persona optimize`` has always done for personas.
+
+    The engine was never persona-specific: ``curate.report``/``apply_safe`` take any memory
+    directory. Only the wiring was, which left the fastest-growing store in the plane — the
+    workspace journal, appended every session and nudged by the memory-cadence hook — with
+    no dedupe, no index repair and no stale review.
+
+    Same two tiers as the persona command, deliberately: ``--apply`` performs only the safe
+    and reversible ops (collapse exact duplicates, repair the index), and proposals (near-dup
+    merges, stale archives) are printed for a human to decide. A read-only run names what
+    ``--apply`` would do, because a read-only run that quietly rewrote an index is how
+    "read-only" stops meaning anything.
+    """
+    from . import curate
+    names = [args.name] if getattr(args, "name", None) else workspace.list_workspaces()
+    if getattr(args, "name", None) and not workspace.workspace_dir(args.name).exists():
+        util.err(f"no workspace '{args.name}'")
+        return 1
+    if not names:
+        util.info("No workspaces to optimize.")
+        return 0
+
+    apply = getattr(args, "apply", False)
+    stale_days = getattr(args, "stale_days", 90)
+    total_actions = 0
+    for n in names:
+        mdir = workspace.memory_dir(n)
+        if not mdir.exists():
+            continue
+        rep = curate.report(mdir, stale_days=stale_days)
+        if rep["total"] == 0:
+            continue
+        print(f"\n◆ {n}  ({rep['total']} memories · {len(rep['exact_dups'])} exact-dup "
+              f"group(s) · {len(rep['near_dups'])} near-dup pair(s) · {len(rep['stale'])} stale)")
+        if apply:
+            actions = curate.apply_safe(mdir)
+            for a in actions:
+                util.ok(f"  auto: {a}")
+            total_actions += len(actions)
+            if actions:
+                rel = str(mdir.relative_to(config.ROOT))
+                commit_memory_reactive(
+                    [rel], f"workspace({n}): curate — {len(actions)} safe op(s)")
+            rep = curate.report(mdir, stale_days=stale_days)
+        else:
+            pending = curate.pending_auto(rep)
+            if pending:
+                print("  would auto-apply (re-run with --apply):")
+                for a in pending:
+                    print(f"    + {a}")
+        props = curate.proposals(rep)
+        if props:
+            print("  proposals (not auto-applied — decide these yourself):")
+            for p in props:
+                print(f"    ? {p}")
+        elif apply:
+            util.info("  clean — nothing to propose.")
+
+    if not apply:
+        util.info("\nRead-only. Re-run with --apply to auto-apply the safe/reversible ops "
+                  "(exact-dup collapse + index repair); proposals always stay manual.")
+    elif total_actions == 0:
+        util.info("\nNo safe ops to apply — the journal is already tidy.")
+    return 0
+
+
 def _work_at_risk(name: str) -> list[str]:
     """Clones **and worktrees** in the workspace with uncommitted or unpushed work.
 

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -566,6 +566,12 @@ def check_memory_indexes() -> Result:
     dangling = unindexed = 0
     worst = []
     large = []
+    # WHICH KIND of base drifted, not just how much. The hint used to name
+    # `charter persona optimize` for every base including `ws:` ones, whose loop never
+    # touches a workspace — so it ran cleanly, fixed nothing, and left the drift reading as
+    # repaired. A remediation hint that silently no-ops is worse than no hint at all.
+    unindexed_kinds: set[str] = set()
+    large_kinds: set[str] = set()
     for label, mem_dir in bases:
         if not mem_dir.exists():
             continue
@@ -573,6 +579,8 @@ def check_memory_indexes() -> Result:
         if d["dangling"] or d["unindexed"]:
             dangling += len(d["dangling"])
             unindexed += len(d["unindexed"])
+            if d["unindexed"]:
+                unindexed_kinds.add("workspace" if label.startswith("ws:") else "persona")
             worst.append(f"{label} ({len(d['dangling'])} dangling, "
                          f"{len(d['unindexed'])} unindexed)")
         # Growth signal. An index only ever appends, so a long-lived persona's grows
@@ -582,18 +590,21 @@ def check_memory_indexes() -> Result:
         n = memstore.index_size(mem_dir)
         if n >= _INDEX_LINES_WARN:
             large.append(f"{label} ({n} entries)")
+            large_kinds.add("workspace" if label.startswith("ws:") else "persona")
     if not worst and not large:
         return Result("memory indexes", OK, detail=f"{len(bases)} base(s) consistent")
     hint = ", ".join(worst[:4]) + (", …" if len(worst) > 4 else "")
     if unindexed:
-        hint += "  → charter persona optimize --all --apply  (links unindexed files)"
+        for kind in sorted(unindexed_kinds):
+            hint += f"  → charter {kind} optimize --all --apply  (links unindexed files)"
     if dangling:
         hint += "  → a dangling link is proposal-only: prune it, or write the memory it names"
     if large:
         if hint:
             hint += "  "
         hint += ("large: " + ", ".join(large[:4]) + (", …" if len(large) > 4 else "")
-                 + "  → charter persona optimize <name>  (curate; growth is not a defect)")
+                 + "".join(f"  → charter {k} optimize <name>" for k in sorted(large_kinds))
+                 + "  (curate; growth is not a defect)")
     if not worst:
         return Result("memory indexes", WARN,
                       detail=f"{len(large)} large index(es)", hint=hint)

--- a/tests/test_workspace_optimize.py
+++ b/tests/test_workspace_optimize.py
@@ -1,0 +1,129 @@
+"""`charter workspace optimize` — curation for the workspace journal (#93), and the
+doctor hint that used to point at a command which could not fix it (#92).
+
+The curation engine was already base-agnostic: `curate.report`/`apply_safe` take any
+memory directory. Every caller lived in `commands_persona.py`, so the fastest-growing store
+in the plane — appended every session, nudged by the memory-cadence hook — had no dedupe,
+no index repair and no stale review.
+
+The two issues are one change. Widening the hint without the command would be a lie the
+other way round, and the hint is what makes the gap visible in the first place.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+
+from charter import doctor, memstore, workspace
+from charter import commands_workspace as cw
+from tests._isolation import PersonaIso
+
+
+class OptimizeCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+        workspace.scaffold("alpha")
+        self.mem = workspace.memory_dir("alpha")
+
+    def write_memory(self, slug: str, body: str, indexed: bool = True) -> None:
+        """A memory file, optionally left OUT of MEMORY.md — which is the drift a merge
+        resolved by taking one side produces, and what `optimize --apply` repairs."""
+        self.mem.mkdir(parents=True, exist_ok=True)
+        (self.mem / f"{slug}.md").write_text(
+            f"---\nname: {slug}\ndescription: {slug}\nmetadata:\n  type: project\n---\n\n{body}\n")
+        idx = memstore.index_path(self.mem)
+        if not idx.exists():
+            idx.write_text("# Memory\n\n")
+        if indexed:
+            idx.write_text(idx.read_text() + f"- [{slug}]({slug}.md) — {slug}\n")
+
+    def optimize(self, name="alpha", apply=False, all=False):
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = cw.cmd_workspace_optimize(SimpleNamespace(
+                name=None if all else name, all=all, apply=apply, stale_days=90))
+        return rc, out.getvalue() + err.getvalue()
+
+
+class TestItCuratesWorkspaceMemory(OptimizeCase):
+    def test_it_reports_a_workspaces_corpus(self):
+        self.write_memory("one", "a durable fact about the api")
+        rc, out = self.optimize()
+        self.assertEqual(rc, 0)
+        self.assertIn("alpha", out)
+
+    def test_apply_repairs_an_unindexed_file(self):
+        """The drift doctor reports. Before this command there was no way to fix it for a
+        workspace base — the memory stayed out of MEMORY.md, and therefore out of the
+        SessionStart digest, indefinitely."""
+        self.write_memory("orphan", "never linked", indexed=False)
+        self.assertEqual(memstore.index_drift(self.mem)["unindexed"], ["orphan.md"])
+        self.optimize(apply=True)
+        self.assertEqual(memstore.index_drift(self.mem)["unindexed"], [])
+
+    def test_read_only_names_what_apply_would_do(self):
+        """A read-only run that silently rewrote the index is how "read-only" stops
+        meaning anything — the persona command's own rule, kept here."""
+        self.write_memory("orphan", "never linked", indexed=False)
+        rc, out = self.optimize(apply=False)
+        self.assertEqual(rc, 0)
+        self.assertIn("orphan", out)
+        self.assertEqual(memstore.index_drift(self.mem)["unindexed"], ["orphan.md"])
+
+    def test_all_covers_every_workspace(self):
+        workspace.ensure("beta")
+        workspace.scaffold("beta")
+        other = workspace.memory_dir("beta")
+        other.mkdir(parents=True, exist_ok=True)
+        (other / "b.md").write_text("---\nname: b\ndescription: b\nmetadata:\n  type: project\n---\n\nbeta fact\n")
+        memstore.index_path(other).write_text("# Memory\n\n")
+        self.write_memory("a", "alpha fact")
+        rc, out = self.optimize(all=True)
+        self.assertEqual(rc, 0)
+        self.assertIn("beta", out)
+
+    def test_an_unknown_workspace_is_an_error(self):
+        rc, _ = self.optimize(name="ghost")
+        self.assertEqual(rc, 1)
+
+    def test_an_empty_corpus_is_not_an_error(self):
+        rc, _ = self.optimize()
+        self.assertEqual(rc, 0)
+
+
+class TestTheDoctorHintNamesACommandThatWorks(OptimizeCase):
+    """#92: doctor reported `ws:<name> (0 dangling, 7 unindexed)` and then suggested
+    `charter persona optimize --all --apply`, whose loop never touches a workspace base.
+    It exited successfully having fixed nothing, so the drift read as repaired."""
+
+    def _check(self) -> str:
+        r = doctor.check_memory_indexes()
+        return f"{r.detail} {r.hint or ''}"
+
+    def test_workspace_drift_points_at_workspace_optimize(self):
+        self.write_memory("orphan", "never linked", indexed=False)
+        self.assertIn("workspace optimize", self._check())
+
+    def test_workspace_drift_does_not_point_at_persona_optimize(self):
+        """The precise failure: a hint that runs cleanly and fixes nothing is worse than no
+        hint, because the drift now reads as handled."""
+        self.write_memory("orphan", "never linked", indexed=False)
+        self.assertNotIn("persona optimize", self._check())
+
+    def test_persona_drift_still_points_at_persona_optimize(self):
+        from charter import config, persona
+        # The shared base, because `check_memory_indexes` always enumerates it — a dir for
+        # a persona that does not exist is never scanned, so it would prove nothing.
+        pdir = persona.memory_dir(config.SHARED_PERSONA, shared=True)
+        pdir.mkdir(parents=True, exist_ok=True)
+        (pdir / "p.md").write_text("---\nname: p\ndescription: p\nmetadata:\n  type: project\n---\n\nx\n")
+        memstore.index_path(pdir).write_text("# Memory\n\n")
+        self.assertIn("persona optimize", self._check())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #93. Closes #92.

Two issues, one change: widening the hint without building the command would be a lie the other way round.

## #93 — the engine was already base-agnostic

`curate.report`/`apply_safe` take any memory directory. Only the *wiring* was persona-specific, so the fastest-growing store in the plane — the workspace journal, appended every session and nudged by the memory-cadence hook — had no dedupe, no index repair, no stale review.

`charter workspace optimize [name] [--apply]` mirrors the persona command, including both tiers: `--apply` performs only the safe reversible ops (collapse exact duplicates, repair the index), proposals stay manual, and a read-only run **names what `--apply` would do** — a read-only run that quietly rewrote an index is how "read-only" stops meaning anything.

## #92 — the hint that fixed nothing

doctor reported `ws:<name> (0 dangling, 7 unindexed)` and suggested `charter persona optimize --all --apply`, whose loop never touches a workspace base. It exited **successfully having fixed nothing**, so the drift read as repaired.

The hint now names the command matching the *kind* of base that drifted, and names both when both did.

## One extra, found next to it

The neighbouring "large index" branch had the identical bug — a large `ws:` index also pointed at `charter persona optimize <name>`. Fixed here, because it was going to be the next report of this same issue.

## Tests

9 new in `tests/test_workspace_optimize.py`: reporting a corpus, `--apply` repairing an unindexed file, read-only naming without mutating, `--all`, unknown workspace, empty corpus — plus the three hint cases, including that workspace drift **does not** name `persona optimize`.

Full suite: 1740 passing, up from 1731.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX