### PR TITLE
An unattended run cannot cut a release (0.46.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.46.0"
+__version__ = "0.46.1"

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -861,6 +861,83 @@ def _single_credential_reason(cmd: str) -> str | None:
 
 
 # --------------------------------------------------------------------------- #
+# A4: RELEASE FLOOR — an unattended run may not publish (#299)                 #
+# --------------------------------------------------------------------------- #
+#: Forge CLI subcommand pairs that publish or land code. `gh pr merge` and `gh release
+#: create` are no kind of `git`, so `_GIT_WRITE_RE` never saw them and nothing else did
+#: either — they were unguarded in every mode.
+_PUBLISH_FORGE = {
+    ("gh", "release", "create"), ("gh", "pr", "merge"),
+    ("glab", "release", "create"), ("glab", "mr", "merge"),
+}
+#: `git tag` flags that only READ or act locally. An autonomous run legitimately needs to
+#: know what the tags are, and deleting a local tag publishes nothing.
+_TAG_HARMLESS = {"-l", "--list", "-d", "--delete", "-n", "--contains", "--points-at",
+                 "--merged", "--no-merged", "-v", "--verify"}
+
+
+def _release_floor_reason(cmd: str, data: dict) -> str | None:
+    """Deny a publish when the host says nobody is watching.
+
+    **Why this exists at all.** 0.46.0 taught `_ask` to fall back to `allow` under
+    ``bypassPermissions`` so a workflow nudge cannot hang an unattended run. That is right
+    for a nudge, and it silently removed the only thing standing between an autonomous
+    agent and an irreversible release: `_clone_commit_reason` matches `_GIT_WRITE_RE`,
+    which includes ``tag`` and ``push``, so tagging from a clone used to return `ask` — and
+    a hook `ask` floors the host's decision at a prompt in EVERY permission mode. It
+    stopped things by accident. Now it allows them.
+
+    **Deny, not ask**, deliberately: an unattended ask is now an allow, so an ask here
+    would be indistinguishable from no guard at all. Deny is also the only verdict that
+    cannot hang — the run gets an immediate refusal naming a remedy, exactly as every other
+    floor guard does.
+
+    **Attended is untouched.** A person keeps whatever they had before (nothing at the
+    plane, the clone nudge inside a clone). A guard that made releases harder for the
+    operator is the cage `_plane_root_branch_reason` warns about, and the fix people reach
+    for then is to switch it off permanently.
+
+    Keyed on TAGGING rather than on a ``v*`` shape. Shape-matching is narrower and reads
+    more correct — `release.yml` triggers on ``v*`` — but it is walked past by naming the
+    tag ``release-1``, and tagging attended costs nothing. The asymmetry favours bluntness:
+    a false stop costs one re-run, a false pass costs a version number that can never be
+    reused.
+    """
+    if not _unattended(data):
+        return None
+    fix = ("Publishing is on charter's floor: a run with nobody watching may not cut a "
+           "release. `bypassPermissions` means *stop asking me*, not *stop knowing "
+           "things*. Re-run this step **attended**, or have a person do it. ")
+    for _toks in _segment_argv(cmd):
+        prog, _env, argv = _split_env(_toks)
+        base = prog.rsplit("/", 1)[-1]
+        args = argv[1:]
+        words = [a for a in args if not a.startswith("-")]
+        if base == "git":
+            sub = _git_subcommand(args)
+            if sub == "tag":
+                # `git tag` alone lists; a bare name is a CREATION — the choke point, since
+                # a tag that does not exist locally cannot be pushed.
+                if any(a in _TAG_HARMLESS for a in args):
+                    return None
+                if len(words) > 1:
+                    return fix + "Creating a tag is the first step of a publish."
+            if sub == "push":
+                if any(a in ("--tags", "--follow-tags") for a in args):
+                    return fix + "`--tags`/`--follow-tags` pushes tags."
+                # defence in depth: a tag that already existed locally
+                if any(a.startswith("refs/tags/") for a in args):
+                    return fix + "This pushes a tag ref."
+                if any(re.fullmatch(r"v?\d+\.\d+(?:\.\d+)?[\w.-]*", w)
+                       for w in words[1:]):
+                    return fix + "This pushes what looks like a version tag."
+        elif base in ("gh", "glab") and len(words) >= 2:
+            if (base, words[0], words[1]) in _PUBLISH_FORGE:
+                return fix + f"`{base} {words[0]} {words[1]}` publishes or lands code."
+    return None
+
+
+# --------------------------------------------------------------------------- #
 # B: clone-boundary guard — deny git-write inside a clone from the control plane #
 # --------------------------------------------------------------------------- #
 _GIT_WRITE_RE = re.compile(r"\bgit\b[^|;&]*?\b(?:commit|push|add|am|cherry-pick|tag|rebase|merge)\b")
@@ -1130,6 +1207,14 @@ def pretooluse() -> int:
     if branch:
         _deny("PreToolUse", branch)
         _trace("deny", sid, reason="plane-root-branch", cmd=head)
+        return 0
+    # A4: an unattended run may not publish (#299). Checked BEFORE the clone nudge, which
+    # is where the hole was: that nudge matches `tag`/`push`, and 0.46.0 turned its
+    # unattended `ask` into an `allow` — so a release walked straight through it.
+    pub = _release_floor_reason(cmd, data) if _cfg.HAS_CONTROL_PLANE else None
+    if pub:
+        _deny("PreToolUse", pub)
+        _trace("deny", sid, reason="release-floor", cmd=head)
         return 0
     # B: committing inside a clone → ASK, not deny. A repo-rooted session is usually better
     # (the repo's own hooks/conventions apply), but it's a preference, not a safety rule —

--- a/docs/news/0.46.1-bounded-reference-resolution.md
+++ b/docs/news/0.46.1-bounded-reference-resolution.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.46.1
 headline: A vault read can no longer hang your session
 ---
 

--- a/docs/news/0.46.1-browser-session-state-ignored.md
+++ b/docs/news/0.46.1-browser-session-state-ignored.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.46.1
 headline: charter ignores the traces your authenticated runs leave behind
 adopt: browser install
 ---

--- a/docs/news/0.46.1-browser-token-reference.md
+++ b/docs/news/0.46.1-browser-token-reference.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.46.1
 headline: Call the API as the user your browser just logged in as
 ---
 

--- a/docs/news/0.46.1-lint-sees-project-skills.md
+++ b/docs/news/0.46.1-lint-sees-project-skills.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.46.1
 headline: `persona lint` can see the skill `browser install` just wrote
 check: persona lint
 ---

--- a/docs/news/0.46.1-release-floor.md
+++ b/docs/news/0.46.1-release-floor.md
@@ -1,0 +1,36 @@
+---
+version: 0.46.1
+headline: An unattended run cannot cut a release
+---
+
+0.46.0 taught charter to allow, rather than ask, when the host reports
+`permission_mode: bypassPermissions` — so a workflow nudge stops hanging a run with nobody
+at the keyboard. That is right for a nudge. It was wrong for the one command that cannot be
+undone, and it removed cover that nobody had noticed was there:
+
+```
+git tag v9.9.9   (attended)              -> ask     ← a hook `ask` floors at a prompt in
+git tag v9.9.9   (bypassPermissions)     -> allow      EVERY mode, so this used to stop
+```
+
+The clone-commit nudge matches `tag` and `push`. It was never designed to guard releases —
+it just did, and pushing a tag fires the release workflow and an irreversible PyPI publish.
+`gh pr merge` and `gh release create` were never guarded at all, being no kind of `git`.
+
+**Publishing is now on the floor.** With nobody watching, charter denies creating a tag,
+pushing tags, `gh release create` / `gh pr merge` and their `glab` equivalents.
+
+Denied rather than asked, deliberately: an unattended ask is now an allow, so an ask here
+would be indistinguishable from no guard. Deny is also the only verdict that cannot hang —
+the run gets an immediate refusal naming the remedy, which is *re-run this step attended*.
+
+Keyed on tagging rather than on a `v*` shape. Shape-matching reads more correct, and is
+walked past by naming the tag `release-1`. Tagging attended costs nothing, so the asymmetry
+favours bluntness: a false stop costs one re-run, a false pass costs a version number that
+can never be reused.
+
+**Attended behaviour is unchanged** — a person cutting a release sees exactly what they saw
+before, and reading stays free in every mode (`git tag -l`, `git tag -d`, `gh release list`,
+an ordinary `git push origin main`).
+
+`bypassPermissions` means *stop asking me*, not *stop knowing things*.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.46.0",
+            "command": "charter hook sessionstart --plugin-version 0.46.1",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.46.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.46.1",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.46.0",
+            "command": "charter hook pretooluse --plugin-version 0.46.1",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.46.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.46.1",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.46.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.46.1"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.46.0",
+            "command": "charter hook pretooluse-edit --plugin-version 0.46.1",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-bash --plugin-version 0.46.0",
+            "command": "charter hook posttooluse-bash --plugin-version 0.46.1",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.46.0",
+            "command": "charter hook posttooluse --plugin-version 0.46.1",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.46.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.46.1",
             "timeout": 5
           }
         ]
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.46.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.46.1",
             "timeout": 5
           }
         ]
@@ -128,7 +128,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-message --plugin-version 0.46.0",
+            "command": "charter hook posttooluse-message --plugin-version 0.46.1",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.46.0"
+version = "0.46.1"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_release_floor.py
+++ b/tests/test_release_floor.py
@@ -1,0 +1,146 @@
+"""Publishing is on the floor: an unattended run may not cut a release.
+
+0.46.0 taught `_ask` to fall back to `allow` under `bypassPermissions`, so a workflow nudge
+stops hanging a run with nobody at the keyboard. Right for a nudge — wrong for the one
+command in this repo that cannot be undone, and the change silently removed the cover that
+was there:
+
+    git tag v9.9.9  (default)            -> ask     # a hook `ask` floors at a prompt in
+    git tag v9.9.9  (bypassPermissions)  -> allow   # EVERY mode, so this used to stop
+
+`_clone_commit_reason` matches `_GIT_WRITE_RE`, which includes `tag` and `push`. It was never
+designed to guard releases; it just did, and pushing a tag fires `release.yml` → an
+irreversible PyPI publish (Trusted Publishing, no token, nothing to retract). `gh pr merge`
+and `gh release create` were never covered at all, being no kind of `git`.
+
+Two properties carry the whole design and are asserted with equal weight:
+
+* **Unattended DENIES.** Not asks — 0.46.0 made an unattended ask into an allow, so an ask
+  here would be indistinguishable from no guard. Deny also cannot hang: the run gets an
+  immediate refusal naming a remedy.
+* **Attended is UNCHANGED.** A person cutting a release must see exactly what they saw
+  before. A guard that made releases harder for the operator is the cage the plane-root
+  guard's docstring warns about, and the fix people reach for then is to disable it forever.
+"""
+
+import unittest
+
+from tests._isolation import run_hook
+from tests.test_hooks import InAControlPlane
+from charter import hooks
+
+UNATTENDED = "bypassPermissions"
+
+
+class FloorCase(InAControlPlane):
+    def decide(self, cmd: str, mode: str | None = None, in_clone: bool = False):
+        cwd = str(self.tmp / "workspaces" / "w" / "r") if in_clone else str(self.tmp)
+        (self.tmp / "workspaces" / "w" / "r").mkdir(parents=True, exist_ok=True)
+        payload = {"tool_input": {"command": cmd}, "cwd": cwd,
+                   "session_id": "s", "tool_use_id": "t"}
+        if mode is not None:
+            payload["permission_mode"] = mode
+        r = run_hook(hooks.pretooluse, payload)
+        return None if r is None else r["hookSpecificOutput"]["permissionDecision"]
+
+
+class TestUnattendedCannotCutARelease(FloorCase):
+    def test_creating_a_tag_is_denied(self):
+        """The choke point: without a local tag there is nothing to push."""
+        self.assertEqual("deny", self.decide("git tag v9.9.9", UNATTENDED))
+
+    def test_creating_a_tag_is_denied_whatever_it_is_called(self):
+        """Keyed on tagging, not on `v*`. Shape-matching is narrower and more 'correct',
+        and is walked past by naming the tag `release-1`."""
+        self.assertEqual("deny", self.decide("git tag release-1", UNATTENDED))
+        self.assertEqual("deny", self.decide("git tag -a 2026-08 -m x", UNATTENDED))
+
+    def test_pushing_tags_is_denied(self):
+        """Defence in depth — a tag that already exists locally could still be pushed."""
+        for cmd in ("git push --tags",
+                    "git push --follow-tags origin main",
+                    "git push origin refs/tags/v9.9.9",
+                    "git push origin v9.9.9"):
+            self.assertEqual("deny", self.decide(cmd, UNATTENDED), cmd)
+
+    def test_forge_release_and_merge_are_denied(self):
+        """Never covered before — no kind of `git`, so `_GIT_WRITE_RE` never saw them."""
+        for cmd in ("gh release create v9.9.9",
+                    "gh pr merge 1 --squash",
+                    "glab release create v9.9.9",
+                    "glab mr merge 1"):
+            self.assertEqual("deny", self.decide(cmd, UNATTENDED), cmd)
+
+    def test_the_denial_names_a_remedy(self):
+        r = run_hook(hooks.pretooluse,
+                     {"tool_input": {"command": "git tag v9.9.9"}, "cwd": str(self.tmp),
+                      "session_id": "s", "permission_mode": UNATTENDED})
+        reason = r["hookSpecificOutput"]["permissionDecisionReason"]
+        self.assertIn("attended", reason)
+
+    def test_it_denies_outside_a_clone_too(self):
+        """Unlike the clone nudge it accidentally replaced, this is not about where you are."""
+        self.assertEqual("deny", self.decide("git tag v9.9.9", UNATTENDED, in_clone=False))
+        self.assertEqual("deny", self.decide("git tag v9.9.9", UNATTENDED, in_clone=True))
+
+
+class TestAttendedIsCompletelyUnchanged(FloorCase):
+    """The regression this guard must not become."""
+
+    def test_a_person_tagging_at_the_plane_is_not_stopped(self):
+        self.assertIsNone(self.decide("git tag v9.9.9", "default"))
+
+    def test_a_person_tagging_in_a_clone_still_only_gets_the_old_nudge(self):
+        self.assertEqual("ask", self.decide("git tag v9.9.9", "default", in_clone=True))
+
+    def test_auto_mode_is_attended(self):
+        """`auto` usually has a human watching — same boundary `_ask` already draws."""
+        self.assertIsNone(self.decide("git tag v9.9.9", "auto"))
+
+    def test_a_missing_mode_is_attended(self):
+        """A host that sends no `permission_mode` must never be read as unattended."""
+        self.assertIsNone(self.decide("git tag v9.9.9", None))
+
+    def test_forge_release_is_untouched_when_attended(self):
+        for cmd in ("gh release create v9.9.9", "gh pr merge 1 --squash"):
+            self.assertIsNone(self.decide(cmd, "default"), cmd)
+
+
+class TestItDoesNotOverreach(FloorCase):
+    """Reading and inspecting must stay free, unattended included — an autonomous run
+    legitimately needs to know what the tags ARE."""
+
+    def test_listing_tags_is_allowed(self):
+        for cmd in ("git tag", "git tag -l", "git tag --list", "git tag -l 'v0.4*'"):
+            self.assertIsNone(self.decide(cmd, UNATTENDED), cmd)
+
+    def test_deleting_a_local_tag_is_allowed(self):
+        """Local only — it publishes nothing."""
+        self.assertIsNone(self.decide("git tag -d v9.9.9", UNATTENDED))
+
+    def test_an_ordinary_push_is_allowed(self):
+        self.assertIsNone(self.decide("git push origin main", UNATTENDED))
+
+    def test_reading_forge_state_is_allowed(self):
+        for cmd in ("gh release list", "gh pr view 1", "gh run list", "glab mr list"):
+            self.assertIsNone(self.decide(cmd, UNATTENDED), cmd)
+
+    def test_prose_mentioning_a_tag_is_not_a_tag(self):
+        self.assertIsNone(
+            self.decide('git commit -m "prepare git tag v9.9.9 notes"', UNATTENDED))
+
+
+class TestItIsAFloorNotANudge(FloorCase):
+    """`bypassPermissions` means stop asking me, not stop knowing things."""
+
+    def test_the_other_floor_guards_still_deny(self):
+        self.assertEqual("deny", self.decide("git clone git@github.com:a/b.git", UNATTENDED))
+
+    def test_it_outranks_the_clone_nudge(self):
+        """In a clone, unattended, the release verb must DENY rather than fall through to
+        the nudge's allow — that fall-through is the whole bug."""
+        self.assertEqual("deny", self.decide("git tag v9.9.9", UNATTENDED, in_clone=True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #299.

## The regression

0.46.0 taught `_ask` to fall back to `allow` under `bypassPermissions`, so a workflow nudge cannot hang a run with nobody at the keyboard. That is right for a nudge. It was wrong for the one command that cannot be undone, and it removed cover nobody had noticed was there:

```
git tag v9.9.9   (attended)             -> ask     ← a hook `ask` floors the host's decision
git tag v9.9.9   (bypassPermissions)    -> allow      at a prompt in EVERY mode
```

`_clone_commit_reason` matches `_GIT_WRITE_RE`, which includes `tag` and `push`. **It was never designed to guard releases — it just did**, and pushing a tag fires `release.yml` → an irreversible PyPI publish (Trusted Publishing, no token, nothing to retract). `gh pr merge` and `gh release create` were never guarded at all, being no kind of `git`.

So after 0.46.0, an instruction of the shape *"commit, push, PR, merge, release"* — realistic, and already observed — would publish, unattended, with nothing in charter objecting at any point.

## What this adds

`_release_floor_reason`, checked **before** the clone nudge, because that fall-through is precisely the hole. Unattended only:

| | |
| --- | --- |
| `git tag <name>` (creation) | **deny** — the choke point; an unpushed tag cannot be pushed |
| `git push --tags` / `--follow-tags` / `refs/tags/…` / version-ish ref | **deny** — defence in depth |
| `gh`/`glab` `release create`, `pr merge`/`mr merge` | **deny** — never covered before |

**Deny, not ask, deliberately.** An unattended ask is now an allow, so an ask here would be indistinguishable from no guard. Deny is also the only verdict that cannot hang: the run gets an immediate refusal naming the remedy — *re-run this step attended*.

**Keyed on tagging, not on a `v*` shape.** Shape-matching reads more correct (`release.yml` triggers on `v*`) and is walked past by naming the tag `release-1`. Tagging attended costs nothing, so the asymmetry favours bluntness: a false stop costs one re-run, a false pass costs a version number that can never be reused. This was the one open question on #299; it is decided here rather than assumed.

## The property that matters as much as the denials

**Attended behaviour is completely unchanged**, and `TestAttendedIsCompletelyUnchanged` asserts it as hard as the denials: nothing at the plane, the old nudge inside a clone, `auto` treated as attended, an absent `permission_mode` treated as attended. A guard that made releases harder for the operator is the cage `_plane_root_branch_reason`'s docstring warns about, and the fix people reach for then is to switch it off permanently.

Reading stays free in every mode — `git tag -l`, `git tag -d`, `gh release list`, `gh pr view`, and an ordinary `git push origin main`.

## Verification

- **2771 tests green** (18 added).
- Probed live against this branch, not only the suite:

```
deny  | bypassPermissions | git tag v0.46.1
deny  | bypassPermissions | git push origin v0.46.1
deny  | bypassPermissions | gh pr merge 1 --squash
allow | bypassPermissions | git tag -l
allow | bypassPermissions | git push origin main
ask   | auto              | git tag v0.46.1          ← unchanged
allow | auto              | gh pr merge 1 --squash   ← unchanged
```

## How it was found

By asking what an autonomous agent would have done with the task that produced 0.46.0 — a question about the feature, not a test of it. The general lesson, now in steward's memory: **when converting an `ask` into an `allow`, enumerate what that ask was *incidentally* covering.** We reasoned carefully about what the nudge was *for* and never asked what else it was catching.

0.46.1 also carries the already-stamped `lint-sees-project-skills` entry from #294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo