### PR TITLE
Release 0.45.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.44.1"
+__version__ = "0.45.0"

--- a/docs/news/0.45.0-charter-update.md
+++ b/docs/news/0.45.0-charter-update.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.45.0
 headline: One command updates charter and tells you what the new version brought
 ---
 

--- a/docs/news/0.45.0-harness-upgrade.md
+++ b/docs/news/0.45.0-harness-upgrade.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.45.0
 headline: Each harness is told how to update itself, not how Claude Code updates
 ---
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.44.1",
+            "command": "charter hook sessionstart --plugin-version 0.45.0",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.44.1",
+            "command": "charter hook userpromptsubmit --plugin-version 0.45.0",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.44.1",
+            "command": "charter hook pretooluse --plugin-version 0.45.0",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.44.1",
+            "command": "charter hook pretooluse-read --plugin-version 0.45.0",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.44.1"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.45.0"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.44.1",
+            "command": "charter hook pretooluse-edit --plugin-version 0.45.0",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.44.1",
+            "command": "charter hook posttooluse --plugin-version 0.45.0",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.44.1",
+            "command": "charter hook posttooluse-skill --plugin-version 0.45.0",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.44.1",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.45.0",
             "timeout": 5
           }
         ]
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-message --plugin-version 0.44.1",
+            "command": "charter hook posttooluse-message --plugin-version 0.45.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.44.1"
+version = "0.45.0"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Cuts 0.45.0 — minor, not patch, because #279 added new surface with no breaking change:
`charter update`, `charter news`, `charter news stamp`, a `Harness.upgrade()` member on
the harness contract, `persona lint --only`, and a fifth shipped skill.

All four version files move together (`tests/test_plugin.py::TestVersionsMoveInLockstep`
pins them): `pyproject.toml`, `charter/__init__.py`, `.claude-plugin/plugin.json`, and all
ten `--plugin-version` flags in `hooks/hooks.json`.

`charter news stamp 0.45.0` renamed both staged entries onto the version and rewrote their
frontmatter, so `charter news --for 0.45.0` prints a non-empty body — which is what the
`guard` job checks before publishing and what `announce` turns into the GitHub Release.

Full suite green locally: 2639 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo