### PR TITLE
A playwright-cli session belongs to the version that opened it

### DIFF
--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -32,7 +32,19 @@ npx @playwright/cli@<version> -s=owner close
 npx @playwright/cli@<version> kill-all      # reap stale processes
 ```
 
-Pin the version explicitly in every command. The tool is pre-1.0 and its behaviour moves.
+**Pin the version explicitly in every command** — and this is a hard requirement, not
+style. A session belongs to the *version* that opened it: state lives in
+`~/Library/Caches/ms-playwright/daemon/<hash>/<name>.session`, and that hash keys on the
+installation, not on your working directory. Two commands that resolve different versions
+therefore look at different daemons, and the second reports:
+
+```
+The browser 'owner' is not open, please run open first
+```
+
+…while the first browser is alive and still logged in. Drop the pin on one command in a
+flow — leaving `npx` to fetch whatever is latest — and you get exactly that. Sessions do
+cross directories; they do not cross versions.
 
 ## Credentials — never typed, never printed
 


### PR DESCRIPTION
Closes #243 — with the real mechanism, which is not the one the report proposed.

## What I measured

Sessions live in `~/Library/Caches/ms-playwright/daemon/<hash>/<name>.session`. What that hash keys on:

```
sessions opened in two DIFFERENT directories   -> same daemon  21f6ba2fd575361c
a session opened with 0.1.17 instead of 0.1.18 -> NEW  daemon  0018e32689295331
```

The hash keys on the **installation**, not the directory. Confirmed from the other side too: a session opened in one directory answers `snapshot` from a completely different one and returns the live page. And `./.playwright-cli/` holds snapshot artifacts (`page-*.yml`), not session state.

So the reported symptom was real and the diagnosis was not: **sessions cross directories; they do not cross versions.**

## What that changes

The skill already said *"pin the version explicitly in every command"*. That was filed under style — the tool is pre-1.0 and its behaviour moves. It is actually a hard requirement, and now says why:

> Drop the pin on **one** command in a flow, `npx` resolves whatever is latest, and that command looks at a different daemon and reports `The browser 'owner' is not open, please run open first` — while the first browser is alive and still logged in.

Which is exactly the error #243 hit. And the recovery is the trap #248 documented: re-running `open` starts a second browser, and the bridge has already shredded the dotenv, so it cannot be authenticated without re-running the whole flow.

## Note

Five browsers were opened during this investigation and all were closed; `daemon/` holds no sessions afterwards.

Suite: **2384 passing**.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUyeVUu8iLZHLsUDUMvdUX