### PR TITLE
feat: --stream, so an MCP server can take a FILE credential

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -583,11 +583,19 @@ def _sa_exec(p):
                         "ENVVAR to its path (repeatable — repeats sharing an "
                         "ENVVAR merge into one file). For tools that read a "
                         "dotenv secrets file, e.g. PLAYWRIGHT_MCP_SECRETS_FILE.")
+    p.add_argument("--stream", dest="stream_mode", action="store_true",
+                   help="Run the command as a CHILD with stdio inherited, wait for it, then "
+                        "shred any --file/--dotenv temp files. For a long-running child "
+                        "whose credential must be a FILE (Google ADC's "
+                        "GOOGLE_APPLICATION_CREDENTIALS takes a path, not a value) — the "
+                        "case --exec cannot serve, because exec leaves nothing alive to "
+                        "clean up. Output is NOT redacted (nothing is captured). Note: a "
+                        "SIGKILLed charter runs no cleanup and the 0600 file survives.")
     p.add_argument("--exec", dest="exec_mode", action="store_true",
                    help="Replace this process with the command (os.exec) instead of capturing "
                         "it, so stdio streams through — required for a long-running child such "
                         "as an MCP stdio server. Output is NOT redacted (nothing is captured); "
-                        "incompatible with --file and --dotenv.")
+                        "incompatible with --file and --dotenv — use --stream for those.")
     p.add_argument("command", nargs="*",
                    help="Command to run; put it after `--`, e.g. -- kubectl get pods.")
 

--- a/charter/commands_secrets.py
+++ b/charter/commands_secrets.py
@@ -510,12 +510,28 @@ def cmd_secret_exec(args) -> int:
 
     exec_mode = bool(getattr(args, "exec_mode", False))
     dotenv_specs = list(getattr(args, "dotenv", None) or [])
+    # `--exec` REPLACES this process, so nothing survives to shred a temp file. A
+    # long-running child whose credential must be a FILE — every Google-ADC server, since
+    # GOOGLE_APPLICATION_CREDENTIALS takes a path and not a value — therefore fitted neither
+    # mode: --file was the only way to materialise it and --exec the only way to run it
+    # (#190).
+    #
+    # `--stream` is the third mode: fork, inherit stdio, wait, then clean up. Streaming was
+    # never what exec bought here — a forked child inherits the parent's descriptors — so the
+    # only thing given up is replacing the process, which is exactly the thing that made
+    # cleanup impossible.
+    stream_mode = bool(getattr(args, "stream_mode", False))
+    if exec_mode and stream_mode:
+        util.err("--exec and --stream are two ways to run the same command; pick one. "
+                 "--stream is the one that can clean up a --file credential.")
+        return 2
     if exec_mode and ((args.file or []) or dotenv_specs):
         flags = " and ".join(f for f, on in (("--file", args.file or []),
                                              ("--dotenv", dotenv_specs)) if on)
         util.err(f"{flags} cannot be combined with --exec: exec replaces this "
                  "process, so the temp file would never be cleaned up. "
-                 "Use --env for an exec'd command.")
+                 "Use --stream instead — it forks, inherits stdio, and shreds the file "
+                 "when the child exits.")
         return 2
 
     env = dict(os.environ)
@@ -614,6 +630,27 @@ def cmd_secret_exec(args) -> int:
             return 0  # unreachable: execvpe replaces the process or raises.
                       # Never fall through to the capturing path below — that
                       # would run the command a second time.
+
+        if stream_mode:
+            # Fork rather than exec, and do NOT capture: the child inherits this process's
+            # stdio, so an MCP stdio server streams exactly as it does under --exec. This
+            # process stays alive for one reason — the `finally` that shreds the temp files
+            # once the child exits.
+            #
+            # The honest limit, stated here and in --help rather than implied away: a
+            # SIGKILLed parent runs no cleanup, so the 0600 file survives in the system temp
+            # directory until it is removed or the machine reboots. That is strictly better
+            # than the alternative it replaces (every persona re-implementing the same trap
+            # in shell, with the same hole) but it is not a guarantee, and describing it as
+            # one would fail silently at the moment something has already gone wrong.
+            #
+            # Output is NOT redacted, for the same reason as --exec: nothing is captured.
+            try:
+                proc = subprocess.run(command, env=env)
+            except FileNotFoundError:
+                util.err(f"command not found: {command[0]}")
+                return 127
+            return proc.returncode
 
         try:
             proc = subprocess.run(command, env=env, text=True,

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -212,14 +212,27 @@ def mcp_render_entry(name: str, vault: str | None, entry: dict) -> dict:
     A server with no ``secrets`` is passed through untouched: dragging a credential-free
     server through charter would buy nothing and add a process.
     """
-    out = {k: v for k, v in entry.items() if k != "secrets"}
+    out = {k: v for k, v in entry.items() if k not in ("secrets", "secret_files")}
     secrets = entry.get("secrets") or {}
-    if not secrets or not vault:
+    # A separate key, not a marker inside `secrets`, because these are different MECHANISMS
+    # rather than two spellings of one: `secrets` puts a VALUE in the environment,
+    # `secret_files` materialises a 0600 file and puts its PATH there. Google ADC needs the
+    # second — `GOOGLE_APPLICATION_CREDENTIALS` takes a path, not a value — and before this a
+    # persona whose servers authenticate that way could not declare them at all (#190).
+    # A reader should see which mechanism is in play without decoding a value.
+    files = entry.get("secret_files") or {}
+    if not (secrets or files) or not vault:
         return out
     args = ["secret", "exec", vault]
     for env_name, key in secrets.items():
         args += ["--env", f"{env_name}={key}"]
-    args += ["--exec", "--"]
+    for env_name, key in files.items():
+        args += ["--file", f"{env_name}={key}"]
+    # `--stream` whenever a file is involved: `--exec` replaces charter, so nothing would
+    # survive to shred the tempfile. Streaming is unaffected — a forked child inherits this
+    # process's descriptors — so the only thing given up is process replacement, which is
+    # precisely what made cleanup impossible.
+    args += ["--stream" if files else "--exec", "--"]
     if out.get("command"):
         args.append(out["command"])
     args += list(out.get("args") or [])

--- a/tests/test_secret_stream.py
+++ b/tests/test_secret_stream.py
@@ -1,0 +1,146 @@
+"""A long-running child whose credential must be a FILE (#190).
+
+`mcp_render_entry` emitted only `--env`, and `--exec` is mandatory for an MCP stdio server:
+it never returns, so the capturing form hangs holding output nobody reads. But `--exec`
+replaces charter, so nothing survives to shred a temp file — which is why it is incompatible
+with `--file`.
+
+Google Application Default Credentials require a filesystem **path**
+(`GOOGLE_APPLICATION_CREDENTIALS` takes a path, not a value). So the two ends did not meet,
+and a persona whose analytics servers authenticate that way could not declare them at all —
+it had to keep a plugin purely to carry them.
+
+`--stream` is the third mode: fork, inherit stdio, wait, clean up. **Streaming was never what
+`exec` bought here** — a forked child inherits the parent's descriptors — so the only thing
+given up is replacing the process, which is exactly the thing that made cleanup impossible.
+
+The limit is stated rather than implied away: a `SIGKILL`ed charter runs no cleanup and the
+0600 file survives until it is removed. That is strictly better than every persona
+re-implementing the same `trap` in shell with the same hole, and it is not a guarantee.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+
+from charter import persona
+from charter import commands_secrets as cs
+from charter.secrets import registry
+from tests._isolation import PersonaIso
+
+
+class StreamCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        # A real vault: `cmd_secret_exec` resolves the provider BEFORE it validates the
+        # mode flags, so without one every case here would fail as "no vault" (rc 1) and
+        # prove nothing about the modes.
+        from charter import config
+        vf = config.ROOT / ".charter" / "vaults" / "v.json"
+        vf.parent.mkdir(parents=True, exist_ok=True)
+        vf.write_text(json.dumps({"k": "s3cret", "sa-json": '{"type":"service_account"}'}))
+        registry.add_vault("v", "plain-file", {"file": str(vf)})
+
+    def run_exec(self, argv, **kw):
+        args = SimpleNamespace(vault="v", env=None, file=None, dotenv=None,
+                               exec_mode=False, stream_mode=False, command=argv)
+        for k, val in kw.items():
+            setattr(args, k, val)
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = cs.cmd_secret_exec(args)
+        return rc, out.getvalue() + err.getvalue()
+
+
+class TestTheRendererEmitsTheRightMode(PersonaIso):
+    def test_an_env_only_server_still_execs(self):
+        """Unchanged for every server that already worked — `--exec` is still right when
+        there is no file to clean up."""
+        e = {"command": "npx", "args": ["posthog-mcp"], "secrets": {"TOKEN": "k"}}
+        got = persona.mcp_render_entry("growth", "vlt", e)
+        self.assertIn("--exec", got["args"])
+        self.assertNotIn("--stream", got["args"])
+
+    def test_a_file_credential_server_streams(self):
+        e = {"command": "uvx", "args": ["ga4-mcp"],
+             "secret_files": {"GOOGLE_APPLICATION_CREDENTIALS": "sa-json"}}
+        got = persona.mcp_render_entry("growth", "vlt", e)
+        self.assertIn("--stream", got["args"])
+        self.assertNotIn("--exec", got["args"])
+        self.assertIn("--file", got["args"])
+        self.assertIn("GOOGLE_APPLICATION_CREDENTIALS=sa-json", got["args"])
+
+    def test_a_server_with_both_streams(self):
+        """One file anywhere in the entry decides the mode: exec cannot clean up, so a
+        mixed server must not exec."""
+        e = {"command": "uvx", "args": ["x"], "secrets": {"TOKEN": "k"},
+             "secret_files": {"GOOGLE_APPLICATION_CREDENTIALS": "sa"}}
+        got = persona.mcp_render_entry("growth", "vlt", e)
+        self.assertIn("--stream", got["args"])
+        self.assertIn("--env", got["args"])
+        self.assertIn("--file", got["args"])
+
+    def test_the_declaration_keys_do_not_leak_into_the_agent(self):
+        e = {"command": "uvx", "secret_files": {"G": "sa"}}
+        got = persona.mcp_render_entry("growth", "vlt", e)
+        self.assertNotIn("secret_files", got)
+        self.assertNotIn("secrets", got)
+
+    def test_no_vault_means_no_rewrite(self):
+        """A persona holding no credentials has nothing to inject, and wrapping the server
+        through charter would buy nothing and add a process."""
+        e = {"command": "uvx", "secret_files": {"G": "sa"}}
+        self.assertEqual(persona.mcp_render_entry("growth", None, e), {"command": "uvx"})
+
+
+class TestTheModesAreExclusive(StreamCase):
+    def test_exec_and_stream_together_is_refused(self):
+        rc, out = self.run_exec(["true"], exec_mode=True, stream_mode=True)
+        self.assertEqual(rc, 2)
+        self.assertIn("pick one", out)
+
+    def test_exec_with_a_file_now_points_at_stream(self):
+        """The old message said "use --env for an exec'd command", which was the only advice
+        available. There is now a mode that does what the caller asked."""
+        rc, out = self.run_exec(["true"], exec_mode=True, file=["G=k"])
+        self.assertEqual(rc, 2)
+        self.assertIn("--stream", out)
+
+
+class TestStreamRunsAndCleansUp(StreamCase):
+    def test_the_child_runs_and_its_exit_code_is_returned(self):
+        rc, _ = self.run_exec(["sh", "-c", "exit 7"], stream_mode=True)
+        self.assertEqual(rc, 7)
+
+    def test_the_child_inherits_stdio_rather_than_being_captured(self):
+        """The property that makes this usable for an MCP stdio server: streaming was never
+        what exec bought, so forking loses nothing."""
+        rc, _ = self.run_exec(["sh", "-c", "exit 0"], stream_mode=True)
+        self.assertEqual(rc, 0)
+
+    def test_a_missing_command_is_127_not_a_traceback(self):
+        rc, out = self.run_exec(["definitely-not-a-real-binary-xyz"], stream_mode=True)
+        self.assertEqual(rc, 127)
+        self.assertIn("command not found", out)
+
+
+class TestTheLimitIsStated(unittest.TestCase):
+    def test_help_says_a_sigkill_leaves_the_file(self):
+        """Charter must not describe this as guaranteed cleanup. A promise that fails
+        silently exactly when something has already gone wrong is worse than none."""
+        from charter import cli
+        text = cli.build_parser().format_help()
+        # The flag's own help is on the subparser; assert the source carries the caveat.
+        import inspect
+        src = inspect.getsource(cli)
+        self.assertIn("SIGKILL", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #190.

`mcp_render_entry` emitted only `--env`, and `--exec` is **mandatory** for an MCP stdio server: it never returns, so the capturing form hangs holding output nobody reads. But `--exec` replaces charter, so nothing survives to shred a temp file — which is exactly why it is incompatible with `--file`.

Google ADC requires a filesystem **path** (`GOOGLE_APPLICATION_CREDENTIALS` takes a path, not a value). The two ends did not meet, so a persona whose analytics servers authenticate that way could not declare them in `mcp.json` at all — it had to keep a plugin purely to carry them, which is the thing the sidecar exists to end.

## `--stream`: fork, inherit stdio, wait, clean up

The load-bearing insight is the reporter's: **streaming was never what `exec` bought here**, because a forked child inherits the parent's descriptors. The only thing given up is *replacing the process* — precisely the thing that made cleanup impossible.

```
"secrets":      { "POSTHOG_TOKEN": "posthog-key" },
"secret_files": { "GOOGLE_APPLICATION_CREDENTIALS": "google-sa-json" }
```

renders as

```
charter secret exec <vault> --file GOOGLE_APPLICATION_CREDENTIALS=google-sa-json --stream -- uvx ga4-mcp
```

## Two keys, not a marker

`secrets` puts a **value** in the environment; `secret_files` materialises a 0600 file and puts its **path** there. Different mechanisms, not two spellings of one — a reader should see which is in play without decoding a value, and the renderer emits a different flag for each. One file anywhere in an entry selects `--stream` for the whole server, since exec cannot clean up.

## The limit, stated rather than implied away

A `SIGKILL`ed charter runs no cleanup and the 0600 file survives until it is removed. That is in the docstring and in `--help`.

It is strictly better than the status quo — every persona re-implementing the same `trap … EXIT INT TERM` in shell, with the same hole, which is the argument the secrets guidance already makes for centralising it. It is **not** a guarantee, and describing it as one would fail silently exactly when something has already gone wrong.

The old refusal advised *"use `--env` for an exec'd command"*, which was the only advice available. It now names the mode that does what the caller actually asked for.

## Tests

11 new in `tests/test_secret_stream.py`: env-only servers still exec, a file-credential server streams, a mixed server streams, declaration keys not leaking into the agent, no-vault meaning no rewrite, the two modes being mutually exclusive, the improved refusal, exit-code passthrough, `127` on a missing binary, and the `SIGKILL` caveat being present rather than assumed.

Full suite: 2020 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX