### PR TITLE
feat: recall searches refs/ — the curated docs a persona collects

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -122,8 +122,12 @@ def build_parser() -> argparse.ArgumentParser:
                          help="The one memory gate: search/list across ALL bases (active workspace + "
                               "active persona own + shared), each hit labeled by source.")
     rcl.add_argument("query", nargs="?", help="Keyword query; omit to list recent memories across bases.")
-    rcl.add_argument("--scope", help="Comma list of scopes to search (workspace,persona,shared,ephemeral); "
-                                     "default workspace,persona,shared.")
+    rcl.add_argument("--scope", help="Comma list of scopes to search "
+                                     "(workspace,persona,shared,refs,ephemeral); default "
+                                     "workspace,persona,shared,refs. `refs` is the curated "
+                                     "docs a persona collects — committed and shared, so it "
+                                     "is searched by default; `ephemeral` is scratch and is "
+                                     "not.")
     rcl.add_argument("--ephemeral", action="store_true", help="Also include the persona's session scratch.")
     rcl.add_argument("--full", action="store_true",
                      help="Also print a line of each memory's body (the path is always shown).")

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1221,6 +1221,12 @@ def cmd_recall(args) -> int:
         util.info(f"Showing {len(results)} — pass --limit 0 for all.")
     if got.undated:
         util.info(f"{got.undated} undated memory(ies) skipped by --since — no recorded date.")
+    if got.undated_refs:
+        # Said separately from the memory count on purpose: an undated MEMORY lost a stamp it
+        # was meant to carry, while a refs document never had one. Blaming a runbook for a
+        # missing date would read as corruption rather than as the filter not applying.
+        util.info(f"{got.undated_refs} ref doc(s) not searched — `--since` filters by "
+                  f"recorded date and refs carry none. Drop --since to include them.")
     return 0
 
 

--- a/charter/recall.py
+++ b/charter/recall.py
@@ -21,8 +21,13 @@ from typing import NamedTuple
 from . import config, memstore
 
 #: The selectable scopes, in the order they're assembled/displayed.
-SCOPES = ("workspace", "persona", "shared", "ephemeral")
-DEFAULT_SCOPES = ("workspace", "persona", "shared")  # the committed bases; ephemeral is opt-in
+SCOPES = ("workspace", "persona", "shared", "ephemeral", "refs")
+#: `refs` is DEFAULT-ON, unlike `ephemeral`. The distinction is standing, not size: refs are
+#: committed, curated and shared — the same standing the other three defaults have — while
+#: ephemeral is session scratch. Opt-in would also fix only the letter of #178: an agent that
+#: must already know to ask for refs is in exactly the position the report describes, told
+#: with a straight face that the runbook does not exist.
+DEFAULT_SCOPES = ("workspace", "persona", "shared", "refs")
 
 
 class Hit(NamedTuple):
@@ -43,6 +48,13 @@ class Recalled(NamedTuple):
     filter you cannot trust — and 0 undated is the common case, so it costs nothing."""
     hits: list[Hit]
     undated: int
+    #: Refs excluded by `since`. Counted apart from `undated` because they are different
+    #: facts: an undated MEMORY lost a stamp it was supposed to carry, while a refs document
+    #: never had one — a date filter over undated documents can only lie or pass everything,
+    #: so refs are excluded, and the message must not blame them for a missing stamp (#178).
+    #: Defaulted so existing positional unpacking of (hits, undated) keeps working — this
+    #: NamedTuple's own docstring records what happened the last time a field was added.
+    undated_refs: int = 0
 
 
 #: `14d` / `2w` / `3m`. Months are 30 days — predictable beats calendar-correct for a
@@ -100,7 +112,34 @@ def sources(session_id: str | None = None, persona_name: str | None = None,
         out.append((f"persona:{name}:ephemeral", p_mod.ephemeral_dir(name, session=session_id)))
     if "shared" in scopes:
         out.append(("shared", p_mod.memory_dir(config.SHARED_PERSONA, shared=True)))
+    if "refs" in scopes:
+        # A different KIND of knowledge, not a different owner: curated documents rather
+        # than recorded facts. Its own scope so `--scope persona` can still mean only
+        # memory — the one thing someone narrowing scope usually wants (#178).
+        if name:
+            for d in _ref_dirs(p_mod.refs_dir(name)):
+                out.append((f"refs:{name}", d))
+        for d in _ref_dirs(p_mod.refs_dir(config.SHARED_PERSONA, shared=True)):
+            out.append(("refs:shared", d))
     return out
+
+
+def _ref_dirs(base: Path) -> list[Path]:
+    """*base* and every directory under it.
+
+    Refs NEST — the reporting plane's own example is `refs/release/keycloak-prerequisites.md`
+    — while `memstore.files` is a flat `*.md` glob, because memory is flat by construction.
+    Rather than teach the memory engine to recurse (and change what every other base
+    searches), each subdirectory is offered as its own source. `memstore.search` already
+    takes a list of dirs, so recursion falls out of the assembly step where the shape
+    difference actually lives.
+    """
+    if not base.exists():
+        return []
+    try:
+        return [base, *(d for d in sorted(base.rglob("*")) if d.is_dir())]
+    except OSError:
+        return [base]
 
 
 def _label_of(path: Path, srcs: list[tuple[str, Path]]) -> str:
@@ -131,7 +170,7 @@ def recall(query: str | None = None, session_id: str | None = None, limit: int =
                    workspace_name=workspace_name, scopes=scopes,
                    all_workspaces=all_workspaces)
     dirs = [d for _lbl, d in srcs]
-    undated = 0
+    undated = undated_refs = 0
 
     def _dated(p: Path) -> datetime.date | None:
         try:
@@ -143,20 +182,29 @@ def recall(query: str | None = None, session_id: str | None = None, limit: int =
         rows = []
         for p, title, score in memstore.search(dirs, query, 0 or 10_000):
             d = _dated(p)
+            lbl = _label_of(p, srcs)
             if since is not None and (d is None or d < since):
-                undated += d is None
+                if lbl.startswith("refs"):
+                    undated_refs += 1
+                else:
+                    undated += d is None
                 continue
-            rows.append(Hit(_label_of(p, srcs), p, title, score, d))
-        return Recalled(rows[:limit] if limit else rows, undated)
+            rows.append(Hit(lbl, p, title, score, d))
+        return Recalled(rows[:limit] if limit else rows, undated, undated_refs)
 
     items: list[tuple[datetime.date, Hit]] = []
     for lbl, d in srcs:
         for p, title, text in memstore.entries(d):
             dt = memstore.memory_date(text, p.name)
             if since is not None and (dt is None or dt < since):
-                undated += dt is None
+                if lbl.startswith("refs"):
+                    undated_refs += 1
+                else:
+                    undated += dt is None
                 continue
+            # `date.min` puts undated last without dropping them: "list everything" must not
+            # silently omit the larger half of the corpus.
             items.append((dt or datetime.date.min, Hit(lbl, p, title, 0, dt)))
     items.sort(key=lambda x: x[0], reverse=True)
     rows = [h for _dt, h in items]
-    return Recalled(rows[:limit] if limit else rows, undated)
+    return Recalled(rows[:limit] if limit else rows, undated, undated_refs)

--- a/tests/test_recall_refs.py
+++ b/tests/test_recall_refs.py
@@ -1,0 +1,135 @@
+"""`recall` searches `refs/` — the curated docs a persona collects (#178).
+
+`recall` calls itself the one memory gate, "search/list across ALL bases". It searched
+memory and not `refs/`, which on the reporting plane was **the larger half of the corpus**:
+46 docs and 6,153 lines of refs against 148 files and 4,792 lines of memory. An agent asking
+charter for a runbook that exists was told, with a straight face, that it does not.
+
+Two shape differences make this more than wiring, and both are covered here.
+
+**Refs nest.** The reporter's own example is `refs/release/keycloak-prerequisites.md`, while
+`memstore.files` is a flat `*.md` glob because memory is flat by construction. Rather than
+teach the memory engine to recurse — and change what every other base searches — each
+subdirectory is offered as its own source, since `memstore.search` already takes a list.
+
+**Refs carry no date.** `--since` filters on a recorded date, so it can only exclude them.
+That exclusion is reported *separately* from undated memories: an undated memory lost a stamp
+it was meant to carry, a refs document never had one, and blaming a runbook for a missing
+date would read as corruption rather than as the filter not applying.
+"""
+
+from __future__ import annotations
+
+import datetime
+import unittest
+
+from charter import config, persona, recall, workspace
+from tests._isolation import PersonaIso
+
+
+class RefsCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("w")
+        workspace.scaffold("w")
+        self.make_persona("dev", role="Dev", vault="none")
+
+    def ref(self, rel: str, body: str, name="dev", shared=False):
+        base = persona.refs_dir(config.SHARED_PERSONA if shared else name, shared=shared)
+        p = base / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+        return p
+
+    def find(self, query, **kw):
+        return recall.recall(query, persona_name="dev", workspace_name="w", **kw)
+
+
+class TestRefsAreSearched(RefsCase):
+    def test_a_ref_doc_is_found(self):
+        self.ref("keycloak.md", "# Keycloak\n\nGate 5: the realm-management roles.\n")
+        hits = self.find("keycloak")
+        self.assertTrue(any("keycloak" in h.path.name for h in hits.hits), hits.hits)
+
+    def test_a_NESTED_ref_doc_is_found(self):
+        """The reported path shape. A flat glob would miss it, and missing it is the whole
+        issue — the runbook that answers the question lives in a subdirectory."""
+        self.ref("release/keycloak-prerequisites.md",
+                 "# Prerequisites\n\nGate 5 records the realm-management roles fix.\n")
+        hits = self.find("keycloak prerequisites")
+        self.assertTrue(any("keycloak-prerequisites" in h.path.name for h in hits.hits),
+                        hits.hits)
+
+    def test_shared_refs_are_searched_too(self):
+        self.ref("conventions.md", "# Conventions\n\nthe canonical grafana dashboard.\n",
+                 shared=True)
+        self.assertTrue(any("conventions" in h.path.name for h in self.find("grafana").hits))
+
+    def test_a_refs_hit_is_labelled_as_refs(self):
+        """Long documents can outrank short memories on raw term frequency, so a reader has
+        to be able to see WHY something is at the top."""
+        self.ref("keycloak.md", "# Keycloak\n\nrealm gates.\n")
+        hits = [h for h in self.find("keycloak").hits if "keycloak" in h.path.name]
+        self.assertTrue(hits)
+        self.assertTrue(hits[0].label.startswith("refs"), hits[0].label)
+
+
+class TestItIsOnByDefault(RefsCase):
+    def test_refs_is_in_the_default_scopes(self):
+        """Opt-in would fix the letter of the issue and not its substance: an agent that has
+        to know to ask for refs first is in exactly the position the report describes."""
+        self.assertIn("refs", recall.DEFAULT_SCOPES)
+
+    def test_ephemeral_is_still_opt_in(self):
+        """The distinction is standing, not size — refs are committed and shared, scratch is
+        not."""
+        self.assertNotIn("ephemeral", recall.DEFAULT_SCOPES)
+
+    def test_narrowing_to_persona_excludes_refs(self):
+        """The reason refs got their own scope rather than folding into `persona`: someone
+        narrowing scope usually wants exactly this."""
+        self.ref("keycloak.md", "# Keycloak\n\nrealm gates.\n")
+        hits = self.find("keycloak", scopes=("persona",))
+        self.assertFalse(any(h.label.startswith("refs") for h in hits.hits))
+
+
+class TestTheSinceFilter(RefsCase):
+    def test_since_excludes_refs(self):
+        self.ref("keycloak.md", "# Keycloak\n\nrealm gates.\n")
+        hits = self.find("keycloak", since=datetime.date(2000, 1, 1))
+        self.assertFalse(any(h.label.startswith("refs") for h in hits.hits))
+
+    def test_the_exclusion_is_counted_separately_from_undated_memories(self):
+        """An undated memory lost a stamp it was meant to carry; a refs doc never had one.
+        Reporting them as one number would blame the runbook for corruption."""
+        self.ref("keycloak.md", "# Keycloak\n\nrealm gates.\n")
+        got = self.find("keycloak", since=datetime.date(2000, 1, 1))
+        self.assertEqual(got.undated_refs, 1)
+        self.assertEqual(got.undated, 0)
+
+    def test_positional_unpacking_of_the_first_two_still_works(self):
+        """`Recalled`'s own docstring records what happened the last time a field was added
+        — every positional unpack in the codebase broke at once."""
+        hits, undated = self.find("keycloak")[:2]
+        self.assertIsInstance(undated, int)
+
+
+class TestListingWithoutAQuery(RefsCase):
+    def test_refs_are_listed_too(self):
+        self.ref("keycloak.md", "# Keycloak\n\nrealm gates.\n")
+        got = recall.recall(None, persona_name="dev", workspace_name="w", limit=0)
+        self.assertTrue(any(h.label.startswith("refs") for h in got.hits))
+
+    def test_undated_refs_sort_after_dated_memories(self):
+        """"List everything" must not silently omit the larger half — but a document with no
+        date has not earned a place above a memory that has one."""
+        persona.remember("dev", "a dated memory about keycloak")
+        self.ref("keycloak.md", "# Keycloak\n\nrealm gates.\n")
+        got = recall.recall(None, persona_name="dev", workspace_name="w", limit=0)
+        labels = [h.label for h in got.hits]
+        self.assertTrue(labels)
+        self.assertTrue(labels[-1].startswith("refs"), labels)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #178.

`recall` calls itself the one memory gate — *"search/list across ALL bases"* — and searched memory but not `refs/`, which on the reporting plane was **the larger half of the corpus**: 46 docs / 6,153 lines of refs against 148 files / 4,792 lines of memory.

An agent asking charter for a runbook that exists was told, with a straight face, that it does not. And the plane had just finished *moving* procedures into refs per its own ADR — so the gap grew as the convention was followed.

## A new scope, not a fold-in

Refs are a different **kind** of knowledge, not a different owner: curated documents rather than recorded facts, where the existing scopes answer *whose*. Folding them into `persona` would also make `--scope persona` unable to exclude them — the one thing someone narrowing scope usually wants. There's a test for that.

**Default-on**, unlike `ephemeral`. The distinction is standing, not size: refs are committed, curated and shared — the same standing the other three defaults have. Opt-in would fix the letter of the issue and not its substance, since an agent that must already know to ask for refs is in exactly the position the report describes.

## Two shape differences did the real work

**Refs nest.** The reported path is `refs/release/keycloak-prerequisites.md`; `memstore.files` is a flat `*.md` glob because memory is flat by construction. Each subdirectory is offered as its own source rather than teaching the memory engine to recurse — no other base changes what it searches, and `memstore.search` already takes a list of dirs.

**Refs carry no date**, so `--since` can only exclude them. That exclusion is counted and reported **separately** from undated memories: an undated memory lost a stamp it was meant to carry, a refs document never had one, and one number for both would read as corruption rather than as the filter not applying.

`undated_refs` is defaulted so existing positional unpacking of `(hits, undated)` keeps working — that NamedTuple's docstring records what happened the last time a field was added.

## Ranking deliberately untouched

Long documents can outrank short memories on raw term frequency. Inventing a length normalisation now would silently re-rank results people already rely on, which is a bigger behavioural change than the feature. Refs hits are labelled `refs:<persona>` so a reader can see why a long doc is at the top; a per-scope cap is the small follow-up if it turns out to swamp.

## Tests

12 new in `tests/test_recall_refs.py`: a ref found, a **nested** ref found, shared refs, the `refs:` label, default-on, ephemeral still opt-in, `--scope persona` excluding refs, `--since` excluding them and counting them apart, positional unpacking still working, and refs listed but sorted after dated memories.

Full suite: 1997 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX