### PR TITLE
feat: the status line refreshes on a timer, not only on events

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -569,7 +569,20 @@ def _ensure_gitignore(root: Path) -> bool:
 
 
 #: What `init` writes into `.claude/settings.json`'s `statusLine` key.
-_STATUSLINE = {"type": "command", "command": "charter statusline", "padding": 0}
+#: `refreshInterval` re-runs the status line every N seconds IN ADDITION to the event-driven
+#: updates. Set because charter's status line is mostly things that change without a session
+#: event: `silent 12m` ages with wall-clock, piece counts move as background workers claim
+#: and declare, and the plane-root warning fires on state another agent created. The docs
+#: name this case exactly — "the event-driven triggers can go quiet when the main session is
+#: idle, for example while a coordinator waits on background subagents".
+#:
+#: TEN, not the permitted minimum of one. Charter renders silence in MINUTES, so a
+#: one-second timer is ~60x finer than the coarsest thing displayed — and a render is ~80ms
+#: on a two-clone plane (a `git status` per tree), so it would burn ~8% of a core
+#: continuously to refresh a number that changes once a minute. Ten is still six times finer
+#: than the granularity, at a tenth of the cost.
+_STATUSLINE = {"type": "command", "command": "charter statusline", "padding": 0,
+               "refreshInterval": 10}
 
 
 def _statusline_snippet() -> str:
@@ -676,6 +689,9 @@ def _ensure_statusline(root: Path) -> tuple[str, Path | None]:
     Returns ``(status, detail)``:
     - ``"created"``, ``None`` — file (or just the key) was written.
     - ``"present"``, ``None`` — a ``statusLine`` already exists; untouched.
+    - ``"updated"``, ``None`` — charter's OWN status line gained a field it now writes
+      (currently ``refreshInterval``). Only ever charter's own, only ever a field that was
+      absent — a hand-set value is never reverted.
     - ``"malformed"``, the settings path — exists but isn't valid JSON; untouched.
     - ``"blocked"``, the ``.claude`` path — that path exists and isn't a directory.
     """
@@ -695,6 +711,23 @@ def _ensure_statusline(root: Path) -> tuple[str, Path | None]:
         return "malformed", p
     if not isinstance(settings, dict):
         return "malformed", p
+    existing = settings.get("statusLine")
+    if isinstance(existing, dict):
+        # Charter's OWN status line, missing a field charter has since started writing.
+        # Adding it is updating a key charter wrote, which is a different act from touching
+        # a user's — and without it the field would reach only brand-new planes. A status
+        # line running someone else's script is left alone, and so is a value someone set by
+        # hand: silently reverting a deliberate choice is what this function exists not to do.
+        if (existing.get("command") == _STATUSLINE["command"]
+                and "refreshInterval" not in existing):
+            existing["refreshInterval"] = _STATUSLINE["refreshInterval"]
+            indent, separators = _json_style(raw)
+            rewritten = json.dumps(settings, indent=indent, separators=separators)
+            if raw.endswith("\n"):
+                rewritten += "\n"
+            p.write_text(rewritten)
+            return "updated", None
+        return "present", None
     if "statusLine" in settings:
         return "present", None
     settings["statusLine"] = dict(_STATUSLINE)
@@ -935,6 +968,8 @@ def cmd_init(args) -> int:
     sl_status, sl_detail = _ensure_statusline(root)
     if sl_status == "created":
         created.append(".claude/settings.json (statusLine)")
+    elif sl_status == "updated":
+        created.append(".claude/settings.json (statusLine refreshInterval)")
     elif sl_status == "present":
         present.append(".claude/settings.json (statusLine already set)")
     elif sl_status == "malformed":
@@ -1044,6 +1079,18 @@ def cmd_reinit(args) -> int:
 
     # The plane-root guard, on the SAME terms as init. `doctor`'s hint for an unwired plane
     # names `charter reinit`, so reinit has to be the command that actually wires it (#168).
+    # The status line, on the same terms as the guard hook below: charter's own key gains a
+    # field charter has since started writing (`refreshInterval`), and nothing else is
+    # touched. Without this the field would reach only brand-new planes.
+    sl_status, sl_detail = _ensure_statusline(config.ROOT)
+    if sl_status == "created":
+        created.append(".claude/settings.json (statusLine)")
+    elif sl_status == "updated":
+        created.append(".claude/settings.json (statusLine refreshInterval)")
+    elif sl_status == "malformed":
+        util.warn(f"{sl_detail} is not valid JSON — left it completely untouched. Add the "
+                  f"status line yourself:\n{_statusline_snippet()}")
+
     gh_status, gh_detail = _ensure_guard_hook(config.ROOT)
     if gh_status == "created":
         created.append(".claude/settings.json (plane-root guard)")

--- a/tests/test_statusline_refresh.py
+++ b/tests/test_statusline_refresh.py
@@ -1,0 +1,114 @@
+"""The status line refreshes on a timer, not only on events.
+
+Claude Code re-runs the status line on session events — a prompt, a tool call, a directory
+change. Those triggers go quiet in exactly the situation charter built the fleet spine for:
+a coordinator waiting on background workers, where nothing in the main session happens for
+minutes at a time. The docs name that case directly:
+
+    The event-driven triggers can go quiet when the main session is idle, for example while
+    a coordinator waits on background subagents. To keep time-based or externally-sourced
+    segments current during idle periods, set `refreshInterval`.
+
+Charter's status line is full of exactly that: `silent 12m` ages with wall-clock, piece
+counts change as background workers claim and declare, and the plane-root warning fires on
+state another agent creates. All of it froze while the session idled.
+
+**Ten seconds, not the one-second minimum.** Charter renders silence in MINUTES, so a
+one-second timer is ~60× finer than the coarsest thing it displays, at ~8% of a core
+continuously (a render is ~80ms on a two-clone plane, and it runs a `git status` per tree).
+Ten is still six times finer than the granularity and costs about a tenth of that.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from charter import commands
+from tests._isolation import PersonaIso
+
+
+class RefreshCase(PersonaIso):
+    def settings_path(self) -> Path:
+        return Path(self.tmp) / ".claude" / "settings.json"
+
+    def write(self, body: dict) -> None:
+        p = self.settings_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(body, indent=2))
+
+    def read(self) -> dict:
+        return json.loads(self.settings_path().read_text())
+
+
+class TestAFreshPlaneGetsIt(RefreshCase):
+    def test_the_written_statusline_carries_a_refresh_interval(self):
+        commands._ensure_statusline(Path(self.tmp))
+        self.assertEqual(self.read()["statusLine"]["refreshInterval"], 10)
+
+    def test_the_command_and_padding_are_unchanged(self):
+        commands._ensure_statusline(Path(self.tmp))
+        sl = self.read()["statusLine"]
+        self.assertEqual(sl["command"], "charter statusline")
+        self.assertEqual(sl["type"], "command")
+
+
+class TestAnExistingPlaneIsUpgraded(RefreshCase):
+    def test_charters_own_statusline_gains_the_field(self):
+        """Without this the feature reaches only brand-new planes — including not this one.
+        Updating a key charter itself wrote is a different act from touching a user's."""
+        self.write({"statusLine": {"type": "command", "command": "charter statusline",
+                                   "padding": 0}})
+        status, _ = commands._ensure_statusline(Path(self.tmp))
+        self.assertEqual(status, "updated")
+        self.assertEqual(self.read()["statusLine"]["refreshInterval"], 10)
+
+    def test_a_deliberate_value_is_never_overwritten(self):
+        """Someone who set 3 meant 3. Silently reverting a hand-made choice is the exact
+        behaviour `_ensure_statusline` was written to avoid."""
+        self.write({"statusLine": {"type": "command", "command": "charter statusline",
+                                   "refreshInterval": 3}})
+        status, _ = commands._ensure_statusline(Path(self.tmp))
+        self.assertEqual(status, "present")
+        self.assertEqual(self.read()["statusLine"]["refreshInterval"], 3)
+
+    def test_someone_elses_statusline_is_left_alone(self):
+        """The whole justification is that charter is updating ITS OWN key. A status line
+        running someone else's script is not charter's to change."""
+        self.write({"statusLine": {"type": "command", "command": "~/bin/my-statusline.sh"}})
+        status, _ = commands._ensure_statusline(Path(self.tmp))
+        self.assertEqual(status, "present")
+        self.assertNotIn("refreshInterval", self.read()["statusLine"])
+
+    def test_other_keys_survive_the_upgrade(self):
+        self.write({"permissions": {"allow": ["Bash(ls:*)"]},
+                    "statusLine": {"type": "command", "command": "charter statusline"}})
+        commands._ensure_statusline(Path(self.tmp))
+        body = self.read()
+        self.assertEqual(body["permissions"], {"allow": ["Bash(ls:*)"]})
+
+    def test_a_malformed_file_is_still_left_completely_alone(self):
+        p = self.settings_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{ not json")
+        status, _ = commands._ensure_statusline(Path(self.tmp))
+        self.assertEqual(status, "malformed")
+        self.assertEqual(p.read_text(), "{ not json")
+
+
+class TestTheIntervalIsJustified(unittest.TestCase):
+    def test_it_is_not_the_aggressive_minimum(self):
+        """A one-second timer is ~60× finer than the minute granularity charter displays,
+        for ~8% of a core continuously. The number should track what is shown, not what is
+        allowed."""
+        self.assertGreaterEqual(commands._STATUSLINE["refreshInterval"], 5)
+
+    def test_it_is_fine_enough_to_beat_the_display_granularity(self):
+        """Silence renders in minutes; a timer coarser than that would notice a stalled
+        worker late, which is the case this exists for."""
+        self.assertLessEqual(commands._STATUSLINE["refreshInterval"], 30)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Claude Code re-runs the status line on session events. Those triggers go quiet in exactly the situation charter built the fleet spine for, and the docs name it:

> The event-driven triggers can go quiet when the main session is idle, for example **while a coordinator waits on background subagents**.

Charter's status line is mostly things that change *without* a session event: `silent 12m` ages with wall-clock, piece counts move as background workers claim and declare, and the plane-root warning fires on state another agent created. All of it froze while the session idled — the moment it is most worth reading.

## Ten seconds, not the permitted minimum of one

Charter renders silence in **minutes**, so a one-second timer is ~60× finer than the coarsest thing it displays. Measured: a render is ~80ms on a two-clone plane (a `git status` per tree), so `refreshInterval: 1` would burn ~8% of a core continuously to refresh a number that changes once a minute — more on a bigger plane, where Claude Code would start cancelling in-flight renders.

Ten is still six times finer than the display granularity, at a tenth of the cost, and well clear of the 300ms debounce.

## `reinit` upgrades existing planes

Without it the field reaches only brand-new planes — including not this one, since `_ensure_statusline` is additive-if-absent.

The justification is narrow and the code holds to it:

- only charter's **own** status line (its `command` is `charter statusline`)
- only a field that is **absent**
- **never** a value someone set by hand
- someone else's status line script is left alone entirely

Updating a key charter itself wrote is a different act from touching a user's — the line `_ensure_statusline` has always drawn.

## Verified end to end

On a plane with an existing charter status line plus an unrelated `permissions` key:

```
before: {'type': 'command', 'command': 'charter statusline', 'padding': 0}
✓ Reinitialized control plane → … .claude/settings.json (statusLine refreshInterval) …
after : {'type': 'command', 'command': 'charter statusline', 'padding': 0, 'refreshInterval': 10}
user key survived: {'allow': ['Bash(ls:*)']}
```

## Tests

9 new in `tests/test_statusline_refresh.py`: fresh planes get it, charter's own statusline is upgraded, a hand-set value is preserved, someone else's script is untouched, other keys survive, a malformed file is still left byte-for-byte alone, and two that pin the interval against both the aggressive minimum and a value coarser than the display.

Full suite: 2044 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX