### PR TITLE
persona(reddit): what reading the live thread taught it

### DIFF
--- a/personas/reddit/memory/MEMORY.md
+++ b/personas/reddit/memory/MEMORY.md
@@ -5,3 +5,5 @@ Written by the persona as it learns; committed and shared.
 - [personas/reddit/mcp.json pins nothing, so 'uvx mcp-server-reddit' resolv](personas-reddit-mcp-json-pins-nothing-so-uvx-mcp.md)
 - [r/ClaudeAI self-promo is rule priority 6, 'Showcase your project in a wa](r-claudeai-self-promo-is-rule-priority-6-showcas.md)
 - [mcp-server-reddit's models are lossy: Post exposes only id/title/author/](mcp-server-reddit-s-models-are-lossy-post-expose.md)
+- [r/claudeskills baseline (Aug 2026): 54.1k subscribers, ~19-22 posts/day](r-claudeskills-baseline-aug-2026-54-1k-subscribe.md)
+- [mcp-server-reddit does not return selftext for image/media posts: get_po](mcp-server-reddit-does-not-return-selftext-for-i.md)

--- a/personas/reddit/memory/mcp-server-reddit-does-not-return-selftext-for-i.md
+++ b/personas/reddit/memory/mcp-server-reddit-does-not-return-selftext-for-i.md
@@ -1,0 +1,5 @@
+# mcp-server-reddit does not return selftext for image/media posts: get_po
+
+_2026-08-14 22:31 · persistent_
+
+mcp-server-reddit does not return selftext for image/media posts: get_post_content sets post_type='link' and content=the post's own permalink, so the body is unverifiable. Plain self-posts return post_type='text' with real body text. Never claim a media post's body is intact from this tool.

--- a/personas/reddit/memory/r-claudeskills-baseline-aug-2026-54-1k-subscribe.md
+++ b/personas/reddit/memory/r-claudeskills-baseline-aug-2026-54-1k-subscribe.md
@@ -1,0 +1,5 @@
+# r/claudeskills baseline (Aug 2026): 54.1k subscribers, ~19-22 posts/day
+
+_2026-08-14 22:31 · persistent_
+
+r/claudeskills baseline (Aug 2026): 54.1k subscribers, ~19-22 posts/day (~0.8/hr, with evening bursts of 6 posts/hour). Same-day posts sit at score 1-3; the best post of a given day is ~14. Top-of-month is 88-330 with one 749 outlier. So a score of 1 on a 1-2 hour old post is the median and carries no signal.


### PR DESCRIPTION
Two memories from the run that checked our own launch post. Committed by hand — `[memory].share` is `local` here, so charter writes them to disk and never commits them.

**A tool limit that would otherwise come back as a false positive.** `mcp-server-reddit` returns `post_type: "link"` and `content` = the post's own permalink for image and media posts, so the body is simply absent. A plain self-post comes back as `"text"` with real selftext, which is exactly what makes the gap easy to miss — the tool looks like it answered.

The persona declined to confirm our post's body or its ownership disclosure on that basis, which was the right call. It pairs with the memory already recorded about the same server exposing no removal state: **this tool answers fewer questions than it appears to**, and both notes exist so the next run doesn't mistake shape for content.

**A baseline, which is what makes a number mean anything.** r/claudeskills is 54.1k subscribers at ~19–22 posts/day; same-day posts sit at 1–3, the best post of a given day is ~14, and top-of-month is 88–330. So score 1 on a two-hour-old post is the **median for its age** and carries no signal in either direction — worth having written down before someone reads a 1 as a verdict.

`personas/_dispatch/` is deliberately left uncommitted: the tally honours `[memory].share` too, and its file is per-machine.

Suite: 1839 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F2B8HT8TqvwGMpcHjhG8o