### PR TITLE
0.39.0 — a plane's version pin finally means something

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.38.1",
+  "version": "0.39.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.38.1"
+__version__ = "0.39.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.38.1",
+            "command": "charter hook sessionstart --plugin-version 0.39.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.38.1",
+            "command": "charter hook userpromptsubmit --plugin-version 0.39.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.38.1",
+            "command": "charter hook pretooluse --plugin-version 0.39.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.38.1",
+            "command": "charter hook pretooluse-read --plugin-version 0.39.0",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.38.1"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.39.0"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.38.1",
+            "command": "charter hook posttooluse --plugin-version 0.39.0",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.38.1",
+            "command": "charter hook posttooluse-skill --plugin-version 0.39.0",
             "timeout": 5
           }
         ]
@@ -100,7 +100,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.38.1",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.39.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.38.1"
+version = "0.39.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only.

**#127 — unparked and closed.** It reported that a per-plane pin cannot be honoured, because `charter` is one machine-global install. Claude Code already keeps the per-version store the issue asked for — `~/.claude/plugins/cache/charter/charter/` held **19 full source trees** — and resolves it **per project**. Two projects on the reporting machine were observed serving 0.38.0 and 0.38.1 simultaneously.

```
WARN | pinned 0.27.0, plugin here runs 0.38.1
   → Run: claude plugin update charter@charter  (this project only — a plugin is
     installed per project, so no other plane moves)
```

`charter version sync` flips its default to that; `--cli` keeps the old machine-global behaviour for a plane with no plugin.

Read from `$CLAUDE_PLUGIN_ROOT` (documented), never the cache layout or `installed_plugins.json` (internals) — building dispatch on an internal path is the bet `bin/edm` made, and it broke silently.

Suite: **2151 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX