### PR TITLE
doctor says whether a guard has ever actually run here, and under which harness

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -628,6 +628,54 @@ def _work_trees() -> list[Path]:
     return _ws.all_trees() if _config.HAS_CONTROL_PLANE else []
 
 
+def check_guard_seen() -> Result:
+    """Has a guard ever actually RUN here, and under which harness?
+
+    A sibling of `check_guard_wired`, not a replacement, for the reason that check is itself
+    a sibling of `check_plugin_skew`: *"Whether the plane runs as a plugin is an
+    implementation detail. Whether the guard fires is the fact the operator needs"* — two
+    facts, two rows, so neither can hide behind the other. Declared and dispatched are just
+    as separate: a plane root was switched between branches four times and committed to,
+    unguarded, while `check_guard_wired` would have reported a tick throughout. The
+    declaration was real. Nothing dispatched it.
+
+    **An age, never a verdict.** A plane worked in from a plain terminal has no dispatch and
+    is fine; a plane whose guard last fired weeks ago under a harness you have since stopped
+    using is the incident. Charter supplies the date and the harness and lets the reader
+    draw that line (ADR 0013).
+
+    Silent on a plane nobody has worked in yet — nothing could have dispatched there, and a
+    warning on day one is how a row stops being read.
+    """
+    from . import guardseen as _seen
+
+    name = "guard seen"
+    rec = _seen.last()
+    if rec:
+        at = _seen_age(rec.get("ts"))
+        where = rec.get("harness") or "an unnamed harness"
+        return Result(name, OK, detail=f"last ran {at} ago under {where}")
+    if not _seen.plane_has_been_used():
+        return Result(name, OK, detail="plane not worked in yet")
+    return Result(name, WARN,
+                  detail="no guard has ever run in this plane",
+                  hint="Charter's guards reach a session through its harness, so work done "
+                       "outside one is unguarded and says nothing about it. If you work "
+                       "here through a harness, it is not wired: -> charter reinit")
+
+
+def _seen_age(ts) -> str:
+    from datetime import datetime, timezone
+
+    from . import pieces as _pieces
+
+    try:
+        when = datetime.fromisoformat(ts)
+    except (TypeError, ValueError):
+        return "?"
+    return _pieces.since(when, datetime.now(timezone.utc))
+
+
 def check_harness_trees() -> Result:
     """Is every harness armed where sessions START, not just where the plane lives?
 
@@ -1570,7 +1618,7 @@ def _checks():
         results.append(check_forge_auth(forge))
     results += [check_ssh(), check_control_plane_config(), check_control_plane_schema(),
                 check_plane_root(), check_harness(), check_harness_trees(),
-                check_guard_wired(), check_nested_plane(),
+                check_guard_wired(), check_guard_seen(), check_nested_plane(),
                 check_workspace_clones(),
                 check_inventory(), check_vaults(),
                 check_vault_registry_divergence(), check_version_lock(),

--- a/charter/guardseen.py
+++ b/charter/guardseen.py
@@ -1,0 +1,104 @@
+"""When a guard was last observed actually running in this plane, and under which harness.
+
+`doctor`'s `check_guard_wired` answers whether the guard is **declared** — a hook line in a
+settings file, or an enabled plugin. That was already one rung better than "is the plugin
+installed" (#177). It is still not the fact the operator needs, and the gap is not academic:
+a plane root was switched between branches four times and committed to, unguarded, while
+that check would have reported a tick the entire time. The declaration was real; nothing
+dispatched it.
+
+So this records the other half. Reaching `hooks.pretooluse` at all is proof the guard is
+live *now*, under *this* harness — a thing no amount of reading configuration can establish.
+
+**An observation with an age, never a boolean.** `silent 3d` and `▸steward 7m` already keep
+this grammar, and for the same reason: charter cannot know that the absence of a dispatch is
+a problem. A plane worked in from a plain terminal all week has no dispatch and is fine. A
+plane whose guard last fired three weeks ago, under a harness you have since stopped using,
+is the incident. The reader draws that line; charter supplies the date and the name.
+
+**The harness is recorded because it is the sentence that explains the incident.** "Last
+seen under claude-code 3 weeks ago" tells you where your protection went in a way "not
+recently" never will.
+
+Overwritten, not appended: this answers "when last", and a history of every turn's guard
+would be unbounded for a question nobody asks. Same shape as `pieces.seen`, deliberately.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from . import config
+
+#: One file per plane, under the state dir — gitignored, machine-local, and about this
+#: machine's harnesses. Committing it would describe one laptop's wiring to everybody.
+FILE_NAME = "guard-seen.json"
+
+
+def path() -> Path:
+    return Path(config.STATE_DIR) / FILE_NAME
+
+
+def mark(harness: str | None = None, when: datetime | None = None) -> Path | None:
+    """Record that a guard just ran. Best-effort — never raises, never blocks a turn.
+
+    Called from the guard handler itself rather than from `sessionstart`, and that choice is
+    the whole point: `check_guard_wired`'s docstring already rejects the softer version —
+    *"a plane wiring only `sessionstart` is unprotected while looking configured, which is
+    this issue again one level down."* Only the handler holding the guard can prove the
+    guard is reachable.
+    """
+    from .harness import registry as _registry
+
+    if harness is None:
+        try:
+            harness = _registry.current()
+        except Exception:
+            harness = None
+    when = when or datetime.now(timezone.utc)
+    p = path()
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"ts": when.isoformat(timespec="seconds"),
+                                 "harness": harness}, sort_keys=True) + "\n")
+        return p
+    except OSError:
+        return None
+
+
+def last() -> dict | None:
+    """The latest observation, or ``None``. A malformed file reads as ``None`` rather than
+    raising: this feeds a preflight line, which must render whatever it finds."""
+    try:
+        obj = json.loads(path().read_text())
+    except (OSError, ValueError, UnicodeDecodeError):
+        return None
+    return obj if isinstance(obj, dict) and obj.get("ts") else None
+
+
+def plane_has_been_used() -> bool:
+    """Whether this plane has been worked in at all.
+
+    The gate on saying anything. A plane created five minutes ago has no dispatch and never
+    could have, and warning there is the cried-wolf failure this repo has paid for twice.
+
+    Evidence is deliberately something a HUMAN made — a persona, or a clone in a workspace.
+    Session state would be circular: it is written by the very hooks whose absence is being
+    detected, so a plane that never dispatched also has no sessions, and the gate would
+    silence exactly the case it exists to report.
+    """
+    try:
+        personas = Path(config.PERSONAS_DIR)
+        if any(d.is_dir() and (d / "persona.md").is_file()
+               for d in personas.glob("*") if not d.name.startswith("_")):
+            return True
+        workspaces = Path(config.WORKSPACES_DIR)
+        for ws in workspaces.glob("*"):
+            if not ws.is_dir() or ws.name.startswith("."):
+                continue
+            if any(c.is_dir() and (c / ".git").exists() for c in ws.glob("*")):
+                return True
+    except OSError:
+        return False
+    return False

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -662,6 +662,16 @@ def _trace(event, session, **f):
         pass
 
 
+def _mark_guard_seen() -> None:
+    """Record that the guard ran. Silent and best-effort, like everything else here — a
+    turn must never fail over bookkeeping."""
+    try:
+        from . import guardseen
+        guardseen.mark()
+    except Exception:
+        return
+
+
 def _touch_piece(data: dict) -> None:
     """Record that the worker in this session's directory is alive.
 
@@ -818,6 +828,10 @@ def _piece_announcement(data: dict) -> str | None:
 
 def pretooluse() -> int:
     data = _read_stdin()
+    # Reaching this handler at all is the proof no configuration can give: the guard is
+    # live, here, under this harness. `check_guard_wired` can only see the declaration, and
+    # a plane root was switched four times unguarded while that check reported a tick.
+    _mark_guard_seen()
     _touch_piece(data)
     ti = data.get("tool_input") or {}
     cmd = ti.get("command", "") or ""

--- a/tests/test_guard_seen.py
+++ b/tests/test_guard_seen.py
@@ -1,0 +1,129 @@
+"""Declared is not dispatched, and only one of the two can be read off configuration.
+
+`check_guard_wired` proves a hook line exists in a settings file, or that a plugin is
+enabled. That was already a rung better than "is it installed" (#177). It is still not the
+fact that matters: a plane root was switched between branches four times and committed to,
+**unguarded**, while that check would have reported a tick the whole time. The declaration
+was real. Nothing dispatched it, because the work ran through a harness charter was not
+wired into — and no amount of reading configuration can see that.
+
+Reaching `hooks.pretooluse` is the proof configuration cannot give. So the handler that
+holds the guard records that it ran, and under which harness.
+
+**An age, never a verdict** — the grammar `silent 3d` and `▸steward 7m` already keep. A
+plane worked in from a plain terminal has no dispatch and is fine; a plane whose guard last
+fired weeks ago under a harness you have stopped using is the incident. Charter supplies the
+date and the name; the reader draws the line (ADR 0013).
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from charter import config, doctor, guardseen, hooks
+from tests._isolation import PersonaIso, run_hook
+
+
+class SeenCase(PersonaIso):
+    def used_plane(self) -> None:
+        """A plane a human has worked in — the gate on saying anything at all."""
+        self.make_persona("ops", role="Ops", vault="none")
+
+    def wrote(self, minutes: int, harness: str | None = "claude-code") -> None:
+        guardseen.mark(harness=harness,
+                       when=datetime.now(timezone.utc) - timedelta(minutes=minutes))
+
+
+class TestTheGuardRecordsThatItRan(SeenCase):
+    def test_nothing_is_recorded_before_a_guard_runs(self):
+        self.assertIsNone(guardseen.last())
+
+    def test_the_pretooluse_handler_records_it(self):
+        """Not `sessionstart`: `check_guard_wired`'s own docstring rejects that reasoning —
+        "a plane wiring only `sessionstart` is unprotected while looking configured, which
+        is this issue again one level down"."""
+        run_hook(hooks.pretooluse, {"tool_input": {"command": "ls"},
+                                    "cwd": str(config.ROOT), "session_id": "s"})
+        self.assertIsNotNone(guardseen.last())
+
+    def test_it_records_which_harness(self):
+        """The sentence that explains the incident. "Last seen under claude-code three
+        weeks ago" says where the protection went; "not recently" never does."""
+        self.wrote(0, harness="opencode")
+        self.assertEqual(guardseen.last()["harness"], "opencode")
+
+    def test_it_is_overwritten_not_appended(self):
+        self.wrote(30)
+        self.wrote(0)
+        blob = json.loads(guardseen.path().read_text())
+        self.assertIsInstance(blob, dict)
+
+    def test_a_malformed_record_reads_as_none(self):
+        """It feeds a preflight line, which must render whatever it finds."""
+        guardseen.path().parent.mkdir(parents=True, exist_ok=True)
+        guardseen.path().write_text("{ not json")
+        self.assertIsNone(guardseen.last())
+
+    def test_marking_never_raises(self):
+        real = guardseen.path
+        guardseen.path = lambda: Path("/proc/nope/guard-seen.json")
+        self.addCleanup(setattr, guardseen, "path", real)
+        self.assertIsNone(guardseen.mark())
+
+
+class TestDoctorReportsAnAgeNotAVerdict(SeenCase):
+    def test_a_recent_dispatch_is_ok_and_names_the_harness(self):
+        self.used_plane()
+        self.wrote(0, harness="claude-code")
+        r = doctor.check_guard_seen()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIn("claude-code", r.detail)
+
+    def test_an_old_dispatch_is_still_ok_but_carries_its_age(self):
+        """Charter cannot know that an old dispatch is a problem — a plane may simply not
+        have been opened in a harness lately. It reports the age and stops."""
+        self.used_plane()
+        self.wrote(60 * 24 * 21, harness="claude-code")
+        r = doctor.check_guard_seen()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIn("21d", r.detail)
+
+    def test_a_used_plane_with_no_dispatch_ever_warns(self):
+        """The incident, detected."""
+        self.used_plane()
+        self.assertEqual(doctor.check_guard_seen().status, doctor.WARN)
+
+    def test_a_fresh_plane_says_nothing(self):
+        """Nothing could have dispatched in a plane created five minutes ago, and warning
+        on day one is how a row stops being read."""
+        self.assertEqual(doctor.check_guard_seen().status, doctor.OK)
+
+    def test_the_used_gate_does_not_depend_on_hook_written_state(self):
+        """Session state would be circular: it is written by the very hooks whose absence is
+        being detected, so the gate would silence exactly the case it exists to report. A
+        persona is something a human made."""
+        self.assertFalse(guardseen.plane_has_been_used())
+        self.used_plane()
+        self.assertTrue(guardseen.plane_has_been_used())
+
+    def test_a_clone_also_counts_as_used(self):
+        ws = Path(config.WORKSPACES_DIR) / "task" / "svc" / ".git"
+        ws.mkdir(parents=True)
+        self.assertTrue(guardseen.plane_has_been_used())
+
+    def test_it_runs_in_doctor(self):
+        names = [r.name for r in doctor.run_all()]
+        self.assertIn("guard seen", names)
+
+    def test_it_is_a_sibling_of_the_wired_check_not_a_replacement(self):
+        """Two facts, two rows — the split `check_plugin_skew` and `check_guard_wired`
+        already keep, so neither can hide behind the other."""
+        names = [r.name for r in doctor.run_all()]
+        self.assertIn("plane-root guard", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_harness_wires_work_trees.py
+++ b/tests/test_harness_wires_work_trees.py
@@ -107,7 +107,13 @@ class LinkedWorktrees(unittest.TestCase):
     def _clone_with_worktree(self) -> tuple[Path, Path]:
         clone = _tmp(self, git=True)
         (clone / "f.txt").write_text("x\n")
+        # `commit.gpgsign=false` is not optional here. A contributor may have signing on
+        # globally, and a 1Password/hardware signer then makes this commit fail (exit 128)
+        # or block on a prompt no test can answer — so the suite is green on CI, which has
+        # no signer, and red on the machines that actually write the code. Every other
+        # fixture in this suite pins it for the same reason.
         for cmd in (["add", "-A"], ["-c", "user.email=t@t", "-c", "user.name=t",
+                                    "-c", "commit.gpgsign=false",
                                     "commit", "-qm", "init"]):
             subprocess.run(["git", "-C", str(clone), *cmd], check=True,
                            capture_output=True)


### PR DESCRIPTION
Closes the loop on this afternoon's incident: a plane root switched between branches **four times** and committed to, unguarded, while `charter doctor` would have reported a tick the entire time.

## Declared is not dispatched

`check_guard_wired` proves a hook line exists in a settings file, or that a plugin is enabled. That was already a rung better than *is it installed* (#177). It still cannot see the fact that matters — the declaration was real, and nothing dispatched it, because the work ran through a harness charter was not wired into.

Reaching `hooks.pretooluse` is the proof configuration cannot give.

```
✓  guard seen    last ran 3m ago under claude-code
!  guard seen    no guard has ever run in this plane
```

**Not `sessionstart`.** `check_guard_wired`'s own docstring rejects that reasoning: *"a plane wiring only `sessionstart` is unprotected while looking configured, which is this issue again one level down."* Only the handler holding the guard can prove the guard is reachable.

**An age, never a verdict.** A plane worked in from a plain terminal has no dispatch and is fine; a plane whose guard last fired weeks ago under a harness you have since stopped using is the incident. Charter supplies the date and the harness name — *"last ran 21d ago under claude-code"* is the sentence that would have explained the whole afternoon — and lets the reader draw the line (ADR 0013).

**A sibling row, not a rewrite** of `check_guard_wired`, for the reason that check is itself a sibling of `check_plugin_skew`: two facts, two rows, so neither hides behind the other.

**Silent on a fresh plane.** The gate is a persona or a clone — something a *human* made. Session state would be circular: it is written by the very hooks whose absence is being detected, so gating on it would silence exactly the case this exists to report.

## Also: a signer failure the harness suite shipped with

`tests/test_harness_wires_work_trees.py` runs `git commit` without `commit.gpgsign=false`. For any contributor with signing on globally it exits 128 or blocks on a hardware prompt — **green on CI, which has no signer, red on the machines that write the code**. Three tests were erroring here and the module was timing out; it now runs in **0.245s**.

Every other fixture in the suite pins it, with the reason written down. This one missed it.

## Tests

14 new in `tests/test_guard_seen.py`, including that the used-plane gate does not depend on hook-written state (the circularity), that a fresh plane stays silent, and that the wired row survives alongside. Full suite: **2319 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX
