### PR TITLE
A plane declares its front door, and choosing a persona stops moving everyone else's

### DIFF
--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -203,12 +203,31 @@ def _print_memory_summary(name: str) -> None:
           f"recall: charter persona recall {name}")
 
 
+def _scope_note(scope: str) -> str:
+    """How far this selection reaches, in the words the reader needs.
+
+    Three answers that differ in ways that matter, so none of them may be left implicit —
+    the reader who is not told goes looking for a bug the next time the status line
+    disagrees with what they picked. Only a terminal pointer survives closing and
+    reopening Claude; a session-scoped choice is gone with the session, and what the next
+    session starts as is the plane's declared front door, which may be nothing at all.
+    """
+    if scope == "terminal":
+        return " for this terminal (kept across closing/reopening Claude)"
+    if scope == "session":
+        nxt = persona.declared_default() or persona.default_persona()
+        starts = f"starts as '{nxt}'" if nxt else "starts with no persona"
+        return (f" for this session only — this terminal reports no pane id, "
+                f"so a new session {starts}")
+    return " for this control plane (no session or pane id to scope it to)"
+
+
 def cmd_persona_use(args) -> int:
     if not persona.load(args.name):
         util.err(f"no persona '{args.name}' (create it: charter persona create {args.name})")
         return 1
-    persona.set_active(args.name)
-    util.ok(f"Active persona set to '{args.name}'.")
+    scope = persona.set_active(args.name)
+    util.ok(f"Active persona set to '{args.name}'{_scope_note(scope)}.")
     _warn_env(args.name)
     _say_mcp_boundary(args.name)
     return 0

--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -263,33 +263,60 @@ def cmd_persona_clear(args) -> int:
 
 
 def cmd_persona_default(args) -> int:
-    """Show / set / clear the committed team-wide default persona (personas/.default) —
-    the one adopted when no --persona / $CHARTER_PERSONA / `charter persona use` is set."""
-    f = config.PERSONAS_DIR / ".default"
+    """Show / set / clear the plane's declared front door — ``charter.toml``'s
+    ``[persona] default``, the persona adopted when no ``--persona`` / ``$CHARTER_PERSONA``
+    / ``charter persona use`` is set.
+
+    Writes ``charter.toml`` rather than the legacy ``personas/.default`` dotfile. Both
+    still resolve (a plane that adopted the dotfile keeps working), but only one of them is
+    in the file a consumer opens to read their plane, and the invisible one is the one that
+    shipped, tested green, and was adopted by nobody — including this repo (#255).
+    """
+    from . import instance as _instance
+
+    legacy = config.PERSONAS_DIR / ".default"
     if getattr(args, "clear", False):
-        if f.exists():
-            f.unlink()
-            util.ok("Cleared the committed default persona (commit with `charter save`).")
+        # Both rungs, or a plane would still declare a front door after being told it no
+        # longer does — the dotfile resolves whenever charter.toml is silent.
+        had = bool(persona.declared_default() or persona.default_persona())
+        _instance.set_default_persona(config.ROOT, None)
+        if legacy.exists():
+            legacy.unlink()
+        if had:
+            util.ok("Cleared the declared default persona (commit with `charter save`).")
         else:
-            util.info("No committed default persona was set.")
+            util.info("No default persona was declared.")
         return 0
     if getattr(args, "name", None):
         if not persona.load(args.name):
             util.err(f"no persona '{args.name}' — create it first (`charter persona create {args.name}`).")
             return 1
-        config.PERSONAS_DIR.mkdir(parents=True, exist_ok=True)
-        f.write_text(args.name + "\n")
-        util.ok(f"Committed default persona set to '{args.name}' → personas/.default (shared; "
-                "commit with `charter save`).")
+        if not _instance.set_default_persona(config.ROOT, args.name):
+            util.err(f"could not write {config.ROOT / 'charter.toml'} — is this a control plane?")
+            return 1
+        util.ok(f"Default persona declared: '{args.name}' → charter.toml [persona] default "
+                "(shared; commit with `charter save`).")
+        if legacy.exists():
+            # Say it at the moment it becomes true, not in a doctor run somebody may never
+            # do: from now on the two files disagree and the dotfile is the one that loses.
+            util.warn(f"personas/.default also exists (naming '{persona.default_persona() or '?'}') "
+                      "and is now IGNORED — charter.toml outranks it. Delete it: "
+                      "rm personas/.default")
         util.info("Overridden per-developer by `charter persona use` / $CHARTER_PERSONA / --persona.")
+        return 0
+    declared = persona.declared_default()
+    if declared:
+        print(declared)
+        util.info("declared front door (charter.toml [persona] default). "
+                  "Change: charter persona default <name>  ·  clear: --clear")
         return 0
     d = persona.default_persona()
     if d:
         print(d)
-        util.info("committed team-wide default (personas/.default). "
-                  "Change: charter persona default <name>  ·  clear: --clear")
+        util.info("committed team-wide default (personas/.default) — the legacy location. "
+                  f"Move it: charter persona default {d}")
     else:
-        util.info("No committed default persona. Set one: charter persona default <name>")
+        util.info("No default persona declared. Set one: charter persona default <name>")
     return 0
 
 

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1249,6 +1249,47 @@ def check_memory_indexes() -> Result:
                   detail=f"{dangling} dangling, {unindexed} unindexed", hint=hint)
 
 
+def check_front_door() -> Result:
+    """The plane's declared default persona still names a persona that exists.
+
+    Both rungs that can declare one — ``charter.toml``'s ``[persona] default`` and the
+    legacy ``personas/.default`` — validate their value and resolve to ``None`` when the
+    persona was renamed or deleted. That resolution is right (no identity beats a broken
+    one) and it used to be the whole response: the plane silently lost its front door, and
+    every surface that would have shown one simply showed nothing.
+
+    Silence is how ``personas/.default`` came to ship, test green, and be adopted by
+    nobody. The replacement does not get to inherit it.
+
+    WARN, never FAIL, on the same reasoning as :func:`check_personas`: doctor's blockers
+    mean "you cannot work", and a plane with no persona still clones, still reaches its
+    forge, still runs.
+    """
+    from . import config, instance as _instance, persona
+    name = "front door"
+    try:
+        declared = _instance.default_persona_of(_instance.load(config.ROOT))
+        legacy = (config.PERSONAS_DIR / ".default")
+        legacy_name = legacy.read_text().strip() if legacy.exists() else ""
+    except Exception as e:
+        return Result(name, WARN, detail=f"not checked ({e})", hint=_NOT_CHECKED_HINT)
+
+    # charter.toml first: it is the rung that wins, so it is the one whose breakage
+    # actually costs the plane its identity.
+    for value, where in ((declared, "charter.toml [persona] default"),
+                         (legacy_name, "personas/.default")):
+        if not value:
+            continue
+        if persona.def_path(value).exists():
+            return Result(name, OK, detail=f"'{value}' via {where}")
+        return Result(
+            name, WARN,
+            detail=f"{where} names '{value}', which is not a persona — this plane has no "
+                   f"front door and every session starts with no identity",
+            hint=f"charter persona default <name>  (or `charter persona create {value}`)")
+    return Result(name, OK, detail="none declared")
+
+
 def check_personas() -> Result:
     """Roster config health — `persona lint` across every persona, summarised.
 
@@ -1631,7 +1672,8 @@ def _checks():
                 check_workspace_clones(),
                 check_inventory(), check_vaults(),
                 check_vault_registry_divergence(), check_version_lock(),
-                check_memory_indexes(), check_personas(), check_ask_rules(),
+                check_memory_indexes(), check_personas(), check_front_door(),
+                check_ask_rules(),
                 check_shadowed_knowledge(),
                 check_mcp_launchers(), check_plugin_skew()]
     return results

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -83,6 +83,22 @@ def default_workspace_of(cfg: dict, fallback: str) -> str:
     return (cfg.get("workspace") or {}).get("default") or fallback
 
 
+def default_persona_of(cfg: dict) -> str | None:
+    """The persona this control plane declares as its front door — ``[persona] default``.
+
+    No fallback argument, unlike its workspace twin above: a plane with no declared
+    workspace still has to act on *some* workspace, while a plane with no declared persona
+    genuinely has no front door, and charter inventing one would be it choosing an identity
+    nobody asked for. Absence returns ``None`` and every caller treats that as "no persona".
+
+    A blank value is absence, not a persona named ``"   "`` — a half-edited key should
+    behave like the key that was there before it.
+    """
+    val = (cfg.get("persona") or {}).get("default")
+    val = str(val).strip() if val is not None else ""
+    return val or None
+
+
 #: How far a written memory travels. Ordered least → most public.
 SHARE_MODES = ("local", "commit", "push")
 
@@ -101,15 +117,39 @@ def locked_version(cfg: dict) -> str | None:
 
 def set_locked_version(root: Path, version: str) -> bool:
     """Write ``[charter] version`` into charter.toml, preserving the rest verbatim.
+    :func:`_set_key` owns the how, and the why it is a textual edit."""
+    return _set_key(root, "charter", "version", version)
+
+
+def set_default_persona(root: Path, name: str | None) -> bool:
+    """Declare (or, with ``name=None``, undeclare) ``[persona] default`` in charter.toml.
+
+    Same textual edit as the version lock, through the same helper: two callers writing a
+    key into a section of one hand-edited file is one behaviour, and hand-rolling it twice
+    is how the second copy learns a lesson the first already knows (here: that ``default``
+    also names a key under ``[workspace]``).
+    """
+    return _set_key(root, "persona", "default", name)
+
+
+def _set_key(root: Path, section: str, key_name: str, value: str | None) -> bool:
+    """Set — or with ``value=None`` remove — ``key_name`` inside ``[section]``.
 
     Edited as text rather than round-tripped: stdlib ``tomllib`` reads TOML but
     cannot write it, and re-emitting through any serialiser would strip every
     comment the file carries — unacceptable in a file people hand-edit.
 
-    The edit is confined to the ``[charter]`` section's own line span. An earlier
-    draft substituted the first ``version =`` line in the file, which happily
-    rewrote ``[[forge]] version = "api-v4"`` and left the lock untouched — silent
-    corruption of a committed config.
+    The edit is confined to the section's own line span. An earlier draft substituted the
+    first ``version =`` line in the file, which happily rewrote ``[[forge]] version =
+    "api-v4"`` and left the lock untouched — silent corruption of a committed config. The
+    span matters more now than it did then: ``default`` is a key under ``[workspace]``
+    *and* under ``[persona]``, so a file-wide substitution would swap a plane's workspace
+    for a persona name.
+
+    Removal leaves an emptied section header in place. Deleting it would mean deciding
+    whether a comment sitting under the header belonged to the key or to the section, and
+    an empty ``[persona]`` reads the same as no ``[persona]`` to every consumer of this
+    file — including :func:`default_persona_of`.
     """
     import re
     p = Path(root) / MARKER
@@ -118,22 +158,27 @@ def set_locked_version(root: Path, version: str) -> bool:
     except OSError:
         return False
 
-    header = re.compile(r"^[ \t]*\[charter\][ \t]*$")
+    header = re.compile(rf"^[ \t]*\[{re.escape(section)}\][ \t]*$")
     any_header = re.compile(r"^[ \t]*\[")
-    key = re.compile(r"^([ \t]*version[ \t]*=[ \t]*).*$")
+    key = re.compile(rf"^([ \t]*{re.escape(key_name)}[ \t]*=[ \t]*).*$")
 
     start = next((i for i, ln in enumerate(lines) if header.match(ln)), None)
     if start is None:
+        if value is None:
+            return True  # nothing declared, nothing to undeclare
         tail = "" if not lines or lines[-1].endswith("\n") else "\n"
-        lines += [tail, "\n", "[charter]\n", f'version = "{version}"\n']
+        lines += [tail, "\n", f"[{section}]\n", f'{key_name} = "{value}"\n']
     else:
         stop = next((i for i in range(start + 1, len(lines)) if any_header.match(lines[i])),
                     len(lines))
         hit = next((i for i in range(start + 1, stop) if key.match(lines[i])), None)
-        if hit is None:
-            lines.insert(start + 1, f'version = "{version}"\n')
+        if value is None:
+            if hit is not None:
+                del lines[hit]
+        elif hit is None:
+            lines.insert(start + 1, f'{key_name} = "{value}"\n')
         else:
-            lines[hit] = key.sub(lambda m: f'{m.group(1)}"{version}"', lines[hit])
+            lines[hit] = key.sub(lambda m: f'{m.group(1)}"{value}"', lines[hit])
     try:
         p.write_text("".join(lines))
     except OSError:

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -309,33 +309,70 @@ def default_persona() -> str | None:
     return val if val and def_path(val).exists() else None
 
 
-def resolve_active(explicit: str | None = None) -> str | None:
-    """Active persona by precedence: ``--persona`` → ``$CHARTER_PERSONA`` → local
-    ``.charter/active-persona`` (``charter persona use``) → committed ``personas/.default`` → none."""
+def declared_default() -> str | None:
+    """The front door this control plane DECLARES — ``charter.toml``'s ``[persona] default``.
+
+    Outranks the legacy ``personas/.default`` dotfile, which keeps resolving so no plane
+    that adopted it breaks. The move is about findability, not capability: the dotfile is
+    invisible to ``ls``, appears in no documentation page, and was used by nobody —
+    including this repo, whose own front door resolved through a gitignored local file
+    instead (#255). ``charter.toml`` is the file a consumer already opens to understand
+    their plane, and ``[workspace] default`` is already in it.
+
+    Validated against what exists, exactly like :func:`default_persona`: a declaration
+    naming a persona that was renamed or deleted resolves to *nothing* rather than to a
+    broken identity. Saying so out loud is `doctor`'s job — silence here is the fail-toward-
+    no-change half, not the whole answer.
+
+    Never raises. A malformed or too-new ``charter.toml`` is a real error, and every actual
+    command surfaces it through :func:`instance.load`; but this rung is read by hooks on
+    every session start and every status-line paint, where the rule is that a hook may cost
+    a session its briefing and never its turn.
+    """
+    from . import instance as _instance
+    try:
+        val = _instance.default_persona_of(_instance.load(config.ROOT))
+    except Exception:
+        return None
+    return val if val and def_path(val).exists() else None
+
+
+def _resolved(explicit: str | None = None) -> tuple[str | None, str]:
+    """``(persona, where it came from)`` — the whole precedence, decided ONCE.
+
+    :func:`resolve_active` and :func:`source` are two questions about a single decision,
+    and they used to walk the rungs separately. Two ladders answering one question is the
+    shape this repo's own convention warns about: adding a rung to one and forgetting the
+    other yields a session that adopts a persona while reporting it came from nowhere.
+    """
     if explicit:
-        return explicit
+        return explicit, "--persona"
     env = os.environ.get("CHARTER_PERSONA")
     if env:
-        return env.strip()
+        return env.strip(), "$CHARTER_PERSONA"
     f = config.ACTIVE_PERSONA_FILE
     if f.exists():
         val = f.read_text().strip()
         if val:
-            return val
-    return default_persona()
+            return val, "active-file"
+    declared = declared_default()
+    if declared:
+        return declared, "charter.toml"
+    committed = default_persona()
+    if committed:
+        return committed, "committed-default"
+    return None, "none"
+
+
+def resolve_active(explicit: str | None = None) -> str | None:
+    """Active persona by precedence: ``--persona`` → ``$CHARTER_PERSONA`` → local
+    ``.charter/active-persona`` (``charter persona use``) → declared ``charter.toml``
+    ``[persona] default`` → committed ``personas/.default`` → none."""
+    return _resolved(explicit)[0]
 
 
 def source(explicit: str | None = None) -> str:
-    if explicit:
-        return "--persona"
-    if os.environ.get("CHARTER_PERSONA"):
-        return "$CHARTER_PERSONA"
-    f = config.ACTIVE_PERSONA_FILE
-    if f.exists() and f.read_text().strip():
-        return "active-file"
-    if default_persona():
-        return "committed-default"
-    return "none"
+    return _resolved(explicit)[1]
 
 
 def set_active(name: str) -> None:

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -337,6 +337,31 @@ def declared_default() -> str | None:
     return val if val and def_path(val).exists() else None
 
 
+def _pointer_files() -> tuple[Path | None, Path | None]:
+    """``(session pointer, terminal pointer)`` for right now — either may be ``None``.
+
+    Mirrors workspaces exactly (``.charter/sessions/<id>.workspace`` and
+    ``.charter/terminals/<id>.workspace``), because the failure it prevents is the same
+    one, one noun over: a single plane-wide file meant `charter persona use forge` in one
+    pane changed the persona in every other pane and every future session, which is the
+    opposite of what a fleet of parallel personas is for (#255).
+    """
+    from . import session as _session
+    sid = _session.current()
+    tid = _session.terminal()
+    return (config.SESSIONS_DIR / f"{sid}.persona" if sid else None,
+            config.TERMINALS_DIR / f"{tid}.persona" if tid else None)
+
+
+def _read_pointer(f: Path | None) -> str | None:
+    if f is None:
+        return None
+    try:
+        return f.read_text().strip() or None
+    except OSError:
+        return None
+
+
 def _resolved(explicit: str | None = None) -> tuple[str | None, str]:
     """``(persona, where it came from)`` — the whole precedence, decided ONCE.
 
@@ -350,6 +375,13 @@ def _resolved(explicit: str | None = None) -> tuple[str | None, str]:
     env = os.environ.get("CHARTER_PERSONA")
     if env:
         return env.strip(), "$CHARTER_PERSONA"
+    sf, tf = _pointer_files()
+    val = _read_pointer(sf)
+    if val:
+        return val, "session"
+    val = _read_pointer(tf)
+    if val:
+        return val, "terminal"
     f = config.ACTIVE_PERSONA_FILE
     if f.exists():
         val = f.read_text().strip()
@@ -375,19 +407,46 @@ def source(explicit: str | None = None) -> str:
     return _resolved(explicit)[1]
 
 
-def set_active(name: str) -> None:
+def set_active(name: str) -> str:
+    """Select *name* for this session and this pane. Returns the reach of what was written
+    (``session`` | ``terminal`` | ``plane``) so a caller can say how long it will last.
+
+    The plane-wide file is written only when there is neither a session id nor a pane id —
+    a bare shell with nothing to key on. That is the one case where it is still the right
+    answer, and it is why the file is kept rather than removed.
+    """
     config.STATE_DIR.mkdir(parents=True, exist_ok=True)
-    config.ACTIVE_PERSONA_FILE.write_text((name or "") + "\n")
+    sf, tf = _pointer_files()
+    for f in (sf, tf):
+        if f is not None:
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text((name or "") + "\n")
+    if sf is None and tf is None:
+        config.ACTIVE_PERSONA_FILE.write_text((name or "") + "\n")
     try:
         from . import trace
         trace.record("persona-use", persona=name)
     except Exception:
         pass
+    # The terminal pointer outlives the session one, so it names the longest-lived thing
+    # that actually landed — the same reasoning `workspace.use` records for its own return.
+    return "terminal" if tf is not None else "session" if sf is not None else "plane"
 
 
 def clear_active() -> None:
-    if config.ACTIVE_PERSONA_FILE.exists():
-        config.ACTIVE_PERSONA_FILE.unlink()
+    """Drop this session's and this pane's selection, and the plane-wide file with them.
+
+    All three, because they are rungs of one ladder: clearing only the top rung would hand
+    the session straight back to a lower one, and "cleared" would be a lie the very next
+    command exposes.
+    """
+    sf, tf = _pointer_files()
+    for f in (sf, tf, config.ACTIVE_PERSONA_FILE):
+        try:
+            if f is not None and f.exists():
+                f.unlink()
+        except OSError:
+            pass
 
 
 # --------------------------------------------------------------------------- #

--- a/charter/session.py
+++ b/charter/session.py
@@ -46,6 +46,55 @@ def current(explicit: str | None = None) -> str | None:
     return sid or None
 
 
+#: Environment variables that identify ONE PANE — one shell, so at most one Claude
+#: session. Safe to key a pointer on.
+_PANE_ID_VARS = (
+    "TERM_SESSION_ID",   # iTerm2 / Terminal.app — per pane, survives reopen
+    "TMUX_PANE",         # tmux pane
+    "STY",               # GNU screen
+    "SSH_TTY",           # the pty of this ssh session
+)
+
+#: Identifies a WINDOW, which holds many tabs and splits. Listed to be explicit that it
+#: is deliberately NOT used — see :func:`terminal`.
+_WINDOW_ID_VARS = ("WINDOWID",)
+
+
+def terminal(explicit: str | None = None) -> str | None:
+    """A stable id for the current terminal PANE, or ``None`` when there isn't one.
+
+    Unlike the session id this survives closing and reopening Claude in the same pane,
+    which is the whole reason a per-terminal pointer exists. It lives here, beside
+    :func:`current`, because "who is this session" and "which pane is it in" are the two
+    halves of one question, and this module exists because that question had three
+    disagreeing answers.
+
+    ``WINDOWID`` is deliberately absent, and used to sit second in this chain. It
+    identifies a *window*, and a window holds many tabs and splits — so every Claude
+    session in that window received the same "terminal" id, wrote the same pointer, and
+    read each other's. Observed exactly that way: two sessions in one window, one runs
+    `charter ws use user-reporting`, and the other — which had no pointer of its own and
+    so fell through to the terminal one — silently moved with it. Parallel workspaces are
+    the feature; sharing one behind the user's back is the failure it exists to prevent.
+
+    So the rule is: key the pointer on something that identifies a pane, or do not write
+    one at all. Returning ``None`` costs only the survives-a-restart convenience, and only
+    in terminals that cannot tell their panes apart — the caller then falls to its
+    per-session pointer, which Claude Code always provides. An id that is wrong in the
+    sharing direction is worse than no id.
+    """
+    raw = explicit or next(
+        (v for v in (os.environ.get(k) for k in _PANE_ID_VARS) if v), None)
+    if not raw:
+        try:
+            raw = os.ttyname(0)              # controlling tty, if stdin is one — per pane
+        except Exception:
+            raw = None
+    if not raw:
+        return None
+    return _SAFE.sub("-", raw.strip()) or None
+
+
 def bucket(explicit: str | None = None) -> str:
     """A directory name for this session's state — :data:`NO_SESSION` when there is none.
 

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1214,6 +1214,17 @@ def _session_news(sid: str | None) -> list[str]:
     return out
 
 
+def _persona_exists(name: str) -> bool:
+    """Whether a persona definition is on disk. One `Path.exists`, so it is affordable on
+    a surface that renders every turn — and it asks `persona.def_path`, which owns where a
+    charter may live (directory layout, or the legacy flat file)."""
+    try:
+        from . import persona
+        return persona.def_path(name).exists()
+    except Exception:
+        return True   # unknown is not "missing": never manufacture an alert from a failure
+
+
 def _alerts(active: str) -> list[str]:
     """Full-width alert lines — a pinned-version mismatch, workspaces needing reinit,
     a nested plane, a plane root being worked in.
@@ -1235,6 +1246,14 @@ def _alerts(active: str) -> list[str]:
         if locked and locked != __version__:
             out.append(f"{_YELLOW}⚠{_R} {_DIM}charter{_R} {__version__} {_DIM}→ pinned{_R} "
                        f"{locked}{_DIM} · charter version sync{_R}")
+        # A declared front door that names nothing resolves to no persona at all, and
+        # every surface that would have shown one shows nothing instead — including this
+        # one, whose persona chip simply disappears. The absence is the symptom and it is
+        # unreadable; the row is what makes it a message. `doctor` has room to explain.
+        declared = _instance.default_persona_of(_instance.load(config.ROOT))
+        if declared and not _persona_exists(declared):
+            out.append(f"{_YELLOW}⚠{_R} {_DIM}front door{_R} {declared} {_DIM}— no such "
+                       f"persona · charter persona default <name>{_R}")
         stale = [w for w in _ws.list_workspaces() if w != active and _ws.needs_reinit(w)]
         if stale:
             out.append(f"{_YELLOW}⚠{_R} {_DIM}reinit{_R} {len(stale)} {_DIM}ws · "

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -57,53 +57,13 @@ def _session_file(sid: str) -> Path:
     return config.SESSIONS_DIR / f"{sid}.workspace"
 
 
-#: Environment variables that identify ONE PANE — one shell, so at most one Claude
-#: session. Safe to key a workspace pointer on.
-_PANE_ID_VARS = (
-    "TERM_SESSION_ID",   # iTerm2 / Terminal.app — per pane, survives reopen
-    "TMUX_PANE",         # tmux pane
-    "STY",               # GNU screen
-    "SSH_TTY",           # the pty of this ssh session
-)
-
-#: Identifies a WINDOW, which holds many tabs and splits. Listed to be explicit that it
-#: is deliberately NOT used — see `_terminal_id`.
-_WINDOW_ID_VARS = ("WINDOWID",)
-
-
 def _terminal_id(explicit: str | None = None) -> str | None:
-    """A stable id for the current terminal PANE, or ``None`` when there isn't one.
-
-    Unlike the Claude session id this survives closing and reopening Claude in the same
-    pane, which is the whole reason a per-terminal pointer exists.
-
-    ``WINDOWID`` is deliberately absent, and used to sit second in this chain. It
-    identifies a *window*, and a window holds many tabs and splits — so every Claude
-    session in that window received the same "terminal" id, wrote the same pointer, and
-    read each other's. Observed exactly that way: two sessions in one window, one runs
-    `charter ws use user-reporting`, and the other — which had no pointer of its own and
-    so fell through to the terminal one — silently moved with it. `source()` said
-    `terminal`; `set_active`'s docstring promised "selecting a workspace in one pane never
-    changes another". Parallel workspaces are the feature; sharing one behind the user's
-    back is the failure it exists to prevent.
-
-    So the rule is now: key the pointer on something that identifies a pane, or do not
-    write one at all. Returning ``None`` costs only the survives-a-restart convenience,
-    and only in terminals that cannot tell their panes apart — `resolve` then falls to the
-    per-session pointer, which Claude Code always provides, and to `default`. An id that
-    is wrong in the sharing direction is worse than no id.
-    """
-    raw = explicit or next(
-        (v for v in (os.environ.get(k) for k in _PANE_ID_VARS) if v), None)
-    if not raw:
-        try:
-            raw = os.ttyname(0)              # controlling tty, if stdin is one — per pane
-        except Exception:
-            raw = None
-    if not raw:
-        return None
-    tid = re.sub(r"[^A-Za-z0-9._-]", "-", raw.strip())
-    return tid or None
+    """This terminal PANE's id, or ``None`` — see :func:`charter.session.terminal`,
+    which owns it. Kept as a module-level name because it is the seam tests patch to
+    simulate a pane-less shell, and because `persona` asks the same question: two
+    copies of the WINDOWID lesson is one copy too many."""
+    from . import session as _session
+    return _session.terminal(explicit)
 
 
 def _terminal_file(tid: str) -> Path:

--- a/docs/adr/0016-charter-presents-the-roster-it-never-guesses-the-owner.md
+++ b/docs/adr/0016-charter-presents-the-roster-it-never-guesses-the-owner.md
@@ -1,0 +1,63 @@
+# charter presents the roster; it never guesses the owner
+
+Personas advertise what they accept. `delegate-when` is prose, written by whoever created
+the persona, rendered into the generated sub-agent description that a router reads. What
+no field has ever expressed is the other direction — when the persona currently *acting*
+should hand work away — and the tally says the gap costs something real: on this plane,
+three dispatches ever, all to one persona, while three others advertised correct triggers,
+linted green, and were never dispatched once.
+
+The obvious way to close it is for charter to match the incoming prompt against every
+`delegate-when` and name a winner: *"this looks like `statusline`'s work."* That is the
+design this ADR refuses, before the code that would host it exists.
+
+## The decision
+
+When charter helps route work, it injects **facts it owns** and nothing else: which
+personas exist, what each one's `delegate-when` claims, when each was last dispatched, and
+whether anything has been dispatched this turn. The model reads that and routes. charter
+never names the owner.
+
+## Why
+
+**charter cannot justify the claim.** A keyword overlap between a prompt and a prose
+advert is not evidence of ownership. ADR 0009 already draws this line for errors — *they
+classify, they do not guess* — and `curate.py` holds it for memory curation, which
+nominates duplicates with stdlib string distance and leaves every judgement to the agent.
+Routing is the same shape: cheap heuristics, expensive mistakes.
+
+**A confident wrong answer is worse than silence.** The roster block rides the
+commitment-point gate, which exists because a nudge that becomes wallpaper stops being
+read. The first time charter says "this belongs to `release`" about a status-line bug, the
+block joins the set of things people skim past — and it takes the honest half of the
+message, the part that says nothing was dispatched, with it.
+
+**A second source of truth would drift.** The alternative to matching prose is a
+`triggers:` field of regexes beside the advert. Then a persona claims its remit twice, in
+two languages, and the copy nobody edits is the one routing reads. `delegate-when` is
+already maintained because it is the description a human sees when choosing.
+
+**Path ownership contradicts the rule the roster teaches.** `owns: charter/statusline.py`
+is the other tempting matcher, and steward's own charter rejects it in prose: *route on
+the work, not the file — a version string inside `tests/test_plugin.py` is `release`'s.*
+
+## Consequences
+
+**The `require` level cannot name a culprit.** With no owner asserted, the strongest thing
+a tool-time check may say is *"you are editing and nothing was dispatched this turn,"*
+listing the roster. That is a weaker sentence than "you should have delegated to
+`statusline`" and it is the one charter can actually stand behind.
+
+**Routing quality depends on the adverts.** A persona with a vague `delegate-when` routes
+badly, and charter cannot compensate. `persona lint` already warns on a missing one; that
+warning is now load-bearing rather than tidy.
+
+**The roster costs context on work-shaped prompts.** Name plus advert plus a date, for each
+persona, on prompts the commitment gate already classifies as work. That is the price of
+not guessing, and it scales with roster size — a plane with forty personas will need a
+narrowing rule (`routes-to:` prioritises; it deliberately does not restrict, because a
+restriction silently hides personas created after it was written).
+
+**This ADR ships before the mechanism it governs.** Deliberately. The matcher is the
+obvious next improvement to a roster block — the kind of change that arrives as a small,
+plausible patch long after everyone has forgotten why the block only ever states facts.

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -206,12 +206,67 @@ edited one would make every charter suspect.
 The analysis is deterministic and stdlib-only. The judgement belongs to whoever reads the
 proposals.
 
+## The front door: which persona a session starts as
+
+A plane declares its default persona in `charter.toml`, beside `[workspace] default`:
+
+```toml
+[persona]
+default = "steward"
+```
+
+Set it with `charter persona default <name>` (or edit the file — it is yours). This is the
+persona a session adopts when nobody has chosen one, and it is the only thing charter knows
+about front doors: **no persona name appears anywhere in charter's own code.** The name is
+your plane's, and the persona is an ordinary file you can rename, rewrite or delete.
+
+`charter init` creates no personas at all, so a fresh plane has no front door until you
+declare one. That is deliberate — charter never invents an identity for you.
+
+### Precedence
+
+Six rungs, highest first. The first one that names an existing persona wins:
+
+| Rung | Where | Scope |
+| --- | --- | --- |
+| `--persona <name>` | the flag | one command |
+| `$CHARTER_PERSONA` | the environment | one shell / one launched session |
+| session pointer | `.charter/sessions/<id>.persona` | this session |
+| terminal pointer | `.charter/terminals/<id>.persona` | this pane, across restarts |
+| declared default | `charter.toml` `[persona] default` | the plane, committed |
+| legacy default | `personas/.default` | the plane, committed — see below |
+
+`charter persona use <name>` writes the session *and* terminal pointers, so two panes hold
+two personas and neither moves the other. Only the terminal pointer survives closing and
+reopening Claude, and only when your terminal reports a pane id — `use` says which of the
+two it got, because the difference is one you act on.
+
+A shell with neither a session id nor a pane id (a bare script, say) has nothing to key a
+pointer on. There `use` writes `.charter/active-persona`, the plane-wide local file, which
+is what that file is now for.
+
+### `personas/.default` (legacy)
+
+`personas/.default` is the older committed declaration. It still resolves, one rung below
+`charter.toml`, so a plane that adopted it keeps working. Prefer the TOML key: it lives in
+the file you already read to understand your plane, while a dotfile inside `personas/` is
+invisible to `ls` and was, in practice, adopted by nobody. When both exist, `charter persona
+default` tells you the dotfile is now ignored.
+
+### When the declaration goes stale
+
+Rename or delete the persona a plane declares and the declaration resolves to *nothing* —
+no identity, rather than a broken one. Two surfaces say so rather than leaving you to notice
+the absence: `charter doctor` reports it (`front door`, a warning, with the fix), and the
+status line carries one row naming the missing persona.
+
 ## Everyday commands
 
 ```
 charter persona list                       # who exists, who's active, vault status
 charter persona show devops                # effective (inheritance-merged) charter
-charter persona use devops                 # make it the active persona (this session)
+charter persona use devops                 # active persona for this session + this pane
+charter persona default devops             # the plane's front door (charter.toml)
 charter persona secret set API_TOKEN --stdin   # store a credential (never on argv)
 charter persona secret exec --env TOKEN=API_TOKEN -- some-cli   # use it without ever seeing it
 charter persona lint                       # dangling uses:/extends:, missing role/vault, drafts, stale agents

--- a/tests/test_dangling_front_door.py
+++ b/tests/test_dangling_front_door.py
@@ -1,0 +1,97 @@
+"""A declared front door that names no persona is said out loud.
+
+`persona.declared_default` and `persona.default_persona` both validate their value against
+what exists and return ``None`` when it does not — the right resolution (fail toward no
+change: no identity beats a broken one), and until now the *entire* response. Rename or
+delete a persona and the plane quietly has no front door: no role block in the briefing,
+no memory digest, no routing, and nothing anywhere saying why.
+
+Silence is exactly how `personas/.default` came to be shipped, tested, documented nowhere
+and adopted by nobody (#255). The same silence must not now guard its replacement.
+
+WARN, not FAIL: doctor's blockers list means "you cannot work", and a plane with no
+persona still clones, still reaches the forge, still runs. Loud is the requirement; a
+blocker is not.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from charter import config, doctor, persona, statusline
+from tests._isolation import PersonaIso
+
+
+class FrontDoorIso(PersonaIso):
+    def declare(self, name: str) -> None:
+        (config.ROOT / "charter.toml").write_text(
+            f'schema = 1\n\n[persona]\ndefault = "{name}"\n')
+
+    def real(self, name: str) -> None:
+        self.make_persona(name, role=name.title(), vault="none")
+
+
+class TestDoctorNamesIt(FrontDoorIso):
+    def test_a_declaration_naming_no_persona_warns(self):
+        self.declare("ghost")
+        r = doctor.check_front_door()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("ghost", r.detail)
+
+    def test_the_hint_says_how_to_fix_it(self):
+        self.declare("ghost")
+        r = doctor.check_front_door()
+        self.assertIn("charter persona default", r.hint or "")
+
+    def test_a_declaration_that_resolves_is_ok(self):
+        self.real("steward")
+        self.declare("steward")
+        r = doctor.check_front_door()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIn("steward", r.detail)
+
+    def test_no_declaration_at_all_is_not_a_problem(self):
+        """A plane may legitimately have no front door — charter never invents one, and a
+        check that nags about an intended state teaches people to skim past doctor."""
+        self.real("steward")
+        (config.ROOT / "charter.toml").write_text("schema = 1\n")
+        r = doctor.check_front_door()
+        self.assertEqual(r.status, doctor.OK)
+
+    def test_a_dangling_legacy_dotfile_warns_too(self):
+        """Same failure, older file — it resolves whenever charter.toml is silent."""
+        (config.PERSONAS_DIR / ".default").write_text("ghost\n")
+        r = doctor.check_front_door()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("ghost", r.detail)
+
+    def test_it_runs_in_the_doctor_sweep(self):
+        """A check registered nowhere reports to nobody — the very defect this closes."""
+        names = [r.name for r in doctor.run_all()]
+        self.assertIn("front door", names)
+
+
+class TestTheStatusLineSaysIt(FrontDoorIso):
+    def _alerts(self) -> str:
+        return "\n".join(statusline._alerts("default"))
+
+    def test_a_dangling_declaration_gets_a_row(self):
+        self.declare("ghost")
+        out = self._alerts()
+        self.assertIn("ghost", out)
+
+    def test_a_resolving_declaration_gets_no_row(self):
+        """Silence is the design: a row that renders every turn is furniture within a day,
+        and then a real one draws no more attention than a zero would."""
+        self.real("steward")
+        self.declare("steward")
+        self.assertNotIn("steward", self._alerts())
+
+    def test_no_declaration_gets_no_row(self):
+        (config.ROOT / "charter.toml").write_text("schema = 1\n")
+        self.assertEqual(self._alerts().strip(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_persona_default_declaration.py
+++ b/tests/test_persona_default_declaration.py
@@ -1,0 +1,198 @@
+"""A plane declares its front door in `charter.toml`, beside `[workspace] default`.
+
+The committed mechanism that already existed — `personas/.default` — is a dotfile inside
+`personas/`, invisible to `ls`, documented in no page, and (issue #255) unused even in
+charter's own plane. It keeps working; the declaration a consumer can actually find moves
+to the file they already read to understand their control plane.
+
+charter learns *which* persona is the front door and nothing about what that persona is
+called: no name is hardcoded anywhere in the engine.
+"""
+from __future__ import annotations
+
+import io
+import os
+import unittest
+from contextlib import redirect_stderr
+from types import SimpleNamespace
+from unittest import mock
+
+from tests._isolation import PersonaIso
+from charter import config, instance, persona
+
+
+class DeclaredDefaultIso(PersonaIso):
+    def _no_env(self):
+        return mock.patch.dict(
+            os.environ,
+            {k: v for k, v in os.environ.items() if k != "CHARTER_PERSONA"},
+            clear=True)
+
+    def declare(self, name: str) -> None:
+        """Write a control plane whose `[persona] default` is *name*."""
+        (config.ROOT / "charter.toml").write_text(
+            f'schema = 1\n\n[[forge]]\nkind = "github"\nowner = "acme"\n\n'
+            f'[persona]\ndefault = "{name}"\n')
+
+
+class TestInstanceReadsTheDeclaration(DeclaredDefaultIso):
+    def test_reads_the_declared_default_persona(self):
+        self.declare("steward")
+        cfg = instance.load(config.ROOT)
+        self.assertEqual(instance.default_persona_of(cfg), "steward")
+
+    def test_silence_is_none_not_a_guess(self):
+        """A plane that declares no front door has none — charter never picks one."""
+        (config.ROOT / "charter.toml").write_text('schema = 1\n')
+        self.assertIsNone(instance.default_persona_of(instance.load(config.ROOT)))
+
+    def test_a_blank_declaration_is_treated_as_absent(self):
+        (config.ROOT / "charter.toml").write_text('schema = 1\n\n[persona]\ndefault = "  "\n')
+        self.assertIsNone(instance.default_persona_of(instance.load(config.ROOT)))
+
+
+class TestResolutionOrder(DeclaredDefaultIso):
+    def test_the_declaration_is_adopted_when_nothing_else_is_set(self):
+        self.make_persona("steward", role="Steward", vault="none")
+        self.declare("steward")
+        with self._no_env():
+            self.assertEqual(persona.resolve_active(), "steward")
+
+    def test_the_source_names_charter_toml(self):
+        """`source()` is what the session briefing prints, so it must say where the
+        identity came from — a consumer looking for the wrong file cannot change it."""
+        self.make_persona("steward", role="Steward", vault="none")
+        self.declare("steward")
+        with self._no_env():
+            self.assertEqual(persona.source(), "charter.toml")
+
+    def test_charter_toml_outranks_the_legacy_dotfile(self):
+        self.make_persona("steward", role="S", vault="none")
+        self.make_persona("older", role="O", vault="none")
+        (config.PERSONAS_DIR / ".default").write_text("older\n")
+        self.declare("steward")
+        with self._no_env():
+            self.assertEqual(persona.resolve_active(), "steward")
+
+    def test_the_dotfile_still_resolves_when_charter_toml_is_silent(self):
+        """Back-compat: a plane that adopted `personas/.default` keeps working untouched."""
+        self.make_persona("older", role="O", vault="none")
+        (config.PERSONAS_DIR / ".default").write_text("older\n")
+        (config.ROOT / "charter.toml").write_text('schema = 1\n')
+        with self._no_env():
+            self.assertEqual(persona.resolve_active(), "older")
+            self.assertEqual(persona.source(), "committed-default")
+
+    def test_the_local_choice_still_outranks_the_declaration(self):
+        """`charter persona use` is a developer's own selection; a plane-wide declaration
+        must never override the person sitting at the terminal."""
+        self.make_persona("steward", role="S", vault="none")
+        self.make_persona("forge", role="F", vault="none")
+        self.declare("steward")
+        persona.set_active("forge")
+        with self._no_env():
+            self.assertEqual(persona.resolve_active(), "forge")
+
+    def test_the_environment_still_outranks_the_declaration(self):
+        self.make_persona("steward", role="S", vault="none")
+        self.declare("steward")
+        with mock.patch.dict(os.environ, {"CHARTER_PERSONA": "forge"}):
+            self.assertEqual(persona.resolve_active(), "forge")
+
+
+class TestDanglingDeclaration(DeclaredDefaultIso):
+    def test_a_declaration_naming_no_persona_resolves_to_none(self):
+        """Fail toward no change: a renamed or deleted persona leaves the session with no
+        identity rather than a broken one. Saying so is `doctor`'s job, not this one's."""
+        self.declare("ghost")
+        with self._no_env():
+            self.assertIsNone(persona.resolve_active())
+            self.assertEqual(persona.source(), "none")
+
+
+
+class TestWritingTheDeclaration(DeclaredDefaultIso):
+    """`charter persona default <name>` writes the declaration a consumer can find."""
+
+    def _plane(self, extra: str = "") -> None:
+        (config.ROOT / "charter.toml").write_text(
+            '# a plane someone hand-edited\nschema = 1\n\n'
+            '[[forge]]\nkind = "github"\nowner = "acme"\n\n'
+            '[workspace]\ndefault = "scratch"\n' + extra)
+
+    def _run(self, name=None, clear=False) -> int:
+        from charter import commands_persona
+        return commands_persona.cmd_persona_default(
+            SimpleNamespace(name=name, clear=clear))
+
+    def test_setting_writes_charter_toml_not_the_dotfile(self):
+        self._plane()
+        self.make_persona("steward", role="S", vault="none")
+        self.assertEqual(self._run(name="steward"), 0)
+        cfg = instance.load(config.ROOT)
+        self.assertEqual(instance.default_persona_of(cfg), "steward")
+        self.assertFalse((config.PERSONAS_DIR / ".default").exists())
+
+    def test_the_rest_of_the_file_survives_verbatim(self):
+        """charter.toml is hand-edited and carries comments; stdlib TOML cannot write, so
+        the edit is textual and must not disturb a line it does not own."""
+        self._plane()
+        self.make_persona("steward", role="S", vault="none")
+        self._run(name="steward")
+        text = (config.ROOT / "charter.toml").read_text()
+        self.assertIn("# a plane someone hand-edited", text)
+        self.assertIn('owner = "acme"', text)
+        self.assertIn('[workspace]', text)
+
+    def test_the_workspace_default_is_not_the_one_rewritten(self):
+        """`[workspace] default` and `[persona] default` are the same key name in two
+        sections — the edit is confined to its own section's line span."""
+        self._plane()
+        self.make_persona("steward", role="S", vault="none")
+        self._run(name="steward")
+        cfg = instance.load(config.ROOT)
+        self.assertEqual(instance.default_workspace_of(cfg, "fallback"), "scratch")
+        self.assertEqual(instance.default_persona_of(cfg), "steward")
+
+    def test_setting_it_twice_replaces_rather_than_appends(self):
+        self._plane()
+        self.make_persona("steward", role="S", vault="none")
+        self.make_persona("forge", role="F", vault="none")
+        self._run(name="steward")
+        self._run(name="forge")
+        text = (config.ROOT / "charter.toml").read_text()
+        self.assertEqual(text.count("[persona]"), 1)
+        self.assertEqual(instance.default_persona_of(instance.load(config.ROOT)), "forge")
+
+    def test_an_unknown_persona_is_refused(self):
+        self._plane()
+        self.assertEqual(self._run(name="ghost"), 1)
+        self.assertIsNone(instance.default_persona_of(instance.load(config.ROOT)))
+
+    def test_clearing_removes_the_declaration_and_the_legacy_dotfile(self):
+        """Both rungs, or `--clear` would leave a plane still declaring a front door."""
+        self._plane()
+        self.make_persona("steward", role="S", vault="none")
+        self.make_persona("older", role="O", vault="none")
+        self._run(name="steward")
+        (config.PERSONAS_DIR / ".default").write_text("older\n")
+        self.assertEqual(self._run(clear=True), 0)
+        with self._no_env():
+            self.assertIsNone(persona.resolve_active())
+
+    def test_setting_it_while_the_dotfile_survives_names_the_migration(self):
+        """A plane with both would resolve through charter.toml and leave the old file
+        quietly disagreeing — say so at the moment it becomes true."""
+        self._plane()
+        self.make_persona("steward", role="S", vault="none")
+        (config.PERSONAS_DIR / ".default").write_text("older\n")
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            self._run(name="steward")
+        out = buf.getvalue().lower()
+        self.assertIn("personas/.default", out)
+        # Naming the file is not enough — it must say the old one no longer decides.
+        self.assertIn("ignored", out)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_persona_selection_scope.py
+++ b/tests/test_persona_selection_scope.py
@@ -1,0 +1,214 @@
+"""Selecting a persona is per-session and per-terminal, exactly like a workspace.
+
+`charter persona use` used to write ONE file for the whole plane
+(`.charter/active-persona`), so choosing `forge` in one pane silently changed the persona
+in every other pane and in every future session — while workspaces, whose pointers this
+mirrors, have kept a per-session *and* a per-terminal pointer for precisely that reason.
+Parallel work with different personas is the feature; sharing one identity behind the
+user's back is the failure this closes (#255).
+
+The legacy plane-wide file keeps resolving one rung lower, so nobody's existing selection
+disappears on upgrade.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from tests._isolation import PersonaIso
+from charter import config, persona
+
+_SCOPE_VARS = ("CHARTER_PERSONA", "CHARTER_SESSION_ID", "CLAUDE_CODE_SESSION_ID",
+               "TERM_SESSION_ID", "TMUX_PANE", "STY", "SSH_TTY")
+
+
+class SelectionScopeIso(PersonaIso):
+    def env(self, **kw):
+        """A pristine environment: no persona override, and only the scope ids given.
+
+        `os.ttyname` is neutralised alongside them. `_terminal_id` falls back to the
+        controlling tty when no pane variable is set, so a suite run from a terminal would
+        find a pane id and one run in CI would not — the machine-is-not-the-runner trap
+        CONTRIBUTING describes, and it would make every "no terminal pointer" assertion
+        below pass locally and fail on the runner.
+        """
+        keep = {k: v for k, v in os.environ.items() if k not in _SCOPE_VARS}
+        keep.update(kw)
+        env = mock.patch.dict(os.environ, keep, clear=True)
+        tty = mock.patch("os.ttyname", side_effect=OSError("no tty"))
+        return _Both(env, tty)
+
+    def persona_(self, name: str) -> str:
+        return self.make_persona(name, role=name.title(), vault="none")
+
+
+class _Both:
+    """Two context managers as one — `with self.env(...)` reads better than a nest."""
+
+    def __init__(self, *cms):
+        self.cms = cms
+
+    def __enter__(self):
+        for c in self.cms:
+            c.__enter__()
+        return self
+
+    def __exit__(self, *exc):
+        for c in reversed(self.cms):
+            c.__exit__(*exc)
+        return False
+
+
+class TestPerSessionSelection(SelectionScopeIso):
+    def test_a_selection_is_scoped_to_the_session_that_made_it(self):
+        self.persona_("forge")
+        with self.env(CHARTER_SESSION_ID="s1"):
+            persona.set_active("forge")
+            self.assertEqual(persona.resolve_active(), "forge")
+        with self.env(CHARTER_SESSION_ID="s2"):
+            self.assertIsNone(persona.resolve_active())
+
+    def test_the_source_names_the_session(self):
+        self.persona_("forge")
+        with self.env(CHARTER_SESSION_ID="s1"):
+            persona.set_active("forge")
+            self.assertEqual(persona.source(), "session")
+
+    def test_clearing_only_clears_this_session(self):
+        self.persona_("forge")
+        self.persona_("release")
+        with self.env(CHARTER_SESSION_ID="s1"):
+            persona.set_active("forge")
+        with self.env(CHARTER_SESSION_ID="s2"):
+            persona.set_active("release")
+            persona.clear_active()
+            self.assertIsNone(persona.resolve_active())
+        with self.env(CHARTER_SESSION_ID="s1"):
+            self.assertEqual(persona.resolve_active(), "forge")
+
+
+class TestPerTerminalSelection(SelectionScopeIso):
+    def test_a_pane_keeps_its_persona_across_sessions(self):
+        """The reason a terminal pointer exists at all: a pane survives closing Claude."""
+        self.persona_("forge")
+        with self.env(CHARTER_SESSION_ID="s1", TMUX_PANE="%7"):
+            persona.set_active("forge")
+        with self.env(CHARTER_SESSION_ID="s2", TMUX_PANE="%7"):
+            self.assertEqual(persona.resolve_active(), "forge")
+            self.assertEqual(persona.source(), "terminal")
+
+    def test_another_pane_is_unaffected(self):
+        self.persona_("forge")
+        with self.env(CHARTER_SESSION_ID="s1", TMUX_PANE="%7"):
+            persona.set_active("forge")
+        with self.env(CHARTER_SESSION_ID="s2", TMUX_PANE="%9"):
+            self.assertIsNone(persona.resolve_active())
+
+    def test_the_session_pointer_outranks_the_pane(self):
+        self.persona_("forge")
+        self.persona_("release")
+        with self.env(CHARTER_SESSION_ID="s1", TMUX_PANE="%7"):
+            persona.set_active("forge")
+        with self.env(CHARTER_SESSION_ID="s2", TMUX_PANE="%7"):
+            persona.set_active("release")
+            self.assertEqual(persona.resolve_active(), "release")
+
+    def test_no_pane_id_writes_no_terminal_pointer(self):
+        """An id that is wrong in the sharing direction is worse than no id."""
+        self.persona_("forge")
+        with self.env(CHARTER_SESSION_ID="s1"):
+            persona.set_active("forge")
+        self.assertFalse(any(config.TERMINALS_DIR.glob("*.persona"))
+                         if config.TERMINALS_DIR.exists() else False)
+
+
+class TestLegacyPlaneWideFile(SelectionScopeIso):
+    def test_it_still_resolves_when_no_pointer_exists(self):
+        """Fail toward no change: an upgrade must not drop someone's current selection."""
+        self.persona_("forge")
+        config.STATE_DIR.mkdir(parents=True, exist_ok=True)
+        config.ACTIVE_PERSONA_FILE.write_text("forge\n")
+        with self.env(CHARTER_SESSION_ID="s1"):
+            self.assertEqual(persona.resolve_active(), "forge")
+            self.assertEqual(persona.source(), "active-file")
+
+    def test_a_session_pointer_outranks_it(self):
+        self.persona_("forge")
+        self.persona_("release")
+        config.STATE_DIR.mkdir(parents=True, exist_ok=True)
+        config.ACTIVE_PERSONA_FILE.write_text("forge\n")
+        with self.env(CHARTER_SESSION_ID="s1"):
+            persona.set_active("release")
+            self.assertEqual(persona.resolve_active(), "release")
+
+    def test_it_outranks_the_declared_default(self):
+        self.persona_("forge")
+        self.persona_("steward")
+        (config.ROOT / "charter.toml").write_text(
+            'schema = 1\n\n[persona]\ndefault = "steward"\n')
+        config.STATE_DIR.mkdir(parents=True, exist_ok=True)
+        config.ACTIVE_PERSONA_FILE.write_text("forge\n")
+        with self.env(CHARTER_SESSION_ID="s1"):
+            self.assertEqual(persona.resolve_active(), "forge")
+
+    def test_clearing_removes_it_too(self):
+        """Otherwise `clear` would leave the plane-wide file quietly deciding again."""
+        self.persona_("forge")
+        config.STATE_DIR.mkdir(parents=True, exist_ok=True)
+        config.ACTIVE_PERSONA_FILE.write_text("forge\n")
+        with self.env(CHARTER_SESSION_ID="s1"):
+            persona.clear_active()
+            self.assertIsNone(persona.resolve_active())
+
+
+class TestWithNoSessionId(SelectionScopeIso):
+    def test_a_selection_with_no_session_and_no_pane_still_works(self):
+        """A bare shell (no harness session id, no pane) must still be able to choose —
+        it falls back to the plane-wide file, which is what that file is now for."""
+        self.persona_("forge")
+        with self.env():
+            persona.set_active("forge")
+            self.assertEqual(persona.resolve_active(), "forge")
+
+
+class TestUseReportsItsReach(SelectionScopeIso):
+    """`persona use` must say how long the selection lasts, because the three answers
+    differ and the reader who is not told goes looking for a bug the next time the status
+    line disagrees with what they chose."""
+
+    def _use(self, name: str) -> str:
+        import io
+        from contextlib import redirect_stderr
+        from types import SimpleNamespace
+        from charter import commands_persona
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            commands_persona.cmd_persona_use(SimpleNamespace(name=name))
+        return buf.getvalue()
+
+    def test_a_pane_selection_says_it_survives_a_restart(self):
+        self.persona_("forge")
+        with self.env(CHARTER_SESSION_ID="s1", TMUX_PANE="%7"):
+            out = self._use("forge").lower()
+        self.assertIn("terminal", out)
+
+    def test_without_a_pane_it_says_the_selection_dies_with_the_session(self):
+        self.persona_("forge")
+        with self.env(CHARTER_SESSION_ID="s1"):
+            out = self._use("forge").lower()
+        self.assertIn("this session only", out)
+
+    def test_without_a_pane_it_names_what_a_new_session_would_start_as(self):
+        """The declared default is what the next session gets — name it, or the reader
+        cannot tell whether the fallback is a persona or nothing at all."""
+        self.persona_("forge")
+        self.persona_("steward")
+        (config.ROOT / "charter.toml").write_text(
+            'schema = 1\n\n[persona]\ndefault = "steward"\n')
+        with self.env(CHARTER_SESSION_ID="s1"):
+            out = self._use("forge")
+        self.assertIn("steward", out)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workspace_parallel_isolation.py
+++ b/tests/test_workspace_parallel_isolation.py
@@ -20,7 +20,7 @@ import os
 import unittest
 from unittest import mock
 
-from charter import workspace
+from charter import session, workspace
 from tests._isolation import PersonaIso
 
 
@@ -29,7 +29,7 @@ def _env(**kw):
     `_terminal_id` falls back to `os.ttyname(0)`, which in an interactive test runner
     would otherwise supply a real id and make these non-deterministic."""
     keep = {k: v for k, v in os.environ.items()
-            if k not in (*workspace._PANE_ID_VARS, *workspace._WINDOW_ID_VARS)}
+            if k not in (*session._PANE_ID_VARS, *session._WINDOW_ID_VARS)}
     return mock.patch.dict(os.environ, {**keep, **kw}, clear=True)
 
 


### PR DESCRIPTION
Increment 1 of the delegation design settled in #255/#256. Three commits, each standing on its own; `python3 -m unittest discover -s tests` is green at 2430 tests, and every behaviour below was also exercised against a scratch plane end to end (declare, show, stale, `doctor`, status line).

**A plane declares its front door in `charter.toml`** (0d9db69)

```toml
[persona]
default = "steward"
```

A committed default already existed — `personas/.default`, written by `charter persona default` — as a dotfile inside `personas/`, invisible to `ls`, named in no documentation page, and used by nobody: this repo's own front door resolved through a gitignored local file instead (#255). It keeps resolving one rung lower, so no plane that adopted it breaks, and `charter persona default` says at the moment it becomes true that the dotfile is now ignored.

charter learns *which* persona is the front door and nothing about what it is called — no persona name appears in the engine.

Two refactors fell out, both the same lesson. `resolve_active` and `source` walked the precedence separately, so adding this rung to one and forgetting the other would have produced a session that adopts a persona while reporting it came from nowhere; they now share `_resolved`. And `set_locked_version`'s textual section edit became `_set_key`, shared with the new declaration — which matters here because `default` is a key under `[workspace]` *and* under `[persona]`, so a file-wide substitution would swap a plane's workspace for a persona name.

**Choosing a persona is per-session and per-pane** (f0f5d0e)

`charter persona use forge` wrote one file for the whole plane, so it changed the persona in every other pane and every future session. Workspaces have kept per-session and per-terminal pointers since the WINDOWID bug for exactly this reason; personas simply never grew them. They now have both, same layout one noun over (`.charter/sessions/<id>.persona`, `.charter/terminals/<id>.persona`).

`_terminal_id` moves to `session.terminal`, beside `session.current` — "who is this session" and "which pane is it in" are two halves of one question, and that module exists because the question already had three disagreeing answers. `persona use` now reports how far the selection reaches, because a pane selection survives a restart, a session one does not, and what the next session starts as is the declared default — which may be nothing, so it says that too.

**A stale front door is said out loud** (19a2a2d)

A declaration naming a renamed or deleted persona resolves to nothing — right, and previously the entire response. `doctor` gains a `front door` check and the status line carries one row naming the missing persona. The row is the point: the absence of a persona chip is the symptom, and an absence is unreadable.

WARN rather than FAIL, deliberately: this repo reserves FAIL for "you cannot work", and a plane with no persona still clones and still reaches its forge.

**ADR 0016 — charter presents the roster; it never guesses the owner**

The decision increment 2 rests on, written before the mechanism exists because a keyword matcher over `delegate-when` is exactly the kind of small plausible patch that arrives after everyone has forgotten why the block only states facts. Consequence accepted in the ADR: `require` can only ever say "you are editing and nothing was dispatched this turn", never name a culprit.

**Docs**: `docs/personas.md` gains the front-door section — the TOML key, all six precedence rungs with their scopes, what `personas/.default` is now for, and what a stale declaration looks like. None of it was documented before, including the mechanism that already existed.

Closes #255. Refs #256.
