### PR TITLE
charter init scaffolds a front door — one generic file the plane then owns

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -70,6 +70,14 @@ def build_parser() -> argparse.ArgumentParser:
                      help="Also clone the git repo you are standing in into the first "
                           "workspace. This is how you accept the offer `charter init` "
                           "prints when it finds one; without it, init clones nothing.")
+    # The front door is a FILE, not a feature: init writes one generic persona and
+    # declares it in charter.toml. The name lives here, in a flag with a default — never
+    # in the engine, which knows only that a plane may declare a default persona.
+    ini.add_argument("--front-door", metavar="NAME", default="steward",
+                     help="Name of the generic front-door persona to scaffold and declare "
+                          "(default: steward). Skipped if this plane already has personas.")
+    ini.add_argument("--no-front-door", dest="front_door", action="store_const", const=None,
+                     help="Scaffold no persona at all; the plane declares no front door.")
     ini.set_defaults(func=commands.cmd_init)
 
     doc_check = sub.add_parser(

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1255,6 +1255,105 @@ def _first_clone_step(root: Path, accepted: bool) -> int:
     return _clone_first_workspace(root)
 
 
+#: The front door `init` scaffolds. Generic by construction: it names no other persona,
+#: because on a fresh plane there are none, and it says so rather than pretending.
+#:
+#: Every line is a true statement about this persona — the same rule `_TEMPLATE` in
+#: commands_persona follows, and for the same reason: whatever is written here is read by
+#: an agent as its actual remit, not as advice to whoever edits the file later.
+#:
+#: The prose does the work the frontmatter cannot. A front door whose charter reads as
+#: though doing the work itself were normal would ship the exact failure this design
+#: exists to fix, pre-installed, in the file every consumer copies from. So it says: you
+#: have nobody to route to yet, here is how to get someone.
+_FRONT_DOOR = """---
+name: {name}
+role: {role}
+vault: none
+routing: advise
+delegate-when: routing work to the right persona, and scoping a request before code is written
+---
+
+# {role}
+
+You are the front door of this control plane. Your job is to understand what is actually
+being asked, then either do it or hand it to the persona that owns it — not to start
+editing the first file that looks relevant.
+
+## Routing
+
+This plane has no other personas yet, so there is nothing to route to. That is the first
+thing worth fixing, not a reason to do everything here:
+
+```
+charter persona create <name> --role "<Role>" \\
+  --delegate-when "<the work that should come to it>"
+```
+
+`delegate-when` is what makes a persona findable — it becomes the description whoever is
+routing reads. Create one the moment a second kind of work appears in this plane.
+
+Once others exist, `routing: advise` above puts them in front of you on work-shaped
+prompts: who exists, what each claims, when each was last dispatched. charter never says
+which one owns the request — that call is yours. Route on the *work*, not on the file a
+change happens to touch.
+
+Cross-cutting changes stay with you: splitting one coherent change across three personas
+costs more in lost context than it saves.
+
+## Scout before you scope
+
+Read the thing before proposing a change to it, and check what this plane already knows —
+`charter recall "<keywords>"` searches your memory, the shared namespace and the active
+workspace's journal at once.
+
+## What you own
+
+Personas, workspaces, memory and vaults — the shape of this plane. Definitions and memory
+are committed and shared; credentials never are.
+
+Record durable facts with `charter persona remember {name} "<fact>"`, and `--shared` for
+anything every persona needs.
+
+This file is yours: rename it, rewrite it, or delete it and declare a different front door
+with `charter persona default <name>`.
+"""
+
+
+def _ensure_front_door(root: Path, name: str | None) -> tuple[str, str] | None:
+    """Scaffold the generated front-door persona and declare it. Returns
+    ``(status, label)`` for init's created/present report, or ``None`` when it did nothing.
+
+    Skipped entirely when the plane already has ANY persona: `init` creates only what is
+    absent, and a roster is not absent because one particular name is. Skipped too when a
+    default is already declared — someone has already answered this question.
+
+    Writes through explicit paths under *root* rather than `config.PERSONAS_DIR`, like
+    every other writer in this command: `init` runs before the plane it is creating exists,
+    so the derived globals may still point somewhere else entirely.
+    """
+    if not name:
+        return None
+    personas = root / "personas"
+    if any(personas.glob("*/persona.md")) or any(personas.glob("*.md")):
+        return None
+    from . import instance as _instance, persona as _persona
+    if _instance.default_persona_of(_instance.load(root)):
+        return None
+    if not _persona.valid_name(name):
+        util.warn(f"--front-door {name!r} is not a valid persona name — skipped.")
+        return None
+    d = personas / name
+    d.mkdir(parents=True, exist_ok=True)
+    role = f"{name.replace('-', ' ').replace('_', ' ').title()}"
+    (d / "persona.md").write_text(_FRONT_DOOR.format(name=name, role=role))
+    for sub in ("memory", "refs"):
+        (d / sub).mkdir(parents=True, exist_ok=True)
+        (d / sub / ".gitkeep").touch()
+    _instance.set_default_persona(root, name)
+    return ("created", f"personas/{name}/ (front door, declared in charter.toml)")
+
+
 def cmd_init(args) -> int:
     """Scaffold a control plane from nothing — the first-run command a stranger needs
     and the one `root.py`'s own "no control plane found" error already points to.
@@ -1322,6 +1421,10 @@ def cmd_init(args) -> int:
     # safety feature that ships off by default stays off.
     for status, label in _wire_harnesses(root):
         (created if status == "created" else present).append(label)
+
+    fd = _ensure_front_door(root, getattr(args, "front_door", None))
+    if fd:
+        created.append(fd[1])
 
     gh_status, gh_detail = _ensure_guard_hook(root)
     if gh_status == "created":

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -16,7 +16,20 @@ kind = "gitlab"
 
 [memory]
 share = "local"
+
+[persona]
+default = "steward"
 ```
+
+That last key is the plane's **front door** — the persona a session adopts when nobody has
+chosen one. `init` also scaffolds it: one generic `personas/steward/persona.md` you own and
+can rename, rewrite or delete. Name it something else with `charter init --front-door ops`,
+or skip it entirely with `--no-front-door`; either way charter's own code knows only *that*
+a plane may declare a default, never which one. If the plane already has personas, `init`
+scaffolds nothing — it creates only what is absent.
+
+The generated charter declares `routing: advise`, so once a second persona exists the front
+door sees the roster on work-shaped prompts. See `charter docs show personas`.
 
 ## Every key, in full
 
@@ -25,6 +38,13 @@ share = "local"
 # schema NEWER than it understands (upgrade the CLI instead of guessing); it has no
 # problem reading an OLDER schema. Omit it and 1 is assumed.
 schema = 1
+
+# Optional. The persona a session adopts when nothing else selects one — this plane's
+# front door. `charter persona default <name>` writes it. Overridden per developer by
+# `charter persona use`, `$CHARTER_PERSONA` and `--persona`; a name that no longer exists
+# resolves to no persona at all, and `charter doctor` says so.
+[persona]
+default = "steward"
 
 # Optional. Only needed to move worktrees off their default location.
 [plane]

--- a/tests/test_init_front_door.py
+++ b/tests/test_init_front_door.py
@@ -1,0 +1,136 @@
+"""`charter init` scaffolds a front door — a generic one, that the plane then owns.
+
+`init` used to create zero personas, so every fresh plane started with no identity, no
+routing, and no example of what a persona looks like. The fix is not for charter to know
+about a persona called `steward`: it is for `init` to write one FILE the consumer can
+rename, rewrite or delete, and to declare it in `charter.toml`. charter's own code still
+knows only *that* a plane may declare a default, never which (#255, #256).
+
+The template's prose matters as much as its frontmatter. A fresh plane has nobody to route
+to, so a front door that reads as though delegating were optional would ship the exact
+failure this design exists to fix — pre-installed, in the file everyone copies from.
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands, config, instance
+
+
+class InitFrontDoorIso(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="charter-fd-")).resolve()
+
+    def _init(self, **kw):
+        args = SimpleNamespace(forge=kw.get("forge", "github"),
+                               owner=kw.get("owner", "acme"),
+                               host=None,
+                               front_door=kw.get("front_door", "steward"))
+        with mock.patch.object(config, "ROOT", self.root):
+            return commands.cmd_init(args)
+
+    def charter_of(self, name: str) -> str:
+        return (self.root / "personas" / name / "persona.md").read_text()
+
+    def declared(self) -> str | None:
+        return instance.default_persona_of(instance.load(self.root))
+
+
+class TestItScaffoldsOne(InitFrontDoorIso):
+    def test_a_fresh_plane_gets_a_front_door_persona(self):
+        self._init()
+        self.assertTrue((self.root / "personas" / "steward" / "persona.md").is_file())
+
+    def test_and_the_plane_declares_it(self):
+        """A generated persona nobody declares is a file, not a front door."""
+        self._init()
+        self.assertEqual(self.declared(), "steward")
+
+    def test_the_name_comes_from_the_flag(self):
+        self._init(front_door="ops")
+        self.assertTrue((self.root / "personas" / "ops" / "persona.md").is_file())
+        self.assertEqual(self.declared(), "ops")
+
+    def test_it_can_be_declined(self):
+        self._init(front_door=None)
+        self.assertEqual(list((self.root / "personas").glob("*/persona.md")), [])
+        self.assertIsNone(self.declared())
+
+    def test_it_carries_the_advise_posture(self):
+        """The default posture arrives in a file the consumer owns, never as a constant
+        inside charter — that is the whole reason there is no plane-level routing setting."""
+        self._init()
+        self.assertIn("routing: advise", self.charter_of("steward"))
+
+    def test_it_is_dispatchable_not_a_draft(self):
+        """`persona create` marks a stub `draft: true` because it is unfinished. This one
+        is complete for its purpose and is adopted by the very next session."""
+        self._init()
+        self.assertNotIn("draft: true", self.charter_of("steward"))
+
+    def test_it_declares_when_work_should_be_routed_to_it(self):
+        self._init()
+        self.assertIn("delegate-when:", self.charter_of("steward"))
+
+
+class TestTheTemplateIsGeneric(InitFrontDoorIso):
+    def test_it_names_none_of_charters_own_personas(self):
+        """The charter in this repo routes to `statusline`, `release` and `forge`. Shipping
+        that into a stranger's plane hands them our furniture."""
+        self._init()
+        text = self.charter_of("steward").lower()
+        for ours in ("statusline", "release", "forge", "plane shape"):
+            self.assertNotIn(ours, text)
+
+    def test_it_says_there_is_nobody_to_route_to_yet(self):
+        """A fresh plane has a roster of one. The template has to say so, or it reads as a
+        persona whose job is to do the work itself."""
+        self._init()
+        text = self.charter_of("steward").lower()
+        self.assertIn("charter persona create", text)
+
+    def test_it_uses_the_name_it_was_given(self):
+        self._init(front_door="ops")
+        text = self.charter_of("ops")
+        self.assertIn("ops", text)
+        self.assertNotIn("steward", text)
+
+
+class TestItStaysAdditive(InitFrontDoorIso):
+    def test_an_existing_persona_of_that_name_is_untouched(self):
+        d = self.root / "personas" / "steward"
+        d.mkdir(parents=True)
+        (d / "persona.md").write_text("---\nname: steward\nrole: Mine\n---\n\nMy own words.\n")
+        self._init()
+        self.assertIn("My own words.", self.charter_of("steward"))
+
+    def test_a_plane_that_already_has_personas_gets_no_new_one(self):
+        """`init` creates only what is absent. A roster is not absent because one
+        particular name is."""
+        d = self.root / "personas" / "ops"
+        d.mkdir(parents=True)
+        (d / "persona.md").write_text("---\nname: ops\nrole: Ops\n---\n\nbody\n")
+        self._init()
+        self.assertFalse((self.root / "personas" / "steward").exists())
+
+    def test_an_existing_declaration_is_not_overwritten(self):
+        self.root.mkdir(parents=True, exist_ok=True)
+        (self.root / "charter.toml").write_text(
+            'schema = 1\n\n[persona]\ndefault = "chosen"\n')
+        self._init()
+        self.assertEqual(self.declared(), "chosen")
+
+    def test_running_it_twice_changes_nothing(self):
+        self._init()
+        first = self.charter_of("steward")
+        self._init()
+        self.assertEqual(self.charter_of("steward"), first)
+        self.assertEqual(self.declared(), "steward")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Increment 3 of the delegation design. **Stacked on #260** (which is stacked on #259), so
this diff is the single commit `5eef210`. GitHub retargets automatically as the stack
merges.

`python3 -m unittest discover -s tests` green at **2481 tests**, and the whole lifecycle was
driven from an empty directory rather than only from the suite.

## The gap

`charter init` created **zero** personas. A fresh plane had no identity, no routing, and no
example of what a persona even looks like — and the one committed way to declare a front
door was undocumented (that half is #259).

## What this does not do

It does not teach charter about a persona called `steward`. The name lives in a flag with a
default and nowhere else:

```
charter init                      # scaffolds personas/steward/, declares it
charter init --front-door ops     # scaffolds personas/ops/ instead
charter init --no-front-door      # scaffolds none, declares none
```

The engine still knows only *that* a plane may declare a default persona, never which one.
What ships is a **file the consumer owns** — rename it, rewrite it, delete it.

## Additive, like the rest of `init`

Skipped entirely when the plane already has any persona (a roster is not absent because one
particular name is), and when a default is already declared. Running `init` twice changes
nothing. An existing `personas/<name>/persona.md` is never overwritten.

## The template's prose is the load-bearing part

It names none of this repo's own personas — shipping our routing table into a stranger's
plane hands them our furniture. And because a fresh plane has a roster of one, it says so
rather than pretending otherwise:

> This plane has no other personas yet, so there is nothing to route to. That is the first
> thing worth fixing, not a reason to do everything here.

followed by the `charter persona create` line that fixes it. A front door whose charter read
as though doing the work itself were normal would ship the exact failure this design exists
to fix, pre-installed, in the file every consumer copies from.

`routing: advise` sits in that frontmatter rather than in charter's code — the whole reason
there is no plane-level routing setting. The default a new plane wants arrives in a file the
consumer can change, instead of a constant somebody else chose.

## Verified from nothing

```
$ charter init --forge github --owner acme
•   + personas/steward/ (front door, declared in charter.toml)

$ charter persona list
Active persona: steward  (via charter.toml)

$ charter doctor
  ✓  personas         1 persona(s), all clean
  ✓  front door       'steward' via charter.toml [persona] default
```

Then the property that matters most, in order: with a roster of one the routing block stays
**silent** (no wallpaper on a plane with nobody to route to), and the moment a second
persona exists it speaks —

```
⬡ Who else could take this. `steward` declares `routing: advise` …
   • `dba` — schema migrations, query plans · never dispatched
```

Docs: `docs/control-plane.md` gains the front-door explanation in the fresh-init example and
the `[persona]` block in the every-key reference.

Refs #255, #256.

---

Supersedes #262, which GitHub closed automatically when its base branch was deleted during the stack merge. Same branch, same commit, same body.
