### PR TITLE
feat: charter report delete — a draft can be discarded

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -229,6 +229,17 @@ def _add_report_parser(sub) -> None:
     sh.add_argument("id")
     sh.set_defaults(func=commands_report.cmd_report_show)
 
+    # The undo for drafting. Drafting is cheap and local on purpose, which only works if
+    # discarding is too — otherwise a redrafted report leaves its superseded twin in `list`
+    # forever and the "not sent" column stops meaning anything.
+    dl = rsub.add_parser("delete", aliases=["discard"],
+                         help="Discard a drafted report (a sent one needs --force).")
+    dl.add_argument("id")
+    dl.add_argument("--force", action="store_true",
+                    help="Discard even one already sent — that also drops the pointer a "
+                         "later identical crash would have reused.")
+    dl.set_defaults(func=commands_report.cmd_report_delete)
+
     # Its own command, not a flag on `send`: a flag an agent can pass is a flag it will
     # pass every time, where a one-off command has a single auditable purpose (ADR 0003).
     cs = rsub.add_parser("consent",

--- a/charter/commands_report.py
+++ b/charter/commands_report.py
@@ -149,6 +149,35 @@ def cmd_report_show(args) -> int:
     return 0
 
 
+def cmd_report_delete(args) -> int:
+    """Discard a report drafted on this machine.
+
+    `not sent` is a TODO, and its worth is that it is actionable. A superseded draft that
+    can never be removed turns `report list` into a list with a permanent false positive,
+    and a list you cannot trust is one where a real pending report gets missed among the
+    dead ones — the failure mode of a suite full of permanently-skipped tests (#155).
+
+    A SENT report needs `--force`, and not merely as ceremony: `prune` keeps sent reports
+    forever on purpose, because they are what lets a later identical crash point at the
+    existing upstream issue instead of drafting a duplicate. Deleting one removes that
+    pointer, and with it the only local trace of something that exists publicly under the
+    Reporter's identity.
+    """
+    rid = getattr(args, "id", None)
+    rec = report.load(rid)
+    if not rec:
+        util.err(f"no report '{rid}'. List them: charter report list")
+        return 1
+    if rec.get("issue_url") and not getattr(args, "force", False):
+        util.err(f"'{rid}' was already sent → {rec['issue_url']}")
+        util.info("Kept so a later identical crash can point at that issue instead of "
+                  "filing a duplicate. Discard it anyway with --force.")
+        return 2
+    report.delete(rid)
+    util.ok(f"Discarded report '{rid}'.")
+    return 0
+
+
 def cmd_report_comment(args) -> int:
     """Add this Reporter's details to an existing upstream issue.
 

--- a/charter/report.py
+++ b/charter/report.py
@@ -302,6 +302,23 @@ def _write(rec: dict) -> str:
     return rec["id"]
 
 
+def delete(report_id: str) -> bool:
+    """Remove one report from local storage. True if it was there.
+
+    The undo for drafting. Drafting is deliberately cheap and local (ADR 0003 keeps
+    recording separate from reporting), and that only works if discarding is cheap too —
+    otherwise a redrafted report leaves its superseded twin in `report list` forever, and a
+    list with permanent false positives stops being read (#155).
+
+    No network, for the same reason drafting has none: this is the Reporter's own disk.
+    """
+    p = _path(report_id)
+    if not p.exists():
+        return False
+    p.unlink(missing_ok=True)
+    return True
+
+
 def prune() -> int:
     """Drop unsent drafts older than :data:`MAX_DRAFT_AGE_DAYS`. Returns how many went.
 

--- a/tests/test_report_delete.py
+++ b/tests/test_report_delete.py
@@ -1,0 +1,139 @@
+"""Discarding a drafted report (#155).
+
+`charter report` had {bug,gap,list,show,consent,send,comment} and no way to throw a draft
+away. A report drafted with a wrong version stamp, redrafted, and sent under the new id left
+the first one in `report list` permanently:
+
+    b66a79e9dac3964a  bug  `vault add --share --force` half-applies …
+        not sent
+    c8e8f6e2723e91b4  bug  `vault add --share --force` half-applies …
+        https://github.com/diazoxide/charter/issues/128
+
+The cost is not tidiness. `not sent` is a TODO, and its value is that it is actionable —
+once the list accumulates drafts nobody will ever send, the reader stops trusting the state
+and a real pending report gets missed among the dead ones. That is the failure mode of a
+suite full of permanently-skipped tests.
+
+Drafting is deliberately cheap and local, which is right; that only works if undoing it is
+cheap too.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+
+from charter import report
+from charter import commands_report as cr
+from tests._isolation import PersonaIso
+
+
+class DeleteCase(PersonaIso):
+    def draft(self, text="charter cannot archive a workspace") -> str:
+        return report.record_gap(text)
+
+    def delete(self, rid, force=False):
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = cr.cmd_report_delete(SimpleNamespace(id=rid, force=force))
+        return rc, out.getvalue() + err.getvalue()
+
+    def listing(self):
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            cr.cmd_report_list(SimpleNamespace())
+        return out.getvalue() + err.getvalue()
+
+
+class TestADraftCanBeDiscarded(DeleteCase):
+    def test_delete_removes_it(self):
+        rid = self.draft()
+        rc, _ = self.delete(rid)
+        self.assertEqual(rc, 0)
+        self.assertIsNone(report.load(rid))
+
+    def test_it_leaves_the_listing(self):
+        """`report list` is the surface for "what have I got pending", and the whole issue
+        is that it grew a permanent false positive."""
+        rid = self.draft("something I will redraft")
+        self.assertIn(rid, self.listing())
+        self.delete(rid)
+        self.assertNotIn(rid, self.listing())
+
+    def test_other_drafts_are_untouched(self):
+        keep = self.draft("the one I still mean to send")
+        drop = self.draft("the superseded one")
+        self.delete(drop)
+        self.assertIsNotNone(report.load(keep))
+
+    def test_an_unknown_id_is_an_error_that_says_how_to_look(self):
+        rc, out = self.delete("nosuchid")
+        self.assertEqual(rc, 1)
+        self.assertIn("report list", out)
+
+
+class TestASentReportIsARecord(DeleteCase):
+    """A sent report is kept forever on purpose — `prune`'s docstring says why: it is what
+    lets a later identical crash point at the existing upstream issue instead of drafting a
+    duplicate. Deleting one silently would remove that pointer AND the only local trace of
+    something that exists publicly under the Reporter's identity."""
+
+    def sent(self) -> str:
+        rid = self.draft("already filed upstream")
+        report.mark_sent(rid, "https://github.com/diazoxide/charter/issues/1")
+        return rid
+
+    def test_deleting_a_sent_report_is_refused(self):
+        rid = self.sent()
+        rc, _ = self.delete(rid)
+        self.assertNotEqual(rc, 0)
+        self.assertIsNotNone(report.load(rid))
+
+    def test_the_refusal_explains_the_consequence(self):
+        rid = self.sent()
+        _, out = self.delete(rid)
+        self.assertIn("issue", out.lower())
+        self.assertIn("--force", out)
+
+    def test_the_refusal_is_distinguishable_from_a_missing_id(self):
+        """A worker or a script needs to tell "there is no such report" from "I am refusing
+        this one", and the exit code is what carries that without parsing English."""
+        sent, _ = self.delete(self.sent())
+        missing, _ = self.delete("nosuchid")
+        self.assertNotEqual(sent, missing)
+
+    def test_force_deletes_it(self):
+        rid = self.sent()
+        rc, _ = self.delete(rid, force=True)
+        self.assertEqual(rc, 0)
+        self.assertIsNone(report.load(rid))
+
+
+class TestTheStoreLayer(DeleteCase):
+    def test_delete_reports_whether_anything_went(self):
+        rid = self.draft()
+        self.assertTrue(report.delete(rid))
+        self.assertFalse(report.delete(rid))
+
+    def test_deleting_is_local_and_touches_no_network(self):
+        """Drafting reaches no network by design (ADR 0003 keeps recording and reporting
+        separate); undoing a draft must not either."""
+        import subprocess
+        rid = self.draft()
+        calls = []
+        real = subprocess.run
+
+        def spy(cmd, *a, **kw):
+            calls.append(cmd)
+            return real(cmd, *a, **kw)
+
+        subprocess.run = spy
+        self.addCleanup(setattr, subprocess, "run", real)
+        self.delete(rid)
+        self.assertEqual([c for c in calls if c and c[0] in ("gh", "glab", "git")], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #155.

`charter report` had `{bug,gap,list,show,consent,send,comment}` and no way to throw a draft away. A report drafted with a wrong version stamp, redrafted, and sent under the new id left the first one in `report list` permanently:

```
b66a79e9dac3964a  bug  `vault add --share --force` half-applies …
    not sent
c8e8f6e2723e91b4  bug  `vault add --share --force` half-applies …
    https://github.com/diazoxide/charter/issues/128
```

## Why it is not tidiness

`not sent` is a **TODO**, and its worth is that it is actionable. Once the list accumulates drafts nobody will ever send, the reader stops trusting the state and a real pending report gets missed among the dead ones — the failure mode of a suite full of permanently-skipped tests.

Drafting is deliberately cheap and local. That only works if undoing it is cheap too.

## A sent report needs `--force`, and the reason is concrete

Not ceremony. `prune`'s own docstring says why sent reports are kept forever: they are what lets a later identical crash **point at the existing upstream issue instead of filing a duplicate**. Deleting one drops that pointer — and with it the only local trace of something that exists publicly under the Reporter's identity. The refusal explains that rather than just saying no.

## Three exit codes

A script needs to tell these apart without parsing English:

| | |
|---|---|
| `0` | discarded |
| `1` | no such report |
| `2` | refused — already sent |

## No network

For the same reason drafting has none — this is the Reporter's own disk, and ADR 0003 keeps recording separate from reporting. A test asserts no `gh`/`glab`/`git` subprocess is spawned.

## Tests

10 new in `tests/test_report_delete.py`: a draft removed and gone from the listing, other drafts untouched, an unknown id erroring with `report list` in the message, a sent report refused with the consequence explained, the refusal distinguishable from a missing id by code, `--force` working, the store layer reporting whether anything went, and the no-network guarantee.

Full suite: 1874 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX