### PR TITLE
0.31.0 — the guard actually fires, and a PR-gated plane can land a change

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.30.0"
+__version__ = "0.31.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.30.0",
+            "command": "charter hook sessionstart --plugin-version 0.31.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.30.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.31.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.30.0",
+            "command": "charter hook pretooluse --plugin-version 0.31.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.30.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.31.0",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.30.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.31.0"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.30.0",
+            "command": "charter hook posttooluse --plugin-version 0.31.0",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.30.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.31.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.30.0"
+version = "0.31.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only — all the code is on `main`. Moves the four version sites together.

0.30.0 shipped the plane-root branch guard. Two reports **from the plane running it** showed the feature was half-delivered.

## #168 — it was inert, and `doctor` was green about it

`✓ not running under the Claude Code plugin` is precisely the state in which no branch move is ever refused. **The absence of a protection rendered as health**, at the moment it mattered most: someone upgrades specifically to get the guard, runs `doctor` to confirm the upgrade, sees all green.

`doctor` now reports whether the **guard fires**, not how charter is packaged — counting all four wiring routes and asserting the `pretooluse` handler specifically. `init`/`reinit` wire it, because a safety feature that ships off by default stays off. Only `pretooluse`: everything else would fire twice once the plugin is installed, and a doubled `sessionstart` means a doubled briefing.

## #167 — it contradicted charter's own advice

`version bump` writes `charter.toml` into the plane root. `save` pushes straight to the default branch and cannot land on a protected one. The guard refuses branching the root. The reporter had to make the same edit twice and discard charter's own copy by hand.

`save` now pushes the commit to `charter/<sha>` when a protected-branch refusal is **recognised**, and hands back the compare URL. No PR API — a compare URL is a plain HTTPS link — and the plane root's HEAD never moves, so #157's invariant is untouched.

## Filed, not fixed

**#171** audits every `doctor` check that goes green because the thing it watches is absent. Both of this release's bugs are instances; the shape deserves its own pass rather than riding along with a fix.

## Footnote

The #157 guard fired on its own author during this batch, refusing `git checkout -b` in the plane root while the decision record was being written. The doc was committed from a worktree instead — which is exactly what the denial message says to do.

Suite: 1925 passing, up from 1897.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX