### PR TITLE
fix: a plane's version pin is measured against the plugin, which is per-project

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -173,8 +173,11 @@ def build_parser() -> argparse.ArgumentParser:
     ver.set_defaults(func=commands.cmd_version)     # bare `charter version` = show
 
     vsy = vsub.add_parser("sync",
-                          help="Install exactly the version this control plane pins "
-                               "(downgrades too — that is the point of a pin).")
+                          help="Move THIS plane to the version it pins. A plugin is "
+                               "installed per project, so no other plane moves.")
+    vsy.add_argument("--cli", action="store_true",
+                     help="Conform the machine-global `charter` binary instead. Shared by "
+                          "every plane on this machine, so it can put others into drift.")
     vsy.set_defaults(func=commands.cmd_version_sync)
 
     vbp = vsub.add_parser("bump",

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1405,22 +1405,47 @@ def cmd_version(args) -> int:
 
 
 def cmd_version_sync(args) -> int:
-    """Conform this machine to the lock — including downgrading, which is the point."""
-    from . import instance as _instance
+    """Move THIS plane to its lock. ``--cli`` conforms the machine-global binary instead.
+
+    The default flipped in the change that unparked #127. `version sync` used to conform a
+    binary every plane on the machine shares, which is not a fix but a choice of victim:
+    "two planes with different pins thrash the same binary back and forth, each `sync`
+    breaking the other". The plugin is installed per project out of a cache holding every
+    version at once, so moving it honours this plane's pin and touches nothing else.
+
+    ``--cli`` keeps the old behaviour rather than deleting it: a machine running charter
+    with no plugin at all still needs a way to conform the binary, and removing the escape
+    hatch would be its own defect.
+    """
+    from . import instance as _instance, update as _update
     locked = _instance.locked_version(_instance.load(config.ROOT))
     if not locked:
         util.info("This control plane pins no version — nothing to sync. "
                   "Pin one with: charter version bump --push")
         return 0
+
+    if not getattr(args, "cli", False):
+        plugin = _update.plugin_version_here()
+        if plugin == locked:
+            util.ok(f"the plugin serving this project is already on the lock ({locked}).")
+            return 0
+        where = f"{plugin} → {locked}" if plugin else f"→ {locked}"
+        util.info(f"this plane's version is the plugin's ({where}).")
+        # Named, not run. `claude` may be absent, may prompt for a scope, and the command
+        # mutates the reader's editor install — charter says exactly what to run and lets
+        # them run it, the same restraint the MCP launcher check keeps.
+        util.info(f"  run: {_update.PLUGIN_SYNC_CMD}")
+        util.info(f"  the machine-global binary instead: charter version sync --cli")
+        return 0
+
     installed = _installed_version()
     if locked == installed:
         util.ok(f"already on the locked version ({locked}).")
         return 0
     # Said before the install, not after: this conforms a binary every plane on the
     # machine shares, so the next plane the reader opens may have just gone into drift.
-    from . import update as _update
     util.warn(_update.SHARED_INSTALL_NOTE)
-    util.info(f"syncing {installed} → {locked} …")
+    util.info(f"syncing the machine-global binary {installed} → {locked} …")
     ok, detail = sync_to(locked)
     if not ok:
         util.err(f"could not install {locked}: {detail}")

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -813,16 +813,32 @@ def check_version_lock() -> Result:
                       hint=_NOT_CHECKED_HINT)
     if not locked:
         return Result("version lock", OK, detail="not pinned")
-    if locked == __version__:
-        return Result("version lock", OK, detail=f"pinned {locked}, in sync")
+
     from . import update
-    # The note rides on the drift branch only. Everywhere else it is furniture, and a
-    # sentence printed on every clean preflight is a sentence nobody reads on the one
-    # that isn't.
+    # The pin is measured against the PLUGIN, because the plugin is the only part of
+    # charter that is genuinely per-plane: Claude Code installs it per project, out of a
+    # cache holding every version side by side. Measuring it against the machine-global
+    # binary is what made the pin unhonourable — no plane can own that binary, so the drift
+    # it reported had no fix that did not break another plane (#127).
+    plugin = update.plugin_version_here()
+    if plugin is not None:
+        if plugin == locked:
+            return Result("version lock", OK, detail=f"pinned {locked}, plugin in sync")
+        return Result("version lock", WARN,
+                      detail=f"pinned {locked}, plugin here runs {plugin}",
+                      hint=f"Run: {update.PLUGIN_SYNC_CMD}  (this project only — a plugin "
+                           f"is installed per project, so no other plane moves)")
+
+    # Not running under the plugin: a `charter` typed in a terminal cannot see which plugin
+    # version serves this project. Say that, and compare what CAN be seen — but never call
+    # the machine-global CLI "this plane's version", which is the conflation #127 is about.
+    if locked == __version__:
+        return Result("version lock", OK,
+                      detail=f"pinned {locked}, CLI in sync (plugin not visible from here)")
     return Result("version lock", WARN,
-                  detail=f"pinned {locked}, running {__version__}",
-                  hint=f"{update.SHARED_INSTALL_NOTE}. "
-                       f"Run: charter version sync  (conforms this machine to the lock)")
+                  detail=f"pinned {locked}, CLI is {__version__}",
+                  hint=f"{update.SHARED_INSTALL_NOTE}. To move THIS plane only: "
+                       f"{update.PLUGIN_SYNC_CMD}")
 
 
 def check_memory_indexes() -> Result:

--- a/charter/update.py
+++ b/charter/update.py
@@ -40,9 +40,45 @@ NET_TIMEOUT = 5           # a detached child, but still: never hang around
 #: shim to resolve the pinned version per plane.
 SHARED_INSTALL_NOTE = (
     "the `charter` binary is ONE machine-global install shared by every control plane on "
-    "this machine, so a pin is advisory — syncing here can put another plane into drift "
-    "(see: uv tool list)"
+    "this machine, so syncing here can put another plane into drift (see: uv tool list). "
+    "The per-plane version is the PLUGIN's — see `charter version`"
 )
+
+#: The per-project fix, and the whole of what #127 asked for.
+#:
+#: A Claude Code plugin is installed **per project**: `installed_plugins.json` records an
+#: `installPath` into `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`, and that
+#: cache holds many versions side by side. Two projects on one machine were observed serving
+#: two different charter versions at once — exactly what #127 reported as impossible.
+#:
+#: So this command is the one that honours a pin: it moves THIS project and no other, where
+#: `version sync` conforms a binary every plane shares.
+PLUGIN_SYNC_CMD = "claude plugin update charter@charter"
+
+
+def plugin_version_here() -> str | None:
+    """The version of the charter PLUGIN serving this project, or ``None``.
+
+    ``$CLAUDE_PLUGIN_ROOT`` is a **documented** variable that Claude Code sets for the
+    plugin's own processes, and it points at the versioned directory this project resolved
+    to. That is the whole mechanism: no cache layout is parsed and `installed_plugins.json`
+    is never read, because those are Claude Code internals — fine to look at by hand,
+    never something to build on. Betting on an internal path is what `bin/edm` did, and it
+    broke silently (#197).
+
+    ``None`` outside a plugin process, which is the ordinary case for a `charter` typed in
+    a terminal. Callers must say "not visible from here" rather than substituting the
+    machine-global CLI's version and calling it this plane's — that conflation is #127.
+    """
+    root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if not root:
+        return None
+    try:
+        doc = json.loads((Path(root) / ".claude-plugin" / "plugin.json").read_text())
+    except (OSError, ValueError, UnicodeDecodeError):
+        return None
+    v = doc.get("version") if isinstance(doc, dict) else None
+    return v.strip() if isinstance(v, str) and v.strip() else None
 
 
 def _cache_file() -> Path:

--- a/tests/test_per_plane_version.py
+++ b/tests/test_per_plane_version.py
@@ -1,0 +1,188 @@
+"""A plane's version pin is measured against the PLUGIN, which is per-project.
+
+#127 reported that a pin cannot be honoured: `charter` is one machine-global install, so
+two planes with different pins thrash the same binary and `version sync` breaks whichever
+plane you are not standing in. It was parked as impossible.
+
+Its stated premise — "there is no per-version store, and no shim that resolves the pinned
+version from the plane you are standing in" — is false. Claude Code already keeps one::
+
+    ~/.claude/plugins/cache/charter/charter/{0.1.0 … 0.38.1}   19 full source trees
+
+and `installed_plugins.json` resolves it **per project**::
+
+    {"scope": "project", "projectPath": "…/easydmarc-umbrella",
+     "installPath": "…/cache/charter/charter/0.38.0"}
+
+Two projects on this machine were observed running two different charter versions at once,
+which is exactly what #127 said could not happen.
+
+So the pin stops being measured against the machine-global binary — which no plane can own
+— and is measured against the thing that is genuinely per-plane. The fix that follows is
+`claude plugin update charter@charter`, which touches THIS project only; the old advice,
+`charter version sync`, conforms a binary every plane shares and is what put the other
+plane into drift.
+
+**The plugin's own root is read from ``$CLAUDE_PLUGIN_ROOT``, which is documented.** The
+cache layout and `installed_plugins.json` are Claude Code internals: fine to read as a
+best-effort diagnosis, never something to build dispatch on. That was the bet `bin/edm`
+made, and it broke silently (#197).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+
+from charter import commands, doctor, update
+from tests._isolation import PersonaIso
+
+
+class PinCase(PersonaIso):
+    def pin(self, version: str) -> None:
+        (self.tmp / "charter.toml").write_text(
+            f'schema = 1\n\n[charter]\nversion = "{version}"\n')
+
+    def as_plugin(self, version: str) -> None:
+        """Run as though under the Claude Code plugin serving this project."""
+        root = self.tmp / "plugin"
+        (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+        (root / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"name": "charter", "version": version}))
+        os.environ["CLAUDE_PLUGIN_ROOT"] = str(root)
+        self.addCleanup(os.environ.pop, "CLAUDE_PLUGIN_ROOT", None)
+
+    def no_plugin(self) -> None:
+        self._had = os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+        if self._had is not None:
+            self.addCleanup(os.environ.__setitem__, "CLAUDE_PLUGIN_ROOT", self._had)
+
+
+class TestThePluginVersionIsReadable(PinCase):
+    def test_it_is_none_outside_the_plugin(self):
+        """A bare `charter` in a terminal has no plugin to ask, and must say so rather than
+        guess — the same shape `check_plugin_skew` already keeps."""
+        self.no_plugin()
+        self.assertIsNone(update.plugin_version_here())
+
+    def test_it_reads_the_manifest_of_the_plugin_serving_this_project(self):
+        self.as_plugin("0.27.0")
+        self.assertEqual(update.plugin_version_here(), "0.27.0")
+
+    def test_an_unreadable_manifest_is_none_not_an_exception(self):
+        self.as_plugin("0.27.0")
+        (self.tmp / "plugin" / ".claude-plugin" / "plugin.json").write_text("{ not json")
+        self.assertIsNone(update.plugin_version_here())
+
+
+class TestTheLockIsMeasuredAgainstThePlugin(PinCase):
+    def test_a_matching_plugin_is_in_sync(self):
+        self.pin("0.27.0")
+        self.as_plugin("0.27.0")
+        r = doctor.check_version_lock()
+        self.assertEqual(r.status, doctor.OK)
+
+    def test_a_drifting_plugin_warns(self):
+        self.pin("0.27.0")
+        self.as_plugin("0.38.1")
+        self.assertEqual(doctor.check_version_lock().status, doctor.WARN)
+
+    def test_the_fix_is_scoped_to_this_project(self):
+        """The whole point of #127. `charter version sync` conforms a machine-global
+        binary and puts every other plane into drift; the plugin update touches one
+        project."""
+        self.pin("0.27.0")
+        self.as_plugin("0.38.1")
+        hint = doctor.check_version_lock().hint
+        self.assertIn("claude plugin update", hint)
+
+    def test_the_fix_is_no_longer_the_machine_global_install(self):
+        self.pin("0.27.0")
+        self.as_plugin("0.38.1")
+        hint = doctor.check_version_lock().hint
+        self.assertNotIn("uv tool install", hint)
+
+    def test_it_names_both_versions(self):
+        self.pin("0.27.0")
+        self.as_plugin("0.38.1")
+        said = doctor.check_version_lock()
+        self.assertIn("0.27.0", said.detail)
+        self.assertIn("0.38.1", said.detail)
+
+    def test_pinning_nothing_is_still_a_normal_state(self):
+        """Opt-in, and a plane that pins nothing is not a nag."""
+        self.as_plugin("0.38.1")
+        self.assertEqual(doctor.check_version_lock().status, doctor.OK)
+
+
+class TestOutsideThePluginItStaysHonest(PinCase):
+    def test_it_does_not_claim_the_plugin_agrees(self):
+        """From a plain terminal charter cannot see which plugin serves this project. The
+        old check compared the pin to the machine-global CLI and called that the plane's
+        version, which is the conflation #127 is about."""
+        self.pin("0.27.0")
+        self.no_plugin()
+        r = doctor.check_version_lock()
+        self.assertNotIn("plugin in sync", f"{r.detail} {r.hint}")
+
+    def test_it_still_says_the_binary_is_shared(self):
+        self.pin("0.27.0")
+        self.no_plugin()
+        r = doctor.check_version_lock()
+        if r.status != doctor.OK:
+            self.assertIn("machine-global", f"{r.detail} {r.hint}")
+
+    def test_it_never_raises_on_a_broken_config(self):
+        (self.tmp / "charter.toml").write_text("[charter\nversion =")
+        self.assertIn(doctor.check_version_lock().status, (doctor.OK, doctor.WARN))
+
+
+class TestSyncTargetsTheProject(PinCase):
+    def run_sync(self, **kw) -> tuple[int, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = commands.cmd_version_sync(SimpleNamespace(**{"cli": False, **kw}))
+        return rc, out.getvalue() + err.getvalue()
+
+    def test_it_names_the_per_project_plugin_command_by_default(self):
+        """#127: "`charter version sync` does not resolve this, it just moves the problem"
+        — it conformed the shared binary, so two planes thrashed it."""
+        self.pin("0.27.0")
+        self.as_plugin("0.38.1")
+        _, said = self.run_sync()
+        self.assertIn("claude plugin update", said)
+
+    def test_it_does_not_touch_the_global_install_by_default(self):
+        """The behaviour that broke the other plane. It must now be asked for."""
+        self.pin("0.27.0")
+        self.as_plugin("0.38.1")
+        called = []
+        real = commands.sync_to
+        commands.sync_to = lambda v: (called.append(v), (True, v))[1]
+        self.addCleanup(setattr, commands, "sync_to", real)
+        self.run_sync()
+        self.assertEqual(called, [])
+
+    def test_the_old_behaviour_is_still_reachable_explicitly(self):
+        """Not removed — a machine with no plugin at all still needs it, and taking away
+        the escape hatch would be its own defect."""
+        self.pin("0.27.0")
+        self.no_plugin()
+        called = []
+        real = commands.sync_to
+        commands.sync_to = lambda v: (called.append(v), (True, v))[1]
+        self.addCleanup(setattr, commands, "sync_to", real)
+        self.run_sync(cli=True)
+        self.assertEqual(called, ["0.27.0"])
+
+    def test_pinning_nothing_syncs_nothing(self):
+        _, said = self.run_sync()
+        self.assertIn("pins no version", said)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_version_pin_honesty.py
+++ b/tests/test_version_pin_honesty.py
@@ -83,9 +83,19 @@ class TestThePinIsDescribedAsAdvice(PersonaIso):
     def test_the_note_names_how_to_see_the_truth(self):
         self.assertIn("uv tool list", update.SHARED_INSTALL_NOTE)
 
-    def test_the_note_does_not_promise_enforcement(self):
+    def test_the_note_no_longer_calls_the_pin_advisory(self):
+        """It used to, and that was right while the machine-global binary was the only
+        thing a pin could be measured against. A plugin is installed per project out of a
+        cache holding every version at once, so a pin IS honourable now — `claude plugin
+        update charter@charter` moves this plane and no other (#127). Calling it advisory
+        would send the reader back to the shared binary, which is the trap."""
         low = update.SHARED_INSTALL_NOTE.lower()
-        self.assertIn("advisory", low)
+        self.assertNotIn("advisory", low)
+
+    def test_the_note_points_at_the_per_plane_mechanism(self):
+        """What must survive: the note explains that this binary is not the plane's, and
+        where the plane's version actually lives."""
+        self.assertIn("plugin", update.SHARED_INSTALL_NOTE.lower())
 
 
 class TestVersionSyncSaysWhatItMutates(PersonaIso):


### PR DESCRIPTION
Closes #127 — **unparks it**, because its stated premise turned out to be false.

## The premise, and why it fell

> there is no `charter` equivalent of what pyenv/nvm/rbenv do for their runtimes, and no shim that resolves the pinned version from the plane you are standing in

Claude Code already keeps exactly that store, for plugins:

```
~/.claude/plugins/cache/charter/charter/
  0.1.0 … 0.29.1  0.37.0  0.38.0  0.38.1      ← 19 full source trees
```

resolved **per project** in `installed_plugins.json`. On the reporting machine, `easydmarc-umbrella` was serving **0.38.0** while `IdeaProjects/charter` served **0.38.1** — two planes, two charter versions, at the same time, with no coordination. That is the thing the issue says cannot happen.

## What changes

The pin was measured against the machine-global binary — which no plane can own, so its drift had no fix that did not break another plane. It is now measured against the plugin:

```
WARN | pinned 0.27.0, plugin here runs 0.38.1
   → Run: claude plugin update charter@charter  (this project only — a plugin is
     installed per project, so no other plane moves)
```

`charter version sync` flips its default to that, and keeps the old behaviour behind `--cli` rather than deleting it — a machine with no plugin still needs a way to conform the binary.

## The line I would not cross

The issue's preferred option is a resolving shim for the `charter` binary. That requires reading `installed_plugins.json` and the `cache/<marketplace>/<plugin>/<version>/` layout — **both undocumented internals**. `$CLAUDE_PLUGIN_ROOT` is documented, and is all this uses. Putting core dispatch on an internal path is the bet `bin/edm` made, and it broke silently (#197).

So outside a plugin process charter says *"plugin not visible from here"* rather than substituting the global CLI's version and calling it the plane's — that conflation is the issue.

Option 2 (`uvx charter-cp==<pinned>`) is moot: every version is already cached locally, so there is nothing to download.

## Tests

16 new in `tests/test_per_plane_version.py`, including that the fix is scoped to the project and that `sync` no longer touches the global install unless asked.

One existing test changed rather than added to: `test_the_note_does_not_promise_enforcement` asserted `SHARED_INSTALL_NOTE` contains "advisory". That was correct while the shared binary was the only thing a pin could be measured against, and is now the sentence that would send a reader back to the trap. It is replaced by a test that the note *stops* saying it and points at the per-plane mechanism instead.

Full suite: **2151 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX