### PR TITLE
doctor names a plane's own copy of what charter ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ charter docs list             # the topics
 charter docs show secrets     # the page, from the install that implements it
 ```
 
+`charter doctor` names a plane that has kept its own copy of one of these, or of a shipped
+skill. It never tells you to delete it — an override may be deliberate — only that a local
+copy wins, is compared to nothing, and drifts unwatched in both directions.
+
 - [docs/install.md](docs/install.md) — both artifacts, alternatives to `uv`, and what
   `charter init` writes before you let it.
 - [docs/control-plane.md](docs/control-plane.md) — `charter.toml` in full: every key, a

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -733,6 +733,81 @@ def check_ask_rules() -> Result:
                        "want — this names it so the prompts are not a mystery.")
 
 
+#: The skills the plugin ships. A constant rather than a directory listing because the CLI
+#: is installed from a wheel that contains no `skills/` — that directory belongs to the
+#: plugin artifact. A test asserts this equals the repo's `skills/`, so the two cannot part
+#: company without the suite saying so.
+SHIPPED_SKILLS = frozenset({"secrets", "working-in-a-clone", "persona", "browser"})
+
+
+def shadowed_knowledge(root) -> dict[str, list[str]]:
+    """A plane's own pages and skills that cover something charter already ships.
+
+    Returns {"skills": [...], "docs": [...]} — names only, sorted.
+
+    Empty when the plane *is* this repo. Charter's own checkout is a control plane, and its
+    `docs/personas.md` is the very page `docs show personas` serves; reporting that as a
+    shadow of itself would make the check noise on the one machine most likely to run it.
+    """
+    from pathlib import Path
+
+    from . import docsrc
+
+    root = Path(root)
+    source = docsrc.source()
+    if source is not None and source.resolve().parent == root.resolve():
+        return {"skills": [], "docs": []}
+
+    skills = sorted(
+        d.name for d in (root / ".claude" / "skills").glob("*")
+        if d.is_dir() and (d / "SKILL.md").is_file() and d.name in SHIPPED_SKILLS
+    )
+    topics = set(docsrc.topics())
+    docs = sorted(
+        p.stem for p in (root / "docs").glob("*.md") if p.stem in topics
+    )
+    return {"skills": skills, "docs": docs}
+
+
+def check_shadowed_knowledge() -> Result:
+    """A plane keeping its own copy of something charter ships.
+
+    This is the failure that produced the check. A plane carried a `setup` skill telling
+    engineers to authenticate over SSH and add an SSH key — months after the rule became
+    token-only-over-HTTPS and charter's own guard began denying exactly that. Nine skills
+    there were in some stage of the same rot. Every one of them looked wired, and nothing
+    compared any of them to the CLI they described.
+
+    Drift runs both ways, which is why this reports rather than resolves: the same plane's
+    persona page had grown sections upstream never received. A copy is not automatically
+    wrong — it is automatically *unwatched*, and that is the whole finding.
+
+    So, like `check_ask_rules`, it never says delete. A plane may be deliberately overriding
+    charter's guidance with something org-specific, and that is the operator's call
+    (ADR 0013). Charter names what is being shadowed and what it costs.
+    """
+    name = "shadowed docs"
+    try:
+        hit = shadowed_knowledge(config.ROOT)
+    except Exception as e:  # noqa: BLE001 - a preflight line must never be the thing that fails
+        return Result(name, WARN, detail=f"not checked ({e})", hint=_NOT_CHECKED_HINT)
+
+    parts = []
+    if hit["skills"]:
+        parts.append("skill(s) " + ", ".join(hit["skills"]))
+    if hit["docs"]:
+        parts.append("docs/" + ", docs/".join(f"{d}.md" for d in hit["docs"]))
+    if not parts:
+        return Result(name, OK, detail="none — charter's own knowledge is not duplicated here")
+
+    return Result(name, WARN, detail=" · ".join(parts) + " duplicate what charter ships",
+                  hint="A local copy wins over charter's and is not compared to it, so it "
+                       "drifts in both directions unwatched — behind on a feature it never "
+                       "learned about, ahead with sections upstream never received. Read "
+                       "the shipped one with `charter docs show <topic>`; keep yours only "
+                       "where it says something charter's does not.")
+
+
 def check_workspace_clones() -> Result:
     """Clones that are behind their upstream — in EVERY workspace, not just the active one.
 
@@ -1403,6 +1478,7 @@ def _checks():
                 check_inventory(), check_vaults(),
                 check_vault_registry_divergence(), check_version_lock(),
                 check_memory_indexes(), check_personas(), check_ask_rules(),
+                check_shadowed_knowledge(),
                 check_mcp_launchers(), check_plugin_skew()]
     return results
 

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -740,22 +740,46 @@ def check_ask_rules() -> Result:
 SHIPPED_SKILLS = frozenset({"secrets", "working-in-a-clone", "persona", "browser"})
 
 
+def _is_charter_checkout(root) -> bool:
+    """True when *root* is a clone of charter itself.
+
+    Structural, and deliberately so: the marker is charter's own source tree sitting beside
+    a `pyproject.toml` that names the distribution. Nothing here depends on how this
+    process was installed, which is what the previous test got wrong.
+    """
+    from pathlib import Path
+
+    root = Path(root)
+    if not (root / "charter" / "docsrc.py").is_file():
+        return False
+    try:
+        return "charter-cp" in (root / "pyproject.toml").read_text()
+    except OSError:
+        return False
+
+
 def shadowed_knowledge(root) -> dict[str, list[str]]:
     """A plane's own pages and skills that cover something charter already ships.
 
     Returns {"skills": [...], "docs": [...]} — names only, sorted.
 
-    Empty when the plane *is* this repo. Charter's own checkout is a control plane, and its
-    `docs/personas.md` is the very page `docs show personas` serves; reporting that as a
-    shadow of itself would make the check noise on the one machine most likely to run it.
+    Empty when the plane *is* charter's own checkout. Its `docs/personas.md` is the very
+    page `docs show personas` serves; reporting that as a shadow of itself would make the
+    check noise on the one machine most likely to run it.
+
+    That test asks what the ROOT is, not where `docsrc` happened to read from. Keying it on
+    `docsrc.source()` looked equivalent and was not: `source()` prefers the packaged copy,
+    so it only matched for someone running `python3 -m charter` from the clone. Every
+    contributor also has `uv tool install charter-cp` — the README says to — and for them
+    the exemption missed and doctor reported all eight of charter's own pages as shadows of
+    themselves. Exactly the noise this paragraph promises to prevent.
     """
     from pathlib import Path
 
     from . import docsrc
 
     root = Path(root)
-    source = docsrc.source()
-    if source is not None and source.resolve().parent == root.resolve():
+    if _is_charter_checkout(root):
         return {"skills": [], "docs": []}
 
     skills = sorted(

--- a/tests/test_doctor_shadowed.py
+++ b/tests/test_doctor_shadowed.py
@@ -1,0 +1,104 @@
+"""A plane keeping its own copy of something charter ships.
+
+The failure this reports was found in a real control plane: a `setup` skill instructing
+engineers to authenticate over SSH and add an SSH key, months after the rule became
+token-only-over-HTTPS and charter's own PreToolUse guard began denying exactly that. Nine
+skills there were in some stage of the same rot. Every one looked wired. Nothing compared
+any of them to the CLI they described.
+
+The check reports and never resolves, because drift runs both ways — the same plane's
+persona page had grown sections upstream never received. A copy is not automatically wrong;
+it is automatically *unwatched*.
+
+The subtle case, and the reason this file exists rather than one assertion: charter's own
+checkout **is** a control plane, and its `docs/personas.md` is the page `docs show personas`
+serves. A naive check flags it as shadowing itself, on the one machine most likely to run
+`doctor`.
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from charter import doctor
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _plane(tmp: Path, *, skills=(), docs=()) -> Path:
+    """A throwaway plane carrying the named skills and doc pages."""
+    for s in skills:
+        d = tmp / ".claude" / "skills" / s
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "SKILL.md").write_text(f"---\nname: {s}\n---\n")
+    for name in docs:
+        d = tmp / "docs"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{name}.md").write_text("# page\n")
+    return tmp
+
+
+class TestShadowDetection(unittest.TestCase):
+    def test_a_plane_copy_of_a_shipped_skill_is_named(self):
+        with tempfile.TemporaryDirectory() as t:
+            root = _plane(Path(t), skills=("secrets", "browser"))
+            hit = doctor.shadowed_knowledge(root)
+            self.assertEqual(hit["skills"], ["browser", "secrets"])
+
+    def test_a_plane_copy_of_a_shipped_page_is_named(self):
+        with tempfile.TemporaryDirectory() as t:
+            root = _plane(Path(t), docs=("personas", "secrets"))
+            hit = doctor.shadowed_knowledge(root)
+            self.assertEqual(hit["docs"], ["personas", "secrets"])
+
+    def test_a_planes_own_skills_and_pages_are_left_alone(self):
+        """The check must not object to a plane having knowledge of its own — only to it
+        re-stating charter's. A false positive here would train operators to ignore it."""
+        with tempfile.TemporaryDirectory() as t:
+            root = _plane(Path(t),
+                          skills=("incident-investigation", "deploy-runbook"),
+                          docs=("topology", "conventions", "onboarding"))
+            hit = doctor.shadowed_knowledge(root)
+            self.assertEqual(hit, {"skills": [], "docs": []})
+
+    def test_topology_is_not_a_shadow(self):
+        """`docs/topology.md` is written *into* a plane by `charter docs`. Reporting
+        charter's own generated output as a duplicate of charter would be absurd, and it is
+        the page most certain to be present."""
+        with tempfile.TemporaryDirectory() as t:
+            root = _plane(Path(t), docs=("topology",))
+            self.assertEqual(doctor.shadowed_knowledge(root)["docs"], [])
+
+    def test_a_directory_without_a_skill_file_is_not_a_skill(self):
+        with tempfile.TemporaryDirectory() as t:
+            (Path(t) / ".claude" / "skills" / "secrets").mkdir(parents=True)
+            self.assertEqual(doctor.shadowed_knowledge(Path(t))["skills"], [])
+
+    def test_an_empty_plane_is_quiet(self):
+        with tempfile.TemporaryDirectory() as t:
+            self.assertEqual(doctor.shadowed_knowledge(Path(t)),
+                             {"skills": [], "docs": []})
+
+
+class TestCharterDoesNotShadowItself(unittest.TestCase):
+    def test_this_repo_reports_nothing(self):
+        """charter's checkout is a plane whose docs/ *is* the served source. Without the
+        guard, `doctor` here would report seven pages shadowing themselves."""
+        hit = doctor.shadowed_knowledge(REPO_ROOT)
+        self.assertEqual(hit, {"skills": [], "docs": []})
+
+
+class TestShippedSkillsStayInSync(unittest.TestCase):
+    def test_the_constant_matches_the_shipped_directory(self):
+        """The CLI ships in a wheel with no `skills/` — that directory belongs to the
+        plugin — so the check carries a constant. Adding a skill without updating it would
+        leave the new skill shadowable and unreported, which is this check's own failure
+        mode turned inward."""
+        on_disk = {d.name for d in (REPO_ROOT / "skills").iterdir()
+                   if d.is_dir() and (d / "SKILL.md").is_file()}
+        self.assertEqual(set(doctor.SHIPPED_SKILLS), on_disk)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_doctor_shadowed.py
+++ b/tests/test_doctor_shadowed.py
@@ -21,7 +21,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from charter import doctor
+from charter import doctor, docsrc  # noqa: F401
+from tests._isolation import PersonaIso
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -102,3 +103,46 @@ class TestShippedSkillsStayInSync(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestCharterItselfIsExemptHoweverItWasInstalled(PersonaIso):
+    """The exemption used to key on `docsrc.source()`, which prefers the PACKAGED copy — so
+    it only matched for someone running `python3 -m charter` from the clone. Every
+    contributor also has `uv tool install charter-cp`, and for them doctor reported all
+    eight of charter's own pages as shadows of themselves: precisely the noise the
+    docstring promises to prevent, on the machine most likely to run the check."""
+
+    def make_checkout(self) -> Path:
+        root = Path(self.tmp) / "charter-clone"
+        (root / "charter").mkdir(parents=True)
+        (root / "charter" / "docsrc.py").write_text("# source\n")
+        (root / "pyproject.toml").write_text('[project]\nname = "charter-cp"\n')
+        (root / "docs").mkdir()
+        for topic in docsrc.topics()[:3] or ["personas"]:
+            (root / "docs" / f"{topic}.md").write_text("# ours\n")
+        return root
+
+    def test_exempt_when_running_from_a_checkout(self):
+        root = self.make_checkout()
+        self.assertEqual(doctor.shadowed_knowledge(root), {"skills": [], "docs": []})
+
+    def test_still_exempt_when_the_cli_is_an_installed_wheel(self):
+        """The case that was broken. `docsrc.source()` points into site-packages and has
+        nothing to do with which plane is being checked."""
+        root = self.make_checkout()
+        packaged = Path(self.tmp) / "site-packages" / "charter" / "_docs"
+        packaged.mkdir(parents=True)
+        for p in (root / "docs").glob("*.md"):
+            (packaged / p.name).write_text(p.read_text())
+        real = docsrc._PACKAGED
+        docsrc._PACKAGED = packaged
+        self.addCleanup(setattr, docsrc, "_PACKAGED", real)
+        self.assertEqual(doctor.shadowed_knowledge(root), {"skills": [], "docs": []})
+
+    def test_an_ordinary_plane_is_still_reported(self):
+        """The exemption must not have widened into "never report anything"."""
+        root = Path(self.tmp) / "someones-plane"
+        (root / "docs").mkdir(parents=True)
+        topic = (docsrc.topics() or ["personas"])[0]
+        (root / "docs" / f"{topic}.md").write_text("# a local copy\n")
+        self.assertIn(topic, doctor.shadowed_knowledge(root)["docs"])


### PR DESCRIPTION
> Stacked on #218 → #217 → #216 → #214. Retarget as those merge.

## The actual defect

Nine skills in one control plane were in some stage of the same rot, **for months**, and nothing flagged any of them. The worst: a `setup` skill telling engineers to authenticate over SSH and add an SSH key — long after the rule became token-only-over-HTTPS and charter's own `PreToolUse` guard began *denying* exactly that.

It still looked wired. Nothing compared it to the CLI it described.

**The detection gap is the defect; the stale pages were symptoms.** ADR 0014 already names the shape — *"a mechanism that looks wired and is not is the failure shape this repo keeps paying for (#177, #197)"* — and already prescribes the answer: *"`doctor` names the overlap."* This is that, for knowledge rather than permissions.

## It reports, and never resolves

Drift runs **both ways**. The same plane's persona page had grown sections upstream never received (which is why the upstream fix in #218 was port-then-delete, not delete). A copy is not automatically wrong — it is automatically *unwatched*, and that's the whole finding.

So, like `check_ask_rules`, it never says delete. An override may be exactly what the operator wants (ADR 0013). Charter names what's shadowed and what it costs.

## Verified against a real plane

```
{'skills': ['browser', 'persona'], 'docs': ['hooks', 'personas', 'secrets']}
```

## The case that earned a test file

**charter's own checkout is a control plane**, and its `docs/personas.md` is the page `docs show personas` serves. Without a guard, `doctor` reports seven pages shadowing themselves — on the one machine most likely to run it.

Also pinned: `docs/topology.md` is not a shadow (charter *writes* it into a plane), a directory without a `SKILL.md` is not a skill, and a plane's own unrelated skills/pages are left alone — a false positive here trains operators to ignore the line.

## Known limit, stated rather than papered over

This matches **by name**. A plane whose skill is called `use-secrets` shadows `charter:secrets` in substance and is **not** reported. Matching substance needs judgement, and encoding one plane's naming choices upstream would be worse than the gap.

`SHIPPED_SKILLS` is a constant because the CLI's wheel contains no `skills/` — that directory belongs to the plugin artifact. A test asserts it equals the repo's `skills/`, so the two can't part company silently; that would be this check's own failure mode turned inward.

`python3 -m unittest discover -s tests` — **2201 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAnq1m9e2URZZy3XjyBFVV