### PR TITLE
fix: say that a version pin is advice, and stop printing a stale `latest`

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1236,10 +1236,11 @@ def cmd_version(args) -> int:
 
     print(f"  installed  {installed}")
     print(f"  locked     {locked or '— (this control plane pins no version)'}")
-    print(f"  latest     {latest or '— (not checked yet)'}")
+    print(f"  latest     {update.latest_display(installed)}")
     print()
     if locked and locked != installed:
         util.warn(f"drift: this control plane pins {locked}, you are running {installed}.")
+        util.info(f"  {update.SHARED_INSTALL_NOTE}")
         util.info(f"  conform this machine:  charter version sync")
         return 1
     if latest and update.newer_than(installed):
@@ -1262,6 +1263,10 @@ def cmd_version_sync(args) -> int:
     if locked == installed:
         util.ok(f"already on the locked version ({locked}).")
         return 0
+    # Said before the install, not after: this conforms a binary every plane on the
+    # machine shares, so the next plane the reader opens may have just gone into drift.
+    from . import update as _update
+    util.warn(_update.SHARED_INSTALL_NOTE)
     util.info(f"syncing {installed} → {locked} …")
     ok, detail = sync_to(locked)
     if not ok:

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -526,9 +526,14 @@ def check_version_lock() -> Result:
         return Result("version lock", OK, detail="not pinned")
     if locked == __version__:
         return Result("version lock", OK, detail=f"pinned {locked}, in sync")
+    from . import update
+    # The note rides on the drift branch only. Everywhere else it is furniture, and a
+    # sentence printed on every clean preflight is a sentence nobody reads on the one
+    # that isn't.
     return Result("version lock", WARN,
                   detail=f"pinned {locked}, running {__version__}",
-                  hint="Run: charter version sync  (conforms this machine to the lock)")
+                  hint=f"{update.SHARED_INSTALL_NOTE}. "
+                       f"Run: charter version sync  (conforms this machine to the lock)")
 
 
 def check_memory_indexes() -> Result:

--- a/charter/update.py
+++ b/charter/update.py
@@ -30,6 +30,21 @@ SPAWN_COOLDOWN = 3600     # and at most one background attempt per hour, success
 NET_TIMEOUT = 5           # a detached child, but still: never hang around
 
 
+#: Said wherever a pin and an install disagree, and nowhere else.
+#:
+#: The pin is per control plane; the binary is one machine-global install. Two planes
+#: pinning different versions cannot both be satisfied, and `version sync` does not fix
+#: that — it picks a winner and puts the other plane into drift, which is how a plane that
+#: nobody touched went from "in sync" to "drift" because of work done somewhere else.
+#: charter is a control plane, not a version manager, so it says this rather than growing a
+#: shim to resolve the pinned version per plane.
+SHARED_INSTALL_NOTE = (
+    "the `charter` binary is ONE machine-global install shared by every control plane on "
+    "this machine, so a pin is advisory — syncing here can put another plane into drift "
+    "(see: uv tool list)"
+)
+
+
 def _cache_file() -> Path:
     return config.STATE_DIR / "cache" / "update.json"
 
@@ -67,6 +82,31 @@ def newer_than(current: str) -> str | None:
         return latest if _parse(latest) > _parse(current) else None
     except Exception:
         return None
+
+
+def latest_display(installed: str) -> str:
+    """The `latest` line, honest about what it is.
+
+    `latest` is a reading of PyPI cached for up to :data:`REFRESH_TTL`, not a live answer.
+    Usually the distinction does not matter. It matters completely in one case: when the
+    INSTALLED version is newer than the cached one, the cache is *provably* out of date —
+    you cannot be running something PyPI has not published — and printing the lower number
+    beside it produced `installed 0.27.2 / latest 0.26.0`, a contradiction on one screen
+    that invites the reader to distrust every other line in the output.
+
+    So that case reports the staleness instead of the number. ADR 0013: do not present as
+    checked what was not checked.
+    """
+    latest = (load().get("latest") or "").strip()
+    if not latest:
+        return "— (not checked yet)"
+    try:
+        stale = bool(installed) and _parse(latest) < _parse(installed)
+    except Exception:
+        stale = False
+    if stale:
+        return f"— (cached {latest} is stale: it predates the {installed} you are running)"
+    return latest
 
 
 def fetch_and_store() -> str | None:

--- a/tests/test_version_pin_honesty.py
+++ b/tests/test_version_pin_honesty.py
@@ -1,0 +1,111 @@
+"""What `version` and `doctor` may claim about a pin they cannot enforce.
+
+A pin lives in `charter.toml`, per control plane. The binary is ONE machine-global install
+— `uv tool install charter-cp` puts a single `charter` on PATH — so two planes pinning
+different versions cannot both be satisfied, and `version sync` does not resolve that, it
+picks a winner and puts the other plane into drift. Reported from the field after exactly
+that: a plane pinning 0.27.0 went from "in sync" to "drift" without a command being run in
+it, because work in another plane upgraded the shared install.
+
+The decision (see the parked issue) is that a pin is **advice**, not a promise charter
+enforces — building a version-resolving shim is a version manager, and charter is a control
+plane. What has to change is what charter *says*: drift is not this plane's private problem,
+and the tooling should stop implying it is.
+
+Separately, `latest` is a ≤24h cached PyPI reading (`update.REFRESH_TTL`). When the
+installed version is NEWER than that cache, the cache is provably stale, and printing the
+lower number as `latest` invites the reader to distrust every other line — which is how the
+field report ended up with `installed 0.27.2 / latest 0.26.0`.
+
+ADR 0013: do not report as checked what was not checked.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from unittest import mock
+
+from charter import doctor, update
+from tests._isolation import PersonaIso
+
+
+class TestLatestIsNotPresentedAsFactWhenStale(PersonaIso):
+    def _cache(self, latest, ts=1.0):
+        f = update._cache_file()
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(f'{{"latest": "{latest}", "ts": {ts}}}')
+
+    def test_no_cache_says_so(self):
+        self.assertIn("not checked", update.latest_display("0.27.2"))
+
+    def test_a_cache_ahead_of_you_shows_the_version(self):
+        self._cache("0.28.0")
+        self.assertIn("0.28.0", update.latest_display("0.27.2"))
+
+    def test_a_cache_equal_to_you_shows_the_version(self):
+        self._cache("0.27.2")
+        self.assertIn("0.27.2", update.latest_display("0.27.2"))
+
+    def test_a_cache_behind_you_is_not_offered_as_the_latest(self):
+        """`installed 0.27.2 / latest 0.26.0` is a self-contradiction on the same screen.
+        The reading is not wrong, it is OLD, and it must say which."""
+        self._cache("0.26.0")
+        shown = update.latest_display("0.27.2")
+        self.assertNotEqual(shown.strip(), "0.26.0")
+        self.assertIn("stale", shown.lower())
+
+    def test_it_never_implies_you_are_behind_when_you_are_ahead(self):
+        self._cache("0.26.0")
+        self.assertIsNone(update.newer_than("0.27.2"))
+
+
+class TestThePinIsDescribedAsAdvice(PersonaIso):
+    def test_the_drift_hint_says_the_install_is_machine_wide(self):
+        """Otherwise drift reads as this plane's private problem, and the fix reads as
+        `version sync` — which just moves the drift to whichever plane you left."""
+        with mock.patch("charter.instance.locked_version", return_value="0.27.0"), \
+             mock.patch("charter.__version__", "0.27.2"):
+            r = doctor.check_version_lock()
+        self.assertEqual(r.status, doctor.WARN)
+        text = (r.detail or "") + " " + (r.hint or "")
+        self.assertIn(update.SHARED_INSTALL_NOTE, text)
+
+    def test_a_plane_in_sync_says_nothing_about_it(self):
+        """The note is for the moment it matters. Everywhere else it is furniture."""
+        with mock.patch("charter.instance.locked_version", return_value="0.27.2"), \
+             mock.patch("charter.__version__", "0.27.2"):
+            r = doctor.check_version_lock()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertNotIn(update.SHARED_INSTALL_NOTE, (r.detail or "") + (r.hint or ""))
+
+    def test_the_note_names_how_to_see_the_truth(self):
+        self.assertIn("uv tool list", update.SHARED_INSTALL_NOTE)
+
+    def test_the_note_does_not_promise_enforcement(self):
+        low = update.SHARED_INSTALL_NOTE.lower()
+        self.assertIn("advisory", low)
+
+
+class TestVersionSyncSaysWhatItMutates(PersonaIso):
+    def test_sync_warns_before_moving_a_shared_install(self):
+        """`version sync` conforms the ONE global binary, so it can put every other plane
+        on this machine into drift. That has to be said at the moment it is run."""
+        from charter import commands
+
+        with mock.patch("charter.instance.locked_version", return_value="0.27.0"), \
+             mock.patch("charter.commands._installed_version", return_value="0.27.2"), \
+             mock.patch("charter.commands.sync_to", return_value=(False, "not really")):
+            out, err = io.StringIO(), io.StringIO()
+            # charter's util writes progress to stderr; capture both so the assertion
+            # does not depend on which stream a given line uses.
+            with redirect_stdout(out), redirect_stderr(err):
+                commands.cmd_version_sync(mock.Mock(yes=True))
+            printed = out.getvalue() + err.getvalue()
+        self.assertIn("machine", printed.lower())
+        self.assertIn(update.SHARED_INSTALL_NOTE, printed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
PR ③ of four. Addresses the reportable half of #127; the rest of that issue is parked in ④ with a stated unpark trigger.

## The pin cannot be enforced, so stop implying it can

The pin lives in `charter.toml`, **per control plane**. The binary is **one machine-global install** — `uv tool install charter-cp` puts a single `charter` on PATH. Two planes pinning different versions cannot both be satisfied. Confirmed on the reporter's machine: three planes, pins of `0.27.0`, `0.24.0` and none, against one installed `0.27.2`.

`version sync` does not resolve this. It picks a winner and puts the other plane into drift — which is exactly how a plane nobody touched went from `✓ in sync` to `! drift` because of work done somewhere else entirely.

The decision is that **charter is a control plane, not a version manager**: no shim resolving the pinned version per plane, because that is pyenv, and supporting it forever is a large bill for a case that appears on machines running several planes at different pins. What changes is what charter *claims*. Wherever a pin and an install disagree — `version`, `doctor`, and `version sync` **before** it mutates anything — it now says the install is shared machine-wide, that the pin is advisory, and names `uv tool list` as the way to see the truth.

The note rides the drift branch only. A sentence printed on every clean preflight is a sentence nobody reads on the preflight that isn't.

## `latest` was reporting a number it could prove was wrong

`latest` is a PyPI reading cached for up to 24h (`update.REFRESH_TTL`), not a live answer. Invisible until the installed version is **newer** than the cache — at which point the cache is provably stale, since you cannot be running something PyPI has not published. charter printed the lower number anyway:

```
installed  0.27.2
latest     0.26.0
```

That contradiction on one screen invites the reader to distrust every other line, and it did: the field report **opens by asking that its own version footer be disregarded**. Now:

```
latest     — (cached 0.26.0 is stale: it predates the 0.27.2 you are running)
```

## Verified against the reporter's exact state

A plane pinning `0.27.0`, a stale `0.26.0` cache, running `0.27.2`:

```
! drift: this control plane pins 0.27.0, you are running 0.27.2.
•   the `charter` binary is ONE machine-global install shared by every control plane on
    this machine, so a pin is advisory — syncing here can put another plane into drift
    (see: uv tool list)
•   conform this machine:  charter version sync
  installed  0.27.2
  locked     0.27.0
  latest     — (cached 0.26.0 is stale: it predates the 0.27.2 you are running)
```

10 new tests, written before the change and watched fail. They also pin the negative: a plane **in sync** says nothing about the shared install, because that is where the note would become furniture.

Suite: 1804 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o