### PR TITLE
mcp_servers() reversed its own documented precedence (#296)

### DIFF
--- a/charter/persona.py
+++ b/charter/persona.py
@@ -207,9 +207,9 @@ def bin_scripts(name: str) -> dict:
     """
     out = {}
     # REVERSED: `lineage()` is child-first, so iterating it directly would let the most
-    # distant ancestor overwrite the child — the opposite of the rule. (`mcp_servers` has
-    # this exact bug; filed separately rather than changed here, since flipping a
-    # precedence is a behaviour change that deserves its own PR.)
+    # distant ancestor overwrite the child — the opposite of the rule. `mcp_servers` below
+    # had exactly that bug (#296); this is the shape both now share, and the reason to reach
+    # for `reversed()` in any future union along the chain.
     for anc in reversed(lineage(name)):
         d = bin_dir(anc)
         if not d.is_dir():
@@ -243,7 +243,12 @@ def mcp_servers(name: str) -> dict:
     `sync-agents` for every persona in the plane.
     """
     out = {}
-    for anc in lineage(name):
+    # REVERSED, and that is the whole fix for #296. `lineage()` is child-first, so feeding it
+    # straight into `dict.update` — last write wins — let the most distant ancestor overwrite
+    # the child: the exact inversion of the rule stated above. Nothing surfaced it, because
+    # the child's entry was parsed and applied and then thrown away, so `sync-agents`
+    # succeeded and the generated agent simply carried somebody else's server.
+    for anc in reversed(lineage(name)):
         try:
             doc = json.loads((dir_of(anc) / MCP_FILE).read_text())
             servers = doc.get("mcpServers") or {}

--- a/docs/news/unreleased-mcp-child-wins.md
+++ b/docs/news/unreleased-mcp-child-wins.md
@@ -1,0 +1,24 @@
+---
+version: unreleased
+headline: A child persona can override its parent's MCP server again
+---
+
+`mcp_servers()` documented the rule — *"parent first, child wins on a name collision"* — and
+did the opposite. It iterated the inheritance chain child-first into a `dict.update`, so the
+most distant ancestor overwrote everything below it.
+
+A child that redeclared a server name its parent already used could not override it. Nothing
+reported this: the child's entry was read, applied, and then overwritten, so
+`charter persona sync-agents` succeeded and the generated sub-agent quietly carried the
+ancestor's config. The only symptom was a server behaving like somebody else's.
+
+Fixed. If you have an `extends:` chain where two personas declare the same server name, the
+**child's** entry now wins — which may change which config a persona actually launches. Check
+with:
+
+```bash
+charter persona sync-agents
+git diff .claude/agents/
+```
+
+A plane with no name collisions in an inheritance chain sees no change at all.

--- a/tests/test_mcp_servers_precedence.py
+++ b/tests/test_mcp_servers_precedence.py
@@ -1,0 +1,67 @@
+"""`mcp_servers()` inverted its own documented precedence (#296).
+
+The docstring states the rule: "parent first, child wins on a name collision. A child that
+silently lost the server its parent declared would be a surprise, and this is the rule the
+rest of the frontmatter already follows."
+
+The loop iterated `lineage()`, which is child-first, into a `dict.update` — last write wins —
+so the most distant ancestor overwrote the child. The guarded-against surprise happened, in
+the other direction: `sync-agents` succeeds, the generated agent carries the ancestor's
+config, and the only symptom is a server behaving like somebody else's.
+
+This is the one place in the inheritance model where a child lost. `resolve()` merges scalar
+frontmatter child-wins; `effective_tools`/`uses` union without a collision concept. That
+asymmetry is what marks it a slip rather than a design.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+
+from charter import persona
+from tests._isolation import PersonaIso
+
+
+class McpPrecedence(PersonaIso):
+    def declare(self, owner: str, server: str, command: str) -> None:
+        d = persona.dir_of(owner)
+        d.mkdir(parents=True, exist_ok=True)
+        (d / persona.MCP_FILE).write_text(
+            json.dumps({"mcpServers": {server: {"command": command}}}))
+
+    def test_a_child_overrides_its_parents_server(self):
+        self.make_persona("base", role="Base", vault="none")
+        self.declare("base", "api", "parent-cmd")
+        self.make_persona("child", role="Child", vault="none", extends="base")
+        self.declare("child", "api", "child-cmd")
+        self.assertEqual(persona.mcp_servers("child")["api"]["command"], "child-cmd")
+
+    def test_a_grandparent_does_not_win_over_the_child(self):
+        """Two levels, because `dict.update` over a child-first list made the FURTHEST
+        ancestor win — so a one-level test could pass on a half-fix."""
+        self.make_persona("grand", role="G", vault="none")
+        self.declare("grand", "api", "grand-cmd")
+        self.make_persona("mid", role="M", vault="none", extends="grand")
+        self.declare("mid", "api", "mid-cmd")
+        self.make_persona("kid", role="K", vault="none", extends="mid")
+        self.declare("kid", "api", "kid-cmd")
+        self.assertEqual(persona.mcp_servers("kid")["api"]["command"], "kid-cmd")
+
+    def test_an_inherited_server_is_still_inherited(self):
+        """The property the docstring was protecting in the first place: a child that
+        declares nothing still gets its parent's server."""
+        self.make_persona("base", role="Base", vault="none")
+        self.declare("base", "api", "parent-cmd")
+        self.make_persona("child", role="Child", vault="none", extends="base")
+        self.assertEqual(persona.mcp_servers("child")["api"]["command"], "parent-cmd")
+
+    def test_distinct_servers_along_the_chain_all_survive(self):
+        self.make_persona("base", role="Base", vault="none")
+        self.declare("base", "from-parent", "p")
+        self.make_persona("child", role="Child", vault="none", extends="base")
+        self.declare("child", "from-child", "c")
+        self.assertEqual(sorted(persona.mcp_servers("child")), ["from-child", "from-parent"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #296.

`persona.mcp_servers()` states the rule in its own docstring:

> Unioned along the lineage the way `tools`/`uses` are — **parent first, child wins on a name
> collision**. A child that silently lost the server its parent declared would be a surprise,
> and this is the rule the rest of the frontmatter already follows.

The loop iterated `lineage()`, which is documented as *"the inheritance chain, child-first"*,
into a `dict.update` — last write wins. So the grandparent overwrote the parent, which
overwrote the child. Precedence exactly inverted, and the guarded-against surprise happened in
the other direction.

## Why nothing caught it

The child's entry *was* read and applied — and then overwritten. So `sync-agents` succeeded,
the generated agent carried the ancestor's config, and the only symptom was a server behaving
like somebody else's. There was no error to trace back.

It was also the only place in the inheritance model where a child loses: `resolve()` merges
scalar frontmatter child-wins, and `effective_tools`/`uses` union without a collision concept
at all. That asymmetry is what marks it a slip rather than an intended design.

## The change

One line — `for anc in reversed(lineage(name)):` — plus four tests.

**This is a behaviour change** for any plane with a duplicate server name in an `extends:`
chain: the child's config now wins where the ancestor's used to. The news entry says so and
gives `charter persona sync-agents && git diff .claude/agents/` as the way to see it. A plane
with no collisions is unaffected.

## Testing

`python3 -m unittest discover -s tests` — 2643 tests, green. Four new, two of which fail
without the fix. The grandparent case is deliberate: `dict.update` over a child-first list
made the *furthest* ancestor win, so a one-level test passes on a half-fix.

Found while implementing the same lineage union for `personas/<name>/bin/` (#295), and kept
out of that PR on purpose — flipping a precedence deserves its own note rather than riding on
an unrelated feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)