### PR TITLE
charter generates Playwright's surface instead of carrying it

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,14 @@ not encryption at rest. The vault is not a password manager.
 
 ## Learn more
 
+Every page below is also readable from the CLI, so an agent working in a control plane
+does not need a vendored copy that can drift from the binary it is describing:
+
+```bash
+charter docs list             # the topics
+charter docs show secrets     # the page, from the install that implements it
+```
+
 - [docs/install.md](docs/install.md) — both artifacts, alternatives to `uv`, and what
   `charter init` writes before you let it.
 - [docs/control-plane.md](docs/control-plane.md) — `charter.toml` in full: every key, a

--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ not encryption at rest. The vault is not a password manager.
   guard denials and tool approvals and memory writes, and `charter persona stats` says
   whether a role is actually being dispatched or whether that work is quietly routing to a
   generic agent.
+- **A plane writing down charter's own rules, and getting them wrong later.** The plugin
+  ships the skills for its surface — `charter:secrets` (use a credential without its value
+  reaching the transcript), `charter:working-in-a-clone` (the boundary between the plane's
+  session and a repo's own `.claude/`), and `charter:persona` (adopting a role, and routing
+  work to one instead of switching). They version with the CLI, so a plane no longer needs
+  a copy that can drift out from under it.
 
 ## The model
 

--- a/README.md
+++ b/README.md
@@ -164,9 +164,14 @@ not encryption at rest. The vault is not a password manager.
 - **A plane writing down charter's own rules, and getting them wrong later.** The plugin
   ships the skills for its surface — `charter:secrets` (use a credential without its value
   reaching the transcript), `charter:working-in-a-clone` (the boundary between the plane's
-  session and a repo's own `.claude/`), and `charter:persona` (adopting a role, and routing
-  work to one instead of switching). They version with the CLI, so a plane no longer needs
-  a copy that can drift out from under it.
+  session and a repo's own `.claude/`), `charter:persona` (adopting a role, and routing
+  work to one instead of switching), and `charter:browser`. They version with the CLI, so a
+  plane no longer needs a copy that can drift out from under it.
+- **A browser login without the password in the transcript.** `charter:browser` bridges a
+  vault into Playwright, so a credential is referred to by name and redacted from output.
+  Charter ships the bridge and none of Playwright's own pages — those are Apache-2.0 and
+  move far faster than charter releases, so `charter browser install` generates them from
+  the tool that owns them, at whatever version you ask for.
 
 ## The model
 

--- a/charter/browser.py
+++ b/charter/browser.py
@@ -1,0 +1,57 @@
+"""Materialising the browser driving surface into a plane, without charter carrying it.
+
+A plane that drives a browser needs two different things, and only one of them is
+charter's:
+
+* **How to drive a page** — the command surface, snapshots, network mocking, tracing. That
+  is Playwright's, it is long, and its own CLI already generates it as a skill.
+* **Where credentials come from, and how parallel workers stay isolated.** That is
+  charter's, and it is the `browser` skill this ships.
+
+Charter deliberately does not vendor the first. `@playwright/cli` is Apache-2.0 and charter
+is MIT: redistributing the generated pages would put a second licence, with its attribution
+obligations, into every wheel and every plugin install — for content charter neither wrote
+nor maintains. Worse, it would pin a pre-1.0 package that publishes frequently to *charter's*
+release cadence, so a Playwright fix would wait on a charter release to reach anyone.
+
+Running the vendor's own generator instead keeps both problems out of the repo: the plane
+gets the pages from the tool that owns them, at the version it asks for, and a bump is one
+command rather than a re-vendor and a release. This is the same shape as ADR 0014 — charter
+writes the host's files and keeps no copy of its own.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+#: The version installed when none is asked for. A default, not a lock: `@playwright/cli`
+#: is pre-1.0 and publishes often, so this is "known to work with the `browser` skill"
+#: rather than a claim about what is current. `--version` exists because it will age.
+PINNED = "0.1.18"
+
+#: Where the generator puts its pages. Claude Code reads project skills from here, so it is
+#: the vendor's choice as much as ours — named so the caller can be told what to expect.
+SKILL_DIR = Path(".claude") / "skills" / "playwright-cli"
+
+
+def install_argv(version: str) -> list[str]:
+    """The generator invocation. Split out so a test can assert the command without a
+    network round trip — the failure worth catching is a malformed `npx` line, and running
+    it for real would make the suite depend on npm being reachable."""
+    return ["npx", f"@playwright/cli@{version}", "install", "--skills"]
+
+
+def npx_available() -> bool:
+    return shutil.which("npx") is not None
+
+
+def install(root: Path, version: str) -> tuple[int, str]:
+    """Run the generator in `root`. Returns (exit status, combined output).
+
+    The output is handed back rather than streamed so the caller can report what landed
+    without the vendor's own progress noise becoming charter's.
+    """
+    proc = subprocess.run(install_argv(version), cwd=str(root),
+                          capture_output=True, text=True)
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -108,8 +108,24 @@ def build_parser() -> argparse.ArgumentParser:
     st.add_argument("--all", action="store_true", help="Detail every workspace.")
     st.set_defaults(func=commands.cmd_status)
 
-    doc = sub.add_parser("docs", help="Regenerate docs/topology.md from the inventory.")
+    doc = sub.add_parser("docs",
+                         help="Regenerate this plane's docs/topology.md — or read "
+                              "charter's own documentation (`show`, `list`).")
+    dsub = doc.add_subparsers(dest="docs_cmd")
+    # Bare `charter docs` still generates. It did that long before it grew subcommands,
+    # and Makefiles in the wild call it that way, so making the group require a
+    # subcommand would break callers that never saw the change.
     doc.set_defaults(func=commands.cmd_docs)
+    dgen = dsub.add_parser("generate", help="Regenerate docs/topology.md from the inventory.")
+    dgen.set_defaults(func=commands.cmd_docs)
+    dls = dsub.add_parser("list", help="List charter's own documentation topics.")
+    dls.set_defaults(func=commands.cmd_docs_list)
+    dsh = dsub.add_parser("show",
+                          help="Print one of charter's own documentation pages — served "
+                               "by the install that implements it, so it cannot be a "
+                               "version behind the CLI reading it.")
+    dsh.add_argument("topic", help="e.g. secrets, personas, git-policy (see `docs list`).")
+    dsh.set_defaults(func=commands.cmd_docs_show)
 
     sv = sub.add_parser("save",
                         help="Commit + push the control plane's own changes via glab (HTTPS token — no SSH pain).")

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -19,6 +19,7 @@ from . import (
     toolgate,
     util,
 )
+from .browser import PINNED as _PLAYWRIGHT_PIN
 from .forge.registry import KINDS as _FORGE_KINDS
 from .secrets.registry import PROVIDERS
 
@@ -107,6 +108,18 @@ def build_parser() -> argparse.ArgumentParser:
     st.add_argument("--workspace", "-w", help="Workspace to detail (default: the active one).")
     st.add_argument("--all", action="store_true", help="Detail every workspace.")
     st.set_defaults(func=commands.cmd_status)
+
+    br = sub.add_parser("browser",
+                        help="The browser lane: charter ships the credential bridge, "
+                             "Playwright ships the page-driving surface.")
+    brsub = br.add_subparsers(dest="browser_cmd", required=True)
+    bri = brsub.add_parser("install",
+                           help="Generate Playwright's driving-surface skill into this "
+                                "plane, from the tool that owns it (charter vendors none "
+                                "of it — Apache-2.0, and it ships far more often than "
+                                "charter does).")
+    bri.add_argument("--version", help=f"@playwright/cli version (default: {_PLAYWRIGHT_PIN}).")
+    bri.set_defaults(func=commands.cmd_browser_install)
 
     doc = sub.add_parser("docs",
                          help="Regenerate this plane's docs/topology.md — or read "

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -213,6 +213,46 @@ def cmd_docs(args) -> int:
     return 0
 
 
+def cmd_browser_install(args) -> int:
+    """Generate Playwright's own driving-surface skill into this plane.
+
+    Charter ships the `browser` skill (vault bridge, per-worker isolation) and none of
+    Playwright's pages — see charter/browser.py for why redistributing them is the wrong
+    trade. This fetches them from the tool that owns them.
+    """
+    from . import browser as _browser
+
+    if not config.HAS_CONTROL_PLANE:
+        util.err("no control plane found (no charter.toml here or in any parent) — "
+                 "`charter browser install` writes into a plane's .claude/skills/.")
+        return 1
+    if not _browser.npx_available():
+        util.err("npx not found — install Node.js to generate the Playwright skill.")
+        util.info("The `browser` skill's credential bridge works regardless; only the "
+                  "page-driving reference needs this.")
+        return 1
+
+    version = getattr(args, "version", None) or _browser.PINNED
+    util.info(f"Generating the Playwright driving surface (@playwright/cli@{version})…")
+    code, output = _browser.install(config.ROOT, version)
+    if code != 0:
+        util.err(f"the generator failed (exit {code}).")
+        # Handed back verbatim: this is npm's diagnosis (offline, no such version, EACCES),
+        # and paraphrasing it would be charter guessing at somebody else's error (ADR 0009).
+        print(output.rstrip())
+        return 1
+
+    landed = config.ROOT / _browser.SKILL_DIR
+    if landed.is_dir():
+        util.ok(f"Wrote {_browser.SKILL_DIR} ({len(list(landed.rglob('*.md')))} page(s))")
+    else:
+        util.warn(f"The generator reported success but {_browser.SKILL_DIR} is not there.")
+        return 1
+    util.info("It is Playwright's, not charter's — regenerate it with this command "
+              "rather than editing it.")
+    return 0
+
+
 def cmd_docs_list(args) -> int:
     """charter's own pages — the ones `docs show` can print.
 

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -7,7 +7,7 @@ import json
 import re
 from pathlib import Path
 
-from . import config, doctor, inventory, render, util, workspace, worktree
+from . import config, docsrc, doctor, inventory, render, util, workspace, worktree
 # One committer for the control plane, in charter/planegit.py. Re-exported rather
 # than moved-and-updated so every existing caller and test keeps working — the point
 # of the extraction is that there is ONE implementation, not that callers churn.
@@ -210,6 +210,42 @@ def cmd_docs(args) -> int:
 
     if refresh_readme_personas():
         util.ok("Refreshed the persona roster block in README.md")
+    return 0
+
+
+def cmd_docs_list(args) -> int:
+    """charter's own pages — the ones `docs show` can print.
+
+    Distinct from `cmd_docs`, which writes the *plane's* generated docs. One command
+    describes charter, the other describes your repos; they share a noun and nothing else.
+    """
+    names = docsrc.topics()
+    if not names:
+        util.warn("No documentation shipped with this charter — reinstall it "
+                  "(the wheel is missing charter/_docs).")
+        return 1
+    util.info(f"charter documentation ({docsrc.source()}):")
+    # The topics go to stdout (so `docs list` pipes) while the framing goes to stderr, as
+    # everywhere else in charter. Flushed before the trailing hint because stderr is
+    # unbuffered and stdout is not: without this the hint overtakes the list it describes
+    # the moment the output is a pipe rather than a terminal.
+    print("\n".join(f"  {name}" for name in names) + "\n", flush=True)
+    util.info("Read one with: charter docs show <topic>")
+    return 0
+
+
+def cmd_docs_show(args) -> int:
+    body = docsrc.read(args.topic)
+    if body is None:
+        names = docsrc.topics()
+        # ADR 0009 — classify, don't guess. `docs show persona` is a plausible typo for
+        # `personas`, and resolving it would be charter deciding what the caller meant;
+        # naming the real topics lets them decide, and costs one line.
+        util.err(f"No charter documentation topic named '{args.topic}'.")
+        if names:
+            util.info("Topics: " + ", ".join(names))
+        return 1
+    print(body, end="" if body.endswith("\n") else "\n")
     return 0
 
 

--- a/charter/docsrc.py
+++ b/charter/docsrc.py
@@ -1,0 +1,71 @@
+"""charter's own documentation pages, resolved for the CLI to print.
+
+A control plane has no reason to vendor a copy of these pages, and every reason not to:
+a copy drifts from the binary that implements what it describes, in both directions and
+invisibly. The page a user reads should come from the same install as the behaviour, so
+`charter docs show secrets` cannot describe a vault the running CLI does not have.
+
+There are two places the pages can live, and both are real:
+
+* **Installed** — `charter/_docs/`, put there by the wheel's `force-include`. This is the
+  case for everyone who did not clone the repo.
+* **A checkout** — the repo's own `docs/`. `CONTRIBUTING.md` tells contributors to run
+  `python3 -m charter ...` from the clone precisely because a `uv tool install` shadows
+  it, so this path is the documented development workflow rather than a courtesy.
+
+Installed wins when both exist. A developer with both is running one specific tree; the
+packaged copy is the one that travelled with the code being executed.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+#: A topic names one page, and nothing else. The command takes a topic rather than a path
+#: on purpose: `charter docs show ../../etc/passwd` must not be a file-read primitive
+#: wearing a documentation command, and `adr/0014` must not quietly widen the surface to
+#: the design record. Anything outside this shape is simply not a topic.
+_TOPIC = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+_PACKAGED = Path(__file__).resolve().parent / "_docs"
+_CHECKOUT = Path(__file__).resolve().parents[1] / "docs"
+
+
+def source() -> Path | None:
+    """The directory the pages are read from, or None when neither exists — which
+    happens only in a build so broken that the wheel shipped without its data."""
+    for candidate in (_PACKAGED, _CHECKOUT):
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def topics() -> list[str]:
+    """Every page that can be shown, sorted. Only top-level `*.md`: `adr/`, `audits/`
+    and `superpowers/` are design record and working notes, not usage documentation."""
+    root = source()
+    if root is None:
+        return []
+    return sorted(p.stem for p in root.glob("*.md") if _TOPIC.match(p.stem))
+
+
+def read(topic: str) -> str | None:
+    """The page's text, or None if `topic` does not name one.
+
+    None covers both "no such page" and "not a topic at all"; the caller classifies once
+    rather than distinguishing a typo from an escape attempt, which it has no reason to
+    treat differently.
+    """
+    root = source()
+    if root is None or not _TOPIC.match(topic or ""):
+        return None
+    page = root / f"{topic}.md"
+    # `_TOPIC` already excludes separators and `..`, so this cannot currently fail. It
+    # stays because the regex is the kind of thing that gets loosened later to allow some
+    # new page name, and the containment check is what makes that safe rather than lucky.
+    if page.parent.resolve() != root.resolve() or not page.is_file():
+        return None
+    try:
+        return page.read_text()
+    except OSError:
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,18 @@ charter = "charter.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["charter"]
+
+# `charter docs show <topic>` serves these, so they must travel with the code: the wheel
+# ships `charter/`, and `docs/` is outside it. Listed page by page rather than as a whole
+# directory so `adr/`, `audits/` and `superpowers/` — design record and working notes —
+# stay out of every user's site-packages. Adding a page here is not optional:
+# tests/test_docs_show.py fails on a `docs/*.md` that is not force-included, because the
+# gap is invisible from a checkout, where the fallback reads the repo and looks fine.
+[tool.hatch.build.targets.wheel.force-include]
+"docs/control-plane.md" = "charter/_docs/control-plane.md"
+"docs/forges.md" = "charter/_docs/forges.md"
+"docs/git-policy.md" = "charter/_docs/git-policy.md"
+"docs/install.md" = "charter/_docs/install.md"
+"docs/mcp.md" = "charter/_docs/mcp.md"
+"docs/personas.md" = "charter/_docs/personas.md"
+"docs/secrets.md" = "charter/_docs/secrets.md"

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: browser
+description: Drive a real browser for a task that needs one — a web login, an end-to-end check, verifying a UI, reaching something behind auth — with credentials pulled from a vault so the password never enters the conversation. Use when browser automation needs to authenticate, or when several workers each need their own logged-in session.
+---
+
+# Driving a browser with vault credentials
+
+Two halves, owned by different projects:
+
+- **How to drive a page** — snapshots, clicking, network mocking, tracing — is
+  Playwright's. Generate its reference into this plane once:
+
+  ```bash
+  charter browser install          # writes .claude/skills/playwright-cli/
+  ```
+
+  Charter ships none of those pages: they are Apache-2.0 and they change far more often
+  than charter releases. Regenerate with that command rather than editing them.
+
+- **Where credentials come from, and how parallel workers stay isolated** — this skill.
+
+## One session per worker
+
+Each worker passes its own `-s=<name>`. Sessions hold independent cookies, localStorage,
+IndexedDB, cache and tabs, so N workers can each be logged in as a different user at once.
+
+```bash
+npx @playwright/cli@<version> -s=owner  open https://example.test/
+npx @playwright/cli@<version> -s=viewer open https://example.test/
+npx @playwright/cli@<version> list          # live sessions
+npx @playwright/cli@<version> -s=owner close
+npx @playwright/cli@<version> kill-all      # reap stale processes
+```
+
+Pin the version explicitly in every command. The tool is pre-1.0 and its behaviour moves.
+
+## Credentials — never typed, never printed
+
+`charter secret exec --dotenv` resolves vault keys into one 0600 temp file and points
+`PLAYWRIGHT_MCP_SECRETS_FILE` at it. You then refer to a secret **by name**; Playwright
+substitutes the value and redacts it from output, so it never reaches the transcript.
+
+> **Open the session *inside* the bridge.** `playwright-cli` reads
+> `PLAYWRIGHT_MCP_SECRETS_FILE` once, when the session daemon starts. Setting it later, on
+> a `fill` against an already-open session, **fails silently** — the literal string `PASS`
+> is typed into the password field and no error is raised. Wrap the whole flow, `open`
+> through the last `fill`, in a single `charter secret exec`.
+
+```bash
+charter secret exec <vault> \
+  --dotenv PLAYWRIGHT_MCP_SECRETS_FILE=USER:<user-key> \
+  --dotenv PLAYWRIGHT_MCP_SECRETS_FILE=PASS:<pass-key> \
+  -- bash -c '
+    P="npx @playwright/cli@<version> -s=owner"
+    $P open https://example.test/
+    $P fill "#username" USER
+    $P fill "#password" PASS
+    $P click "button[type=submit]"
+    $P snapshot
+  '
+```
+
+Use `charter persona secret exec` to read the **active persona's** vault instead of naming
+one. A different fixture account is a different pair of keys, not a different mechanism.
+
+To avoid re-authenticating on every run, save the logged-in state once and reload it — see
+`storage-state` in the generated Playwright reference.
+
+## Hard rules
+
+- **Never read a filled secret back.** No evaluating `el.value`, no screenshot of a filled
+  password field, no dumping the dotenv file. Substitution and redaction exist precisely to
+  keep the value out of the conversation; reading it back defeats both.
+- Never type a credential in directly, even "just once to test". Use the bridge.
+- Never commit a session directory or a storage-state file — they carry live cookies, which
+  are the credential in another form.

--- a/skills/persona/SKILL.md
+++ b/skills/persona/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: persona
+description: Adopt, create, or route work to a charter persona — a role with its own charter, memory and vault. Use when asked to act as a role, to switch or create a persona, or when deciding which persona a piece of work belongs to.
+---
+
+# Personas
+
+A persona is *who does the work* — a role with a written charter, its own memory, and its
+own vault. Adopting one means taking on its responsibilities, its conventions, and its
+credentials.
+
+Mechanics in full — the charter format, inheritance, the memory model, roster health:
+`charter docs show personas`.
+
+## Know which one is active
+
+```bash
+charter persona current        # the active persona, and how it resolved
+charter persona list           # all of them; * marks active; shows vault state
+charter persona show <name>    # its charter — the role to actually adopt
+```
+
+Resolution: `--persona` → `$CHARTER_PERSONA` (pinned at launch) → local selection
+(`charter persona use`) → the committed default (`personas/.default`) → none.
+
+## Adopt one
+
+1. Read its charter with `charter persona show <name>` and behave as that role — its
+   responsibilities, its focus, its definition of done.
+2. Take credentials from its vault, never from anywhere else, and never print them
+   (see the `secrets` skill).
+3. Stay in role until asked to switch.
+
+**Do not switch the active persona unless asked.** Switching changes the session's identity
+for everyone downstream; routing a task does not.
+
+## Route work instead of switching
+
+Every persona declares a `delegate-when:`, surfaced in its sub-agent description.
+
+- **Clear match → delegate** to that persona's sub-agent rather than doing it yourself.
+  Delegation isolates context: only the result comes back, and the persona runs with *its*
+  vault and tools.
+- **Partial or ambiguous → name the persona you would use and ask** before dispatching.
+- **No persona fits → say so.** Offer to create one only when the domain is genuinely large
+  enough to own; a charter alone, with no credential or tool behind it, loses to a
+  general-purpose agent.
+- **Only route to personas that exist.** Never invent a name.
+
+A persona sub-agent is generated from its charter:
+
+```bash
+charter persona sync-agents        # regenerate after editing any charter
+```
+
+## Capability handoff
+
+A persona reaches only its own vault and its own declared tools. When a task needs access
+it does not have, **delegate that step to the persona that holds it** rather than guessing
+with partial credentials or borrowing a secret. Awareness of another persona's capability
+is not access to it — only an explicit `uses:` shares a vault.
+
+## Memory
+
+A persona remembers across sessions. Search rather than bulk-reading:
+
+```bash
+charter recall "<keywords>"                            # every base at once, labelled by source
+charter persona remember <name> "<durable fact>"       # persistent, committed
+charter persona remember <name> "<fact>" --shared      # for every persona
+```
+
+Record what the work *taught* you — a decision, a gotcha, a verified fact — not what the
+repo already records. **Never put a secret in memory**; that is what the vault is for.
+
+## Creating one
+
+```bash
+charter persona create <name> --role "<Role>" [--with-vault] [--use]
+```
+
+This writes a committed `personas/<name>/`. Edit the charter, then commit it — personas are
+shared. A persona earns its place by carrying a capability a general-purpose agent cannot
+have: a credential, a tool, or a domain narrow enough to name.
+
+## Guardrails
+
+- One persona at a time; never mix two personas' vaults.
+- Editing or removing a persona changes a committed file — commit it.
+- Re-run `charter persona sync-agents` after any charter edit, or the dispatchable
+  sub-agent silently describes the old role.

--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: secrets
+description: Use a credential held in a charter vault — a database password, API token, kubeconfig, SSH key or server login — without its value entering the conversation. Use when a task needs a secret, when asked to store one, or before running any command that requires a credential.
+---
+
+# Using a charter vault
+
+The rule this exists to keep: **use a secret, never reveal it.** A value that reaches the
+transcript is disclosed — to the model's context, to whatever logs the session, and to
+anyone the transcript is later shared with. Deleting the message afterwards does not undo
+any of that.
+
+Full model, including what the vault does *not* protect against: `charter docs show secrets`.
+
+## Find out what exists
+
+```bash
+charter vault list                 # vaults: name, provider, persona, status — no values
+charter secret list <vault>        # the KEYS in one vault — no values
+```
+
+## Store one — the value never goes on the command line
+
+```bash
+printf '%s' "<value>" | charter secret set <vault> <key> --stdin
+charter secret set <vault> <key> --from-file <path>    # multi-line or verbatim: kubeconfig, PEM
+```
+
+An argument list is not private: it is visible in `ps`, in shell history, and in this
+transcript. Ask the user to supply the value by stdin or file, or to set it themselves.
+
+## Use one — pick an injection path
+
+**As an environment variable:**
+
+```bash
+charter secret exec <vault> --env NAME=<key> -- <command...>
+```
+
+**As a file** (kubeconfig, certificate, key):
+
+```bash
+charter secret exec <vault> --file KUBECONFIG=<key> -- kubectl get pods
+charter secret cp <vault> <key> <dest>     # persist at 0600; prints only the path
+```
+
+**As a dotenv file**, for a tool that reads one (this is how a browser driver gets a
+login without the password being typed into the page by you):
+
+```bash
+charter secret exec <vault> --dotenv ENVFILE=USER:<key>,PASS:<key> -- <command...>
+```
+
+In every case the value is injected into the subprocess and **redacted from its output**,
+so a command that echoes it still cannot leak it into the transcript.
+
+**Just checking one is present:**
+
+```bash
+charter secret get <vault> <key>       # masked: length + sha256 prefix
+```
+
+## Hard rules
+
+- **Never `charter secret get --reveal`.** It refuses a non-interactive stdout by design.
+  Forcing it puts the value in context, which is the one outcome the vault exists to
+  prevent. Use `exec` or `cp`.
+- Never echo a secret, write it into a tracked file, or pass it as a literal argument.
+- Never put a secret in memory, a persona charter, a workspace charter, or a commit
+  message. The vault is the only place for one.
+- If the vault or key does not exist, say so and ask for it to be added — do not work
+  around it with a value pasted into the conversation.
+
+## Working as a persona
+
+A persona owns a vault. When one is active, prefer the persona form — same commands,
+resolved against the active persona's vault, no vault name to get wrong:
+
+```bash
+charter persona secret list
+charter persona secret exec --env TOKEN=<key> -- <command...>
+```
+
+A persona can only reach its own vault. When a task needs a credential another persona
+holds, delegate that step to that persona rather than copying the secret across — it runs
+with its own vault and you never see the value.

--- a/skills/working-in-a-clone/SKILL.md
+++ b/skills/working-in-a-clone/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: working-in-a-clone
+description: Do real work inside a repo a workspace owns — build, test, change, commit. Use when asked to work on a named repo from a control plane, and to get the boundary right between the plane's session and the repo's own configuration.
+---
+
+# Working inside a clone
+
+A control plane orchestrates repos; it is not where their work happens (ADR 0008). The
+plane deliberately does not know how to build or test any of them — that knowledge lives
+in each repo. This skill crosses that boundary correctly.
+
+## 1. Know the workspace, and stay inside it
+
+```bash
+charter workspace current      # the active workspace, and how it resolved
+```
+
+Clones live at `workspaces/<workspace>/<repo>`. Work in the **active** workspace only.
+A repo needed by this task that sits in another workspace gets cloned into this one —
+never reached across.
+
+## 2. Make sure it is cloned
+
+```bash
+charter clone <repo>           # skipped if already present; checks out its real default branch
+```
+
+Default branches differ across an org (`main`, `master`, `develop`). `charter clone` reads
+each repo's actual default branch, so never assume one.
+
+## 3. Adopt the repo's own conventions before editing
+
+Read whichever of `CLAUDE.md`, `AGENTS.md`, `README.md` the repo ships, then skim its
+manifest (`package.json`, `pom.xml`, `pyproject.toml`, `go.mod`) for its real build and
+test commands. Use those — never commands carried over from a different repo.
+
+## 4. Commit to the repo you are in
+
+A clone is its own git repository, so committing there touches *its* history and never the
+plane's. Push per that repo's workflow.
+
+The plane's own tracked files are a separate concern — `charter save` commits and pushes
+those.
+
+## The boundary that is easy to get wrong
+
+Claude Code binds configuration to the **project root fixed when the session launched** —
+the plane. Two layers resolve differently:
+
+- **Content loads natively.** A clone's `CLAUDE.md` / `AGENTS.md` is pulled into context as
+  you work in its subtree. That is enough for cross-repo work and light edits, and the
+  plane's own layer (personas, vaults, the tool gate, the status line) stays active.
+- **The clone's `.claude/` stays inert.** Its `skills/`, `commands/`, `agents/`,
+  `settings.json`, hooks, plugins and MCP servers belong to *that* project root. `cd` does
+  not re-root the project, so they do not load here.
+
+**Never import or run a clone's `.claude/` in the plane's session.** Those are executable
+code belonging to another project, and running them from the plane merges two trust
+boundaries that were separated on purpose.
+
+To use them, open a session rooted in the repo — the supported way:
+
+```bash
+cd workspaces/<workspace>/<repo> && claude
+```
+
+There the repo's full configuration loads natively, and `charter` still works from inside
+it when the control plane is needed.
+
+## Guardrails
+
+- Confirm the working directory is `workspaces/<active>/<repo>` before a build or a commit.
+- Never operate across two workspaces in one action.
+- A clone you cannot access simply fails to clone — surface that rather than working around
+  it. Partial access to an org is normal.

--- a/tests/test_browser_install.py
+++ b/tests/test_browser_install.py
@@ -1,0 +1,83 @@
+"""Charter generates Playwright's driving surface; it does not carry it.
+
+Vendoring the generated pages would have cost twice. `@playwright/cli` is Apache-2.0 and
+charter is MIT, so every wheel and every plugin install would inherit a second licence and
+its attribution obligations, for content charter neither wrote nor maintains. And the pin
+would move to *charter's* release cadence: a Playwright fix would wait on a charter release
+to reach anybody, for a package that is pre-1.0 and publishes often.
+
+Running the vendor's own generator has neither cost. What has to hold instead is that the
+invocation is right — a malformed `npx` line fails at the moment somebody needs a browser,
+which is the worst time to discover it. The suite must not reach the network, so the
+command is asserted rather than run.
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from charter import browser
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestInstallInvocation(unittest.TestCase):
+    def test_it_pins_the_version_it_installs(self):
+        """An unpinned `npx @playwright/cli` resolves to whatever is current that day, so
+        two engineers on the same plane get different behaviour from the same skill."""
+        argv = browser.install_argv("1.2.3")
+        self.assertIn("@playwright/cli@1.2.3", argv)
+        self.assertNotIn("@playwright/cli", argv, "the bare, unpinned spec must not appear")
+
+    def test_it_asks_for_skills_not_a_browser_install(self):
+        """`npx @playwright/cli install` (without --skills) downloads browser binaries —
+        hundreds of megabytes, and not what this command is for."""
+        argv = browser.install_argv(browser.PINNED)
+        self.assertEqual(argv[-2:], ["install", "--skills"])
+
+    def test_the_default_pin_is_a_release_shaped_string(self):
+        self.assertRegex(browser.PINNED, r"^\d+\.\d+\.\d+$")
+
+    def test_it_writes_where_claude_code_reads_project_skills(self):
+        self.assertEqual(browser.SKILL_DIR, Path(".claude") / "skills" / "playwright-cli")
+
+
+class TestCharterShipsNoneOfIt(unittest.TestCase):
+    def test_the_repo_vendors_no_playwright_pages(self):
+        """The licence decision, kept honest. Someone adding the generated skill to the
+        repo "just so it is there" would put Apache-2.0 content into an MIT wheel without
+        the attribution that requires, and this is the only thing that would notice."""
+        vendored = ROOT / "skills" / "playwright-cli"
+        self.assertFalse(vendored.exists(),
+                         "charter must not vendor Playwright's generated pages — "
+                         "`charter browser install` generates them into a plane instead")
+
+    def test_the_browser_skill_points_at_the_generator(self):
+        """A skill that describes the credential bridge but never says where the page
+        surface comes from leaves the reader to guess, and guessing here means vendoring."""
+        body = (ROOT / "skills" / "browser" / "SKILL.md").read_text()
+        self.assertIn("charter browser install", body)
+
+
+class TestBridgeGuidanceSurvives(unittest.TestCase):
+    """The two things that silently produce a leaked or bogus login. Both were learned the
+    hard way and are worthless if an edit quietly drops them."""
+
+    def _body(self) -> str:
+        return (ROOT / "skills" / "browser" / "SKILL.md").read_text()
+
+    def test_it_warns_the_session_must_open_inside_the_bridge(self):
+        """`PLAYWRIGHT_MCP_SECRETS_FILE` is read once, when the session daemon starts.
+        Set it later and the literal placeholder is typed into the password field with no
+        error at all — the failure looks like a wrong password, not a wiring mistake."""
+        body = self._body().lower()
+        self.assertIn("silently", body)
+        self.assertIn("open", body)
+
+    def test_it_forbids_reading_a_filled_secret_back(self):
+        body = self._body().lower()
+        self.assertIn("never read a filled secret back", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_docs_show.py
+++ b/tests/test_docs_show.py
@@ -1,0 +1,137 @@
+"""charter serves its own documentation, so a control plane does not have to carry a copy.
+
+The failure this prevents is one the project has now watched happen downstream. A plane
+that vendors its own copy of `personas.md` or `secrets.md` starts identical and then
+drifts, in both directions at once: the copy falls behind a feature it never learned about
+(a plane was still describing vaults as plain-file only, long after reference vaults and
+1Password landed — while *using* reference vaults), and it also runs ahead, growing
+sections upstream never receives. Neither half is visible from either side, because
+nothing compares them.
+
+`charter docs show <topic>` removes the reason to copy: the CLI that implements the
+behaviour is the thing that describes it, so the page can never be a version behind the
+binary reading it.
+
+Two properties carry that promise and are pinned here:
+
+* **Every page ships.** The wheel installs `charter/`, not the repo, so a page that is not
+  force-included does not exist for an installed user. Adding `docs/newthing.md` without
+  wiring it would leave `charter docs show newthing` failing on every machine except the
+  contributor's checkout, where the fallback quietly covers it up.
+* **An unknown topic classifies rather than guesses** (ADR 0009). Printing the nearest
+  match would be a guess about intent; naming the real topics lets the caller choose.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tomllib
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_DIR = REPO_ROOT / "docs"
+
+#: The pages `docs show` serves: the top-level topic pages. `adr/`, `audits/` and
+#: `superpowers/` are deliberately not topics — they are design record and working notes,
+#: not "how do I use this", and shipping them would put internal plans in every wheel.
+def _page_names() -> list[str]:
+    return sorted(p.stem for p in DOCS_DIR.glob("*.md"))
+
+
+class TestDocSource(unittest.TestCase):
+    def test_every_page_is_a_topic(self):
+        """A page nobody can reach is the same as no page."""
+        from charter import docsrc
+
+        self.assertEqual(_page_names(), sorted(docsrc.topics()))
+
+    def test_a_topic_reads_back_its_page(self):
+        from charter import docsrc
+
+        body = docsrc.read("git-policy")
+        self.assertIsNotNone(body, "git-policy is a page in docs/")
+        self.assertEqual((DOCS_DIR / "git-policy.md").read_text(), body)
+
+    def test_an_unknown_topic_reads_as_none(self):
+        from charter import docsrc
+
+        self.assertIsNone(docsrc.read("no-such-topic"))
+
+    def test_a_topic_cannot_escape_the_doc_directory(self):
+        """`read` takes a topic, not a path. Without this, `charter docs show
+        ../../etc/passwd` is a file-read primitive wearing a documentation command."""
+        from charter import docsrc
+
+        for hostile in ("../pyproject", "../../etc/passwd", "adr/0014", "a/b"):
+            self.assertIsNone(docsrc.read(hostile), hostile)
+
+
+class TestPagesShip(unittest.TestCase):
+    def test_every_page_is_force_included_in_the_wheel(self):
+        """The wheel ships `packages = ["charter"]`; `docs/` is outside it. Each page
+        therefore needs an explicit force-include, and adding a page without one is a
+        drift that only shows up on someone else's machine — the contributor's own
+        checkout falls back to `docs/` and looks fine."""
+        pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+        forced = (pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]
+                  .get("force-include", {}))
+        for name in _page_names():
+            src = f"docs/{name}.md"
+            self.assertIn(src, forced, f"{src} would not ship in the wheel")
+            self.assertEqual(forced[src], f"charter/_docs/{name}.md", src)
+
+    def test_nothing_else_is_force_included(self):
+        """Keeps `adr/`, `audits/` and `superpowers/` — internal record and working
+        notes — out of every user's site-packages."""
+        pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+        forced = (pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]
+                  .get("force-include", {}))
+        self.assertEqual(sorted(forced), sorted(f"docs/{n}.md" for n in _page_names()))
+
+
+class TestDocsCli(unittest.TestCase):
+    """Drives the real entrypoint: `docs` grew subcommands, and the parser change is
+    the part that can silently break an existing caller."""
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run([sys.executable, "-m", "charter", "docs", *args],
+                              cwd=REPO_ROOT, capture_output=True, text=True, timeout=60)
+
+    def test_show_prints_the_page(self):
+        r = self._run("show", "git-policy")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("one credential", r.stdout.lower())
+
+    def test_list_names_every_topic(self):
+        r = self._run("list")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        for name in _page_names():
+            self.assertIn(name, r.stdout, name)
+
+    def test_unknown_topic_fails_and_names_the_real_ones(self):
+        """ADR 0009 — errors classify, they do not guess. A near-miss must not be
+        silently resolved to the page charter thinks you meant."""
+        r = self._run("show", "persona")           # the page is `personas`
+        self.assertNotEqual(r.returncode, 0)
+        out = r.stdout + r.stderr
+        self.assertIn("personas", out)
+        self.assertNotIn("# Personas", out, "naming the topics is not printing one")
+
+    def test_bare_docs_still_generates(self):
+        """`charter docs` regenerated the plane's topology long before it grew
+        subcommands, and Makefiles in the wild call it that way. Turning it into a
+        group that demands a subcommand would break them at a distance."""
+        r = subprocess.run([sys.executable, "-m", "charter", "docs", "--help"],
+                           cwd=REPO_ROOT, capture_output=True, text=True, timeout=60)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        from charter import cli
+
+        args = cli.build_parser().parse_args(["docs"])
+        from charter import commands
+
+        self.assertIs(args.func, commands.cmd_docs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -1,0 +1,128 @@
+"""The plugin ships skills, and every command they name is real.
+
+Charter's knowledge used to reach agents only two ways: a SessionStart injection that
+costs every session whether or not it is needed, and `--help`, which answers "what are the
+flags" rather than "what must I not get wrong". Anything in between got written down in
+each control plane instead — and a plane's copy drifts, silently, because nothing compares
+it to the CLI.
+
+The concrete case: a plane carried a `setup` skill telling engineers to authenticate over
+SSH and add an SSH key, months after charter's rule became token-only-over-HTTPS and its
+own guard began *denying* exactly that. The skill still looked wired. Nothing read it
+against the thing it described.
+
+So the check that matters here is not that the files exist — it is that every `charter …`
+command a skill puts in front of an agent still resolves against the parser in this same
+commit. A skill that names a removed or renamed command is the same failure again, and it
+would ship to every user of the plugin rather than one repo.
+"""
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILLS = ROOT / "skills"
+
+#: Commands appear in `backticks` or fenced blocks. Prose does not: "a charter alone loses
+#: to a general-purpose agent" is a sentence about charters, not an invocation, and
+#: scanning raw prose would read `alone` as a subcommand.
+_CODE_SPAN = re.compile(r"`([^`\n]+)`")
+_CODE_FENCE = re.compile(r"```[a-z]*\n(.*?)```", re.S)
+_INVOCATION = re.compile(r"\bcharter\s+([a-z][a-z-]*)")
+
+
+def _skill_files() -> list[Path]:
+    return sorted(SKILLS.glob("*/SKILL.md"))
+
+
+def _frontmatter(text: str) -> dict[str, str]:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    out = {}
+    for ln in lines[1:]:
+        if ln.strip() == "---":
+            break
+        if ":" in ln and not ln.startswith((" ", "\t")):
+            k, v = ln.split(":", 1)
+            out[k.strip()] = v.strip().strip("\"'")
+    return out
+
+
+def _top_level_commands() -> set[str]:
+    """Every subcommand the CLI actually accepts, read from the parser rather than a
+    hand-kept list — a list would be one more thing to drift."""
+    import argparse
+
+    from charter import cli
+
+    found: set[str] = set()
+    for action in cli.build_parser()._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            found.update(action.choices)
+    return found
+
+
+class TestSkillsShip(unittest.TestCase):
+    def test_the_plugin_has_a_skills_directory(self):
+        self.assertTrue(SKILLS.is_dir(), "the plugin ships no skills/ directory")
+        self.assertTrue(_skill_files(), "skills/ contains no SKILL.md")
+
+    def test_each_skill_declares_a_name_matching_its_directory(self):
+        """Claude Code addresses a plugin skill as `<plugin>:<name>`. A name that
+        disagrees with its directory produces a handle nobody can guess, and the
+        charter lint that validates `charter:<skill>` references would reject it."""
+        for path in _skill_files():
+            fm = _frontmatter(path.read_text())
+            self.assertEqual(fm.get("name"), path.parent.name, str(path))
+
+    def test_each_skill_describes_when_to_use_it(self):
+        """The description is the only thing an agent sees before deciding to load a
+        skill. One that describes the topic rather than the trigger never gets picked."""
+        for path in _skill_files():
+            fm = _frontmatter(path.read_text())
+            desc = fm.get("description", "")
+            self.assertGreater(len(desc), 40, str(path))
+            self.assertIn("use when", desc.lower(), str(path))
+
+    def test_every_skill_is_model_invokable(self):
+        """These exist to be loaded by an agent mid-task. `disable-model-invocation`
+        would make them human-only slash commands, which a sub-agent cannot reach."""
+        for path in _skill_files():
+            fm = _frontmatter(path.read_text())
+            self.assertNotEqual(fm.get("disable-model-invocation", "").lower(), "true",
+                                str(path))
+
+
+class TestSkillsNameRealCommands(unittest.TestCase):
+    def test_every_charter_command_a_skill_names_exists(self):
+        """The `setup`-skill failure, generalised: a skill that instructs an agent to run
+        a command the CLI does not have is wrong in a way only its reader discovers."""
+        valid = _top_level_commands()
+        self.assertIn("workspace", valid, "sanity: the parser was read correctly")
+
+        for path in _skill_files():
+            text = path.read_text()
+            snippets = _CODE_SPAN.findall(text) + _CODE_FENCE.findall(text)
+            for snippet in snippets:
+                for cmd in _INVOCATION.findall(snippet):
+                    self.assertIn(cmd, valid,
+                                  f"{path.parent.name} names `charter {cmd}`, "
+                                  f"which the CLI does not accept")
+
+    def test_a_skill_names_at_least_one_command(self):
+        """Guards the check above from passing vacuously if the extraction regexes are
+        ever narrowed — a green suite with nothing scanned is the worst outcome here."""
+        valid = _top_level_commands()
+        seen = set()
+        for path in _skill_files():
+            text = path.read_text()
+            for snippet in _CODE_SPAN.findall(text) + _CODE_FENCE.findall(text):
+                seen.update(_INVOCATION.findall(snippet))
+        self.assertTrue(seen & valid, "no charter invocations were scanned at all")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> Stacked on #216 → #214. Base is `plugin-skills`; retarget as those merge.

## The licence this avoids

The browser lane is two halves owned by two projects. *How to drive a page* — snapshots, mocking, tracing — is Playwright's, and its own CLI already generates that as a skill. *Where credentials come from, and how parallel workers stay isolated* is charter's.

Vendoring the first half would have cost twice:

- **`@playwright/cli` is Apache-2.0; charter is MIT.** Every wheel and plugin install would inherit a second licence and its §4 attribution obligations, for content charter neither wrote nor maintains.
- **The pin would move to charter's release cadence.** A Playwright fix would wait on a charter release to reach anyone — for a package that is pre-1.0 and publishes often.

`charter browser install` runs the vendor's own generator into the plane's `.claude/skills/` instead. Charter stores none of it, the plane gets the pages from the tool that owns them, and a version bump is one command rather than a re-vendor plus a release.

Same shape as ADR 0014: write the host's files, keep no copy of your own.

## The half that is charter's

`charter:browser` carries the credential bridge — and the two failures here are silent rather than loud, which is why they're written down:

- **`PLAYWRIGHT_MCP_SECRETS_FILE` is read once**, when the session daemon starts. Set it later, on a `fill` against an already-open session, and the literal placeholder string is typed into the password field **with no error at all**. It reads as a wrong password, not as a wiring mistake. So the whole flow — `open` through the last `fill` — goes inside one `secret exec`.
- **Reading a filled secret back** (evaluating `el.value`, screenshotting a filled field) defeats substitution and redaction both, and puts in the transcript exactly what the bridge existed to keep out.

## Tests

Network-free by construction — the invocation is asserted, never run:

- the spec is pinned (an unpinned `npx @playwright/cli` gives two engineers different behaviour from the same skill)
- it asks for `--skills`, not the browser-binary download
- **the repo vendors no Playwright pages** — the only thing that would notice someone adding them back "just so they're there", which is how the licence decision quietly reverses

`python3 -m unittest discover -s tests` — **2193 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAnq1m9e2URZZy3XjyBFVV