### PR TITLE
persona(steward): two rules the overnight batch paid for

### DIFF
--- a/personas/steward/memory/MEMORY.md
+++ b/personas/steward/memory/MEMORY.md
@@ -12,3 +12,5 @@ Written by the persona as it learns; committed and shared.
 - [charter persona remember run from inside a WORKTREE writes to the clone,](charter-persona-remember-run-from-inside-a-workt.md)
 - [Rendering 'charter statusline' for screenshots/assets: the payload's ses](rendering-charter-statusline-for-screenshots-ass.md)
 - [Validating mermaid before committing it (GitHub renders a syntax error a](validating-mermaid-before-committing-it-github-r.md)
+- [Overnight autonomous batches: a parked issue is a DECISION, not a backlo](overnight-autonomous-batches-a-parked-issue-is-a.md)
+- [Test fixtures must pin init.defaultBranch: 'git init --bare' WITHOUT -b](test-fixtures-must-pin-init-defaultbranch-git-in.md)

--- a/personas/steward/memory/overnight-autonomous-batches-a-parked-issue-is-a.md
+++ b/personas/steward/memory/overnight-autonomous-batches-a-parked-issue-is-a.md
@@ -1,0 +1,5 @@
+# Overnight autonomous batches: a parked issue is a DECISION, not a backlo
+
+_2026-08-16 09:23 · persistent_
+
+Overnight autonomous batches: a parked issue is a DECISION, not a backlog item. #124/#127 each carry a written unpark trigger; implementing them because an unattended agent had time would override a documented decision for the worst reason. Also: never accept/close an external contributor's PR or policy question unattended — that speaks under the operator's identity.

--- a/personas/steward/memory/test-fixtures-must-pin-init-defaultbranch-git-in.md
+++ b/personas/steward/memory/test-fixtures-must-pin-init-defaultbranch-git-in.md
@@ -1,0 +1,5 @@
+# Test fixtures must pin init.defaultBranch: 'git init --bare' WITHOUT -b
+
+_2026-08-16 09:23 · persistent_
+
+Test fixtures must pin init.defaultBranch: 'git init --bare' WITHOUT -b takes HEAD from the machine's git config, so a clone of it has no upstream on a runner defaulting to master while working fine on a Mac defaulting to main. Every 'behind' assertion then reads as the code being wrong. Pass -b main to bare repos too, and make fixtures assert their own preconditions.


### PR DESCRIPTION
Memory only.

**A parked issue is a decision, not a backlog item.** #124 and #127 each carry a written unpark trigger; neither has fired. Building them because an unattended agent had time would override a documented decision for the worst available reason. Same rule for an external contributor's PR or policy question — answering one speaks under the operator's identity.

**Test fixtures must pin `init.defaultBranch`.** `git init --bare` *without* `-b` takes HEAD from the machine's git config, so a clone of it has no upstream on a runner defaulting to `master` while working perfectly on a Mac defaulting to `main` — and every "behind" assertion then reads as the code under test being wrong. Cost one CI cycle to diagnose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX