### PR TITLE
fix: the vault guard covers file-reading tools, not just Bash

### DIFF
--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -505,6 +505,58 @@ def _touch_piece(data: dict) -> None:
 _CONTINUATIONS = ("resume", "clear", "compact")
 
 
+#: Tools that surface file CONTENT, and therefore leak a vault's plaintext into the
+#: transcript. `Glob` is deliberately absent: it returns NAMES, which is why `ls` is absent
+#: from `_READERS` too — that a vault exists is not the secret.
+_CONTENT_TOOLS = frozenset(("Read", "Grep"))
+
+#: Where each of them carries the thing it will read.
+_PATH_KEYS = ("file_path", "path", "notebook_path")
+
+
+def pretooluse_read() -> int:
+    """Deny a file-reading TOOL that would print a vault's plaintext into the transcript.
+
+    `pretooluse` guards Bash by inspecting ``tool_input["command"]``. A
+    ``Read(file_path=".charter/vaults/devops.json")`` carries no command and matched no
+    registered matcher, so it reached none of that — while the Bash denial helpfully *named
+    the path it refused*, making `Read` on that path the agent's obvious next move.
+
+    Same regex as the Bash guard on purpose (:data:`_VAULT_PATH_RE`), including its
+    carve-out: ``.charter/vaults.json`` is the registry — provider config and paths, never
+    values — and only ``.charter/vaults/`` holds secrets. Two guards that disagreed about
+    what counts as a vault would be worse than one, because the gap would sit exactly where
+    nobody looks.
+
+    Known limit, shared with the Bash guard and stated rather than papered over: a `Grep`
+    rooted at the repo top searches vault files as collateral. Denying every broad search is
+    untenable, so this checks the path the caller actually named.
+    """
+    data = _read_stdin()
+    _touch_piece(data)
+    try:
+        if (data.get("tool_name") or "") not in _CONTENT_TOOLS:
+            return 0
+        ti = data.get("tool_input") or {}
+        targets = [str(ti[k]) for k in _PATH_KEYS if ti.get(k)]
+        # Each target is tested with a trailing slash appended as well. `_VAULT_PATH_RE`
+        # requires `vaults/` — the slash is what keeps `.charter/vaults.json`, the registry,
+        # out of it — so a Grep rooted at the DIRECTORY `.charter/vaults` would otherwise
+        # walk past a guard that stops every file inside it. Appending cannot create a false
+        # positive: `.charter/vaults.json/` still has no `vaults/` in it.
+        if not any(_VAULT_PATH_RE.search(t) or _VAULT_PATH_RE.search(t + "/")
+                   for t in targets):
+            return 0
+        reason = ("reads a vault/secret file directly (would print plaintext). "
+                  "Use `charter … secret exec`/`cp` instead of reading `.charter/`")
+        _deny("PreToolUse", reason)
+        _trace("deny", data.get("session_id"), reason=reason[:70],
+               cmd=(data.get("tool_name") or "")[:40])
+    except Exception:
+        return 0
+    return 0
+
+
 def _piece_announcement(data: dict) -> str | None:
     """Tell a session which piece it holds and what it owes — the whole reason declarations
     ever get made, since a worker is otherwise just a session sitting in a directory.
@@ -1523,6 +1575,7 @@ _HANDLERS = {
     "sessionstart": sessionstart,
     "userpromptsubmit": userpromptsubmit,
     "pretooluse": pretooluse,
+    "pretooluse-read": pretooluse_read,
     "pretooluse-dispatch": pretooluse_dispatch,
     "posttooluse": posttooluse,
     "posttooluse-dispatch": posttooluse_dispatch,

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -51,9 +51,18 @@ shell history**, while still letting an agent *use* the credential:
   argument — an argument shows up in shell history and `ps` output for any other
   process on the machine to read.
 - A Claude Code guard hook denies `--reveal` outright, and denies reading a vault file
-  directly (`cat .charter/vaults/…`) — both would print a secret straight into the
-  conversation. **A denial here is that guard working, not a bug** — see the README's
-  "one credential" section for the same idea applied to git auth.
+  directly — both would print a secret straight into the conversation. **A denial here is
+  that guard working, not a bug** — see the README's "one credential" section for the same
+  idea applied to git auth.
+
+  "Directly" covers the shell (`cat`, `grep`, `head`, … on `.charter/vaults/…`) **and** the
+  harness's own file-reading tools (`Read`, `Grep`). It used to mean only the shell, which
+  made this bullet false in the way that mattered: the shell denial names the path it
+  refused, so reading that path with `Read` was the obvious next move and it worked (#90).
+
+  `Glob` is not denied — it returns file *names*, and that a vault exists is not the secret.
+  Neither is a search rooted far above `.charter/`, which reads vault files as collateral;
+  denying every broad search is untenable, so the guard checks the path you actually named.
 
 ## Setting one up
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -55,6 +55,16 @@
         ]
       },
       {
+        "matcher": "Read|Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "charter hook pretooluse-read --plugin-version 0.26.0",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Task|Agent",
         "hooks": [
           {

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -95,6 +95,11 @@ class TestPluginManifest(unittest.TestCase):
             ("SessionStart", "charter gl-refresh"),              # refresh forge state
             ("UserPromptSubmit", "charter hook userpromptsubmit --plugin-version"),
             ("PreToolUse", "charter hook pretooluse --plugin-version"),
+            # The vault guard for file-reading TOOLS. A separate matcher rather than folding
+            # it into `pretooluse`, because that one is registered for Bash and reads
+            # `tool_input["command"]` — a Read carries no command and would reach none of it
+            # (#90). Registered for Read|Grep only: Glob returns names, not contents.
+            ("PreToolUse", "charter hook pretooluse-read --plugin-version"),
             ("PreToolUse", "charter hook pretooluse-dispatch --plugin-version"),
             ("PostToolUse", "charter hook posttooluse --plugin-version"),
             ("PostToolUse", "charter hook posttooluse-dispatch --plugin-version"),

--- a/tests/test_vault_read_guard.py
+++ b/tests/test_vault_read_guard.py
@@ -1,0 +1,126 @@
+"""The vault guard covers file-reading TOOLS, not just Bash (#90).
+
+PreToolUse registered two matchers — `Bash` and `Task|Agent` — and `pretooluse` reads
+`tool_input["command"]`. A `Read(file_path=".charter/vaults/devops.json")` carries no
+`command`, matches no matcher, and reached none of it.
+
+What made that worse than a plain gap: the Bash denial *names the path it refused*. So the
+agent ran `cat .charter/vaults/devops.json`, read a well-worded denial containing the path,
+and its obvious next move — `Read` on that same path — succeeded and dumped every plaintext
+credential into the transcript. The guard handed over the target.
+
+Not a privilege escalation: anyone who can run the agent can already read the file. It was a
+hole in the one mitigation charter documents — keeping the value out of the model's context
+and out of the transcript — and `docs/secrets.md` claimed the mitigation existed.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from charter import hooks
+from tests._isolation import PersonaIso, run_hook
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _decision(r) -> str | None:
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+
+
+def _reason(r) -> str:
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
+
+
+class ReadGuardCase(PersonaIso):
+    def read(self, path: str, tool: str = "Read", **extra):
+        ti = {"file_path": path} if tool == "Read" else {"path": path, **extra}
+        return run_hook(hooks.pretooluse_read,
+                        {"tool_name": tool, "tool_input": ti, "session_id": "s", "cwd": "/tmp"})
+
+
+class TestReadingAVaultIsDenied(ReadGuardCase):
+    def test_read_of_a_vault_file_is_denied(self):
+        self.assertEqual(_decision(self.read(".charter/vaults/devops.json")), "deny")
+
+    def test_an_absolute_vault_path_is_denied(self):
+        self.assertEqual(_decision(self.read("/home/me/plane/.charter/vaults/devops.json")),
+                         "deny")
+
+    def test_the_denial_names_the_supported_alternative(self):
+        """Same wording as the Bash guard. A denial that only says no teaches nothing, and
+        the agent's next move is to find another way to the same bytes."""
+        r = self.read(".charter/vaults/devops.json")
+        self.assertIn("secret exec", _reason(r))
+
+    def test_grep_into_the_vault_directory_is_denied(self):
+        self.assertEqual(_decision(self.read(".charter/vaults", tool="Grep", pattern="token")),
+                         "deny")
+
+    def test_the_browser_and_active_paths_are_covered_too(self):
+        """`_VAULT_PATH_RE` already covers these for Bash; the two guards must not disagree
+        about what counts as a vault."""
+        for p in (".charter/browser", ".charter/active-persona"):
+            self.assertEqual(_decision(self.read(p)), "deny", p)
+
+
+class TestItDoesNotOverreach(ReadGuardCase):
+    def test_the_registry_is_not_a_vault_file(self):
+        """`.charter/vaults.json` holds provider config and paths, never values — the same
+        carve-out the Bash guard makes, and for the same reason. Note the regex's trailing
+        slash: `vaults/` is the directory of secrets, `vaults.json` is the map."""
+        self.assertIsNone(_decision(self.read(".charter/vaults.json")))
+
+    def test_an_ordinary_file_is_untouched(self):
+        self.assertIsNone(_decision(self.read("charter/hooks.py")))
+
+    def test_glob_is_not_denied(self):
+        """Glob returns NAMES, not contents — the same reason `ls` is absent from the Bash
+        guard's `_READERS`. Denying it would block discovering that a vault exists, which
+        is not the secret."""
+        self.assertIsNone(_decision(self.read(".charter/vaults", tool="Glob",
+                                              pattern=".charter/vaults/*")))
+
+    def test_a_payload_with_no_path_is_not_an_error(self):
+        r = run_hook(hooks.pretooluse_read,
+                     {"tool_name": "Read", "tool_input": {}, "session_id": "s"})
+        self.assertIsNone(_decision(r))
+
+    def test_an_unknown_tool_is_ignored(self):
+        r = run_hook(hooks.pretooluse_read,
+                     {"tool_name": "Bash", "tool_input": {"command": "cat .charter/vaults/x"},
+                      "session_id": "s"})
+        self.assertIsNone(_decision(r))
+
+
+class TestItIsActuallyWired(unittest.TestCase):
+    """A guard the manifest does not dispatch is a guard that does not run — which is the
+    entire content of this issue, one layer up."""
+
+    def _hooks(self):
+        return json.loads((ROOT / "hooks" / "hooks.json").read_text())["hooks"]
+
+    def test_pretooluse_registers_a_file_reading_matcher(self):
+        matchers = [e.get("matcher", "") for e in self._hooks()["PreToolUse"]]
+        self.assertTrue(any("Read" in m for m in matchers), matchers)
+
+    def test_the_engine_knows_the_handler_the_manifest_names(self):
+        cmds = [h["command"] for e in self._hooks()["PreToolUse"] for h in e["hooks"]]
+        named = {c.split("charter hook ")[1].split()[0] for c in cmds if "charter hook " in c}
+        self.assertIn("pretooluse-read", named)
+        self.assertLessEqual(named, set(hooks._HANDLERS))
+
+
+class TestTheDocsClaimIsTrueAgain(unittest.TestCase):
+    def test_secrets_doc_still_claims_direct_reads_are_denied(self):
+        """`docs/secrets.md` stated the guard denies reading a vault file directly. That was
+        true for Bash and false for every file-reading tool the harness offers. The claim is
+        worth keeping only while this test can be here."""
+        text = (ROOT / "docs" / "secrets.md").read_text()
+        self.assertIn("vault", text.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #90.

PreToolUse registered two matchers — `Bash` and `Task|Agent` — and `pretooluse` inspects `tool_input["command"]`. A `Read(file_path=".charter/vaults/devops.json")` carries no command, matched no matcher, and reached none of it.

**What made it worse than a plain gap:** the Bash denial *names the path it refused*. The agent ran `cat .charter/vaults/devops.json`, read a well-worded denial containing the path, and its obvious next move — `Read` on that path — succeeded and dumped every plaintext credential into the transcript. The guard handed over the target.

## The fix

A `pretooluse-read` handler on a `Read|Grep` matcher, **sharing `_VAULT_PATH_RE`** with the Bash guard rather than restating it. Two guards disagreeing about what counts as a vault would be worse than one, because the gap would sit exactly where nobody looks — and sharing inherits the registry carve-out (`.charter/vaults.json` holds provider config and paths, never values).

## A real gap found while testing

The regex requires `vaults/` **with** the slash — which is what keeps the registry out — so a `Grep` rooted at the *directory* `.charter/vaults` walked past a guard that stops every file inside it. Each target is now tested with a trailing slash appended as well; that cannot produce a false positive, since `.charter/vaults.json/` still contains no `vaults/`.

## Why Glob is not denied

It returns **names**, not contents — the same reason `ls` is absent from the Bash guard's `_READERS`. That a vault exists is not the secret.

## Docs

`docs/secrets.md` claimed this guard already existed for direct reads. True of the shell, false of every file-reading tool the harness offers. Now true of both — and it states plainly where it still does not reach: a search rooted far above `.charter/` reads vault files as collateral, and denying every broad search is untenable.

## Scope

Not a privilege escalation in either direction: anyone who can run the agent can read the file. This was a hole in the one mitigation charter documents — keeping the value out of the model's context and the transcript.

## Tests

13 new in `tests/test_vault_read_guard.py`: vault reads denied (relative and absolute), the alternative named, Grep into the directory, browser/active paths, the registry **not** denied, ordinary files untouched, Glob allowed, malformed payloads, unknown tools — plus two that assert the manifest actually dispatches it, since a guard the manifest does not wire is this issue one layer up.

`test_plugin.py`'s hook-parity list gains the new entry (it pins an exact set, by design).

Full suite: 1762 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX