### PR TITLE
fix: `workspace use` stops promising a persistence it did not write

### DIFF
--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -633,8 +633,18 @@ def cmd_workspace_pushbg(args) -> int:
 
 
 def _scope_note(scope: str) -> str:
-    if scope in ("session", "terminal"):
+    """How far the selection reaches, in the words the reader needs.
+
+    Only a terminal pointer survives closing and reopening Claude. A session-scoped
+    selection is gone the moment the session is, and saying so is the whole point: the
+    reader who is not told goes looking for a bug the next time the status line says
+    `default`.
+    """
+    if scope == "terminal":
         return " (this terminal only — kept across closing/reopening Claude)"
+    if scope == "session":
+        return (f" (this session only — this terminal reports no pane id, so a new "
+                f"session starts at '{config.DEFAULT_WORKSPACE}')")
     return ""
 
 

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -299,20 +299,24 @@ def set_active(name: str, session_id: str | None = None, force: bool = False) ->
     if locked and locked != name and not force:
         return "locked"
     config.STATE_DIR.mkdir(parents=True, exist_ok=True)
-    scope = "none"
     tid = _terminal_id()
     if tid:
         config.TERMINALS_DIR.mkdir(parents=True, exist_ok=True)
         _terminal_file(tid).write_text(name + "\n")
-        scope = "terminal"
     sid = _session_id(session_id)
     if sid:
         config.SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
         _session_file(sid).write_text(name + "\n")
         _lock_file(sid).write_text(name + "\n")  # confirming = locking for the session
-        scope = "session"
     _prune()
-    return scope
+    # The scope is the REACH of what was written, so it names the longest-lived pointer
+    # that actually landed — and the terminal one outlives the session one. These used to
+    # be assigned in sequence, so the session branch overwrote the terminal branch and
+    # every caller was told `session`. `_scope_note` reads persistence out of this value,
+    # so a pane that HAD kept its workspace across restarts was told it had not, and a
+    # shell with no pane id at all was told it had, which is the direction that costs
+    # someone their selection with nothing having said so.
+    return "terminal" if tid else "session" if sid else "none"
 
 
 def reconcile(session_id: str | None = None, terminal_id: str | None = None) -> str | None:

--- a/tests/test_workspace_scope_honesty.py
+++ b/tests/test_workspace_scope_honesty.py
@@ -1,0 +1,105 @@
+"""What `workspace use` promises must be what it wrote.
+
+`set_active` writes up to two pointers: a **per-terminal** one, which is what lets a pane
+keep its workspace across closing and reopening Claude, and a **per-session** one, which
+lasts exactly as long as the session. Only the first survives a restart.
+
+It reported both as ``"session"`` — the terminal branch set the scope and the session
+branch overwrote it — and `_scope_note` printed "kept across closing/reopening Claude" for
+that value. So a terminal that could not supply a pane id (no ``TERM_SESSION_ID``, no
+``TMUX_PANE``, no ``STY``, no ``SSH_TTY``, no tty — an agent shell, a CI runner) got the
+persistence promise while nothing persistent had been written. Reopen, and the workspace
+is `default` again with nothing having said so.
+
+The scope is the *reach* of what was written, so it must name the strongest pointer that
+actually landed, and the message must follow it rather than assume the good case.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from charter import config, workspace
+from charter.commands_workspace import _scope_note
+from tests._isolation import PersonaIso
+
+
+class ScopeBase(PersonaIso):
+    SID = "sess-scope-test"
+
+    def setUp(self) -> None:
+        super().setUp()
+        config.WORKSPACES_DIR.mkdir(parents=True, exist_ok=True)
+        (config.WORKSPACES_DIR / "alpha").mkdir(exist_ok=True)
+
+        # Stand outside every workspace tree: the cwd rung outranks the pointers, and
+        # this suite is about the pointers.
+        self._cwd = os.getcwd()
+        os.chdir(self.tmp)
+        self.addCleanup(lambda: os.chdir(self._cwd))
+
+        self._env = {k: os.environ.get(k)
+                     for k in ("CLAUDE_CODE_SESSION_ID", "CHARTER_WORKSPACE")}
+        os.environ["CLAUDE_CODE_SESSION_ID"] = self.SID
+        os.environ.pop("CHARTER_WORKSPACE", None)
+        self.addCleanup(self._restore_env)
+
+    def _restore_env(self) -> None:
+        for k, v in self._env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+class TestScopeNamesWhatWasWritten(ScopeBase):
+    def test_a_pane_id_yields_terminal_scope(self):
+        with mock.patch.object(workspace, "_terminal_id", return_value="pane-1"):
+            self.assertEqual(workspace.set_active("alpha"), "terminal")
+
+    def test_no_pane_id_yields_session_scope(self):
+        with mock.patch.object(workspace, "_terminal_id", return_value=None):
+            self.assertEqual(workspace.set_active("alpha"), "session")
+
+    def test_terminal_scope_means_a_terminal_pointer_exists(self):
+        """The claim and the file have to travel together."""
+        with mock.patch.object(workspace, "_terminal_id", return_value="pane-1"):
+            scope = workspace.set_active("alpha")
+        self.assertEqual(scope, "terminal")
+        self.assertTrue(workspace._terminal_file("pane-1").exists())
+
+    def test_session_scope_leaves_nothing_a_new_session_can_read(self):
+        """Which is the whole reason it must not claim to survive one."""
+        with mock.patch.object(workspace, "_terminal_id", return_value=None):
+            workspace.set_active("alpha")
+        self.assertEqual(workspace.resolve(session_id="a-different-session"),
+                         config.DEFAULT_WORKSPACE)
+
+    def test_the_session_pointer_is_still_written_either_way(self):
+        """Reporting the terminal scope must not cost the status line its pointer."""
+        with mock.patch.object(workspace, "_terminal_id", return_value="pane-1"):
+            workspace.set_active("alpha")
+        self.assertEqual(workspace.resolve(session_id=self.SID), "alpha")
+
+
+class TestTheMessageFollowsTheScope(ScopeBase):
+    def test_terminal_scope_may_promise_a_restart(self):
+        self.assertIn("reopening", _scope_note("terminal"))
+
+    def test_session_scope_must_not_promise_a_restart(self):
+        note = _scope_note("session")
+        self.assertNotIn("reopening", note)
+        self.assertIn("session", note.lower())
+
+    def test_session_scope_says_what_happens_instead(self):
+        """A limit the reader has to discover by losing their workspace was concealed."""
+        self.assertIn(config.DEFAULT_WORKSPACE, _scope_note("session"))
+
+    def test_nothing_written_promises_nothing(self):
+        self.assertEqual(_scope_note("none"), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

`set_active` writes up to two pointers. Only the **per-terminal** one survives closing and reopening Claude; the **per-session** one lasts exactly as long as the session. The two branches assigned `scope` in sequence:

```python
scope = "none"
tid = _terminal_id()
if tid:  ... scope = "terminal"
sid = _session_id(session_id)
if sid:  ... scope = "session"      # ← overwrites, unconditionally
```

so every caller was told `session`, and `_scope_note` printed *"kept across closing/reopening Claude"* for that value.

Both directions were wrong, and one of them costs someone their selection:

- a pane that **had** kept its workspace across restarts was described as if it had not;
- a shell that can supply **no pane id at all** — no `TERM_SESSION_ID`, no `TMUX_PANE`, no `STY`, no `SSH_TTY`, no tty, which is an agent shell or a CI runner — was promised persistence while nothing persistent had been written.

Reopen, and the workspace is `default` again with nothing having said so. That reads as a bug in the status line, which is where it gets reported.

## How it surfaced

A session ran `charter workspace use showcase`, was told the choice was "kept across closing/reopening Claude", and a second window on the same plane showed `default`. It was working exactly as built — no pane id was derivable, so only a session pointer existed, and a session pointer reaches exactly one session.

## The change

The scope now names the **longest-lived pointer that actually landed**, and the message follows it:

| scope | message |
| --- | --- |
| `terminal` | this terminal only — kept across closing/reopening Claude |
| `session` | this session only — this terminal reports no pane id, so a new session starts at `'default'` |
| `none` | *(nothing)* |

Verified against real CLI output, both with and without a pane id present.

## What this deliberately does not fix

The missing fallback. Nothing below the session pointer catches a new session, and adding a plane-level "last active workspace" would reintroduce precisely the cross-session leak `_terminal_id` was hardened against when `WINDOWID` let every session in one window share a pointer — an incident its docstring records. That is a design decision with a real trade-off on both sides, so it is filed as its own issue. This PR only stops the message from concealing it.

## Tests

`tests/test_workspace_scope_honesty.py`, 9 tests, written before the fix and watched fail. They pin the scope value in both directions, that `terminal` scope means the file a new session could read actually exists, that `session` scope leaves nothing such a session can read, that the session pointer is still written either way (the status line depends on it), and that the message never claims more than the scope earned.

Full suite: 1781 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o