### PR TITLE
0.29.1 — doctor says how far behind the plane root is

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.29.0"
+__version__ = "0.29.1"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.29.0",
+            "command": "charter hook sessionstart --plugin-version 0.29.1",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.29.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.29.1",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.29.0",
+            "command": "charter hook pretooluse --plugin-version 0.29.1",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.29.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.29.1",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.29.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.29.1"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.29.0",
+            "command": "charter hook posttooluse --plugin-version 0.29.1",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.29.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.29.1",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.29.0"
+version = "0.29.1"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only. All four locations move together, pinned by `TestVersionsMoveInLockstep`.

**Patch** — an added detail line and a corrected one. No new check, no new failure mode, nothing that was `OK` becomes `WARN` or `FAIL`. (Contrast 0.28.0, which was minor precisely because it made an unchanged machine start failing preflight.)

## What ships

- **#146 / #150** — `✓ plane root  clean on main` is true, and reads as *"up to date"*. It is a statement about the working **tree**, and the root drifts behind `origin` precisely *because* nobody works in it. Now: `clean on main, 3 behind origin/main at last fetch` — on **both** the clean and the findings path, since #146 originally put it only on the clean one and a root that is dirty *and* behind is the common case, not the edge one.
- **#147** — `personas/reddit/mcp.json` pinned nothing, so `uvx` resolved `mcp>=2.0.0` and `mcp-server-reddit` died at import. The host then registered **zero tools** and the sub-agent silently had none. Found by dispatching the persona at a real task — emitting correct config is not evidence a server runs.
- **#145** — the reddit persona gains that server: the first use of 0.29.0's per-persona MCP against something real, exercising both the tool-grant derivation and the credential-free passthrough.
- **#148 / #149** — a fixture built its bare remote without `-b`, so its default branch followed the machine's `init.defaultBranch` (`main` here, `master` on the runner) and it described a *different repository* on each. Green locally, red on `main`. CONTRIBUTING now states the rule rather than the instance.
- **#151** — three reddit-persona memories, including that `mcp-server-reddit` exposes no removal state, so a normal-looking record is not evidence a post is live.

Suite: 1839 passing, verified under the simulated runner git config per the new CONTRIBUTING section.

## After merge

```
git tag -a v0.29.1 -m "0.29.1 — doctor says how far behind the plane root is"
git push origin v0.29.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o