### PR TITLE
The plugin ships the skills for charter's own surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ not encryption at rest. The vault is not a password manager.
   guard denials and tool approvals and memory writes, and `charter persona stats` says
   whether a role is actually being dispatched or whether that work is quietly routing to a
   generic agent.
+- **A plane writing down charter's own rules, and getting them wrong later.** The plugin
+  ships the skills for its surface — `charter:secrets` (use a credential without its value
+  reaching the transcript), `charter:working-in-a-clone` (the boundary between the plane's
+  session and a repo's own `.claude/`), and `charter:persona` (adopting a role, and routing
+  work to one instead of switching). They version with the CLI, so a plane no longer needs
+  a copy that can drift out from under it.
 
 ## The model
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ not encryption at rest. The vault is not a password manager.
 
 ## Learn more
 
+Every page below is also readable from the CLI, so an agent working in a control plane
+does not need a vendored copy that can drift from the binary it is describing:
+
+```bash
+charter docs list             # the topics
+charter docs show secrets     # the page, from the install that implements it
+```
+
 - [docs/install.md](docs/install.md) — both artifacts, alternatives to `uv`, and what
   `charter init` writes before you let it.
 - [docs/control-plane.md](docs/control-plane.md) — `charter.toml` in full: every key, a

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -108,8 +108,24 @@ def build_parser() -> argparse.ArgumentParser:
     st.add_argument("--all", action="store_true", help="Detail every workspace.")
     st.set_defaults(func=commands.cmd_status)
 
-    doc = sub.add_parser("docs", help="Regenerate docs/topology.md from the inventory.")
+    doc = sub.add_parser("docs",
+                         help="Regenerate this plane's docs/topology.md — or read "
+                              "charter's own documentation (`show`, `list`).")
+    dsub = doc.add_subparsers(dest="docs_cmd")
+    # Bare `charter docs` still generates. It did that long before it grew subcommands,
+    # and Makefiles in the wild call it that way, so making the group require a
+    # subcommand would break callers that never saw the change.
     doc.set_defaults(func=commands.cmd_docs)
+    dgen = dsub.add_parser("generate", help="Regenerate docs/topology.md from the inventory.")
+    dgen.set_defaults(func=commands.cmd_docs)
+    dls = dsub.add_parser("list", help="List charter's own documentation topics.")
+    dls.set_defaults(func=commands.cmd_docs_list)
+    dsh = dsub.add_parser("show",
+                          help="Print one of charter's own documentation pages — served "
+                               "by the install that implements it, so it cannot be a "
+                               "version behind the CLI reading it.")
+    dsh.add_argument("topic", help="e.g. secrets, personas, git-policy (see `docs list`).")
+    dsh.set_defaults(func=commands.cmd_docs_show)
 
     sv = sub.add_parser("save",
                         help="Commit + push the control plane's own changes via glab (HTTPS token — no SSH pain).")

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -7,7 +7,7 @@ import json
 import re
 from pathlib import Path
 
-from . import config, doctor, inventory, render, util, workspace, worktree
+from . import config, docsrc, doctor, inventory, render, util, workspace, worktree
 # One committer for the control plane, in charter/planegit.py. Re-exported rather
 # than moved-and-updated so every existing caller and test keeps working — the point
 # of the extraction is that there is ONE implementation, not that callers churn.
@@ -210,6 +210,42 @@ def cmd_docs(args) -> int:
 
     if refresh_readme_personas():
         util.ok("Refreshed the persona roster block in README.md")
+    return 0
+
+
+def cmd_docs_list(args) -> int:
+    """charter's own pages — the ones `docs show` can print.
+
+    Distinct from `cmd_docs`, which writes the *plane's* generated docs. One command
+    describes charter, the other describes your repos; they share a noun and nothing else.
+    """
+    names = docsrc.topics()
+    if not names:
+        util.warn("No documentation shipped with this charter — reinstall it "
+                  "(the wheel is missing charter/_docs).")
+        return 1
+    util.info(f"charter documentation ({docsrc.source()}):")
+    # The topics go to stdout (so `docs list` pipes) while the framing goes to stderr, as
+    # everywhere else in charter. Flushed before the trailing hint because stderr is
+    # unbuffered and stdout is not: without this the hint overtakes the list it describes
+    # the moment the output is a pipe rather than a terminal.
+    print("\n".join(f"  {name}" for name in names) + "\n", flush=True)
+    util.info("Read one with: charter docs show <topic>")
+    return 0
+
+
+def cmd_docs_show(args) -> int:
+    body = docsrc.read(args.topic)
+    if body is None:
+        names = docsrc.topics()
+        # ADR 0009 — classify, don't guess. `docs show persona` is a plausible typo for
+        # `personas`, and resolving it would be charter deciding what the caller meant;
+        # naming the real topics lets them decide, and costs one line.
+        util.err(f"No charter documentation topic named '{args.topic}'.")
+        if names:
+            util.info("Topics: " + ", ".join(names))
+        return 1
+    print(body, end="" if body.endswith("\n") else "\n")
     return 0
 
 

--- a/charter/docsrc.py
+++ b/charter/docsrc.py
@@ -1,0 +1,89 @@
+"""charter's own documentation pages, resolved for the CLI to print.
+
+A control plane has no reason to vendor a copy of these pages, and every reason not to:
+a copy drifts from the binary that implements what it describes, in both directions and
+invisibly. The page a user reads should come from the same install as the behaviour, so
+`charter docs show secrets` cannot describe a vault the running CLI does not have.
+
+There are two places the pages can live, and both are real:
+
+* **Installed** — `charter/_docs/`, put there by the wheel's `force-include`. This is the
+  case for everyone who did not clone the repo.
+* **A checkout** — the repo's own `docs/`. `CONTRIBUTING.md` tells contributors to run
+  `python3 -m charter ...` from the clone precisely because a `uv tool install` shadows
+  it, so this path is the documented development workflow rather than a courtesy.
+
+Installed wins when both exist. A developer with both is running one specific tree; the
+packaged copy is the one that travelled with the code being executed.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+#: A topic names one page, and nothing else. The command takes a topic rather than a path
+#: on purpose: `charter docs show ../../etc/passwd` must not be a file-read primitive
+#: wearing a documentation command, and `adr/0014` must not quietly widen the surface to
+#: the design record. Anything outside this shape is simply not a topic.
+_TOPIC = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+_PACKAGED = Path(__file__).resolve().parent / "_docs"
+_CHECKOUT = Path(__file__).resolve().parents[1] / "docs"
+
+
+def _is_checkout(docs: Path) -> bool:
+    """True when *docs* is the repo's own `docs/`, not a directory that merely sits where
+    one would.
+
+    Installed, ``_CHECKOUT`` resolves to ``<site-packages>/docs`` — a path that belongs to
+    nobody and that another distribution can create by shipping a stray top-level
+    directory. Without this, a wheel built without its `_docs` would not report the broken
+    build `source`'s docstring describes; it would quietly serve a stranger's pages as
+    charter's. `pyproject.toml` beside `docs/` is what a checkout has and site-packages
+    never does.
+    """
+    return (docs.parent / "pyproject.toml").is_file()
+
+
+def source() -> Path | None:
+    """The directory the pages are read from, or None when neither exists — which
+    happens only in a build so broken that the wheel shipped without its data."""
+    if _PACKAGED.is_dir():
+        return _PACKAGED
+    if _CHECKOUT.is_dir() and _is_checkout(_CHECKOUT):
+        return _CHECKOUT
+    return None
+
+
+def topics() -> list[str]:
+    """Every page that can be shown, sorted. Only top-level `*.md`: `adr/`, `audits/`
+    and `superpowers/` are design record and working notes, not usage documentation."""
+    root = source()
+    if root is None:
+        return []
+    return sorted(p.stem for p in root.glob("*.md") if _TOPIC.match(p.stem))
+
+
+def read(topic: str) -> str | None:
+    """The page's text, or None if `topic` does not name one.
+
+    None covers both "no such page" and "not a topic at all"; the caller classifies once
+    rather than distinguishing a typo from an escape attempt, which it has no reason to
+    treat differently.
+    """
+    root = source()
+    if root is None or not _TOPIC.match(topic or ""):
+        return None
+    page = root / f"{topic}.md"
+    # Containment is asserted on the RESOLVED page, not on its parent. `page.parent` is
+    # `root` by construction, so checking that asked a question whose answer was always
+    # yes — including for a symlink sitting inside the directory and pointing anywhere on
+    # disk, which `is_file()` follows and `read_text()` then prints. Resolving the page
+    # itself is what makes the check real, both for that case and for the regex being
+    # loosened later to admit some new page name.
+    if page.resolve().parent != root.resolve() or not page.is_file():
+        return None
+    try:
+        return page.read_text()
+    except OSError:
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,18 @@ charter = "charter.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["charter"]
+
+# `charter docs show <topic>` serves these, so they must travel with the code: the wheel
+# ships `charter/`, and `docs/` is outside it. Listed page by page rather than as a whole
+# directory so `adr/`, `audits/` and `superpowers/` — design record and working notes —
+# stay out of every user's site-packages. Adding a page here is not optional:
+# tests/test_docs_show.py fails on a `docs/*.md` that is not force-included, because the
+# gap is invisible from a checkout, where the fallback reads the repo and looks fine.
+[tool.hatch.build.targets.wheel.force-include]
+"docs/control-plane.md" = "charter/_docs/control-plane.md"
+"docs/forges.md" = "charter/_docs/forges.md"
+"docs/git-policy.md" = "charter/_docs/git-policy.md"
+"docs/install.md" = "charter/_docs/install.md"
+"docs/mcp.md" = "charter/_docs/mcp.md"
+"docs/personas.md" = "charter/_docs/personas.md"
+"docs/secrets.md" = "charter/_docs/secrets.md"

--- a/skills/persona/SKILL.md
+++ b/skills/persona/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: persona
+description: Adopt, create, or route work to a charter persona — a role with its own charter, memory and vault. Use when asked to act as a role, to switch or create a persona, or when deciding which persona a piece of work belongs to.
+---
+
+# Personas
+
+A persona is *who does the work* — a role with a written charter, its own memory, and its
+own vault. Adopting one means taking on its responsibilities, its conventions, and its
+credentials.
+
+Mechanics in full — the charter format, inheritance, the memory model, roster health:
+`charter docs show personas`.
+
+## Know which one is active
+
+```bash
+charter persona current        # the active persona, and how it resolved
+charter persona list           # all of them; * marks active; shows vault state
+charter persona show <name>    # its charter — the role to actually adopt
+```
+
+Resolution: `--persona` → `$CHARTER_PERSONA` (pinned at launch) → local selection
+(`charter persona use`) → the committed default (`personas/.default`) → none.
+
+## Adopt one
+
+1. Read its charter with `charter persona show <name>` and behave as that role — its
+   responsibilities, its focus, its definition of done.
+2. Take credentials from its vault, never from anywhere else, and never print them
+   (see the `secrets` skill).
+3. Stay in role until asked to switch.
+
+**Do not switch the active persona unless asked.** Switching changes the session's identity
+for everyone downstream; routing a task does not.
+
+## Route work instead of switching
+
+Every persona declares a `delegate-when:`, surfaced in its sub-agent description.
+
+- **Clear match → delegate** to that persona's sub-agent rather than doing it yourself.
+  Delegation isolates context: only the result comes back, and the persona runs with *its*
+  vault and tools.
+- **Partial or ambiguous → name the persona you would use and ask** before dispatching.
+- **No persona fits → say so.** Offer to create one only when the domain is genuinely large
+  enough to own; a charter alone, with no credential or tool behind it, loses to a
+  general-purpose agent.
+- **Only route to personas that exist.** Never invent a name.
+
+A persona sub-agent is generated from its charter:
+
+```bash
+charter persona sync-agents        # regenerate after editing any charter
+```
+
+## Capability handoff
+
+A persona reaches only its own vault and its own declared tools. When a task needs access
+it does not have, **delegate that step to the persona that holds it** rather than guessing
+with partial credentials or borrowing a secret. Awareness of another persona's capability
+is not access to it — only an explicit `uses:` shares a vault.
+
+## Memory
+
+A persona remembers across sessions. Search rather than bulk-reading:
+
+```bash
+charter recall "<keywords>"                            # every base at once, labelled by source
+charter persona remember <name> "<durable fact>"       # persistent, committed
+charter persona remember <name> "<fact>" --shared      # for every persona
+```
+
+Record what the work *taught* you — a decision, a gotcha, a verified fact — not what the
+repo already records. **Never put a secret in memory**; that is what the vault is for.
+
+## Creating one
+
+```bash
+charter persona create <name> --role "<Role>" [--with-vault] [--use]
+```
+
+This writes a committed `personas/<name>/`. Edit the charter, then commit it — personas are
+shared. A persona earns its place by carrying a capability a general-purpose agent cannot
+have: a credential, a tool, or a domain narrow enough to name.
+
+## Guardrails
+
+- One persona at a time; never mix two personas' vaults.
+- Editing or removing a persona changes a committed file — commit it.
+- Re-run `charter persona sync-agents` after any charter edit, or the dispatchable
+  sub-agent silently describes the old role.

--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: secrets
+description: Use a credential held in a charter vault — a database password, API token, kubeconfig, SSH key or server login — without its value entering the conversation. Use when a task needs a secret, when asked to store one, or before running any command that requires a credential.
+---
+
+# Using a charter vault
+
+The rule this exists to keep: **use a secret, never reveal it.** A value that reaches the
+transcript is disclosed — to the model's context, to whatever logs the session, and to
+anyone the transcript is later shared with. Deleting the message afterwards does not undo
+any of that.
+
+Full model, including what the vault does *not* protect against: `charter docs show secrets`.
+
+## Find out what exists
+
+```bash
+charter vault list                 # vaults: name, provider, persona, status — no values
+charter secret list <vault>        # the KEYS in one vault — no values
+```
+
+## Store one — the value never goes on the command line
+
+```bash
+printf '%s' "<value>" | charter secret set <vault> <key> --stdin
+charter secret set <vault> <key> --from-file <path>    # multi-line or verbatim: kubeconfig, PEM
+```
+
+An argument list is not private: it is visible in `ps`, in shell history, and in this
+transcript. Ask the user to supply the value by stdin or file, or to set it themselves.
+
+## Use one — pick an injection path
+
+**As an environment variable:**
+
+```bash
+charter secret exec <vault> --env NAME=<key> -- <command...>
+```
+
+**As a file** (kubeconfig, certificate, key):
+
+```bash
+charter secret exec <vault> --file KUBECONFIG=<key> -- kubectl get pods
+charter secret cp <vault> <key> <dest>     # persist at 0600; prints only the path
+```
+
+**As a dotenv file**, for a tool that reads one (this is how a browser driver gets a
+login without the password being typed into the page by you):
+
+```bash
+charter secret exec <vault> --dotenv ENVFILE=USER:<key>,PASS:<key> -- <command...>
+```
+
+In every case the value is injected into the subprocess and **redacted from its output**,
+so a command that echoes it still cannot leak it into the transcript.
+
+**Just checking one is present:**
+
+```bash
+charter secret get <vault> <key>       # masked: length + sha256 prefix
+```
+
+## Hard rules
+
+- **Never `charter secret get --reveal`.** It refuses a non-interactive stdout by design.
+  Forcing it puts the value in context, which is the one outcome the vault exists to
+  prevent. Use `exec` or `cp`.
+- Never echo a secret, write it into a tracked file, or pass it as a literal argument.
+- Never put a secret in memory, a persona charter, a workspace charter, or a commit
+  message. The vault is the only place for one.
+- If the vault or key does not exist, say so and ask for it to be added — do not work
+  around it with a value pasted into the conversation.
+
+## Working as a persona
+
+A persona owns a vault. When one is active, prefer the persona form — same commands,
+resolved against the active persona's vault, no vault name to get wrong:
+
+```bash
+charter persona secret list
+charter persona secret exec --env TOKEN=<key> -- <command...>
+```
+
+A persona can only reach its own vault. When a task needs a credential another persona
+holds, delegate that step to that persona rather than copying the secret across — it runs
+with its own vault and you never see the value.

--- a/skills/working-in-a-clone/SKILL.md
+++ b/skills/working-in-a-clone/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: working-in-a-clone
+description: Do real work inside a repo a workspace owns — build, test, change, commit. Use when asked to work on a named repo from a control plane, and to get the boundary right between the plane's session and the repo's own configuration.
+---
+
+# Working inside a clone
+
+A control plane orchestrates repos; it is not where their work happens (ADR 0008). The
+plane deliberately does not know how to build or test any of them — that knowledge lives
+in each repo. This skill crosses that boundary correctly.
+
+## 1. Know the workspace, and stay inside it
+
+```bash
+charter workspace current      # the active workspace, and how it resolved
+```
+
+Clones live at `workspaces/<workspace>/<repo>`. Work in the **active** workspace only.
+A repo needed by this task that sits in another workspace gets cloned into this one —
+never reached across.
+
+## 2. Make sure it is cloned
+
+```bash
+charter clone <repo>           # skipped if already present; checks out its real default branch
+```
+
+Default branches differ across an org (`main`, `master`, `develop`). `charter clone` reads
+each repo's actual default branch, so never assume one.
+
+## 3. Adopt the repo's own conventions before editing
+
+Read whichever of `CLAUDE.md`, `AGENTS.md`, `README.md` the repo ships, then skim its
+manifest (`package.json`, `pom.xml`, `pyproject.toml`, `go.mod`) for its real build and
+test commands. Use those — never commands carried over from a different repo.
+
+## 4. Commit to the repo you are in
+
+A clone is its own git repository, so committing there touches *its* history and never the
+plane's. Push per that repo's workflow.
+
+The plane's own tracked files are a separate concern — `charter save` commits and pushes
+those.
+
+## The boundary that is easy to get wrong
+
+Claude Code binds configuration to the **project root fixed when the session launched** —
+the plane. Two layers resolve differently:
+
+- **Content loads natively.** A clone's `CLAUDE.md` / `AGENTS.md` is pulled into context as
+  you work in its subtree. That is enough for cross-repo work and light edits, and the
+  plane's own layer (personas, vaults, the tool gate, the status line) stays active.
+- **The clone's `.claude/` stays inert.** Its `skills/`, `commands/`, `agents/`,
+  `settings.json`, hooks, plugins and MCP servers belong to *that* project root. `cd` does
+  not re-root the project, so they do not load here.
+
+**Never import or run a clone's `.claude/` in the plane's session.** Those are executable
+code belonging to another project, and running them from the plane merges two trust
+boundaries that were separated on purpose.
+
+To use them, open a session rooted in the repo — the supported way:
+
+```bash
+cd workspaces/<workspace>/<repo> && claude
+```
+
+There the repo's full configuration loads natively, and `charter` still works from inside
+it when the control plane is needed.
+
+## Guardrails
+
+- Confirm the working directory is `workspaces/<active>/<repo>` before a build or a commit.
+- Never operate across two workspaces in one action.
+- A clone you cannot access simply fails to clone — surface that rather than working around
+  it. Partial access to an org is normal.

--- a/tests/test_docs_show.py
+++ b/tests/test_docs_show.py
@@ -1,0 +1,199 @@
+"""charter serves its own documentation, so a control plane does not have to carry a copy.
+
+The failure this prevents is one the project has now watched happen downstream. A plane
+that vendors its own copy of `personas.md` or `secrets.md` starts identical and then
+drifts, in both directions at once: the copy falls behind a feature it never learned about
+(a plane was still describing vaults as plain-file only, long after reference vaults and
+1Password landed — while *using* reference vaults), and it also runs ahead, growing
+sections upstream never receives. Neither half is visible from either side, because
+nothing compares them.
+
+`charter docs show <topic>` removes the reason to copy: the CLI that implements the
+behaviour is the thing that describes it, so the page can never be a version behind the
+binary reading it.
+
+Two properties carry that promise and are pinned here:
+
+* **Every page ships.** The wheel installs `charter/`, not the repo, so a page that is not
+  force-included does not exist for an installed user. Adding `docs/newthing.md` without
+  wiring it would leave `charter docs show newthing` failing on every machine except the
+  contributor's checkout, where the fallback quietly covers it up.
+* **An unknown topic classifies rather than guesses** (ADR 0009). Printing the nearest
+  match would be a guess about intent; naming the real topics lets the caller choose.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+from charter import docsrc
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_DIR = REPO_ROOT / "docs"
+
+#: The pages `docs show` serves: the top-level topic pages. `adr/`, `audits/` and
+#: `superpowers/` are deliberately not topics — they are design record and working notes,
+#: not "how do I use this", and shipping them would put internal plans in every wheel.
+def _page_names() -> list[str]:
+    return sorted(p.stem for p in DOCS_DIR.glob("*.md"))
+
+
+class TestDocSource(unittest.TestCase):
+    def test_every_page_is_a_topic(self):
+        """A page nobody can reach is the same as no page."""
+        from charter import docsrc
+
+        self.assertEqual(_page_names(), sorted(docsrc.topics()))
+
+    def test_a_topic_reads_back_its_page(self):
+        from charter import docsrc
+
+        body = docsrc.read("git-policy")
+        self.assertIsNotNone(body, "git-policy is a page in docs/")
+        self.assertEqual((DOCS_DIR / "git-policy.md").read_text(), body)
+
+    def test_an_unknown_topic_reads_as_none(self):
+        from charter import docsrc
+
+        self.assertIsNone(docsrc.read("no-such-topic"))
+
+    def test_a_topic_cannot_escape_the_doc_directory(self):
+        """`read` takes a topic, not a path. Without this, `charter docs show
+        ../../etc/passwd` is a file-read primitive wearing a documentation command."""
+        from charter import docsrc
+
+        for hostile in ("../pyproject", "../../etc/passwd", "adr/0014", "a/b"):
+            self.assertIsNone(docsrc.read(hostile), hostile)
+
+
+class TestPagesShip(unittest.TestCase):
+    def test_every_page_is_force_included_in_the_wheel(self):
+        """The wheel ships `packages = ["charter"]`; `docs/` is outside it. Each page
+        therefore needs an explicit force-include, and adding a page without one is a
+        drift that only shows up on someone else's machine — the contributor's own
+        checkout falls back to `docs/` and looks fine."""
+        pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+        forced = (pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]
+                  .get("force-include", {}))
+        for name in _page_names():
+            src = f"docs/{name}.md"
+            self.assertIn(src, forced, f"{src} would not ship in the wheel")
+            self.assertEqual(forced[src], f"charter/_docs/{name}.md", src)
+
+    def test_nothing_else_is_force_included(self):
+        """Keeps `adr/`, `audits/` and `superpowers/` — internal record and working
+        notes — out of every user's site-packages."""
+        pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+        forced = (pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]
+                  .get("force-include", {}))
+        self.assertEqual(sorted(forced), sorted(f"docs/{n}.md" for n in _page_names()))
+
+
+class TestDocsCli(unittest.TestCase):
+    """Drives the real entrypoint: `docs` grew subcommands, and the parser change is
+    the part that can silently break an existing caller."""
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run([sys.executable, "-m", "charter", "docs", *args],
+                              cwd=REPO_ROOT, capture_output=True, text=True, timeout=60)
+
+    def test_show_prints_the_page(self):
+        r = self._run("show", "git-policy")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("one credential", r.stdout.lower())
+
+    def test_list_names_every_topic(self):
+        r = self._run("list")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        for name in _page_names():
+            self.assertIn(name, r.stdout, name)
+
+    def test_unknown_topic_fails_and_names_the_real_ones(self):
+        """ADR 0009 — errors classify, they do not guess. A near-miss must not be
+        silently resolved to the page charter thinks you meant."""
+        r = self._run("show", "persona")           # the page is `personas`
+        self.assertNotEqual(r.returncode, 0)
+        out = r.stdout + r.stderr
+        self.assertIn("personas", out)
+        self.assertNotIn("# Personas", out, "naming the topics is not printing one")
+
+    def test_bare_docs_still_generates(self):
+        """`charter docs` regenerated the plane's topology long before it grew
+        subcommands, and Makefiles in the wild call it that way. Turning it into a
+        group that demands a subcommand would break them at a distance."""
+        r = subprocess.run([sys.executable, "-m", "charter", "docs", "--help"],
+                           cwd=REPO_ROOT, capture_output=True, text=True, timeout=60)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        from charter import cli
+
+        args = cli.build_parser().parse_args(["docs"])
+        from charter import commands
+
+        self.assertIs(args.func, commands.cmd_docs)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestTheContainmentCheckIsReal(unittest.TestCase):
+    """`page.parent` is `root` by construction, so checking it asked a question whose
+    answer was always yes. A symlink inside the docs directory pointed anywhere on disk,
+    `is_file()` followed it, and `read_text()` printed it — through a command whose whole
+    contract is "a topic names one page, and nothing else"."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.docs = self.tmp / "_docs"
+        self.docs.mkdir()
+        (self.docs / "real.md").write_text("# real\n")
+        self._orig = docsrc._PACKAGED
+        docsrc._PACKAGED = self.docs
+        self.addCleanup(setattr, docsrc, "_PACKAGED", self._orig)
+
+    def test_a_symlink_out_of_the_docs_dir_is_not_read(self):
+        secret = self.tmp / "outside.txt"
+        secret.write_text("NOT A DOCUMENTATION PAGE\n")
+        (self.docs / "leak.md").symlink_to(secret)
+        self.assertIsNone(docsrc.read("leak"))
+
+    def test_a_real_page_still_reads(self):
+        self.assertEqual(docsrc.read("real"), "# real\n")
+
+
+class TestTheCheckoutFallbackIsNotSitePackages(unittest.TestCase):
+    """Installed, `_CHECKOUT` resolves to `<site-packages>/docs` — a path that belongs to
+    nobody, which another distribution can create by shipping a stray top-level directory.
+    A wheel built without its `_docs` must report the broken build `source` describes,
+    not quietly serve a stranger's pages as charter's."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self._pkg, self._chk = docsrc._PACKAGED, docsrc._CHECKOUT
+        self.addCleanup(setattr, docsrc, "_PACKAGED", self._pkg)
+        self.addCleanup(setattr, docsrc, "_CHECKOUT", self._chk)
+        docsrc._PACKAGED = self.tmp / "absent"          # the broken-wheel case
+
+    def test_a_stray_site_packages_docs_dir_is_not_a_source(self):
+        stray = self.tmp / "site-packages" / "docs"
+        stray.mkdir(parents=True)
+        (stray / "install.md").write_text("# someone else's page\n")
+        docsrc._CHECKOUT = stray
+        self.assertIsNone(docsrc.source())
+        self.assertIsNone(docsrc.read("install"))
+
+    def test_a_real_checkout_still_resolves(self):
+        repo = self.tmp / "repo"
+        (repo / "docs").mkdir(parents=True)
+        (repo / "pyproject.toml").write_text("[project]\nname='charter-cp'\n")
+        (repo / "docs" / "install.md").write_text("# ours\n")
+        docsrc._CHECKOUT = repo / "docs"
+        self.assertEqual(docsrc.source(), repo / "docs")
+        self.assertEqual(docsrc.read("install"), "# ours\n")

--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -1,0 +1,128 @@
+"""The plugin ships skills, and every command they name is real.
+
+Charter's knowledge used to reach agents only two ways: a SessionStart injection that
+costs every session whether or not it is needed, and `--help`, which answers "what are the
+flags" rather than "what must I not get wrong". Anything in between got written down in
+each control plane instead — and a plane's copy drifts, silently, because nothing compares
+it to the CLI.
+
+The concrete case: a plane carried a `setup` skill telling engineers to authenticate over
+SSH and add an SSH key, months after charter's rule became token-only-over-HTTPS and its
+own guard began *denying* exactly that. The skill still looked wired. Nothing read it
+against the thing it described.
+
+So the check that matters here is not that the files exist — it is that every `charter …`
+command a skill puts in front of an agent still resolves against the parser in this same
+commit. A skill that names a removed or renamed command is the same failure again, and it
+would ship to every user of the plugin rather than one repo.
+"""
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILLS = ROOT / "skills"
+
+#: Commands appear in `backticks` or fenced blocks. Prose does not: "a charter alone loses
+#: to a general-purpose agent" is a sentence about charters, not an invocation, and
+#: scanning raw prose would read `alone` as a subcommand.
+_CODE_SPAN = re.compile(r"`([^`\n]+)`")
+_CODE_FENCE = re.compile(r"```[a-z]*\n(.*?)```", re.S)
+_INVOCATION = re.compile(r"\bcharter\s+([a-z][a-z-]*)")
+
+
+def _skill_files() -> list[Path]:
+    return sorted(SKILLS.glob("*/SKILL.md"))
+
+
+def _frontmatter(text: str) -> dict[str, str]:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    out = {}
+    for ln in lines[1:]:
+        if ln.strip() == "---":
+            break
+        if ":" in ln and not ln.startswith((" ", "\t")):
+            k, v = ln.split(":", 1)
+            out[k.strip()] = v.strip().strip("\"'")
+    return out
+
+
+def _top_level_commands() -> set[str]:
+    """Every subcommand the CLI actually accepts, read from the parser rather than a
+    hand-kept list — a list would be one more thing to drift."""
+    import argparse
+
+    from charter import cli
+
+    found: set[str] = set()
+    for action in cli.build_parser()._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            found.update(action.choices)
+    return found
+
+
+class TestSkillsShip(unittest.TestCase):
+    def test_the_plugin_has_a_skills_directory(self):
+        self.assertTrue(SKILLS.is_dir(), "the plugin ships no skills/ directory")
+        self.assertTrue(_skill_files(), "skills/ contains no SKILL.md")
+
+    def test_each_skill_declares_a_name_matching_its_directory(self):
+        """Claude Code addresses a plugin skill as `<plugin>:<name>`. A name that
+        disagrees with its directory produces a handle nobody can guess, and the
+        charter lint that validates `charter:<skill>` references would reject it."""
+        for path in _skill_files():
+            fm = _frontmatter(path.read_text())
+            self.assertEqual(fm.get("name"), path.parent.name, str(path))
+
+    def test_each_skill_describes_when_to_use_it(self):
+        """The description is the only thing an agent sees before deciding to load a
+        skill. One that describes the topic rather than the trigger never gets picked."""
+        for path in _skill_files():
+            fm = _frontmatter(path.read_text())
+            desc = fm.get("description", "")
+            self.assertGreater(len(desc), 40, str(path))
+            self.assertIn("use when", desc.lower(), str(path))
+
+    def test_every_skill_is_model_invokable(self):
+        """These exist to be loaded by an agent mid-task. `disable-model-invocation`
+        would make them human-only slash commands, which a sub-agent cannot reach."""
+        for path in _skill_files():
+            fm = _frontmatter(path.read_text())
+            self.assertNotEqual(fm.get("disable-model-invocation", "").lower(), "true",
+                                str(path))
+
+
+class TestSkillsNameRealCommands(unittest.TestCase):
+    def test_every_charter_command_a_skill_names_exists(self):
+        """The `setup`-skill failure, generalised: a skill that instructs an agent to run
+        a command the CLI does not have is wrong in a way only its reader discovers."""
+        valid = _top_level_commands()
+        self.assertIn("workspace", valid, "sanity: the parser was read correctly")
+
+        for path in _skill_files():
+            text = path.read_text()
+            snippets = _CODE_SPAN.findall(text) + _CODE_FENCE.findall(text)
+            for snippet in snippets:
+                for cmd in _INVOCATION.findall(snippet):
+                    self.assertIn(cmd, valid,
+                                  f"{path.parent.name} names `charter {cmd}`, "
+                                  f"which the CLI does not accept")
+
+    def test_a_skill_names_at_least_one_command(self):
+        """Guards the check above from passing vacuously if the extraction regexes are
+        ever narrowed — a green suite with nothing scanned is the worst outcome here."""
+        valid = _top_level_commands()
+        seen = set()
+        for path in _skill_files():
+            text = path.read_text()
+            for snippet in _CODE_SPAN.findall(text) + _CODE_FENCE.findall(text):
+                seen.update(_INVOCATION.findall(snippet))
+        self.assertTrue(seen & valid, "no charter invocations were scanned at all")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> Stacked on #214 (`charter docs show`), which the skills reference. Base is `docs-show`; retarget to `main` once that merges.

## The failure this prevents

Charter's knowledge reaches agents two ways today: a SessionStart injection that every session pays for whether or not it's needed, and `--help`, which answers *"what are the flags"* rather than *"what must I not get wrong"*. Everything in between gets written down in each control plane instead — and a plane's copy drifts, because nothing compares it to the CLI it describes.

The case this is drawn from: a plane carried a `setup` skill telling engineers to **authenticate over SSH and add an SSH key**, months after charter's rule became token-only-over-HTTPS and its own `PreToolUse` guard began *denying* exactly that. It still looked wired. Nine skills in that plane were in some stage of the same rot, and nothing had flagged any of them.

## Three skills

Chosen because each carries **judgement an agent needs before it acts wrong**, not a verb it could have read from `--help`:

| skill | the thing that goes wrong without it |
|---|---|
| `charter:secrets` | `--reveal` is refused by the CLI, but nothing stops an agent pasting a value as an argument or echoing it |
| `charter:working-in-a-clone` | a clone's `.claude/` is executable code belonging to another project, and `cd` does not re-root the session |
| `charter:persona` | switching the session's identity when the task only needed routing |

Deliberately *not* shipped: anything that merely names a verb (`clone`, `discover`, `status`, `sync`), and anything the SessionStart hook already injects.

## The test that matters

Not that the files exist — that **every `charter …` command a skill puts in front of an agent resolves against the parser in the same commit**. Invocations are read from code spans and fences only, so prose ("a charter alone loses to a general-purpose agent") isn't mistaken for one.

Mutation-checked: adding `charter frobnicate` to a skill fails the suite with `persona names 'charter frobnicate', which the CLI does not accept`.

A skill naming a removed command is the `setup` failure again — and from here it would ship to every plugin user rather than to one repo.

## Verification

- `python3 -m unittest discover -s tests` — **2185 passed**
- `_walk_installed_skills()` already scans `~/.claude/plugins` recursively, so these are discovered by the existing charter-lint with no change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAnq1m9e2URZZy3XjyBFVV