### PR TITLE
Folding init's summary was right; it also needed a different shape

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1362,8 +1362,17 @@ def cmd_init(args) -> int:
         return 1
 
     if created:
-        util.ok(f"Initialized control plane (schema {_instance.SCHEMA}) → "
-                f"{', '.join(_fold_entries(created))}.")
+        # Folding the settings entries together (0.41.0) took this from 254 columns to
+        # 194. It still does not wrap, so it is still unreadable in an 80-column terminal,
+        # and because the README's demo is a real capture it still drives that image to
+        # 1518px. The fold was right; the shape was the rest of it. A COUNT on the
+        # headline, the names underneath: what a reader needs first is "it worked, here is
+        # how much", and the inventory of paths is detail that belongs under a headline.
+        entries = _fold_entries(created)
+        util.ok(f"Initialized control plane (schema {_instance.SCHEMA}) — "
+                f"{len(entries)} item(s) written.")
+        for item in entries:
+            util.info(f"  + {item}")
     else:
         util.ok(f"Control plane already fully set up (schema {_instance.SCHEMA}) — "
                 f"nothing to do.")

--- a/docs/assets/capture-demo.sh
+++ b/docs/assets/capture-demo.sh
@@ -31,6 +31,18 @@ COLS="${COLUMNS:-88}"
 # "succeeded" with exit 0, and the assets quietly stopped being regenerable.
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# The capture must show THIS tree's charter, not whichever version happens to be on the
+# developer's PATH. Without it the asset silently documents an older build: regenerating
+# against an installed CLI faithfully reproduces output the tree has already changed.
+SRC_ROOT="$(cd "$HERE/../.." && pwd)"
+SHIM="$(mktemp -d -t charter-shim)"
+cat > "$SHIM/charter" <<SH
+#!/bin/sh
+exec python3 -c 'import sys; sys.path.insert(0, "$SRC_ROOT"); sys.path = [p for p in sys.path if p not in ("", "$DIR")]; from charter.cli import main; sys.exit(main())' "\$@"
+SH
+chmod +x "$SHIM/charter"
+PATH="$SHIM:$PATH"
+
 rm -rf "$DIR"; mkdir -p "$DIR"; cd "$DIR" || exit 1
 REAL="$(pwd -P)"
 unset $(env | grep -o '^CHARTER_[A-Z_]*' || true) 2>/dev/null || true

--- a/docs/assets/demo.svg
+++ b/docs/assets/demo.svg
@@ -1,11 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1518" height="622" viewBox="0 0 1518.00 622.20" role="img" aria-label="nothing → a working control plane">
-<rect x="0.5" y="0.5" width="1517.00" height="621.20" rx="9" fill="#0d1117" stroke="#30363d"/>
-<path d="M0.5 9.5a9 9 0 0 1 9-9h1499.00a9 9 0 0 1 9 9v21.00h-1517.00z" fill="#161b22" stroke="#30363d"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1050" height="763" viewBox="0 0 1050.00 763.25" role="img" aria-label="nothing → a working control plane">
+<rect x="0.5" y="0.5" width="1049.00" height="762.25" rx="9" fill="#0d1117" stroke="#30363d"/>
+<path d="M0.5 9.5a9 9 0 0 1 9-9h1031.00a9 9 0 0 1 9 9v21.00h-1049.00z" fill="#161b22" stroke="#30363d"/>
 <circle cx="18" cy="15.0" r="5" fill="#ff5f57"/>
 <circle cx="34" cy="15.0" r="5" fill="#febc2e"/>
 <circle cx="50" cy="15.0" r="5" fill="#28c840"/>
-<text x="759.00" y="19.0" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', monospace" font-size="11" fill="#8b949e">nothing → a working control plane</text>
-<style>.ln{animation:11.45s linear infinite both}@keyframes k0{0%,8.287%{opacity:0}8.297%,100%{opacity:1}}.l0{animation-name:k0}@keyframes k1{0%,10.907%{opacity:0}10.917%,100%{opacity:1}}.l1{animation-name:k1}@keyframes k2{0%,19.204%{opacity:0}19.214%,100%{opacity:1}}.l2{animation-name:k2}@keyframes k3{0%,20.077%{opacity:0}20.087%,100%{opacity:1}}.l3{animation-name:k3}@keyframes k4{0%,20.951%{opacity:0}20.961%,100%{opacity:1}}.l4{animation-name:k4}@keyframes k5{0%,23.571%{opacity:0}23.581%,100%{opacity:1}}.l5{animation-name:k5}@keyframes k6{0%,31.868%{opacity:0}31.878%,100%{opacity:1}}.l6{animation-name:k6}@keyframes k7{0%,32.741%{opacity:0}32.751%,100%{opacity:1}}.l7{animation-name:k7}@keyframes k8{0%,33.614%{opacity:0}33.624%,100%{opacity:1}}.l8{animation-name:k8}@keyframes k9{0%,34.488%{opacity:0}34.498%,100%{opacity:1}}.l9{animation-name:k9}@keyframes k10{0%,35.361%{opacity:0}35.371%,100%{opacity:1}}.l10{animation-name:k10}@keyframes k11{0%,36.235%{opacity:0}36.245%,100%{opacity:1}}.l11{animation-name:k11}@keyframes k12{0%,38.855%{opacity:0}38.865%,100%{opacity:1}}.l12{animation-name:k12}@keyframes k13{0%,47.152%{opacity:0}47.162%,100%{opacity:1}}.l13{animation-name:k13}@keyframes k14{0%,48.025%{opacity:0}48.035%,100%{opacity:1}}.l14{animation-name:k14}@keyframes k15{0%,48.898%{opacity:0}48.908%,100%{opacity:1}}.l15{animation-name:k15}@keyframes k16{0%,49.772%{opacity:0}49.782%,100%{opacity:1}}.l16{animation-name:k16}@keyframes k17{0%,52.392%{opacity:0}52.402%,100%{opacity:1}}.l17{animation-name:k17}@keyframes k18{0%,60.689%{opacity:0}60.699%,100%{opacity:1}}.l18{animation-name:k18}@keyframes k19{0%,61.562%{opacity:0}61.572%,100%{opacity:1}}.l19{animation-name:k19}@keyframes k20{0%,64.182%{opacity:0}64.192%,100%{opacity:1}}.l20{animation-name:k20}@keyframes k21{0%,65.056%{opacity:0}65.066%,100%{opacity:1}}.l21{animation-name:k21}@keyframes k22{0%,67.676%{opacity:0}67.686%,100%{opacity:1}}.l22{animation-name:k22}@keyframes k23{0%,68.549%{opacity:0}68.559%,100%{opacity:1}}.l23{animation-name:k23}@keyframes k24{0%,69.422%{opacity:0}69.432%,100%{opacity:1}}.l24{animation-name:k24}@keyframes k25{0%,70.296%{opacity:0}70.306%,100%{opacity:1}}.l25{animation-name:k25}@keyframes k26{0%,72.916%{opacity:0}72.926%,100%{opacity:1}}.l26{animation-name:k26}@keyframes k27{0%,73.789%{opacity:0}73.799%,100%{opacity:1}}.l27{animation-name:k27}</style>
+<text x="525.00" y="19.0" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', monospace" font-size="11" fill="#8b949e">nothing → a working control plane</text>
+<style>.ln{animation:12.15s linear infinite both}@keyframes k0{0%,7.809%{opacity:0}7.819%,100%{opacity:1}}.l0{animation-name:k0}@keyframes k1{0%,10.278%{opacity:0}10.288%,100%{opacity:1}}.l1{animation-name:k1}@keyframes k2{0%,18.097%{opacity:0}18.107%,100%{opacity:1}}.l2{animation-name:k2}@keyframes k3{0%,18.920%{opacity:0}18.930%,100%{opacity:1}}.l3{animation-name:k3}@keyframes k4{0%,19.743%{opacity:0}19.753%,100%{opacity:1}}.l4{animation-name:k4}@keyframes k5{0%,20.566%{opacity:0}20.576%,100%{opacity:1}}.l5{animation-name:k5}@keyframes k6{0%,21.389%{opacity:0}21.399%,100%{opacity:1}}.l6{animation-name:k6}@keyframes k7{0%,22.212%{opacity:0}22.222%,100%{opacity:1}}.l7{animation-name:k7}@keyframes k8{0%,23.035%{opacity:0}23.045%,100%{opacity:1}}.l8{animation-name:k8}@keyframes k9{0%,23.858%{opacity:0}23.868%,100%{opacity:1}}.l9{animation-name:k9}@keyframes k10{0%,24.681%{opacity:0}24.691%,100%{opacity:1}}.l10{animation-name:k10}@keyframes k11{0%,25.504%{opacity:0}25.514%,100%{opacity:1}}.l11{animation-name:k11}@keyframes k12{0%,27.974%{opacity:0}27.984%,100%{opacity:1}}.l12{animation-name:k12}@keyframes k13{0%,35.792%{opacity:0}35.802%,100%{opacity:1}}.l13{animation-name:k13}@keyframes k14{0%,36.616%{opacity:0}36.626%,100%{opacity:1}}.l14{animation-name:k14}@keyframes k15{0%,37.439%{opacity:0}37.449%,100%{opacity:1}}.l15{animation-name:k15}@keyframes k16{0%,38.262%{opacity:0}38.272%,100%{opacity:1}}.l16{animation-name:k16}@keyframes k17{0%,39.085%{opacity:0}39.095%,100%{opacity:1}}.l17{animation-name:k17}@keyframes k18{0%,39.908%{opacity:0}39.918%,100%{opacity:1}}.l18{animation-name:k18}@keyframes k19{0%,42.377%{opacity:0}42.387%,100%{opacity:1}}.l19{animation-name:k19}@keyframes k20{0%,50.196%{opacity:0}50.206%,100%{opacity:1}}.l20{animation-name:k20}@keyframes k21{0%,51.019%{opacity:0}51.029%,100%{opacity:1}}.l21{animation-name:k21}@keyframes k22{0%,51.842%{opacity:0}51.852%,100%{opacity:1}}.l22{animation-name:k22}@keyframes k23{0%,52.665%{opacity:0}52.675%,100%{opacity:1}}.l23{animation-name:k23}@keyframes k24{0%,55.134%{opacity:0}55.144%,100%{opacity:1}}.l24{animation-name:k24}@keyframes k25{0%,62.953%{opacity:0}62.963%,100%{opacity:1}}.l25{animation-name:k25}@keyframes k26{0%,63.776%{opacity:0}63.786%,100%{opacity:1}}.l26{animation-name:k26}@keyframes k27{0%,66.245%{opacity:0}66.255%,100%{opacity:1}}.l27{animation-name:k27}@keyframes k28{0%,67.068%{opacity:0}67.078%,100%{opacity:1}}.l28{animation-name:k28}@keyframes k29{0%,69.537%{opacity:0}69.547%,100%{opacity:1}}.l29{animation-name:k29}@keyframes k30{0%,70.360%{opacity:0}70.370%,100%{opacity:1}}.l30{animation-name:k30}@keyframes k31{0%,71.183%{opacity:0}71.193%,100%{opacity:1}}.l31{animation-name:k31}@keyframes k32{0%,72.006%{opacity:0}72.016%,100%{opacity:1}}.l32{animation-name:k32}@keyframes k33{0%,74.476%{opacity:0}74.486%,100%{opacity:1}}.l33{animation-name:k33}@keyframes k34{0%,75.299%{opacity:0}75.309%,100%{opacity:1}}.l34{animation-name:k34}</style>
 <g font-family="ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', monospace" font-size="13.0">
 <g class="ln l0">
 <text x="18.00" y="57.00" fill="#3fb950">❯</text>
@@ -33,214 +33,245 @@
 <text x="189.60 197.40 205.20 213.00 220.80" y="117.45" fill="#c9d1d9">plane</text>
 <text x="236.40 244.20 252.00 259.80 267.60 275.40 283.20" y="117.45" fill="#c9d1d9">(schema</text>
 <text x="298.80 306.60" y="117.45" fill="#c9d1d9">1)</text>
-<text x="322.20" y="117.45" fill="#c9d1d9">→</text>
-<text x="337.80 345.60 353.40 361.20 369.00 376.80 384.60 392.40 400.20 408.00 415.80 423.60 431.40" y="117.45" fill="#c9d1d9">charter.toml,</text>
-<text x="447.00 454.80 462.60 470.40 478.20 486.00 493.80 501.60 509.40 517.20" y="117.45" fill="#c9d1d9">personas/,</text>
-<text x="532.80 540.60 548.40 556.20 564.00 571.80 579.60 587.40 595.20 603.00 610.80" y="117.45" fill="#c9d1d9">inventory/,</text>
-<text x="626.40 634.20 642.00 649.80 657.60 665.40 673.20 681.00 688.80 696.60 704.40 712.20" y="117.45" fill="#c9d1d9">workspaces/,</text>
-<text x="727.80 735.60 743.40 751.20 759.00 766.80 774.60 782.40 790.20 798.00 805.80" y="117.45" fill="#c9d1d9">.gitignore,</text>
-<text x="821.40 829.20 837.00 844.80 852.60 860.40 868.20 876.00 883.80 891.60 899.40 907.20 915.00 922.80 930.60 938.40 946.20 954.00 961.80 969.60 977.40" y="117.45" fill="#c9d1d9">.claude/settings.json</text>
-<text x="993.00 1000.80 1008.60 1016.40 1024.20 1032.00 1039.80 1047.60 1055.40 1063.20 1071.00 1078.80" y="117.45" fill="#c9d1d9">(statusLine,</text>
-<text x="1094.40 1102.20 1110.00 1117.80" y="117.45" fill="#c9d1d9">env,</text>
-<text x="1133.40 1141.20 1149.00 1156.80 1164.60 1172.40 1180.20 1188.00 1195.80 1203.60" y="117.45" fill="#c9d1d9">plane-root</text>
-<text x="1219.20 1227.00 1234.80 1242.60 1250.40 1258.20 1266.00" y="117.45" fill="#c9d1d9">guard),</text>
-<text x="1281.60 1289.40 1297.20 1305.00 1312.80 1320.60 1328.40 1336.20 1344.00 1351.80 1359.60 1367.40 1375.20 1383.00 1390.80 1398.60 1406.40 1414.20 1422.00 1429.80 1437.60 1445.40 1453.20 1461.00 1468.80 1476.60 1484.40 1492.20" y="117.45" fill="#c9d1d9">.opencode/plugin/charter.ts.</text>
+<text x="322.20" y="117.45" fill="#c9d1d9">—</text>
+<text x="337.80" y="117.45" fill="#c9d1d9">7</text>
+<text x="353.40 361.20 369.00 376.80 384.60 392.40 400.20" y="117.45" fill="#c9d1d9">item(s)</text>
+<text x="415.80 423.60 431.40 439.20 447.00 454.80 462.60 470.40" y="117.45" fill="#c9d1d9">written.</text>
 </g>
 <g class="ln l4">
 <text x="18.00" y="137.60" fill="#39c5cf">•</text>
-<text x="33.60 41.40 49.20 57.00 64.80" y="137.60" fill="#c9d1d9">Next:</text>
-<text x="80.40 88.20 96.00 103.80 111.60 119.40 127.20 135.00" y="137.60" fill="#c9d1d9">`charter</text>
-<text x="150.60 158.40 166.20 174.00 181.80 189.60 197.40" y="137.60" fill="#c9d1d9">doctor`</text>
-<text x="213.00 220.80" y="137.60" fill="#c9d1d9">to</text>
-<text x="236.40 244.20 252.00 259.80 267.60 275.40 283.20 291.00 298.80 306.60" y="137.60" fill="#c9d1d9">preflight,</text>
-<text x="322.20 330.00 337.80 345.60" y="137.60" fill="#c9d1d9">then</text>
-<text x="361.20 369.00 376.80 384.60 392.40 400.20 408.00 415.80" y="137.60" fill="#c9d1d9">`charter</text>
-<text x="431.40 439.20 447.00 454.80 462.60 470.40 478.20 486.00 493.80" y="137.60" fill="#c9d1d9">discover`</text>
-<text x="509.40 517.20" y="137.60" fill="#c9d1d9">to</text>
-<text x="532.80 540.60 548.40 556.20 564.00" y="137.60" fill="#c9d1d9">build</text>
-<text x="579.60 587.40 595.20" y="137.60" fill="#c9d1d9">the</text>
-<text x="610.80 618.60 626.40 634.20 642.00 649.80 657.60 665.40 673.20 681.00" y="137.60" fill="#c9d1d9">inventory.</text>
+<text x="49.20" y="137.60" fill="#c9d1d9">+</text>
+<text x="64.80 72.60 80.40 88.20 96.00 103.80 111.60 119.40 127.20 135.00 142.80 150.60" y="137.60" fill="#c9d1d9">charter.toml</text>
 </g>
 <g class="ln l5">
+<text x="18.00" y="157.75" fill="#39c5cf">•</text>
+<text x="49.20" y="157.75" fill="#c9d1d9">+</text>
+<text x="64.80 72.60 80.40 88.20 96.00 103.80 111.60 119.40 127.20" y="157.75" fill="#c9d1d9">personas/</text>
 </g>
 <g class="ln l6">
-<text x="18.00" y="177.90" fill="#3fb950">❯</text>
-<text x="33.60 41.40 49.20 57.00 64.80 72.60 80.40" y="177.90" fill="#c9d1d9">charter</text>
-<text x="96.00 103.80 111.60 119.40 127.20 135.00 142.80 150.60" y="177.90" fill="#c9d1d9">discover</text>
+<text x="18.00" y="177.90" fill="#39c5cf">•</text>
+<text x="49.20" y="177.90" fill="#c9d1d9">+</text>
+<text x="64.80 72.60 80.40 88.20 96.00 103.80 111.60 119.40 127.20 135.00" y="177.90" fill="#c9d1d9">inventory/</text>
 </g>
 <g class="ln l7">
 <text x="18.00" y="198.05" fill="#39c5cf">•</text>
-<text x="33.60 41.40 49.20 57.00 64.80 72.60 80.40 88.20" y="198.05" fill="#c9d1d9">Querying</text>
-<text x="103.80 111.60 119.40 127.20 135.00 142.80" y="198.05" fill="#c9d1d9">github</text>
-<text x="158.40 166.20 174.00" y="198.05" fill="#c9d1d9">org</text>
-<text x="189.60 197.40 205.20 213.00 220.80 228.60 236.40 244.20 252.00 259.80 267.60" y="198.05" fill="#c9d1d9">`diazoxide`</text>
-<text x="283.20" y="198.05" fill="#c9d1d9">…</text>
+<text x="49.20" y="198.05" fill="#c9d1d9">+</text>
+<text x="64.80 72.60 80.40 88.20 96.00 103.80 111.60 119.40 127.20 135.00 142.80" y="198.05" fill="#c9d1d9">workspaces/</text>
 </g>
 <g class="ln l8">
 <text x="18.00" y="218.20" fill="#39c5cf">•</text>
-<text x="33.60 41.40 49.20 57.00 64.80" y="218.20" fill="#c9d1d9">Found</text>
-<text x="80.40 88.20" y="218.20" fill="#c9d1d9">47</text>
-<text x="103.80 111.60 119.40 127.20 135.00 142.80 150.60 158.40 166.20 174.00" y="218.20" fill="#c9d1d9">project(s)</text>
-<text x="189.60 197.40" y="218.20" fill="#c9d1d9">on</text>
-<text x="213.00 220.80 228.60 236.40 244.20 252.00 259.80" y="218.20" fill="#c9d1d9">github.</text>
-<text x="275.40 283.20 291.00 298.80 306.60 314.40 322.20" y="218.20" fill="#c9d1d9">Probing</text>
-<text x="337.80 345.60 353.40 361.20" y="218.20" fill="#c9d1d9">repo</text>
-<text x="376.80 384.60 392.40 400.20 408.00 415.80" y="218.20" fill="#c9d1d9">stacks</text>
-<text x="431.40" y="218.20" fill="#c9d1d9">…</text>
+<text x="49.20" y="218.20" fill="#c9d1d9">+</text>
+<text x="64.80 72.60 80.40 88.20 96.00 103.80 111.60 119.40 127.20 135.00" y="218.20" fill="#c9d1d9">.gitignore</text>
 </g>
 <g class="ln l9">
-<text x="18.00" y="238.35" fill="#3fb950">✓</text>
-<text x="33.60 41.40 49.20 57.00 64.80" y="238.35" fill="#c9d1d9">Wrote</text>
-<text x="80.40 88.20" y="238.35" fill="#c9d1d9">47</text>
-<text x="103.80 111.60 119.40 127.20 135.00" y="238.35" fill="#c9d1d9">repos</text>
-<text x="150.60 158.40" y="238.35" fill="#c9d1d9">to</text>
-<text x="174.00 181.80 189.60 197.40 205.20 213.00 220.80 228.60 236.40 244.20 252.00 259.80 267.60 275.40 283.20 291.00 298.80 306.60 314.40 322.20" y="238.35" fill="#c9d1d9">inventory/repos.json</text>
+<text x="18.00" y="238.35" fill="#39c5cf">•</text>
+<text x="49.20" y="238.35" fill="#c9d1d9">+</text>
+<text x="64.80 72.60 80.40 88.20 96.00 103.80 111.60 119.40 127.20 135.00 142.80 150.60 158.40 166.20 174.00 181.80 189.60 197.40 205.20 213.00 220.80" y="238.35" fill="#c9d1d9">.claude/settings.json</text>
+<text x="236.40 244.20 252.00 259.80 267.60 275.40 283.20 291.00 298.80 306.60 314.40 322.20" y="238.35" fill="#c9d1d9">(statusLine,</text>
+<text x="337.80 345.60 353.40 361.20" y="238.35" fill="#c9d1d9">env,</text>
+<text x="376.80 384.60 392.40 400.20 408.00 415.80 423.60 431.40 439.20 447.00" y="238.35" fill="#c9d1d9">plane-root</text>
+<text x="462.60 470.40 478.20 486.00 493.80 501.60" y="238.35" fill="#c9d1d9">guard)</text>
 </g>
 <g class="ln l10">
 <text x="18.00" y="258.50" fill="#39c5cf">•</text>
-<text x="33.60 41.40 49.20" y="258.50" fill="#c9d1d9">New</text>
-<text x="64.80 72.60" y="258.50" fill="#c9d1d9">in</text>
-<text x="88.20 96.00 103.80 111.60 119.40 127.20" y="258.50" fill="#c9d1d9">group:</text>
-<text x="142.80 150.60 158.40 166.20 174.00 181.80 189.60 197.40 205.20 213.00 220.80 228.60 236.40" y="258.50" fill="#c9d1d9">ElasticPress,</text>
-<text x="252.00 259.80 267.60 275.40 283.20 291.00 298.80 306.60" y="258.50" fill="#c9d1d9">ToolJet,</text>
-<text x="322.20 330.00 337.80 345.60 353.40 361.20" y="258.50" fill="#c9d1d9">actAg,</text>
-<text x="376.80 384.60 392.40 400.20 408.00 415.80 423.60 431.40 439.20 447.00 454.80 462.60 470.40 478.20" y="258.50" fill="#c9d1d9">active-record,</text>
-<text x="493.80 501.60 509.40 517.20 525.00 532.80 540.60 548.40 556.20 564.00 571.80 579.60 587.40 595.20 603.00 610.80 618.60 626.40 634.20 642.00 649.80 657.60 665.40 673.20 681.00 688.80 696.60 704.40 712.20 720.00" y="258.50" fill="#c9d1d9">argon2-password-hash-provider,</text>
-<text x="735.60" y="258.50" fill="#c9d1d9">…</text>
-<text x="751.20 759.00 766.80" y="258.50" fill="#c9d1d9">and</text>
-<text x="782.40 790.20" y="258.50" fill="#c9d1d9">42</text>
-<text x="805.80 813.60 821.40 829.20" y="258.50" fill="#c9d1d9">more</text>
+<text x="49.20" y="258.50" fill="#c9d1d9">+</text>
+<text x="64.80 72.60 80.40 88.20 96.00 103.80 111.60 119.40 127.20 135.00 142.80 150.60 158.40 166.20 174.00 181.80 189.60 197.40 205.20 213.00 220.80 228.60 236.40 244.20 252.00 259.80 267.60" y="258.50" fill="#c9d1d9">.opencode/plugin/charter.ts</text>
 </g>
 <g class="ln l11">
-<text x="18.00" y="278.65" fill="#3fb950">✓</text>
-<text x="33.60 41.40 49.20 57.00 64.80 72.60 80.40 88.20 96.00" y="278.65" fill="#c9d1d9">Generated</text>
-<text x="111.60 119.40 127.20 135.00 142.80 150.60 158.40 166.20 174.00 181.80 189.60 197.40 205.20 213.00 220.80 228.60" y="278.65" fill="#c9d1d9">docs/topology.md</text>
-<text x="244.20 252.00 259.80" y="278.65" fill="#c9d1d9">(47</text>
-<text x="275.40 283.20 291.00 298.80 306.60 314.40" y="278.65" fill="#c9d1d9">repos)</text>
+<text x="18.00" y="278.65" fill="#39c5cf">•</text>
+<text x="33.60 41.40 49.20 57.00 64.80" y="278.65" fill="#c9d1d9">Next:</text>
+<text x="80.40 88.20 96.00 103.80 111.60 119.40 127.20 135.00" y="278.65" fill="#c9d1d9">`charter</text>
+<text x="150.60 158.40 166.20 174.00 181.80 189.60 197.40" y="278.65" fill="#c9d1d9">doctor`</text>
+<text x="213.00 220.80" y="278.65" fill="#c9d1d9">to</text>
+<text x="236.40 244.20 252.00 259.80 267.60 275.40 283.20 291.00 298.80 306.60" y="278.65" fill="#c9d1d9">preflight,</text>
+<text x="322.20 330.00 337.80 345.60" y="278.65" fill="#c9d1d9">then</text>
+<text x="361.20 369.00 376.80 384.60 392.40 400.20 408.00 415.80" y="278.65" fill="#c9d1d9">`charter</text>
+<text x="431.40 439.20 447.00 454.80 462.60 470.40 478.20 486.00 493.80" y="278.65" fill="#c9d1d9">discover`</text>
+<text x="509.40 517.20" y="278.65" fill="#c9d1d9">to</text>
+<text x="532.80 540.60 548.40 556.20 564.00" y="278.65" fill="#c9d1d9">build</text>
+<text x="579.60 587.40 595.20" y="278.65" fill="#c9d1d9">the</text>
+<text x="610.80 618.60 626.40 634.20 642.00 649.80 657.60 665.40 673.20 681.00" y="278.65" fill="#c9d1d9">inventory.</text>
 </g>
 <g class="ln l12">
 </g>
 <g class="ln l13">
 <text x="18.00" y="318.95" fill="#3fb950">❯</text>
 <text x="33.60 41.40 49.20 57.00 64.80 72.60 80.40" y="318.95" fill="#c9d1d9">charter</text>
-<text x="96.00 103.80 111.60 119.40 127.20" y="318.95" fill="#c9d1d9">clone</text>
-<text x="142.80 150.60 158.40 166.20 174.00 181.80 189.60" y="318.95" fill="#c9d1d9">charter</text>
+<text x="96.00 103.80 111.60 119.40 127.20 135.00 142.80 150.60" y="318.95" fill="#c9d1d9">discover</text>
 </g>
 <g class="ln l14">
 <text x="18.00" y="339.10" fill="#39c5cf">•</text>
-<text x="33.60 41.40 49.20 57.00 64.80 72.60 80.40 88.20 96.00 103.80" y="339.10" fill="#c9d1d9">workspace:</text>
-<text x="119.40 127.20 135.00 142.80 150.60 158.40 166.20" y="339.10" fill="#c9d1d9">default</text>
-<text x="189.60 197.40 205.20 213.00" y="339.10" fill="#c9d1d9">(via</text>
-<text x="228.60 236.40 244.20 252.00 259.80 267.60 275.40" y="339.10" fill="#c9d1d9">default</text>
-<text x="291.00 298.80 306.60" y="339.10" fill="#c9d1d9">(no</text>
-<text x="322.20 330.00 337.80 345.60" y="339.10" fill="#c9d1d9">pane</text>
-<text x="361.20 369.00" y="339.10" fill="#c9d1d9">id</text>
-<text x="384.60" y="339.10" fill="#c9d1d9">—</text>
-<text x="400.20 408.00 415.80 423.60 431.40 439.20 447.00" y="339.10" fill="#c9d1d9">nothing</text>
-<text x="462.60 470.40 478.20 486.00 493.80 501.60 509.40 517.20" y="339.10" fill="#c9d1d9">persists</text>
-<text x="532.80 540.60 548.40 556.20 564.00 571.80 579.60" y="339.10" fill="#c9d1d9">between</text>
-<text x="595.20 603.00 610.80 618.60 626.40 634.20 642.00 649.80 657.60 665.40" y="339.10" fill="#c9d1d9">sessions))</text>
+<text x="33.60 41.40 49.20 57.00 64.80 72.60 80.40 88.20" y="339.10" fill="#c9d1d9">Querying</text>
+<text x="103.80 111.60 119.40 127.20 135.00 142.80" y="339.10" fill="#c9d1d9">github</text>
+<text x="158.40 166.20 174.00" y="339.10" fill="#c9d1d9">org</text>
+<text x="189.60 197.40 205.20 213.00 220.80 228.60 236.40 244.20 252.00 259.80 267.60" y="339.10" fill="#c9d1d9">`diazoxide`</text>
+<text x="283.20" y="339.10" fill="#c9d1d9">…</text>
 </g>
 <g class="ln l15">
-<text x="18.00" y="359.25" fill="#3fb950">✓</text>
-<text x="33.60 41.40 49.20 57.00 64.80 72.60 80.40" y="359.25" fill="#c9d1d9">charter</text>
-<text x="96.00" y="359.25" fill="#c9d1d9">→</text>
-<text x="111.60 119.40 127.20 135.00 142.80 150.60 158.40 166.20 174.00 181.80 189.60 197.40 205.20 213.00 220.80 228.60 236.40 244.20 252.00 259.80 267.60 275.40 283.20 291.00 298.80 306.60" y="359.25" fill="#c9d1d9">workspaces/default/charter</text>
-<text x="322.20 330.00 337.80 345.60 353.40 361.20 369.00 376.80" y="359.25" fill="#c9d1d9">(charter</text>
-<text x="392.40 400.20 408.00 415.80 423.60 431.40" y="359.25" fill="#c9d1d9">(main)</text>
-<text x="447.00 454.80 462.60" y="359.25" fill="#c9d1d9">via</text>
-<text x="478.20 486.00 493.80" y="359.25" fill="#c9d1d9">gh,</text>
-<text x="509.40 517.20 525.00 532.80 540.60 548.40" y="359.25" fill="#c9d1d9">HTTPS)</text>
+<text x="18.00" y="359.25" fill="#39c5cf">•</text>
+<text x="33.60 41.40 49.20 57.00 64.80" y="359.25" fill="#c9d1d9">Found</text>
+<text x="80.40 88.20" y="359.25" fill="#c9d1d9">47</text>
+<text x="103.80 111.60 119.40 127.20 135.00 142.80 150.60 158.40 166.20 174.00" y="359.25" fill="#c9d1d9">project(s)</text>
+<text x="189.60 197.40" y="359.25" fill="#c9d1d9">on</text>
+<text x="213.00 220.80 228.60 236.40 244.20 252.00 259.80" y="359.25" fill="#c9d1d9">github.</text>
+<text x="275.40 283.20 291.00 298.80 306.60 314.40 322.20" y="359.25" fill="#c9d1d9">Probing</text>
+<text x="337.80 345.60 353.40 361.20" y="359.25" fill="#c9d1d9">repo</text>
+<text x="376.80 384.60 392.40 400.20 408.00 415.80" y="359.25" fill="#c9d1d9">stacks</text>
+<text x="431.40" y="359.25" fill="#c9d1d9">…</text>
 </g>
 <g class="ln l16">
-<text x="18.00" y="379.40" fill="#39c5cf">•</text>
-<text x="49.20" y="379.40" fill="#c9d1d9">↳</text>
-<text x="64.80 72.60 80.40 88.20 96.00 103.80 111.60" y="379.40" fill="#c9d1d9">charter</text>
-<text x="127.20 135.00 142.80 150.60 158.40" y="379.40" fill="#c9d1d9">ships</text>
-<text x="174.00 181.80 189.60" y="379.40" fill="#c9d1d9">its</text>
-<text x="205.20 213.00 220.80" y="379.40" fill="#c9d1d9">own</text>
-<text x="236.40 244.20 252.00 259.80 267.60 275.40 283.20 291.00 298.80" y="379.40" fill="#c9d1d9">README.md</text>
-<text x="314.40" y="379.40" fill="#c9d1d9">—</text>
-<text x="330.00 337.80 345.60 353.40" y="379.40" fill="#c9d1d9">read</text>
-<text x="369.00 376.80" y="379.40" fill="#c9d1d9">it</text>
-<text x="392.40 400.20 408.00 415.80 423.60 431.40" y="379.40" fill="#c9d1d9">before</text>
-<text x="447.00 454.80 462.60 470.40 478.20 486.00 493.80" y="379.40" fill="#c9d1d9">working</text>
-<text x="509.40 517.20 525.00 532.80 540.60 548.40" y="379.40" fill="#c9d1d9">there.</text>
+<text x="18.00" y="379.40" fill="#3fb950">✓</text>
+<text x="33.60 41.40 49.20 57.00 64.80" y="379.40" fill="#c9d1d9">Wrote</text>
+<text x="80.40 88.20" y="379.40" fill="#c9d1d9">47</text>
+<text x="103.80 111.60 119.40 127.20 135.00" y="379.40" fill="#c9d1d9">repos</text>
+<text x="150.60 158.40" y="379.40" fill="#c9d1d9">to</text>
+<text x="174.00 181.80 189.60 197.40 205.20 213.00 220.80 228.60 236.40 244.20 252.00 259.80 267.60 275.40 283.20 291.00 298.80 306.60 314.40 322.20" y="379.40" fill="#c9d1d9">inventory/repos.json</text>
 </g>
 <g class="ln l17">
+<text x="18.00" y="399.55" fill="#39c5cf">•</text>
+<text x="33.60 41.40 49.20" y="399.55" fill="#c9d1d9">New</text>
+<text x="64.80 72.60" y="399.55" fill="#c9d1d9">in</text>
+<text x="88.20 96.00 103.80 111.60 119.40 127.20" y="399.55" fill="#c9d1d9">group:</text>
+<text x="142.80 150.60 158.40 166.20 174.00 181.80 189.60 197.40 205.20 213.00 220.80 228.60 236.40" y="399.55" fill="#c9d1d9">ElasticPress,</text>
+<text x="252.00 259.80 267.60 275.40 283.20 291.00 298.80 306.60" y="399.55" fill="#c9d1d9">ToolJet,</text>
+<text x="322.20 330.00 337.80 345.60 353.40 361.20" y="399.55" fill="#c9d1d9">actAg,</text>
+<text x="376.80 384.60 392.40 400.20 408.00 415.80 423.60 431.40 439.20 447.00 454.80 462.60 470.40 478.20" y="399.55" fill="#c9d1d9">active-record,</text>
+<text x="493.80 501.60 509.40 517.20 525.00 532.80 540.60 548.40 556.20 564.00 571.80 579.60 587.40 595.20 603.00 610.80 618.60 626.40 634.20 642.00 649.80 657.60 665.40 673.20 681.00 688.80 696.60 704.40 712.20 720.00" y="399.55" fill="#c9d1d9">argon2-password-hash-provider,</text>
+<text x="735.60" y="399.55" fill="#c9d1d9">…</text>
+<text x="751.20 759.00 766.80" y="399.55" fill="#c9d1d9">and</text>
+<text x="782.40 790.20" y="399.55" fill="#c9d1d9">42</text>
+<text x="805.80 813.60 821.40 829.20" y="399.55" fill="#c9d1d9">more</text>
 </g>
 <g class="ln l18">
-<text x="18.00" y="419.70" fill="#3fb950">❯</text>
-<text x="33.60 41.40 49.20 57.00 64.80 72.60 80.40" y="419.70" fill="#c9d1d9">charter</text>
-<text x="96.00 103.80 111.60 119.40 127.20 135.00" y="419.70" fill="#c9d1d9">status</text>
+<text x="18.00" y="419.70" fill="#3fb950">✓</text>
+<text x="33.60 41.40 49.20 57.00 64.80 72.60 80.40 88.20 96.00" y="419.70" fill="#c9d1d9">Generated</text>
+<text x="111.60 119.40 127.20 135.00 142.80 150.60 158.40 166.20 174.00 181.80 189.60 197.40 205.20 213.00 220.80 228.60" y="419.70" fill="#c9d1d9">docs/topology.md</text>
+<text x="244.20 252.00 259.80" y="419.70" fill="#c9d1d9">(47</text>
+<text x="275.40 283.20 291.00 298.80 306.60 314.40" y="419.70" fill="#c9d1d9">repos)</text>
 </g>
 <g class="ln l19">
-<text x="18.00 25.80 33.60 41.40 49.20 57.00 64.80 72.60 80.40 88.20" y="439.85" fill="#c9d1d9">diazoxide:</text>
-<text x="103.80 111.60" y="439.85" fill="#c9d1d9">47</text>
-<text x="127.20 135.00 142.80 150.60 158.40" y="439.85" fill="#c9d1d9">repos</text>
-<text x="174.00 181.80" y="439.85" fill="#c9d1d9">in</text>
-<text x="197.40 205.20 213.00 220.80 228.60 236.40 244.20 252.00 259.80" y="439.85" fill="#c9d1d9">inventory</text>
-<text x="275.40" y="439.85" fill="#c9d1d9">·</text>
-<text x="291.00" y="439.85" fill="#c9d1d9">1</text>
-<text x="306.60 314.40 322.20 330.00 337.80 345.60 353.40 361.20 369.00 376.80 384.60 392.40" y="439.85" fill="#c9d1d9">workspace(s)</text>
-<text x="408.00" y="439.85" fill="#c9d1d9">·</text>
-<text x="423.60 431.40 439.20 447.00 454.80 462.60 470.40" y="439.85" fill="#c9d1d9">active:</text>
-<text x="486.00 493.80 501.60 509.40 517.20 525.00 532.80" y="439.85" fill="#c9d1d9">default</text>
-<text x="548.40 556.20 564.00 571.80" y="439.85" fill="#c9d1d9">(via</text>
-<text x="587.40 595.20 603.00 610.80 618.60 626.40 634.20" y="439.85" fill="#c9d1d9">default</text>
-<text x="649.80 657.60 665.40" y="439.85" fill="#c9d1d9">(no</text>
-<text x="681.00 688.80 696.60 704.40" y="439.85" fill="#c9d1d9">pane</text>
-<text x="720.00 727.80" y="439.85" fill="#c9d1d9">id</text>
-<text x="743.40" y="439.85" fill="#c9d1d9">—</text>
-<text x="759.00 766.80 774.60 782.40 790.20 798.00 805.80" y="439.85" fill="#c9d1d9">nothing</text>
-<text x="821.40 829.20 837.00 844.80 852.60 860.40 868.20 876.00" y="439.85" fill="#c9d1d9">persists</text>
-<text x="891.60 899.40 907.20 915.00 922.80 930.60 938.40" y="439.85" fill="#c9d1d9">between</text>
-<text x="954.00 961.80 969.60 977.40 985.20 993.00 1000.80 1008.60 1016.40 1024.20" y="439.85" fill="#c9d1d9">sessions))</text>
 </g>
 <g class="ln l20">
+<text x="18.00" y="460.00" fill="#3fb950">❯</text>
+<text x="33.60 41.40 49.20 57.00 64.80 72.60 80.40" y="460.00" fill="#c9d1d9">charter</text>
+<text x="96.00 103.80 111.60 119.40 127.20" y="460.00" fill="#c9d1d9">clone</text>
+<text x="142.80 150.60 158.40 166.20 174.00 181.80 189.60" y="460.00" fill="#c9d1d9">charter</text>
 </g>
 <g class="ln l21">
-<text x="33.60" y="480.15" fill="#c9d1d9">*</text>
-<text x="49.20 57.00 64.80 72.60 80.40 88.20 96.00" y="480.15" fill="#c9d1d9">default</text>
-<text x="119.40 127.20" y="480.15" fill="#c9d1d9">(1</text>
-<text x="142.80 150.60 158.40 166.20 174.00 181.80 189.60" y="480.15" fill="#c9d1d9">cloned)</text>
+<text x="18.00" y="480.15" fill="#39c5cf">•</text>
+<text x="33.60 41.40 49.20 57.00 64.80 72.60 80.40 88.20 96.00 103.80" y="480.15" fill="#c9d1d9">workspace:</text>
+<text x="119.40 127.20 135.00 142.80 150.60 158.40 166.20" y="480.15" fill="#c9d1d9">default</text>
+<text x="189.60 197.40 205.20 213.00" y="480.15" fill="#c9d1d9">(via</text>
+<text x="228.60 236.40 244.20 252.00 259.80 267.60 275.40" y="480.15" fill="#c9d1d9">default</text>
+<text x="291.00 298.80 306.60" y="480.15" fill="#c9d1d9">(no</text>
+<text x="322.20 330.00 337.80 345.60" y="480.15" fill="#c9d1d9">pane</text>
+<text x="361.20 369.00" y="480.15" fill="#c9d1d9">id</text>
+<text x="384.60" y="480.15" fill="#c9d1d9">—</text>
+<text x="400.20 408.00 415.80 423.60 431.40 439.20 447.00" y="480.15" fill="#c9d1d9">nothing</text>
+<text x="462.60 470.40 478.20 486.00 493.80 501.60 509.40 517.20" y="480.15" fill="#c9d1d9">persists</text>
+<text x="532.80 540.60 548.40 556.20 564.00 571.80 579.60" y="480.15" fill="#c9d1d9">between</text>
+<text x="595.20 603.00 610.80 618.60 626.40 634.20 642.00 649.80 657.60 665.40" y="480.15" fill="#c9d1d9">sessions))</text>
 </g>
 <g class="ln l22">
+<text x="18.00" y="500.30" fill="#3fb950">✓</text>
+<text x="33.60 41.40 49.20 57.00 64.80 72.60 80.40" y="500.30" fill="#c9d1d9">charter</text>
+<text x="96.00" y="500.30" fill="#c9d1d9">→</text>
+<text x="111.60 119.40 127.20 135.00 142.80 150.60 158.40 166.20 174.00 181.80 189.60 197.40 205.20 213.00 220.80 228.60 236.40 244.20 252.00 259.80 267.60 275.40 283.20 291.00 298.80 306.60" y="500.30" fill="#c9d1d9">workspaces/default/charter</text>
+<text x="322.20 330.00 337.80 345.60 353.40 361.20 369.00 376.80" y="500.30" fill="#c9d1d9">(charter</text>
+<text x="392.40 400.20 408.00 415.80 423.60 431.40" y="500.30" fill="#c9d1d9">(main)</text>
+<text x="447.00 454.80 462.60" y="500.30" fill="#c9d1d9">via</text>
+<text x="478.20 486.00 493.80" y="500.30" fill="#c9d1d9">gh,</text>
+<text x="509.40 517.20 525.00 532.80 540.60 548.40" y="500.30" fill="#c9d1d9">HTTPS)</text>
 </g>
 <g class="ln l23">
-<text x="18.00" y="520.45" fill="#c9d1d9">—</text>
-<text x="33.60 41.40 49.20 57.00 64.80 72.60 80.40 88.20 96.00 103.80" y="520.45" fill="#c9d1d9">workspace:</text>
-<text x="119.40 127.20 135.00 142.80 150.60 158.40 166.20" y="520.45" fill="#c9d1d9">default</text>
-<text x="181.80 189.60 197.40 205.20 213.00 220.80 228.60 236.40" y="520.45" fill="#c9d1d9">(active)</text>
-<text x="252.00" y="520.45" fill="#c9d1d9">·</text>
-<text x="267.60" y="520.45" fill="#c9d1d9">1</text>
-<text x="283.20 291.00 298.80 306.60 314.40 322.20 330.00" y="520.45" fill="#c9d1d9">repo(s)</text>
-<text x="345.60" y="520.45" fill="#c9d1d9">—</text>
+<text x="18.00" y="520.45" fill="#39c5cf">•</text>
+<text x="49.20" y="520.45" fill="#c9d1d9">↳</text>
+<text x="64.80 72.60 80.40 88.20 96.00 103.80 111.60" y="520.45" fill="#c9d1d9">charter</text>
+<text x="127.20 135.00 142.80 150.60 158.40" y="520.45" fill="#c9d1d9">ships</text>
+<text x="174.00 181.80 189.60" y="520.45" fill="#c9d1d9">its</text>
+<text x="205.20 213.00 220.80" y="520.45" fill="#c9d1d9">own</text>
+<text x="236.40 244.20 252.00 259.80 267.60 275.40 283.20 291.00 298.80" y="520.45" fill="#c9d1d9">README.md</text>
+<text x="314.40" y="520.45" fill="#c9d1d9">—</text>
+<text x="330.00 337.80 345.60 353.40" y="520.45" fill="#c9d1d9">read</text>
+<text x="369.00 376.80" y="520.45" fill="#c9d1d9">it</text>
+<text x="392.40 400.20 408.00 415.80 423.60 431.40" y="520.45" fill="#c9d1d9">before</text>
+<text x="447.00 454.80 462.60 470.40 478.20 486.00 493.80" y="520.45" fill="#c9d1d9">working</text>
+<text x="509.40 517.20 525.00 532.80 540.60 548.40" y="520.45" fill="#c9d1d9">there.</text>
 </g>
 <g class="ln l24">
-<text x="33.60 41.40 49.20 57.00" y="540.60" fill="#c9d1d9">REPO</text>
-<text x="337.80 345.60 353.40 361.20 369.00" y="540.60" fill="#c9d1d9">STACK</text>
-<text x="439.20 447.00 454.80 462.60 470.40 478.20" y="540.60" fill="#c9d1d9">BRANCH</text>
-<text x="493.80" y="540.60" fill="#c9d1d9">/</text>
-<text x="509.40 517.20 525.00 532.80" y="540.60" fill="#c9d1d9">NOTE</text>
 </g>
 <g class="ln l25">
+<text x="18.00" y="560.75" fill="#3fb950">❯</text>
 <text x="33.60 41.40 49.20 57.00 64.80 72.60 80.40" y="560.75" fill="#c9d1d9">charter</text>
-<text x="337.80 345.60 353.40 361.20 369.00 376.80" y="560.75" fill="#c9d1d9">python</text>
-<text x="439.20 447.00 454.80 462.60" y="560.75" fill="#c9d1d9">main</text>
-<text x="478.20" y="560.75" fill="#c9d1d9">·</text>
-<text x="493.80 501.60 509.40 517.20 525.00" y="560.75" fill="#c9d1d9">clean</text>
+<text x="96.00 103.80 111.60 119.40 127.20 135.00" y="560.75" fill="#c9d1d9">status</text>
 </g>
 <g class="ln l26">
+<text x="18.00 25.80 33.60 41.40 49.20 57.00 64.80 72.60 80.40 88.20" y="580.90" fill="#c9d1d9">diazoxide:</text>
+<text x="103.80 111.60" y="580.90" fill="#c9d1d9">47</text>
+<text x="127.20 135.00 142.80 150.60 158.40" y="580.90" fill="#c9d1d9">repos</text>
+<text x="174.00 181.80" y="580.90" fill="#c9d1d9">in</text>
+<text x="197.40 205.20 213.00 220.80 228.60 236.40 244.20 252.00 259.80" y="580.90" fill="#c9d1d9">inventory</text>
+<text x="275.40" y="580.90" fill="#c9d1d9">·</text>
+<text x="291.00" y="580.90" fill="#c9d1d9">1</text>
+<text x="306.60 314.40 322.20 330.00 337.80 345.60 353.40 361.20 369.00 376.80 384.60 392.40" y="580.90" fill="#c9d1d9">workspace(s)</text>
+<text x="408.00" y="580.90" fill="#c9d1d9">·</text>
+<text x="423.60 431.40 439.20 447.00 454.80 462.60 470.40" y="580.90" fill="#c9d1d9">active:</text>
+<text x="486.00 493.80 501.60 509.40 517.20 525.00 532.80" y="580.90" fill="#c9d1d9">default</text>
+<text x="548.40 556.20 564.00 571.80" y="580.90" fill="#c9d1d9">(via</text>
+<text x="587.40 595.20 603.00 610.80 618.60 626.40 634.20" y="580.90" fill="#c9d1d9">default</text>
+<text x="649.80 657.60 665.40" y="580.90" fill="#c9d1d9">(no</text>
+<text x="681.00 688.80 696.60 704.40" y="580.90" fill="#c9d1d9">pane</text>
+<text x="720.00 727.80" y="580.90" fill="#c9d1d9">id</text>
+<text x="743.40" y="580.90" fill="#c9d1d9">—</text>
+<text x="759.00 766.80 774.60 782.40 790.20 798.00 805.80" y="580.90" fill="#c9d1d9">nothing</text>
+<text x="821.40 829.20 837.00 844.80 852.60 860.40 868.20 876.00" y="580.90" fill="#c9d1d9">persists</text>
+<text x="891.60 899.40 907.20 915.00 922.80 930.60 938.40" y="580.90" fill="#c9d1d9">between</text>
+<text x="954.00 961.80 969.60 977.40 985.20 993.00 1000.80 1008.60 1016.40 1024.20" y="580.90" fill="#c9d1d9">sessions))</text>
 </g>
 <g class="ln l27">
-<text x="18.00 25.80 33.60" y="601.05" fill="#c9d1d9">(47</text>
-<text x="49.20 57.00 64.80 72.60 80.40" y="601.05" fill="#c9d1d9">repos</text>
-<text x="96.00 103.80 111.60 119.40 127.20 135.00 142.80 150.60 158.40" y="601.05" fill="#c9d1d9">available</text>
-<text x="174.00 181.80" y="601.05" fill="#c9d1d9">to</text>
-<text x="197.40 205.20 213.00 220.80 228.60" y="601.05" fill="#c9d1d9">clone</text>
-<text x="244.20" y="601.05" fill="#c9d1d9">—</text>
-<text x="259.80 267.60 275.40" y="601.05" fill="#c9d1d9">see</text>
-<text x="291.00 298.80 306.60 314.40 322.20 330.00 337.80 345.60 353.40 361.20 369.00 376.80 384.60 392.40 400.20 408.00 415.80" y="601.05" fill="#c9d1d9">docs/topology.md)</text>
+</g>
+<g class="ln l28">
+<text x="33.60" y="621.20" fill="#c9d1d9">*</text>
+<text x="49.20 57.00 64.80 72.60 80.40 88.20 96.00" y="621.20" fill="#c9d1d9">default</text>
+<text x="119.40 127.20" y="621.20" fill="#c9d1d9">(1</text>
+<text x="142.80 150.60 158.40 166.20 174.00 181.80 189.60" y="621.20" fill="#c9d1d9">cloned)</text>
+</g>
+<g class="ln l29">
+</g>
+<g class="ln l30">
+<text x="18.00" y="661.50" fill="#c9d1d9">—</text>
+<text x="33.60 41.40 49.20 57.00 64.80 72.60 80.40 88.20 96.00 103.80" y="661.50" fill="#c9d1d9">workspace:</text>
+<text x="119.40 127.20 135.00 142.80 150.60 158.40 166.20" y="661.50" fill="#c9d1d9">default</text>
+<text x="181.80 189.60 197.40 205.20 213.00 220.80 228.60 236.40" y="661.50" fill="#c9d1d9">(active)</text>
+<text x="252.00" y="661.50" fill="#c9d1d9">·</text>
+<text x="267.60" y="661.50" fill="#c9d1d9">1</text>
+<text x="283.20 291.00 298.80 306.60 314.40 322.20 330.00" y="661.50" fill="#c9d1d9">repo(s)</text>
+<text x="345.60" y="661.50" fill="#c9d1d9">—</text>
+</g>
+<g class="ln l31">
+<text x="33.60 41.40 49.20 57.00" y="681.65" fill="#c9d1d9">REPO</text>
+<text x="337.80 345.60 353.40 361.20 369.00" y="681.65" fill="#c9d1d9">STACK</text>
+<text x="439.20 447.00 454.80 462.60 470.40 478.20" y="681.65" fill="#c9d1d9">BRANCH</text>
+<text x="493.80" y="681.65" fill="#c9d1d9">/</text>
+<text x="509.40 517.20 525.00 532.80" y="681.65" fill="#c9d1d9">NOTE</text>
+</g>
+<g class="ln l32">
+<text x="33.60 41.40 49.20 57.00 64.80 72.60 80.40" y="701.80" fill="#c9d1d9">charter</text>
+<text x="337.80 345.60 353.40 361.20 369.00 376.80" y="701.80" fill="#c9d1d9">python</text>
+<text x="439.20 447.00 454.80 462.60" y="701.80" fill="#c9d1d9">main</text>
+<text x="478.20" y="701.80" fill="#c9d1d9">·</text>
+<text x="493.80 501.60 509.40 517.20 525.00" y="701.80" fill="#c9d1d9">clean</text>
+</g>
+<g class="ln l33">
+</g>
+<g class="ln l34">
+<text x="18.00 25.80 33.60" y="742.10" fill="#c9d1d9">(47</text>
+<text x="49.20 57.00 64.80 72.60 80.40" y="742.10" fill="#c9d1d9">repos</text>
+<text x="96.00 103.80 111.60 119.40 127.20 135.00 142.80 150.60 158.40" y="742.10" fill="#c9d1d9">available</text>
+<text x="174.00 181.80" y="742.10" fill="#c9d1d9">to</text>
+<text x="197.40 205.20 213.00 220.80 228.60" y="742.10" fill="#c9d1d9">clone</text>
+<text x="244.20" y="742.10" fill="#c9d1d9">—</text>
+<text x="259.80 267.60 275.40" y="742.10" fill="#c9d1d9">see</text>
+<text x="291.00 298.80 306.60 314.40 322.20 330.00 337.80 345.60 353.40 361.20 369.00 376.80 384.60 392.40 400.20 408.00 415.80" y="742.10" fill="#c9d1d9">docs/topology.md)</text>
 </g>
 </g></svg>

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -15,6 +15,7 @@ belong in this module.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import unittest
@@ -124,3 +125,48 @@ class CliSmokeTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestInitDoesNotPrintOneEnormousLine(unittest.TestCase):
+    """The headline is a count; the paths go underneath it.
+
+    That line named every path it had written on one line that does not wrap, and it grew
+    every time charter learned to write something new: 184 characters at 0.38, 254 once
+    harness wiring landed, 194 after 0.41.0 folded the settings entries together. Folding
+    was right and was not enough — the shape was the rest of it.
+
+    It is not only a terminal problem. The README's demo is a real capture, so this line
+    set the width of that image: 1518px for one sentence nobody can read at 80 columns.
+    The regression is silent — nothing fails, the asset just gets worse each release — so
+    it is pinned here.
+    """
+
+    MAX = 100
+
+    def _init(self):
+        import tempfile
+        from pathlib import Path
+        d = tempfile.mkdtemp(prefix="charter-initwidth-")
+        p = subprocess.run([sys.executable, "-m", "charter", "init",
+                            "--forge", "github", "--owner", "acme"],
+                           cwd=d, capture_output=True, text=True,
+                           env={**os.environ, "CHARTER_ROOT": d,
+                                "PYTHONPATH": str(Path(__file__).resolve().parents[1])})
+        return p, (p.stdout or "") + (p.stderr or "")
+
+    def test_no_line_of_init_output_is_absurdly_wide(self):
+        p, out = self._init()
+        # Exit code first. Without it this passes against "No module named charter" — a
+        # one-line error is narrow, so the width assertion holds while init never ran.
+        self.assertEqual(p.returncode, 0, out)
+        widest = max((len(ln) for ln in out.splitlines()), default=0)
+        self.assertLessEqual(widest, self.MAX,
+                             f"widest init line is {widest} cols:\n" +
+                             "\n".join(ln for ln in out.splitlines() if len(ln) > self.MAX))
+
+    def test_it_still_says_what_it_wrote(self):
+        """Narrower must not mean vaguer — every path is still named, just underneath."""
+        p, out = self._init()
+        self.assertEqual(p.returncode, 0, out)
+        for expected in ("charter.toml", "personas/", "inventory/", "workspaces/"):
+            self.assertIn(expected, out)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -194,10 +194,15 @@ class TestSummaryStaysReadable(InitIso):
         buf = io.StringIO()
         with redirect_stderr(buf):
             self._init()
-        line = next(l for l in buf.getvalue().splitlines() if "Initialized" in l)
-        self.assertEqual(line.count(".claude/settings.json"), 1, line)
-        self.assertIn("statusLine", line)
-        self.assertIn("plane-root guard", line)
+        # Asserted over the whole summary rather than the headline: the fold is still the
+        # behaviour under test, but the paths now sit UNDER the headline rather than on it,
+        # because folding took the line from 254 columns to 194 and 194 still does not
+        # wrap. The fold is what keeps this one entry instead of three; the shape is what
+        # keeps the line readable.
+        out = buf.getvalue()
+        self.assertEqual(out.count(".claude/settings.json"), 1, out)
+        self.assertIn("statusLine", out)
+        self.assertIn("plane-root guard", out)
 
     def test_the_line_stays_under_a_readable_width(self):
         import io


### PR DESCRIPTION
0.41.0 folded the settings entries into one mention of the file, taking the summary from **254 columns to 194**. Correct fix, not the whole one: 194 characters on a line that does not wrap is still unreadable at 80 columns — and because the README's demo is a real capture, it still set that image's width at **1518px**.

The fold stays; it is what keeps this one entry instead of three. The shape is the rest.

```
✓ Initialized control plane (schema 1) — 7 item(s) written.
•   + charter.toml
•   + .claude/settings.json (statusLine, env, plane-root guard)
•   + .opencode/plugin/charter.ts
```

**194 columns → 86. Demo image 1518px → 1050px.**

## The capture pipeline was documenting the wrong charter

It ran whichever `charter` was on `PATH`, so regenerating against an installed build faithfully reproduced output the tree had **already changed** — which is how a fixed `init` line kept reappearing in a freshly regenerated asset. It now runs the tree's own code, which is what *"captures are generated from real command output"* was supposed to mean.

## Tests

The existing fold test now asserts over the whole summary rather than the headline — the fold is still the behaviour under test, the paths just moved below the line. A new test pins the width, because this regression is **silent**: nothing fails, the asset simply gets worse each release. It also asserts the exit code, having first been written in a way that passed against `No module named charter` (a one-line error is narrow).

Suite: **2323 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX