### PR TITLE
Read a logged-in session's token without printing it (#277)

### DIFF
--- a/charter/browser.py
+++ b/charter/browser.py
@@ -126,3 +126,28 @@ def ensure_output_ignored(root: Path) -> list[str]:
     from . import util
     return util.append_gitignore(root, [f"{OUTPUT_DIR}/"],
                                  "added by `charter browser install`")
+
+#: The two places a logged-in session keeps a token, and the only two this reads. Both are
+#: `--raw` reads of ONE named value: charter never dumps whole storage state, because a
+#: dump is a credential blob whose contents nobody declared and the redactor cannot know.
+SESSION_SOURCES = ("localstorage", "cookie")
+
+
+def session_read_argv(session: str, source: str, name: str,
+                      version: str | None = None) -> list[str]:
+    """The invocation that reads one named value out of an open session.
+
+    `--raw` is not optional. Without it the reply carries page status and generated-code
+    sections, so the "secret" charter injected downstream would be a decorated blob — and
+    the redactor would then be scrubbing a string that never appears in the API call the
+    value was fetched for. The vendor documents `--raw` for exactly this: "returning only
+    the result value. Use it to pipe command output into other tools."
+
+    The version is the whole reason this belongs to charter rather than to a shell script.
+    A session belongs to the version that opened it — state is keyed on the installation —
+    so an unpinned `npx` talks to a different daemon and reports `not open` while the first
+    browser is alive and still logged in. Charter knows the pin; a hand-written `$(...)` is
+    precisely where an operator forgets it.
+    """
+    return ["npx", "--yes", f"@playwright/cli@{version or PINNED}", f"-s={session}",
+            "--raw", f"{source}-get", name]

--- a/charter/secrets/reference.py
+++ b/charter/secrets/reference.py
@@ -33,7 +33,7 @@ from .. import util
 from .base import SecretNotFound, VaultError, VaultProvider
 
 
-def _op_argv(uri: str) -> tuple[list[str], str]:
+def _op_argv(uri: str, config: dict) -> tuple[list[str], str]:
     """``op://vault/item/field`` → the 1Password CLI reads the whole URI itself."""
     parts = urlsplit(uri)
     if not parts.netloc or len(parts.path.strip("/").split("/")) < 2:
@@ -42,7 +42,7 @@ def _op_argv(uri: str) -> tuple[list[str], str]:
     return ["op", "read", "--no-newline", uri], "op"
 
 
-def _vault_argv(uri: str) -> tuple[list[str], str]:
+def _vault_argv(uri: str, config: dict) -> tuple[list[str], str]:
     """``vault://secret/data/app#FIELD`` → ``vault kv get -field=FIELD secret/data/app``."""
     parts = urlsplit(uri)
     path = (parts.netloc + parts.path).strip("/")
@@ -53,8 +53,42 @@ def _vault_argv(uri: str) -> tuple[list[str], str]:
     return ["vault", "kv", "get", f"-field={field}", path], "vault"
 
 
+def _browser_argv(uri: str, config: dict) -> tuple[list[str], str]:
+    """``browser://<session>/localstorage/<key>`` — one value out of a logged-in browser.
+
+    A session is a place a credential lives, the same way a 1Password item is, and the half
+    charter owns is identical in both cases: resolve by name, never print, never put the
+    value in argv. What made this worth a scheme rather than a shell snippet is that the
+    vendor's own documented idiom is ``TOKEN=$(playwright-cli --raw cookie-get session_id)``
+    — command substitution straight into a transcript, with nothing redacting it, which is
+    the outcome the browser lane exists to prevent (#277).
+
+    The version comes from the vault's config (``{"version": "0.1.19"}``), defaulting to
+    charter's pin — ``account`` already sets the precedent for provider-specific config on a
+    shared provider. It has to be overridable: a session opened at another version is
+    invisible at this one, and the symptom is ``not open`` against a browser that is alive
+    and still logged in.
+    """
+    from .. import browser
+
+    parts = urlsplit(uri)
+    session = parts.netloc
+    # `partition`, not `split`: a localStorage key may itself contain a slash, and the key
+    # is the rest of the path verbatim — including a trailing one.
+    source, sep, name = parts.path.lstrip("/").partition("/")
+    if not session or not source or not sep or not name:
+        raise VaultError(f"malformed browser reference '{uri}' — expected "
+                         f"browser://<session>/<{'|'.join(browser.SESSION_SOURCES)}>/<name>")
+    if source not in browser.SESSION_SOURCES:
+        raise VaultError(f"'{source}' is not a readable browser source in '{uri}' — "
+                         f"charter reads {', '.join(browser.SESSION_SOURCES)}. Whole storage "
+                         f"state is deliberately not among them: a dump is a credential blob "
+                         f"nobody declared, and the redactor cannot scrub what it cannot name.")
+    return browser.session_read_argv(session, source, name, config.get("version")), "npx"
+
+
 #: scheme → (argv builder, CLI name). Argv, never a shell string.
-_RESOLVERS = {"op": _op_argv, "vault": _vault_argv}
+_RESOLVERS = {"op": _op_argv, "vault": _vault_argv, "browser": _browser_argv}
 
 #: How long one reference may take to resolve before charter stops waiting on it.
 #:
@@ -128,7 +162,7 @@ class ReferenceProvider(VaultProvider):
                 f"      charter secret set <name> {key} --from-file <path>\n"
                 f"  To keep the value on this machine instead: --provider plain-file.\n"
                 f"  To register an item you created elsewhere: pass its URI here.")
-        _RESOLVERS[scheme_of(value)](value)  # validate shape now, not at read time
+        _RESOLVERS[scheme_of(value)](value, self.config)  # validate now, not at read time
         data = self._load()
         data[key] = value
         self._save(data)
@@ -152,7 +186,7 @@ class ReferenceProvider(VaultProvider):
         if not scheme:
             raise VaultError(f"'{key}' in vault '{self.name}' is not a supported reference: "
                              f"'{uri}'")
-        argv, cli = _RESOLVERS[scheme](uri)
+        argv, cli = _RESOLVERS[scheme](uri, self.config)
         if not shutil.which(cli):
             raise VaultError(f"'{key}' needs the '{cli}' CLI to resolve {uri} — it is not "
                              f"on PATH. Install it and authenticate, then retry.")
@@ -214,10 +248,11 @@ class ReferenceProvider(VaultProvider):
             return True, "no references yet"
         needed = sorted({s for s in (scheme_of(v) for v in data.values()) if s})
         missing = [s for s in needed if not shutil.which(_RESOLVERS[s](
-            next(v for v in data.values() if scheme_of(v) == s))[1])]
+            next(v for v in data.values() if scheme_of(v) == s), self.config)[1])]
         n = len(data)
         if missing:
             clis = ", ".join(sorted({_RESOLVERS[s](
-                next(v for v in data.values() if scheme_of(v) == s))[1] for s in missing}))
+                next(v for v in data.values() if scheme_of(v) == s), self.config)[1]
+                for s in missing}))
             return False, f"{n} reference(s), but not on PATH: {clis}"
         return True, f"{n} reference(s) via {', '.join(needed)}"

--- a/docs/news/unreleased-browser-token-reference.md
+++ b/docs/news/unreleased-browser-token-reference.md
@@ -1,0 +1,35 @@
+---
+version: unreleased
+headline: Call the API as the user your browser just logged in as
+---
+
+The browser lane got you authenticated and stopped there. The step after — reading the
+token that session now holds, so the same run can check that the UI and the API agree —
+had no supported shape, and the obvious workaround was the one Playwright's own reference
+documents:
+
+```bash
+TOKEN=$(playwright-cli --raw cookie-get session_id)   # the leak
+```
+
+Command substitution puts the token in a shell variable, in a transcript, with nothing
+redacting it. That is the outcome the lane exists to prevent.
+
+A browser session is just another place a credential lives, so it is now a **reference**,
+resolved like `op://` and `vault://`:
+
+```bash
+charter secret set qa API_TOKEN --value 'browser://owner/localstorage/access_token'
+charter secret exec qa --env TOKEN=API_TOKEN -- \
+  curl -sH "Authorization: Bearer $TOKEN" https://api.example.test/me
+```
+
+`browser://<session>/localstorage/<key>` and `browser://<session>/cookie/<name>`. No new
+command and no new flag — every consuming path (`--env`, `--file`, `--dotenv`, redaction,
+`charter persona secret exec`) already worked, and works here unchanged.
+
+Charter builds the invocation, so the version pin is right by construction — the mistake
+that otherwise reports `not open` against a browser that is alive and still logged in.
+Override it per vault with `{"version": "0.1.19"}` when a session was opened at another
+version. Whole storage state is deliberately not readable this way: a dump is a credential
+blob nobody declared, and the redactor cannot scrub what it cannot name.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -293,6 +293,41 @@ The distinction is who owns the item, not which CLI is involved — both end up 
 1Password. Reach for `reference` when a human or another system should stay in charge of
 rotating the credential, and for `1password` when charter should.
 
+#### `browser://` — the token a logged-in session is holding
+
+A browser session is a place a credential lives, so it is a reference like any other. This
+closes the step after a bridged login: check that the UI and the API agree, by calling the
+API **as the user you just logged in**.
+
+```bash
+charter secret set qa API_TOKEN --value 'browser://owner/localstorage/access_token'
+charter secret exec qa --env TOKEN=API_TOKEN -- \
+  curl -sH "Authorization: Bearer $TOKEN" https://api.example.test/me
+```
+
+The value never reaches your transcript. That matters more here than it looks, because the
+obvious alternative is the idiom Playwright's own reference documents:
+
+```bash
+TOKEN=$(playwright-cli --raw cookie-get session_id)   # ← the leak
+```
+
+Command substitution puts the token in a shell variable, in a transcript, with nothing
+redacting it — the outcome the whole browser lane exists to prevent. Through a reference it
+is resolved at the moment of use, injected into the child, and scrubbed from the output that
+comes back.
+
+Two things charter needs to be right about, and one it will not do:
+
+- **The session must be open**, and `charter secret exec` does not open it. Read the token
+  inside the same flow that logged in; a resolve against a closed session fails with the
+  vendor's `not open`.
+- **The version is charter's pin** unless the vault overrides it with
+  `{"version": "0.1.19"}` in its config. A session belongs to the version that opened it, so
+  a mismatch reports `not open` against a browser that is alive and still logged in.
+- **Whole storage state is not readable this way.** A dump is a credential blob nobody
+  declared, and the redactor cannot scrub what it cannot name — name the one key you want.
+
 Every consuming path works unchanged — the value is resolved only when something
 actually needs it:
 
@@ -305,6 +340,8 @@ charter secret exec team --dotenv F=TOKEN:DEPLOY_TOKEN -- some-tool
 | --- | --- |
 | `op://<vault>/<item>/<field>` | `op read --no-newline <uri>` |
 | `vault://<path>#<FIELD>` | `vault kv get -field=<FIELD> <path>` |
+| `browser://<session>/localstorage/<key>` | `playwright-cli -s=<session> --raw localstorage-get <key>` |
+| `browser://<session>/cookie/<name>` | `playwright-cli -s=<session> --raw cookie-get <name>` |
 
 Deliberate properties:
 
@@ -314,6 +351,10 @@ Deliberate properties:
   type it, not at 3am when something tries to read it.
 - **Resolvers are invoked as argv, never a shell string**, so a reference can never be
   command injection whatever it contains.
+- **Redaction covers what comes back, not what the child does with it.** `secret exec`
+  scrubs the value from captured output, so a `curl -v` that echoes an `Authorization`
+  header is masked. `--exec` and `--stream` capture nothing by design, and therefore redact
+  nothing — that trade-off is the same for every scheme.
 - **`health()` never resolves.** `vault list` and `doctor` call it routinely; resolving
   there would hit 1Password on every listing and could prompt for re-auth.
 - **A failed resolve reports status, not output** — a resolver's stderr can echo what it

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -116,6 +116,32 @@ one. A different fixture account is a different pair of keys, not a different me
 To avoid re-authenticating on every run, save the logged-in state once and reload it — see
 `storage-state` in the generated Playwright reference.
 
+## Reading the token the session is holding
+
+The step after logging in: call the API **as the user you just logged in**, so the UI and
+the API can be checked against each other.
+
+Do not read it into a shell variable. Playwright's own reference documents
+`TOKEN=$(playwright-cli --raw cookie-get session_id)`, and that is command substitution
+into a transcript with nothing redacting it — the outcome this whole lane exists to
+prevent. Register it as a reference instead and let the bridge carry it:
+
+```bash
+charter secret set <vault> API_TOKEN --value 'browser://owner/localstorage/access_token'
+charter secret exec <vault> --env TOKEN=API_TOKEN -- \
+  curl -sH "Authorization: Bearer $TOKEN" https://api.example.test/me
+```
+
+`browser://<session>/localstorage/<key>` and `browser://<session>/cookie/<name>` are the two
+forms. Charter builds the invocation, so the version pin is right by construction. The
+session must already be open — resolving does not open one — so do this in the same flow
+that logged in.
+
+This is not an exception to the hard rule below. That rule forbids reading back a secret
+**you filled in**; the value here is one the *session* minted, it is never printed, and it
+reaches the API through the same bridge the password came in on. Reading it any other way —
+`eval`, a screenshot, a bare `cookie-get` — is still out.
+
 ## Hard rules
 
 - **Never read a filled secret back.** No evaluating `el.value`, no screenshot of a filled

--- a/tests/test_browser_reference.py
+++ b/tests/test_browser_reference.py
@@ -1,0 +1,147 @@
+"""Reading a logged-in session's token without printing it (#277).
+
+The gap the report named was not "no way to read the token" — `@playwright/cli` has three,
+and the vendor's own reference documents the idiom::
+
+    TOKEN=$(playwright-cli --raw cookie-get session_id)
+
+That IS the leak. The value lands in a shell variable through command substitution, in a
+transcript, with nothing redacting it — which is the outcome the whole browser lane exists
+to prevent. The gap is reading it *without* printing it.
+
+Charter already owns that discipline end to end, for values that come from a vault: resolve
+by name, inject into a child process, scrub from captured output, never put it in argv. A
+browser session is just another place a value comes from — so this is one row in the
+existing resolver table, not a new command. Everything downstream (`--env`, `--file`,
+`--dotenv`, redaction, `persona secret exec`) then works unchanged and untouched.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import browser
+from charter.secrets import reference
+from charter.secrets.base import VaultError
+
+
+class _Vault(reference.ReferenceProvider):
+    def __init__(self, refs, config=None):
+        super().__init__("t", config or {})
+        self._refs = dict(refs)
+
+    def reference_for(self, key):
+        return self._refs[key]
+
+
+class TestTheSchemeIsRecognised(unittest.TestCase):
+    def test_browser_is_a_reference_scheme(self):
+        self.assertEqual(reference.scheme_of("browser://owner/localstorage/tok"), "browser")
+
+    def test_an_unknown_scheme_is_still_refused(self):
+        self.assertIsNone(reference.scheme_of("ftp://owner/x"))
+
+
+class TestTheInvocation(unittest.TestCase):
+    """Asserted, never run: the suite must not reach the network, and the failure worth
+    catching is a malformed argv that only shows up when somebody needs a browser."""
+
+    def _argv(self, uri, config=None):
+        return reference._RESOLVERS["browser"](uri, config or {})[0]
+
+    def test_it_pins_the_version(self):
+        """The `browser` skill's loudest warning: a session belongs to the VERSION that
+        opened it, and an unpinned `npx` resolves to a different daemon that reports
+        `not open` while the first browser is alive and still logged in. Charter knows the
+        pin, which is most of why this belongs to charter rather than to a hand-rolled
+        `$(...)` in a shell script."""
+        argv = self._argv("browser://owner/localstorage/tok")
+        self.assertIn(f"@playwright/cli@{browser.PINNED}", argv)
+        self.assertNotIn("@playwright/cli", argv, "the bare, unpinned spec must not appear")
+
+    def test_the_vault_may_override_the_version(self):
+        """A session opened at another version is unreadable at the pin — the same
+        `not open` trap. `account` already sets the precedent for provider-specific vault
+        config."""
+        argv = self._argv("browser://owner/localstorage/tok", {"version": "0.1.19"})
+        self.assertIn("@playwright/cli@0.1.19", argv)
+
+    def test_it_names_the_session(self):
+        self.assertIn("-s=owner", self._argv("browser://owner/cookie/session_id"))
+
+    def test_it_asks_for_raw_output(self):
+        """Without `--raw` the reply carries page status and generated-code sections, so
+        the "secret" charter injected would be a decorated blob — and the redactor would
+        then be scrubbing a string that never appears in the API call."""
+        self.assertIn("--raw", self._argv("browser://owner/localstorage/tok"))
+
+    def test_localstorage_and_cookie_reach_different_subcommands(self):
+        self.assertIn("localstorage-get", self._argv("browser://o/localstorage/tok"))
+        self.assertIn("cookie-get", self._argv("browser://o/cookie/session_id"))
+
+    def test_the_key_is_passed_as_argv_not_interpolated(self):
+        """The module's standing property: "a reference can never be command injection,
+        whatever it contains"."""
+        argv = self._argv("browser://o/localstorage/a b;rm -rf /")
+        self.assertIn("a b;rm -rf /", argv)
+
+    def test_it_resolves_through_npx(self):
+        self.assertEqual(reference._RESOLVERS["browser"]("browser://o/cookie/c", {})[1], "npx")
+
+
+class TestMalformedReferencesAreRefused(unittest.TestCase):
+    """Validated when written, not at 3am when something tries to read it — the property
+    `docs/secrets.md` already claims for the other schemes."""
+
+    def _bad(self, uri):
+        with self.assertRaises(VaultError) as caught:
+            reference._RESOLVERS["browser"](uri, {})
+        return str(caught.exception)
+
+    def test_a_missing_session_is_named(self):
+        self.assertIn("browser://", self._bad("browser:///localstorage/tok"))
+
+    def test_an_unknown_source_is_named_with_the_ones_that_exist(self):
+        said = self._bad("browser://owner/sessionstorage/tok")
+        self.assertIn("localstorage", said)
+        self.assertIn("cookie", said)
+
+    def test_a_missing_key_is_named(self):
+        self.assertIn("browser://", self._bad("browser://owner/localstorage"))
+
+
+class TestTheValueThatComesBack(unittest.TestCase):
+    def setUp(self):
+        self.enterContext(mock.patch.object(reference.shutil, "which", lambda c: f"/bin/{c}"))
+
+    def test_it_is_the_raw_value_with_the_trailing_newline_stripped(self):
+        v = _Vault({"tok": "browser://owner/localstorage/access_token"})
+        v.runner = staticmethod(lambda argv, **kw: mock.Mock(returncode=0, stdout="ey.J.Z\n"))
+        self.assertEqual(v.get("tok"), "ey.J.Z")
+
+    def test_a_closed_session_fails_without_echoing_anything_it_read(self):
+        """`not open` is the common failure, and its stdout can carry whatever the page
+        held. The module's withholding rule has to cover this scheme too."""
+        v = _Vault({"tok": "browser://owner/localstorage/access_token"})
+        v.runner = staticmethod(
+            lambda argv, **kw: mock.Mock(returncode=1, stdout="ey.J.Z", stderr="not open"))
+        with self.assertRaises(VaultError) as caught:
+            v.get("tok")
+        self.assertNotIn("ey.J.Z", str(caught.exception))
+
+    def test_resolution_is_bounded_like_every_other_scheme(self):
+        """npx can reach the network. The generic bound covers it — no per-scheme rule."""
+        seen = {}
+
+        def runner(argv, **kw):
+            seen.update(kw)
+            return mock.Mock(returncode=0, stdout="v")
+
+        v = _Vault({"tok": "browser://owner/cookie/sid"})
+        v.runner = staticmethod(runner)
+        v.get("tok")
+        self.assertIn("timeout", seen)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #277. **Stacked on #284** (the resolver timeout) — review that one first; this base
retargets to `main` when it merges.

## The gap was mis-stated, and the correct statement is what makes it charter's

The report says there is "no way to read the authenticated session's token." There are
three — `localstorage-get`, `cookie-get`, `state-save` — and the vendor's own reference
documents the idiom:

```bash
TOKEN=$(playwright-cli --raw cookie-get session_id)
```

That *is* the gap. Command substitution puts the token in a shell variable, in a transcript,
with nothing redacting it — precisely the outcome the browser lane exists to prevent. What
was missing was reading it **without printing it**.

Which is a discipline charter already owns end to end, for values that come from a vault:
resolve by name, inject into the child process, scrub from captured output, never put it in
argv.

## One row, not a column

A browser session is just another place a credential lives, so it is a **reference scheme**,
not a new command:

```bash
charter secret set qa API_TOKEN --value 'browser://owner/localstorage/access_token'
charter secret exec qa --env TOKEN=API_TOKEN -- \
  curl -sH "Authorization: Bearer $TOKEN" https://api.example.test/me
```

`browser://<session>/localstorage/<key>` and `browser://<session>/cookie/<name>`. No new
verb, no new flag, no new concept. `--env`, `--file`, `--dotenv`, redaction and
`charter persona secret exec` all already worked; they are untouched here and work with this.

I originally proposed a `charter browser token` subcommand. It was a column — it would have
re-implemented capture, injection, shredding and redaction that `secret exec` already does
correctly.

## Details that are load-bearing

- **`--raw` is not optional.** Without it the reply carries page status and generated-code
  sections, so the injected "secret" would be a decorated blob — and the redactor would be
  scrubbing a string that never appears in the API call.
- **The version pin is the reason this is charter's.** A session belongs to the version that
  opened it, so an unpinned `npx` talks to a different daemon and reports `not open` while
  the first browser is alive and still logged in. Charter builds the argv, so the pin is
  right by construction; a hand-written `$(...)` is exactly where it gets forgotten.
  Overridable per vault (`{"version": "0.1.19"}`) — `account` sets the precedent for
  provider-specific config on a shared provider.
- **Whole storage state is deliberately not readable this way.** A dump is a credential blob
  nobody declared, and the redactor cannot scrub what it cannot name.
- **The resolver table's signature is now `(uri, config)`** so a scheme can see its vault's
  config. Four call sites, all local to `reference.py`.
- **What charter promises is stated, not oversold.** `secret exec` scrubs the value from
  captured output, so a `curl -v` echoing the header is masked; `--exec` and `--stream`
  capture nothing and so redact nothing. Documented rather than special-cased — a per-scheme
  behaviour rule would be a column again.

## Testing

`python3 -m unittest discover -s tests` — 2658 tests, green. 15 new, failing without the
fix: the invocation is asserted rather than run (no network, matching the existing browser
suite), including the pin, `-s=`, `--raw`, both subcommands, an injection-shaped key passed
as argv, malformed URIs named on write, and a failed resolve that never echoes what it read.

## Correction to something in the issue thread

`SKILL.md`'s pointer to `storage-state` is **not** a stale command name, as I said earlier
while scoping this — `references/storage-state.md` is a real page in the generated reference.
Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)