### PR TITLE
A persona can carry its own executables (#283)

### DIFF
--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -185,6 +185,13 @@ def cmd_persona_show(args) -> int:
     tools = persona.tools_of(args.name)
     if tools:
         print(f"tools:   {', '.join(sorted(tools))}  (auto-approved when this persona is active)")
+    scripts = persona.bin_scripts(args.name)
+    if scripts:
+        # Disclosure, not a warning. A LIVE persona is committed and synced, so these reach
+        # a teammate's disk and run with their credentials — worth stating plainly wherever
+        # somebody inspects the persona (ADR 0017's "state it" half).
+        print(f"scripts: {', '.join(sorted(scripts))}  "
+              f"(executables this persona carries — run by path)")
     print(f"file:    {persona.path(args.name).relative_to(config.ROOT)}")
     _print_memory_summary(args.name)
     print()
@@ -540,6 +547,15 @@ _CHARTER_OWN_KEYS = (
 )
 
 
+def _rel(path) -> str:
+    """Plane-relative when it can be, absolute when it cannot — a path outside the plane is
+    still better than a name the reader has to resolve."""
+    try:
+        return str(path.relative_to(config.ROOT))
+    except ValueError:
+        return str(path)
+
+
 def _render_agent(name: str, meta: dict, charter: str) -> str:
     role = meta.get("role") or name.title()
     desc = meta.get("agent-description") or meta.get("description") or _agent_description(name, meta)
@@ -618,6 +634,23 @@ def _render_agent(name: str, meta: dict, charter: str) -> str:
             f"`personas/{name}/memory/` and is reached with `charter recall`. **Search "
             f"charter's first**; write there for anything a teammate would want, and keep "
             f"the generic store to what isn't already in it."
+        )
+
+    # A script the dispatched agent never learns about is the same as no script at all.
+    # PATH would have made these discoverable by habit — but a PreToolUse hook decides
+    # whether a Bash call runs, not what environment it runs in, so the brief has to name
+    # them outright (#283). Paths, not just names: without one the agent has to guess, and
+    # a bare name resolves through PATH, which the tool guard deliberately refuses.
+    scripts = persona.bin_scripts(name)
+    bin_note = ""
+    if scripts:
+        listed = "\n".join(
+            f"  - `{_rel(path)}`" for _n, path in sorted(scripts.items()))
+        bin_note = (
+            f"\n- **You carry your own executables.** Run them by path, not by name:\n"
+            f"{listed}\n"
+            f"  A bare name is refused by the tool guard — it resolves through PATH, which "
+            f"charter cannot vouch for."
         )
 
     uses = [u.strip() for u in (meta.get("uses") or "").split(",") if u.strip() and u.strip() != name]
@@ -718,7 +751,7 @@ isolated context. Adopt the charter below as your role.
 {charter}
 
 ## As a persona sub-agent
-- {_credential_rule()}{creds}{uses_note}{memory_note}{handoff}
+- {_credential_rule()}{creds}{bin_note}{uses_note}{memory_note}{handoff}
 - Follow the control plane's conventions (see CLAUDE.md); report results concisely to the caller.
 {mem}
 """

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -172,6 +172,65 @@ def _csv_list(v) -> list[str]:
 #: snippet unchanged, which is the form these arrive in.
 MCP_FILE = "mcp.json"
 
+#: A persona's own executables. The fifth capability, alongside memory, refs, ephemeral
+#: scratch and `mcp.json` — and the one whose absence kept a whole Claude Code plugin alive
+#: as a file carrier (#283).
+#:
+#: Deliberately NOT put on PATH, because it cannot be: a `PreToolUse` hook decides whether a
+#: Bash call runs, not what environment it runs in, and wrapping every Bash call to inject
+#: one is the takeover of a host mechanism ADR 0014 exists to refuse. Scripts are invoked by
+#: path — which already worked; what was missing is charter knowing they are there, so it can
+#: surface them to the agent and vouch for them at the guard.
+BIN_DIR = "bin"
+
+
+def bin_dir(name: str) -> Path:
+    """Where *name*'s own executables live. Not created eagerly — an empty `bin/` in every
+    persona is noise in a directory a human reads."""
+    return dir_of(name) / BIN_DIR
+
+
+def bin_scripts(name: str) -> dict:
+    """``{script_name: path}`` this persona can run, inheritance applied.
+
+    Unioned along ``lineage()`` — the same chain ``mcp_servers`` uses, and for the same
+    reason: a child that silently lost what its parent declared would be a surprise. Child
+    wins on a name collision, so a persona can override an inherited script.
+
+    ``uses:``/``borrows:`` deliberately do NOT carry scripts. Borrowing is a grant to run
+    another persona's *declared tools*; shipping its code is a different thing, and conflating
+    them is how #257 got the tool grant wrong in the first place.
+
+    Executable files only. Git preserves the mode bit, so a file committed without ``+x``
+    reaches every clone unable to run — failing at the moment somebody needs it, with a
+    shell error that points nowhere near here. `lint` names those separately.
+    """
+    out = {}
+    # REVERSED: `lineage()` is child-first, so iterating it directly would let the most
+    # distant ancestor overwrite the child — the opposite of the rule. (`mcp_servers` has
+    # this exact bug; filed separately rather than changed here, since flipping a
+    # precedence is a behaviour change that deserves its own PR.)
+    for anc in reversed(lineage(name)):
+        d = bin_dir(anc)
+        if not d.is_dir():
+            continue
+        for f in sorted(d.iterdir()):
+            if f.is_file() and os.access(f, os.X_OK):
+                out[f.name] = f
+    return out
+
+
+def bin_issues(name: str) -> list[tuple[str, str]]:
+    """A file in `bin/` that cannot run. Its own check because the failure is invisible
+    until dispatch and reads as a broken script rather than a missing mode bit."""
+    d = bin_dir(name)
+    if not d.is_dir():
+        return []
+    return [("warn", f"`{BIN_DIR}/{f.name}` is not executable — it will fail at the moment "
+                     f"it is needed; `chmod +x {f.relative_to(config.ROOT)}`")
+            for f in sorted(d.iterdir())
+            if f.is_file() and not os.access(f, os.X_OK)]
+
 
 def mcp_servers(name: str) -> dict:
     """``{server_name: config}`` a persona declares, inheritance applied.
@@ -870,6 +929,7 @@ def lint(name: str, deep: bool = True) -> list[tuple[str, str]]:
         issues.append(("warn", f"frontmatter key '{key}' is neither read by charter nor "
                                f"emitted into the sub-agent — it does nothing (typo?)"))
     issues += structural_errors(name)
+    issues += bin_issues(name)
     if deep:
         issues += _skill_ref_issues(d["charter"])
     # A declared MCP server whose `secrets` cannot be resolved. Reported rather than

--- a/charter/toolgate.py
+++ b/charter/toolgate.py
@@ -79,7 +79,40 @@ def decide(command: str):
         return None
     if _is_dangerous(binary, args):
         return None  # declared, but a destructive subcommand → fall back to a prompt
+    if not _provenance_ok(name, command, binary):
+        return None  # a name charter owns, invoked from somewhere charter did not put it
     return name, binary
+
+
+def _provenance_ok(name: str, command: str, binary: str) -> bool:
+    """True unless *binary* names one of the persona's own scripts and the command is
+    reaching a DIFFERENT file of that name.
+
+    `_parse` reduces a command to `os.path.basename`, which is right for `gh` or `kubectl`:
+    they are system binaries, the plane does not own them, and their location is not
+    charter's business. For a persona's own script it inverts the guarantee — the
+    declaration looks specific and the check is not, so `/tmp/site-health.sh` inherits the
+    auto-approval of `personas/seo/bin/site-health.sh`, including a `/tmp` copy an agent
+    wrote seconds earlier.
+
+    Tightened only where charter has ground truth. A declared name with no script behind it
+    is left exactly as it was: charter has nothing to compare against, and inventing a
+    restriction would break planes that declare an ordinary binary with a script-shaped
+    name.
+    """
+    from . import persona
+
+    scripts = persona.bin_scripts(name)
+    owned = scripts.get(binary)
+    if owned is None:
+        return True
+    token = next((t for t in command.strip().split() if os.path.basename(t) == binary), "")
+    if os.path.basename(token) == token:
+        return False  # a bare name resolves through PATH, which charter cannot vouch for
+    try:
+        return os.path.realpath(token) == os.path.realpath(owned)
+    except OSError:
+        return False
 
 
 def main(argv=None) -> int:

--- a/docs/news/unreleased-persona-bin.md
+++ b/docs/news/unreleased-persona-bin.md
@@ -1,0 +1,39 @@
+---
+version: unreleased
+headline: A persona can carry its own executables
+check: persona lint
+---
+
+A persona owns memory, refs, ephemeral scratch and MCP servers — but a role whose work was a
+handful of shell scripts still needed a whole Claude Code plugin alongside it, existing for
+no reason except to be somewhere the files could live. Two packaging systems for one
+identity.
+
+`personas/<name>/bin/` is now charter's:
+
+```bash
+charter persona show devops
+# scripts: site-health.sh, psi.sh  (executables this persona carries — run by path)
+```
+
+Scripts are inherited down the `extends:` chain (child wins on a collision), the way
+`mcp.json` servers are, and each one's path is named in the persona's generated sub-agent so
+a dispatched agent knows what it is carrying.
+
+**They are not put on `PATH`**, and that is deliberate rather than pending: a `PreToolUse`
+hook decides *whether* a Bash call runs, not what environment it runs in, so charter would
+have to wrap every Bash call to fake it — the takeover of a host mechanism ADR 0014 exists
+to refuse. Call them by path.
+
+**Declaring one now means what it looks like it means.** The tool guard matches by basename,
+which is correct for `gh` or `kubectl`. For a script the persona owns it was not: `tools:
+site-health.sh` auto-approved *any* `site-health.sh`, including one an agent had just written
+to `/tmp`. A declared name that matches a script in the persona's own `bin/` is now approved
+only when the command reaches that file.
+
+`charter persona lint` also names a file in `bin/` that is missing its executable bit — git
+preserves the mode, so one committed without `+x` reaches every clone unable to run, and
+fails at the moment somebody needs it.
+
+Nothing to migrate: a persona with no `bin/` is unaffected, and a declared tool with no
+script behind it behaves exactly as before.

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -12,8 +12,42 @@ A persona lives in a **committed** directory, `personas/<name>/`:
 personas/devops/
 ├── persona.md     # frontmatter (role, vault, tools, …) + the charter itself (prose)
 ├── memory/        # persistent, committed knowledge — MEMORY.md index + one file per fact
-└── refs/          # curated docs/links/snippets for the role, also committed
+├── refs/          # curated docs/links/snippets for the role, also committed
+└── bin/           # optional: executables this persona carries (see below)
 ```
+
+### `bin/` — executables the persona carries
+
+A persona that needs its own scripts puts them in `personas/<name>/bin/` and makes them
+executable. They are committed like everything else, and they are **inherited down the
+`extends:` chain** (child wins on a name collision), exactly as `mcp.json` servers are.
+
+```bash
+charter persona show devops      # lists them under `scripts:`
+```
+
+They are **not** put on `PATH`, and cannot be: a `PreToolUse` hook decides *whether* a Bash
+call runs, not what environment it runs in, and wrapping every Bash call to inject one would
+be charter taking over a mechanism the host owns ([ADR 0014](adr/0014-policy-that-fits-a-pattern-belongs-to-the-host.md)).
+Call them by path. Charter names each script's path in the persona's generated sub-agent, so
+a dispatched agent knows what it is carrying without being told twice.
+
+Declare the ones the persona should run without a prompt, the same as any other tool:
+
+```
+tools: site-health.sh, gh
+```
+
+**Provenance is checked for these, unlike system binaries.** The tool guard matches a command
+by basename, which is right for `gh` — the plane does not own it. For a script the persona
+*does* own, the same rule would auto-approve any file of that name, including one an agent
+had just written elsewhere. So a declared name that matches a script in the persona's `bin/`
+is approved only when the command reaches **that file**; a bare name (which resolves through
+`PATH`) and any other copy both fall back to a prompt.
+
+`bin/` travels with the persona, so on a LIVE persona it reaches teammates' machines and runs
+with their credentials. That is disclosed wherever the persona is inspected rather than
+gated: anyone who can commit `bin/` can commit an `mcp.json` pointing at the same file.
 
 Definitions, memory, and refs are all **committed and shared** with the team — every
 engineer (and every agent) sees the same devops persona and everything it has learned.

--- a/tests/test_persona_bin.py
+++ b/tests/test_persona_bin.py
@@ -1,0 +1,170 @@
+"""A persona carrying its own executables (#283).
+
+The report asked for `personas/<name>/bin/` "exposed on PATH while that persona is active",
+on the grounds that a persona "cannot carry an executable, so a plugin survives purely as a
+file carrier". Both halves turned out to be wrong, and checking them is what produced this
+much smaller change:
+
+* **It can already carry one.** `personas/<name>/` is committed wholesale, `bin/` is not
+  gitignored, and git preserves the executable bit.
+* **The tool guard already lets it run.** `toolgate._parse` reduces a command to
+  `os.path.basename`, so a persona declaring `tools: site-health.sh` already gets
+  `./personas/seo/bin/site-health.sh` auto-approved.
+* **PATH cannot be done at all.** A `PreToolUse` hook decides *whether* a Bash call runs; it
+  cannot alter the environment it runs in. Wrapping every Bash call to inject one is exactly
+  the takeover of a host mechanism ADR 0014 rejects.
+
+So what was actually missing was charter *knowing* the directory exists — and one hole the
+report gestured at without noticing: basename matching means declaring a script's name
+auto-approves that name **anywhere**, including a file an agent just wrote to /tmp.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+
+from charter import persona, toolgate
+from tests._isolation import PersonaIso
+
+
+class BinCase(PersonaIso):
+    def script(self, owner: str, name: str, *, executable: bool = True) -> None:
+        d = persona.bin_dir(owner)
+        d.mkdir(parents=True, exist_ok=True)
+        f = d / name
+        f.write_text("#!/bin/sh\necho hi\n")
+        if executable:
+            f.chmod(0o755)
+
+
+class TestCharterKnowsTheDirectory(BinCase):
+    def test_a_persona_with_no_bin_has_no_scripts(self):
+        self.make_persona("seo", role="SEO", vault="none")
+        self.assertEqual(persona.bin_scripts("seo"), {})
+
+    def test_an_executable_script_is_found(self):
+        self.make_persona("seo", role="SEO", vault="none")
+        self.script("seo", "site-health.sh")
+        self.assertIn("site-health.sh", persona.bin_scripts("seo"))
+
+    def test_a_non_executable_file_is_not_a_script(self):
+        """The trap this exists to catch: git preserves the mode bit, so a file committed
+        without +x fails at the moment someone needs it, with a shell error rather than
+        anything pointing back here."""
+        self.make_persona("seo", role="SEO", vault="none")
+        self.script("seo", "lib.sh", executable=False)
+        self.assertEqual(persona.bin_scripts("seo"), {})
+
+    def test_lint_names_a_file_that_cannot_run(self):
+        self.make_persona("seo", role="SEO", vault="none")
+        self.script("seo", "lib.sh", executable=False)
+        issues = persona.lint("seo")
+        self.assertTrue(any("chmod" in m for _l, m in issues), issues)
+
+    def test_scripts_are_inherited_down_the_extends_chain(self):
+        """`mcp_servers` unions along exactly this lineage, and a child silently losing what
+        its parent declared would be the surprise the rest of the frontmatter avoids."""
+        self.make_persona("base", role="Base", vault="none")
+        self.script("base", "doctor.sh")
+        self.make_persona("child", role="Child", vault="none", extends="base")
+        self.assertIn("doctor.sh", persona.bin_scripts("child"))
+
+    def test_a_child_shadows_its_parents_script_of_the_same_name(self):
+        self.make_persona("base", role="Base", vault="none")
+        self.script("base", "doctor.sh")
+        self.make_persona("child", role="Child", vault="none", extends="base")
+        self.script("child", "doctor.sh")
+        self.assertEqual(persona.bin_scripts("child")["doctor.sh"].parent,
+                         persona.bin_dir("child"))
+
+
+class TestProvenance(BinCase):
+    """Declaring a script's name must not auto-approve that name anywhere.
+
+    For `gh` or `kubectl` basename matching is right — they are system binaries and the
+    plane does not own them. For a persona's own script it inverts the guarantee: the
+    declaration looks specific and the check is not, so a file an agent wrote to /tmp with
+    the same name inherits the persona's auto-approval.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.make_persona("seo", role="SEO", vault="none", tools="site-health.sh, gh")
+        self.script("seo", "site-health.sh")
+        persona.set_active("seo")
+
+    def test_the_persona_s_own_script_is_approved(self):
+        rel = persona.bin_dir("seo") / "site-health.sh"
+        self.assertIsNotNone(toolgate.decide(f"{rel} --full"))
+
+    def test_the_same_name_from_somewhere_else_is_not(self):
+        self.assertIsNone(toolgate.decide("/tmp/site-health.sh --full"))
+
+    def test_a_bare_name_is_not_approved_either(self):
+        """`site-health.sh` alone resolves through PATH — which is precisely the thing
+        charter cannot see and therefore cannot vouch for."""
+        self.assertIsNone(toolgate.decide("site-health.sh --full"))
+
+    def test_a_system_binary_is_unaffected(self):
+        """The rule tightens only where charter has ground truth. `gh` is declared and is
+        not one of this persona's scripts, so nothing about it changes."""
+        self.assertIsNotNone(toolgate.decide("gh pr list"))
+
+    def test_a_declared_name_with_no_script_behind_it_is_unchanged(self):
+        """No bin/ entry means charter has nothing to check against, and inventing a
+        restriction there would break planes that declare an ordinary binary with a
+        script-shaped name."""
+        self.make_persona("dev", role="Dev", vault="none", tools="mytool.sh")
+        persona.set_active("dev")
+        self.assertIsNotNone(toolgate.decide("mytool.sh --x"))
+
+
+class TestTheAgentIsToldTheyExist(BinCase):
+    """Carrying a script the dispatched agent never learns about is the same as not
+    carrying it. PATH would have made them discoverable by habit; since PATH is off the
+    table, the brief has to say so explicitly."""
+
+    def test_the_generated_sub_agent_names_the_scripts_and_their_paths(self):
+        from charter import commands_persona
+
+        self.make_persona("seo", role="SEO", vault="none")
+        self.script("seo", "site-health.sh")
+        d = persona.resolve("seo")
+        body = commands_persona._render_agent("seo", d["meta"], d["charter"])
+        self.assertIn("site-health.sh", body)
+        self.assertIn(f"personas/seo/{persona.BIN_DIR}/", body)
+
+    def test_a_persona_with_no_scripts_gets_no_section(self):
+        from charter import commands_persona
+
+        self.make_persona("plain", role="Plain", vault="none")
+        d = persona.resolve("plain")
+        self.assertNotIn(persona.BIN_DIR + "/", commands_persona._render_agent(
+            "plain", d["meta"], d["charter"]))
+
+
+class TestShowDisclosesThem(BinCase):
+    """A LIVE persona is committed and synced, so `bin/` puts someone else's code on a
+    teammate's disk, run with their credentials. `mcp.json` is already committed and already
+    launches processes — but it names commands that must already exist, while this ships the
+    code. Disclosure rather than a gate: anyone who can commit `bin/` can commit an
+    `mcp.json` pointing at the same file."""
+
+    def test_show_lists_the_scripts(self):
+        import io
+        from contextlib import redirect_stdout
+        from unittest import mock
+        from charter import commands_persona
+
+        self.make_persona("seo", role="SEO", vault="none")
+        self.script("seo", "site-health.sh")
+        args = mock.Mock()
+        args.name = "seo"          # `Mock(name=…)` names the mock, it does not set .name
+        out = io.StringIO()
+        with redirect_stdout(out):
+            commands_persona.cmd_persona_show(args)
+        self.assertIn("site-health.sh", out.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #283.

The issue asked for `personas/<name>/bin/` "exposed on PATH while that persona is active",
on the grounds that a persona *"cannot carry an executable, so a plugin survives purely as a
file carrier"*. Checking both halves against the source made the change much smaller — and
turned up a security hole the issue gestured at without noticing.

## Three things the report got wrong

- **A persona can already carry an executable.** `personas/<name>/` is committed wholesale,
  `bin/` is not gitignored (`git check-ignore` confirms), and git preserves the mode bit.
- **The tool guard already let it run.** `toolgate._parse` returns
  `os.path.basename(tokens[i])`, so a persona declaring `tools: site-health.sh` already got
  `./personas/seo/bin/site-health.sh` auto-approved with no prompt.
- **PATH cannot be built at all.** A `PreToolUse` hook decides *whether* a Bash call runs,
  not what environment it runs in. Faking it means charter wrapping every Bash invocation —
  the takeover of a host mechanism [ADR 0014](../blob/main/docs/adr/0014-policy-that-fits-a-pattern-belongs-to-the-host.md)
  exists to refuse. (A Claude Code plugin doesn't provide PATH either, so the plugin was
  never buying that.)

So the plugin can be deleted today; what was actually missing is charter **knowing** the
directory is there.

## What this adds

- `persona.bin_scripts(name)` — `{script: path}`, unioned down the `extends:` chain exactly
  as `mcp_servers()` is, child winning on a collision. `uses:`/`borrows:` deliberately do
  *not* carry scripts: borrowing grants another persona's *declared tools*; shipping its code
  is a different thing, and conflating the two is how #257 got the tool grant wrong.
- **The generated sub-agent names each script and its path.** A carried script the dispatched
  agent never learns about is the same as no script. PATH would have made them discoverable
  by habit; without it the brief has to say so.
- `charter persona show` lists them under `scripts:` — disclosure, since a LIVE persona's
  `bin/` reaches teammates' disks and runs with their credentials.
- `charter persona lint` names a file in `bin/` missing `+x`. Git preserves the mode, so one
  committed without it reaches every clone unable to run, failing where nothing points back
  here.

## The hole that was already there

Basename matching is right for `gh` or `kubectl` — system binaries the plane does not own.
For a script the persona *does* own it inverts the guarantee: the declaration looks specific
and the check isn't, so `tools: site-health.sh` auto-approved **any** `site-health.sh`,
including one an agent had written to `/tmp` seconds earlier.

A declared name that matches a script in the persona's own `bin/` is now approved only when
the command reaches **that file**. A bare name falls back to a prompt too — it resolves
through `PATH`, which is precisely what charter cannot vouch for.

Tightened only where charter has ground truth: a declared name with **no** script behind it
is left exactly as it was, so planes declaring an ordinary binary with a script-shaped name
are unaffected.

## Found on the way, not fixed here

`persona.mcp_servers()` documents *"parent first, child wins on a name collision"* but
iterates `lineage()`, which is **child-first** — so the most distant ancestor overwrites the
child, the opposite of the stated rule. Filed separately: flipping a precedence is a
behaviour change that deserves its own PR, not a rider on this one. `bin_scripts()` iterates
`reversed(lineage())` and matches the documented rule.

## Testing

`python3 -m unittest discover -s tests` — 2653 tests, green. 14 new, failing without the
change: discovery and the executable-bit rule, inheritance and child-shadowing, lint's
`chmod` hint, the four provenance cases (own script approved; same name elsewhere refused;
bare name refused; system binary and undeclared-script cases unchanged), and both surfacing
paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)