### PR TITLE
persona(reddit): three things the dispatched agent learned

### DIFF
--- a/personas/reddit/memory/MEMORY.md
+++ b/personas/reddit/memory/MEMORY.md
@@ -2,3 +2,6 @@
 
 One line per memory; each links a file holding a single durable fact.
 Written by the persona as it learns; committed and shared.
+- [personas/reddit/mcp.json pins nothing, so 'uvx mcp-server-reddit' resolv](personas-reddit-mcp-json-pins-nothing-so-uvx-mcp.md)
+- [r/ClaudeAI self-promo is rule priority 6, 'Showcase your project in a wa](r-claudeai-self-promo-is-rule-priority-6-showcas.md)
+- [mcp-server-reddit's models are lossy: Post exposes only id/title/author/](mcp-server-reddit-s-models-are-lossy-post-expose.md)

--- a/personas/reddit/memory/mcp-server-reddit-s-models-are-lossy-post-expose.md
+++ b/personas/reddit/memory/mcp-server-reddit-s-models-are-lossy-post-expose.md
@@ -1,0 +1,5 @@
+# mcp-server-reddit's models are lossy: Post exposes only id/title/author/
+
+_2026-08-14 22:21 · persistent_
+
+mcp-server-reddit's models are lossy: Post exposes only id/title/author/score/subreddit/url/created_at/comment_count/post_type/content — NO upvote_ratio, NO flair, and NO removed_by_category/banned_by, so it cannot tell you whether a post was removed by AutoMod or a mod. SubredditInfo returns only name/subscriber_count/public_description — it cannot read subreddit rules. Moderation status and rules checks need a different server or a human with a browser.

--- a/personas/reddit/memory/personas-reddit-mcp-json-pins-nothing-so-uvx-mcp.md
+++ b/personas/reddit/memory/personas-reddit-mcp-json-pins-nothing-so-uvx-mcp.md
@@ -1,0 +1,5 @@
+# personas/reddit/mcp.json pins nothing, so 'uvx mcp-server-reddit' resolv
+
+_2026-08-14 19:23 · persistent_
+
+personas/reddit/mcp.json pins nothing, so 'uvx mcp-server-reddit' resolves mcp>=2.0.0 and the server crashes at import (ImportError: cannot import name 'McpError' from mcp.shared.exceptions — renamed MCPError in mcp 2.0.0). The mcp__reddit__* tools are therefore absent from sub-agent sessions. Fix: pin the SDK, e.g. args ['--from','mcp-server-reddit','--with','mcp<2','mcp-server-reddit'].

--- a/personas/reddit/memory/r-claudeai-self-promo-is-rule-priority-6-showcas.md
+++ b/personas/reddit/memory/r-claudeai-self-promo-is-rule-priority-6-showcas.md
@@ -1,0 +1,5 @@
+# r/ClaudeAI self-promo is rule priority 6, 'Showcase your project in a wa
+
+_2026-08-14 19:23 · persistent_
+
+r/ClaudeAI self-promo is rule priority 6, 'Showcase your project in a way that helps educate and inspire others': project must be built with Claude BY YOU, state what was built + how Claude helped, must be FREE TO TRY and say so (paid tiers OK), minimal promotional language, no referral links (plain project link OK). Hard gate: 'Posts on the feed now require OP karma> 50'. Nothing in the rules, sidebar, submit_text, widgets or AutoMod requires a prompt for the 'Built with Claude' flair — the secondary-source claim is unsupported.


### PR DESCRIPTION
Memories written by the `reddit` persona while researching the subreddit and the model post. Committed by hand because `[memory].share` is `local` on this plane — charter writes them to disk and never commits them.

**The one worth reading twice:** `mcp-server-reddit`'s Pydantic models are **lossy**. `Post` carries no `upvote_ratio`, no flair, and **no `removed_by_category`/`banned_by`** — so the server cannot tell you whether a post was removed. `SubredditInfo` is equally thin: name, subscribers, description, no rules.

The near-miss the persona flagged is the dangerous half:

> a removed post often still returns a plausible-looking record with its score, so a future run could report "post is fine" purely because the field that would say otherwise does not exist. Absence of a removal signal from this server is not evidence the post is up.

That is ADR 0013's failure shape arriving from a third-party tool rather than from charter's own code, which is a useful reminder that the rule has to be applied to what we *read*, not only to what we *write*.

Also recorded: the unpinned-server diagnosis (kept even though the pin has since shipped — the note is *why* the pin exists), and r/ClaudeAI's rule 7 verbatim, including the two clauses that decide a launch post there: the project must be "free to try and say so", and OP karma must exceed 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o