### PR TITLE
0.28.1 — the plugin-upgrade advice now upgrades the plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.28.0"
+__version__ = "0.28.1"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.28.0",
+            "command": "charter hook sessionstart --plugin-version 0.28.1",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.28.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.28.1",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.28.0",
+            "command": "charter hook pretooluse --plugin-version 0.28.1",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.28.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.28.1",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.28.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.28.1"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.28.0",
+            "command": "charter hook posttooluse --plugin-version 0.28.1",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.28.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.28.1",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.28.0"
+version = "0.28.1"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only. All four locations move together, pinned by `TestVersionsMoveInLockstep`.

**Patch**: corrected text, no new check and no new failure mode — unlike 0.28.0, which was minor because it made an unchanged machine start failing preflight.

## Ships

- **#134** — `doctor` told an out-of-date plugin to *"upgrade it for the newest hooks"* and named no command. Both steps it actually needs were missing: the marketplace refresh, without which `plugin update` silently no-ops against a stale git clone, and the scope, which defaults to `user` while the plugin is usually installed per project. The plugin id is read from the manifests the installed plugin already carries, so it is exact without parsing Claude Code's cache layout. **Closes #126.**
- **#133** — two steward memories from the front-door session.

Suite: 1813 passing.

## After merge

```
git tag -a v0.28.1 -m "0.28.1 — the plugin-upgrade advice now upgrades the plugin"
git push origin v0.28.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o