### PR TITLE
fix: the guard-wired check no longer cries wolf on a plane the plugin protects

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -439,6 +439,39 @@ def check_plane_root() -> Result:
     )
 
 
+
+def _plugin_declaring_guard() -> str | None:
+    """The installed Claude Code plugin whose own ``hooks.json`` dispatches the guard.
+
+    ``CLAUDE_PLUGIN_ROOT`` is set only for the plugin's OWN processes, so a `charter doctor`
+    a human runs in a terminal never sees it — even on a machine where the plugin is
+    installed and the guard demonstrably fires. Checking the env var alone therefore cries
+    wolf on exactly the planes that ARE protected, which is the failure this check was
+    written to avoid, pointed the other way.
+
+    Read from ``installed_plugins.json`` rather than globbed out of the plugin cache: the
+    cache keeps every version ever fetched, so a stale copy would answer "wired" for a
+    plugin that has since been removed. The manifest is what the host actually installed.
+    """
+    manifest = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
+    try:
+        doc = json.loads(manifest.read_text())
+    except (OSError, ValueError):
+        return None
+    for pid, entries in (doc.get("plugins") or {}).items():
+        for entry in entries or []:
+            path = (entry or {}).get("installPath")
+            if not path:
+                continue
+            hooks_json = Path(path) / "hooks" / "hooks.json"
+            try:
+                if "charter hook pretooluse" in hooks_json.read_text():
+                    return pid
+            except (OSError, UnicodeDecodeError):
+                continue
+    return None
+
+
 def check_guard_wired() -> Result:
     """Can `charter hook pretooluse` actually be invoked? (#168)
 
@@ -470,6 +503,9 @@ def check_guard_wired() -> Result:
         return Result(name, OK, detail="no control plane found")
     if os.environ.get("CLAUDE_PLUGIN_ROOT"):
         return Result(name, OK, detail="wired (Claude Code plugin)")
+    installed = _plugin_declaring_guard()
+    if installed:
+        return Result(name, OK, detail=f"wired (installed plugin {installed})")
 
     candidates = [
         Path(_config.ROOT) / ".claude" / "settings.json",

--- a/tests/test_doctor_guard_wired.py
+++ b/tests/test_doctor_guard_wired.py
@@ -79,6 +79,37 @@ class TestEveryWiringRouteCounts(GuardWiredCase):
     """A plane that IS wired but gets warned every session teaches people to ignore the
     row — the failure `check_memory_indexes` already records. All four routes count."""
 
+    def test_an_INSTALLED_plugin_counts_even_without_the_env_var(self):
+        """The false positive this check shipped with. `CLAUDE_PLUGIN_ROOT` is set only for
+        the plugin's OWN processes, so a `charter doctor` a human runs in a terminal never
+        sees it — and warned on a machine where the plugin was installed and the guard
+        demonstrably fired. Read from `installed_plugins.json`, which is what the host
+        actually installed, rather than the plugin cache, which keeps every version ever
+        fetched and would answer "wired" for one since removed.
+        """
+        plug = self.tmp / "plug"
+        (plug / "hooks").mkdir(parents=True)
+        (plug / "hooks" / "hooks.json").write_text(json.dumps(
+            {"hooks": {"PreToolUse": [{"hooks": [
+                {"type": "command", "command": "charter hook pretooluse"}]}]}}))
+        man = self.home / ".claude" / "plugins" / "installed_plugins.json"
+        man.parent.mkdir(parents=True, exist_ok=True)
+        man.write_text(json.dumps({"version": 2, "plugins": {
+            "charter@charter": [{"scope": "user", "installPath": str(plug)}]}}))
+        self.assertEqual(doctor.check_guard_wired().status, OK)
+
+    def test_a_plugin_that_does_not_declare_the_guard_does_not_count(self):
+        plug = self.tmp / "other"
+        (plug / "hooks").mkdir(parents=True)
+        (plug / "hooks" / "hooks.json").write_text(json.dumps(
+            {"hooks": {"SessionStart": [{"hooks": [
+                {"type": "command", "command": "other-tool hook"}]}]}}))
+        man = self.home / ".claude" / "plugins" / "installed_plugins.json"
+        man.parent.mkdir(parents=True, exist_ok=True)
+        man.write_text(json.dumps({"version": 2, "plugins": {
+            "other@market": [{"scope": "user", "installPath": str(plug)}]}}))
+        self.assertEqual(doctor.check_guard_wired().status, WARN)
+
     def test_the_plugin_counts(self):
         os.environ["CLAUDE_PLUGIN_ROOT"] = str(self.tmp / "plugin")
         self.addCleanup(os.environ.pop, "CLAUDE_PLUGIN_ROOT", None)


### PR DESCRIPTION
Follow-up to #169, caught by running 0.31.0 on this plane immediately after release.

`charter doctor` reported:

```
!  plane-root guard pretooluse is not wired — branch moves in the plane root are NOT refused
```

…on a machine where the guard had, **minutes earlier**, refused a `git checkout -b` in that very root.

## Why

`CLAUDE_PLUGIN_ROOT` is set only for the plugin's **own** processes. A `charter doctor` a human runs in a terminal is not one, so the variable is absent even where the plugin is installed and dispatching the hook.

Checking it alone cries wolf on exactly the planes that **are** protected — the failure this check was written to avoid, pointed the other way. A warning that fires on the healthy case is one people learn to skip, which is how the row stops working for the case it exists for.

## The fix

Consult the installed plugin's own `hooks.json`, resolved through `~/.claude/plugins/installed_plugins.json` — **not** globbed out of the plugin cache. The cache keeps every version ever fetched, so a stale copy would answer "wired" for a plugin since removed. The manifest is what the host actually installed.

## Tests

Two regressions: an installed plugin declaring the guard counts without the env var, and one declaring some *other* hook does not.

Full suite: 1927 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX