### PR TITLE
feat: a persona declares the skills it starts holding

### DIFF
--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -456,7 +456,7 @@ _AGENT_PASSTHROUGH_KEYS = ("model", "color", "memory")
 _CHARTER_OWN_KEYS = (
     "name", "role", "vault", "extends", "uses", "delegate-when", "description",
     "agent-description", "agent-tools", "tools", "activity", "dispatch-isolation",
-    "draft",
+    "draft", "skills",
 )
 
 
@@ -482,6 +482,22 @@ def _render_agent(name: str, meta: dict, charter: str) -> str:
         fm.append(f"tools: {', '.join([tools, *grants]) if grants else tools}")
     # No `agent-tools` means the sub-agent inherits every tool, so adding a narrowing
     # `tools:` line here to carry the grant would be a downgrade rather than a grant.
+
+    # Declared skills, PRELOADED into the sub-agent at startup — the host injects each
+    # skill's full text, not just its description. That is what makes a persona's skills
+    # standing equipment rather than something it might discover mid-task, and it is the
+    # one thing charter can do with the list that reading the charter prose cannot.
+    #
+    # NOT an allowlist: the host has none. A sub-agent can still invoke unlisted skills
+    # through the Skill tool, and the only real restriction is withholding `Skill` itself
+    # via `agent-tools`. Saying "allowed skills" here would promise an enforcement charter
+    # cannot deliver.
+    #
+    # The cost is why lint is strict about dead entries: full text, injected on EVERY
+    # dispatch of this persona, for as long as the line is there.
+    skills = persona.declared_skills(name)
+    if skills:
+        fm.append(f"skills: {', '.join(skills)}")
 
     if servers:
         fm.append("mcpServers:")

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -522,6 +522,58 @@ def structural_errors(name: str, known: set[str] | None = None) -> list[tuple[st
     return issues
 
 
+def declared_skills(name: str) -> list[str]:
+    """The skills this persona is accountable for, from its ``skills:`` frontmatter.
+
+    Not an allowlist — the host has no such thing. `skills:` **preloads** the full text of
+    each skill into the sub-agent's context at startup, so a declared skill is standing
+    equipment the persona begins holding rather than something it might discover. Access is
+    all-or-nothing and lives elsewhere: ``Skill`` in or out of ``agent-tools``.
+
+    The prose and this list answer different questions, which is what keeps them from being
+    the duplicate index ADR 0010 warns about. Prose says *when and how* to use a skill; this
+    says *what the persona starts holding*. Only this one can be acted on — charter emits it
+    into the generated agent, and prose can only mention.
+
+    Comma-separated, matching ``uses:`` — one frontmatter idiom for one shape of list.
+    """
+    d = load(name)
+    if not d:
+        return []
+    raw = (d["meta"].get("skills") or "").strip()
+    return [t.strip() for t in raw.split(",") if t.strip()]
+
+
+def declared_skill_issues(name: str) -> list[tuple[str, str]]:
+    """Lint a persona's DECLARED skills, on the same terms as the ones its prose names.
+
+    A declared skill that does not resolve is worse than a prose mention that does not: the
+    prose is advice a reader can route around, while this is emitted into the agent, so the
+    failure is silent at the moment it matters.
+
+    Costs context on every dispatch, which is the part worth being strict about — `skills:`
+    injects full content at startup, so a dead entry is paid forever for nothing.
+    """
+    names = declared_skills(name)
+    if not names:
+        return []
+    skills = _installed_skills()
+    if skills is None:  # no plugin cache here → cannot verify; skip, as `_skill_ref_issues` does
+        return []
+    out: list[tuple[str, str]] = []
+    for ref in names:
+        leaf = ref.split(":", 1)[-1]
+        if leaf not in skills:
+            out.append(("error", f"declares skill `{ref}` — not installed here; it is "
+                                 f"preloaded into the agent, so this fails silently at "
+                                 f"dispatch. Remove it or install the plugin"))
+        elif not skills[leaf]:
+            out.append(("warn", f"declares skill `{ref}`, which is human-only "
+                                f"(disable-model-invocation) — preloading its text is "
+                                f"harmless but the agent can never invoke it"))
+    return out
+
+
 def lint(name: str, deep: bool = True) -> list[tuple[str, str]]:
     """Config-correctness checks for one persona → ``[(level, message)]`` where
     level is ``'error'`` (dangling ``uses:``, or a charter naming a human-only/unknown
@@ -541,6 +593,10 @@ def lint(name: str, deep: bool = True) -> list[tuple[str, str]]:
         return [("error", f"persona '{name}' does not load")]
     meta = d["meta"]
     issues: list[tuple[str, str]] = []
+    if deep:
+        # Declared skills are checked on the same walk as the prose references — one plugin
+        # cache read serves both, which is what `_installed_skills`' memo exists for.
+        issues += declared_skill_issues(name)
     if not meta.get("role"):
         issues.append(("warn", "no role"))
     if not vault_of(name) and not declares_no_vault(name):

--- a/tests/test_persona_skills.py
+++ b/tests/test_persona_skills.py
@@ -1,0 +1,132 @@
+"""A persona declares the skills it starts holding.
+
+A persona is a durable agent; a skill is a repeatable workflow. The link between them
+existed only as prose that `_skill_ref_issues` linted — which catches a dead *mention* and
+can do nothing else, because prose cannot be acted on.
+
+`skills:` can. The host **preloads** each declared skill's full text into the sub-agent at
+startup, so a declared skill is standing equipment rather than something the agent might
+discover mid-task. That is the one thing charter can do with a list that reading the charter
+cannot, and it is why the key earns its place beside prose rather than duplicating it
+(ADR 0010: two sources, two questions — prose says *when and how*, this says *what you start
+holding*).
+
+**Not an allowlist.** The host has none: a sub-agent can still invoke unlisted skills through
+the Skill tool, and the only real restriction is withholding `Skill` itself. Charter must not
+imply an enforcement it cannot deliver.
+
+The cost is the reason lint is strict here. Full text, injected on EVERY dispatch, for as
+long as the line exists — so a dead entry is paid forever for nothing.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import persona
+from charter import commands_persona as cp
+from tests._isolation import PersonaIso
+
+
+class SkillsCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        self._orig_skills = persona._installed_skills
+        persona._installed_skills = lambda: {
+            "test-driven-development": True,
+            "systematic-debugging": True,
+            "ask-matt": False,          # human-only
+        }
+        self.addCleanup(setattr, persona, "_installed_skills", self._orig_skills)
+
+    def make(self, name="dev", skills=None, **kw):
+        self.make_persona(name, role="Dev", vault="none", **kw)
+        if skills is not None:
+            p = persona.def_path(name)
+            text = p.read_text()
+            text = text.replace("---\n", f"---\nskills: {skills}\n", 1)
+            p.write_text(text)
+        return name
+
+
+class TestDeclaringSkills(SkillsCase):
+    def test_a_persona_with_no_skills_declares_none(self):
+        self.make("dev")
+        self.assertEqual(persona.declared_skills("dev"), [])
+
+    def test_declared_skills_are_read_in_order(self):
+        self.make("dev", skills="test-driven-development, systematic-debugging")
+        self.assertEqual(persona.declared_skills("dev"),
+                         ["test-driven-development", "systematic-debugging"])
+
+    def test_a_plugin_qualified_ref_is_kept_whole(self):
+        """The host takes the qualified form; charter must not helpfully strip it."""
+        self.make("dev", skills="superpowers:test-driven-development")
+        self.assertEqual(persona.declared_skills("dev"),
+                         ["superpowers:test-driven-development"])
+
+
+class TestItIsPreloadedIntoTheAgent(SkillsCase):
+    def _agent(self, name="dev") -> str:
+        d = persona.load(name)
+        return cp._render_agent(name, d["meta"], d["charter"])
+
+    def test_the_generated_agent_carries_the_skills_key(self):
+        self.make("dev", skills="test-driven-development")
+        self.assertIn("skills: test-driven-development", self._agent())
+
+    def test_a_persona_declaring_none_emits_no_key(self):
+        """An empty `skills:` line would preload nothing and still read as a declaration."""
+        self.make("dev")
+        self.assertNotIn("skills:", self._agent())
+
+    def test_it_does_not_call_them_allowed(self):
+        """Charter must not imply an enforcement the host cannot deliver: a sub-agent can
+        still invoke unlisted skills, and the only real restriction is withholding `Skill`."""
+        self.make("dev", skills="test-driven-development")
+        agent = self._agent().lower()
+        self.assertNotIn("allowed skills", agent)
+        self.assertNotIn("allowedskills", agent)
+
+
+class TestLintingWhatWasDeclared(SkillsCase):
+    def test_an_uninstalled_skill_is_an_error(self):
+        """Worse than a dead prose mention: prose is advice a reader can route around, this
+        is emitted into the agent and fails silently at dispatch."""
+        self.make("dev", skills="does-not-exist")
+        issues = persona.declared_skill_issues("dev")
+        self.assertTrue(any(lvl == "error" for lvl, _ in issues), issues)
+
+    def test_a_human_only_skill_is_a_warning_not_an_error(self):
+        """Preloading its text is harmless — it just can never be invoked. That is a
+        different severity from a skill that is not there at all."""
+        self.make("dev", skills="ask-matt")
+        issues = persona.declared_skill_issues("dev")
+        self.assertTrue(issues)
+        self.assertTrue(all(lvl == "warn" for lvl, _ in issues), issues)
+
+    def test_a_good_declaration_is_clean(self):
+        self.make("dev", skills="test-driven-development, systematic-debugging")
+        self.assertEqual(persona.declared_skill_issues("dev"), [])
+
+    def test_lint_includes_it(self):
+        self.make("dev", skills="does-not-exist")
+        self.assertTrue(any("does-not-exist" in m for _l, m in persona.lint("dev")))
+
+    def test_the_shallow_lint_skips_it(self):
+        """`deep=False` is what the status line renders on every turn — it must not walk
+        the plugin cache."""
+        self.make("dev", skills="does-not-exist")
+        self.assertFalse(any("does-not-exist" in m
+                             for _l, m in persona.lint("dev", deep=False)))
+
+    def test_no_plugin_cache_means_no_opinion(self):
+        """On a fresh clone or CI without plugins the skills cannot be resolved, and
+        inventing failures there would make lint useless exactly where it runs unattended."""
+        persona._installed_skills = lambda: None
+        self.make("dev", skills="does-not-exist")
+        self.assertEqual(persona.declared_skill_issues("dev"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
First half of the persona↔skill work. A persona is a durable agent; a skill is a repeatable workflow. The link between them existed only as **prose that gets linted** — which catches a dead mention and can do nothing else, because prose cannot be acted on.

## Why `skills:` earns a place beside the prose

The host **preloads** each declared skill's *full text* into the sub-agent at startup:

> `skills` — Skills to preload into the subagent's context at startup. The full skill content is injected, not only the description.

So a declared skill is **standing equipment**, not something the agent might discover mid-task. That is the one thing charter can do with a list that reading the charter cannot — and it is the test ADR 0010 sets for a second source: two questions, not two indexes. **Prose says *when and how*; `skills:` says *what you start holding*.**

## Deliberately not an allowlist

The host has no per-skill restriction:

> Subagents can still invoke unlisted project, user, and plugin skills through the Skill tool. To prevent a subagent from invoking skills entirely, omit `Skill` from the `tools` list.

Charter implying an enforcement it cannot deliver would be the same defect as a green tick over an inert guard, one subsystem over. There's a test asserting the word "allowed" never appears in the generated agent.

## Lint severity is the interesting part

- **Uninstalled → error.** A dead *prose mention* is advice a reader can route around; a dead *declaration* is emitted into the agent and fails silently at dispatch.
- **Human-only → warning.** Preloading its text is harmless; it simply can never be invoked.

Both ride the existing deep pass, so one plugin-cache walk serves prose and declarations alike — and `deep=False`, what the status line renders every turn, still walks nothing.

## The cost that makes the next half measurable

Full skill text, injected on **every dispatch**, for as long as the line exists. A dead entry is paid forever for nothing — which is what turns declared-but-unused from untidy into a measurable defect, and is what the skill tally (next PR) reports against.

## Tests

12 new in `tests/test_persona_skills.py`: reading the list in order, qualified refs kept whole, the key emitted, no key when nothing is declared, the never-say-"allowed" assertion, both lint severities, a clean declaration, inclusion in `lint`, exclusion from the shallow lint, and no opinion at all when there is no plugin cache.

Full suite: 1955 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX