### PR TITLE
Test git repos ran background maintenance and raced their own teardown

### DIFF
--- a/tests/test_doctor_plane_root.py
+++ b/tests/test_doctor_plane_root.py
@@ -47,6 +47,18 @@ def init_repo(path: Path, branch: str = "main") -> Path:
                    check=True, capture_output=True)
     git(path, "config", "user.email", "t@example.com")
     git(path, "config", "user.name", "t")
+    # Background maintenance races the teardown. `git maintenance run --auto` fires after
+    # ordinary commands, takes `.git/maintenance.lock`, and releases it — while
+    # `shutil.rmtree` is walking that directory, which then dies on a name that existed
+    # when it was listed and not when it was unlinked. Seen on CI as
+    # `FileNotFoundError: 'maintenance.lock'` in a test that only deletes a fixture, on one
+    # Python job while the others passed the same commit.
+    #
+    # Disabled at the source rather than tolerated in each teardown: a fixture repo has
+    # nothing to maintain, and `ignore_errors=True` on the rmtree would hide real breakage
+    # in tests whose whole subject is what is on disk.
+    git(path, "config", "gc.auto", "0")
+    git(path, "config", "maintenance.auto", "false")
     git(path, "config", "commit.gpgsign", "false")
     git(path, "add", "-A")
     git(path, "commit", "-qm", "init")

--- a/tests/test_init_first_clone.py
+++ b/tests/test_init_first_clone.py
@@ -45,6 +45,18 @@ def init_repo(path: Path, branch: str = "main") -> Path:
                    check=True, capture_output=True)
     git(path, "config", "user.email", "t@example.com")
     git(path, "config", "user.name", "t")
+    # Background maintenance races the teardown. `git maintenance run --auto` fires after
+    # ordinary commands, takes `.git/maintenance.lock`, and releases it — while
+    # `shutil.rmtree` is walking that directory, which then dies on a name that existed
+    # when it was listed and not when it was unlinked. Seen on CI as
+    # `FileNotFoundError: 'maintenance.lock'` in a test that only deletes a fixture, on one
+    # Python job while the others passed the same commit.
+    #
+    # Disabled at the source rather than tolerated in each teardown: a fixture repo has
+    # nothing to maintain, and `ignore_errors=True` on the rmtree would hide real breakage
+    # in tests whose whole subject is what is on disk.
+    git(path, "config", "gc.auto", "0")
+    git(path, "config", "maintenance.auto", "false")
     (path / "README.md").write_text("hello\n")
     git(path, "add", "README.md")
     git(path, "-c", "commit.gpgsign=false", "commit", "-qm", "init")

--- a/tests/test_statusline_plane_root_warning.py
+++ b/tests/test_statusline_plane_root_warning.py
@@ -46,6 +46,18 @@ def init_repo(path: Path, branch: str = "main") -> Path:
                    check=True, capture_output=True)
     git(path, "config", "user.email", "t@example.com")
     git(path, "config", "user.name", "t")
+    # Background maintenance races the teardown. `git maintenance run --auto` fires after
+    # ordinary commands, takes `.git/maintenance.lock`, and releases it — while
+    # `shutil.rmtree` is walking that directory, which then dies on a name that existed
+    # when it was listed and not when it was unlinked. Seen on CI as
+    # `FileNotFoundError: 'maintenance.lock'` in a test that only deletes a fixture, on one
+    # Python job while the others passed the same commit.
+    #
+    # Disabled at the source rather than tolerated in each teardown: a fixture repo has
+    # nothing to maintain, and `ignore_errors=True` on the rmtree would hide real breakage
+    # in tests whose whole subject is what is on disk.
+    git(path, "config", "gc.auto", "0")
+    git(path, "config", "maintenance.auto", "false")
     # Guarantees there is something to commit: an empty first commit leaves no
     # `refs/heads/<branch>`, and half of what is under test here is read from the ref
     # store. A repo with no content is not the fixture any of these tests mean.

--- a/tests/test_statusline_worktree_rows.py
+++ b/tests/test_statusline_worktree_rows.py
@@ -44,6 +44,18 @@ def init_repo(path: Path, branch: str = "main") -> Path:
                    check=True, capture_output=True)
     git(path, "config", "user.email", "t@example.com")
     git(path, "config", "user.name", "t")
+    # Background maintenance races the teardown. `git maintenance run --auto` fires after
+    # ordinary commands, takes `.git/maintenance.lock`, and releases it — while
+    # `shutil.rmtree` is walking that directory, which then dies on a name that existed
+    # when it was listed and not when it was unlinked. Seen on CI as
+    # `FileNotFoundError: 'maintenance.lock'` in a test that only deletes a fixture, on one
+    # Python job while the others passed the same commit.
+    #
+    # Disabled at the source rather than tolerated in each teardown: a fixture repo has
+    # nothing to maintain, and `ignore_errors=True` on the rmtree would hide real breakage
+    # in tests whose whole subject is what is on disk.
+    git(path, "config", "gc.auto", "0")
+    git(path, "config", "maintenance.auto", "false")
     (path / "README.md").write_text("hello\n")
     git(path, "add", "README.md")
     git(path, "-c", "commit.gpgsign=false", "commit", "-qm", "init")


### PR DESCRIPTION
`main` went red on a commit that added two memory files. The failure had nothing to do with it:

```
ERROR: test_a_dirty_tree_around_a_plane_that_is_not_a_repo_is_not_borrowed
  tests/test_statusline_plane_root_warning.py:291   shutil.rmtree(outer / ".git")
FileNotFoundError: [Errno 2] No such file or directory: 'maintenance.lock'
```

`git maintenance run --auto` fires after ordinary commands, takes `.git/maintenance.lock` and releases it. When that lands while `shutil.rmtree` is walking the same directory, rmtree dies on a name that existed when it listed the directory and no longer existed when it unlinked it.

**The tell that it was a race and not a regression:** Python **3.12 passed the identical commit** while 3.11 failed (3.13/3.14 were cancelled by fail-fast). A re-run of the failed job then passed, which is how `main` is green right now — but re-running only hides this.

## The fix

`gc.auto=0` and `maintenance.auto=false` in every fixture repo, at the source.

A fixture repo has nothing to maintain. The alternative — `ignore_errors=True` on the teardown — would hide real breakage in tests whose entire subject is what is on disk, which is the wrong trade in exactly these files.

Applied to all four `init_repo` helpers. They are four copies of one function, and this is the second reason to notice that; consolidating them is a separate change, not one to make while `main` is red.

## Why nothing caught it sooner

**22 test files build real git repos and not one disabled auto-maintenance**, so the race was available to any of them. This test just drew the short straw — which also means the fix is worth having across all four helpers rather than at the one call site that happened to fail.

## Verification

- Full suite green (2789).
- The previously-flaky module run **25 consecutive times, zero failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo