### PR TITLE
persona: what this session learned, and one thing it had wrong

### DIFF
--- a/personas/statusline/memory/MEMORY.md
+++ b/personas/statusline/memory/MEMORY.md
@@ -6,4 +6,4 @@ Written by the persona as it learns; committed and shared.
 - [Use East-Asian Neutral glyphs in width-critical cells: U+25AA ▪, U+25B8](use-east-asian-neutral-glyphs-in-width-critical-.md)
 - [Claude Code's footer collapses a BLANK row to column 0, so a row that mu](claude-code-s-footer-collapses-a-blank-row-to-co.md)
 - [_TREE_WT (╰─) must stay textually distinct from _TREE_END (└─): render's](tree-wt-must-stay-textually-distinct-from-tree-e.md)
-- [The status line renders on EVERY turn: no git subprocess and no network](the-status-line-renders-on-every-turn-no-git-sub.md)
+- [The status line renders on EVERY turn and is fast, but it is NOT subproc](the-status-line-renders-on-every-turn-and-is-fas.md)

--- a/personas/statusline/memory/the-status-line-renders-on-every-turn-and-is-fas.md
+++ b/personas/statusline/memory/the-status-line-renders-on-every-turn-and-is-fas.md
@@ -1,0 +1,5 @@
+# The status line renders on EVERY turn and is fast, but it is NOT subproc
+
+_2026-08-14 12:03 · persistent_
+
+The status line renders on EVERY turn and is fast, but it is NOT subprocess-free — the module docstring claimed that for years and it was never true. _run_state runs 'git status --porcelain --branch' per tree, and origin's URL costs another. What is true: BRANCHES never fork (util.branch_of reads .git/HEAD), and nothing new may add a subprocess per ROW — bounded by repos, never by rows. Corrected 2026-08-14 after a test written from the docstring failed.

--- a/personas/statusline/memory/the-status-line-renders-on-every-turn-no-git-sub.md
+++ b/personas/statusline/memory/the-status-line-renders-on-every-turn-no-git-sub.md
@@ -1,5 +1,0 @@
-# The status line renders on EVERY turn: no git subprocess and no network
-
-_2026-08-09 22:54 · persistent_
-
-The status line renders on EVERY turn: no git subprocess and no network on the render path. Branches come from .git via util.branch_of; forge state from a cache another process fills.

--- a/personas/steward/memory/MEMORY.md
+++ b/personas/steward/memory/MEMORY.md
@@ -6,3 +6,7 @@ Written by the persona as it learns; committed and shared.
 - [In an embedded plane, worktrees live OUTSIDE the codebase. Inside, each](in-an-embedded-plane-worktrees-live-outside-the-.md)
 - [A worktree is a view of a repo, not a plane. charter.toml is tracked, so](a-worktree-is-a-view-of-a-repo-not-a-plane-chart.md)
 - [Recurring bug shape in this repo: a module global read where the file on](recurring-bug-shape-in-this-repo-a-module-global.md)
+- [Fleet design (ADR 0011/0012, 2026-08-13): a piece IS a worktree and the](fleet-design-adr-0011-0012-2026-08-13-a-piece-is.md)
+- [Live-testing charter CLI changes from a worktree does NOT work: charter.](live-testing-charter-cli-changes-from-a-worktree.md)
+- [macOS vs Linux filesystem divergence that turned CI red in this repo: pa](macos-vs-linux-filesystem-divergence-that-turned.md)
+- [charter persona remember run from inside a WORKTREE writes to the clone,](charter-persona-remember-run-from-inside-a-workt.md)

--- a/personas/steward/memory/charter-persona-remember-run-from-inside-a-workt.md
+++ b/personas/steward/memory/charter-persona-remember-run-from-inside-a-workt.md
@@ -1,0 +1,5 @@
+# charter persona remember run from inside a WORKTREE writes to the clone,
+
+_2026-08-14 12:03 · persistent_
+
+charter persona remember run from inside a WORKTREE writes to the clone, not the plane: root.find_root resolves a plane-less worktree back to its main tree. The memory is not lost, it lands in workspaces/<ws>/<repo>/personas/... and dirties the clone. Record memory from the plane root.

--- a/personas/steward/memory/fleet-design-adr-0011-0012-2026-08-13-a-piece-is.md
+++ b/personas/steward/memory/fleet-design-adr-0011-0012-2026-08-13-a-piece-is.md
@@ -1,0 +1,5 @@
+# Fleet design (ADR 0011/0012, 2026-08-13): a piece IS a worktree and the
+
+_2026-08-13 22:17 · persistent_
+
+Fleet design (ADR 0011/0012, 2026-08-13): a piece IS a worktree and the claim IS its creation — but that mutex is only real if the WORKER creates its own worktree. An orchestrator that pre-creates N worktrees then starts N workers wins a race nobody ran, while the real race (two workers in one tree) goes unguarded. Pre-assignment makes git's atomicity decorative.

--- a/personas/steward/memory/live-testing-charter-cli-changes-from-a-worktree.md
+++ b/personas/steward/memory/live-testing-charter-cli-changes-from-a-worktree.md
@@ -1,0 +1,5 @@
+# Live-testing charter CLI changes from a worktree does NOT work: charter.
+
+_2026-08-13 23:40 · persistent_
+
+Live-testing charter CLI changes from a worktree does NOT work: charter.toml is tracked, so a worktree of charter is its own plane root and sees none of the real plane's workspaces. Use a throwaway plane (charter init in a temp dir) with PYTHONPATH pointed at the worktree instead.

--- a/personas/steward/memory/macos-vs-linux-filesystem-divergence-that-turned.md
+++ b/personas/steward/memory/macos-vs-linux-filesystem-divergence-that-turned.md
@@ -1,0 +1,5 @@
+# macOS vs Linux filesystem divergence that turned CI red in this repo: pa
+
+_2026-08-14 12:01 · persistent_
+
+macOS vs Linux filesystem divergence that turned CI red in this repo: pathlib does NOT swallow EACCES (only ENOENT/ENOTDIR/EBADF/ELOOP), so Path.is_dir() and Path.glob() on an unreadable directory RAISE on Linux and answer False/[] on macOS. Any local-only test of an unreadable path is untested on CI's platform — patch the raising behaviour in explicitly.


### PR DESCRIPTION
Four durable facts from the fleet-spine work, plus a correction to committed knowledge that was actively misleading by the time anyone read it.

## steward — three

- **A piece IS a worktree and the claim IS its creation** — but that mutex is only real if the *worker* creates its own worktree. An orchestrator that pre-creates N of them wins a race nobody ran, while the real race (two workers in one tree) goes unguarded.
- **Live-testing CLI changes from a worktree does not work**: a worktree of charter resolves back to its main tree, so it sees none of the real plane's workspaces.
- **`charter persona remember` from inside a worktree writes to the CLONE, not the plane.** Recorded because it happened *while recording the memory next to it* — the file turned up two directories from where it was expected, and dirtied the clone.

## steward — the one that cost a CI cycle

`pathlib` does not swallow `EACCES` (only `ENOENT`/`ENOTDIR`/`EBADF`/`ELOOP`), so listing or stat-ing an unreadable directory **raises on Linux and answers `[]`/`False` on macOS**. Any local-only test of an unreadable path is untested on the platform CI runs.

## statusline — a correction, and the reason the above happened

Its memory said *"no git subprocess and no network on the render path"*. The second half is true. The first was **never** true of the module — `_run_state` runs `git status --porcelain --branch` per tree, and origin's URL costs another.

It agreed with a module docstring that was also wrong, so the claim was confirmed from two places and neither was checked. A test written from it passed review and failed on Linux, taking `main` red after #110.

Replaced with the narrower claim that actually holds: **branches never fork** (`.git/HEAD`), and **nothing new may add a subprocess per row** — bounded by repos, never by rows. Forgotten rather than edited, because the filename encoded the false half.

Memory index health verified (`test_memory_index_health`, `test_persona_memory`).