### PR TITLE
feat: a workspace choice that survives a session boundary

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -342,6 +342,13 @@ def _add_workspace_parser(sub) -> None:
     ri.add_argument("--all", action="store_true", help="Reinit every workspace (after a charter upgrade).")
     ri.set_defaults(func=commands_workspace.cmd_workspace_reinit)
 
+    dflt = wsub.add_parser("default",
+                           help="Nominate the workspace a session lands on when nothing "
+                                "else decided (committed; mirrors `persona default`).")
+    dflt.add_argument("name", nargs="?", help="Workspace to nominate; omit to show it.")
+    dflt.add_argument("--clear", action="store_true", help="Remove the declared default.")
+    dflt.set_defaults(func=commands_workspace.cmd_workspace_default)
+
     opt = wsub.add_parser("optimize",
                           help="Curate a workspace's memory: collapse exact duplicates and "
                                "repair the index with --apply; propose the rest.")

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -244,6 +244,40 @@ def cmd_workspace_rename(args) -> int:
     return commit_push(config.ROOT, ["add", "-A", "--", *tracked_old, *new_rel, ".gitignore"], msg)
 
 
+def cmd_workspace_default(args) -> int:
+    """Nominate the workspace a session lands on when nothing else has decided (#193).
+
+    Mirrors `charter persona default`. The rung sits below the per-session and per-terminal
+    pointers and above the built-in `default`, so an explicit choice survives a session
+    boundary the way an explicit persona choice does — which matters most on a terminal that
+    reports no pane id, where the pointer meant to cover "new session, same terminal" can
+    never fire.
+    """
+    name = getattr(args, "name", None)
+    if not name:
+        cur = workspace.declared_default()
+        if cur:
+            util.info(f"Declared default workspace: {cur}")
+        else:
+            util.info("No declared default — a session with nothing else selected lands on "
+                      f"'{config.DEFAULT_WORKSPACE}'. Set one: charter workspace default <ws>")
+        return 0
+    if getattr(args, "clear", False):
+        workspace.clear_declared_default()
+        util.ok("Cleared the declared default workspace.")
+        return 0
+    if not workspace.workspace_dir(name).exists():
+        util.err(f"no workspace '{name}' (create it: charter workspace create {name})")
+        return 1
+    workspace.set_declared_default(name)
+    util.ok(f"Default workspace set to '{name}' — sessions land here when nothing else "
+            f"has decided.")
+    util.info("  Committed, so it travels with the plane. It is read LAST, so an explicit "
+              "`--workspace`, $CHARTER_WORKSPACE, the tree you are standing in, or a "
+              "session/terminal selection all still win.")
+    return 0
+
+
 def cmd_workspace_optimize(args) -> int:
     """Optimize a workspace's memory (one, or ``--all``) — the workspace half of what
     ``charter persona optimize`` has always done for personas.

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -190,6 +190,43 @@ def from_path(path=None) -> str | None:
     return parts[0] if len(parts) >= 2 else None
 
 
+#: A committed, deliberately-chosen fallback workspace — `workspaces/.default`.
+#:
+#: NOT the "last active workspace" pointer #124 rejected, and the distinction is the whole
+#: argument. That one is IMPLICIT: written by every `workspace use`, changing under sessions
+#: that never asked, which is the failure `_terminal_id` was hardened against ("an id that is
+#: wrong in the sharing direction is worse than no id"). This is EXPLICIT: set once by a
+#: human, stable, and read only when every other rung has missed. `charter persona default`
+#: is exactly this shape and already ships.
+DEFAULT_FILE = ".default"
+
+
+def default_file() -> Path:
+    return config.WORKSPACES_DIR / DEFAULT_FILE
+
+
+def declared_default() -> str | None:
+    """The workspace nominated by `charter workspace default`, or ``None``."""
+    try:
+        val = default_file().read_text().strip()
+    except OSError:
+        return None
+    return val or None
+
+
+def set_declared_default(name: str) -> None:
+    d = default_file()
+    d.parent.mkdir(parents=True, exist_ok=True)
+    d.write_text(name.strip() + "\n")
+
+
+def clear_declared_default() -> None:
+    try:
+        default_file().unlink()
+    except OSError:
+        pass
+
+
 def resolve(explicit: str | None = None, session_id: str | None = None,
             cwd=None) -> str:
     """Active workspace by precedence: ``--workspace`` → ``$CHARTER_WORKSPACE`` → **the
@@ -224,6 +261,15 @@ def resolve(explicit: str | None = None, session_id: str | None = None,
         val = _read(_terminal_file(tid))
         if val:
             return val
+    # Below both pointers, above the built-in. What this replaces is not a considered
+    # answer — it is a literal `default` workspace nobody chose either — so slotting a
+    # nominated one here does not make workspaces less per-task; it makes the FALLBACK
+    # something a human picked, and lets `default` go back to meaning "nobody ever chose"
+    # (#193, unparking #124 on its own stated trigger: a terminal in common use that
+    # supplies no pane id).
+    declared = declared_default()
+    if declared:
+        return declared
     return config.DEFAULT_WORKSPACE
 
 
@@ -249,7 +295,15 @@ def source(explicit: str | None = None, session_id: str | None = None,
     tid = _terminal_id()
     if tid and _read(_terminal_file(tid)):
         return "terminal"
-    return "default"
+    if declared_default():
+        return "declared default"
+    # Say WHY nothing answered, not just that nothing did. The operator's complaint was
+    # "why are you in default workspace again?" — a surface asserting an answer with no
+    # reason, twice, where reconstructing it meant reading `resolve`. ADR 0013's second
+    # rule, aimed at the line people read every turn.
+    if not _terminal_id():
+        return "default (no pane id — nothing persists between sessions)"
+    return "default (nothing selected)"
 
 
 def _lock_file(sid: str) -> Path:

--- a/tests/test_statusline_session_cwd.py
+++ b/tests/test_statusline_session_cwd.py
@@ -67,7 +67,10 @@ class TestResolveTakesACwd(SessionCwdBase):
 
     def test_a_cwd_outside_any_workspace_falls_through(self):
         """Standing in the plane root is not a claim about which workspace is active."""
-        self.assertEqual(workspace.source(cwd=str(self.tmp)), "default")
+        # `startswith`, not equality: since #193 the fall-through label also says WHY
+        # nothing answered ("no pane id — nothing persists between sessions"). What this
+        # test is about — the cwd rung not firing — is unchanged.
+        self.assertTrue(workspace.source(cwd=str(self.tmp)).startswith("default"))
 
     def test_an_explicit_workspace_still_outranks_the_cwd(self):
         self.assertEqual(workspace.resolve("beta", cwd=str(self.alpha)), "beta")
@@ -107,7 +110,7 @@ class TestStatusLineUsesTheSessionCwd(SessionCwdBase):
         outside = Path(self.tmp).parent / "somewhere-else" / "workspaces" / "ghost" / "r"
         ws, src = statusline._active(session_id="no-such-session", cwd=str(outside))
         self.assertEqual(ws, config.DEFAULT_WORKSPACE)
-        self.assertEqual(src, "default")
+        self.assertTrue(src.startswith("default"))   # see the note above on #193
 
 
 if __name__ == "__main__":

--- a/tests/test_workspace_default.py
+++ b/tests/test_workspace_default.py
@@ -1,0 +1,147 @@
+"""A workspace choice that survives a session boundary (#193, unparking #124).
+
+`workspace.resolve()` runs `--workspace` → `$CHARTER_WORKSPACE` → the tree you are standing
+in → per-session pointer → per-terminal pointer → `default`. On a terminal that reports no
+pane id, the per-terminal rung — the one that exists precisely to cover "new session, same
+terminal" — can never fire. So a shell at the plane root lands on `default` every time, and
+the operator asks "why are you in default workspace again?"
+
+That is #124's own unpark trigger: *"a terminal in common use turns out to supply no pane
+id"*. It fired.
+
+**This is not the fix #124 rejected.** That was an IMPLICIT last-active pointer — written by
+every `workspace use`, changing under sessions that never asked, which is the failure
+`_terminal_id` was hardened against ("an id that is wrong in the sharing direction is worse
+than no id"). This is EXPLICIT: set once by a human, stable, read only when every other rung
+has missed. `charter persona default` is exactly this shape and already ships.
+
+And what it replaces was never a considered answer either — it was a literal `default`
+workspace nobody chose. Slotting a nominated one there does not make workspaces less
+per-task; it makes the fallback something a human picked, and lets `default` mean "nobody
+ever chose" again.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+
+from charter import config, workspace
+from charter import commands_workspace as cw
+from tests._isolation import PersonaIso
+
+
+class DefaultCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        os.environ.pop("CHARTER_WORKSPACE", None)
+        for n in ("alpha", "beta"):
+            workspace.ensure(n)
+            workspace.scaffold(n)
+
+    def run_default(self, name=None, clear=False):
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = cw.cmd_workspace_default(SimpleNamespace(name=name, clear=clear))
+        return rc, out.getvalue() + err.getvalue()
+
+    def resolve(self, **kw):
+        # A cwd outside any workspace tree: the plane root, which is the normal place to
+        # stand and the case the report is about.
+        return workspace.resolve(cwd=str(config.ROOT), **kw)
+
+
+class TestTheDeclaredDefaultAnswers(DefaultCase):
+    def test_without_one_a_rootless_session_lands_on_the_builtin(self):
+        self.assertEqual(self.resolve(), config.DEFAULT_WORKSPACE)
+
+    def test_with_one_it_lands_there_instead(self):
+        self.run_default("alpha")
+        self.assertEqual(self.resolve(), "alpha")
+
+    def test_it_survives_a_session_boundary(self):
+        """The whole point: a new session has a new id and no pointer, and on this terminal
+        no pane id either."""
+        self.run_default("alpha")
+        self.assertEqual(self.resolve(session_id="a-fresh-session-id"), "alpha")
+
+    def test_it_is_committed_under_workspaces(self):
+        """Committed, so it travels with the plane — the same standing `personas/.default`
+        has."""
+        self.run_default("alpha")
+        self.assertTrue((config.WORKSPACES_DIR / ".default").exists())
+
+
+class TestItIsReadLast(DefaultCase):
+    def test_an_explicit_flag_still_wins(self):
+        self.run_default("alpha")
+        self.assertEqual(self.resolve(explicit="beta"), "beta")
+
+    def test_the_env_var_still_wins(self):
+        self.run_default("alpha")
+        os.environ["CHARTER_WORKSPACE"] = "beta"
+        self.addCleanup(os.environ.pop, "CHARTER_WORKSPACE", None)
+        self.assertEqual(self.resolve(), "beta")
+
+    def test_the_tree_you_stand_in_still_wins(self):
+        """The cwd rung cannot be wrong — being inside a workspace's tree IS the fact, not a
+        hint — so a nominated default must never override it."""
+        self.run_default("alpha")
+        inside = workspace.workspace_dir("beta") / "repo"
+        inside.mkdir(parents=True, exist_ok=True)
+        self.assertEqual(workspace.resolve(cwd=str(inside)), "beta")
+
+    def test_a_session_pointer_still_wins(self):
+        self.run_default("alpha")
+        workspace.set_active("beta", session_id="s1")
+        self.assertEqual(self.resolve(session_id="s1"), "beta")
+
+
+class TestTheCommand(DefaultCase):
+    def test_it_shows_the_current_one(self):
+        self.run_default("alpha")
+        _, out = self.run_default()
+        self.assertIn("alpha", out)
+
+    def test_it_says_there_is_none_and_how_to_set_one(self):
+        _, out = self.run_default()
+        self.assertIn("charter workspace default", out)
+
+    def test_an_unknown_workspace_is_refused(self):
+        rc, _ = self.run_default("ghost")
+        self.assertEqual(rc, 1)
+        self.assertIsNone(workspace.declared_default())
+
+    def test_clear_removes_it(self):
+        self.run_default("alpha")
+        self.run_default("alpha", clear=True)
+        self.assertIsNone(workspace.declared_default())
+        self.assertEqual(self.resolve(), config.DEFAULT_WORKSPACE)
+
+
+class TestTheSurfaceSaysWhichRungAnswered(DefaultCase):
+    def test_the_declared_default_is_named_as_the_source(self):
+        self.run_default("alpha")
+        self.assertIn("declared default", workspace.source(cwd=str(config.ROOT)))
+
+    def test_falling_through_says_WHY_not_just_that_it_did(self):
+        """The operator's actual complaint: a surface asserting `default` with no reason,
+        twice, where reconstructing it meant reading `resolve`. ADR 0013's second rule aimed
+        at the line people read every turn."""
+        src = workspace.source(cwd=str(config.ROOT))
+        self.assertIn("default", src)
+        self.assertNotEqual(src, "default")
+
+    def test_it_names_the_missing_pane_id_when_that_is_the_cause(self):
+        """`workspace use` already admits this; the surface that shows the RESULT did not."""
+        real = workspace._terminal_id
+        workspace._terminal_id = lambda: None
+        self.addCleanup(setattr, workspace, "_terminal_id", real)
+        self.assertIn("pane id", workspace.source(cwd=str(config.ROOT)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #193. **Unparks #124** on its own stated trigger.

`resolve()` runs `--workspace` → `$CHARTER_WORKSPACE` → the tree you are standing in → per-session pointer → per-terminal pointer → `default`. On a terminal that reports no pane id, the per-terminal rung — the one that exists *precisely* to cover "new session, same terminal" — can never fire. A shell at the plane root lands on `default` every time.

The operator asked *"why are you in default workspace again?"* twice, and both times the answer required reading `resolve()`.

#124 was parked with the trigger: *"a terminal in common use turns out to supply no pane id."* It fired.

## This is not the fix #124 rejected

The parking conflated two different things:

| | |
|---|---|
| **Rejected** — implicit last-active pointer | written by every `workspace use`, changing under sessions that never asked. The failure `_terminal_id` was hardened against: *"an id that is wrong in the sharing direction is worse than no id."* |
| **This** — explicit declared default | set once by a human, stable, read only when every other rung missed. The shape `charter persona default` already ships. |

## The conceptual objection, answered by what it replaces

*"A persona is a durable role, a workspace is a task, so tasks shouldn't be sticky."* But the last rung today is a literal `default` workspace **nobody chose either**. A nominated one doesn't make workspaces less per-task — it makes the fallback something a human picked, and lets `default` mean *"nobody ever chose"* again.

Read **last**: `--workspace`, `$CHARTER_WORKSPACE`, the tree you stand in, and both pointers all still win. The cwd rung especially — being inside a workspace's tree *is* the fact, not a hint.

## The half that matters even with a default set

The fall-through now says **why** nothing answered, not just that nothing did:

```
default (no pane id — nothing persists between sessions)
```

`workspace use` already admitted this; the surface showing the *result* did not. ADR 0013's second rule, aimed at the line people read every turn. This was the reporter's own narrower fix, and it stays true whatever the resolution does.

## Test changes to expect

Two existing tests move from an exact `"default"` to a prefix match. What they assert — the cwd rung not firing — is unchanged; the label just got more informative.

15 new in `tests/test_workspace_default.py`. Full suite: 2000 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX