### PR TITLE
`--` is not proof of a file restore, and two branch moves used it to get past the guard

### DIFF
--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -511,9 +511,21 @@ def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
             continue
 
         post = rest[rest.index(sub) + 1:]
-        # `git checkout -- <path>` restores a file and never moves HEAD.
+        # `--` separates refs from PATHS, and only what follows it is a path. Treating the
+        # token itself as proof of a file restore let two real branch moves through:
+        # `git checkout <branch> --` and `git checkout -b <new> --` both switch — verified
+        # against git, which answers "Switched to branch" for each — while the guard read
+        # them as restores and allowed them in the plane root.
+        #
+        # So the test is what comes AFTER the separator, not whether it is present:
+        # something after it means paths, and `git checkout <tree-ish> -- <paths>` leaves
+        # HEAD where it was. Nothing after it means the separator is decoration on a branch
+        # move, and the operands before it still count.
         if "--" in post:
-            continue
+            cut = post.index("--")
+            if post[cut + 1:]:
+                continue                    # paths follow: a restore, HEAD does not move
+            post = post[:cut]               # a trailing bare `--` still switches
         creating = any(a in _BRANCH_CREATORS for a in post)
         # A bare `-` is a REF (the previous branch), not a flag — and `git checkout -` is
         # what makes a six-switch session cheap to repeat, so reading it as a flag would

--- a/tests/test_plane_root_branch_guard.py
+++ b/tests/test_plane_root_branch_guard.py
@@ -151,3 +151,39 @@ class TestItIsScopedToAPlane(PlaneRootCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestTheSeparatorIsNotProofOfARestore(PlaneRootCase):
+    """`--` separates refs from PATHS, and only what follows it is a path.
+
+    Treating the token itself as proof of a file restore let two real branch moves through.
+    Verified against git, which answers "Switched to branch 'other'" for the first and
+    "Switched to a new branch 'created'" for the second:
+
+        git checkout <branch> --        switches
+        git checkout -b <new> --        creates and switches
+
+    The guard read both as restores and allowed them in the plane root — the exact move it
+    exists to refuse, reachable by appending two characters.
+    """
+
+    def test_a_bare_trailing_separator_does_not_excuse_a_switch(self):
+        self.assertEqual(_decision(self.run_cmd("git checkout feature --")), "deny")
+
+    def test_a_bare_trailing_separator_does_not_excuse_a_creation(self):
+        self.assertEqual(_decision(self.run_cmd("git checkout -b created --")), "deny")
+
+    def test_switch_with_a_trailing_separator_is_caught_too(self):
+        self.assertEqual(_decision(self.run_cmd("git switch -c created --")), "deny")
+
+    def test_restoring_a_path_is_still_allowed(self):
+        """The case the skip was written for: paths follow, so HEAD does not move."""
+        self.assertNotEqual(_decision(self.run_cmd("git checkout -- README")), "deny")
+
+    def test_restoring_a_path_from_another_branch_is_still_allowed(self):
+        """`git checkout <tree-ish> -- <paths>` reads from that tree and leaves HEAD alone —
+        confirmed against git."""
+        self.assertNotEqual(_decision(self.run_cmd("git checkout feature -- README")), "deny")
+
+    def test_the_remedy_still_runs_with_a_separator(self):
+        self.assertNotEqual(_decision(self.run_cmd("git checkout main --")), "deny")


### PR DESCRIPTION
You asked me to test whether the plane-root guard has a hole. **It has two**, and they are reachable by appending two characters.

## What I found

The guard skipped any `git checkout`/`switch` whose arguments contained `--`, reasoning that `git checkout -- <path>` restores a file and never moves HEAD. True of the form it was written for; false of two others. Verified against real git in a throwaway repo:

```
$ git checkout other --          → Switched to branch 'other'
$ git checkout -b created --     → Switched to a new branch 'created'
```

Both were **allowed in the plane root** — the one thing this guard exists to refuse.

## The rule, precisely

`--` separates refs from **paths**, and only what *follows* it is a path. So the test is what comes after the separator, not whether it is present:

| form | after `--` | HEAD | verdict |
|---|---|---|---|
| `git checkout -- README` | paths | stays | allow |
| `git checkout feature -- README` | paths | stays | allow (verified) |
| `git checkout feature --` | nothing | **moves** | deny |
| `git checkout -b new --` | nothing | **moves** | deny |

## What this does not explain

I went looking because a session switched the plane root four times and committed there while the guard was live — the reflog is unambiguous. This hole would explain it *if* that session happened to use the `--` forms, which is not the likely shape of an agent's command. So treat this as a real defect found on the way, **not** as the confirmed cause. The other candidate — that session running against the stale 0.29.1 plugin before the reload — is still open and worth a separate look.

## Tests

6 new in `tests/test_plane_root_branch_guard.py`, covering both bypasses, both restore forms that must stay allowed, and the documented remedy with a separator (`git checkout main --`). Full suite: **2223 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX