### PR TITLE
fix: the status line reads the session's cwd, not the hook's

### DIFF
--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -146,10 +146,18 @@ _PALETTE = (
     "\033[35m", "\033[34m", "\033[36m", "\033[32m",
     "\033[33m", "\033[95m", "\033[94m", "\033[92m",
 )
-def _active(session_id: str | None = None) -> tuple[str, str]:
+def _active(session_id: str | None = None, cwd: str | None = None) -> tuple[str, str]:
+    """``(workspace, source)`` for the SESSION, not for this process.
+
+    ``cwd`` is the session's directory out of the payload. It matters because the cwd rung
+    outranks every pointer, so reading the hook's own directory there does not merely miss
+    a better answer — it overrides the right one. The renderer already trusts the payload
+    for :func:`_current`, and the two must agree: marking a row in one workspace under a
+    header naming another is worse than either mistake alone.
+    """
     from . import workspace
-    return (workspace.resolve(session_id=session_id),
-            workspace.source(session_id=session_id))
+    return (workspace.resolve(session_id=session_id, cwd=cwd),
+            workspace.source(session_id=session_id, cwd=cwd))
 
 
 def _count_workspaces() -> int:
@@ -1513,7 +1521,8 @@ def render(payload: dict | None = None) -> str:
     failure anywhere in data-gathering falls back to the same minimal string."""
     payload = payload or {}
     try:
-        active, src = _active(payload.get("session_id"))
+        active, src = _active(payload.get("session_id"),
+                              (payload.get("workspace") or {}).get("current_dir"))
         nws = _count_workspaces()
         # The active workspace's clones, and only those. The plane's own tree is
         # deliberately not a row: it is the plane, not a repo you work in, and drawing it

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -190,7 +190,8 @@ def from_path(path=None) -> str | None:
     return parts[0] if len(parts) >= 2 else None
 
 
-def resolve(explicit: str | None = None, session_id: str | None = None) -> str:
+def resolve(explicit: str | None = None, session_id: str | None = None,
+            cwd=None) -> str:
     """Active workspace by precedence: ``--workspace`` → ``$CHARTER_WORKSPACE`` → **the
     tree you are standing in** → per-session pointer → per-terminal pointer → ``default``.
 
@@ -198,13 +199,19 @@ def resolve(explicit: str | None = None, session_id: str | None = None) -> str:
     at paths that name the workspace, so being inside one is not a hint about which
     workspace is active, it is the fact. The pointers remain for the case with no tree to
     stand in — a shell at the plane root.
+
+    ``cwd`` names *whose* directory that rung should read, and exists because the process
+    asking is not always the session being described. A status line is the case: Claude
+    Code runs the hook and passes the session's directory in the payload, so a renderer
+    reading ``os.getcwd()`` would answer for the hook. Callers that ARE the session — every
+    CLI command — leave it unset and get the process cwd, which is the same fact.
     """
     if explicit:
         return explicit
     env = os.environ.get("CHARTER_WORKSPACE")
     if env:
         return env.strip()
-    here = from_path()
+    here = from_path(cwd)
     if here:
         return here
     sid = _session_id(session_id)
@@ -220,13 +227,20 @@ def resolve(explicit: str | None = None, session_id: str | None = None) -> str:
     return config.DEFAULT_WORKSPACE
 
 
-def source(explicit: str | None = None, session_id: str | None = None) -> str:
-    """Human label for where the active workspace came from (for display)."""
+def source(explicit: str | None = None, session_id: str | None = None,
+           cwd=None) -> str:
+    """Human label for where the active workspace came from (for display).
+
+    Takes ``cwd`` for the same reason :func:`resolve` does, and must be called with the
+    same one: a header that named the workspace from the session's directory and the
+    *reason* from the process's would explain the answer by naming a rung that did not
+    decide it.
+    """
     if explicit:
         return "--workspace"
     if os.environ.get("CHARTER_WORKSPACE"):
         return "$CHARTER_WORKSPACE"
-    if from_path():
+    if from_path(cwd):
         return "cwd"      # must mirror `resolve`'s order, or the status line explains
                           # the active workspace by naming a source that did not decide it
     sid = _session_id(session_id)

--- a/tests/test_statusline_session_cwd.py
+++ b/tests/test_statusline_session_cwd.py
@@ -1,0 +1,114 @@
+"""The status line resolves the active workspace from the SESSION's cwd, not its own.
+
+Claude Code hands the status line the session's working directory in the payload
+(`workspace.current_dir`) precisely because the hook process's own cwd is not guaranteed
+to be it. The renderer already trusts that field for one job — `_current` uses it to mark
+which repo or worktree row you are standing in — and used to ignore it for the other,
+resolving the active workspace from `os.getcwd()` instead.
+
+Two notions of "where the session is" in a single render, and when they disagreed the
+result was the confusing half-right state: the row for a repo in workspace A marked as
+current, under a header naming workspace B. `resolve`'s own docstring is the argument
+against it — the cwd rung outranks every pointer because "being inside one is not a hint
+about which workspace is active, it is the fact" — and a fact read from the wrong process
+is not that fact.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import unittest
+from pathlib import Path
+
+from charter import config, statusline, workspace
+from tests._isolation import PersonaIso
+
+
+def _plain(s: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+class SessionCwdBase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        # Two workspaces, each with a repo, so "which one" has a wrong answer available.
+        self.alpha = config.WORKSPACES_DIR / "alpha" / "billing-api"
+        self.beta = config.WORKSPACES_DIR / "beta" / "checkout-ui"
+        for d in (self.alpha, self.beta):
+            d.mkdir(parents=True, exist_ok=True)
+
+        # The process sits at the plane root — inside no workspace at all, which is the
+        # ordinary case for a hook and the one that exposes the bug.
+        self._cwd = os.getcwd()
+        os.chdir(self.tmp)
+        self.addCleanup(lambda: os.chdir(self._cwd))
+
+        self._env = {k: os.environ.get(k) for k in ("CHARTER_WORKSPACE", "COLUMNS")}
+        os.environ.pop("CHARTER_WORKSPACE", None)
+        self.addCleanup(self._restore_env)
+
+    def _restore_env(self) -> None:
+        for k, v in self._env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+class TestResolveTakesACwd(SessionCwdBase):
+    def test_resolve_reads_the_cwd_it_is_given(self):
+        self.assertEqual(workspace.resolve(cwd=str(self.alpha)), "alpha")
+        self.assertEqual(workspace.resolve(cwd=str(self.beta)), "beta")
+
+    def test_source_agrees_with_resolve(self):
+        """A header that names the workspace and the reason must not disagree about it."""
+        self.assertEqual(workspace.source(cwd=str(self.alpha)), "cwd")
+
+    def test_a_cwd_outside_any_workspace_falls_through(self):
+        """Standing in the plane root is not a claim about which workspace is active."""
+        self.assertEqual(workspace.source(cwd=str(self.tmp)), "default")
+
+    def test_an_explicit_workspace_still_outranks_the_cwd(self):
+        self.assertEqual(workspace.resolve("beta", cwd=str(self.alpha)), "beta")
+
+    def test_the_env_var_still_outranks_the_cwd(self):
+        os.environ["CHARTER_WORKSPACE"] = "beta"
+        self.assertEqual(workspace.resolve(cwd=str(self.alpha)), "beta")
+
+
+class TestStatusLineUsesTheSessionCwd(SessionCwdBase):
+    def _header(self, payload: dict) -> str:
+        os.environ["COLUMNS"] = "200"
+        return _plain(statusline.render(payload).split("\n")[1])
+
+    def test_active_follows_the_payload(self):
+        ws, src = statusline._active(session_id="no-such-session", cwd=str(self.alpha))
+        self.assertEqual(ws, "alpha")
+        self.assertEqual(src, "cwd")
+
+    def test_the_rendered_header_names_the_sessions_workspace(self):
+        """The end-to-end shape of the bug: the process is in neither workspace, the
+        session is in `alpha`, and the header used to say `default`."""
+        header = self._header({"workspace": {"current_dir": str(self.alpha)},
+                               "session_id": "no-such-session"})
+        self.assertIn("alpha", header)
+        self.assertNotIn("default", header)
+
+    def test_a_payload_without_a_cwd_is_not_an_error(self):
+        """Payloads come from another program; the field is not guaranteed."""
+        for payload in ({}, {"workspace": {}}, {"workspace": {"current_dir": ""}}):
+            with self.subTest(payload=payload):
+                self.assertIn("default", self._header(payload))
+
+    def test_a_cwd_in_some_other_plane_does_not_name_a_workspace_here(self):
+        """A path outside this plane's `workspaces/` says nothing about this plane, and
+        must fall through to the pointers rather than inventing a name from its parts."""
+        outside = Path(self.tmp).parent / "somewhere-else" / "workspaces" / "ghost" / "r"
+        ws, src = statusline._active(session_id="no-such-session", cwd=str(outside))
+        self.assertEqual(ws, config.DEFAULT_WORKSPACE)
+        self.assertEqual(src, "default")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

`charter statusline` used two different notions of "where the session is" in a single render:

- `_current(payload)` reads `payload["workspace"]["current_dir"]` — the session's directory — to decide **which repo or worktree row to mark as current**
- `_active(session_id)` → `workspace.resolve()` → `from_path()` read **`os.getcwd()`** — the *hook process's* directory — to decide **which workspace is active**

Claude Code passes `current_dir` in the payload precisely because the hook's own cwd is not guaranteed to be it. When the two disagreed, the render was half-right in the most confusing way available: a row for a repo in workspace A marked as current, under a header naming workspace B.

This is an override, not a missed improvement. The cwd rung outranks every pointer — `resolve`'s own docstring argues it "cannot be wrong: being inside one is not a hint about which workspace is active, it is the fact" — so reading the wrong process's directory there **beats** the answer `charter workspace use` recorded.

## Reproduction

Process at the plane root, payload naming a repo inside the `fleet` workspace, session id matching no pointer:

```
before : ⬢ default · todo 2 · ws 6
after  : ⬢ fleet · ws 6
```

`from_path()` given that same path returned `fleet` the whole time — the right answer was available and unasked-for. (The `todo 2` chip correctly disappears with the fix: that count belonged to `default`.)

## The change

`resolve()` and `source()` take a `cwd`, and must be given the same one — a header naming the workspace from one directory and the *reason* from another would explain its answer by citing a rung that did not decide it. `_active()` passes the payload's `current_dir` through. Every CLI caller **is** the session, leaves it unset, and keeps reading the process cwd, which is the same fact.

## Tests

`tests/test_statusline_session_cwd.py`, 9 tests, written before the fix and watched fail — including the end-to-end case that rendered `default` for a session standing in `alpha`. They also pin the precedence that must **not** change: `--workspace` and `$CHARTER_WORKSPACE` still outrank the cwd, a cwd inside no workspace still falls through to the pointers, a cwd in some other plane names nothing here, and a payload with no `current_dir` is not an error.

Full suite: 1772 passing.

## Note

This is a CLI code change, so it reaches users only on a release — the plugin is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o