### PR TITLE
`charter browser install` left traces of authenticated runs untracked (#278)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,12 @@ you use. The browser lane additionally shells out to `npx`. That is the whole li
   a Claude Code `permissions.ask` rule into the plane's committed settings. charter keeps no
   list of its own — one record, nothing to sync.
   → [ADR 0014](docs/adr/0014-policy-that-fits-a-pattern-belongs-to-the-host.md)
+- **A live browser session sitting untracked in your tree.** `charter browser install`
+  gitignores `.playwright-cli/` and says that it did — a session directory is cookies, and
+  cookies are the credential in another form. The generated Playwright reference beside it
+  carries no credential, so charter names the cost of committing it either way and leaves
+  the choice to the plane.
+  → [ADR 0017](docs/adr/0017-charter-ignores-what-carries-credentials.md)
 - **A tool that silently stopped existing.** After a rename removed the shim they launched
   through, MCP servers failed with ENOENT and their tools simply vanished from the session.
   `charter doctor` now names any registered launcher whose path does not exist, and the

--- a/charter/browser.py
+++ b/charter/browser.py
@@ -33,6 +33,23 @@ PINNED = "0.1.18"
 #: the vendor's choice as much as ours — named so the caller can be told what to expect.
 SKILL_DIR = Path(".claude") / "skills" / "playwright-cli"
 
+#: The CLI's OUTPUT directory — `cliOutputDir` in the vendor's own source, with traces under
+#: `.playwright-cli/trace` and snapshots, screenshots and PDFs beside them. Created when
+#: something is written there, not by `install`, which is why an operator meets it as a
+#: surprise `??` entry with nothing on screen to connect it to the command that caused it.
+#:
+#: Not the session store, despite the name: a session lives in
+#: `~/Library/Caches/ms-playwright/daemon/<hash>/<name>.session`, outside any repo, as the
+#: `browser` skill already says. #278 reported this directory as "per-machine session state";
+#: it is artifacts, and that turns out to matter MORE rather than less — see `ensure_output_ignored`.
+OUTPUT_DIR = Path(".playwright-cli")
+
+#: The workspace directory `install` itself creates (`initWorkspace`), for
+#: `.playwright/cli.config.json`. Project configuration, not credentials and not generated
+#: output — so ADR 0017 puts it on the "state it, do not decide it" side of the line, and
+#: charter says nothing about whether you commit it beyond naming it in `docs/browser.md`.
+CONFIG_DIR = Path(".playwright")
+
 
 #: How long the generator may take before charter stops waiting on it.
 #:
@@ -83,3 +100,29 @@ def install(root: Path, version: str) -> tuple[int, str]:
                    f"waiting; try the command by hand:\n"
                    f"  {' '.join(install_argv(version))}")
     return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def ensure_output_ignored(root: Path) -> list[str]:
+    """Ignore the CLI's output directory in *root*'s `.gitignore`. Returns what was added.
+
+    The reason is traces, and it is sharper than the "live session" #278 described. A
+    Playwright trace records the **network**: requests with their headers and bodies, plus
+    DOM snapshots of the pages that produced them. So a trace taken during a `charter secret
+    exec` login captures the login POST — the exact thing the credential bridge exists to
+    keep out of reach. Charter redacts the value from its own output and Playwright
+    substitutes it into the page without printing it; a trace then writes the authenticated
+    traffic to disk beside your source, where `git add -A` is waiting.
+
+    That is charter's rule already, not a new opinion: `commands_secrets` refuses a vault
+    file git would take, and the `browser` skill's hard rules forbid committing session or
+    storage-state files "because they carry live cookies, which are the credential in
+    another form". A trace carries more.
+
+    Deliberately silent about `SKILL_DIR` and `CONFIG_DIR`. Generated pages and a project
+    config file carry no credential, so whether a plane commits them is a real trade-off with
+    two defensible answers — and charter's job there is to state them, not settle them by
+    writing a line while nobody is looking (ADR 0017).
+    """
+    from . import util
+    return util.append_gitignore(root, [f"{OUTPUT_DIR}/"],
+                                 "added by `charter browser install`")

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -250,6 +250,21 @@ def cmd_browser_install(args) -> int:
         return 1
     util.info("It is Playwright's, not charter's — regenerate it with this command "
               "rather than editing it.")
+
+    # The paths this command leaves behind are different in kind, and #278 was filed because
+    # saying nothing about any of them left every plane to re-derive the lot, in silence.
+    # `.playwright-cli/` is where traces land, and a trace records network requests with
+    # their headers and bodies — so a trace of a bridged login holds the credential the
+    # bridge exists to protect. That one charter ignores (ADR 0017). The generated pages and
+    # `.playwright/cli.config.json` carry no credential, so whether they are committed is a
+    # real trade-off the plane owns; charter owes it the costs, not a decision taken while
+    # nobody was looking.
+    for line in _browser.ensure_output_ignored(config.ROOT):
+        util.ok(f"Ignored {line} — traces and snapshots of authenticated runs, not source.")
+    util.info(f"{_browser.SKILL_DIR} and {_browser.CONFIG_DIR}/ are left tracked-or-not as "
+              f"you choose: commit the pages and a fresh clone needs no npx round trip, at "
+              f"the cost of a tree a later `install` rewrites under you. Both answers are "
+              f"fine — docs/browser.md states them; charter does not pick for you.")
     return 0
 
 
@@ -651,12 +666,20 @@ def _ensure_gitignore(root: Path) -> bool:
     existing_lines = {line.strip() for line in body.splitlines()}
     missing = []
     if "!/workspaces/.gitkeep" not in existing_lines:
-        missing.append("/workspaces/*/*\n!/workspaces/.gitkeep\n")
+        missing += ["/workspaces/*/*", "!/workspaces/.gitkeep"]
     if ".charter/" not in body:
-        missing.append("/.charter/\n")
+        missing.append("/.charter/")
     if not missing:
         return False
-    p.write_text(body.rstrip("\n") + "\n\n# added by `charter init`\n" + "\n".join(missing))
+    # The write itself goes through the one shared appender — `charter browser install`
+    # needs the same append-only, idempotent, whole-line behaviour, and a second
+    # implementation of it is how a plane ends up with one rule twice. The DETECTION above
+    # stays here on purpose: the `.charter/` substring test and the `!/workspaces/.gitkeep`
+    # whole-line test each record a specific bug, and neither generalises. Passing only the
+    # lines this already decided are missing makes the two equivalent — a line the
+    # substring test finds is never handed over, and one it does not find is absent as a
+    # whole line too.
+    util.append_gitignore(root, missing, "added by `charter init`")
     return True
 
 

--- a/charter/util.py
+++ b/charter/util.py
@@ -259,3 +259,34 @@ def detach_self(args: list[str]) -> bool:
     except Exception:
         return False
     return True
+
+
+def append_gitignore(root, lines, header: str) -> list[str]:
+    """Append the ignore *lines* a plane's ``.gitignore`` is missing. Returns the ones
+    actually written, so a caller can report what it changed rather than what it asked for
+    (ADR 0013).
+
+    **Append-only, and that is a hard requirement rather than politeness.** The file is not
+    free-form: ``workspace.set_live()`` splices its managed block at the literal anchor line
+    ``!/workspaces/.gitkeep``, so a writer that rewrote or reordered would break live
+    workspaces from across the codebase, with a symptom pointing nowhere near here.
+
+    Whole-line matching, never a substring. ``_ensure_gitignore``'s docstring records what
+    the substring version cost: ``"workspaces/" in body`` matched a pre-existing
+    ``build/workspaces/output/`` and skipped writing the anchor the splice depends on.
+
+    One writer, deliberately. ``charter init`` had the only implementation, inlined, and the
+    second command needing to ignore a path it creates would otherwise have grown a rival —
+    which is how a plane ends up with one rule twice.
+    """
+    from pathlib import Path
+
+    p = Path(root) / ".gitignore"
+    body = p.read_text() if p.exists() else ""
+    present = {ln.strip() for ln in body.splitlines()}
+    missing = [ln for ln in lines if ln not in present]
+    if not missing:
+        return []
+    prefix = (body.rstrip("\n") + "\n\n") if body.strip() else ""
+    p.write_text(prefix + f"# {header}\n" + "".join(f"{ln}\n" for ln in missing))
+    return missing

--- a/docs/adr/0017-charter-ignores-what-carries-credentials.md
+++ b/docs/adr/0017-charter-ignores-what-carries-credentials.md
@@ -1,0 +1,74 @@
+# charter ignores what carries credentials
+
+A charter command that writes into a plane leaves paths behind, and each one raises the
+same question: does this get committed? Two rules, drawn where the answer stops being a
+matter of taste:
+
+1. **A path charter's own command causes to exist, and which carries credential material,
+   charter ignores** — it writes the `.gitignore` line itself and says that it did.
+2. **Every other path it leaves behind, charter states and does not decide.** It owes the
+   operator the trade-off in its own output; it does not settle a legitimate choice by
+   writing a line while nobody is looking.
+
+## Why it is written down
+
+Because it was being derived one site at a time, and the site that skipped it produced
+[#278](https://github.com/diazoxide/charter/issues/278) — `charter browser install` left
+several paths untracked with nothing said about any of them. The report's own words: *"each
+plane picks one, in silence, and the reasoning is nowhere for the next reader."*
+
+Deriving it per site also gets the *facts* wrong, which that report demonstrates. It
+described `.playwright-cli/` as "per-machine session state". It is not: the vendor's source
+names it `cliOutputDir`, with traces under `.playwright-cli/trace` and snapshots beside
+them, while a session lives outside any repo in
+`~/Library/Caches/ms-playwright/daemon/<hash>/<name>.session`. The conclusion survived the
+correction — ignore it — but only because the rule is about what a path *carries*, and the
+real answer there is worse than the reported one.
+
+The rule was already being obeyed elsewhere, which is the signal that it is a rule rather
+than a run of coincidences:
+
+- `commands_secrets` refuses a vault file inside the plane that is not gitignored — *"it
+  holds credentials"* — rather than trusting the operator to notice.
+- `charter init` writes `/.charter/` into the baseline for the same reason, before any
+  vault exists to protect.
+- The `browser` skill's hard rules already said it in prose: *"never commit a session
+  directory or a storage-state file — they carry live cookies, which are the credential in
+  another form."* What was missing was not the decision. It was charter acting on a
+  decision it had already published — and noticing that a trace is the same category with
+  more in it.
+
+## Where the line falls, and why there
+
+Credential material is not a matter of preference. A Playwright trace records the network:
+requests with their headers and bodies, and DOM snapshots of the pages that produced them.
+A trace taken during a `charter secret exec` login therefore holds the login POST — the one
+thing the credential bridge exists to keep out of reach — and committing it puts that in
+everyone's clone and in the forge's history, recoverable long after a `git rm`. There is no
+plane for which that is the right answer, so charter does not ask.
+
+Generated content and configuration are the opposite. `.claude/skills/playwright-cli/` has
+two defensible postures — committed, and a fresh clone works with no `npx` round trip, at the cost of a
+tree a later `install` silently rewrites; or untracked, and the tree stays honest at the
+cost of a generator run per clone. `.playwright/cli.config.json` is a project config file,
+which many teams would reasonably commit. Charter has no standing to pick either, and a
+`.gitignore` line written quietly *is* picking. Naming both costs in the command's own output is the whole
+obligation, and it discharges the part of #278 that actually recurs: not the missing line,
+but the missing reasoning.
+
+## Consequences
+
+- One writer: `util.append_gitignore` — append-only, idempotent, whole-line. Rewriting the
+  file is not available to any caller, because `workspace.set_live()` splices its managed
+  block at the literal anchor `!/workspaces/.gitkeep`.
+- Charter reports the line it wrote, not the line it intended to write
+  ([ADR 0013](0013-success-is-checked-divergence-is-named.md)).
+- The vendor keeps its own half. `.playwright-cli/` is `@playwright/cli`'s directory, and
+  the durable fix is upstream in the tool that writes it; charter's line is a stopgap for
+  the operator standing in front of charter rather than in front of npm.
+- **Check the path, do not take its description on trust.** The row here was nearly written
+  against a claim about the directory that the vendor's own source contradicts. A rule about
+  what a path carries is only as good as knowing what is in it.
+- This does not license charter to manage a plane's `.gitignore` generally. The trigger is
+  narrow — charter's command created the path, and the path carries credentials. A path
+  that fails either half gets a sentence, not a write.

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -1,0 +1,82 @@
+# The browser lane
+
+Driving a browser splits cleanly in two, and only one half is charter's.
+
+| | owner |
+| --- | --- |
+| How to drive a page — snapshots, clicking, network mocking, tracing | Playwright |
+| Where credentials come from, and how parallel workers stay isolated | charter |
+
+Charter ships the `charter:browser` skill for its half and **none** of Playwright's pages.
+`@playwright/cli` is Apache-2.0 and charter is MIT: redistributing the generated reference
+would put a second licence, with its attribution obligations, into every wheel — for content
+charter neither wrote nor maintains. It would also pin a pre-1.0 package that publishes
+frequently to *charter's* release cadence, so a Playwright fix would wait on a charter
+release to reach anyone.
+
+```bash
+charter browser install                 # generate Playwright's reference into this plane
+charter browser install --version 0.1.19
+```
+
+## The paths it leaves behind
+
+Three, of different kinds. Charter decides one and states the others — see
+[ADR 0017](adr/0017-charter-ignores-what-carries-credentials.md) for why the line falls
+there.
+
+| path | what it is | posture |
+| --- | --- | --- |
+| `.playwright-cli/` | traces, snapshots, screenshots | **ignored by charter** |
+| `.claude/skills/playwright-cli/` | the generated reference | yours to decide |
+| `.playwright/` | `cli.config.json`, project config | yours to decide |
+
+### `.playwright-cli/` — ignored, and not your call
+
+The CLI's **output** directory: `.playwright-cli/trace` plus snapshots, screenshots and
+PDFs. It appears when something writes there, not at install, which is why it tends to show
+up as an unexplained `??` entry some time after the command that caused it.
+
+Not a session, despite the name — a session lives in
+`~/Library/Caches/ms-playwright/daemon/<hash>/<name>.session`, outside any repo. What makes
+it credential material is **traces**: a trace records network requests with their headers and
+bodies, and DOM snapshots of the pages that produced them. So a trace taken while
+`charter secret exec` was logging in holds the login POST — the one thing the credential
+bridge exists to keep out of reach.
+
+Charter appends it to the plane's `.gitignore` and says so. Committing it would put that in
+everyone's clone, and into the forge's history, where a later `git rm` does not reach it.
+That is credential material, so charter does not ask.
+
+### `.claude/skills/playwright-cli/` and `.playwright/` — stated, entirely your call
+
+The generated reference, and the workspace config directory `install` creates for
+`cli.config.json`. Charter leaves both untracked and ignores neither, because both answers
+are defensible and the decision is the plane's. For the reference:
+
+- **Commit it** — a fresh clone works with no `npx` round trip and no network. The cost is
+  a tree holding ten pages that a later `install` rewrites without warning, so an edit to
+  them looks durable right up until it is not.
+- **Leave it untracked** — the tree stays honest about what is generated. The cost is a
+  generator run per clone, and the reference simply being absent until someone does it.
+
+`.playwright/cli.config.json` is ordinary project configuration — plenty of teams would
+commit it, and charter has no opinion.
+
+Whichever you pick, pick it once and write it down. Regenerate rather than edit: the pages
+are Playwright's, and `install` is the only supported way to change them.
+
+## Credentials
+
+The bridge itself — `charter secret exec --dotenv`, one session per worker, and the failure
+modes that silently produce a bogus login — lives in the `charter:browser` skill, which
+ships with the plugin and so versions with the CLI rather than with a plane's copy of it.
+Your harness loads it by name; `charter doctor` reports it missing. For the vault side of
+it, see [docs/secrets.md](secrets.md).
+## Sessions belong to a version
+
+State lives under `~/Library/Caches/ms-playwright/daemon/<hash>/<name>.session`, and the
+hash keys on the *installation*, not the working directory. Two commands that resolve
+different versions talk to different daemons, and the second reports `The browser 'owner' is
+not open, please run open first` while the first browser is alive and still logged in. Pin
+the version explicitly in every command.

--- a/docs/news/unreleased-browser-session-state-ignored.md
+++ b/docs/news/unreleased-browser-session-state-ignored.md
@@ -1,0 +1,26 @@
+---
+version: unreleased
+headline: charter ignores the traces your authenticated runs leave behind
+adopt: browser install
+---
+
+`charter browser install` left two untracked paths and said nothing about either, so every
+plane worked out the same two answers from scratch — and one of those answers was about
+credentials.
+
+`.playwright-cli/` is the CLI's output directory — traces, snapshots, screenshots. A trace
+records network requests with their **headers and bodies**, so a trace taken while
+`charter secret exec` was logging in holds the login POST: the one thing the credential
+bridge exists to keep out of reach. Charter now appends it to the plane's `.gitignore` and
+reports the line it wrote. Committing it would put that in everyone's clone and in the
+forge's history, where deleting the file later does not reach it.
+
+`.claude/skills/playwright-cli/` (the generated reference) and `.playwright/`
+(`cli.config.json`) are deliberately *not* ignored. Committing either is a real trade-off
+with two defensible answers, so the install now names the costs and leaves the choice where
+it belongs. The rule charter is
+following, and the narrow trigger that keeps it from managing your `.gitignore` generally,
+is written down in [ADR 0017](../adr/0017-charter-ignores-what-carries-credentials.md).
+
+Re-run `charter browser install` on any plane that already has the lane — it is idempotent,
+and it will add the line it should have added the first time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ packages = ["charter"]
 # tests/test_docs_show.py fails on a `docs/*.md` that is not force-included, because the
 # gap is invisible from a checkout, where the fallback reads the repo and looks fine.
 [tool.hatch.build.targets.wheel.force-include]
+"docs/browser.md" = "charter/_docs/browser.md"
 "docs/control-plane.md" = "charter/_docs/control-plane.md"
 "docs/forges.md" = "charter/_docs/forges.md"
 "docs/git-policy.md" = "charter/_docs/git-policy.md"

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -17,6 +17,11 @@ Two halves, owned by different projects:
   Charter ships none of those pages: they are Apache-2.0 and they change far more often
   than charter releases. Regenerate with that command rather than editing them.
 
+  That command also gitignores `.playwright-cli/` — where traces and snapshots land, and a
+  trace holds the network traffic of whatever it recorded, logins included — and states,
+  without deciding, whether the generated reference and `.playwright/cli.config.json` should
+  be committed. All three postures are in `docs/browser.md`.
+
 - **Where credentials come from, and how parallel workers stay isolated** — this skill.
 
 ## One session per worker
@@ -118,4 +123,7 @@ To avoid re-authenticating on every run, save the logged-in state once and reloa
   keep the value out of the conversation; reading it back defeats both.
 - Never type a credential in directly, even "just once to test". Use the bridge.
 - Never commit a session directory or a storage-state file — they carry live cookies, which
-  are the credential in another form.
+  are the credential in another form. The same goes for traces: a trace records requests
+  with their headers and bodies, so tracing a bridged login writes the credential to disk
+  even though it never reached your transcript. `charter browser install` gitignores
+  `.playwright-cli/` for exactly this.

--- a/tests/test_browser_install.py
+++ b/tests/test_browser_install.py
@@ -122,3 +122,91 @@ class TestTheGeneratorCannotHangOrPromptInvisibly(unittest.TestCase):
         self.assertNotEqual(code, 0)
         self.assertIn("did not finish", out)
         self.assertIn("npx", out)
+
+
+class TestTheOutputDirectoryIsIgnored(unittest.TestCase):
+    """`.playwright-cli/` is the CLI's OUTPUT directory — `cliOutputDir` in the vendor's
+    source, holding traces under `trace/` plus snapshots and screenshots. #278 called it
+    "per-machine session state"; it is not (a session lives under
+    `~/Library/Caches/ms-playwright/daemon/`), and the truth is worse. A trace records
+    network requests with their headers and bodies, so a trace taken during a
+    `charter secret exec` login holds the login POST — the one thing the credential bridge
+    exists to keep out of reach.
+
+    So the ignore line is charter enforcing a rule it had already written down, not a new
+    opinion: `commands_secrets` already refuses a vault file git would take.
+
+    The generated skill and `.playwright/` are deliberately NOT covered. Neither carries a
+    credential, so committing them is a plane's call, and charter states the trade-off
+    instead of quietly deciding it (ADR 0017).
+    """
+
+    def setUp(self) -> None:
+        import tempfile
+        self.root = Path(tempfile.mkdtemp(prefix="charter-browser-"))
+
+    def test_the_output_dir_is_the_vendors_cli_output_dir(self):
+        """Pinned against the vendor's `cliOutputDir`, not against the name in the report
+        that prompted this — the two disagreed, and the source won."""
+        self.assertEqual(browser.OUTPUT_DIR, Path(".playwright-cli"))
+
+    def test_the_config_dir_is_known_but_not_ignored(self):
+        """`install` creates it (`initWorkspace`, for cli.config.json). Charter names it so
+        the operator is not surprised, and ignores nothing about it."""
+        self.assertEqual(browser.CONFIG_DIR, Path(".playwright"))
+
+    def test_it_ignores_the_output_directory(self):
+        added = browser.ensure_output_ignored(self.root)
+        body = (self.root / ".gitignore").read_text()
+        self.assertIn(".playwright-cli/", body.splitlines())
+        self.assertEqual(added, [".playwright-cli/"])
+
+    def test_it_ignores_neither_the_generated_skill_nor_the_config_dir(self):
+        """The opinionated half, pinned so a later "while we're here" cannot quietly
+        take either decision away from the plane."""
+        browser.ensure_output_ignored(self.root)
+        body = (self.root / ".gitignore").read_text()
+        self.assertNotIn("playwright-cli/", body.replace(".playwright-cli/", ""))
+        self.assertNotIn(str(browser.SKILL_DIR), body)
+        self.assertNotIn(f"{browser.CONFIG_DIR}/", body)
+
+    def test_running_it_twice_changes_nothing(self):
+        browser.ensure_output_ignored(self.root)
+        self.assertEqual(browser.ensure_output_ignored(self.root), [])
+
+
+class TestTheInstallStatesBothPostures(unittest.TestCase):
+    """The whole complaint in #278 is that the command said nothing about either path, so
+    every plane re-decided both in silence. Silence is the regression to guard against."""
+
+    def _run_install(self):
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+        from unittest import mock
+        import tempfile
+        from charter import commands, config
+
+        root = Path(tempfile.mkdtemp(prefix="charter-install-"))
+        (root / browser.SKILL_DIR).mkdir(parents=True)
+        (root / browser.SKILL_DIR / "page.md").write_text("x")
+        out, err = io.StringIO(), io.StringIO()
+        with mock.patch.object(config, "ROOT", root), \
+             mock.patch.object(config, "HAS_CONTROL_PLANE", True), \
+             mock.patch.object(browser, "npx_available", lambda: True), \
+             mock.patch.object(browser, "install", lambda r, v: (0, "")), \
+             redirect_stdout(out), redirect_stderr(err):
+            code = commands.cmd_browser_install(mock.Mock(version=None))
+        return code, out.getvalue() + err.getvalue(), root
+
+    def test_it_reports_the_ignore_line_it_wrote(self):
+        code, said, root = self._run_install()
+        self.assertEqual(code, 0)
+        self.assertIn(".playwright-cli/", said)
+        self.assertIn(".playwright-cli/", (root / ".gitignore").read_text().splitlines())
+
+    def test_it_states_the_undecided_paths_are_the_planes_call(self):
+        """Not "commit it" and not "do not" — the costs, and whose decision it is."""
+        _, said, _ = self._run_install()
+        self.assertIn(str(browser.SKILL_DIR), said)
+        self.assertIn(str(browser.CONFIG_DIR), said)
+        self.assertIn("docs/browser.md", said)

--- a/tests/test_gitignore_append.py
+++ b/tests/test_gitignore_append.py
@@ -1,0 +1,72 @@
+"""The one writer every command that adds an ignore rule goes through.
+
+`charter init` had the only implementation, inlined, and the next command that needed to
+ignore a path it creates (`charter browser install`, for the live browser session under
+`.playwright-cli/`) would otherwise have written a second one. Two writers is how a plane
+ends up with the same rule twice, or with one of them silently reordering a file the other
+appends to — and `.gitignore` here is not free-form: `workspace.set_live()` splices its
+managed block at the literal anchor line `!/workspaces/.gitkeep`, so a writer that rewrites
+rather than appends breaks a feature that has nothing to do with it.
+
+What this pins is therefore the contract, not the caller: append-only, idempotent, and
+existing content untouched.
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from charter import util
+
+
+class TestAppendGitignore(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="charter-ignore-"))
+        self.p = self.root / ".gitignore"
+
+    def test_it_creates_the_file_when_the_plane_has_none(self):
+        """A plane that has never needed one is the common case for a fresh clone, and
+        "no .gitignore" must not read as "nothing to do"."""
+        added = util.append_gitignore(self.root, [".playwright-cli/"], "by a test")
+        self.assertEqual(added, [".playwright-cli/"])
+        self.assertIn(".playwright-cli/", self.p.read_text().splitlines())
+
+    def test_it_is_idempotent(self):
+        """Every `browser install` re-runs this. A second run that appends again would
+        grow the file without bound and make the diff of an unrelated PR unreadable."""
+        util.append_gitignore(self.root, [".playwright-cli/"], "by a test")
+        added = util.append_gitignore(self.root, [".playwright-cli/"], "by a test")
+        self.assertEqual(added, [])
+        self.assertEqual(self.p.read_text().count(".playwright-cli/"), 1)
+
+    def test_it_never_touches_what_is_already_there(self):
+        """The anchor `workspace.set_live()` greps for lives in this file. A writer that
+        rewrote or reordered would break live workspaces from across the codebase."""
+        before = "/workspaces/*/*\n!/workspaces/.gitkeep\n\n# mine\n*.log\n"
+        self.p.write_text(before)
+        util.append_gitignore(self.root, [".playwright-cli/"], "by a test")
+        self.assertTrue(self.p.read_text().startswith(before.rstrip("\n")))
+        self.assertIn("!/workspaces/.gitkeep", self.p.read_text())
+
+    def test_it_appends_only_the_lines_that_are_missing(self):
+        self.p.write_text("*.log\n.playwright-cli/\n")
+        added = util.append_gitignore(self.root, [".playwright-cli/", "seen/"], "by a test")
+        self.assertEqual(added, ["seen/"])
+
+    def test_a_line_matches_only_as_a_whole_line(self):
+        """A substring test would see `.playwright-cli/` inside `build/.playwright-cli/x`
+        and skip the write — the exact bug `_ensure_gitignore`'s docstring records for
+        `workspaces/`, where a wrong skip cost the live-workspace anchor."""
+        self.p.write_text("build/.playwright-cli/output\n")
+        added = util.append_gitignore(self.root, [".playwright-cli/"], "by a test")
+        self.assertEqual(added, [".playwright-cli/"])
+
+    def test_the_header_says_which_command_wrote_the_lines(self):
+        """A rule with no provenance is a rule nobody dares delete."""
+        util.append_gitignore(self.root, ["x/"], "added by `charter browser install`")
+        self.assertIn("# added by `charter browser install`", self.p.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #278.

`charter browser install` created untracked paths and said nothing about any of them, so
every plane re-derived the same answers in silence. The report's own words: *"each plane
picks one, in silence, and the reasoning is nowhere for the next reader."*

## The report's premise is wrong, and the truth is worse

#278 describes `.playwright-cli/` as *"per-machine session state"*. It isn't. From the
vendor's own source (`playwright-core/lib/coreBundle.js:11322`):

```js
traceDir = path.join(".playwright-cli", "trace");
cliOutputDir = ".playwright-cli";
```

It is the CLI's **output** directory — traces, snapshots, screenshots. A *session* lives
outside any repo, in `~/Library/Caches/ms-playwright/daemon/<hash>/<name>.session`, exactly
as charter's own `browser` skill already says.

The conclusion survives, and gets sharper. **A trace records the network** — requests with
their headers and bodies, plus DOM snapshots of the pages that produced them. So a trace
taken while `charter secret exec` was logging in holds the login POST: precisely the thing
the credential bridge exists to keep out of reach. Charter keeps the password out of the
transcript and Playwright substitutes it into the page without printing it — and then a
trace writes the authenticated traffic to disk beside your source, where `git add -A` is
waiting.

Charter had already decided this class and simply wasn't acting on it:
`commands_secrets.py:131` refuses a vault file inside the plane that git would take, and the
`browser` skill's hard rules forbid committing session and storage-state files *"because
they carry live cookies, which are the credential in another form."* A trace carries more.

## What is *not* ignored, on purpose

| path | what it is | posture |
| --- | --- | --- |
| `.playwright-cli/` | traces, snapshots, screenshots | **ignored by charter** |
| `.claude/skills/playwright-cli/` | the generated reference | stated, plane decides |
| `.playwright/` | `cli.config.json`, written by `initWorkspace` | stated, plane decides |

Neither of the latter carries a credential. Both postures are defensible — commit the
reference and a fresh clone needs no `npx`, at the cost of a tree a later `install` rewrites
under you; `cli.config.json` is ordinary project config plenty of teams would commit.
Charter has no standing to pick, and a `.gitignore` line written quietly *is* picking. The
install names the costs and points at `docs/browser.md`.

(`.playwright/` isn't in #278 at all — it turned up while checking the report's claim.)

## ADR 0017

The rule, written down so it stops being re-derived: **charter ignores what carries
credentials; everything else it states and does not decide.** The trigger is deliberately
narrow — charter's own command created the path, *and* the path carries credentials — so
this does not become charter managing a plane's `.gitignore` generally.

It also records what this nearly got wrong: a rule about what a path *carries* is only as
good as knowing what is in it. This row was almost written against the report's description
instead of the vendor's source.

## One writer

`util.append_gitignore` — append-only, idempotent, whole-line — is now the single
implementation, used by `init` and `browser install`. Append-only is a hard requirement, not
politeness: `workspace.set_live()` splices its managed block at the literal anchor
`!/workspaces/.gitkeep`, so a rewriting writer would break live workspaces from across the
codebase. `init` keeps its own detection (the `.charter/` substring test and the anchor test
each record a specific bug); only the write is shared, and passing just the lines it already
found missing makes the two paths equivalent.

## Not in this PR

- The durable fix is upstream in the tool that writes the directory; charter's line is a
  stopgap for the operator standing in front of charter rather than npm. Filed separately.
- A `charter doctor` check for the same rule — #287, stacked on this.

## Testing

`python3 -m unittest discover -s tests` — 2652 tests, green. New tests fail without the fix:
6 for the shared writer's contract, 7 for the install's postures — including ones pinning
that the generated skill and `.playwright/` are *not* ignored, so a later "while we're here"
can't quietly take those decisions away from the plane, and one pinning `OUTPUT_DIR` against
the vendor's `cliOutputDir` rather than against the name in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)