### PR TITLE
feat: charter writes the host's force-prompt rules, and keeps no list of its own

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -172,6 +172,19 @@ def build_parser() -> argparse.ArgumentParser:
     vsub = ver.add_subparsers(dest="version_cmd")
     ver.set_defaults(func=commands.cmd_version)     # bare `charter version` = show
 
+    gd = sub.add_parser("guard",
+                        help="Force-prompt rules for this plane. Written as Claude Code "
+                             "`permissions.ask` rules in .claude/settings.json — charter "
+                             "keeps no list of its own (ADR 0014).")
+    gsub = gd.add_subparsers(dest="guard_cmd")
+    gd.set_defaults(func=commands.cmd_guard_list)
+    ga = gsub.add_parser("ask", help="Always prompt before this command runs.")
+    ga.add_argument("pattern", help="e.g. 'terraform apply *' — wrapped as Bash(...) "
+                                    "unless it already names a tool.")
+    ga.set_defaults(func=commands.cmd_guard_ask)
+    gl = gsub.add_parser("list", help="Show this plane's force-prompt rules.")
+    gl.set_defaults(func=commands.cmd_guard_list)
+
     vsy = vsub.add_parser("sync",
                           help="Move THIS plane to the version it pins. A plugin is "
                                "installed per project, so no other plane moves.")

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -686,6 +686,124 @@ def _json_style(text: str) -> tuple[str | None, tuple[str, str]]:
     return None, (", " if comma_space else ",", ": " if colon_space else ":")
 
 
+#: Tools whose rules charter writes verbatim. Anything else is wrapped as ``Bash(...)``.
+#:
+#: `Bash(...)` is the host's syntax and the operator should not have to know it, but a rule
+#: naming another tool must survive untouched — wrapping `Read(./secrets/**)` would produce
+#: `Bash(Read(./secrets/**))`, which matches nothing and fails in the silent direction.
+_RULE_TOOLS = ("Bash", "Read", "Edit", "Write", "Grep", "Glob", "WebFetch", "NotebookEdit",
+               "Task", "mcp__")
+
+
+def _as_rule(pattern: str) -> str:
+    """A permission rule for *pattern*, wrapping a bare command in ``Bash(...)``."""
+    p = (pattern or "").strip()
+    if p.startswith(_RULE_TOOLS) and ("(" in p or p in ("Bash",)):
+        return p
+    return f"Bash({p})"
+
+
+def _settings_path(root: Path) -> Path:
+    return Path(root) / ".claude" / "settings.json"
+
+
+def _load_settings(root: Path) -> tuple[dict | None, Path]:
+    """``(settings, path)``; ``None`` when the file exists and is not parseable.
+
+    A missing file reads as ``{}`` — writing the first rule into a plane that has no
+    settings yet is ordinary. A *malformed* one reads as ``None`` so callers refuse rather
+    than repair: the operator's content is in there, and `_ensure_statusline` already keeps
+    that restraint for the same file.
+    """
+    p = _settings_path(root)
+    if not p.exists():
+        return {}, p
+    try:
+        doc = json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None, p
+    return (doc if isinstance(doc, dict) else None), p
+
+
+def cmd_guard_ask(args) -> int:
+    """Add a force-prompt rule to `permissions.ask` in the plane's `.claude/settings.json`.
+
+    Charter writes the **host's** rule and keeps no list of its own (ADR 0014). Claude Code
+    already evaluates `deny → ask → allow`, segments compound commands correctly — the job
+    `hooks._segment_argv` does by hand and got wrong once — and the file is committed, so
+    every engineer on the repo gets the same list with nothing to install or sync. A
+    `charter.toml` list would be a second engine that could not win: *"a matching ask rule
+    still prompts even when the hook returned `allow` or `ask`"*.
+
+    `_ensure_statusline`'s docstring says settings.json holds keys "charter has no business
+    touching (``permissions``, …)". That still holds for `init`, which writes unasked. This
+    is the opposite: the operator named the rule and the command that writes it, so charter
+    is the editor rather than the author.
+    """
+    pattern = (getattr(args, "pattern", "") or "").strip()
+    if not pattern:
+        util.err("Nothing to add. Example: charter guard ask 'terraform apply *'")
+        return 2
+    root = Path(config.ROOT)
+    settings, path = _load_settings(root)
+    if settings is None:
+        util.err(f"{path} is not valid JSON — left untouched.")
+        util.info("  Fix it by hand, then re-run. charter never repairs this file.")
+        return 1
+
+    rule = _as_rule(pattern)
+    perms = settings.setdefault("permissions", {})
+    if not isinstance(perms, dict):
+        util.err(f"{path}: `permissions` is not an object — left untouched.")
+        return 1
+    ask = perms.setdefault("ask", [])
+    if not isinstance(ask, list):
+        util.err(f"{path}: `permissions.ask` is not a list — left untouched.")
+        return 1
+    if rule in ask:
+        util.ok(f"already asking for {rule}.")
+        return 0
+    ask.append(rule)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(settings, indent=2) + "\n")
+    util.ok(f"{rule} → permissions.ask")
+    util.info(f"  {path} is committed, so this applies to everyone on this repo.")
+    _warn_if_shadowing(rule)
+    return 0
+
+
+def cmd_guard_list(args) -> int:
+    """Show the plane's force-prompt rules — read from the host's file, not a charter one."""
+    root = Path(config.ROOT)
+    settings, path = _load_settings(root)
+    if settings is None:
+        util.err(f"{path} is not valid JSON.")
+        return 1
+    perms = settings.get("permissions")
+    ask = (perms or {}).get("ask") if isinstance(perms, dict) else None
+    if not ask:
+        util.info("No force-prompt rules in this plane. "
+                  "Add one: charter guard ask 'terraform apply *'")
+        return 0
+    print(f"  {path}")
+    for rule in ask:
+        print(f"    {rule}")
+    return 0
+
+
+def _warn_if_shadowing(rule: str) -> None:
+    """Say at write time if this rule will shadow a persona's declared tool.
+
+    Doctor reports the same overlap; this is the moment the operator can still change their
+    mind, and charter knows it then.
+    """
+    from . import doctor as _doctor
+    hit = _doctor.shadowed_tools([rule])
+    if hit:
+        util.warn(f"this also prompts for {', '.join(sorted(hit))}, which a persona "
+                  f"declares — an ask rule outranks charter's tool-gate.")
+
+
 def _ensure_statusline(root: Path) -> tuple[str, Path | None]:
     """Write ``.claude/settings.json``'s ``statusLine`` key IF ABSENT. That file is
     user-owned, git-tracked, has no comment syntax, and holds keys charter has no

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -636,6 +636,103 @@ def check_nested_plane() -> Result:
                         f"{util.short_path(outer)}.  → unset CHARTER_ROOT to use it"))
 
 
+def _ask_rules() -> list | None:
+    """`permissions.ask` from the plane's settings — ``None`` when it cannot be read."""
+    from . import config as _config
+    p = Path(_config.ROOT) / ".claude" / "settings.json"
+    if not p.exists():
+        return []
+    try:
+        doc = json.loads(p.read_text())
+    except (OSError, ValueError, UnicodeDecodeError):
+        return None
+    if not isinstance(doc, dict):
+        return None
+    perms = doc.get("permissions")
+    if not isinstance(perms, dict):
+        return []
+    ask = perms.get("ask")
+    return ask if isinstance(ask, list) else []
+
+
+def _declared_binaries() -> dict[str, set[str]]:
+    """``{binary: {persona, …}}`` — every tool any persona declares, and who declares it."""
+    from . import persona as _persona
+    out: dict[str, set[str]] = {}
+    for name in _persona.list_personas():
+        try:
+            for tool in _persona.effective_tools(name) or ():
+                out.setdefault(tool, set()).add(name)
+        except Exception:
+            continue
+    return out
+
+
+def shadowed_tools(rules) -> set[str]:
+    """Declared persona tools that *rules* would force a prompt for.
+
+    Matching is deliberately coarse — the first token inside ``Bash(...)``, plus the blanket
+    forms ``Bash`` and ``Bash(*)`` which match everything. Charter is not re-implementing
+    the host's matcher; it is answering "would this obviously shadow a tool", and a coarse
+    answer that is right about `Bash(kubectl *)` is worth more than a precise one nobody
+    maintains.
+    """
+    declared = _declared_binaries()
+    if not declared:
+        return set()
+    hit: set[str] = set()
+    for raw in rules or ():
+        if not isinstance(raw, str):
+            continue
+        rule = raw.strip()
+        if rule in ("Bash", "Bash(*)", "*"):
+            return set(declared)
+        if not rule.startswith("Bash(") or not rule.endswith(")"):
+            continue
+        inner = rule[len("Bash("):-1].strip()
+        head = inner.split()[0] if inner.split() else ""
+        head = head.rstrip("*")
+        if head and head in declared:
+            hit.add(head)
+    return hit
+
+
+def check_ask_rules() -> Result:
+    """An `ask` rule that shadows a tool a persona declares.
+
+    ADR 0014 puts pattern-shaped policy in the host's `permissions`, which creates exactly
+    one interaction charter must not leave silent: *"a matching ask rule still prompts even
+    when the hook returned `allow` or `ask`"*. So `toolgate` can return `allow` for a
+    binary the active persona declares and the operator is prompted anyway — the persona's
+    tools quietly stop being pre-approved, with nothing naming the cause. That is the
+    looks-wired-but-isn't shape this repo has paid for twice (#177, #197).
+
+    It never suggests deleting the rule. The rule is the operator's policy and is probably
+    deliberate; charter names the consequence and leaves the choice (ADR 0013).
+    """
+    name = "ask rules"
+    rules = _ask_rules()
+    if rules is None:
+        return Result(name, WARN, detail="settings.json not readable",
+                      hint=_NOT_CHECKED_HINT)
+    if not rules:
+        return Result(name, OK, detail="none")
+    try:
+        hit = shadowed_tools(rules)
+    except Exception as e:
+        return Result(name, WARN, detail=f"not checked ({e})", hint=_NOT_CHECKED_HINT)
+    if not hit:
+        return Result(name, OK, detail=f"{len(rules)} rule(s), none shadow a persona tool")
+    declared = _declared_binaries()
+    who = sorted({p for t in hit for p in declared.get(t, ())})
+    return Result(name, WARN,
+                  detail=f"{', '.join(sorted(hit))} prompt(s) despite being declared by "
+                         f"{', '.join(who)}",
+                  hint="An ask rule outranks a PreToolUse allow, so charter's persona "
+                       "tool-gate cannot pre-approve these. That may be exactly what you "
+                       "want — this names it so the prompts are not a mystery.")
+
+
 def check_workspace_clones() -> Result:
     """Clones that are behind their upstream — in EVERY workspace, not just the active one.
 
@@ -1305,7 +1402,7 @@ def _checks():
                 check_workspace_clones(),
                 check_inventory(), check_vaults(),
                 check_vault_registry_divergence(), check_version_lock(),
-                check_memory_indexes(), check_personas(),
+                check_memory_indexes(), check_personas(), check_ask_rules(),
                 check_mcp_launchers(), check_plugin_skew()]
     return results
 

--- a/docs/adr/0014-policy-that-fits-a-pattern-belongs-to-the-host.md
+++ b/docs/adr/0014-policy-that-fits-a-pattern-belongs-to-the-host.md
@@ -1,0 +1,72 @@
+# Policy that fits a pattern belongs to the host
+
+Charter guards Bash calls through a `PreToolUse` hook: it denies a command that would leak
+a secret, denies a branch move in the plane root, denies SSH and signing, asks before a
+commit inside a clone, and allows a binary the active persona declares.
+
+The obvious next step — letting a plane list its own commands to force-prompt, in
+`charter.toml` — is the one this rejects.
+
+**Policy that can be written as a command pattern belongs to Claude Code's `permissions`.
+Charter keeps only the policy that needs context the host cannot see.**
+
+## Why
+
+Claude Code already has the feature, and has more of it than charter would build:
+
+* `permissions.ask` sits between `deny` and `allow`, evaluated in that order, first match
+  wins.
+* Rules live in the plane's own `.claude/settings.json`, which is **committed**, so every
+  engineer on the repo gets the same list with nothing to install or sync.
+* It segments compound commands correctly. The recognised separators are `&&`, `||`, `;`,
+  `|`, `|&`, `&` and newlines, and *"a rule must match each subcommand independently"* —
+  which is precisely the job `hooks._segment_argv` does by hand, and got wrong once when a
+  `shlex` fallback collapsed a command into a single token and blinded the leak guard.
+
+A `charter.toml` list would therefore be a second policy engine for a job the host does
+better, and would have to re-implement shell segmentation to be safe. Worse, the two
+engines cannot be made to agree: **a hook cannot relax a permission rule.** The
+documentation is explicit — *"a matching ask rule still prompts even when the hook returned
+`allow` or `ask`"* — so charter's own decisions are already subordinate to the host's, and a
+second list inside charter would be advisory over a mechanism that outranks it.
+
+## What charter keeps, and why that is the whole line
+
+The four guards split on one question: can the rule be stated without knowing where you are
+standing or who you are?
+
+| guard | needs | expressible as a rule |
+| --- | --- | --- |
+| `_leak_reason` | argv, and the plane's vault paths | no |
+| `_plane_root_branch_reason` | the working directory | no |
+| `_clone_commit_reason` | the working directory | no |
+| `toolgate.decide` | the active persona's declared tools | no |
+| `_single_credential_reason` | the command alone | **yes** |
+
+Only the last is static, and it deliberately stays in the hook anyway. A native `deny` rule
+prints no reason, and the reason is most of what that guard is for: a developer who reads
+*"one credential — each forge's token over HTTPS; no SSH, no signing"* learns the rule,
+while one who reads a bare refusal files a bug. Charter trades the scoping win for the
+explanation.
+
+That trade is not free and is worth restating: because the guard is not project-scoped, it
+needs `config.HAS_CONTROL_PLANE` to stay silent outside a plane — a gate added after it
+fired in unrelated repos and explained a control plane that did not exist there.
+
+## What this permits charter to do
+
+Write the host's rules, never keep its own. `charter guard ask <pattern>` edits
+`permissions.ask` in the plane's `.claude/settings.json` — the same file charter already
+maintains for the status line and the plane-root guard. There is no charter-side list, no
+sync step, and nothing that can drift, because there is only one record.
+
+## Consequences
+
+* A plane's force-prompt list is portable to anyone using Claude Code, with or without
+  charter.
+* Charter must **detect** the one interaction this creates rather than assume it away: a
+  broad ask rule shadows `toolgate`'s `allow`, so a persona's declared tools start prompting
+  and nothing says why. `doctor` names the overlap. A mechanism that looks wired and is not
+  is the failure shape this repo keeps paying for (#177, #197).
+* If Claude Code ever gains directory-scoped rules, three more guards become expressible and
+  this decision should be revisited rather than defended.

--- a/tests/test_guard_ask.py
+++ b/tests/test_guard_ask.py
@@ -1,0 +1,175 @@
+"""`charter guard ask` writes Claude Code's rules; charter keeps no list of its own.
+
+ADR 0014. Policy that can be written as a command pattern belongs to `permissions.ask` in
+the plane's committed `.claude/settings.json` — a file charter already maintains for the
+status line and the plane-root guard. Charter keeps only the guards that need context the
+host cannot express: the working directory, the plane's vault paths, the active persona.
+
+The temptation was a list in `charter.toml`. It would have been a second policy engine for
+a job the host does better — it segments compound commands, which charter hand-rolls and
+got wrong once — and the two could not have been reconciled, because **a hook cannot relax
+a permission rule**: *"a matching ask rule still prompts even when the hook returned `allow`
+or `ask`"*.
+
+That last sentence is also the one interaction this creates, and the reason `doctor` grows a
+check: a broad ask rule silently shadows `toolgate`'s `allow`, so a persona's declared tools
+start prompting and nothing says why. A mechanism that looks wired and is not is the failure
+shape this repo keeps paying for.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import commands, config, doctor
+from tests._isolation import PersonaIso
+
+
+class GuardCase(PersonaIso):
+    def settings(self) -> Path:
+        return Path(config.ROOT) / ".claude" / "settings.json"
+
+    def write(self, body: dict) -> None:
+        p = self.settings()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(body, indent=2))
+
+    def read(self) -> dict:
+        return json.loads(self.settings().read_text())
+
+    def invoke(self, fn, **kw) -> tuple[int, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = fn(SimpleNamespace(**kw))
+        return rc, out.getvalue() + err.getvalue()
+
+
+class TestItWritesTheHostsRule(GuardCase):
+    def test_a_pattern_lands_in_permissions_ask(self):
+        self.invoke(commands.cmd_guard_ask, pattern="terraform apply *")
+        self.assertIn("Bash(terraform apply *)", self.read()["permissions"]["ask"])
+
+    def test_a_bare_pattern_is_wrapped_as_a_bash_rule(self):
+        """`Bash(...)` is the host's syntax. Making the operator type it would be charter
+        asking them to know an encoding it could apply itself."""
+        self.invoke(commands.cmd_guard_ask, pattern="rm -rf *")
+        self.assertIn("Bash(rm -rf *)", self.read()["permissions"]["ask"])
+
+    def test_an_already_qualified_rule_is_left_alone(self):
+        """A rule naming a non-Bash tool must survive untouched — wrapping it would produce
+        `Bash(Read(./secrets))`, which matches nothing and fails silently."""
+        self.invoke(commands.cmd_guard_ask, pattern="Read(./secrets/**)")
+        self.assertIn("Read(./secrets/**)", self.read()["permissions"]["ask"])
+
+    def test_it_is_idempotent(self):
+        self.invoke(commands.cmd_guard_ask, pattern="terraform apply *")
+        self.invoke(commands.cmd_guard_ask, pattern="terraform apply *")
+        self.assertEqual(self.read()["permissions"]["ask"].count("Bash(terraform apply *)"), 1)
+
+    def test_existing_rules_survive(self):
+        self.write({"permissions": {"ask": ["Bash(kubectl delete *)"], "deny": ["Bash(rm -rf /)"]}})
+        self.invoke(commands.cmd_guard_ask, pattern="terraform apply *")
+        body = self.read()["permissions"]
+        self.assertIn("Bash(kubectl delete *)", body["ask"])
+        self.assertEqual(body["deny"], ["Bash(rm -rf /)"])
+
+    def test_unrelated_settings_survive(self):
+        self.write({"statusLine": {"type": "command", "command": "charter statusline"}})
+        self.invoke(commands.cmd_guard_ask, pattern="terraform apply *")
+        self.assertEqual(self.read()["statusLine"]["command"], "charter statusline")
+
+    def test_a_malformed_settings_file_is_never_overwritten(self):
+        """The same restraint `_ensure_statusline` keeps: charter does not rewrite a file it
+        could not parse, because the operator's content is in there."""
+        p = self.settings()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{ not json")
+        rc, said = self.invoke(commands.cmd_guard_ask, pattern="terraform apply *")
+        self.assertEqual(p.read_text(), "{ not json")
+        self.assertNotEqual(rc, 0)
+
+
+class TestThereIsNoCharterSideList(GuardCase):
+    def test_charter_toml_is_not_touched(self):
+        """ADR 0014's whole point: one record, so nothing can drift. A second list in
+        `charter.toml` would need a sync step, and a sync step is where #127 lived."""
+        toml = Path(config.ROOT) / "charter.toml"
+        toml.write_text("schema = 1\n")
+        before = toml.read_text()
+        self.invoke(commands.cmd_guard_ask, pattern="terraform apply *")
+        self.assertEqual(toml.read_text(), before)
+
+    def test_listing_reads_the_settings_file(self):
+        self.write({"permissions": {"ask": ["Bash(terraform apply *)"]}})
+        _, said = self.invoke(commands.cmd_guard_list)
+        self.assertIn("terraform apply", said)
+
+    def test_listing_an_empty_plane_says_so_rather_than_printing_nothing(self):
+        _, said = self.invoke(commands.cmd_guard_list)
+        self.assertTrue(said.strip())
+
+
+class TestDoctorNamesTheShadowedTools(GuardCase):
+    def persona_with(self, *tools: str) -> None:
+        self.make_persona("ops", role="Ops", vault="none", tools=", ".join(tools))
+        from charter import persona
+        persona.set_active("ops")
+
+    def test_no_ask_rules_is_ok(self):
+        self.persona_with("kubectl")
+        self.assertEqual(doctor.check_ask_rules().status, doctor.OK)
+
+    def test_an_unrelated_ask_rule_is_ok(self):
+        self.persona_with("kubectl")
+        self.write({"permissions": {"ask": ["Bash(terraform apply *)"]}})
+        self.assertEqual(doctor.check_ask_rules().status, doctor.OK)
+
+    def test_an_ask_rule_over_a_declared_tool_warns(self):
+        """The interaction ADR 0014 creates. `toolgate` returns `allow` for a declared
+        binary; the host prompts anyway, and the persona's tools quietly stop being
+        pre-approved with nothing naming the cause."""
+        self.persona_with("kubectl", "glab")
+        self.write({"permissions": {"ask": ["Bash(kubectl *)"]}})
+        r = doctor.check_ask_rules()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("kubectl", f"{r.detail} {r.hint}")
+
+    def test_it_names_the_persona_whose_tool_is_shadowed(self):
+        self.persona_with("kubectl")
+        self.write({"permissions": {"ask": ["Bash(kubectl *)"]}})
+        self.assertIn("ops", f"{doctor.check_ask_rules().detail} {doctor.check_ask_rules().hint}")
+
+    def test_a_blanket_bash_rule_is_reported(self):
+        """`Bash` and `Bash(*)` match every command, so they shadow every declared tool."""
+        self.persona_with("kubectl")
+        self.write({"permissions": {"ask": ["Bash"]}})
+        self.assertEqual(doctor.check_ask_rules().status, doctor.WARN)
+
+    def test_it_does_not_tell_you_to_delete_the_rule(self):
+        """The rule is the operator's policy and probably deliberate. Charter names the
+        consequence and leaves the choice — ADR 0013, and the restraint the MCP launcher
+        check keeps."""
+        self.persona_with("kubectl")
+        self.write({"permissions": {"ask": ["Bash(kubectl *)"]}})
+        self.assertNotIn("remove", (doctor.check_ask_rules().hint or "").lower())
+
+    def test_an_unreadable_settings_file_does_not_pass_silently(self):
+        """#171: absence of information is not evidence of health."""
+        p = self.settings()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{ not json")
+        self.persona_with("kubectl")
+        self.assertEqual(doctor.check_ask_rules().status, doctor.WARN)
+
+    def test_it_runs_in_doctor(self):
+        names = [r.name for r in doctor.run_all()]
+        self.assertIn("ask rules", names)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The obvious feature was a list of force-ask commands in `charter.toml`. **ADR 0014 rejects it**, and the research is the substance of this PR.

## Why not build it

Claude Code already has `permissions.ask`, and has more of it than charter would have built:

- Evaluated `deny → ask → allow`, first match wins.
- Lives in the plane's **committed** `.claude/settings.json` — *"You can check permission settings into version control to share them with every developer"* — so no install, no sync.
- It segments compound commands: *"The recognized command separators are `&&`, `||`, `;`, `|`, `|&`, `&`, and newlines. A rule must match each subcommand independently."* That is exactly what `hooks._segment_argv` does by hand, and **got wrong once** — a `shlex` fallback collapsed a command into a single token and blinded the leak guard.

And the two engines could never have been reconciled: **a hook cannot relax a permission rule.** *"A matching ask rule still prompts even when the hook returned `allow` or `ask`."* A charter-side list would have been advisory over a mechanism that outranks it.

## What ships

```
$ charter guard ask 'terraform apply *'
✓ Bash(terraform apply *) → permissions.ask
•   …/.claude/settings.json is committed, so this applies to everyone on this repo.

$ charter guard ask 'kubectl *'
✓ Bash(kubectl *) → permissions.ask
! this also prompts for kubectl, which a persona declares — an ask rule outranks
  charter's tool-gate.
```

One record, no sync step, nothing to drift. `charter guard list` reads the same file.

## What charter keeps, and the line

| guard | needs | expressible as a rule |
|---|---|---|
| `_leak_reason` | argv + vault paths | ✗ |
| `_plane_root_branch_reason` | **cwd** | ✗ |
| `_clone_commit_reason` | **cwd** | ✗ |
| `toolgate.decide` | active persona | ✗ |
| `_single_credential_reason` | command only | **✓** |

Only the last is static, and it **stays in the hook anyway**: a native `deny` prints no reason, and the reason is most of what it is for — a developer who reads *"one credential, each forge's token over HTTPS; no SSH, no signing"* learns the rule; one who reads a bare refusal files a bug. The ADR records that this trade costs the project-scoping that `HAS_CONTROL_PLANE` currently fakes.

## The one interaction, not left silent

An ask rule shadows `toolgate`'s `allow`, so a persona's declared tools quietly stop being pre-approved. `doctor` names the overlap and `guard ask` warns at write time. **Neither suggests deleting the rule** — it is the operator's policy and probably deliberate; charter names the consequence and leaves the choice (ADR 0013).

## Tests

18 new in `tests/test_guard_ask.py`, including that `charter.toml` is never touched (the no-second-store guarantee), that a malformed settings file is refused rather than repaired, and that the hint does not say "remove". Full suite: **2169 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX