### PR TITLE
0.27.1 — the status line stops answering for the wrong directory

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.27.0"
+__version__ = "0.27.1"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.27.0",
+            "command": "charter hook sessionstart --plugin-version 0.27.1",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.27.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.27.1",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.27.0",
+            "command": "charter hook pretooluse --plugin-version 0.27.1",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.27.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.27.1",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.27.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.27.1"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.27.0",
+            "command": "charter hook posttooluse --plugin-version 0.27.1",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.27.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.27.1",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.27.0"
+version = "0.27.1"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only. All four locations move together — `pyproject.toml`, `charter/__init__.py`, `.claude-plugin/plugin.json`, and the seven `--plugin-version` flags in `hooks/hooks.json` — pinned by `tests/test_plugin.py::TestVersionsMoveInLockstep`.

**Patch, not minor**: the release exists for #121, which adds no CLI flag, no config key and no changed default. It corrects an answer that was already wrong.

## What ships

- **#121** — the status line resolved the active workspace from the *hook process's* directory instead of the session's. Because the cwd rung outranks every pointer, that didn't merely miss a better answer, it overrode the one `charter workspace use` recorded — while correctly marking a row inside the right workspace, so the render was half-right in the most confusing available way.
- **#119** — README front door, four figures, OSS metadata files.
- **#120** — the `## Prose` section in `CONTEXT.md`.

## After merge

Tag from `main` only, matching `pyproject.toml` exactly — the `guard` job is the last safety net, not the plan, since PyPI will not allow a version to be re-uploaded and Trusted Publishing leaves no token to fix it by hand.

```
git tag -a v0.27.1 -m "0.27.1 — the status line stops answering for the wrong directory"
git push origin v0.27.1
```

Full suite: 1772 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o