### PR TITLE
0.40.0 — charter runs in three harnesses, and says what each one cannot do

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for Claude Code agents across many repos",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.39.0"
+__version__ = "0.40.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.39.0",
+            "command": "charter hook sessionstart --plugin-version 0.40.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.39.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.40.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.39.0",
+            "command": "charter hook pretooluse --plugin-version 0.40.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.39.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.40.0",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.39.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.40.0"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.39.0",
+            "command": "charter hook posttooluse --plugin-version 0.40.0",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.39.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.40.0",
             "timeout": 5
           }
         ]
@@ -100,7 +100,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.39.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.40.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.39.0"
+version = "0.40.0"
 description = "Personas, workspaces and memory for Claude Code agents across many repos"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only: `pyproject.toml`, `charter/__init__.py`, `.claude-plugin/plugin.json` and the eight `--plugin-version` pins in `hooks/hooks.json`, all 0.39.0 → 0.40.0.

Ships #223 — charter targets harnesses as a registered kind (Claude Code, opencode, Codex) with `doctor` naming each one's ceilings. ADR 0015 has the reasoning.

`docs/assets/captured.json` stays at 0.39.0, which `test_asset_freshness` permits: one minor of slack by design, so the captures need no regeneration this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo