### PR TITLE
feat: recall returns an address, not a hint

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -125,6 +125,8 @@ def build_parser() -> argparse.ArgumentParser:
     rcl.add_argument("--scope", help="Comma list of scopes to search (workspace,persona,shared,ephemeral); "
                                      "default workspace,persona,shared.")
     rcl.add_argument("--ephemeral", action="store_true", help="Also include the persona's session scratch.")
+    rcl.add_argument("--full", action="store_true",
+                     help="Also print a line of each memory's body (the path is always shown).")
     rcl.add_argument("--persona", help="Search this persona instead of the active one.")
     # One workspace or every workspace — never both. `-w beta --all-workspaces` has no
     # coherent reading, and argparse refusing it beats silently honouring one of them.

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1021,6 +1021,41 @@ def cmd_doctor(args) -> int:
     return 0
 
 
+def _rel_to_root(path) -> str:
+    """Plane-relative where possible. An absolute path out of a temp dir or someone else's
+    home is noise in a transcript, and every other charter surface prints relative."""
+    try:
+        return str(Path(path).relative_to(config.ROOT))
+    except (ValueError, TypeError):
+        return str(path)
+
+
+def _body_snippet(path, width: int = 90) -> str:
+    """The first real line of a memory's body — enough to tell whether this is the hit you
+    wanted, without a `Read`. Frontmatter, headings and the `_Avoid_`-style italic lines are
+    skipped because none of them distinguish one memory from another.
+
+    Unreadable is not an error: `recall` runs constantly and must degrade to less, never to
+    a failure.
+    """
+    try:
+        lines = Path(path).read_text().splitlines()
+    except OSError:
+        return ""
+    in_front = False
+    for i, raw in enumerate(lines):
+        ln = raw.strip()
+        if i == 0 and ln == "---":
+            in_front = True
+            continue
+        if in_front:
+            in_front = ln != "---"
+            continue
+        if ln and not ln.startswith("#") and not ln.startswith("_"):
+            return ln[:width] + ("…" if len(ln) > width else "")
+    return ""
+
+
 def cmd_recall(args) -> int:
     """The single memory-fetch gate: search (or list) across every relevant memory base —
     the active workspace's journal, the active persona's own memory, and the shared
@@ -1071,15 +1106,25 @@ def cmd_recall(args) -> int:
             util.info(f"{got.undated} undated memory(ies) skipped — no recorded date to compare.")
         return 0
     width = max((len(h.label) for h in results), default=8)
+    full = getattr(args, "full", False)
     for h in results:
         tag = f"  ({h.score})" if h.score else ""
         # The date leads because when listing it IS the sort key — and the column order
         # stays identical under a query (where score orders instead), since a layout that
         # rearranges itself per mode is harder to read than one that never moves.
         print(f"  {h.date.isoformat() if h.date else '—':<10}  {h.label:<{width}}  {h.title}{tag}")
+        # The ADDRESS, on every hit. This used to be a closing sentence telling the reader
+        # to go and find the file, which is a direction rather than a location — and the
+        # slug rules differ per base (the journal timestamps its filenames, persona memory
+        # does not), so following it cost an inference and a `Read` per hit.
+        print(f"              {_rel_to_root(h.path)}")
+        if full:
+            snip = _body_snippet(h.path)
+            if snip:
+                print(f"              {snip}")
     where = "every workspace" if all_ws else ", ".join(scopes)
-    util.info(f"{len(results)} memory(ies) across {where}. "
-              f"Read one: find the file under its base (workspaces/… or personas/…).")
+    util.info(f"{len(results)} memory(ies) across {where}."
+              + ("" if full else "  Pass --full for a line of each body."))
     if truncated:
         util.info(f"Showing {len(results)} — pass --limit 0 for all.")
     if got.undated:

--- a/tests/test_recall_addresses.py
+++ b/tests/test_recall_addresses.py
@@ -1,0 +1,108 @@
+"""`charter recall` returns an address, not a hint (#94).
+
+`recall` is the command charter tells every agent to run before deciding something is
+unknown. It printed `date · label · title` and then "find the file under its base
+(workspaces/… or personas/…)" — which is a direction, not an address. `Hit.path` was
+already carried on every result and never rendered.
+
+The cost was a round trip per hit: eight results meant inferring eight filesystem paths,
+with slug rules that differ between stores (workspace journal files carry a
+`YYYYMMDD-HHMMSS-` prefix, persona files are slug-only), then eight `Read` calls to find
+out which one mattered.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+
+from charter import commands, config, memstore, persona, workspace
+from tests._isolation import PersonaIso
+
+
+class RecallOutputCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("w")
+        workspace.scaffold("w")
+        # Title and body deliberately differ: for a one-line memory the title IS the body,
+        # so a snippet test written against such a memory passes without a snippet.
+        memstore.write(workspace.memory_dir("w"),
+                       "the keycloak token rotates every ninety days",
+                       title="keycloak token policy", timestamped=True)
+        self.make_persona("dev", role="Dev", vault="d")
+        persona.remember("dev", "keycloak deploys need the staging realm first")
+
+    def recall(self, query="keycloak", **kw):
+        args = SimpleNamespace(query=query, scope=None, ephemeral=False, persona="dev",
+                               workspace="w", all_workspaces=False, since=None, limit=8,
+                               full=False)
+        for k, v in kw.items():
+            setattr(args, k, v)
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = commands.cmd_recall(args)
+        return rc, out.getvalue() + err.getvalue()
+
+
+class TestEveryHitCarriesItsPath(RecallOutputCase):
+    def test_the_path_is_printed(self):
+        rc, out = self.recall()
+        self.assertEqual(rc, 0)
+        self.assertIn("workspaces/w/memory/", out)
+
+    def test_both_bases_render_their_own_path(self):
+        """The slug rules differ per store, which is exactly why inferring them was the
+        expensive part: the journal timestamps its filenames, persona memory does not."""
+        _, out = self.recall()
+        self.assertIn("workspaces/w/memory/", out)
+        self.assertIn("personas/dev/memory/", out)
+
+    def test_the_path_is_relative_to_the_plane_root(self):
+        """An absolute path from a temp dir is noise in a transcript, and every other
+        charter surface prints plane-relative paths."""
+        _, out = self.recall()
+        self.assertNotIn(str(config.ROOT), out)
+
+    def test_it_no_longer_tells_the_reader_to_go_find_the_file(self):
+        """The line this replaces. Leaving it beside real addresses would read as though
+        the addresses were insufficient."""
+        _, out = self.recall()
+        self.assertNotIn("find the file under its base", out)
+
+    def test_listing_without_a_query_also_carries_paths(self):
+        _, out = self.recall(query=None)
+        self.assertIn("workspaces/w/memory/", out)
+
+
+class TestTheBodyIsAvailableWithoutASecondCall(RecallOutputCase):
+    def test_full_prints_a_body_snippet(self):
+        _, out = self.recall(full=True)
+        self.assertIn("ninety days", out)
+
+    def test_the_default_stays_compact(self):
+        """Eight hits × a body is most of a screen. The address is what every caller needs;
+        the body is what some do, so it is opt-in rather than the default."""
+        _, out = self.recall()
+        self.assertNotIn("ninety days", out)
+
+    def test_full_still_prints_the_path(self):
+        _, out = self.recall(full=True)
+        self.assertIn("workspaces/w/memory/", out)
+
+    def test_an_unreadable_body_does_not_break_the_listing(self):
+        """`recall` runs constantly and must degrade to less, never to an error."""
+        d = workspace.memory_dir("w")
+        for p in d.glob("*.md"):
+            if p.name != "MEMORY.md":
+                p.chmod(0o000)
+                self.addCleanup(p.chmod, 0o600)
+        rc, out = self.recall(full=True)
+        self.assertEqual(rc, 0)
+        self.assertIn("personas/dev/memory/", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #94.

`charter recall` is the command charter tells every agent to run before deciding something is unknown. It printed `date · label · title` and closed with *"find the file under its base (workspaces/… or personas/…)"* — a direction, not a location. `Hit.path` was already on every result and never rendered.

The cost was a round trip **per hit**: eight results meant inferring eight paths — with slug rules that differ between stores (the journal timestamps its filenames, persona memory does not) — then eight `Read` calls to find out which one mattered.

## After

```
  2026-08-14  persona:dev    keycloak deploys need the staging realm first  (5)
              personas/dev/memory/keycloak-deploys-need-the-staging-realm-first.md
  2026-08-14  workspace:w    keycloak token policy  (1)
              workspaces/w/memory/20260814-105809-the-keycloak-token-rotates-every-ninety-days.md
• 2 memory(ies) across workspace, persona, shared.  Pass --full for a line of each body.
```

## Why the body is opt-in

The **address** is what every caller needs; a **body** is what some do, and eight hits × a body is most of a screen. So the path is unconditional and `--full` adds the first real line of each body — enough to tell whether this is the hit you wanted without opening it.

The snippet skips frontmatter, headings and `_italic_` lines (none of which distinguish one memory from another), and an unreadable file yields no snippet rather than an error: recall runs constantly and must degrade to less, never to a failure.

## Tests

9 new in `tests/test_recall_addresses.py`: the path printed, both bases rendering their own path, plane-relative rather than absolute, the old go-find-it line gone, listing-without-a-query also carrying paths, `--full` printing a body, the default staying compact, and an unreadable body not breaking the listing.

Full suite: 1740 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX