### PR TITLE
The browser skill's worked example raced the page it was demonstrating

### DIFF
--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -46,19 +46,45 @@ substitutes the value and redacts it from output, so it never reaches the transc
 > is typed into the password field and no error is raised. Wrap the whole flow, `open`
 > through the last `fill`, in a single `charter secret exec`.
 
+> **Wait for each field before filling it.** `open` returns as soon as the first response
+> lands, not when the page you are logging in to exists — an SPA typically redirects to an
+> identity provider afterwards. Filling immediately fails with
+> `"#username" does not match any elements`, which reads as a **wrong selector** and sends
+> you hunting for a better one when the flow was already right. It is not free to get wrong
+> here: `charter secret exec` shreds the dotenv file when it exits, so the still-open
+> session can no longer be filled with a secret, and recovering means re-running the whole
+> flow rather than the failed step. The example waits so it never needs to.
+
 ```bash
 charter secret exec <vault> \
   --dotenv PLAYWRIGHT_MCP_SECRETS_FILE=USER:<user-key> \
   --dotenv PLAYWRIGHT_MCP_SECRETS_FILE=PASS:<pass-key> \
   -- bash -c '
     P="npx @playwright/cli@<version> -s=owner"
+
+    # `open` returning is not the page existing. Poll for the element itself rather than
+    # sleeping a fixed amount: a redirect to an IdP can take a moment or several.
+    wait_for() {
+      for _ in $(seq 1 15); do
+        $P eval "() => !!document.querySelector(\"$1\")" 2>/dev/null | grep -q true && return 0
+        sleep 2
+      done
+      echo "TIMEOUT waiting for $1" >&2; return 1
+    }
+
     $P open https://example.test/
+    wait_for "#username" || exit 1
     $P fill "#username" USER
+    wait_for "#password" || exit 1
     $P fill "#password" PASS
     $P click "button[type=submit]"
     $P snapshot
   '
 ```
+
+The second `wait_for` is not redundant: an identity provider may ask for the username on
+one screen and the password on the next, so `#password` can be absent at the moment the
+first field is submitted.
 
 Use `charter persona secret exec` to read the **active persona's** vault instead of naming
 one. A different fixture account is a different pair of keys, not a different mechanism.


### PR DESCRIPTION
The credential-bridge example went `open` → fill → click with nothing in between. Against the case it is literally about — logging in — that races: an SPA hands off to an identity provider and `open` returns before the redirect settles.

Observed against a real Keycloak-backed app:

```
Error: "#username" does not match any elements.
Error: "button[name=login]" does not match any elements.
Error: "#password" does not match any elements.
```

Three errors that all read as **bad selectors**. They were correct — the page did not exist yet. That wrong conclusion is cheap to reach and expensive to act on: the reader goes hunting for a better selector, snapshotting and guessing at refs, when the flow was already right.

## Why this belongs in the skill

The bridge makes a retry **costly rather than free**. `charter secret exec` shreds the dotenv file on exit, so the still-open session can no longer be filled with a secret; recovering means re-running the whole flow, not the failed step. The skill's own hard-won rule — *open the session inside the bridge* — is precisely what makes a mid-flow retry impossible. So the example has to not need one.

## The fix

The example polls for each element rather than sleeping a fixed amount, and the failure mode is named right beside it so the error text is recognisable when it does appear.

The second wait is not redundant: an identity provider may ask for the username on one screen and the password on the next, so `#password` can be absent when the first field is submitted.

## Verified

Ran the example's shape against a stub `playwright-cli` — waits succeed for a present element, time out cleanly for an absent one, and the nested quoting survives `bash -c '…'`. An example that does not parse would be the same defect one level down.

Suite: **2361 passing**.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX