### PR TITLE
borrows: splits what uses: overloaded, one persona at a time

### DIFF
--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -536,7 +536,7 @@ _AGENT_PASSTHROUGH_KEYS = ("model", "color", "memory")
 _CHARTER_OWN_KEYS = (
     "name", "role", "vault", "extends", "uses", "delegate-when", "description",
     "agent-description", "agent-tools", "tools", "activity", "dispatch-isolation",
-    "draft", "skills", "disallowed-tools", "routing", "routes-to",
+    "draft", "skills", "disallowed-tools", "routing", "routes-to", "borrows",
 )
 
 
@@ -621,13 +621,35 @@ def _render_agent(name: str, meta: dict, charter: str) -> str:
         )
 
     uses = [u.strip() for u in (meta.get("uses") or "").split(",") if u.strip() and u.strip() != name]
+    borrows = persona.borrows_of(name)
     uses_note = ""
     if uses:
         joined = ", ".join(f"`{u}`" for u in uses)
-        uses_note = (
-            f"\n- **You may also use these personas: {joined}.** Read their vault "
-            f"(`charter persona secret list --persona <name>`), run their tools, or delegate a "
-            f"sub-task to their sub-agent (Agent tool, `subagent_type: <name>`)."
+        if borrows is None:
+            # Legacy: `uses:` still grants all three. Wording unchanged for a plane that
+            # has not opted into the split.
+            uses_note = (
+                f"\n- **You may also use these personas: {joined}.** Read their vault "
+                f"(`charter persona secret list --persona <name>`), run their tools, or delegate a "
+                f"sub-task to their sub-agent (Agent tool, `subagent_type: <name>`)."
+            )
+        else:
+            # Opted in: `uses:` is a routing edge. The charter must say so, because it is
+            # what a dispatched agent believes about itself — if it still read "run their
+            # tools", the tool-gate would refuse and the agent would have no idea why.
+            uses_note = (
+                f"\n- **You may delegate to these personas: {joined}.** Hand them a sub-task "
+                f"(Agent tool, `subagent_type: <name>`). You do NOT hold their credentials "
+                f"and their tools are not auto-approved for you — that is what `borrows:` is "
+                f"for, and it is deliberate: doing their work yourself should cost more than "
+                f"handing it over."
+            )
+    if borrows:
+        joined_b = ", ".join(f"`{b}`" for b in borrows)
+        uses_note += (
+            f"\n- **You borrow from: {joined_b}.** Read their vault "
+            f"(`charter persona secret list --persona <name>`) and run their tools without a "
+            f"prompt."
         )
 
     # Generic capability handoff — every persona gets this, so it hands work outside its

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -543,13 +543,46 @@ def uses_of(name: str) -> list[str]:
     return _csv_list(r["meta"].get("uses")) if r else []
 
 
+#: A `borrows:` value meaning "deliberately nothing" — the same spelling `vault: none`
+#: already uses for the same idea, so the vocabulary stays one vocabulary.
+BORROWS_NONE = "none"
+
+
+def borrows_of(name: str) -> list[str] | None:
+    """Personas whose tools and vault this one may use — its ``borrows:``, or ``None`` when
+    the key is absent.
+
+    ``None`` and ``[]`` are different answers and the difference is the whole feature:
+    absent means "I have not opted in, keep the legacy `uses:` grant", while
+    ``borrows: none`` means "I borrow nothing". Collapsing them would either break every
+    existing plane or make opting out unsayable.
+    """
+    r = resolve(name)
+    if not r or "borrows" not in r["meta"]:
+        return None
+    vals = _csv_list(r["meta"].get("borrows"))
+    return [v for v in vals if v != BORROWS_NONE]
+
+
 def effective_tools(name: str) -> set[str]:
-    """The persona's own auto-approved tools plus those of the personas it ``uses:``
-    (one level). Used by the tool-gate so an adopted persona can run a reused
-    persona's tools without a prompt."""
+    """The persona's own auto-approved tools, plus those it may borrow (one level).
+
+    Which personas those are depends on whether this persona has opted into the split:
+
+    * ``borrows:`` declared → its tools come from that list, and ``uses:`` is a routing
+      edge only. This is the point of the field. ``uses:`` granted vault access, tool
+      auto-approval and delegation in one word, and the middle grant is why delegating
+      always lost: a front door declaring ``uses: forge, release`` could do both personas'
+      work with both personas' tools and never pay a prompt, while handing the work over
+      cost a dispatch and the context with it (#257).
+    * ``borrows:`` absent → the legacy grant, unchanged. Fails toward no change, per
+      persona: opting one persona in must never alter another's permissions, which is
+      exactly what a plane-wide switch would have done.
+    """
     tools = tools_of(name)
-    for u in uses_of(name):
-        tools |= tools_of(u)
+    borrows = borrows_of(name)
+    for other in (uses_of(name) if borrows is None else borrows):
+        tools |= tools_of(other)
     return tools
 
 
@@ -697,6 +730,9 @@ def structural_errors(name: str, known: set[str] | None = None) -> list[tuple[st
     for u in uses_of(name):
         if u not in allnames:
             issues.append(("error", f"uses: '{u}' — no such persona (dangling)"))
+    for b in borrows_of(name) or ():
+        if b not in allnames:
+            issues.append(("error", f"borrows: '{b}' — no such persona (dangling)"))
     d = load(name)
     ext = ((d["meta"] if d else {}).get("extends") or "").strip()
     if ext and ext not in allnames:

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -184,6 +184,35 @@ it explicitly and visibly, not acquire a transitive reach nobody declared.
 one being removed, removal is refused and the dependents are named (`--force` overrides).
 Before that, a dangling reference was only discovered later, by `lint`.
 
+## Borrowing vs routing (`uses:` and `borrows:`)
+
+`uses:` historically granted three things in one word: read that persona's vault, run its
+tools without a permission prompt, and delegate to its sub-agent. The middle grant quietly
+decides how much delegation happens — a persona declaring `uses: forge, release` can do both
+their jobs with both their tools and never pay a prompt, while handing the work over costs a
+dispatch and the context that goes with it.
+
+`borrows:` separates them, **per persona**:
+
+```yaml
+uses: forge, release      # personas I may hand work to
+borrows: release          # …and whose tools/vault I may actually use
+```
+
+| Declared | What `uses:` means | Tools auto-approved from |
+| --- | --- | --- |
+| no `borrows:` | vault + tools + delegation (unchanged) | the `uses:` list |
+| `borrows: <names>` | delegation only | the `borrows:` list |
+| `borrows: none` | delegation only | nobody — own tools only |
+
+Nothing changes for a persona that does not declare `borrows:`, and one persona opting in
+never alters another's permissions — which is exactly why this is a frontmatter field and
+not a setting in `charter.toml`.
+
+The generated sub-agent charter says which is which, because that text is what a dispatched
+agent believes about itself: if it still read "run their tools" while the gate refused, the
+agent would have no way to find out why.
+
 ## Curating memory: `charter persona optimize`
 
 Memory grows, and growth is not a defect — but a base that has accumulated near-duplicates

--- a/tests/test_persona_borrows.py
+++ b/tests/test_persona_borrows.py
@@ -1,0 +1,120 @@
+"""`borrows:` splits what `uses:` overloaded — per persona, and only when asked.
+
+`uses:` granted three things in one word: read that persona's vault, **run its tools with
+auto-approval**, and delegate to its sub-agent. The middle grant is why delegation loses
+every time it is offered: a front door declaring `uses: forge, release` can do both
+personas' work with both personas' tools and never pay a permission prompt, while
+delegating costs a dispatch, a brief and the context that goes with it. The incentive
+points away from the behaviour the roster block exists to produce (#257).
+
+The split is **per persona and never plane-wide**. A persona that declares `borrows:` takes
+its auto-approved tools from that list, and `uses:` becomes a routing edge for that persona
+alone. A persona that declares nothing keeps today's behaviour exactly. One persona's
+opt-in must never change another persona's tool permissions — which is what a
+`charter.toml` flag would have done.
+"""
+from __future__ import annotations
+
+import unittest
+
+from charter import persona
+from tests._isolation import PersonaIso
+
+
+class BorrowsIso(PersonaIso):
+    def p(self, name, **meta):
+        return self.make_persona(name, role=name.title(), vault="none",
+                                 **{"delegate-when": f"{name} work", **meta})
+
+
+class TestLegacyIsUntouched(BorrowsIso):
+    def test_uses_still_grants_tools_when_borrows_is_absent(self):
+        """Fail toward no change: an upgrade must alter nothing for a plane that has not
+        opted in, or the split becomes a silent permission change."""
+        self.p("forge", tools="gh")
+        self.p("steward", uses="forge")
+        self.assertIn("gh", persona.effective_tools("steward"))
+
+
+class TestDeclaringBorrows(BorrowsIso):
+    def test_tools_come_from_borrows_not_from_uses(self):
+        self.p("forge", tools="gh")
+        self.p("release", tools="twine")
+        self.p("steward", uses="forge", borrows="release")
+        tools = persona.effective_tools("steward")
+        self.assertIn("twine", tools)
+        self.assertNotIn("gh", tools)
+
+    def test_borrows_none_borrows_nothing(self):
+        """`vault: none` is the established spelling for 'deliberately nothing here'."""
+        self.p("forge", tools="gh")
+        self.p("steward", uses="forge", borrows="none", tools="jq")
+        tools = persona.effective_tools("steward")
+        self.assertEqual(tools, {"jq"})
+
+    def test_its_own_tools_are_always_kept(self):
+        self.p("forge", tools="gh")
+        self.p("steward", uses="forge", borrows="none", tools="jq")
+        self.assertIn("jq", persona.effective_tools("steward"))
+
+    def test_it_is_inherited(self):
+        self.p("release", tools="twine")
+        self.p("base", borrows="release")
+        self.p("child", extends="base")
+        self.assertIn("twine", persona.effective_tools("child"))
+
+
+class TestOnePersonaOptingInChangesNobodyElse(BorrowsIso):
+    def test_a_sibling_keeps_its_legacy_grant(self):
+        """The reason this is a per-persona field and not a plane-wide switch."""
+        self.p("forge", tools="gh")
+        self.p("strict", uses="forge", borrows="none")
+        self.p("legacy", uses="forge")
+        self.assertNotIn("gh", persona.effective_tools("strict"))
+        self.assertIn("gh", persona.effective_tools("legacy"))
+
+
+class TestItIsChecked(BorrowsIso):
+    def test_borrows_is_a_known_key(self):
+        self.p("forge", tools="gh")
+        self.p("steward", borrows="forge")
+        self.assertNotIn("borrows", " ".join(m for _lvl, m in persona.lint("steward")))
+
+    def test_a_dangling_borrows_is_a_structural_error(self):
+        """Same failure as a dangling `uses:`, which `lint` already had to grow a check
+        for: a persona pointing at somebody who is not there."""
+        self.p("steward", borrows="ghost")
+        self.assertTrue(persona.structural_errors("steward"))
+
+    def test_none_is_not_a_dangling_reference(self):
+        self.p("steward", borrows="none")
+        self.assertFalse(persona.structural_errors("steward"))
+
+
+class TestTheGeneratedCharterSaysWhichIsWhich(BorrowsIso):
+    def _charter(self, name: str) -> str:
+        from charter import commands_persona, config
+        commands_persona._write_agent(name)
+        return (config.ROOT / ".claude" / "agents" / f"{name}.md").read_text()
+
+    def test_with_borrows_uses_reads_as_routing_only(self):
+        """The generated charter is what a dispatched agent believes about itself. If it
+        still said 'run their tools' the toolgate would refuse and the agent would not know
+        why."""
+        self.p("forge", tools="gh")
+        self.p("release", tools="twine")
+        self.p("steward", uses="forge", borrows="release")
+        text = self._charter("steward")
+        self.assertIn("release", text)
+        self.assertIn("forge", text)
+        route_line = [ln for ln in text.splitlines() if "`forge`" in ln and "vault" in ln]
+        self.assertEqual(route_line, [])
+
+    def test_without_borrows_the_wording_is_unchanged(self):
+        self.p("forge", tools="gh")
+        self.p("steward", uses="forge")
+        self.assertIn("vault", self._charter("steward"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Increment 5 — the last of the delegation rollout. **Stacked on #263** (→ #262 → #260 →
#259), so this diff is the single commit. 2502 tests green.

## The incentive, not the reminder

`uses:` granted three things in one word: read that persona's vault, **run its tools with
auto-approval**, and delegate to its sub-agent. The middle grant is why delegation loses
every time it is offered — a front door declaring `uses: forge, release` can do both
personas' work with both personas' tools and never pay a permission prompt, while handing
the work over costs a dispatch, a brief, and the context that goes with them.

Everything else in this stack is a reminder. This is the only change that alters what is
*cheap*.

```yaml
uses: forge, release      # personas I may hand work to
borrows: release          # …and whose tools/vault I may actually use
```

| Declared | What `uses:` means | Tools auto-approved from |
| --- | --- | --- |
| no `borrows:` | vault + tools + delegation (unchanged) | the `uses:` list |
| `borrows: <names>` | delegation only | the `borrows:` list |
| `borrows: none` | delegation only | nobody — own tools only |

## Per persona, never plane-wide

An earlier draft of this design had `[routing] borrow = legacy|explicit` in `charter.toml`.
It was cut for the reason this field exists: one persona opting in must not change another
persona's tool permissions. There is a test asserting exactly that — a `strict` persona and
a `legacy` persona side by side, both declaring `uses: forge`, and only the one that opted
in loses the borrowed tool.

## Two details worth reviewing

**`None` and `[]` are different answers** in `borrows_of`, deliberately. Absent means "not
opted in, keep the legacy grant"; empty means "I borrow nothing". Collapsing them would
either break every existing plane or make opting out unsayable.

**The generated sub-agent charter says which list is which.** That text is what a dispatched
agent believes about itself — if it still read "run their tools" while the tool-gate
refused, the agent would have no way to find out why. With `borrows:` declared, the `uses:`
line reads as delegation only and says plainly that doing their work yourself is *meant* to
cost more than handing it over.

A dangling `borrows:` is a structural error, like a dangling `uses:` — same failure, a
persona pointing at somebody who is not there. `none` is not treated as a dangling name.

Refs #257.
