### PR TITLE
0.29.0 — a persona can hold its own MCP server

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.28.1",
+  "version": "0.29.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.28.1"
+__version__ = "0.29.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.28.1",
+            "command": "charter hook sessionstart --plugin-version 0.29.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.28.1",
+            "command": "charter hook userpromptsubmit --plugin-version 0.29.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.28.1",
+            "command": "charter hook pretooluse --plugin-version 0.29.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.28.1",
+            "command": "charter hook pretooluse-read --plugin-version 0.29.0",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.28.1"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.29.0"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.28.1",
+            "command": "charter hook posttooluse --plugin-version 0.29.0",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.28.1",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.29.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.28.1"
+version = "0.29.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only. All four locations move together, pinned by `TestVersionsMoveInLockstep`.

**MINOR — new surface.** `personas/<name>/mcp.json` is a file charter did not read before, and `sync-agents` emits frontmatter it did not emit before. (0.28.0 was minor for a different reason: it made an unchanged machine start *failing* preflight. 0.28.1 was a patch — corrected text only.)

## What ships

- **#143** — a persona declares its own MCP servers in `personas/<name>/mcp.json`, and `sync-agents` renders them into the sub-agent's `mcpServers:` with each command wrapped in `charter secret exec <the persona's vault> --exec`. The server is scoped to that persona's sub-agent, its tool descriptions never cost the main conversation any context, and the credential reaches the process without reaching a context window. Declaring a server also grants `mcp__<server>__*`, so the tool list can't drift from the server list.
- **#142** — the docs correction that preceded it. `docs/mcp.md` had asserted the opposite, that the host could not scope a server to a sub-agent. It was wrong, and it was the only written guidance on the subject.
- **#136** — the release runbook now ends with upgrading this machine: CLI before plugin, pinned and refreshed, because a propagation lag otherwise leaves the plugin *newer* than the CLI.
- **#138** — the asset index stopped claiming more than it listed.

Suite: 1831 passing.

## After merge

```
git tag -a v0.29.0 -m "0.29.0 — a persona can hold its own MCP server"
git push origin v0.29.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o