### PR TITLE
docs: the asset index claimed more than it listed

### DIFF
--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,14 +1,33 @@
 # README assets
 
-Every image in this directory is **generated from real command output**. None of them are
-mockups, and none should be hand-edited — regenerate instead, so a screenshot can never
-quietly drift from what charter actually prints.
+Two kinds of image live here, and the difference matters when one needs updating.
 
-| File | What it is | How to regenerate |
-| --- | --- | --- |
-| `statusline.svg` | The status line, rendered against the demo plane below | `demo-plane.sh` → `charter statusline` → `ansi2svg.py` |
-| `demo.svg` | The quickstart, animated | `capture-demo.sh` → `ansi2svg.py --animate` |
-| `model.svg` | The on-disk model, hand-drawn | Edit by hand — it is a diagram, not a capture |
+**Captures** are generated from real command output. None of them are mockups and none
+should ever be hand-edited — regenerate instead, so a screenshot cannot quietly drift from
+what charter actually prints. **Drawings** are authored by hand and say what they mean to
+say; they have no source to re-run.
+
+| File | Kind | What it is | How to update |
+| --- | --- | --- | --- |
+| `statusline.svg` | capture | The status line, rendered against the demo plane below | `demo-plane.sh` → `charter statusline` → `ansi2svg.py` |
+| `demo.svg` | capture | The quickstart, animated | `capture-demo.sh` → `ansi2svg.py --animate` |
+| `model.svg` | drawing | The on-disk model | Edit by hand |
+| `social-card.svg` | drawing | GitHub's social preview — the image link previews show | Edit by hand |
+| `social-card.png` | rendered | `social-card.svg` at 2560×1280 (2:1), for upload | See below; do not edit the PNG |
+
+`social-card.png` is the only asset here that is not used by the repo itself: GitHub stores
+the social preview separately, uploaded through **Settings → General → Social preview**,
+which has no CLI. The PNG is committed so the upload is reproducible rather than a one-off
+that exists only inside a settings page.
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless \
+  --force-device-scale-factor=2 --window-size=1280,640 \
+  --screenshot=docs/assets/social-card.png file://$PWD/docs/assets/social-card.svg
+```
+
+GitHub recommends 1280×640 and caps uploads at 1MB; rendering at 2× keeps it sharp on
+retina and still lands around 120KB.
 
 ## The tools
 


### PR DESCRIPTION
Small, but it is the file whose entire job is to say how each asset is reproduced, so being wrong about that is worse here than elsewhere.

Two problems in one paragraph:

1. **It overclaimed.** It opened with *"every image in this directory is generated from real command output"* while `model.svg` — listed two lines below as hand-drawn — is not, and the social card added later is not either.
2. **It had stopped covering the directory.** `social-card.svg` and `social-card.png` arrived without rows. (They arrived, in fairness, because a `git add -A` in the 0.27.2 release commit swept them in — which is its own lesson.)

Now it separates **captures** from **drawings**, because that is the distinction that decides what to do when one needs updating: a capture is regenerated and must never be hand-edited; a drawing has no source to re-run.

The social card also gets what it was missing — GitHub stores the preview separately and offers no CLI for it, so the PNG is committed to make the upload reproducible rather than a one-off that exists only inside a settings page, with the render command written down beside it.

Verified mechanically: every one of the 9 files in `docs/assets/` is now named in the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o