### PR TITLE
Selecting a workspace leaves a trace, so "who moved my workspace" is answerable

### DIFF
--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -302,6 +302,27 @@ def source(explicit: str | None = None, session_id: str | None = None,
     return "default (nothing selected)"
 
 
+def _trace(event: str, session_id: str | None, **fields) -> None:
+    """Record one workspace-selection event, best-effort.
+
+    `persona.set_active` has recorded `persona-use` since the trace existed; the function
+    that writes both workspace pointers AND the session lock recorded nothing, so "who
+    moved my workspace" could only ever be answered from the pointer files themselves —
+    which say what they hold and never who wrote it, when, or why. #254 is what that costs:
+    two investigations, two confident wrong conclusions, settled in the end by a harness
+    transcript charter cannot rely on existing.
+
+    Swallows everything. Observability must never break the thing it observes, and a
+    selection that failed because its own audit line failed would be the worst possible
+    trade.
+    """
+    try:
+        from . import session as _session, trace as _trace_mod
+        _trace_mod.record(event, session=_session.current(session_id), **fields)
+    except Exception:
+        pass
+
+
 def _lock_file(sid: str) -> Path:
     return config.SESSIONS_DIR / f"{sid}.lock"
 
@@ -347,6 +368,7 @@ def set_active(name: str, session_id: str | None = None, force: bool = False) ->
     (``session`` | ``terminal`` | ``none``) on success, or ``"locked"`` when refused."""
     locked = is_locked(session_id)
     if locked and locked != name and not force:
+        _trace("workspace-refused", session_id, workspace=name, locked_to=locked)
         return "locked"
     config.STATE_DIR.mkdir(parents=True, exist_ok=True)
     tid = _terminal_id()
@@ -359,6 +381,9 @@ def set_active(name: str, session_id: str | None = None, force: bool = False) ->
         _session_file(sid).write_text(name + "\n")
         _lock_file(sid).write_text(name + "\n")  # confirming = locking for the session
     _prune()
+    _trace("workspace-use", session_id, workspace=name,
+           scope=("terminal" if tid else "session" if sid else "none"),
+           forced=True if force and locked and locked != name else None)
     # The scope is the REACH of what was written, so it names the longest-lived pointer
     # that actually landed — and the terminal one outlives the session one. These used to
     # be assigned in sequence, so the session branch overwrote the terminal branch and
@@ -382,6 +407,9 @@ def reconcile(session_id: str | None = None, terminal_id: str | None = None) -> 
     if val:
         config.SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
         _session_file(sid).write_text(val + "\n")
+        # The one pointer write nobody typed. If any write is ever going to look as though
+        # it came from nowhere, it is this one — so it says where it came from.
+        _trace("workspace-seeded", session_id, workspace=val, **{"from": "terminal"})
     return val
 
 

--- a/tests/test_workspace_selection_is_traced.py
+++ b/tests/test_workspace_selection_is_traced.py
@@ -1,0 +1,110 @@
+"""Selecting a workspace leaves a trace, so "who moved my workspace" is answerable.
+
+`persona.set_active` has always recorded a `persona-use` event. `workspace.set_active` —
+the function that writes BOTH pointer files and the session lock — recorded nothing at all,
+and neither did the two other things that can change what a session resolves to: a refused
+switch, and the SessionStart reconcile that seeds a pointer from the pane.
+
+That asymmetry is what #254 cost. A session appeared to have been moved to a workspace
+nobody selected; the only way to investigate was to read pointer files after the fact,
+where a file says *what* it holds and never *who wrote it, when, or why*. Two separate
+investigations reached confident wrong conclusions from that evidence before a transcript
+settled it — and a transcript is not a thing charter can rely on being kept.
+
+Nothing here changes what is written. It records what was already happening, in the store
+built for exactly this question, which is the cheapest possible answer to "prove it".
+"""
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from charter import trace, workspace
+from tests._isolation import PersonaIso
+
+SID = "s-trace"
+
+
+class TraceCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.dict(
+            os.environ,
+            {k: v for k, v in os.environ.items()
+             if k not in ("CHARTER_WORKSPACE", "CHARTER_SESSION_ID", "CLAUDE_CODE_SESSION_ID",
+                          "TERM_SESSION_ID", "TMUX_PANE", "STY", "SSH_TTY")},
+            clear=True))
+        self.enterContext(mock.patch("os.ttyname", side_effect=OSError("no tty")))
+        workspace.ensure("alpha")
+        workspace.ensure("beta")
+
+    def events(self, kind: str | None = None) -> list[dict]:
+        evs = trace.read(SID)
+        return [e for e in evs if kind is None or e.get("event") == kind]
+
+
+class TestASelectionIsRecorded(TraceCase):
+    def test_choosing_a_workspace_records_it(self):
+        workspace.set_active("alpha", session_id=SID)
+        self.assertEqual([e["workspace"] for e in self.events("workspace-use")], ["alpha"])
+
+    def test_it_lands_in_the_trace_of_the_session_that_made_it(self):
+        """The whole point: the record identifies WHO selected, and a per-session file is
+        that identification. #254 turned on which session a pointer belonged to."""
+        workspace.set_active("alpha", session_id=SID)
+        self.assertEqual(trace.read("someone-else"), [])
+
+    def test_the_reach_is_recorded_with_it(self):
+        """`session` vs `terminal` vs `plane` is what decides whether a selection outlives
+        the session, and it is the first thing asked when one appears to have persisted."""
+        workspace.set_active("alpha", session_id=SID)
+        self.assertIn(self.events("workspace-use")[0].get("scope"),
+                      ("session", "terminal", "none"))
+
+
+class TestARefusalIsRecordedToo(TraceCase):
+    def test_a_locked_session_refusing_a_switch_says_so(self):
+        """A refusal explains an absence — "why is it still on alpha" — and an absence is
+        the hardest thing to investigate after the fact, because nothing changed."""
+        workspace.set_active("alpha", session_id=SID)
+        workspace.set_active("beta", session_id=SID)
+        refused = self.events("workspace-refused")
+        self.assertEqual(len(refused), 1)
+        self.assertEqual(refused[0].get("workspace"), "beta")
+        self.assertEqual(refused[0].get("locked_to"), "alpha")
+
+    def test_a_forced_switch_is_recorded_as_forced(self):
+        workspace.set_active("alpha", session_id=SID)
+        workspace.set_active("beta", session_id=SID, force=True)
+        self.assertTrue(self.events("workspace-use")[-1].get("forced"))
+
+
+class TestASeededPointerIsRecorded(TraceCase):
+    def test_reconcile_records_where_the_pointer_came_from(self):
+        """This is the one write nobody typed: a pane's selection copied into a fresh
+        session at SessionStart. If any write ever *does* look like it came from nowhere,
+        this is the one — so it says where it came from."""
+        with mock.patch.object(workspace, "_terminal_id", return_value="pane-7"):
+            workspace.set_active("alpha", session_id="earlier-session")
+            workspace.reconcile(session_id=SID)
+        seeded = self.events("workspace-seeded")
+        self.assertEqual(len(seeded), 1)
+        self.assertEqual(seeded[0].get("workspace"), "alpha")
+        self.assertEqual(seeded[0].get("from"), "terminal")
+
+    def test_nothing_is_recorded_when_there_is_nothing_to_seed(self):
+        workspace.reconcile(session_id=SID)
+        self.assertEqual(self.events("workspace-seeded"), [])
+
+
+class TestRecordingNeverCostsTheSelection(TraceCase):
+    def test_a_broken_trace_does_not_break_the_write(self):
+        """Observability must never break the thing it observes — the module's own rule."""
+        with mock.patch.object(trace, "record", side_effect=RuntimeError("boom")):
+            workspace.set_active("alpha", session_id=SID)
+        self.assertEqual(workspace.resolve(session_id=SID, cwd=str(self.tmp)), "alpha")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Comes out of investigating #254, which turns out **not to be a defect** — see the comment
there for the evidence. What the investigation did expose is a real gap, and this closes it.

## The gap

`persona.set_active` has recorded a `persona-use` event since the trace existed.
`workspace.set_active` — the function that writes **both** pointer files *and* the session
lock — recorded nothing at all. Neither did the two other things that change what a session
resolves to: a refused switch, and the SessionStart reconcile that seeds a pointer from the
pane.

So when a session appeared to have been moved to a workspace nobody selected, the only
evidence available was the pointer files, which say *what* they hold and never *who* wrote
it, *when*, or *why*. Two separate investigations — the reporter's and my first pass —
reached confident wrong conclusions from that evidence before a harness transcript settled
it. A transcript is not something charter can rely on existing.

## Three events

| Event | The question it answers |
| --- | --- |
| `workspace-use` | who selected, and with what **reach** (`session`/`terminal` — what decides whether it outlives the session), plus `forced` when it overrode a lock |
| `workspace-refused` | why it is *still* on the old workspace — a refusal explains an **absence**, the hardest thing to investigate after the fact because nothing changed |
| `workspace-seeded` | the one pointer write nobody typed: a pane's selection copied into a fresh session at SessionStart. If any write is ever going to look as though it came from nowhere, it is this one |

Working, against a real plane:

```
$ charter workspace use alpha
$ charter workspace use beta
✗ Workspace is 🔒 locked to 'alpha' for this session…

$ charter trace --session demo-session
2026-08-18T22:32:11  workspace-use      workspace=alpha  scope=session
2026-08-18T22:32:11  workspace-refused  workspace=beta   locked_to=alpha
```

That is precisely the question #254 could not answer.

## What does not change

Nothing about which files get written, or when. This records what was already happening,
into the store built for exactly this question — the cheapest possible answer to "prove it".

Every call swallows its errors, with a test pinning that: observability must never break the
thing it observes, and a workspace selection that failed because its own audit line failed
would be the worst possible trade.

Refs #254.
