### PR TITLE
0.32.0 — a green tick now means the guard will actually fire

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.31.1",
+  "version": "0.32.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.31.1"
+__version__ = "0.32.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.31.1",
+            "command": "charter hook sessionstart --plugin-version 0.32.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.31.1",
+            "command": "charter hook userpromptsubmit --plugin-version 0.32.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.31.1",
+            "command": "charter hook pretooluse --plugin-version 0.32.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.31.1",
+            "command": "charter hook pretooluse-read --plugin-version 0.32.0",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.31.1"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.32.0"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.31.1",
+            "command": "charter hook posttooluse --plugin-version 0.32.0",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.31.1",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.32.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.31.1"
+version = "0.32.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only; the code is on `main`.

Two fixes in one family: **a check is only worth its glyph if the glyph means what a reader takes it to mean.**

## #171 — the audit

Every `OK` in `doctor.py`, read. Six checks returned `OK` with the detail `not checked (<error>)` — two of them **directly under the comment** *"a check that silently does nothing is worse than no check"*. They now WARN, with a hint saying the silence means nothing. WARN and never FAIL: an unreadable tree is not *"you cannot work"*, it is *"charter cannot tell you either way"*.

Also: the vault-registry row stopped claiming *"shared and local halves agree"* with no vaults registered, and `workspace clones` stopped reporting a clean sweep of nothing. `check_inventory` was already right and is deliberately untouched — the model the rest was measured against.

## #177 — installed is not enabled

0.31.1 accepted an **installed** plugin as proof the guard fires, printing a tick over a plane where `git checkout -b` in the root succeeded. Wired now means a `PreToolUse` entry actually in force: in the settings the host resolves, or from a plugin **enabled** in them.

Deliberately **not** version-checked, against the report's own suggestion — a plugin supplies only the wiring, and the handler is whatever `charter` is on PATH, so an enabled 0.29.1 plugin runs today's guard. Requiring a version would warn on protected planes, which is the failure 0.31.1 was fixing.

Suite: 1943 passing, up from 1927.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX