### PR TITLE
doctor: report a credential path git would still take

### DIFF
--- a/charter/commands_secrets.py
+++ b/charter/commands_secrets.py
@@ -91,13 +91,9 @@ def _unignored_plaintext(configured: str):
         p.resolve().relative_to(_P(config.ROOT).resolve())
     except (ValueError, OSError):
         return None                                   # outside the plane
-    if util.run(["git", "-C", str(config.ROOT), "rev-parse", "--git-dir"],
-                check=False).returncode != 0:
-        return None                                   # not a repo; nothing to commit to
-    ignored = util.run(["git", "-C", str(config.ROOT), "check-ignore", "-q", str(p)],
-                       check=False).returncode == 0
-    if ignored:
-        return None
+    ignored = util.git_ignores(config.ROOT, p)
+    if ignored is None or ignored:
+        return None                # not a repo (nothing to commit to), or already ignored
     try:
         return str(p.resolve().relative_to(_P(config.ROOT).resolve()))
     except (ValueError, OSError):

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1667,6 +1667,75 @@ def _launcher_missing(command: str) -> bool:
         return False
 
 
+#: Paths a charter command causes to exist that carry credential material, with the command
+#: that (re-)ignores each. ADR 0017: charter ignores what carries credentials; everything
+#: else it states and leaves to the plane. Grown by adding a row — a path that is merely
+#: generated, or merely noisy, does not belong here and gets a sentence in some command's
+#: output instead.
+CREDENTIAL_PATHS = (
+    (Path(".playwright-cli"), "traces and snapshots of authenticated runs",
+     "charter browser install"),
+)
+
+
+def check_credential_paths() -> Result:
+    """Credential-bearing paths charter created, that git would still take.
+
+    `charter browser install` writes the ignore line, so a plane that runs it today is fine.
+    This is for the ones that are not: a plane that installed the lane *before* that landed,
+    or whose line lost a merge. Nothing else would say so — the directory appears only once a
+    trace or snapshot is written, well after the command that caused it, and it reads as
+    ordinary untracked noise right up until `git add -A` commits it. A trace records network
+    requests with their headers and bodies, so tracing a bridged login puts the credential on
+    disk even though it never reached the transcript.
+
+    That is the shape #278 was actually about. The missing `.gitignore` line was the symptom;
+    the cost was every plane working the same thing out again, in silence, and this is the
+    half that reaches planes charter has already touched.
+
+    FAIL, not WARN: `vault add` already exits non-zero for the identical condition —
+    credential material inside the plane that git would take — and two answers to one
+    question is worse than either.
+
+    Only paths that EXIST are considered. Most planes never open a browser, and a row that is
+    permanently yellow on an ordinary machine costs the findings that matter
+    (`check_workspace_clones` records the same concern).
+    """
+    from . import config as _config
+
+    name = "credential paths"
+    if not _config.HAS_CONTROL_PLANE:
+        return Result(name, OK, detail="no control plane found")
+
+    exposed: list[tuple[str, str, str]] = []
+    checked = 0
+    for rel, what, fix in CREDENTIAL_PATHS:
+        target = Path(_config.ROOT) / rel
+        if not target.exists():
+            continue
+        ignored = util.git_ignores(_config.ROOT, target)
+        if ignored is None:
+            # Not a repository. Nothing to commit to, so no risk to report — reporting one
+            # would be inventing a finding, which is the direction ADR 0009 forbids.
+            return Result(name, OK, detail="plane is not a git repository")
+        checked += 1
+        if not ignored:
+            exposed.append((str(rel), what, fix))
+
+    if not exposed:
+        return Result(name, OK,
+                      detail=f"{checked} present and gitignored" if checked
+                      else "none present")
+
+    first = exposed[0]
+    detail = ", ".join(f"{p}/ — {what}" for p, what, _ in exposed)
+    return Result(name, FAIL,
+                  detail=f"{detail}: git would take {'them' if len(exposed) > 1 else 'this'}",
+                  hint=f"`{first[2]}` adds the line (it is idempotent, and re-running it is "
+                       f"safe). Committing this publishes a live credential to everyone with "
+                       f"the clone — see ADR 0017.")
+
+
 def check_mcp_launchers() -> Result:
     """An MCP server whose launcher does not exist can never start — and says nothing.
 
@@ -1789,6 +1858,7 @@ def _checks():
                 check_news_adoption(),
                 check_ask_rules(),
                 check_shadowed_knowledge(),
+                check_credential_paths(),
                 check_mcp_launchers(), check_plugin_skew()]
     return results
 

--- a/charter/util.py
+++ b/charter/util.py
@@ -290,3 +290,19 @@ def append_gitignore(root, lines, header: str) -> list[str]:
     prefix = (body.rstrip("\n") + "\n\n") if body.strip() else ""
     p.write_text(prefix + f"# {header}\n" + "".join(f"{ln}\n" for ln in missing))
     return missing
+
+
+def git_ignores(root, path) -> bool | None:
+    """Whether git would ignore *path* inside *root*. ``None`` when the question does not
+    apply — *root* is not a repository, so there is nothing for a credential to be committed
+    to.
+
+    Asked of ``git check-ignore`` rather than read out of ``.gitignore``: nested ignore
+    files, negations and global excludes all count, and the question is only ever "would git
+    take this file", where git is the authority and a hand-rolled parser is a second opinion
+    that will eventually differ.
+    """
+    if run(["git", "-C", str(root), "rev-parse", "--git-dir"], check=False).returncode != 0:
+        return None
+    return run(["git", "-C", str(root), "check-ignore", "-q", str(path)],
+               check=False).returncode == 0

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -48,6 +48,10 @@ Charter appends it to the plane's `.gitignore` and says so. Committing it would 
 everyone's clone, and into the forge's history, where a later `git rm` does not reach it.
 That is credential material, so charter does not ask.
 
+`charter doctor` checks the same thing, because the install-time write only helps a plane
+that runs the install *after* this landed — and the directory appears well after the command
+that caused it, so it reads as ordinary untracked noise until something commits it.
+
 ### `.claude/skills/playwright-cli/` and `.playwright/` — stated, entirely your call
 
 The generated reference, and the workspace config directory `install` creates for

--- a/docs/news/unreleased-browser-session-state-ignored.md
+++ b/docs/news/unreleased-browser-session-state-ignored.md
@@ -22,5 +22,9 @@ it belongs. The rule charter is
 following, and the narrow trigger that keeps it from managing your `.gitignore` generally,
 is written down in [ADR 0017](../adr/0017-charter-ignores-what-carries-credentials.md).
 
+`charter doctor` now reports the same condition, so a plane that installed the lane before
+this — or lost the line in a merge — is told rather than left to find out when `git add -A`
+takes somebody's live cookies.
+
 Re-run `charter browser install` on any plane that already has the lane — it is idempotent,
 and it will add the line it should have added the first time.

--- a/tests/test_doctor_credential_paths.py
+++ b/tests/test_doctor_credential_paths.py
@@ -1,0 +1,86 @@
+"""ADR 0017, enforced after the fact as well as at the moment of writing.
+
+`charter browser install` now gitignores the live session directory it causes to exist. That
+binds at install time and nowhere else — so a plane that ran the command *before* the fix,
+or whose `.gitignore` line was dropped in a merge, sits with traces of authenticated runs
+staged for the next `git add -A`, and nothing says so. A trace records network requests with
+their headers and bodies, so tracing a bridged login writes the credential to disk even
+though it never reached the transcript. Which is the complaint #278 was actually
+about: the same thing being re-derived, per plane, in silence.
+
+FAIL rather than WARN, deliberately. `vault add` already exits non-zero for the identical
+condition — credential material inside the plane that git would take — and the two must not
+disagree about how serious it is.
+"""
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import browser, config, doctor
+
+
+def _repo() -> Path:
+    root = Path(tempfile.mkdtemp(prefix="charter-credpath-")).resolve()
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    return root
+
+
+class TestCredentialPathsAreIgnored(unittest.TestCase):
+    def _check(self, root):
+        with mock.patch.object(config, "ROOT", root), \
+             mock.patch.object(config, "HAS_CONTROL_PLANE", True):
+            return doctor.check_credential_paths()
+
+    def test_a_path_that_does_not_exist_is_not_a_finding(self):
+        """Most planes never open a browser. A check that shouts at them is a check people
+        learn to scroll past."""
+        r = self._check(_repo())
+        self.assertEqual(r.status, doctor.OK)
+
+    def test_an_output_dir_git_would_take_fails(self):
+        root = _repo()
+        (root / browser.OUTPUT_DIR).mkdir()
+        r = self._check(root)
+        self.assertEqual(r.status, doctor.FAIL)
+        self.assertIn(str(browser.OUTPUT_DIR), r.detail)
+
+    def test_the_failure_names_the_command_that_fixes_it(self):
+        """A finding whose remedy the reader has to work out is half a finding."""
+        root = _repo()
+        (root / browser.OUTPUT_DIR).mkdir()
+        self.assertIn("charter browser install", self._check(root).hint)
+
+    def test_an_ignored_output_dir_is_fine(self):
+        root = _repo()
+        (root / browser.OUTPUT_DIR).mkdir()
+        (root / ".gitignore").write_text(f"{browser.OUTPUT_DIR}/\n")
+        self.assertEqual(self._check(root).status, doctor.OK)
+
+    def test_git_is_the_authority_not_the_root_gitignore_file(self):
+        """Asked via `git check-ignore`, so nested ignore files, negations and global
+        excludes all count — the same reasoning `_unignored_plaintext` already records."""
+        root = _repo()
+        (root / browser.OUTPUT_DIR).mkdir()
+        (root / ".git" / "info").mkdir(parents=True, exist_ok=True)
+        (root / ".git" / "info" / "exclude").write_text(f"{browser.OUTPUT_DIR}/\n")
+        self.assertEqual(self._check(root).status, doctor.OK)
+
+    def test_a_plane_that_is_not_a_repo_is_not_a_finding(self):
+        """Nothing to commit to means no risk to report — not a warning about a risk that
+        cannot exist."""
+        root = Path(tempfile.mkdtemp(prefix="charter-credpath-nogit-")).resolve()
+        (root / browser.OUTPUT_DIR).mkdir()
+        self.assertEqual(self._check(root).status, doctor.OK)
+
+    def test_the_table_covers_the_browser_output_dir(self):
+        """Pinned so dropping the row is a deliberate act with a failing test, not a
+        silent regression to the state #278 was filed about."""
+        self.assertIn(browser.OUTPUT_DIR, [p for p, _, _ in doctor.CREDENTIAL_PATHS])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Stacked on #282** (ADR 0017 + the install-time write) — review that first; this base
retargets to `main` when it merges.

## Why the install-time write isn't the whole fix

`charter browser install` now gitignores `.playwright-cli/`. That binds at install time and
nowhere else. A plane that installed the lane *before* that landed, or whose line lost a
merge, still has traces of authenticated runs staged for the next `git add -A`, and nothing
says so.

A trace records network requests **with their headers and bodies**, so tracing a bridged
login puts the credential on disk even though it never reached the transcript. And it reads
as ordinary untracked noise: the directory appears when a trace or snapshot is *written*,
well after the command that caused it, so there is nothing on screen connecting the two.

That is the shape #278 was actually about. The missing `.gitignore` line was the symptom;
the cost was every plane working the same thing out again in silence — and this is the half
that reaches planes charter has already touched.

## The check

`CREDENTIAL_PATHS` — a table of paths a charter command causes to exist that carry
credential material, each with the command that re-ignores it. One row today. Grown by
adding a row; a path that is merely *generated* or merely configuration does not belong in
it and gets a sentence in some command's output instead (ADR 0017 draws that line, and #282
puts `.claude/skills/playwright-cli/` and `.playwright/` on the other side of it).

- **FAIL, not WARN.** `vault add` already exits non-zero for the identical condition —
  credential material inside the plane that git would take. Two answers to one question is
  worse than either.
- **Only paths that exist.** Most planes never open a browser, and a permanently yellow row
  costs the findings that matter (`check_workspace_clones` records the same concern).
- **Not a repo → not a finding.** Nothing to commit to means no risk to report; inventing
  one is the direction ADR 0009 forbids.

## One question, one asker

`util.git_ignores(root, path)` is now the single place charter asks git whether it would
take a file. `_unignored_plaintext` was asking it inline and now shares it. Via
`git check-ignore` rather than parsing `.gitignore`, so nested ignore files, negations and
global excludes all count — a hand-rolled parser is a second opinion that eventually differs.

## Testing

`python3 -m unittest discover -s tests` — 2659 tests, green. Seven new, failing without the
check: absent path is silent, present-and-unignored fails and names the fixing command,
`.git/info/exclude` counts (proving git is the authority, not the root `.gitignore`), a
non-repo is not a finding, and the table still covers the browser output directory so
dropping that row is a deliberate act with a failing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)