### PR TITLE
Two hook tests wrote into the developer's real control plane

### DIFF
--- a/tests/test_hook_process_boundary.py
+++ b/tests/test_hook_process_boundary.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 
 import json
 import subprocess
+import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -25,11 +27,23 @@ _REPO = Path(__file__).resolve().parent.parent
 
 
 def _hook(name: str, payload: dict | None = None) -> subprocess.CompletedProcess:
-    """Run `charter hook <name>` as a real process, exactly as the manifest does."""
+    """Run `charter hook <name>` as a real process, exactly as the manifest does.
+
+    ``$CHARTER_ROOT`` is pinned to a throwaway directory, and that is not tidiness. These
+    are SUBPROCESSES, so `PersonaIso` cannot reach them — it redirects module globals in
+    this interpreter, not in a child. The child resolves its own plane by walking up from
+    `cwd`, and since `find_root` began hopping outward through `workspaces/` (0.37.0) a
+    checkout that happens to sit inside somebody's plane resolves to THAT plane. A handler
+    that writes anything — a trace row, a guard-seen mark — then writes it into the
+    developer's real control plane, from a test run.
+    """
+    root = tempfile.mkdtemp(prefix="charter-hookproc-")
+    (Path(root) / "charter.toml").write_text("schema = 1\n")
     return subprocess.run(
         [sys.executable, "-m", "charter", "hook", name],
         input=json.dumps(payload if payload is not None else {}),
         capture_output=True, text=True, cwd=_REPO,
+        env={**os.environ, "CHARTER_ROOT": root},
     )
 
 
@@ -98,9 +112,12 @@ class GuardAcrossTheProcessBoundary(unittest.TestCase):
                   for _e, c in _manifest_hooks() if "charter hook " in c}
         for name in sorted(engine):
             with self.subTest(hook=name):
+                root = tempfile.mkdtemp(prefix="charter-hookproc-")
+                (Path(root) / "charter.toml").write_text("schema = 1\n")
                 p = subprocess.run([sys.executable, "-m", "charter", "hook", name],
                                    input="not json at all", capture_output=True,
-                                   text=True, cwd=_REPO)
+                                   text=True, cwd=_REPO,
+                                   env={**os.environ, "CHARTER_ROOT": root})
                 self.assertEqual(p.returncode, 0,
                                  f"{name} exited {p.returncode}: {p.stderr[:300]}")
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -264,6 +264,24 @@ if __name__ == "__main__":
 
 
 class TestSkewReachesTheUser(unittest.TestCase):
+    # `hooks.dispatch` runs REAL handlers, and a handler may write plane state — a trace
+    # row, a guard-seen mark. Without redirecting the root those writes land in whatever
+    # plane this checkout resolves to, which since `find_root` began hopping outward
+    # through `workspaces/` (0.37.0) is the developer's own control plane. A test must not
+    # be able to touch it; `config.use` is the seam the rest of the suite already uses.
+    def setUp(self) -> None:
+        import tempfile
+        from charter import config as _config
+        self._tmp = tempfile.mkdtemp(prefix="charter-skew-")
+        (Path(self._tmp) / "charter.toml").write_text("schema = 1\n")
+        self._orig = _config.use(Path(self._tmp))
+
+    def tearDown(self) -> None:
+        import shutil
+        from charter import config as _config
+        _config.restore(self._orig)
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
     """`README.md` promises "a plugin newer than the CLI says so loudly at session start".
     It did not. `dispatch` printed to stderr and returned 0, and Claude Code routes a
     zero-exit hook's stderr to the debug log only — so neither the user nor the model ever


### PR DESCRIPTION
Found by deleting `.charter/guard-seen.json` in the real plane, running the suite, and watching it come back.

## The hole

`PersonaIso` redirects module globals in **this** interpreter. It cannot reach a subprocess, and it is not used at all by a plain `unittest.TestCase`. Two paths exercised real hook handlers outside it:

| test | how it escaped |
| --- | --- |
| `test_hook_process_boundary` | spawns `charter hook <name>` with `cwd=<repo>` and no `CHARTER_ROOT`, so the child walks up and finds a plane on its own |
| `test_plugin` | calls `hooks.dispatch()`, running real handlers in-process against whatever `config.ROOT` points at |

Both were survivable while those handlers wrote nothing.

They stopped being survivable in **0.37.0**, when `find_root` began hopping outward through `workspaces/`: a charter checkout that sits inside somebody's plane no longer resolves to itself — it resolves to **that plane**. So a test run reached out of its sandbox and wrote into the developer's real control plane.

This was already happening for **trace rows**, silently. `guard-seen` only made it visible, because it writes one predictable file you can delete and watch reappear.

## The fix

Where the convention already lives:

- the subprocesses get `CHARTER_ROOT` pinned to a throwaway plane;
- the in-process class redirects via `config.use`, the seam the rest of the suite uses.

No production code changes.

## Verified by the method that found it

Delete `.charter/guard-seen.json`, run all **2319** tests, confirm it stays gone. Before: it reappeared on every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX
