### PR TITLE
charter update: one command that upgrades charter and says what it brought

### DIFF
--- a/.claude/agents/release.md
+++ b/.claude/agents/release.md
@@ -25,6 +25,10 @@ A release moves **all four together**, or the drift ships:
    `pretooluse-edit`). Substitute globally, then re-grep for the OLD version across all
    four files — never work from a remembered count.
 
+Not five: `docs/news/` carries a version too, but it is *stamped* rather than edited — see
+the sequence. "A release has notes" is a different obligation from "the four numbers agree",
+and bolting it onto the lockstep test would blur one into the other.
+
 `tests/test_plugin.py::TestVersionsMoveInLockstep` pins all four and names them on failure.
 That test exists because they were **not** in lockstep for twelve releases: the CLI reached
 0.13.1 while both plugin artifacts still said 0.1.0, and a comment above
@@ -44,17 +48,35 @@ secrets. Consequences:
 - Land the version bump through a PR and let CI go green **before** tagging.
 - The tag must match `pyproject.toml` exactly; the `guard` job refuses the publish
   otherwise, which is the last safety net rather than the plan.
+- The same `guard` job refuses a version that ships **no news entry** — it asks
+  `charter news --for <X.Y.Z>`, the same call that renders the Release body, so "the guard
+  passed" and "the notes render" cannot disagree. Every published version needs one,
+  including a patch, whose entry may be a single line with no `check:`/`adopt:`.
 - Tag only from `main`, after the bump is merged.
 
 ## The sequence
 
 ```
-# 1. bump all four files on a branch, PR, green, merge
-# 2. sync main, then:
+# 1. on a branch: bump all four files, then
+charter news stamp <X.Y.Z>        # moves every docs/news/unreleased-*.md onto this
+                                  # version — renames the file AND rewrites `version:`
+# 2. PR, green, merge. Then sync main:
 git tag -a v<X.Y.Z> -m "<X.Y.Z> — <headline>"
 git push origin v<X.Y.Z>          # this is the publish; nothing else triggers it
 gh run watch <id> --exit-status
 ```
+
+**Why a command and not a fifth thing to remember.** A feature PR cannot name the version
+that will ship it — the next release may be a patch, or the PR may sit through three of
+them — so it stages `docs/news/unreleased-<slug>.md` and the bump stamps it. `stamp` is
+all-or-nothing: if one target name is already taken it renames *nothing* and says so,
+because a half-stamped release publishes with an entry silently missing from the notes and
+nothing anywhere reports it. It also reads back afterwards and fails if the version still
+has no entry — the guard would catch that too, but at the tag, which is the expensive end.
+
+Before you bump: read the merged PRs since the last tag, and check every user-visible one
+has an entry. That review is the gate; no CI check blocks a feature PR that ships none,
+because most PRs are refactors and a required entry per PR manufactures filler.
 
 Verify against PyPI's **version endpoint**, not the project endpoint — the latter is
 CDN-cached and lags by minutes, which reads as a failed publish when it is not:
@@ -62,6 +84,14 @@ CDN-cached and lags by minutes, which reads as a failed publish when it is not:
 ```
 https://pypi.org/pypi/charter-cp/<X.Y.Z>/json
 ```
+
+A successful publish is followed by one more job, which creates the **GitHub Release** with
+`gh release create v<X.Y.Z>` and a body generated from `charter news --for <X.Y.Z>`. Do not
+write release notes by hand: the shipped entry is the single source for both the public
+notes and the offline `charter news` suggestion, and hand-editing forks them. To change what
+a Release says, change the entry and the text follows. That job carries `contents: write`
+alone — the workflow's top-level grant stays `contents: read` — and it leaves an existing
+Release untouched, so a `workflow_dispatch` retry after a partial failure is safe to run.
 
 ## Then upgrade this machine — CLI first, pinned
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,5 +16,9 @@ not a restatement of the diff.
 - [ ] Nothing here reports success for a state it did not read back, or resolves a
       divergence without naming it ([ADR 0013](../docs/adr/0013-success-is-checked-divergence-is-named.md))
 - [ ] Docs updated in the same PR, if a command or flag changed
+- [ ] A user-visible change ships `docs/news/unreleased-<slug>.md` — the note the next
+      release turns into its notes, and `charter news` offers to adopt. Refactors need
+      none; nothing here blocks the PR, but nobody can reconstruct it for you later
+      ([CONTRIBUTING](../CONTRIBUTING.md#what-a-good-change-looks-like))
 - [ ] No new runtime dependencies
 - [ ] If this contradicts an ADR in `docs/adr/`, that's called out above

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,15 @@ permissions:
 
 jobs:
   guard:
-    name: Verify tag matches the packaged version
+    name: Verify the tag matches the packaged version, and that it has notes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Pinned rather than inherited: both steps below run charter itself, which needs
+      # 3.11+ for tomllib. The runner's default `python` is a version nobody here chose.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - name: Compare the git tag to pyproject.toml
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
@@ -32,6 +37,21 @@ jobs:
           echo "tag=$tag  pyproject=$pkg"
           if [ "$tag" != "$pkg" ]; then
             echo "::error::tag v$tag does not match pyproject.toml version $pkg — refusing to publish"
+            exit 1
+          fi
+      - name: Refuse to publish a version that ships no news entry
+        run: |
+          # The version comes from pyproject, not the tag: it is defined on BOTH trigger
+          # paths (a workflow_dispatch retry has no tag to read), and the step above has
+          # already refused a tag that disagrees with it.
+          #
+          # And charter is asked rather than the directory globbed, because this is the
+          # same call that renders the Release body below. Globbing would be a second
+          # answer to one question, free to say yes on a release whose notes come out
+          # empty. `charter news --for` exits non-zero when there is nothing to render.
+          version=$(python -c 'import tomllib;print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
+          if ! python -m charter news --for "$version" >/dev/null; then
+            echo "::error::no docs/news/$version-<slug>.md — every published version ships an entry, including a patch. Run: charter news stamp $version"
             exit 1
           fi
 
@@ -83,3 +103,36 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  announce:
+    name: Create the GitHub Release from the shipped news entry
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      # On this job alone. The workflow's top-level grant stays `contents: read`, so
+      # `test` and `build` — which run the repository's own code — never hold write.
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Publish the notes charter already ships
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version=$(python -c 'import tomllib;print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
+          tag="v$version"
+          # `workflow_dispatch` re-runs a release that failed somewhere, and the publish
+          # may well have been the part that worked. An existing Release is left exactly
+          # as it stands — overwriting one is not this job's business, and additive-only
+          # is the rule everywhere else charter writes.
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "release $tag already exists — leaving it as it stands"
+            exit 0
+          fi
+          # Generated, never written here. The entry in docs/news is the single source
+          # for both the public notes and the offline `charter news` suggestion, so the
+          # two cannot drift: one is printed from the other.
+          python -m charter news --for "$version" > "$RUNNER_TEMP/notes.md"
+          gh release create "$tag" --title "$tag" --notes-file "$RUNNER_TEMP/notes.md"

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,6 +50,13 @@ Workspace-scoped intent that expires: it stops being true the moment it is done 
 abandoned, which is why it lives beside memory rather than inside it (ADR 0004).
 _Avoid_: task, ticket, item
 
+**News**:
+A shipped, per-item note that a version introduced something, carrying an optional probe
+for whether this plane has adopted it. Not a changelog: an entry exists to be *acted on*,
+and one with nothing to adopt is one line. Staged as `unreleased-<slug>.md` until a release
+stamps it, so an entry never names a version that was not true.
+_Avoid_: changelog, release notes, announcement
+
 ### Parallel work
 
 **Plan**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,21 @@ command.
   machine is not the runner* below, which this keeps turning out to be a case of.
 - **Docs move with the code.** A flag that is not in `docs/` does not exist. If you change
   what a command does, update the page that describes it in the same PR.
+- **A user-visible change ships a news entry.** One file, `docs/news/unreleased-<slug>.md`,
+  in the shape of [`docs/news/0.44.0-delegate-when.md`](docs/news/0.44.0-delegate-when.md):
+  flat frontmatter with a `headline`, plus an optional `check:` (a charter subcommand that
+  exits 0 where the thing is already adopted) and `adopt:` (the one that adopts it). It
+  says `version: unreleased` because your PR cannot know which release will carry it — the
+  next one may be a patch, or your PR may sit through three of them — and the release runs
+  `charter news stamp <version>` to move it onto the version that ships it. Entries travel
+  inside the wheel, so `charter news` works offline on any harness.
+
+  Write it in the PR that builds the thing: you are the only person who knows why it
+  matters and what would prove somebody has taken it up, and reconstructing that from
+  commit titles at release time is how notes become a changelog nobody reads. Nothing in CI
+  blocks a PR that ships none — most PRs are refactors, and a required entry per PR
+  manufactures filler. The gate is at the release, where a version with no entry does not
+  publish at all.
 
 ## Your machine is not the runner
 

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -238,7 +238,15 @@ def build_parser() -> argparse.ArgumentParser:
     nw.add_argument("--until", help="Stop at this version (default: the running one).")
     nw.add_argument("--for", dest="for_version", metavar="VERSION",
                     help="One version's entries, as the body of its release notes.")
-    nw.set_defaults(func=commands.cmd_news)
+    nwsub = nw.add_subparsers(dest="news_cmd")
+    nw.set_defaults(func=commands.cmd_news)         # bare `charter news` = the range view
+    nst = nwsub.add_parser("stamp",
+                           help="Move every staged `unreleased-*` entry onto the version "
+                                "about to ship — the bump PR's step, beside the four "
+                                "files that carry a version number.")
+    nst.add_argument("version", help="The version about to be published, e.g. 0.45.0 — "
+                                     "the number alone, not the tag name.")
+    nst.set_defaults(func=commands.cmd_news_stamp)
 
     ver = sub.add_parser("version",
                          help="The control plane's charter version lock: show drift, "

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 from . import (
+    commands_update,
     __version__,
     commands,
     commands_harness,
@@ -216,6 +217,17 @@ def build_parser() -> argparse.ArgumentParser:
     # Hidden from help — nobody needs to run it, and it is not part of the UX.
     vc = sub.add_parser("_version-check")
     vc.set_defaults(func=commands.cmd_version_check)
+
+    up = sub.add_parser("update",
+                        help="Move charter to a newer version — CLI, this harness's "
+                             "artifact, and the pin — then say what the new version "
+                             "brings and what this plane has not adopted.")
+    up.add_argument("--to", help="Install exactly this version instead of the default "
+                                 "target (the pin, or the latest published).")
+    up.add_argument("--bump", action="store_true",
+                    help="Also move this plane's pin, which moves every teammate on their "
+                         "next session. Written only after the install is verified.")
+    up.set_defaults(func=commands_update.cmd_update)
 
     nw = sub.add_parser("news",
                         help="What a version brought, and what this plane has not adopted.")

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -217,6 +217,17 @@ def build_parser() -> argparse.ArgumentParser:
     vc = sub.add_parser("_version-check")
     vc.set_defaults(func=commands.cmd_version_check)
 
+    nw = sub.add_parser("news",
+                        help="What a version brought, and what this plane has not adopted.")
+    nw.add_argument("--pending", action="store_true",
+                    help="Every entry, any version, whose probe says you have not adopted "
+                         "it yet.")
+    nw.add_argument("--since", help="Report entries newer than this version.")
+    nw.add_argument("--until", help="Stop at this version (default: the running one).")
+    nw.add_argument("--for", dest="for_version", metavar="VERSION",
+                    help="One version's entries, as the body of its release notes.")
+    nw.set_defaults(func=commands.cmd_news)
+
     ver = sub.add_parser("version",
                          help="The control plane's charter version lock: show drift, "
                               "conform this machine to it, or move the pin.")
@@ -810,6 +821,10 @@ def _add_persona_parser(sub) -> None:
     dd.set_defaults(func=commands_persona.cmd_persona_dedupe)
 
     lt = psub.add_parser("lint", help="Config eval: dangling uses:, missing role/vault/delegate-when, stale agents.")
+    lt.add_argument("--only", metavar="KEY",
+                    help="Report only findings mentioning KEY, and exit non-zero solely "
+                         "on those — what a news entry's probe needs to ask about one "
+                         "feature.")
     lt.add_argument("name", nargs="?", help="Only this persona (default: all).")
     lt.set_defaults(func=commands_persona.cmd_persona_lint)
 

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1852,8 +1852,12 @@ def cmd_news(args) -> int:
         return 0
     for e in entries:
         status, _ = news.probe(e)
-        mark = "" if status in (news.ADOPTED,) else _news_line(e, status)
-        print(f"{e.version}  {e.headline}" if not mark else f"{e.version}  {e.headline}\n{mark}")
+        print(f"{e.version}  {e.headline}")
+        # Only an entry with something to DO gets the action line. An informational entry
+        # — a patch note, usually — exists to say there is nothing to take up, so printing
+        # "adopt: manual" beneath it invents a chore out of the line that denies one.
+        if status == news.PENDING:
+            print(_news_line(e, status))
     return 0
 
 

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1797,6 +1797,66 @@ def cmd_version_check(args) -> int:
     return 0
 
 
+def _news_line(e, status: str) -> str:
+    """One entry, one line, in the shape the reader acts on.
+
+    Deliberately not JSON. The skill is a Claude Code artifact and opencode gets none, so
+    this text is the only thing an agent on another harness has — a machine surface would
+    become the parsed one, and this the unchecked one.
+    """
+    how = f"adopt: charter {e.adopt}" if e.adopt else "adopt: manual (see the entry)"
+    return f"  {e.slug} · {e.headline}\n      {how}"
+
+
+def cmd_news(args) -> int:
+    """What a version brought, and what this plane has not taken up."""
+    from . import news
+
+    version = getattr(args, "for_version", None)
+    if version:
+        body = news.render_body(version)
+        if not body:
+            util.err(f"no news entry for {version}.")
+            return 1
+        print(body)
+        return 0
+
+    if getattr(args, "pending", False):
+        shown = 0
+        for e in news.released():
+            status, why = news.probe(e)
+            if status == news.PENDING:
+                print(_news_line(e, status))
+                shown += 1
+            elif status == news.UNKNOWN:
+                # Said, not swallowed. A probe that could not run is the one case where
+                # silence would be read as "nothing to adopt" — the shape ADR 0013 and
+                # `doctor`'s not-checked hint both exist to refuse.
+                util.warn(f"{e.slug}: {why}")
+        if not shown:
+            util.ok("nothing pending — every entry with a probe reports adopted.")
+        return 0
+
+    since = (getattr(args, "since", None) or "").strip()
+    until = (getattr(args, "until", None) or _installed_version()).strip()
+    if not since:
+        # No baseline is not a range. Replaying every entry ever written as though it were
+        # news would be charter presenting old text as new — so it says what it can and
+        # points at the view that IS honest without one.
+        util.info("no baseline recorded, so there is no range to report.")
+        util.info("  what this plane has not adopted:  charter news --pending")
+        return 0
+    entries = news.between(since, until)
+    if not entries:
+        util.ok(f"nothing new between {since} and {until}.")
+        return 0
+    for e in entries:
+        status, _ = news.probe(e)
+        mark = "" if status in (news.ADOPTED,) else _news_line(e, status)
+        print(f"{e.version}  {e.headline}" if not mark else f"{e.version}  {e.headline}\n{mark}")
+    return 0
+
+
 # --------------------------------------------------------------------------- #
 # version lock — `[charter] version` in charter.toml                          #
 # --------------------------------------------------------------------------- #

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1874,16 +1874,32 @@ def cmd_version_sync(args) -> int:
         return 0
 
     if not getattr(args, "cli", False):
-        plugin = _update.plugin_version_here()
-        if plugin == locked:
-            util.ok(f"the plugin serving this project is already on the lock ({locked}).")
+        # ASK THE HARNESS. This branch used to read `$CLAUDE_PLUGIN_ROOT` and then print
+        # `claude plugin update charter@charter` unconditionally — so an opencode user,
+        # for whom that variable is always absent, was told to run a command belonging to
+        # a harness they are not in. `Harness.upgrade` makes it one question with one
+        # answer, and charter moves only the artifacts it authored.
+        from . import harness as _harness
+
+        h = _harness.get(_harness.current())
+        if h is None:
+            util.warn("no harness detected, so charter cannot say how this plane's "
+                      "artifact moves — `charter harness list`.")
+            util.info("  the machine-global binary instead: charter version sync --cli")
             return 0
-        where = f"{plugin} → {locked}" if plugin else f"→ {locked}"
-        util.info(f"this plane's version is the plugin's ({where}).")
-        # Named, not run. `claude` may be absent, may prompt for a scope, and the command
-        # mutates the reader's editor install — charter says exactly what to run and lets
-        # them run it, the same restraint the MCP launcher check keeps.
-        util.info(f"  run: {_update.PLUGIN_SYNC_CMD}")
+        status, detail = h.upgrade(config.ROOT)
+        if status == "current":
+            util.ok(f"the {h.name} artifact serving this project is already on {detail}.")
+        elif status == "moved":
+            util.ok(f"moved: {detail}")
+        elif status == "manual":
+            # Named, not run. The host owns the artifact: its command may be absent, may
+            # prompt for a scope, and it mutates the reader's editor install — the same
+            # restraint the MCP launcher check keeps.
+            util.info(f"this plane's version is its {h.name} artifact's (→ {locked}).")
+            util.info(f"  run: {detail}")
+        else:
+            util.warn(detail)
         util.info(f"  the machine-global binary instead: charter version sync --cli")
         return 0
 

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1808,9 +1808,21 @@ def _news_line(e, status: str) -> str:
     return f"  {e.slug} · {e.headline}\n      {how}"
 
 
+#: Said once, where a probe would otherwise be run against nothing.
+#:
+#: "Has this plane adopted it?" has no subject outside a control plane. Running the probes
+#: anyway would spend a subprocess each to report whatever a plane-less charter happens to
+#: exit with — an answer to a question nobody asked, indistinguishable in the output from
+#: one that means something.
+_NO_PLANE = ("no control plane here, so charter cannot tell which of these this plane has "
+             "adopted — run `charter news --pending` from inside one")
+
+
 def cmd_news(args) -> int:
     """What a version brought, and what this plane has not taken up."""
     from . import news
+
+    planeless = not config.HAS_CONTROL_PLANE
 
     version = getattr(args, "for_version", None)
     if version:
@@ -1822,6 +1834,9 @@ def cmd_news(args) -> int:
         return 0
 
     if getattr(args, "pending", False):
+        if planeless:
+            util.warn(_NO_PLANE)
+            return 0
         shown = 0
         for e in news.released():
             status, why = news.probe(e)
@@ -1850,8 +1865,10 @@ def cmd_news(args) -> int:
     if not entries:
         util.ok(f"nothing new between {since} and {until}.")
         return 0
+    if planeless:
+        util.warn(_NO_PLANE)
     for e in entries:
-        status, _ = news.probe(e)
+        status, _ = (news.INFORMATIONAL, "") if planeless else news.probe(e)
         print(f"{e.version}  {e.headline}")
         # Only an entry with something to DO gets the action line. An informational entry
         # — a patch note, usually — exists to say there is nothing to take up, so printing

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1857,6 +1857,39 @@ def cmd_news(args) -> int:
     return 0
 
 
+def cmd_news_stamp(args) -> int:
+    """Move every staged entry onto the version about to ship.
+
+    The bump PR's one mechanical step, beside the four files that carry a version number.
+    A command rather than a fifth thing to remember, for the reason the release charter
+    gives about `hooks.json`: never work from a remembered count.
+    """
+    from . import news
+
+    version = (getattr(args, "version", "") or "").strip()
+    renamed, blocked = news.stamp(version)
+    for why in blocked:
+        util.err(why)
+    if blocked:
+        return 1
+    for src, dst in renamed:
+        util.ok(f"{src.name} → {dst.name}")
+    if not renamed:
+        util.info(f"no staged entries — nothing to move onto {version}.")
+
+    # Read back what is on disk rather than trusting the run. Nothing staged is a
+    # legitimate state (the entry may already name the version), and an entry missing
+    # altogether is not — the two are indistinguishable from the rename count alone, and
+    # only one of them publishes a version with no notes. Naming it here costs a line;
+    # letting the tag find it costs a release (ADR 0013).
+    if not news.stamped(version):
+        util.err(f"no entry names {version}. Every published version needs one, including "
+                 f"a patch — write docs/news/{version}-<slug>.md before tagging, or the "
+                 f"release guard refuses to publish.")
+        return 1
+    return 0
+
+
 # --------------------------------------------------------------------------- #
 # version lock — `[charter] version` in charter.toml                          #
 # --------------------------------------------------------------------------- #

--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -990,9 +990,18 @@ def cmd_persona_lint(args) -> int:
     if not names:
         util.info("No personas to lint.")
         return 0
+    # `--only` narrows to ONE finding so an exit code can answer one question. A news
+    # entry's probe needs exactly that: bare `lint` fails for dangling `uses:` too, and a
+    # probe that fires on unrelated findings tells a plane to adopt what it already has.
+    only = (getattr(args, "only", None) or "").strip()
     errors = 0
     for n in names:
         issues = list(persona.lint(n)) + _agent_sync_issues(n)
+        if only:
+            issues = [(lvl, msg) for lvl, msg in issues if only in msg]
+            # Every match is an error under `--only`: the caller asked about one thing, so
+            # "present but only as a warning" is still the answer "not adopted".
+            issues = [("error", msg) for _lvl, msg in issues]
         if not issues:
             util.ok(f"{n}: ok")
             continue

--- a/charter/commands_update.py
+++ b/charter/commands_update.py
@@ -1,0 +1,255 @@
+"""`charter update` — move charter, then say what the new version brings.
+
+Three things get called "updating charter", and they have three different blast radii:
+
+* the **CLI**, one machine-global install shared by every plane on this machine;
+* the **harness artifact**, per project (see :meth:`charter.harness.base.Harness.upgrade`);
+* the **pin** in ``charter.toml``, shared with every teammate once it is pushed.
+
+This command converges them in the only order that is safe and stops at the one decision
+that is not charter's to make. It is **idempotent**: run it when already current and it
+goes straight to the news phase, which is what makes it safe for an agent to call without
+first working out whether there is anything to do.
+
+**CLI before the harness artifact.** Plugin-newer-than-CLI is the one direction that
+breaks — the plugin dispatches ``charter hook <name>`` for handlers an older CLI does not
+have, and `hooks.skew_message` is deliberately one-directional, so it stays quiet the other
+way round. The release charter says this; the sequence here obeys it for the same reason.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+from . import config, util
+from .update import SHARED_INSTALL_NOTE, _parse
+
+#: The distribution, and the install commands that actually move it.
+#:
+#: NOT `uv tool upgrade`: it reports "Nothing to upgrade" for a git-installed charter and
+#: leaves you pinned, which `commands._sync_cmd` already carries a comment about. Pinned
+#: and `--refresh`ed rather than bare `--force`, because PyPI's simple index lags its
+#: metadata endpoint and an unrefreshed install can succeed against a cached index while
+#: leaving you on the old version.
+_INSTALLERS = {
+    "uv": ["uv", "tool", "install", "charter-cp=={version}", "--force", "--refresh"],
+    "pipx": ["pipx", "install", "charter-cp=={version}", "--force"],
+}
+
+#: How an install identifies its owner. Path-shaped rather than "which binary exists",
+#: because uv and pipx are frequently both installed and only one of them owns THIS
+#: charter — asking the wrong one produces a confident no-op.
+_MARKERS = (("uv", ("/uv/tools/",)), ("pipx", ("/pipx/venvs/",)))
+
+
+def installer_for(executable: Path) -> tuple[str, list[str] | None]:
+    """Which tool owns the install *executable* belongs to, and how it moves it.
+
+    ``("unknown", None)`` is a real answer, not a failure: `docs/install.md` documents uv,
+    pipx and pip, and there is no reliable way to move a plain `pip install` in somebody
+    else's environment. Ambiguity resolves to *named, not run* — the same restraint charter
+    keeps for a host's plugin command, for the same reason: a wrong guess here mutates the
+    reader's machine.
+    """
+    p = str(executable)
+    for name, markers in _MARKERS:
+        if any(m in p for m in markers):
+            return name, list(_INSTALLERS[name])
+    return "unknown", None
+
+
+def _baseline_file() -> Path:
+    return config.STATE_DIR / "cache" / "update-baseline"
+
+
+def read_baseline() -> str | None:
+    """The version this plane last updated FROM, or ``None``.
+
+    Per-developer and gitignored (it lives under ``STATE_DIR``): which version this laptop
+    came from is not a fact about the plane, and ADR 0011 keeps the committed record to
+    what git cannot know.
+    """
+    try:
+        return _baseline_file().read_text().strip() or None
+    except OSError:
+        return None
+
+
+def _stamp_baseline(version: str) -> None:
+    try:
+        p = _baseline_file()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(version)
+    except OSError:
+        pass          # a missing baseline degrades the news RANGE, never the update
+
+
+def _installed_version() -> str:
+    from . import __version__
+
+    return __version__
+
+
+def _latest(live: bool = True) -> str | None:
+    """The newest published version. A live read here, unlike the status line's.
+
+    `update.maybe_spawn` exists so rendering never blocks on the network. This is an
+    explicit command a person typed and is waiting on, so it asks — and falls back to the
+    cache, saying so, rather than refusing to work offline.
+    """
+    from . import update
+
+    if live:
+        update.fetch_and_store()
+    return (update.load().get("latest") or "").strip() or None
+
+
+def _sync_to(version: str) -> tuple[bool, str]:
+    """Install exactly *version* through whichever tool owns this install."""
+    name, argv = installer_for(Path(sys.executable))
+    if argv is None:
+        return False, (f"charter was not installed by uv or pipx, so charter will not "
+                       f"guess how to move it — run the equivalent of: "
+                       f"pip install --upgrade charter-cp=={version}")
+    if not shutil.which(argv[0]):
+        return False, f"{name} owns this install but is not on PATH"
+    cmd = [a.format(version=version) for a in argv]
+    proc = util.run(cmd, check=False)
+    if proc.returncode != 0:
+        why = (proc.stderr or proc.stdout or "").strip().splitlines()
+        return False, (why[-1][:200] if why else f"exit {proc.returncode}")
+    return True, version
+
+
+def _handoff(target: str, baseline: str) -> tuple[bool, str]:
+    """Run the news phase in a fresh process of the NEWLY INSTALLED binary.
+
+    Two jobs in one subprocess, which is why it is not optional. The new version's entries
+    and probes exist only in the new wheel — this process is still the old build, as
+    `cmd_version_sync` already says out loud — and a binary that answers with the target
+    version IS the proof the install took. Without that, an install that succeeded against
+    a cached index reports success while leaving you where you started.
+    """
+    binary = shutil.which("charter")
+    if not binary:
+        return False, "the `charter` command is not on PATH from here"
+    got = util.run([binary, "--version"], check=False)
+    said = (got.stdout or got.stderr or "").strip().split()
+    if got.returncode != 0 or not said or said[-1] != target:
+        return False, f"the installed `charter` reports {' '.join(said) or '?'}, expected {target}"
+    news = util.run([binary, "news", "--since", baseline], check=False)
+    out = (news.stdout or "").strip()
+    if out:
+        print(out)
+    return True, ""
+
+
+def _bump_pin(target: str) -> bool:
+    """Write the pin and land it. Team-affecting, so it happens only after verification.
+
+    `charter save` rather than raw git: the pin lives in the PLANE ROOT, and on a plane
+    whose repo requires pull requests that is the one tree #157 forbids branching — `save`
+    knows how to land it either way (#167).
+    """
+    from . import commands, instance
+
+    if not instance.set_locked_version(config.ROOT, target):
+        util.err(f"could not write the lock into {config.ROOT / 'charter.toml'}")
+        return False
+    util.ok(f"pinned this control plane to charter {target}.")
+    util.info(f"  share it: charter save 'charter: pin to {target}'")
+    return True
+
+
+def _resolve_target(args, installed: str, locked: str | None) -> tuple[str | None, bool]:
+    """``(target, proposed)``. *proposed* means charter stopped and asked.
+
+    Moving the machine PAST a pin manufactures the drift `charter version` reports as an
+    error, so the pin decides the target rather than being an afterthought to it.
+    """
+    explicit = (getattr(args, "to", None) or "").strip()
+    if explicit:
+        return explicit, False
+    if locked and _parse(installed) < _parse(locked):
+        return locked, False          # conforming to a pin somebody chose affects nobody
+    if not locked:
+        return _latest() or installed, False
+    latest = _latest()
+    if latest and _parse(latest) > _parse(installed):
+        if not getattr(args, "bump", False):
+            return None, True         # moving past the pin moves the TEAM
+        return latest, False
+    return installed, False
+
+
+def cmd_update(args) -> int:
+    from . import doctor, harness, instance
+
+    if doctor._is_charter_checkout(config.ROOT):
+        # `CONTRIBUTING.md` tells contributors to run `python3 -m charter …` from the
+        # clone. Installing over that is never what "let me try the update command" meant,
+        # and the failure is silent: the news phase would hand off to a binary that is not
+        # the tree being edited, and report on it as though it were.
+        util.err("this is a charter checkout — refusing to install over the tree you are "
+                 "editing.")
+        util.info("  what you probably want:  charter version")
+        return 2
+
+    installed = _installed_version()
+    locked = instance.locked_version(instance.load(config.ROOT))
+    target, proposed = _resolve_target(args, installed, locked)
+    if proposed:
+        util.info(f"this plane pins {locked}, and {_latest()} is published.")
+        util.info("  moving past the pin moves every teammate on their next session.")
+        util.info("  do it:  charter update --bump")
+        return 0
+    if target is None:
+        util.err("could not determine a target version (offline?). "
+                 "Pass one explicitly: charter update --to X.Y.Z")
+        return 1
+
+    # BEFORE anything moves, so an interrupted update still knows where it started.
+    _stamp_baseline(installed)
+
+    if target != installed:
+        util.warn(SHARED_INSTALL_NOTE)
+        util.info(f"installing charter {installed} → {target} …")
+        ok, detail = _sync_to(target)
+        if not ok:
+            util.err(f"could not install {target}: {detail}")
+            return 1
+
+    h = harness.get(harness.current())
+    if h is None:
+        # Never "nothing to do": absence of information is not evidence of health, and a
+        # terminal-run update is the likeliest place for that to mislead.
+        util.warn("no harness detected, so its charter artifact was not checked — "
+                  "`charter harness list`.")
+    else:
+        status, detail = h.upgrade(config.ROOT)
+        if status == "moved":
+            util.ok(f"moved: {detail}")
+        elif status == "current":
+            util.ok(f"the {h.name} artifact is already on {detail}.")
+        elif status == "manual":
+            util.info(f"the {h.name} artifact is the host's to move:")
+            util.info(f"  run: {detail}")
+        else:
+            util.warn(detail)
+        stale = h.stale_wiring()
+        if stale:
+            util.warn(f"this plane's {h.name} wiring was written by {stale} — "
+                      f"`charter reinit` adds what is missing.")
+
+    ok, why = _handoff(target, installed)
+    if not ok:
+        util.err(f"the install did not take: {why}")
+        util.info("  nothing was reported about the new version, because charter could "
+                  "not confirm it is the one running.")
+        return 1
+
+    if getattr(args, "bump", False) and target != locked:
+        _bump_pin(target)
+    return 0

--- a/charter/commands_update.py
+++ b/charter/commands_update.py
@@ -256,5 +256,10 @@ def cmd_update(args) -> int:
         return 1
 
     if getattr(args, "bump", False) and target != locked:
-        _bump_pin(target)
+        if not config.HAS_CONTROL_PLANE:
+            # Nothing to pin TO. Writing a charter.toml here would conjure a control plane
+            # out of a version bump, in whatever directory the command was typed.
+            util.warn("no control plane here, so there is no pin to move.")
+        else:
+            _bump_pin(target)
     return 0

--- a/charter/commands_update.py
+++ b/charter/commands_update.py
@@ -163,25 +163,30 @@ def _bump_pin(target: str) -> bool:
     return True
 
 
-def _resolve_target(args, installed: str, locked: str | None) -> tuple[str | None, bool]:
-    """``(target, proposed)``. *proposed* means charter stopped and asked.
+def _resolve_target(args, installed: str, locked: str | None) -> tuple[str | None, bool, str | None]:
+    """``(target, proposed, latest)``. *proposed* means charter stopped and asked.
 
     Moving the machine PAST a pin manufactures the drift `charter version` reports as an
     error, so the pin decides the target rather than being an afterthought to it.
+
+    *latest* travels back out because :func:`_latest` is a LIVE read — this is a command a
+    person is waiting on, not the status line's cached glance — and the caller needs the
+    same number to explain what it is proposing. Asking PyPI twice to answer one question
+    doubles that wait for nothing.
     """
     explicit = (getattr(args, "to", None) or "").strip()
     if explicit:
-        return explicit, False
+        return explicit, False, None
     if locked and _parse(installed) < _parse(locked):
-        return locked, False          # conforming to a pin somebody chose affects nobody
-    if not locked:
-        return _latest() or installed, False
+        return locked, False, None    # conforming to a pin somebody chose affects nobody
     latest = _latest()
+    if not locked:
+        return latest or installed, False, latest
     if latest and _parse(latest) > _parse(installed):
         if not getattr(args, "bump", False):
-            return None, True         # moving past the pin moves the TEAM
-        return latest, False
-    return installed, False
+            return None, True, latest  # moving past the pin moves the TEAM
+        return latest, False, latest
+    return installed, False, latest
 
 
 def cmd_update(args) -> int:
@@ -199,9 +204,9 @@ def cmd_update(args) -> int:
 
     installed = _installed_version()
     locked = instance.locked_version(instance.load(config.ROOT))
-    target, proposed = _resolve_target(args, installed, locked)
+    target, proposed, latest = _resolve_target(args, installed, locked)
     if proposed:
-        util.info(f"this plane pins {locked}, and {_latest()} is published.")
+        util.info(f"this plane pins {locked}, and {latest} is published.")
         util.info("  moving past the pin moves every teammate on their next session.")
         util.info("  do it:  charter update --bump")
         return 0

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -912,7 +912,7 @@ def check_ask_rules() -> Result:
 #: is installed from a wheel that contains no `skills/` — that directory belongs to the
 #: plugin artifact. A test asserts this equals the repo's `skills/`, so the two cannot part
 #: company without the suite saying so.
-SHIPPED_SKILLS = frozenset({"secrets", "working-in-a-clone", "persona", "browser"})
+SHIPPED_SKILLS = frozenset({"secrets", "working-in-a-clone", "persona", "browser", "update"})
 
 
 def _is_charter_checkout(root) -> bool:

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1228,6 +1228,44 @@ def check_version_lock() -> Result:
                   hint=f"{update.SHARED_INSTALL_NOTE}{move}")
 
 
+def check_news_adoption() -> Result:
+    """What this version brought that this plane has not taken up.
+
+    The only surface besides `charter update` where a suggestion reaches somebody. NOT the
+    session-start hook: each probe is real work, and running every one of them on every
+    session start is the cost `update.py` exists to keep off the status line's clock.
+
+    WARN rather than OK for pending entries, and WARN rather than FAIL: an un-adopted
+    feature is not a broken plane (`cmd_doctor` exits non-zero only on FAIL), but a green
+    tick over "there are three things here for you" is a row nobody ever reads twice.
+    """
+    from . import news
+
+    try:
+        entries = news.released()
+    except Exception as e:
+        return Result("news", WARN, detail=f"not checked ({e})", hint=_NOT_CHECKED_HINT)
+    pending, unchecked = [], []
+    for e in entries:
+        status, _why = news.probe(e)
+        if status == news.PENDING:
+            pending.append(e)
+        elif status == news.UNKNOWN:
+            unchecked.append(e)
+    if not pending and not unchecked:
+        return Result("news", OK, detail="nothing to adopt")
+    bits = []
+    if pending:
+        bits.append(f"{len(pending)} not adopted here")
+    if unchecked:
+        # Named separately, never folded into the count. "Could not tell" and "you do not
+        # have it" are different answers, and merging them is how a probe that quietly
+        # stopped working reads as a feature you keep declining.
+        bits.append(f"{len(unchecked)} unchecked")
+    return Result("news", WARN, detail=", ".join(bits),
+                  hint="See them: charter news --pending")
+
+
 def check_memory_indexes() -> Result:
     """Every memory base's MEMORY.md must agree with the files beside it.
 
@@ -1748,6 +1786,7 @@ def _checks():
                 check_inventory(), check_vaults(),
                 check_vault_registry_divergence(), check_version_lock(),
                 check_memory_indexes(), check_personas(), check_front_door(),
+                check_news_adoption(),
                 check_ask_rules(),
                 check_shadowed_knowledge(),
                 check_mcp_launchers(), check_plugin_skew()]

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1212,10 +1212,20 @@ def check_version_lock() -> Result:
     if locked == __version__:
         return Result("version lock", OK,
                       detail=f"pinned {locked}, CLI in sync (plugin not visible from here)")
+    # "To move THIS plane only" is the harness's answer, not one command for everybody.
+    # Naming the Claude Code plugin here told every opencode and Codex reader — and every
+    # bare terminal, which is what this branch IS — to run a command belonging to a
+    # harness they are not in. Same defect as `cmd_version_sync`'s, same fix.
+    from . import harness as _harness
+
+    h = _harness.get(_harness.current())
+    status, detail = h.upgrade(_config.ROOT) if h else ("absent", "")
+    move = (f". To move THIS plane only: {detail}" if status == "manual"
+            else f". {detail}" if status == "absent" and detail
+            else "")
     return Result("version lock", WARN,
                   detail=f"pinned {locked}, CLI is {__version__}",
-                  hint=f"{update.SHARED_INSTALL_NOTE}. To move THIS plane only: "
-                       f"{update.PLUGIN_SYNC_CMD}")
+                  hint=f"{update.SHARED_INSTALL_NOTE}{move}")
 
 
 def check_memory_indexes() -> Result:

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -73,6 +73,25 @@ class Harness:
         """
         return []
 
+    def upgrade(self, root: Path) -> tuple[str, str]:
+        """Move THIS harness's installed charter artifact to the running CLI's version.
+
+        ``("moved", detail)`` — charter rewrote a file it authored.
+        ``("current", version)`` — already on this version, nothing to do.
+        ``("manual", command)`` — a host owns the artifact, so charter NAMES the command.
+        ``("absent", why)`` — charter does not know how this harness updates.
+
+        The default is ``absent`` rather than a plausible command, and that is the whole
+        reason this member exists on the base class. Two code paths used to answer this
+        question without knowing about each other — `update.plugin_version_here()` and
+        :meth:`stale_wiring` — and the caller consulted one, then printed a Claude Code
+        command to everybody. :class:`Deficit` already records why a guess is worse than a
+        gap ("sends somebody off to configure something that does not exist"); here the
+        guess would be *run*, not merely read.
+        """
+        return ("absent", f"charter has not pinned how {self.name or 'this harness'} "
+                          f"updates its charter artifact — `charter harness list`")
+
     def ask_rule(self, pattern: str):
         """*pattern* in this harness's own rule syntax, or ``None`` if it has none.
 

--- a/charter/harness/claude_code.py
+++ b/charter/harness/claude_code.py
@@ -51,6 +51,17 @@ class ClaudeCodeHarness(Harness):
         status, _path = commands.ensure_env_var(root, "CHARTER_HARNESS", self.name)
         return [(status, ".claude/settings.json (env)")]
 
+    def upgrade(self, root: Path) -> tuple[str, str]:
+        """Named, never run — the restraint `cmd_version_sync` already keeps.
+
+        `claude` may be absent, may prompt for a scope, and the command mutates the
+        reader's editor install. What changes here is only that this answer is now Claude
+        Code's answer rather than the answer charter gave every harness.
+        """
+        from .. import update
+
+        return "manual", update.PLUGIN_SYNC_CMD
+
     def ask_rule(self, pattern: str) -> str:
         from .. import commands
 

--- a/charter/harness/codex.py
+++ b/charter/harness/codex.py
@@ -37,6 +37,21 @@ NAME = "codex"
 HOOK_ENTRY_KEYS = ("type", "command")
 HOOK_TYPE = "command"
 
+#: How a Codex plugin moves, pinned against codex-cli 0.147.0.
+#:
+#: `codex plugin update` does NOT exist — the binary answers "error: unrecognized
+#: subcommand 'update'", which is the rejection this file treats as the only real
+#: evidence. What exists is add / list / marketplace / remove, and the snapshot a plugin
+#: installs FROM is refreshed at the marketplace level. So updating is two commands, and
+#: it is the same shape Claude Code has (`marketplace update` then the plugin) rather than
+#: a quirk worth explaining twice.
+#:
+#: Named, never run, for the reason every host command is: it mutates an install charter
+#: does not own, and `codex` may not be on the reader's PATH at all.
+PLUGIN_UPDATE_CMD = ("codex plugin marketplace upgrade charter && "
+                     "codex plugin add charter@charter")
+
+
 def config_path() -> Path:
     """Codex's config file. There is **no project-level one**: a `.codex/config.toml` or
     `codex.toml` planted in a project directory is ignored, checked by putting a
@@ -134,13 +149,11 @@ class CodexHarness(Harness):
         moves THAT is a fact nobody has pinned against a real Codex.
 
         Every fact in this file was pinned against codex-cli 0.147.0 rather than its
-        documentation. A `codex plugin update` written from memory would be the first line
-        here that is a guess, and unlike the rest it would be executed by whoever read it.
+        documentation, and this one the same way: `codex plugin update` — the command
+        everyone reaches for, including the first draft of this method — is rejected by the
+        binary, and the two-step in :data:`PLUGIN_UPDATE_CMD` is what it actually offers.
         """
-        return ("absent",
-                "charter has not pinned how a Codex plugin updates — its hooks come from "
-                "the charter@charter plugin, so update it the way you installed it; "
-                "`charter harness list` will say when charter knows")
+        return "manual", PLUGIN_UPDATE_CMD
 
     def detect(self) -> bool:
         """Nothing native to detect, and saying so beats guessing.

--- a/charter/harness/codex.py
+++ b/charter/harness/codex.py
@@ -37,15 +37,6 @@ NAME = "codex"
 HOOK_ENTRY_KEYS = ("type", "command")
 HOOK_TYPE = "command"
 
-#: The hooks charter wires, mirroring what the Claude Code plugin's own `hooks.json`
-#: declares. `matcher` is carried only where Codex's contract uses one.
-_WIRING = (
-    ("SessionStart", None, "charter hook sessionstart"),
-    ("UserPromptSubmit", None, "charter hook userpromptsubmit"),
-    ("PreToolUse", "Bash", "charter hook pretooluse"),
-)
-
-
 def config_path() -> Path:
     """Codex's config file. There is **no project-level one**: a `.codex/config.toml` or
     `codex.toml` planted in a project directory is ignored, checked by putting a
@@ -133,6 +124,23 @@ class CodexHarness(Harness):
                 "the terminal-pane key. Hooks are unaffected — their payload carries "
                 "`session_id` directly."),
     )
+
+    def upgrade(self, root: Path) -> tuple[str, str]:
+        """Codex's own config block never needs moving; its PLUGIN does.
+
+        `_block()` writes only `shell_environment_policy` — a constant naming the harness,
+        with no version in it — so an upgraded CLI is served by the same block. The hooks
+        come from the charter plugin, installed by `codex plugin`, and the command that
+        moves THAT is a fact nobody has pinned against a real Codex.
+
+        Every fact in this file was pinned against codex-cli 0.147.0 rather than its
+        documentation. A `codex plugin update` written from memory would be the first line
+        here that is a guess, and unlike the rest it would be executed by whoever read it.
+        """
+        return ("absent",
+                "charter has not pinned how a Codex plugin updates — its hooks come from "
+                "the charter@charter plugin, so update it the way you installed it; "
+                "`charter harness list` will say when charter knows")
 
     def detect(self) -> bool:
         """Nothing native to detect, and saying so beats guessing.

--- a/charter/harness/opencode.py
+++ b/charter/harness/opencode.py
@@ -344,6 +344,26 @@ class OpenCodeHarness(Harness):
         """
         return False
 
+    def upgrade(self, root: Path) -> tuple[str, str]:
+        """The one harness charter can move itself — via the writer that already exists.
+
+        `refresh_shim` is `wire`'s writer, and it already encodes the only judgement that
+        matters: the stamp says whether the file is charter's to rewrite. Answering this
+        with a second writer would be two code paths for one question, which is the shape
+        this whole member was added to remove.
+
+        ``not-ours`` becomes ``manual`` rather than ``absent``: charter knows exactly how
+        this moves, it is declining to overwrite an operator's edit (additive-only).
+        """
+        g = global_dir()
+        got = refresh_shim(g)
+        if got == "current":
+            return "current", __version__
+        if got in ("refreshed", "created"):
+            return "moved", f"opencode {SHIM_PATH} → {__version__}"
+        return "manual", (f"{g / SHIM_PATH} carries no charter stamp, so charter will not "
+                          f"overwrite it — move it aside and run `charter reinit`")
+
     def wire(self, root: Path) -> list[tuple[str, str]]:
         """Install once, where opencode reads for every project.
 

--- a/charter/news.py
+++ b/charter/news.py
@@ -84,6 +84,17 @@ def _dir() -> Path | None:
     return None
 
 
+def checkout_dir() -> Path | None:
+    """The repo's own ``docs/news``, or ``None`` when this is not a checkout.
+
+    Deliberately not :func:`_dir`. Reading prefers the packaged copy; *writing* has only
+    one legitimate target, because ``charter/_news`` is force-included from ``docs/news``
+    on every build. A stamp applied to the packaged copy is discarded by the next wheel —
+    silently, and after the release engineer was told it worked.
+    """
+    return _CHECKOUT if _CHECKOUT.is_dir() and _is_checkout(_CHECKOUT) else None
+
+
 def _read(p: Path) -> Entry | None:
     try:
         meta, body = persona.parse(p.read_text())
@@ -219,3 +230,116 @@ def probe(entry: Entry) -> tuple[str, str]:
 def pending() -> list[Entry]:
     """Every entry, any version, whose probe says this plane has not adopted it."""
     return [e for e in released() if probe(e)[0] == PENDING]
+
+
+# --------------------------------------------------------------------------- #
+# stamping — the bump PR's one mechanical step                                #
+# --------------------------------------------------------------------------- #
+def _is_version(v: str) -> bool:
+    """Is *v* a version number, rather than the tag that carries it?
+
+    ``v0.45.0`` is the tag; ``0.45.0`` is what frontmatter holds. Stamping the tag name
+    would produce an entry whose ``version:`` can never equal ``__version__``, so both
+    release catches pass and `charter news` still shows the user nothing — the exact
+    class of silent wrongness staging exists to remove. Refused rather than tidied up,
+    because guessing which of the two the caller meant is how the guess gets shipped.
+    """
+    parts = v.strip().split(".")
+    if len(parts) < 2:
+        return False
+    # A loop, not `all(...)`: this module's own `all()` shadows the builtin.
+    for part in parts:
+        if not part.isdigit():
+            return False
+    return True
+
+
+def unstamped() -> list[Path]:
+    """Entry files in the repo still waiting for a version."""
+    d = checkout_dir()
+    return sorted(d.glob(f"{UNRELEASED}-*.md")) if d else []
+
+
+def stamped(version: str) -> list[Path]:
+    """Entry files in the repo naming *version*.
+
+    The read-back for :func:`stamp`, and it reads the directory that was *written*:
+    :func:`all` prefers the packaged copy, so on a tree that has been built in place it
+    would answer the same question from a different, staler file.
+    """
+    d = checkout_dir()
+    return sorted(d.glob(f"{version}-*.md")) if d else []
+
+
+def _restamp(text: str, version: str) -> str | None:
+    """*text* with its frontmatter ``version:`` rewritten, byte-for-byte otherwise.
+    ``None`` when there is no frontmatter version line to rewrite.
+
+    Not `persona.parse` followed by re-serialisation: that parser is lossy by design — it
+    flattens frontmatter into a dict and strips the body — so a round trip would rewrite
+    the author's file, reordering keys and dropping whatever a flat parser does not keep.
+    A rename must not become an edit.
+    """
+    if not text.startswith("---"):
+        return None
+    lines = text.splitlines(keepends=True)
+    out, found = list(lines), False
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            break
+        key, sep, _ = lines[i].partition(":")
+        if sep and key.strip() == "version":
+            out[i] = f"version: {version}\n"
+            found = True
+    else:
+        return None                      # unterminated frontmatter: not an entry
+    return "".join(out) if found else None
+
+
+def stamp(version: str) -> tuple[list[tuple[Path, Path]], list[str]]:
+    """Move every staged entry onto *version*: rename the file, rewrite the field.
+
+    Returns ``(renamed, blocked)``. ``renamed`` is ``(from, to)`` pairs; ``blocked`` is
+    reasons, each already a sentence a release engineer can act on.
+
+    **All or nothing.** A partially stamped release is the one outcome worse than a
+    failed stamp: the guard asks only whether *some* entry names the version, so a run
+    that stamped two of three entries publishes with the third missing from both the
+    release body and `charter news`, and nothing anywhere reports it. A blocked run
+    leaves every entry staged, which fails loudly at the next catch.
+    """
+    if not _is_version(version):
+        return [], [f"{version!r} is not a version — pass the number alone, as in 0.45.0, "
+                    f"not the tag name"]
+    d = checkout_dir()
+    if d is None:
+        return [], ["news entries are stamped in the repo, and this is not a charter "
+                    "checkout — run it from a clone (`python3 -m charter news stamp …`)"]
+
+    plan: list[tuple[Path, Path, str]] = []
+    blocked: list[str] = []
+    for src in unstamped():
+        slug = src.stem.split("-", 1)[1]
+        dst = d / f"{version}-{slug}.md"
+        if dst.exists():
+            blocked.append(f"{src.name} → {dst.name}: that name is already taken, and "
+                           f"charter will not overwrite an entry that already shipped")
+            continue
+        text = _restamp(src.read_text(), version)
+        if text is None:
+            blocked.append(f"{src.name}: no `version:` line in its frontmatter to stamp")
+            continue
+        plan.append((src, dst, text))
+    if blocked:
+        return [], blocked
+
+    renamed: list[tuple[Path, Path]] = []
+    for src, dst, text in plan:
+        # Write the new file BEFORE dropping the old one. The reverse order can leave a
+        # file renamed but not rewritten — a filename saying 0.45.0 over frontmatter
+        # still saying `unreleased`, which is invisible to every view. A leftover staged
+        # copy, the failure mode of this order, blocks the next stamp and says so.
+        dst.write_text(text)
+        src.unlink()
+        renamed.append((src, dst))
+    return renamed, []

--- a/charter/news.py
+++ b/charter/news.py
@@ -1,0 +1,221 @@
+"""What a version brought, and whether THIS plane has taken it up.
+
+A *news entry* is a shipped, per-item note that a version introduced something, carrying
+an optional probe for whether this plane has adopted it. Not a changelog: an entry exists
+to be **acted on**, and one with nothing to adopt is one line.
+
+Three properties are load-bearing.
+
+**It ships in the wheel.** Entries travel with the code that implements them, resolved the
+way :mod:`charter.docsrc` resolves documentation — packaged copy first, the repo's
+``docs/news/`` as the checkout fallback. A control plane has no reason to vendor a copy and
+every reason not to: a copy drifts from the binary, invisibly and in both directions.
+
+**A probe is checked, never assumed.** ``check:`` answers "does this plane already have
+it?" with an exit code. A probe that *cannot run* is :data:`UNKNOWN` — not "adopted" and
+not "pending". Reporting it as pending invents work; reporting it as adopted hides the
+entry forever. This is `doctor`'s ``_NOT_CHECKED_HINT`` in another costume: the absence of
+information is not evidence of health (ADR 0013).
+
+**Actions are charter subcommands, dispatched in-process.** No shell is ever involved and
+no argv is ever handed to one, so an entry cannot become an arbitrary-command primitive.
+`docsrc._TOPIC` keeps the same restraint for `docs show` — "must not be a file-read
+primitive wearing a documentation command" — and the stakes are higher here, because this
+one runs rather than prints. Being in-process is also what makes a dozen probes cheap
+enough for `doctor` to run on demand.
+"""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from typing import NamedTuple
+
+from . import persona, update
+
+#: The version a staged entry carries until a release stamps it. A feature PR cannot know
+#: which version will ship it — the next release may be a patch, or the PR may sit through
+#: three of them — so it does not guess. `charter news stamp <version>` renames the file
+#: and rewrites this field. Until then the entry is invisible to every user-facing view:
+#: an entry naming a version that was never true is the one failure staging exists to
+#: prevent.
+UNRELEASED = "unreleased"
+
+ADOPTED, PENDING, UNKNOWN, INFORMATIONAL = "adopted", "pending", "unknown", "informational"
+
+#: Anything a shell would treat as syntax. Present only as a belt to the braces: nothing
+#: here is ever passed to a shell, so this rejects an entry whose AUTHOR believed it might
+#: be — which is a broken entry either way, and better reported than silently truncated.
+_SHELLISH = set(";|&<>$`()\\\n\"'")
+
+_PACKAGED = Path(__file__).resolve().parent / "_news"
+_CHECKOUT = Path(__file__).resolve().parents[1] / "docs" / "news"
+
+
+class Entry(NamedTuple):
+    version: str
+    slug: str
+    headline: str
+    check: str
+    adopt: str
+    body: str
+    path: Path
+
+
+def _is_checkout(d: Path) -> bool:
+    """True when *d* is the repo's own ``docs/news``, not a directory that merely sits
+    where one would.
+
+    Installed, ``_CHECKOUT`` resolves to ``<site-packages>/docs/news`` — a path belonging
+    to nobody, which another distribution can create by shipping a stray top-level
+    directory. `docsrc` carries this same guard for the same reason.
+    """
+    return (d.parents[1] / "pyproject.toml").is_file()
+
+
+def _dir() -> Path | None:
+    """Where entries live, packaged first. A developer with both is running one specific
+    tree, and the packaged copy is the one that travelled with the code being executed."""
+    if _PACKAGED.is_dir():
+        return _PACKAGED
+    if _CHECKOUT.is_dir() and _is_checkout(_CHECKOUT):
+        return _CHECKOUT
+    return None
+
+
+def _read(p: Path) -> Entry | None:
+    try:
+        meta, body = persona.parse(p.read_text())
+    except (OSError, UnicodeDecodeError):
+        return None
+    version = (meta.get("version") or "").strip()
+    if not version:
+        return None
+    # The slug is the filename's, the version is the frontmatter's. Two sources for one
+    # fact would drift the moment `news stamp` renamed a file and missed the field.
+    slug = p.stem.split("-", 1)[1] if "-" in p.stem else p.stem
+    return Entry(version=version, slug=slug,
+                 headline=(meta.get("headline") or "").strip(),
+                 check=(meta.get("check") or "").strip(),
+                 adopt=(meta.get("adopt") or "").strip(),
+                 body=body, path=p)
+
+
+def all() -> list[Entry]:
+    """Every entry that parses, oldest version first; staged entries last."""
+    d = _dir()
+    if d is None:
+        return []
+    found = [e for e in (_read(p) for p in sorted(d.glob("*.md"))) if e is not None]
+    return sorted(found, key=lambda e: (e.version == UNRELEASED, update._parse(e.version)))
+
+
+def released() -> list[Entry]:
+    return [e for e in all() if e.version != UNRELEASED]
+
+
+def between(lo: str, hi: str) -> list[Entry]:
+    """Entries newer than *lo*, up to and including *hi*.
+
+    Exclusive at the bottom because *lo* is where you already were: you have seen it.
+    """
+    try:
+        low, high = update._parse(lo), update._parse(hi)
+    except Exception:
+        return []
+    return [e for e in released() if low < update._parse(e.version) <= high]
+
+
+def for_version(version: str) -> list[Entry]:
+    return [e for e in all() if e.version == version]
+
+
+def render_body(version: str) -> str:
+    """One version's entries as the body of a GitHub Release.
+
+    The shipped entry is the single source for both the offline suggestion and the public
+    notes, so the two cannot drift: one is printed from the other.
+    """
+    parts = []
+    for e in for_version(version):
+        parts.append(f"### {e.headline}\n\n{e.body}".rstrip())
+    return "\n\n".join(parts)
+
+
+def _tokens(argv: str) -> list[str] | None:
+    """*argv* as a charter subcommand's tokens, or ``None`` if it is not one.
+
+    Two refusals, both structural rather than advisory: anything a shell would read as
+    syntax, and any first token that is not a registered subcommand. `charter` is implied
+    and must not be written, so an entry cannot reach a different binary.
+    """
+    if not argv or set(argv) & _SHELLISH:
+        return None
+    tokens = argv.split()
+    if not tokens:
+        return None
+    from . import cli
+
+    if tokens[0] not in cli._subcommand_names(cli.build_parser()):
+        return None
+    return tokens
+
+
+def resolves(parser, argv: str) -> bool:
+    """Does ``charter <argv>`` PARSE? Never runs it.
+
+    Used by the suite over every shipped entry, so a flag removed by some future PR fails
+    that PR's tests rather than degrading a probe to permanent `unknown` in the field.
+    """
+    tokens = _tokens(argv)
+    if tokens is None:
+        return False
+    try:
+        with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            parser.parse_args(tokens)
+    except SystemExit:
+        return False
+    except Exception:
+        return False
+    return True
+
+
+def _dispatch(argv: str) -> int | None:
+    """Run ``charter <argv>`` in this process. Exit code, or ``None`` if it could not run.
+
+    ``None`` is the whole reason this returns an Optional rather than an int: a probe that
+    did not run must not be reported as an answer.
+    """
+    tokens = _tokens(argv)
+    if tokens is None:
+        return None
+    from . import cli
+
+    try:
+        with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            args = cli.build_parser().parse_args(tokens)
+            func = getattr(args, "func", None)
+            if func is None:
+                return None
+            return int(func(args) or 0)
+    except SystemExit:
+        return None
+    except Exception:
+        return None
+
+
+def probe(entry: Entry) -> tuple[str, str]:
+    """Has this plane adopted *entry*? ``(status, why)``."""
+    if not entry.check:
+        return INFORMATIONAL, ""
+    code = _dispatch(entry.check)
+    if code is None:
+        return UNKNOWN, (f"`charter {entry.check}` did not run here, so this entry is "
+                         f"unchecked — neither adopted nor pending")
+    return (ADOPTED if code == 0 else PENDING), ""
+
+
+def pending() -> list[Entry]:
+    """Every entry, any version, whose probe says this plane has not adopted it."""
+    return [e for e in released() if probe(e)[0] == PENDING]

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -34,14 +34,18 @@ row — an unverified integration and a complete one must not read the same.
 **What differs is not what charter enforces — it is what each harness lets charter
 offer**, and `charter doctor` prints the gap rather than leaving you to find it:
 
-| | how it is installed | what it cannot carry | what to do about it |
-| --- | --- | --- | --- |
-| Claude Code | the plugin (`claude plugin install charter@charter`) | — | — |
-| opencode | `charter init` — one plugin under opencode's config dir, read by every project | no status bar; no per-turn prompt hook | `charter statusline --watch`; mid-session notes ride tool output already |
-| Codex | the same plugin (`codex plugin`), plus `charter harness install codex` to name the harness | no status bar; no command-pattern permissions | `charter statusline --watch`; `guard ask` rules stay in charter's own hook |
+| | how it is installed | how it updates | what it cannot carry | what to do about it |
+| --- | --- | --- | --- | --- |
+| Claude Code | the plugin (`claude plugin install charter@charter`) | `claude plugin update charter@charter` | — | — |
+| opencode | `charter init` — one plugin under opencode's config dir, read by every project | charter moves it — its own file, stamped | no status bar; no per-turn prompt hook | `charter statusline --watch`; mid-session notes ride tool output already |
+| Codex | the same plugin (`codex plugin`), plus `charter harness install codex` to name the harness | `codex plugin marketplace upgrade charter && codex plugin add charter@charter` | no status bar; no command-pattern permissions | `charter statusline --watch`; `guard ask` rules stay in charter's own hook |
+
+You never have to remember that third column — `charter update` asks the harness you are in
+and names its command (or, for opencode, just moves it). It is written down because a
+column charter fills in from one place is a column that cannot quietly go stale in three.
 
 One artifact per harness, installed once — nothing is written into the repos you work in.
-`charter doctor` and `charter harness list` print that fourth column against whichever
+`charter doctor` and `charter harness list` print that last column against whichever
 harness you are in, each ceiling carrying its own answer. Where it is empty it stays empty:
 charter cannot conjure opencode a per-turn prompt hook, and a workaround that does not
 exist costs more to chase than an honest gap.

--- a/docs/news/0.44.0-delegate-when.md
+++ b/docs/news/0.44.0-delegate-when.md
@@ -1,0 +1,23 @@
+---
+version: 0.44.0
+headline: A persona says when it should hand work away
+check: persona lint --only delegate-when
+---
+
+Every persona now declares `delegate-when:` — the one sentence that becomes its sub-agent
+description, so routing to it stops being a guess the host makes from a role title.
+
+Personas written before 0.44.0 have no such line. They still work, and they are still
+dispatchable by name; what they cannot do is advertise themselves, so work that should
+have routed to them quietly goes to a general-purpose agent instead.
+
+Adding one is a judgement, not a substitution — it is the sentence *you* would say when
+handing this persona a task, and nothing can write it for you:
+
+1. `charter persona list` — the roster, with the ones missing a line reported by the probe
+   above.
+2. For each, `charter persona show <name>` and read what it is actually accountable for.
+3. Add `delegate-when: <the work you would hand it>` to its frontmatter — concrete nouns
+   beat adjectives ("cutting a release, version bumps, PyPI publish" reads better to a
+   router than "release-related work").
+4. `charter persona sync-agents` to regenerate the sub-agents from the charters.

--- a/docs/news/0.44.1-persona-stats.md
+++ b/docs/news/0.44.1-persona-stats.md
@@ -1,0 +1,7 @@
+---
+version: 0.44.1
+headline: persona stats no longer claims more than its data supports
+---
+
+Two lines in `charter persona stats` presented inference as measurement. Nothing to adopt
+— the numbers simply stopped overstating what committed memory can actually show.

--- a/docs/news/unreleased-charter-update.md
+++ b/docs/news/unreleased-charter-update.md
@@ -1,0 +1,21 @@
+---
+version: unreleased
+headline: One command updates charter and tells you what the new version brought
+---
+
+`charter update` moves the CLI, asks this harness how its own artifact moves, proves the
+install took, and then reports what the versions you skipped actually brought you.
+
+It stops in exactly one place: when this plane already sits on its pin and something newer
+is published, moving past the pin moves every teammate on their next session, so charter
+proposes `charter update --bump` and waits.
+
+What a version brought now ships with the code that implements it, so it works offline and
+carries an optional probe for whether this plane has taken it up:
+
+```bash
+charter news --pending      # every entry, any version, you have not adopted here
+```
+
+`charter version sync` is unchanged and still the right tool for conforming to the lock
+without a network read.

--- a/docs/news/unreleased-harness-upgrade.md
+++ b/docs/news/unreleased-harness-upgrade.md
@@ -1,0 +1,15 @@
+---
+version: unreleased
+headline: Each harness is told how to update itself, not how Claude Code updates
+---
+
+`charter version sync` and `charter doctor` printed `claude plugin update charter@charter`
+to everybody — including opencode and Codex sessions, and any bare terminal, where that
+command has nothing to do with your install.
+
+Both now ask the harness you are actually in. opencode's plugin is charter's own file, so
+charter moves it; Claude Code's and Codex's belong to their hosts, so charter names the
+command and leaves it to you. Codex's is two steps, because `codex plugin update` does not
+exist — the snapshot a plugin installs from is refreshed at the marketplace level.
+
+Nothing to adopt: the advice you get is simply the advice for the harness you are running.

--- a/docs/superpowers/plans/2026-08-19-charter-update.md
+++ b/docs/superpowers/plans/2026-08-19-charter-update.md
@@ -1,0 +1,105 @@
+# `charter update` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** One command that moves charter to a newer version on any harness, then tells you what that version brings and offers to adopt it.
+
+**Architecture:** The CLI decides and acts; the skill only converses. `Harness.upgrade()` makes "how does this harness's artifact move?" one question with one answer. News entries ship inside the wheel as flat-frontmatter markdown carrying an optional in-process probe, so "have you adopted this?" is checked rather than assumed.
+
+**Tech Stack:** Python 3.11+, stdlib only (charter has zero dependencies). `unittest` (`python -m unittest discover -s tests`). hatchling force-include for packaging.
+
+**Spec:** `docs/superpowers/specs/2026-08-19-charter-update-skill-design.md`
+
+## Global Constraints
+
+- **Zero dependencies.** No YAML, no requests. Frontmatter parses via `charter.persona.parse`; version comparison via `charter.update._parse`.
+- **ONE source of truth.** If two code paths answer the same question they call the same function. `upgrade()` reuses `opencode.refresh_shim`; news ordering reuses `update._parse`; entry resolution mirrors `docsrc`.
+- **Additive-only.** Never delete or rename a user's file. Name the blocker and do everything unblocked.
+- **Fail toward no change.** An unrecognised value falls back to the behaviour that alters nothing.
+- **A check that could not run is `unknown`, never `ok` and never `pending`** (ADR 0013, `doctor._NOT_CHECKED_HINT`).
+- **Comments record the WHY** — usually the reason a previous, more obvious approach failed.
+- **Probes and adopts are charter subcommands only**, dispatched in-process. No shell, ever.
+- Tests live in `tests/test_*.py`, use `unittest`, and isolate via `tests/_isolation.py`.
+
+---
+
+### Task 1: `Harness.upgrade()` and one answer for "how does this harness move?"
+
+**Files:**
+- Modify: `charter/harness/base.py` (add `upgrade`)
+- Modify: `charter/harness/claude_code.py`, `charter/harness/opencode.py`, `charter/harness/codex.py`
+- Modify: `charter/commands.py:1856-1906` (`cmd_version_sync` routes through it)
+- Test: `tests/test_harness_upgrade.py`
+
+**Interfaces:**
+- Produces: `Harness.upgrade(self, root: Path) -> tuple[str, str]` with status in
+  `{"moved", "current", "manual", "absent"}`. `"manual"`'s detail is the command to run.
+
+- [ ] **Step 1: Write the failing test** — every registered harness answers; Claude Code names the plugin command; opencode moves its shim; Codex admits it does not know.
+- [ ] **Step 2: Run it, expect AttributeError**
+- [ ] **Step 3: Add `upgrade()` to `base.Harness`** returning `("absent", …)` by default, with the docstring explaining that inventing a command is a claim.
+- [ ] **Step 4: Implement per harness.** Claude Code → `("manual", update.PLUGIN_SYNC_CMD)`. opencode → map `refresh_shim(global_dir())`: `refreshed`/`created` → `moved`, `current` → `current`, `not-ours` → `manual`. Codex → `("absent", …)`.
+- [ ] **Step 5: Delete dead `_WIRING`** (`codex.py:44`) — defined, referenced nowhere.
+- [ ] **Step 6: Route `cmd_version_sync` through `upgrade()`** so opencode stops being told to run a Claude Code command.
+- [ ] **Step 7: Run full suite, commit.**
+
+---
+
+### Task 2: `charter/news.py` + `charter news`
+
+**Files:**
+- Create: `charter/news.py`, `docs/news/` (+ backfilled entries), `tests/test_news.py`
+- Modify: `charter/cli.py` (subcommand), `charter/commands.py` (`cmd_news`), `pyproject.toml` (force-include), `CONTEXT.md` (glossary)
+
+**Interfaces:**
+- Produces: `news.Entry` (`version`, `slug`, `headline`, `check`, `adopt`, `body`),
+  `news.all() -> list[Entry]`, `news.between(lo, hi)`, `news.probe(entry) -> str` in
+  `{"adopted", "pending", "unknown"}`, `news.render_body(version) -> str`.
+
+- [ ] **Step 1: Write failing tests** — parse; `unreleased` never surfaces; ordering via `update._parse`; probe returns `unknown` for an unresolvable subcommand; every shipped entry's `check:`/`adopt:` parses against the live argparse parser.
+- [ ] **Step 2: Run, expect ImportError**
+- [ ] **Step 3: Implement `news.py`** — `_PACKAGED`/`_CHECKOUT` resolution mirroring `docsrc`; `persona.parse` for frontmatter; in-process dispatch for probes with stdout/stderr captured.
+- [ ] **Step 4: Wire `charter news [--pending] [--since] [--for]`**
+- [ ] **Step 5: Force-include `docs/news` → `charter/_news`; add the backfill entries; add the CONTEXT.md glossary entry.**
+- [ ] **Step 6: Run suite, commit.**
+
+---
+
+### Task 3: `charter update`
+
+**Files:**
+- Create: `charter/commands_update.py`, `tests/test_update_command.py`
+- Modify: `charter/cli.py`, `charter/doctor.py` (pending-adoptions row)
+
+**Interfaces:**
+- Consumes: `Harness.upgrade` (Task 1), `news.between`/`news.probe` (Task 2)
+- Produces: `cmd_update(args) -> int`; `installer.detect() -> tuple[str, list[str]]`
+
+- [ ] **Step 1: Write failing tests** — the three pin cases; refuses in a charter checkout; baseline stamped before any move; handoff failure names the command; outside a harness reports *not checked*.
+- [ ] **Step 2: Run, expect ImportError**
+- [ ] **Step 3: Implement installer detection** (uv / pipx / pip / ambiguous→name-it).
+- [ ] **Step 4: Implement the 7-step sequence** with the handoff doubling as verification.
+- [ ] **Step 5: Add the `doctor` row.**
+- [ ] **Step 6: Run suite, commit.**
+
+---
+
+### Task 4: Release gate *(release persona)*
+
+**Files:** `.github/workflows/release.yml`, `charter/commands.py` (`news stamp`), `personas/release/persona.md`, `CONTRIBUTING.md`, `.github/pull_request_template.md`, `tests/test_news_gate.py`
+
+- [ ] **Step 1:** Failing test — an entry exists whose `version:` equals `__version__`.
+- [ ] **Step 2:** `charter news stamp <version>` renames `unreleased-*` and stamps frontmatter.
+- [ ] **Step 3:** `guard` job asserts an entry for the tag; new post-publish job creates the GitHub Release from `charter news --for`.
+- [ ] **Step 4:** Release charter gains the stamp step; CONTRIBUTING + PR template gain the prompt.
+- [ ] **Step 5:** Run suite, commit.
+
+---
+
+### Task 5: The skill
+
+**Files:** `skills/update/SKILL.md`
+
+- [ ] **Step 1:** Write it with `mattpocock-skills:writing-for-agents`.
+- [ ] **Step 2:** Verify no persona declares it in `skills:`.
+- [ ] **Step 3:** Commit.

--- a/docs/superpowers/specs/2026-08-19-charter-update-skill-design.md
+++ b/docs/superpowers/specs/2026-08-19-charter-update-skill-design.md
@@ -1,0 +1,402 @@
+# `charter update` — one command that moves charter, then tells you what moved
+
+_2026-08-19 · steward · workspace `charter-update-skill`_
+
+## The ask
+
+A user says "update charter to the latest version" and the harness does it: upgrade what
+can be upgraded, then say what the new version brings, offer to adopt it where adoption is
+mechanical, and write a guide where it is not.
+
+## What already exists
+
+charter is not starting from nothing here, and the design is mostly about not duplicating
+what is already right:
+
+- `charter version` — installed / locked / latest, and drift as a non-zero exit.
+- `charter version sync [--cli]` — conform this plane (plugin) or this machine (binary).
+- `charter version bump [--to] [--push]` — install → verify → write the pin → commit.
+- `charter/update.py` — the cached, non-blocking PyPI check the status line rides on,
+  plus `plugin_version_here()` and `SHARED_INSTALL_NOTE`.
+
+What does **not** exist: anything that tells a harness to use them, and any notion of
+"here is what this version brings *you*".
+
+## Decisions
+
+### 1. The CLI decides and acts; the skill converses
+
+Deterministic behaviour lands in the CLI, where it is tested and where every harness
+reaches it. The skill carries only dialogue: which question to ask, in what order, and what
+never to do without a yes.
+
+This is not a style preference. `skills/` ships in the Claude Code plugin; `charter/`
+ships on PyPI to every harness. Behaviour placed in the skill is behaviour opencode does
+not get. Therefore **`charter update`'s output must be self-sufficient** — an agent with no
+skill at all, reading only the command's output, must be able to finish the job. The skill
+is an accelerator, never the carrier.
+
+### 1b. The upgrade path is the installer that owns the install
+
+`sync_to()` shells out to `uv tool install` and errors when uv is absent — but
+`docs/install.md:15` documents pipx and pip as supported fallbacks, so "maximum automatic"
+would die at the first move for anyone who took a documented path.
+
+`charter update` detects which tool owns the running install (`sys.prefix` /
+`sys.executable` — a `uv/tools/` path, a `pipx/venvs/` path, or neither) and uses the
+matching command. **Where detection is ambiguous, it names the command instead of guessing**
+— the same restraint it keeps for the plugin.
+
+Two places it refuses or degrades rather than proceeding:
+
+- **Inside a charter checkout** (`doctor._is_charter_checkout`) it refuses. `CONTRIBUTING.md`
+  tells contributors to run `python3 -m charter …` from the clone; installing over that is
+  never what "test the update command" meant, and the recovery is annoying. It names
+  `charter version` as the read-only thing they probably wanted.
+- **Outside a control plane** it runs degraded: the CLI moves, the pin is skipped (there is
+  nothing to conform to), and the news *range* prints without probes — "no control plane
+  here, so charter cannot tell which of these you have adopted", pointing at
+  `charter news --pending` from inside one.
+
+### 2. There is no single "the plugin" — ask the harness
+
+Each harness relates differently to the artifact that serves it:
+
+| harness | artifact | how it moves |
+| --- | --- | --- |
+| Claude Code | the plugin, host-installed into a versioned cache | `claude plugin update charter@charter` — charter *names* it, will not run it |
+| Codex | the same plugin artifact, via `codex plugin` | **not pinned** — see below |
+| opencode | a shim charter writes itself, version-stamped | charter rewrites it — it is charter's own file |
+
+So the `Harness` contract gains one member:
+
+```python
+def upgrade(self, root: Path) -> tuple[str, str]:
+    """Move THIS harness's installed charter artifact to the running CLI's version.
+    ("moved", detail) | ("current", version) | ("manual", command) | ("absent", why)
+    """
+```
+
+Registering a harness then covers `update` the day it is registered — the stated reason
+`registry.KINDS` exists.
+
+**Codex's own config block never needs moving.** `_block()` (`codex.py:62`) writes only
+`shell_environment_policy` to name the harness; the hooks come from the plugin. So Codex's
+artifact is the plugin, and the command that moves it is a fact charter has not pinned.
+`upgrade()` therefore returns `("absent", "charter has not pinned how a Codex plugin
+updates")` rather than a plausible-looking `codex plugin update`. `base.py` is explicit that
+"an empty remedy is a claim too — inventing one sends somebody off to configure something
+that does not exist", and `codex.py`'s entire discipline is facts pinned against the binary
+rather than its documentation. Pinning it is a follow-up errand, not a blocker: Codex users
+are no worse off than today, where nothing tells them anything.
+
+While in that file: `_WIRING` (`codex.py:44`) is dead — defined, referenced nowhere, left
+from when charter wrote Codex's hooks itself. It goes with this change.
+
+**opencode's `upgrade()` calls the existing writer.** `refresh_shim()` (`opencode.py:227`)
+already re-stamps the shim and `wire()` already calls it; `upgrade()` reports what it
+returns and learns nothing about the file's shape. Two code paths answering one question
+must call one function.
+
+**Charter moves what it authored, and names what it does not.** opencode's shim is
+charter's own file, stamped by charter, already rewritten by `init`/`reinit`; moving it is
+not a new liberty. The plugin belongs to the host, and the existing restraint stays exactly
+where its comment says it was earned.
+
+### 3. This fixes a defect rather than building beside it
+
+`cmd_version_sync` prints `PLUGIN_SYNC_CMD` — the literal `claude plugin update
+charter@charter` — unconditionally (`commands.py:1886`). Under opencode,
+`plugin_version_here()` reads `$CLAUDE_PLUGIN_ROOT`, gets `None`, and the user is told to
+run a Claude Code command that has nothing to do with their install.
+
+Two harness-blind code paths already answer "is the artifact current?" without knowing
+about each other: `update.plugin_version_here()` (Claude Code) and `Harness.stale_wiring()`
+(opencode). `Harness.upgrade()` makes it one question with one answer, and the defect
+disappears as a consequence rather than as a patch. `version sync` and `charter update`
+both route through it. The issue is filed for the record; the fix lands here, first.
+
+### 4. "What's new" ships inside the wheel
+
+A per-item entry file, force-included the way `docs/*.md` already is. It works offline, on
+any plane, with no forge auth — and it is the same text CI publishes as the GitHub Release
+body, so the two cannot drift.
+
+**Entries are written by the feature's own PR, not reconstructed at release time.** The
+person who built the thing is the only one who knows why it matters and what probe proves
+adoption; rebuilding that from commit titles at bump time is how release notes become a
+changelog nobody reads.
+
+That means a PR must name a version that does not exist yet — so it does not. Entries are
+staged as `docs/news/unreleased-<slug>.md` with `version: unreleased`, and the bump PR runs
+**`charter news stamp <version>`**, which renames each and stamps its frontmatter. This
+removes the only way an entry can be *silently wrong*: a real version number that was never
+true. `charter news` treats `unreleased` as not shipped, so a staged entry never surfaces to
+a user.
+
+No CI check blocks a feature PR that ships no entry — most PRs are refactors, and a required
+entry per PR manufactures filler, which is the failure this design exists to avoid. The PR
+template prompts; the bump PR's checklist is "read the merged PRs since the last tag, every
+user-visible one has an entry"; the gate bites where being wrong is most expensive.
+
+`docs/news/<version>-<slug>.md`, one file per item:
+
+```markdown
+---
+version: 0.44.0
+headline: A persona says when it should hand work away
+check: persona lint --only delegate-when
+adopt: persona sync-agents
+---
+
+Every persona now declares `delegate-when:` — the sentence that becomes its sub-agent
+description, so routing stops being a guess. Personas written before 0.44 have no such
+line and are invisible to the router until they get one.
+```
+
+- **Flat frontmatter, parsed by `persona.parse`.** charter has no dependencies, so there is
+  no YAML to nest with, and the repo teaches one frontmatter idiom. One file per *item*
+  rather than per version follows from that: a flat parser cannot express several adopt
+  blocks in one file.
+- **Force-included as a directory** — `"docs/news" = "charter/_news"`. `docs/*.md` is listed
+  page by page to keep `adr/`, `audits/` and `superpowers/` out of site-packages; news has
+  no such exclusion, so a directory mapping removes a per-release `pyproject.toml` edit.
+- **`check:` and `adopt:` are charter subcommands only** — parsed as argv, **dispatched
+  in-process** through the CLI parser with output captured, never spawned through a shell.
+  In-process is both faster (`doctor` may run a dozen) and makes "charter subcommands only" a
+  *structural* guarantee rather than a rule a validator enforces: there is no shell and no
+  argv to escape into. The exit code is the entire contract; stdout/stderr are shown only
+  when a probe reports `unknown`. Same restraint `docsrc._TOPIC` keeps for `docs show`.
+- **`check:` exit 0 means adopted here**, non-zero means pending. Omitting it makes the
+  entry informational. An entry with no *narrow* probe available ships without one rather
+  than with a sloppy one — `charter persona lint` reports many findings under one exit code,
+  so probes will need narrow flags (`persona lint --only <key>` is the likely first). That
+  is work to do, not an assumption to make.
+- **A probe that cannot run is `unknown`, never `pending`.** A `check:` naming a
+  subcommand this CLI does not have (an entry read by an older binary, a flag not yet
+  added) exits non-zero for a reason that has nothing to do with adoption. Charter reports
+  it as unchecked and says why, the way `doctor` refuses to paint a green glyph over a
+  check that did not run (`_NOT_CHECKED_HINT`). Silence is not evidence of health.
+- **`adopt:` present means automatable.** Absent means the body *is* the guide, and the
+  skill turns that prose into steps.
+
+Three views:
+
+| command | answers |
+| --- | --- |
+| `charter news` | what changed between your baseline and now — the post-upgrade report |
+| `charter news --pending` | every entry, any version, whose probe says you have not adopted it |
+| `charter news --for <v>` | one version's entries — what CI turns into the Release body |
+
+`--pending` is why no dismissal state is needed: the range view moves past a declined
+suggestion on the next update, and `--pending` exists for when you want to be asked again.
+
+**The baseline** — the version a range is measured from — is written under `STATE_DIR`
+(per-developer, gitignored, beside the update cache it is read with). It is not committed:
+which version *this laptop* last updated from is not a fact about the plane, and ADR 0011
+keeps the record to what git cannot know.
+
+**With no baseline recorded** — first run after adopting this feature — there is no range,
+and charter says so rather than inventing one. It prints the running version's entries and
+points at `--pending` for everything else. It must not silently replay every entry ever
+written as though it were news.
+
+**Where entries are read from** mirrors `docsrc`: the packaged `charter/_news/` wins, the
+repo's `docs/news/` is the checkout fallback. This is what lets CI generate the Release
+body with `python -m charter news --for <v>` from the tree it just tagged.
+
+**Backfill is selective.** Forty-four versions of reconstructed prose is exactly the
+low-value text this design avoids. Entries go back only where there is a *probe worth
+running* — a handful of adoptable items from 0.4x, `delegate-when` and the front door among
+them — so `--pending` earns its keep on day one instead of being empty until the next
+release.
+
+**Where pending adoptions surface.** `charter update` reports them, and `charter doctor`
+gains one row: a count plus "run `charter news --pending`". The session-start hook stays out
+of it — probes are real work, and N of them on every session start is precisely the cost
+`update.py` exists to keep off the status line's clock. The status line keeps its bare
+`↑<version>` (`statusline.py:1546`); the session-start nudge is where the command gets
+named, and that change belongs to the `statusline` persona.
+
+**Output is prose, not JSON.** One stable line per pending item
+(`slug · headline · adopt: <cmd>` or `adopt: manual`). A `--json` mode would immediately
+become the thing the skill parses and the prose the thing nobody checks — and the output has
+to be self-sufficient for an opencode agent with no skill at all (decision 1). One surface,
+kept readable.
+
+**"News" enters charter's vocabulary deliberately.** `CONTEXT.md`'s Language section is a
+glossary with `_Avoid_` lists, and this design adds a noun to it:
+
+> **News**: a shipped, per-item note that a version introduced something, carrying an
+> optional probe for whether this plane has adopted it. Not a changelog — an entry exists to
+> be *acted on*, and one with nothing to adopt is one line.
+> _Avoid_: changelog, release notes, announcement
+
+### 5. The order `charter update` runs in
+
+```
+1. resolve target      live PyPI fetch (an explicit command, not the status line's cached
+                       read); fall back to cache when offline and say it is a fallback
+2. stamp baseline      record the version in use NOW, before anything moves
+3. move the CLI        via the installer that owns this install (uv / pipx / pip),
+                       SHARED_INSTALL_NOTE printed BEFORE the install
+4. move the artifact   harness.upgrade(root)
+5. hand off            re-invoke the newly installed binary for the news phase
+6. news + probes       entries baseline→target; run each check:; print only what is pending
+7. the pin             proposed, never written
+```
+
+**CLI before the artifact.** Plugin-newer-than-CLI is the one direction that breaks — the
+plugin dispatches `charter hook <name>` for handlers an older CLI does not have, and
+`skew_message` is one-directional, so it stays quiet the other way. The release charter
+already says this; `update` obeys the same order for the same reason.
+
+**Step 5 is load-bearing.** The process running steps 1–4 is still the old build —
+`cmd_version_sync` says so already (`commands.py:1904`). The new version's entries and
+probes exist only in the new wheel, so the news phase must run in a fresh process of the
+installed binary. If charter cannot locate or launch it, it names the exact command instead
+of reporting a phase it did not run (ADR 0009, ADR 0013).
+
+**Step 2 before step 3** so an interrupted update still knows where it started.
+
+**The handoff is also the verification.** If the new binary cannot run, or reports a version
+other than the target, `update` says the install did not take and names the manual command
+— rather than printing news and implying success. It costs nothing, because that subprocess
+has to happen anyway, and it closes the window the release charter warns about: an upgrade
+that "succeeds against a cached index and leaves you on the old version reporting success".
+
+**Stale plane wiring is named, never repaired.** A new version may want wiring the old one
+never wrote. `update` finishes by reporting each harness's `stale_wiring()` and pointing at
+`charter reinit`. Running it would make `update` write into the plane as a side effect of a
+version change — a different act from moving a binary, and the kind of quiet scope creep
+that makes a command people run casually stop being trusted.
+
+### 6. The pin decides the target, and only one case needs a human
+
+Moving the machine past a pin manufactures the drift `charter version` reports as an error.
+
+| this plane | target | unattended? |
+| --- | --- | --- |
+| pins nothing | latest | yes — end to end |
+| pins a version you are behind | the pin | yes — conforming to an existing pin affects nobody |
+| pin == installed, latest is newer | latest | no — moving means moving the team; proposes `charter update --bump` |
+
+`charter update` becomes the front door that subsumes `version sync` without replacing it,
+and it is **idempotent**: run it when already current and it goes straight to the news
+phase. That is what makes it safe for the skill to call unconditionally.
+
+Flags: `--to <version>` (explicit target) and `--bump`. There is no separate `--push`:
+`--bump` writes the pin and lands it through `charter save`, which already knows to open a
+pull request on a plane whose repo requires one (#167). Splitting them would recreate the
+trap where the pin is written, nothing is shared, and the plane reports drift against a lock
+only its author can see. No dry-run flag — `charter version` is already the read-only view.
+
+**`charter version sync` survives, undeprecated.** It answers a narrower question — conform
+me to the lock, no PyPI call, no news phase — which is what a CI job or an offline machine
+wants. `update` gets the discoverability; `sync` keeps the precision. Both route through
+`Harness.upgrade()`, which is the point.
+
+**Outside a harness** — a plain terminal, where `harness.current()` is `None` and both
+opencode and Codex `detect()` return `False` by design — `update` moves the CLI and then says
+the harness artifact was **not checked**, pointing at `charter harness list`. Never "nothing
+to do": absence of information is not evidence of health.
+
+### 7. A release without notes does not publish
+
+Two catches, deliberately at different times:
+
+- `tests/test_news.py` asserts an entry exists whose `version:` equals
+  `charter.__version__`. This fails **in the bump PR**, before any tag exists.
+- `release.yml`'s `guard` job re-asserts it against the tag — covering a tag that skipped
+  the PR, and failing **before** the irreversible publish.
+
+**Every published version needs an entry, including patches** — and a patch's entry may be
+one line with no `check:`/`adopt:`. A loose gate is worse than none here: "no entry" and
+"forgot the entry" are indistinguishable from CI, and 0.44.1 shipping silently is what
+trains people to skip it.
+
+The bump PR's sequence gains one mechanical step, `charter news stamp <version>`, beside the
+four version files it already moves. That file's own warning — "never work from a remembered
+count" — is why this is a tested command rather than a fifth thing to remember; CI's guard
+then checks the result rather than the intent.
+
+After `publish` succeeds, a new job runs `gh release create v<X.Y.Z>` with the body from
+`charter news --for <v>`. The shipped entry is the single source for both the offline
+suggestion and the public notes. That job carries `contents: write` on its own; the
+workflow's top-level `permissions: contents: read` stays. It must tolerate the
+`workflow_dispatch` retry path, where the release may already exist.
+
+This is **not** a fifth file for `TestVersionsMoveInLockstep`, which pins four files that
+carry a version *number*. "A release has notes" is a different obligation and gets its own
+test rather than being bolted onto one that means something else.
+
+### 8. The skill
+
+`skills/update/SKILL.md` — triggered by "update charter", "is there a new charter",
+"what's new in charter":
+
+1. Run `charter update`. Read its output; do not re-derive what it reported.
+2. Walk pending adoptions **one at a time**. `adopt:` present → explain, ask, run on a yes.
+   Absent → turn the entry body into a step-by-step guide.
+3. Never move the pin without an explicit yes. Never run a host plugin command charter
+   deliberately declined to run.
+4. The skill driving the upgrade is the **old** version's copy; the new skill text arrives
+   with the plugin, next session.
+
+**No persona declares this skill in `skills:`.** Declaring preloads the full text on every
+dispatch of that persona — `skilluse.py` says it outright: "cheap to write and expensive to
+keep". Updating charter is user-triggered, not something a persona does mid-task, and the
+steward would pay that cost on every dispatch for a skill used a few times a year.
+
+**Named `update`**, invoked as `charter:update`. The collision with this harness's built-in
+`update-config` is cosmetic, and any longer name reads worse beside `persona`, `secrets`,
+`browser` and `working-in-a-clone` — each the plain noun for what it is about. The
+description does the disambiguating.
+
+Skills reach Claude Code, and Codex insofar as it installs the same plugin artifact.
+opencode gets none — and charter's existing four skills are already Claude-Code-only with
+no `Deficit` recording it. Verify what opencode and Codex actually carry, then declare the
+gap where it is real. An unverified integration and a complete one must not read the same.
+
+## Proof
+
+| piece | test |
+| --- | --- |
+| `Harness.upgrade()` | every registered harness answers it; Claude Code → `("manual", PLUGIN_SYNC_CMD)`; opencode → `refresh_shim` moves and re-stamps; Codex → `("absent", …)`, never a guessed command; **`version sync` under opencode no longer prints a Claude Code command** |
+| installer detection | uv / pipx / pip each resolve to the right command; ambiguous resolves to *named, not run* |
+| news parsing | flat frontmatter via `persona.parse`; ordering via `update._parse` (the same comparator, not a second one); `check:`/`adopt:` reject anything that is not charter argv |
+| packaging | `docs/news/` readable from the packaged path — the `test_docs_show.py` pattern |
+| `charter update` | the three pin cases; baseline stamped before anything moves; handoff names the command when it cannot launch the new binary |
+| entry validity | every shipped `check:`/`adopt:` resolves against the **live argparse parser** — not run, just proved to parse, so a removed flag fails the suite of the PR that removed it |
+| release gate | an entry exists for `__version__`; the guard fails a tag with no entry; `news stamp` renames and stamps every staged entry |
+| degraded paths | refuses inside a charter checkout; outside a harness and outside a plane it reports **not checked**, never a clean bill |
+
+## Order of work
+
+Five independently landable changes, each green on its own:
+
+1. `Harness.upgrade()` + route `version sync` through it — fixes the defect, adds no
+   surface. Deletes dead `_WIRING`. **steward**
+2. `charter/news.py` + `charter news` + `CONTEXT.md` glossary + the backfilled entries.
+   **steward** — independent of step 1, so the two can land in parallel.
+3. `charter update` (+ the `doctor` row). Depends on 1 and 2. **steward**
+4. Release gate: `release.yml`, `charter news stamp`, the release charter, `CONTRIBUTING.md`
+   and the PR template. Depends on 2. **release persona** — it changes a workflow that
+   publishes irreversibly, which is precisely what that persona exists to get right.
+5. The skill. Depends on 3. **steward**, written with `mattpocock-skills:writing-for-agents`.
+
+Alongside, not blocking: **forge** files both defects now — `PLUGIN_SYNC_CMD`'s
+harness-blind advice and Codex's unpinned update command — so they are on record whether or
+not this ships. **statusline** takes the session-start nudge as a one-line change once step 3
+lands.
+
+## Out of scope
+
+- Dismissal state for declined suggestions — `--pending` covers the need without a store.
+- A dry-run flag — `charter version` is the read-only view.
+- Downgrades. `--to` accepts any version; nothing special-cases going backwards.
+- Teaching opencode to carry skills. Declare the gap; do not invent a workaround.
+- A `--json` output mode. One surface, kept readable.
+- Blocking feature PRs that ship no entry. The gate is the bump.
+- Full historical backfill. Only entries with a probe worth running.
+- Widening the status line to carry a command. The nudge does that.

--- a/personas/release/persona.md
+++ b/personas/release/persona.md
@@ -24,6 +24,10 @@ A release moves **all four together**, or the drift ships:
    `pretooluse-edit`). Substitute globally, then re-grep for the OLD version across all
    four files — never work from a remembered count.
 
+Not five: `docs/news/` carries a version too, but it is *stamped* rather than edited — see
+the sequence. "A release has notes" is a different obligation from "the four numbers agree",
+and bolting it onto the lockstep test would blur one into the other.
+
 `tests/test_plugin.py::TestVersionsMoveInLockstep` pins all four and names them on failure.
 That test exists because they were **not** in lockstep for twelve releases: the CLI reached
 0.13.1 while both plugin artifacts still said 0.1.0, and a comment above
@@ -43,17 +47,35 @@ secrets. Consequences:
 - Land the version bump through a PR and let CI go green **before** tagging.
 - The tag must match `pyproject.toml` exactly; the `guard` job refuses the publish
   otherwise, which is the last safety net rather than the plan.
+- The same `guard` job refuses a version that ships **no news entry** — it asks
+  `charter news --for <X.Y.Z>`, the same call that renders the Release body, so "the guard
+  passed" and "the notes render" cannot disagree. Every published version needs one,
+  including a patch, whose entry may be a single line with no `check:`/`adopt:`.
 - Tag only from `main`, after the bump is merged.
 
 ## The sequence
 
 ```
-# 1. bump all four files on a branch, PR, green, merge
-# 2. sync main, then:
+# 1. on a branch: bump all four files, then
+charter news stamp <X.Y.Z>        # moves every docs/news/unreleased-*.md onto this
+                                  # version — renames the file AND rewrites `version:`
+# 2. PR, green, merge. Then sync main:
 git tag -a v<X.Y.Z> -m "<X.Y.Z> — <headline>"
 git push origin v<X.Y.Z>          # this is the publish; nothing else triggers it
 gh run watch <id> --exit-status
 ```
+
+**Why a command and not a fifth thing to remember.** A feature PR cannot name the version
+that will ship it — the next release may be a patch, or the PR may sit through three of
+them — so it stages `docs/news/unreleased-<slug>.md` and the bump stamps it. `stamp` is
+all-or-nothing: if one target name is already taken it renames *nothing* and says so,
+because a half-stamped release publishes with an entry silently missing from the notes and
+nothing anywhere reports it. It also reads back afterwards and fails if the version still
+has no entry — the guard would catch that too, but at the tag, which is the expensive end.
+
+Before you bump: read the merged PRs since the last tag, and check every user-visible one
+has an entry. That review is the gate; no CI check blocks a feature PR that ships none,
+because most PRs are refactors and a required entry per PR manufactures filler.
 
 Verify against PyPI's **version endpoint**, not the project endpoint — the latter is
 CDN-cached and lags by minutes, which reads as a failed publish when it is not:
@@ -61,6 +83,14 @@ CDN-cached and lags by minutes, which reads as a failed publish when it is not:
 ```
 https://pypi.org/pypi/charter-cp/<X.Y.Z>/json
 ```
+
+A successful publish is followed by one more job, which creates the **GitHub Release** with
+`gh release create v<X.Y.Z>` and a body generated from `charter news --for <X.Y.Z>`. Do not
+write release notes by hand: the shipped entry is the single source for both the public
+notes and the offline `charter news` suggestion, and hand-editing forks them. To change what
+a Release says, change the entry and the text follows. That job carries `contents: write`
+alone — the workflow's top-level grant stays `contents: read` — and it leaves an existing
+Release untouched, so a `workflow_dispatch` retry after a partial failure is safe to run.
 
 ## Then upgrade this machine — CLI first, pinned
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,10 @@ packages = ["charter"]
 "docs/personas.md" = "charter/_docs/personas.md"
 "docs/secrets.md" = "charter/_docs/secrets.md"
 "docs/workspaces.md" = "charter/_docs/workspaces.md"
+
+# News entries, mapped as a DIRECTORY rather than page by page. The listing above is
+# deliberate — it keeps `adr/`, `audits/` and `superpowers/` out of every user's
+# site-packages — and news has no such exclusion: every entry is meant to ship, and a
+# per-release edit here is one more thing a release can forget. `tests/test_news.py`
+# fails if what ships cannot be read back.
+"docs/news" = "charter/_news"

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: update
+description: Update charter to a newer version and adopt what it brings — moves the CLI, this harness's artifact and the pin, then walks what this plane has not taken up. Use when asked to update or upgrade charter, whether a newer charter is published, what a version added, or how to adopt a new charter feature.
+---
+
+# Updating charter
+
+One command converges the upgrade. Your job is the conversation around it.
+
+```bash
+charter update
+```
+
+It moves the CLI, asks this harness how its own artifact moves, proves the install took by
+handing off to the new binary, and reports what the new version brought. **Read its output
+and relay it** — that text is the report, not a summary of one. It is idempotent: run it
+without first working out whether there is anything to do.
+
+## Where it stops, and what you do there
+
+**The pin.** When this plane already sits on its pin and something newer is published,
+`update` proposes `charter update --bump` and stops. Moving the pin moves every teammate on
+their next session, so get an explicit yes before running it.
+
+**A host's command.** Claude Code's plugin and Codex's belong to the host, so charter names
+the command rather than running it. Hand that command to the person and let them run it.
+
+**A charter checkout.** `update` refuses, because installing over the tree being edited is
+never what was meant. `charter version` is the read-only view.
+
+## Adopt what the version brought
+
+```bash
+charter news --pending
+```
+
+Each line is one entry: its slug, what it gives you, and how to take it up. Work them **one
+at a time**, and ask before each:
+
+1. Say what it is and why it matters — `charter news --for <version>` prints the entry.
+2. `adopt: charter <command>` → run it once they say yes.
+3. `adopt: manual` → turn the entry's body into steps they can follow. These are the ones
+   that need a judgement only they can make: adding `delegate-when:` to a persona means
+   deciding what that persona should be handed, and no command can decide it.
+
+## Report what charter could not check
+
+An entry whose probe could not run is reported as **unchecked** — neither adopted nor
+pending. Say so in those words. Charter distinguishes "you do not have this" from "I could
+not tell", and collapsing them turns a probe that quietly broke into a feature the person
+appears to keep declining.
+
+## This skill is the version you are upgrading FROM
+
+The plugin carries this text, so the new version's skill arrives with the plugin — next
+session. When `update` handed you a host command to run, everything here stays the previous
+version's wording until it is run and the session restarts.

--- a/tests/test_docs_show.py
+++ b/tests/test_docs_show.py
@@ -87,11 +87,19 @@ class TestPagesShip(unittest.TestCase):
 
     def test_nothing_else_is_force_included(self):
         """Keeps `adr/`, `audits/` and `superpowers/` — internal record and working
-        notes — out of every user's site-packages."""
+        notes — out of every user's site-packages.
+
+        `docs/news` is the one directory mapping, and it is deliberate: every news entry is
+        meant to ship (that is what makes `charter update` work offline), so listing them
+        one by one would add a per-release edit here for no exclusion in return. The
+        allowlist stays exact — a second directory mapping still fails this test.
+        """
         pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
         forced = (pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]
                   .get("force-include", {}))
-        self.assertEqual(sorted(forced), sorted(f"docs/{n}.md" for n in _page_names()))
+        expected = [f"docs/{n}.md" for n in _page_names()] + ["docs/news"]
+        self.assertEqual(sorted(forced), sorted(expected))
+        self.assertEqual(forced["docs/news"], "charter/_news")
 
 
 class TestDocsCli(unittest.TestCase):

--- a/tests/test_harness_upgrade.py
+++ b/tests/test_harness_upgrade.py
@@ -101,15 +101,26 @@ class OpenCode(unittest.TestCase):
 
 
 class Codex(unittest.TestCase):
-    def test_admits_it_does_not_know_rather_than_guessing(self):
-        """`codex.py` pins every fact against the binary, never its documentation. A
-        `codex plugin update` nobody has run would be the first line in it that is a
-        guess — and this one gets EXECUTED by a reader, not merely read."""
+    def test_names_the_two_step_codex_actually_has(self):
+        """Pinned against codex-cli 0.147.0 the way every other fact in `codex.py` was.
+
+        `codex plugin --help` offers add / list / marketplace / remove, and the snapshot a
+        plugin installs from is refreshed at the MARKETPLACE level — so updating is two
+        commands, the same shape as Claude Code's marketplace-then-plugin pair.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             status, detail = harness.get(harness.CODEX).upgrade(Path(tmp))
-        self.assertEqual(status, "absent")
+        self.assertEqual(status, "manual")
+        self.assertIn("codex plugin marketplace upgrade", detail)
+        self.assertIn("codex plugin add charter@charter", detail)
+
+    def test_it_does_not_name_the_subcommand_codex_rejects(self):
+        """`codex plugin update` is the command everyone reaches for and the one codex
+        does not have: it exits with "unrecognized subcommand 'update'". A rejection is
+        the only kind of evidence this file accepts, and this is the rejection."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _status, detail = harness.get(harness.CODEX).upgrade(Path(tmp))
         self.assertNotIn("codex plugin update", detail)
-        self.assertIn("charter harness list", detail)
 
     def test_the_dead_wiring_table_is_gone(self):
         """`_WIRING` declared hooks charter stopped writing when `_block()` narrowed to
@@ -145,10 +156,10 @@ class VersionSyncRoutesThroughTheHarness(unittest.TestCase):
         out = self._sync({"CHARTER_HARNESS": "claude-code"})
         self.assertIn(update.PLUGIN_SYNC_CMD, out)
 
-    def test_codex_is_told_what_charter_does_not_know(self):
+    def test_codex_gets_its_own_two_step_not_claude_code_s_command(self):
         out = self._sync({"CHARTER_HARNESS": "codex"})
         self.assertNotIn("claude plugin update", out)
-        self.assertIn("has not pinned", out)
+        self.assertIn("codex plugin add charter@charter", out)
 
 
 class DoctorNamesTheRightHarnessToo(PersonaIso):

--- a/tests/test_harness_upgrade.py
+++ b/tests/test_harness_upgrade.py
@@ -1,0 +1,182 @@
+"""Every harness answers "how does MY installed charter artifact move?" — itself.
+
+Before this, two code paths answered that question without knowing about each other:
+`update.plugin_version_here()` (Claude Code's `$CLAUDE_PLUGIN_ROOT`) and
+`Harness.stale_wiring()` (opencode's stamped shim). `cmd_version_sync` consulted only the
+first and then printed a Claude Code command unconditionally, so an opencode user was told
+to run `claude plugin update charter@charter` — a command with nothing to do with their
+install.
+
+The contract is four statuses and no fifth: charter MOVED it, it is already CURRENT, a
+host owns it so charter can only NAME the command (`manual`), or charter does not know how
+this harness updates (`absent`). `absent` is not a hole to fill with a plausible-looking
+command: `base.Deficit` already says an invented remedy "sends somebody off to configure
+something that does not exist", and that applies with more force here, where the command
+would be run rather than read.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import __version__, doctor, harness, update
+from charter.harness import codex, opencode
+from tests._isolation import PersonaIso
+
+STATUSES = {"moved", "current", "manual", "absent"}
+
+
+class EveryHarnessAnswers(unittest.TestCase):
+    def test_every_registered_harness_returns_a_known_status(self):
+        """A harness added to KINDS is covered by `update` the day it is registered —
+        the stated reason the registry exists, rather than a literal in `update` that
+        somebody has to remember."""
+        with tempfile.TemporaryDirectory() as tmp:
+            for h in harness.all():
+                with self.subTest(harness=h.name), \
+                     mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": tmp}, clear=True):
+                    status, detail = h.upgrade(Path(tmp))
+                    self.assertIn(status, STATUSES)
+                    self.assertTrue(detail.strip(), "a status with no detail explains nothing")
+
+
+class ClaudeCode(unittest.TestCase):
+    def test_names_the_plugin_command_and_does_not_run_it(self):
+        """The host owns the plugin: `claude` may be absent, may prompt for a scope, and
+        the command mutates the reader's editor install. charter says what to run."""
+        h = harness.get(harness.CLAUDE_CODE)
+        with tempfile.TemporaryDirectory() as tmp:
+            status, detail = h.upgrade(Path(tmp))
+        self.assertEqual(status, "manual")
+        self.assertEqual(detail, update.PLUGIN_SYNC_CMD)
+
+
+class OpenCode(unittest.TestCase):
+    """opencode's shim is charter's OWN file, stamped by charter and already rewritten by
+    `init`/`reinit` — so moving it is not a new liberty, and `refresh_shim` is the writer
+    that already knows how."""
+
+    def _global(self, tmp: str) -> Path:
+        with mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": tmp}, clear=True):
+            return opencode.global_dir()
+
+    def test_a_stale_shim_is_moved_and_restamped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            g = self._global(tmp)
+            p = g / opencode.SHIM_PATH
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("// charter-version: 0.0.1\nold body\n")
+            with mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": tmp}, clear=True):
+                status, _ = harness.get(harness.OPENCODE).upgrade(Path(tmp))
+                self.assertEqual(status, "moved")
+                self.assertEqual(opencode.shim_version(g), __version__)
+
+    def test_a_current_shim_is_left_alone(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            g = self._global(tmp)
+            opencode.ensure_shim(g)
+            with mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": tmp}, clear=True):
+                status, _ = harness.get(harness.OPENCODE).upgrade(Path(tmp))
+        self.assertEqual(status, "current")
+
+    def test_a_shim_charter_did_not_write_is_never_overwritten(self):
+        """Additive-only: an operator who edited the shim keeps their edit and is told,
+        which is the trade `refresh_shim` already makes."""
+        with tempfile.TemporaryDirectory() as tmp:
+            g = self._global(tmp)
+            p = g / opencode.SHIM_PATH
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("mine, hands off\n")
+            with mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": tmp}, clear=True):
+                status, _ = harness.get(harness.OPENCODE).upgrade(Path(tmp))
+            self.assertEqual(status, "manual")
+            self.assertEqual(p.read_text(), "mine, hands off\n")
+
+
+class Codex(unittest.TestCase):
+    def test_admits_it_does_not_know_rather_than_guessing(self):
+        """`codex.py` pins every fact against the binary, never its documentation. A
+        `codex plugin update` nobody has run would be the first line in it that is a
+        guess — and this one gets EXECUTED by a reader, not merely read."""
+        with tempfile.TemporaryDirectory() as tmp:
+            status, detail = harness.get(harness.CODEX).upgrade(Path(tmp))
+        self.assertEqual(status, "absent")
+        self.assertNotIn("codex plugin update", detail)
+        self.assertIn("charter harness list", detail)
+
+    def test_the_dead_wiring_table_is_gone(self):
+        """`_WIRING` declared hooks charter stopped writing when `_block()` narrowed to
+        `shell_environment_policy` — it has been referenced nowhere since."""
+        self.assertFalse(hasattr(codex, "_WIRING"))
+
+
+class VersionSyncRoutesThroughTheHarness(unittest.TestCase):
+    """The defect this member was extracted to remove.
+
+    `cmd_version_sync` read `$CLAUDE_PLUGIN_ROOT` and then printed
+    `claude plugin update charter@charter` unconditionally. Under opencode that variable
+    is absent, so the branch fell through to advice about a harness the reader is not in.
+    """
+
+    def _sync(self, env: dict) -> str:
+        from charter import commands
+
+        err = io.StringIO()
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch("charter.instance.load", return_value={}), \
+             mock.patch("charter.instance.locked_version", return_value="9.9.9"), \
+             redirect_stderr(err), redirect_stdout(io.StringIO()):
+            commands.cmd_version_sync(SimpleNamespace(cli=False))
+        return err.getvalue()
+
+    def test_opencode_is_not_told_to_run_a_claude_code_command(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = self._sync({"CHARTER_HARNESS": "opencode", "XDG_CONFIG_HOME": tmp})
+        self.assertNotIn("claude plugin update", out)
+
+    def test_claude_code_still_gets_its_command(self):
+        out = self._sync({"CHARTER_HARNESS": "claude-code"})
+        self.assertIn(update.PLUGIN_SYNC_CMD, out)
+
+    def test_codex_is_told_what_charter_does_not_know(self):
+        out = self._sync({"CHARTER_HARNESS": "codex"})
+        self.assertNotIn("claude plugin update", out)
+        self.assertIn("has not pinned", out)
+
+
+class DoctorNamesTheRightHarnessToo(PersonaIso):
+    """The third site of the same defect.
+
+    `check_version_lock`'s LAST branch — "not running under the plugin", which is every
+    opencode session, every Codex session and every bare terminal — ended with "To move
+    THIS plane only: claude plugin update charter@charter". Correct for exactly one of
+    those readers.
+    """
+
+    def _hint(self, env: dict) -> str:
+        (self.tmp / "charter.toml").write_text('schema = 1\n\n[charter]\nversion = "9.9.9"\n')
+        with mock.patch.dict(os.environ, env, clear=True):
+            return doctor.check_version_lock().hint
+
+    def test_opencode_is_not_told_to_run_a_claude_code_command(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            hint = self._hint({"CHARTER_HARNESS": "opencode", "XDG_CONFIG_HOME": tmp})
+        self.assertNotIn("claude plugin update", hint)
+
+    def test_the_shared_install_note_survives(self):
+        """It is the reason the row exists: the binary is machine-global, so conforming
+        it here can put another plane into drift."""
+        with tempfile.TemporaryDirectory() as tmp:
+            hint = self._hint({"CHARTER_HARNESS": "opencode", "XDG_CONFIG_HOME": tmp})
+        self.assertIn("machine-global", hint)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -1,0 +1,190 @@
+"""News: what a version brought, and whether THIS plane has taken it up.
+
+Two properties carry the design. First, an entry is *checked*, never assumed — a `check:`
+that cannot run is `unknown`, which is neither "you have it" nor "you need it" (ADR 0013,
+and `doctor._NOT_CHECKED_HINT`: absence of information is not evidence of health). Second,
+`check:`/`adopt:` are charter subcommands dispatched IN-PROCESS: there is no shell and no
+argv to escape into, so a news entry cannot become an arbitrary-command primitive — the
+restraint `docsrc._TOPIC` keeps for `docs show`, applied to something that executes.
+"""
+
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+from pathlib import Path
+from unittest import mock
+
+from charter import cli, news
+
+ENTRY = """\
+---
+version: 0.44.0
+headline: A persona says when it should hand work away
+check: persona lint
+adopt: persona sync-agents
+---
+
+Every persona now declares `delegate-when:`.
+"""
+
+
+class NewsDir(unittest.TestCase):
+    """Entries read from a throwaway directory, so a test never depends on what shipped."""
+
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        patch = mock.patch.object(news, "_PACKAGED", self.dir)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def write(self, name: str, text: str) -> None:
+        (self.dir / name).write_text(text)
+
+
+class Parsing(NewsDir):
+    def test_an_entry_carries_its_version_headline_and_actions(self):
+        self.write("0.44.0-delegate-when.md", ENTRY)
+        e, = news.all()
+        self.assertEqual(e.version, "0.44.0")
+        self.assertEqual(e.slug, "delegate-when")
+        self.assertEqual(e.headline, "A persona says when it should hand work away")
+        self.assertEqual(e.check, "persona lint")
+        self.assertEqual(e.adopt, "persona sync-agents")
+        self.assertIn("delegate-when", e.body)
+
+    def test_an_entry_with_no_probe_is_informational_not_broken(self):
+        self.write("0.44.1-patch.md", "---\nversion: 0.44.1\nheadline: Fixes a crash\n---\n")
+        e, = news.all()
+        self.assertEqual(e.check, "")
+        self.assertEqual(news.probe(e)[0], "informational")
+
+
+class Unreleased(NewsDir):
+    def test_a_staged_entry_never_surfaces_to_a_user(self):
+        """A feature PR writes `unreleased-<slug>.md`; the bump stamps it. Until then it
+        names no version that was ever true, so it must not appear in any user-facing
+        view — the whole reason staging exists rather than guessing a version number."""
+        self.write("unreleased-thing.md",
+                   "---\nversion: unreleased\nheadline: Not out yet\n---\n")
+        self.write("0.44.0-out.md", ENTRY)
+        self.assertEqual([e.slug for e in news.released()], ["out"])
+        self.assertEqual([e.slug for e in news.between("0.43.0", "0.99.0")], ["out"])
+
+
+class Ordering(NewsDir):
+    def test_versions_sort_numerically_not_lexically(self):
+        """0.10.0 is newer than 0.2.0. `update._parse` already knows this; a second
+        comparator here would be a second answer to one question."""
+        for v in ("0.2.0", "0.10.0"):
+            self.write(f"{v}-x.md", f"---\nversion: {v}\nheadline: v{v}\n---\n")
+        self.assertEqual([e.version for e in news.released()], ["0.2.0", "0.10.0"])
+
+    def test_between_is_exclusive_of_where_you_were_and_inclusive_of_where_you_land(self):
+        for v in ("0.43.0", "0.44.0", "0.45.0"):
+            self.write(f"{v}-x.md", f"---\nversion: {v}\nheadline: v{v}\n---\n")
+        self.assertEqual([e.version for e in news.between("0.43.0", "0.45.0")],
+                         ["0.44.0", "0.45.0"])
+
+
+class Probing(NewsDir):
+    def _entry(self, check: str):
+        self.write("0.44.0-x.md",
+                   f"---\nversion: 0.44.0\nheadline: h\ncheck: {check}\n---\n")
+        return news.all()[0]
+
+    def test_exit_zero_means_this_plane_already_has_it(self):
+        with mock.patch.object(news, "_dispatch", return_value=0):
+            self.assertEqual(news.probe(self._entry("persona lint"))[0], "adopted")
+
+    def test_a_non_zero_exit_means_pending(self):
+        with mock.patch.object(news, "_dispatch", return_value=1):
+            self.assertEqual(news.probe(self._entry("persona lint"))[0], "pending")
+
+    def test_a_probe_that_cannot_run_is_unknown_never_pending(self):
+        """A `check:` naming a subcommand this CLI does not have exits non-zero for a
+        reason that has nothing to do with adoption. Reporting that as "you need this"
+        invents work; reporting it as "you have it" hides the entry forever."""
+        status, why = news.probe(self._entry("persona no-such-subcommand"))
+        self.assertEqual(status, "unknown")
+        self.assertTrue(why.strip())
+
+    def test_a_probe_is_never_handed_to_a_shell(self):
+        status, _ = news.probe(self._entry("persona lint; rm -rf /"))
+        self.assertEqual(status, "unknown")
+
+    def test_a_probe_cannot_name_a_non_charter_command(self):
+        status, _ = news.probe(self._entry("/bin/sh -c whoami"))
+        self.assertEqual(status, "unknown")
+
+
+class TheCommand(NewsDir):
+    """`charter news` output must be self-sufficient.
+
+    The skill is a Claude Code artifact; opencode gets none. So an agent reading only this
+    output has to be able to finish the job, which is also why there is no `--json`: a
+    machine surface would immediately become the thing that is parsed, and the prose the
+    thing nobody checks.
+    """
+
+    def _run(self, **kw) -> str:
+        from charter import commands
+
+        out = io.StringIO()
+        args = SimpleNamespace(pending=False, since=None, until=None, for_version=None)
+        for k, v in kw.items():
+            setattr(args, k, v)
+        with redirect_stdout(out), redirect_stderr(io.StringIO()):
+            commands.cmd_news(args)
+        return out.getvalue()
+
+    def test_a_pending_entry_is_one_line_naming_how_to_adopt_it(self):
+        self.write("0.44.0-delegate-when.md", ENTRY)
+        with mock.patch.object(news, "_dispatch", return_value=1):
+            out = self._run(pending=True)
+        self.assertIn("delegate-when", out)
+        self.assertIn("A persona says when it should hand work away", out)
+        self.assertIn("persona sync-agents", out)
+
+    def test_an_adopted_entry_is_not_offered_again(self):
+        self.write("0.44.0-delegate-when.md", ENTRY)
+        with mock.patch.object(news, "_dispatch", return_value=0):
+            out = self._run(pending=True)
+        self.assertNotIn("delegate-when", out)
+
+    def test_an_entry_with_no_adopt_command_says_it_is_manual(self):
+        self.write("0.44.0-x.md",
+                   "---\nversion: 0.44.0\nheadline: Do it by hand\ncheck: persona lint\n---\nbody\n")
+        with mock.patch.object(news, "_dispatch", return_value=1):
+            out = self._run(pending=True)
+        self.assertIn("manual", out)
+
+    def test_for_a_version_prints_the_release_body(self):
+        self.write("0.44.0-delegate-when.md", ENTRY)
+        out = self._run(for_version="0.44.0")
+        self.assertIn("A persona says when it should hand work away", out)
+        self.assertIn("delegate-when", out)
+
+
+class ShippedEntriesAreValid(unittest.TestCase):
+    def test_every_shipped_action_resolves_against_the_live_parser(self):
+        """A `check:` referencing a removed flag degrades to permanent silence, which is
+        the failure `_NOT_CHECKED_HINT` exists to name. Proving it PARSES (never running
+        it) fails the suite of the PR that removes the flag, where the cost is lowest —
+        the same insight as `test_docs_show.py`: the gap is invisible from a checkout."""
+        parser = cli.build_parser()
+        for e in news.all():
+            for field in ("check", "adopt"):
+                argv = getattr(e, field)
+                if not argv:
+                    continue
+                with self.subTest(entry=e.slug, field=field):
+                    self.assertTrue(news.resolves(parser, argv),
+                                    f"{e.path.name}: `charter {argv}` does not parse")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -162,6 +162,22 @@ class TheCommand(NewsDir):
             out = self._run(pending=True)
         self.assertIn("manual", out)
 
+    def test_an_informational_entry_is_not_dressed_up_as_work(self):
+        """An entry with no probe and no adopt command has nothing for the reader to do —
+        a patch note, usually. Printing "adopt: manual (see the entry)" under it invents a
+        chore out of a line that exists to say there is none."""
+        self.write("0.44.1-patch.md",
+                   "---\nversion: 0.44.1\nheadline: Fixes a crash\n---\nnothing to do\n")
+        out = self._run(since="0.44.0", until="0.44.1")
+        self.assertIn("Fixes a crash", out)
+        self.assertNotIn("adopt:", out)
+
+    def test_a_pending_entry_in_the_range_still_says_how_to_take_it_up(self):
+        self.write("0.44.0-delegate-when.md", ENTRY)
+        with mock.patch.object(news, "_dispatch", return_value=1):
+            out = self._run(since="0.43.0", until="0.44.0")
+        self.assertIn("persona sync-agents", out)
+
     def test_for_a_version_prints_the_release_body(self):
         self.write("0.44.0-delegate-when.md", ENTRY)
         out = self._run(for_version="0.44.0")

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -185,6 +185,49 @@ class TheCommand(NewsDir):
         self.assertIn("delegate-when", out)
 
 
+class OutsideAControlPlane(NewsDir):
+    """A probe asks "has THIS PLANE adopted it?" — a question with no subject here.
+
+    Running the probes anyway would answer a question nobody asked, slowly, and report
+    whatever a plane-less charter happens to exit with as though it meant something.
+    """
+
+    def _run(self, **kw) -> tuple[str, str]:
+        from charter import commands, config
+
+        out, err = io.StringIO(), io.StringIO()
+        args = SimpleNamespace(pending=False, since=None, until=None, for_version=None)
+        for k, v in kw.items():
+            setattr(args, k, v)
+        with mock.patch.object(config, "HAS_CONTROL_PLANE", False), \
+             redirect_stdout(out), redirect_stderr(err):
+            commands.cmd_news(args)
+        return out.getvalue(), err.getvalue()
+
+    def test_the_range_still_prints(self):
+        self.write("0.44.0-delegate-when.md", ENTRY)
+        out, _ = self._run(since="0.43.0", until="0.44.0")
+        self.assertIn("A persona says when it should hand work away", out)
+
+    def test_it_says_once_that_it_cannot_tell_what_you_have_adopted(self):
+        self.write("0.44.0-delegate-when.md", ENTRY)
+        _, err = self._run(since="0.43.0", until="0.44.0")
+        self.assertIn("no control plane", err)
+
+    def test_no_probe_is_run(self):
+        self.write("0.44.0-delegate-when.md", ENTRY)
+        with mock.patch.object(news, "_dispatch") as d:
+            self._run(since="0.43.0", until="0.44.0")
+        d.assert_not_called()
+
+    def test_pending_says_what_it_cannot_answer_rather_than_answering_it(self):
+        self.write("0.44.0-delegate-when.md", ENTRY)
+        with mock.patch.object(news, "_dispatch") as d:
+            out, err = self._run(pending=True)
+        d.assert_not_called()
+        self.assertIn("no control plane", err)
+
+
 class ShippedEntriesAreValid(unittest.TestCase):
     def test_every_shipped_action_resolves_against_the_live_parser(self):
         """A `check:` referencing a removed flag degrades to permanent silence, which is

--- a/tests/test_news_gate.py
+++ b/tests/test_news_gate.py
@@ -1,0 +1,234 @@
+"""A release without notes does not publish.
+
+The obligation is one sentence — every published version ships an entry — and it is
+caught twice, at deliberately different times, because the two catches fail in different
+places at different costs:
+
+* here, against ``charter.__version__``, so a bump PR goes red **before any tag exists**;
+* in ``release.yml``'s ``guard`` job, against the tag, so a tag that skipped the PR fails
+  **before the irreversible PyPI upload**.
+
+Between them sits ``charter news stamp <version>``: the bump's one mechanical step, which
+moves every staged entry onto the version that is about to ship. It is a tested command
+rather than a fifth thing for a release engineer to remember, for the same reason
+``hooks.json``'s ``--plugin-version`` count is — "never work from a remembered count".
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import shutil
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import __version__, cli, commands, news
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+STAGED = """\
+---
+version: unreleased
+headline: A persona says when it should hand work away
+check: persona lint --only delegate-when
+---
+
+Body text with a `---` rule below it, and trailing structure that must survive.
+
+1. one
+2. two
+"""
+
+
+class TestEveryPublishedVersionHasNotes(unittest.TestCase):
+    def test_an_entry_names_the_version_this_tree_would_publish(self):
+        """The catch that fires in the bump PR.
+
+        `TestVersionsMoveInLockstep` pins the four files that carry a version *number*;
+        "a release has notes" is a different obligation and gets its own test rather than
+        being bolted onto one that means something else.
+        """
+        versions = {e.version for e in news.all()}
+        self.assertIn(
+            __version__, versions,
+            f"no news entry names {__version__}. Every published version needs one, "
+            f"including a patch — write docs/news/{__version__}-<slug>.md. "
+            f'"No entry" and "forgot the entry" are indistinguishable from CI.')
+
+
+class StampDir(unittest.TestCase):
+    """A throwaway checkout, so a stamp test never renames a file that really ships."""
+
+    def setUp(self):
+        self.repo = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.repo, ignore_errors=True)
+        (self.repo / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+        self.dir = self.repo / "docs" / "news"
+        self.dir.mkdir(parents=True)
+        # The packaged copy is pointed at nothing: these tests are about the repo's own
+        # directory, and a real `charter/_news` would otherwise leak shipped entries in.
+        for attr, value in (("_CHECKOUT", self.dir), ("_PACKAGED", self.repo / "absent")):
+            patch = mock.patch.object(news, attr, value)
+            patch.start()
+            self.addCleanup(patch.stop)
+
+    def write(self, name: str, text: str = STAGED) -> Path:
+        p = self.dir / name
+        p.write_text(text)
+        return p
+
+
+class TestStamp(StampDir):
+    def test_a_staged_entry_takes_the_version_in_its_name_and_in_its_frontmatter(self):
+        self.write("unreleased-delegate-when.md")
+        renamed, blocked = news.stamp("0.45.0")
+        self.assertEqual(blocked, [])
+        self.assertEqual([dst.name for _, dst in renamed], ["0.45.0-delegate-when.md"])
+        self.assertFalse((self.dir / "unreleased-delegate-when.md").exists())
+        entry, = news.all()
+        self.assertEqual(entry.version, "0.45.0")
+        self.assertEqual(entry.slug, "delegate-when")
+
+    def test_only_the_version_line_is_rewritten(self):
+        """The rest of the file is the author's. Round-tripping through `persona.parse`
+        would reorder the frontmatter and drop whatever the flat parser does not keep."""
+        self.write("unreleased-x.md")
+        news.stamp("0.45.0")
+        after = (self.dir / "0.45.0-x.md").read_text()
+        self.assertEqual(after, STAGED.replace("version: unreleased", "version: 0.45.0"))
+
+    def test_a_target_name_already_taken_stamps_nothing_at_all(self):
+        """All or nothing. A partial stamp is worse than a failed one: the guard only
+        asks whether SOME entry names the version, so a run that stamped one of two
+        entries publishes with the other silently missing from the notes."""
+        self.write("unreleased-taken.md")
+        self.write("unreleased-fine.md")
+        self.write("0.45.0-taken.md", STAGED.replace("unreleased", "0.45.0"))
+        renamed, blocked = news.stamp("0.45.0")
+        self.assertEqual(renamed, [])
+        self.assertTrue(any("taken" in why for why in blocked), blocked)
+        self.assertTrue((self.dir / "unreleased-fine.md").exists(),
+                        "an unblocked entry was renamed even though the run was blocked")
+
+    def test_an_already_stamped_entry_is_left_where_it_is(self):
+        self.write("0.44.1-shipped.md", STAGED.replace("unreleased", "0.44.1"))
+        renamed, blocked = news.stamp("0.45.0")
+        self.assertEqual((renamed, blocked), ([], []))
+        self.assertTrue((self.dir / "0.44.1-shipped.md").exists())
+
+    def test_a_tag_name_is_refused_because_the_frontmatter_carries_no_leading_v(self):
+        """`v0.45.0` is the tag; `0.45.0` is the version. Stamping the tag name produces
+        an entry that can never equal `__version__`, so both catches pass and `charter
+        news` still shows the user nothing."""
+        self.write("unreleased-x.md")
+        renamed, blocked = news.stamp("v0.45.0")
+        self.assertEqual(renamed, [])
+        self.assertTrue(blocked)
+        self.assertTrue((self.dir / "unreleased-x.md").exists())
+
+    def test_stamping_outside_a_checkout_refuses_rather_than_editing_site_packages(self):
+        """The packaged copy is rebuilt from `docs/news` on every build, so a stamp
+        applied there is thrown away — silently, and after the release engineer was told
+        it worked."""
+        with mock.patch.object(news, "_CHECKOUT", self.repo / "docs" / "elsewhere"):
+            renamed, blocked = news.stamp("0.45.0")
+        self.assertEqual(renamed, [])
+        self.assertTrue(blocked)
+
+
+class TestTheCommand(StampDir):
+    def _run(self, version: str) -> tuple[int, str]:
+        err = io.StringIO()
+        with redirect_stdout(io.StringIO()), redirect_stderr(err):
+            code = commands.cmd_news_stamp(SimpleNamespace(version=version))
+        return code, err.getvalue()
+
+    def test_stamping_reports_each_rename_and_succeeds(self):
+        self.write("unreleased-delegate-when.md")
+        code, out = self._run("0.45.0")
+        self.assertEqual(code, 0)
+        self.assertIn("0.45.0-delegate-when.md", out)
+
+    def test_a_version_left_with_no_entry_is_named_not_assumed_fine(self):
+        """Read back what was written. Exiting 0 here would hand the release engineer a
+        clean run and let the failure surface at the tag instead, which is the expensive
+        end of ADR 0013's point about success being checked."""
+        code, out = self._run("0.45.0")
+        self.assertEqual(code, 1)
+        self.assertIn("0.45.0", out)
+
+    def test_the_existing_news_flags_still_parse_now_that_news_has_a_subcommand(self):
+        parser = cli.build_parser()
+        for argv in (["news"], ["news", "--pending"], ["news", "--since", "0.44.0"],
+                     ["news", "--for", "0.44.1"]):
+            with self.subTest(argv=argv):
+                args = parser.parse_args(argv)
+                self.assertIs(args.func, commands.cmd_news)
+        stamp = parser.parse_args(["news", "stamp", "0.45.0"])
+        self.assertIs(stamp.func, commands.cmd_news_stamp)
+        self.assertEqual(stamp.version, "0.45.0")
+
+
+def _jobs(text: str) -> dict[str, str]:
+    """`release.yml`'s job blocks by name. Flat text, because charter has no YAML."""
+    body = text.split("\njobs:\n", 1)[1]
+    starts = [(m.start(), m.group(1)) for m in re.finditer(r"^  ([\w-]+):$", body, re.M)]
+    out = {}
+    for i, (pos, name) in enumerate(starts):
+        end = starts[i + 1][0] if i + 1 < len(starts) else len(body)
+        out[name] = body[pos:end]
+    return out
+
+
+class TestTheReleaseWorkflow(unittest.TestCase):
+    """The half of decision 7 that lives in CI, pinned here because a workflow is never
+    exercised by the suite that ships beside it — it is exercised once, irreversibly."""
+
+    def setUp(self):
+        self.text = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text()
+        self.jobs = _jobs(self.text)
+
+    def test_the_guard_asks_charter_whether_the_version_has_notes(self):
+        self.assertIn("news --for", self.jobs["guard"])
+
+    def test_the_guard_runs_before_anything_is_published(self):
+        self.assertIn("needs: guard", self.jobs["test"])
+        self.assertIn("needs: build", self.jobs["publish"])
+
+    def test_one_job_creates_the_github_release_after_publish_succeeds(self):
+        after = [name for name, block in self.jobs.items() if "needs: publish" in block]
+        self.assertEqual(len(after), 1, f"expected exactly one post-publish job: {after}")
+        block = self.jobs[after[0]]
+        self.assertIn("gh release create", block)
+
+    def test_the_release_body_is_generated_from_the_shipped_entry(self):
+        """Decision 7's whole point: one text is the offline suggestion and the public
+        notes, so the two cannot drift. A hand-written `--notes` would fork them."""
+        block = next(b for b in self.jobs.values() if "gh release create" in b)
+        self.assertIn("news --for", block)
+        self.assertIn("--notes-file", block)
+        self.assertNotIn('--notes "', block)
+
+    def test_the_release_job_carries_write_alone(self):
+        """`contents: write` on the one job that needs it. Widening the workflow's
+        top-level grant would hand it to `test` and `build` as well, which run the
+        repository's own code."""
+        self.assertIn("permissions:\n  contents: read\n", self.text)
+        block = next(b for b in self.jobs.values() if "gh release create" in b)
+        self.assertIn("contents: write", block)
+        for name in ("guard", "test", "build"):
+            self.assertNotIn("contents: write", self.jobs[name])
+
+    def test_the_retry_path_does_not_fail_on_a_release_that_already_exists(self):
+        """`workflow_dispatch` re-runs a failed release without a new tag, and the
+        publish may have been the step that succeeded."""
+        block = next(b for b in self.jobs.values() if "gh release create" in b)
+        self.assertIn("gh release view", block)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_persona_lint_only.py
+++ b/tests/test_persona_lint_only.py
@@ -1,0 +1,59 @@
+"""`persona lint --only <key>` — one finding, one exit code.
+
+A news entry's `check:` has to answer ONE question: has this plane adopted THIS feature?
+Bare `persona lint` cannot: its exit code covers dangling `uses:`, unloadable personas and
+stale agents all at once, so a plane failing it for an unrelated reason would be told to
+adopt something it already has. That is the "sloppy probe" the design refuses — an entry
+with no narrow probe ships with none rather than with a misleading one.
+
+So the narrowing is a real flag with real tests, not a convention in a markdown file.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+
+from charter import commands_persona
+from tests._isolation import PersonaIso
+
+
+class LintOnly(PersonaIso):
+    def lint(self, only=None) -> tuple[int, str]:
+        err = io.StringIO()
+        args = SimpleNamespace(name=None, only=only)
+        with redirect_stderr(err), redirect_stdout(io.StringIO()):
+            code = commands_persona.cmd_persona_lint(args)
+        return code, err.getvalue()
+
+    def test_a_persona_missing_the_key_makes_the_probe_fail(self):
+        self.make_persona("scribe", role="Scribe", vault="none")
+        code, out = self.lint(only="delegate-when")
+        self.assertEqual(code, 1)
+        self.assertIn("scribe", out)
+
+    def test_a_persona_carrying_the_key_makes_the_probe_pass(self):
+        self.make_persona("scribe", role="Scribe", vault="none",
+                          **{"delegate-when": "writing things down"})
+        code, _ = self.lint(only="delegate-when")
+        self.assertEqual(code, 0)
+
+    def test_only_ignores_findings_that_are_not_its_key(self):
+        """The whole point. `uses: nobody` is a real lint error, and it must not make the
+        delegate-when probe claim this plane has work to do about delegate-when."""
+        self.make_persona("scribe", role="Scribe", vault="none",
+                          **{"delegate-when": "writing things down", "uses": "nobody"})
+        code, _ = self.lint(only="delegate-when")
+        self.assertEqual(code, 0)
+
+    def test_without_only_the_command_is_unchanged(self):
+        self.make_persona("scribe", role="Scribe", vault="none",
+                          **{"delegate-when": "writing things down", "uses": "nobody"})
+        code, _ = self.lint()
+        self.assertEqual(code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_update_command.py
+++ b/tests/test_update_command.py
@@ -97,6 +97,23 @@ class ThePinDecidesTheTarget(UpdateCase):
         self.assertEqual(self.moved, ["0.43.0"])
 
 
+class TheNetworkIsReadOnce(PersonaIso):
+    """`_latest` is a LIVE read — an explicit command a person is waiting on, unlike the
+    status line's cached one. Asking twice to answer one question doubles that wait for
+    nothing, and the propose path (pin == installed, something newer published) is the
+    one most likely to be run repeatedly."""
+
+    def test_proposing_a_bump_reads_pypi_once(self):
+        (self.tmp / "charter.toml").write_text(
+            f'schema = 1\n\n[charter]\nversion = "{INSTALLED}"\n')
+        with mock.patch("charter.commands_update._installed_version", return_value=INSTALLED), \
+             mock.patch("charter.update.fetch_and_store") as fetch, \
+             mock.patch("charter.update.load", return_value={"latest": "0.46.0"}), \
+             redirect_stderr(io.StringIO()), redirect_stdout(io.StringIO()):
+            cu.cmd_update(SimpleNamespace(to=None, bump=False))
+        self.assertEqual(fetch.call_count, 1)
+
+
 class ThingsItRefusesOrDegrades(UpdateCase):
     def test_it_refuses_inside_a_charter_checkout(self):
         """`CONTRIBUTING.md` tells contributors to run `python3 -m charter` from the

--- a/tests/test_update_command.py
+++ b/tests/test_update_command.py
@@ -1,0 +1,208 @@
+"""`charter update` — move charter, then say what moved and what it brought.
+
+The command exists because three things called "updating charter" were three separate
+commands with three different blast radii: a machine-global binary, a per-project harness
+artifact, and a pin shared with teammates. This one converges them in the only order that
+is safe, and stops at the one decision that is not charter's to make.
+
+The pin decides the target. Moving the machine PAST a pin manufactures the drift
+`charter version` reports as an error, so a plane that pins nothing goes to latest, a plane
+behind its pin goes to the pin (conforming to a pin affects nobody), and a plane already ON
+its pin with something newer available is asked — because that move is the team's.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_update as cu
+from tests._isolation import PersonaIso
+
+INSTALLED = "0.44.1"
+
+
+class UpdateCase(PersonaIso):
+    def setUp(self):
+        super().setUp()
+        for target, new in (
+            ("charter.commands_update._installed_version", lambda: INSTALLED),
+            ("charter.commands_update._latest", lambda live=True: "0.46.0"),
+        ):
+            pt = mock.patch(target, new); pt.start(); self.addCleanup(pt.stop)
+        self.moved: list[str] = []
+        self.baseline_when_moved: list[str | None] = []
+
+        def fake_sync(version: str):
+            self.moved.append(version)
+            self.baseline_when_moved.append(cu.read_baseline())
+            return True, version
+        pt = mock.patch("charter.commands_update._sync_to", fake_sync)
+        pt.start(); self.addCleanup(pt.stop)
+        pt = mock.patch("charter.commands_update._handoff", return_value=(True, ""))
+        pt.start(); self.addCleanup(pt.stop)
+
+    def pin(self, version: str) -> None:
+        (self.tmp / "charter.toml").write_text(
+            f'schema = 1\n\n[charter]\nversion = "{version}"\n')
+
+    def update(self, **kw) -> tuple[int, str]:
+        args = SimpleNamespace(to=None, bump=False)
+        for k, v in kw.items():
+            setattr(args, k, v)
+        err = io.StringIO()
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "claude-code"}), \
+             redirect_stderr(err), redirect_stdout(io.StringIO()):
+            code = cu.cmd_update(args)
+        return code, err.getvalue()
+
+
+class ThePinDecidesTheTarget(UpdateCase):
+    def test_a_plane_that_pins_nothing_goes_to_latest(self):
+        code, _ = self.update()
+        self.assertEqual(code, 0)
+        self.assertEqual(self.moved, ["0.46.0"])
+
+    def test_a_plane_behind_its_pin_conforms_to_the_pin_not_to_latest(self):
+        """Conforming to a pin somebody already chose affects nobody — this is exactly
+        what `version sync` does, so it needs no confirmation."""
+        self.pin("0.45.0")
+        code, _ = self.update()
+        self.assertEqual(code, 0)
+        self.assertEqual(self.moved, ["0.45.0"])
+
+    def test_a_plane_on_its_pin_is_asked_before_the_team_moves(self):
+        """The pin is shared. Moving past it means every teammate conforms on their next
+        session, so charter proposes and stops."""
+        self.pin(INSTALLED)
+        code, out = self.update()
+        self.assertEqual(self.moved, [])
+        self.assertIn("charter update --bump", out)
+
+    def test_bump_is_the_yes(self):
+        self.pin(INSTALLED)
+        with mock.patch("charter.commands_update._bump_pin", return_value=True) as bump:
+            code, _ = self.update(bump=True)
+        self.assertEqual(self.moved, ["0.46.0"])
+        bump.assert_called_once_with("0.46.0")
+
+    def test_to_overrides_everything(self):
+        self.pin("0.45.0")
+        self.update(to="0.43.0")
+        self.assertEqual(self.moved, ["0.43.0"])
+
+
+class ThingsItRefusesOrDegrades(UpdateCase):
+    def test_it_refuses_inside_a_charter_checkout(self):
+        """`CONTRIBUTING.md` tells contributors to run `python3 -m charter` from the
+        clone. Installing over that is never what "let me try the update command" meant,
+        and the damage is silent — the news phase would then hand off to a binary that is
+        not the tree being edited."""
+        (self.tmp / "charter").mkdir(parents=True, exist_ok=True)
+        (self.tmp / "charter" / "docsrc.py").write_text("")
+        (self.tmp / "pyproject.toml").write_text('name = "charter-cp"\n')
+        code, out = self.update()
+        self.assertEqual(self.moved, [])
+        self.assertNotEqual(code, 0)
+        self.assertIn("charter version", out)
+
+    def test_outside_a_harness_it_says_the_artifact_was_not_checked(self):
+        with mock.patch.dict(os.environ, {}, clear=True), \
+             mock.patch("charter.harness.current", return_value=None):
+            err = io.StringIO()
+            with redirect_stderr(err), redirect_stdout(io.StringIO()):
+                cu.cmd_update(SimpleNamespace(to=None, bump=False))
+        self.assertIn("not checked", err.getvalue())
+
+    def test_a_failed_handoff_says_the_install_did_not_take(self):
+        """PyPI's simple index lags its metadata endpoint. In that window an install can
+        succeed against a cached index and leave you on the old version reporting success
+        — so the news phase, which must run on the NEW binary anyway, doubles as the
+        proof that it is there."""
+        with mock.patch("charter.commands_update._handoff",
+                        return_value=(False, "reports 0.44.1, expected 0.46.0")):
+            code, out = self.update()
+        self.assertNotEqual(code, 0)
+        self.assertIn("did not take", out)
+
+
+class TheBaselineIsStampedBeforeAnythingMoves(UpdateCase):
+    def test_an_interrupted_update_still_knows_where_it_started(self):
+        self.update()
+        self.assertEqual(self.baseline_when_moved, [INSTALLED])
+
+
+class InstallerDetection(unittest.TestCase):
+    """`uv tool install` is not everyone's install. `docs/install.md` documents pipx and
+    pip as fallbacks, so assuming uv would kill the automatic path for anyone who took a
+    documented route."""
+
+    def test_a_uv_tool_install_is_recognised(self):
+        name, argv = cu.installer_for(Path("/home/x/.local/share/uv/tools/charter-cp/bin/python"))
+        self.assertEqual(name, "uv")
+        self.assertIn("uv", argv[0])
+
+    def test_a_pipx_install_is_recognised(self):
+        name, argv = cu.installer_for(Path("/home/x/.local/pipx/venvs/charter-cp/bin/python"))
+        self.assertEqual(name, "pipx")
+
+    def test_an_unrecognised_install_is_named_not_guessed(self):
+        """Ambiguity resolves to *named, not run* — the same restraint charter keeps for
+        a host's plugin command."""
+        name, argv = cu.installer_for(Path("/usr/bin/python3"))
+        self.assertEqual(name, "unknown")
+        self.assertIsNone(argv)
+
+
+class TheDoctorRow(PersonaIso):
+    """Where "suggest new features" reaches somebody who did not just type `update`.
+
+    Only `doctor` — not the session-start hook. A probe is real work, and running N of them
+    on every session start is exactly the cost `update.py` was built to keep off the status
+    line's clock. `doctor` is already where you go to ask "is this plane in good shape?".
+    """
+
+    def _row(self, entries):
+        from charter import doctor, news
+
+        with mock.patch.object(news, "released", return_value=entries):
+            return doctor.check_news_adoption()
+
+    def test_nothing_pending_is_a_clean_row(self):
+        from charter import doctor
+
+        r = self._row([])
+        self.assertEqual(r.status, doctor.OK)
+
+    def test_pending_entries_are_counted_and_name_the_command(self):
+        from charter import doctor, news
+
+        e = news.Entry("0.44.0", "delegate-when", "h", "persona lint", "", "b", Path("x"))
+        with mock.patch.object(news, "probe", return_value=(news.PENDING, "")):
+            r = self._row([e])
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("1", r.detail)
+        self.assertIn("charter news --pending", r.hint)
+
+    def test_an_unprobeable_entry_is_reported_as_unchecked_not_as_health(self):
+        from charter import doctor, news
+
+        e = news.Entry("0.44.0", "x", "h", "persona gone", "", "b", Path("x"))
+        with mock.patch.object(news, "probe", return_value=(news.UNKNOWN, "no such")):
+            r = self._row([e])
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("unchecked", r.detail)
+
+    def test_the_row_is_registered_so_it_actually_runs(self):
+        from charter import doctor
+
+        self.assertIn("news", [r.name for r in doctor.run_all()])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_update_command.py
+++ b/tests/test_update_command.py
@@ -48,8 +48,15 @@ class UpdateCase(PersonaIso):
         pt.start(); self.addCleanup(pt.stop)
 
     def pin(self, version: str) -> None:
+        """Write the lock — and say so, because `HAS_CONTROL_PLANE` is DERIVED at config
+        load. Writing charter.toml afterwards leaves the flag reading False, which is a
+        control plane the code correctly does not believe in."""
+        from charter import config
+
         (self.tmp / "charter.toml").write_text(
             f'schema = 1\n\n[charter]\nversion = "{version}"\n')
+        pt = mock.patch.object(config, "HAS_CONTROL_PLANE", True)
+        pt.start(); self.addCleanup(pt.stop)
 
     def update(self, **kw) -> tuple[int, str]:
         args = SimpleNamespace(to=None, bump=False)


### PR DESCRIPTION
`charter update` moves the CLI, asks this harness how its own artifact moves, proves the install took, and then reports what the versions you skipped actually brought — with an offer to adopt what is adoptable.

## Why it is shaped this way

**Three things were called "updating charter"** — a machine-global binary, a per-project harness artifact, and a pin shared with teammates — each with its own command and its own blast radius. This converges them in the order the release charter already requires: CLI before the artifact, because plugin-newer-than-CLI is the direction that breaks and `skew_message` is one-directional, so it stays quiet the other way.

**The pin decides the target**, so charter never manufactures the drift it reports as an error:

| this plane | target | unattended? |
| --- | --- | --- |
| pins nothing | latest | yes |
| pins a version you are behind | the pin | yes — conforming to a pin affects nobody |
| pin == installed, latest is newer | latest | **no** — moving past it moves the team |

**News ships inside the wheel.** What a version brought travels with the code that implements it, so it works offline with no forge auth, and it is the same text CI publishes as the GitHub Release body — the two cannot drift, because one is printed from the other.

**A suggestion is checked, never guessed.** An entry carries an optional probe; a probe that cannot run is `unknown` — never adopted, never pending — because absence of information is not evidence of health (ADR 0013). Probes are charter subcommands dispatched **in-process**: there is no shell to escape into, which makes "charter subcommands only" structural rather than validated.

## Two defects fixed on the way

- **#275** — `cmd_version_sync` and `doctor.check_version_lock` printed `claude plugin update charter@charter` to everybody, including every opencode and Codex session and every bare terminal. Two code paths answered "is this artifact current?" without knowing about each other; `Harness.upgrade()` makes it one question with one answer, and registering a harness now covers `version sync`, `doctor` and `update` the day it is registered.
- **#276** — Codex's update command was unpinned. Pinned against codex-cli 0.147.0 by rejection: `codex plugin update` answers `error: unrecognized subcommand 'update'`. The real path is `marketplace upgrade` then `add`.

## A release with no notes does not publish

Caught twice, at deliberately different times: a test against `__version__` so a bump PR goes red before any tag exists, and `release.yml`'s `guard` so a tag that skipped the PR fails **before** the irreversible upload. A feature PR cannot know which version will ship it, so it stages `unreleased-<slug>.md` and the bump runs `charter news stamp <version>`.

## Review order

The ten commits are meant to be read in order; each is green on its own.

## Verification

- `python3 -m unittest discover -s tests` → **2639 tests, OK** (2580 before this work).
- Wheel builds; `charter/_news/*.md` ships; `skills/` correctly absent.
- `charter update` refuses inside a charter checkout; `news --pending/--since/--for/stamp` exercised for real.

Closes #275
Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo