### PR TITLE
0.44.0 — a persona says when it should hand work away

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.43.2",
+  "version": "0.44.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.43.2"
+__version__ = "0.44.0"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.43.2",
+            "command": "charter hook sessionstart --plugin-version 0.44.0",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.43.2",
+            "command": "charter hook userpromptsubmit --plugin-version 0.44.0",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.43.2",
+            "command": "charter hook pretooluse --plugin-version 0.44.0",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.43.2",
+            "command": "charter hook pretooluse-read --plugin-version 0.44.0",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.43.2"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.44.0"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.43.2",
+            "command": "charter hook pretooluse-edit --plugin-version 0.44.0",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.43.2",
+            "command": "charter hook posttooluse --plugin-version 0.44.0",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.43.2",
+            "command": "charter hook posttooluse-skill --plugin-version 0.44.0",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.43.2",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.44.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.43.2"
+version = "0.44.0"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
The headline is delegation. Until now a persona described what it was; it had no way to say what belongs to somebody else. Five PRs give it one, and every rung is opt-in.

## Delegation

- **#259** — `[persona] default` in `charter.toml` declares a plane's front door; the legacy `personas/.default` still resolves one rung below it. Persona selection became per-session and per-terminal — it was one plane-wide file, so choosing a persona in one pane changed every other pane. A stale declaration is now reported by `doctor` and the status line. ADR 0016 writes the rule down: *charter presents the roster; it never guesses the owner.*
- **#260** — per-persona `routing: off|advise|require` (absent = off) and `routes-to:`, which prioritises the roster and never restricts it. At `advise` the existing commitment gate leads with the roster: who exists, what each advertises, when each was last dispatched. Advice is tallied, and `charter persona stats` reports fired-vs-followed.
- **#267** — `charter init --front-door <name>` (default `steward`, `--no-front-door` to decline) scaffolds one generic front-door persona and declares it. The default posture ships in that generated file's frontmatter, not in charter's code — the plane owns it from the first commit.
- **#263** — `routing: require` adds a tool-time **ask** (never a deny) on the first edit of a turn where the roster fired and nothing was dispatched. New hook: `PreToolUse` on `Write|Edit|MultiEdit` → `charter hook pretooluse-edit`.
- **#264** — `borrows:` splits what `uses:` overloaded. Declaring it takes tools from that list and makes `uses:` a routing edge; declaring nothing keeps existing behaviour exactly.

## Cross-workspace awareness

- **#265** — SessionStart names the other workspaces (vision line, open-todo count, last worked), as knowledge and explicitly never as instructions.

## Fixes

- **#266** — the secret-leak guard stopped denying writes that merely *mention* a guarded path: heredoc bodies fed to a reader, `sed`/`awk` script operands, `grep` patterns.
- **#268** — `doctor` no longer reports the plane-root guard as wired when a plugin is merely *enabled*. A plugin's hooks load at session start, so it says the guard is wired for the NEXT session and THIS one may be unguarded, until a sighting proves otherwise. A guard sighting now records which declaration produced it.
- **#269** — workspace selection, refusal and SessionStart seeding are traced, so "who moved my workspace" is answerable from `charter trace`.

## Compatibility

Every change is additive and fails toward no change. A plane that upgrades and declares nothing new behaves exactly as before — `routing:` absent means off, `borrows:` absent keeps the legacy `uses:` grant, `personas/.default` keeps resolving. The one visible change without opt-in is `doctor`'s stricter guard row (#268), which is the point of that fix.

## Why minor, not patch

A new `charter.toml` key, three persona frontmatter keys, two `init` flags and a new hook — new surface, so minor.

## The bump itself

All four version locations move together, as `tests/test_plugin.py::TestVersionsMoveInLockstep` requires:

| file | |
|---|---|
| `pyproject.toml` | `version` |
| `charter/__init__.py` | `__version__` |
| `.claude-plugin/plugin.json` | `version` |
| `hooks/hooks.json` | all nine `--plugin-version` flags |

Suite green locally at 2550 tests with the bump applied. `docs/assets/captured.json` is left alone deliberately: `demo.svg` and `statusline.svg` are stamped `0.43.0`, which is a one-minor lag — exactly the slack `MAX_MINOR_LAG` allows. The next minor will need a regenerate.

Merging this is not the publish. The tag is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo
