### PR TITLE
0.27.0 — a fleet that finishes 7 of 8 stops reading as success

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.26.0"
+__version__ = "0.27.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.26.0",
+            "command": "charter hook sessionstart --plugin-version 0.27.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.26.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.27.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.26.0",
+            "command": "charter hook pretooluse --plugin-version 0.27.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.26.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.27.0",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.26.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.27.0"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.26.0",
+            "command": "charter hook posttooluse --plugin-version 0.27.0",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.26.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.27.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.26.0"
+version = "0.27.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only — all the code is already on `main`. Bumps the four version sites together: `pyproject.toml`, `charter/__init__.py`, the plugin manifest, and the **seven** `--plugin-version` flags in `hooks.json` (six until this release, plus the new `pretooluse-read` guard).

## What 0.27.0 is

Parallel agents could always work in worktrees; nothing recorded what became of one. A branch with three commits and no further activity looked identical whether its worker finished deliberately, hit a denial, or was killed — so a fleet completed seven of eight pieces and **reported success**.

The outcome spine closes that (#95 → #96–#101):

- A worker **claims** a piece by creating its worktree, so git's own atomicity decides who gets it; the loser gets a distinct exit code rather than a message to parse.
- It **declares** `done` or `abandoned` with a reason.
- A hook records that it was **alive** without the worker remembering — the worker most worth catching is the one that did not — so a piece that says nothing reads as **silent, with an age**, in `worktree list` and on the status line.
- charter never **diagnoses** that silence. No threshold turns it into "failed": a piece running a forty-minute test suite is not a dead one.

## Also in this release

| | |
|---|---|
| #93 / #92 | `charter workspace optimize`, and a doctor hint that can actually fix workspace drift |
| #94 | `charter recall` prints each hit's path; `--full` adds a line of the body |
| #90 | the vault guard covers file-reading tools, not just Bash |
| #91 / #104 | workspace removal stops destroying worktrees it cannot see; "at risk" narrowed to commits reachable from no other ref |

New vocabulary in `CONTEXT.md`; the two hard-to-reverse decisions in **ADR 0011** (what the record may hold) and **ADR 0012** (the plan is todos, the lifecycle is the piece's).

Every issue on the tracker is closed as of this release.

Suite: 1763 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX