### PR TITLE
feat: tally which skills a persona actually invokes, and name the drift

### DIFF
--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -935,6 +935,30 @@ def cmd_persona_stats(args) -> int:
         dormant += r["status"] == "dormant"
         idle += r["status"] == "idle"
     print()
+
+    # Declared-vs-used skills. A separate block rather than a column, because it is per
+    # persona and variable-length — and because it is the answer to a different question
+    # than the table's: the table asks whether a persona is USED, this asks whether the
+    # equipment it carries is worth carrying.
+    from . import skilluse
+    drifted = []
+    for r in rows:
+        if r["persona"] == config.SHARED_PERSONA:
+            continue
+        d = skilluse.drift(r["persona"])
+        if d["unused"] or d["undeclared"]:
+            drifted.append((r["persona"], d))
+    if drifted:
+        print("SKILLS — declared vs actually invoked")
+        for name, d in drifted:
+            if d["unused"]:
+                # Not untidy: `skills:` preloads full text on EVERY dispatch, so an unused
+                # declaration is a standing context cost bought for nothing.
+                print(f"  {name:<26} unused: {', '.join(d['unused'])}"
+                      f"   (preloaded every dispatch)")
+            if d["undeclared"]:
+                print(f"  {name:<26} used but not declared: {', '.join(d['undeclared'])}")
+        print()
     util.info(f"RECENT = memories in the last {getattr(args, 'recent_days', 14)} days · "
               f"VERIFY = share carrying a verification marker (quality proxy) · DUP = share "
               f"in a near-dup pair (noise) · DISP = times DISPATCHED as a sub-agent (committed "
@@ -944,6 +968,11 @@ def cmd_persona_stats(args) -> int:
         util.info(f"Routing: {total - gen}/{total} dispatches went to a persona · {gen} to a "
                   f"generic agent ({100 * gen // total}%). A high generic share means the work "
                   f"a persona owns is being done without it.")
+    if drifted:
+        util.info("SKILLS drift is named, not resolved: an unused declaration may be dead "
+                  "weight or a skill whose moment has not come, and an undeclared one may "
+                  "be a charter out of date or a persona reaching past its remit. Which it "
+                  "is depends on intent charter cannot read.")
     else:
         util.info("No dispatches recorded yet — the tally starts filling as sub-agents are "
                   "dispatched (`charter persona dispatch-backfill` seeds it from past sessions).")

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -1382,6 +1382,34 @@ def pretooluse_dispatch() -> int:
     return 0
 
 
+def posttooluse_skill() -> int:
+    """Tally a Skill invocation against the persona that made it.
+
+    The observability half of the persona↔skill link. A persona declares the skills it
+    starts holding and the host preloads their full text on every dispatch; nothing could
+    see whether any of it was used. Same blindness `dispatch.py` was built for, aimed at a
+    persona's equipment rather than at the persona.
+
+    Records the skill NAME and the active persona — never the arguments, which is where a
+    workspace or client name would travel. `skilluse.record` swallows its own failures: a
+    tally must never break a turn.
+    """
+    data = _read_stdin()
+    _touch_piece(data)
+    try:
+        if (data.get("tool_name") or "") != "Skill":
+            return 0
+        name = ((data.get("tool_input") or {}).get("skill") or "").strip()
+        if not name:
+            return 0
+        from . import persona as _persona, skilluse
+        if skilluse.record(name, _persona.resolve_active()):
+            _trace("skill", data.get("session_id"), skill=name[:60])
+    except Exception:
+        return 0
+    return 0
+
+
 def posttooluse_dispatch() -> int:
     data = _read_stdin()
     if (data.get("tool_name") or "") not in ("Task", "Agent"):
@@ -1689,6 +1717,7 @@ _HANDLERS = {
     "pretooluse-read": pretooluse_read,
     "pretooluse-dispatch": pretooluse_dispatch,
     "posttooluse": posttooluse,
+    "posttooluse-skill": posttooluse_skill,
     "posttooluse-dispatch": posttooluse_dispatch,
 }
 

--- a/charter/skilluse.py
+++ b/charter/skilluse.py
@@ -1,0 +1,149 @@
+"""Committed skill tally — which skills each persona actually *invokes*.
+
+A persona declares the skills it starts holding (``skills:`` — see
+:func:`charter.persona.declared_skills`), and the host preloads their full text into the
+sub-agent at startup. Declaring is cheap to write and expensive to keep: the text is
+injected on **every dispatch** of that persona, for as long as the line exists.
+
+Nothing could see whether any of it was used. That is the same blindness ``dispatch.py``
+was built for one level up — a persona that lints green and is never dispatched — aimed
+here at a persona's *equipment* rather than at the persona itself.
+
+Shape of the store::
+
+    personas/_skills/<YYYY-MM>.<host>.jsonl     one JSON object per line
+
+The three properties are ``dispatch.py``'s, for the same reasons:
+
+* **Counts and dates only.** A line is ``{"ts": …, "skill": …, "persona": …}`` — never the
+  arguments a skill was invoked with, which is where a workspace or client name would
+  travel. There is no secret surface to scan.
+* **Parallel-writer safe.** Small lines opened ``O_APPEND``, so a fan-out of sub-agents
+  each invoking skills appends without a lock.
+* **Conflict-free across engineers.** The host is in the filename, so two people recording
+  the same month never touch the same file — the committed tally merges by addition rather
+  than conflicting.
+
+A separate store from the dispatch tally rather than a column added to it, because they
+answer different questions: dispatch asks *was this persona used*, this asks *was the
+equipment it carries worth carrying*. Merging them would make one of the two questions
+unanswerable, which is ADR 0010's rule stated the other way round.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+from datetime import datetime, timezone
+from pathlib import Path
+
+from . import config
+
+#: Directory under ``personas/`` holding the tally. Leading underscore so it can never
+#: collide with a persona name — the same convention ``_dispatch`` and ``_shared`` use.
+DIR_NAME = "_skills"
+
+
+def _host() -> str:
+    """Short, filename-safe hostname — keeps each engineer on their own file."""
+    raw = (socket.gethostname() or "unknown").split(".")[0]
+    return re.sub(r"[^A-Za-z0-9_-]", "", raw)[:32] or "unknown"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _dir() -> Path:
+    return config.ROOT / "personas" / DIR_NAME
+
+
+def path_for(when: datetime | None = None) -> Path:
+    when = when or _now()
+    return _dir() / f"{when:%Y-%m}.{_host()}.jsonl"
+
+
+def record(skill: str, persona_name: str | None = None,
+           when: datetime | None = None) -> Path | None:
+    """Append one skill invocation. Best-effort: a tally must never break a turn, so any
+    failure is swallowed and reported as ``None``."""
+    skill = (skill or "").strip()
+    if not skill:
+        return None
+    when = when or _now()
+    p = path_for(when)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps({"ts": when.isoformat(timespec="seconds"),
+                           "skill": skill,
+                           "persona": (persona_name or "").strip() or None},
+                          sort_keys=True) + "\n"
+        # O_APPEND: concurrent sub-agents interleave safely without a lock.
+        fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        try:
+            os.write(fd, line.encode())
+        finally:
+            os.close(fd)
+        return p
+    except OSError:
+        return None
+
+
+def _read_all() -> list[dict]:
+    d = _dir()
+    if not d.exists():
+        return []
+    out: list[dict] = []
+    try:
+        files = sorted(d.glob("*.jsonl"))
+    except OSError:
+        # Listing an unreadable directory raises on Linux and yields nothing on macOS —
+        # the divergence that took CI red once already (#171's neighbourhood).
+        return []
+    for f in files:
+        try:
+            text = f.read_text()
+        except OSError:
+            continue
+        for raw in text.splitlines():
+            try:
+                obj = json.loads(raw)
+            except ValueError:
+                continue
+            if isinstance(obj, dict) and obj.get("skill"):
+                out.append(obj)
+    return out
+
+
+def by_persona(name: str) -> dict[str, int]:
+    """``{skill: count}`` for one persona. Leaf names, so a declaration written
+    ``superpowers:tdd`` matches an invocation recorded as ``tdd``."""
+    out: dict[str, int] = {}
+    for e in _read_all():
+        if (e.get("persona") or "") != name:
+            continue
+        leaf = str(e["skill"]).split(":", 1)[-1]
+        out[leaf] = out.get(leaf, 0) + 1
+    return out
+
+
+def drift(name: str) -> dict[str, list[str]]:
+    """What a persona declared against what it actually used.
+
+    Returns ``{"unused": [...], "undeclared": [...]}``.
+
+    **unused** — declared, never invoked. Not merely untidy: the skill's full text is
+    preloaded on every dispatch of this persona, so an unused declaration is a standing
+    context cost bought for nothing.
+
+    **undeclared** — invoked, never declared. The more interesting direction, and the one
+    the declaration makes answerable at all: the persona is doing work its charter does not
+    describe, so either the charter is out of date or the persona is reaching past its
+    remit. charter names the divergence and does not resolve it (ADR 0013), because which
+    of those it is depends on intent charter cannot read.
+    """
+    from . import persona as _persona
+    declared = {s.split(":", 1)[-1] for s in _persona.declared_skills(name)}
+    used = set(by_persona(name))
+    return {"unused": sorted(declared - used), "undeclared": sorted(used - declared)}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -86,6 +86,16 @@
         ]
       },
       {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "charter hook posttooluse-skill --plugin-version 0.32.0",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Task|Agent",
         "hooks": [
           {

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -102,6 +102,9 @@ class TestPluginManifest(unittest.TestCase):
             ("PreToolUse", "charter hook pretooluse-read --plugin-version"),
             ("PreToolUse", "charter hook pretooluse-dispatch --plugin-version"),
             ("PostToolUse", "charter hook posttooluse --plugin-version"),
+            # The skill tally: which skills a persona actually invokes, against the ones its
+            # charter declares and the host preloads on every dispatch.
+            ("PostToolUse", "charter hook posttooluse-skill --plugin-version"),
             ("PostToolUse", "charter hook posttooluse-dispatch --plugin-version"),
             ("Stop", "charter workspace _autosave"),             # debounced auto-save
             ("SubagentStop", "charter workspace _autosave"),     # ditto, per dispatch

--- a/tests/test_skill_tally.py
+++ b/tests/test_skill_tally.py
@@ -1,0 +1,147 @@
+"""Which skills a persona actually invokes, against the ones it declares.
+
+A persona declares the skills it starts holding, and the host preloads their **full text**
+into the sub-agent on every dispatch. Declaring is cheap to write and expensive to keep, and
+nothing could see whether any of it was used.
+
+That is the blindness `dispatch.py` was built for — a persona that lints green and is never
+dispatched — aimed one level in, at a persona's *equipment* rather than at the persona.
+
+The store borrows dispatch's three properties for dispatch's reasons: counts and dates only
+(never the arguments a skill was invoked with, which is where a client name would travel),
+`O_APPEND` so concurrent sub-agents interleave without a lock, and the host in the filename
+so a committed tally merges by addition instead of conflicting.
+
+Drift is **named, not resolved** (ADR 0013). An unused declaration may be dead weight or a
+skill whose moment has not come; an undeclared one may be a stale charter or a persona
+reaching past its remit. Which it is depends on intent charter cannot read.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime, timezone
+
+from charter import hooks, persona, skilluse
+from tests._isolation import PersonaIso, run_hook
+
+
+class TallyCase(PersonaIso):
+    def declare(self, name="dev", skills=None):
+        self.make_persona(name, role="Dev", vault="none")
+        if skills:
+            p = persona.def_path(name)
+            p.write_text(p.read_text().replace("---\n", f"---\nskills: {skills}\n", 1))
+        return name
+
+    def invoke(self, skill: str, who: str | None = "dev"):
+        return run_hook(hooks.posttooluse_skill, {
+            "tool_name": "Skill",
+            "tool_input": {"skill": skill, "args": "some args"},
+            "session_id": "s"}) if who is None else self._as(who, skill)
+
+    def _as(self, who: str, skill: str):
+        real = persona.resolve_active
+        persona.resolve_active = lambda *a, **k: who
+        try:
+            return run_hook(hooks.posttooluse_skill, {
+                "tool_name": "Skill",
+                "tool_input": {"skill": skill, "args": "some args"},
+                "session_id": "s"})
+        finally:
+            persona.resolve_active = real
+
+
+class TestTheTallyRecords(TallyCase):
+    def test_an_invocation_is_recorded_against_the_active_persona(self):
+        self.declare("dev")
+        self.invoke("test-driven-development")
+        self.assertEqual(skilluse.by_persona("dev"), {"test-driven-development": 1})
+
+    def test_repeats_accumulate(self):
+        self.declare("dev")
+        for _ in range(3):
+            self.invoke("systematic-debugging")
+        self.assertEqual(skilluse.by_persona("dev")["systematic-debugging"], 3)
+
+    def test_a_qualified_name_matches_a_bare_declaration(self):
+        """A charter may write `superpowers:tdd` while the invocation records `tdd`. Two
+        spellings of one skill must not read as drift in both directions at once."""
+        self.declare("dev", skills="superpowers:test-driven-development")
+        self.invoke("test-driven-development")
+        self.assertEqual(skilluse.drift("dev"), {"unused": [], "undeclared": []})
+
+    def test_another_tool_is_not_tallied(self):
+        self.declare("dev")
+        run_hook(hooks.posttooluse_skill, {
+            "tool_name": "Bash", "tool_input": {"command": "ls"}, "session_id": "s"})
+        self.assertEqual(skilluse.by_persona("dev"), {})
+
+    def test_no_active_persona_still_records_the_skill(self):
+        """The skill was still used. Dropping it would make the tally lie about totals to
+        keep the per-persona view tidy."""
+        self.declare("dev")
+        self._as("", "grilling")
+        self.assertTrue(any(e["skill"] == "grilling" for e in skilluse._read_all()))
+
+
+class TestItCarriesNoArguments(TallyCase):
+    def test_the_arguments_are_never_written(self):
+        """dispatch.py's rule: counts and dates only. A skill's arguments are exactly where
+        a workspace, client or repo name would travel to a committed file."""
+        self.declare("dev")
+        self._as("dev", "grilling")
+        blob = skilluse.path_for().read_text()
+        self.assertNotIn("some args", blob)
+        self.assertEqual(set(json.loads(blob.splitlines()[0])), {"ts", "skill", "persona"})
+
+
+class TestDrift(TallyCase):
+    def test_declared_and_never_used_is_unused(self):
+        self.declare("dev", skills="test-driven-development")
+        self.assertEqual(skilluse.drift("dev")["unused"], ["test-driven-development"])
+
+    def test_used_and_never_declared_is_undeclared(self):
+        self.declare("dev")
+        self.invoke("grilling")
+        self.assertEqual(skilluse.drift("dev")["undeclared"], ["grilling"])
+
+    def test_declared_and_used_is_neither(self):
+        self.declare("dev", skills="grilling")
+        self.invoke("grilling")
+        self.assertEqual(skilluse.drift("dev"), {"unused": [], "undeclared": []})
+
+    def test_another_personas_use_does_not_count(self):
+        """Skills are global and reused freely; the tally is per persona or it answers
+        nothing about this one's equipment."""
+        self.declare("dev", skills="grilling")
+        self.declare("ops")
+        self._as("ops", "grilling")
+        self.assertEqual(skilluse.drift("dev")["unused"], ["grilling"])
+
+
+class TestItNeverBreaksATurn(TallyCase):
+    def test_an_unwritable_store_is_silent(self):
+        self.declare("dev")
+        d = skilluse._dir()
+        d.mkdir(parents=True, exist_ok=True)
+        d.chmod(0o500)
+        self.addCleanup(d.chmod, 0o700)
+        self.assertIsNone(skilluse.record("grilling", "dev"))
+
+    def test_a_malformed_line_is_skipped_rather_than_fatal(self):
+        self.declare("dev")
+        p = skilluse.path_for()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text('{"not json\n{"ts":"x","skill":"grilling","persona":"dev"}\n')
+        self.assertEqual(skilluse.by_persona("dev"), {"grilling": 1})
+
+    def test_the_hook_returns_zero_whatever_happens(self):
+        self.declare("dev")
+        self.assertEqual(hooks._HANDLERS["posttooluse-skill"].__name__,
+                         "posttooluse_skill")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Second half of the persona↔skill work, on top of #182.

A persona declares the skills it starts holding, and the host preloads their **full text** on every dispatch. Declaring is cheap to write and expensive to keep — and nothing could see whether any of it was used.

That is the blindness `dispatch.py` was built for (*a persona that lints green and is never dispatched*), aimed one level in: at a persona's **equipment** rather than at the persona.

## What `charter persona stats` now says

```
SKILLS — declared vs actually invoked
  release                    unused: to-spec   (preloaded every dispatch)
  statusline                 used but not declared: systematic-debugging
```

- **unused** — declared, never invoked. Not untidy: it is preloaded on every dispatch, so it is a standing context cost bought for nothing.
- **used but not declared** — the more interesting direction, and the one the declaration makes answerable *at all*.

**Named, not resolved** (ADR 0013). An unused declaration may be dead weight or a skill whose moment has not come; an undeclared one may be a stale charter or a persona reaching past its remit. Which it is depends on intent charter cannot read.

## Why a separate store from the dispatch tally

They answer different questions: dispatch asks whether the **persona** was used, this asks whether the **equipment it carries** is worth carrying. Merging them would make one of the two unanswerable — ADR 0010's rule stated the other way round.

The three properties are dispatch's, for dispatch's reasons:

- **Counts and dates only** — never the arguments a skill was invoked with, which is exactly where a workspace or client name would travel into a *committed* file. A test asserts the record's key set is closed.
- **`O_APPEND`** so concurrent sub-agents interleave without a lock.
- **Host in the filename** so the committed tally merges by addition instead of conflicting.

## One detail worth a look

A qualified declaration (`superpowers:tdd`) matches a bare invocation (`tdd`). Without that, one skill under two spellings reads as drift in *both* directions at once — unused and undeclared simultaneously.

## Tests

13 new in `tests/test_skill_tally.py`: recording against the active persona, accumulation, qualified-vs-bare matching, other tools ignored, no-active-persona still recorded (dropping it would make the tally lie about totals), the closed key set, all three drift outcomes, another persona's use not counting, an unwritable store staying silent, and a malformed line skipped rather than fatal.

Full suite: 1968 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX