### PR TITLE
fix: bound the persona column, which was driving the status line's height

### DIFF
--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -68,6 +68,12 @@ _TREE_MID, _TREE_END, _TREE_PIPE, _TREE_WT = "├─ ", "└─ ", "│  ", "╰
 # emits 2 lines, so counting repos alone let the footer grow past its budget.
 _MAX_REPO_LINES = 14  # keep the footer from growing unbounded
 
+# The SAME budget for the persona column, and for the same reason. The repo side was capped
+# and the persona side was not — and because the layout pads the shorter column to match the
+# longer, personas alone drove total height: measured at 35 lines for 30 personas, whatever
+# the repo count. A status line taller than the conversation is not a status line.
+_MAX_PERSONA_LINES = 14
+
 # Fixed column widths for the strict-table repo view (visible chars).
 _NAME_W, _BRANCH_W, _CI_W = 32, 34, 12
 _MR_W = 6  # fixed MR cell, so a right-hand persona column stays aligned
@@ -1042,10 +1048,16 @@ def _persona_chips(session: str | None = None) -> list[str]:
         order = ([active] if active in names else []) + [n for n in names if n != active]
         known = set(names)   # computed once for the whole column, not once per persona
         chips = []
+        flagged_names: set[str] = set()
         for n in order:
             dot = _vault_dot(persona.vault_of(n))
             badge = _mem_badge(_mem_count(n), _mem_count(n, ephemeral=True, session=session))
             health = _health_mark(n, known=known)
+            if health:
+                # `_health_mark` speaks ONLY when something is wrong, so its presence is
+                # the signal — recorded here rather than recovered from the rendered chip,
+                # which would tie truncation to a glyph choice.
+                flagged_names.add(n)
             # The marker is always exactly two columns, so every persona name starts in
             # the same column as every other AND as the column header above them — the
             # header carries `_MARK_HEAD` for exactly that reason. All three markers are
@@ -1055,6 +1067,23 @@ def _persona_chips(session: str | None = None) -> list[str]:
                 chips.append(f"{_MAGENTA}{_MARK_ACTIVE} {_BOLD}{n}{_R}{dot}{badge}{health}")
             else:
                 chips.append(f"{_DIM}{_MARK_IDLE} {n}{_R}{dot}{badge}{health}")
+        if len(chips) > _MAX_PERSONA_LINES:
+            # Which ones survive matters more than how many. Keeping the first N
+            # alphabetically would drop exactly the personas worth seeing, so the order is
+            # by what a truncated column is FOR: the active persona, then anything carrying
+            # a health mark (`_health_mark` speaks only when something is wrong), then the
+            # rest. The count of what is hidden is shown rather than implied — the same
+            # contract `_repo_rows` keeps with its own "(+N more)".
+            keep = _MAX_PERSONA_LINES - 1          # one row spent saying what was dropped
+            by_name = dict(zip(order, chips))
+            head = [n for n in order[:1] if n == active]
+            rest = [n for n in order if n not in head]
+            ordered = head + [n for n in rest if n in flagged_names] \
+                           + [n for n in rest if n not in flagged_names]
+            shown = ordered[:keep]
+            hidden = len(order) - len(shown)
+            chips = [by_name[n] for n in shown]
+            chips.append(f"{_DIM}  …(+{hidden} more · charter persona list){_R}")
         return chips
     except Exception:
         return []

--- a/tests/test_statusline_persona_cap.py
+++ b/tests/test_statusline_persona_cap.py
@@ -1,0 +1,115 @@
+"""The persona column is bounded, like the repo column already was.
+
+Claude Code's status line has no scroll and no max height — it is stdout, one row per line
+printed, and the docs say only "keep output short". So height is charter's to bound, and
+charter bounded half of it: `_MAX_REPO_LINES` caps the repo tree, and nothing capped the
+personas.
+
+Because the layout pads the shorter column to match the longer, that made personas alone
+drive the whole box. Measured before this change:
+
+     personas  repos  lines
+            3      2      8
+           16      2     21
+           30      2     35        <- whatever the repo count
+            3     20     19        <- 20 repos still fits: the repo cap works
+
+A status line taller than the conversation is not a status line.
+
+**Which chips survive matters more than how many.** Keeping the first N alphabetically would
+drop exactly the personas worth seeing, so the order is what a truncated column is FOR: the
+active persona, then anything carrying a health mark — `_health_mark` speaks only when
+something is wrong — then the rest.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import config, persona, statusline
+from tests._isolation import PersonaIso
+
+
+class ColumnCase(PersonaIso):
+    def make_many(self, n: int, draft: str | None = None) -> None:
+        for i in range(n):
+            name = f"p{i:02d}"
+            self.make_persona(name, role=f"Role {i}", vault="none")
+        if draft:
+            p = persona.def_path(draft)
+            p.write_text(p.read_text().replace("---\n", "---\ndraft: yes\n", 1))
+
+    def chips(self):
+        return statusline._persona_chips(None)
+
+
+class TestTheColumnIsCapped(ColumnCase):
+    def test_a_small_roster_is_untouched(self):
+        """The cap must not change what a normal plane shows — most planes are small, and a
+        truncation notice on them would be noise."""
+        self.make_many(4)
+        self.assertEqual(len(self.chips()), 4)
+        self.assertFalse(any("more" in c for c in self.chips()))
+
+    def test_a_large_roster_is_bounded(self):
+        self.make_many(30)
+        self.assertLessEqual(len(self.chips()), statusline._MAX_PERSONA_LINES)
+
+    def test_it_matches_the_repo_budget(self):
+        """One number for one question — how tall may a column get — rather than two that
+        drift apart."""
+        self.assertEqual(statusline._MAX_PERSONA_LINES, statusline._MAX_REPO_LINES)
+
+
+class TestItSaysWhatItHid(ColumnCase):
+    def test_the_hidden_count_is_shown(self):
+        """The contract `_repo_rows` already keeps with its own "(+N more)": a column that
+        silently drops rows reads as a complete roster."""
+        self.make_many(30)
+        tail = self.chips()[-1]
+        self.assertIn("more", tail)
+
+    def test_the_count_is_correct(self):
+        self.make_many(30)
+        chips = self.chips()
+        shown = len(chips) - 1                       # the notice row is not a persona
+        self.assertIn(f"+{30 - shown} more", chips[-1])
+
+    def test_it_names_where_to_see_the_rest(self):
+        self.make_many(30)
+        self.assertIn("charter persona list", self.chips()[-1])
+
+
+class TestTheRightChipsSurvive(ColumnCase):
+    def test_the_active_persona_is_kept(self):
+        self.make_many(30)
+        persona.set_active("p29")                    # last alphabetically
+        self.assertTrue(any("p29" in c for c in self.chips()))
+
+    def test_an_unhealthy_persona_is_kept_over_a_healthy_one(self):
+        """A truncated column exists to show what is wrong. `p29` would fall off the end of
+        an alphabetical cut, and it is precisely the one worth seeing."""
+        self.make_many(30, draft="p29")
+        self.assertTrue(any("p29" in c for c in self.chips()))
+
+    def test_a_healthy_persona_may_be_dropped(self):
+        """The other half of the same statement — something has to go."""
+        self.make_many(30)
+        chips = self.chips()
+        names = {f"p{i:02d}" for i in range(30)}
+        shown = {n for n in names if any(n in c for c in chips)}
+        self.assertLess(len(shown), len(names))
+
+
+class TestItNeverBreaksTheRender(ColumnCase):
+    def test_a_broken_roster_still_returns_a_list(self):
+        """`_persona_chips` runs on every turn and its own contract is to degrade to an
+        empty column rather than take the footer down."""
+        real = persona.list_personas
+        persona.list_personas = lambda: (_ for _ in ()).throw(OSError("nope"))
+        self.addCleanup(setattr, persona, "list_personas", real)
+        self.assertEqual(self.chips(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Claude Code's status line has **no scroll and no max height** — it is stdout, one row per line printed, and the docs offer only *"keep output short"*. So height is charter's to bound.

Charter bounded half of it. `_MAX_REPO_LINES` capped the repo tree; nothing capped the personas. And because the layout **pads the shorter column to match the longer**, personas alone drove the whole box.

## Measured, before → after

| personas | repos | before | after |
|---:|---:|---:|---:|
| 3 | 2 | 8 | 8 |
| 16 | 2 | 21 | 19 |
| 30 | 2 | **35** | **19** |
| 3 | 20 | 19 | 19 |

20 repos already fitted in 19 lines — the repo cap working. 30 personas took 35 whatever the repo count.

## Which chips survive matters more than how many

Keeping the first N alphabetically would drop exactly the personas worth seeing. The order is what a truncated column is *for*:

1. the active persona
2. anything carrying a health mark
3. the rest

`_health_mark` speaks **only when something is wrong**, so its presence *is* the signal. It's recorded while the chip is built rather than recovered by grepping the rendered string — which would tie truncation to a glyph choice.

The hidden count is shown and names where to see the rest (`charter persona list`), keeping the contract `_repo_rows` already has with its own `(+N more)`: a column that silently drops rows reads as a complete roster.

## Tests

10 new in `tests/test_statusline_persona_cap.py`: a small roster untouched (no truncation notice on ordinary planes), a large one bounded, the budget matching the repo one, the hidden count shown and correct, the active persona kept even when last alphabetically, an **unhealthy** persona kept over a healthy one, a healthy one droppable, and the column still degrading to empty rather than taking the footer down.

Full suite: 2045 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX