### PR TITLE
fix: doctor reports whether the plane-root guard FIRES, and init wires it

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -578,6 +578,73 @@ def _statusline_snippet() -> str:
     return json.dumps({"statusLine": _STATUSLINE}, indent=2)
 
 
+#: The ONE hook charter wires itself, and only this one.
+#:
+#: It is the plane-root branch guard (#157) — the safety feature — and #168 was filed
+#: because it ships inert on any plane not running the plugin while `doctor` showed a green
+#: tick over it. A safety feature that ships off by default stays off.
+#:
+#: Only `pretooluse`, deliberately. If the plugin is installed later, everything wired here
+#: fires TWICE. For `pretooluse` that is harmless: the same denial computed twice is the
+#: same denial. For `sessionstart` it is not — the persona briefing, memory digest and todo
+#: list would render twice every session. So the other five stay plugin-only, where the
+#: plugin owns their lifecycle, and charter's footprint in a user-owned file stays at one
+#: hook rather than six.
+_GUARD_HOOK = {
+    "matcher": "Bash",
+    "hooks": [{"type": "command", "command": "charter hook pretooluse", "timeout": 10}],
+}
+
+
+def _hooks_snippet() -> str:
+    """The exact JSON for a user whose settings file charter could not safely touch."""
+    return json.dumps({"hooks": {"PreToolUse": [_GUARD_HOOK]}}, indent=2)
+
+
+def _ensure_guard_hook(root: Path) -> tuple[str, Path | None]:
+    """Wire `charter hook pretooluse` into ``.claude/settings.json`` IF ABSENT.
+
+    Same contract and the same restraint as :func:`_ensure_statusline`, for the same
+    reason: that file is user-owned and git-tracked and holds keys charter has no business
+    touching. This adds one entry under one key, only when no charter `pretooluse` hook is
+    already declared there, and never rewrites a malformed file.
+
+    Returns ``(status, detail)`` — ``"created"`` / ``"present"`` / ``"malformed"`` /
+    ``"blocked"``, matching `_ensure_statusline` so callers report both the same way.
+    """
+    d = root / ".claude"
+    p = d / "settings.json"
+    if not p.exists():
+        try:
+            d.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return "blocked", d
+        p.write_text(json.dumps({"hooks": {"PreToolUse": [_GUARD_HOOK]}}, indent=2) + "\n")
+        return "created", None
+    raw = p.read_text()
+    try:
+        settings = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        return "malformed", p
+    if not isinstance(settings, dict):
+        return "malformed", p
+    hooks_block = settings.get("hooks")
+    if hooks_block is not None and not isinstance(hooks_block, dict):
+        return "malformed", p
+    pre = (hooks_block or {}).get("PreToolUse") or []
+    if not isinstance(pre, list):
+        return "malformed", p
+    if any("charter hook pretooluse" in json.dumps(entry) for entry in pre):
+        return "present", None
+    settings.setdefault("hooks", {}).setdefault("PreToolUse", []).append(_GUARD_HOOK)
+    indent, separators = _json_style(raw)
+    rewritten = json.dumps(settings, indent=indent, separators=separators)
+    if raw.endswith("\n"):
+        rewritten += "\n"
+    p.write_text(rewritten)
+    return "created", None
+
+
 def _json_style(text: str) -> tuple[str | None, tuple[str, str]]:
     """Best-effort ``(indent, separators)`` for ``json.dumps`` that echoes ``text``'s own
     formatting, so adding one key doesn't reformat the whole file. Not a true round-trip
@@ -877,6 +944,20 @@ def cmd_init(args) -> int:
     elif sl_status == "blocked":
         blocked.append((".claude", sl_detail))
 
+    # The plane-root branch guard (#157). Wired here because #168: it shipped inert on any
+    # plane not running the plugin, with `doctor` showing a green tick over it — and a
+    # safety feature that ships off by default stays off.
+    gh_status, gh_detail = _ensure_guard_hook(root)
+    if gh_status == "created":
+        created.append(".claude/settings.json (plane-root guard)")
+    elif gh_status == "present":
+        present.append(".claude/settings.json (plane-root guard already wired)")
+    elif gh_status == "malformed":
+        util.warn(f"{gh_detail} is not valid JSON — left it completely untouched. Wire the "
+                  f"plane-root guard yourself:\n{_hooks_snippet()}")
+    elif gh_status == "blocked":
+        blocked.append((".claude", gh_detail))
+
     # Same failure shape either way — "you asked for this, it did not happen" — so both
     # exit non-zero: a blocked baseline path (file already prints its own util.err above)
     # and a malformed settings.json (its util.warn already fired where sl_status was
@@ -960,6 +1041,17 @@ def cmd_reinit(args) -> int:
     from . import instance as _instance
 
     created, present, blocked = _create_baseline_dirs(config.ROOT)
+
+    # The plane-root guard, on the SAME terms as init. `doctor`'s hint for an unwired plane
+    # names `charter reinit`, so reinit has to be the command that actually wires it (#168).
+    gh_status, gh_detail = _ensure_guard_hook(config.ROOT)
+    if gh_status == "created":
+        created.append(".claude/settings.json (plane-root guard)")
+    elif gh_status == "present":
+        present.append(".claude/settings.json (plane-root guard already wired)")
+    elif gh_status == "malformed":
+        util.warn(f"{gh_detail} is not valid JSON — left it completely untouched. Wire the "
+                  f"plane-root guard yourself:\n{_hooks_snippet()}")
 
     if blocked:
         for d, p in blocked:

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -439,6 +439,57 @@ def check_plane_root() -> Result:
     )
 
 
+def check_guard_wired() -> Result:
+    """Can `charter hook pretooluse` actually be invoked? (#168)
+
+    The plane-root branch guard (#157) lives in that handler. If nothing is wired to call
+    it, no branch move is ever refused — and `check_plugin_skew` printed a green
+    ``✓ not running under the Claude Code plugin`` over exactly that state. **The absence
+    of a protection rendered as health**, at the moment it mattered most: someone upgrades
+    to get the guard, runs `doctor` to confirm the upgrade, sees all green, and reasonably
+    believes they are protected.
+
+    Whether the plane runs as a plugin is an implementation detail. Whether the guard fires
+    is the fact the operator needs, so this reports the guard and `check_plugin_skew` keeps
+    answering its own separate question about version skew.
+
+    Reachable means ANY of: running under the plugin, or `charter hook pretooluse` declared
+    in the plane's ``.claude/settings.json``, its ``.claude/settings.local.json``, or the
+    user's ``~/.claude/settings.json``. All four, because a plane that IS wired and gets
+    warned every session teaches people to ignore the row — the failure
+    `check_memory_indexes` already records.
+
+    It asserts that specific handler rather than "some hook exists": a plane wiring only
+    `sessionstart` is unprotected while looking configured, which is this issue again one
+    level down.
+    """
+    from . import config as _config
+
+    name = "plane-root guard"
+    if not _config.HAS_CONTROL_PLANE:
+        return Result(name, OK, detail="no control plane found")
+    if os.environ.get("CLAUDE_PLUGIN_ROOT"):
+        return Result(name, OK, detail="wired (Claude Code plugin)")
+
+    candidates = [
+        Path(_config.ROOT) / ".claude" / "settings.json",
+        Path(_config.ROOT) / ".claude" / "settings.local.json",
+        Path.home() / ".claude" / "settings.json",
+    ]
+    for p in candidates:
+        try:
+            if "charter hook pretooluse" in p.read_text():
+                return Result(name, OK, detail=f"wired ({p})")
+        except (OSError, UnicodeDecodeError):
+            continue
+    return Result(name, WARN,
+                  detail="pretooluse is not wired — branch moves in the plane root are "
+                         "NOT refused",
+                  hint=("The 0.30.0 guard only fires through `charter hook pretooluse`.  "
+                        "→ charter reinit  (wires it into .claude/settings.json), or "
+                        "install the Claude Code plugin."))
+
+
 def check_nested_plane() -> Result:
     """Is the plane charter resolved sitting inside ANOTHER plane's ``workspaces/``? (#140)
 
@@ -961,7 +1012,8 @@ def _checks():
         results.append(check_forge_cli(forge))
         results.append(check_forge_auth(forge))
     results += [check_ssh(), check_control_plane_config(), check_control_plane_schema(),
-                check_plane_root(), check_nested_plane(), check_workspace_clones(),
+                check_plane_root(), check_guard_wired(), check_nested_plane(),
+                check_workspace_clones(),
                 check_inventory(), check_vaults(),
                 check_vault_registry_divergence(), check_version_lock(),
                 check_memory_indexes(), check_personas(),

--- a/tests/test_doctor_guard_wired.py
+++ b/tests/test_doctor_guard_wired.py
@@ -1,0 +1,175 @@
+"""`doctor` reports whether the plane-root guard FIRES, not how charter is packaged (#168).
+
+0.30.0's headline feature lives in `charter hook pretooluse`. If nothing is wired to call
+it, no branch move is ever refused — and `check_plugin_skew` printed a green
+``✓ not running under the Claude Code plugin`` over exactly that state.
+
+The reporter's framing, which is the whole issue: **the absence of a protection renders as
+health.** Someone upgrades specifically to get the guard, runs `doctor` to confirm the
+upgrade is healthy, sees all green, and reasonably believes they are protected. They are
+not, and this plane had already branched its root six times.
+
+Whether the plane runs as a plugin is an implementation detail; whether the guard fires is
+the fact the operator needs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+
+from charter import commands, config, doctor
+from tests._isolation import PersonaIso
+
+OK, WARN = doctor.OK, doctor.WARN
+
+
+class GuardWiredCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.HAS_CONTROL_PLANE = True
+        os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+        # A HOME with no user-level settings, so the check cannot pass on the developer's
+        # own machine config and silently prove nothing on CI.
+        self.home = self.tmp / "home"
+        self.home.mkdir(exist_ok=True)
+        self._real_home = os.environ.get("HOME")
+        os.environ["HOME"] = str(self.home)
+        self.addCleanup(self._restore_home)
+
+    def _restore_home(self):
+        if self._real_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = self._real_home
+
+    def settings(self, path: Path, body: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(body, indent=2))
+
+    def wired(self) -> dict:
+        return {"hooks": {"PreToolUse": [
+            {"matcher": "Bash",
+             "hooks": [{"type": "command", "command": "charter hook pretooluse"}]}]}}
+
+
+class TestAnUnwiredPlaneIsNotGreen(GuardWiredCase):
+    def test_it_warns_when_nothing_is_wired(self):
+        r = doctor.check_guard_wired()
+        self.assertEqual(r.status, WARN)
+
+    def test_it_says_branch_moves_are_not_refused(self):
+        """Naming the consequence, not the configuration. The operator's question is "am I
+        protected", and "no hook is wired" only answers that if you already know #157 lives
+        in a hook."""
+        r = doctor.check_guard_wired()
+        self.assertIn("NOT refused", f"{r.detail} {r.hint}")
+
+    def test_the_hint_names_a_command_that_wires_it(self):
+        self.assertIn("charter reinit", doctor.check_guard_wired().hint)
+
+    def test_doctor_runs_it(self):
+        self.assertIn("plane-root guard", {r.name for r in doctor.run_all()})
+
+
+class TestEveryWiringRouteCounts(GuardWiredCase):
+    """A plane that IS wired but gets warned every session teaches people to ignore the
+    row — the failure `check_memory_indexes` already records. All four routes count."""
+
+    def test_the_plugin_counts(self):
+        os.environ["CLAUDE_PLUGIN_ROOT"] = str(self.tmp / "plugin")
+        self.addCleanup(os.environ.pop, "CLAUDE_PLUGIN_ROOT", None)
+        self.assertEqual(doctor.check_guard_wired().status, OK)
+
+    def test_project_settings_count(self):
+        self.settings(Path(config.ROOT) / ".claude" / "settings.json", self.wired())
+        self.assertEqual(doctor.check_guard_wired().status, OK)
+
+    def test_project_local_settings_count(self):
+        self.settings(Path(config.ROOT) / ".claude" / "settings.local.json", self.wired())
+        self.assertEqual(doctor.check_guard_wired().status, OK)
+
+    def test_user_settings_count(self):
+        self.settings(self.home / ".claude" / "settings.json", self.wired())
+        self.assertEqual(doctor.check_guard_wired().status, OK)
+
+
+class TestItAssertsTheRightHandler(GuardWiredCase):
+    def test_wiring_only_another_hook_is_still_unprotected(self):
+        """This issue one level down: a plane wiring `sessionstart` looks configured and is
+        not guarded. The guard lives in `pretooluse` specifically."""
+        self.settings(Path(config.ROOT) / ".claude" / "settings.json",
+                      {"hooks": {"SessionStart": [
+                          {"hooks": [{"type": "command",
+                                      "command": "charter hook sessionstart"}]}]}})
+        self.assertEqual(doctor.check_guard_wired().status, WARN)
+
+    def test_an_unreadable_settings_file_does_not_crash_the_check(self):
+        p = Path(config.ROOT) / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(b"\xff\xfe not text")
+        self.assertEqual(doctor.check_guard_wired().status, WARN)
+
+
+class TestInitAndReinitWireIt(GuardWiredCase):
+    """A safety feature that ships off by default stays off — the reporter's own point."""
+
+    def test_it_writes_the_hook_when_the_file_is_absent(self):
+        status, _ = commands._ensure_guard_hook(Path(config.ROOT))
+        self.assertEqual(status, "created")
+        self.assertEqual(doctor.check_guard_wired().status, OK)
+
+    def test_it_is_idempotent(self):
+        commands._ensure_guard_hook(Path(config.ROOT))
+        status, _ = commands._ensure_guard_hook(Path(config.ROOT))
+        self.assertEqual(status, "present")
+        body = json.loads((Path(config.ROOT) / ".claude" / "settings.json").read_text())
+        self.assertEqual(len(body["hooks"]["PreToolUse"]), 1)
+
+    def test_it_preserves_keys_charter_does_not_own(self):
+        """`_ensure_statusline`'s rule, applied: that file is user-owned and holds keys
+        charter has no business touching. Only the one entry is added."""
+        p = Path(config.ROOT) / ".claude" / "settings.json"
+        self.settings(p, {"permissions": {"allow": ["Bash(ls:*)"]},
+                          "statusLine": {"type": "command", "command": "charter statusline"}})
+        commands._ensure_guard_hook(Path(config.ROOT))
+        body = json.loads(p.read_text())
+        self.assertEqual(body["permissions"], {"allow": ["Bash(ls:*)"]})
+        self.assertIn("statusLine", body)
+        self.assertIn("PreToolUse", body["hooks"])
+
+    def test_a_malformed_file_is_left_completely_alone(self):
+        p = Path(config.ROOT) / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{ not json")
+        status, detail = commands._ensure_guard_hook(Path(config.ROOT))
+        self.assertEqual(status, "malformed")
+        self.assertEqual(p.read_text(), "{ not json")
+
+    def test_an_existing_pretooluse_entry_is_not_duplicated(self):
+        """Wiring a second copy would fire the guard twice. Harmless for a denial, but it
+        is still charter writing noise into a user's file."""
+        p = Path(config.ROOT) / ".claude" / "settings.json"
+        self.settings(p, self.wired())
+        status, _ = commands._ensure_guard_hook(Path(config.ROOT))
+        self.assertEqual(status, "present")
+
+
+class TestOnlyTheGuardIsWired(GuardWiredCase):
+    def test_no_other_hook_is_written(self):
+        """Only `pretooluse`, deliberately. If the plugin is installed later, everything
+        wired here fires TWICE — idempotent for a denial, but `sessionstart` would render
+        the persona briefing, memory digest and todo list twice every session."""
+        commands._ensure_guard_hook(Path(config.ROOT))
+        body = json.loads((Path(config.ROOT) / ".claude" / "settings.json").read_text())
+        self.assertEqual(list(body["hooks"]), ["PreToolUse"])
+        blob = json.dumps(body)
+        for other in ("sessionstart", "userpromptsubmit", "posttooluse"):
+            self.assertNotIn(other, blob, other)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #168.

0.30.0's headline feature lives in `charter hook pretooluse`. If nothing is wired to call it, **no branch move is ever refused** — and `check_plugin_skew` printed a green `✓ not running under the Claude Code plugin` over exactly that state.

The reporter's framing is the whole issue: **the absence of a protection renders as health.** Someone upgrades specifically to get the guard, runs `doctor` to confirm the upgrade is healthy, sees all green, and reasonably believes they are protected. The reporting plane had already branched its root six times.

## Report the guard, not the packaging

Whether charter runs as a plugin is an implementation detail. Whether the guard fires is the fact an operator needs. `check_plugin_skew` stays as its own row — it answers a real and *different* question about version skew, and merging them would lose one of the two answers.

**Reachable** means any of four routes: the plugin, the plane's `.claude/settings.json`, its `settings.local.json`, or the user's `~/.claude/settings.json`. All four, because a plane that *is* wired and gets warned every session teaches people to ignore the row — the failure `check_memory_indexes` already records.

It asserts **that specific handler**, not "some hook exists": a plane wiring only `sessionstart` is unprotected while looking configured, which is this issue again one level down. There's a test for it.

## init and reinit wire it

A safety feature that ships off by default stays off. This is **not** a new stance on `.claude/settings.json` — `_ensure_statusline` already writes to that exact file, and this follows it precisely: one key charter owns, only when absent, never repairing a malformed file, reporting which of those happened. `reinit` wires it too, because `doctor`'s hint names `charter reinit` as the fix and a hint that doesn't fix anything is worse than none.

## Only `pretooluse`, and that is the interesting constraint

If the plugin is installed later, everything wired here fires **twice**. For a denial that is harmless — the same decision computed twice is the same decision. For `sessionstart` it is not: the persona briefing, memory digest and todo list would render twice every session.

So charter's footprint in a user-owned file is one hook, not six. The other five stay plugin-only, where the plugin owns their lifecycle. A test asserts nothing else gets written.

## Tests

16 new in `tests/test_doctor_guard_wired.py`: unwired warns and names the consequence, the hint names a working command, all four wiring routes count, `sessionstart`-only still warns, an unreadable settings file doesn't crash the check, the writer is idempotent, keys charter doesn't own survive, a malformed file is untouched byte-for-byte, and no hook but the guard is written. `HOME` is redirected so the check can't pass on the developer's own machine config.

Full suite: 1913 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX