### PR TITLE
0.30.0 — charter stops the branch switch instead of describing it afterwards

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.29.1",
+  "version": "0.30.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.29.1"
+__version__ = "0.30.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.29.1",
+            "command": "charter hook sessionstart --plugin-version 0.30.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.29.1",
+            "command": "charter hook userpromptsubmit --plugin-version 0.30.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.29.1",
+            "command": "charter hook pretooluse --plugin-version 0.30.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.29.1",
+            "command": "charter hook pretooluse-read --plugin-version 0.30.0",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.29.1"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.30.0"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.29.1",
+            "command": "charter hook posttooluse --plugin-version 0.30.0",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.29.1",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.30.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.29.1"
+version = "0.30.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only — all the code is on `main`. Moves the four version sites together: `pyproject.toml`, `charter/__init__.py`, the plugin manifest, and the seven `--plugin-version` flags in `hooks.json`.

## The headline

The plane root is one working tree every session shares. ADR 0008 chose to **report** that rather than refuse it, and said prevention was waiting on evidence about *which commands count*.

The evidence arrived: one session switched the root **six times**, reading and dismissing `doctor`'s correct warning each time, while two background agents in one tree clobber each other through exactly that. `pretooluse` now **denies** a branch move in the plane root — `checkout` and `switch` only, `git commit` untouched, and returning to the default branch always allowed, because a guard that blocks the fix it recommends is a trap. ADR 0008 carries the amendment (#157).

## Also in 0.30.0

| | |
|---|---|
| #156 | `doctor` sees clones behind their upstream in **every** workspace — read from already-fetched refs, so it can under-report and never invent |
| #140 | `doctor` names a plane nested inside another plane's `workspaces/`; the rule now lives once, in `root.enclosing_plane` |
| #137 / #154 | report redaction covers the whole identifier cluster, with per-category placeholders and a statement of what was removed |
| #155 | `charter report delete` — a sent report needs `--force`, since it is the pointer a later crash reuses |

## The shape of the batch

Two issues argued with each other and were decided together: #157 wanted **prevention** because a warning did not hold; #140's cheapest fix was **a warning**. The rule applied was *prevent the unambiguous, name the ambiguous* — switching branches in a shared tree has one right answer, "which plane did you mean" does not. Reasoning in `docs/superpowers/specs/2026-08-16-open-issues-grilled.md`.

**#124 and #127 stay parked.** Each has a written unpark trigger and neither has fired. Implementing them because an unattended agent had time would override a documented decision for the worst available reason.

Suite: 1897 passing, up from 1839 at the start of the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX