### PR TITLE
0.43.1 — the installed plugin stays current, and charter stops declaring hooks it already has

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.43.0"
+__version__ = "0.43.1"

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -706,6 +706,27 @@ def _hooks_snippet() -> str:
     return json.dumps({"hooks": {"PreToolUse": [_GUARD_HOOK]}}, indent=2)
 
 
+def _charter_plugin_enabled(settings_path: Path) -> bool:
+    """Is a charter plugin switched on in *settings_path*'s ``enabledPlugins``?
+
+    ``enabled: false`` is not a declaration — the operator turned it off, and the hook is
+    then the only thing between the plane root and an unguarded branch move. Somebody
+    else's plugin does not count either.
+
+    Never raises: a malformed file is handled by the caller, which refuses to repair it.
+    """
+    try:
+        doc = json.loads(settings_path.read_text())
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return False
+    if not isinstance(doc, dict):
+        return False
+    enabled = doc.get("enabledPlugins")
+    if not isinstance(enabled, dict):
+        return False
+    return any(on and str(name).split("@")[0] == "charter" for name, on in enabled.items())
+
+
 def _ensure_guard_hook(root: Path) -> tuple[str, Path | None]:
     """Wire `charter hook pretooluse` into ``.claude/settings.json`` IF ABSENT.
 
@@ -719,6 +740,13 @@ def _ensure_guard_hook(root: Path) -> tuple[str, Path | None]:
     """
     d = root / ".claude"
     p = d / "settings.json"
+    # An ENABLED charter plugin already declares this hook, and `doctor.check_guard_wired`
+    # counts it as wired for exactly that reason. Writing one here too leaves both live, so
+    # `charter hook pretooluse` runs twice for every Bash call — the same doubling Codex
+    # got from two installers, arrived at here by one writer and one checker disagreeing
+    # about what "wired" means in the same file.
+    if _charter_plugin_enabled(p):
+        return "present", p
     if not p.exists():
         try:
             d.mkdir(parents=True, exist_ok=True)

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.43.0",
+            "command": "charter hook sessionstart --plugin-version 0.43.1",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.43.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.43.1",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.43.0",
+            "command": "charter hook pretooluse --plugin-version 0.43.1",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.43.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.43.1",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.43.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.43.1"
           }
         ]
       }
@@ -78,7 +78,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.43.0",
+            "command": "charter hook posttooluse --plugin-version 0.43.1",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.43.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.43.1",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.43.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.43.1",
             "timeout": 5
           }
         ]

--- a/opencode.json
+++ b/opencode.json
@@ -1,5 +1,0 @@
-{
-  "instructions": [
-    ".opencode/charter-context.md"
-  ]
-}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.43.0"
+version = "0.43.1"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_guard_hook_defers_to_the_plugin.py
+++ b/tests/test_guard_hook_defers_to_the_plugin.py
@@ -1,0 +1,79 @@
+"""`init` stops declaring a hook the enabled plugin already declares.
+
+`doctor.check_guard_wired` treats an enabled charter plugin as wired — it says so:
+"wired (enabled plugin charter@charter)". `_ensure_guard_hook` never asked, and wrote its
+own `PreToolUse` entry into `.claude/settings.json` anyway. Both are then live, and
+`charter hook pretooluse` runs twice for every Bash call.
+
+That is the Codex bug on Claude Code. There it was two installers not knowing about each
+other; here it is one writer and one checker disagreeing about what "wired" means, in the
+same file, in the same process. Nothing is broken either time — everything is doubled,
+which is the harder failure to see.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from charter import commands
+
+
+class _Plane(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="charter-guardhook-"))
+        self.addCleanup(lambda: shutil.rmtree(self.root, True))
+        self.settings = self.root / ".claude" / "settings.json"
+        self.settings.parent.mkdir(parents=True, exist_ok=True)
+
+    def _write(self, doc: dict) -> None:
+        self.settings.write_text(json.dumps(doc, indent=2) + "\n")
+
+    def _hooks(self) -> dict:
+        return json.loads(self.settings.read_text()).get("hooks", {})
+
+
+class WhenThePluginIsEnabled(_Plane):
+    def test_no_hook_is_declared(self):
+        self._write({"enabledPlugins": {"charter@charter": True}})
+        status, _ = commands._ensure_guard_hook(self.root)
+        self.assertEqual(status, "present")
+        self.assertEqual(self._hooks(), {},
+                         "the plugin declares pretooluse; declaring it here too runs "
+                         "charter twice per Bash call")
+
+    def test_a_disabled_plugin_is_not_a_declaration(self):
+        """`enabled: false` means the operator turned it off. The hook is then the only
+        thing standing between the plane root and an unguarded branch move."""
+        self._write({"enabledPlugins": {"charter@charter": False}})
+        commands._ensure_guard_hook(self.root)
+        self.assertIn("PreToolUse", self._hooks())
+
+    def test_somebody_elses_plugin_does_not_count(self):
+        self._write({"enabledPlugins": {"other@marketplace": True}})
+        commands._ensure_guard_hook(self.root)
+        self.assertIn("PreToolUse", self._hooks())
+
+
+class WhenThereIsNoPlugin(_Plane):
+    def test_the_hook_is_still_written(self):
+        self._write({"statusLine": {"type": "command", "command": "charter statusline"}})
+        self.assertEqual(commands._ensure_guard_hook(self.root)[0], "created")
+        self.assertIn("PreToolUse", self._hooks())
+
+    def test_a_plane_with_no_settings_at_all_gets_the_hook(self):
+        self.settings.unlink(missing_ok=True)
+        self.assertEqual(commands._ensure_guard_hook(self.root)[0], "created")
+        self.assertIn("PreToolUse", self._hooks())
+
+    def test_an_existing_charter_hook_is_not_duplicated(self):
+        commands._ensure_guard_hook(self.root)
+        self.assertEqual(commands._ensure_guard_hook(self.root)[0], "present")
+        self.assertEqual(len(self._hooks()["PreToolUse"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ships **#247**: `wire()` refreshes rather than only creating, so an opencode plugin an older charter wrote is replaced instead of surviving every upgrade while `doctor` reports it wired. An edited plugin is still named, never overwritten.

Two more found by reading this plane's `git status` after upgrading — both the same shape as the Codex doubling:

### `init` declared a hook the enabled plugin already declares

`_ensure_guard_hook` wrote a `PreToolUse` entry into `.claude/settings.json` without ever asking whether the charter plugin was enabled — while `doctor.check_guard_wired` counts an enabled plugin as wired and *says so*: `wired (enabled plugin charter@charter)`. Both live, so `charter hook pretooluse` ran **twice for every Bash call**.

One writer and one checker disagreeing about what "wired" means, in the same file, in the same process.

`enabled: false` is still not a declaration — the operator turned it off, and the hook is then the only thing between the plane root and an unguarded branch move. Somebody else's plugin doesn't count either.

### A committed config pointing at a file that no longer exists

`opencode.json` was committed at the plane root in #223 with `instructions: [".opencode/charter-context.md"]`. 0.43.0 stopped writing that file into the plane, so the repo shipped a config naming a path that never appears. Removed.

Any leftover `.opencode/` in a clone is inert and safe to delete — `docs/install.md` says so, and part of it is opencode's own `node_modules`, not charter's.

2369 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo