### PR TITLE
0.43.2 — the guard is decided by one function, and a doubled one is reported

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.43.1",
+  "version": "0.43.2",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.43.1"
+__version__ = "0.43.2"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.43.1",
+            "command": "charter hook sessionstart --plugin-version 0.43.2",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.43.1",
+            "command": "charter hook userpromptsubmit --plugin-version 0.43.2",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.43.1",
+            "command": "charter hook pretooluse --plugin-version 0.43.2",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.43.1",
+            "command": "charter hook pretooluse-read --plugin-version 0.43.2",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.43.1"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.43.2"
           }
         ]
       }
@@ -78,7 +78,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.43.1",
+            "command": "charter hook posttooluse --plugin-version 0.43.2",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.43.1",
+            "command": "charter hook posttooluse-skill --plugin-version 0.43.2",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.43.1",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.43.2",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.43.1"
+version = "0.43.2"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Ships **#251** — which fixes a hole 0.43.1 opened, and adds the detection 0.43.1 could not give the planes that already had the problem.

**The hole.** 0.43.1 taught `_ensure_guard_hook` to skip when a charter plugin is enabled, read from `enabledPlugins`. But *installed, enabled and wired are three different states, and only the third protects anything* (#177) — a plugin from before the guard existed is enabled and dispatches nothing, so charter would have declined to write the hook and **left the plane root unguarded while looking configured**. The writer now asks the same function `doctor` asks.

**The detection.** A plane wired before 0.43.1 still carries both declarations, and `doctor` called it wired. It now says `declared twice`, names the file, and says which half to remove — without editing it.

Narrow in reach, worth a release anyway: it is the guard, and "unguarded while looking configured" is the failure this repo has paid for in #168, #177 and #197.

2389 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo