### PR TITLE
fix: report the drift even when the root also has findings

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -413,6 +413,13 @@ def check_plane_root() -> Result:
     # every change arrives through a workspace clone and a PR, and nothing pulls the root.
     # Observed three times in one session, twice acting on a stale checkout.
     #
+    # Appended to BOTH paths. The first version put it only on the clean one, so a root
+    # that was dirty *and* behind said nothing about being behind — and those two states
+    # share a cause, since the same neglect that leaves memory files uncommitted is what
+    # leaves the checkout stale. It stayed silent on the one occasion it mattered: a plane
+    # three commits behind, holding the fix for the bug being debugged, reporting only its
+    # uncommitted file.
+    #
     # "at last fetch" is not hedging. The number is read from a ref that is only as current
     # as the last fetch, and presenting it as a live reading would be the failure ADR 0013
     # names — in the check whose whole job is to report state honestly.
@@ -425,7 +432,7 @@ def check_plane_root() -> Result:
     # that fires with both findings at once — which is the common case, since whoever
     # branched in the root is also editing in it.
     return Result(
-        name, WARN, detail=", ".join(findings),
+        name, WARN, detail=", ".join(findings) + drift,
         hint=" ".join(actions) + " Anything that is not control plane belongs in a "
              "workspace clone — charter workspace create <task>, then charter clone "
              "<repo>; the plane root is one working tree every session shares.",

--- a/tests/test_doctor_plane_root_behind.py
+++ b/tests/test_doctor_plane_root_behind.py
@@ -127,6 +127,18 @@ class TestTheCleanLineSaysWhetherItIsCurrent(PlaneRootBehindBase):
         r = doctor.check_plane_root()
         self.assertIn("uncommitted", r.detail)
 
+    def test_dirt_does_not_suppress_the_drift(self):
+        """The first version reported drift only on the clean path, so a root that was
+        BOTH dirty and behind said nothing about being behind — and a root nobody works in
+        is dirty for exactly the reason it is also stale: memory files accumulate while no
+        one pulls. Observed: a plane three commits behind, holding the fix for the very
+        thing being debugged, reporting only the uncommitted file."""
+        self._advance_remote(2)
+        (self.root / "seed.txt").write_text("edited\n")
+        r = doctor.check_plane_root()
+        self.assertIn("uncommitted", r.detail)
+        self.assertIn("2 behind", r.detail)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up to #146, fixing a gap in it.

I put the drift line on the **clean path only**, so a root that was dirty *and* behind reported the dirt and said nothing about being behind:

```
!  plane root       1 uncommitted file(s)
```

Those two states share a cause — the same neglect that leaves memory files uncommitted is what leaves the checkout stale — so in practice they arrive **together**, which means the gap covers the common case rather than an edge one.

## It stayed silent exactly when it mattered

That plane was **three commits behind**, and the commits it lacked contained the fix for the bug being debugged at that moment (an unpinned MCP server). A dispatched sub-agent read the stale config and correctly reported a capability missing that had already been repaired — costing a full round trip to rediscover a known answer.

The check built to end this class of surprise sat that one out.

## The change

`drift` now appends to both returns. Status is unchanged either way: findings still `WARN`, clean still `OK`. Being behind stays a **fact in the detail** rather than a finding of its own, for the reason already recorded in #146 — a row that is permanently yellow is a row people stop reading.

8 tests (one new, asserting dirt does not suppress drift). Suite: 1839 passing, verified under the simulated runner git config per the new CONTRIBUTING section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o