### PR TITLE
feat: charter save lands a change on a plane whose repo requires pull requests

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1400,5 +1400,12 @@ def cmd_version_bump(args) -> int:
             return rc
         util.ok("committed + pushed — teammates conform on their next session.")
     else:
-        util.info(f"  commit it to share: git add {rel} && git commit -m 'charter: pin to {target}'")
+        # `charter save`, not raw git. The pin is written into the PLANE ROOT, and on a plane
+        # whose repo requires pull requests the root is the one tree #157 forbids branching —
+        # so "commit it yourself" stranded the change and sent the operator to make the same
+        # edit twice (#167). `save` now knows how to land it either way.
+        util.info(f"  share it: charter save 'charter: pin to {target}'")
+        util.info(f"  (on a plane whose repo requires pull requests, that pushes a branch "
+                  f"and hands you the URL to open one — {rel} lives in the plane root, which "
+                  f"is not a tree to branch by hand.)")
     return 0

--- a/charter/planegit.py
+++ b/charter/planegit.py
@@ -116,6 +116,80 @@ def commit_memory_reactive(paths: list[str], title: str) -> int:
     return commit_push(config.ROOT, ["add", "--", *paths], msg, background=True)
 
 
+#: Signatures a forge uses to say "this branch requires a pull request". Matched, never
+#: interpolated, and each one observed rather than imagined — ADR 0009's rule: charter may
+#: name a cause it RECOGNISED, never one it inferred. An unmatched rejection falls through
+#: to the generic "push failed" warning, which costs precision and can never mislead.
+_PROTECTED_SIGNATURES = (
+    "protected branch",              # GitHub + GitLab both use this wording
+    "GH006",                         # GitHub's protected-branch push rejection code
+    "pre-receive hook declined",     # generic server-side policy hook
+    "required status check",
+    "merge_request",                 # GitLab: "you are not allowed to push … open a MR"
+    "not allowed to push",
+)
+
+
+def _is_protected_rejection(stderr: str) -> bool:
+    blob = (stderr or "").lower()
+    return any(s.lower() in blob for s in _PROTECTED_SIGNATURES)
+
+
+def _compare_url(https: str, branch: str) -> str | None:
+    """A one-click "open a pull request for this branch" URL.
+
+    A plain HTTPS link, deliberately: charter has no PR-creation capability in any forge
+    adapter, and this closes the PR-gated workflow **without** adding one — no API call, no
+    extra token scope, no new adapter surface.
+    """
+    base = (https or "").removesuffix(".git")
+    if not base.startswith("https://"):
+        return None
+    if "github.com" in base:
+        return f"{base}/compare/{branch}?expand=1"
+    # GitLab, and self-hosted GitLab, use the same new-MR form.
+    return (f"{base}/-/merge_requests/new?merge_request%5Bsource_branch%5D={branch}")
+
+
+def _land_via_branch(root, https: str, cred: list, default_branch: str) -> int:
+    """Push the commit that is already on HEAD to a NEW remote branch, and hand back a URL.
+
+    The sanctioned path for a control plane whose own repo requires pull requests (#167).
+    charter's guidance is that control-plane content is committed with `charter save`,
+    straight to the default branch — which works only where a direct push lands. On a
+    protected `main` it cannot, and 0.30.0's guard (#157) refuses the obvious workaround of
+    branching the plane root. The operator was left making the same edit twice and
+    discarding one.
+
+    **The plane root's HEAD never moves.** That is what keeps this compatible with the guard
+    instead of poking a hole in it: `git push HEAD:refs/heads/<new>` needs no checkout, no
+    branch creation and no worktree — only a different *remote* ref for a commit that
+    already exists locally. (A throwaway worktree was the first design; it turned out to be
+    machinery for a problem that does not exist, since nothing here needs a second working
+    tree.)
+
+    The cost, stated rather than hidden: local `<default_branch>` is left one commit ahead
+    of the remote until the pull request lands, and the caller says so with the command that
+    reconciles it.
+    """
+    sha = _git(["rev-parse", "--short", "HEAD"], cwd=root).stdout.strip() or "change"
+    branch = f"charter/{sha}"
+    p = _git([*cred, "push", https, f"HEAD:refs/heads/{branch}"], cwd=root)
+    if p.returncode != 0:
+        util.err(f"'{default_branch}' requires a pull request, and pushing the branch "
+                 f"'{branch}' also failed:")
+        for ln in (p.stderr or p.stdout or "").splitlines()[-4:]:
+            util.err("  " + ln)
+        return 1
+    util.ok(f"'{default_branch}' requires a pull request — pushed {branch} instead.")
+    url = _compare_url(https, branch)
+    if url:
+        util.info(f"  open it: {url}")
+    util.info(f"  the commit is also on your local {default_branch}, one ahead of the "
+              f"remote. After the PR merges: git -C {root} pull --rebase")
+    return 0
+
+
 def commit_push(root, add_cmd: list, message: str | None,
                 sign: bool = False, no_push: bool = False, background: bool = False) -> int:
     """Stage (``add_cmd``) → secret-scan staged memory/refs → commit → push via the
@@ -221,6 +295,12 @@ def commit_push(root, add_cmd: list, message: str | None,
     if p.returncode == 0:
         _git(["update-ref", f"refs/remotes/origin/{branch}", "HEAD"], cwd=root)  # sync tracking
         util.ok(f"Pushed {branch} via {forge.cli} (HTTPS token — no SSH, no 1Password).")
+    elif _is_protected_rejection(p.stderr or p.stdout or ""):
+        # The plane's own repo requires a pull request. That is a supported shape (#167),
+        # not a failure to report and abandon: without this the change is stranded in the
+        # one tree #157 forbids branching, and the operator has to make the same edit again
+        # somewhere else and discard this one.
+        return _land_via_branch(root, https, cred, branch)
     else:
         util.warn(f"Committed, but the {forge.cli} push failed:")
         for ln in (p.stderr or p.stdout or "").splitlines()[-4:]:

--- a/tests/test_save_pr_gated.py
+++ b/tests/test_save_pr_gated.py
@@ -1,0 +1,181 @@
+"""A control plane whose own repo requires pull requests (#167).
+
+charter's guidance is that control-plane content is committed with `charter save`, straight
+to the default branch. That works only where a direct push lands. On a protected `main` it
+cannot — and 0.30.0's guard (#157) refuses the obvious workaround of branching the plane
+root, since the root is one working tree every session shares.
+
+The reporter was left making the same edit twice: once in the root where `version bump` put
+it, once in a workspace clone they could actually branch, then discarding charter's own
+copy by hand. `doctor` sat on `! plane root 1 uncommitted file(s)` throughout, pointing at
+a file the tool had just written and they were not permitted to commit the normal way.
+
+The fix keeps #157's invariant exactly: **the plane root's HEAD never moves.**
+`git push HEAD:refs/heads/<new>` needs no checkout, no branch creation and no worktree —
+only a different *remote* ref for a commit that already exists locally.
+"""
+
+from __future__ import annotations
+
+import io
+import subprocess
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+from charter import config, planegit
+from tests._isolation import PersonaIso
+
+
+def git(where, *args):
+    return subprocess.run(["git", "-C", str(where), *args], check=True,
+                          capture_output=True, text=True)
+
+
+class SaveCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.HAS_CONTROL_PLANE = True
+        self.root = Path(config.ROOT)
+        subprocess.run(["git", "init", "-q", "-b", "main", str(self.root)],
+                       check=True, capture_output=True)
+        git(self.root, "config", "user.email", "t@e")
+        git(self.root, "config", "user.name", "t")
+        (self.root / "seed").write_text("x\n")
+        git(self.root, "add", "-A")
+        git(self.root, "-c", "commit.gpgsign=false", "commit", "-qm", "seed")
+        # An origin on a forge charter recognises: without one `commit_push` warns and
+        # skips the push entirely, so every assertion below would pass vacuously.
+        git(self.root, "remote", "add", "origin", "https://github.com/acme/plane.git")
+
+    def head(self) -> str:
+        return git(self.root, "symbolic-ref", "--short", "HEAD").stdout.strip()
+
+    def run_save(self, protected: bool, push_branch_ok: bool = True):
+        """Drive `commit_push` with a fake git that refuses the default-branch push the way
+        a protected remote does, and accepts a branch push."""
+        real = planegit._git
+        seen = []
+
+        def fake(args, cwd=None, **kw):
+            seen.append(list(args))
+            # `push` is not args[0]: `commit_push` prefixes the credential flag, so the
+            # invocation is `-c credential.helper=… push <url> <refspec>`.
+            if "push" in args:
+                target = args[-1]
+                if protected and target.endswith(":main"):
+                    return subprocess.CompletedProcess(
+                        args, 1, "",
+                        "remote: error: GH006: Protected branch update failed for "
+                        "refs/heads/main.\nremote: error: Required status check")
+                if not push_branch_ok:
+                    return subprocess.CompletedProcess(args, 1, "", "remote: boom")
+                return subprocess.CompletedProcess(args, 0, "", "")
+            return real(args, cwd=cwd, **kw)
+
+        planegit._git = fake
+        self.addCleanup(setattr, planegit, "_git", real)
+        (self.root / "personas").mkdir(exist_ok=True)
+        (self.root / "personas" / "note.md").write_text("control plane content\n")
+
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = planegit.commit_push(self.root, ["add", "-A"], "charter: a change")
+        return rc, out.getvalue() + err.getvalue(), seen
+
+
+class TestAProtectedDefaultBranchIsSupported(SaveCase):
+    def test_it_pushes_a_branch_instead_of_failing(self):
+        rc, out, seen = self.run_save(protected=True)
+        self.assertEqual(rc, 0)
+        pushed = [a for a in seen if "push" in a]
+        self.assertTrue(any(p[-1].startswith("HEAD:refs/heads/charter/") for p in pushed),
+                        pushed)
+
+    def test_it_hands_back_a_url_to_open_the_pull_request(self):
+        """The whole point of not needing a PR API: a compare URL is a plain HTTPS link."""
+        _, out, _ = self.run_save(protected=True)
+        self.assertIn("github.com/acme/plane/compare/charter/", out)
+
+    def test_it_says_the_default_branch_required_a_pull_request(self):
+        _, out, _ = self.run_save(protected=True)
+        self.assertIn("requires a pull request", out)
+
+    def test_it_says_local_main_is_ahead_and_how_to_reconcile(self):
+        """The cost, stated rather than hidden — the commit stays on local main until the
+        PR lands."""
+        _, out, _ = self.run_save(protected=True)
+        self.assertIn("pull --rebase", out)
+
+
+class TestTheGuardsInvariantHolds(SaveCase):
+    def test_the_plane_roots_HEAD_never_moves(self):
+        """#157's invariant, asserted directly. If landing a change required checking out a
+        branch in the root, this fix would be undoing the guard it has to coexist with."""
+        before = self.head()
+        self.run_save(protected=True)
+        self.assertEqual(self.head(), before)
+
+    def test_no_checkout_switch_or_branch_is_ever_run_in_the_root(self):
+        _, _, seen = self.run_save(protected=True)
+        for args in seen:
+            for verb in ("checkout", "switch", "worktree", "branch"):
+                self.assertNotIn(verb, args, args)
+
+
+class TestItOnlyFiresOnARecognisedRefusal(SaveCase):
+    def test_an_ordinary_push_failure_is_reported_not_rerouted(self):
+        """ADR 0009: charter may name a cause it RECOGNISED. An auth failure is not a
+        protected branch, and silently pushing a side branch for one would be inventing a
+        diagnosis — and doing something surprising on the back of it."""
+        real = planegit._git
+        seen = []
+
+        def fake(args, cwd=None, **kw):
+            seen.append(list(args))
+            if "push" in args:
+                return subprocess.CompletedProcess(args, 1, "", "fatal: Authentication failed")
+            return real(args, cwd=cwd, **kw)
+
+        planegit._git = fake
+        self.addCleanup(setattr, planegit, "_git", real)
+        (self.root / "personas").mkdir(exist_ok=True)
+        (self.root / "personas" / "n.md").write_text("x\n")
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            planegit.commit_push(self.root, ["add", "-A"], "m")
+        blob = out.getvalue() + err.getvalue()
+        self.assertNotIn("requires a pull request", blob)
+        self.assertFalse(any(a[-1].startswith("HEAD:refs/heads/charter/")
+                             for a in seen if "push" in a))
+
+    def test_an_unprotected_plane_still_pushes_straight_to_main(self):
+        rc, out, seen = self.run_save(protected=False)
+        self.assertEqual(rc, 0)
+        self.assertNotIn("requires a pull request", out)
+
+    def test_a_branch_push_that_also_fails_is_an_error(self):
+        """Reporting success here would be the failure mode `commit_push`'s own docstring
+        records twice: a green tick over a push that never happened."""
+        rc, out, _ = self.run_save(protected=True, push_branch_ok=False)
+        self.assertEqual(rc, 1)
+
+
+class TestCompareUrls(unittest.TestCase):
+    def test_github(self):
+        self.assertEqual(
+            planegit._compare_url("https://github.com/acme/plane.git", "charter/abc"),
+            "https://github.com/acme/plane/compare/charter/abc?expand=1")
+
+    def test_gitlab(self):
+        url = planegit._compare_url("https://gitlab.com/acme/plane.git", "charter/abc")
+        self.assertIn("/-/merge_requests/new", url)
+        self.assertIn("charter/abc", url)
+
+    def test_an_unknown_scheme_yields_nothing_rather_than_a_guess(self):
+        self.assertIsNone(planegit._compare_url("git@github.com:acme/plane.git", "b"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #167.

Two features shipped from the same plane's reports contradicted each other. charter's guidance is that control-plane content is committed with `charter save` — straight to the default branch. That works only where a direct push lands. On a protected `main` it cannot, and 0.30.0's guard (#157) refuses the obvious workaround of branching the plane root.

The reporter was left making the same edit **twice**: once in the root where `version bump` wrote it, once in a clone they could actually branch, then discarding charter's own copy by hand — with `doctor` sitting on `! plane root 1 uncommitted file(s)` throughout, pointing at a file the tool had just written and they were not permitted to commit the normal way.

## What happens now

When a push to the default branch is refused **for protection**, `save` pushes the same commit to `charter/<sha>` and prints the compare URL:

```
✓ 'main' requires a pull request — pushed charter/4bc7dc0 instead.
• open it: https://github.com/acme/plane/compare/charter/4bc7dc0?expand=1
• the commit is also on your local main, one ahead of the remote.
  After the PR merges: git -C <plane> pull --rebase
```

## Two properties make this a shape rather than a workaround

**It needs no PR API.** A compare URL is a plain HTTPS link, so this closes the workflow without adding the PR-creation capability no forge adapter has — no API call, no extra token scope, no new adapter surface.

**The plane root's HEAD never moves**, so #157's invariant holds exactly as written.

## A deviation from what we agreed in grilling

The agreed design was a *throwaway worktree*. Implementing it showed the worktree is machinery for a problem that does not exist: `git push HEAD:refs/heads/<new>` needs no checkout, no branch creation and no working tree — only a different **remote** ref for a commit that already exists locally. Same guarantee, less machinery. A test asserts no `checkout`/`switch`/`branch`/`worktree` verb ever runs.

## Only a recognised refusal reroutes

An auth failure is not a protected branch. Quietly pushing a side branch for one would be inventing a diagnosis *and then acting surprisingly on it* — ADR 0009's rule applied to a git rejection instead of an error message. Every signature matched here was observed, never imagined; anything unmatched falls through to today's generic warning.

## The cost, stated

Local `main` is left one commit ahead until the PR lands, and the output carries the `pull --rebase` that reconciles it.

`version bump` now points at `charter save` instead of raw `git add && git commit` — advice that stranded the change on exactly the planes this fixes.

## Tests

12 new in `tests/test_save_pr_gated.py`: the branch push, the compare URL, both explanatory lines, **HEAD never moving**, no branch-moving verb ever running, an ordinary push failure *not* rerouting, an unprotected plane still pushing to main, a failed branch push being an error rather than a green tick, and the URL builders for both forges.

Full suite: 1909 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX