### PR TITLE
fix: a check that could not run is not a healthy check

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -44,6 +44,20 @@ class Result:
         return line
 
 
+#: Why a check that could not RUN is a warning rather than a tick (#171).
+#:
+#: "not checked" is the absence of information, not evidence of health — and a green glyph
+#: over it is read as the latter by anyone scanning the column, which is how the whole class
+#: this audit came from works. Two of these sites already carried the comment "a check that
+#: silently does nothing is worse than no check" and then returned OK anyway; the principle
+#: was right and the status contradicted it.
+#:
+#: WARN, never FAIL: `cmd_doctor` exits non-zero only on FAIL, and an unreadable tree or a
+#: git that timed out is not "you cannot work" — it is "charter cannot tell you either way".
+_NOT_CHECKED_HINT = ("This check could not run, so its silence means nothing. Re-run "
+                     "`charter doctor` — if it persists, the reason above is the thing to fix.")
+
+
 def _first_line(text: str) -> str:
     text = (text or "").strip()
     return text.splitlines()[0] if text else ""
@@ -392,7 +406,8 @@ def check_plane_root() -> Result:
         upstream = _git_in(root, "rev-parse", "--abbrev-ref", "@{upstream}")
         upstream_ref = upstream.stdout.strip() if upstream.returncode == 0 else ""
     except (util.ProcTimeout, OSError) as e:
-        return Result(name, OK, detail=f"not checked ({e})")
+        return Result(name, WARN, detail=f"not checked ({e})",
+                      hint=_NOT_CHECKED_HINT)
 
     findings, actions = [], []
     if branch is None:
@@ -555,7 +570,8 @@ def check_nested_plane() -> Result:
     try:
         outer = _root.enclosing_plane(Path(_config.ROOT))
     except OSError as e:
-        return Result(name, OK, detail=f"not checked ({e})")
+        return Result(name, WARN, detail=f"not checked ({e})",
+                      hint=_NOT_CHECKED_HINT)
     if outer is None:
         return Result(name, OK, detail="not nested")
     return Result(name, WARN,
@@ -614,9 +630,12 @@ def check_workspace_clones() -> Result:
     except (util.ProcTimeout, OSError, ValueError) as e:
         # Narrow, per `check_memory_indexes`: a broad catch here once swallowed a NameError
         # and reported OK, and a check that silently does nothing is worse than no check.
-        return Result(name, OK, detail=f"not checked ({e})")
+        return Result(name, WARN, detail=f"not checked ({e})",
+                      hint=_NOT_CHECKED_HINT)
 
     if not behind:
+        if not total:
+            return Result(name, OK, detail="no clones in any workspace — nothing to check")
         return Result(name, OK, detail=f"{total} clone(s) across all workspaces, none behind")
     return Result(name, WARN,
                   detail=", ".join(behind[:4]) + (", …" if len(behind) > 4 else ""),
@@ -736,7 +755,8 @@ def check_version_lock() -> Result:
     try:
         locked = _instance.locked_version(_instance.load(_config.ROOT))
     except Exception as e:
-        return Result("version lock", OK, detail=f"not checked ({e})")
+        return Result("version lock", WARN, detail=f"not checked ({e})",
+                      hint=_NOT_CHECKED_HINT)
     if not locked:
         return Result("version lock", OK, detail="not pinned")
     if locked == __version__:
@@ -781,7 +801,8 @@ def check_memory_indexes() -> Result:
         # Only an unreadable/absent tree is tolerated. A broader `except` here once
         # swallowed a NameError and reported OK — a check that silently does
         # nothing is worse than no check.
-        return Result("memory indexes", OK, detail=f"not checked ({e})")
+        return Result("memory indexes", WARN, detail=f"not checked ({e})",
+                      hint=_NOT_CHECKED_HINT)
 
     dangling = unindexed = 0
     worst = []
@@ -854,7 +875,8 @@ def check_personas() -> Result:
     try:
         names = persona.list_personas()
     except Exception as e:
-        return Result("personas", OK, detail=f"not checked ({e})")
+        return Result("personas", WARN, detail=f"not checked ({e})",
+                      hint=_NOT_CHECKED_HINT)
     if not names:
         return Result("personas", OK, detail="none defined")
 
@@ -929,7 +951,15 @@ def check_vault_registry_divergence() -> Result:
             clashes.append(f"{name}.{key}: shared {sc[key]!r}, local {lc[key]!r}")
 
     if not clashes:
-        return Result("vault registry", OK, detail="shared and local halves agree")
+        if not shared and not local:
+            # Claiming "the halves agree" when neither half holds anything is an agreement
+            # nothing was compared to reach — the exact wording `check_plugin_skew` already
+            # warns about in this file ("it must not claim agreement it hasn't checked").
+            return Result("vault registry", OK,
+                          detail="no vaults registered — nothing to compare")
+        return Result("vault registry", OK,
+                      detail=f"shared and local halves agree ({len(shared) + len(local)} "
+                             f"entr{'y' if len(shared) + len(local) == 1 else 'ies'})")
     shown = "; ".join(clashes[:3])
     if len(clashes) > 3:
         shown += f" (+{len(clashes) - 3} more)"

--- a/tests/test_doctor_absent_is_not_health.py
+++ b/tests/test_doctor_absent_is_not_health.py
@@ -1,0 +1,131 @@
+"""A check that could not run is not a healthy check (#171).
+
+The audit filed out of #168, whose shape is: **the absence of a protection renders as
+health.** A reader scanning `doctor`'s glyph column sees ✓ and concludes the thing is fine;
+what it actually meant was that there was nothing to look at, or that looking failed.
+
+Two confirmed instances led here — #168's `✓ not running under the Claude Code plugin` over
+a guard that never fires, and the empty-vault case before it — and reading every `OK` in
+`doctor.py` turned up three more shapes.
+
+The sharpest is that six checks returned **OK** with the detail ``not checked (<error>)``.
+Two of them carried the comment *"a check that silently does nothing is worse than no
+check"* directly above the line that returned OK: the principle was already written down
+and the status contradicted it.
+
+Deliberately NOT changed: `check_inventory`, which already distinguishes "not built, and
+derivable anyway" (OK, with the reason) from "empty and not derivable" (WARN). It is the
+model the rest of this audit was measured against.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from charter import config, doctor
+from tests._isolation import PersonaIso
+
+OK, WARN = doctor.OK, doctor.WARN
+
+
+class AuditCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.HAS_CONTROL_PLANE = True
+
+
+class TestACheckThatCouldNotRunWarns(AuditCase):
+    """Every site that reports `not checked` must say so in the STATUS, not only in prose
+    a scanner never reads."""
+
+    def _raising(self, module, attr):
+        def boom(*a, **kw):
+            raise OSError("unreadable")
+        real = getattr(module, attr)
+        setattr(module, attr, boom)
+        self.addCleanup(setattr, module, attr, real)
+
+    def test_workspace_clones(self):
+        from charter import workspace
+        self._raising(workspace, "list_workspaces")
+        r = doctor.check_workspace_clones()
+        self.assertEqual(r.status, WARN)
+        self.assertIn("not checked", r.detail)
+
+    def test_memory_indexes(self):
+        from charter import workspace
+        self._raising(workspace, "list_workspaces")
+        self.assertEqual(doctor.check_memory_indexes().status, WARN)
+
+    def test_personas(self):
+        from charter import persona
+        self._raising(persona, "list_personas")
+        self.assertEqual(doctor.check_personas().status, WARN)
+
+    def test_nested_plane(self):
+        from charter import root as _root
+        self._raising(_root, "enclosing_plane")
+        self.assertEqual(doctor.check_nested_plane().status, WARN)
+
+    def test_version_lock(self):
+        from charter import instance
+        self._raising(instance, "load")
+        self.assertEqual(doctor.check_version_lock().status, WARN)
+
+    def test_the_hint_says_the_silence_means_nothing(self):
+        """The point of the row. Without this a reader treats a failed check the way they
+        treat a passed one, which is the entire class."""
+        from charter import persona
+        self._raising(persona, "list_personas")
+        self.assertIn("means nothing", doctor.check_personas().hint)
+
+    def test_it_warns_rather_than_fails(self):
+        """`cmd_doctor` exits non-zero only on FAIL, and that exit code drives the
+        SessionStart preflight banner. An unreadable tree is not "you cannot work" — it is
+        "charter cannot tell you either way"."""
+        from charter import persona
+        self._raising(persona, "list_personas")
+        self.assertNotEqual(doctor.check_personas().status, doctor.FAIL)
+
+
+class TestItDoesNotClaimAnAgreementItNeverChecked(AuditCase):
+    def test_no_vaults_says_there_was_nothing_to_compare(self):
+        """`check_plugin_skew` already records this exact failure in this file — it "must
+        not claim agreement it hasn't checked". With no vaults registered, "shared and local
+        halves agree" is vacuously true and reads as a verified result."""
+        r = doctor.check_vault_registry_divergence()
+        self.assertEqual(r.status, OK)
+        self.assertIn("nothing to compare", r.detail)
+
+    def test_registered_vaults_still_report_agreement(self):
+        from charter.secrets import registry
+        registry.add_vault("alpha", "plain-file", {"file": ".charter/vaults/alpha.json"})
+        r = doctor.check_vault_registry_divergence()
+        self.assertEqual(r.status, OK)
+        self.assertIn("agree", r.detail)
+        self.assertNotIn("nothing to compare", r.detail)
+
+
+class TestAZeroCountSaysThereWasNothingToLookAt(AuditCase):
+    def test_no_clones_anywhere(self):
+        """"0 clone(s) across all workspaces, none behind" is technically true and reads as
+        a clean sweep of something. There was nothing to sweep."""
+        r = doctor.check_workspace_clones()
+        self.assertEqual(r.status, OK)
+        self.assertIn("nothing to check", r.detail)
+
+
+class TestTheModelIsLeftAlone(AuditCase):
+    def test_inventory_still_distinguishes_absent_from_broken(self):
+        """`check_inventory` was already right and is deliberately unchanged: it separates
+        "not built, and this plane's repo is clonable anyway" from "empty and not
+        derivable". The audit measured everything else against it."""
+        r = doctor.check_inventory()
+        self.assertIn(r.status, (OK, WARN))
+        self.assertTrue(r.detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_doctor_plane_root.py
+++ b/tests/test_doctor_plane_root.py
@@ -182,7 +182,10 @@ class PlaneRootCheck(PersonaIso):
         something is wrong. It may not be the thing that breaks."""
         with mock.patch("charter.doctor.util.run", side_effect=OSError("no git here")):
             r = doctor.check_plane_root()
-        self.assertEqual(r.status, doctor.OK)
+        # WARN since #171, not OK: it still degrades to a report rather than raising, which
+        # is what this test is about — but "not checked" is the absence of information, and
+        # a green glyph over it is read as health by anyone scanning the column.
+        self.assertEqual(r.status, doctor.WARN)
         self.assertIn("not checked", r.detail)
 
     def test_a_git_that_never_answers_degrades_to_a_report(self):
@@ -192,7 +195,10 @@ class PlaneRootCheck(PersonaIso):
         with mock.patch("charter.doctor.util.run",
                         side_effect=util.ProcTimeout(["git", "status"], 5.0)):
             r = doctor.check_plane_root()
-        self.assertEqual(r.status, doctor.OK)
+        # WARN since #171, not OK: it still degrades to a report rather than raising, which
+        # is what this test is about — but "not checked" is the absence of information, and
+        # a green glyph over it is read as health by anyone scanning the column.
+        self.assertEqual(r.status, doctor.WARN)
         self.assertIn("not checked", r.detail)
 
     # -------------------------------------------------------------- integration


### PR DESCRIPTION
Closes #171 — the audit filed out of #168.

The shape: **the absence of a protection renders as health.** A reader scanning `doctor`'s glyph column sees ✓ and concludes the thing is fine, when what it meant was that there was nothing to look at, or that looking *failed*.

Reading every `OK` in `doctor.py` turned up three shapes worth changing, and one worth leaving alone.

## 1. Six checks reported OK when they could not run

`plane root`, `nested plane`, `workspace clones`, `version lock`, `memory indexes`, `personas` — all returned `OK` with the detail `not checked (<error>)`.

Two of them carried this comment **directly above the line that returned OK**:

> a check that silently does nothing is worse than no check

The principle was already written down and the status contradicted it. They now `WARN`, with a hint saying the silence means nothing.

`WARN`, not `FAIL`: `cmd_doctor` exits non-zero only on `FAIL`, and that exit code drives the SessionStart preflight banner. An unreadable tree is not *"you cannot work"* — it is *"charter cannot tell you either way"*.

## 2. An agreement nothing was compared to reach

`vault registry` reported **"shared and local halves agree"** with no vaults registered at all. `check_plugin_skew` records this exact failure in the same file — *"it must not claim agreement it hasn't checked"* — so the right wording was three hundred lines away. It now says there was nothing to compare, and counts the entries when there were some.

## 3. A clean sweep of nothing

`workspace clones` reported `0 clone(s) across all workspaces, none behind`. True, and it reads as a swept floor. There was nothing to sweep.

## Deliberately unchanged

`check_inventory`. It already separates *"not built, and this plane's repo is clonable anyway"* (OK, with the reason) from *"empty and not derivable"* (WARN) — exactly the distinction this audit is making everywhere else. It is the model the rest was measured against, and saying so is more useful than touching it.

## Tests

11 new in `tests/test_doctor_absent_is_not_health.py`: each of the six not-run sites warning, the hint saying the silence means nothing, WARN never becoming FAIL, the vault-registry vacuous-agreement case and its non-vacuous counterpart, the zero-clone case, and inventory still doing the right thing.

Two existing tests move to the new contract — they assert `check_plane_root` *degrades to a report rather than raising*, which still holds; only the status changes.

Full suite: 1938 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX