### PR TITLE
test: pin the git defaults the plane-root fixture depends on

### DIFF
--- a/tests/test_doctor_plane_root_behind.py
+++ b/tests/test_doctor_plane_root_behind.py
@@ -29,8 +29,19 @@ from charter import config, doctor
 from tests._isolation import PersonaIso
 
 
+#: Pinned on every invocation rather than inherited. `init.defaultBranch` decides what a
+#: bare repo's HEAD points at, `git fetch` copies that into `refs/remotes/origin/HEAD`, and
+#: that ref is the FIRST thing `_plane_default_branch` trusts. A machine that sets it to
+#: `main` and a CI runner that leaves it unset therefore disagree about what this fixture
+#: even is — which is how these tests passed locally and failed on `main`.
+#: Signing is pinned off for the reason charter has a whole rule about: a commit that stops
+#: to ask for a passphrase hangs a suite with nobody there to answer.
+_PINS = ["-c", "init.defaultBranch=main", "-c", "commit.gpgsign=false",
+         "-c", "tag.gpgsign=false"]
+
+
 def _git(cwd, *args):
-    return subprocess.run(["git", "-C", str(cwd), *args],
+    return subprocess.run(["git", *_PINS, "-C", str(cwd), *args],
                           capture_output=True, text=True, check=False)
 
 
@@ -51,8 +62,8 @@ class PlaneRootBehindBase(PersonaIso):
 
         # A real upstream, so `@{upstream}` resolves the way it does on a live plane.
         bare = self.tmp.parent / f"{self.tmp.name}-remote.git"
-        _git(root, "init", "-q", "--bare", str(bare)) if False else \
-            subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=False)
+        subprocess.run(["git", *_PINS, "init", "-q", "-b", "main", "--bare", str(bare)],
+                       check=False, capture_output=True)
         self.addCleanup(lambda: __import__("shutil").rmtree(bare, ignore_errors=True))
         _git(root, "remote", "add", "origin", str(bare))
         _git(root, "push", "-q", "-u", "origin", "main")
@@ -61,7 +72,8 @@ class PlaneRootBehindBase(PersonaIso):
     def _advance_remote(self, n=3):
         """Move origin/main ahead of the root, the way a merged PR does."""
         clone = self.tmp.parent / f"{self.tmp.name}-clone"
-        subprocess.run(["git", "clone", "-q", str(self.bare), str(clone)], check=False)
+        subprocess.run(["git", *_PINS, "clone", "-q", str(self.bare), str(clone)],
+                       check=False, capture_output=True)
         self.addCleanup(lambda: __import__("shutil").rmtree(clone, ignore_errors=True))
         _git(clone, "config", "user.email", "t@example.test")
         _git(clone, "config", "user.name", "T")


### PR DESCRIPTION
`main` is red. Three failures, all from `test_doctor_plane_root_behind.py`, which passed on its own PR branch and on my machine:

```
AssertionError: '3 behind' not found in 'on main, not master'
```

## Cause

The fixture built its bare remote with a plain `git init --bare`, so that remote's `HEAD` followed whatever `init.defaultBranch` the machine sets. `git fetch` copies it into `refs/remotes/origin/HEAD` — and that ref is the **first** thing `_plane_default_branch` trusts, ahead of any local branch.

| | `init.defaultBranch` | fixture's default resolves to | check takes |
| --- | --- | --- | --- |
| my machine | `main` | `main` | the clean path — drift string renders |
| CI runner | unset | `master` | the *finding* path — "on main, not master" |

The drift string is only emitted on the clean path, so on CI it never ran. The assertions were right; **the fixture was describing a different repository on each machine.**

## Fix

Every git invocation in the file pins `init.defaultBranch=main`, and the bare remote is created with an explicit `-b main`. Signing is pinned off in the same list — a commit that stops to ask for a passphrase hangs a suite with nobody there to answer, which is precisely what happened while reproducing this, and is the thing charter has a whole rule about.

## Verified both ways, not assumed

- The failure **reproduces locally** with `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=init.defaultBranch GIT_CONFIG_VALUE_0=master` — same three tests, same message.
- With the fix, that file passes under **both** configs.
- The **whole 1838-test suite** passes under the simulated runner config, so this file was the only one affected.

Side effect: the file runs 6× faster (10.8s → 1.8s), because it is no longer attempting to sign each fixture commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o