### PR TITLE
fix: report redaction covers the whole identifier cluster, and says so

### DIFF
--- a/charter/report.py
+++ b/charter/report.py
@@ -143,42 +143,112 @@ REDACTED = "[redacted]"
 _HOME_PATH_RE = re.compile(r"(?:/Users|/home)/\S*")
 
 
-def scrub(text: str) -> str:
-    """Remove from *text* what charter can positively identify as the Reporter's.
+#: Vault config keys whose VALUES are the Reporter's identifiers rather than charter's
+#: wiring: which 1Password vault, which item, which token variable. `file` is deliberately
+#: absent — it is a path, and paths are handled by `_HOME_PATH_RE` above.
+_VAULT_ID_KEYS = ("op-vault", "op_vault", "op-item", "op_item", "token-env", "token_env")
 
-    The advantage over a generic scrubber is that charter knows its own **workspace** and
-    **persona** names — which are routinely named after the client or the project. That is
-    also the trade-off: a workspace named after a common word will redact that word out of
-    ordinary prose. Preferring a mangled sentence to a leaked client name is deliberate,
-    and the Reporter reads the result before it is sent either way.
+#: Per-category placeholders rather than one `[redacted]` for everything. The complaint in
+#: #137/#154 was not only that the scrub was incoherent but that it cost READABILITY: a
+#: maintainer reading `charter vault add [redacted] --op-vault "[redacted]"` cannot follow
+#: the command. Naming the category keeps the shape legible while removing the value.
+_W, _P, _V, _T = "[workspace]", "[persona]", "[vault]", "[token-env]"
+
+
+def _identifiers() -> list[tuple[str, str]]:
+    """(value, placeholder) for every identifier charter knows about this machine.
+
+    Lazy imports: importing `report` happens on every `cli` invocation, and this is the only
+    place that needs the workspace, persona and vault machinery.
     """
-    # Lazy imports: this is the only place report.py needs them, and keeping them out of
-    # module scope means importing `report` (which `cli` does on every invocation) does not
-    # drag the workspace and persona machinery in.
     from . import persona, workspace
+    from .secrets import registry
 
-    out = _HOME_PATH_RE.sub(REDACTED, text)
-
-    names = set(workspace.list_workspaces()) | set(persona.list_personas())
+    out: list[tuple[str, str]] = []
+    for w in workspace.list_workspaces():
+        out.append((w, _W))
+    for p in persona.list_personas():
+        out.append((p, _P))
+    try:
+        for name, vc in (registry.vaults() or {}).items():
+            out.append((name, _V))
+            cfg = (vc or {}).get("config") or {}
+            for key in _VAULT_ID_KEYS:
+                val = cfg.get(key)
+                if isinstance(val, str) and val.strip():
+                    out.append((val.strip(), _T if "token" in key else _V))
+    except Exception:
+        # A registry that cannot be read must not stop the rest of the scrub: the failure
+        # direction that matters is "scrubbed less than it could", never "sent nothing".
+        pass
     # `default` exists on every install, so it identifies nobody — and redacting it would
     # mangle ordinary English in most reports.
-    names.discard(config.DEFAULT_WORKSPACE)
+    return [(v, ph) for v, ph in out if v and v != config.DEFAULT_WORKSPACE]
+
+
+def scrub(text: str) -> tuple[str, list[str]]:
+    """Remove what charter can positively identify as the Reporter's, and say what it removed.
+
+    Returns ``(text, categories)``.
+
+    The advantage over a generic scrubber is that charter knows its own names — workspaces,
+    personas, **vaults, vault items and token variables** — which are routinely named after
+    the client, the project or the company.
+
+    **The whole cluster or none of it.** Redacting the persona/vault *alias* while leaving
+    the real 1Password vault name and `OP_..._SERVICE_ACCOUNT_TOKEN` on the adjacent lines
+    cost readability and bought no privacy — the alias was recoverable in one step — and it
+    created false confidence, because seeing `[redacted]` reads as "the identifiers were
+    handled" and stops an author checking what else is going out on a PUBLIC tracker under
+    their own identity (#137, #154).
+
+    Between "redact everything charter knows" and "redact only the unambiguous", this takes
+    the first: a vault name is frequently a **company** name, which is precisely the class
+    of identifier this exists to keep off a public tracker.
+
+    The known cost is unchanged and still deliberate — a workspace named after a common word
+    redacts that word out of ordinary prose — and is paid down two ways rather than argued
+    away: per-category placeholders keep a command's shape followable, and the returned
+    categories give the Reporter's mandatory read (ADR 0003) something to check against
+    instead of having to notice absences.
+    """
+    out = text
+    used: set[str] = set()
+
+    if _HOME_PATH_RE.search(out):
+        used.add("home paths")
+        out = _HOME_PATH_RE.sub(REDACTED, out)
+
     # Longest first, so `acme-migration` is removed whole rather than being half-eaten by
-    # a shorter `acme` and leaving `[redacted]-migration` behind.
-    for name in sorted(names, key=len, reverse=True):
-        out = re.sub(rf"\b{re.escape(name)}\b", REDACTED, out)
-    return out
+    # a shorter `acme` and leaving `[workspace]-migration` behind.
+    for value, placeholder in sorted(_identifiers(), key=lambda p: len(p[0]), reverse=True):
+        pattern = rf"\b{re.escape(value)}\b" if value[:1].isalnum() else re.escape(value)
+        if re.search(pattern, out):
+            used.add(placeholder)
+            out = re.sub(pattern, placeholder, out)
+    return out, sorted(used)
+
+
+def scrubbed(text: str) -> str:
+    """`scrub` for callers that only want the text."""
+    return scrub(text)[0]
 
 
 def gap_payload(text: str) -> dict:
     """The publishable part of a **gap** report. No exception type and no frames — a gap
     is not a crash — but the same version context, which is what tells the maintainer
     whether the capability landed since."""
+    body, scrubbed_categories = scrub(text)
     return {
         "charter_version": __version__,
         "python_version": platform.python_version(),
         "os": platform.platform(),
-        "text": scrub(text),
+        "text": body,
+        # Carried in the payload so `render` can state it. ADR 0003 makes the Reporter read
+        # the draft before it is sent; without this the read has to notice ABSENCES, which
+        # is the hardest thing to check for and the reason a half-redaction went out
+        # looking handled (#137).
+        "scrubbed": scrubbed_categories,
     }
 
 
@@ -333,6 +403,12 @@ def render(rec: dict) -> str:
         lines.append("")
     if rec.get("occurrences", 1) > 1:
         lines.append(f"Hit {rec['occurrences']} times on this machine.")
+    if p.get("scrubbed"):
+        # Named categories, because the Reporter's mandatory read (ADR 0003) is otherwise a
+        # search for things that are NOT there. A visible `[vault]` also stops the failure
+        # #154 describes — seeing a redaction and concluding the identifiers were handled.
+        lines.append(f"_Scrubbed before drafting: {', '.join(p['scrubbed'])}. "
+                     f"Restore anything over-redacted before sending._")
     lines.append(
         f"charter {p.get('charter_version')} · Python {p.get('python_version')} "
         f"· {p.get('os')}")

--- a/tests/test_report_command.py
+++ b/tests/test_report_command.py
@@ -47,7 +47,7 @@ class TestDraftingABug(PersonaIso):
         workspace.ensure("acme-migration")
         _, out = self._run("clone fails in acme-migration")
         self.assertNotIn("acme-migration", out)
-        self.assertIn(report.REDACTED, out)
+        self.assertIn("[workspace]", out)
 
 
 class TestDraftingTouchesNoNetwork(PersonaIso):

--- a/tests/test_report_gap.py
+++ b/tests/test_report_gap.py
@@ -18,26 +18,26 @@ from tests._isolation import PersonaIso
 class TestScrubbingProse(PersonaIso):
     def test_an_absolute_home_path_does_not_survive(self):
         """Absolute paths carry the Reporter's username in the second segment."""
-        out = report.scrub(f"it broke at {Path.home()}/code/billing/app.py")
+        out, _ = report.scrub(f"it broke at {Path.home()}/code/billing/app.py")
         self.assertNotIn(str(Path.home()), out)
 
     def test_a_workspace_name_is_replaced(self):
         """charter knows its own workspace names, which a generic scrubber never would.
         A workspace is usually named after the client or the project."""
         workspace.ensure("acme-migration")
-        out = report.scrub("charter clone fails inside acme-migration every time")
+        out, _ = report.scrub("charter clone fails inside acme-migration every time")
         self.assertNotIn("acme-migration", out)
 
     def test_a_persona_name_is_replaced(self):
         self.make_persona("client-billing-reviewer")
-        out = report.scrub("the client-billing-reviewer persona cannot do this")
+        out, _ = report.scrub("the client-billing-reviewer persona cannot do this")
         self.assertNotIn("client-billing-reviewer", out)
 
     def test_the_surrounding_prose_survives(self):
         """Scrubbing must not shred the report — what remains has to still describe the
         gap, or the Reporter is left approving something useless."""
         workspace.ensure("acme")
-        out = report.scrub("charter clone fails inside acme every time")
+        out, _ = report.scrub("charter clone fails inside acme every time")
         self.assertIn("charter clone fails inside", out)
         self.assertIn("every time", out)
 
@@ -45,18 +45,23 @@ class TestScrubbingProse(PersonaIso):
         """A redaction the Reporter cannot see reads as charter having sent the original.
         The placeholder is the signal that something was removed."""
         workspace.ensure("acme-migration")
-        self.assertIn(report.REDACTED, report.scrub("broken in acme-migration"))
+        # A per-CATEGORY placeholder since #137: `[workspace]` keeps a command's shape
+        # followable where a uniform `[redacted]` did not, and still shows plainly that
+        # something was removed.
+        out, used = report.scrub("broken in acme-migration")
+        self.assertIn("[workspace]", out)
+        self.assertEqual(used, ["[workspace]"])
 
     def test_text_with_nothing_sensitive_is_returned_unchanged(self):
         text = "charter has no way to archive a workspace"
-        self.assertEqual(report.scrub(text), text)
+        self.assertEqual(report.scrub(text), (text, []))
 
     def test_the_default_workspace_name_is_not_scrubbed(self):
         """`default` exists on every install, so it identifies nobody — and redacting it
         would mangle ordinary English in most reports."""
         workspace.ensure(config.DEFAULT_WORKSPACE)
         text = f"the {config.DEFAULT_WORKSPACE} workspace behaves differently"
-        self.assertEqual(report.scrub(text), text)
+        self.assertEqual(report.scrub(text), (text, []))
 
 
 class TestRecordingAGap(PersonaIso):

--- a/tests/test_report_scrub_cluster.py
+++ b/tests/test_report_scrub_cluster.py
@@ -1,0 +1,142 @@
+"""Redaction covers the whole identifier cluster, or none of it (#137, #154).
+
+The reported draft, verbatim:
+
+    charter vault add [redacted] --provider 1password \\
+      --op-vault "VolatiCloud Marketing" --op-item charter-[redacted] \\
+      --persona [redacted] --token-env OP_VOLATICLOUD_MARKETING_SERVICE_ACCOUNT_TOKEN \\
+      --share --force
+
+The persona/vault **alias** was removed while the real 1Password vault name, the item and
+the token variable survived on the adjacent lines. No secret VALUE leaked — these are all
+names — but the policy was applied to one class of identifier and not to the others it sits
+beside, so `[redacted]` was recoverable in one step. It cost readability and bought no
+privacy.
+
+Worse, per #154: a visible `[redacted]` creates **false confidence**. An author who sees one
+concludes the identifiers were handled and stops checking what else is going out on a public
+tracker under their own identity.
+
+Two decisions are pinned here. **Redact everything charter knows**, because a vault name is
+frequently a company name — the exact class of identifier this exists to keep off a public
+tracker. And **say what was scrubbed**, because ADR 0003 makes the Reporter read the draft,
+and a read that has to notice ABSENCES is the hardest kind to do well.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import config, report, workspace
+from charter.secrets import registry
+from tests._isolation import PersonaIso
+
+
+class ClusterCase(PersonaIso):
+    def register_vault(self, name="marketing", op_vault="VolatiCloud Marketing",
+                       op_item="charter-marketing",
+                       token_env="OP_VOLATICLOUD_MARKETING_SERVICE_ACCOUNT_TOKEN"):
+        registry.add_vault(name, "1password",
+                           {"op-vault": op_vault, "op-item": op_item,
+                            "token-env": token_env})
+
+    def draft(self) -> str:
+        return ("charter vault add marketing --provider 1password "
+                '--op-vault "VolatiCloud Marketing" --op-item charter-marketing '
+                "--token-env OP_VOLATICLOUD_MARKETING_SERVICE_ACCOUNT_TOKEN --share")
+
+
+class TestTheWholeClusterGoes(ClusterCase):
+    def test_the_real_vault_name_does_not_survive(self):
+        self.register_vault()
+        out, _ = report.scrub(self.draft())
+        self.assertNotIn("VolatiCloud Marketing", out)
+
+    def test_the_token_variable_does_not_survive(self):
+        self.register_vault()
+        out, _ = report.scrub(self.draft())
+        self.assertNotIn("OP_VOLATICLOUD_MARKETING_SERVICE_ACCOUNT_TOKEN", out)
+
+    def test_the_item_name_does_not_survive(self):
+        self.register_vault()
+        out, _ = report.scrub(self.draft())
+        self.assertNotIn("charter-marketing", out)
+
+    def test_the_alias_still_goes_too(self):
+        """The half that already worked. Dropping it would be the other incoherent policy."""
+        self.register_vault()
+        out, _ = report.scrub(self.draft())
+        self.assertNotIn("marketing", out)
+
+    def test_nothing_recoverable_is_left_beside_a_redaction(self):
+        """The actual complaint, asserted as one statement: after scrubbing, no fragment of
+        the cluster remains from which the removed alias could be reconstructed."""
+        self.register_vault()
+        out, _ = report.scrub(self.draft())
+        for leak in ("VolatiCloud", "MARKETING", "marketing"):
+            self.assertNotIn(leak, out, leak)
+
+
+class TestItStaysReadable(ClusterCase):
+    def test_the_command_shape_survives(self):
+        """A maintainer has to be able to follow the command. That is what the uniform
+        `[redacted]` destroyed and what per-category placeholders restore."""
+        self.register_vault()
+        out, _ = report.scrub(self.draft())
+        self.assertIn("charter vault add", out)
+        self.assertIn("--provider 1password", out)
+        self.assertIn("--share", out)
+
+    def test_categories_are_distinguishable(self):
+        self.register_vault()
+        out, _ = report.scrub(self.draft())
+        self.assertIn("[vault]", out)
+        self.assertIn("[token-env]", out)
+
+
+class TestItSaysWhatItRemoved(ClusterCase):
+    def test_the_categories_are_reported(self):
+        self.register_vault()
+        _, used = report.scrub(self.draft())
+        self.assertIn("[vault]", used)
+        self.assertIn("[token-env]", used)
+
+    def test_a_clean_report_claims_nothing(self):
+        """A summary that fires when nothing was removed is how the line stops being read."""
+        self.assertEqual(report.scrub("charter cannot archive a workspace"),
+                         ("charter cannot archive a workspace", []))
+
+    def test_the_rendered_draft_states_it(self):
+        """ADR 0003 makes the Reporter read the draft before sending. Without this the read
+        is a search for things that are NOT there — the hardest kind — which is how a
+        half-redaction went out looking handled."""
+        self.register_vault()
+        rid = report.record_gap(self.draft())
+        body = report.render(report.load(rid))
+        self.assertIn("Scrubbed before drafting", body)
+        self.assertIn("[vault]", body)
+
+    def test_a_clean_draft_carries_no_scrub_line(self):
+        rid = report.record_gap("charter cannot archive a workspace")
+        self.assertNotIn("Scrubbed before drafting", report.render(report.load(rid)))
+
+
+class TestItDegradesRatherThanFails(ClusterCase):
+    def test_an_unreadable_registry_still_scrubs_the_rest(self):
+        """The failure direction that matters is "scrubbed less than it could", never
+        "the report never got drafted"."""
+        workspace.ensure("acme-migration")
+        real = registry.vaults
+
+        def boom(*a, **kw):
+            raise OSError("registry unreadable")
+
+        registry.vaults = boom
+        self.addCleanup(setattr, registry, "vaults", real)
+        out, used = report.scrub("clone fails inside acme-migration")
+        self.assertNotIn("acme-migration", out)
+        self.assertIn("[workspace]", used)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #137. Closes #154 (already closed as a duplicate; its evidence drove this).

The drafted command that produced the issue:

```
charter vault add [redacted] --provider 1password \
  --op-vault "VolatiCloud Marketing" --op-item charter-[redacted] \
  --persona [redacted] --token-env OP_VOLATICLOUD_MARKETING_SERVICE_ACCOUNT_TOKEN
```

The alias was removed while the real vault name, the item and the token variable survived **on the adjacent lines**. No secret *value* leaked — these are names — but the policy applied to one class of identifier and not the others beside it, so `[redacted]` was recoverable in one step: readability spent, no privacy bought.

And it is worse than neutral. Per #154, a visible redaction creates **false confidence** — an author who sees one concludes the identifiers were handled and stops checking what else is going out on a public tracker under their own identity.

## Decision 1 — everything charter knows, not only the unambiguous

Both were live options in #137. A vault name is frequently a **company** name, which is precisely the class of identifier this exists to keep off a public tracker, so the narrower rule would have dropped the thing most worth protecting.

Now covered: workspaces, personas, vault names, vault items, token variables.

## Decision 2 — say what was scrubbed

ADR 0003 makes the Reporter read the draft before sending. Without a summary, that read is a *search for things that are not there* — the hardest kind to do well, and exactly how a half-redaction went out looking handled. Drafts now end with:

> _Scrubbed before drafting: [token-env], [vault]. Restore anything over-redacted before sending._

## The cost, paid down rather than argued away

The known trade-off is unchanged — a workspace named after a common word still redacts that word out of prose — but per-category placeholders (`[workspace]`, `[persona]`, `[vault]`, `[token-env]`) keep a command's **shape** followable where a uniform `[redacted]` destroyed it. A maintainer can still read the command; they just cannot recover the names.

## Contract change

`scrub` returns `(text, categories)`. Five existing tests move to it, and one changes *meaning* rather than shape: *"scrubbing is visible, not silent"* now asserts the category placeholder, because that is what visibility looks like after this.

A registry that cannot be read no longer stops the rest of the scrub — the failure direction that matters is "scrubbed less than it could", never "the report never got drafted".

## Tests

12 new in `tests/test_report_scrub_cluster.py`, written against the verbatim reported draft: each cluster member gone, the alias still gone, **nothing recoverable left beside a redaction**, the command shape surviving, categories distinguishable and reported, the rendered draft stating them, a clean draft claiming nothing, and graceful degradation on an unreadable registry.

Full suite: 1876 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX