### PR TITLE
A report body can reach charter without going through the shell

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -279,11 +279,23 @@ def _add_report_parser(sub) -> None:
     rsub = r.add_subparsers(dest="report_cmd", required=True)
 
     bug = rsub.add_parser("bug", help="Charter did something wrong.")
-    bug.add_argument("text", help="What went wrong, in your own words.")
+    # Optional, and joined by --from-file/--stdin: a body worth filing carries backticks,
+    # `$` and fenced code, none of which survives being a shell argument. Same two flags,
+    # same spelling, as `secret set` — there to keep a value off argv, here to keep one
+    # intact.
+    bug.add_argument("text", nargs="?", help="What went wrong, in your own words. Use `-` to read it from stdin.")
+    bug.add_argument("--from-file", help="Read the body verbatim from a file.")
+    bug.add_argument("--stdin", action="store_true", help="Read the body from stdin.")
     bug.set_defaults(func=commands_report.cmd_report_bug)
 
     gap = rsub.add_parser("gap", help="Charter cannot do something it should.")
-    gap.add_argument("text", help="What is missing, in your own words.")
+    # Optional, and joined by --from-file/--stdin: a body worth filing carries backticks,
+    # `$` and fenced code, none of which survives being a shell argument. Same two flags,
+    # same spelling, as `secret set` — there to keep a value off argv, here to keep one
+    # intact.
+    gap.add_argument("text", nargs="?", help="What is missing, in your own words. Use `-` to read it from stdin.")
+    gap.add_argument("--from-file", help="Read the body verbatim from a file.")
+    gap.add_argument("--stdin", action="store_true", help="Read the body from stdin.")
     gap.set_defaults(func=commands_report.cmd_report_gap)
 
     ls = rsub.add_parser("list", help="Reports drafted on this machine, and what was sent.")

--- a/charter/commands_report.py
+++ b/charter/commands_report.py
@@ -11,12 +11,56 @@ approval could not be a y/n prompt; it is a second command instead.
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 from . import __version__, report, util
+
+
+def _body(args) -> str | None:
+    """The report body, from a file, from stdin, or from argv. ``None`` on a read error.
+
+    A body worth filing is exactly the text that does not survive a shell argument: it
+    carries backticks, ``$``, quotes and fenced code. Passed inline, backticked terms are
+    command-substituted **away** — "when `open` returns" is stored as "when  returns", a
+    word silently deleted from a sentence still grammatical enough to skim past — and
+    ``$(…)`` inside a code sample executes.
+
+    charter already treats "do not put this on argv" as first-class for `secret set`, and
+    these are the same two flags spelled the same way. There the reason is disclosure; here
+    it is corruption, and the stakes are comparable: a report is published irreversibly, on
+    a public tracker, under the reporter's own identity, and the material that gets mangled
+    is the code sample that made it worth filing.
+    """
+    src = getattr(args, "from_file", None)
+    if src:
+        try:
+            return Path(src).expanduser().read_text()
+        except OSError as e:
+            util.err(f"could not read {src}: {e}")
+            return None
+    text = getattr(args, "text", None)
+    # `-` is the conventional spelling and costs nothing to honour.
+    if getattr(args, "stdin", False) or text == "-":
+        return sys.stdin.read()
+    if text:
+        return text
+    # A body arriving down a pipe with no flag is the ordinary shape, exactly as it is for
+    # `secret set`, whose docstring records that demanding an explicit `--stdin` broke every
+    # working pipeline to prevent a mistake an emptiness check already catches.
+    if not sys.stdin.isatty():
+        return sys.stdin.read()
+    return ""
 
 
 def _draft(kind: str, text: str) -> int:
     if not (text or "").strip():
-        util.err(f"nothing to report — describe the {kind}: charter report {kind} \"<what>\"")
+        util.err(f"nothing to report — describe the {kind}.")
+        util.info(f"  short:  charter report {kind} \"<what>\"")
+        util.info(f"  long:   charter report {kind} --from-file <path>   "
+                  f"(or --stdin, or `-`)")
+        util.info("  A long body does not survive the shell — backticks and `$(…)` are "
+                  "expanded before charter ever sees them.")
         return 1
 
     rid = report.record_described(kind, text)
@@ -40,12 +84,14 @@ def _draft(kind: str, text: str) -> int:
 def cmd_report_bug(args) -> int:
     """Draft a **bug** the Reporter describes by hand. The automatic path (a real crash,
     with a traceback) records itself; this is for "it did the wrong thing"."""
-    return _draft("bug", getattr(args, "text", None))
+    body = _body(args)
+    return 1 if body is None else _draft("bug", body)
 
 
 def cmd_report_gap(args) -> int:
     """Draft a **gap** — charter cannot do something it should."""
-    return _draft("gap", getattr(args, "text", None))
+    body = _body(args)
+    return 1 if body is None else _draft("gap", body)
 
 
 def cmd_report_consent(args) -> int:

--- a/tests/test_report_body_source.py
+++ b/tests/test_report_body_source.py
@@ -1,0 +1,102 @@
+"""A report body has a route that never touches the shell.
+
+The body was a single positional argument, so anything substantial had to be quoted inline
+on a command line — and a report worth filing is exactly the text that does not survive
+there. Observed while filing #239:
+
+* every backticked term was command-substituted **away**. "when `open` returns" was stored
+  as "when  returns" — a word silently deleted from a sentence still grammatical enough to
+  skim past;
+* `$(…)` inside the intended code sample executed, and `$P open https://app.example/` ran
+  macOS's `/usr/bin/open`.
+
+The draft saved in that state. What is published is irreversible, on a public tracker,
+under the reporter's own identity, and the material that gets mangled is precisely the code
+sample that made the report worth reading.
+
+`secret set` already solves this shape with `--stdin`/`--from-file`; there the reason is
+disclosure, here it is corruption, and the mechanism and the fix are identical. So these
+are the same two flags, spelled the same way.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import commands_report
+from tests._isolation import ReportIso
+
+#: Every construct that dies on argv, in one string.
+HOSTILE = ("A body with `backticks`, a $(echo SUBSTITUTION), a $VAR and a fence:\n"
+           "\n```bash\n$P open https://app.example/\n```\n")
+
+
+class BodyCase(ReportIso):
+    def args(self, **kw):
+        base = {"text": None, "from_file": None, "stdin": False}
+        return SimpleNamespace(**{**base, **kw})
+
+    def with_stdin(self, text: str):
+        real = sys.stdin
+        sys.stdin = io.StringIO(text)
+        self.addCleanup(setattr, sys, "stdin", real)
+
+
+class TestTheBodyCanAvoidTheShell(BodyCase):
+    def test_from_file_is_verbatim(self):
+        p = Path(tempfile.mkdtemp()) / "body.md"
+        p.write_text(HOSTILE)
+        self.assertEqual(commands_report._body(self.args(from_file=str(p))), HOSTILE)
+
+    def test_stdin_flag_is_verbatim(self):
+        self.with_stdin(HOSTILE)
+        self.assertEqual(commands_report._body(self.args(stdin=True)), HOSTILE)
+
+    def test_a_bare_dash_means_stdin(self):
+        """The conventional spelling, and free to honour."""
+        self.with_stdin(HOSTILE)
+        self.assertEqual(commands_report._body(self.args(text="-")), HOSTILE)
+
+    def test_a_pipe_with_no_flag_is_read(self):
+        """The ordinary shape, and the one `secret set` records as having been broken once
+        by demanding an explicit flag for every pipeline."""
+        self.with_stdin(HOSTILE)
+        self.assertEqual(commands_report._body(self.args()), HOSTILE)
+
+    def test_an_inline_body_still_works(self):
+        """Short reports keep the positional — the point is that a long one has a route,
+        not that the easy one is taken away."""
+        self.assertEqual(commands_report._body(self.args(text="it broke")), "it broke")
+
+    def test_inline_text_wins_over_a_non_tty_stdin(self):
+        """An agent's Bash tool presents a non-tty stdin with nothing behind it. Reading it
+        in preference to the argument the caller actually passed would substitute silence
+        for their report."""
+        self.with_stdin("")
+        self.assertEqual(commands_report._body(self.args(text="it broke")), "it broke")
+
+    def test_an_unreadable_file_is_reported_not_swallowed(self):
+        """None, not "" — an empty body and a missing file are different failures, and
+        drafting an empty report because a path was wrong is the silent one."""
+        self.assertIsNone(commands_report._body(self.args(from_file="/nope/missing.md")))
+
+
+class TestTheEmptyCaseNamesTheRoutes(BodyCase):
+    def test_it_names_the_file_route(self):
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf), contextlib.redirect_stdout(io.StringIO()):
+            rc = commands_report._draft("bug", "")
+        self.assertEqual(rc, 1)
+        said = buf.getvalue()
+        self.assertIn("--from-file", said)
+        self.assertIn("does not survive the shell", said)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The body was a single positional argument, so anything substantial had to be quoted inline — and a report worth filing is exactly the text that does not survive there.

## What happened filing #239

- every backticked term was command-substituted **away**. `"when `open` returns"` was stored as `"when  returns"` — a word silently deleted from a sentence still grammatical enough to skim past;
- `$(…)` inside the intended code sample **executed**: `$P open https://app.example/` ran macOS's `/usr/bin/open` and printed its help.

The draft saved in that state. `charter report show` caught it. Without that check the published issue — public tracker, reporter's own GitHub identity, not editable from here — would have carried a code sample with a word missing from it.

## Same problem charter already solved once

`secret set` offers `--stdin`/`--from-file` precisely so a value never becomes a shell argument. There the reason is **disclosure**; here it is **corruption**. The mechanism and the fix are identical, so these are the same two flags spelled the same way:

```bash
charter report bug --from-file <path>
charter report bug --stdin < body.md
charter report bug -
```

A bare pipe with no flag is read too — the shape `_read_value`'s own docstring records as having been broken once by demanding an explicit flag for every pipeline. **Inline text still wins over a non-tty stdin**: an agent's Bash tool presents an empty one, and preferring it would substitute silence for the report the caller actually passed.

An unreadable `--from-file` returns `None` rather than `""`, because drafting an empty report because a path was wrong is the silent failure.

## Also

The positional stays for short reports. The empty-body error now names the long route and says *why* it exists — knowing to write a quoted heredoc and pass `"$(cat file)"` is a thing you have to already know.

8 new tests drive a deliberately hostile body (backticks, `$(…)`, `$VAR`, a fence) through every route. Suite: **2367 passing**.

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX