### PR TITLE
feat: a named ceiling now carries what to do about it

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ That is the status line under Claude Code, redrawn from disk every turn — the 
 the repos it owns and what branch each is sitting on, which are dirty or unpushed, CI and
 open PRs, and the roles you can hand work to. No git subprocess and no network on the
 render path. It is generated, not mocked: `docs/assets/` holds the script that produced it.
+On a harness with no status bar, `charter statusline --watch` puts the same render in any
+spare terminal.
 
 ## 60 seconds
 
@@ -76,11 +78,21 @@ clone and not in the plane root. Nothing to install per harness, with one except
 **What differs is not what charter enforces — it is what each harness lets charter
 offer**, and `charter doctor` prints the gap rather than leaving you to find it:
 
-| | wiring | what it cannot carry |
-| --- | --- | --- |
-| Claude Code | the plugin, plus `.claude/settings.json` | — |
-| opencode | generated into every work tree by `charter init` | no status bar (`/charter` renders it on demand); no per-turn prompt hook, so mid-session notes ride tool output |
-| Codex | **opt-in**: `charter harness install codex` | no command-pattern permissions, so `charter guard ask` rules stay in charter's own hook |
+| | wiring | what it cannot carry | what to do about it |
+| --- | --- | --- | --- |
+| Claude Code | the plugin, plus `.claude/settings.json` | — | — |
+| opencode | generated into every work tree by `charter init` | no status bar; no per-turn prompt hook | `charter statusline --watch`; mid-session notes ride tool output already |
+| Codex | **opt-in**: `charter harness install codex` | no status bar; no command-pattern permissions; config is machine-wide | `charter statusline --watch`; `guard ask` rules stay in charter's own hook |
+
+`charter doctor` and `charter harness list` print that fourth column against whichever
+harness you are in, each ceiling carrying its own answer. Where the last column is empty
+it stays empty: charter cannot conjure opencode a per-turn prompt hook, and a workaround
+that does not exist costs more to chase than an honest gap.
+
+**`charter statusline --watch`** is the one worth knowing. It repaints the plane state in
+place in any spare terminal — no status-bar socket, no multiplexer, the same render on
+every harness including the one that has a bar. It shows the plane, not the session, so
+the token and context columns are blank and it says so.
 
 Codex is the exception because it has no project-level config: its hooks live in
 `~/.codex/config.toml` and arming them affects **every repo on the machine**. `charter

--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ charter harness list          # every harness, what it can't carry, and which on
 charter harness install codex # Codex only — see below
 ```
 
+```
+  claude-code
+* opencode
+      ↳ status-bar: no status-bar socket: opencode has no `statusLine` config …
+          → charter statusline --watch
+      ↳ prompt-hook: no per-turn prompt hook: charter's mid-session nudges ride …
+  codex
+      ↳ status-bar: `tui.status_line` takes a list of built-in segments, not a command …
+          → charter statusline --watch
+      ↳ session-lock: `shell_environment_policy.set` holds constants, so no per-session …
+      ↳ wiring-scope: no project-level config: hooks live only in `~/.codex/config.toml` …
+```
+
+The `*` is the harness this session is in, and those names are what `$CHARTER_HARNESS`
+holds. A harness charter has no record of is reported too, as a warning rather than a
+clean row — an unverified integration and a complete one must not read the same.
+
 `charter init` writes each harness's wiring into the plane, and `charter clone` /
 `charter worktree add` arm every tree as it is created, because a session starts in a
 clone and not in the plane root. Nothing to install per harness, with one exception.

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -182,8 +182,17 @@ def build_parser() -> argparse.ArgumentParser:
     gp.set_defaults(func=commands.cmd_git_policy)
 
     sl = sub.add_parser("statusline",
-                        help="Render the Claude Code status line (reads a JSON payload on stdin).")
-    sl.set_defaults(func=lambda args: statusline.main())
+                        help="Render the plane's status line — from a JSON payload on "
+                             "stdin, or ambiently with --watch on a harness that has no "
+                             "status bar of its own.")
+    sl.add_argument("--watch", action="store_true",
+                    help="Repaint in place until Ctrl-C, in any spare terminal. Needs no "
+                         "status-bar socket and no multiplexer, so it is the same render "
+                         "on every harness.")
+    sl.add_argument("--interval", type=float, default=statusline.WATCH_INTERVAL,
+                    help="Seconds between repaints with --watch.")
+    sl.set_defaults(func=lambda args: statusline.main(
+        (["--watch", "--interval", str(args.interval)] if args.watch else [])))
 
     gl = sub.add_parser("gl-refresh",
                         help="Refresh the status line's forge state (open MRs/PRs + CI) "

--- a/charter/commands_harness.py
+++ b/charter/commands_harness.py
@@ -21,6 +21,8 @@ def cmd_harness_list(args) -> int:
         util.info(f"{mark} {h.name}")
         for d in h.deficits:
             util.info(f"      ↳ {d.key}: {d.detail}")
+            if d.remedy:
+                util.info(f"          → {d.remedy}")
     if live and registry.get(live) is None:
         util.warn(f"  running under '{live}', which charter has no record of — its "
                   f"surfaces are unverified.")

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -615,7 +615,13 @@ def check_harness() -> Result:
     gaps = _harness.deficits(current)
     if not gaps:
         return Result(name, OK, detail=current)
-    listed = "\n".join(f"        ↳ {d.key}: {d.detail}" for d in gaps)
+    def _line(d):
+        # The remedy sits on the ceiling it answers, not in a footnote: a limit stated and
+        # left there reads as "nothing can be done", and the operator stops looking.
+        fix = f"  → {d.remedy}" if d.remedy else ""
+        return f"        ↳ {d.key}: {d.detail}{fix}"
+
+    listed = "\n".join(_line(d) for d in gaps)
     plural = "" if len(gaps) == 1 else "s"
     return Result(name, OK, detail=f"{current} — {len(gaps)} capability ceiling{plural}\n{listed}")
 

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -25,6 +25,10 @@ class Deficit(NamedTuple):
 
     key: str
     detail: str
+    #: A command that closes the gap, or "" when charter has no answer. An empty remedy
+    #: is a claim too — inventing one sends somebody off to configure something that does
+    #: not exist, which costs more than an honest gap.
+    remedy: str = ""
 
 
 class Harness:

--- a/charter/harness/codex.py
+++ b/charter/harness/codex.py
@@ -117,7 +117,8 @@ class CodexHarness(Harness):
         Deficit("status-bar",
                 "`tui.status_line` takes a list of built-in segments, not a command "
                 "(a string or bool is rejected, an array of strings is not) — so charter "
-                "cannot render into it, and `/charter` renders on demand instead."),
+                "cannot render into it, and `/charter` renders on demand instead.",
+                "charter statusline --watch"),
         Deficit("session-lock",
                 "`shell_environment_policy.set` holds constants, so no per-session "
                 "`$CHARTER_SESSION_ID` reaches a shell; the workspace lock falls back to "

--- a/charter/harness/opencode.py
+++ b/charter/harness/opencode.py
@@ -298,7 +298,7 @@ class OpenCodeHarness(Harness):
     deficits = (
         Deficit("status-bar",
                 "no status-bar socket: opencode has no `statusLine` config, so the plane "
-                "state renders on demand via `/charter` rather than ambiently."),
+                "state renders on demand via `/charter` rather than ambiently.", "charter statusline --watch"),
         Deficit("prompt-hook",
                 "no per-turn prompt hook: charter's mid-session nudges ride the output of "
                 "effectful tools (write/edit/bash) instead of arriving beside them."),

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -37,6 +37,7 @@ even though its commands honor the env var. Cosmetic only.
 
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import subprocess
@@ -1816,7 +1817,66 @@ def _columns(left_lines: list[str], right_lines: list[str] | None, width: int) -
     return "\n".join(node.render(width))
 
 
+#: How often the ambient render repaints. The same cadence charter writes into Claude
+#: Code's `statusLine.refreshInterval`, so the plane state ages at one rate whichever
+#: harness you are looking at it through.
+WATCH_INTERVAL = 10.0
+
+_HOME_CLEAR = "\033[H\033[J"
+_HIDE_CURSOR, _SHOW_CURSOR = "\033[?25l", "\033[?25h"
+
+
+def watch(interval: float = WATCH_INTERVAL) -> int:
+    """Repaint the plane state in place until Ctrl-C. ``charter statusline --watch``.
+
+    The remedy for a harness with no status bar (ADR 0015). Claude Code renders the line
+    every turn because it has a socket for one; opencode has none, and Codex's
+    `tui.status_line` takes built-in segments rather than a command. This needs neither —
+    a spare terminal, no multiplexer, and the same render on every harness.
+
+    **What it cannot show, and says so.** There is no session payload here, so the token
+    and context columns are blank. A render that looks like the real thing while silently
+    omitting a column teaches the reader to trust a number that is not on the screen.
+
+    The cursor is hidden while painting and restored on the way out, including on Ctrl-C:
+    an ambient display that leaves the operator's terminal broken is a worse failure than
+    the one it set out to fix. A render that raises is drawn as a single line rather than
+    ending the loop, for the same reason `main` guards it — this process is meant to sit
+    there for hours.
+    """
+    out = sys.stdout
+    out.write(_HIDE_CURSOR)
+    try:
+        while True:
+            try:
+                body = render({})
+            except Exception:
+                body = f"{_CYAN}⬢{_R} charter — render failed; still watching"
+            out.write(f"{_HOME_CLEAR}{body}\n")
+            out.write(f"{_DIM}no session attached — token and context columns are blank; "
+                      f"this is the plane, not the session. Ctrl-C to stop.{_R}\n")
+            out.flush()
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        return 0
+    finally:
+        out.write(_SHOW_CURSOR)
+        out.flush()
+
+
 def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(prog="charter statusline", add_help=True)
+    ap.add_argument("--watch", action="store_true",
+                    help="repaint the plane state in place until Ctrl-C — an ambient "
+                         "status line on a harness that has no bar of its own.")
+    ap.add_argument("--interval", type=float, default=WATCH_INTERVAL,
+                    help=f"seconds between repaints with --watch (default {WATCH_INTERVAL:g}).")
+    # `argv or []`, never None: `parse_args(None)` reads sys.argv, and this function is
+    # called programmatically (and by the crash-guard test) with no arguments at all —
+    # where inheriting the parent process's flags would turn a render into a usage error.
+    a = ap.parse_args(argv or [])
+    if a.watch:
+        return watch(interval=a.interval)
     try:
         payload = json.load(sys.stdin)
     except Exception:

--- a/docs/adr/0015-the-boundary-moves-with-the-harness.md
+++ b/docs/adr/0015-the-boundary-moves-with-the-harness.md
@@ -149,6 +149,24 @@ parsed, it loaded, it did nothing. Bun takes stdin by redirection (`$`cmd < ${bl
 the test that now pins it drives the hook through a `$` stub implementing only what Bun
 implements. **Asserting that generated code parses is not the same as asserting it works.**
 
+## A ceiling that carries what to do about it
+
+`doctor` earned its deficit list by refusing to render a lower ceiling as health. The next
+failure is subtler: **a limit stated and left there reads as "nothing can be done"**, and
+the operator stops looking. So a `Deficit` carries a `remedy` — a command that closes the
+gap — printed on the ceiling it answers rather than in a footnote.
+
+`charter statusline --watch` is the first: the plane state repainting in place in any
+spare terminal, needing no status-bar socket and no multiplexer, and identical on every
+harness including the one that does have a bar. It says what it cannot show — there is no
+session payload, so the token and context columns are blank — because a render that looks
+like the real thing while silently omitting a column teaches the reader to trust a number
+that is not on the screen.
+
+An empty remedy is a claim too, and stays empty. charter cannot conjure opencode a
+per-turn prompt hook, and inventing one would send somebody off to configure a thing that
+does not exist — which costs more than an honest gap.
+
 ## What this is NOT
 
 It is not two implementations of charter. The opencode integration is written concretely and

--- a/docs/install.md
+++ b/docs/install.md
@@ -100,6 +100,16 @@ own directory and does **not** search parent directories, so a session started i
 would otherwise be unguarded. `charter doctor`'s `harness trees` row names any tree that
 is missing them; `charter reinit` backfills.
 
+opencode has no status bar, so the plane state renders on demand through the `/charter`
+command charter writes into each tree — or ambiently, in any spare terminal:
+
+```bash
+charter statusline --watch
+```
+
+That works on every harness, including Claude Code, and needs no multiplexer. It shows the
+plane rather than the session, so the token and context columns are blank and it says so.
+
 **Codex: one opt-in command.**
 
 ```bash

--- a/tests/test_deficit_remedies.py
+++ b/tests/test_deficit_remedies.py
@@ -1,0 +1,51 @@
+"""A named ceiling that carries what to do about it.
+
+`doctor` earned its deficit list by refusing to render a lower ceiling as health. The next
+failure is subtler: a limit stated and left there reads as "nothing can be done", and the
+operator stops looking. Where charter HAS an answer, the deficit carries it.
+
+Where it has none, it says nothing rather than inventing one — an empty remedy is a claim
+too, and a wrong workaround costs more than an honest gap.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import doctor
+from charter.harness import registry
+
+
+class RemediesAreOffered(unittest.TestCase):
+    def test_a_missing_status_bar_names_the_ambient_render(self):
+        for name in ("opencode", "codex"):
+            with self.subTest(harness=name):
+                d = next(d for d in registry.get(name).deficits if d.key == "status-bar")
+                self.assertIn("charter statusline --watch", d.remedy)
+
+    def test_a_deficit_with_no_answer_offers_none(self):
+        """opencode has no per-turn prompt hook and charter cannot conjure one — the
+        nudges already ride tool output, which the `detail` explains. Inventing a remedy
+        here would send someone off to configure something that does not exist."""
+        d = next(d for d in registry.get("opencode").deficits if d.key == "prompt-hook")
+        self.assertEqual(d.remedy, "")
+
+    def test_every_remedy_is_a_command_the_operator_can_run(self):
+        for h in registry.all():
+            for d in h.deficits:
+                if d.remedy:
+                    with self.subTest(harness=h.name, key=d.key):
+                        self.assertIn("charter ", d.remedy)
+
+
+class DoctorShowsThem(unittest.TestCase):
+    def test_the_row_carries_the_remedy_beside_the_ceiling(self):
+        import os
+        from unittest import mock
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "opencode"}, clear=True):
+            r = doctor.check_harness()
+        self.assertIn("charter statusline --watch", r.detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_readme_states_the_ceilings.py
+++ b/tests/test_readme_states_the_ceilings.py
@@ -1,0 +1,80 @@
+"""The README has to say what each harness cannot do, and what to do about it.
+
+Twice in two releases the code shipped and the front door did not. 0.40.0 registered three
+harnesses while the README still called charter a tool for Claude Code agents; the next
+change gave every ceiling a remedy and the README went on saying "no status bar" with no
+hint that anything answered it — which is precisely the "nothing can be done" reading that
+change existed to prevent.
+
+Both misses have the same shape: the ADR gets updated because that is where the reasoning
+happens, and the README does not because by then nobody is thinking about the reader. This
+is `test_asset_freshness`'s trick applied to prose — the repo already fails a build when a
+screenshot drifts from what charter prints, and a capability the front door never mentions
+is the same drift in a cheaper medium.
+
+**Deliberately only `README.md`.** It is the file PyPI renders and the first thing anyone
+evaluating charter reads. Extending this to every doc would make it a chore that gets
+suppressed rather than a check that gets heeded.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from charter.harness import registry
+
+README = Path(__file__).resolve().parents[1] / "README.md"
+
+
+def undocumented(prose: str, required: dict[str, str]) -> list[str]:
+    """Which of *required* (``label -> text``) is absent from *prose*.
+
+    A plain substring test, on purpose: anything cleverer (fuzzy matching, stripping
+    punctuation) would start passing on prose that merely resembles the claim, and a check
+    that can be satisfied by accident is worse than none.
+    """
+    return [f"{label}: {text!r}" for label, text in required.items() if text not in prose]
+
+
+class TheCheckerCatchesWhatItIsFor(unittest.TestCase):
+    """The checker is tested before it is trusted — a green assertion that cannot go red
+    proves nothing, which is the lesson the opencode shim taught this session."""
+
+    def test_a_missing_claim_is_reported(self):
+        missing = undocumented("charter runs anywhere.",
+                               {"remedy": "charter statusline --watch"})
+        self.assertEqual(len(missing), 1)
+        self.assertIn("charter statusline --watch", missing[0])
+
+    def test_a_present_claim_is_not(self):
+        self.assertEqual(
+            undocumented("Run `charter statusline --watch` in a spare terminal.",
+                         {"remedy": "charter statusline --watch"}), [])
+
+
+class TheReadmeSaysIt(unittest.TestCase):
+    def setUp(self) -> None:
+        self.prose = README.read_text()
+
+    def test_every_registered_harness_is_named(self):
+        """0.40.0's miss. A harness charter supports and the README never mentions is one
+        nobody discovers."""
+        missing = undocumented(self.prose,
+                               {h.name: h.name for h in registry.all()})
+        self.assertEqual(missing, [], f"README does not name: {missing}")
+
+    def test_every_remedy_charter_offers_is_documented(self):
+        """The second miss. A ceiling with an answer that only `doctor` knows about leaves
+        the reader believing the limit is absolute."""
+        required = {f"{h.name}/{d.key}": d.remedy
+                    for h in registry.all() for d in h.deficits if d.remedy}
+        self.assertTrue(required, "no remedies exist — this test would pass vacuously")
+        missing = undocumented(self.prose, required)
+        self.assertEqual(missing, [],
+                         "README states a ceiling without its remedy — add it to the "
+                         f"harness table's last column: {missing}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_statusline_watch.py
+++ b/tests/test_statusline_watch.py
@@ -1,0 +1,92 @@
+"""`charter statusline --watch` — an ambient plane state on a harness that has no bar.
+
+Naming a ceiling is honest; leaving it there is half a job. Claude Code renders the status
+line every turn because it has a socket for one. opencode has none, and Codex's
+`tui.status_line` takes a list of built-in segments rather than a command — so on both, the
+plane state has nowhere ambient to live. This puts it in any spare terminal, which needs no
+socket and no multiplexer, and works the same on every harness including the one that does
+have a bar.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+from charter import statusline
+
+
+class Watch(unittest.TestCase):
+    def _run(self, frames: int = 3, **kw) -> str:
+        """Drive the loop for *frames* repaints, then interrupt it the way Ctrl-C does."""
+        calls = {"n": 0}
+
+        def fake_sleep(_seconds):
+            calls["n"] += 1
+            if calls["n"] >= frames:
+                raise KeyboardInterrupt
+
+        buf = io.StringIO()
+        with mock.patch.object(statusline.time, "sleep", fake_sleep), \
+                mock.patch.object(statusline, "render", return_value="PLANE"), \
+                redirect_stdout(buf):
+            self.rc = statusline.watch(**kw)
+        return buf.getvalue()
+
+    def test_it_repaints_until_interrupted_and_exits_cleanly(self):
+        out = self._run(frames=3)
+        self.assertEqual(self.rc, 0)
+        self.assertEqual(out.count("PLANE"), 3)
+
+    def test_it_repaints_in_place_rather_than_scrolling(self):
+        """A status line that scrolls is a log. The point of an ambient render is that it
+        occupies the same rows every time, so a glance costs nothing."""
+        out = self._run(frames=2)
+        self.assertIn("\033[H", out)
+
+    def test_it_leaves_the_cursor_visible_after_ctrl_c(self):
+        """Hiding the cursor and dying without restoring it leaves the operator's terminal
+        broken, which is a worse failure than the one this feature fixes."""
+        out = self._run(frames=1)
+        self.assertIn("\033[?25l", out)
+        self.assertTrue(out.rstrip().endswith("\033[?25h")
+                        or "\033[?25h" in out.split("PLANE")[-1])
+
+    def test_it_says_what_it_cannot_show(self):
+        """There is no session payload here, so the token and context columns are blank.
+        A render that looks like the real thing while silently omitting a column teaches
+        the reader to trust a number that is not there."""
+        out = self._run(frames=1)
+        self.assertIn("no session", out.lower())
+
+    def test_the_render_is_never_allowed_to_kill_the_loop(self):
+        buf = io.StringIO()
+        with mock.patch.object(statusline.time, "sleep", side_effect=KeyboardInterrupt), \
+                mock.patch.object(statusline, "render", side_effect=RuntimeError("boom")), \
+                redirect_stdout(buf):
+            self.assertEqual(statusline.watch(), 0)
+
+
+class WatchIsReachableFromTheCli(unittest.TestCase):
+    def test_the_flag_routes_to_the_loop(self):
+        with mock.patch.object(statusline, "watch", return_value=0) as w:
+            self.assertEqual(statusline.main(["--watch"]), 0)
+        w.assert_called_once()
+
+    def test_the_interval_is_the_operators_to_choose(self):
+        with mock.patch.object(statusline, "watch", return_value=0) as w:
+            statusline.main(["--watch", "--interval", "5"])
+        self.assertEqual(w.call_args.kwargs.get("interval"), 5.0)
+
+    def test_without_the_flag_it_still_reads_a_payload_and_prints_once(self):
+        with mock.patch.object(statusline, "render", return_value="ONCE"):
+            buf = io.StringIO()
+            with mock.patch("sys.stdin", io.StringIO("{}")), redirect_stdout(buf):
+                statusline.main([])
+        self.assertEqual(buf.getvalue().strip(), "ONCE")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`doctor` earned its deficit list by refusing to render a lower ceiling as health. The next failure is subtler: **a limit stated and left there reads as "nothing can be done"**, and the operator stops looking.

A `Deficit` now carries a `remedy` — a command that closes the gap — printed on the ceiling it answers rather than in a footnote:

```
✓  harness   opencode — 2 capability ceilings
   ↳ status-bar: no status-bar socket… renders on demand via `/charter` rather than
     ambiently.  → charter statusline --watch
   ↳ prompt-hook: no per-turn prompt hook: charter's mid-session nudges ride the output
     of effectful tools (write/edit/bash) instead of arriving beside them.
```

### `charter statusline --watch`

The plane state, repainting in place in any spare terminal. No status-bar socket, **no multiplexer** — there is none on this machine, and building a tmux bridge I could not run is the mistake this session already made once with `.stdin()`. So it is the same render on every harness, including the one that does have a bar.

It says what it cannot show: no session payload, so the token and context columns are blank, and the footer says so. A render that looks like the real thing while silently omitting a column teaches the reader to trust a number that is not on the screen. The cursor is hidden while painting and restored on the way out including on Ctrl-C, and a render that raises is drawn as one line rather than ending a loop meant to sit there for hours.

Driven against the real plane, not only mocked: two repaints, cursor restored, exit 0.

### An empty remedy is a claim too

It stays empty. charter cannot conjure opencode a per-turn prompt hook, and inventing a workaround would send somebody off to configure something that does not exist — which costs more than an honest gap. A test pins that.

### Found while adding the flag

`main(argv=None)` now parses `argv or []`, never `None`. `parse_args(None)` reads `sys.argv`, and `main()` is called programmatically — inheriting the parent's flags turned a render into a usage error. The existing crash-guard test caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo