### PR TITLE
0.37.0 — the plane holding the vault wins

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.36.0"
+__version__ = "0.37.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.36.0",
+            "command": "charter hook sessionstart --plugin-version 0.37.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.36.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.37.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.36.0",
+            "command": "charter hook pretooluse --plugin-version 0.37.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.36.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.37.0",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.36.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.37.0"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.36.0",
+            "command": "charter hook posttooluse --plugin-version 0.37.0",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.36.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.37.0",
             "timeout": 5
           }
         ]
@@ -100,7 +100,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.36.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.37.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.36.0"
+version = "0.37.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only: the four sites, `hooks.json` carrying 8 of them.

## What ships

**#200 (resolution) — a plane cloned into another plane's `workspaces/` now resolves to the outer one.**

```
standing in the clone, before:  ⬢ default · ws 3        (a plane with no vaults)
standing in the clone, after:   ⬢ fleet · pieces 1 · ws 6
```

This **overturns #140**, which detected the hazard and chose not to re-resolve, naming charter's own dogfooding as the case where the inner plane is the one you mean. In that exact case the inner plane has no vault, a subset of the workspaces, and 47 *tracked* persona files — so `charter persona remember` there writes into the cloned repo's git index. The rationale did not survive its own example.

Narrow by construction: the hop is allowed only through an enclosing plane's own `workspaces/`, never "topmost marker wins", and `$CHARTER_ROOT` still wins outright as the escape hatch.

**The nested-plane alert had been firing correctly and saying nothing.** It named planes by directory name, and when charter is cloned into its own plane both are called `charter` — so it rendered *"memory and vault go to charter, not charter"*. `Path.name` is not an identifier; planes are named by `~`-shortened path now.

## Release hygiene

`0.36.0` → `0.37.0` is the same byte length — the shape that served stale `.pyc` on an earlier release. Bytecode cleared, interpreter asked to confirm it sees `0.37.0`.

Suite: **2099 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX