### PR TITLE
charter guard allow --local: a rule that is yours, not the team's (#301)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -263,6 +263,7 @@ def build_parser() -> argparse.ArgumentParser:
     ga = gsub.add_parser("ask", help="Always prompt before this command runs.")
     ga.add_argument("pattern", help="e.g. 'terraform apply *' — wrapped as Bash(...) "
                                     "unless it already names a tool.")
+    ga.add_argument("--local", action="store_true", help="Write this machine's own file (`.claude/settings.local.json`, gitignored) instead of the plane's committed settings — the rule is yours alone.")
     ga.set_defaults(func=commands.cmd_guard_ask)
     gl = gsub.add_parser("list", help="Show this plane's force-prompt rules.")
     gl.set_defaults(func=commands.cmd_guard_list)
@@ -274,6 +275,7 @@ def build_parser() -> argparse.ArgumentParser:
                               "(writes the host's own allow rule).")
     gw.add_argument("pattern", nargs="?", default="",
                     help="e.g. 'git status *'. Bare patterns are wrapped as Bash rules.")
+    gw.add_argument("--local", action="store_true", help="Write this machine's own file (`.claude/settings.local.json`, gitignored) instead of the plane's committed settings — the rule is yours alone.")
     gw.set_defaults(func=commands.cmd_guard_allow)
 
     vsy = vsub.add_parser("sync",

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -856,7 +856,24 @@ def _load_settings(root: Path) -> tuple[dict | None, Path]:
     return (doc if isinstance(doc, dict) else None), p
 
 
-def add_permission_rule(root: Path, rule: str, bucket: str) -> tuple[str, str]:
+def _load_json_settings(path: Path):
+    """`(doc, path)` for a settings file, or `(None, path)` when it is not usable.
+
+    `_load_settings` answers this for the plane's committed file specifically. This is the
+    same restraint for any path: a missing file is an empty document, an unparseable one is
+    somebody's to fix and charter reports it rather than overwriting it.
+    """
+    if not path.exists():
+        return {}, path
+    try:
+        doc = json.loads(path.read_text())
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None, path
+    return (doc, path) if isinstance(doc, dict) else (None, path)
+
+
+def add_permission_rule(root: Path, rule: str, bucket: str,
+                        local: bool = False) -> tuple[str, str]:
     """Append *rule* to ``permissions.<bucket>`` in the plane's `.claude/settings.json`.
 
     Extracted from `cmd_guard_ask` when a second harness needed the same command: the
@@ -868,8 +885,14 @@ def add_permission_rule(root: Path, rule: str, bucket: str) -> tuple[str, str]:
     Parameterised over the bucket when `guard allow` arrived: `ask` and `allow` are the
     same job with opposite verbs, and two copies of this function would eventually
     disagree about what "malformed" means — in a file charter only half-owns.
+
+    `local=True` targets `.claude/settings.local.json` instead — gitignored by `charter
+    init`, so the rule is one person's, on one machine. Same reasoning one level down: the
+    two files differ only in blast radius, so they must not differ in how carefully they
+    are parsed or how firmly a malformed one is refused.
     """
-    settings, path = _load_settings(root)
+    settings, path = (_load_json_settings(Path(root) / LOCAL_SETTINGS) if local
+                      else _load_settings(root))
     if settings is None:
         return "malformed", str(path)
     perms = settings.setdefault("permissions", {})
@@ -886,14 +909,20 @@ def add_permission_rule(root: Path, rule: str, bucket: str) -> tuple[str, str]:
     return "added", str(path)
 
 
-def add_ask_rule(root: Path, rule: str) -> tuple[str, str]:
+#: The plane's MACHINE-LOCAL settings — gitignored by `charter init`, so a rule written here
+#: is one person's decision on one machine. `.claude/settings.json`, its committed sibling,
+#: carries the same key names and a completely different blast radius.
+LOCAL_SETTINGS = Path(".claude") / "settings.local.json"
+
+
+def add_ask_rule(root: Path, rule: str, local: bool = False) -> tuple[str, str]:
     """`permissions.ask` — force a prompt for *rule*."""
-    return add_permission_rule(root, rule, "ask")
+    return add_permission_rule(root, rule, "ask", local=local)
 
 
-def add_allow_rule(root: Path, rule: str) -> tuple[str, str]:
+def add_allow_rule(root: Path, rule: str, local: bool = False) -> tuple[str, str]:
     """`permissions.allow` — stop prompting for *rule*."""
-    return add_permission_rule(root, rule, "allow")
+    return add_permission_rule(root, rule, "allow", local=local)
 
 
 def cmd_guard_allow(args) -> int:
@@ -910,6 +939,7 @@ def cmd_guard_allow(args) -> int:
     when charter denies only three narrow things (#291).
     """
     pattern = (getattr(args, "pattern", "") or "").strip()
+    local = bool(getattr(args, "local", False))
     if not pattern:
         util.err("Nothing to add. Example: charter guard allow 'git status *'")
         return 2
@@ -918,7 +948,7 @@ def cmd_guard_allow(args) -> int:
     root = Path(config.ROOT)
     rc, wrote = 0, False
     for h in registry.all():
-        status, detail = h.apply_allow_rule(root, pattern)
+        status, detail = h.apply_allow_rule(root, pattern, local=local)
         if status == "added":
             util.ok(f"{h.name}: allowing {h.allow_rule(pattern)} → {detail}")
             wrote = True
@@ -934,8 +964,15 @@ def cmd_guard_allow(args) -> int:
     if not wrote and rc == 0:
         util.warn("  No harness took the rule.")
     if wrote:
-        util.info("  These files are committed, so the rule applies to everyone on this "
-                  "repo — no sync step, and nothing that can drift (ADR 0014).")
+        if local:
+            util.info("  Machine-local (gitignored) — this rule is yours, on this machine.")
+        else:
+            # Deliberately not the reassuring ADR 0014 line `guard ask` prints. An ASK rule
+            # narrows what happens without a human, so sharing it is conservative. An ALLOW
+            # rule widens it, and sharing extends one person's trust decision to everyone
+            # who clones the repo, on machines and under identities they did not choose.
+            util.warn("  COMMITTED — this stops the prompt for everyone on this repo, not "
+                      "just you. Use `--local` for a rule that is yours alone.")
         util.info("  charter's own guards are unaffected: an allow rule relaxes the HOST's "
                   "prompt, never the secret, credential or plane-root denials.")
     return rc
@@ -957,6 +994,7 @@ def cmd_guard_ask(args) -> int:
     is the editor rather than the author.
     """
     pattern = (getattr(args, "pattern", "") or "").strip()
+    local = bool(getattr(args, "local", False))
     if not pattern:
         util.err("Nothing to add. Example: charter guard ask 'terraform apply *'")
         return 2
@@ -965,7 +1003,7 @@ def cmd_guard_ask(args) -> int:
     root = Path(config.ROOT)
     rc, wrote = 0, False
     for h in registry.all():
-        status, detail = h.apply_ask_rule(root, pattern)
+        status, detail = h.apply_ask_rule(root, pattern, local=local)
         if status == "added":
             util.ok(f"{h.name}: asking for {h.ask_rule(pattern)} → {detail}")
             wrote = True
@@ -984,8 +1022,11 @@ def cmd_guard_ask(args) -> int:
     if not wrote and rc == 0:
         util.warn("  No harness took the rule.")
     if wrote:
-        util.info("  These files are committed, so the rule applies to everyone on this "
-                  "repo — no sync step, and nothing that can drift (ADR 0014).")
+        if local:
+            util.info("  Machine-local (gitignored) — this rule is yours, on this machine.")
+        else:
+            util.info("  These files are committed, so the rule applies to everyone on this "
+                      "repo — no sync step, and nothing that can drift (ADR 0014).")
         _warn_if_shadowing(registry.get(registry.CLAUDE_CODE).ask_rule(pattern))
     return rc
 

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -101,7 +101,8 @@ class Harness:
         """
         return None
 
-    def apply_ask_rule(self, root: Path, pattern: str) -> tuple[str, str]:
+    def apply_ask_rule(self, root: Path, pattern: str,
+                       local: bool = False) -> tuple[str, str]:
         """Write the rule under *root*. ``(status, detail)``.
 
         ``"added"``, ``"present"``, ``"malformed"`` (refused, never repaired), or
@@ -121,7 +122,15 @@ class Harness:
         """
         return self.ask_rule(pattern)
 
-    def apply_allow_rule(self, root: Path, pattern: str) -> tuple[str, str]:
+    def apply_allow_rule(self, root: Path, pattern: str,
+                         local: bool = False) -> tuple[str, str]:
         """Write the allow rule under *root*. ``(status, detail)``, as
-        :meth:`apply_ask_rule`."""
+        :meth:`apply_ask_rule`.
+
+        ``local=True`` asks for the harness's MACHINE-LOCAL file — a rule that is one
+        person's, on one machine. A harness with no such file must return ``unsupported``
+        and say why rather than falling back to a shared one: an `allow` rule widens what
+        runs unprompted, so a silent fallback would publish a personal trust decision to
+        everybody, which is the failure the flag exists to prevent.
+        """
         return "unsupported", f"{self.name} has no command-pattern permissions"

--- a/charter/harness/claude_code.py
+++ b/charter/harness/claude_code.py
@@ -67,12 +67,14 @@ class ClaudeCodeHarness(Harness):
 
         return commands._as_rule(pattern)
 
-    def apply_ask_rule(self, root: Path, pattern: str) -> tuple[str, str]:
+    def apply_ask_rule(self, root: Path, pattern: str,
+                       local: bool = False) -> tuple[str, str]:
         from .. import commands
 
-        return commands.add_ask_rule(root, self.ask_rule(pattern))
+        return commands.add_ask_rule(root, self.ask_rule(pattern), local=local)
 
-    def apply_allow_rule(self, root: Path, pattern: str) -> tuple[str, str]:
+    def apply_allow_rule(self, root: Path, pattern: str,
+                         local: bool = False) -> tuple[str, str]:
         from .. import commands
 
-        return commands.add_allow_rule(root, self.allow_rule(pattern))
+        return commands.add_allow_rule(root, self.allow_rule(pattern), local=local)

--- a/charter/harness/opencode.py
+++ b/charter/harness/opencode.py
@@ -402,10 +402,25 @@ class OpenCodeHarness(Harness):
                     return oc_id, p[len(prefix):-1]
         return "bash", p
 
-    def apply_ask_rule(self, root: Path, pattern: str) -> tuple[str, str]:
+    #: Declined deliberately, not unimplemented. opencode's only uncommitted config is
+    #: `global_dir()` (`~/.config/opencode`), which applies to EVERY project on the machine.
+    #: Trading a team-wide rule for an all-my-projects-wide one is not narrower, and an
+    #: `allow` written there would silently widen every other repo this person opens. Saying
+    #: so is the same restraint `apply_ask_rule` keeps for a harness with no patterns at all.
+    _NO_LOCAL = ("opencode has no project-local uncommitted config — its only uncommitted "
+                 "config is ~/.config/opencode, which applies to every project on this "
+                 "machine, so charter will not narrow a team rule into a broader one")
+
+    def apply_ask_rule(self, root: Path, pattern: str,
+                       local: bool = False) -> tuple[str, str]:
+        if local:
+            return "unsupported", self._NO_LOCAL
         return self._apply_rule(root, pattern, "ask")
 
-    def apply_allow_rule(self, root: Path, pattern: str) -> tuple[str, str]:
+    def apply_allow_rule(self, root: Path, pattern: str,
+                         local: bool = False) -> tuple[str, str]:
+        if local:
+            return "unsupported", self._NO_LOCAL
         return self._apply_rule(root, pattern, "allow")
 
     def _apply_rule(self, root: Path, pattern: str, decision: str) -> tuple[str, str]:

--- a/tests/test_guard_local.py
+++ b/tests/test_guard_local.py
@@ -1,0 +1,166 @@
+"""`--local` — a permission rule for THIS MACHINE, not for the team.
+
+`guard ask` and `guard allow` both write the plane's committed files, and the command says
+so as reassurance: *"These files are committed, so the rule applies to everyone on this repo
+— no sync step, and nothing that can drift (ADR 0014)."* For `ask` that is a feature. For
+`allow` it is often exactly wrong, and there was no way to say so.
+
+The two are not mirrors, and they differ in the direction that matters:
+
+* an **ask** rule NARROWS what happens without a human — sharing it is conservative, and the
+  worst case is a colleague sees one more prompt;
+* an **allow** rule WIDENS it — sharing it extends one person's trust decision to everyone
+  who clones the repo, on machines and under identities they did not choose.
+
+Concretely: reaching for `charter guard allow 'gh pr merge *'` to unblock your own session
+committed unprompted PR merges for the whole team, and nothing warned, because from the
+command's point of view it had done its job.
+
+ADR 0014 is right about the ENGINE — charter writes the host's rules and keeps no list of its
+own. "Therefore always the shared file" is the part that does not follow when the rule widens.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import cli, commands, config
+from charter.harness import registry
+from tests._isolation import PersonaIso
+
+
+class LocalCase(PersonaIso):
+    def shared(self) -> Path:
+        return Path(config.ROOT) / ".claude" / "settings.json"
+
+    def local(self) -> Path:
+        return Path(config.ROOT) / ".claude" / "settings.local.json"
+
+    def read(self, p: Path) -> dict:
+        return json.loads(p.read_text())
+
+    def invoke(self, fn, **kw) -> tuple[int, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = fn(SimpleNamespace(**kw))
+        return rc, out.getvalue() + err.getvalue()
+
+    def allow(self, pattern, local=False):
+        return self.invoke(commands.cmd_guard_allow, pattern=pattern, local=local)
+
+    def ask(self, pattern, local=False):
+        return self.invoke(commands.cmd_guard_ask, pattern=pattern, local=local)
+
+
+class TestLocalWritesTheMachineLocalFile(LocalCase):
+    def test_allow_local_lands_in_settings_local(self):
+        self.allow("gh pr merge *", local=True)
+        self.assertIn("Bash(gh pr merge *)", self.read(self.local())["permissions"]["allow"])
+
+    def test_it_does_not_touch_the_committed_file(self):
+        """The whole point: a personal unblock must not become team policy."""
+        self.allow("gh pr merge *", local=True)
+        self.assertFalse(self.shared().exists(), "wrote the COMMITTED settings file")
+
+    def test_ask_local_works_too(self):
+        """Symmetry — a personal extra prompt is as legitimate as a personal allowance."""
+        self.ask("terraform apply *", local=True)
+        self.assertIn("Bash(terraform apply *)", self.read(self.local())["permissions"]["ask"])
+
+    def test_local_is_idempotent(self):
+        self.allow("gh pr merge *", local=True)
+        self.allow("gh pr merge *", local=True)
+        self.assertEqual(1, self.read(self.local())["permissions"]["allow"]
+                         .count("Bash(gh pr merge *)"))
+
+    def test_local_preserves_unrelated_local_settings(self):
+        self.local().parent.mkdir(parents=True, exist_ok=True)
+        self.local().write_text(json.dumps({"enabledPlugins": {"x@y": True}}))
+        self.allow("gh pr merge *", local=True)
+        self.assertEqual({"x@y": True}, self.read(self.local())["enabledPlugins"])
+
+    def test_the_two_files_are_independent(self):
+        self.allow("git status *")               # shared
+        self.allow("gh pr merge *", local=True)  # local
+        self.assertEqual(["Bash(git status *)"], self.read(self.shared())["permissions"]["allow"])
+        self.assertEqual(["Bash(gh pr merge *)"], self.read(self.local())["permissions"]["allow"])
+
+
+class TestTheDefaultIsUnchanged(LocalCase):
+    """Committed remains the default — this adds a choice, it does not move the door."""
+
+    def test_allow_without_local_still_writes_the_committed_file(self):
+        self.allow("git status *")
+        self.assertIn("Bash(git status *)", self.read(self.shared())["permissions"]["allow"])
+        self.assertFalse(self.local().exists())
+
+    def test_ask_without_local_still_writes_the_committed_file(self):
+        self.ask("terraform apply *")
+        self.assertIn("Bash(terraform apply *)", self.read(self.shared())["permissions"]["ask"])
+        self.assertFalse(self.local().exists())
+
+
+class TestTheSharedAllowSaysItIsTeamWide(LocalCase):
+    """The output used to read as reassurance — 'no sync step, nothing that can drift' —
+    which is the wrong register for a rule that widens what runs unprompted."""
+
+    def test_a_shared_allow_names_the_blast_radius_and_the_alternative(self):
+        _, out = self.allow("gh pr merge *")
+        self.assertIn("everyone", out)
+        self.assertIn("--local", out)
+
+    def test_a_local_allow_does_not_claim_to_be_team_wide(self):
+        _, out = self.allow("gh pr merge *", local=True)
+        self.assertNotIn("everyone", out)
+
+
+class TestAHarnessWithoutALocalFileSaysSo(LocalCase):
+    """Naming the limit is the difference between a limit and a lie — the restraint
+    `apply_ask_rule` already keeps for a harness with no command patterns."""
+
+    def test_opencode_reports_unsupported_rather_than_writing_its_global_config(self):
+        """opencode's only uncommitted config is `~/.config/opencode`, which applies to
+        EVERY project. Swapping team-wide for all-my-projects-wide is not narrower, so
+        this declines and says why."""
+        h = registry.get(registry.OPENCODE)
+        status, detail = h.apply_allow_rule(Path(config.ROOT), "gh pr merge *", local=True)
+        self.assertEqual("unsupported", status)
+        self.assertTrue(detail)
+        self.assertFalse((Path(config.ROOT) / "opencode.json").exists())
+
+    def test_the_command_still_succeeds_when_one_harness_declines(self):
+        """Claude Code took it; opencode could not. That is a partial success, not a failure."""
+        rc, out = self.allow("gh pr merge *", local=True)
+        self.assertEqual(0, rc)
+        self.assertIn("Bash(gh pr merge *)", self.read(self.local())["permissions"]["allow"])
+
+
+class TestItRefusesRatherThanRepairing(LocalCase):
+    def test_a_malformed_local_file_is_left_alone(self):
+        self.local().parent.mkdir(parents=True, exist_ok=True)
+        self.local().write_text("{ not json")
+        self.allow("gh pr merge *", local=True)
+        self.assertEqual("{ not json", self.local().read_text())
+
+
+class TestItIsWiredIntoTheCli(unittest.TestCase):
+    def test_allow_takes_local(self):
+        ns = cli.build_parser().parse_args(["guard", "allow", "--local", "gh pr merge *"])
+        self.assertTrue(ns.local)
+
+    def test_ask_takes_local(self):
+        ns = cli.build_parser().parse_args(["guard", "ask", "--local", "terraform apply *"])
+        self.assertTrue(ns.local)
+
+    def test_local_defaults_to_false(self):
+        self.assertFalse(cli.build_parser().parse_args(["guard", "allow", "x"]).local)
+        self.assertFalse(cli.build_parser().parse_args(["guard", "ask", "x"]).local)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #301.

## The problem

`guard ask` and `guard allow` both wrote the plane's **committed** settings, and the command said so as reassurance:

> *"These files are committed, so the rule applies to everyone on this repo — no sync step, and nothing that can drift (ADR 0014)."*

For `ask` that is a feature. For `allow` it is often exactly wrong, and there was no way to say otherwise.

**They look like mirrors and differ in the direction that matters:**

- an **ask** rule *narrows* what happens without a human — sharing it is conservative, worst case a colleague sees one more prompt
- an **allow** rule *widens* it — sharing extends one person's trust decision to everyone who clones the repo, on machines and under identities they did not choose

Concretely, and this is how it was found: reaching for `charter guard allow 'gh pr merge *'` to unblock your own session would have committed unprompted PR merges for the whole team, with nothing warning you, because from the command's point of view it had done its job.

ADR 0014 is right about the **engine** — charter writes the host's rules and keeps no list of its own. *"Therefore always the shared file"* is the part that does not follow once the rule widens.

## What this adds

`--local` on both `guard allow` and `guard ask`, writing `.claude/settings.local.json` — which `charter init` **already gitignores**. Committed stays the default: this adds a choice, it does not move the door.

**opencode declines `--local` rather than falling back.** Its only uncommitted config is `~/.config/opencode`, which applies to *every project on the machine* — trading a team-wide rule for an all-my-projects-wide one is not narrower, and an `allow` written there would silently widen every other repo that person opens. Naming the limit is the difference between a limit and a lie, the same restraint `apply_ask_rule` already keeps for a harness with no command patterns at all.

The shared-`allow` footer now **warns instead of reassuring**, and names the alternative:

```
COMMITTED — this stops the prompt for everyone on this repo, not just you.
Use `--local` for a rule that is yours alone.
```

`guard ask` keeps its original ADR 0014 line, because for the narrowing direction that line is still true and still reassuring.

## Verification

2805 tests, green — 16 added, covering: `--local` writes the local file and **provably does not touch the committed one**; the default is unchanged for both verbs; the two files stay independent; a malformed local file is refused rather than repaired; opencode reports `unsupported` and writes nothing; and the command still succeeds when one harness declines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo