### PR TITLE
fix: `clean on main` no longer reads as up to date

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -383,6 +383,14 @@ def check_plane_root() -> Result:
         # permanently in the yellow, which costs the two findings that do matter.
         status = _git_in(root, "status", "--porcelain", "--untracked-files=no")
         dirty = [ln for ln in status.stdout.splitlines() if ln.strip()]
+        # How far the root has drifted behind its upstream. Read from the ALREADY-FETCHED
+        # remote ref — never a live query, because this runs from the SessionStart hook and
+        # must not reach the network. `@{upstream}` fails cleanly on a root with no
+        # tracking branch (a plane `git init`-ed by hand), which is not a fault.
+        behind = _git_in(root, "rev-list", "--count", "HEAD..@{upstream}")
+        behind_n = int(behind.stdout.strip() or 0) if behind.returncode == 0 else 0
+        upstream = _git_in(root, "rev-parse", "--abbrev-ref", "@{upstream}")
+        upstream_ref = upstream.stdout.strip() if upstream.returncode == 0 else ""
     except (util.ProcTimeout, OSError) as e:
         return Result(name, OK, detail=f"not checked ({e})")
 
@@ -397,8 +405,21 @@ def check_plane_root() -> Result:
     if dirty:
         findings.append(f"{len(dirty)} uncommitted file(s)")
         actions.append("Commit control-plane content with `charter save`.")
+    # Said in the DETAIL and never as a finding: a root behind its upstream is the normal
+    # resting state of a directory nobody works in, so warning about it would put this row
+    # permanently in the yellow — the cost this check already refuses to pay for untracked
+    # memory files. But `clean on main` is a statement about the working TREE that reads as
+    # one about the plane, and a root drifts behind precisely BECAUSE nobody works in it:
+    # every change arrives through a workspace clone and a PR, and nothing pulls the root.
+    # Observed three times in one session, twice acting on a stale checkout.
+    #
+    # "at last fetch" is not hedging. The number is read from a ref that is only as current
+    # as the last fetch, and presenting it as a live reading would be the failure ADR 0013
+    # names — in the check whose whole job is to report state honestly.
+    drift = (f", {behind_n} behind {upstream_ref or 'upstream'} at last fetch"
+             if behind_n else "")
     if not findings:
-        return Result(name, OK, detail=f"clean on {branch}")
+        return Result(name, OK, detail=f"clean on {branch}{drift}")
     # Where the work belongs is said ONCE, after the per-finding actions. Saying it per
     # finding printed the same "move it into a workspace clone" clause twice in a row
     # that fires with both findings at once — which is the common case, since whoever

--- a/tests/test_doctor_plane_root_behind.py
+++ b/tests/test_doctor_plane_root_behind.py
@@ -1,0 +1,120 @@
+"""`clean on main` is true and reads as "up to date".
+
+`check_plane_root` answers one question — is anyone working in the plane root — and answers
+it well. Its clean line says `clean on main`, which is a statement about the working tree.
+A reader takes it as a statement about the plane, and the plane root drifts behind `origin`
+constantly *because* nobody works in it: every change arrives through a workspace clone and
+a PR, and nothing pulls the root.
+
+Observed three times in one session, twice misleading the reader into acting on a stale
+checkout — once into re-registering a vault that the newer code would have placed
+differently.
+
+Being behind is not a fault and must not warn: it is the normal resting state of a
+directory nobody edits. So the status stays OK and only the *detail* gains the count.
+
+The count comes from the already-fetched remote ref, never a network call — `doctor` runs
+from the SessionStart hook. That makes it a reading of the last fetch rather than of the
+remote, and the wording says so, because a number presented as current when it is cached is
+the failure ADR 0013 names.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+from charter import config, doctor
+from tests._isolation import PersonaIso
+
+
+def _git(cwd, *args):
+    return subprocess.run(["git", "-C", str(cwd), *args],
+                          capture_output=True, text=True, check=False)
+
+
+class PlaneRootBehindBase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        root = Path(config.ROOT)
+        (root / "charter.toml").write_text("schema = 1\n")
+        # Derived when the tmp plane was created, i.e. before the marker above existed.
+        config.HAS_CONTROL_PLANE = True
+        self.addCleanup(lambda: setattr(config, "HAS_CONTROL_PLANE", False))
+        _git(root, "init", "-q", "-b", "main")
+        _git(root, "config", "user.email", "t@example.test")
+        _git(root, "config", "user.name", "T")
+        (root / "seed.txt").write_text("seed\n")
+        _git(root, "add", "-A")
+        _git(root, "commit", "-qm", "seed")
+
+        # A real upstream, so `@{upstream}` resolves the way it does on a live plane.
+        bare = self.tmp.parent / f"{self.tmp.name}-remote.git"
+        _git(root, "init", "-q", "--bare", str(bare)) if False else \
+            subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=False)
+        self.addCleanup(lambda: __import__("shutil").rmtree(bare, ignore_errors=True))
+        _git(root, "remote", "add", "origin", str(bare))
+        _git(root, "push", "-q", "-u", "origin", "main")
+        self.root, self.bare = root, bare
+
+    def _advance_remote(self, n=3):
+        """Move origin/main ahead of the root, the way a merged PR does."""
+        clone = self.tmp.parent / f"{self.tmp.name}-clone"
+        subprocess.run(["git", "clone", "-q", str(self.bare), str(clone)], check=False)
+        self.addCleanup(lambda: __import__("shutil").rmtree(clone, ignore_errors=True))
+        _git(clone, "config", "user.email", "t@example.test")
+        _git(clone, "config", "user.name", "T")
+        for i in range(n):
+            (clone / f"f{i}.txt").write_text("x\n")
+            _git(clone, "add", "-A")
+            _git(clone, "commit", "-qm", f"c{i}")
+        _git(clone, "push", "-q")
+        _git(self.root, "fetch", "-q", "origin")   # the root now KNOWS, without pulling
+
+
+class TestTheCleanLineSaysWhetherItIsCurrent(PlaneRootBehindBase):
+    def test_up_to_date_says_nothing_extra(self):
+        """A count of zero on every clean preflight would be furniture."""
+        r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertNotIn("behind", r.detail)
+
+    def test_behind_is_counted_in_the_detail(self):
+        self._advance_remote(3)
+        r = doctor.check_plane_root()
+        self.assertIn("3 behind", r.detail)
+
+    def test_being_behind_is_not_a_warning(self):
+        """It is the normal resting state of a directory nobody works in."""
+        self._advance_remote(2)
+        self.assertEqual(doctor.check_plane_root().status, doctor.OK)
+
+    def test_it_says_the_number_is_from_the_last_fetch(self):
+        """It is read from an already-fetched ref, never a live query — doctor runs from
+        the SessionStart hook. Presenting a cached number as current is the ADR 0013
+        failure this check exists to avoid repeating."""
+        self._advance_remote(1)
+        self.assertIn("fetch", doctor.check_plane_root().detail.lower())
+
+    def test_it_still_reports_the_branch(self):
+        self._advance_remote(1)
+        self.assertIn("main", doctor.check_plane_root().detail)
+
+    def test_no_upstream_is_not_an_error(self):
+        """A plane whose root was `git init`-ed by hand has no tracking branch."""
+        _git(self.root, "branch", "--unset-upstream")
+        r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertNotIn("behind", r.detail)
+
+    def test_a_dirty_root_still_reports_dirt_first(self):
+        """The existing finding is the one that needs acting on; this must not bury it."""
+        self._advance_remote(1)
+        (self.root / "seed.txt").write_text("edited\n")
+        r = doctor.check_plane_root()
+        self.assertIn("uncommitted", r.detail)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`check_plane_root` answers one question — *is anyone working in the plane root* — and answers it well. Its clean line said `clean on main`, which is true, and is a statement about the working **tree**. A reader takes it as a statement about the **plane**.

The root drifts behind `origin` precisely *because* nobody works in it: every change arrives through a workspace clone and a PR, and nothing pulls the root. Observed three times in one session, twice acting on a stale checkout — once re-registering a vault that the newer code would have placed differently.

```
✓  plane root       clean on main, 3 behind origin/main at last fetch
```

## Three deliberate choices

- **In the detail, never a finding; status stays `OK`.** A root behind its upstream is the normal resting state of a directory nobody edits. Warning would put this row permanently in the yellow — the exact cost this check already refuses to pay for untracked memory files.
- **Read from the already-fetched ref, never a live query.** `doctor` runs from the SessionStart hook and must not reach the network.
- **"at last fetch" is not hedging.** The number is only as current as the last fetch, and presenting it as a live reading would be the ADR 0013 failure — in the check whose whole job is reporting state honestly.

Nothing extra is printed for a root that is up to date (a zero on every clean preflight is furniture) or one with no tracking branch (a plane `git init`-ed by hand).

## Verified beyond the fixtures

Against a real checkout of this repo reset three commits back:

```
detail: clean on main, 3 behind origin/main at last fetch
```

The first attempt at that verification was **invalid and I caught it**: running `python3 -m charter` from inside the cloned checkout loaded *that* checkout's charter — three commits old, without the fix — rather than the one on `PYTHONPATH`. Re-run from outside any checkout. Same trap that has now cost time twice today.

7 new tests, written first. Suite: 1838 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o