### PR TITLE
The release charter counts hooks instead of remembering how many there were

### DIFF
--- a/personas/release/persona.md
+++ b/personas/release/persona.md
@@ -19,10 +19,12 @@ A release moves **all four together**, or the drift ships:
 1. `pyproject.toml` — `version`
 2. `charter/__init__.py` — `__version__`
 3. `.claude-plugin/plugin.json` — `version`
-4. `hooks/hooks.json` — **every** `--plugin-version` flag. Nine at 0.44.0, six when this
-   line was first written, and the count grows whenever a hook is added (#263 added
-   `pretooluse-edit`). Substitute globally, then re-grep for the OLD version across all
-   four files — never work from a remembered count.
+4. `hooks/hooks.json` — **every** `--plugin-version` flag. Count them with
+   `grep -c plugin-version hooks/hooks.json`; do not carry a number in your head, and do
+   not trust one written here. This line used to name the count and went stale twice — six
+   when it was first written, nine at 0.44.0, ten by 0.44.1 — each time because a release
+   added a hook and nobody thought to edit a sentence about counting. Substitute globally,
+   then re-grep for the OLD version across all four files.
 
 Not five: `docs/news/` carries a version too, but it is *stamped* rather than edited — see
 the sequence. "A release has notes" is a different obligation from "the four numbers agree",


### PR DESCRIPTION
`personas/release/persona.md` named the number of `--plugin-version` flags in
`hooks/hooks.json`. It has now gone stale three times — six when the line was written, nine
at 0.44.0, ten by 0.44.1 — each time because a release added a hook and nobody thought to
edit a sentence whose whole subject is *not* trusting remembered counts.

Cutting 0.45.0 hit it again: the charter said nine, the file had ten. Nothing shipped wrong,
because the same paragraph tells you to re-grep — the advice was right and the number beside
it was not, which is the most expensive shape a doc can take.

So it names the command instead. A count that is computed cannot go stale.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo