### PR TITLE
0.42.1 — two fixes for people already running charter

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.42.0"
+__version__ = "0.42.1"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.42.0",
+            "command": "charter hook sessionstart --plugin-version 0.42.1",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.42.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.42.1",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.42.0",
+            "command": "charter hook pretooluse --plugin-version 0.42.1",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.42.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.42.1",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.42.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.42.1"
           }
         ]
       }
@@ -78,7 +78,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.42.0",
+            "command": "charter hook posttooluse --plugin-version 0.42.1",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.42.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.42.1",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.42.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.42.1",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.42.0"
+version = "0.42.1"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Both affect **shipped** versions, which is why this is a patch rather than a wait.

**#233 — a stale shim no longer passes as wired.** 0.40.0 generated a plugin whose guard called `.stdin()` on Bun's shell, threw on every tool call, and failed open. 0.41.0 fixed the *generator*, and `ensure_shim` never repairs — so the broken file survived every upgrade while `doctor` reported the tree wired. The shim now carries the version that wrote it, `doctor` reports stale trees separately from absent ones, and `reinit` replaces a shim charter can still recognise as its own while refusing to touch one it cannot.

**#234 — hooks stop asking for a feature only one harness has.** Codex skips async hooks and says so twice a session, so `charter persona _gc` and `charter gl-refresh` never ran there. They detach themselves now, via the `start_new_session` pattern already used in three other places, which needs nothing from the host. Verified against the binary: no warning, and four SessionStart hooks dispatch where two did.

### Upgrade note

Anyone who ran `charter init` at 0.40.0 or 0.41.0 should run **`charter reinit`** after upgrading. That is what replaces the stale plugin, and until it does the opencode guard stays inert. `charter doctor` names the trees that need it.

Merged `main` into #234 and re-ran the suite before merging, since #233 landed underneath it — 2358 green against the combined tree, not just the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo