### PR TITLE
0.38.0 — the row for a tree says who was last seen in it

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.37.0"
+__version__ = "0.38.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.37.0",
+            "command": "charter hook sessionstart --plugin-version 0.38.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.37.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.38.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.37.0",
+            "command": "charter hook pretooluse --plugin-version 0.38.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.37.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.38.0",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.37.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.38.0"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.37.0",
+            "command": "charter hook posttooluse --plugin-version 0.38.0",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.37.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.38.0",
             "timeout": 5
           }
         ]
@@ -100,7 +100,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.37.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.38.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.37.0"
+version = "0.38.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only: the four sites, `hooks.json` carrying 8.

```
  ├─ charter                    main ▸steward now +1              ✓ passed
```

## What ships

**#207 — which persona was last seen in a tree, on that tree's row.** A coordinator could see what a piece *declared* and how long it had been *silent*, never who was in it.

An **observation, never an assertion** — charter cannot verify anyone is working, so it reads like `silent 3d`: a name and an age. A fresh beat says `now`, because a bare `▸steward` is the claim of activity ADR 0011 refuses to make, and `0m` reads as broken.

The persona is **recorded** in the heartbeat, not joined from the claim — the claim names whoever *created* the piece, which is wrong the moment a second persona picks it up. **Clones are tracked too** (working directly in one was invisible); the **plane root deliberately is not**, since it already carries an alert saying work belongs in a workspace clone. A **second persona is counted** rather than silently overwritten, inside a one-hour window so `+N` cannot decay into "someone was here once".

Presence loses its columns before the branch or its markers do, and adds no rows — two releases after one was spent bounding this column.

## Release hygiene

`0.37.0` → `0.38.0`, same byte length as ever; bytecode cleared and the interpreter asked to confirm.

Suite: **2126 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX