### PR TITLE
doctor's shadowed-docs check could never run

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -965,8 +965,14 @@ def check_shadowed_knowledge() -> Result:
     (ADR 0013). Charter names what is being shadowed and what it costs.
     """
     name = "shadowed docs"
+    # `_config`, imported here, the way every other check in this module reads the root.
+    # A bare `config` was never bound in this scope, so this check raised NameError on
+    # every single invocation and the `except` below rendered it as a benign environment
+    # warning — a mechanism that looks wired and is not, inside the check written to find
+    # exactly that (ADR 0014).
+    from . import config as _config
     try:
-        hit = shadowed_knowledge(config.ROOT)
+        hit = shadowed_knowledge(_config.ROOT)
     except Exception as e:  # noqa: BLE001 - a preflight line must never be the thing that fails
         return Result(name, WARN, detail=f"not checked ({e})", hint=_NOT_CHECKED_HINT)
 

--- a/tests/test_doctor_shadowed.py
+++ b/tests/test_doctor_shadowed.py
@@ -21,7 +21,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from charter import doctor, docsrc  # noqa: F401
+from charter import config, doctor, docsrc  # noqa: F401
 from tests._isolation import PersonaIso
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -146,3 +146,60 @@ class TestCharterItselfIsExemptHoweverItWasInstalled(PersonaIso):
         topic = (docsrc.topics() or ["personas"])[0]
         (root / "docs" / f"{topic}.md").write_text("# a local copy\n")
         self.assertIn(topic, doctor.shadowed_knowledge(root)["docs"])
+
+
+class TestTheCheckItselfIsWired(PersonaIso):
+    """The helper was well covered and the check could never run.
+
+    `tests/test_doctor_shadowed.py` exercised only `shadowed_knowledge(root)` with an
+    explicit argument, so the one line that resolves the root — the only line that could
+    raise — was never executed. 2201 tests passed over a check that raised NameError on
+    every invocation, and the `except Exception` around it rendered that as a benign
+    "not checked" environment warning.
+
+    A helper-only test cannot catch a wiring bug by construction. This calls the check.
+    """
+
+    def test_it_returns_a_real_verdict(self):
+        r = doctor.check_shadowed_knowledge()
+        self.assertIn(r.status, (doctor.OK, doctor.WARN))
+        self.assertNotIn("not checked", r.detail)
+
+    def test_it_reports_a_shadow_when_there_is_one(self):
+        """Wired AND correct: the check reaches the helper whose logic the rest of this
+        file covers."""
+        topic = (docsrc.topics() or ["personas"])[0]
+        docs = Path(config.ROOT) / "docs"
+        docs.mkdir(parents=True, exist_ok=True)
+        (docs / f"{topic}.md").write_text("# a local copy\n")
+        r = doctor.check_shadowed_knowledge()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn(topic, r.detail)
+
+
+class TestNoCheckHidesAPythonErrorInAWarning(PersonaIso):
+    """The class, not the instance.
+
+    Any check whose `not checked` branch can be reached by a NameError or AttributeError
+    reports a code defect as a soft environment warning — which reads as "your machine is
+    odd" rather than "this is broken", and is why the above shipped green.
+
+    Asserting on the *exception signature* rather than on the words "not checked": a
+    genuinely unreadable directory or a timed-out subprocess is entitled to say that, and a
+    test forbidding it outright would be wrong the first time someone's disk misbehaved.
+    """
+
+    #: What a leaked Python error looks like inside a detail string.
+    _SIGNATURES = ("is not defined", "has no attribute", "NameError", "AttributeError",
+                   "TypeError", "unexpected keyword", "not subscriptable")
+
+    def test_no_check_reports_a_python_error_as_an_environment_warning(self):
+        leaked = []
+        for r in doctor.run_all():
+            blob = f"{r.detail} {r.hint}"
+            for sig in self._SIGNATURES:
+                if sig in blob:
+                    leaked.append(f"{r.name}: {r.detail}")
+                    break
+        self.assertEqual(leaked, [], "a code defect is being reported as 'not checked':\n"
+                                     + "\n".join(leaked))


### PR DESCRIPTION
```
!  shadowed docs    not checked (name 'config' is not defined)
```

`check_shadowed_knowledge` read `config.ROOT`, but `doctor.py` never imports `config` — every other check binds it locally as `_config` inside the function, deliberately, so each read sees the **current** root rather than a stale import-time one. The bare name was unbound in that scope, so the check raised `NameError` on every invocation.

## Why it shipped green

Two things hid it, and both are worth naming:

1. The `except Exception` around the call was written for an unreadable directory. It also swallows a `NameError`, and renders a code defect as a benign environment warning.
2. **No test called the check.** The suite exercised only the pure helper `shadowed_knowledge(root)` with an explicit argument, so the one line that resolves the root — the only line that could raise — was never executed. 2201 tests passed over a check that could not run.

A mechanism that looks wired and is not, inside the check written to detect exactly that.

## Covered twice

- A test that calls `check_shadowed_knowledge()` **itself** — a helper-only test cannot catch a wiring bug by construction.
- A test that **no** check reports a Python error signature, catching the class rather than this instance.

That second one asserts on the *exception signature*, not on the words "not checked": a genuinely unreadable directory or a timed-out subprocess is entitled to say that, and forbidding it outright would be wrong the first time somebody's disk misbehaved.

Verified red: all three new tests fail against the unfixed module (stashing only `doctor.py`, keeping the tests).

Suite: **2361 passing**.

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX