### PR TITLE
`--local` wrote a file the plane did not ignore (0.46.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.46.2",
+  "version": "0.46.3",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.46.2"
+__version__ = "0.46.3"

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -637,6 +637,10 @@ _GITIGNORE_BASELINE = """\
 # NEVER commit this — it holds credentials.
 /.charter/
 
+# This machine's own harness permissions (`charter guard ask|allow --local`). Its committed
+# sibling `.claude/settings.json` is deliberately NOT ignored — that one is the team's.
+/.claude/settings.local.json
+
 # Python
 __pycache__/
 *.py[cod]
@@ -669,6 +673,8 @@ def _ensure_gitignore(root: Path) -> bool:
         missing += ["/workspaces/*/*", "!/workspaces/.gitkeep"]
     if ".charter/" not in body:
         missing.append("/.charter/")
+    if LOCAL_SETTINGS_IGNORE not in existing_lines:
+        missing.append(LOCAL_SETTINGS_IGNORE)
     if not missing:
         return False
     # The write itself goes through the one shared appender — `charter browser install`
@@ -891,6 +897,8 @@ def add_permission_rule(root: Path, rule: str, bucket: str,
     two files differ only in blast radius, so they must not differ in how carefully they
     are parsed or how firmly a malformed one is refused.
     """
+    if local:
+        _ensure_local_settings_ignored(root)
     settings, path = (_load_json_settings(Path(root) / LOCAL_SETTINGS) if local
                       else _load_settings(root))
     if settings is None:
@@ -909,10 +917,37 @@ def add_permission_rule(root: Path, rule: str, bucket: str,
     return "added", str(path)
 
 
-#: The plane's MACHINE-LOCAL settings — gitignored by `charter init`, so a rule written here
-#: is one person's decision on one machine. `.claude/settings.json`, its committed sibling,
-#: carries the same key names and a completely different blast radius.
+#: The plane's MACHINE-LOCAL settings — a rule written here is one person's decision on one
+#: machine. `.claude/settings.json`, its committed sibling, carries the same key names and a
+#: completely different blast radius.
 LOCAL_SETTINGS = Path(".claude") / "settings.local.json"
+
+#: The `.gitignore` line that makes :data:`LOCAL_SETTINGS` actually local. Written by the
+#: baseline for a fresh plane AND ensured by `_ensure_local_settings_ignored` at the moment a
+#: local rule is written, because a plane created before this existed has neither.
+LOCAL_SETTINGS_IGNORE = "/.claude/settings.local.json"
+
+
+def _ensure_local_settings_ignored(root: Path) -> None:
+    """Make `--local`'s promise true in THIS plane before relying on it.
+
+    The flag shipped claiming `charter init` gitignored the file. It did not — charter's own
+    repo has that line by hand, and checking there and generalising is how the claim was
+    made. In a fresh plane the file was committable, so the one command the flag exists for,
+    `charter guard allow --local 'gh pr merge *'`, would have landed in the next commit as
+    the team-wide rule it was chosen to avoid.
+
+    Fixing the baseline alone would leave every plane created before today broken, which is
+    precisely where somebody reaches for `--local` and is silently let down. So the guarantee
+    lives at the point of use as well: additive, idempotent, and never rewriting a line
+    anybody else put there.
+    """
+    p = Path(root) / ".gitignore"
+    body = p.read_text() if p.exists() else ""
+    if LOCAL_SETTINGS_IGNORE in {ln.strip() for ln in body.splitlines()}:
+        return
+    util.append_gitignore(root, [LOCAL_SETTINGS_IGNORE],
+                          "added by `charter guard --local`")
 
 
 def add_ask_rule(root: Path, rule: str, local: bool = False) -> tuple[str, str]:

--- a/docs/news/0.46.3-local-settings-ignored.md
+++ b/docs/news/0.46.3-local-settings-ignored.md
@@ -1,0 +1,27 @@
+---
+version: 0.46.3
+headline: `--local` now actually keeps the rule local
+---
+
+0.46.2 added `charter guard ask|allow --local` on the strength of one sentence: that
+`charter init` gitignores `.claude/settings.local.json`. **It did not.** charter's own repo
+carries that line by hand, and checking there and generalising is how the claim was made.
+
+So in a fresh plane the file was committable, and the single command the flag exists for —
+
+```bash
+charter guard allow --local 'gh pr merge *'
+```
+
+— would have landed in the next commit and become the team-wide rule it was chosen to avoid.
+A promise that holds only in the repo where it was tested is worse than no promise, because
+the flag reads as a guarantee.
+
+Fixed in two places, because either alone leaves a gap: the baseline `.gitignore` a fresh
+plane gets now carries the rule, **and** writing a local rule ensures it in whatever plane
+you are in — additive and idempotent, never rewriting a line somebody else put there. That
+second half matters most for planes created before 0.46.2, which is exactly where someone
+reaches for `--local` and would be let down silently.
+
+`.claude/settings.json`, the committed sibling, is deliberately still not ignored. That one
+is the team's.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.46.2",
+            "command": "charter hook sessionstart --plugin-version 0.46.3",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.46.2",
+            "command": "charter hook userpromptsubmit --plugin-version 0.46.3",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.46.2",
+            "command": "charter hook pretooluse --plugin-version 0.46.3",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.46.2",
+            "command": "charter hook pretooluse-read --plugin-version 0.46.3",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.46.2"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.46.3"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.46.2",
+            "command": "charter hook pretooluse-edit --plugin-version 0.46.3",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-bash --plugin-version 0.46.2",
+            "command": "charter hook posttooluse-bash --plugin-version 0.46.3",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.46.2",
+            "command": "charter hook posttooluse --plugin-version 0.46.3",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.46.2",
+            "command": "charter hook posttooluse-skill --plugin-version 0.46.3",
             "timeout": 5
           }
         ]
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.46.2",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.46.3",
             "timeout": 5
           }
         ]
@@ -128,7 +128,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-message --plugin-version 0.46.2",
+            "command": "charter hook posttooluse-message --plugin-version 0.46.3",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.46.2"
+version = "0.46.3"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -168,8 +168,12 @@ class TestGitignorePresenceCheckIsPrecise(InitIso):
         self.assertIn("!/workspaces/.gitkeep", body)
 
     def test_the_real_anchor_is_still_recognised_as_present(self):
+        """Nothing is re-added when every baseline rule is already there. The fixture
+        lists them all deliberately — a rule missing from it would make this assert
+        idempotence while actually exercising the append path."""
         (self.root / ".gitignore").write_text(
-            "/workspaces/*/*\n!/workspaces/.gitkeep\n/.charter/\n")
+            "/workspaces/*/*\n!/workspaces/.gitkeep\n/.charter/\n"
+            f"{commands.LOCAL_SETTINGS_IGNORE}\n")
         before = (self.root / ".gitignore").read_text()
         self._init()
         after = (self.root / ".gitignore").read_text()

--- a/tests/test_local_settings_are_ignored.py
+++ b/tests/test_local_settings_are_ignored.py
@@ -1,0 +1,105 @@
+"""`--local` promises a rule that stays on this machine. The plane must actually ignore it.
+
+`guard --local` writes `.claude/settings.local.json` on the strength of one sentence — that
+`charter init` gitignores it. It did not. charter's OWN repo does (a hand-maintained line
+nobody generated), and checking there and generalising is how the claim got made.
+
+So in a fresh plane the file was committable, and `charter guard allow --local 'gh pr merge
+*'` — the exact command the feature exists for — would land in the next commit and become
+the team-wide rule it was chosen to avoid. A promise that holds only in the repo where it
+was tested is worse than no promise, because the flag reads as a guarantee.
+
+Asserted on the SHIPPED artifacts (the baseline text and a real `init`), not on a constant,
+because the bug was that the constant and the plane disagreed.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import commands, config
+from tests._isolation import PersonaIso
+
+IGNORE_LINE = "/.claude/settings.local.json"
+
+
+class IgnoreCase(PersonaIso):
+    def init_plane(self):
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            commands.cmd_init(SimpleNamespace(forge="github", owner="x", shape=None,
+                                              here=False, path=None))
+        return (Path(config.ROOT) / ".gitignore").read_text()
+
+    def allow_local(self, pattern):
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            commands.cmd_guard_allow(SimpleNamespace(pattern=pattern, local=True))
+
+
+class TestAFreshPlaneIgnoresIt(IgnoreCase):
+    def test_the_baseline_carries_the_rule(self):
+        self.assertIn(IGNORE_LINE, commands._GITIGNORE_BASELINE)
+
+    def test_a_real_init_writes_it(self):
+        """The baseline is a constant; this asserts the file a plane actually gets."""
+        self.assertIn(IGNORE_LINE, self.init_plane())
+
+    def test_the_committed_sibling_is_NOT_ignored(self):
+        """`.claude/settings.json` is charter's shared, committed file — ignoring it would
+        break the status line and the guard wiring for every teammate."""
+        body = self.init_plane()
+        self.assertNotIn("/.claude/settings.json\n", body)
+
+
+class TestTheRuleIsEnsuredWhereItMatters(IgnoreCase):
+    """A plane created before this shipped still has the old `.gitignore`, and that is
+    exactly where `--local` would betray its promise. The command guarantees it rather
+    than assuming a fresh plane."""
+
+    def test_writing_a_local_rule_ensures_the_ignore(self):
+        p = Path(config.ROOT) / ".gitignore"
+        p.write_text("# a plane from before this shipped\n/.charter/\n")
+        self.allow_local("gh pr merge *")
+        self.assertIn(IGNORE_LINE, p.read_text())
+
+    def test_it_is_appended_not_rewritten(self):
+        p = Path(config.ROOT) / ".gitignore"
+        p.write_text("# a plane from before this shipped\n/.charter/\n/my/own/rule\n")
+        self.allow_local("gh pr merge *")
+        body = p.read_text()
+        self.assertIn("/my/own/rule", body)
+        self.assertIn("/.charter/", body)
+
+    def test_it_is_not_added_twice(self):
+        p = Path(config.ROOT) / ".gitignore"
+        self.allow_local("gh pr merge *")
+        self.allow_local("git status *")
+        self.assertEqual(1, p.read_text().count(IGNORE_LINE))
+
+    def test_a_shared_rule_does_not_touch_the_gitignore(self):
+        """Only `--local` needs the guarantee; the committed file is meant to be committed."""
+        p = Path(config.ROOT) / ".gitignore"
+        p.write_text("/.charter/\n")
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            commands.cmd_guard_allow(SimpleNamespace(pattern="git status *", local=False))
+        self.assertNotIn(IGNORE_LINE, p.read_text())
+
+
+class TestTheFileIsStillWritten(IgnoreCase):
+    def test_the_rule_lands_and_the_plane_ignores_it(self):
+        self.allow_local("gh pr merge *")
+        local = Path(config.ROOT) / ".claude" / "settings.local.json"
+        self.assertIn("Bash(gh pr merge *)",
+                      json.loads(local.read_text())["permissions"]["allow"])
+        self.assertIn(IGNORE_LINE, (Path(config.ROOT) / ".gitignore").read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
0.46.2 shipped `charter guard ask|allow --local` on the strength of one sentence: that `charter init` gitignores `.claude/settings.local.json`.

**It does not.** charter's own repo carries that line by hand (`.gitignore:58`), and checking there and generalising is how the claim got into both the code comment and issue #301.

So in a fresh plane the file was committable, and the single command the flag exists for —

```bash
charter guard allow --local 'gh pr merge *'
```

— would have landed in the next commit and become the team-wide rule it was chosen to avoid. **A promise that holds only in the repo where it was tested is worse than no promise**, because the flag reads as a guarantee.

## The fix, in two places

Either alone leaves a gap:

1. the **baseline** `.gitignore` a fresh plane gets now carries the rule;
2. writing a local rule **ensures** it in whatever plane you are in — additive, idempotent, never rewriting a line somebody else put there.

The second half matters most. Fixing the baseline alone would leave every plane created before 0.46.2 untouched, and that is exactly where someone reaches for `--local` and is let down silently.

`.claude/settings.json` stays un-ignored deliberately. That one is the team's, and ignoring it would break the status line and guard wiring for everybody.

## How it was found, and why the tests missed it

By running the **published** 0.46.2 against a fresh plane and checking the `.gitignore` for real. The 16 unit tests added with the feature all passed: they asserted the local file was written, that it did not touch the committed file, that it was idempotent, that opencode declined. **Not one asked whether git would keep it** — the property the flag's whole value rests on.

The new tests assert on the shipped artifacts (the baseline text, a real `cmd_init`, and a pre-0.46.2 `.gitignore`) rather than on a constant, because the bug was precisely that the constant and the plane disagreed.

`test_init`'s idempotence fixture gains the new line: it asserts nothing is re-added when every baseline rule is present, so a rule missing from the fixture would have it exercising the append path while claiming to prove idempotence.

## Verification

2813 tests green (8 added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo