### PR TITLE
routing: require asks once when a turn edits without having dispatched

### DIFF
--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -1503,6 +1503,9 @@ def pretooluse_dispatch() -> int:
     the most honest thing available is to say so at the moment of dispatch.
     """
     data = _read_stdin()
+    # Clear the routing mark first — the dispatch IS the routing, and clearing ahead of the
+    # early returns below means a read-only fan-out counts as routing too.
+    _route_mark_clear(data.get("session_id"))
     if (data.get("tool_name") or "") not in ("Task", "Agent"):
         return 0
     agent = ((data.get("tool_input") or {}).get("subagent_type") or "").strip()
@@ -1726,7 +1729,87 @@ _DIAGNOSE_RE = re.compile(
     r"not\s+work|doesn'?t\s+work|stack\s?trace|500\b|502\b|422\b|403\b|timeout)", re.I)
 
 
-def _roster_block() -> str:
+# --------------------------------------------------------------------------- #
+# `routing: require` — the one mark this design keeps, and what clears it.      #
+#                                                                              #
+# The mark says: the roster was shown this turn, at `require`, and nothing has  #
+# been dispatched since. It is written by the roster block, and cleared by any  #
+# of three things — a dispatch beginning (the routing happened), the ask having #
+# fired (once per turn, not once per edit), or the next prompt (a mark that     #
+# outlives its turn would ask about a roster nobody was shown).                 #
+#                                                                              #
+# Sub-agents need no detection because of the first of those: the dispatch that #
+# creates the sub-agent is what clears the mark, so there is nothing left to    #
+# fire inside it. Detection would have been a guess about the harness; this is  #
+# a fact about the sequence.                                                    #
+# --------------------------------------------------------------------------- #
+def _route_mark(sid: str | None) -> Path | None:
+    if not sid:
+        return None
+    return config.SESSIONS_DIR / f"{re.sub(r'[^A-Za-z0-9._-]', '', sid)}.route-pending"
+
+
+def _route_mark_set(sid: str | None, names: list[str]) -> None:
+    f = _route_mark(sid)
+    if f is None:
+        return
+    try:
+        f.parent.mkdir(parents=True, exist_ok=True)
+        # The roster's NAMES, so the ask can list them without re-deriving the roster from
+        # a persona that may have changed mid-turn. Names only — the same counts-and-names
+        # discipline the tally keeps; no prompt text goes anywhere near this file.
+        f.write_text(",".join(names) + "\n")
+    except OSError:
+        pass
+
+
+def _route_mark_take(sid: str | None) -> list[str] | None:
+    """Read and clear the mark. Returns the roster names, or None when unmarked."""
+    f = _route_mark(sid)
+    if f is None or not f.exists():
+        return None
+    try:
+        val = f.read_text().strip()
+        f.unlink()
+    except OSError:
+        return None
+    return [n for n in val.split(",") if n]
+
+
+def _route_mark_clear(sid: str | None) -> None:
+    f = _route_mark(sid)
+    try:
+        if f is not None and f.exists():
+            f.unlink()
+    except OSError:
+        pass
+
+
+def pretooluse_edit() -> int:
+    """`require`'s tool-time half: ask once when a turn edits without dispatching.
+
+    Asks — never denies. A hard block would make a genuinely cross-cutting change
+    unworkable, and the fix a person reaches for then is `routing: off`, permanently.
+
+    The reason states a fact about this session (the roster was shown, nothing was
+    dispatched) and lists who was on it. It does not say which persona should have had the
+    work, because charter cannot know that (ADR 0016) — and a prompt that asserts it would
+    be wrong often enough to be dismissed on sight.
+    """
+    data = _read_stdin()
+    names = _route_mark_take(data.get("session_id"))
+    if not names:
+        return 0
+    who = ", ".join(f"`{n}`" for n in names)
+    _ask("PreToolUse",
+         f"the roster was shown this turn and nothing was dispatched — you are editing as "
+         f"the acting persona. Available: {who}. charter is not saying this is theirs; "
+         f"approve to carry on, or dispatch instead. (`routing: require`)")
+    _trace("routing-ask", data.get("session_id"))
+    return 0
+
+
+def _roster_block(sid: str | None) -> str:
     """Who else could take this work — facts only, never a verdict (ADR 0016).
 
     Fires when the ACTING persona declares ``routing: advise`` or ``require``. charter
@@ -1760,6 +1843,8 @@ def _roster_block() -> str:
             claim = r["delegate_when"] or f"{r['role']} work (no delegate-when declared)"
             rows.append(f"   • `{r['name']}` — {claim} · {when}")
         dispatch.record_advice()
+        if level == "require":
+            _route_mark_set(sid, [r["name"] for r in roster])
         return (
             f"⬡ **Who else could take this.** `{active}` declares `routing: {level}`, and "
             f"these personas advertise work of their own. charter is **not** saying which "
@@ -1783,7 +1868,7 @@ def _commitment_nudge(prompt: str, sid: str | None) -> str:
     # of the gate the sub-agent's problem, not this session's. Inside, because two blocks
     # on one prompt is how wallpaper gets manufactured, which is the failure this gate's
     # own history is about.
-    roster = _roster_block()
+    roster = _roster_block(sid)
     lead = roster + "\n\n" if roster else ""
     diagnosing = bool(_DIAGNOSE_RE.search(prompt or ""))
     if diagnosing:
@@ -1822,6 +1907,10 @@ def userpromptsubmit() -> int:
     data = _read_stdin()
     _touch_piece(data)
     sid = data.get("session_id")
+    # A mark belongs to the turn that made it. The gate has a cooldown, so a later prompt
+    # may show no roster at all — and an ask about a roster nobody was shown is exactly the
+    # stale prompt that gets a feature switched off.
+    _route_mark_clear(sid)
     parts = []
     try:
         msg = _config_update_nudge(sid)
@@ -1918,6 +2007,7 @@ _HANDLERS = {
     "pretooluse": pretooluse,
     "pretooluse-read": pretooluse_read,
     "pretooluse-dispatch": pretooluse_dispatch,
+    "pretooluse-edit": pretooluse_edit,
     "posttooluse": posttooluse,
     "posttooluse-skill": posttooluse_skill,
     "posttooluse-dispatch": posttooluse_dispatch,

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -66,6 +66,10 @@ with the **roster** — who else exists, what each advertises, when each was las
 One message, not two: two blocks on one prompt is how a nudge becomes wallpaper. charter
 never says which persona owns the prompt (ADR 0016); see `docs show personas`.
 
+At `routing: require` a second, quieter hook joins it: `PreToolUse` on `Write|Edit|MultiEdit`
+**asks** once when a turn edits after the roster fired and nothing was dispatched. It never
+denies, and a dispatch — or the next prompt — clears it.
+
 ## What gets counted
 
 Two tallies — tracked, not ignored, though charter never commits them for you (`[memory].share` defaults to `local`) — both counts-and-dates only, never prompt text, and both

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -275,7 +275,7 @@ routes-to: forge, release
 | --- | --- |
 | `off` | nothing. The default when the key is absent. |
 | `advise` | on a work-shaped prompt, the commitment gate leads with the roster. |
-| `require` | the same today; a tool-time check lands in a later release. |
+| `require` | the same, plus an **ask** on the first edit of a turn where the roster fired and nothing was dispatched. |
 
 There is **no plane-level routing setting**. The level is only ever read from the one
 persona acting in a session, so a plane-wide floor would apply to personas that never asked
@@ -292,6 +292,16 @@ work stays put.
 It never names the owner. A keyword overlap between a prompt and a prose advert is not
 evidence of ownership, and the first confident wrong answer would cost the block the reader
 it needs. That decision, and its consequences, are recorded in `docs/adr/0016`.
+
+At `require`, the same restraint shapes the permission prompt: it states that the roster was
+shown and nothing was dispatched, lists who was on it, and says charter is not claiming the
+work is theirs. It **asks and never denies** — a hard block would make a genuinely
+cross-cutting change unworkable, and the fix people reach for then is `routing: off`,
+permanently. It asks once per turn, not once per edit.
+
+Sub-agents never see it: the mark is cleared the moment a dispatch begins, so a persona that
+was handed work is never told to hand it on. That is a property of the sequence rather than
+a guess about the harness.
 
 `routes-to:` puts named personas first. It **prioritises and never restricts** — a
 restriction would silently hide every persona created after the line was written.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -70,6 +70,16 @@
             "command": "charter hook pretooluse-dispatch --plugin-version 0.43.2"
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "charter hook pretooluse-edit --plugin-version 0.43.2",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -101,6 +101,10 @@ class TestPluginManifest(unittest.TestCase):
             # (#90). Registered for Read|Grep only: Glob returns names, not contents.
             ("PreToolUse", "charter hook pretooluse-read --plugin-version"),
             ("PreToolUse", "charter hook pretooluse-dispatch --plugin-version"),
+            # `routing: require`'s tool-time half. Registered for the WRITE tools only:
+            # the ask is about editing without having dispatched, and a Read that triggered
+            # it would fire on the scouting the gate asks for two lines earlier.
+            ("PreToolUse", "charter hook pretooluse-edit --plugin-version"),
             ("PostToolUse", "charter hook posttooluse --plugin-version"),
             # The skill tally: which skills a persona actually invokes, against the ones its
             # charter declares and the host preloads on every dispatch.

--- a/tests/test_routing_require_gate.py
+++ b/tests/test_routing_require_gate.py
@@ -1,0 +1,159 @@
+"""`routing: require` — the tool-time half: an ask on the first edit with no dispatch.
+
+At `advise` the roster is a line of context and nothing more. At `require` the acting
+persona has declared that work of another persona's should actually leave this session, so
+the first Write/Edit of a turn where the roster fired and nothing was dispatched surfaces a
+permission prompt.
+
+Two properties are load-bearing, and both were settled before any of this was written:
+
+* **It asks; it never denies.** `toolgate.py` promises the same, and "hooks never break a
+  turn" is a stated convention. The failure mode of denying is a genuine cross-cutting
+  change — which the front door's own charter says stays with it — becoming unworkable,
+  and the fix someone reaches for is `routing: off`, permanently.
+* **It names no owner.** ADR 0016. The strongest sentence available is "the roster was
+  shown and nothing was dispatched", which is a fact about this session rather than a
+  claim about who owns the request.
+
+Sub-agents are excluded *by construction* rather than by detection: the pending mark is
+cleared the moment a dispatch begins, so inside the sub-agent there is nothing left to
+fire. A persona that was handed work has by definition already been routed to, and telling
+it to route again is the loop that gets a feature switched off on day one.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from charter import hooks
+from tests._isolation import PersonaIso, run_hook
+
+WORK = "refactor the release tagging flow, maybe something cleaner"
+
+
+def _decision(r) -> str | None:
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+
+
+def _reason(r) -> str:
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
+
+
+class RequireCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "default"}))
+
+    def p(self, name, **meta):
+        return self.make_persona(name, role=name.title(), vault="none",
+                                 **{"delegate-when": f"{name} work", **meta})
+
+    def acting(self, name):
+        return mock.patch.dict(os.environ, {"CHARTER_PERSONA": name})
+
+    def prompt(self, text=WORK, sid="s1"):
+        return run_hook(hooks.userpromptsubmit, {"session_id": sid, "prompt": text})
+
+    def edit(self, sid="s1"):
+        return run_hook(hooks.pretooluse_edit,
+                        {"session_id": sid, "tool_name": "Edit",
+                         "tool_input": {"file_path": "/tmp/x.py"}})
+
+    def dispatch_starts(self, sid="s1"):
+        return run_hook(hooks.pretooluse_dispatch,
+                        {"session_id": sid, "tool_name": "Task",
+                         "tool_input": {"subagent_type": "forge"}})
+
+
+class TestItAsks(RequireCase):
+    def test_an_edit_after_an_unfollowed_roster_asks(self):
+        self.p("steward", routing="require")
+        self.p("forge")
+        with self.acting("steward"):
+            self.prompt()
+            self.assertEqual(_decision(self.edit()), "ask")
+
+    def test_it_never_denies(self):
+        """The one property protected everywhere else in this repo."""
+        self.p("steward", routing="require")
+        self.p("forge")
+        with self.acting("steward"):
+            self.prompt()
+            self.assertNotEqual(_decision(self.edit()), "deny")
+
+    def test_the_reason_states_the_fact_not_a_verdict(self):
+        self.p("steward", routing="require")
+        self.p("forge")
+        with self.acting("steward"):
+            self.prompt()
+            reason = _reason(self.edit()).lower()
+        self.assertIn("nothing was dispatched", reason)
+        self.assertIn("forge", reason)
+
+    def test_it_asks_once_per_turn_not_once_per_edit(self):
+        """A prompt on every edit of a long turn is a prompt people click through."""
+        self.p("steward", routing="require")
+        self.p("forge")
+        with self.acting("steward"):
+            self.prompt()
+            self.assertEqual(_decision(self.edit()), "ask")
+            self.assertIsNone(_decision(self.edit()))
+
+
+class TestItStaysQuiet(RequireCase):
+    def test_advise_never_asks(self):
+        """`advise` is context, not a gate — that is the whole difference between them."""
+        self.p("steward", routing="advise")
+        self.p("forge")
+        with self.acting("steward"):
+            self.prompt()
+            self.assertIsNone(_decision(self.edit()))
+
+    def test_off_never_asks(self):
+        self.p("steward", routing="off")
+        self.p("forge")
+        with self.acting("steward"):
+            self.prompt()
+            self.assertIsNone(_decision(self.edit()))
+
+    def test_a_dispatch_clears_it(self):
+        """The routing happened. Asking afterwards would be charter arguing with a
+        decision it asked for."""
+        self.p("steward", routing="require")
+        self.p("forge")
+        with self.acting("steward"):
+            self.prompt()
+            self.dispatch_starts()
+            self.assertIsNone(_decision(self.edit()))
+
+    def test_an_edit_inside_a_dispatched_sub_agent_does_not_ask(self):
+        """Excluded by construction: the dispatch cleared the mark, so a persona that was
+        handed work is never told to hand it on."""
+        self.p("steward", routing="require")
+        self.p("forge", routing="require")
+        with self.acting("steward"):
+            self.prompt()
+            self.dispatch_starts()
+        with self.acting("forge"):
+            self.assertIsNone(_decision(self.edit()))
+
+    def test_a_later_turn_does_not_inherit_the_mark(self):
+        """The gate has a cooldown, so a prompt or two later the roster does not re-fire.
+        A mark that outlived its turn would ask about a roster nobody was shown."""
+        self.p("steward", routing="require")
+        self.p("forge")
+        with self.acting("steward"):
+            self.prompt()
+            self.prompt("carry on", sid="s1")     # cooldown: no roster this time
+            self.assertIsNone(_decision(self.edit()))
+
+    def test_an_edit_with_no_prompt_before_it_never_asks(self):
+        self.p("steward", routing="require")
+        self.p("forge")
+        with self.acting("steward"):
+            self.assertIsNone(_decision(self.edit()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Increment 4 of the delegation design. **Stacked on #262** (→ #260 → #259), so this diff is
the single commit `2b3699e`. 2491 tests green.

`advise` puts the roster in front of you and stops there. `require` is the level that
actually costs something: the first `Write`/`Edit`/`MultiEdit` of a turn where the roster
fired and **nothing was dispatched** surfaces a permission prompt.

```
charter nudge: the roster was shown this turn and nothing was dispatched — you are editing
as the acting persona. Available: `release`, `forge`. charter is not saying this is theirs;
approve to carry on, or dispatch instead. (`routing: require`)
```

## It asks; it never denies

`toolgate.py` makes the same promise, and *hooks never break a turn* is a stated
convention. The failure mode of denying is concrete rather than theoretical: a genuinely
cross-cutting change — which the front door's own charter says stays with it — becomes
unworkable, and the fix a person reaches for is `routing: off`, permanently.

## It names no owner

ADR 0016 (#259) said this level would only ever be able to state a fact about the session,
never a verdict about ownership, and that is what shipped. The prompt says the roster was
shown, that nothing was dispatched, who was on it, and explicitly that charter is not
claiming the work is theirs.

## Sub-agents: excluded by construction, not by detection

The design flagged this as the thing to **verify by running rather than reason about** —
`PreToolUse` fires inside sub-agents, so a naive gate would tell the `statusline` persona to
delegate `statusline.py`.

It needed no detection in the end. The mark is cleared the moment a dispatch *begins*, so
inside the resulting sub-agent there is nothing left to fire. Detection would have been a
guess about what a harness puts in a hook payload; this is a fact about the sequence.

Three things clear the mark, each closing a way the prompt could go stale:

| Cleared by | Because |
| --- | --- |
| a dispatch beginning | the routing happened; asking after would be charter arguing with the decision it asked for |
| the ask itself | once per turn, not once per edit — a prompt on every edit is a prompt people click through |
| the next prompt | the gate has a cooldown, so a later turn may show no roster at all, and an ask about a roster nobody was shown is exactly the stale prompt that gets a feature switched off |

## Verified by running

```
$ echo '{"session_id":"req1","prompt":"refactor the release tagging flow, maybe something cleaner"}' | charter hook userpromptsubmit
$ echo '{"session_id":"req1","tool_name":"Edit",...}' | charter hook pretooluse-edit
{"permissionDecision": "ask", "permissionDecisionReason": "charter nudge: the roster was shown…"}

$ # second edit, same turn
(nothing)

$ # a turn where a dispatch came first
(nothing)
```

## Wiring

One new `PreToolUse` matcher, `Write|Edit|MultiEdit` → `charter hook pretooluse-edit`. The
write tools only: a Read that triggered it would fire on the scouting the same gate asks for
two lines earlier. `tests/test_plugin.py`'s hook-parity list gains the entry, which is how
this repo keeps the plugin manifest and the handler registry from drifting.

Docs updated in both pages — `docs/personas.md`'s level table no longer says the tool-time
half is pending, and `docs/hooks.md` names the second hook.

Refs #256.
