### PR TITLE
feat: a persona isolates itself, denies tools, and says where its servers apply

### DIFF
--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -210,7 +210,40 @@ def cmd_persona_use(args) -> int:
     persona.set_active(args.name)
     util.ok(f"Active persona set to '{args.name}'.")
     _warn_env(args.name)
+    _say_mcp_boundary(args.name)
     return 0
+
+
+def _say_mcp_boundary(name: str) -> None:
+    """Say plainly which boundary persona-scoped MCP servers apply at (#186).
+
+    Charter scopes a persona's servers at DISPATCH: `_render_agent` emits them inline, the
+    host connects them when the sub-agent starts and disconnects them when it finishes, and
+    their tool descriptions never reach the main conversation. That is a stronger guarantee
+    than an allowlist — the server does not run at all for this session.
+
+    It is also not the guarantee someone reads into `persona use`. The reporter switched to a
+    generalist, found another persona's five analytics servers still live, and reasonably
+    concluded charter had no MCP story at all — while the story existed for a boundary they
+    were not using (#186).
+
+    So charter names the boundary rather than moving it. Scoping the main session would mean
+    writing `disabledMcpServers` into a user-owned settings file and then OWNING it forever:
+    stateful, subtractive, and effective only on the next session — so `persona use` would
+    print a scoping claim that is not true of the session you are in. Naming beats resolving
+    where the tool cannot honestly deliver, which is the call #140 made for the same reason.
+    """
+    try:
+        servers = persona.mcp_servers(name)
+    except Exception:
+        return
+    if not servers:
+        return
+    util.info(f"  {len(servers)} MCP server(s) declared: {', '.join(sorted(servers))}.")
+    util.info("  These are scoped to DISPATCH — the host starts them when this persona runs "
+              "as a sub-agent and stops them after, and their tools never enter this "
+              "conversation. They are NOT started for the session you are in, and servers "
+              "already live here (from .mcp.json or an enabled plugin) stay live.")
 
 
 def cmd_persona_current(args) -> int:
@@ -398,13 +431,14 @@ def _agent_description(name: str, meta: dict) -> str:
         tail = f" Pulls credentials from the '{vault}' vault."
     else:
         tail = " Holds no credentials of its own."
-    # `isolation` is a parameter of the Agent TOOL, chosen by the caller at dispatch
-    # time — there is no agent-side way to declare it (confirmed against the shipped
-    # Claude Code schema). A persona that writes code therefore cannot isolate itself;
-    # the best charter can do is say so in the one string the router actually reads
-    # when it picks an agent. Advisory by construction, and aimed at whoever decides.
+    # `isolation` USED to be a dispatch-time parameter of the Agent tool with no agent-side
+    # way to declare it, so this string was the only place a persona could ask for it —
+    # advisory, aimed at whoever chose. The host has since gained an `isolation:` frontmatter
+    # field, and `_render_agent` now emits it, so the persona isolates ITSELF and the router
+    # has nothing to remember. The sentence stays because it still tells the router why this
+    # persona behaves differently, but it no longer asks for anything (#185).
     if (meta.get("dispatch-isolation") or "").strip() == "worktree":
-        tail += " Dispatch with isolation: worktree — it writes code, and parallel dispatches share one working tree."
+        tail += " Runs in its own git worktree — it writes code, and parallel dispatches would otherwise share one working tree."
     # The `delegate-when` triggers are what let the agent auto-route work here; a
     # persona without them falls back to a generic (weakly-triggering) description.
     if when:
@@ -456,7 +490,7 @@ _AGENT_PASSTHROUGH_KEYS = ("model", "color", "memory")
 _CHARTER_OWN_KEYS = (
     "name", "role", "vault", "extends", "uses", "delegate-when", "description",
     "agent-description", "agent-tools", "tools", "activity", "dispatch-isolation",
-    "draft", "skills",
+    "draft", "skills", "disallowed-tools",
 )
 
 
@@ -498,6 +532,20 @@ def _render_agent(name: str, meta: dict, charter: str) -> str:
     skills = persona.declared_skills(name)
     if skills:
         fm.append(f"skills: {', '.join(skills)}")
+
+    # The host's own field, emitted from the charter key that already means this. NOT a
+    # second spelling: `dispatch-isolation:` predates the host gaining `isolation:`, and
+    # renaming it would churn every persona to say the same thing. One name in a charter,
+    # one behaviour in the agent (#185).
+    if (meta.get("dispatch-isolation") or "").strip() == "worktree":
+        fm.append("isolation: worktree")
+
+    # A DENYLIST, which is often the honest shape where `agent-tools` forces an allowlist:
+    # "everything except Bash" is one line here and an enumeration of every other tool
+    # there. Passed straight through — unlike `permissionMode`/`maxTurns`, which would let
+    # a persona charter widen its own permissions and are deliberately left out.
+    if (meta.get("disallowed-tools") or "").strip():
+        fm.append(f"disallowedTools: {meta['disallowed-tools'].strip()}")
 
     if servers:
         fm.append("mcpServers:")

--- a/tests/test_persona_agent_forge_wording.py
+++ b/tests/test_persona_agent_forge_wording.py
@@ -122,11 +122,16 @@ class GeneratedAgentBody(unittest.TestCase):
 
 
 class DispatchIsolationHint(unittest.TestCase):
-    """#12: `isolation` is an Agent TOOL parameter, chosen by the caller.
+    """#12, revised by #185: `isolation` WAS only an Agent-tool parameter chosen by the
+    caller, so a persona that writes code could not isolate itself and the `description` was
+    the only lever charter had — advisory by construction.
 
-    There is no agent-side way to declare it, so a persona that writes code cannot
-    isolate itself. The only lever charter has is the `description` — the one string
-    the router reads when picking an agent. Advisory by construction.
+    The host has since gained an `isolation:` subagent frontmatter field. The persona now
+    isolates ITSELF (`_render_agent` emits it from the `dispatch-isolation:` key that already
+    meant this), so the description no longer asks the router for anything. It still says
+    WHY this persona behaves differently, because that is what the router reads when picking
+    one — but stale advice telling a caller to pass a parameter the agent now sets is worse
+    than none.
     """
 
     def _desc(self, **extra):
@@ -140,17 +145,27 @@ class DispatchIsolationHint(unittest.TestCase):
 
     def test_present_when_the_charter_asks_for_it(self):
         d = self._desc(**{"dispatch-isolation": "worktree"})
-        self.assertIn("isolation: worktree", d)
+        self.assertIn("own git worktree", d)
         self.assertIn("share one working tree", d)   # says why, not just what
+        self.assertNotIn("Dispatch with", d)         # no longer asks the caller to pass it
+
+    def test_the_agent_declares_it_rather_than_requesting_it(self):
+        """The upgrade #185 made possible: advisory prose became an enforced field."""
+        from charter.commands_persona import _render_agent
+        body = _render_agent("dev", {"role": "Dev", "vault": "v",
+                                     "dispatch-isolation": "worktree"}, "# body\n")
+        self.assertIn("isolation: worktree", body.split("---")[1])
 
     def test_only_worktree_is_recognised(self):
-        """An unknown value must not silently produce a nonsense instruction."""
-        self.assertNotIn("isolation", self._desc(**{"dispatch-isolation": "sandbox"}))
+        """An unknown value must not silently produce a nonsense instruction. Asserted on
+        `worktree` rather than the word "isolation", which the description no longer uses —
+        the old assertion would now pass for every input."""
+        self.assertNotIn("worktree", self._desc(**{"dispatch-isolation": "sandbox"}))
 
     def test_the_hint_lands_at_the_end_where_truncation_costs_least(self):
         """delegate-when triggers drive routing; the hint must not displace them."""
         d = self._desc(**{"dispatch-isolation": "worktree"})
-        self.assertLess(d.index("writing code"), d.index("isolation: worktree"))
+        self.assertLess(d.index("writing code"), d.index("own git worktree"))
 
     def test_the_key_is_in_the_lint_vocabulary(self):
         """Otherwise the whitelist added for #8 would flag charter's own key."""

--- a/tests/test_persona_capability.py
+++ b/tests/test_persona_capability.py
@@ -1,0 +1,144 @@
+"""Executable capability: where a persona's servers apply, and what it may declare.
+
+Two issues, one theme — charter says what it can actually deliver.
+
+**#186.** The reporter migrated persona knowledge into charter and concluded the executable
+half was missing: `charter persona use <a>` left another persona's five analytics servers
+live for the whole session. The MCP story existed — servers are declared per persona, emitted
+inline into the generated sub-agent, and launched through `charter secret exec` so the
+credential never reaches a context window — but it applies at **dispatch**, which is not the
+boundary they were using.
+
+Charter names that boundary rather than moving it. Moving it would mean writing
+`disabledMcpServers` into a user-owned settings file and then owning it forever: stateful,
+subtractive, and effective only on the *next* session — so `persona use` would print a
+scoping claim untrue of the session you are in. Naming beats resolving where the tool cannot
+honestly deliver (the call #140 made, for the same reason).
+
+**#185.** `isolation` used to be a dispatch-time parameter with no agent-side way to declare
+it — the code said so, "confirmed against the shipped schema". The host has since gained an
+`isolation:` frontmatter field, so a persona that writes code can now isolate *itself*
+instead of asking the router to remember. That is emitted from the `dispatch-isolation:` key
+that already meant it, not a second spelling of the same idea.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+
+from charter import persona
+from charter import commands_persona as cp
+from tests._isolation import PersonaIso
+
+
+class CapabilityCase(PersonaIso):
+    def make(self, name="dev", **front):
+        self.make_persona(name, role="Dev", vault="none")
+        if front:
+            p = persona.def_path(name)
+            block = "".join(f"{k}: {v}\n" for k, v in front.items())
+            p.write_text(p.read_text().replace("---\n", f"---\n{block}", 1))
+        return name
+
+    def agent(self, name="dev") -> str:
+        d = persona.load(name)
+        return cp._render_agent(name, d["meta"], d["charter"])
+
+    def use(self, name="dev") -> str:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            cp.cmd_persona_use(SimpleNamespace(name=name))
+        return out.getvalue() + err.getvalue()
+
+
+class TestIsolationIsDeclaredNotRequested(CapabilityCase):
+    def test_the_agent_declares_isolation(self):
+        """The host gained the field, so the persona isolates itself. Previously charter
+        could only put a sentence in the description and hope the router passed it."""
+        self.make("dev", **{"dispatch-isolation": "worktree"})
+        self.assertIn("isolation: worktree", self.agent())
+
+    def test_a_persona_that_does_not_ask_for_it_gets_nothing(self):
+        self.make("dev")
+        self.assertNotIn("isolation:", self.agent())
+
+    def test_there_is_only_one_spelling_in_a_charter(self):
+        """`dispatch-isolation:` predates the host's field. Adding `isolation:` as a second
+        charter key would churn every persona to say the same thing twice."""
+        self.assertIn("dispatch-isolation", cp._CHARTER_OWN_KEYS)
+        self.assertNotIn("isolation", cp._CHARTER_OWN_KEYS)
+
+    def test_the_description_no_longer_asks_the_router_to_pass_it(self):
+        """Stale advice is worse than none: it tells the caller to do something the agent
+        now does for itself."""
+        self.make("dev", **{"dispatch-isolation": "worktree"})
+        desc = cp._agent_description("dev", persona.load("dev")["meta"])
+        self.assertNotIn("Dispatch with isolation", desc)
+        self.assertIn("own git worktree", desc)
+
+
+class TestDisallowedTools(CapabilityCase):
+    def test_a_denylist_is_emitted(self):
+        """Often the honest shape: "everything except Bash" is one line here and an
+        enumeration of every other tool under `agent-tools`."""
+        self.make("dev", **{"disallowed-tools": "Bash, WebFetch"})
+        self.assertIn("disallowedTools: Bash, WebFetch", self.agent())
+
+    def test_nothing_is_emitted_when_not_declared(self):
+        self.make("dev")
+        self.assertNotIn("disallowedTools", self.agent())
+
+    def test_permission_widening_fields_are_deliberately_absent(self):
+        """`permissionMode` and `maxTurns` would let a persona charter widen its own
+        permissions. Charter's stance elsewhere is deliberately conservative about exactly
+        that, so they are left out rather than passed through unexamined."""
+        self.make("dev", **{"permissionMode": "bypassPermissions", "maxTurns": "99"})
+        agent = self.agent()
+        self.assertNotIn("permissionMode", agent)
+        self.assertNotIn("maxTurns", agent)
+
+
+class TestTheMcpBoundaryIsNamed(CapabilityCase):
+    def declare_server(self, name="dev"):
+        d = persona.dir_of(name)
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "mcp.json").write_text(
+            '{"mcpServers": {"analytics": '
+            '{"command": "npx", "args": ["-y", "analytics-mcp"]}}}')
+
+    def test_persona_use_says_the_servers_are_dispatch_scoped(self):
+        """The reporter's misreading, pre-empted at the moment it forms: they ran
+        `persona use` and expected the session to be scoped."""
+        self.make("dev")
+        self.declare_server()
+        out = self.use()
+        self.assertIn("analytics", out)
+        self.assertIn("DISPATCH", out)
+
+    def test_it_says_servers_already_live_stay_live(self):
+        """The exact surprise: another persona's servers remained in scope after switching."""
+        self.make("dev")
+        self.declare_server()
+        self.assertIn("stay live", self.use())
+
+    def test_a_persona_with_no_servers_says_nothing_about_mcp(self):
+        """A line that renders for every persona is a line nobody reads."""
+        self.make("dev")
+        out = self.use()
+        self.assertNotIn("DISPATCH", out)
+
+    def test_it_never_breaks_persona_use(self):
+        """`persona use` is a navigation command; a malformed mcp.json must not take it
+        down — the same rule `mcp_servers` already follows."""
+        self.make("dev")
+        d = persona.dir_of("dev")
+        (d / "mcp.json").write_text("{not json")
+        out = self.use()
+        self.assertIn("Active persona set to", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #185. Closes #186. Two issues, one theme: **charter says what it can actually deliver.**

## #186 — mostly already built, for a boundary the reporter wasn't using

Two of its three asks exist today. A persona declares MCP servers (`persona.mcp_servers`, inheritance applied), `_render_agent` emits them **inline** so the host starts them when the sub-agent starts and stops them after, and `mcp_render_entry` launches each through `charter secret exec --exec` — so the credential never reaches a context window. That last one is precisely the tempfile-and-trap dance the report asks charter to own.

What was missing: **none of it applies to the main session, and nothing said so.** The reporter migrated knowledge into charter and concluded the executable half was absent.

`persona use` now names the boundary:

```
✓ Active persona set to 'growth'.
• 5 MCP server(s) declared: analytics, ga4, ...
• These are scoped to DISPATCH — the host starts them when this persona runs as a
  sub-agent and stops them after, and their tools never enter this conversation. They
  are NOT started for the session you are in, and servers already live here stay live.
```

**Named rather than moved, deliberately.** Scoping the session *is* possible — `disabledMcpServers` is a settings-file list. It would mean writing a **subtractive** key into a user-owned file and then owning it forever, correct across every persona switch, while taking effect only on the **next** session — so `persona use` would print a scoping claim untrue of the session you are in. That is the call #140 made, for the same reason.

Not built: `personas/<name>/bin/` on `PATH`. Charter cannot change a running session's `PATH` any more than its MCP set, and a `bin/` that worked only for dispatched sub-agents would be a *fourth* place executables live — the opposite of the report's goal of one artifact.

## #185 — a comment that had gone out of date

The code said `isolation` is a dispatch-time parameter with *"no agent-side way to declare it (confirmed against the shipped Claude Code schema)"*. **The host has since gained an `isolation:` frontmatter field.**

So a persona that writes code now isolates **itself** instead of asking the router to remember — emitted from the `dispatch-isolation:` key that already meant this. Not a second spelling: renaming would churn every persona to say the same thing twice. Advisory prose became an enforced field, and the description stops asking a caller to pass what the agent now sets.

`disallowedTools` added — a denylist is often the honest shape where `agent-tools` forces an allowlist.

**Deliberately not passed through:** `permissionMode` and `maxTurns` (would let a persona charter widen its own permissions, where charter's stance elsewhere is conservative); `effort`, `background`, `initialPrompt`, `hooks` (no named failure behind them, which is this codebase's bar).

## Test changes to expect

`DispatchIsolationHint` asserted the old premise as fact. Its docstring and three assertions move to the new contract — including one that would now pass for *every* input, since the description no longer uses the word "isolation".

11 new in `tests/test_persona_capability.py`; full suite 1997 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX