### PR TITLE
0.34.0 — a persona carries its capability, and a workspace choice survives the session

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.33.0"
+__version__ = "0.34.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.33.0",
+            "command": "charter hook sessionstart --plugin-version 0.34.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.33.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.34.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.33.0",
+            "command": "charter hook pretooluse --plugin-version 0.34.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.33.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.34.0",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.33.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.34.0"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.33.0",
+            "command": "charter hook posttooluse --plugin-version 0.34.0",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.33.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.34.0",
             "timeout": 5
           }
         ]
@@ -100,7 +100,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.33.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.34.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.33.0"
+version = "0.34.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only; the code is on `main`. Four issues, one theme: **charter says what it can actually deliver, and where.**

| | |
|---|---|
| **#186** | `persona use` names the boundary — declared MCP servers are scoped to **dispatch**, and servers already live stay live. Two of its three asks were already built; what was missing is that nothing said where they applied. Named rather than moved: scoping the session means owning a subtractive key in a user-owned file forever, effective only next session. |
| **#190** | `--stream` — fork, inherit stdio, wait, clean up. `--exec` is mandatory for an MCP stdio server and incompatible with `--file`, which excluded every Google-ADC server. Streaming was never what exec bought. `secret_files:` renders it; the SIGKILL limit is stated, not implied away. |
| **#185** | The host gained an `isolation:` field the code said did not exist, so a persona that writes code now isolates **itself**. `disallowedTools` added; `permissionMode`/`maxTurns` deliberately not. |
| **#193** | `charter workspace default` — a committed, explicitly chosen fallback, read last. **Unparks #124** on its own stated trigger. The fall-through now says *why* nothing answered. |

**#192** was closed as a decision rather than a defect: its symptom (fork inheriting 0 repos) is fixed — verified by reproduction — and the self-heal it asks for is what ADR 0010 rejected in writing, including the `doctor` check it suggests.

Tracker is now empty but for #127, which stays parked with its trigger unfired.

Suite: 2035 passing, up from 1985.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX