### PR TITLE
Release 0.46.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.46.1",
+  "version": "0.46.2",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.46.1"
+__version__ = "0.46.2"

--- a/docs/news/0.46.2-guard-allow-local.md
+++ b/docs/news/0.46.2-guard-allow-local.md
@@ -1,0 +1,34 @@
+---
+version: 0.46.2
+headline: A permission rule that is yours, not the whole team's
+---
+
+`charter guard ask` and `charter guard allow` both wrote the plane's **committed** settings,
+and said so as reassurance: *"These files are committed, so the rule applies to everyone on
+this repo."* For `ask` that is a feature. For `allow` it is often exactly wrong.
+
+The two look like mirrors and differ in the direction that matters. An **ask** rule narrows
+what happens without a human — sharing it is conservative, and the worst case is a colleague
+sees one more prompt. An **allow** rule widens it, and sharing extends one person's trust
+decision to everyone who clones the repo, on machines and under identities they did not
+choose.
+
+Found the obvious way: reaching for `charter guard allow 'gh pr merge *'` to unblock one
+session would have committed unprompted PR merges for the whole team, with nothing warning
+about it.
+
+```bash
+charter guard allow --local 'gh pr merge *'
+```
+
+`--local` writes `.claude/settings.local.json`, which `charter init` already gitignores, so
+the rule is yours on this machine. Available on `guard ask` too. **Committed stays the
+default** — this adds a choice, it does not move the door — and the shared `allow` now warns
+rather than reassures, naming `--local` as the alternative.
+
+opencode **declines** `--local` instead of falling back to something broader: its only
+uncommitted config applies to every project on the machine, and trading a team-wide rule for
+an all-my-projects-wide one is not narrower.
+
+ADR 0014 is unchanged and still right about the engine — charter writes the host's rules and
+keeps no list of its own. Only *"therefore always the shared file"* needed revisiting.

--- a/docs/news/0.46.2-mcp-child-wins.md
+++ b/docs/news/0.46.2-mcp-child-wins.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.46.2
 headline: A child persona can override its parent's MCP server again
 ---
 

--- a/docs/news/0.46.2-persona-bin.md
+++ b/docs/news/0.46.2-persona-bin.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.46.2
 headline: A persona can carry its own executables
 check: persona lint
 ---

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.46.1",
+            "command": "charter hook sessionstart --plugin-version 0.46.2",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.46.1",
+            "command": "charter hook userpromptsubmit --plugin-version 0.46.2",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.46.1",
+            "command": "charter hook pretooluse --plugin-version 0.46.2",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.46.1",
+            "command": "charter hook pretooluse-read --plugin-version 0.46.2",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.46.1"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.46.2"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.46.1",
+            "command": "charter hook pretooluse-edit --plugin-version 0.46.2",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-bash --plugin-version 0.46.1",
+            "command": "charter hook posttooluse-bash --plugin-version 0.46.2",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.46.1",
+            "command": "charter hook posttooluse --plugin-version 0.46.2",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.46.1",
+            "command": "charter hook posttooluse-skill --plugin-version 0.46.2",
             "timeout": 5
           }
         ]
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.46.1",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.46.2",
             "timeout": 5
           }
         ]
@@ -128,7 +128,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-message --plugin-version 0.46.1",
+            "command": "charter hook posttooluse-message --plugin-version 0.46.2",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.46.1"
+version = "0.46.2"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump and news for **0.46.2**.

Carries three entries:

- **`charter guard allow --local`** (#301, PR #303) — a permission rule that is yours on this machine rather than the whole team's. An `allow` rule *widens* what runs unprompted, so writing it to the plane's committed settings extended one person's trust decision to everyone who clones the repo.
- **A persona can carry its own executables** (#295) — entry was already waiting.
- **`mcp_servers()` reversed its own documented precedence** (#297) — entry was already waiting.

Also on `main` since 0.46.1, with no news entry because it is internal test hygiene: PR #302, which stopped fixture git repos running background maintenance and racing their own teardown. That was the intermittent `FileNotFoundError: 'maintenance.lock'` that turned `main` red earlier today.

Pre-flight: all five version points consistent, `charter news --for 0.46.2` passes, captures still stamped within one minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo