### PR TITLE
fix: the guard reads commands, not prose — and stops blocking its own advice

### DIFF
--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -145,8 +145,8 @@ def _leak_reason(cmd: str) -> str | None:
     vault registered elsewhere is therefore still unguarded here — a separate finding,
     not something to half-fix on the hot path.
     """
-    for seg in _segments(cmd):
-        prog, _env, args = _invocation(seg)
+    for _toks in _segment_argv(cmd):
+        prog, _env, args = _split_env(_toks)
         if not prog:
             continue
         if _is_charter(prog, args) and any(
@@ -294,11 +294,74 @@ def _is_sshcommand_config_write(args: list[str]) -> bool:
     return any(a in _CONFIG_WRITE_ONLY_FLAGS for a in args)
 
 
+#: Shell operators that end one separately-executed command and begin the next.
+_OPERATORS = (";", "&&", "||", "|", "&", "\n")
+
+
+def _segment_argv(cmd: str) -> list[list[str]]:
+    """A shell command as **argv per separately-executed segment**, quoting respected.
+
+    This replaced a regex split on shell operators, which ran BEFORE any tokenizer and
+    therefore split on operators living inside a quoted argument. The result was that
+
+        echo 'example: cd somewhere ; git checkout -b my-branch'
+
+    became two "commands", the second of which looked exactly like a branch move — and the
+    stray closing quote rode along into what the guard believed was a branch name (#183).
+    Worse, `_invocation`'s naive fallback for unbalanced quotes then DIGNIFIED the fragment:
+    the regex created it and the fallback made it look like a real invocation.
+
+    ``shlex`` with ``punctuation_chars`` is the stdlib's own answer — it emits the operators
+    as distinct tokens while honouring quotes natively, so prose stays prose. No dependency,
+    which the zero-dependency promise requires.
+
+    **On a command that cannot be parsed at all** (genuinely unbalanced quotes) this returns
+    the whole string as ONE segment, and that single behaviour gives every caller the
+    failure direction it needs without a per-caller flag:
+
+    * the leak guard scans the entire text and stays **fail-closed** — not printing a secret
+      is a safety invariant, and swallowing an unparseable command would be the one failure
+      it may not have;
+    * the plane-root guard sees a program that is not ``git`` and does not fire —
+      **fail-open**, which is right for a guard whose failure mode is annoyance.
+    """
+    import shlex
+    try:
+        lex = shlex.shlex(cmd or "", punctuation_chars=True, posix=True)
+        lex.whitespace_split = True
+        toks = list(lex)
+    except ValueError:
+        # ONE segment, but still tokenized: the leak guard has to be able to see
+        # `--reveal` among the arguments, and a single opaque blob would hide it. Naive
+        # whitespace split is exactly the old `_invocation` fallback — kept for the guard
+        # that must fail CLOSED, minus the operator splitting that created phantom commands.
+        return [(cmd or "").split()]
+    out: list[list[str]] = []
+    cur: list[str] = []
+    for t in toks:
+        if t in _OPERATORS:
+            out.append(cur)
+            cur = []
+        else:
+            cur.append(t)
+    out.append(cur)
+    return [c for c in out if c]
+
+
+def _split_env(toks: list[str]) -> tuple[str, list[str], list[str]]:
+    """``(program, env-assignment prefixes, argv)`` for one already-tokenized segment."""
+    env = []
+    toks = list(toks)
+    while toks and _ENV_ASSIGN_RE.match(toks[0]):
+        env.append(toks.pop(0))
+    return (toks[0] if toks else ""), env, toks
+
+
 def _segments(cmd: str) -> list[str]:
-    """Split a shell command into separately-executed segments, so we inspect real
-    invocations rather than scanning prose (a commit message may legitimately *mention*
-    an SSH URL — that must not trip the guard)."""
-    return re.split(r"&&|\|\||[|;&\n]", cmd or "")
+    """Back-compat string form of :func:`_segment_argv`, for callers that re-tokenize."""
+    import shlex
+    return [shlex.join(a) if hasattr(shlex, "join") else " ".join(a)
+            for a in _segment_argv(cmd)]
 
 
 def _invocation(seg: str) -> tuple[str, list[str], list[str]]:
@@ -422,11 +485,22 @@ def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
     except OSError:
         return None
 
-    for seg in _segments(cmd):
-        prog, _env, args = _invocation(seg)
-        if not prog or os.path.basename(prog) != "git":
+    here = cwd
+    for _toks in _segment_argv(cmd):
+        prog, _env, args = _split_env(_toks)
+        base = os.path.basename(prog or "")
+        # A `cd` earlier in the SAME command moves where the later segments run. Without
+        # this the guard refused `cd workspaces/<ws>/<repo> && git checkout -b x` — which is
+        # the workflow its own denial message recommends, so the first time someone obeyed
+        # the message they were told they were doing the forbidden thing (#183).
+        if base == "cd":
+            dest = next((a for a in args[1:] if not a.startswith("-")), None)
+            if dest:
+                here = str(Path(here or ".") / dest) if not os.path.isabs(dest) else dest
             continue
-        target, rest = _git_target(cwd, args)
+        if base != "git":
+            continue
+        target, rest = _git_target(here, args)
         sub = next((a for a in rest if not a.startswith("-")), "")
         if sub not in _BRANCH_MOVERS:
             continue
@@ -480,8 +554,8 @@ def _single_credential_reason(cmd: str) -> str | None:
     # straight through it.
     lower_prefix_hosts = {p.lower(): h for p, h in ssh_prefix_hosts.items()}
     lower_prefixes = tuple(lower_prefix_hosts)
-    for seg in _segments(cmd):
-        prog, env, argv = _invocation(seg)
+    for _toks in _segment_argv(cmd):
+        prog, env, argv = _split_env(_toks)
         base = prog.rsplit("/", 1)[-1]
         if base == "git":
             args = argv[1:]

--- a/tests/test_guard_parsing.py
+++ b/tests/test_guard_parsing.py
@@ -1,0 +1,147 @@
+"""The guard reads commands, not prose — and does not block the workflow it recommends (#183).
+
+Two parsing defects in the plane-root guard, both false positives on things that are not
+branch moves at all.
+
+**Prose inside a quoted argument was treated as a command.** `_segments` split on shell
+operators with a regex, *before* any tokenizer, so an operator living inside a quoted string
+split it. `echo 'example: cd somewhere ; git checkout -b my-branch'` became two "commands",
+the second an apparent branch move — with the string's closing quote riding along into what
+the guard believed was a branch name. And `_invocation`'s naive fallback for unbalanced
+quotes then dignified the fragment: the regex created it, the fallback made it look real.
+
+The sharp end: `charter report bug '<text containing such an example>'` was refused, so
+**the guard blocked its own bug report**. The reporter had to file via a file. So did I,
+reproducing it.
+
+**A `cd` in the same command was ignored.** The denial says branch work belongs in a
+workspace clone — and `cd workspaces/ws/repo && git checkout -b x` was refused, because the
+target came from the session cwd. The first time someone obeys the message they are told
+they are doing the forbidden thing.
+
+What is deliberately unchanged: the guard already fires only when the target **positively
+resolves** to the plane root, and already treats an unresolvable target as not-the-root. The
+inversion the report asks for was there; the `cd` was what it was missing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+from charter import config, hooks
+from tests._isolation import PersonaIso, run_hook
+
+
+def _decision(r) -> str | None:
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+
+
+class GuardCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.HAS_CONTROL_PLANE = True
+        self.root = Path(config.ROOT)
+        subprocess.run(["git", "init", "-q", "-b", "main", str(self.root)],
+                       check=True, capture_output=True)
+        self.clone = config.WORKSPACES_DIR / "ws" / "repo"
+        self.clone.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "init", "-q", "-b", "main", str(self.clone)],
+                       check=True, capture_output=True)
+
+    def run_cmd(self, cmd: str, cwd=None):
+        return run_hook(hooks.pretooluse, {
+            "tool_input": {"command": cmd},
+            "cwd": str(cwd if cwd is not None else self.root),
+            "session_id": "s"})
+
+
+class TestProseIsNotACommand(GuardCase):
+    def test_a_quoted_example_containing_an_operator_is_not_a_branch_move(self):
+        """The reported case, verbatim. Nothing is executed and no branch is created."""
+        cmd = "echo " + repr("example: cd somewhere ; git checkout -b my-branch")
+        self.assertIsNone(_decision(self.run_cmd(cmd)))
+
+    def test_filing_a_bug_report_about_this_is_not_refused(self):
+        """The guard blocked its own bug report. That is a denial of the path people use to
+        tell us about denials, which is the worst possible thing for it to block."""
+        body = "the guard fires on: cd somewhere ; git checkout -b my-branch"
+        self.assertIsNone(_decision(self.run_cmd("charter report bug " + repr(body))))
+
+    def test_a_commit_message_mentioning_a_branch_move_is_not_one(self):
+        self.assertIsNone(_decision(
+            self.run_cmd("git commit -m " + repr("docs: run git checkout -b x to branch"))))
+
+    def test_a_heredoc_style_body_is_not_a_command(self):
+        self.assertIsNone(_decision(
+            self.run_cmd("printf %s " + repr("step 1 ; git switch other"))))
+
+
+class TestTheRecommendedWorkflowIsNotBlocked(GuardCase):
+    def test_cd_into_a_clone_then_branch_is_allowed(self):
+        """Exactly what the denial message tells you to do."""
+        self.assertIsNone(_decision(
+            self.run_cmd(f"cd {self.clone} && git checkout -b feature/x")))
+
+    def test_a_relative_cd_is_honoured_too(self):
+        self.assertIsNone(_decision(
+            self.run_cmd("cd workspaces/ws/repo && git checkout -b feature/x")))
+
+    def test_cd_elsewhere_then_back_to_the_root_still_fires(self):
+        """The `cd` is followed, not merely noticed: landing back in the root is still the
+        root."""
+        self.assertEqual(_decision(
+            self.run_cmd(f"cd {self.clone} && cd {self.root} && git checkout -b x")), "deny")
+
+
+class TestItStillGuards(GuardCase):
+    def test_a_real_branch_move_in_the_root_is_denied(self):
+        self.assertEqual(_decision(self.run_cmd("git checkout -b real")), "deny")
+
+    def test_a_real_switch_is_denied(self):
+        self.assertEqual(_decision(self.run_cmd("git switch other")), "deny")
+
+    def test_a_chained_real_move_is_denied(self):
+        """Quoting is respected, not ignored — an operator OUTSIDE quotes still separates."""
+        self.assertEqual(_decision(self.run_cmd("echo hi && git checkout -b real")), "deny")
+
+    def test_git_dash_C_into_the_root_from_a_clone_is_denied(self):
+        self.assertEqual(_decision(
+            self.run_cmd(f"git -C {self.root} checkout -b x", cwd=self.clone)), "deny")
+
+
+class TestUnparseableInput(GuardCase):
+    def test_the_plane_root_guard_fails_OPEN(self):
+        """One segment for the whole string, so the program is not `git` and nothing fires.
+        Right direction for a guard whose failure mode is annoyance."""
+        self.assertIsNone(_decision(self.run_cmd("echo 'unbalanced ; git checkout -b x")))
+
+    def test_the_leak_guard_still_fails_CLOSED(self):
+        """The opposite direction, from the same behaviour: the whole string stays one
+        segment, so the secret guard still scans it. Not printing a secret is a safety
+        invariant, and swallowing an unparseable command is the one failure it may not have.
+        """
+        r = self.run_cmd("charter secret get v k --reveal 'unbalanced")
+        self.assertEqual(_decision(r), "deny")
+
+
+class TestTheTokenizer(unittest.TestCase):
+    def test_quoted_operators_do_not_split(self):
+        self.assertEqual(hooks._segment_argv("echo " + repr("a ; b")),
+                         [["echo", "a ; b"]])
+
+    def test_unquoted_operators_do_split(self):
+        self.assertEqual(hooks._segment_argv("a && b"), [["a"], ["b"]])
+
+    def test_unparseable_yields_one_segment(self):
+        # One segment, but tokenized — the leak guard must still see the arguments.
+        self.assertEqual(hooks._segment_argv("echo 'x"), [["echo", "'x"]])
+
+    def test_empty_is_empty(self):
+        self.assertEqual(hooks._segment_argv(""), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #183. Two false positives in the plane-root guard, on things that are not branch moves at all.

## Defect 1 — prose inside a quoted argument was read as a command

`_segments` split on shell operators with a **regex, before any tokenizer**, so an operator living inside a quoted string split it. A quoted example became two "commands", the second an apparent branch move — with the string's closing quote riding along into what the guard believed was a branch name.

`_invocation`'s naive fallback for unbalanced quotes then *dignified* the fragment: the regex created it, the fallback made it look real.

**The sharp end:** `charter report bug` was refused when the report quoted such an example, so **the guard blocked its own bug report**. The reporter filed via a file. So did I — the guard denied the command I wrote to reproduce the denial.

Replaced with `shlex(punctuation_chars=True)`: operators come back as distinct tokens, quoting honoured natively, no dependency. All three guards share it, so this is one implementation rather than three.

## The unparseable case, and why one behaviour serves both directions

A command that cannot be parsed now returns **one segment, still tokenized**. That single behaviour gives each guard the direction it needs with no per-caller flag:

| Guard | Direction | Why |
|---|---|---|
| leak / `--reveal` | **fail-closed** | scans the whole text; not printing a secret is a safety invariant, and swallowing an unparseable command is the one failure it may not have |
| plane-root | **fail-open** | sees a program that is not `git`, does not fire; right for a guard whose failure mode is annoyance |

Both pinned by tests. Tokenized rather than one opaque blob, because the leak guard has to be able to see `--reveal` *among the arguments* — that distinction cost a red test and is now commented.

## Defect 2 — the guard blocked the workflow it recommends

`cd workspaces/<ws>/<repo> && git checkout -b x` was refused: the target came from the session cwd, and the `cd` in the same command was ignored. So **the first time someone follows the denial message, they are told they are doing the forbidden thing.**

A leading `cd` is now honoured the way `-C` already was — and *followed*, not merely noticed: cd-ing away and back to the root still fires.

## Deliberately unchanged

The guard already fired only when the target **positively resolves** to the plane root, and already treated an unresolvable target as not-the-root. The inversion the report asks for was already there; the `cd` was what was missing.

## Tests

17 new in `tests/test_guard_parsing.py`: the reported case verbatim, a bug report about it not being refused, commit messages and `printf` bodies mentioning branch moves, `cd`-into-clone allowed (absolute and relative), cd-away-and-back still denied, real moves still denied including chained ones and `git -C`, both unparseable directions, and four tokenizer unit cases.

Full suite: 1985 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX