### PR TITLE
Release 0.44.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.44.0"
+__version__ = "0.44.1"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.44.0",
+            "command": "charter hook sessionstart --plugin-version 0.44.1",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.44.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.44.1",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.44.0",
+            "command": "charter hook pretooluse --plugin-version 0.44.1",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.44.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.44.1",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.44.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.44.1"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.44.0",
+            "command": "charter hook pretooluse-edit --plugin-version 0.44.1",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.44.0",
+            "command": "charter hook posttooluse --plugin-version 0.44.1",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.44.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.44.1",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.44.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.44.1",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.44.0"
+version = "0.44.1"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Patch release. One shipped change since v0.44.0 — PR #271 (`d654dfe`): two lines in `charter persona stats` asserted more than their data supported.

- **"No dispatches recorded yet"** was printed from the `else` of the *skills-drift* check, so a plane whose personas all declared their skills correctly was told its dispatch tally was empty — beside a table showing five dispatches. It is now attached to the tally it describes.
- **"fired N · M dispatch(es) followed"** paired the advice count against the *lifetime* dispatch total. On this plane it read "fired 1 · 5 dispatches followed" where three of the five predated the feature by four days. It now counts dispatches at or after the first advice and names the window: "fired N · M dispatch(es) since the first one (YYYY-MM-DD)". "since", not "because" — a window in which the claim is possible is the strongest honest form the data allows.

**Why patch, not minor:** no new config keys, no new CLI flags, no new hooks, no changed default. The one new function, `dispatch.dispatches_since_first_advice`, is internal and not user-facing.

Everything else since v0.44.0 is plane/persona files that do not ship.

## Version bump

All four locations move together:

- `pyproject.toml`
- `charter/__init__.py`
- `.claude-plugin/plugin.json`
- `hooks/hooks.json` — all **nine** `--plugin-version` flags

Verified by re-grepping for the old version across all four files: zero occurrences of `0.44.0` remain, and all nine flags read `0.44.1`. `tests/test_plugin.py::TestVersionsMoveInLockstep` pins this.

`tests/test_asset_freshness.py` stays green: the social card and statusline captures are stamped `0.43.0` and `MAX_MINOR_LAG = 1`; a patch does not move the minor, so the lag is unchanged. Those captures still need regenerating before 0.45.0.

Full suite green locally: 2558 tests, `python -m unittest discover -s tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo