### PR TITLE
0.33.0 — personas declare the skills they carry, and the guard reads commands not prose

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.32.0"
+__version__ = "0.33.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.32.0",
+            "command": "charter hook sessionstart --plugin-version 0.33.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.32.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.33.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.32.0",
+            "command": "charter hook pretooluse --plugin-version 0.33.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.32.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.33.0",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.32.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.33.0"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.32.0",
+            "command": "charter hook posttooluse --plugin-version 0.33.0",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.32.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.33.0",
             "timeout": 5
           }
         ]
@@ -100,7 +100,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.32.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.33.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.32.0"
+version = "0.33.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only; the code is on `main`.

## Personas gain skills (#182, #184)

A persona is a durable agent; a skill is a repeatable workflow. The link existed only as **prose that lint could check and nothing could act on**.

`skills:` is emitted into the generated sub-agent, and the host **preloads each skill's full text** at startup — so a declared skill is standing equipment the persona begins holding, not something it might discover. That is the one thing charter can do with the list that reading the prose cannot, and it is what earns the key its place beside the prose rather than duplicating it.

**Not an allowlist.** The host has no per-skill restriction; the only real gate is withholding the `Skill` tool. Charter must not imply an enforcement it cannot deliver.

Because preload costs full text on **every dispatch**, declaring became measurable. `charter persona stats` now reports declared-but-never-invoked (context paid forever for nothing) and invoked-but-never-declared (work the charter does not describe), from a committed tally of counts and dates only — never a skill's arguments. Named, not resolved.

## The guard stops reading prose as commands (#183)

It split on shell operators *before* tokenizing, so a quoted example became a phantom branch move — and `charter report bug` was refused when the report quoted one, meaning **the guard blocked its own bug report**. It also ignored a `cd` in the same command, refusing the workspace-clone workflow its own denial recommends.

The unparseable case now fails **closed** for the secret guard and **open** for the plane-root guard, from one shared behaviour.

## Note

The bump initially reported the *old* version from a file that on disk said the new one: `0.32.0` → `0.33.0` is the same byte length, so a same-second write let Python's `(mtime, size)` bytecode check pass and reuse a stale `.pyc`. Caught by the lockstep tests. Recorded to the release persona's memory.

Suite: 1985 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX