### PR TITLE
feat: a persona declares its own MCP servers, wrapped in its vault

### DIFF
--- a/.claude/agents/reddit.md
+++ b/.claude/agents/reddit.md
@@ -84,12 +84,12 @@ charter secret exec reddit \
 so stdio streams through. An MCP server never exits, so the capturing form would hang
 holding output nobody reads. See `docs/secrets.md` and `docs/mcp.md`.
 
-**No MCP server is wired to this persona yet.** Claude Code scopes servers per sub-agent
-via `mcpServers:` in the generated agent file, but `sync-agents` overwrites that file, so
-charter has to emit it — tracked in issue #141. Until then this persona works from
-`WebFetch`, `WebSearch` and `Bash`, and `agent-tools` deliberately does **not** name
-`mcp__reddit__*`: listing a tool that resolves to nothing is a claim this persona cannot
-honour, and enough of them in a `tools:` list prevents a sub-agent from launching at all.
+**No MCP server is wired to this persona yet** — declaring one is a decision about which
+third-party code runs on this machine, and it is not charter's to make for you. When it is
+chosen, it goes in `personas/reddit/mcp.json` and `charter persona sync-agents` wraps it in
+this vault automatically; `agent-tools` then gains `mcp__reddit__*` on its own, so do not
+add it by hand. See `docs/mcp.md`. Until then this persona works from `WebFetch`,
+`WebSearch` and `Bash`.
 
 Never `--reveal` a Reddit credential, never paste one into a draft, and never put one in a
 `.mcp.json` `env` block — that file is committed.

--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -8,6 +8,7 @@ credentials — and, per the secrets contract, never sees the plaintext.
 
 from __future__ import annotations
 
+import json
 import os
 
 from . import commands_secrets, config, persona, trace, util
@@ -463,8 +464,32 @@ def _render_agent(name: str, meta: dict, charter: str) -> str:
     role = meta.get("role") or name.title()
     desc = meta.get("agent-description") or meta.get("description") or _agent_description(name, meta)
     fm = [f"name: {name}", f"description: {_yaml_str(desc)}"]
+
+    # Declared MCP servers, wrapped in the persona's vault. Claude Code connects an inline
+    # server when the sub-agent starts and disconnects it when it finishes, and its tool
+    # descriptions never reach the parent conversation — so this is per-persona scoping of
+    # the server itself, not merely of the tools.
+    servers = persona.mcp_servers(name)
+    vault = meta.get("vault")
+
     if meta.get("agent-tools"):
-        fm.append(f"tools: {meta['agent-tools']}")  # narrow the toolset; omit = inherit all
+        tools = meta["agent-tools"]
+        # Declaring a server grants its tools. Otherwise `tools:` and the server list are
+        # two hand-kept lists that must agree, and disagreement surfaces at DISPATCH time
+        # as "unresolved entries" — a message about the symptom, not the cause.
+        grants = [f"mcp__{s}__*" for s in servers
+                  if f"mcp__{s}" not in tools]
+        fm.append(f"tools: {', '.join([tools, *grants]) if grants else tools}")
+    # No `agent-tools` means the sub-agent inherits every tool, so adding a narrowing
+    # `tools:` line here to carry the grant would be a downgrade rather than a grant.
+
+    if servers:
+        fm.append("mcpServers:")
+        for server_name in sorted(servers):
+            entry = persona.mcp_render_entry(name, vault, servers[server_name])
+            # JSON, because JSON is valid YAML — this emits a nested block without
+            # hand-rolling a YAML writer or taking a dependency to do it.
+            fm.append(f"  - {server_name}: {json.dumps(entry, ensure_ascii=False)}")
     for k in _AGENT_PASSTHROUGH_KEYS:  # pass through when the charter sets them
         if meta.get(k):
             fm.append(f"{k}: {meta[k]}")

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -165,6 +165,69 @@ def _csv_list(v) -> list[str]:
     return [x.strip() for x in (v or "").strip("[]").split(",") if x.strip()]
 
 
+#: The sidecar naming a persona's MCP servers, same schema as `.mcp.json` plus a
+#: charter-only `secrets` map per server. A separate FILE rather than frontmatter because
+#: `parse` above is line-based and charter carries no runtime dependencies: nested YAML can
+#: be emitted (JSON is valid YAML) but not read. A sidecar also takes a server's own README
+#: snippet unchanged, which is the form these arrive in.
+MCP_FILE = "mcp.json"
+
+
+def mcp_servers(name: str) -> dict:
+    """``{server_name: config}`` a persona declares, inheritance applied.
+
+    Unioned along the lineage the way ``tools``/``uses`` are — parent first, child wins on
+    a name collision. A child that silently lost the server its parent declared would be a
+    surprise, and this is the rule the rest of the frontmatter already follows.
+
+    Never raises. The file is hand-edited, and a stray comma in it must not take down
+    `sync-agents` for every persona in the plane.
+    """
+    out = {}
+    for anc in lineage(name):
+        try:
+            doc = json.loads((dir_of(anc) / MCP_FILE).read_text())
+            servers = doc.get("mcpServers") or {}
+        except (OSError, ValueError, AttributeError):
+            continue
+        if isinstance(servers, dict):
+            out.update(servers)
+    return out
+
+
+def mcp_render_entry(name: str, vault: str | None, entry: dict) -> dict:
+    """One declared server, as the generated agent should carry it.
+
+    A ``secrets`` map — ``{ENV_VAR: vault-key}`` — turns the entry into a
+    ``charter secret exec … --exec -- <original command>`` invocation, so the value reaches
+    the server's environment without ever reaching a context window. The env var names
+    belong to the third-party server, which is why they are declared rather than inferred:
+    charter cannot know them, and injecting every key in the vault would hand a server
+    every credential the persona holds instead of the two it needs.
+
+    ``--exec`` is not optional. It replaces the process rather than capturing it, and an
+    MCP stdio server never returns — the capturing form would hang holding output nobody
+    reads.
+
+    A server with no ``secrets`` is passed through untouched: dragging a credential-free
+    server through charter would buy nothing and add a process.
+    """
+    out = {k: v for k, v in entry.items() if k != "secrets"}
+    secrets = entry.get("secrets") or {}
+    if not secrets or not vault:
+        return out
+    args = ["secret", "exec", vault]
+    for env_name, key in secrets.items():
+        args += ["--env", f"{env_name}={key}"]
+    args += ["--exec", "--"]
+    if out.get("command"):
+        args.append(out["command"])
+    args += list(out.get("args") or [])
+    out["command"] = "charter"
+    out["args"] = args
+    return out
+
+
 def lineage(name: str) -> list[str]:
     """The inheritance chain, child-first: ``[name, parent, grandparent, …]``.
     Cycle-safe (stops if it revisits a persona)."""
@@ -500,6 +563,21 @@ def lint(name: str, deep: bool = True) -> list[tuple[str, str]]:
     issues += structural_errors(name)
     if deep:
         issues += _skill_ref_issues(d["charter"])
+    # A declared MCP server whose `secrets` cannot be resolved. Reported rather than
+    # refused: the persona charter is committed and SHARED, while a vault is machine-local
+    # by design, so a teammate cloning this repo legitimately has neither the vault nor the
+    # keys. The wrapper charter emits is correct either way — only the run would fail — and
+    # refusing to render would break `sync-agents` on a fresh clone (ADR 0013: name the
+    # divergence, do not resolve it).
+    servers = mcp_servers(name)
+    if servers:
+        vault = (resolve(name) or {}).get("meta", {}).get("vault")
+        needs_secrets = sorted(s for s, e in servers.items() if (e or {}).get("secrets"))
+        if needs_secrets and (not vault or vault == "none"):
+            issues.append(("error",
+                           f"mcp: server(s) {', '.join(needs_secrets)} declare `secrets` but "
+                           f"this persona names no vault — add `vault:` or drop the secrets"))
+
     return issues
 
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,12 +1,5 @@
 # MCP servers, personas, and credentials
 
-> **Corrected.** An earlier version of this page said Claude Code could not scope an MCP
-> *server* to a sub-agent, and that charter should therefore never grow an `mcp:` field.
-> Both claims were wrong. Sub-agent frontmatter has an `mcpServers` field, and it does
-> exactly what that paragraph said was impossible. What follows is what the host actually
-> supports; charter's own modelling of it is tracked in
-> [#141](https://github.com/diazoxide/charter/issues/141) and is not built yet.
-
 ## The host scopes servers per sub-agent
 
 A sub-agent's frontmatter takes `mcpServers:` — a list whose entries are either a string
@@ -69,19 +62,70 @@ Two things that will bite:
 - **Never put values in an `env` block.** Agent files are committed. That is the failure
   this whole path exists to prevent.
 
-## Until #141 lands
+## Declaring one on a persona
 
-`charter persona sync-agents` **generates** `.claude/agents/<name>.md`, so an `mcpServers:`
-block added there by hand is overwritten the next time any persona changes. Today the
-options are to declare the server in `.mcp.json` — which gives up the per-persona scoping
-above — or to accept that the hand-edit is temporary.
+`charter persona sync-agents` **generates** `.claude/agents/<name>.md`, so a block written
+there by hand is overwritten the next time any persona changes. charter emits it instead,
+from a sidecar beside the charter:
 
-`agent-tools:` still works and is unaffected: it narrows the generated `tools:` line, and
-accepts MCP patterns (`mcp__<server>`, `mcp__<server>__*`). Note that if **no** entry in a
-`tools:` list resolves to a real tool, the sub-agent usually fails to launch — so naming an
-MCP server that is not connected is not free.
+```jsonc
+// personas/reddit/mcp.json — same schema as .mcp.json, plus `secrets`
+{
+  "mcpServers": {
+    "reddit": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["some-reddit-mcp"],
+      "secrets": {
+        "REDDIT_CLIENT_ID": "client-id",
+        "REDDIT_CLIENT_SECRET": "client-secret"
+      }
+    }
+  }
+}
+```
 
-## Caveats that survive #141
+A sidecar rather than frontmatter because `persona.md`'s parser is line-based and charter
+carries no runtime dependencies: nested YAML can be emitted (JSON is valid YAML) but not
+read. It also means a server's own README snippet pastes in unchanged.
+
+`secrets` maps an env var **the server demands** to a key **in this persona's vault**.
+charter consumes it and emits the wrapper:
+
+```yaml
+tools: Read, WebFetch, Bash, mcp__reddit__*
+mcpServers:
+  - reddit: {"type": "stdio", "command": "charter", "args": ["secret", "exec", "reddit",
+      "--env", "REDDIT_CLIENT_ID=client-id", "--env", "REDDIT_CLIENT_SECRET=client-secret",
+      "--exec", "--", "uvx", "some-reddit-mcp"]}
+```
+
+Three things it does on your behalf:
+
+- **Wraps the command in the persona's vault.** The generated file names the *keys*; no
+  value is resolved until the sub-agent starts the server, and then only into that
+  process's environment.
+- **Grants the tools.** Every declared server contributes `mcp__<server>__*` to `tools:`
+  when `agent-tools` is set. Otherwise the server list and the tool list are two things
+  that must agree by hand, and disagreement surfaces at *dispatch* time as an error about
+  "unresolved entries" — the symptom, not the cause. With no `agent-tools` the sub-agent
+  inherits every tool already, so nothing is added.
+- **Leaves credential-free servers alone.** No `secrets`, no wrapper: dragging a public
+  server through charter would add a process and buy nothing.
+
+Servers are **inherited and unioned** along `extends:`, parent first, child winning a name
+collision — the rule `tools` and `uses` already follow.
+
+### A missing vault does not block the sync
+
+The charter is committed and shared; a vault is machine-local by design. A teammate cloning
+this repo legitimately has neither the vault nor the keys, so `sync-agents` renders the
+wrapper regardless — it is correct either way, and only the *run* would fail. `charter
+persona lint` reports a server declaring `secrets` on a persona that names no vault. That
+is ADR 0013 applied: name the divergence, do not resolve it, and do not refuse a sync on a
+fresh clone.
+
+## Caveats
 
 - **`mcpServers` is ignored for plugin sub-agents**, deliberately, for security. charter's
   personas generate into `.claude/agents/` and charter's plugin declares no agents, so this

--- a/personas/reddit/persona.md
+++ b/personas/reddit/persona.md
@@ -82,12 +82,12 @@ charter secret exec reddit \
 so stdio streams through. An MCP server never exits, so the capturing form would hang
 holding output nobody reads. See `docs/secrets.md` and `docs/mcp.md`.
 
-**No MCP server is wired to this persona yet.** Claude Code scopes servers per sub-agent
-via `mcpServers:` in the generated agent file, but `sync-agents` overwrites that file, so
-charter has to emit it — tracked in issue #141. Until then this persona works from
-`WebFetch`, `WebSearch` and `Bash`, and `agent-tools` deliberately does **not** name
-`mcp__reddit__*`: listing a tool that resolves to nothing is a claim this persona cannot
-honour, and enough of them in a `tools:` list prevents a sub-agent from launching at all.
+**No MCP server is wired to this persona yet** — declaring one is a decision about which
+third-party code runs on this machine, and it is not charter's to make for you. When it is
+chosen, it goes in `personas/reddit/mcp.json` and `charter persona sync-agents` wraps it in
+this vault automatically; `agent-tools` then gains `mcp__reddit__*` on its own, so do not
+add it by hand. See `docs/mcp.md`. Until then this persona works from `WebFetch`,
+`WebSearch` and `Bash`.
 
 Never `--reveal` a Reddit credential, never paste one into a draft, and never put one in a
 `.mcp.json` `env` block — that file is committed.

--- a/tests/test_persona_mcp.py
+++ b/tests/test_persona_mcp.py
@@ -1,0 +1,176 @@
+"""A persona declares its own MCP servers, and charter wraps them in its vault.
+
+Claude Code scopes MCP servers per sub-agent: `mcpServers:` in the agent frontmatter takes
+inline definitions that are "connected when the subagent starts and disconnected when it
+finishes", and whose tool descriptions never reach the parent conversation. charter
+generates those agent files, so a hand-written block there is destroyed by the next
+`sync-agents` — charter has to emit it or the capability is unreachable from a persona.
+
+The definition lives in a sidecar, `personas/<name>/mcp.json`, for two reasons that are not
+style: charter's frontmatter parser is line-based and charter carries no runtime
+dependencies, so nested YAML cannot be parsed in `persona.md` — only emitted. A sidecar
+also takes a server's own README snippet unchanged.
+
+The wrapper is the point. `secrets` maps an env var the third-party server demands to a key
+in the persona's vault, and charter turns the whole entry into a `charter secret exec …
+--exec` invocation. The generated file names the keys; the values never enter a context
+window. `--exec` is required because an MCP stdio server never returns.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+from charter import persona
+from tests._isolation import PersonaIso
+
+
+SERVER = {
+    "mcpServers": {
+        "reddit": {
+            "type": "stdio",
+            "command": "uvx",
+            "args": ["some-reddit-mcp", "--read-only"],
+            "secrets": {"REDDIT_CLIENT_ID": "client-id",
+                        "REDDIT_CLIENT_SECRET": "client-secret"},
+        }
+    }
+}
+
+
+class McpBase(PersonaIso):
+    def _persona(self, name="reddit", servers=SERVER, **meta):
+        self.make_persona(name, role="Reddit Manager", vault=meta.pop("vault", "reddit"),
+                          **{"delegate-when": "reddit things", **meta})
+        if servers is not None:
+            (persona.dir_of(name) / "mcp.json").write_text(json.dumps(servers))
+        return name
+
+
+class TestReadingTheSidecar(McpBase):
+    def test_no_sidecar_means_no_servers(self):
+        self._persona(servers=None)
+        self.assertEqual(persona.mcp_servers("reddit"), {})
+
+    def test_it_reads_the_declared_servers(self):
+        self._persona()
+        self.assertIn("reddit", persona.mcp_servers("reddit"))
+
+    def test_malformed_json_does_not_explode(self):
+        """A sidecar is edited by hand; a broken one must not take down sync-agents."""
+        self._persona()
+        (persona.dir_of("reddit") / "mcp.json").write_text("{ not json")
+        self.assertEqual(persona.mcp_servers("reddit"), {})
+
+    def test_servers_are_inherited_and_unioned(self):
+        """Matching `tools`/`uses`: list-like fields union, parent first, child wins on a
+        name collision. A child silently losing its parent's server would be a surprise."""
+        self.make_persona("base", role="Base", vault="reddit",
+                          **{"delegate-when": "base"})
+        (persona.dir_of("base") / "mcp.json").write_text(json.dumps(SERVER))
+        self.make_persona("child", role="Child", extends="base",
+                          **{"delegate-when": "child"})
+        self.assertIn("reddit", persona.mcp_servers("child"))
+
+
+class TestTheVaultWrapper(McpBase):
+    def _entry(self, name="reddit"):
+        return persona.mcp_render_entry(name, "reddit",
+                                        persona.mcp_servers(name)["reddit"])
+
+    def test_the_command_becomes_charter(self):
+        self._persona()
+        self.assertEqual(self._entry()["command"], "charter")
+
+    def test_it_execs_the_original_command_after_a_separator(self):
+        self._persona()
+        args = self._entry()["args"]
+        self.assertIn("--exec", args)
+        self.assertEqual(args[args.index("--") + 1:], ["uvx", "some-reddit-mcp", "--read-only"])
+
+    def test_every_secret_becomes_an_env_flag(self):
+        self._persona()
+        args = self._entry()["args"]
+        self.assertIn("REDDIT_CLIENT_ID=client-id", args)
+        self.assertIn("REDDIT_CLIENT_SECRET=client-secret", args)
+
+    def test_it_names_the_personas_vault(self):
+        self._persona()
+        args = self._entry()["args"]
+        self.assertEqual(args[:3], ["secret", "exec", "reddit"])
+
+    def test_no_secrets_means_no_wrapper(self):
+        """A server needing no credential should not be dragged through charter."""
+        plain = {"mcpServers": {"reddit": {"type": "stdio", "command": "uvx",
+                                           "args": ["public-server"]}}}
+        self._persona(servers=plain)
+        e = self._entry()
+        self.assertEqual(e["command"], "uvx")
+        self.assertEqual(e["args"], ["public-server"])
+
+    def test_the_secrets_key_is_consumed_not_emitted(self):
+        """It is charter's own field. Leaving it in would hand Claude Code an unknown key
+        and put the vault key names in the server config for no reason."""
+        self._persona()
+        self.assertNotIn("secrets", self._entry())
+
+    def test_no_secret_VALUE_appears_anywhere(self):
+        self._persona()
+        blob = json.dumps(self._entry())
+        self.assertNotIn("hunter2", blob)   # nothing resolves at render time
+        self.assertIn("client-id", blob)    # the KEY is named, which is the point
+
+
+class TestTheGeneratedAgent(McpBase):
+    def _rendered(self, name="reddit"):
+        from charter.commands_persona import _render_agent
+        d = persona.resolve(name)
+        return _render_agent(name, d["meta"], d["charter"])
+
+    def test_the_agent_declares_the_server(self):
+        self._persona()
+        self.assertIn("mcpServers:", self._rendered())
+
+    def test_the_block_is_parseable_as_the_host_expects(self):
+        """A list whose entries are single-key maps. JSON is valid YAML, so the value is
+        emitted as JSON rather than by hand-rolling a YAML writer."""
+        self._persona()
+        out = self._rendered()
+        line = next(l for l in out.splitlines() if l.strip().startswith("- reddit:"))
+        payload = json.loads(line.split("- reddit:", 1)[1].strip())
+        self.assertEqual(payload["command"], "charter")
+
+    def test_declaring_a_server_grants_its_tools(self):
+        """Two hand-kept lists that must agree is a divergence generator, and this one
+        fails at dispatch with an error about unresolved entries."""
+        self._persona(**{"agent-tools": "Read, Bash"})
+        self.assertIn("mcp__reddit__*", self._rendered())
+
+    def test_no_agent_tools_means_no_derived_grant(self):
+        """Omitting `tools:` inherits everything, so adding a narrowing line would be a
+        downgrade, not a grant."""
+        self._persona()
+        self.assertNotIn("tools:", self._rendered())
+
+    def test_a_persona_without_servers_is_unchanged(self):
+        self._persona(servers=None)
+        self.assertNotIn("mcpServers", self._rendered())
+
+
+class TestLintReportsWhatItCannotResolve(McpBase):
+    def _levels(self, name="reddit"):
+        return {msg for _lvl, msg in persona.lint(name)}
+
+    def test_secrets_without_a_vault_is_an_error(self):
+        self._persona(vault="")
+        self.assertTrue(any("vault" in m and "mcp" in m.lower() for m in self._levels()),
+                        f"expected an mcp/vault complaint, got: {self._levels()}")
+
+    def test_a_clean_declaration_lints_clean(self):
+        self._persona()
+        self.assertFalse([m for m in self._levels() if "mcp" in m.lower()])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #141. Implements the design grilled out in that issue.

## What you can now write

```jsonc
// personas/reddit/mcp.json — .mcp.json's schema, plus `secrets`
{
  "mcpServers": {
    "reddit": {
      "type": "stdio",
      "command": "uvx",
      "args": ["some-reddit-mcp"],
      "secrets": { "REDDIT_CLIENT_ID": "client-id", "REDDIT_CLIENT_SECRET": "client-secret" }
    }
  }
}
```

and what `charter persona sync-agents` generates:

```yaml
tools: Read, WebFetch, Bash, mcp__reddit__*
mcpServers:
  - reddit: {"type":"stdio","command":"charter","args":["secret","exec","reddit",
      "--env","REDDIT_CLIENT_ID=client-id","--env","REDDIT_CLIENT_SECRET=client-secret",
      "--exec","--","uvx","some-reddit-mcp"]}
```

The server is scoped to that persona's sub-agent — it does not run for the session, and its tool descriptions never cost the main conversation any context. The credential comes from that persona's vault and no value is resolved until the sub-agent starts the server.

## Decisions worth knowing

- **Sidecar, not frontmatter.** `persona.md`'s parser is line-based and charter has zero runtime dependencies — nested YAML can be *emitted* (JSON is valid YAML) but not *read*. The sidecar also takes a server's own README snippet unchanged.
- **`secrets` is declared, not inferred.** The env var names belong to the third-party server. Injecting every vault key by convention would hand a server every credential the persona holds rather than the two it needs.
- **Declaring a server grants its tools.** Otherwise the server list and `tools:` are two hand-kept lists that must agree, and disagreement surfaces at *dispatch* time as "unresolved entries" — the symptom, not the cause. With no `agent-tools`, the sub-agent already inherits everything, so nothing is added.
- **Credential-free servers pass through untouched** — no wrapper, no extra process.
- **Inherited and unioned along `extends:`**, parent first, child wins a collision — the rule `tools`/`uses` already follow.
- **A missing vault does not block the sync.** The charter is committed and shared; a vault is machine-local by design, so a teammate cloning this repo legitimately has neither. The wrapper is correct either way and only the *run* would fail, so `persona lint` reports it rather than `sync-agents` refusing — which would break a fresh clone. ADR 0013: name the divergence, don't resolve it.

## Verification

Beyond 18 new unit tests written before the code: rendered against a real plane with two servers (one credentialed stdio, one credential-free http) and **parsed the emitted frontmatter with a real YAML parser** — `mcpServers` is a list of single-key maps, `secrets` is consumed rather than emitted, the wrapper is intact, and no secret value appears anywhere in the file.

The `reddit` persona is *not* wired to a server here: choosing which third-party code runs on your machine isn't charter's decision to make for you.

Suite: 1831 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o