### PR TITLE
fix: doctor reports a guard declared twice, and one function decides what "wired" means

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -706,25 +706,21 @@ def _hooks_snippet() -> str:
     return json.dumps({"hooks": {"PreToolUse": [_GUARD_HOOK]}}, indent=2)
 
 
-def _charter_plugin_enabled(settings_path: Path) -> bool:
-    """Is a charter plugin switched on in *settings_path*'s ``enabledPlugins``?
+def _plugin_dispatches_guard() -> str | None:
+    """The enabled plugin whose own ``hooks.json`` dispatches `charter hook pretooluse`.
 
-    ``enabled: false`` is not a declaration — the operator turned it off, and the hook is
-    then the only thing between the plane root and an unguarded branch move. Somebody
-    else's plugin does not count either.
+    Deliberately NOT "is a charter plugin enabled". `doctor._plugin_declaring_guard`
+    records why, and 0.43.1 got it wrong by reading `enabledPlugins` instead: **installed,
+    enabled and wired are three different states, and only the third protects anything**
+    (#177). A plugin from before the guard existed is enabled and dispatches nothing — and
+    skipping the hook for it would leave the plane root unguarded while looking configured.
 
-    Never raises: a malformed file is handled by the caller, which refuses to repair it.
+    Shared with `doctor.check_guard_wired` on purpose. A writer and a checker answering
+    "is this wired?" from different evidence is how the guard came to be declared twice.
     """
-    try:
-        doc = json.loads(settings_path.read_text())
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-        return False
-    if not isinstance(doc, dict):
-        return False
-    enabled = doc.get("enabledPlugins")
-    if not isinstance(enabled, dict):
-        return False
-    return any(on and str(name).split("@")[0] == "charter" for name, on in enabled.items())
+    from . import doctor
+
+    return doctor._plugin_declaring_guard()
 
 
 def _ensure_guard_hook(root: Path) -> tuple[str, Path | None]:
@@ -745,7 +741,7 @@ def _ensure_guard_hook(root: Path) -> tuple[str, Path | None]:
     # `charter hook pretooluse` runs twice for every Bash call — the same doubling Codex
     # got from two installers, arrived at here by one writer and one checker disagreeing
     # about what "wired" means in the same file.
-    if _charter_plugin_enabled(p):
+    if _plugin_dispatches_guard():
         return "present", p
     if not p.exists():
         try:

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -563,18 +563,40 @@ def check_guard_wired() -> Result:
     name = "plane-root guard"
     if not _config.HAS_CONTROL_PLANE:
         return Result(name, OK, detail="no control plane found")
-    if os.environ.get("CLAUDE_PLUGIN_ROOT"):
-        return Result(name, OK, detail="wired (Claude Code plugin)")
-    installed = _plugin_declaring_guard()
-    if installed:
-        return Result(name, OK, detail=f"wired (enabled plugin {installed})")
 
+    # `commands._ensure_guard_hook` asks the SAME question through the same function.
+    # Reading different evidence is how a writer and a checker disagreed about "wired"
+    # and left the guard declared twice — and enabled is not dispatched (#177).
+    plugin = ("Claude Code plugin" if os.environ.get("CLAUDE_PLUGIN_ROOT")
+              else _plugin_declaring_guard())
+
+    declared = []
     for p in _settings_files():
         try:
             if "charter hook pretooluse" in p.read_text():
-                return Result(name, OK, detail=f"wired ({p})")
+                declared.append(p)
         except (OSError, UnicodeDecodeError):
             continue
+
+    if plugin and declared:
+        # Not broken — doubled, which is why nobody finds it: two denials for one command
+        # read as one stubborn denial. 0.43.1 stopped `init` writing this; planes wired
+        # before it still carry the copy, and charter will not delete from a file that is
+        # the operator's and git-tracked.
+        where = ", ".join(str(p) for p in declared[:2])
+        return Result(name, WARN,
+                      detail=f"declared twice — the {plugin} dispatches it, and so does "
+                             f"{where}",
+                      hint=f"charter runs `hook pretooluse` once per declaration, so every "
+                           f"Bash call is guarded twice. Remove the charter `hooks` block "
+                           f"from {where} and keep the plugin — or disable the plugin and "
+                           f"keep the block. charter does not edit that file for you.")
+    if plugin:
+        detail = ("wired (Claude Code plugin)" if plugin == "Claude Code plugin"
+                  else f"wired (enabled plugin {plugin})")
+        return Result(name, OK, detail=detail)
+    if declared:
+        return Result(name, OK, detail=f"wired ({declared[0]})")
     return Result(name, WARN,
                   detail="pretooluse is not wired — branch moves in the plane root are "
                          "NOT refused",

--- a/tests/test_doctor_guard_doubled.py
+++ b/tests/test_doctor_guard_doubled.py
@@ -1,0 +1,98 @@
+"""`doctor` reports a guard declared twice, not just one declared nowhere.
+
+`check_guard_wired` was built for the absence case (#168): nothing dispatches the hook and
+the row said health. The opposite state arrived by charter's own hand — `_ensure_guard_hook`
+wrote a `PreToolUse` entry into `.claude/settings.json` without asking whether the charter
+plugin was already enabled in that same file. Both were live, so `charter hook pretooluse`
+ran twice for every Bash call.
+
+0.43.1 stopped `init` adding it. That does nothing for the planes that already have it, and
+`doctor` calls them wired — the same "looks fine from the outside" state, arrived at from
+the other direction. A guard running twice is not broken, which is exactly why nobody finds
+it: two denials for one command read as one stubborn denial.
+
+Charter reports and does not delete. The file is the operator's, git-tracked, and holds keys
+charter has no business touching — the restraint `_ensure_statusline` has kept since it was
+written.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import config, doctor
+
+
+class _Plane(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="charter-doubled-"))
+        self.addCleanup(lambda: shutil.rmtree(self.root, True))
+        (self.root / ".claude").mkdir(parents=True)
+        self.settings = self.root / ".claude" / "settings.json"
+        self.enterContext(mock.patch.object(config, "ROOT", self.root))
+        self.enterContext(mock.patch.object(config, "HAS_CONTROL_PLANE", True))
+        # No ambient plugin install and no plugin-owned process: each test says which.
+        self.enterContext(mock.patch.dict("os.environ", {}, clear=True))
+        self.dispatching = self.enterContext(
+            mock.patch.object(doctor, "_plugin_declaring_guard", return_value=None))
+        self.enterContext(mock.patch.object(doctor, "_settings_files",
+                                            return_value=[self.settings]))
+
+    def _write(self, doc: dict) -> None:
+        self.settings.write_text(json.dumps(doc, indent=2) + "\n")
+
+    _HOOK = {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [
+        {"type": "command", "command": "charter hook pretooluse", "timeout": 10}]}]}}
+
+
+class DeclaredTwice(_Plane):
+    def test_a_plugin_and_a_settings_hook_is_reported(self):
+        self.dispatching.return_value = "charter@charter"
+        self._write(dict(self._HOOK))
+        r = doctor.check_guard_wired()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("twice", r.detail.lower())
+
+    def test_it_names_the_file_to_edit_and_does_not_edit_it(self):
+        self.dispatching.return_value = "charter@charter"
+        self._write(dict(self._HOOK))
+        before = self.settings.read_text()
+        r = doctor.check_guard_wired()
+        self.assertIn("settings.json", r.hint)
+        self.assertEqual(self.settings.read_text(), before,
+                         "doctor reports; it never edits the operator's file")
+
+
+class DeclaredOnce(_Plane):
+    def test_the_plugin_alone_is_a_clean_row(self):
+        self.dispatching.return_value = "charter@charter"
+        self._write({})
+        r = doctor.check_guard_wired()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIn("plugin", r.detail)
+
+    def test_a_settings_hook_alone_is_a_clean_row(self):
+        self._write(dict(self._HOOK))
+        self.assertEqual(doctor.check_guard_wired().status, doctor.OK)
+
+    def test_a_plugin_that_dispatches_nothing_beside_a_hook_is_not_doubled(self):
+        """Enabled is not dispatched (#177). A plugin from before the guard existed wires
+        nothing, so the hook is the only guard there is — calling that doubled would send
+        someone to delete their only protection."""
+        self._write(dict(self._HOOK))          # `_plugin_declaring_guard` stays None
+        self.assertEqual(doctor.check_guard_wired().status, doctor.OK)
+
+    def test_neither_is_still_the_warning_this_check_was_built_for(self):
+        self._write({"statusLine": {"type": "command", "command": "charter statusline"}})
+        r = doctor.check_guard_wired()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("NOT refused", r.detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_guard_hook_defers_to_the_plugin.py
+++ b/tests/test_guard_hook_defers_to_the_plugin.py
@@ -19,11 +19,17 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from charter import commands
+from unittest import mock
+
+from charter import commands, doctor
 
 
 class _Plane(unittest.TestCase):
     def setUp(self) -> None:
+        # Mocked, never read from the machine: the real one inspects the DEVELOPER's
+        # ~/.claude/plugins, so these tests passed or failed by who ran them.
+        self.dispatching = self.enterContext(
+            mock.patch.object(doctor, "_plugin_declaring_guard", return_value=None))
         self.root = Path(tempfile.mkdtemp(prefix="charter-guardhook-"))
         self.addCleanup(lambda: shutil.rmtree(self.root, True))
         self.settings = self.root / ".claude" / "settings.json"
@@ -36,29 +42,27 @@ class _Plane(unittest.TestCase):
         return json.loads(self.settings.read_text()).get("hooks", {})
 
 
-class WhenThePluginIsEnabled(_Plane):
+class WhenAPluginDispatchesTheGuard(_Plane):
     def test_no_hook_is_declared(self):
-        self._write({"enabledPlugins": {"charter@charter": True}})
+        self.dispatching.return_value = "charter@charter"
+        self._write({})
         status, _ = commands._ensure_guard_hook(self.root)
         self.assertEqual(status, "present")
         self.assertEqual(self._hooks(), {},
                          "the plugin declares pretooluse; declaring it here too runs "
                          "charter twice per Bash call")
 
-    def test_a_disabled_plugin_is_not_a_declaration(self):
-        """`enabled: false` means the operator turned it off. The hook is then the only
-        thing standing between the plane root and an unguarded branch move."""
-        self._write({"enabledPlugins": {"charter@charter": False}})
+    def test_a_plugin_that_dispatches_nothing_is_not_a_declaration(self):
+        """Installed, enabled and wired are three states and only the third protects
+        anything (#177). 0.43.1 read `enabledPlugins` and would have skipped the hook for
+        a plugin from before the guard existed — leaving the plane root unguarded while
+        looking configured."""
+        self._write({"enabledPlugins": {"charter@charter": True}})   # enabled, wires nothing
         commands._ensure_guard_hook(self.root)
         self.assertIn("PreToolUse", self._hooks())
 
-    def test_somebody_elses_plugin_does_not_count(self):
-        self._write({"enabledPlugins": {"other@marketplace": True}})
-        commands._ensure_guard_hook(self.root)
-        self.assertIn("PreToolUse", self._hooks())
 
-
-class WhenThereIsNoPlugin(_Plane):
+class WhenNothingDispatchesIt(_Plane):
     def test_the_hook_is_still_written(self):
         self._write({"statusLine": {"type": "command", "command": "charter statusline"}})
         self.assertEqual(commands._ensure_guard_hook(self.root)[0], "created")


### PR DESCRIPTION
`check_guard_wired` was built for the **absence** case (#168): nothing dispatches the hook and the row said health. The opposite state arrived by charter's own hand — `_ensure_guard_hook` wrote a `PreToolUse` entry into `.claude/settings.json` without asking whether a plugin already dispatched the guard. Both live, so `charter hook pretooluse` ran **twice for every Bash call**.

0.43.1 stopped `init` adding it. That did nothing for planes wired before it, and `doctor` called them wired.

> A doubled guard is not broken, which is why nobody finds it: two denials for one command read as one stubborn denial.

```
!  plane-root guard  declared twice — the charter@charter plugin dispatches it, and so
                     does …/.claude/settings.json
   → charter runs `hook pretooluse` once per declaration, so every Bash call is guarded
     twice. Remove the charter `hooks` block … or disable the plugin and keep the block.
     charter does not edit that file for you.
```

### The root cause wasn't either side

The writer and the checker answered *"is this wired?"* from **different evidence**, in the same file, in the same process. They now call one function.

### Which exposed a hole 0.43.1 shipped

It read `enabledPlugins` — and **installed, enabled and wired are three different states; only the third protects anything** (#177, recorded in `_plugin_declaring_guard`'s own docstring). A charter plugin from before the guard existed is enabled and dispatches nothing, and 0.43.1 would have skipped writing the hook for it, **leaving the plane root unguarded while looking configured**.

I reintroduced the error that docstring exists to prevent, one commit after reading it. Fixed here.

charter reports and does not delete — the file is the operator's and git-tracked.

Also: the 0.43.1 tests read the *developer's* `~/.claude/plugins`, so they passed or failed by who ran them. Mocked.

2389 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo