### PR TITLE
0.35.0 — the status line stays current and bounded, and a dead MCP launcher speaks up

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.34.0"
+__version__ = "0.35.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.34.0",
+            "command": "charter hook sessionstart --plugin-version 0.35.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.34.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.35.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.34.0",
+            "command": "charter hook pretooluse --plugin-version 0.35.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.34.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.35.0",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.34.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.35.0"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.34.0",
+            "command": "charter hook posttooluse --plugin-version 0.35.0",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.34.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.35.0",
             "timeout": 5
           }
         ]
@@ -100,7 +100,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.34.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.35.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.34.0"
+version = "0.35.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only: `pyproject.toml`, `charter/__init__.py`, `.claude-plugin/plugin.json`, `hooks/hooks.json` (8 sites). All four move together, and `MIN_PLUGIN_VERSION` derives from `__version__` rather than being a fifth place to forget.

## What ships

**#198 — the status line refreshes on a timer, not only on session events.** Those triggers go quiet in exactly the case the fleet spine was built for: a coordinator waiting on background workers, where `silent 12m` ages with wall-clock and piece counts move while the main session does nothing. `refreshInterval: 10` — six times finer than the minute granularity charter actually displays, rather than the one-second minimum.

**#199 — the persona column is bounded, like the repo column already was.** The layout pads the shorter column to match the longer, so an uncapped persona list drove the whole box: 30 personas took 35 rows whatever the repo count. Survivors are ordered active → health-flagged → rest.

| personas | repos | before | after |
|---:|---:|---:|---:|
| 16 | 2 | 21 | 19 |
| 30 | 2 | 35 | 19 |
| 3 | 20 | 19 | 19 |

**#197 — a dead MCP launcher is named instead of failing silently.** The `edm`->`charter` rename removed `bin/edm`; every server registered through that shim began failing with ENOENT while Claude Code showed nothing. `doctor` now classifies the fact — an absolute launcher path that does not exist cannot be executed — and gives the one-line fix.

## Release hygiene

`0.34.0` and `0.35.0` are the same byte length, which is how a same-second write let Python's `(mtime, size)` bytecode check serve stale `.pyc` on a previous release. Bytecode was cleared before the suite ran and the interpreter was asked to confirm it sees `0.35.0`.

Suite: **2071 passing** on the bumped tree.

## Known, not shipped

- **#200** — a clone of charter is mistaken for a plane root, because `charter.toml` is tracked. Real and reproducible, but the fix changes root resolution for every plane; it gets its own pass rather than riding a release.
- **#127** stays parked. It is a recorded decision, not backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX