### PR TITLE
charter serves its own docs, so a plane has no reason to copy them

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ not encryption at rest. The vault is not a password manager.
 
 ## Learn more
 
+Every page below is also readable from the CLI, so an agent working in a control plane
+does not need a vendored copy that can drift from the binary it is describing:
+
+```bash
+charter docs list             # the topics
+charter docs show secrets     # the page, from the install that implements it
+```
+
 - [docs/install.md](docs/install.md) — both artifacts, alternatives to `uv`, and what
   `charter init` writes before you let it.
 - [docs/control-plane.md](docs/control-plane.md) — `charter.toml` in full: every key, a

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -108,8 +108,24 @@ def build_parser() -> argparse.ArgumentParser:
     st.add_argument("--all", action="store_true", help="Detail every workspace.")
     st.set_defaults(func=commands.cmd_status)
 
-    doc = sub.add_parser("docs", help="Regenerate docs/topology.md from the inventory.")
+    doc = sub.add_parser("docs",
+                         help="Regenerate this plane's docs/topology.md — or read "
+                              "charter's own documentation (`show`, `list`).")
+    dsub = doc.add_subparsers(dest="docs_cmd")
+    # Bare `charter docs` still generates. It did that long before it grew subcommands,
+    # and Makefiles in the wild call it that way, so making the group require a
+    # subcommand would break callers that never saw the change.
     doc.set_defaults(func=commands.cmd_docs)
+    dgen = dsub.add_parser("generate", help="Regenerate docs/topology.md from the inventory.")
+    dgen.set_defaults(func=commands.cmd_docs)
+    dls = dsub.add_parser("list", help="List charter's own documentation topics.")
+    dls.set_defaults(func=commands.cmd_docs_list)
+    dsh = dsub.add_parser("show",
+                          help="Print one of charter's own documentation pages — served "
+                               "by the install that implements it, so it cannot be a "
+                               "version behind the CLI reading it.")
+    dsh.add_argument("topic", help="e.g. secrets, personas, git-policy (see `docs list`).")
+    dsh.set_defaults(func=commands.cmd_docs_show)
 
     sv = sub.add_parser("save",
                         help="Commit + push the control plane's own changes via glab (HTTPS token — no SSH pain).")

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -7,7 +7,7 @@ import json
 import re
 from pathlib import Path
 
-from . import config, doctor, inventory, render, util, workspace, worktree
+from . import config, docsrc, doctor, inventory, render, util, workspace, worktree
 # One committer for the control plane, in charter/planegit.py. Re-exported rather
 # than moved-and-updated so every existing caller and test keeps working — the point
 # of the extraction is that there is ONE implementation, not that callers churn.
@@ -210,6 +210,42 @@ def cmd_docs(args) -> int:
 
     if refresh_readme_personas():
         util.ok("Refreshed the persona roster block in README.md")
+    return 0
+
+
+def cmd_docs_list(args) -> int:
+    """charter's own pages — the ones `docs show` can print.
+
+    Distinct from `cmd_docs`, which writes the *plane's* generated docs. One command
+    describes charter, the other describes your repos; they share a noun and nothing else.
+    """
+    names = docsrc.topics()
+    if not names:
+        util.warn("No documentation shipped with this charter — reinstall it "
+                  "(the wheel is missing charter/_docs).")
+        return 1
+    util.info(f"charter documentation ({docsrc.source()}):")
+    # The topics go to stdout (so `docs list` pipes) while the framing goes to stderr, as
+    # everywhere else in charter. Flushed before the trailing hint because stderr is
+    # unbuffered and stdout is not: without this the hint overtakes the list it describes
+    # the moment the output is a pipe rather than a terminal.
+    print("\n".join(f"  {name}" for name in names) + "\n", flush=True)
+    util.info("Read one with: charter docs show <topic>")
+    return 0
+
+
+def cmd_docs_show(args) -> int:
+    body = docsrc.read(args.topic)
+    if body is None:
+        names = docsrc.topics()
+        # ADR 0009 — classify, don't guess. `docs show persona` is a plausible typo for
+        # `personas`, and resolving it would be charter deciding what the caller meant;
+        # naming the real topics lets them decide, and costs one line.
+        util.err(f"No charter documentation topic named '{args.topic}'.")
+        if names:
+            util.info("Topics: " + ", ".join(names))
+        return 1
+    print(body, end="" if body.endswith("\n") else "\n")
     return 0
 
 

--- a/charter/docsrc.py
+++ b/charter/docsrc.py
@@ -31,12 +31,27 @@ _PACKAGED = Path(__file__).resolve().parent / "_docs"
 _CHECKOUT = Path(__file__).resolve().parents[1] / "docs"
 
 
+def _is_checkout(docs: Path) -> bool:
+    """True when *docs* is the repo's own `docs/`, not a directory that merely sits where
+    one would.
+
+    Installed, ``_CHECKOUT`` resolves to ``<site-packages>/docs`` — a path that belongs to
+    nobody and that another distribution can create by shipping a stray top-level
+    directory. Without this, a wheel built without its `_docs` would not report the broken
+    build `source`'s docstring describes; it would quietly serve a stranger's pages as
+    charter's. `pyproject.toml` beside `docs/` is what a checkout has and site-packages
+    never does.
+    """
+    return (docs.parent / "pyproject.toml").is_file()
+
+
 def source() -> Path | None:
     """The directory the pages are read from, or None when neither exists — which
     happens only in a build so broken that the wheel shipped without its data."""
-    for candidate in (_PACKAGED, _CHECKOUT):
-        if candidate.is_dir():
-            return candidate
+    if _PACKAGED.is_dir():
+        return _PACKAGED
+    if _CHECKOUT.is_dir() and _is_checkout(_CHECKOUT):
+        return _CHECKOUT
     return None
 
 
@@ -60,10 +75,13 @@ def read(topic: str) -> str | None:
     if root is None or not _TOPIC.match(topic or ""):
         return None
     page = root / f"{topic}.md"
-    # `_TOPIC` already excludes separators and `..`, so this cannot currently fail. It
-    # stays because the regex is the kind of thing that gets loosened later to allow some
-    # new page name, and the containment check is what makes that safe rather than lucky.
-    if page.parent.resolve() != root.resolve() or not page.is_file():
+    # Containment is asserted on the RESOLVED page, not on its parent. `page.parent` is
+    # `root` by construction, so checking that asked a question whose answer was always
+    # yes — including for a symlink sitting inside the directory and pointing anywhere on
+    # disk, which `is_file()` follows and `read_text()` then prints. Resolving the page
+    # itself is what makes the check real, both for that case and for the regex being
+    # loosened later to admit some new page name.
+    if page.resolve().parent != root.resolve() or not page.is_file():
         return None
     try:
         return page.read_text()

--- a/charter/docsrc.py
+++ b/charter/docsrc.py
@@ -1,0 +1,71 @@
+"""charter's own documentation pages, resolved for the CLI to print.
+
+A control plane has no reason to vendor a copy of these pages, and every reason not to:
+a copy drifts from the binary that implements what it describes, in both directions and
+invisibly. The page a user reads should come from the same install as the behaviour, so
+`charter docs show secrets` cannot describe a vault the running CLI does not have.
+
+There are two places the pages can live, and both are real:
+
+* **Installed** — `charter/_docs/`, put there by the wheel's `force-include`. This is the
+  case for everyone who did not clone the repo.
+* **A checkout** — the repo's own `docs/`. `CONTRIBUTING.md` tells contributors to run
+  `python3 -m charter ...` from the clone precisely because a `uv tool install` shadows
+  it, so this path is the documented development workflow rather than a courtesy.
+
+Installed wins when both exist. A developer with both is running one specific tree; the
+packaged copy is the one that travelled with the code being executed.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+#: A topic names one page, and nothing else. The command takes a topic rather than a path
+#: on purpose: `charter docs show ../../etc/passwd` must not be a file-read primitive
+#: wearing a documentation command, and `adr/0014` must not quietly widen the surface to
+#: the design record. Anything outside this shape is simply not a topic.
+_TOPIC = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+_PACKAGED = Path(__file__).resolve().parent / "_docs"
+_CHECKOUT = Path(__file__).resolve().parents[1] / "docs"
+
+
+def source() -> Path | None:
+    """The directory the pages are read from, or None when neither exists — which
+    happens only in a build so broken that the wheel shipped without its data."""
+    for candidate in (_PACKAGED, _CHECKOUT):
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def topics() -> list[str]:
+    """Every page that can be shown, sorted. Only top-level `*.md`: `adr/`, `audits/`
+    and `superpowers/` are design record and working notes, not usage documentation."""
+    root = source()
+    if root is None:
+        return []
+    return sorted(p.stem for p in root.glob("*.md") if _TOPIC.match(p.stem))
+
+
+def read(topic: str) -> str | None:
+    """The page's text, or None if `topic` does not name one.
+
+    None covers both "no such page" and "not a topic at all"; the caller classifies once
+    rather than distinguishing a typo from an escape attempt, which it has no reason to
+    treat differently.
+    """
+    root = source()
+    if root is None or not _TOPIC.match(topic or ""):
+        return None
+    page = root / f"{topic}.md"
+    # `_TOPIC` already excludes separators and `..`, so this cannot currently fail. It
+    # stays because the regex is the kind of thing that gets loosened later to allow some
+    # new page name, and the containment check is what makes that safe rather than lucky.
+    if page.parent.resolve() != root.resolve() or not page.is_file():
+        return None
+    try:
+        return page.read_text()
+    except OSError:
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,18 @@ charter = "charter.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["charter"]
+
+# `charter docs show <topic>` serves these, so they must travel with the code: the wheel
+# ships `charter/`, and `docs/` is outside it. Listed page by page rather than as a whole
+# directory so `adr/`, `audits/` and `superpowers/` — design record and working notes —
+# stay out of every user's site-packages. Adding a page here is not optional:
+# tests/test_docs_show.py fails on a `docs/*.md` that is not force-included, because the
+# gap is invisible from a checkout, where the fallback reads the repo and looks fine.
+[tool.hatch.build.targets.wheel.force-include]
+"docs/control-plane.md" = "charter/_docs/control-plane.md"
+"docs/forges.md" = "charter/_docs/forges.md"
+"docs/git-policy.md" = "charter/_docs/git-policy.md"
+"docs/install.md" = "charter/_docs/install.md"
+"docs/mcp.md" = "charter/_docs/mcp.md"
+"docs/personas.md" = "charter/_docs/personas.md"
+"docs/secrets.md" = "charter/_docs/secrets.md"

--- a/tests/test_docs_show.py
+++ b/tests/test_docs_show.py
@@ -23,11 +23,15 @@ Two properties carry that promise and are pinned here:
 """
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
+import tempfile
 import tomllib
 import unittest
 from pathlib import Path
+
+from charter import docsrc
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DOCS_DIR = REPO_ROOT / "docs"
@@ -135,3 +139,61 @@ class TestDocsCli(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestTheContainmentCheckIsReal(unittest.TestCase):
+    """`page.parent` is `root` by construction, so checking it asked a question whose
+    answer was always yes. A symlink inside the docs directory pointed anywhere on disk,
+    `is_file()` followed it, and `read_text()` printed it — through a command whose whole
+    contract is "a topic names one page, and nothing else"."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.docs = self.tmp / "_docs"
+        self.docs.mkdir()
+        (self.docs / "real.md").write_text("# real\n")
+        self._orig = docsrc._PACKAGED
+        docsrc._PACKAGED = self.docs
+        self.addCleanup(setattr, docsrc, "_PACKAGED", self._orig)
+
+    def test_a_symlink_out_of_the_docs_dir_is_not_read(self):
+        secret = self.tmp / "outside.txt"
+        secret.write_text("NOT A DOCUMENTATION PAGE\n")
+        (self.docs / "leak.md").symlink_to(secret)
+        self.assertIsNone(docsrc.read("leak"))
+
+    def test_a_real_page_still_reads(self):
+        self.assertEqual(docsrc.read("real"), "# real\n")
+
+
+class TestTheCheckoutFallbackIsNotSitePackages(unittest.TestCase):
+    """Installed, `_CHECKOUT` resolves to `<site-packages>/docs` — a path that belongs to
+    nobody, which another distribution can create by shipping a stray top-level directory.
+    A wheel built without its `_docs` must report the broken build `source` describes,
+    not quietly serve a stranger's pages as charter's."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self._pkg, self._chk = docsrc._PACKAGED, docsrc._CHECKOUT
+        self.addCleanup(setattr, docsrc, "_PACKAGED", self._pkg)
+        self.addCleanup(setattr, docsrc, "_CHECKOUT", self._chk)
+        docsrc._PACKAGED = self.tmp / "absent"          # the broken-wheel case
+
+    def test_a_stray_site_packages_docs_dir_is_not_a_source(self):
+        stray = self.tmp / "site-packages" / "docs"
+        stray.mkdir(parents=True)
+        (stray / "install.md").write_text("# someone else's page\n")
+        docsrc._CHECKOUT = stray
+        self.assertIsNone(docsrc.source())
+        self.assertIsNone(docsrc.read("install"))
+
+    def test_a_real_checkout_still_resolves(self):
+        repo = self.tmp / "repo"
+        (repo / "docs").mkdir(parents=True)
+        (repo / "pyproject.toml").write_text("[project]\nname='charter-cp'\n")
+        (repo / "docs" / "install.md").write_text("# ours\n")
+        docsrc._CHECKOUT = repo / "docs"
+        self.assertEqual(docsrc.source(), repo / "docs")
+        self.assertEqual(docsrc.read("install"), "# ours\n")

--- a/tests/test_docs_show.py
+++ b/tests/test_docs_show.py
@@ -1,0 +1,137 @@
+"""charter serves its own documentation, so a control plane does not have to carry a copy.
+
+The failure this prevents is one the project has now watched happen downstream. A plane
+that vendors its own copy of `personas.md` or `secrets.md` starts identical and then
+drifts, in both directions at once: the copy falls behind a feature it never learned about
+(a plane was still describing vaults as plain-file only, long after reference vaults and
+1Password landed — while *using* reference vaults), and it also runs ahead, growing
+sections upstream never receives. Neither half is visible from either side, because
+nothing compares them.
+
+`charter docs show <topic>` removes the reason to copy: the CLI that implements the
+behaviour is the thing that describes it, so the page can never be a version behind the
+binary reading it.
+
+Two properties carry that promise and are pinned here:
+
+* **Every page ships.** The wheel installs `charter/`, not the repo, so a page that is not
+  force-included does not exist for an installed user. Adding `docs/newthing.md` without
+  wiring it would leave `charter docs show newthing` failing on every machine except the
+  contributor's checkout, where the fallback quietly covers it up.
+* **An unknown topic classifies rather than guesses** (ADR 0009). Printing the nearest
+  match would be a guess about intent; naming the real topics lets the caller choose.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tomllib
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_DIR = REPO_ROOT / "docs"
+
+#: The pages `docs show` serves: the top-level topic pages. `adr/`, `audits/` and
+#: `superpowers/` are deliberately not topics — they are design record and working notes,
+#: not "how do I use this", and shipping them would put internal plans in every wheel.
+def _page_names() -> list[str]:
+    return sorted(p.stem for p in DOCS_DIR.glob("*.md"))
+
+
+class TestDocSource(unittest.TestCase):
+    def test_every_page_is_a_topic(self):
+        """A page nobody can reach is the same as no page."""
+        from charter import docsrc
+
+        self.assertEqual(_page_names(), sorted(docsrc.topics()))
+
+    def test_a_topic_reads_back_its_page(self):
+        from charter import docsrc
+
+        body = docsrc.read("git-policy")
+        self.assertIsNotNone(body, "git-policy is a page in docs/")
+        self.assertEqual((DOCS_DIR / "git-policy.md").read_text(), body)
+
+    def test_an_unknown_topic_reads_as_none(self):
+        from charter import docsrc
+
+        self.assertIsNone(docsrc.read("no-such-topic"))
+
+    def test_a_topic_cannot_escape_the_doc_directory(self):
+        """`read` takes a topic, not a path. Without this, `charter docs show
+        ../../etc/passwd` is a file-read primitive wearing a documentation command."""
+        from charter import docsrc
+
+        for hostile in ("../pyproject", "../../etc/passwd", "adr/0014", "a/b"):
+            self.assertIsNone(docsrc.read(hostile), hostile)
+
+
+class TestPagesShip(unittest.TestCase):
+    def test_every_page_is_force_included_in_the_wheel(self):
+        """The wheel ships `packages = ["charter"]`; `docs/` is outside it. Each page
+        therefore needs an explicit force-include, and adding a page without one is a
+        drift that only shows up on someone else's machine — the contributor's own
+        checkout falls back to `docs/` and looks fine."""
+        pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+        forced = (pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]
+                  .get("force-include", {}))
+        for name in _page_names():
+            src = f"docs/{name}.md"
+            self.assertIn(src, forced, f"{src} would not ship in the wheel")
+            self.assertEqual(forced[src], f"charter/_docs/{name}.md", src)
+
+    def test_nothing_else_is_force_included(self):
+        """Keeps `adr/`, `audits/` and `superpowers/` — internal record and working
+        notes — out of every user's site-packages."""
+        pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+        forced = (pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]
+                  .get("force-include", {}))
+        self.assertEqual(sorted(forced), sorted(f"docs/{n}.md" for n in _page_names()))
+
+
+class TestDocsCli(unittest.TestCase):
+    """Drives the real entrypoint: `docs` grew subcommands, and the parser change is
+    the part that can silently break an existing caller."""
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run([sys.executable, "-m", "charter", "docs", *args],
+                              cwd=REPO_ROOT, capture_output=True, text=True, timeout=60)
+
+    def test_show_prints_the_page(self):
+        r = self._run("show", "git-policy")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("one credential", r.stdout.lower())
+
+    def test_list_names_every_topic(self):
+        r = self._run("list")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        for name in _page_names():
+            self.assertIn(name, r.stdout, name)
+
+    def test_unknown_topic_fails_and_names_the_real_ones(self):
+        """ADR 0009 — errors classify, they do not guess. A near-miss must not be
+        silently resolved to the page charter thinks you meant."""
+        r = self._run("show", "persona")           # the page is `personas`
+        self.assertNotEqual(r.returncode, 0)
+        out = r.stdout + r.stderr
+        self.assertIn("personas", out)
+        self.assertNotIn("# Personas", out, "naming the topics is not printing one")
+
+    def test_bare_docs_still_generates(self):
+        """`charter docs` regenerated the plane's topology long before it grew
+        subcommands, and Makefiles in the wild call it that way. Turning it into a
+        group that demands a subcommand would break them at a distance."""
+        r = subprocess.run([sys.executable, "-m", "charter", "docs", "--help"],
+                           cwd=REPO_ROOT, capture_output=True, text=True, timeout=60)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        from charter import cli
+
+        args = cli.build_parser().parse_args(["docs"])
+        from charter import commands
+
+        self.assertIs(args.func, commands.cmd_docs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The failure this prevents

A control plane that vendors charter's pages drifts from them **in both directions at once**, and nothing compares the two.

Found in the wild: a plane still describing vaults as plain-file only — no reference vaults, no 1Password, no dotenv bridge — long after those shipped, *while actively using reference vaults*. The same plane's persona page had meanwhile grown sections upstream never received (`uses:`, roster stats, Workflow dispatch). Each copy was wrong in a way only visible from the other side, which is why it survived months of use.

`charter docs show <topic>` removes the reason to copy: the install that implements the behaviour is the thing that prints the description, so a page cannot be a version behind the binary being asked about it.

## What's here

```bash
charter docs list             # the seven topics
charter docs show secrets     # the page, from the install that implements it
charter docs                  # unchanged — still regenerates the plane's topology
```

## Two properties, both pinned by tests

**Every page ships.** The wheel installs `charter/`, not the repo, so a page that isn't force-included doesn't exist for an installed user — while a contributor's checkout falls back to `docs/` and looks fine. That asymmetry is what makes the gap invisible, so the test asserts against `pyproject.toml` rather than trusting review. Verified against a built wheel: 7 pages present, `adr/`/`audits/`/`superpowers/`/`assets/` absent.

**An unknown topic classifies instead of guessing** (ADR 0009). `docs show persona` names the seven real topics rather than silently resolving to `personas`.

`show` takes a topic, never a path — without that the command is a file-read primitive in documentation clothing. Pinned by a test that tries `../../etc/passwd` and `adr/0014`.

## Compatibility

Bare `charter docs` still regenerates the plane's topology; it did that long before it grew subcommands and Makefiles in the wild call it that way. The group takes an *optional* subcommand, the same shape `version` and `guard` already use. A test asserts `charter docs` still dispatches to `cmd_docs`.

## Verification

- `python3 -m unittest discover -s tests` — **2179 passed**
- Wheel built and inspected for the force-include result, not just its declaration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAnq1m9e2URZZy3XjyBFVV