### PR TITLE
feat: the row for a tree says which persona was last seen in it

### DIFF
--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -655,8 +655,19 @@ def _touch_piece(data: dict) -> None:
 
     Called from the handlers that already run whenever a session is doing anything, which
     is the point: liveness must not depend on the worker remembering, because the worker we
-    most need to catch is precisely the one that did not. A session outside a worktree has
-    no piece and writes nothing.
+    most need to catch is precisely the one that did not.
+
+    **Clones as well as worktrees.** This used to return early outside a worktree, which
+    made a persona working directly in a clone invisible — an ordinary way to work, and the
+    one the operator was using when they asked for this. A clone records under
+    ``piece=None``. The plane root records nothing: it already carries an alert whose whole
+    message is *work belongs in a workspace clone*, and marking who is present there would
+    decorate the thing charter is telling you to stop doing.
+
+    **The persona is recorded, not derived.** The claim log has carried one since ADR 0011,
+    and reading it back here would have needed no new field — but it names whoever CREATED
+    the piece, and a second persona picking up someone else's piece is the case the fleet
+    spine exists for.
 
     Silent and best-effort like everything else in this module — a turn must never fail
     over bookkeeping. It is one small overwritten file, so the cost is a write, not a grep.
@@ -666,12 +677,18 @@ def _touch_piece(data: dict) -> None:
         if not cwd:
             return
         from pathlib import Path as _Path
-        from . import pieces, worktree
-        here = worktree.locate(_Path(cwd))
-        if here is None:
-            return
-        ws, repo, piece = here
-        pieces.seen(ws, repo, piece, session=data.get("session_id"))
+        from . import persona as _persona, pieces, workspace as _workspace, worktree
+        here = _Path(cwd)
+        loc = worktree.locate(here)
+        if loc is not None:
+            ws, repo, piece = loc
+        else:
+            clone = _workspace.clone_of(here)
+            if clone is None:
+                return
+            ws, repo, piece = clone[0], clone[1], None
+        pieces.seen(ws, repo, piece, session=data.get("session_id"),
+                    persona=_persona.resolve_active())
     except Exception:
         return
 

--- a/charter/pieces.py
+++ b/charter/pieces.py
@@ -41,7 +41,7 @@ import json
 import os
 import re
 import socket
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from . import persona, session, workspace
@@ -209,22 +209,110 @@ def declaration_for(ws: str, repo: str, piece: str) -> dict | None:
 SEEN_DIR = "seen"
 
 
-def seen_path(ws: str, repo: str, piece: str) -> Path:
-    return dir_for(ws) / SEEN_DIR / repo / f"{piece}.json"
+#: How long a persona stays counted in ``by`` after its last beat.
+#:
+#: Without a window the count only ever grows, and ``+3`` decays into "three personas were
+#: in here at some point", which is not a fact worth a column. An hour is long enough to
+#: cover a pause — a review, a long build, lunch — and short enough that whoever left this
+#: morning is no longer presented as company.
+PRESENCE_WINDOW = timedelta(hours=1)
+
+#: Hard cap on ``by``, independent of the window. The window alone bounds the map in
+#: practice; this bounds it in principle, so a pathological plane cannot grow one heartbeat
+#: file without limit.
+PRESENCE_KEEP = 8
 
 
-def seen(ws: str, repo: str, piece: str, session: str | None = None,
-         when: datetime | None = None) -> Path | None:
-    """Mark a piece's worker alive now. Best-effort — never raises, never blocks a turn."""
+def seen_path(ws: str, repo: str, piece: str | None) -> Path:
+    """Where a tree's heartbeat lives. ``piece=None`` means the clone itself.
+
+    The clone's record is a file *beside* the piece directory, never inside it: a piece
+    named like any sentinel we might have used would otherwise collide with the clone's own
+    record, and piece names come from branch names, which are not ours to constrain.
+    """
+    base = dir_for(ws) / SEEN_DIR
+    return base / f"{repo}.json" if piece is None else base / repo / f"{piece}.json"
+
+
+def seen(ws: str, repo: str, piece: str | None, session: str | None = None,
+         persona: str | None = None, when: datetime | None = None) -> Path | None:
+    """Mark the worker in this tree alive now. Best-effort — never raises, never blocks.
+
+    ``persona`` is *recorded*, not derived. The claim log has carried a persona since ADR
+    0011, and joining to it would have needed no new field at all — but that names whoever
+    CREATED the piece, and a second persona picking up someone else's piece is the case the
+    fleet spine exists for. This records who is *there*; the claim records who *was*.
+
+    The file stays one small overwritten blob. ``by`` keeps the last beat per persona so a
+    second worker is counted rather than silently overwritten, pruned by
+    :data:`PRESENCE_WINDOW` and capped at :data:`PRESENCE_KEEP`.
+    """
     p = seen_path(ws, repo, piece)
     when = when or _now()
+    stamp = when.isoformat(timespec="seconds")
+    by: dict[str, str] = {}
+    if persona:
+        prev = last_seen(ws, repo, piece) or {}
+        old = prev.get("by")
+        if isinstance(old, dict):
+            for name, ts in old.items():
+                at = _parse(ts if isinstance(ts, str) else None)
+                if isinstance(name, str) and at is not None and when - at <= PRESENCE_WINDOW:
+                    by[name] = ts
+        by[persona] = stamp
+        if len(by) > PRESENCE_KEEP:
+            keep = sorted(by.items(), key=lambda kv: kv[1], reverse=True)[:PRESENCE_KEEP]
+            by = dict(keep)
+    blob = {"ts": stamp, "session": session}
+    if persona:
+        blob["persona"] = persona
+        blob["by"] = by
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(json.dumps({"ts": when.isoformat(timespec="seconds"),
-                                 "session": session}, sort_keys=True) + "\n")
+        p.write_text(json.dumps(blob, sort_keys=True) + "\n")
         return p
     except OSError:
         return None
+
+
+def presence(ws: str, repo: str, piece: str | None) -> tuple[str, str, int] | None:
+    """``(persona, age, others)`` for the tree, or ``None`` when no persona was recorded.
+
+    An **observation**, never an assertion: charter cannot verify that anyone is working,
+    so the caller renders a name and an age and lets the reader draw the conclusion — the
+    grammar `silence` already uses, and the reason ADR 0011 has no ``failed`` state.
+
+    ``None`` rather than a guess for a heartbeat written by an older charter, which carries
+    no persona at all: those are overwritten within a turn, and a cell that invents a name
+    for one turn is worse than a cell that waits.
+    """
+    rec = last_seen(ws, repo, piece)
+    if not rec:
+        return None
+    who = rec.get("persona")
+    if not isinstance(who, str) or not who:
+        return None
+    at = _parse(rec.get("ts"))
+    now = _now()
+    by = rec.get("by")
+    others = 0
+    if isinstance(by, dict):
+        for name, ts in by.items():
+            seen_at = _parse(ts if isinstance(ts, str) else None)
+            if name != who and seen_at is not None and now - seen_at <= PRESENCE_WINDOW:
+                others += 1
+    return who, _presence_age(at, now), others
+
+
+def _presence_age(at: datetime | None, now: datetime) -> str:
+    """``now`` under a minute, then the coarse age.
+
+    ``0m`` is technically correct and reads as broken; a bare name would be the claim of
+    activity charter is not entitled to make.
+    """
+    if at is None:
+        return "?"
+    return "now" if (now - at).total_seconds() < 60 else since(at, now)
 
 
 def last_seen(ws: str, repo: str, piece: str) -> dict | None:

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -538,6 +538,84 @@ def _current(payload: dict) -> tuple[str | None, str] | None:
     return None
 
 
+#: Marks the persona last seen in a tree. The same glyph the persona column uses for the
+#: ACTIVE persona, deliberately: both answer "who is here", and one glyph for one question
+#: is what keeps the two columns readable together. East-Asian Neutral, like every other
+#: marker in this layout — see the width notes at the top of the module.
+_PRESENCE = "▸"
+
+
+def _presence_text(ws: str, repo: str, piece: str | None) -> str:
+    """``▸steward now`` / ``▸steward 7m +1`` for a tree, or ``""``.
+
+    An **observation**, never an assertion. Charter cannot verify that anybody is working,
+    so this reads the way `silent 3d` already does — a name and an age, with the reader
+    drawing the conclusion. A bare ``▸steward`` would be the claim of activity ADR 0011
+    refuses to let charter make, which is why a fresh beat says ``now`` rather than nothing.
+
+    ``+N`` counts other personas seen in the same tree inside `pieces.PRESENCE_WINDOW`. The
+    heartbeat is one overwritten file, so a second worker used to vanish without trace; the
+    count is the honest admission that the cell is not the whole truth, and `charter
+    worktree list` is where the full picture belongs — the split `_piece_state` already
+    keeps when it drops a declaration's reason.
+
+    Returns ``""`` on anything unreadable: every-turn render path, and a footer that blanks
+    is worse than one that shows less.
+    """
+    try:
+        from . import pieces as _p
+        got = _p.presence(ws, repo, piece)
+    except Exception:
+        return ""
+    if not got:
+        return ""
+    who, age, others = got
+    tail = f" {_DIM}+{others}{_R}" if others else ""
+    return f"{_MAGENTA}{_PRESENCE}{who}{_R} {_DIM}{age}{_R}{tail}"
+
+
+def _branch_cell_for(branch_text: str, presence: str, marks_plain: str = "",
+                     marks_col: str = "", is_dirty: bool = False) -> str:
+    """The branch cell's contents: branch, markers, and presence **if it still fits**.
+
+    The losing order matters more than the layout. Markers and the branch name are true of
+    the tree; presence is an extra observation about who happened to be standing in it. So
+    the branch is truncated only so far as the markers demand — the rule this cell already
+    kept — and presence is appended only out of whatever room is genuinely left over. On a
+    narrow pane presence disappears and nothing that was there before moves.
+    """
+    br = tui.truncate(branch_text, max(1, _BRANCH_W - tui.width(marks_plain)))
+    out = f"{_YELLOW if is_dirty else _DIM}{br}{_R}{marks_col}"
+    if not presence:
+        return out
+    used = tui.width(br) + tui.width(marks_plain)
+    room = _BRANCH_W - used
+    need = tui.width(_strip(presence)) + 1        # +1 for the separating space
+    return out + f" {presence}" if room >= need else out
+
+
+def _strip(text: str) -> str:
+    import re as _re
+    return _re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _presence_for_dir(d) -> str:
+    """Presence for whatever kind of tree *d* is — a worktree or a clone.
+
+    Both, because `_tree_cells` draws both and working directly in a clone is ordinary; it
+    was invisible only because the liveness hook returned early outside a worktree.
+    """
+    try:
+        from . import worktree as _wt, workspace as _ws
+        loc = _wt.locate(d)
+        if loc:
+            return _presence_text(loc[0], loc[1], loc[2])
+        clone = _ws.clone_of(d)
+        return _presence_text(clone[0], clone[1], None) if clone else ""
+    except Exception:
+        return ""
+
+
 def _tree_cells(lead: str, label: str, d, states, branches, gl, branch=None) -> tui.Row:
     """One table row — ``<lead><label>`` in the name column, then branch+markers, CI, change.
 
@@ -559,8 +637,8 @@ def _tree_cells(lead: str, label: str, d, states, branches, gl, branch=None) -> 
     # branch + markers: truncate the *branch* so the markers always survive
     marks_plain, marks_col, is_dirty = _markers(states.get(d, {}))
     text = branches.get(d, "?") if branch is None else branch
-    br = tui.truncate(text, max(1, _BRANCH_W - tui.width(marks_plain)))
-    branch = tui.Cell(f"{_YELLOW if is_dirty else _DIM}{br}{_R}{marks_col}", _BRANCH_W)
+    branch = tui.Cell(_branch_cell_for(text, _presence_for_dir(d),
+                                       marks_plain, marks_col, is_dirty), _BRANCH_W)
 
     info = gl.get(d, {})
     ci = tui.Cell(_ci_part(info.get("ci")), _CI_W)

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -190,6 +190,42 @@ def from_path(path=None) -> str | None:
     return parts[0] if len(parts) >= 2 else None
 
 
+def clone_of(path=None) -> tuple[str, str] | None:
+    """``(workspace, repo)`` when *path* is inside a **clone**, else ``None``.
+
+    The clone counterpart to `worktree.locate`, and deliberately exclusive of it: a path
+    inside a worktree answers ``None`` here, so a caller asking both questions can never
+    record the same directory twice under two identities.
+
+    ``None`` for the plane root, which is the point — the root already carries an alert
+    whose entire message is *work belongs in a workspace clone*, and marking who is present
+    there would decorate the thing charter is telling you to stop doing. ``None`` too for
+    ``workspaces/<ws>`` itself, which is a container rather than a tree.
+
+    Path arithmetic only, no git and no subprocess: this is reached from a hook that fires
+    every turn and from the status line's render path.
+    """
+    from . import worktree
+    try:
+        here = Path(path or os.getcwd()).resolve()
+    except (OSError, RuntimeError):
+        return None
+    if worktree.locate(here):
+        return None
+    try:
+        parts = here.relative_to(Path(config.WORKSPACES_DIR).resolve()).parts
+    except (ValueError, OSError, RuntimeError):
+        return None
+    if len(parts) < 2:
+        return None
+    # A dotted second segment is charter's own furniture (`.worktrees/`), never a repo.
+    # `worktree.locate` catches those whose layout it knows; this catches the rest rather
+    # than inventing a repo called `.worktrees`.
+    if parts[1].startswith("."):
+        return None
+    return parts[0], parts[1]
+
+
 #: A committed, deliberately-chosen fallback workspace — `workspaces/.default`.
 #:
 #: NOT the "last active workspace" pointer #124 rejected, and the distinction is the whole

--- a/tests/test_persona_presence.py
+++ b/tests/test_persona_presence.py
@@ -1,0 +1,222 @@
+"""Which persona was last seen in a tree, rendered on the row for that tree.
+
+A fleet coordinator reading the status line can see what each piece *declared* and how long
+it has been *silent*, but not who is in it. The claim log has carried ``persona`` since ADR
+0011 — but that names whoever *created* the piece, and stays true forever after they leave.
+The heartbeat, which is the thing that actually decays, carried only ``{ts, session}``.
+
+**An observation, never an assertion.** Charter cannot verify that anyone is working, so
+the cell reads like `silent 3d` already does — a name and an age, with the reader drawing
+the conclusion. `▸steward now` says "seen just now", not "steward is working here". ADR
+0011 has no ``failed`` or ``blocked`` for exactly this reason, and `_piece_state`'s
+docstring makes the same point: never a verdict.
+
+**Recorded, not joined.** The persona could have been derived by looking up the claim for
+this piece and reading the persona off it — no schema change at all. It would be wrong the
+moment a second persona picks up someone else's piece, which is the case the fleet spine
+exists for. The heartbeat records who is *there*; the claim records who *was*.
+
+**Clones too, the plane root never.** Working directly in a clone is ordinary and was
+invisible. The plane root already carries an alert whose whole message is *don't work
+here*; marking who is present would decorate the thing charter is telling you to stop.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from charter import config, pieces, workspace
+from tests._isolation import PersonaIso
+
+
+def _plain(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+class PresenceCase(PersonaIso):
+    WS = "w1"
+
+    def at(self, minutes: int) -> datetime:
+        return datetime.now(timezone.utc) - timedelta(minutes=minutes)
+
+    def beat(self, persona: str, minutes: int = 0, repo: str = "svc",
+             piece: str | None = "p1", session: str = "s") -> None:
+        pieces.seen(self.WS, repo, piece, session=session, persona=persona,
+                    when=self.at(minutes))
+
+
+class TestTheHeartbeatCarriesThePersona(PresenceCase):
+    def test_it_is_written(self):
+        self.beat("steward")
+        self.assertEqual(pieces.last_seen(self.WS, "svc", "p1")["persona"], "steward")
+
+    def test_an_older_record_without_one_still_reads(self):
+        """Heartbeats written by an earlier charter carry no persona. They are overwritten
+        within a turn, but the render in between must not blow up on them."""
+        p = pieces.seen_path(self.WS, "svc", "p1")
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"ts": self.at(2).isoformat(), "session": "s"}))
+        self.assertIsNone(pieces.presence(self.WS, "svc", "p1"))
+
+    def test_the_claim_is_not_used_as_the_answer(self):
+        """The claim knows a persona, and reading it here would need no new field at all —
+        and would report the persona who CREATED the piece as the one standing in it."""
+        pieces.record(self.WS, "claimed", "svc", "p1")
+        self.assertIsNone(pieces.presence(self.WS, "svc", "p1"))
+
+
+class TestItReadsAsAnObservation(PresenceCase):
+    def test_a_fresh_beat_says_now(self):
+        """`0m` is technically right and reads as broken; a bare name is the assertion
+        charter is not entitled to make."""
+        self.beat("steward", minutes=0)
+        self.assertEqual(pieces.presence(self.WS, "svc", "p1")[1], "now")
+
+    def test_an_older_beat_carries_its_age(self):
+        self.beat("steward", minutes=7)
+        self.assertEqual(pieces.presence(self.WS, "svc", "p1")[1], "7m")
+
+    def test_a_much_older_beat_reads_coarsely(self):
+        """Same grammar `pieces.since` already uses — the number is context for a human
+        decision, not an input to one charter is making."""
+        self.beat("steward", minutes=60 * 5)
+        self.assertEqual(pieces.presence(self.WS, "svc", "p1")[1], "5h")
+
+    def test_nothing_seen_reads_as_nothing(self):
+        self.assertIsNone(pieces.presence(self.WS, "svc", "p1"))
+
+
+class TestASecondPersonaIsCounted(PresenceCase):
+    def test_the_most_recent_persona_wins_the_cell(self):
+        self.beat("forge", minutes=9)
+        self.beat("steward", minutes=1)
+        self.assertEqual(pieces.presence(self.WS, "svc", "p1")[0], "steward")
+
+    def test_the_other_is_counted_not_dropped(self):
+        """One overwritten file per piece keeps the store bounded, so the second persona
+        used to vanish without trace. The count is the honest admission that the cell is
+        not the whole truth."""
+        self.beat("forge", minutes=9)
+        self.beat("steward", minutes=1)
+        self.assertEqual(pieces.presence(self.WS, "svc", "p1")[2], 1)
+
+    def test_one_persona_counts_no_others(self):
+        self.beat("steward")
+        self.assertEqual(pieces.presence(self.WS, "svc", "p1")[2], 0)
+
+    def test_the_same_persona_twice_is_still_one(self):
+        self.beat("steward", minutes=9)
+        self.beat("steward", minutes=1)
+        self.assertEqual(pieces.presence(self.WS, "svc", "p1")[2], 0)
+
+    def test_a_persona_who_left_long_ago_is_not_counted(self):
+        """Otherwise `+1` accumulates forever and means "someone was here once", which is
+        not a fact worth a column."""
+        self.beat("forge", minutes=60 * 24)
+        self.beat("steward", minutes=1)
+        self.assertEqual(pieces.presence(self.WS, "svc", "p1")[2], 0)
+
+    def test_the_map_cannot_grow_without_bound(self):
+        for i in range(20):
+            self.beat(f"p{i:02d}", minutes=1)
+        blob = json.loads(pieces.seen_path(self.WS, "svc", "p1").read_text())
+        self.assertLessEqual(len(blob.get("by") or {}), pieces.PRESENCE_KEEP)
+
+
+class TestACloneIsTrackedToo(PresenceCase):
+    def test_a_clone_has_its_own_heartbeat(self):
+        """`piece=None` is a clone: working in one directly is ordinary and was invisible,
+        because `_touch_piece` returned early outside a worktree."""
+        self.beat("steward", piece=None)
+        self.assertEqual(pieces.presence(self.WS, "svc", None)[0], "steward")
+
+    def test_a_clone_and_its_worktree_do_not_share_a_record(self):
+        """A file beside the directory, never inside it — a piece named like the sentinel
+        could otherwise collide with the clone's own record."""
+        self.beat("steward", piece=None)
+        self.beat("forge", piece="p1")
+        self.assertEqual(pieces.presence(self.WS, "svc", None)[0], "steward")
+        self.assertEqual(pieces.presence(self.WS, "svc", "p1")[0], "forge")
+
+    def test_the_clone_record_is_not_inside_the_piece_directory(self):
+        clone = pieces.seen_path(self.WS, "svc", None)
+        piece_dir = pieces.seen_path(self.WS, "svc", "p1").parent
+        self.assertNotEqual(clone.parent, piece_dir)
+
+
+class TestWhereTheHookLooks(PersonaIso):
+    def paths_for(self, cwd):
+        from charter import worktree
+        return worktree.locate(cwd), workspace.clone_of(cwd)
+
+    def test_a_clone_is_recognised(self):
+        d = config.WORKSPACES_DIR / "w1" / "svc"
+        d.mkdir(parents=True, exist_ok=True)
+        self.assertEqual(workspace.clone_of(d), ("w1", "svc"))
+
+    def test_a_directory_inside_a_clone_is_recognised(self):
+        d = config.WORKSPACES_DIR / "w1" / "svc" / "src" / "deep"
+        d.mkdir(parents=True, exist_ok=True)
+        self.assertEqual(workspace.clone_of(d), ("w1", "svc"))
+
+    def test_the_plane_root_is_not_a_clone(self):
+        """It has its own alert telling you not to work there."""
+        self.assertIsNone(workspace.clone_of(config.ROOT))
+
+    def test_the_workspace_directory_itself_is_not_a_clone(self):
+        d = config.WORKSPACES_DIR / "w1"
+        d.mkdir(parents=True, exist_ok=True)
+        self.assertIsNone(workspace.clone_of(d))
+
+    def test_somewhere_outside_the_plane_is_not_a_clone(self):
+        self.assertIsNone(workspace.clone_of(self.tmp / "elsewhere"))
+
+
+class TestItRendersOnTheRow(PresenceCase):
+    def test_the_suffix_names_the_persona_and_the_age(self):
+        from charter import statusline
+        self.beat("steward", minutes=3)
+        self.assertEqual(_plain(statusline._presence_text(self.WS, "svc", "p1")),
+                         "▸steward 3m")
+
+    def test_the_suffix_carries_the_other_count(self):
+        from charter import statusline
+        self.beat("forge", minutes=5)
+        self.beat("steward", minutes=1)
+        self.assertEqual(_plain(statusline._presence_text(self.WS, "svc", "p1")),
+                         "▸steward 1m +1")
+
+    def test_nothing_seen_renders_nothing(self):
+        from charter import statusline
+        self.assertEqual(statusline._presence_text(self.WS, "svc", "p1"), "")
+
+    def test_it_never_raises(self):
+        """Every-turn render path: it degrades to an empty cell rather than blanking the
+        footer."""
+        from charter import statusline
+        real = pieces.presence
+        pieces.presence = lambda *a, **k: (_ for _ in ()).throw(OSError("nope"))
+        self.addCleanup(setattr, pieces, "presence", real)
+        self.assertEqual(statusline._presence_text(self.WS, "svc", "p1"), "")
+
+    def test_it_loses_the_column_before_the_branch_does(self):
+        """The losing order settled in Q4/Q5: markers and the branch name are true of the
+        tree, presence is an extra. A long branch keeps its cell and presence drops out
+        rather than squeezing what was already there."""
+        from charter import statusline
+        self.beat("steward", minutes=3)
+        long_branch = "feature/" + ("x" * statusline._BRANCH_W)
+        row = _plain(statusline._branch_cell_for(long_branch, "▸steward 3m"))
+        self.assertNotIn("steward", row)
+
+    def test_it_keeps_the_column_when_there_is_room(self):
+        from charter import statusline
+        row = _plain(statusline._branch_cell_for("main", "▸steward 3m"))
+        self.assertIn("steward", row)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A fleet coordinator could see what each piece **declared** and how long it had been **silent**, but not who was in it.

```
  ├─ charter                    main ▸steward now +1              ✓ passed
  │  ╰─ persona-presence        *
```

## Four decisions, each with a rejected alternative

**An observation, never an assertion.** Charter cannot verify anyone is working, so the cell reads the way `silent 3d` already does — a name and an age, reader draws the conclusion. A bare `▸steward` would be the claim of activity ADR 0011 refuses to let charter make. A fresh beat says `now`: `0m` is technically right and reads as broken.

**Recorded, not joined.** The claim log has carried `persona` since ADR 0011, so this could have been derived with *no schema change at all* — and would be wrong the moment a second persona picks up someone else's piece, which is the case the fleet spine exists for. The heartbeat records who is *there*; the claim records who *was*.

**Clones too, the plane root never.** `_touch_piece` returned early outside a worktree, so a persona working directly in a clone was invisible — an ordinary way to work, and the one in use when this was asked for. The plane root records nothing: it already carries an alert whose whole message is *work belongs in a workspace clone*, and marking who is present would decorate the thing charter is telling you to stop.

**A second persona is counted, not dropped.** One overwritten file per piece kept the store bounded and made the second worker vanish silently. `by` now holds the last beat per persona, pruned to `PRESENCE_WINDOW` (1h) and capped at `PRESENCE_KEEP` (8). Without the window `+N` only grows and decays into "someone was here once".

## Layout

It loses its columns first. Markers and the branch name are true of the tree; presence is an extra, so `_branch_cell_for` appends it only out of genuinely leftover room — on a narrow pane it disappears and nothing that was already there moves. Zero new rows, which matters two releases after one was spent bounding this column's height.

`_tree_cells` is shared by repo rows and nested worktree rows, so both got it from one change — the same reason that function exists.

## Tests

27 new in `tests/test_persona_presence.py`, including the ones that pin the *rejected* alternatives: `test_the_claim_is_not_used_as_the_answer`, `test_a_persona_who_left_long_ago_is_not_counted`, `test_the_plane_root_is_not_a_clone`, `test_it_loses_the_column_before_the_branch_does`. Heartbeats written by an older charter carry no persona and read as `None` rather than raising. Full suite: **2126 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX