### PR TITLE
0.31.1 — the guard-wired check stops crying wolf

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.31.0"
+__version__ = "0.31.1"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.31.0",
+            "command": "charter hook sessionstart --plugin-version 0.31.1",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.31.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.31.1",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.31.0",
+            "command": "charter hook pretooluse --plugin-version 0.31.1",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.31.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.31.1",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.31.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.31.1"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.31.0",
+            "command": "charter hook posttooluse --plugin-version 0.31.1",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.31.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.31.1",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.31.0"
+version = "0.31.1"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Patch release. Version bump only; the fix is on `main` (#175).

0.31.0's new `plane-root guard` row warned *"pretooluse is not wired"* on a plane where the guard had, minutes earlier, refused a branch move. `CLAUDE_PLUGIN_ROOT` is set only for the plugin's own processes, so a `charter doctor` run in a terminal never sees it — the row fired on exactly the planes that **are** protected.

It now consults the installed plugin's own `hooks.json`, resolved through `installed_plugins.json` rather than the plugin cache (which keeps every version ever fetched and would answer for one since removed).

Found by running 0.31.0 on this plane within a minute of publishing it.

Suite: 1927 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX