### PR TITLE
fix: 'work at risk' means commits nowhere else, not a missing upstream

### DIFF
--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -342,12 +342,16 @@ def _worktrees_at_risk(name: str) -> list[str]:
     a FILE. That exclusion is deliberate and correct for counting repos, and it is exactly
     what left worktrees unguarded while `shutil.rmtree` took them anyway.
 
-    The **rule** differs from the clone rule above, not just the paths. `charter worktree
-    remove` treats a branch with NO upstream as work at risk — its commits exist nowhere
-    else — where the clone loop does not. That difference is the point rather than an
-    inconsistency: a parallel agent's piece is unpushed with no upstream almost by
-    definition, so applying the clone rule here would keep missing the very case this
-    exists for. The two guards now refuse on the same grounds.
+    The **rule** differs from the clone rule above, not just the paths. A worktree is at
+    risk when it holds commits reachable from no other ref — the work that would actually
+    cease to exist — which `charter worktree remove` uses too, so the two guards refuse on
+    identical grounds. Keeping them identical is the point: they answer one question, and a
+    workspace that removed what a worktree refused to would be the original bug again.
+
+    Not "has no upstream", which is what this was first written as (#91) and then narrowed
+    (#104): a parallel agent's piece has no upstream from the moment it is created, so that
+    reading refused over pieces with nothing to lose — and a guard that fires on the
+    harmless common case teaches the `--force` habit that stops it protecting anything.
 
     This fires even when the worktree directory lives outside the workspace — a relocated
     ``[plane] worktrees`` root, which `shutil.rmtree` never touches. That is not an
@@ -367,11 +371,11 @@ def _worktrees_at_risk(name: str) -> list[str]:
             if worktree.is_dirty(wt):
                 out.append(f"{label}: uncommitted changes")
                 continue
-            ahead = worktree.unpushed(wt)
-            if ahead is None:
-                out.append(f"{label}: no upstream, so its commits exist nowhere else")
-            elif ahead:
-                out.append(f"{label}: {ahead} unpushed commit(s)")
+            alone = worktree.unique_commits(wt)
+            if alone is None:
+                out.append(f"{label}: could not be checked for unique commits")
+            elif alone:
+                out.append(f"{label}: {alone} commit(s) that exist nowhere else")
     return out
 
 

--- a/charter/commands_worktree.py
+++ b/charter/commands_worktree.py
@@ -303,15 +303,20 @@ def cmd_worktree_remove(args) -> int:
             util.err(f"'{args.piece}' has uncommitted changes — refusing to remove.")
             util.info("Commit them, or discard with --force.")
             return 1
-        ahead = worktree.unpushed(path)
-        if ahead is None:
-            util.err(f"'{args.piece}' has no upstream, so its commits exist nowhere else "
+        # What would actually cease to exist: commits on this branch and on no other ref.
+        # The old test was "has no upstream", which refused over a just-created piece that
+        # had nothing to lose — and a guard that fires on the harmless common case is how
+        # `--force` becomes a habit (#104).
+        alone = worktree.unique_commits(path)
+        if alone is None:
+            util.err(f"could not determine whether '{args.piece}' holds unique commits "
                      "— refusing to remove.")
-            util.info("Push the branch, or discard with --force.")
+            util.info("Check the worktree by hand, or discard with --force.")
             return 1
-        if ahead:
-            util.err(f"'{args.piece}' has {ahead} unpushed commit(s) — refusing to remove.")
-            util.info("Push them, or discard with --force.")
+        if alone:
+            util.err(f"'{args.piece}' has {alone} commit(s) that exist nowhere else "
+                     "— refusing to remove.")
+            util.info("Push the branch or merge it, or discard with --force.")
             return 1
 
     if stale is not None:

--- a/charter/worktree.py
+++ b/charter/worktree.py
@@ -164,6 +164,46 @@ def unpushed(path: Path) -> int | None:
         return None
 
 
+def unique_commits(path: Path) -> int | None:
+    """Commits reachable from HEAD and from **no other ref** — the work that would actually
+    cease to exist if this tree were deleted. ``None`` when git could not answer.
+
+    This replaces "has no upstream" as the definition of work at risk. That reading was
+    conservative in the right direction but wrong about the common case: a piece created a
+    minute ago has no upstream and nothing to lose, and refusing over it taught the habit of
+    reaching for ``--force`` — which is how a guard stops protecting the commits it exists
+    for. Fleets create worktrees constantly, so the harmless case was about to become the
+    usual one.
+
+    Asking git directly is both narrower and stronger. A fresh piece sits on its base's tip,
+    which some other branch still reaches, so it scores zero. A worker's unpushed commits are
+    on no other branch and score more than zero. A pushed branch is reached by its
+    remote-tracking ref and scores zero without anyone consulting an upstream setting — so a
+    branch pushed somewhere other than its configured upstream is now correctly safe, which
+    the old rule got wrong in the opposite direction.
+    """
+    cur = _git(path, "branch", "--show-current").stdout.strip()
+    args = ["rev-list", "--count", "HEAD", "--not"]
+    if cur:
+        # The pattern is interpreted RELATIVE to refs/heads when it precedes `--branches`,
+        # so it is the bare branch name — `refs/heads/<cur>` silently excludes nothing, and
+        # the failure mode is the guard reporting zero unique commits for work that is
+        # genuinely unique.
+        #
+        # `--exclude` also applies to the NEXT ref-listing option only, which is what we
+        # want: this branch is dropped from `--branches`, while `--remotes` still counts its
+        # remote-tracking copy — that copy existing is exactly what "pushed" means.
+        args.append(f"--exclude={cur}")
+    args += ["--branches", "--remotes"]
+    r = _git(path, *args)
+    if r.returncode != 0:
+        return None
+    try:
+        return int(r.stdout.strip())
+    except ValueError:
+        return None
+
+
 def branch_exists(clone: Path, name: str) -> bool:
     return _git(clone, "rev-parse", "--verify", "--quiet",
                 f"refs/heads/{name}").returncode == 0

--- a/tests/test_workspace_remove.py
+++ b/tests/test_workspace_remove.py
@@ -148,10 +148,15 @@ class TestWorktreesAreGuardedToo(RemoveCase):
     it from being *guarded*, while `shutil.rmtree` took it anyway. `charter worktree remove`
     refuses to lose this work; `charter workspace remove` said `✓ Removed workspace`.
 
-    The guard follows `worktree remove`'s stance rather than the clone rule beside it: for a
-    worktree, *no upstream* counts as at risk. That difference is the whole point — a
-    parallel agent's branch is unpushed with no upstream almost by definition, so the clone
-    rule would keep missing exactly the case this exists for.
+    The guard follows `worktree remove`'s stance rather than the clone rule beside it: a
+    worktree is at risk when it holds commits reachable from **no other ref**. That
+    difference is the whole point — a parallel agent's branch is unpushed almost by
+    definition, so the clone rule would keep missing exactly the case this exists for.
+
+    That rule started as "has no upstream" (#91) and was narrowed to unique commits (#104),
+    because the first version also refused over freshly created pieces that had nothing to
+    lose. Both guards moved together, and must continue to: they answer one question, and a
+    workspace that removed what a worktree refused to would be the original bug again.
     """
 
     def test_uncommitted_work_in_a_worktree_refuses_removal(self):
@@ -202,17 +207,34 @@ class TestWorktreesAreGuardedToo(RemoveCase):
         self.assertEqual(rc, 0, out)
         self.assertFalse(workspace.workspace_dir("alpha").exists())
 
-    def test_a_fresh_worktree_blocks_because_it_has_no_upstream(self):
-        """Pinned deliberately rather than left to be discovered. A just-created piece has
-        nothing to lose, so refusing over it is a false positive — but it is the same false
-        positive `charter worktree remove` already has, and the two guards agreeing on what
-        "at risk" means matters more than shaving it here. Narrowing the rule to commits
-        unique to the branch changes that definition, and belongs in its own ticket.
+    def test_a_fresh_worktree_does_not_block(self):
+        """The inversion #104 was filed for. This asserted the opposite when #91 landed:
+        the rule was "has no upstream", which a just-created piece satisfies from the
+        moment it exists — so removal refused over a worktree with nothing to lose.
+
+        A guard that fires on the harmless common case is how `--force` becomes a habit,
+        and fleets create worktrees constantly, so the harmless case was about to become
+        the usual one. The rule is now "commits reachable from no other ref", which a fresh
+        piece scores zero on because its base's branch still reaches its tip.
         """
         self.make_clone_with_worktree()
         rc, out = self.remove()
-        self.assertNotEqual(rc, 0)
-        self.assertIn("slice", out)
+        self.assertEqual(rc, 0, out)
+        self.assertFalse(workspace.workspace_dir("alpha").exists())
+
+    def test_work_that_landed_on_another_branch_does_not_block(self):
+        """The rule is *reachable from somewhere else*, not *pushed*. A piece whose commits
+        were merged into the clone's own branch is safe to delete with no remote involved
+        at all — which the old no-upstream rule got wrong, and which is the ordinary end of
+        a piece's life once its work is integrated.
+        """
+        clone, wt = self.make_clone_with_worktree()
+        (wt / "feature.txt").write_text("done and merged\n")
+        self.commit(wt, "work")
+        self.git(clone, "merge", "--no-edit", "-q", "slice")
+        rc, out = self.remove()
+        self.assertEqual(rc, 0, out)
+        self.assertFalse(workspace.workspace_dir("alpha").exists())
 
     def test_force_still_removes_a_worktree_holding_work(self):
         _, wt = self.make_clone_with_worktree()

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -419,7 +419,9 @@ class TestRemove(WorktreeIso):
             _Args(workspace=self.ws, repo="iam-service", piece="spi-schema"))
         self.assertEqual(rc, 1)
         self.assertTrue(self.wt.exists())
-        self.assertIn("unpushed", (out + err).lower())
+        # Wording follows the rule: the guard now refuses over commits reachable from no
+        # other ref (#104), which is what "ahead of its upstream" is a special case of.
+        self.assertIn("exist nowhere else", (out + err).lower())
 
     def test_delete_branch_drops_the_branch_the_worktree_is_actually_on(self):
         """`remove` deliberately deletes the branch the worktree was CHECKED OUT ON


### PR DESCRIPTION
Closes #104.

Both guards asked *"does this branch have an upstream?"* and treated its absence as work at risk. Conservative in the right direction, wrong about the common case: a piece created a minute ago has no upstream and **nothing to lose**, so removal refused over worktrees that were safe to delete.

Fleets create worktrees constantly, so that harmless case was about to become the usual one — and a guard that fires on it is how `--force` becomes a habit, which is how a guard stops protecting the commits it exists for.

## The rule

`worktree.unique_commits` asks git the narrower and stronger question: **commits reachable from HEAD and from no other ref** — the work that would actually cease to exist.

- A fresh piece sits on its base's tip, which another branch still reaches → **0**, safe.
- A worker's unpushed commits are on no other branch → **>0**, refused.
- A branch merged into the clone's own branch → **0**, safe *with no remote involved at all*. The old rule got this wrong, and it is the ordinary end of a piece's life.
- A branch pushed somewhere other than its configured upstream → reached by its remote-tracking ref → **0**, correctly safe. The old rule got this wrong in the opposite direction.

## One git subtlety, commented at the call site

`--exclude` is interpreted **relative to `refs/heads`** when it precedes `--branches`, so the pattern must be the bare branch name. `--exclude=refs/heads/<cur>` silently excludes nothing — and the failure mode is the guard reporting *zero* unique commits for work that is genuinely unique. A guard that quietly stops guarding. It cost a debugging pass; the comment is there so it costs nobody else one.

## Both guards move together

`charter worktree remove` and `charter workspace remove` answer one question, and the docstrings now say they must stay identical: a workspace that removed what a worktree refused to would be #91 all over again.

## Test changes to expect

`test_a_fresh_worktree_blocks_because_it_has_no_upstream` **inverts** — it pinned that false positive deliberately when #91 landed, with a note that narrowing it belonged in its own ticket. This is that ticket. One existing test's wording assertion follows the new vocabulary, and a new test covers the merged-into-another-branch case.

Full suite: 1749 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX