### PR TITLE
0.38.1 — the MCP repair hint produces a launcher that starts

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.38.0"
+__version__ = "0.38.1"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.38.0",
+            "command": "charter hook sessionstart --plugin-version 0.38.1",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.38.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.38.1",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.38.0",
+            "command": "charter hook pretooluse --plugin-version 0.38.1",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.38.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.38.1",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.38.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.38.1"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.38.0",
+            "command": "charter hook posttooluse --plugin-version 0.38.1",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.38.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.38.1",
             "timeout": 5
           }
         ]
@@ -100,7 +100,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.38.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.38.1",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.38.0"
+version = "0.38.1"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only.

**#209 — the 0.35.0 repair hint half-worked.** It said to set the command to `charter` and leave the args unchanged. Those args are `secret exec <vault>`, and a bare `charter` resolves its plane from the launching directory — while a top-level `mcpServers` entry is user-scope and launches for every project. The repaired server would start, fail to find the vault, and the tools would be missing again, silently, exactly as before. A repair hint that half-works is worse than a bare diagnosis, because the operator stops looking.

The hint now names `CHARTER_ROOT` and the vault, and only when the args show a vault is actually being opened.

Also: `0 launcher(s) resolve` for a plane whose only server sits on a bare command — zero were *checked* and none were broken, which is a different fact.

Verified against the real registration. Suite: **2134 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX