### PR TITLE
Two lines in persona stats asserted more than the data supported

### DIFF
--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -1090,15 +1090,26 @@ def cmd_persona_stats(args) -> int:
     # a line people learn to skip, and it takes the rest of the report with it.
     advice = dispatch.advice_tally()
     if advice:
-        util.info(f"Routing advice: fired {advice} time(s) · {total} dispatch(es) followed. "
-                  f"Advice that fires and is never followed is the block failing, not the "
-                  f"roster — read it that way before adding more personas.")
+        since = dispatch.first_advice()
+        followed = dispatch.dispatches_since_first_advice()
+        # SINCE the first advice, never the lifetime total: a dispatch older than the
+        # roster cannot have followed it, and pairing the two made this line claim five
+        # dispatches followed one piece of advice — three of them four days its senior.
+        # "since" rather than "because", because a window is all the data supports.
+        util.info(f"Routing advice: fired {advice} time(s) · {followed} dispatch(es) since "
+                  f"the first one ({since:%Y-%m-%d}). Advice that fires and is never "
+                  f"followed is the block failing, not the roster — read it that way "
+                  f"before adding more personas.")
     if drifted:
         util.info("SKILLS drift is named, not resolved: an unused declaration may be dead "
                   "weight or a skill whose moment has not come, and an undeclared one may "
                   "be a charter out of date or a persona reaching past its remit. Which it "
                   "is depends on intent charter cannot read.")
-    else:
+    if not total:
+        # Attached to the TALLY, not to the drift check above it. It was the `else` of
+        # `if drifted:` — so a roster whose skills all lined up was told its dispatch tally
+        # was empty, beside a table showing five. Invisible while every plane had some
+        # drift; surfaced the moment one stopped.
         util.info("No dispatches recorded yet — the tally starts filling as sub-agents are "
                   "dispatched (`charter persona dispatch-backfill` seeds it from past sessions).")
     # How complete this tally is, stated rather than implied. `PostToolUse(Task|Agent)`

--- a/charter/dispatch.py
+++ b/charter/dispatch.py
@@ -120,6 +120,34 @@ def advice_tally(days: int | None = None) -> int:
     return len(rows)
 
 
+def first_advice() -> datetime | None:
+    """When routing advice was FIRST shown here, or ``None`` if it never has."""
+    stamps = [t for o in _read_all() if o.get("event") == ADVICE and (t := _ts(o))]
+    return min(stamps) if stamps else None
+
+
+def dispatches_since_first_advice() -> int:
+    """Dispatches recorded at or after the first advice — the only count that can honestly
+    sit beside :func:`advice_tally`.
+
+    The pair is meant to read as fired-vs-followed, and a dispatch that happened before the
+    roster ever appeared cannot have followed it. Pairing advice against the LIFETIME total
+    is how this line came to claim, on the plane that shipped the feature, that five
+    dispatches followed one piece of advice — three of them four days older than the
+    feature. Same failure ADR 0016 forbids elsewhere: a conclusion stated with more
+    confidence than its provenance earns, here in the very line that exists to check
+    whether ADR 0016's mechanism works.
+
+    Still not proof of causation, and the report says "since" rather than "because" for
+    that reason. It is a window in which the claim is at least possible.
+    """
+    since = first_advice()
+    if since is None:
+        return 0
+    return sum(1 for o in _read_all()
+               if o.get("agent") and (t := _ts(o)) and t >= since)
+
+
 def _read_all() -> list[dict]:
     d = _dir()
     if not d.exists():

--- a/tests/test_stats_lines_say_what_is_true.py
+++ b/tests/test_stats_lines_say_what_is_true.py
@@ -1,0 +1,99 @@
+"""Two lines in `persona stats` asserted things the data did not support.
+
+**"No dispatches recorded yet"** was printed from the `else` of the SKILLS-DRIFT check, so a
+plane whose personas all declared their skills correctly was told its dispatch tally was
+empty — beside a table showing five dispatches. A mis-attached `else`, invisible for as long
+as every plane had some drift, and surfaced the moment one stopped.
+
+**"fired N · M dispatch(es) followed"** paired the advice count against the LIFETIME
+dispatch total. On the plane that shipped the feature, three of those dispatches predated it
+by four days, and the line read as though the roster had caused them. That is a causal claim
+from a coincidence of counters — the thing ADR 0016 exists to forbid, in the line whose only
+job is to measure whether ADR 0016's mechanism works.
+
+Both are the same failure: a number stated with more confidence than its provenance earns.
+"""
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from charter import commands_persona, dispatch
+from tests._isolation import PersonaIso
+
+
+def _ago(**kw) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(**kw)
+
+
+class StatsCase(PersonaIso):
+    def persona(self, name: str, **meta) -> None:
+        self.make_persona(name, role=name.title(), vault="none",
+                          **{"delegate-when": f"{name} work", **meta})
+
+    def report(self) -> str:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            commands_persona.cmd_persona_stats(SimpleNamespace(shared=False, days=None))
+        return (out.getvalue() + err.getvalue()).lower()
+
+
+class TestTheEmptyTallyLine(StatsCase):
+    def test_it_is_not_printed_when_dispatches_exist(self):
+        """The bug: it was the `else` of the skills-drift check, so a clean roster was told
+        its tally was empty."""
+        self.persona("forge")
+        dispatch.record("forge")
+        self.assertNotIn("no dispatches recorded yet", self.report())
+
+    def test_it_is_printed_when_the_tally_really_is_empty(self):
+        self.persona("forge")
+        self.assertIn("no dispatches recorded yet", self.report())
+
+    def test_skills_drift_does_not_decide_it_either_way(self):
+        """Drift and an empty tally are unrelated facts; one must never speak for the other.
+        A persona declaring a skill it never invokes has drift AND dispatches."""
+        self.persona("forge", skills="charter:working-in-a-clone")
+        dispatch.record("forge")
+        self.assertNotIn("no dispatches recorded yet", self.report())
+
+
+class TestTheAdviceLineComparesLikeWithLike(StatsCase):
+    def test_dispatches_before_the_first_advice_are_not_counted_as_following_it(self):
+        """The line's whole purpose is fired-vs-followed. A dispatch that happened before
+        the roster ever appeared cannot have followed it."""
+        dispatch.record("forge", when=_ago(days=4))
+        dispatch.record_advice(when=_ago(hours=1))
+        self.assertEqual(dispatch.dispatches_since_first_advice(), 0)
+
+    def test_a_dispatch_after_the_first_advice_counts(self):
+        dispatch.record_advice(when=_ago(hours=2))
+        dispatch.record("forge", when=_ago(hours=1))
+        self.assertEqual(dispatch.dispatches_since_first_advice(), 1)
+
+    def test_no_advice_means_nothing_to_compare(self):
+        dispatch.record("forge")
+        self.assertEqual(dispatch.dispatches_since_first_advice(), 0)
+
+    def test_the_report_uses_that_number_not_the_lifetime_total(self):
+        self.persona("forge")
+        dispatch.record("forge", when=_ago(days=4))     # long before the feature existed
+        dispatch.record_advice(when=_ago(hours=1))
+        text = self.report()
+        self.assertIn("routing advice", text)
+        # The old line said "1 time(s) · 1 dispatch(es) followed" from the lifetime total.
+        self.assertNotIn("1 dispatch(es) followed", text)
+
+    def test_it_says_since_when(self):
+        """A bare pair of numbers invites the reader to supply the window themselves, and
+        the window is the whole reason the pair means anything."""
+        self.persona("forge")
+        dispatch.record_advice(when=_ago(hours=1))
+        self.assertIn("since", self.report())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two lines in `charter persona stats` asserted more than their data supported. Both surfaced
within an hour on this plane; both are the same failure.

## "No dispatches recorded yet" — printed from the wrong `else`

It was the `else` of the **skills-drift** check:

```python
if drifted:
    util.info("SKILLS drift is named, not resolved: …")
else:
    util.info("No dispatches recorded yet — the tally starts filling …")
```

So a plane whose personas all declared their skills correctly was told its dispatch tally
was empty — directly beside a table showing five dispatches and a routing ratio computed
from them:

```
• Routing: 5/5 dispatches went to a persona · 0 to a generic agent (0%).
• No dispatches recorded yet — the tally starts filling as sub-agents are dispatched…
steward   22  …  0  ⚑ never dispatched
release    7  …  1  ● active
reddit     5  …  3  ● active
```

Invisible for as long as every plane had *some* drift. It appeared the moment one stopped —
which happened here about an hour ago when a persona's `skills:` were brought in line with
what it actually invokes. Now attached to the tally it describes.

## "fired N · M dispatch(es) followed" — a causal claim from a coincidence of counters

This one is mine, shipped in #260. It paired the advice count against the **lifetime**
dispatch total, so on the plane that shipped the feature it read:

> Routing advice: fired 1 time(s) · **5 dispatch(es) followed**

Three of those five were dispatched four days before the feature existed. The line whose
only job is to measure whether the roster block changes routing was itself asserting a
causal link it could not support — the thing **ADR 0016** was written to forbid, one level
up from where it was written.

It now counts dispatches at or after the **first** advice, and names the window:

> Routing advice: fired 1 time(s) · 0 dispatch(es) since the first one (2026-08-18)

Still not proof of causation, and the wording is deliberately **"since"** rather than
"because": a window in which the claim is *possible* is the strongest honest form the data
allows. `dispatches_since_first_advice()` carries that reasoning in its docstring so the
next person to "simplify" it back to the lifetime total has to argue with it.

## Tests

Eight, and the ones I care about most are the two that pin the *separation*: skills drift
and an empty tally are unrelated facts, and neither may speak for the other. Plus the direct
reproduction — a dispatch four days older than the first advice must not count as having
followed it.

2558 tests green.

## How it was found

By reading the output of `charter persona stats` after adopting the feature on this plane.
Neither line is covered by a test that asserts what it *says* — they were checked for
presence, not for truth. That is the same gap `release`'s charter describes about the
version-skew flags: "the one test reading those flags checked they were present, never what
they said."
