### PR TITLE
Handing more work to a running persona counts as delegation

### DIFF
--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -1091,15 +1091,15 @@ def cmd_persona_stats(args) -> int:
     advice = dispatch.advice_tally()
     if advice:
         since = dispatch.first_advice()
-        followed = dispatch.dispatches_since_first_advice()
+        followed = dispatch.handoffs_since_first_advice()
         # SINCE the first advice, never the lifetime total: a dispatch older than the
         # roster cannot have followed it, and pairing the two made this line claim five
         # dispatches followed one piece of advice — three of them four days its senior.
         # "since" rather than "because", because a window is all the data supports.
-        util.info(f"Routing advice: fired {advice} time(s) · {followed} dispatch(es) since "
-                  f"the first one ({since:%Y-%m-%d}). Advice that fires and is never "
-                  f"followed is the block failing, not the roster — read it that way "
-                  f"before adding more personas.")
+        util.info(f"Routing advice: fired {advice} time(s) · work handed to a persona "
+                  f"{followed} time(s) since the first one ({since:%Y-%m-%d}). Advice that "
+                  f"fires and is never followed is the block failing, not the roster — "
+                  f"read it that way before adding more personas.")
     if drifted:
         util.info("SKILLS drift is named, not resolved: an unused declaration may be dead "
                   "weight or a skill whose moment has not come, and an undeclared one may "

--- a/charter/dispatch.py
+++ b/charter/dispatch.py
@@ -120,13 +120,55 @@ def advice_tally(days: int | None = None) -> int:
     return len(rows)
 
 
+#: Marks a row where work was handed to a persona that was ALREADY running — a resume,
+#: not a new sub-agent. Its own kind because `DISP` answers "times dispatched as a
+#: sub-agent", and folding resumes into that inflates the answer to a question nobody
+#: asked, in the column people retire personas on.
+RESUME = "resume"
+
+
+def record_resume(agent: str, when: datetime | None = None) -> Path | None:
+    """Append one 'more work handed to a running persona' event. Best-effort.
+
+    `posttooluse_dispatch` fires on Task/Agent, so it sees a sub-agent being CREATED and
+    nothing after. Continuing that agent is delegation the tally could not see: on the day
+    the roster block shipped, one persona cut two releases and ran a sweep, and the sweep —
+    a resume — was invisible to the pair of numbers that exist to measure exactly that.
+    """
+    agent = (agent or "").strip()
+    if not agent:
+        return None
+    when = when or _now()
+    p = path_for(when)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps({"agent": agent, "event": RESUME,
+                           "ts": when.isoformat(timespec="seconds")}, sort_keys=True) + "\n"
+        fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        try:
+            os.write(fd, line.encode())
+        finally:
+            os.close(fd)
+        return p
+    except OSError:
+        return None
+
+
+def resume_tally(days: int | None = None) -> int:
+    rows = [o for o in _read_all() if o.get("event") == RESUME]
+    if days is not None:
+        cutoff = _now() - timedelta(days=days)
+        rows = [o for o in rows if (t := _ts(o)) and t >= cutoff]
+    return len(rows)
+
+
 def first_advice() -> datetime | None:
     """When routing advice was FIRST shown here, or ``None`` if it never has."""
     stamps = [t for o in _read_all() if o.get("event") == ADVICE and (t := _ts(o))]
     return min(stamps) if stamps else None
 
 
-def dispatches_since_first_advice() -> int:
+def handoffs_since_first_advice() -> int:
     """Dispatches recorded at or after the first advice — the only count that can honestly
     sit beside :func:`advice_tally`.
 
@@ -140,10 +182,16 @@ def dispatches_since_first_advice() -> int:
 
     Still not proof of causation, and the report says "since" rather than "because" for
     that reason. It is a window in which the claim is at least possible.
+
+    Boundary, stated rather than hidden: rows are stamped to the second, so a handoff in
+    the SAME second as the first advice counts as after it. It can only over-count, by at
+    most the handoffs sharing one second with the moment advice first appeared.
     """
     since = first_advice()
     if since is None:
         return 0
+    # Dispatches AND resumes: the pair measures whether the roster moved work to a persona,
+    # and it does not care whether that persona was already running.
     return sum(1 for o in _read_all()
                if o.get("agent") and (t := _ts(o)) and t >= since)
 
@@ -184,11 +232,15 @@ def tally(days: int | None = None) -> Counter:
     if days is not None:
         cutoff = _now() - timedelta(days=days)
         rows = [o for o in rows if (t := _ts(o)) and t >= cutoff]
-    return Counter(o["agent"] for o in rows if o.get("agent"))
+    # A resume row carries an agent too, and must NOT land here: this column is read as
+    # "times dispatched as a sub-agent", and it is what personas get retired on.
+    return Counter(o["agent"] for o in rows if o.get("agent") and not o.get("event"))
 
 
 def last_seen(agent: str) -> str | None:
-    """ISO date of the most recent dispatch of *agent*, or None if never dispatched."""
+    """ISO date this persona was last WORKED, or None. Counts resumes as well as
+    dispatches — it feeds the roster block's "last dispatched" line, and a persona that was
+    handed work an hour ago has not been idle since whenever it was first created."""
     best = None
     for o in _read_all():
         if o.get("agent") != agent:

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -1765,6 +1765,87 @@ def posttooluse_skill() -> int:
     return 0
 
 
+# --------------------------------------------------------------------------- #
+# Agent id → persona. Local, gitignored, and learned rather than inferred.      #
+#                                                                              #
+# A resume (`SendMessage`) addresses an OPAQUE AGENT ID, not a persona name —   #
+# every resume in the session that motivated this did. The id is not something  #
+# charter can decode, but it is something charter WATCHED get created: the      #
+# Task result that created it carries it, beside the `subagent_type` that names #
+# the persona. So the mapping is an observation, not a guess (ADR 0009), and    #
+# when charter has no mapping it records nothing rather than attributing work   #
+# to a persona it cannot name.                                                  #
+#                                                                              #
+# Never committed: these ids are the harness's internal handles, and the        #
+# dispatch store's discipline is counts and dates. This is bookkeeping, like    #
+# `inflight`, and lives beside it under the state dir.                          #
+# --------------------------------------------------------------------------- #
+_AGENT_ID_RE = re.compile(r"\bagentId:\s*([0-9a-f]{6,})", re.I)
+#: Cap on remembered mappings — this is a lookup for live agents, not a history.
+_AGENT_MAP_MAX = 200
+
+
+def _agent_map_file() -> Path:
+    return config.STATE_DIR / "agent-personas.json"
+
+
+def _agent_map_remember(agent_id: str, persona_name: str) -> None:
+    try:
+        f = _agent_map_file()
+        f.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            data = json.loads(f.read_text())
+        except (OSError, ValueError):
+            data = {}
+        if not isinstance(data, dict):
+            data = {}
+        data[agent_id] = persona_name
+        if len(data) > _AGENT_MAP_MAX:                 # keep the newest, drop the tail
+            data = dict(list(data.items())[-_AGENT_MAP_MAX:])
+        f.write_text(json.dumps(data, sort_keys=True))
+    except OSError:
+        pass
+
+
+def _agent_map_lookup(target: str) -> str | None:
+    try:
+        data = json.loads(_agent_map_file().read_text())
+        val = data.get(target) if isinstance(data, dict) else None
+        return str(val) if val else None
+    except (OSError, ValueError):
+        return None
+
+
+def posttooluse_message() -> int:
+    """A resume — more work handed to a persona already running — recorded as such.
+
+    `posttooluse_dispatch` sees a sub-agent being CREATED and nothing after, so continuing
+    one was delegation the tally could not see. Recorded as its own event kind, never as a
+    second dispatch: `DISP` is read as "times dispatched as a sub-agent", and that column
+    is what personas get retired on.
+
+    Silent when the target is neither a known persona name nor an id charter watched get
+    created — `main`, another session, a teammate's agent. Attributing those would be
+    inventing a delegation that did not happen.
+    """
+    data = _read_stdin()
+    if (data.get("tool_name") or "") != "SendMessage":
+        return 0
+    target = ((data.get("tool_input") or {}).get("to") or "").strip()
+    if not target:
+        return 0
+    try:
+        from . import dispatch, persona
+        name = target if target in persona.list_personas() else _agent_map_lookup(target)
+        if not name:
+            return 0
+        dispatch.record_resume(name)
+        _trace("resume", data.get("session_id"), agent=name)
+    except Exception:
+        return 0  # a tally must never break a turn
+    return 0
+
+
 def posttooluse_dispatch() -> int:
     data = _read_stdin()
     if (data.get("tool_name") or "") not in ("Task", "Agent"):
@@ -1775,6 +1856,13 @@ def posttooluse_dispatch() -> int:
     try:
         from . import dispatch
         p = dispatch.record(agent)
+        # The result carries the id the harness just created. Remembering it here is what
+        # lets a later resume — which addresses that id and not the name — be attributed
+        # without guessing. Best-effort and after the tally: the dispatch record must not
+        # depend on a mapping that is only ever a convenience.
+        m = _AGENT_ID_RE.search(str(data.get("tool_response") or ""))
+        if m:
+            _agent_map_remember(m.group(1), agent)
         if not p:
             return 0
         _trace("dispatch", data.get("session_id"), agent=agent)
@@ -2216,6 +2304,7 @@ _HANDLERS = {
     "posttooluse": posttooluse,
     "posttooluse-skill": posttooluse_skill,
     "posttooluse-dispatch": posttooluse_dispatch,
+    "posttooluse-message": posttooluse_message,
 }
 
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -112,6 +112,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "SendMessage",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "charter hook posttooluse-message --plugin-version 0.44.1",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "Stop": [

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -110,6 +110,9 @@ class TestPluginManifest(unittest.TestCase):
             # charter declares and the host preloads on every dispatch.
             ("PostToolUse", "charter hook posttooluse-skill --plugin-version"),
             ("PostToolUse", "charter hook posttooluse-dispatch --plugin-version"),
+            # Resumes: more work handed to a persona already running. Its own matcher
+            # because `Task|Agent` fires when a sub-agent is CREATED and never again.
+            ("PostToolUse", "charter hook posttooluse-message --plugin-version"),
             ("Stop", "charter workspace _autosave"),             # debounced auto-save
             ("SubagentStop", "charter workspace _autosave"),     # ditto, per dispatch
         ]

--- a/tests/test_resumed_delegation_counts.py
+++ b/tests/test_resumed_delegation_counts.py
@@ -1,0 +1,122 @@
+"""Handing more work to a running persona is delegation the tally could not see.
+
+`posttooluse_dispatch` fires on `Task`/`Agent`, so it records the moment a sub-agent is
+CREATED. Continuing that agent — `SendMessage` to it — is work handed to a persona and
+recorded nowhere. On the day the roster block shipped, `release` cut two releases and ran a
+plugin sweep; the sweep was a resume, so the tally read 2, and the fired-vs-followed pair
+undercounted the thing it exists to measure.
+
+Two decisions shape this, and both are about not overstating:
+
+* **A resume is not a new dispatch.** `DISP` answers "how many times was this persona
+  dispatched as a sub-agent"; a resume is more work sent to one already running. Counting
+  it there would inflate an answer to a question nobody asked. It gets its own event kind.
+* **Attribution comes from observation, never inference.** A resume addresses an opaque
+  agent id, not a persona name — every resume in the motivating session did. charter learns
+  the id→persona mapping from the dispatch it already watched create that id, and when it
+  has no mapping it records nothing rather than guessing.
+"""
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from charter import dispatch, hooks
+from tests._isolation import PersonaIso, run_hook
+
+AGENT_ID = "a1b2c3d4e5f6a7b8"
+
+
+def _ago(**kw) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(**kw)
+
+
+class ResumeCase(PersonaIso):
+    def dispatched(self, persona: str, agent_id: str = AGENT_ID):
+        """The harness's own Task result carries the id it just created."""
+        return run_hook(hooks.posttooluse_dispatch, {
+            "session_id": "s1", "tool_name": "Task",
+            "tool_input": {"subagent_type": persona},
+            "tool_response": f"Async agent launched successfully.\nagentId: {agent_id} "
+                             f"(internal ID - do not mention to user.)"})
+
+    def resumed(self, to: str):
+        return run_hook(hooks.posttooluse_message, {
+            "session_id": "s1", "tool_name": "SendMessage",
+            "tool_input": {"to": to, "message": "carry on"}})
+
+
+class TestAResumeIsRecorded(ResumeCase):
+    def test_a_resume_by_agent_id_is_attributed_to_the_persona(self):
+        """The motivating case: every resume in the real session addressed an opaque id."""
+        self.dispatched("release")
+        self.resumed(AGENT_ID)
+        self.assertEqual(dispatch.resume_tally(), 1)
+
+    def test_a_resume_addressed_by_persona_name_is_recorded_too(self):
+        self.make_persona("release", role="R", vault="none")
+        self.resumed("release")
+        self.assertEqual(dispatch.resume_tally(), 1)
+
+    def test_an_unknown_target_records_nothing(self):
+        """No mapping, no persona of that name — charter does not guess who was addressed."""
+        self.resumed("some-other-session")
+        self.assertEqual(dispatch.resume_tally(), 0)
+
+    def test_a_message_to_main_records_nothing(self):
+        self.resumed("main")
+        self.assertEqual(dispatch.resume_tally(), 0)
+
+
+class TestAResumeIsNotANewDispatch(ResumeCase):
+    def test_disp_counts_only_real_dispatches(self):
+        """`DISP` answers "times dispatched as a sub-agent". Inflating it with resumes
+        answers a question nobody asked, in the column people retire personas on."""
+        self.dispatched("release")
+        self.resumed(AGENT_ID)
+        self.resumed(AGENT_ID)
+        self.assertEqual(dispatch.tally()["release"], 1)
+
+    def test_but_the_persona_counts_as_recently_used(self):
+        """`last_seen` feeds the roster block's "last dispatched" line, and a persona that
+        was working an hour ago has not been idle since its first dispatch."""
+        self.dispatched("release")
+        self.resumed(AGENT_ID)
+        self.assertIsNotNone(dispatch.last_seen("release"))
+
+
+class TestTheFiredVsFollowedPairCountsIt(ResumeCase):
+    def test_a_resume_after_advice_counts_as_a_handoff(self):
+        """The pair measures whether the roster moves work to a persona. It does not care
+        whether that persona was already running."""
+        dispatch.record_advice(when=_ago(hours=2))
+        self.dispatched("release")
+        self.resumed(AGENT_ID)
+        self.assertEqual(dispatch.handoffs_since_first_advice(), 2)
+
+    def test_handoffs_before_the_advice_still_do_not_count(self):
+        """Written with explicit times rather than back-to-back calls: the store stamps to
+        SECOND resolution, so three events in one second cannot be ordered by it. That is a
+        real boundary, not a test artifact — it can only ever over-count handoffs sharing a
+        second with the first advice, which is why the docstring names it."""
+        dispatch.record("release", when=_ago(hours=3))
+        dispatch.record_resume("release", when=_ago(hours=2))
+        dispatch.record_advice(when=_ago(hours=1))
+        self.assertEqual(dispatch.handoffs_since_first_advice(), 0)
+
+
+class TestItNeverBreaksTheTurn(ResumeCase):
+    def test_a_malformed_payload_is_survivable(self):
+        self.assertEqual(run_hook(hooks.posttooluse_message, {"tool_name": "SendMessage"}), None)
+        self.assertEqual(dispatch.resume_tally(), 0)
+
+    def test_a_dispatch_result_without_an_id_still_records_the_dispatch(self):
+        """The mapping is a bonus; the dispatch tally must not depend on it."""
+        run_hook(hooks.posttooluse_dispatch, {
+            "session_id": "s1", "tool_name": "Task",
+            "tool_input": {"subagent_type": "release"}, "tool_response": "no id here"})
+        self.assertEqual(dispatch.tally()["release"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stats_lines_say_what_is_true.py
+++ b/tests/test_stats_lines_say_what_is_true.py
@@ -67,16 +67,16 @@ class TestTheAdviceLineComparesLikeWithLike(StatsCase):
         the roster ever appeared cannot have followed it."""
         dispatch.record("forge", when=_ago(days=4))
         dispatch.record_advice(when=_ago(hours=1))
-        self.assertEqual(dispatch.dispatches_since_first_advice(), 0)
+        self.assertEqual(dispatch.handoffs_since_first_advice(), 0)
 
     def test_a_dispatch_after_the_first_advice_counts(self):
         dispatch.record_advice(when=_ago(hours=2))
         dispatch.record("forge", when=_ago(hours=1))
-        self.assertEqual(dispatch.dispatches_since_first_advice(), 1)
+        self.assertEqual(dispatch.handoffs_since_first_advice(), 1)
 
     def test_no_advice_means_nothing_to_compare(self):
         dispatch.record("forge")
-        self.assertEqual(dispatch.dispatches_since_first_advice(), 0)
+        self.assertEqual(dispatch.handoffs_since_first_advice(), 0)
 
     def test_the_report_uses_that_number_not_the_lifetime_total(self):
         self.persona("forge")
@@ -85,7 +85,7 @@ class TestTheAdviceLineComparesLikeWithLike(StatsCase):
         text = self.report()
         self.assertIn("routing advice", text)
         # The old line said "1 time(s) · 1 dispatch(es) followed" from the lifetime total.
-        self.assertNotIn("1 dispatch(es) followed", text)
+        self.assertNotIn("dispatch(es) followed", text)
 
     def test_it_says_since_when(self):
         """A bare pair of numbers invites the reader to supply the window themselves, and


### PR DESCRIPTION
`charter persona stats` on this plane read `release … DISP 2` while `release` had done three
things: cut 0.44.0, cut 0.44.1, and run the plugin sweep. The sweep was a **resume** —
`SendMessage` to the running agent — and `posttooluse_dispatch` only fires on `Task`/`Agent`,
so it sees a sub-agent being *created* and nothing after.

That makes resumed delegation invisible to the fired-vs-followed pair, which exists
specifically to measure whether the roster block moves work to a persona.

## A resume is not a new dispatch

`DISP` is read as *"times dispatched as a sub-agent"*, and it is the column personas get
retired on. Folding resumes into it would inflate the answer to a question nobody asked. So
a resume is its own event kind, and the three consumers disagree deliberately:

| | counts a resume? | why |
| --- | --- | --- |
| `tally()` → `DISP` | **no** | it answers "dispatched as a sub-agent", and a resume isn't one |
| `last_seen()` | **yes** | feeds the roster's "last dispatched"; a persona handed work an hour ago isn't idle |
| fired-vs-followed | **yes** | asks whether work *moved*, not whether the persona was already running |

## Attribution is observed, never inferred

The hard part: a resume addresses an **opaque agent id**, not a persona name. Every resume in
the session that motivated this did:

```
Agent        → forge
SendMessage  → aff78d7c89bbe39ec
Agent        → release
SendMessage  → ae4679b91a9bc996f
```

charter can't decode that id — but it *watched it get created*. The `Task` result carries it
beside the `subagent_type` that names the persona, so the mapping is learned from a dispatch
charter already observes (ADR 0009: classify, don't guess). Stored local and gitignored
beside `inflight`, because these are the harness's internal handles and the committed tally's
discipline is counts and dates.

With no mapping and no matching persona name — `main`, another session, a teammate's agent —
it records **nothing** rather than attributing work to a persona it cannot name. There's a
test for each of those.

## Verified against real hooks

```
$ echo '{"tool_name":"Task","tool_input":{"subagent_type":"release"},
         "tool_response":"agentId: ff00ff00ff00ff00"}' | charter hook posttooluse-dispatch
$ echo '{"tool_name":"SendMessage","tool_input":{"to":"ff00ff00ff00ff00"}}' | charter hook posttooluse-message
$ echo '{"tool_name":"SendMessage","tool_input":{"to":"main"}}'             | charter hook posttooluse-message

DISP (dispatches only): {'release': 1}      ← not 2
resumes             : 1
last_seen(release)  : 2026-08-19
```

## Two things I got wrong on the way, both now guarded

A regex anchored on the first `"matcher": "Task|Agent"` put the new hook under **PreToolUse**
— that matcher name exists under both events. The manifest is now rewritten from the parsed
structure rather than hand-patched, and the diff is +10 lines with no reformatting churn.

A test asserted three events in one second could be ordered; the store stamps to second
resolution and cannot. The test now uses explicit times, and `handoffs_since_first_advice`
states the boundary in its docstring: it can only ever over-count, by at most one second's
worth.

2568 tests green.
