### PR TITLE
persona(release): upgrading this machine is part of the sequence

### DIFF
--- a/.claude/agents/release.md
+++ b/.claude/agents/release.md
@@ -60,6 +60,31 @@ CDN-cached and lags by minutes, which reads as a failed publish when it is not:
 https://pypi.org/pypi/charter-cp/<X.Y.Z>/json
 ```
 
+## Then upgrade this machine — CLI first, pinned
+
+That endpoint answers "does the artifact exist", which is **not** the same as "can it be
+installed". The simple index that installers actually read propagates a little later, and
+in that window an upgrade either fails outright or, worse, succeeds against a cached index
+and leaves you on the old version reporting success.
+
+```
+uv tool install --force --refresh charter-cp==<X.Y.Z>   # pinned and refreshed, not bare --force
+claude plugin marketplace update charter                # the plugin is a separate artifact
+claude plugin update charter@charter --scope <project|user>
+```
+
+**CLI before plugin, and it is not a style preference.** If the lag catches you, upgrading
+the plugin first leaves the plugin NEWER than the CLI — the one direction that breaks
+things, because the plugin can dispatch `charter hook <name>` for a handler this CLI does
+not have, so the guard looks installed and is not. Doing the CLI first means a lag leaves
+the plugin *behind*, which is quietly supported.
+
+Both failure modes are real and were seen in consecutive releases: `uv tool install --force
+charter-cp` silently kept 0.27.2 after 0.28.0 published, then failed as "requirements are
+unsatisfiable" moments after 0.28.1 did. Neither announced itself; both were caught only by
+re-reading `charter --version` afterwards, which is therefore part of the sequence and not
+a courtesy.
+
 ## Choosing the number
 
 Minor for new config keys, new CLI flags, or a changed default. Patch for fixes that add no

--- a/personas/release/persona.md
+++ b/personas/release/persona.md
@@ -59,6 +59,31 @@ CDN-cached and lags by minutes, which reads as a failed publish when it is not:
 https://pypi.org/pypi/charter-cp/<X.Y.Z>/json
 ```
 
+## Then upgrade this machine — CLI first, pinned
+
+That endpoint answers "does the artifact exist", which is **not** the same as "can it be
+installed". The simple index that installers actually read propagates a little later, and
+in that window an upgrade either fails outright or, worse, succeeds against a cached index
+and leaves you on the old version reporting success.
+
+```
+uv tool install --force --refresh charter-cp==<X.Y.Z>   # pinned and refreshed, not bare --force
+claude plugin marketplace update charter                # the plugin is a separate artifact
+claude plugin update charter@charter --scope <project|user>
+```
+
+**CLI before plugin, and it is not a style preference.** If the lag catches you, upgrading
+the plugin first leaves the plugin NEWER than the CLI — the one direction that breaks
+things, because the plugin can dispatch `charter hook <name>` for a handler this CLI does
+not have, so the guard looks installed and is not. Doing the CLI first means a lag leaves
+the plugin *behind*, which is quietly supported.
+
+Both failure modes are real and were seen in consecutive releases: `uv tool install --force
+charter-cp` silently kept 0.27.2 after 0.28.0 published, then failed as "requirements are
+unsatisfiable" moments after 0.28.1 did. Neither announced itself; both were caught only by
+re-reading `charter --version` afterwards, which is therefore part of the sequence and not
+a courtesy.
+
 ## Choosing the number
 
 Minor for new config keys, new CLI flags, or a changed default. Patch for fixes that add no


### PR DESCRIPTION
The release charter ended at *"verify against PyPI's version endpoint"*. That endpoint answers whether the artifact **exists**, which is not the same as whether it can be **installed** — the simple index that installers actually read propagates a little later.

Inside that window an upgrade either fails outright, or — worse — succeeds against a cached index and leaves you on the old version reporting success.

## Both happened, in consecutive releases

- after **0.28.0** published: `uv tool install --force charter-cp` silently kept `0.27.2`
- moments after **0.28.1** published: the same command failed as *"requirements are unsatisfiable"*

Neither announced itself. Both were caught only by re-reading `charter --version` afterwards, which is why that is now written into the sequence rather than left as a courtesy.

## CLI before plugin, and it is not a style preference

Both times the **plugin** upgraded cleanly while the CLI did not — leaving the plugin **newer** than the CLI, which is the one direction that breaks things: the plugin can dispatch `charter hook <name>` for a handler this CLI does not have, so the guard looks installed and is not. `skew_message` exists precisely for that case.

Doing the CLI first means a propagation lag leaves the plugin *behind* instead, which is quietly supported and harms nothing.

```
uv tool install --force --refresh charter-cp==<X.Y.Z>   # pinned and refreshed, not bare --force
claude plugin marketplace update charter
claude plugin update charter@charter --scope <project|user>
```

## The generated agent moves with it

`.claude/agents/release.md` embeds the charter body, so it is regenerated in the same commit. Leaving it would be a charter and an agent disagreeing about the procedure — the divergence ADR 0013 is about, in the file that documents how to avoid shipping one.

Suite: 1813 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o