### PR TITLE
persona lint could not see a skill charter itself had written (#286)

### DIFF
--- a/charter/persona.py
+++ b/charter/persona.py
@@ -624,17 +624,40 @@ def _installed_skills() -> dict[str, bool] | None:
     return _SKILLS_CACHE  # type: ignore[return-value]
 
 
-def _walk_installed_skills() -> dict[str, bool] | None:
-    """Map each installed skill's leaf-name → is it **model-invokable** (i.e. not
-    ``disable-model-invocation: true``), scanned from the local Claude plugin cache.
-    Returns None when no cache exists (plugins not installed in this checkout) so lint
-    can skip the check gracefully on a fresh clone / CI without plugins."""
+def _skill_roots() -> list:
+    """Every directory the harness resolves a skill from, in the order it reads them.
+
+    Three, not one. Walking only the plugin cache made two charter commands disagree about
+    what a skill is (#286): `charter browser install` writes
+    `.claude/skills/playwright-cli/` — that path chosen because the harness reads project
+    skills from there — and `persona lint` then called it "not installed here … Remove it or
+    install the plugin". There is no plugin to install; charter deliberately does not vendor
+    those pages, which is the whole reason `browser install` exists.
+
+    The lint's own justification is that a declared skill costs context on every dispatch, so
+    a dead entry is paid forever for nothing. That argues for accuracy about what EXISTS, not
+    about what happens to be packaged.
+    """
     from pathlib import Path as _P
-    base = _P.home() / ".claude" / "plugins"
-    if not base.exists():
+    home = _P.home() / ".claude"
+    return [home / "plugins", home / "skills", _P(config.ROOT) / ".claude" / "skills"]
+
+
+def _walk_installed_skills() -> dict[str, bool] | None:
+    """Map each available skill's leaf-name → is it **model-invokable** (i.e. not
+    ``disable-model-invocation: true``), scanned from :func:`_skill_roots`.
+
+    Returns None when the plugin cache is absent, so lint can skip gracefully on a fresh
+    clone / CI without plugins. Keyed on the PLUGIN cache specifically, even though project
+    skills are now walked too: without it charter cannot see plugin-provided skills at all,
+    so checking anyway would report every one of them as missing — confidently wrong, which
+    is worse than silent."""
+    from pathlib import Path as _P
+    roots = _skill_roots()
+    if not roots[0].exists():
         return None
     out: dict[str, bool] = {}
-    for sk in base.rglob("SKILL.md"):
+    for sk in [f for r in roots if r.exists() for f in r.rglob("SKILL.md")]:
         try:
             lines = sk.read_text().splitlines()
         except OSError:
@@ -775,7 +798,12 @@ def declared_skill_issues(name: str) -> list[tuple[str, str]]:
     Costs context on every dispatch, which is the part worth being strict about — `skills:`
     injects full content at startup, so a dead entry is paid forever for nothing.
     """
-    names = declared_skills(name)
+    return _declared_skill_issues(declared_skills(name))
+
+
+def _declared_skill_issues(names: list[str]) -> list[tuple[str, str]]:
+    """The check itself, over already-resolved names — so it can be tested against a
+    controlled skill tree rather than a persona that has to exist on disk."""
     if not names:
         return []
     skills = _installed_skills()
@@ -785,9 +813,13 @@ def declared_skill_issues(name: str) -> list[tuple[str, str]]:
     for ref in names:
         leaf = ref.split(":", 1)[-1]
         if leaf not in skills:
-            out.append(("error", f"declares skill `{ref}` — not installed here; it is "
+            # ADR 0009 — name what was actually checked. The old remedy ("install the
+            # plugin") was impossible for a skill charter generates INTO the plane, and sent
+            # the reader hunting for a package that does not exist (#286).
+            out.append(("error", f"declares skill `{ref}` — not found in ~/.claude/plugins, "
+                                 f"~/.claude/skills or this plane's .claude/skills. It is "
                                  f"preloaded into the agent, so this fails silently at "
-                                 f"dispatch. Remove it or install the plugin"))
+                                 f"dispatch. Install it, generate it, or drop the entry"))
         elif not skills[leaf]:
             out.append(("warn", f"declares skill `{ref}`, which is human-only "
                                 f"(disable-model-invocation) — preloading its text is "

--- a/docs/news/unreleased-lint-sees-project-skills.md
+++ b/docs/news/unreleased-lint-sees-project-skills.md
@@ -1,0 +1,26 @@
+---
+version: unreleased
+headline: `persona lint` can see the skill `browser install` just wrote
+check: persona lint
+---
+
+Two charter commands disagreed about what a skill is.
+
+`charter browser install` writes `.claude/skills/playwright-cli/` — that path chosen because
+the harness reads project skills from there. `charter persona lint` walked only
+`~/.claude/plugins`, so a persona declaring `skills: playwright-cli` was told the skill was
+*"not installed here … Remove it or install the plugin"*.
+
+That remedy could not be followed. There is no plugin to install: charter deliberately does
+not vendor Playwright's pages, which is the entire reason `browser install` exists. The only
+way out was to drop the declaration — and then nothing preloads the one skill charter told
+you to install.
+
+Lint now resolves a declared skill against all three places the harness reads from:
+`~/.claude/plugins`, `~/.claude/skills`, and this plane's `.claude/skills`. When a skill
+genuinely is missing, the error names all three rather than sending you after a package that
+may not exist.
+
+Unchanged: with no plugin cache at all, the check still stays silent. Charter cannot see
+plugin-provided skills there, so checking anyway would report every one of them as missing —
+confidently wrong, which is worse than quiet.

--- a/tests/test_persona_lint_project_skills.py
+++ b/tests/test_persona_lint_project_skills.py
@@ -1,0 +1,103 @@
+"""Two charter commands disagreeing about what a skill is (#286).
+
+`charter browser install` writes `.claude/skills/playwright-cli/` — that path chosen, in its
+own words, "because Claude Code reads project skills from here". `charter persona lint` then
+walked only `~/.claude/plugins` and rejected the result as *"not installed here … Remove it
+or install the plugin"*.
+
+That remedy cannot be followed. There is no plugin to install: charter deliberately does not
+vendor Playwright's pages (Apache-2.0 into an MIT wheel, and a pre-1.0 pin moving to
+charter's release cadence), and `browser install` exists precisely so the plane gets them
+from the vendor at a version it picks. A reader who trusts the message hunts for a package
+that does not exist; a reader who drops the declaration loses the preload for the one skill
+charter told them to install.
+
+The lint's own justification is that a dead entry is paid forever at dispatch for nothing —
+which argues for accuracy about what EXISTS, not about what happens to be packaged.
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import config, persona
+
+
+def _skill(root: Path, name: str, *, human_only: bool = False) -> None:
+    d = root / name
+    d.mkdir(parents=True, exist_ok=True)
+    dmi = "\ndisable-model-invocation: true" if human_only else ""
+    (d / "SKILL.md").write_text(f"---\nname: {name}\ndescription: x{dmi}\n---\n\nbody\n")
+
+
+class ProjectSkillsAreVisible(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="charter-home-")).resolve()
+        self.root = Path(tempfile.mkdtemp(prefix="charter-plane-")).resolve()
+        # A plugin cache must exist, or the walk skips entirely by design.
+        _skill(self.home / ".claude" / "plugins" / "charter" / "skills", "browser")
+        self.enterContext(mock.patch.object(Path, "home", staticmethod(lambda: self.home)))
+        self.enterContext(mock.patch.object(config, "ROOT", self.root))
+        persona._reset_skill_cache()
+        self.addCleanup(persona._reset_skill_cache)
+
+    def test_a_project_skill_is_found(self):
+        """The exact shape `charter browser install` leaves behind."""
+        _skill(self.root / ".claude" / "skills", "playwright-cli")
+        self.assertIn("playwright-cli", persona._walk_installed_skills())
+
+    def test_a_personal_skill_is_found(self):
+        """`~/.claude/skills/` is the third place Claude Code reads from, and a persona
+        declaring one is in exactly the same position."""
+        _skill(self.home / ".claude" / "skills", "my-own-thing")
+        self.assertIn("my-own-thing", persona._walk_installed_skills())
+
+    def test_plugin_skills_still_resolve(self):
+        self.assertIn("browser", persona._walk_installed_skills())
+
+    def test_declaring_a_project_skill_no_longer_errors(self):
+        """The end-to-end case from the report."""
+        _skill(self.root / ".claude" / "skills", "playwright-cli")
+        self.assertEqual(persona._declared_skill_issues(["playwright-cli"]), [])
+
+    def test_a_human_only_project_skill_is_still_warned_about(self):
+        """Visibility must not cost the check its other half."""
+        _skill(self.root / ".claude" / "skills", "handbook", human_only=True)
+        issues = persona._declared_skill_issues(["handbook"])
+        self.assertTrue(any("human-only" in m for _l, m in issues), issues)
+
+    def test_a_genuinely_absent_skill_is_still_an_error(self):
+        issues = persona._declared_skill_issues(["nope"])
+        self.assertTrue(any(l == "error" for l, _m in issues), issues)
+
+    def test_the_error_names_every_place_that_was_searched(self):
+        """The old remedy — "install the plugin" — was impossible for a generated skill.
+        Whatever the message says now, it must not send the reader after a package that
+        does not exist."""
+        issues = persona._declared_skill_issues(["nope"])
+        said = " ".join(m for _l, m in issues)
+        self.assertIn(".claude/skills", said)
+
+
+class NoPluginCacheStillSkips(unittest.TestCase):
+    """Unchanged on purpose. Without the plugin cache charter cannot see plugin-provided
+    skills, so checking would flag every one of them as missing — the check has to stay
+    silent rather than become confidently wrong on a fresh clone or in CI."""
+
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="charter-nohome-")).resolve()
+        self.root = Path(tempfile.mkdtemp(prefix="charter-plane2-")).resolve()
+        self.enterContext(mock.patch.object(Path, "home", staticmethod(lambda: self.home)))
+        self.enterContext(mock.patch.object(config, "ROOT", self.root))
+        persona._reset_skill_cache()
+        self.addCleanup(persona._reset_skill_cache)
+
+    def test_no_plugin_cache_returns_none_even_with_project_skills(self):
+        _skill(self.root / ".claude" / "skills", "playwright-cli")
+        self.assertIsNone(persona._walk_installed_skills())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #286.

Two charter commands disagreed about what a skill is.

- `charter/browser.py` — `SKILL_DIR = .claude/skills/playwright-cli`, chosen (in its own
  comment) *"because Claude Code reads project skills from here"*.
- `charter/persona.py:633` — `base = Path.home()/".claude"/"plugins"`, and nothing else
  walked.

So `persona lint` rejected the skill charter had just generated:

> declares skill `playwright-cli` — not installed here; it is preloaded into the agent, so
> this fails silently at dispatch. **Remove it or install the plugin**

## Neither branch of that remedy exists

There is no plugin to install. Charter deliberately does not vendor Playwright's pages —
Apache-2.0 into an MIT wheel, plus a pre-1.0 pin moving to charter's release cadence — and
`browser install` exists precisely so the plane gets them from the vendor at a version it
picks. A reader who trusts the message hunts for a package that does not exist.

The other branch, dropping the declaration, is what the reporter did — and then nothing
preloads the one skill charter told them to install, so the `skills:` mechanism does not
cover charter's own driving surface.

## The fix

The lint's own justification is that a declared skill costs context on every dispatch, so a
dead entry is paid forever for nothing. That argues for accuracy about what **exists**, not
about what happens to be packaged. `_skill_roots()` now returns all three places the harness
resolves from, in read order:

```
~/.claude/plugins      ~/.claude/skills      <plane>/.claude/skills
```

**The `None` case is unchanged, and deliberately still keyed on the plugin cache.** Without
it charter cannot see plugin-provided skills at all, so checking anyway would report every
one of them as missing — confidently wrong, which is worse than silent on a fresh clone or
in CI.

**The message now names what was searched** rather than offering one impossible remedy
(ADR 0009): *"not found in ~/.claude/plugins, ~/.claude/skills or this plane's
.claude/skills … Install it, generate it, or drop the entry."*

`declared_skill_issues(name)` gained a pure inner `_declared_skill_issues(names)`, so the
check can be tested against a controlled skill tree instead of a persona that has to exist
on disk.

## Testing

`python3 -m unittest discover -s tests` — 2647 tests, green. Eight new, failing without the
fix: project and personal skills resolve, plugin skills still do, the end-to-end
`playwright-cli` declaration stops erroring, a human-only project skill is still *warned*
about (visibility must not cost the check its other half), a genuinely absent skill is still
an error, the error names the searched locations, and no-plugin-cache still returns `None`
even when project skills exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)