### PR TITLE
0.42.0 — a ceiling charter names now carries what to do about it

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.41.0"
+__version__ = "0.42.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.41.0",
+            "command": "charter hook sessionstart --plugin-version 0.42.0",
             "timeout": 5
           },
           {
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.41.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.42.0",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.41.0",
+            "command": "charter hook pretooluse --plugin-version 0.42.0",
             "timeout": 10
           }
         ]
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.41.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.42.0",
             "timeout": 5
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.41.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.42.0"
           }
         ]
       }
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.41.0",
+            "command": "charter hook posttooluse --plugin-version 0.42.0",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.41.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.42.0",
             "timeout": 5
           }
         ]
@@ -100,7 +100,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.41.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.42.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.41.0"
+version = "0.42.0"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Ships **#230** (every deficit carries a remedy, and `charter statusline --watch` is the first real one) and **#231** (init's summary became a list, 194 columns → 86).

**Minor, not patch.** A new CLI flag and a new field on a public type. A plane's pin is measured against this number.

Two notes on what was deliberately *not* changed:

- `charter/commands.py` keeps its `0.41.0`. It is a comment recording **when** the summary was folded, not a version to move — a historical reference that tracks the current release stops being a record of anything.
- The captures sit one minor behind, which `test_asset_freshness` permits by design, and #231 regenerated them at 0.41.0 for its own reasons. Nothing to redo.

Merged `main` into #230 and re-ran the suite before merging it, because CI had only tested that branch in isolation and #231 had landed underneath it. 2339 green against the merge result, not just the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo