### PR TITLE
The leak guard stops treating a reader that writes as a reader that reads

### DIFF
--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -125,6 +125,115 @@ def _is_charter(prog: str, args: list[str]) -> bool:
     return False
 
 
+#: `<<DELIM`, `<<'DELIM'`, `<<"DELIM"`, `<<-DELIM` — the start of a heredoc.
+_HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+
+
+def _reader_of(line: str) -> bool:
+    """Whether *line* starts by invoking a program in :data:`_READERS`."""
+    toks = line.strip().split()
+    i = 0
+    while i < len(toks) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", toks[i]):
+        i += 1  # leading VAR=value assignments
+    return i < len(toks) and os.path.basename(toks[i]).lower() in _READERS
+
+
+def _strip_reader_heredocs(cmd: str) -> str:
+    """Remove heredoc BODIES fed to a reader — they are stdin data, never arguments.
+
+    `_segment_argv` shlex-splits the whole command string, so `cat > file <<'DOC' … DOC`
+    hands the body to the leak check as `cat`'s argv, and a document *describing* charter's
+    own layout is refused as a *read* of it (#258). Documentation about charter is exactly
+    the text most likely to name these paths.
+
+    Only a reader's heredoc. A body fed to `bash`/`python` is a script, not data, and
+    removing it would hide commands from a guard rather than prose — a distinction worth
+    the extra condition even though this guard does not scan such bodies today.
+    """
+    if "<<" not in cmd:
+        return cmd
+    lines = cmd.split("\n")
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        out.append(line)
+        m = _HEREDOC_RE.search(line)
+        if m and _reader_of(line):
+            delim = m.group(2)
+            i += 1
+            while i < len(lines) and lines[i].strip() != delim:
+                i += 1  # drop the body
+            i += 1       # and the terminator
+            continue
+        i += 1
+    return "\n".join(out)
+
+
+#: Readers whose FIRST non-flag operand is a program or pattern rather than a file, and the
+#: flags that supply it instead (after which no positional is consumed for that purpose).
+#: Getting this wrong in the permissive direction costs a false negative, so the set is
+#: kept to the three tools where the operand is unambiguous.
+_SCRIPT_OPERAND = {
+    "sed": ("-e", "--expression", "-f", "--file"),
+    "awk": ("-f", "--file"),
+    "grep": ("-e", "--regexp", "-f", "--file"),
+    "rg": ("-e", "--regexp", "-f", "--file"),
+    "ag": ("-e", "--regexp", "-f", "--file"),
+}
+
+
+#: Flags whose VALUE is a separate token and is never a path. Per tool, because the same
+#: spelling differs: `head -n 5` takes a count, `sed -n` is "quiet" and takes nothing, and
+#: treating sed's `-n` as consuming a value swallows the script operand — which would let
+#: `sed -n 1p .charter/active-persona` through, a real read.
+_TAKES_VALUE = {
+    "head": ("-n", "-c", "--lines", "--bytes"),
+    "tail": ("-n", "-c", "--lines", "--bytes"),
+    "grep": ("-m", "-A", "-B", "-C", "--max-count", "--after-context", "--before-context"),
+    "rg": ("-m", "-A", "-B", "-C", "--max-count"),
+    "ag": ("-m", "-A", "-B", "-C", "--max-count"),
+    "od": ("-N", "-j", "-t"),
+    "xxd": ("-l", "-s", "-c"),
+}
+
+
+def _file_operands(prog: str, args: list[str]) -> list[str]:
+    """The arguments *prog* would actually open — its file operands.
+
+    The leak rule used to scan every token, which is true enough for `cat` and false for
+    every tool whose first operand is a program or a pattern: `sed -i 's|<path>|…|' f`
+    rewrites a mention, `grep -rn "<path>" docs/` searches for one. Neither opens the path,
+    and both were denied as reads of it.
+
+    Flag VALUES are skipped for the same reason — `grep -e <path> file` supplies the
+    pattern behind a flag — while the file that follows stays an operand, so hiding a real
+    read behind `-e` does not work.
+    """
+    base = os.path.basename(prog).lower()
+    flags = _SCRIPT_OPERAND.get(base)
+    # `_split_env` hands back argv WITH the program still at [0]; dropping it here is what
+    # makes "the first positional is the script" mean the first real operand.
+    argv = args[1:] if args and args[0] == prog else args
+    out, skip_next, script_taken = [], False, flags is None
+    for a in argv:
+        if skip_next:
+            skip_next = False
+            continue
+        if a.startswith("-"):
+            if flags and a in flags:
+                script_taken = True     # the pattern/program came from this flag
+                skip_next = "=" not in a
+            elif "=" not in a and a in _TAKES_VALUE.get(base, ()):
+                skip_next = True        # its value is a count, never a path
+            continue
+        if not script_taken:
+            script_taken = True         # this positional IS the script/pattern
+            continue
+        out.append(a)
+    return out
+
+
 def _leak_reason(cmd: str) -> str | None:
     """Deny a command that would print a secret into the transcript.
 
@@ -146,7 +255,7 @@ def _leak_reason(cmd: str) -> str | None:
     vault registered elsewhere is therefore still unguarded here — a separate finding,
     not something to half-fix on the hot path.
     """
-    for _toks in _segment_argv(cmd):
+    for _toks in _segment_argv(_strip_reader_heredocs(cmd)):
         prog, _env, args = _split_env(_toks)
         if not prog:
             continue
@@ -155,7 +264,7 @@ def _leak_reason(cmd: str) -> str | None:
             return ("would reveal a secret value into the conversation (--reveal). "
                     "Use `charter … secret exec`/`cp` — never --reveal for an agent")
         if os.path.basename(prog).lower() in _READERS and any(
-                _VAULT_PATH_RE.search(a) for a in args):
+                _VAULT_PATH_RE.search(a) for a in _file_operands(prog, args)):
             return ("reads a vault/secret file directly (would print plaintext). "
                     "Use `charter … secret exec`/`cp` instead of catting `.charter/`")
     return None

--- a/tests/test_leak_guard_readers_that_write.py
+++ b/tests/test_leak_guard_readers_that_write.py
@@ -1,0 +1,117 @@
+"""The leak guard assumed a reader reads its arguments. Sometimes it writes them (#258).
+
+`_leak_reason` fires when the program is in `_READERS` and any argument matches a vault
+path. Both halves are satisfied by commands that read nothing at all:
+
+* `cat > file <<'DOC' … DOC` — the heredoc body is stdin *data*, and `_segment_argv`
+  shlex-splits the whole command string, so prose describing charter's own layout became
+  `cat`'s argv and a write was denied as a read.
+* `sed -i 's|<guarded-path>|…|' file`, `awk '… <guarded-path> …' f` — the path is inside
+  the script operand, which is a program, not a file.
+* `grep -rn "<guarded-path>" docs/` — the path is the *pattern*.
+
+This is the second round of the same class. The first (`git commit -m "…--reveal…"`,
+`grep -rn vaults .charter/vaults.json`) was fixed by shlex-accurate argv so a quoted string
+stays one token; the assumption that survived it is that a program in `_READERS` opens the
+tokens that follow it.
+
+Both directions are pinned here, and the deny half comes first: this is a security guard,
+and a fix that quietly widened the hole would be worse than the false positive it removes.
+"""
+from __future__ import annotations
+
+import unittest
+
+from charter import hooks
+
+
+class LeakCase(unittest.TestCase):
+    def denied(self, cmd: str) -> bool:
+        return hooks._leak_reason(cmd) is not None
+
+
+class TestItStillDeniesRealReads(LeakCase):
+    """Every one of these opens a guarded path. None may become allowed."""
+
+    def test_cat_of_a_vault_file(self):
+        self.assertTrue(self.denied("cat .charter/vaults/db.json"))
+
+    def test_head_of_the_active_persona_file(self):
+        self.assertTrue(self.denied("head -n 5 .charter/active-persona"))
+
+    def test_tail_follow(self):
+        self.assertTrue(self.denied("tail -f .charter/vaults/db.json"))
+
+    def test_grep_with_a_pattern_and_a_guarded_file(self):
+        self.assertTrue(self.denied("grep -rn secret .charter/vaults/db.json"))
+
+    def test_grep_recursive_into_the_vault_directory(self):
+        """With the trailing slash — `_VAULT_PATH_RE` requires it deliberately, so that
+        `.charter/vaults.json` (the registry: provider config and paths, never values) stays
+        an ordinary read. A bare `.charter/vaults` is not matched today; that is a coverage
+        gap of its own, not this bug, and widening the pattern here would be a different
+        change smuggled into a false-positive fix."""
+        self.assertTrue(self.denied("grep -r . .charter/vaults/"))
+
+    def test_sed_printing_a_guarded_file(self):
+        self.assertTrue(self.denied("sed -n 1p .charter/active-persona"))
+
+    def test_awk_over_a_guarded_file(self):
+        self.assertTrue(self.denied("awk '{print}' .charter/browser/state.json"))
+
+    def test_a_pattern_flag_does_not_hide_the_file(self):
+        self.assertTrue(self.denied("grep -e secret .charter/vaults/db.json"))
+
+    def test_still_denied_inside_a_compound_command(self):
+        self.assertTrue(self.denied("cd /tmp && cat .charter/vaults/db.json"))
+
+    def test_an_unparseable_command_still_fails_closed(self):
+        """The invariant `test_guard_parsing` pins: not printing a secret is the one
+        failure this guard may not have."""
+        self.assertTrue(self.denied("cat '.charter/vaults/db.json"))
+
+
+class TestAWriterIsNotAReader(LeakCase):
+    def test_a_heredoc_body_mentioning_a_guarded_path(self):
+        """The reported bug. The body is stdin data being written to a file under
+        `workspaces/`; nothing is opened."""
+        cmd = ("cat > workspaces/ws/design.md <<'DOC'\n"
+               "The local active-persona file lives under .charter/active-persona.\n"
+               "DOC")
+        self.assertFalse(self.denied(cmd))
+
+    def test_an_unquoted_heredoc_delimiter_too(self):
+        cmd = "cat > notes.md <<DOC\nsee .charter/vaults/ for the layout\nDOC"
+        self.assertFalse(self.denied(cmd))
+
+    def test_a_dash_heredoc_too(self):
+        cmd = "cat > notes.md <<-DOC\n\tsee .charter/active-persona\n\tDOC"
+        self.assertFalse(self.denied(cmd))
+
+    def test_sed_rewriting_a_mention_of_the_path(self):
+        self.assertFalse(self.denied("sed -i 's|.charter/active-persona|X|' notes.md"))
+
+    def test_awk_matching_a_mention_of_the_path(self):
+        self.assertFalse(self.denied("awk '/.charter\\/active-/ {print}' notes.md"))
+
+    def test_grep_searching_docs_for_a_mention(self):
+        """Documentation about charter is exactly the text most likely to name these
+        paths, and this repo is full of it."""
+        self.assertFalse(self.denied('grep -rn "\\.charter/active-persona" docs/'))
+
+    def test_grep_with_the_pattern_behind_a_flag(self):
+        self.assertFalse(self.denied("grep -e .charter/active-persona docs/personas.md"))
+
+    def test_an_interpreters_heredoc_is_not_stripped(self):
+        """Only a READER's heredoc is removed. A body fed to a shell is a script, not data,
+        and stripping it would hide commands from the guard.
+
+        The outcome is unchanged either way — `bash` is not in `_READERS`, so this guard
+        never scanned such a body and still does not. Pinned so that the stripping rule is
+        not later "simplified" to apply everywhere, which would make the difference real."""
+        cmd = "bash <<'EOF'\ncat .charter/vaults/db.json\nEOF"
+        self.assertFalse(self.denied(cmd))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #258. Independent of the delegation stack — based on `workspace-neighbours` only
because that is where the branch was cut; it touches `_leak_reason` and nothing else those
PRs go near. 2532 tests green.

## The bug

`_leak_reason` fires when the program is in `_READERS` **and** any argument matches a
guarded path. Both halves are satisfied by commands that open nothing:

| Command | What it actually does |
| --- | --- |
| `cat > file <<'DOC' … DOC` | writes a file; the heredoc body is stdin data that `_segment_argv` shlex-split into `cat`'s argv |
| `sed -i 's\|<path>\|…\|' f` | rewrites a mention; the path is in the script |
| `awk '… <path> …' f` | matches a mention; same |
| `grep -rn "<path>" docs/` | searches for a mention; the path is the pattern |

Documentation about charter is exactly the text most likely to name these paths, and this
repo is largely that.

## Why it is worth a careful fix rather than a quick one

This is the **second round of the same class**. The first — `git commit -m "…--reveal…"`,
`grep -rn vaults .charter/vaults.json` — was fixed by shlex-accurate argv so a quoted string
stays one token. The assumption that survived that round is the one this removes: *a program
in `_READERS` opens the tokens after it*.

Which matters because the obvious next fix is to make the scan cleverer about strings, and
that is the fix that already shipped.

## Two narrow rules, both conservative

**Heredoc bodies fed to a reader are stripped before parsing.** They are stdin data, never
arguments. *Only* a reader's — a body fed to `bash`/`python` is a script, and stripping it
would hide commands from a guard rather than prose. The outcome is unchanged today (a shell
is not in `_READERS`), and a test pins the distinction so the rule is not later "simplified"
into applying everywhere, which would make the difference real.

**Only real file operands are matched.** The script/pattern operand of `sed`, `awk` and
`grep` no longer counts, and a value belonging to a flag is skipped with it — so
`grep -e <path> file` skips the pattern and still sees the file.

## The regression that appeared while writing this

The value-flag table is **per tool**, and that is not fussiness. `head -n 5` takes a count;
`sed -n` is "quiet" and takes nothing. A shared list swallows sed's script operand and lets
`sed -n 1p .charter/active-persona` through — a real read. It got through exactly once,
locally, and is now a test.

## The deny half is pinned harder than the allow half

Ten cases must keep being refused: `cat`/`head`/`tail` of a vault file, `grep` with a
pattern and a guarded file, `grep -r` into the vault directory, `sed -n` printing one, `awk`
over one, a guarded file hidden behind `-e`, a read inside a compound command, and an
unparseable command still failing **CLOSED**. A false-positive fix that quietly widened the
hole would be worse than the false positive.

Verified through the real hook, not only the suite:

```
$ # the reported bug
$ echo '{"tool_input":{"command":"cat > workspaces/ws/design.md <<'"'"'DOC'"'"'\n…. charter/active-persona …\nDOC"}}' | charter hook pretooluse
(nothing — allowed)

$ echo '{"tool_input":{"command":"cat .charter/vaults/db.json"}}' | charter hook pretooluse
deny — charter guard: reads a vault/secret file directly…

$ echo '{"tool_input":{"command":"sed -n 1p .charter/active-persona"}}' | charter hook pretooluse
deny
```

## One thing deliberately not changed

A bare `.charter/vaults` (no trailing slash) is still unmatched. The trailing slash is
deliberate — `.charter/vaults.json` is the registry and holds provider config, never values
— so widening it changes *what is guarded*, which is not part of removing a false positive.
It is named in a test rather than left to be rediscovered, and it is worth its own issue if
you want the directory form covered.
