### PR TITLE
fix: a plane cloned into another plane's workspaces resolves to the outer one

### DIFF
--- a/charter/config.py
+++ b/charter/config.py
@@ -174,11 +174,18 @@ def _repoint_vault_registry(legacy_dir: Path, new_dir: Path) -> None:
               file=sys.stderr)
 
 
-def derive(root: Path) -> dict:
+def derive(root: Path, start: Path | None = None) -> dict:
     """Every setting that follows from *root*, as ``{NAME: value}``.
 
     The single definition. :func:`use` applies it; the module bootstraps itself with it
     at import; the test harness calls :func:`use` instead of copying any of it.
+
+    *start* is the directory the plane was located FROM, and matters only for
+    ``NESTED_ORIGIN`` — "which plane am I standing in" is a fact about a directory, not
+    about the root that directory resolved to. ``None`` means the process cwd, which is the
+    truth at import; :func:`use` passes *root* instead so the test harness is not reading
+    the developer's actual working directory (it was: the suite ran from a worktree inside
+    a nested clone and picked up the real one).
     """
     root = Path(root)
     d: dict = {}
@@ -191,6 +198,19 @@ def derive(root: Path) -> dict:
     #: False when no ``charter.toml`` was found. Commands that need a control plane check
     #: this and fail with a clear message; ``--version`` and ``init`` do not.
     d["HAS_CONTROL_PLANE"] = (root / _root.MARKER).is_file()
+
+    #: The nested plane the caller is STANDING IN, when one encloses it — else ``None``.
+    #:
+    #: `find_root` hops outward through ``workspaces/`` so the plane holding the vault
+    #: wins, which means ``enclosing_plane(ROOT)`` is ``None`` by construction whenever the
+    #: hop fired. Without recording the origin, charter would silently act on a plane the
+    #: operator cannot see it choose. Three states, and each reads differently:
+    #:
+    #: * ``None`` — no nesting. Say nothing.
+    #: * ``!= ROOT`` — the hop fired: standing in a plane, acting on the one above it.
+    #: * ``== ROOT`` — ``$CHARTER_ROOT`` pinned this session INSIDE the nested plane, so
+    #:   the hop was overridden and the hazard #140 described is live.
+    d["NESTED_ORIGIN"] = _root.standing_in_nested_plane(start)
 
     #: Parsed once. ``config`` is imported by every command (including ``charter
     #: --version``), so a malformed ``charter.toml`` or a too-new schema must never crash
@@ -304,7 +324,9 @@ def use(root) -> dict:
     the derivation, and restores by handing the snapshot to :func:`restore`.
     """
     previous = {k: globals().get(k) for k in DERIVED}
-    globals().update(derive(root))
+    # `start=root`, never the process cwd: a test that redirected ROOT into a tmp dir must
+    # not have `NESTED_ORIGIN` answered from wherever the suite happens to be running.
+    globals().update(derive(root, start=root))
     return previous
 
 

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -615,13 +615,25 @@ def check_nested_plane() -> Result:
         return Result(name, WARN, detail=f"not checked ({e})",
                       hint=_NOT_CHECKED_HINT)
     if outer is None:
+        # Standing in a nested clone no longer reaches here: `find_root` hops outward
+        # through `workspaces/`, so ROOT is already the outer plane and there is nothing to
+        # warn about. Say which plane answered anyway — the hop is a correction charter
+        # made on the operator's behalf, and ADR 0013's second rule covers charter's own
+        # corrections too.
+        origin = getattr(_config, "NESTED_ORIGIN", None)
+        if origin is not None and origin != _config.ROOT:
+            return Result(name, OK,
+                          detail=f"standing in {util.short_path(origin)}, acting on "
+                                 f"{util.short_path(_config.ROOT)}")
         return Result(name, OK, detail="not nested")
+    # Reached only when $CHARTER_ROOT refused the hop, which is the one state where the
+    # inner plane really does take the writes.
     return Result(name, WARN,
-                  detail=f"this plane sits inside {outer}'s workspaces/",
-                  hint=("Commands here act on THIS plane — its vaults, its workspace "
-                        "pointers — and the outer plane never sees them. That is often "
-                        "not what you meant: a clone ships `charter.toml`, so it is a "
-                        f"plane too.  → to act on the outer one: cd {outer}"))
+                  detail=f"pinned inside {util.short_path(outer)}'s workspaces/",
+                  hint=("$CHARTER_ROOT points at a plane nested in another one, so vaults "
+                        "and workspace pointers go to the inner plane and the outer never "
+                        "sees them. Without the override charter would resolve to "
+                        f"{util.short_path(outer)}.  → unset CHARTER_ROOT to use it"))
 
 
 def check_workspace_clones() -> Result:

--- a/charter/root.py
+++ b/charter/root.py
@@ -49,7 +49,7 @@ def find_root(start: Path | None = None) -> Path:
     cur = (start or Path.cwd()).resolve()
     for d in (cur, *cur.parents):
         if (d / MARKER).is_file():      # is_file, not exists: a directory is not a marker
-            return _plane_of(d)
+            return _outermost(_plane_of(d))
 
     # Nothing above us. Before giving up, ask whether we are standing in a linked
     # WORKTREE whose plane lives in the repo it was cut from.
@@ -71,10 +71,76 @@ def find_root(start: Path | None = None) -> Path:
             continue
         for m in (main, *main.parents):
             if (m / MARKER).is_file():
-                return _plane_of(m)
+                return _outermost(_plane_of(m))
         break                            # its main tree has no plane either — stop here
 
     raise ControlPlaneNotFound(_explain(f"in {cur} or any parent"))
+
+
+def _outermost(marked: Path) -> Path:
+    """Follow ``workspaces/`` nesting outward until no plane encloses this one.
+
+    The innermost marker is the git/cargo/npm contract and is right almost everywhere. It
+    is wrong for the one structure charter builds itself: `charter clone` puts clones at
+    ``workspaces/<ws>/<repo>``, and a cloned repo may carry its own tracked
+    ``charter.toml``. Standing in one, the active plane silently became a different plane —
+    different personas, no vault, memory written where nobody chose (#200).
+
+    #140 detected that and left resolution alone, reasoning the inner plane is sometimes
+    the one you mean and naming charter's own dogfooding as the case. Measured against that
+    case, the inner plane carries no vault, a subset of the workspaces, and *tracked*
+    persona files, so a memory written there lands in the cloned repo's git index instead
+    of the operator's plane. The justification did not survive its own example.
+
+    **Not "outermost marker wins".** The hop is allowed only through an enclosing plane's
+    own ``workspaces/`` — `enclosing_plane`'s existing test. A bare walk to the topmost
+    marker would let one stray ``charter.toml`` in ``~`` swallow every plane beneath it,
+    turning a narrow mistake into a total one.
+
+    Loops until the answer stops moving, so a plane inside a plane inside a plane lands on
+    the one actually holding the vault rather than in the middle. ``seen`` guards against a
+    symlink arrangement that could otherwise cycle.
+
+    ``$CHARTER_ROOT`` never reaches here — it wins outright in :func:`find_root`, and is
+    the escape hatch for anyone who genuinely means the inner plane.
+    """
+    seen = {marked}
+    cur = marked
+    while True:
+        try:
+            outer = enclosing_plane(cur)
+        except OSError:
+            return cur
+        if outer is None or outer in seen:
+            return cur
+        seen.add(outer)
+        cur = outer
+
+
+def standing_in_nested_plane(start: Path | None = None) -> Path | None:
+    """The nested plane the caller is standing in, when :func:`find_root` redirected past
+    it — else ``None``.
+
+    Without this the redirect is invisible. Once `find_root` answers with the outer plane,
+    ``enclosing_plane(config.ROOT)`` is ``None`` *by construction* (the outer is not
+    nested), so every surface that used to name the nesting would fall silent and charter
+    would be quietly acting on a plane the operator cannot see it choose. ADR 0013's second
+    rule applies to charter's own corrections too.
+
+    Never raises: it is read on the status line's render path.
+    """
+    try:
+        cur = (start or Path.cwd()).resolve()
+    except (OSError, RuntimeError):
+        return None
+    try:
+        for d in (cur, *cur.parents):
+            if (d / MARKER).is_file():
+                inner = _plane_of(d)
+                return inner if enclosing_plane(inner) is not None else None
+    except OSError:
+        return None
+    return None
 
 
 def main_worktree_of(tree: Path) -> Path | None:

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1160,11 +1160,27 @@ def _alerts(active: str) -> list[str]:
         if stale:
             out.append(f"{_YELLOW}⚠{_R} {_DIM}reinit{_R} {len(stale)} {_DIM}ws · "
                        f"charter ws reinit --all{_R}")
-        outer = _nested_under()
+        # Fires only when the resolution was OVERRIDDEN into a nested plane — `find_root`
+        # now hops outward through `workspaces/`, so reaching here at all means
+        # $CHARTER_ROOT pinned this session inside the inner one. Standing in a nested
+        # clone no longer produces this row, and must not: the memory and the vault go to
+        # the outer plane now, so the warning would be false and would cost a row on every
+        # render of a session that is doing nothing wrong.
+        #
+        # Both planes by PATH, never `Path.name`. Clone charter into its own plane and both
+        # directories are called `charter`, so this row used to render "memory and vault go
+        # to charter, not charter" — it fired correctly and said nothing, which is why the
+        # nesting went unexplained for so long (#200).
+        # Only when the hop was OVERRIDDEN — `config.NESTED_ORIGIN == ROOT` means
+        # $CHARTER_ROOT pinned this session inside the nested plane, so charter
+        # really is writing there. After a plain hop ROOT is the outer plane and
+        # this row would be false.
+        outer = _nested_under() if getattr(config, "NESTED_ORIGIN", None) == config.ROOT else None
         if outer is not None:
+            from .util import short_path
             out.append(f"{_RED}⚠{_R} {_DIM}nested plane{_R} — {_DIM}memory and vault go to"
-                       f"{_R} {config.ROOT.name}{_DIM}, not{_R} {outer.name}"
-                       f"{_DIM} · export CHARTER_ROOT={outer}{_R}")
+                       f"{_R} {short_path(config.ROOT)}{_DIM}, not{_R} {short_path(outer)}"
+                       f"{_DIM} · unset CHARTER_ROOT{_R}")
         root_line = _plane_root_alert()
         if root_line:
             out.append(root_line)
@@ -1271,43 +1287,6 @@ def _head_detached(gitdir: Path) -> bool:
     except OSError:
         return False
     return bool(txt) and not txt.startswith("ref:")
-
-
-def _nested_plane_mark() -> str | None:
-    """``⚠ nested in <outer>`` when this plane sits inside another plane's ``workspaces/``,
-    else ``None`` — which is the ordinary case, and renders nothing.
-
-    ``charter.toml`` is tracked, so every clone of a plane is itself a plane, and `charter
-    clone` puts clones exactly where the walk will find them first. `root.enclosing_plane`
-    has detected this since #140; what was missing is that the surface read every turn
-    never said it. The status line rendered another plane's workspace count, another
-    plane's personas and no active marker, and the operator had no reason to suspect the
-    plane rather than the workspace (#200).
-
-    **It does not change resolution.** #140 decided that deliberately: sometimes the inner
-    plane IS the one you mean — charter's own dogfooding clones charter into a workspace,
-    and that clone is a plane you might legitimately manage. This is ADR 0013's second
-    rule, a divergence charter can see being named rather than silently resolved.
-
-    The outer plane's **directory name**, not its path: the header is one row competing
-    with everything else on it, and the name is what the operator recognises as theirs.
-    `doctor` carries the full path and the `cd` that fixes it.
-
-    ``config.ROOT`` is passed explicitly rather than letting `enclosing_plane` default to
-    the process cwd. The renderer describes the SESSION, and a hook's own directory is not
-    the session's — the same trap `_active` documents, where reading the wrong cwd does
-    not merely miss a better answer, it overrides the right one.
-    """
-    from . import root as _root
-    try:
-        outer = _root.enclosing_plane(config.ROOT)
-    except OSError:
-        # This runs on every turn. An unreadable ancestor makes the answer unknown, and an
-        # unknown answer here is worth strictly less than the rest of the line.
-        return None
-    if outer is None:
-        return None
-    return f"{_YELLOW}⚠ nested in {_BOLD}{outer.name}{_R}"
 
 
 def _plane_root_alert() -> str | None:
@@ -1611,7 +1590,6 @@ def render(payload: dict | None = None) -> str:
         glstate.maybe_spawn(scan, active)
 
         pin = f"{_YELLOW}*{_R}" if src == "$CHARTER_WORKSPACE" else ""
-        nested = _nested_plane_mark()
         # Reinit tip sits right after the name so it survives truncation on narrow panes.
         # Nothing informational goes in front of it: it is the one item on this row that
         # reports something BROKEN, and it carries the command that fixes it. A pane with
@@ -1650,11 +1628,6 @@ def render(payload: dict | None = None) -> str:
         ntodo = _todo_count(active)
         summary = f"{_DIM} · {_R}".join(filter(None, [
             f"{_CYAN}⬢{_R} {_BOLD}{active}{_R}{pin}",
-            # Ahead of the reinit tip, which is the only thing that outranks information
-            # on this row — because when the PLANE is not the one you meant, the structure
-            # that tip reports as stale belongs to the wrong plane too. Naming the plane
-            # first stops the operator fixing something they never chose.
-            nested,
             reinit,
             f"{_DIM}todo{_R} {ntodo}" if ntodo else None,
             _piece_summary(active),

--- a/charter/util.py
+++ b/charter/util.py
@@ -35,40 +35,66 @@ def err(msg: str) -> None:
     print(_c("31", "✗") + " " + msg, file=sys.stderr)
 
 
+def short_path(p) -> str:
+    """A path an operator can tell apart from another, short enough for one row.
+
+    Planes were identified by ``Path.name``, which collapses exactly when it matters: clone
+    charter into its own plane and both directories are called ``charter``, so the alert
+    read "memory and vault go to charter, not charter" and told nobody anything (#200). A
+    name is not an identifier — it is a coincidence that usually holds.
+
+    ``~`` rather than the full path because these render on one line beside other things,
+    and the home prefix is the longest part carrying the least information.
+    """
+    p = Path(p)
+    try:
+        return f"~/{p.relative_to(Path.home())}"
+    except (ValueError, RuntimeError, OSError):
+        return str(p)
+
+
 def nested_plane_note() -> str | None:
-    """The sentence naming the outer plane when this one sits inside another's
-    ``workspaces/``, else ``None`` — the ordinary case, which says nothing.
+    """One sentence when the caller is standing in a plane charter did **not** act on,
+    else ``None`` — the ordinary case, which says nothing.
 
     ``charter.toml`` is tracked, so every clone of a plane is a plane too, and `charter
-    clone` puts clones exactly where the upward walk finds them first. Resolution stops at
-    the inner one and every count a command prints silently describes a plane the operator
-    did not choose (#200).
+    clone` puts clones exactly where the upward walk finds them first. `find_root` now
+    hops outward through ``workspaces/`` so the plane holding the vault wins, which makes
+    this a *notice* rather than a warning: nothing is going astray, but charter is acting
+    on a plane other than the directory the operator is standing in, and a correction it
+    makes silently is one it cannot be argued with (ADR 0013).
 
-    Resolution is **unchanged** — #140 settled that, because sometimes the inner plane is
-    genuinely the one you mean. This only says which plane answered, which is ADR 0013's
-    second rule: a divergence charter can see, charter names.
+    Both planes are named by path, never by ``Path.name`` — clone charter into its own
+    plane and both directories are called ``charter``, which is how the old wording came
+    out as "memory and vault go to charter, not charter" (#200).
 
-    It lives here, beside `info`/`err`, so the surfaces that say it — `charter status` and
-    the not-cloned error — cannot drift into two wordings of the same fact. It **returns**
-    the sentence rather than printing it because the two callers want different streams:
-    for `charter status` this is part of the answer and belongs on stdout with the header
-    it qualifies, while beside `util.err` it is diagnostic and belongs on stderr. A helper
-    that printed would have to pick one and be wrong for the other.
+    It lives here, beside `info`/`err`, so the surfaces that say it cannot drift into two
+    wordings of one fact, and it **returns** the sentence rather than printing it because
+    the callers want different streams: part of the answer on stdout for `charter status`,
+    diagnostic on stderr beside `util.err`.
 
     Imports are deferred because `util` sits below `config` and `root` in the import order
     and must stay there.
     """
     from . import config
     from . import root as _root
-    try:
-        outer = _root.enclosing_plane(config.ROOT)
-    except OSError:
-        # Every caller is on a path that has something more useful to say than a traceback.
+    origin = getattr(config, "NESTED_ORIGIN", None)
+    if origin is None:
         return None
-    if outer is None:
-        return None
-    return (f"nested plane: this one sits inside {outer}'s workspaces/ — "
-            f"to act on that one instead: cd {outer}")
+    if origin == config.ROOT:
+        # The hop was overridden by $CHARTER_ROOT, so charter really is acting on the inner
+        # plane and the hazard #140 described is live. A warning, not a notice.
+        try:
+            outer = _root.enclosing_plane(config.ROOT)
+        except OSError:
+            return None
+        if outer is None:
+            return None
+        return (f"nested plane: acting on {short_path(config.ROOT)}, inside "
+                f"{short_path(outer)}'s workspaces/ — memory and vaults go to the inner "
+                f"one. Unset ${_root.ENV_VAR} to use {short_path(outer)}")
+    return (f"you are standing in {short_path(origin)}, which is a plane too — "
+            f"charter is acting on {short_path(config.ROOT)}")
 
 
 class ProcTimeout(RuntimeError):

--- a/tests/test_doctor_nested_plane.py
+++ b/tests/test_doctor_nested_plane.py
@@ -84,10 +84,16 @@ class TestDoctorSaysSo(NestedCase):
 
     def test_the_hint_says_commands_here_do_not_reach_the_outer_plane(self):
         """The incident was a `vault add` that reported success into the wrong plane, so
-        the hint has to name the consequence, not just the geometry."""
+        the hint has to name the consequence, not just the geometry.
+
+        Asserted on the consequence rather than one phrasing of it: `find_root` now hops
+        outward, so reaching this state at all means $CHARTER_ROOT refused the hop, and the
+        hint was rewritten to say so. What must survive a rewrite is that it names what
+        goes wrong."""
         config.ROOT = self.nest()
         hint = doctor.check_nested_plane().hint or ""
-        self.assertIn("outer plane never sees", hint)
+        self.assertIn("never sees", hint)
+        self.assertIn("CHARTER_ROOT", hint)
 
     def test_an_ordinary_plane_is_ok(self):
         self.assertEqual(doctor.check_nested_plane().status, OK)

--- a/tests/test_nested_plane_named.py
+++ b/tests/test_nested_plane_named.py
@@ -1,51 +1,50 @@
-"""A nested plane is named where the wrong impression forms, not only in `doctor`.
+"""What charter SAYS about a nested plane, now that resolution handles it.
 
-`charter.toml` is tracked, so every clone of a plane is itself a plane — and `charter
-clone` puts clones at `workspaces/<ws>/<repo>`. Standing in one, resolution stops at the
-first marker walking up and the inner plane shadows the outer (#140).
+`charter.toml` is tracked, so every clone of a plane is a plane, and `charter clone` puts
+clones at ``workspaces/<ws>/<repo>``. `find_root` hops outward through ``workspaces/`` so
+the plane holding the vault wins.
 
-`root.enclosing_plane` already detects this and `doctor` already reports it. #140 chose
-that deliberately: resolution stays put, because sometimes the inner plane IS the one you
-mean — charter's own dogfooding clones charter into a workspace. **This does not revisit
-that choice.** What it fixes is the silence around it.
+That leaves three states, and each has to read differently — which is the whole content of
+this file:
 
-Observed (#200): the status line rendered `⬢ default · ws 3` — a different plane, a
-different workspace count, the active-persona marker gone — with nothing saying the plane
-had changed. The operator saw `default`, could not account for it, and had no reason to
-suspect the plane rather than the workspace. `doctor` would have explained it, but nobody
-runs `doctor` because the status line looks odd; the status line is the surface read every
-turn. This is the complaint `workspace.source` was already extended for — "why are you in
-default workspace again?" — one level up, and ADR 0013's second rule aimed at that line.
+* **flat** — no nesting. Say nothing. Most planes, every render.
+* **hopped** — standing in a nested plane, acting on the one above it. A *notice*: nothing
+  is going astray, but a correction charter makes silently is one nobody can argue with.
+* **overridden** — ``$CHARTER_ROOT`` pinned inside the nested plane, so the hop was refused
+  and charter really is writing there. A *warning*: this is the hazard #140 described.
 
-Three surfaces, and no more. A nesting notice on every command is how a real signal becomes
-furniture:
+0.36.0 marked the nesting in the status line header, because charter was resolving to the
+inner plane and the operator had to be told. Once resolution is right, the status line
+shows the right plane and a row about a corrected situation is furniture on every render.
+The old alert said "memory and vault go to X, not Y" — after the hop that sentence is
+false.
 
-* the **status line**, where the wrong impression forms;
-* **`charter status`**, whose whole job is "where am I";
-* the **`isn't cloned in workspace X` error**, which is worse than silent — it names a
-  cause that is not real and advises cloning into a plane nobody asked for (ADR 0009).
+Every plane is identified by **path**, never ``Path.name``: clone charter into its own
+plane and both directories are called ``charter``, which is how that alert came out as
+"memory and vault go to charter, not charter" and told nobody anything (#200).
 """
 
 from __future__ import annotations
 
 import io
+import re
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from types import SimpleNamespace
 
-from charter import commands, commands_worktree, config, root, statusline, workspace
+from charter import commands, commands_worktree, config, root, statusline, util
 from tests._isolation import PersonaIso
 
 
 class NestedCase(PersonaIso):
     """A plane whose root really does sit under another plane's ``workspaces/``.
 
-    Built on disk rather than mocked, because `enclosing_plane`'s whole job is a path
-    relationship — a stubbed answer would pass while the real arithmetic was wrong.
+    Built on disk rather than mocked: the behaviour is a path relationship, and a stubbed
+    answer would pass while the arithmetic was wrong.
     """
 
-    def nest(self) -> Path:
+    def dirs(self) -> tuple[Path, Path]:
         # A name that cannot collide with anything the renderer already prints — the brand
         # row carries the word "charter", so an outer plane called that would let a test
         # pass on the wrong line.
@@ -54,92 +53,102 @@ class NestedCase(PersonaIso):
         inner.mkdir(parents=True, exist_ok=True)
         (outer / "charter.toml").write_text("schema = 1\n")
         (inner / "charter.toml").write_text("schema = 1\n")
-        config.use(inner)
+        return outer, inner
+
+    def hopped(self) -> tuple[Path, Path]:
+        """Production shape after the hop: ROOT is the OUTER, and ``NESTED_ORIGIN`` records
+        the plane the operator is standing in."""
+        outer, inner = self.dirs()
+        config.use(outer)
+        config.NESTED_ORIGIN = inner.resolve()
         config.PERSONAS_DIR.mkdir(parents=True, exist_ok=True)
-        (config.WORKSPACES_DIR).mkdir(parents=True, exist_ok=True)
-        return outer
+        config.WORKSPACES_DIR.mkdir(parents=True, exist_ok=True)
+        return outer, inner
+
+    def overridden(self) -> tuple[Path, Path]:
+        """``$CHARTER_ROOT`` pinned inside the nested plane: ROOT *is* the inner one."""
+        outer, inner = self.dirs()
+        config.use(inner)
+        config.NESTED_ORIGIN = config.ROOT
+        config.PERSONAS_DIR.mkdir(parents=True, exist_ok=True)
+        config.WORKSPACES_DIR.mkdir(parents=True, exist_ok=True)
+        return outer, inner
 
     def flat(self) -> None:
-        """The ordinary case: a plane with no plane above it."""
         (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.use(self.tmp)
+        config.NESTED_ORIGIN = None
 
 
 class TestTheFixtureIsReal(NestedCase):
-    def test_the_nested_plane_is_actually_detected(self):
-        """A precondition, not a feature. If `enclosing_plane` cannot see this fixture,
-        every other test in the file passes for the wrong reason."""
-        outer = self.nest()
-        # `.resolve()` on both sides: `enclosing_plane` canonicalises, and on macOS the
-        # temp dir arrives as /var/… while the resolved answer is /private/var/…. Comparing
-        # unresolved would fail on a symlink rather than on the behaviour under test.
-        self.assertEqual(root.enclosing_plane(config.ROOT), outer.resolve())
+    def test_the_nesting_is_actually_detected(self):
+        """A precondition, not a feature. If `enclosing_plane` cannot see this shape, every
+        other test in the file passes for the wrong reason."""
+        outer, inner = self.dirs()
+        self.assertEqual(root.enclosing_plane(inner), outer.resolve())
 
-    def test_a_flat_plane_is_not_detected_as_nested(self):
-        self.flat()
-        self.assertIsNone(root.enclosing_plane(config.ROOT))
+    def test_resolution_hops_to_the_outer_plane(self):
+        outer, inner = self.dirs()
+        self.assertEqual(root.find_root(inner), outer.resolve())
 
 
-class TestTheStatusLineNamesIt(NestedCase):
-    def test_a_flat_plane_gets_no_mark(self):
-        """Most planes are flat, and a notice on them would be furniture."""
-        self.flat()
-        self.assertIsNone(statusline._nested_plane_mark())
+class TestTheStatusLineStaysQuietAfterTheHop(NestedCase):
+    def test_no_nested_marker_rides_the_header(self):
+        self.hopped()
+        header = [ln for ln in _plain(statusline.render(_payload())).splitlines()
+                  if "⬢" in ln]
+        self.assertTrue(header, "no header row rendered")
+        self.assertNotIn("nested", " ".join(header).lower())
 
-    def test_a_nested_plane_is_marked(self):
-        self.nest()
-        self.assertIsNotNone(statusline._nested_plane_mark())
+    def test_the_false_alert_row_is_not_rendered(self):
+        """"memory and vault go to X, not Y" is false once they go to the outer plane."""
+        self.hopped()
+        self.assertNotIn("memory and vault", _plain(statusline.render(_payload())))
 
-    def test_the_mark_names_the_outer_plane(self):
-        """"Nested" alone does not tell you which plane you meant to be in — the operator
-        needs the name to recognise it as theirs."""
-        outer = self.nest()
-        self.assertIn(outer.name, statusline._nested_plane_mark())
-
-    def test_it_reaches_the_rendered_header(self):
-        """A helper nothing renders is the same silence this fixes."""
-        outer = self.nest()
-        out = statusline.render({"session_id": "s", "workspace": {"current_dir": str(config.ROOT)}})
-        self.assertIn(outer.name, _plain(out))
-
-    def test_it_never_takes_the_render_down(self):
-        """`render` runs every turn and degrades to a bare brand rather than showing the
-        operator a traceback. An unreadable ancestor must not change that."""
-        real = root.enclosing_plane
-        root.enclosing_plane = lambda *a, **k: (_ for _ in ()).throw(OSError("nope"))
-        self.addCleanup(setattr, root, "enclosing_plane", real)
-        self.assertIsNone(statusline._nested_plane_mark())
-
-    def test_it_rides_the_header_row(self):
-        """Q2's whole reason for choosing the header over a warning row: the release
-        immediately before this one was spent bounding the status line's height, and the
-        correction belongs against the token being misread rather than three rows below
-        it. Asserted as "the outer name shares a line with the `⬢` header" rather than by
-        counting rows, because a flat plane and a nested one are different fixtures and
-        their row counts are not comparable."""
-        outer = self.nest()
-        named = [ln for ln in _plain(statusline.render(_payload())).splitlines()
-                 if outer.name in ln]
-        self.assertTrue(named, "the outer plane is not named anywhere")
-        self.assertTrue(any("⬢" in ln for ln in named),
-                        f"the mark did not ride the header row: {named}")
+    def test_the_duplicate_wrapper_is_gone(self):
+        """`_nested_under`'s docstring warns this rule "was implemented twice, here and
+        there, which is how two surfaces come to disagree about what nested means". 0.36.0
+        made it three."""
+        self.assertFalse(hasattr(statusline, "_nested_plane_mark"))
 
 
-class TestStatusNamesIt(NestedCase):
+class TestTheOverrideStillWarns(NestedCase):
+    def test_the_alert_row_fires(self):
+        """Refusing the hop is exactly the state #140 warned about, and the only one where
+        a warning is still true."""
+        self.overridden()
+        self.assertIn("memory and vault", _plain(statusline.render(_payload())))
+
+    def test_both_planes_are_identified_by_path_not_name(self):
+        """The defect that made the original alert useless. Here the two planes have
+        DIFFERENT names, so a bare-name rendering would pass — the assertion is on the
+        separator that only a path can contain."""
+        self.overridden()
+        row = [ln for ln in _plain(statusline.render(_payload())).splitlines()
+               if "memory and vault" in ln][0]
+        self.assertIn("/", row)
+
+
+class TestStatusNamesTheHop(NestedCase):
     def run_status(self) -> str:
         buf = io.StringIO()
         with redirect_stdout(buf), redirect_stderr(io.StringIO()):
             commands.cmd_status(SimpleNamespace(workspace=None, all=False))
         return buf.getvalue()
 
-    def test_a_nested_plane_is_named(self):
-        """"Where am I" is the whole job of this command, and the plane is the outermost
-        part of that answer."""
-        outer = self.nest()
-        self.assertIn(outer.name, self.run_status())
+    def test_the_hop_is_stated(self):
+        """A correction charter makes silently is one nobody can argue with — and "where am
+        I" is this command's whole job."""
+        outer, inner = self.hopped()
+        out = self.run_status()
+        self.assertIn(str(inner.resolve()), out.replace("~", str(Path.home())))
+        self.assertIn("acting on", out)
 
-    def test_a_flat_plane_says_nothing_about_nesting(self):
+    def test_a_flat_plane_says_nothing(self):
         self.flat()
-        self.assertNotIn("nested", self.run_status().lower())
+        said = self.run_status().lower()
+        self.assertNotIn("nested", said)
+        self.assertNotIn("acting on", said)
 
 
 class TestTheMisleadingErrorIsCorrected(NestedCase):
@@ -149,32 +158,31 @@ class TestTheMisleadingErrorIsCorrected(NestedCase):
             commands_worktree._resolve(SimpleNamespace(repo="charter", workspace=None))
         return buf.getvalue()
 
-    def test_it_names_the_plane_when_nested(self):
-        """The message the operator actually met was "'charter' isn't cloned in workspace
-        'default'" — for a clone that exists, in a plane they never chose. Advising a
-        second clone is charter guessing at a cause it can see is wrong (ADR 0009)."""
-        outer = self.nest()
-        self.assertIn(outer.name, self.resolve_err())
+    def test_it_states_the_hop_when_one_happened(self):
+        """The message the operator met was "'charter' isn't cloned in workspace 'default'"
+        — for a clone they were standing in, in a plane they never chose. Naming which
+        plane answered is what makes the rest of the message readable."""
+        outer, inner = self.hopped()
+        self.assertIn("acting on", self.resolve_err())
 
     def test_the_plane_is_named_before_the_clone_advice(self):
-        """Order is the correction. The clone tip is the fallback for the flat case; when
-        charter can see the plane is nested, that is the likelier cause and has to be read
-        first."""
-        self.nest()
+        """Order is the correction: the clone tip is the fallback, and when charter can see
+        the plane moved that is the likelier explanation."""
+        self.hopped()
         err = self.resolve_err()
-        self.assertLess(err.lower().index("nested"), err.index("Clone it first"))
+        self.assertLess(err.index("acting on"), err.index("Clone it first"))
 
     def test_the_clone_advice_survives(self):
-        """Not-cloned is still possible in a nested plane — charter names the more likely
-        cause without deleting the other one."""
-        self.nest()
+        """Not-cloned stays possible either way — charter names the likelier cause without
+        deleting the other one (ADR 0009)."""
+        self.hopped()
         self.assertIn("Clone it first", self.resolve_err())
 
     def test_a_flat_plane_keeps_the_original_message(self):
         self.flat()
         err = self.resolve_err()
         self.assertIn("isn't cloned in workspace", err)
-        self.assertNotIn("nested", err.lower())
+        self.assertNotIn("acting on", err)
 
 
 def _payload() -> dict:
@@ -182,7 +190,6 @@ def _payload() -> dict:
 
 
 def _plain(text: str) -> str:
-    import re
     return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 

--- a/tests/test_outer_plane_wins.py
+++ b/tests/test_outer_plane_wins.py
@@ -1,0 +1,161 @@
+"""A plane cloned into another plane's ``workspaces/`` resolves to the OUTER one.
+
+`find_root` took the innermost ``charter.toml`` — the git/cargo/npm contract, and right
+almost everywhere. But `charter clone` puts clones at ``workspaces/<ws>/<repo>``, and a
+cloned repo may carry its own tracked ``charter.toml``. Standing in one, the active plane
+silently became a different plane: different personas, no vault, memory landing where
+nobody chose.
+
+#140 detected this and deliberately left resolution alone, reasoning that sometimes the
+inner plane IS the one you mean — naming charter's own dogfooding as the example. Measured
+against that very example, the inner plane holds **no vaults**, a subset of the workspaces,
+and 47 **tracked** persona files, so `charter persona remember` there writes into the
+charter repo's git index rather than the operator's plane. The justification was
+contradicted by the one case it named (#200).
+
+**Scoped to the `workspaces/` relationship, not "outermost wins".** A bare walk to the
+topmost marker would let a stray ``charter.toml`` in ``~`` capture every plane beneath it.
+The redirect fires only for the structural relationship charter itself creates, which is
+exactly what `enclosing_plane` already tested.
+
+**The redirect must remember what it redirected from.** Once `find_root` answers with the
+outer plane, ``enclosing_plane(config.ROOT)`` is `None` by construction — the outer is not
+nested — so every surface that named the nesting would go quiet, and `charter` would be
+silently doing something the operator cannot see. `standing_in_nested_plane` is that fact.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+
+from charter import root, util
+from tests._isolation import PersonaIso
+
+
+class PlaneCase(PersonaIso):
+    def plane(self, *parts: str) -> Path:
+        d = self.tmp.joinpath(*parts)
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "charter.toml").write_text("schema = 1\n")
+        return d
+
+    def setUp(self) -> None:
+        super().setUp()
+        # `find_root` consults $CHARTER_ROOT before walking, and the developer running the
+        # suite may well have one exported — it would win outright and every walk test
+        # would assert against their plane instead of the fixture.
+        self._env = os.environ.pop(root.ENV_VAR, None)
+        if self._env is not None:
+            self.addCleanup(os.environ.__setitem__, root.ENV_VAR, self._env)
+
+
+class TestTheOuterPlaneWins(PlaneCase):
+    def test_a_clone_in_workspaces_resolves_to_the_outer_plane(self):
+        outer = self.plane("outer")
+        inner = self.plane("outer", "workspaces", "w1", "repo")
+        self.assertEqual(root.find_root(inner), outer.resolve())
+
+    def test_a_directory_below_the_clone_resolves_the_same_way(self):
+        """The operator is rarely standing exactly on the marker — they are in `charter/`
+        or `tests/` inside it."""
+        outer = self.plane("outer")
+        inner = self.plane("outer", "workspaces", "w1", "repo")
+        deep = inner / "charter" / "sub"
+        deep.mkdir(parents=True)
+        self.assertEqual(root.find_root(deep), outer.resolve())
+
+    def test_a_lone_plane_still_resolves_to_itself(self):
+        """The ordinary case, and the one that must not move."""
+        solo = self.plane("solo")
+        self.assertEqual(root.find_root(solo), solo.resolve())
+
+    def test_a_chain_resolves_to_the_outermost_of_the_chain(self):
+        """A plane inside a plane inside a plane. Hopping once would leave the answer in
+        the middle — still not the plane holding the vault."""
+        top = self.plane("top")
+        mid = self.plane("top", "workspaces", "a", "mid")
+        bottom = self.plane("top", "workspaces", "a", "mid", "workspaces", "b", "leaf")
+        self.assertEqual(root.find_root(bottom), top.resolve())
+        self.assertEqual(root.find_root(mid), top.resolve())
+
+
+class TestTheRedirectIsNarrow(PlaneCase):
+    def test_a_marker_above_that_is_not_via_workspaces_does_not_capture(self):
+        """The whole reason this is not "outermost wins": a `charter.toml` anywhere up the
+        tree — a stray one in `~`, an unrelated plane — would otherwise swallow every plane
+        beneath it."""
+        self.plane("above")
+        inner = self.plane("above", "somewhere", "else", "plane")
+        self.assertEqual(root.find_root(inner), inner.resolve())
+
+    def test_a_sibling_workspaces_dir_does_not_capture(self):
+        """`workspaces/` has to be the OUTER plane's own, on the path between the two."""
+        self.plane("above")
+        inner = self.plane("above", "notworkspaces", "w1", "repo")
+        self.assertEqual(root.find_root(inner), inner.resolve())
+
+    def test_charter_root_still_wins_outright(self):
+        """The escape hatch for anyone who genuinely means the inner plane. `find_root`
+        documents $CHARTER_ROOT as winning outright, and that must survive a rule which
+        would otherwise make the inner plane unreachable."""
+        self.plane("outer")
+        inner = self.plane("outer", "workspaces", "w1", "repo")
+        os.environ[root.ENV_VAR] = str(inner)
+        self.addCleanup(os.environ.pop, root.ENV_VAR, None)
+        self.assertEqual(root.find_root(self.tmp), inner.resolve())
+
+
+class TestTheRedirectRemembersItsOrigin(PlaneCase):
+    def test_it_names_the_plane_it_redirected_past(self):
+        """Without this the change is invisible: once `find_root` answers with the outer,
+        `enclosing_plane(config.ROOT)` is None by construction and every surface that used
+        to name the nesting goes quiet."""
+        self.plane("outer")
+        inner = self.plane("outer", "workspaces", "w1", "repo")
+        self.assertEqual(root.standing_in_nested_plane(inner), inner.resolve())
+
+    def test_a_lone_plane_has_no_origin(self):
+        solo = self.plane("solo")
+        self.assertIsNone(root.standing_in_nested_plane(solo))
+
+    def test_somewhere_with_no_plane_at_all_has_no_origin(self):
+        bare = self.tmp / "bare"
+        bare.mkdir()
+        self.assertIsNone(root.standing_in_nested_plane(bare))
+
+    def test_it_never_raises_on_a_hostile_path(self):
+        """It runs on the status line's render path, which must degrade rather than fail."""
+        self.assertIsNone(root.standing_in_nested_plane(self.tmp / "nope" / "gone"))
+
+
+class TestPlanesAreNamedUnambiguously(PlaneCase):
+    def test_a_bare_name_is_not_used_to_identify_a_plane(self):
+        """The bug this fixes: the inner plane's directory is named `charter` and so is the
+        outer's, so the old alert read "memory and vault go to charter, not charter" —
+        which is why it told the operator nothing (#200). `.name` is not an identifier; it
+        is a coincidence that usually holds."""
+        outer = self.plane("charter")
+        inner = self.plane("charter", "workspaces", "fleet", "charter")
+        a, b = util.short_path(outer), util.short_path(inner)
+        self.assertNotEqual(a, b)
+
+    def test_a_path_under_home_is_shortened(self):
+        self.assertTrue(util.short_path(Path.home() / "x" / "y").startswith("~/"))
+
+    def test_a_path_outside_home_is_left_absolute(self):
+        self.assertEqual(util.short_path(Path("/opt/thing")), "/opt/thing")
+
+
+class TestTheDuplicateWrapperIsGone(unittest.TestCase):
+    def test_the_render_path_has_one_wrapper_over_the_rule(self):
+        """`_nested_under`'s own docstring warns that this rule "was implemented twice,
+        here and there, which is how two surfaces come to disagree about what nested
+        means". 0.36.0 added a third; this collapses it back."""
+        from charter import statusline
+        self.assertFalse(hasattr(statusline, "_nested_plane_mark"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up to #200 / 0.36.0, and it **overturns a decision** — worth reading for that alone.

## The reversal

`find_root` took the innermost `charter.toml`. #140 detected the nesting hazard and deliberately left resolution alone, reasoning that sometimes the inner plane IS the one you mean — and naming **charter's own dogfooding** as the example.

Measured against that example, the inner plane holds:

| | outer (real plane) | inner (the clone) |
|---|---|---|
| vaults | 3 | **none** |
| workspaces | 6 | 3 — the tracked subset |
| personas | the operator's | **47 tracked repo files** |

So `charter persona remember` run there writes into the cloned repo's **git index**, not the plane. The justification did not survive its own example, and the operator hit it twice in one session.

**Scoped to the `workspaces/` relationship, not "outermost wins."** A bare walk to the topmost marker would let one stray `charter.toml` in `~` swallow every plane beneath it — a narrow mistake turned into a total one. `$CHARTER_ROOT` still wins outright and remains the escape hatch.

## The consequence that shapes the design

Once `find_root` answers with the outer plane, `enclosing_plane(ROOT)` is `None` **by construction** — the outer isn't nested. Every surface that named the nesting would go silent, and charter would be quietly acting on a plane nobody can see it choose. `config.NESTED_ORIGIN` records it, and its three states are the whole UX:

| state | meaning | surface |
|---|---|---|
| `None` | no nesting | say nothing |
| `!= ROOT` | hop fired | *notice* — "standing in X, acting on Y" |
| `== ROOT` | `$CHARTER_ROOT` refused the hop | *warning* — #140's hazard is live |

## Two defects found on the way

**The status line already had a nested-plane alert.** It fired correctly and read:

```
⚠ nested plane — memory and vault go to charter, not charter
```

The inner plane's directory is named `charter`; so is the outer's. It said nothing because **`Path.name` is not an identifier — it is a coincidence that usually holds.** Planes are now named by `~`-shortened path. That row is also *false* after a hop, so it fires only for the override.

**0.36.0 added a third wrapper** around this rule, which `_nested_under`'s own docstring warns is how "two surfaces come to disagree about what nested means." Collapsed back to one.

## Verified live

```
standing in the clone, before:  ⬢ default · ws 3        (a plane with no vaults)
standing in the clone, after:   ⬢ fleet · pieces 1 · ws 6

charter status:
  active: fleet (via cwd)
  you are standing in ~/IdeaProjects/charter/workspaces/fleet/charter, which is a
  plane too — charter is acting on ~/IdeaProjects/charter
```

## Tests

15 new in `tests/test_outer_plane_wins.py` (redirect, narrowness, chained nesting, `$CHARTER_ROOT` precedence, origin recording, path naming); `test_nested_plane_named.py` rewritten around the three states, keeping "says nothing here" as an asserted decision rather than an absence. Full suite: **2099 passing**.

A test-isolation leak is fixed too: `NESTED_ORIGIN` is derived from `start`, and `config.use()` passes the root — before that it read `Path.cwd()`, so the suite was answering from the developer's actual worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX