### PR TITLE
fix: the MCP repair hint has to produce a launcher that starts

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1113,7 +1113,24 @@ def _claude_json() -> Path:
     return Path.home() / ".claude.json"
 
 
-def _registered_launchers(doc: dict) -> list[tuple[str, str]]:
+def _vault_in_args(args) -> str | None:
+    """The vault a ``charter secret exec <vault> …`` invocation opens, or ``None``.
+
+    Read off the args rather than assumed, because it is the difference between advice that
+    works and advice that half-works: a launcher charter merely *starts* has no plane to
+    resolve, while one that opens a vault must find the plane holding it. Advice that
+    applies to every entry is read as boilerplate and then not read at all.
+    """
+    if not isinstance(args, list):
+        return None
+    flat = [a for a in args if isinstance(a, str)]
+    for i in range(len(flat) - 2):
+        if flat[i] == "secret" and flat[i + 1] == "exec" and not flat[i + 2].startswith("-"):
+            return flat[i + 2]
+    return None
+
+
+def _registered_launchers(doc: dict) -> list[tuple[str, str, list]]:
     """``(server name, command)`` for every **stdio** MCP server the host has registered.
 
     Both scopes, because checking only the top level would miss most real registrations —
@@ -1128,7 +1145,7 @@ def _registered_launchers(doc: dict) -> list[tuple[str, str]]:
         for body in projects.values():
             if isinstance(body, dict):
                 scopes.append(body.get("mcpServers"))
-    out: list[tuple[str, str]] = []
+    out: list[tuple[str, str, list]] = []
     for servers in scopes:
         if not isinstance(servers, dict):
             continue
@@ -1136,7 +1153,7 @@ def _registered_launchers(doc: dict) -> list[tuple[str, str]]:
             # An SSE/HTTP server has a `url` and no `command`. Absence of a launcher is
             # not a missing launcher.
             if isinstance(entry, dict) and isinstance(entry.get("command"), str):
-                out.append((str(name), entry["command"]))
+                out.append((str(name), entry["command"], entry.get("args") or []))
     return out
 
 
@@ -1189,19 +1206,43 @@ def check_mcp_launchers() -> Result:
         return Result("mcp", WARN, detail="~/.claude.json is not an object",
                       hint=_NOT_CHECKED_HINT)
 
-    checkable = [(n, c) for n, c in _registered_launchers(doc) if os.path.isabs(c)]
-    broken = [(n, c) for n, c in checkable if _launcher_missing(c)]
+    registered = _registered_launchers(doc)
+    checkable = [(n, c, a) for n, c, a in registered if os.path.isabs(c)]
+    broken = [(n, c, a) for n, c, a in checkable if _launcher_missing(c)]
     if not broken:
+        # "0 launcher(s) resolve" was shown for a plane whose only server had just been
+        # repaired onto a bare command. Zero were CHECKED and none were broken; printing
+        # the first as though it were a count of what resolves reads as "nothing is
+        # registered", which is a different claim about a different fact.
+        if not registered:
+            return Result("mcp", OK, detail="no MCP servers registered")
+        if not checkable:
+            # Every registered launcher is a bare command, resolved against the PATH of
+            # whoever starts it — which charter cannot see, and so does not claim to have
+            # checked. Saying how many exist keeps that honest without inventing a verdict.
+            return Result("mcp", OK,
+                          detail=f"{len(registered)} server(s), none on an absolute path")
         return Result("mcp", OK, detail=f"{len(checkable)} launcher(s) resolve")
 
     hints = []
-    for name, command in broken:
+    for name, command, args in broken:
         if Path(command).name in _REMOVED_SHIMS:
             # Charter removed this one, so it knows what replaced it. Naming the
             # replacement turns a diagnosis into a one-line fix.
-            hints.append(f"{name}: {command} is gone (the edm→charter rename removed that "
-                         f"shim) — set this server's command to `charter`, leaving its args "
-                         f"unchanged")
+            fix = (f"{name}: {command} is gone (the edm→charter rename removed that shim) "
+                   f"— set this server's command to `charter`, leaving its args unchanged")
+            vault = _vault_in_args(args)
+            if vault:
+                # The half of the advice that was missing. The old command was an absolute
+                # path into a particular umbrella; a bare `charter` resolves its plane from
+                # the LAUNCHING directory, and an `mcpServers` entry at the top level of
+                # `~/.claude.json` is user-scope — it launches for every project, most of
+                # which are not that plane. The server then starts, fails to find the vault,
+                # and the tools are missing again, silently, exactly as before.
+                fix += (f". It opens vault `{vault}`, so also set CHARTER_ROOT in this "
+                        f"server's `env` to the plane holding that vault — a user-scope "
+                        f"server has no directory to resolve one from")
+            hints.append(fix)
         else:
             # No claim about WHY it went missing: charter did not remove it and does not
             # know. It reports the fact and the two ways out.
@@ -1209,7 +1250,7 @@ def check_mcp_launchers() -> Result:
                          f"repoint its command or remove the registration")
     return Result("mcp", FAIL,
                   detail=f"{len(broken)} of {len(checkable)} launcher(s) missing: "
-                         + ", ".join(n for n, _ in broken),
+                         + ", ".join(n for n, _, _ in broken),
                   hint="; ".join(hints))
 
 

--- a/tests/test_doctor_mcp_hint.py
+++ b/tests/test_doctor_mcp_hint.py
@@ -1,0 +1,115 @@
+"""The repair hint has to produce a launcher that actually starts.
+
+0.35.0 told the operator to "set this server's command to `charter`, leaving its args
+unchanged". Applied to the registration that prompted #197, that advice **half-works**, and
+the half that fails is silent in the same way the original breakage was.
+
+The registration is::
+
+    command: <umbrella>/bin/edm
+    args:    secret exec elastic-logs-master --env … --exec -- node <server>
+
+`charter secret exec <vault>` has to find a plane holding that vault. The old command was an
+absolute path into the umbrella; a bare `charter` resolves its plane from **the launching
+directory**, and an `mcpServers` entry at the top level of `~/.claude.json` is user-scope —
+it launches for every project, most of which are not that plane. So the server starts, fails
+to find the vault, and the tools are missing again.
+
+`$CHARTER_ROOT` is exactly the anchor for this, and it belongs in the hint whenever the args
+show charter is being asked to open a vault. Verified against the real registration: with
+the env var the credentials inject, without it the vault is not found.
+
+Also: `0 launcher(s) resolve` was reported for a plane whose only MCP server had just been
+repaired to a bare command. True — zero *absolute* launchers were checked — but read as
+"nothing is registered", which is a different claim.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+
+from charter import doctor
+from tests._isolation import PersonaIso
+
+
+class HintCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        self.home = self.tmp / "home"
+        self.home.mkdir(exist_ok=True)
+        self._real_home = os.environ.get("HOME")
+        os.environ["HOME"] = str(self.home)
+        self.addCleanup(self._restore_home)
+
+    def _restore_home(self) -> None:
+        if self._real_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = self._real_home
+
+    def write(self, servers: dict) -> None:
+        (self.home / ".claude.json").write_text(json.dumps({"mcpServers": servers}))
+
+    def shim(self, args: list[str] | None = None) -> str:
+        self.write({"es": {"command": str(self.tmp / "umbrella" / "bin" / "edm"),
+                           "args": args or []}})
+        return doctor.check_mcp_launchers().hint or ""
+
+
+class TestAVaultOpeningLauncherIsAnchored(HintCase):
+    ARGS = ["secret", "exec", "elastic-logs-master", "--env", "A=b", "--exec", "--", "node", "x"]
+
+    def test_the_hint_names_charter_root(self):
+        """Without it the repaired server resolves its plane from whatever project happens
+        to be open — and a user-scope entry launches for all of them."""
+        self.assertIn("CHARTER_ROOT", self.shim(self.ARGS))
+
+    def test_the_hint_still_names_the_replacement_command(self):
+        self.assertIn("`charter`", self.shim(self.ARGS))
+
+    def test_the_hint_names_the_vault_it_must_reach(self):
+        """"Set CHARTER_ROOT" is not actionable without saying which plane — and the vault
+        name is the only clue charter has to which one that is."""
+        self.assertIn("elastic-logs-master", self.shim(self.ARGS))
+
+    def test_a_launcher_that_opens_no_vault_is_not_told_to_anchor(self):
+        """Advice that applies to everything is read as boilerplate and then not read. A
+        server charter merely launches has no plane to resolve."""
+        hint = self.shim(["--port", "3000"])
+        self.assertNotIn("CHARTER_ROOT", hint)
+        self.assertIn("`charter`", hint)
+
+    def test_an_unrelated_missing_launcher_is_untouched(self):
+        self.write({"x": {"command": str(self.tmp / "opt" / "node"), "args": []}})
+        hint = doctor.check_mcp_launchers().hint or ""
+        self.assertNotIn("CHARTER_ROOT", hint)
+        self.assertNotIn("rename", hint.lower())
+
+
+class TestTheHealthyDetailIsHonest(HintCase):
+    def test_nothing_absolute_does_not_read_as_nothing_registered(self):
+        """`0 launcher(s) resolve` was shown for a plane with a working server on a bare
+        command. Zero were *checked*; none were broken. Saying "0 resolve" states the second
+        as if it were the first."""
+        self.write({"es": {"command": "charter", "args": ["secret", "exec", "v"]}})
+        r = doctor.check_mcp_launchers()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertNotIn("0 launcher", r.detail)
+
+    def test_it_still_counts_what_it_did_check(self):
+        p = self.tmp / "real"
+        p.write_text("#!/bin/sh\n")
+        p.chmod(0o755)
+        self.write({"a": {"command": str(p)}, "b": {"command": "npx"}})
+        self.assertIn("1", doctor.check_mcp_launchers().detail)
+
+    def test_no_servers_at_all_still_says_so(self):
+        self.write({})
+        self.assertIn("no MCP servers", doctor.check_mcp_launchers().detail)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Found by applying my own 0.35.0 advice to the registration that prompted #197 and watching it half-work.

## The incomplete advice

0.35.0 said: *"set this server's command to `charter`, leaving its args unchanged."*

The registration is:

```
command: <umbrella>/bin/edm
args:    secret exec elastic-logs-master --env … --exec -- node <server>
```

`charter secret exec <vault>` must find a plane holding that vault. The old command was an absolute path into a particular umbrella; a bare `charter` resolves its plane from **the launching directory** — and an `mcpServers` entry at the top level of `~/.claude.json` is **user-scope**, so it launches for every project, most of which are not that plane.

The server would start, fail to find the vault, and the tools would be missing again — silently, exactly as before. A repair hint that half-works is worse than a bare diagnosis, because the operator stops looking.

## The fix

```
elasticsearch: …/bin/edm is gone (the edm→charter rename removed that shim) — set this
server's command to `charter`, leaving its args unchanged. It opens vault
`elastic-logs-master`, so also set CHARTER_ROOT in this server's `env` to the plane
holding that vault — a user-scope server has no directory to resolve one from
```

Only when the args actually show `secret exec <vault>`. A launcher charter merely *starts* has no plane to resolve, and advice that applies to every entry is read as boilerplate and then not read at all.

**Verified against the real registration**: with the anchor the credentials inject (checked by length, never value); without it the vault is not found.

## Second, smaller honesty fix

`0 launcher(s) resolve` was printed for a plane whose only server had just been repaired onto a bare command. Zero were *checked* and none were broken — printing the first as a count of what resolves reads as "nothing is registered", a claim about a different fact. It now says `1 server(s), none on an absolute path`, and `no MCP servers registered` stays reserved for actually having none.

## Tests

8 new in `tests/test_doctor_mcp_hint.py`, including the negative case that keeps the anchor advice from becoming boilerplate. Full suite: **2134 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX