### PR TITLE
fix: tell the reader how to upgrade an older plugin

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -724,6 +724,24 @@ def check_vault_registry_divergence() -> Result:
                        "charter vault add <name> --provider <p> … --share --force")
 
 
+def _plugin_ids(root: Path) -> tuple[str, str]:
+    """``(plugin, marketplace)`` from the manifests the installed plugin carries.
+
+    Both files sit in the directory ``CLAUDE_PLUGIN_ROOT`` already names, so the id is
+    exact without parsing Claude Code's cache path — a layout charter does not own and
+    must not depend on. Either being absent falls back to a placeholder: the id is a
+    convenience, while naming the two *steps* is the part that was missing.
+    """
+    def name(filename: str, fallback: str) -> str:
+        try:
+            doc = json.loads((root / ".claude-plugin" / filename).read_text())
+            return (doc.get("name") or "").strip() or fallback
+        except (OSError, ValueError, AttributeError):
+            return fallback
+
+    return name("plugin.json", "<plugin>"), name("marketplace.json", "<marketplace>")
+
+
 def check_plugin_skew() -> Result:
     """`charter` ships as two artifacts — the CLI (pip/uv) and the Claude Code plugin
     (``.claude-plugin/plugin.json`` + ``hooks/hooks.json``) — with two version numbers.
@@ -764,9 +782,24 @@ def check_plugin_skew() -> Result:
     # matches the installed CLI" against a v0.13.1 CLI is how the drift stayed invisible.
     if plugin_version == hooks.MIN_PLUGIN_VERSION:
         return Result("plugin", OK, detail=f"v{plugin_version} matches the installed CLI")
+    # The advice goes in `detail`, not `hint`: `Result.render` drops the hint entirely
+    # when the status is OK, so guidance written there would be invisible while looking
+    # shipped — which is the failure ADR 0013 is about, and it would be an unusually poor
+    # place to commit it.
+    #
+    # Both steps, in order, because "upgrade it" did not upgrade anything. The marketplace
+    # is a git clone advertising whatever it last fetched, so without refreshing it first
+    # `plugin update` finds the installed version already current and correctly does
+    # nothing; and `update` defaults to `user` scope while the plugin is usually installed
+    # per project, which fails outright rather than silently. Observed together: a plugin
+    # two minor versions behind, with `doctor` run repeatedly throughout.
+    plugin_name, marketplace = _plugin_ids(Path(root))
     return Result("plugin", OK,
                   detail=f"v{plugin_version} (CLI v{hooks.MIN_PLUGIN_VERSION}) — older "
-                         f"plugin, supported; upgrade it for the newest hooks")
+                         f"plugin, supported. Upgrade: `claude plugin marketplace update "
+                         f"{marketplace}` (skip it and the next is a no-op), then `claude "
+                         f"plugin update {plugin_name}@{marketplace} --scope "
+                         f"<project|user, see: claude plugin list>`")
 
 
 #: Seconds a single preflight check may take before it is reported as timed out rather

--- a/tests/test_plugin_upgrade_hint.py
+++ b/tests/test_plugin_upgrade_hint.py
@@ -1,0 +1,106 @@
+""""Upgrade it for the newest hooks" did not tell anyone how to upgrade it.
+
+`check_plugin_skew` reports an older plugin as OK-with-a-note, which is right — an older
+plugin wires fewer hooks, and that is benign in a way a newer one is not. What it did not
+do is say what to type. Following the note the obvious way fails twice over:
+
+    $ claude plugin update charter@charter
+    ✘ Failed to update plugin "charter@charter": Plugin "charter" is not installed at
+      scope user
+
+— because `update` defaults to `user` scope and the plugin is usually installed at
+`project` scope; and because the marketplace is a git clone that advertises whatever
+version it last fetched, so without `marketplace update` first the command finds the
+installed version already current and correctly does nothing. A no-op that reports
+success-shaped output is how a plugin sat two minor versions behind while `doctor` was run
+repeatedly.
+
+Both names are read from the manifests charter is already given — the installed plugin
+directory carries `plugin.json` AND `marketplace.json` — so the id is exact rather than a
+placeholder, with no dependency on the shape of Claude Code's cache path.
+
+The assertions run against `Result.render()`, not against `.hint`. `render()` suppresses
+the hint field entirely when the status is OK, so a fix written into `hint` would have
+rendered nothing at all while looking done — the failure ADR 0013 exists to name.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest.mock
+import unittest
+from pathlib import Path
+
+from charter import doctor
+from tests._isolation import PersonaIso
+
+
+class PluginHintBase(PersonaIso):
+    def _install(self, version: str, plugin="charter", marketplace="charter",
+                 with_marketplace=True):
+        root = self.tmp / "plugin-root"
+        (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+        (root / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"name": plugin, "version": version}))
+        if with_marketplace:
+            (root / ".claude-plugin" / "marketplace.json").write_text(
+                json.dumps({"name": marketplace}))
+        self.enterContext(unittest.mock.patch.dict(
+            "os.environ", {"CLAUDE_PLUGIN_ROOT": str(root)}))
+        return root
+
+
+class TestAnOlderPluginIsToldHowToUpgrade(PluginHintBase):
+    def _rendered(self, version="0.25.0", **kw):
+        self._install(version, **kw)
+        with unittest.mock.patch("charter.hooks.MIN_PLUGIN_VERSION", "0.28.0"):
+            return doctor.check_plugin_skew().render()
+
+    def test_it_names_the_marketplace_step(self):
+        """The step whose absence makes the next line a silent no-op."""
+        self.assertIn("marketplace update", self._rendered())
+
+    def test_it_names_the_update_step_with_the_exact_plugin_id(self):
+        out = self._rendered()
+        self.assertIn("plugin update charter@charter", out)
+
+    def test_it_names_the_scope(self):
+        """`update` defaults to user scope; the plugin is usually installed per project."""
+        self.assertIn("--scope", self._rendered())
+
+    def test_the_marketplace_step_comes_first(self):
+        out = self._rendered()
+        self.assertLess(out.index("marketplace update"), out.index("plugin update"))
+
+    def test_it_still_reports_ok(self):
+        """An older plugin is supported. This changes the advice, not the severity."""
+        self._install("0.25.0")
+        with unittest.mock.patch("charter.hooks.MIN_PLUGIN_VERSION", "0.28.0"):
+            self.assertEqual(doctor.check_plugin_skew().status, doctor.OK)
+
+    def test_the_advice_survives_rendering(self):
+        """render() drops `hint` when the status is OK, so advice written there would be
+        invisible — shipped-looking and doing nothing."""
+        self._install("0.25.0")
+        with unittest.mock.patch("charter.hooks.MIN_PLUGIN_VERSION", "0.28.0"):
+            r = doctor.check_plugin_skew()
+        self.assertIn("marketplace update", r.render())
+
+    def test_a_matching_plugin_says_none_of_it(self):
+        self._install("0.28.0")
+        with unittest.mock.patch("charter.hooks.MIN_PLUGIN_VERSION", "0.28.0"):
+            out = doctor.check_plugin_skew().render()
+        self.assertNotIn("marketplace update", out)
+
+    def test_a_missing_marketplace_manifest_does_not_crash(self):
+        """Read defensively: the id is a convenience, not a guarantee."""
+        out = self._rendered(with_marketplace=False)
+        self.assertIn("marketplace update", out)
+
+    def test_it_uses_the_names_it_was_given(self):
+        out = self._rendered(plugin="other", marketplace="mkt")
+        self.assertIn("other@mkt", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #126 — the cheap half, which turned out to be the whole of the actionable part.

## The advice did not work

`check_plugin_skew` reported an older plugin as *"supported; upgrade it for the newest hooks"*. Following that the obvious way fails twice:

```
$ claude plugin update charter@charter
✘ Failed to update plugin "charter@charter": Plugin "charter" is not installed at scope user
```

- **Scope.** `update` defaults to `user`; the plugin is usually installed at `project` scope. This one at least fails loudly.
- **Stale marketplace.** The marketplace is a git clone advertising whatever it last fetched. Without `marketplace update` first, `plugin update` finds the installed version already current and correctly does nothing — a **silent** no-op with success-shaped output.

Both were observed together: a plugin two minor versions behind while `doctor` was run repeatedly.

## Now

```
✓  plugin   v0.25.0 (CLI v0.28.0) — older plugin, supported. Upgrade: `claude plugin
            marketplace update charter` (skip it and the next is a no-op), then `claude
            plugin update charter@charter --scope <project|user, see: claude plugin list>`
```

The names come from the manifests the installed plugin **already carries** — `plugin.json` and `marketplace.json` both sit inside `CLAUDE_PLUGIN_ROOT` — so the id is exact without parsing Claude Code's cache path, which is the coupling #126 flagged as needing a deliberate decision. Either file missing degrades to a placeholder; naming the two *steps* was the missing part, not the id.

## One thing worth reading

The advice is in `detail`, not `hint`, because **`Result.render` drops `hint` when the status is `OK`** (`doctor.py:42`). Written into `hint` — the obvious place — it would have rendered nothing at all while looking shipped. That is precisely ADR 0013's failure, occurring inside the fix for the issue about it. The tests assert on `render()` rather than the field for exactly that reason.

Severity is unchanged: an older plugin wires fewer hooks and remains `OK`. This changes the advice, not the verdict.

## What #126 asked for and is not getting

Distinguishing "no plugin installed" from "installed but not loaded here" still requires reading Claude Code's plugin cache, a layout charter does not own. That stays undone deliberately; the issue closes because its actionable half is shipped and the remainder is a speculative coupling rather than a known-broken hint.

9 new tests, written first and watched fail. Suite: 1813 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o