### PR TITLE
fix: keep the installed plugin current — the refresh path moved out with the per-tree code

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -612,6 +612,17 @@ def check_harness() -> Result:
                             f"which surfaces {current} carries. Register it in "
                             f"`charter/harness/registry.py` (KINDS) with its own deficits, "
                             f"or unset $CHARTER_HARNESS if it was set by mistake."))
+    live = _harness.get(current)
+    stale = live.stale_wiring() if live else ""
+    if stale:
+        from . import __version__
+
+        return Result(name, WARN,
+                      detail=f"{current} — its plugin was written by {stale}, charter is "
+                             f"{__version__}",
+                      hint=("A plugin an older charter wrote is still a file where a "
+                            "working one belongs — 0.40.0's guard never fired. → charter "
+                            "reinit (an edited plugin is reported, never overwritten)"))
     gaps = _harness.deficits(current)
     if not gaps:
         return Result(name, OK, detail=current)

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -52,6 +52,14 @@ class Harness:
         """
         return False
 
+    def stale_wiring(self) -> str:
+        """Which charter wrote this harness's installed wiring, when not the running one.
+
+        ``""`` for a harness whose wiring charter does not generate — Claude Code's plugin
+        is installed by the host and carries its own version check.
+        """
+        return ""
+
     def wire(self, root: Path) -> list[tuple[str, str]]:
         """Write what this harness needs under *root*, IF ABSENT.
 

--- a/charter/harness/opencode.py
+++ b/charter/harness/opencode.py
@@ -321,6 +321,19 @@ class OpenCodeHarness(Harness):
                 "effectful tools (write/edit/bash) instead of arriving beside them."),
     )
 
+    def stale_wiring(self) -> str:
+        """The version that wrote the installed plugin, when it is not this one.
+
+        ``""`` when current or absent — absent is `harness`'s other sentence, and two rows
+        saying the plane is unwired teaches people to skim. ``"unstamped"`` for a plugin
+        charter cannot vouch for, which includes every one written before the stamp.
+        """
+        g = global_dir()
+        if not (g / SHIM_PATH).is_file():
+            return ""
+        got = shim_version(g)
+        return "" if got == __version__ else (got or "unstamped")
+
     def detect(self) -> bool:
         """Nothing native to detect.
 
@@ -343,7 +356,11 @@ class OpenCodeHarness(Harness):
         # Labels are RELATIVE to the config dir, and say which harness they belong to.
         # An absolute path here is unbounded — a deep home directory turned `init`'s
         # summary into a 130-column line, which is the readability budget #231 set.
-        out = [(ensure_shim(g), f"opencode {SHIM_PATH}")]
+        # `refresh_shim`, not `ensure_shim`: an install that only ever creates is a
+        # one-shot, and a plugin an older charter wrote then survives every upgrade while
+        # `doctor` reports it wired. That was #233's bug per tree; moving to one global
+        # file took the refresh path with it and brought the bug back.
+        out = [(refresh_shim(g), f"opencode {SHIM_PATH}")]
         cmd = g / COMMAND_PATH
         if not cmd.exists():
             cmd.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_deficit_remedies.py
+++ b/tests/test_deficit_remedies.py
@@ -10,6 +10,7 @@ too, and a wrong workaround costs more than an honest gap.
 
 from __future__ import annotations
 
+import tempfile
 import unittest
 
 from charter import doctor
@@ -42,7 +43,12 @@ class DoctorShowsThem(unittest.TestCase):
     def test_the_row_carries_the_remedy_beside_the_ceiling(self):
         import os
         from unittest import mock
-        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "opencode"}, clear=True):
+        # `clear=True` wipes the suite-wide sandbox redirect too, so `global_dir()` would
+        # fall back to the developer's REAL ~/.config/opencode — which is both a leak and
+        # a flake, since a stale plugin there would fail this test.
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "opencode",
+                                          "XDG_CONFIG_HOME": tempfile.mkdtemp()},
+                             clear=True):
             r = doctor.check_harness()
         self.assertIn("charter statusline --watch", r.detail)
 

--- a/tests/test_doctor_harness.py
+++ b/tests/test_doctor_harness.py
@@ -9,6 +9,7 @@ written for, one level up.
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 from unittest import mock
 
@@ -17,7 +18,12 @@ from charter import doctor, harness
 
 class DoctorHarness(unittest.TestCase):
     def test_the_opencode_row_names_every_ceiling(self):
-        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "opencode"}, clear=True):
+        # `clear=True` wipes the suite-wide sandbox redirect too, so `global_dir()` would
+        # fall back to the developer's REAL ~/.config/opencode — which is both a leak and
+        # a flake, since a stale plugin there would fail this test.
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "opencode",
+                                          "XDG_CONFIG_HOME": tempfile.mkdtemp()},
+                             clear=True):
             r = doctor.check_harness()
         self.assertEqual(r.status, doctor.OK)
         self.assertIn("opencode", r.detail)

--- a/tests/test_global_shim_is_kept_current.py
+++ b/tests/test_global_shim_is_kept_current.py
@@ -1,0 +1,90 @@
+"""The one installed plugin has to be kept current, or the install is a one-shot.
+
+#233 fixed this for per-tree shims: a plugin an older charter wrote survived every upgrade
+while `doctor` reported it wired. #241 moved the plugin to one global location and deleted
+the per-tree machinery — and took the refresh path with it, leaving `refresh_shim`
+orphaned and `doctor` printing a clean harness row over a 0.42.1 plugin under 0.43.0.
+
+Same bug, one level up, reintroduced by the change that simplified everything else. The
+mechanism that keeps a generated file honest has to move with the file.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import __version__, doctor
+from charter.harness import opencode, registry
+
+
+class InstallingKeepsItCurrent(unittest.TestCase):
+    def setUp(self) -> None:
+        self.home = Path(tempfile.mkdtemp(prefix="charter-gsr-"))
+        self.addCleanup(lambda: shutil.rmtree(self.home, True))
+        self.enterContext(mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": str(self.home)}))
+        self.shim = opencode.global_dir() / opencode.SHIM_PATH
+
+    def _plant(self, body: str) -> None:
+        self.shim.parent.mkdir(parents=True, exist_ok=True)
+        self.shim.write_text(body)
+
+    def test_a_plugin_an_older_charter_wrote_is_replaced(self):
+        opencode.ensure_shim(opencode.global_dir())
+        self._plant(self.shim.read_text().replace(__version__, "0.40.0"))
+        registry.get("opencode").wire(Path("/unused"))
+        self.assertEqual(opencode.shim_version(opencode.global_dir()), __version__)
+
+    def test_a_plugin_somebody_edited_is_left_alone(self):
+        """Charter cannot tell a pre-stamp plugin from a rewritten one, and guessing wrong
+        destroys work. It reports instead — which is what `doctor` is for."""
+        self._plant("// mine\n")
+        registry.get("opencode").wire(Path("/unused"))
+        self.assertEqual(self.shim.read_text(), "// mine\n")
+
+    def test_an_absent_plugin_is_written(self):
+        registry.get("opencode").wire(Path("/unused"))
+        self.assertEqual(opencode.shim_version(opencode.global_dir()), __version__)
+
+
+class DoctorNamesAStalePlugin(unittest.TestCase):
+    def setUp(self) -> None:
+        self.home = Path(tempfile.mkdtemp(prefix="charter-gsr-d-"))
+        self.addCleanup(lambda: shutil.rmtree(self.home, True))
+        self.enterContext(mock.patch.dict(os.environ,
+                                          {"XDG_CONFIG_HOME": str(self.home),
+                                           "CHARTER_HARNESS": "opencode"}))
+
+    def test_a_stale_plugin_is_not_a_clean_row(self):
+        opencode.ensure_shim(opencode.global_dir())
+        p = opencode.global_dir() / opencode.SHIM_PATH
+        p.write_text(p.read_text().replace(__version__, "0.40.0"))
+        r = doctor.check_harness()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("0.40.0", r.detail)
+        self.assertIn("reinit", r.hint)
+
+    def test_an_edited_plugin_says_so_and_says_what_to_do(self):
+        p = opencode.global_dir() / opencode.SHIM_PATH
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("// mine\n")
+        r = doctor.check_harness()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertTrue(r.hint)
+
+    def test_a_current_plugin_is_a_clean_row(self):
+        registry.get("opencode").wire(Path("/unused"))
+        self.assertEqual(doctor.check_harness().status, doctor.OK)
+
+    def test_no_plugin_at_all_is_not_reported_as_stale(self):
+        """An uninstalled harness is a different sentence, and `harness` already says the
+        plane is not wired — two rows saying the same thing teaches people to skim."""
+        self.assertEqual(doctor.check_harness().status, doctor.OK)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**#233** fixed this for per-tree shims: a plugin an older charter wrote survived every upgrade while `doctor` reported it wired. **#241** moved the plugin to one global location, deleted the per-tree machinery, and took the refresh path with it — leaving `refresh_shim` orphaned and `doctor` printing a clean harness row over a **0.42.1 plugin under 0.43.0**.

Same bug, one level up, reintroduced by the change that simplified everything else.

Caught by installing 0.43.0 and looking, not by the suite:

```
$ charter reinit
✓ Up to date (schema 1) — nothing to do.
$ head -1 ~/.config/opencode/plugin/charter.ts
// charter-version: 0.42.1
```

### The fix

`wire()` refreshes rather than only creating, and `doctor`'s harness row reports a plugin charter did not write with this version. An **unstamped or edited** plugin is still never overwritten — charter cannot tell one it wrote before stamps existed from one somebody rewrote — so it is named instead.

### A leak in the other direction

Two tests were reading the developer's real `~/.config/opencode`. They cleared the whole environment to isolate `$CHARTER_HARNESS`, which also wiped the sandbox redirect `tests/__init__.py` installs, so `global_dir()` fell back to the real home. Both a leak and a flake — a stale plugin there failed them. They now carry the sandbox through the clear.

2370 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo