### PR TITLE
`not open` is not a cue to re-open the browser session

### DIFF
--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -40,6 +40,13 @@ Pin the version explicitly in every command. The tool is pre-1.0 and its behavio
 `PLAYWRIGHT_MCP_SECRETS_FILE` at it. You then refer to a secret **by name**; Playwright
 substitutes the value and redacts it from output, so it never reaches the transcript.
 
+> **`not open` is not a cue to re-open.** A second `open` with the same `-s=<name>` starts
+> a *new* browser and orphans the first — which is the one that is logged in. Worse, the
+> new one cannot be authenticated: `charter secret exec` shreds its dotenv on exit, so
+> filling a secret into it means re-running the whole bridged flow. Check the session is
+> really gone first (a `snapshot` against it is cheap and answers the question); if it is,
+> re-run the flow rather than `open`.
+
 > **Open the session *inside* the bridge.** `playwright-cli` reads
 > `PLAYWRIGHT_MCP_SECRETS_FILE` once, when the session daemon starts. Setting it later, on
 > a `fill` against an already-open session, **fails silently** — the literal string `PASS`


### PR DESCRIPTION
Half of #243 — and only the half that survived checking.

## Verified, and now in the skill

A second `open` with the same `-s=<name>` starts a **new** browser rather than finding the existing one, and orphans the first — which is the authenticated one:

```
first  open: pid 8900
second open: pid 9062
```

It cannot be recovered either: `charter secret exec` shreds its dotenv on exit, so filling a secret into the new session means re-running the whole bridged flow. That makes `not open` a message whose obvious response costs a stranded browser **plus** a full re-authentication.

## Deliberately not written, because it is not true

#243 attributes the `not open` it saw to playwright-cli sessions being scoped to the working directory, with state in `./.playwright-cli/`. Tested against 0.1.18:

```
opened in D
FROM A DIFFERENT DIR -> SESSION FOUND
### Page
- Page URL: https://example.com/
```

A session opened in one directory answers `snapshot` from a completely different one and returns the live page. `./.playwright-cli/` holds snapshot artifacts (`page-*.yml`), not session state.

The symptom was real; the mechanism is not. Shipping it would have put a confidently wrong sentence into a skill that reaches **every plugin user** — the exact failure this skill set exists to prevent. Counter-evidence posted on the issue, which stays open for the real cause.

Suite: **2359 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX