### PR TITLE
Two shipped commands that were documented nowhere, and the hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ charter docs show secrets     # the page, from the install that implements it
   against, `secret exec`, and feeding a tool that wants a dotenv file.
 - [docs/git-policy.md](docs/git-policy.md) — the one-credential rule, and why a denial from
   the plugin's guard is the rule working rather than a bug.
+- [docs/hooks.md](docs/hooks.md) — everything the plugin does without being asked: what
+  fires when, the four guards, what gets injected, and what gets counted.
 - [docs/mcp.md](docs/mcp.md) — giving an MCP server a persona's vault credentials without
   the value entering the model, and what the per-persona tool allowlist does and does not
   constrain.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,88 @@
+# The hooks
+
+The CLI is one of charter's two artifacts. The other is a **Claude Code plugin**, and the
+plugin is almost entirely hooks: the things that have to happen without anyone remembering
+to ask for them.
+
+Install both — a CLI with no plugin leaves every guard and every injection dead, while
+looking completely installed. See [install.md](install.md).
+
+The plugin ships **no Python**. Every hook is a `charter hook <name>` call against the CLI
+on `PATH`, which is why a version skew between the two is worth shouting about and is the
+one thing a hook is allowed to shout about.
+
+## What fires, and when
+
+| Event | Matcher | What it does |
+| --- | --- | --- |
+| `SessionStart` | — | reconcile workspace state, GC persona scratch, inject context, run `doctor`, refresh forge state |
+| `UserPromptSubmit` | — | the commitment gate (below) |
+| `PreToolUse` | `Bash` | the four guards (below) |
+| `PreToolUse` | `Read\|Grep` | keeps a vault file from being read into context |
+| `PreToolUse` | `Task\|Agent` | notes a dispatch about to happen |
+| `PostToolUse` | `Write\|Edit\|MultiEdit` | the record-memory nudge |
+| `PostToolUse` | `Skill` | tallies which skills a persona actually invokes |
+| `PostToolUse` | `Task\|Agent` | tallies the dispatch |
+| `Stop`, `SubagentStop` | — | autosave a LIVE workspace |
+
+## The guards
+
+A denial from these is **the rule working, not a bug** — the single most common thing
+mistaken for a defect. Each prints why, because a developer who reads the reason learns the
+rule while one who reads a bare refusal files an issue.
+
+- **Secret leak.** A command whose argv would put a vault's contents into the transcript.
+  Needs argv *and* the plane's vault paths, so it cannot be expressed as a static rule.
+- **Plane-root branch move.** The plane is not a work tree (ADR 0008); a branch switch there
+  is almost always meant for a clone.
+- **One credential.** SSH to a forge, `GIT_SSH_COMMAND`, `-S`/`--gpg-sign`, and the
+  `core.sshCommand` family that reaches the same transport by another road (`-c`,
+  `--config-env`, `GIT_CONFIG_KEY_n`, and a `git config` write of it). This one *is*
+  expressible as a pattern and stays in the hook anyway, so it can explain itself — see
+  [git-policy.md](git-policy.md) and ADR 0014.
+- **Commit inside a clone.** Asks rather than denies: committing there is usually intended,
+  and only the working directory reveals which case it is.
+
+A fifth path is not a guard but an allowance: a binary the **active persona** declares in
+`tools:` runs without a prompt while that persona is active, and only then.
+
+Policy that *can* be written as a command pattern belongs in Claude Code's own
+`permissions`, not here — `charter guard ask <pattern>` writes it there. Charter keeps only
+what needs context the host cannot see. That line is ADR 0014.
+
+## What gets injected
+
+`SessionStart` puts a bounded amount of context in front of the session: the active
+persona's role, a digest of memory (a digest, not the corpus — recall is a search, not a
+preload), the workspace to confirm, and a warning when the plane's config has moved on
+since the session began.
+
+The `UserPromptSubmit` gate is narrower than it sounds. It fires when a prompt asks for
+work *and* carries a real fork — open-ended, broad, destructive, or multi-part — and its
+only effect is to say: scout first, then ask, before dispatching or editing.
+
+## What gets counted
+
+Two tallies — tracked, not ignored, though charter never commits them for you (`[memory].share` defaults to `local`) — both counts-and-dates only, never prompt text, and both
+parallel-writer safe with the host in the filename so two engineers never conflict:
+
+- **Dispatches** (`personas/_dispatch/`) — was this persona ever actually used, or did its
+  work quietly route to a generic agent? Surfaces in `charter persona stats` as the
+  `⚑ never dispatched` flag and the persona-vs-generic ratio.
+- **Skill invocations** (`personas/_skills/`) — a persona's declared `skills:` are preloaded
+  into every dispatch of it, so declaring one is cheap to write and expensive to keep. This
+  says whether the equipment was worth carrying.
+
+Neither has a secret surface to scan, by construction.
+
+## When a hook fails
+
+Hooks swallow their exceptions. A tally that breaks a turn is worse than a tally that
+misses a row, and none of this is load-bearing for the work itself.
+
+The deliberate exception is version skew: a stale CLI would stop firing the gate while
+everything still looked installed. That is the failure shape this project keeps paying for,
+so it is the one thing a hook says out loud.
+
+Seeing what actually happened: `charter trace` reports guard denials, tool approvals, secret
+warnings and memory writes for the session.

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -157,6 +157,55 @@ committed store, so `charter persona stats` can show *actual* routing health —
 that lints clean but has never once been dispatched is flagged `⚑ never dispatched`,
 the blind spot memory volume alone can't see.
 
+`charter persona dispatch-backfill` seeds that tally from past sessions' transcripts, so a
+roster that predates the tally has a baseline immediately instead of reading as *"nothing
+was ever dispatched"*. It skips anything already covered by live records, so re-running it
+never double-counts.
+
+A workflow run reaches the same personas: an `agent()` call resolves `agentType:
+"<persona>"` from the registry the Agent tool uses, so a workflow step can run **as a
+persona** rather than as a generic worker.
+
+## Reusing another persona (`uses:`)
+
+`extends:` inherits a charter. `uses:` is the other relationship — composition rather than
+inheritance — and it is what makes one persona able to reach another's capability without
+becoming it. A persona that `uses: devops` may:
+
+- read that persona's vault (`charter persona secret --persona devops …`),
+- run its declared `tools:` without a prompt while adopted — the tool gate unions them in,
+- and delegate a sub-task to its sub-agent.
+
+**Reuse is one level deep**, and it never touches the reused persona's own active state.
+That bound is the point: a role that needs a cluster credential for one step should borrow
+it explicitly and visibly, not acquire a transitive reach nobody declared.
+
+`charter persona remove` refuses to orphan — if another persona `extends:` or `uses:` the
+one being removed, removal is refused and the dependents are named (`--force` overrides).
+Before that, a dangling reference was only discovered later, by `lint`.
+
+## Curating memory: `charter persona optimize`
+
+Memory grows, and growth is not a defect — but a base that has accumulated near-duplicates
+and years-old scratch answers a `recall` worse than a smaller one would. `optimize` curates
+it in two tiers, split by whether a mistake is reversible:
+
+```
+charter persona optimize                 # read-only report, every persona + _shared
+charter persona optimize devops          # just one
+charter persona optimize --apply         # auto-apply only the safe, reversible half
+charter persona optimize --stale-days 60 # age past which a memory is *proposed* for archival (default 90)
+```
+
+With `--apply` it performs only what can be undone: collapsing exact-duplicate memories
+into `memory/archive/` and repairing the `MEMORY.md` index. Everything requiring judgement
+— near-duplicate merges, age-based archival, promoting a recurring fact into the charter —
+is **proposed and never applied**. A charter is a human artifact; a tool that silently
+edited one would make every charter suspect.
+
+The analysis is deterministic and stdlib-only. The judgement belongs to whoever reads the
+proposals.
+
 ## Everyday commands
 
 ```
@@ -167,6 +216,8 @@ charter persona secret set API_TOKEN --stdin   # store a credential (never on ar
 charter persona secret exec --env TOKEN=API_TOKEN -- some-cli   # use it without ever seeing it
 charter persona lint                       # dangling uses:/extends:, missing role/vault, drafts, stale agents
 charter persona stats                      # roster health: usage, verification rate, dispatch count
+charter persona optimize --apply           # curate memory: safe ops applied, the rest proposed
+charter persona dispatch-backfill          # seed the dispatch tally from past sessions
 ```
 
 ## Health: where it surfaces

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ packages = ["charter"]
 "docs/control-plane.md" = "charter/_docs/control-plane.md"
 "docs/forges.md" = "charter/_docs/forges.md"
 "docs/git-policy.md" = "charter/_docs/git-policy.md"
+"docs/hooks.md" = "charter/_docs/hooks.md"
 "docs/install.md" = "charter/_docs/install.md"
 "docs/mcp.md" = "charter/_docs/mcp.md"
 "docs/personas.md" = "charter/_docs/personas.md"


### PR DESCRIPTION
> Stacked on #217 → #216 → #214. Retarget as those merge.

## The gap

`charter persona optimize` and `charter persona dispatch-backfill` both ship in the CLI and appear in **no page under `docs/`**. By this project's own rule — *a flag that is not in `docs/` does not exist* — they didn't.

This surfaced while consolidating a control plane that had been keeping its own copy of these pages. **The copy documented both commands. Upstream never had.** Drift between a plane and this repo runs in both directions, and this is the direction nobody looks for — the plane being *ahead*.

## What's added to `docs/personas.md`

- **`charter persona optimize`** — the two-tier split, and why it's a split: `--apply` performs only what can be undone (exact-duplicate collapse into `memory/archive/`, index repair); near-dup merges, age-based archival and charter promotions are *proposed and never applied*. A charter is a human artifact, and a tool that silently edited one would make every charter suspect.
- **`charter persona dispatch-backfill`** — why a roster predating the tally otherwise reads as "nothing was ever dispatched", and that re-running never double-counts.
- **`uses:` as a relationship, not a frontmatter key.** It was listed in the charter-format table and never explained: what reuse grants (vault read, tool union, delegation) and that it's **one level deep**. That bound is the point — borrowing a credential for one step should be explicit and visible, not a transitive reach nobody declared.
- **`persona remove` refusing to orphan** a persona another `extends:` or `uses:`, which previously only surfaced later as a lint finding.
- Dispatching a persona from a workflow via `agentType`.

## `docs/hooks.md` — new

The plugin is almost entirely hooks and had no page at all. A denial from one is the single most common thing mistaken for a defect, so it leads with the four guards and why each can't be a static `permissions` rule (ADR 0014), then what gets injected and what gets counted — including why neither tally has a secret surface.

**Written from `hooks/hooks.json` and the handlers**, not ported from the plane's copy — that copy is precisely the artifact whose accuracy is in question.

## The shipping test earned its keep immediately

`docs/hooks.md` needed a force-include, and the test added in #214 failed until it got one:

```
AssertionError: 'docs/hooks.md' not found in {...} : docs/hooks.md would not ship in the wheel
```

That gap is invisible from a checkout, where the fallback reads `docs/` and looks fine.

`python3 -m unittest discover -s tests` — **2193 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAnq1m9e2URZZy3XjyBFVV