### PR TITLE
A persona says when it should hand work away, and charter shows the roster without picking

### DIFF
--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -130,8 +130,8 @@ def cmd_persona_create(args) -> int:
                   f"charter vault add {vault} --provider plain-file --persona {args.name}")
 
     if args.use:
-        persona.set_active(args.name)
-        util.ok(f"Active persona set to '{args.name}'.")
+        scope = persona.set_active(args.name)
+        util.ok(f"Active persona set to '{args.name}'{_scope_note(scope)}.")
         _warn_env(args.name)
     return 0
 
@@ -536,7 +536,7 @@ _AGENT_PASSTHROUGH_KEYS = ("model", "color", "memory")
 _CHARTER_OWN_KEYS = (
     "name", "role", "vault", "extends", "uses", "delegate-when", "description",
     "agent-description", "agent-tools", "tools", "activity", "dispatch-isolation",
-    "draft", "skills", "disallowed-tools",
+    "draft", "skills", "disallowed-tools", "routing", "routes-to",
 )
 
 
@@ -1062,6 +1062,15 @@ def cmd_persona_stats(args) -> int:
         util.info(f"Routing: {total - gen}/{total} dispatches went to a persona · {gen} to a "
                   f"generic agent ({100 * gen // total}%). A high generic share means the work "
                   f"a persona owns is being done without it.")
+    # Fired-vs-followed. The roster block is a bet that showing who exists changes where
+    # work goes; this is the pair of numbers that can falsify it. Silent when advice has
+    # never fired — a "fired 0 · dispatched 0" row on every plane that has not opted in is
+    # a line people learn to skip, and it takes the rest of the report with it.
+    advice = dispatch.advice_tally()
+    if advice:
+        util.info(f"Routing advice: fired {advice} time(s) · {total} dispatch(es) followed. "
+                  f"Advice that fires and is never followed is the block failing, not the "
+                  f"roster — read it that way before adding more personas.")
     if drifted:
         util.info("SKILLS drift is named, not resolved: an unused declaration may be dead "
                   "weight or a skill whose moment has not come, and an undeclared one may "

--- a/charter/dispatch.py
+++ b/charter/dispatch.py
@@ -11,8 +11,11 @@ Shape of the store::
 
 Three properties matter:
 
-* **Counts and dates only.** A line is ``{"ts": …, "agent": …}`` — never the prompt, the
-  description, or any tool input. There is no secret surface to scan.
+* **Counts and dates only.** A line is ``{"ts": …, "agent": …}`` for a dispatch, or
+  ``{"ts": …, "event": "advice"}`` for routing advice having been shown — never the
+  prompt, the description, or any tool input. There is no secret surface to scan, and the
+  second shape was added under exactly that constraint: it records that the roster
+  appeared, never what it appeared about.
 * **Parallel-writer safe.** Lines are small and opened ``O_APPEND``, so concurrent
   dispatches (a fan-out of 8 sub-agents) append atomically without a lock.
 * **Conflict-free across engineers.** The filename carries the host, so two people
@@ -82,6 +85,41 @@ def record(agent: str, when: datetime | None = None) -> Path | None:
         return None
 
 
+#: Marks a row that records ROUTING ADVICE being shown rather than a dispatch happening.
+#: Same store, same two-fields-only discipline: a timestamp and this word. The pair
+#: "advice shown" vs "dispatches that followed" is the only number that can falsify the
+#: bet the roster block rests on — that seeing the roster changes routing — and a bet
+#: shipped without it repeats the gap this module's docstring was written about.
+ADVICE = "advice"
+
+
+def record_advice(when: datetime | None = None) -> Path | None:
+    """Append one 'routing advice was shown' event. Best-effort, like :func:`record`."""
+    when = when or _now()
+    p = path_for(when)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps({"event": ADVICE, "ts": when.isoformat(timespec="seconds")},
+                          sort_keys=True) + "\n"
+        fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        try:
+            os.write(fd, line.encode())
+        finally:
+            os.close(fd)
+        return p
+    except OSError:
+        return None
+
+
+def advice_tally(days: int | None = None) -> int:
+    """How many times routing advice was shown, optionally within the last *days*."""
+    rows = [o for o in _read_all() if o.get("event") == ADVICE]
+    if days is not None:
+        cutoff = _now() - timedelta(days=days)
+        rows = [o for o in rows if (t := _ts(o)) and t >= cutoff]
+    return len(rows)
+
+
 def _read_all() -> list[dict]:
     d = _dir()
     if not d.exists():
@@ -97,7 +135,7 @@ def _read_all() -> list[dict]:
                     o = json.loads(ln)
                 except ValueError:
                     continue
-                if isinstance(o, dict) and o.get("agent"):
+                if isinstance(o, dict) and (o.get("agent") or o.get("event")):
                     out.append(o)
         except OSError:
             continue
@@ -118,7 +156,7 @@ def tally(days: int | None = None) -> Counter:
     if days is not None:
         cutoff = _now() - timedelta(days=days)
         rows = [o for o in rows if (t := _ts(o)) and t >= cutoff]
-    return Counter(o["agent"] for o in rows)
+    return Counter(o["agent"] for o in rows if o.get("agent"))
 
 
 def last_seen(agent: str) -> str | None:
@@ -183,8 +221,8 @@ def _live_keys() -> set[tuple[str, str]]:
                 t = _ts(o)
             except ValueError:
                 continue
-            if t:
-                keys.add((t.isoformat(timespec="seconds"), str(o.get("agent") or "")))
+            if t and o.get("agent"):
+                keys.add((t.isoformat(timespec="seconds"), str(o.get("agent"))))
     return keys
 
 

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1287,6 +1287,20 @@ def check_front_door() -> Result:
             detail=f"{where} names '{value}', which is not a persona — this plane has no "
                    f"front door and every session starts with no identity",
             hint=f"charter persona default <name>  (or `charter persona create {value}`)")
+
+    # Nothing declared. Legitimate — charter never invents a front door — but on a plane
+    # that HAS personas it is worth saying once, here, that the roster block can never
+    # fire: the level is read from the acting persona, and there is none. Said in doctor
+    # rather than on every prompt, because a plane may mean exactly this.
+    try:
+        others = [n for n in persona.list_personas() if not n.startswith("_")]
+    except Exception:
+        others = []
+    if others:
+        return Result(name, OK,
+                      detail=f"none declared — {len(others)} persona(s) exist, so routing "
+                             f"advice is inert (no acting persona means no `routing:` level)",
+                      hint="charter persona default <name>")
     return Result(name, OK, detail="none declared")
 
 

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -1726,10 +1726,65 @@ _DIAGNOSE_RE = re.compile(
     r"not\s+work|doesn'?t\s+work|stack\s?trace|500\b|502\b|422\b|403\b|timeout)", re.I)
 
 
+def _roster_block() -> str:
+    """Who else could take this work — facts only, never a verdict (ADR 0016).
+
+    Fires when the ACTING persona declares ``routing: advise`` or ``require``. charter
+    states what it owns: who exists, what each one's ``delegate-when`` claims, when each
+    was last dispatched. It does not say which of them owns *this* prompt, because a
+    keyword overlap between a request and a prose advert is not evidence of ownership —
+    and a confident wrong answer would cost this block the reader it needs, taking the
+    honest half of the message with it.
+
+    Silent when the roster minus the acting persona is empty: a plane whose only persona
+    is the one acting has nobody to route to, and a block saying so on every work-shaped
+    prompt is the purest wallpaper this design could ship.
+
+    Rides the commitment gate's trigger and cooldown — see the caller.
+    """
+    try:
+        from . import dispatch, persona
+        active = persona.resolve_active()
+        if not active:
+            return ""          # no identity, no declared posture — the plane opted out
+        level = persona.routing_level(active)
+        if level not in ("advise", "require"):
+            return ""
+        roster = persona.roster_for(active)
+        if not roster:
+            return ""
+        rows = []
+        for r in roster:
+            when = (f"last dispatched {r['last_dispatched']}" if r["last_dispatched"]
+                    else "**never dispatched**")
+            claim = r["delegate_when"] or f"{r['role']} work (no delegate-when declared)"
+            rows.append(f"   • `{r['name']}` — {claim} · {when}")
+        dispatch.record_advice()
+        return (
+            f"⬡ **Who else could take this.** `{active}` declares `routing: {level}`, and "
+            f"these personas advertise work of their own. charter is **not** saying which "
+            f"one owns this — it cannot know that, and will not guess it (docs/adr/0016). "
+            f"These are the facts; the routing call is yours:\n"
+            + "\n".join(rows) + "\n"
+            f"Nothing has been dispatched this turn. Hand it over with the Agent tool, or "
+            f"say in one line why it stays with `{active}` — a cross-cutting change that "
+            f"would be split across three personas is a good reason."
+        )
+    except Exception:
+        return ""
+
+
 def _commitment_nudge(prompt: str, sid: str | None) -> str:
     signals = _commitment_signals(prompt)
     if not signals or not _commit_gate_due(sid):
         return ""
+    # The roster goes FIRST and inside this same message, deliberately. First because
+    # "whose work is this" precedes "how should I scope it" — routing away makes the rest
+    # of the gate the sub-agent's problem, not this session's. Inside, because two blocks
+    # on one prompt is how wallpaper gets manufactured, which is the failure this gate's
+    # own history is about.
+    roster = _roster_block()
+    lead = roster + "\n\n" if roster else ""
     diagnosing = bool(_DIAGNOSE_RE.search(prompt or ""))
     if diagnosing:
         shape = ("this reads as a **symptom to diagnose**, not a design to choose, and it "
@@ -1747,7 +1802,7 @@ def _commitment_nudge(prompt: str, sid: str | None) -> str:
         method = ("`superpowers:brainstorming` before a creative build · "
                   "`superpowers:test-driven-development` for code · "
                   "`superpowers:verification-before-completion` always")
-    return (
+    return lead + (
         f"⬢ **Commitment point** — {shape} {' · '.join(signals)}. "
         f"Before you dispatch, plan, or edit code:\n"
         f"1. **Scout first.** Read the code / measure it / check what already exists — enough to "

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -309,6 +309,82 @@ def default_persona() -> str | None:
     return val if val and def_path(val).exists() else None
 
 
+#: The outbound postures a persona may declare, least → most insistent. `off` is what an
+#: absent or unrecognised `routing:` means: a typo must not silently switch a gate on, and
+#: an upgrade must change nothing for a plane that has declared nothing.
+ROUTING_LEVELS = ("off", "advise", "require")
+
+
+def routing_level(name: str) -> str:
+    """How insistently *name* hands work away — its ``routing:``, inheritance-merged.
+
+    ``delegate-when`` says what a persona accepts; this says when it should stop doing the
+    work itself. Two directions, two words, deliberately unalike: a field called
+    ``delegation`` beside ``delegate-when`` would be one letter and one glance apart from
+    its own opposite.
+
+    Read from the ACTING persona only — the one whose session this is. That is the whole
+    reason there is no plane-level setting to merge with here: a floor would apply to
+    personas that never declared anything, which is the action-at-a-distance this design
+    was reshaped to avoid.
+    """
+    try:
+        r = resolve(name)
+    except Exception:
+        return "off"
+    if not r:
+        return "off"
+    val = str(r["meta"].get("routing") or "").strip().lower()
+    return val if val in ROUTING_LEVELS else "off"
+
+
+def routes_to(name: str) -> list[str]:
+    """Personas *name* considers first — its ``routes-to:``, inheritance-merged.
+
+    Priority, never restriction: it reorders the roster and removes nobody. A restricting
+    form would silently hide every persona created after the line was written, and nothing
+    would report the omission — the same failure shape `lint` had to grow a dangling-`uses:`
+    check for.
+    """
+    r = resolve(name)
+    return _csv_list(r["meta"].get("routes-to")) if r else []
+
+
+def roster_for(active: str | None) -> list[dict]:
+    """Every persona this session could hand work to, as ``{name, role, delegate_when,
+    last_dispatched}`` — the facts charter owns, and nothing more.
+
+    charter does not decide which of these owns the prompt (ADR 0016). It states who
+    exists, what each one claims, and when each was last dispatched; the reader routes.
+
+    Excludes the acting persona (routing to yourself is noise in a block that cannot
+    afford any) and drafts (charter generates no sub-agent for a draft, so offering one
+    would advertise a route that does not exist).
+    """
+    from . import dispatch
+    rows = []
+    for n in list_personas():
+        if n == active or is_draft(n):
+            continue
+        try:
+            r = resolve(n) or {}
+            meta = r.get("meta", {})
+        except Exception:
+            continue
+        rows.append({
+            "name": n,
+            "role": meta.get("role") or n,
+            "delegate_when": (meta.get("delegate-when") or "").strip(),
+            "last_dispatched": dispatch.last_seen(n),
+        })
+    first = routes_to(active) if active else []
+    order = {n: i for i, n in enumerate(first)}
+    # Declared order first, then everyone else alphabetically — a stable order matters on a
+    # block that reappears: a roster that reshuffles between prompts reads as new content.
+    rows.sort(key=lambda r: (order.get(r["name"], len(order)), r["name"]))
+    return rows
+
+
 def declared_default() -> str | None:
     """The front door this control plane DECLARES — ``charter.toml``'s ``[persona] default``.
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -59,7 +59,12 @@ since the session began.
 
 The `UserPromptSubmit` gate is narrower than it sounds. It fires when a prompt asks for
 work *and* carries a real fork — open-ended, broad, destructive, or multi-part — and its
-only effect is to say: scout first, then ask, before dispatching or editing.
+effect is to say: scout first, then ask, before dispatching or editing.
+
+When the acting persona declares `routing: advise` or `require`, the same message leads
+with the **roster** — who else exists, what each advertises, when each was last dispatched.
+One message, not two: two blocks on one prompt is how a nudge becomes wallpaper. charter
+never says which persona owns the prompt (ADR 0016); see `docs show personas`.
 
 ## What gets counted
 
@@ -69,6 +74,9 @@ parallel-writer safe with the host in the filename so two engineers never confli
 - **Dispatches** (`personas/_dispatch/`) — was this persona ever actually used, or did its
   work quietly route to a generic agent? Surfaces in `charter persona stats` as the
   `⚑ never dispatched` flag and the persona-vs-generic ratio.
+- **Routing advice** (`personas/_dispatch/`, as `{"ts", "event": "advice"}` rows) — how
+  often the roster was shown. Paired with dispatches in `charter persona stats`, it is the
+  number that can say the block is not working.
 - **Skill invocations** (`personas/_skills/`) — a persona's declared `skills:` are preloaded
   into every dispatch of it, so declaring one is cheap to write and expensive to keep. This
   says whether the equipment was worth carrying.

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -260,6 +260,55 @@ no identity, rather than a broken one. Two surfaces say so rather than leaving y
 the absence: `charter doctor` reports it (`front door`, a warning, with the fix), and the
 status line carries one row naming the missing persona.
 
+## Routing: handing work to the persona that owns it
+
+`delegate-when` is **inbound** — the advert other agents read when choosing where to send
+work. `routing:` is the other direction: how insistently *this* persona, while acting,
+hands work away.
+
+```yaml
+routing: advise      # off | advise | require   (absent means off)
+routes-to: forge, release
+```
+
+| Level | What happens |
+| --- | --- |
+| `off` | nothing. The default when the key is absent. |
+| `advise` | on a work-shaped prompt, the commitment gate leads with the roster. |
+| `require` | the same today; a tool-time check lands in a later release. |
+
+There is **no plane-level routing setting**. The level is only ever read from the one
+persona acting in a session, so a plane-wide floor would apply to personas that never asked
+for it. A new plane gets a sensible posture because `charter init --front-door` generates a
+front door carrying `routing: advise` in its own frontmatter — config in a file you own,
+not a constant inside charter.
+
+### What the block says, and what it refuses to say
+
+It lists every other persona, its `delegate-when`, and when it was last dispatched — then
+states that nothing has been dispatched this turn and asks you to route or to say why the
+work stays put.
+
+It never names the owner. A keyword overlap between a prompt and a prose advert is not
+evidence of ownership, and the first confident wrong answer would cost the block the reader
+it needs. That decision, and its consequences, are recorded in `docs/adr/0016`.
+
+`routes-to:` puts named personas first. It **prioritises and never restricts** — a
+restriction would silently hide every persona created after the line was written.
+
+### When it stays quiet
+
+- the acting persona declares `off`, or declares nothing
+- there is no acting persona at all (`charter doctor` says so once, under `front door`)
+- the roster minus the acting persona is empty
+- the prompt is a question, or the gate's cooldown is still running
+
+### Whether it works
+
+`charter persona stats` prints how often advice fired against how many dispatches
+followed. Advice that fires and is never followed is the block failing — read it that way
+before adding more personas.
+
 ## Everyday commands
 
 ```

--- a/tests/test_persona_routing_level.py
+++ b/tests/test_persona_routing_level.py
@@ -1,0 +1,139 @@
+"""A persona declares its own outbound routing posture: `routing: off | advise | require`.
+
+`delegate-when` is inbound — an advert other agents read when choosing. Nothing has ever
+expressed the other direction: when the persona *currently acting* should hand work away.
+That gap is what the dispatch tally measures (#256).
+
+The posture is per-persona and nowhere else. There is deliberately no `[routing]` section
+in `charter.toml`: the level is only ever read from the ONE acting persona in a session, so
+a plane-wide floor would reach personas that never asked for it. A fresh plane gets a
+sensible default because the generated front-door template carries `routing: advise` in its
+own frontmatter — config in a file the consumer owns, not a constant in charter.
+"""
+from __future__ import annotations
+
+import unittest
+
+from charter import config, persona
+from tests._isolation import PersonaIso
+
+
+class RoutingIso(PersonaIso):
+    def p(self, name, **meta):
+        return self.make_persona(name, role=name.title(), vault="none",
+                                 **{"delegate-when": f"{name} work", **meta})
+
+
+class TestTheLevel(RoutingIso):
+    def test_absent_is_off(self):
+        """Absence is the default, so upgrading a plane changes nothing until someone
+        opts in — and the default that new planes get comes from a template they own."""
+        self.p("steward")
+        self.assertEqual(persona.routing_level("steward"), "off")
+
+    def test_a_declared_level_is_read(self):
+        self.p("steward", routing="advise")
+        self.assertEqual(persona.routing_level("steward"), "advise")
+
+    def test_require_is_a_level(self):
+        self.p("steward", routing="require")
+        self.assertEqual(persona.routing_level("steward"), "require")
+
+    def test_an_unknown_level_falls_back_to_off(self):
+        """Fail toward no change: a typo must not silently enable a gate, and must not
+        crash the hook that reads it on every prompt."""
+        self.p("steward", routing="loud")
+        self.assertEqual(persona.routing_level("steward"), "off")
+
+    def test_case_and_padding_do_not_matter(self):
+        self.p("steward", routing="  Advise ")
+        self.assertEqual(persona.routing_level("steward"), "advise")
+
+    def test_it_is_inherited(self):
+        """Frontmatter is inheritance-merged everywhere else; a posture that ignored
+        `extends:` would be the one field a child could not receive."""
+        self.p("base", routing="advise")
+        self.p("child", extends="base")
+        self.assertEqual(persona.routing_level("child"), "advise")
+
+    def test_a_child_overrides_its_parent(self):
+        self.p("base", routing="require")
+        self.p("child", extends="base", routing="off")
+        self.assertEqual(persona.routing_level("child"), "off")
+
+    def test_an_unknown_persona_is_off_not_an_error(self):
+        self.assertEqual(persona.routing_level("ghost"), "off")
+
+
+class TestItIsAKnownKey(RoutingIso):
+    def test_lint_does_not_call_routing_an_unknown_key(self):
+        """`persona lint` flags unknown frontmatter, which is how a silently inert typo
+        gets caught — so a real key missing from that vocabulary is reported as a mistake."""
+        self.p("steward", routing="advise")
+        issues = persona.lint("steward")
+        self.assertNotIn("routing", " ".join(m for _lvl, m in issues))
+
+    def test_routes_to_is_a_known_key_too(self):
+        self.p("steward", **{"routes-to": "forge"})
+        issues = persona.lint("steward")
+        self.assertNotIn("routes-to", " ".join(m for _lvl, m in issues))
+
+
+class TestRoutesTo(RoutingIso):
+    def test_absent_is_empty(self):
+        self.p("steward")
+        self.assertEqual(persona.routes_to("steward"), [])
+
+    def test_it_reads_a_list(self):
+        self.p("steward", **{"routes-to": "forge, release"})
+        self.assertEqual(persona.routes_to("steward"), ["forge", "release"])
+
+
+class TestTheRoster(RoutingIso):
+    def test_it_excludes_the_acting_persona(self):
+        """Telling the front door it could route to itself is noise in the one block that
+        cannot afford any."""
+        self.p("steward")
+        self.p("forge")
+        names = [r["name"] for r in persona.roster_for("steward")]
+        self.assertEqual(names, ["forge"])
+
+    def test_it_carries_the_advert_each_persona_wrote(self):
+        self.p("steward")
+        self.p("forge", **{"delegate-when": "GitHub APIs, CI state"})
+        row = persona.roster_for("steward")[0]
+        self.assertEqual(row["delegate_when"], "GitHub APIs, CI state")
+
+    def test_routes_to_comes_first_but_hides_nobody(self):
+        """Priority, never restriction — a persona created after `routes-to:` was written
+        must not become invisible to routing forever, with nothing reporting it."""
+        self.p("steward", **{"routes-to": "release"})
+        self.p("forge")
+        self.p("release")
+        names = [r["name"] for r in persona.roster_for("steward")]
+        self.assertEqual(names[0], "release")
+        self.assertIn("forge", names)
+
+    def test_a_draft_persona_is_left_out(self):
+        """charter generates no sub-agent for a draft, so it cannot be dispatched —
+        offering it as a destination would advertise a route that does not exist."""
+        self.p("steward")
+        self.p("halfbaked", draft="true")
+        self.assertEqual([r["name"] for r in persona.roster_for("steward")], [])
+
+    def test_it_reports_when_each_was_last_dispatched(self):
+        """The date is what makes the block evidence rather than advice: a persona that
+        has never been dispatched is the whole finding."""
+        self.p("steward")
+        self.p("forge")
+        row = persona.roster_for("steward")[0]
+        self.assertIn("last_dispatched", row)
+        self.assertIsNone(row["last_dispatched"])
+
+    def test_an_empty_roster_is_empty_not_an_error(self):
+        self.p("steward")
+        self.assertEqual(persona.roster_for("steward"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_persona_selection_scope.py
+++ b/tests/test_persona_selection_scope.py
@@ -210,5 +210,21 @@ class TestUseReportsItsReach(SelectionScopeIso):
             out = self._use("forge")
         self.assertIn("steward", out)
 
+class TestCreateUseReportsItTheSameWay(SelectionScopeIso):
+    def test_create_use_says_how_far_the_selection_reaches(self):
+        """`create --use` and `use` select the same way, so they must report the same way —
+        two commands describing one act differently is how a reader learns to distrust both."""
+        import io
+        from contextlib import redirect_stderr
+        from types import SimpleNamespace
+        from charter import commands_persona
+        args = SimpleNamespace(name="fresh", role="Fresh", vault=None, extends=None,
+                               with_vault=False, use=True, force=False,
+                               delegate_when="fresh work")
+        buf = io.StringIO()
+        with self.env(CHARTER_SESSION_ID="s1"), redirect_stderr(buf):
+            commands_persona.cmd_persona_create(args)
+        self.assertIn("this session only", buf.getvalue().lower())
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_routing_roster_block.py
+++ b/tests/test_routing_roster_block.py
@@ -1,0 +1,230 @@
+"""The roster block: who else exists, what each claims, when each was last dispatched.
+
+charter never names the owner of a prompt (ADR 0016). On a work-shaped prompt, when the
+acting persona declares `routing: advise` or `require`, it injects the facts it owns and
+lets the reader route. That is the whole mechanism — no matcher, no `triggers:` field, no
+path ownership.
+
+It rides the EXISTING commitment-point gate rather than adding a second hook message: two
+blocks on one prompt is how wallpaper gets manufactured, and that gate's own comment
+records what happens to a nudge people learn to skim.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from charter import config, dispatch, hooks, persona
+from tests._isolation import PersonaIso, run_hook
+
+#: Trips the commitment classifier: an action verb plus a real fork (open-ended wording).
+WORK = "refactor the statusline column widths, maybe something cleaner"
+#: Pure information-seeking — the gate stays silent, so the roster must too.
+LOOKUP = "what does the statusline column width do"
+
+
+def _context(r) -> str:
+    return (r or {}).get("hookSpecificOutput", {}).get("additionalContext", "")
+
+
+class RosterCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        # The workspace confirm nudge is a different signal with its own several hundred
+        # words; pin the workspace so assertions here read only what this block adds.
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "default"}))
+
+    def p(self, name, **meta):
+        return self.make_persona(name, role=name.title(), vault="none",
+                                 **{"delegate-when": f"{name} work", **meta})
+
+    def prompt(self, text=WORK, sid="s1") -> str:
+        return _context(run_hook(hooks.userpromptsubmit,
+                                 {"session_id": sid, "prompt": text}))
+
+    def acting(self, name):
+        """Make *name* the acting persona for the assertions that follow."""
+        return mock.patch.dict(os.environ, {"CHARTER_PERSONA": name})
+
+
+class TestWhenItFires(RosterCase):
+    def test_advise_puts_the_roster_on_a_work_shaped_prompt(self):
+        self.p("steward", routing="advise")
+        self.p("forge", **{"delegate-when": "GitHub APIs, CI state"})
+        with self.acting("steward"):
+            out = self.prompt()
+        self.assertIn("forge", out)
+        self.assertIn("GitHub APIs, CI state", out)
+
+    def test_require_fires_the_same_block(self):
+        """At prompt time the two levels say the same thing; `require` differs later, at
+        tool time, which is a separate increment."""
+        self.p("steward", routing="require")
+        self.p("forge")
+        with self.acting("steward"):
+            self.assertIn("forge", self.prompt())
+
+    def test_off_says_nothing(self):
+        self.p("steward", routing="off")
+        self.p("forge")
+        with self.acting("steward"):
+            self.assertNotIn("forge", self.prompt())
+
+    def test_an_undeclared_level_says_nothing(self):
+        """Absent is `off`: upgrading a plane that declared nothing changes nothing."""
+        self.p("steward")
+        self.p("forge")
+        with self.acting("steward"):
+            self.assertNotIn("forge", self.prompt())
+
+    def test_a_lookup_prompt_says_nothing(self):
+        """It shares the gate's trigger. A question is not a commitment point, and a block
+        that fires on one teaches the reader to skim the block that matters."""
+        self.p("steward", routing="advise")
+        self.p("forge")
+        with self.acting("steward"):
+            self.assertNotIn("forge", self.prompt(LOOKUP))
+
+    def test_an_empty_roster_says_nothing(self):
+        """A plane whose only persona is the one acting has nobody to route to, and a
+        block saying so every time would be the purest wallpaper this design could ship."""
+        self.p("steward", routing="advise")
+        with self.acting("steward"):
+            out = self.prompt()
+        self.assertNotIn("routing", out.lower().split("commitment point")[0])
+
+    def test_no_acting_persona_means_no_level_and_no_block(self):
+        """No declared front door, no active persona: the plane has opted out of personas
+        and charter says nothing. `doctor` reports the inertness; a prompt hook does not."""
+        self.p("forge")
+        with mock.patch.dict(os.environ, {k: v for k, v in os.environ.items()
+                                          if k != "CHARTER_PERSONA"}, clear=True):
+            self.assertNotIn("forge", self.prompt())
+
+
+class TestWhatItSays(RosterCase):
+    def test_it_lists_every_persona_rather_than_choosing_one(self):
+        """ADR 0016: charter presents the roster and never guesses the owner. Naming a
+        winner is the one change that would break this block."""
+        self.p("steward", routing="advise")
+        self.p("forge")
+        self.p("release")
+        with self.acting("steward"):
+            out = self.prompt()
+        self.assertIn("forge", out)
+        self.assertIn("release", out)
+
+    def test_it_reports_a_persona_that_has_never_been_dispatched(self):
+        """The date is the evidence. 'Never dispatched' is the finding this whole design
+        exists to act on."""
+        self.p("steward", routing="advise")
+        self.p("forge")
+        with self.acting("steward"):
+            out = self.prompt()
+        self.assertIn("never", out.lower())
+
+    def test_it_reports_the_date_of_a_real_dispatch(self):
+        self.p("steward", routing="advise")
+        self.p("forge")
+        dispatch.record("forge")
+        with self.acting("steward"):
+            out = self.prompt().lower()
+        self.assertIn("last dispatched", out)
+        self.assertNotIn("never dispatched", out)
+
+    def test_the_acting_persona_is_not_offered_as_a_destination(self):
+        """It is named — the block says whose posture is speaking, and asks for one line
+        if the work stays put. What it must never do is list the acting persona as
+        somewhere to route TO, which is noise in a block that cannot afford any."""
+        self.p("steward", routing="advise")
+        self.p("forge")
+        with self.acting("steward"):
+            out = self.prompt()
+        rows = [ln for ln in out.splitlines() if ln.strip().startswith("•")]
+        self.assertTrue(rows)
+        self.assertFalse([ln for ln in rows if "`steward`" in ln])
+
+
+class TestItIsMeasured(RosterCase):
+    def test_firing_is_tallied(self):
+        """Everything here is a bet that visibility changes routing. Shipping without the
+        number that could falsify it repeats the gap `dispatch.py` was written about."""
+        self.p("steward", routing="advise")
+        self.p("forge")
+        with self.acting("steward"):
+            self.prompt()
+        self.assertEqual(dispatch.advice_tally(), 1)
+
+    def test_not_firing_is_not_tallied(self):
+        self.p("steward", routing="off")
+        self.p("forge")
+        with self.acting("steward"):
+            self.prompt()
+        self.assertEqual(dispatch.advice_tally(), 0)
+
+    def test_the_tally_records_no_prompt_text(self):
+        """The dispatch store is counts and dates only — there is no secret surface to
+        scan, and this event must not become the first one."""
+        self.p("steward", routing="advise")
+        self.p("forge")
+        with self.acting("steward"):
+            self.prompt("refactor the statusline, maybe with SECRETVALUE in it")
+        blob = "".join(f.read_text() for f in (config.PERSONAS_DIR / "_dispatch").glob("*.jsonl"))
+        self.assertNotIn("SECRETVALUE", blob)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestItIsReported(RosterCase):
+    """The fired-vs-followed pair has to reach a human surface, or measuring it is the
+    same write-only gesture the todo store's docstring warns about."""
+
+    def _stats(self) -> str:
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+        from types import SimpleNamespace
+        from charter import commands_persona
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            commands_persona.cmd_persona_stats(SimpleNamespace(shared=False, days=None))
+        return out.getvalue() + err.getvalue()
+
+    def test_stats_reports_advice_shown_against_dispatches(self):
+        self.p("steward", routing="advise")
+        self.p("forge")
+        with self.acting("steward"):
+            self.prompt()
+        dispatch.record("forge")
+        out = self._stats().lower()
+        self.assertIn("routing advice", out)
+        self.assertIn("fired 1", out)
+
+    def test_stats_says_nothing_about_advice_that_never_fired(self):
+        """A line reading 'fired 0 · dispatched 0' on every plane that has not opted in is
+        a row people learn to skip, and it takes the rest of the report's credibility."""
+        self.p("steward")
+        self.p("forge")
+        self.assertNotIn("routing advice", self._stats().lower())
+
+
+class TestDoctorSaysWhenRoutingIsInert(RosterCase):
+    def test_personas_but_no_front_door_is_named(self):
+        """Settled during the grill: no declared default and no active persona means the
+        roster block can never fire. That is a legitimate choice, so it is said once in
+        `doctor` — not on every prompt."""
+        from charter import doctor
+        self.p("forge")
+        self.p("release")
+        (config.ROOT / "charter.toml").write_text("schema = 1\n")
+        r = doctor.check_front_door()
+        self.assertIn("inert", (r.detail + " " + (r.hint or "")).lower())
+
+    def test_a_plane_with_no_personas_at_all_is_silent(self):
+        """Nothing to route to and nothing declared — an empty plane is not a problem."""
+        from charter import doctor
+        (config.ROOT / "charter.toml").write_text("schema = 1\n")
+        r = doctor.check_front_door()
+        self.assertNotIn("inert", (r.detail + " " + (r.hint or "")).lower())


### PR DESCRIPTION
Increment 2 of the delegation design (#256). **Stacked on #259** — base is
`persona-default-in-charter-toml`, so this diff is the one commit `dc487f8`. GitHub
retargets it to `main` automatically when #259 merges.

`python3 -m unittest discover -s tests` is green at **2467 tests**, and every behaviour
below was exercised against a real scratch plane through the actual hook, not only the
suite.

## The gap

`delegate-when` is inbound — an advert other agents read when choosing where to send work.
Nothing has ever expressed the other direction: when the persona *currently acting* should
stop doing the work itself. The tally is what that gap looks like from outside — three
personas advertising correctly, linting green, never dispatched once.

## What a persona now declares

```yaml
routing: advise      # off | advise | require   (absent means off)
routes-to: forge, release
```

There is deliberately **no `[routing]` section in `charter.toml`**. The level is only ever
read from the one persona acting in a session, so a plane-wide floor would apply to
personas that never asked for it. The default a new plane wants arrives instead from the
generated front-door template (increment 3), which carries `routing: advise` in frontmatter
the consumer owns — config in their file, not a constant in ours.

## What fires, and what it says

At `advise`, the **existing** commitment gate leads with the roster. One message, not two:
two blocks on one prompt is how a nudge becomes wallpaper, which that gate's own comment is
about. Real output:

```
⬡ Who else could take this. `steward` declares `routing: advise`, and these personas
advertise work of their own. charter is not saying which one owns this — it cannot know
that, and will not guess it (docs/adr/0016). These are the facts; the routing call is yours:
   • `release` — version bumps, tags, PyPI publish · never dispatched
   • `forge` — GitHub APIs, CI state, PR lookups · never dispatched
Nothing has been dispatched this turn. Hand it over with the Agent tool, or say in one line
why it stays with `steward` — a cross-cutting change that would be split across three
personas is a good reason.
```

`release` is first there because `steward` declares `routes-to: release`. That
prioritises and never restricts: a restricting form would silently hide every persona
created after the line was written, with nothing reporting the omission.

**It never names an owner** (ADR 0016, merged in #259). Consequence taken knowingly:
`require` says the same thing as `advise` at prompt time, and its tool-time half is
increment 4. The docs say that rather than implying it already bites.

## When it stays quiet

The acting persona declares `off` or nothing · there is no acting persona at all · the
roster minus that persona is empty · the prompt is a question · the shared cooldown is
running. Verified: a question produces no hook output at all, and `routing: off` leaves the
commitment gate firing alone.

## Whether it works

Advice-shown lands in the dispatch store as `{"ts", "event": "advice"}` — counts and dates
only, the same two-fields discipline, no prompt text (there is a test asserting a prompt
containing a secret-shaped token leaves nothing in the store). `charter persona stats`
prints it against the dispatches that followed:

```
• Routing advice: fired 1 time(s) · 0 dispatch(es) followed. Advice that fires and is never
  followed is the block failing, not the roster — read it that way before adding more personas.
```

Shipping the bet without the number that could falsify it would repeat the gap
`dispatch.py`'s own docstring was written about.

`doctor` also names the inert case once, in a preflight rather than on every prompt:
personas exist, no front door declared, so no acting persona, so no level, so the block can
never fire. A plane may mean exactly that, which is why it is `OK` with a detail rather than
a warning.

## Also here

`charter persona create --use` now reports how far the selection reaches, the same way
`persona use` does since #259 — two commands describing one act differently is how a reader
learns to distrust both.

Refs #256.
