### PR TITLE
fix: `vault add --share` no longer publishes into its own shadow

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -670,6 +670,55 @@ def check_personas() -> Result:
                   hint="charter persona lint  (per-persona detail and how to fix each)")
 
 
+def check_vault_registry_divergence() -> Result:
+    """The two halves of the vault registry, disagreeing about the same vault.
+
+    `registry.load_registry` layers local over shared **per field**, so where both halves
+    define one, the local value is what every read resolves through — silently, and while
+    `vault list` reports the scope as `both` and says nothing more. The failure it produces
+    is an empty vault rather than an error: `secret get` reports the key missing,
+    `vault verify` finds no references, and `check_vaults` stays green because reachability
+    is not resolution.
+
+    FAIL rather than WARN, per ADR 0013: `cmd_doctor` exits non-zero only on FAIL, and that
+    exit code is the only thing that makes the SessionStart wrapper print. A divergence
+    worth naming is worth failing for.
+
+    :data:`LOCAL_ONLY_KEYS` are excluded by construction — an account pin layered over a
+    shared entry is the design working, not a fault.
+    """
+    from .secrets import base, registry
+
+    try:
+        shared = registry.load_shared().get("vaults", {})
+        local = registry.load_local().get("vaults", {})
+    except base.VaultError as e:
+        return Result("vault registry", WARN, hint=str(e))
+
+    clashes = []
+    for name in sorted(set(shared) & set(local)):
+        s, l = shared[name] or {}, local[name] or {}
+        for key in ("provider", "persona"):
+            sv, lv = s.get(key), l.get(key)
+            if sv is not None and lv is not None and sv != lv:
+                clashes.append(f"{name}.{key}: shared {sv!r}, local {lv!r}")
+        sc, lc = s.get("config") or {}, l.get("config") or {}
+        for key in sorted(set(sc) & set(lc)):
+            if key in registry.LOCAL_ONLY_KEYS or sc[key] == lc[key]:
+                continue
+            clashes.append(f"{name}.{key}: shared {sc[key]!r}, local {lc[key]!r}")
+
+    if not clashes:
+        return Result("vault registry", OK, detail="shared and local halves agree")
+    shown = "; ".join(clashes[:3])
+    if len(clashes) > 3:
+        shown += f" (+{len(clashes) - 3} more)"
+    return Result("vault registry", FAIL, detail=shown,
+                  hint="the local half shadows the shared one field by field, so these "
+                       "resolve through the local value. Re-publish to clear it: "
+                       "charter vault add <name> --provider <p> … --share --force")
+
+
 def check_plugin_skew() -> Result:
     """`charter` ships as two artifacts — the CLI (pip/uv) and the Claude Code plugin
     (``.claude-plugin/plugin.json`` + ``hooks/hooks.json``) — with two version numbers.
@@ -747,7 +796,8 @@ def _checks():
         results.append(check_forge_auth(forge))
     results += [check_ssh(), check_control_plane_config(), check_control_plane_schema(),
                 check_plane_root(),
-                check_inventory(), check_vaults(), check_version_lock(),
+                check_inventory(), check_vaults(),
+                check_vault_registry_divergence(), check_version_lock(),
                 check_memory_indexes(), check_personas(),
                 check_plugin_skew()]
     return results

--- a/charter/secrets/registry.py
+++ b/charter/secrets/registry.py
@@ -204,9 +204,26 @@ def add_vault(name: str, provider: str, cfg: dict, persona: str | None = None,
         save_shared(shared)
         # An account pin still belongs to this machine, so it is layered on top rather
         # than published with the rest of the entry.
-        if local_cfg:
-            local = load_local()
-            local["vaults"].setdefault(name, {}).setdefault("config", {}).update(local_cfg)
+        #
+        # The local half is also REDUCED to those keys, which is the other half of the
+        # same idea. `load_registry` layers local over shared per field, so a registration
+        # that already existed locally shadows the one just published — every field of it,
+        # guaranteed, not as a race. Publishing without clearing it therefore did nothing
+        # at all: the entry landed in the committed half while every read still resolved
+        # through the stale local copy, and `vault add` printed the old item name back
+        # under a success line because it read the merged view (ADR 0013).
+        local = load_local()
+        previous = local["vaults"].get(name)
+        keep = {k: v for k, v in ((previous or {}).get("config") or {}).items()
+                if k in LOCAL_ONLY_KEYS}
+        keep.update(local_cfg)
+        if keep:
+            local["vaults"][name] = {"config": keep}
+            save_registry(local)
+        elif previous is not None:
+            # Nothing local-only to preserve, so the entry goes rather than lingering as
+            # an empty shadow waiting to shadow the next change.
+            del local["vaults"][name]
             save_registry(local)
     else:
         entry["config"] = {**cfg, **local_cfg}

--- a/tests/test_vault_share_shadow.py
+++ b/tests/test_vault_share_shadow.py
@@ -1,0 +1,135 @@
+"""`--share` over an existing local registration, and the divergence it used to leave.
+
+The two registry halves merge per FIELD, shared as the base with local layered over it
+(`registry.load_registry`). So a vault registered with the bare form and then re-registered
+with `--share --force` kept resolving through the OLD local entry: the shared half got the
+new provider, item and persona, and every one of them was shadowed. Not a race — guaranteed
+by the merge order, for any field the local copy defines.
+
+`vault add` then printed a success line quoting the item name it read back from the merged
+view, which is to say the stale one. Reported from the field: registration announced ✓, the
+vault resolved to nothing, `vault verify` said "no references to verify", and `doctor`
+stayed green because reachability is not resolution.
+
+Every existing test in `test_vault_registration.py` starts from `share=True`, which is why
+the sequence that bit — bare first, then shared — had no coverage at all.
+
+ADR 0013: `--force` now replaces both halves, and a registry that disagrees with itself is
+named rather than silently resolved.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import doctor
+from charter.secrets import registry
+from tests._isolation import PersonaIso
+
+
+class ShareOverLocalBase(PersonaIso):
+    def _bare(self, **cfg):
+        registry.add_vault("ops", "1password",
+                           {"op-vault": "Engineering", "op-item": "SECRET", **cfg},
+                           persona="ops")
+
+    def _shared(self, **cfg):
+        registry.add_vault("ops", "1password",
+                           {"op-vault": "Engineering", "op-item": "charter-ops", **cfg},
+                           persona="ops", force=True, share=True)
+
+
+class TestShareClearsTheShadow(ShareOverLocalBase):
+    def test_the_merged_view_resolves_to_the_new_item(self):
+        """The whole bug in one assertion."""
+        self._bare()
+        self._shared()
+        self.assertEqual(registry.vaults()["ops"]["config"]["op-item"], "charter-ops")
+
+    def test_the_local_half_keeps_no_substantive_field(self):
+        """Anything it kept would shadow the shared entry again on the next change."""
+        self._bare()
+        self._shared()
+        local = registry.load_local().get("vaults", {}).get("ops", {})
+        self.assertNotIn("op-item", local.get("config", {}))
+        self.assertIsNone(local.get("provider"))
+
+    def test_the_account_pin_survives(self):
+        """It is the one field that legitimately belongs to this machine, so clearing the
+        shadow must not take it — that would silently unpin the developer's account."""
+        self._bare(account="me@corp.com")
+        self._shared()
+        self.assertEqual(registry.vaults()["ops"]["config"]["account"], "me@corp.com")
+        self.assertNotIn("account", registry.load_shared()["vaults"]["ops"]["config"])
+
+    def test_a_new_account_pin_still_lands_locally(self):
+        self._bare()
+        self._shared(account="me@corp.com")
+        self.assertEqual(registry.load_local()["vaults"]["ops"]["config"]["account"],
+                         "me@corp.com")
+        self.assertNotIn("account", registry.load_shared()["vaults"]["ops"]["config"])
+
+    def test_sharing_from_scratch_is_unchanged(self):
+        self._shared()
+        self.assertEqual(registry.vaults()["ops"]["config"]["op-item"], "charter-ops")
+        self.assertEqual(registry.scope_of("ops"), "shared")
+
+    def test_it_still_refuses_without_force(self):
+        """Clearing the shadow is what `--force` now means; it is not a new licence."""
+        self._bare()
+        with self.assertRaises(Exception):
+            registry.add_vault("ops", "plain-file", {}, persona="ops", share=True)
+
+
+class TestDoctorNamesADisagreeingRegistry(ShareOverLocalBase):
+    def _result(self):
+        return doctor.check_vault_registry_divergence()
+
+    def test_a_registry_that_disagrees_with_itself_fails(self):
+        """FAIL, not WARN: doctor exits non-zero only on FAIL, and that exit code is the
+        only thing that makes the SessionStart wrapper print (ADR 0013)."""
+        registry.save_shared({"vaults": {"ops": {"provider": "1password", "persona": "ops",
+                                                 "config": {"op-item": "charter-ops"}}}})
+        registry.save_registry({"vaults": {"ops": {"provider": "1password", "persona": "ops",
+                                                   "config": {"op-item": "SECRET"}}}})
+        r = self._result()
+        self.assertEqual(r.status, doctor.FAIL)
+        self.assertIn("ops", r.detail + (r.hint or ""))
+
+    def test_it_names_the_field_and_both_values(self):
+        registry.save_shared({"vaults": {"ops": {"config": {"op-item": "charter-ops"}}}})
+        registry.save_registry({"vaults": {"ops": {"config": {"op-item": "SECRET"}}}})
+        text = " ".join(filter(None, [self._result().detail, self._result().hint]))
+        for expected in ("op-item", "SECRET", "charter-ops"):
+            self.assertIn(expected, text)
+
+    def test_an_account_pin_is_not_a_divergence(self):
+        """Layering a local account over a shared entry is the design, not a fault."""
+        registry.save_shared({"vaults": {"ops": {"config": {"op-item": "charter-ops"}}}})
+        registry.save_registry({"vaults": {"ops": {"config": {"account": "me@corp.com"}}}})
+        self.assertEqual(self._result().status, doctor.OK)
+
+    def test_a_vault_in_one_half_only_is_not_a_divergence(self):
+        registry.save_shared({"vaults": {"team": {"config": {"op-item": "x"}}}})
+        registry.save_registry({"vaults": {"solo": {"config": {"op-item": "y"}}}})
+        self.assertEqual(self._result().status, doctor.OK)
+
+    def test_agreeing_halves_are_fine(self):
+        registry.save_shared({"vaults": {"ops": {"config": {"op-item": "same"}}}})
+        registry.save_registry({"vaults": {"ops": {"config": {"op-item": "same"}}}})
+        self.assertEqual(self._result().status, doctor.OK)
+
+    def test_the_fix_leaves_nothing_for_the_check_to_find(self):
+        """The two halves of this PR, meeting in the middle."""
+        self._bare(account="me@corp.com")
+        self._shared()
+        self.assertEqual(self._result().status, doctor.OK)
+
+    def test_the_check_runs_in_the_real_preflight(self):
+        """A check nobody calls is a check nobody has."""
+        self.assertIn("vault registry",
+                      [r.name for r in doctor.run_all()])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #128. PR ② of four. Cites #129 (ADR 0013).

## The mechanism

Sharper than the report could see from outside: this is not a race, and not "the runtime file was stale".

`load_registry` merges the two halves **per field** — shared as the base, local layered over it. So a vault registered with the bare form and then re-registered with `--share --force` kept resolving through the **old local entry**. The shared half took the new provider, item and persona; every one of them was shadowed. Guaranteed by the merge order, for any field the local copy defines.

`vault add` then printed the old item name back under a success line, because it reads the merged view — which is to say, the shadow. From the field: registered ✓, vault resolves to nothing, `vault verify` reports no references, `doctor` green throughout because reachability is not resolution. The tempting next move is to reach past charter to raw `op`, which is the behaviour the reference-vault design exists to prevent.

## The fix

**`--force` replaces both halves.** The local entry is reduced to `LOCAL_ONLY_KEYS`, so a developer's 1Password account pin survives — that field is genuinely per-machine, and clearing it would silently unpin the account. An entry with nothing left to keep is deleted outright rather than lingering as an empty shadow waiting to shadow the next change.

**`doctor` names a registry that disagrees with itself** — the first application of ADR 0013's second rule. FAIL rather than WARN, because `doctor` exits non-zero only on FAIL and that exit code is the only thing that makes the SessionStart wrapper print. It reports vault, field and both values, and excludes `LOCAL_ONLY_KEYS`, since an account pin layered over a shared entry is the design working rather than a fault.

## Verified end to end, not only in fixtures

Register bare, then `--share --force`:

```
✓ Vault 'ops' registered (provider: plain-file) [local only].
! Replaced the previous 'ops' registration … They remain at ops-old.json.
✓ Vault 'ops' registered (provider: plain-file) [shared — commit vaults.json].

VAULT   PROVIDER     SCOPE   STATUS
ops     plain-file   shared  not created yet (ops-new.json)     ← was ops-old.json
✓  vault registry   shared and local halves agree
```

And a registry hand-placed into the reported split state:

```
✗  vault registry   ops.op-item: shared 'charter-ops', local 'SECRET'
      → the local half shadows the shared one field by field … --share --force
✗ 1 blocker(s): vault registry.
doctor exit: 1
```

The `account` pin in that same local entry was correctly **not** flagged.

## On the missing coverage

Every existing test in `tests/test_vault_registration.py` starts from `share=True` — including the one that pins the account-pin overlay. The sequence that bit, **bare first and then shared**, had no coverage at all. The 13 new tests were written before the fix and watched fail; the headline one reproduced the report exactly (`'SECRET' != 'charter-ops'`).

Suite: 1794 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o