### PR TITLE
persona: two things this session learned the hard way

### DIFF
--- a/personas/steward/memory/MEMORY.md
+++ b/personas/steward/memory/MEMORY.md
@@ -10,3 +10,5 @@ Written by the persona as it learns; committed and shared.
 - [Live-testing charter CLI changes from a worktree does NOT work: charter.](live-testing-charter-cli-changes-from-a-worktree.md)
 - [macOS vs Linux filesystem divergence that turned CI red in this repo: pa](macos-vs-linux-filesystem-divergence-that-turned.md)
 - [charter persona remember run from inside a WORKTREE writes to the clone,](charter-persona-remember-run-from-inside-a-workt.md)
+- [Rendering 'charter statusline' for screenshots/assets: the payload's ses](rendering-charter-statusline-for-screenshots-ass.md)
+- [Validating mermaid before committing it (GitHub renders a syntax error a](validating-mermaid-before-committing-it-github-r.md)

--- a/personas/steward/memory/rendering-charter-statusline-for-screenshots-ass.md
+++ b/personas/steward/memory/rendering-charter-statusline-for-screenshots-ass.md
@@ -1,0 +1,5 @@
+# Rendering 'charter statusline' for screenshots/assets: the payload's ses
+
+_2026-08-14 12:39 · persistent_
+
+Rendering 'charter statusline' for screenshots/assets: the payload's session_id decides the workspace. workspace.resolve() precedence is --workspace -> $CHARTER_WORKSPACE -> cwd (os.getcwd(), NOT the payload's workspace.current_dir) -> per-session pointer -> per-terminal pointer -> default. 'charter workspace use X' writes a per-SESSION pointer, so a made-up session_id in a hand-fed payload renders 'default' even while 'charter workspace list' says 'X (via session)'. For a reproducible capture, pin [workspace] default = "<ws>" in that plane's charter.toml so the last rung is right.

--- a/personas/steward/memory/validating-mermaid-before-committing-it-github-r.md
+++ b/personas/steward/memory/validating-mermaid-before-committing-it-github-r.md
@@ -1,0 +1,5 @@
+# Validating mermaid before committing it (GitHub renders a syntax error a
+
+_2026-08-14 13:47 · persistent_
+
+Validating mermaid before committing it (GitHub renders a syntax error as a red error box): the official CLI works offline-ish against the already-installed Chrome — write puppeteer.json {"executablePath":"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome","args":["--no-sandbox"]} then PUPPETEER_SKIP_DOWNLOAD=1 npx -y @mermaid-js/mermaid-cli@11 -p puppeteer.json -i x.mmd -o x.svg. Extract the fenced blocks from the README and validate them AS EMBEDDED, not the sources they came from.


### PR DESCRIPTION
Two steward memories from the README/front-door session. Both cost real time before they were understood, and both recur — the assets they concern get regenerated whenever the status line or a diagram changes.

**`charter statusline` resolves its workspace from the payload's `session_id`.** A hand-fed payload with a made-up id renders `default` while `charter workspace list` simultaneously reports the real workspace "via session". Every screenshot taken that way is of the wrong workspace, silently, unless the plane pins one in `charter.toml`. This is what sent us looking for a workspace-switching bug that did not exist — and, in looking, found the two that did (#121, #123).

**Mermaid can be validated before GitHub renders a syntax error as a red box on the front page.** Point the official CLI at the Chrome already installed (`PUPPETEER_SKIP_DOWNLOAD=1` plus a `puppeteer.json` naming the executable) — no download, no toolchain. And validate the blocks **as embedded in the README**, not the sources they came from: extraction is a regex over fences, and a ` ```bash ` block's *closing* fence reads as an opening one, so a naive scan pairs the wrong things and silently checks nothing.

Committed by hand, because `[memory].share` is `local` on this plane: charter writes these to disk and never commits them. The eight already in this directory arrived the same way (#118).

`personas/steward/memory` tests: 23 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o