### PR TITLE
0.28.0 — a registry that disagrees with itself gets named

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.27.2",
+  "version": "0.28.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.27.2"
+__version__ = "0.28.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.27.2",
+            "command": "charter hook sessionstart --plugin-version 0.28.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.27.2",
+            "command": "charter hook userpromptsubmit --plugin-version 0.28.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.27.2",
+            "command": "charter hook pretooluse --plugin-version 0.28.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.27.2",
+            "command": "charter hook pretooluse-read --plugin-version 0.28.0",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.27.2"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.28.0"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.27.2",
+            "command": "charter hook posttooluse --plugin-version 0.28.0",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.27.2",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.28.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.27.2"
+version = "0.28.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only. All four locations move together, pinned by `TestVersionsMoveInLockstep`.

## Why minor rather than patch

The new `doctor` check makes a machine whose two vault-registry halves disagree **FAIL preflight for a state it also had yesterday**. No flag and no config key changed, so the letter of the rule in `personas/release/persona.md` says patch — but a `doctor` that exits 1 where it exited 0, on an unchanged machine, is a changed default in the only sense a user experiences. ADR 0013 names that consequence explicitly; the version number should carry it too.

## What ships

- **#129** — ADR 0013, *success is checked, divergence is named*. Descriptive rather than new law: the rule had already been derived three times in comments, and the one site where nobody had derived it (`_scope_note`) is the one that shipped a false promise.
- **#130** — `vault add --share` published into its own shadow. The registry halves merge per field with local over shared, so `--share --force` left every new value shadowed by the old local entry while the success line read the shadow back. `--force` now replaces both halves, keeping the per-machine account pin; `doctor` gained the FAIL check. **Closes #128.**
- **#131** — a version pin is advice, not a promise. The binary is one machine-global install, and charter now says so wherever a pin and an install disagree. `latest` stops printing a cached number it can prove is stale.

**#130 and #131 both came from consumer reports filed through `charter report`** (#128, #127) — the first end-to-end use of that path. #124, #126 and the unfixed half of #127 are labelled `parked`, each with a stated unpark trigger.

Suite: 1804 passing.

## After merge

```
git tag -a v0.28.0 -m "0.28.0 — a registry that disagrees with itself gets named"
git push origin v0.28.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o