### PR TITLE
0.36.0 — a nested plane says so, in the line you actually read

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.35.0"
+__version__ = "0.36.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.35.0",
+            "command": "charter hook sessionstart --plugin-version 0.36.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.35.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.36.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.35.0",
+            "command": "charter hook pretooluse --plugin-version 0.36.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.35.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.36.0",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.35.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.36.0"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.35.0",
+            "command": "charter hook posttooluse --plugin-version 0.36.0",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.35.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.36.0",
             "timeout": 5
           }
         ]
@@ -100,7 +100,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.35.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.36.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.35.0"
+version = "0.36.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only: `pyproject.toml`, `charter/__init__.py`, `.claude-plugin/plugin.json`, `hooks/hooks.json` (8 sites).

## What ships

**#200 — a nested plane is named where the wrong impression forms.**

`charter.toml` is tracked, so every clone of a plane is itself a plane, and `charter clone` puts clones exactly where the upward walk finds them first. The status line rendered another plane's workspace count, another plane's personas and no active marker, with nothing saying the plane had changed.

```
before   ⬢ default · ws 3
after    ⬢ default · ⚠ nested in charter · ws 3
```

In the header rather than a row of its own — the correction belongs against the token being misread, and 0.35.0 was spent bounding this thing's height. `charter status` says it too, and the `isn't cloned in workspace X` error says it *first*, because that message named a cause that was not real and advised cloning into a plane nobody asked for.

**Resolution is unchanged.** #140 settled that deliberately — sometimes the inner plane is the one you mean, which is charter's own dogfooding layout. This is ADR 0013's second rule: a divergence charter can see, charter names.

## Release hygiene

`0.35.0` and `0.36.0` are the same byte length — the shape that let a same-second write serve stale `.pyc` on an earlier release. Bytecode cleared before the suite ran, and the interpreter asked to confirm it sees `0.36.0`.

Suite: **2085 passing** on the bumped tree.

## Tracker

Empty but for **#127**, which stays parked as a recorded decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX