### PR TITLE
The concept charter is most opinionated about now has a page

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,9 @@ copy wins, is compared to nothing, and drifts unwatched in both directions.
   self-hosted example, a mixed-forge example, the memory posture, the version pin.
 - [docs/personas.md](docs/personas.md) — the charter format, inheritance, the memory model,
   and dispatching a persona as a sub-agent, end to end.
+- [docs/workspaces.md](docs/workspaces.md) — the session lock and how to get out of it,
+  LIVE vs LOCAL and where your notes actually go, and what belongs in `workspace.md`
+  versus memory versus the manifest.
 - [docs/secrets.md](docs/secrets.md) — exactly what the vault does and does not protect
   against, `secret exec`, and feeding a tool that wants a dotenv file.
 - [docs/git-policy.md](docs/git-policy.md) — the one-credential rule, and why a denial from

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -1,0 +1,131 @@
+# Workspaces
+
+A **workspace** is one task's worth of the world: a directory of repo clones, the notes
+made while working on them, and a written account of what the task is for.
+
+    workspaces/<name>/
+      <repo>/           a clone, on its own branch
+      .worktrees/       further splits of those clones (see below)
+      workspace.md      the living charter: Vision, Context & decisions, Glossary
+      workspace.json    the committed manifest: which repos, which branches
+      memory/           durable notes, one file per fact, with a MEMORY.md index
+      todos/            what this task still means to do
+
+`default` always exists. `charter workspace create <name> --use` starts another.
+
+## Which workspace am I in
+
+Resolved fresh on every command, in this order. The first rung that answers, wins:
+
+1. `--workspace <name>` on the command
+2. `$CHARTER_WORKSPACE`
+3. **the tree you are standing in**
+4. the per-session pointer
+5. the per-terminal pointer
+6. the nominated default (`charter workspace default <name>`)
+7. `default`
+
+The cwd sits above the pointers because it cannot be wrong: a workspace's trees live at
+paths that name the workspace, so being inside one is not a hint, it is the fact.
+
+`charter workspace current` prints the answer *and the rung that produced it*, which is
+usually the faster question to ask than "which workspace am I in".
+
+## The lock, and how to get out of it
+
+Confirming a workspace **locks the session to it**. A mid-session switch is then refused:
+
+    Workspace is 🔒 locked to 'billing' for this session — switching to 'search'
+    mid-session is disabled (never mix workspaces). Start a new session to pick
+    another, or force it: `charter workspace use search --force`
+    (or `charter workspace unlock` first).
+
+This exists because a workspace swapped out from under a running task is silent: the agent
+keeps working, in the wrong clones, against the wrong branches, and nothing looks wrong
+until the commits land somewhere unexpected. The lock is per **session**, so a second
+terminal picks its own workspace freely and neither disturbs the other.
+
+Three ways past it, in the order you should reach for them:
+
+- **start a new session** — the honest one, and usually what you meant;
+- `charter workspace unlock` — release the lock, then select;
+- `charter workspace use <name> --force` — switch and re-lock in one step.
+
+## workspace.md, memory, and workspace.json
+
+Three stores, three jobs. Putting a thing in the wrong one is the common mistake:
+
+| | holds | changes |
+| --- | --- | --- |
+| `workspace.md` | Vision, Context & decisions, Glossary | when the *task* changes |
+| `memory/` | facts learned while working | constantly, one file per fact |
+| `workspace.json` | repos + branches | when you `snapshot` |
+
+**`workspace.md` is the charter** — what this task is for and what has been decided. Seed
+it with `create --vision "…"`; a `fork` inherits it. It answers "why does this workspace
+exist", so it should be short enough that a newcomer reads all of it.
+
+**Memory is a store, not a log.** One file per fact with an index, because a single
+growing notes file is written once and searched never. `charter workspace remember "…"`
+adds one; `charter recall <query>` searches **across every base at once** — workspace
+memory, persona memory, shared memory and refs — which is the only search you need to
+remember.
+
+**`workspace.json` is a snapshot, not an inventory.** It records what was there when you
+asked, and is what `restore` rebuilds from. It does not track drift; see ADR 0010.
+
+## LIVE or LOCAL — where your notes go
+
+The most consequential per-workspace choice, and it is one flag.
+
+- **LOCAL** (the default): everything above stays on disk. Nothing is committed. Nothing
+  reaches anyone.
+- **LIVE** (`charter workspace live <name>`): `workspace.json`, `workspace.md`, `memory/`
+  and `todos/` are un-ignored, and a memory written to a LIVE workspace is committed and
+  pushed **immediately** — reactively, not on a later save.
+
+`charter workspace live <name> --off` puts it back. `charter workspace save` is the manual
+counterpart for a LIVE workspace whose writes were deferred with `--no-sync`. Writing to a
+LOCAL workspace tells you it stayed put, rather than letting you assume it travelled.
+
+The clones themselves are never committed by any of this. Only the metadata is.
+
+## Worktrees
+
+A clone can be split into git worktrees, so parallel workers each get their own branch of
+the *same* repo without re-cloning it:
+
+    workspaces/<ws>/.worktrees/<repo>/<piece>
+
+Each is a **piece** — one unit of work whose creation *is* the claim, because git already
+arbitrates who wins the path. See [adr/0011](adr/0011-the-record-holds-only-what-git-cannot-know.md).
+
+## Structure versioning, and `reinit`
+
+A workspace's layout carries a version stamp. When charter learns to create something new
+(a `todos/` directory, a memory index), existing workspaces do not have it, and the status
+line says so:
+
+    ⚠ reinit 3 ws · charter ws reinit --all
+
+`charter workspace reinit <name>` creates what is missing and re-stamps the marker. It is
+additive: nothing you wrote is touched.
+
+## Moving a workspace around
+
+- **`fork <src> <new>`** — a new workspace pre-loaded with the source's charter, manifest
+  and memory, so a branch of the work starts with the context rather than without it.
+  Repos come with `--restore`, or on demand later.
+- **`snapshot`** — write the current repos and branches into `workspace.json`.
+- **`restore <name>`** — rebuild from that manifest on another machine: clone each repo,
+  check out each branch.
+- **`rename <old> <new>`** — moves the clones and the memory, and commits the move if the
+  workspace is LIVE.
+- **`remove <name>`** — deletes the workspace and its clones, and refuses if that would
+  lose unpushed work.
+
+## See also
+
+- [control-plane.md](control-plane.md) — `charter.toml`, and the plane's view of a workspace
+- [personas.md](personas.md) — the other memory base, and how a persona is dispatched
+- [adr/0010](adr/0010-the-manifest-is-a-snapshot-not-an-inventory.md) — why `workspace.json` is not an inventory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,4 @@ packages = ["charter"]
 "docs/mcp.md" = "charter/_docs/mcp.md"
 "docs/personas.md" = "charter/_docs/personas.md"
 "docs/secrets.md" = "charter/_docs/secrets.md"
+"docs/workspaces.md" = "charter/_docs/workspaces.md"


### PR DESCRIPTION
`charter docs show` served eight topics and none of them was `workspaces`. `docs/control-plane.md` covers a workspace only as far as `charter.toml` needs it — the plane's view. None of the behaviour a user actually collides with was written down anywhere in charter.

Most of all the **session lock**. The feature most likely to refuse someone mid-task had no page to send them to: `--help` states the rule (*"no mid-session switch"*) without the reasoning or the way out, and the refusal names `--force` and `unlock` without saying which to reach for.

## Also now written down

- what `workspace.md` holds versus `memory/` versus `workspace.json` — three stores, three jobs, and putting a thing in the wrong one is the common mistake;
- **LIVE vs LOCAL**, and that a LIVE workspace commits *and pushes* a memory **immediately**, not at some later save;
- `charter recall` as the one search across every base;
- structure versioning, and what the status line's `reinit` marker means;
- `fork`/`snapshot`/`restore`/`rename`/`remove` beyond their one-line help.

## Written from source, not ported

The same discipline `docs/hooks.md` was held to in review. The resolution order is read off `workspace.resolve`; the lock text is the string `_locked_msg` actually prints; LIVE's four un-ignored paths are the ones `_live_block` writes.

## The second cost of the gap

A plane consolidating onto `charter docs show` could delete its copies of `personas.md`, `secrets.md`, `hooks.md` and `browser.md` — and had to **keep** its `workspaces.md`, because deleting it would have destroyed the only written account of that behaviour anywhere. A plane holding the sole documentation for charter's own feature is exactly the drift doctor's shadowing check exists to discourage, and that check stayed silent because it can only flag a page charter actually ships.

## The packaging guard earned its keep

The page failed `test_every_page_is_force_included_in_the_wheel` until it was added to the force-include list — which is the whole reason that test exists, since the gap is invisible from a checkout where the fallback reads the repo and looks fine.

Suite: **2358 passing**.

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX