### PR TITLE
Enabled is not loaded, and a sighting belongs to the declaration that made it

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -592,9 +592,30 @@ def check_guard_wired() -> Result:
                            f"from {where} and keep the plugin — or disable the plugin and "
                            f"keep the block. charter does not edit that file for you.")
     if plugin:
-        detail = ("wired (Claude Code plugin)" if plugin == "Claude Code plugin"
-                  else f"wired (enabled plugin {plugin})")
-        return Result(name, OK, detail=detail)
+        if plugin == "Claude Code plugin":
+            # `$CLAUDE_PLUGIN_ROOT` means this very process was launched by the plugin, so
+            # its hooks are demonstrably live. Nothing to qualify.
+            return Result(name, OK, detail="wired (Claude Code plugin)")
+        # ENABLED is not LOADED (#261). A plugin's hooks are loaded by the harness at
+        # session start, so a plugin installed mid-session — or one whose duplicate
+        # settings block was just removed on this check's own advice — is declared for the
+        # NEXT session while this one holds no declaration at all. The reporter branched
+        # the plane root in that window and nothing refused it.
+        #
+        # Reaching the handler is the only proof available, which is what `guardseen`
+        # exists to record; a sighting from THIS plugin is that proof.
+        from . import guardseen as _seen
+        if _seen.last_source() == _seen.PLUGIN:
+            return Result(name, OK,
+                          detail=f"wired (enabled plugin {plugin}) — and it has fired here")
+        return Result(
+            name, WARN,
+            detail=f"enabled plugin {plugin} declares it, but nothing has fired here yet — "
+                   f"a plugin's hooks load at session start, so this is wired for the NEXT "
+                   f"session and THIS one may be unguarded",
+            hint="Restart the session (or run a Bash command through it and re-check). If "
+                 "you just removed a duplicate `hooks` block on this check's advice, that "
+                 "was right — but it was the declaration this session actually had.")
     if declared:
         return Result(name, OK, detail=f"wired ({declared[0]})")
     return Result(name, WARN,
@@ -659,6 +680,16 @@ def check_harness() -> Result:
     return Result(name, OK, detail=f"{current} — {len(gaps)} capability ceiling{plural}\n{listed}")
 
 
+def _read_text(p) -> str:
+    """A settings file's text, or ``""`` when it cannot be read. A file charter is not
+    allowed to open is not evidence of anything, and a preflight row must render whatever
+    it finds rather than raise on it."""
+    try:
+        return p.read_text()
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
 def check_guard_seen() -> Result:
     """Has a guard ever actually RUN here, and under which harness?
 
@@ -685,6 +716,26 @@ def check_guard_seen() -> Result:
     if rec:
         at = _seen_age(rec.get("ts"))
         where = rec.get("harness") or "an unnamed harness"
+        # A sighting is evidence for the declaration that PRODUCED it and for no other. The
+        # settings block that fired minutes ago can have been deleted since — on this
+        # command's own duplicate-guard advice — and "last ran 0m ago" then invites the
+        # reader to conclude the surviving declaration is working (#261). An unrecorded
+        # source predates the field and stays unqualified: unknown is not suspect.
+        src = _seen.last_source()
+        settings_declare = any("charter hook pretooluse" in _read_text(p)
+                               for p in _settings_files())
+        # Narrow deliberately: `settings` is also what a Codex or opencode dispatch records,
+        # and those declarations live in files this check never reads (`~/.codex/config.toml`),
+        # so "no settings file declares it" alone would warn at planes that are wired fine.
+        # The reported case is specific — the settings block was removed in favour of a
+        # plugin — so the plugin has to be the thing that survived it.
+        if src == _seen.SETTINGS and not settings_declare and _plugin_declaring_guard():
+            return Result(
+                name, WARN,
+                detail=f"last ran {at} ago under {where}, but from a settings declaration "
+                       f"that is no longer there",
+                hint="That sighting is not evidence for whatever declares the guard now. "
+                     "Run a Bash command in a fresh session and re-check.")
         return Result(name, OK, detail=f"last ran {at} ago under {where}")
     if not _seen.plane_has_been_used():
         return Result(name, OK, detail="plane not worked in yet")

--- a/charter/guardseen.py
+++ b/charter/guardseen.py
@@ -40,7 +40,21 @@ def path() -> Path:
     return Path(config.STATE_DIR) / FILE_NAME
 
 
-def mark(harness: str | None = None, when: datetime | None = None) -> Path | None:
+#: Source recorded when the running process was launched by the plugin — `$CLAUDE_PLUGIN_ROOT`
+#: is set only for a command the plugin itself dispatches, which is the one fact that
+#: distinguishes a declaration that IS loaded from one that is merely enabled (#261).
+PLUGIN = "plugin"
+#: Source recorded otherwise: a `charter hook pretooluse` line in a settings file.
+SETTINGS = "settings"
+
+
+def _source() -> str:
+    import os
+    return PLUGIN if os.environ.get("CLAUDE_PLUGIN_ROOT") else SETTINGS
+
+
+def mark(harness: str | None = None, when: datetime | None = None,
+         source: str | None = None) -> Path | None:
     """Record that a guard just ran. Best-effort — never raises, never blocks a turn.
 
     Called from the guard handler itself rather than from `sessionstart`, and that choice is
@@ -57,14 +71,32 @@ def mark(harness: str | None = None, when: datetime | None = None) -> Path | Non
         except Exception:
             harness = None
     when = when or datetime.now(timezone.utc)
+    # WHICH declaration dispatched this, so a sighting can never be read as evidence for a
+    # declaration that did not produce it. The reporter deleted the settings block on
+    # doctor's own advice, and the sighting it left behind then read as proof that the
+    # plugin replacing it was live — while the running session held no declaration at all
+    # (#261). A sighting belongs to the thing that made it.
+    src = source or _source()
     p = path()
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(json.dumps({"ts": when.isoformat(timespec="seconds"),
-                                 "harness": harness}, sort_keys=True) + "\n")
+                                 "harness": harness, "source": src},
+                                sort_keys=True) + "\n")
         return p
     except OSError:
         return None
+
+
+def last_source() -> str | None:
+    """Which declaration produced the latest sighting, or ``None`` when it predates the
+    field. ``None`` means *unknown*, never *suspect*: a plane that upgrades mid-week must
+    not have its own history read back to it as a fault."""
+    rec = last()
+    if not rec:
+        return None
+    val = rec.get("source")
+    return str(val) if val else None
 
 
 def last() -> dict | None:

--- a/tests/test_doctor_guard_doubled.py
+++ b/tests/test_doctor_guard_doubled.py
@@ -25,7 +25,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from charter import config, doctor
+from charter import guardseen, config, doctor
 
 
 class _Plane(unittest.TestCase):
@@ -72,6 +72,10 @@ class DeclaredOnce(_Plane):
     def test_the_plugin_alone_is_a_clean_row(self):
         self.dispatching.return_value = "charter@charter"
         self._write({})
+        # #261: enabled is not loaded — a plugin's hooks arrive at session start, so the
+        # tick now needs proof the declaration actually fired. This test's own reasoning
+        # already rested on that ("the guard demonstrably fired"); it is now checkable.
+        guardseen.mark(harness="claude-code", source=guardseen.PLUGIN)
         r = doctor.check_guard_wired()
         self.assertEqual(r.status, doctor.OK)
         self.assertIn("plugin", r.detail)

--- a/tests/test_doctor_guard_wired.py
+++ b/tests/test_doctor_guard_wired.py
@@ -20,7 +20,7 @@ import os
 import unittest
 from pathlib import Path
 
-from charter import commands, config, doctor
+from charter import guardseen, commands, config, doctor
 from tests._isolation import PersonaIso
 
 OK, WARN = doctor.OK, doctor.WARN
@@ -105,6 +105,10 @@ class TestEveryWiringRouteCounts(GuardWiredCase):
 
     def test_an_enabled_plugin_counts(self):
         self._install(enabled=True)
+        # #261: enabled is not loaded — a plugin's hooks arrive at session start, so the
+        # tick now needs proof the declaration actually fired. This test's own reasoning
+        # already rested on that ("the guard demonstrably fired"); it is now checkable.
+        guardseen.mark(harness="claude-code", source=guardseen.PLUGIN)
         self.assertEqual(doctor.check_guard_wired().status, OK)
 
     def test_a_plugin_disabled_by_an_explicit_false_does_not_count(self):
@@ -125,6 +129,10 @@ class TestEveryWiringRouteCounts(GuardWiredCase):
         plug = self._install(enabled=True)
         (plug / ".claude-plugin").mkdir(parents=True, exist_ok=True)
         (plug / ".claude-plugin" / "plugin.json").write_text(json.dumps({"version": "0.29.1"}))
+        # #261: enabled is not loaded — a plugin's hooks arrive at session start, so the
+        # tick now needs proof the declaration actually fired. This test's own reasoning
+        # already rested on that ("the guard demonstrably fired"); it is now checkable.
+        guardseen.mark(harness="claude-code", source=guardseen.PLUGIN)
         self.assertEqual(doctor.check_guard_wired().status, OK)
 
     def test_an_enabled_plugin_that_wires_something_else_does_not_count(self):
@@ -151,6 +159,10 @@ class TestEveryWiringRouteCounts(GuardWiredCase):
         # Enabled too, since #177: installation alone no longer satisfies the check.
         self.settings(Path(config.ROOT) / ".claude" / "settings.json",
                       {"enabledPlugins": {"charter@charter": True}})
+        # And fired, since #261: enabled is not loaded. This test's own reasoning is that
+        # the check warned "on a machine where the plugin was installed and the guard
+        # demonstrably fired" — the sighting is that demonstration, now recorded.
+        guardseen.mark(harness="claude-code", source=guardseen.PLUGIN)
         self.assertEqual(doctor.check_guard_wired().status, OK)
 
     def test_a_plugin_that_does_not_declare_the_guard_does_not_count(self):

--- a/tests/test_guard_enabled_is_not_loaded.py
+++ b/tests/test_guard_enabled_is_not_loaded.py
@@ -1,0 +1,150 @@
+"""Enabled is not loaded, and a sighting belongs to the declaration that produced it (#261).
+
+Third variant of one family. #168 was *packaged* read as protection; #177 was *installed*
+read as wired; this is **enabled read as loaded**.
+
+A plugin's hooks are loaded by the harness at session start. Install the plugin mid-session
+— or follow #251's correct advice and delete the now-duplicate `hooks` block from
+`.claude/settings.json` — and the running session holds no declaration at all, while
+`check_guard_wired` reports a tick because one is *enabled*. The reporter branched the plane
+root in that window and nothing refused it.
+
+`guard seen` made it worse rather than better: it was true and it was about the wrong thing.
+The sighting came from the settings block that had just been deleted, and read as evidence
+for the plugin that replaced it. A recent sighting of a removed declaration is not evidence
+for a surviving one, and until now nothing recorded which declaration a sighting came from.
+
+Both halves are fixed here, and both keep the grammar these rows already use: an observation
+with an age, never a verdict (ADR 0013).
+"""
+from __future__ import annotations
+
+import os
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+from charter import config, doctor, guardseen
+from tests._isolation import PersonaIso
+
+
+class GuardCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        # A plane the operator has actually worked in, so the "not worked in yet" gate does
+        # not silence the rows under test.
+        self.make_persona("someone", role="Someone", vault="none")
+        (config.ROOT / "charter.toml").write_text('schema = 1\n')
+        # `HAS_CONTROL_PLANE` is derived when the isolation fixture points config at the
+        # tmp dir — before the charter.toml above exists — and `check_guard_wired` returns
+        # early without one. Asserted here rather than worked around, so the fixture says
+        # out loud that these rows are about a real plane.
+        self.enterContext(mock.patch.object(config, "HAS_CONTROL_PLANE", True))
+
+    def plugin_enabled(self):
+        """The plugin is enabled in settings — declared, and loaded only at session start."""
+        return mock.patch.object(doctor, "_plugin_declaring_guard", return_value="charter@charter")
+
+    def running_under_plugin(self):
+        return mock.patch.dict(os.environ, {"CLAUDE_PLUGIN_ROOT": "/somewhere"})
+
+    def not_running_under_plugin(self):
+        return mock.patch.dict(
+            os.environ, {k: v for k, v in os.environ.items() if k != "CLAUDE_PLUGIN_ROOT"},
+            clear=True)
+
+    def seen(self, source: str | None, minutes: int = 1) -> None:
+        guardseen.mark(harness="claude-code", source=source,
+                       when=datetime.now(timezone.utc) - timedelta(minutes=minutes))
+
+
+class TestASightingRemembersItsDeclaration(GuardCase):
+    def test_the_source_is_recorded(self):
+        """Two values, not a plugin id: the handler knows whether IT was launched by a
+        plugin (`$CLAUDE_PLUGIN_ROOT`), which is the distinction that matters. Recording an
+        id would imply charter can tell one enabled plugin's sighting from another's, and
+        it cannot."""
+        self.seen(guardseen.PLUGIN)
+        self.assertEqual(guardseen.last().get("source"), guardseen.PLUGIN)
+
+    def test_an_older_record_without_a_source_still_reads(self):
+        """The file is overwritten in place and predates this field; a plane that upgrades
+        must not have its history read as corrupt."""
+        guardseen.path().parent.mkdir(parents=True, exist_ok=True)
+        guardseen.path().write_text('{"ts": "2026-08-01T00:00:00+00:00", "harness": "x"}')
+        self.assertIsNotNone(guardseen.last())
+        self.assertIsNone(guardseen.last().get("source"))
+
+
+class TestEnabledIsNotLoaded(GuardCase):
+    def test_an_enabled_plugin_with_no_sighting_from_it_is_not_a_tick(self):
+        """The reported bug: green while the running session cannot fire the guard."""
+        with self.plugin_enabled(), self.not_running_under_plugin():
+            r = doctor.check_guard_wired()
+        self.assertEqual(r.status, doctor.WARN)
+
+    def test_and_it_says_the_session_is_the_unguarded_one(self):
+        with self.plugin_enabled(), self.not_running_under_plugin():
+            r = doctor.check_guard_wired()
+        text = (r.detail + " " + (r.hint or "")).lower()
+        self.assertIn("next session", text)
+
+    def test_a_sighting_from_the_plugin_is_the_proof_and_restores_the_tick(self):
+        """Reaching the handler is the only thing that proves the declaration is live —
+        which is exactly what `guardseen` was created to record."""
+        self.seen(guardseen.PLUGIN)
+        with self.plugin_enabled(), self.not_running_under_plugin():
+            r = doctor.check_guard_wired()
+        self.assertEqual(r.status, doctor.OK)
+
+    def test_running_under_the_plugin_is_proof_enough_on_its_own(self):
+        """`$CLAUDE_PLUGIN_ROOT` means this very process was launched by it."""
+        with self.running_under_plugin():
+            r = doctor.check_guard_wired()
+        self.assertEqual(r.status, doctor.OK)
+
+    def test_a_settings_declaration_is_unaffected(self):
+        """It is read by the session that is running now, so it was never in doubt."""
+        (config.ROOT / ".claude").mkdir(parents=True, exist_ok=True)
+        (config.ROOT / ".claude" / "settings.json").write_text(
+            '{"hooks": {"PreToolUse": [{"hooks": [{"command": "charter hook pretooluse"}]}]}}')
+        with self.not_running_under_plugin():
+            r = doctor.check_guard_wired()
+        self.assertEqual(r.status, doctor.OK)
+
+
+class TestASightingDoesNotOutliveItsDeclaration(GuardCase):
+    def _settings_declare(self) -> None:
+        (config.ROOT / ".claude").mkdir(parents=True, exist_ok=True)
+        (config.ROOT / ".claude" / "settings.json").write_text(
+            '{"hooks": {"PreToolUse": [{"hooks": [{"command": "charter hook pretooluse"}]}]}}')
+
+    def test_a_sighting_from_a_removed_settings_block_is_not_credited(self):
+        """The subtle half of the report. The block that fired minutes ago is gone; saying
+        'last ran 0m ago' invites the reader to conclude the survivor is working."""
+        self.seen(guardseen.SETTINGS)
+        with self.plugin_enabled(), self.not_running_under_plugin():
+            r = doctor.check_guard_seen()
+        self.assertIn("no longer", (r.detail + " " + (r.hint or "")).lower())
+
+    def test_a_sighting_from_a_declaration_still_present_reads_normally(self):
+        self._settings_declare()
+        self.seen(guardseen.SETTINGS)
+        with self.not_running_under_plugin():
+            r = doctor.check_guard_seen()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIn("last ran", r.detail)
+
+    def test_a_sighting_with_no_recorded_source_is_still_reported(self):
+        """Recorded before this field existed. Unknown provenance is not evidence of a
+        problem, and inventing one would be the same overreach in the other direction."""
+        guardseen.path().parent.mkdir(parents=True, exist_ok=True)
+        guardseen.path().write_text('{"ts": "2026-08-18T00:00:00+00:00", "harness": "x"}')
+        with self.not_running_under_plugin():
+            r = doctor.check_guard_seen()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIn("last ran", r.detail)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #261. 2542 tests green, and both halves of the report were reproduced against a real
plane before and after.

## Enabled is not loaded

A plugin's hooks are loaded by the harness **at session start**. Install the plugin
mid-session — or follow #251's correct advice and delete the now-duplicate `hooks` block —
and the running session holds no declaration at all, while the row reports a tick because
one is *enabled*. Taking the tool's own advice is what opens the gap, which is why it is
worth a fix rather than a doc note.

```
BEFORE (the reported window)
  ✓  plane-root guard wired (enabled plugin charter@charter)
  ✓  guard seen       last ran 0m ago under an unnamed harness
     …and `git checkout -b` in the plane root succeeded.

AFTER
  !  plane-root guard enabled plugin charter@charter declares it, but nothing has fired here
                      yet — a plugin's hooks load at session start, so this is wired for the
                      NEXT session and THIS one may be unguarded
  !  guard seen       no guard has ever run in this plane

AFTER, once it has actually fired under the plugin
  ✓  plane-root guard wired (enabled plugin charter@charter) — and it has fired here
  ✓  guard seen       last ran 0m ago under claude-code
```

## A sighting belongs to the declaration that made it

The subtler half, and the one that made `guard seen` actively misleading: the sighting was
*true* and it was about the *wrong thing*. It came from the settings block that had just
been deleted, and read as evidence for the plugin that replaced it.

A sighting now records its source — `plugin` when `$CLAUDE_PLUGIN_ROOT` is set (the process
was launched **by** the plugin, the one fact separating loaded from enabled), `settings`
otherwise:

```
  !  guard seen  last ran 0m ago under claude-code, but from a settings declaration that is
                 no longer there
        → That sighting is not evidence for whatever declares the guard now.
```

Two values, not a plugin id: recording an id would imply charter can tell one enabled
plugin's sighting from another's, and it cannot.

## What is deliberately narrow

The stale-sighting warning needs **all three** conditions: the sighting is settings-sourced,
no settings file declares the guard any more, *and* a plugin is what survived. `settings` is
also what a Codex or opencode dispatch records, and those declarations live in files this
check never reads (`~/.codex/config.toml`) — the looser rule would warn at planes that are
wired perfectly well, which is the cry-wolf failure #177's fix was itself avoiding.

A sighting with **no** recorded source predates the field and stays unqualified. Unknown is
not suspect; a plane that upgrades mid-week must not have its own history read back to it as
a fault.

## Four existing tests gain one line each

They assert that an enabled plugin counts — #177's contract, still true. What changed is
that the tick now wants evidence, and their own reasoning already rested on it:
`test_an_INSTALLED_plugin_counts_even_without_the_env_var` says the check "warned on a
machine where the plugin was installed and **the guard demonstrably fired**." That
demonstration is now something charter records, so those tests state it rather than assume
it.
