### PR TITLE
feat: branch moves in the plane root are refused, not just reported

### DIFF
--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -361,6 +361,109 @@ def _ssh_prefix_hosts(forges: dict[str, object]) -> dict[str, str]:
     return out
 
 
+#: git subcommands that move HEAD from one branch to another. Deliberately short: `reset`,
+#: `rebase` and `merge` also rewrite the shared tree, but the evidence in #157 is about
+#: SWITCHING, and ADR 0008 asked for the command set to follow evidence rather than
+#: imagination. Widening it later is cheap; a guard that over-blocks gets disabled once and
+#: then protects nothing.
+_BRANCH_MOVERS = ("checkout", "switch")
+
+#: Flags that make one of the above CREATE a branch rather than move to an existing one.
+_BRANCH_CREATORS = ("-b", "-B", "-c", "-C")
+
+
+def _git_target(cwd: str, args: list[str]) -> tuple[Path, list[str]]:
+    """Which repo a git invocation acts on, and its argv with ``-C <path>`` removed.
+
+    `git -C <path>` is how a session standing in a workspace reaches the shared tree, so a
+    guard that only looked at the cwd would leave the door open from every clone.
+
+    *args* is `_invocation`'s argv, which INCLUDES the program — dropping it here is what
+    lets the caller take "the first non-flag token" as the subcommand rather than as `git`.
+    """
+    target = Path(cwd or ".")
+    rest: list[str] = []
+    i = 1 if args else 0
+    while i < len(args):
+        if args[i] == "-C" and i + 1 < len(args):
+            target = Path(args[i + 1])
+            i += 2
+            continue
+        rest.append(args[i])
+        i += 1
+    return target, rest
+
+
+def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
+    """Deny a git command that would move the PLANE ROOT between branches (#157).
+
+    The plane root is one working tree every session shares. ADR 0008 chose to report this
+    rather than refuse it, and said prevention was the real answer once there was evidence
+    about which commands count. There is now: one session switched the root six times,
+    reading and dismissing `doctor`'s warning each time, while two background agents in one
+    tree silently clobber each other through exactly this.
+
+    Three things keep it a guard rather than a cage:
+
+    * **Only branch moves.** `git commit` is untouched — `charter save` commits here by
+      design, and advancing HEAD along the branch you are on is not the failure.
+    * **Only the root.** A workspace clone is where branch work belongs, so it is never
+      touched, whether reached by cwd or by ``git -C``.
+    * **The remedy stays executable.** `doctor` prints *"Put the root back:
+      `git -C <plane> checkout main`"*, so returning to the plane's default branch is
+      always allowed. A guard that blocks the fix it recommends teaches people to bypass it.
+
+    Costs one `git symbolic-ref` only once a candidate is found — this runs on every Bash
+    call, and the common case exits on a string comparison.
+    """
+    from . import config as _cfg
+    try:
+        root = Path(_cfg.ROOT).resolve()
+    except OSError:
+        return None
+
+    for seg in _segments(cmd):
+        prog, _env, args = _invocation(seg)
+        if not prog or os.path.basename(prog) != "git":
+            continue
+        target, rest = _git_target(cwd, args)
+        sub = next((a for a in rest if not a.startswith("-")), "")
+        if sub not in _BRANCH_MOVERS:
+            continue
+        try:
+            if target.resolve() != root:
+                continue
+        except OSError:
+            continue
+
+        post = rest[rest.index(sub) + 1:]
+        # `git checkout -- <path>` restores a file and never moves HEAD.
+        if "--" in post:
+            continue
+        creating = any(a in _BRANCH_CREATORS for a in post)
+        # A bare `-` is a REF (the previous branch), not a flag — and `git checkout -` is
+        # what makes a six-switch session cheap to repeat, so reading it as a flag would
+        # leave the guard blind to the cheapest form of the thing it exists to stop.
+        wants = [a for a in post if a == "-" or not a.startswith("-")]
+        if not wants and not creating:
+            continue  # bare `git checkout` moves nothing
+
+        if not creating and wants:
+            from .doctor import _plane_default_branch
+            if wants[0] == _plane_default_branch(root):
+                continue  # the documented remedy — must stay runnable
+
+        moving = f"create '{wants[0]}'" if creating and wants else (
+            f"switch to '{wants[0]}'" if wants else "switch branches")
+        return (
+            f"would {moving} in the PLANE ROOT, which is one working tree every session "
+            f"shares — two agents here silently clobber each other's branches, and the "
+            f"symptom looks like an unrelated bug. Branch work belongs in a workspace "
+            f"clone: `charter workspace create <task>`, then `charter clone <repo>`. "
+            f"Returning the root to its default branch is always allowed.")
+    return None
+
+
 def _single_credential_reason(cmd: str) -> str | None:
     """Deny a git action that would depend on SSH or commit signing instead of that
     repo's own forge's credential (its token over HTTPS) — golden rule 0, per forge.
@@ -644,6 +747,14 @@ def pretooluse() -> int:
     if cred:
         _deny("PreToolUse", cred)
         _trace("deny", sid, reason="single-credential", cmd=head)
+        return 0
+    # A3: the plane root is one shared working tree — refuse a branch move in it (#157).
+    # Same gate as A2, and for the same reason: outside a plane there is no plane root, and
+    # denying there would explain a control plane that does not exist on that machine.
+    branch = _plane_root_branch_reason(cmd, cwd) if _cfg.HAS_CONTROL_PLANE else None
+    if branch:
+        _deny("PreToolUse", branch)
+        _trace("deny", sid, reason="plane-root-branch", cmd=head)
         return 0
     # B: committing inside a clone → ASK, not deny. A repo-rooted session is usually better
     # (the repo's own hooks/conventions apply), but it's a preference, not a safety rule —

--- a/docs/adr/0008-the-plane-root-is-not-a-work-tree.md
+++ b/docs/adr/0008-the-plane-root-is-not-a-work-tree.md
@@ -45,3 +45,31 @@ A warning you can work through is a warning you learn to work through, and this 
 expected to be ignored at first. That is accepted for now, and it is the reason this ADR
 exists: so that when someone later proposes making it an error, the note explaining why it
 was not one on day one is already here.
+
+## 2026-08-16 — the evidence arrived, so branch moves are now refused (#157)
+
+The prediction above held exactly. In one session an agent switched the plane root between
+branches **six times**, with `doctor` printing its correct, complete, actionable warning on
+every run in between; it was read, judged "expected mid-work", and dismissed each time. Not
+missed and not unclear — rationalised past, repeatedly, by precisely the consumer charter is
+built for. The operator's notes supply the cost: two background agents in one working tree
+clobber each other through `git checkout`, and the symptom presents as an unrelated bug.
+
+That is the evidence this ADR said prevention was waiting on, so `pretooluse` now **denies**
+a branch move in the plane root. The judgement it asked for — *which commands count* — is
+answered as narrowly as the evidence supports:
+
+* **`checkout` and `switch` only.** `reset`, `rebase` and `merge` also rewrite the shared
+  tree, and are deliberately not covered: the evidence is about switching, and a guard that
+  over-blocks is disabled once and then protects nothing.
+* **`git commit` is untouched.** `charter save` commits here by design, and advancing HEAD
+  along the branch you are on was never the failure.
+* **Returning to the default branch is always allowed.** The warning's own remedy is
+  `git -C <plane> checkout main`; a guard that blocks the fix it recommends is a trap, and
+  would be routed around within a session.
+
+What does **not** change: the warning stays, because it is what explains the denial when one
+arrives, and because it still covers the states prevention cannot — a root left dirty, or
+sitting on a non-default branch from before this shipped. Signal and refusal are not
+alternatives here; the refusal stops the next switch, and the signal describes the tree you
+are already in.

--- a/tests/test_plane_root_branch_guard.py
+++ b/tests/test_plane_root_branch_guard.py
@@ -1,0 +1,153 @@
+"""Branch switching in the plane root is REFUSED, not merely reported (#157).
+
+ADR 0008 chose signal over refusal and said why prevention was not what shipped first:
+
+    Preventing it outright — refusing commands that would operate in the root — is the real
+    answer and is deliberately not what ships first. Which commands count is a judgement
+    that wants evidence.
+
+#157 is that evidence. One session switched the plane root between branches six times;
+`doctor` printed its correct, complete, actionable warning on every run in between, and the
+agent rationalised past it each time — the exact consumer charter is built for. The
+operator's notes add the cost: two background agents in one working tree clobber each other
+through `git checkout`, and the symptom looks like an unrelated mystery.
+
+So this implements ADR 0008's own next step rather than contradicting it, and is scoped to
+what the evidence shows: **moving HEAD between branches, in the plane root, and nothing
+else**. In particular `doctor`'s remedy — `git -C <plane> checkout main` — has to keep
+working, because a guard that blocks the fix it recommends is a trap rather than a guard.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+from charter import config, hooks
+from tests._isolation import PersonaIso, run_hook
+
+
+def _decision(r) -> str | None:
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+
+
+def _reason(r) -> str:
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
+
+
+class PlaneRootCase(PersonaIso):
+    """A plane root that is a real git repo on `main`, plus a clone that is not the root."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.HAS_CONTROL_PLANE = True
+        self.root = Path(config.ROOT)
+        self._git("init", "-q", "-b", "main", str(self.root))
+        (self.root / "README").write_text("plane\n")
+        self._in(self.root, "add", "-A")
+        self._in(self.root, "-c", "commit.gpgsign=false", "-c", "user.email=t@e",
+                 "-c", "user.name=t", "commit", "-qm", "init")
+        self._in(self.root, "branch", "feature")
+        self.clone = config.WORKSPACES_DIR / "ws" / "svc"
+        self.clone.mkdir(parents=True, exist_ok=True)
+        self._git("init", "-q", "-b", "main", str(self.clone))
+
+    @staticmethod
+    def _git(*args):
+        return subprocess.run(["git", *args], check=True, capture_output=True, text=True)
+
+    @staticmethod
+    def _in(where, *args):
+        return subprocess.run(["git", "-C", str(where), *args], check=True,
+                              capture_output=True, text=True)
+
+    def run_cmd(self, cmd: str, cwd: Path | None = None):
+        return run_hook(hooks.pretooluse, {
+            "tool_input": {"command": cmd},
+            "cwd": str(cwd if cwd is not None else self.root),
+            "session_id": "s"})
+
+
+class TestSwitchingBranchesInTheRootIsRefused(PlaneRootCase):
+    def test_git_switch_is_denied(self):
+        self.assertEqual(_decision(self.run_cmd("git switch feature")), "deny")
+
+    def test_git_checkout_of_another_branch_is_denied(self):
+        self.assertEqual(_decision(self.run_cmd("git checkout feature")), "deny")
+
+    def test_creating_a_branch_is_denied(self):
+        for flag in ("-b", "-B"):
+            self.assertEqual(_decision(self.run_cmd(f"git checkout {flag} chore/x")),
+                             "deny", flag)
+        self.assertEqual(_decision(self.run_cmd("git switch -c chore/x")), "deny")
+
+    def test_switching_back_to_the_previous_branch_is_denied(self):
+        """`git checkout -` is the move that made the six-switch session cheap to repeat."""
+        self.assertEqual(_decision(self.run_cmd("git checkout -")), "deny")
+
+    def test_it_fires_from_anywhere_when_the_root_is_targeted(self):
+        """`git -C <plane> checkout` is how a session in a workspace reaches the shared
+        tree, so scoping the guard to the cwd alone would leave the door open."""
+        self.assertEqual(_decision(self.run_cmd(f"git -C {self.root} checkout feature",
+                                                cwd=self.clone)), "deny")
+
+    def test_the_denial_names_the_alternative(self):
+        """A refusal that only says no gets worked around. The remedy is the same one
+        `doctor` prints: the work belongs in a workspace clone."""
+        r = self.run_cmd("git checkout feature")
+        self.assertIn("workspace", _reason(r).lower())
+
+
+class TestTheRemedyStaysExecutable(PlaneRootCase):
+    def test_checking_out_the_default_branch_is_allowed(self):
+        """`doctor` tells you to run exactly this to undo the damage. Blocking it would
+        make the guard a trap — the one carve-out that keeps this a guard rather than a
+        cage."""
+        self._in(self.root, "checkout", "-q", "feature")
+        self.assertIsNone(_decision(self.run_cmd("git checkout main")))
+        self.assertIsNone(_decision(self.run_cmd(f"git -C {self.root} checkout main")))
+
+    def test_creating_a_branch_named_like_the_default_is_still_denied(self):
+        """The carve-out is for RETURNING to the default, not for the name."""
+        self.assertEqual(_decision(self.run_cmd("git checkout -b main")), "deny")
+
+
+class TestItDoesNotOverreach(PlaneRootCase):
+    def test_restoring_a_file_is_allowed(self):
+        """`git checkout -- <path>` never moves HEAD. Denying it would block an ordinary
+        undo and teach people the guard is noise."""
+        self.assertIsNone(_decision(self.run_cmd("git checkout -- README")))
+
+    def test_committing_in_the_root_is_allowed(self):
+        """`charter save` commits in the root by design. Advancing HEAD along the branch
+        you are already on is not the failure this guards."""
+        self.assertIsNone(_decision(self.run_cmd("git commit -m x")))
+
+    def test_switching_inside_a_workspace_clone_is_allowed(self):
+        """The whole point is that branch work belongs in a clone."""
+        self.assertIsNone(_decision(self.run_cmd("git checkout -b feature/x",
+                                                 cwd=self.clone)))
+
+    def test_status_and_log_are_allowed(self):
+        for cmd in ("git status", "git log --oneline", "git branch --list"):
+            self.assertIsNone(_decision(self.run_cmd(cmd)), cmd)
+
+    def test_a_commit_message_mentioning_checkout_is_not_a_switch(self):
+        """The prose trap every other guard in this module already had to survive."""
+        self.assertIsNone(_decision(
+            self.run_cmd('git commit -m "docs: explain git checkout main"')))
+
+
+class TestItIsScopedToAPlane(PlaneRootCase):
+    def test_no_control_plane_means_no_opinion(self):
+        """The plugin installs per user; the handler runs everywhere. Outside a plane there
+        is no plane root to protect, and denying there explains a plane that does not
+        exist — the mistake `_single_credential_reason` was gated to stop repeating."""
+        config.HAS_CONTROL_PLANE = False
+        self.assertIsNone(_decision(self.run_cmd("git checkout feature")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #157.

ADR 0008 chose signal over refusal and named its own bar for changing that:

> Preventing it outright — refusing commands that would operate in the root — is the real answer and is deliberately not what ships first. **Which commands count is a judgement that wants evidence.**

The evidence arrived. One session switched the plane root between branches **six times**, with `doctor` printing its correct, complete, actionable warning on every run in between — read, judged *"expected mid-work"*, and dismissed each time. Not missed, not unclear: rationalised past, repeatedly, by exactly the consumer charter is built for. Two background agents in one working tree clobber each other through `git checkout`, and the symptom presents as an unrelated bug.

So this implements ADR 0008's next step rather than overriding it, and **the ADR carries an amendment saying so** — a posture that changes without a note gets changed back.

## Scoped to the evidence

- **`checkout` and `switch` only.** `reset`, `rebase` and `merge` also rewrite the shared tree and are deliberately uncovered: the evidence is about *switching*, and a guard that over-blocks is disabled once and then protects nothing.
- **`git commit` untouched** — `charter save` commits here by design, and advancing HEAD along the branch you are on was never the failure.

## Three carve-outs, each load-bearing

- **Returning to the default branch is always allowed.** `doctor`'s own remedy is `git -C <plane> checkout main`; a guard that blocks the fix it recommends is a trap that gets routed around inside one session. Creating a branch *named* `main` is still refused — the carve-out is for returning, not for the name.
- **`git checkout -- <path>`** restores a file and never moves HEAD.
- **Workspace clones are never touched**, whether reached by cwd or `git -C`. The guard follows `-C`, so a session in a clone cannot reach around it into the shared tree.

`git checkout -` counts as a branch move: `-` is a ref, not a flag, and it is the cheapest way to repeat the six-switch pattern.

## What does not change

The warning stays. It is what explains a denial when one arrives, and it still covers the states prevention cannot — a root left dirty, or already sitting on a non-default branch. Signal and refusal are not alternatives: the refusal stops the next switch, the signal describes the tree you are already in.

## Tests

14 new in `tests/test_plane_root_branch_guard.py`: switch/checkout/`-b`/`-B`/`-c`/`-` denied; `git -C <root>` denied from inside a clone; the denial naming the remedy; the default-branch carve-out (and that `-b main` is still refused); file-restore, `commit`, `status`/`log`/`branch --list` allowed; a commit message *mentioning* `git checkout main` not tripping it; and no opinion at all outside a plane.

Full suite: 1853 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX