### PR TITLE
fix: a nested plane is named where the wrong impression forms

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -401,7 +401,15 @@ def cmd_status(args) -> int:
     active = workspace.resolve(explicit)
 
     print(f"{config.GROUP}: {len(inv_by_name)} repos in inventory · "
-          f"{len(all_ws)} workspace(s) · active: {active} (via {workspace.source(explicit)})\n")
+          f"{len(all_ws)} workspace(s) · active: {active} (via {workspace.source(explicit)})")
+    # "Where am I" is this command's whole job, and the plane is the outermost part of that
+    # answer — every count above is a count *of this plane*, and a nested one reports
+    # numbers that look like the outer plane's and are not (#200). Resolution is unchanged
+    # (#140); this only says which plane answered.
+    nested = util.nested_plane_note()
+    if nested:
+        print(nested)
+    print()
 
     if all_ws:
         for n in all_ws:

--- a/charter/commands_worktree.py
+++ b/charter/commands_worktree.py
@@ -39,6 +39,18 @@ def _resolve(args) -> tuple[str, Path | None]:
     clone = clone_for(ws, args.repo)
     if clone is None:
         util.err(f"'{args.repo}' isn't cloned in workspace '{ws}'.")
+        # Before the clone tip, because when this plane is nested the tip is the wrong
+        # answer: the clone usually DOES exist, in the outer plane, and following the
+        # advice makes a second one in a plane nobody chose. Observed on charter's own
+        # dogfooding layout (#200) — `charter worktree add charter <branch>` run from
+        # inside the charter clone reported the repo missing while standing in it.
+        #
+        # The tip still prints. Not-cloned remains possible in a nested plane, and ADR
+        # 0009 is that charter classifies what it can see rather than picking one cause
+        # and hiding the other.
+        nested = util.nested_plane_note()
+        if nested:
+            util.info(nested)
         util.info(f"Clone it first: charter clone {args.repo} -w {ws}")
     return ws, clone
 

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1273,6 +1273,43 @@ def _head_detached(gitdir: Path) -> bool:
     return bool(txt) and not txt.startswith("ref:")
 
 
+def _nested_plane_mark() -> str | None:
+    """``⚠ nested in <outer>`` when this plane sits inside another plane's ``workspaces/``,
+    else ``None`` — which is the ordinary case, and renders nothing.
+
+    ``charter.toml`` is tracked, so every clone of a plane is itself a plane, and `charter
+    clone` puts clones exactly where the walk will find them first. `root.enclosing_plane`
+    has detected this since #140; what was missing is that the surface read every turn
+    never said it. The status line rendered another plane's workspace count, another
+    plane's personas and no active marker, and the operator had no reason to suspect the
+    plane rather than the workspace (#200).
+
+    **It does not change resolution.** #140 decided that deliberately: sometimes the inner
+    plane IS the one you mean — charter's own dogfooding clones charter into a workspace,
+    and that clone is a plane you might legitimately manage. This is ADR 0013's second
+    rule, a divergence charter can see being named rather than silently resolved.
+
+    The outer plane's **directory name**, not its path: the header is one row competing
+    with everything else on it, and the name is what the operator recognises as theirs.
+    `doctor` carries the full path and the `cd` that fixes it.
+
+    ``config.ROOT`` is passed explicitly rather than letting `enclosing_plane` default to
+    the process cwd. The renderer describes the SESSION, and a hook's own directory is not
+    the session's — the same trap `_active` documents, where reading the wrong cwd does
+    not merely miss a better answer, it overrides the right one.
+    """
+    from . import root as _root
+    try:
+        outer = _root.enclosing_plane(config.ROOT)
+    except OSError:
+        # This runs on every turn. An unreadable ancestor makes the answer unknown, and an
+        # unknown answer here is worth strictly less than the rest of the line.
+        return None
+    if outer is None:
+        return None
+    return f"{_YELLOW}⚠ nested in {_BOLD}{outer.name}{_R}"
+
+
 def _plane_root_alert() -> str | None:
     """One line when the **plane root** is being worked in — dirty, detached, or off its
     default branch. ``None`` otherwise, which is the ordinary case.
@@ -1574,6 +1611,7 @@ def render(payload: dict | None = None) -> str:
         glstate.maybe_spawn(scan, active)
 
         pin = f"{_YELLOW}*{_R}" if src == "$CHARTER_WORKSPACE" else ""
+        nested = _nested_plane_mark()
         # Reinit tip sits right after the name so it survives truncation on narrow panes.
         # Nothing informational goes in front of it: it is the one item on this row that
         # reports something BROKEN, and it carries the command that fixes it. A pane with
@@ -1612,6 +1650,11 @@ def render(payload: dict | None = None) -> str:
         ntodo = _todo_count(active)
         summary = f"{_DIM} · {_R}".join(filter(None, [
             f"{_CYAN}⬢{_R} {_BOLD}{active}{_R}{pin}",
+            # Ahead of the reinit tip, which is the only thing that outranks information
+            # on this row — because when the PLANE is not the one you meant, the structure
+            # that tip reports as stale belongs to the wrong plane too. Naming the plane
+            # first stops the operator fixing something they never chose.
+            nested,
             reinit,
             f"{_DIM}todo{_R} {ntodo}" if ntodo else None,
             _piece_summary(active),

--- a/charter/util.py
+++ b/charter/util.py
@@ -35,6 +35,42 @@ def err(msg: str) -> None:
     print(_c("31", "✗") + " " + msg, file=sys.stderr)
 
 
+def nested_plane_note() -> str | None:
+    """The sentence naming the outer plane when this one sits inside another's
+    ``workspaces/``, else ``None`` — the ordinary case, which says nothing.
+
+    ``charter.toml`` is tracked, so every clone of a plane is a plane too, and `charter
+    clone` puts clones exactly where the upward walk finds them first. Resolution stops at
+    the inner one and every count a command prints silently describes a plane the operator
+    did not choose (#200).
+
+    Resolution is **unchanged** — #140 settled that, because sometimes the inner plane is
+    genuinely the one you mean. This only says which plane answered, which is ADR 0013's
+    second rule: a divergence charter can see, charter names.
+
+    It lives here, beside `info`/`err`, so the surfaces that say it — `charter status` and
+    the not-cloned error — cannot drift into two wordings of the same fact. It **returns**
+    the sentence rather than printing it because the two callers want different streams:
+    for `charter status` this is part of the answer and belongs on stdout with the header
+    it qualifies, while beside `util.err` it is diagnostic and belongs on stderr. A helper
+    that printed would have to pick one and be wrong for the other.
+
+    Imports are deferred because `util` sits below `config` and `root` in the import order
+    and must stay there.
+    """
+    from . import config
+    from . import root as _root
+    try:
+        outer = _root.enclosing_plane(config.ROOT)
+    except OSError:
+        # Every caller is on a path that has something more useful to say than a traceback.
+        return None
+    if outer is None:
+        return None
+    return (f"nested plane: this one sits inside {outer}'s workspaces/ — "
+            f"to act on that one instead: cd {outer}")
+
+
 class ProcTimeout(RuntimeError):
     """A subprocess outlived its ``timeout``.
 

--- a/tests/test_nested_plane_named.py
+++ b/tests/test_nested_plane_named.py
@@ -1,0 +1,190 @@
+"""A nested plane is named where the wrong impression forms, not only in `doctor`.
+
+`charter.toml` is tracked, so every clone of a plane is itself a plane — and `charter
+clone` puts clones at `workspaces/<ws>/<repo>`. Standing in one, resolution stops at the
+first marker walking up and the inner plane shadows the outer (#140).
+
+`root.enclosing_plane` already detects this and `doctor` already reports it. #140 chose
+that deliberately: resolution stays put, because sometimes the inner plane IS the one you
+mean — charter's own dogfooding clones charter into a workspace. **This does not revisit
+that choice.** What it fixes is the silence around it.
+
+Observed (#200): the status line rendered `⬢ default · ws 3` — a different plane, a
+different workspace count, the active-persona marker gone — with nothing saying the plane
+had changed. The operator saw `default`, could not account for it, and had no reason to
+suspect the plane rather than the workspace. `doctor` would have explained it, but nobody
+runs `doctor` because the status line looks odd; the status line is the surface read every
+turn. This is the complaint `workspace.source` was already extended for — "why are you in
+default workspace again?" — one level up, and ADR 0013's second rule aimed at that line.
+
+Three surfaces, and no more. A nesting notice on every command is how a real signal becomes
+furniture:
+
+* the **status line**, where the wrong impression forms;
+* **`charter status`**, whose whole job is "where am I";
+* the **`isn't cloned in workspace X` error**, which is worse than silent — it names a
+  cause that is not real and advises cloning into a plane nobody asked for (ADR 0009).
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import commands, commands_worktree, config, root, statusline, workspace
+from tests._isolation import PersonaIso
+
+
+class NestedCase(PersonaIso):
+    """A plane whose root really does sit under another plane's ``workspaces/``.
+
+    Built on disk rather than mocked, because `enclosing_plane`'s whole job is a path
+    relationship — a stubbed answer would pass while the real arithmetic was wrong.
+    """
+
+    def nest(self) -> Path:
+        # A name that cannot collide with anything the renderer already prints — the brand
+        # row carries the word "charter", so an outer plane called that would let a test
+        # pass on the wrong line.
+        outer = self.tmp / "umbrella"
+        inner = outer / "workspaces" / "w1" / "inner"
+        inner.mkdir(parents=True, exist_ok=True)
+        (outer / "charter.toml").write_text("schema = 1\n")
+        (inner / "charter.toml").write_text("schema = 1\n")
+        config.use(inner)
+        config.PERSONAS_DIR.mkdir(parents=True, exist_ok=True)
+        (config.WORKSPACES_DIR).mkdir(parents=True, exist_ok=True)
+        return outer
+
+    def flat(self) -> None:
+        """The ordinary case: a plane with no plane above it."""
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+
+
+class TestTheFixtureIsReal(NestedCase):
+    def test_the_nested_plane_is_actually_detected(self):
+        """A precondition, not a feature. If `enclosing_plane` cannot see this fixture,
+        every other test in the file passes for the wrong reason."""
+        outer = self.nest()
+        # `.resolve()` on both sides: `enclosing_plane` canonicalises, and on macOS the
+        # temp dir arrives as /var/… while the resolved answer is /private/var/…. Comparing
+        # unresolved would fail on a symlink rather than on the behaviour under test.
+        self.assertEqual(root.enclosing_plane(config.ROOT), outer.resolve())
+
+    def test_a_flat_plane_is_not_detected_as_nested(self):
+        self.flat()
+        self.assertIsNone(root.enclosing_plane(config.ROOT))
+
+
+class TestTheStatusLineNamesIt(NestedCase):
+    def test_a_flat_plane_gets_no_mark(self):
+        """Most planes are flat, and a notice on them would be furniture."""
+        self.flat()
+        self.assertIsNone(statusline._nested_plane_mark())
+
+    def test_a_nested_plane_is_marked(self):
+        self.nest()
+        self.assertIsNotNone(statusline._nested_plane_mark())
+
+    def test_the_mark_names_the_outer_plane(self):
+        """"Nested" alone does not tell you which plane you meant to be in — the operator
+        needs the name to recognise it as theirs."""
+        outer = self.nest()
+        self.assertIn(outer.name, statusline._nested_plane_mark())
+
+    def test_it_reaches_the_rendered_header(self):
+        """A helper nothing renders is the same silence this fixes."""
+        outer = self.nest()
+        out = statusline.render({"session_id": "s", "workspace": {"current_dir": str(config.ROOT)}})
+        self.assertIn(outer.name, _plain(out))
+
+    def test_it_never_takes_the_render_down(self):
+        """`render` runs every turn and degrades to a bare brand rather than showing the
+        operator a traceback. An unreadable ancestor must not change that."""
+        real = root.enclosing_plane
+        root.enclosing_plane = lambda *a, **k: (_ for _ in ()).throw(OSError("nope"))
+        self.addCleanup(setattr, root, "enclosing_plane", real)
+        self.assertIsNone(statusline._nested_plane_mark())
+
+    def test_it_rides_the_header_row(self):
+        """Q2's whole reason for choosing the header over a warning row: the release
+        immediately before this one was spent bounding the status line's height, and the
+        correction belongs against the token being misread rather than three rows below
+        it. Asserted as "the outer name shares a line with the `⬢` header" rather than by
+        counting rows, because a flat plane and a nested one are different fixtures and
+        their row counts are not comparable."""
+        outer = self.nest()
+        named = [ln for ln in _plain(statusline.render(_payload())).splitlines()
+                 if outer.name in ln]
+        self.assertTrue(named, "the outer plane is not named anywhere")
+        self.assertTrue(any("⬢" in ln for ln in named),
+                        f"the mark did not ride the header row: {named}")
+
+
+class TestStatusNamesIt(NestedCase):
+    def run_status(self) -> str:
+        buf = io.StringIO()
+        with redirect_stdout(buf), redirect_stderr(io.StringIO()):
+            commands.cmd_status(SimpleNamespace(workspace=None, all=False))
+        return buf.getvalue()
+
+    def test_a_nested_plane_is_named(self):
+        """"Where am I" is the whole job of this command, and the plane is the outermost
+        part of that answer."""
+        outer = self.nest()
+        self.assertIn(outer.name, self.run_status())
+
+    def test_a_flat_plane_says_nothing_about_nesting(self):
+        self.flat()
+        self.assertNotIn("nested", self.run_status().lower())
+
+
+class TestTheMisleadingErrorIsCorrected(NestedCase):
+    def resolve_err(self) -> str:
+        buf = io.StringIO()
+        with redirect_stderr(buf), redirect_stdout(io.StringIO()):
+            commands_worktree._resolve(SimpleNamespace(repo="charter", workspace=None))
+        return buf.getvalue()
+
+    def test_it_names_the_plane_when_nested(self):
+        """The message the operator actually met was "'charter' isn't cloned in workspace
+        'default'" — for a clone that exists, in a plane they never chose. Advising a
+        second clone is charter guessing at a cause it can see is wrong (ADR 0009)."""
+        outer = self.nest()
+        self.assertIn(outer.name, self.resolve_err())
+
+    def test_the_plane_is_named_before_the_clone_advice(self):
+        """Order is the correction. The clone tip is the fallback for the flat case; when
+        charter can see the plane is nested, that is the likelier cause and has to be read
+        first."""
+        self.nest()
+        err = self.resolve_err()
+        self.assertLess(err.lower().index("nested"), err.index("Clone it first"))
+
+    def test_the_clone_advice_survives(self):
+        """Not-cloned is still possible in a nested plane — charter names the more likely
+        cause without deleting the other one."""
+        self.nest()
+        self.assertIn("Clone it first", self.resolve_err())
+
+    def test_a_flat_plane_keeps_the_original_message(self):
+        self.flat()
+        err = self.resolve_err()
+        self.assertIn("isn't cloned in workspace", err)
+        self.assertNotIn("nested", err.lower())
+
+
+def _payload() -> dict:
+    return {"session_id": "s", "workspace": {"current_dir": str(config.ROOT)}}
+
+
+def _plain(text: str) -> str:
+    import re
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #200.

## What this is not

It does **not** change plane resolution. #140 settled that deliberately — sometimes the inner plane IS the one you mean, which is charter's own dogfooding layout — and `root.enclosing_plane` has detected the nesting ever since. `doctor` already reports it clearly. **The defect was the silence around a decision that is otherwise correct.**

(My original "Direction" note on #200 proposed keying the root off untracked `.charter/` state. That contradicted #140 and I withdrew it [in a comment](https://github.com/diazoxide/charter/issues/200#issuecomment-5313244619) once I had read `root.py` properly.)

## The failure

`charter.toml` is tracked, so every clone of a plane is a plane, and `charter clone` puts clones exactly where the upward walk finds them first. The status line rendered:

```
⬢ default · ws 3
▪ repos 0/1                        │ ▪ personas 5
                                   │ ▫ steward · ✎12      <- active marker gone
⚠ reinit 3 ws · charter ws reinit --all
```

A different plane, a different workspace count, different persona state — and nothing saying the plane had changed. `doctor` would have explained it, but nobody runs `doctor` because the status line looks odd; the status line is the surface read every turn.

## Three surfaces, and no more

A nesting notice on every command is how a real signal becomes furniture.

**Status line** — in the header, not a row of its own. The correction belongs against the token being misread, and the release immediately before this one was spent bounding this thing's height. It sits *ahead* of the reinit tip: when the plane is wrong, the structure that tip calls stale belongs to the wrong plane too.

```
⬢ default · ⚠ nested in charter · ws 3
```

**`charter status`** — "where am I" is its whole job, and every count it prints is a count *of this plane*.

**The `isn't cloned in workspace X` error** — this one was worse than silent:

```
✗ 'charter' isn't cloned in workspace 'default'.
• nested plane: this one sits inside /Users/…/charter's workspaces/ — to act on that one instead: cd /Users/…/charter
• Clone it first: charter clone charter -w default
```

It named a cause that was not real and advised cloning into a plane nobody asked for — for a clone the operator was standing in. Nesting is stated first as the likelier cause; the clone tip still prints, because not-cloned stays possible and ADR 0009 is that charter classifies what it can see rather than picking one cause and hiding the other.

## Notes

`util.nested_plane_note()` **returns** the sentence rather than printing it, because the two CLI callers need different streams — part of the answer on stdout for `status`, diagnostic on stderr beside `util.err`. Single-sourced so the wordings cannot drift.

`config.ROOT` is passed to `enclosing_plane` explicitly rather than letting it default to the process cwd — the renderer describes the *session*, and a hook's own directory is not the session's. That is the trap `_active` already documents.

## Tests

14 new tests in `tests/test_nested_plane_named.py`, built on a **real on-disk nested plane** rather than a stubbed `enclosing_plane` — the whole behaviour is a path relationship, and a mocked answer would pass while the arithmetic was wrong. Includes two precondition tests that fail loudly if the fixture stops being nested, so the rest cannot pass for the wrong reason. Full suite: **2085 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX