### PR TITLE
A vault read could hang a session forever

### DIFF
--- a/charter/secrets/reference.py
+++ b/charter/secrets/reference.py
@@ -56,6 +56,21 @@ def _vault_argv(uri: str) -> tuple[list[str], str]:
 #: scheme → (argv builder, CLI name). Argv, never a shell string.
 _RESOLVERS = {"op": _op_argv, "vault": _vault_argv}
 
+#: How long one reference may take to resolve before charter stops waiting on it.
+#:
+#: `util.run`'s docstring records the failure this bounds, by example: "every un-timeouted
+#: path could hang indefinitely: a 1Password session needing re-auth stalled the SessionStart
+#: preflight". This call is that exact CLI, and it had no bound at all.
+#:
+#: The hang costs more here than there, because of where a resolve happens. A reference is
+#: read inside `charter secret exec`, which an agent runs unattended — so a CLI waiting on a
+#: prompt nobody will see does not fail, it stops, silently, for as long as the session lasts.
+#:
+#: Sixty seconds: long enough for a real re-authentication (a biometric prompt someone has
+#: to walk back to their desk for is already lost, whatever the number), short enough that
+#: the failure arrives while the operator still remembers running the command.
+RESOLVE_TIMEOUT = 60.0
+
 
 def scheme_of(value: str) -> str | None:
     """The reference scheme of *value*, or None if it isn't a supported reference."""
@@ -141,7 +156,22 @@ class ReferenceProvider(VaultProvider):
         if not shutil.which(cli):
             raise VaultError(f"'{key}' needs the '{cli}' CLI to resolve {uri} — it is not "
                              f"on PATH. Install it and authenticate, then retry.")
-        proc = self.runner(argv, check=False, env=self.env_overlay())
+        try:
+            proc = self.runner(argv, check=False, env=self.env_overlay(),
+                               timeout=RESOLVE_TIMEOUT)
+        except util.ProcTimeout:
+            # ADR 0009 — a cause charter recognised, not one it inferred. A bare "timed
+            # out" sends the reader to look at the network, which is almost never it: the
+            # CLI is far more likely to be sitting on an authentication prompt that has
+            # nowhere to render. Same withholding rule as the exit-status path below —
+            # nothing the resolver produced goes into the message.
+            raise VaultError(
+                f"resolving '{key}' via {cli} did not finish within "
+                f"{RESOLVE_TIMEOUT:g}s and was stopped{self.identity_note()}.\n"
+                f"  Almost always this is {cli} waiting on an authentication prompt that "
+                f"an unattended run has nowhere to display — re-authenticate in a terminal "
+                f"({cli} sign-in), then retry.\n"
+                f"  (Resolver output withheld — it can contain the secret.)")
         if proc.returncode != 0:
             raise VaultError(
                 f"resolving '{key}' via {cli} failed (exit {proc.returncode}) for {uri}"

--- a/docs/news/unreleased-bounded-reference-resolution.md
+++ b/docs/news/unreleased-bounded-reference-resolution.md
@@ -1,0 +1,22 @@
+---
+version: unreleased
+headline: A vault read can no longer hang your session
+---
+
+Resolving a reference vault — `op://`, `vault://` — shelled out to the provider's CLI with
+no timeout at all, on the one operation in that module that leaves the machine.
+
+`util.run`'s own docstring names the failure by example: *"every un-timeouted path could
+hang indefinitely: a 1Password session needing re-auth stalled the SessionStart preflight."*
+Reference resolution was that exact CLI, unbounded.
+
+It costs more there than in a preflight, because of *where* a resolve happens. References
+are read inside `charter secret exec`, which an agent runs unattended. A CLI waiting on an
+authentication prompt that has nowhere to render does not fail and does not print — it
+stops, for as long as the session lasts, with nothing to say why.
+
+Resolution is now bounded at 60 seconds, and a timeout arrives as a named cause with the
+action that fixes it (re-authenticate in a terminal), not a traceback. Resolver output stays
+withheld on that path too — it can contain the secret.
+
+Nothing to adopt: every reference vault gets this on upgrade.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -318,6 +318,9 @@ Deliberate properties:
   there would hit 1Password on every listing and could prompt for re-auth.
 - **A failed resolve reports status, not output** — a resolver's stderr can echo what it
   fetched.
+- **A resolve is bounded** (60s) and a timeout is reported as a named cause rather than a
+  traceback. Unattended runs are the reason: a CLI sitting on an authentication prompt with
+  nowhere to render it does not fail, it stops — silently, for as long as the session lasts.
 - You still need the CLI installed and authenticated; charter shells out to it and says
   so plainly when it is missing.
 

--- a/tests/test_reference_resolution_is_bounded.py
+++ b/tests/test_reference_resolution_is_bounded.py
@@ -1,0 +1,93 @@
+"""A vault read that can hang forever is a session that can hang forever.
+
+`util.run`'s own docstring records the failure this prevents, by example: "every
+un-timeouted path could hang indefinitely: a 1Password session needing re-auth stalled the
+SessionStart preflight". Reference resolution shells out to exactly that CLI — `op read`,
+`vault kv get` — and did so with no bound at all, on the one operation in the module that
+leaves the machine.
+
+The hang is worse here than the docstring's case, because of WHERE a resolve happens: a
+reference is read inside `charter secret exec`, which an agent runs unattended. A prompt
+that waits for an answer nobody is going to see does not fail; it stops, with no output to
+explain why, for as long as the session lasts.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import util
+from charter.secrets import reference
+from charter.secrets.base import VaultError
+
+
+class _Vault(reference.ReferenceProvider):
+    """A provider whose reference table is in memory — the resolver is what is under test,
+    not the 0600 file it usually reads."""
+
+    def __init__(self):
+        super().__init__("t", {})
+        self._refs = {"tok": "op://Eng/deploy/token"}
+
+    def reference_for(self, key):          # noqa: D102 - see class docstring
+        return self._refs[key]
+
+
+class TestResolutionIsBounded(unittest.TestCase):
+    def setUp(self) -> None:
+        self.v = _Vault()
+        self.enterContext(mock.patch.object(reference.shutil, "which", lambda c: f"/usr/bin/{c}"))
+
+    def test_the_resolver_is_given_a_timeout(self):
+        """Not "a timeout exists somewhere" — that this call passes one."""
+        seen = {}
+
+        def runner(argv, **kw):
+            seen.update(kw)
+            return mock.Mock(returncode=0, stdout="v")
+
+        self.v.runner = staticmethod(runner)
+        self.v.get("tok")
+        self.assertIn("timeout", seen)
+        self.assertTrue(0 < seen["timeout"] <= 300,
+                        "bounded, and generous enough for a CLI that may re-auth")
+
+    def test_a_timeout_is_classified_not_a_traceback(self):
+        """ADR 0009 — charter names a cause it recognised. A `ProcTimeout` escaping as a
+        traceback would be charter failing to classify its own failure, in the one place
+        the operator most needs to be told what to do next."""
+        def runner(argv, **kw):
+            raise util.ProcTimeout("op", 60.0)
+
+        self.v.runner = staticmethod(runner)
+        with self.assertRaises(VaultError) as caught:
+            self.v.get("tok")
+        said = str(caught.exception)
+        self.assertIn("op", said)
+        self.assertIn("tok", said)
+
+    def test_the_timeout_message_names_re_authentication(self):
+        """The overwhelmingly likely cause, and the one the operator can act on. A bare
+        "timed out" sends them looking at the network."""
+        def runner(argv, **kw):
+            raise util.ProcTimeout("op", 60.0)
+
+        self.v.runner = staticmethod(runner)
+        with self.assertRaises(VaultError) as caught:
+            self.v.get("tok")
+        self.assertIn("auth", str(caught.exception).lower())
+
+    def test_a_timeout_never_carries_the_reference_output(self):
+        """The module's existing rule — "Resolver output withheld — it can contain the
+        secret" — has to hold on this path too, which is a second, later exit."""
+        def runner(argv, **kw):
+            raise util.ProcTimeout("op", 60.0)
+
+        self.v.runner = staticmethod(runner)
+        with self.assertRaises(VaultError) as caught:
+            self.v.get("tok")
+        self.assertNotIn("stdout", str(caught.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reference resolution shelled out to `op read` / `vault kv get` **with no timeout at all** —
the one operation in `charter/secrets/reference.py` that leaves the machine.

`util.run`'s own docstring names this failure by example:

> every un-timeouted path could hang indefinitely: a 1Password session needing re-auth
> stalled the SessionStart preflight

That call *is* this CLI. It was unbounded.

## Why it costs more here than in a preflight

Because of **where** a resolve happens. A reference is read inside `charter secret exec`,
which an agent runs unattended. A CLI sitting on an authentication prompt that has nowhere
to render does not fail and does not print — it stops, silently, for as long as the session
lasts. There is no output to point at and nothing to time out against.

## The change

- `RESOLVE_TIMEOUT = 60.0`, applied to the one resolver call. Long enough for a real
  re-authentication; short enough that the failure arrives while the operator still
  remembers running the command.
- A timeout is **classified** (ADR 0009) with the action that fixes it — re-authenticate in
  a terminal — rather than escaping as a `ProcTimeout` traceback. A bare "timed out" sends
  the reader to look at the network, which is almost never it.
- The module's existing withholding rule (*"Resolver output withheld — it can contain the
  secret"*) holds on this second exit too.

## How it was found

Designing the `browser://` reference scheme for #277, which would have put `npx` — a
network fetch — on this same unbounded path. Fixing it generically first, so that PR lands
on a resolver that cannot hang, and so `op://` and `vault://` stop being able to hang today.

## Testing

`python3 -m unittest discover -s tests` — 2643 tests, green. Four new tests, all failing
without the fix: that the call is given a timeout at all, that a timeout raises `VaultError`
rather than a traceback, that the message names re-authentication, and that resolver output
never reaches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)