### PR TITLE
A plugin behind the CLI ran fewer hooks and said nothing (#306)

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1520,21 +1520,11 @@ def check_vault_registry_divergence() -> Result:
 
 
 def _plugin_ids(root: Path) -> tuple[str, str]:
-    """``(plugin, marketplace)`` from the manifests the installed plugin carries.
-
-    Both files sit in the directory ``CLAUDE_PLUGIN_ROOT`` already names, so the id is
-    exact without parsing Claude Code's cache path — a layout charter does not own and
-    must not depend on. Either being absent falls back to a placeholder: the id is a
-    convenience, while naming the two *steps* is the part that was missing.
-    """
-    def name(filename: str, fallback: str) -> str:
-        try:
-            doc = json.loads((root / ".claude-plugin" / filename).read_text())
-            return (doc.get("name") or "").strip() or fallback
-        except (OSError, ValueError, AttributeError):
-            return fallback
-
-    return name("plugin.json", "<plugin>"), name("marketplace.json", "<marketplace>")
+    """``(plugin, marketplace)`` — see :func:`hooks.plugin_ids`, which owns this now that
+    the hook surface prints the same upgrade instructions. Two copies could disagree about
+    what to type, which is the one thing this string exists to get right."""
+    from . import hooks
+    return hooks.plugin_ids(root)
 
 
 def check_plugin_skew() -> Result:
@@ -1589,12 +1579,30 @@ def check_plugin_skew() -> Result:
     # per project, which fails outright rather than silently. Observed together: a plugin
     # two minor versions behind, with `doctor` run repeatedly throughout.
     plugin_name, marketplace = _plugin_ids(Path(root))
+    # Version lag on its own is not a finding — an older plugin that still dispatches every
+    # handler behaves identically, and warning about it would train people to scroll past
+    # the row, which costs the case below. What matters is whether `hooks/hooks.json`
+    # actually invokes what this CLI ships: a handler the manifest never names simply does
+    # not run, and the tally it would have written reads as empty rather than absent (#306).
+    #
+    # WARN, not FAIL: nothing is broken, and `cmd_doctor` exits non-zero only on FAIL, which
+    # would turn a benign lag into a blocked preflight. Reaching the session is not this
+    # row's job either — `hooks.stale_plugin_message` rides out as `systemMessage` at
+    # sessionstart, because a WARN here prints through no surface at all (see the FAIL
+    # branch above, which records exactly that).
+    stale = hooks.stale_plugin_message(Path(root))
+    upgrade = (f"`claude plugin marketplace update {marketplace}` (skip it and the next is "
+               f"a no-op), then `claude plugin update {plugin_name}@{marketplace} --scope "
+               f"<project|user, see: claude plugin list>`")
+    if stale:
+        missing = sorted(set(hooks._HANDLERS) - (hooks.dispatched_handlers(Path(root)) or set()))
+        return Result("plugin", WARN,
+                      detail=f"v{plugin_version} (CLI v{hooks.MIN_PLUGIN_VERSION}) — not "
+                             f"dispatching {', '.join(missing)}",
+                      hint=f"those handlers ship with this CLI and never run here. {upgrade}")
     return Result("plugin", OK,
                   detail=f"v{plugin_version} (CLI v{hooks.MIN_PLUGIN_VERSION}) — older "
-                         f"plugin, supported. Upgrade: `claude plugin marketplace update "
-                         f"{marketplace}` (skip it and the next is a no-op), then `claude "
-                         f"plugin update {plugin_name}@{marketplace} --scope "
-                         f"<project|user, see: claude plugin list>`")
+                         f"plugin, dispatching every handler. Upgrade: {upgrade}")
 
 
 #: Launcher basenames charter itself removed, so it can name the replacement instead of

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -2576,6 +2576,136 @@ def skew_message(plugin_version: str | None) -> str | None:
     )
 
 
+def plugin_ids(root) -> tuple[str, str]:
+    """``(plugin, marketplace)`` from the manifests the installed plugin carries.
+
+    Both files sit in the directory ``CLAUDE_PLUGIN_ROOT`` already names, so the id is exact
+    without parsing Claude Code's cache path — a layout charter does not own and must not
+    depend on. Either being absent falls back to a placeholder: the id is a convenience,
+    while naming the two *steps* is the part that was missing.
+
+    Lives here rather than in `doctor` because both surfaces now need it, and the upgrade
+    instructions must not be able to disagree with each other.
+    """
+    from pathlib import Path as _P
+
+    def name(filename: str, fallback: str) -> str:
+        try:
+            doc = json.loads((_P(root) / ".claude-plugin" / filename).read_text())
+            return (doc.get("name") or "").strip() or fallback
+        except (OSError, ValueError, AttributeError):
+            return fallback
+
+    return name("plugin.json", "<plugin>"), name("marketplace.json", "<marketplace>")
+
+
+_HOOK_CMD_RE = re.compile(r"\bcharter\s+hook\s+([A-Za-z0-9_-]+)")
+
+
+def dispatched_handlers(root) -> set | None:
+    """Handler names the INSTALLED manifest actually invokes, or None if it cannot be read.
+
+    None rather than an empty set, and the distinction is load-bearing: "I could not look"
+    rendered as "it dispatches nothing" would report every handler in the CLI as missing and
+    produce exactly the confidently-wrong output this whole check exists to prevent.
+
+    Only ``charter hook <name>`` counts. The manifest also runs `charter workspace
+    _autosave`, `charter doctor` and others; those are work the plugin schedules, not the
+    handler table.
+    """
+    from pathlib import Path as _P
+    try:
+        doc = json.loads((_P(root) / "hooks" / "hooks.json").read_text())
+    except (OSError, ValueError):
+        return None
+    found = set()
+
+    def walk(node):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if k == "command" and isinstance(v, str):
+                    found.update(_HOOK_CMD_RE.findall(v))
+                else:
+                    walk(v)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(doc)
+    return found
+
+
+def stale_plugin_message(root) -> str | None:
+    """A message naming the handlers this CLI ships that the installed plugin never
+    dispatches — the direction `skew_message` deliberately does not cover (#306).
+
+    **Handler sets, not version numbers.** `hooks/hooks.json` is what decides which handlers
+    run at all, so an older manifest simply runs fewer of them, silently. Comparing what the
+    manifest invokes against what the CLI ships removes a judgement call the version
+    comparison would have forced — whether a plugin one PATCH behind should say anything —
+    because a patch that adds no handler produces an empty diff and stays quiet. It also
+    measures the thing that actually breaks rather than a proxy for it.
+
+    Why this direction was worth covering at all: it fails SOFTLY, and it is the one that
+    happens by default, since `uv tool install charter-cp --force` moves the CLI and touches
+    no plugin. Observed: a plane on plugin 0.44.1 against CLI 0.46.3 recorded 299 `ask`
+    events and 0 `ask-approved`, because `posttooluse-bash` — the handler that records
+    approvals — was never dispatched. The honest conclusion from that tally ("nobody ever
+    approves an ask") is the opposite of the truth, which is what makes a silent miss worse
+    than a loud break.
+
+    Returns None for a plugin that dispatches everything, including one carrying handlers
+    this CLI does not have: that is the NEWER-plugin case, `skew_message` already hard-fails
+    on it, and saying it twice in two voices with two different remedies is worse than
+    either.
+    """
+    dispatched = dispatched_handlers(root)
+    if dispatched is None:
+        return None
+    missing = sorted(set(_HANDLERS) - dispatched)
+    if not missing:
+        return None
+    plugin, marketplace = plugin_ids(root)
+    return (
+        f"⬢ charter plugin is behind this CLI (v{MIN_PLUGIN_VERSION}): its hooks.json does "
+        f"not dispatch {', '.join(missing)}, so {'those handlers are' if len(missing) > 1 else 'that handler is'} "
+        f"not running here. Nothing is broken — some things are simply not happening, which "
+        f"is why the tallies they write look empty rather than absent. Refresh the plugin: "
+        f"`claude plugin marketplace update {marketplace}` (skip it and the next is a "
+        f"no-op), then `claude plugin update {plugin}@{marketplace} --scope "
+        f"<project|user, see: claude plugin list>`."
+    )
+
+
+def _queue_plugin_notices(name: str, plugin_version: str | None) -> None:
+    """Both skew directions, on the one hook where saying it is useful.
+
+    **sessionstart only, and that is the gate.** `pretooluse` fires on every Bash call, so
+    emitting there would print the same warning dozens of times a session and teach people
+    to scroll past it — which is how a guard stops working even once it is finally visible.
+
+    The newer-plugin message keeps its stderr line on other hooks (it hard-fails, and the
+    debug log is worth having); the behind-plugin one does not. It describes a standing
+    condition rather than a failure of this call, and repeating it per Bash invocation would
+    be noise about something that has not changed since the session began.
+    """
+    msg = skew_message(plugin_version)
+    if msg:
+        if name == "sessionstart":
+            _pending_system.append(msg)
+        else:
+            print(msg, file=sys.stderr)
+        return
+    if name != "sessionstart":
+        return
+    root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if not root:
+        return  # not running under the plugin; there is no manifest to be behind
+    stale = stale_plugin_message(root)
+    if stale:
+        _pending_system.append(stale)
+
+
 #: Every hook the plugin's `hooks/hooks.json` dispatches into, by the name it passes as
 #: `charter hook <name>`. Each handler still reads stdin and returns an exit code exactly
 #: as it always did when the umbrella wired it directly (`from edm.hooks import <fn>`) —
@@ -2601,26 +2731,16 @@ def dispatch(name: str, plugin_version: str | None) -> int:
     actually invokes (the plugin ships no Python, so it can't import these handlers
     directly the way the umbrella's inline `python3 -c "from edm.hooks import …"` does).
 
-    Runs the skew check first — the one place this module speaks up rather than
-    swallowing — then the named handler, unchanged.
+    Runs the skew checks first — the one place this module speaks up rather than
+    swallowing — then the named handler, unchanged. Both directions live in
+    `_queue_plugin_notices`, including the gate that keeps them to sessionstart.
 
     The skew message used to go to stderr and stop there: Claude Code routes a zero-exit
     hook's stderr to the debug log, so neither the user nor the model ever saw it, while
     README.md promised "a plugin newer than the CLI says so loudly at session start". It
     now rides out as `systemMessage`, which renders at exit 0 and blocks nothing.
-
-    Surfaced on **sessionstart only**, and that is the gate. `pretooluse` fires on every
-    Bash call, so emitting there would print the same warning dozens of times a session
-    and teach people to scroll past it — which is how the guard stops working even when it
-    is finally visible. Once, at the start, is what the README already promised. Other
-    hooks keep the stderr line for the debug log.
     """
-    msg = skew_message(plugin_version)
-    if msg:
-        if name == "sessionstart":
-            _pending_system.append(msg)
-        else:
-            print(msg, file=sys.stderr)
+    _queue_plugin_notices(name, plugin_version)
     fn = _HANDLERS.get(name)
     if fn is None:
         print(f"charter hook: unknown hook '{name}' (known: {', '.join(sorted(_HANDLERS))})",

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -92,9 +92,22 @@ Neither has a secret surface to scan, by construction.
 Hooks swallow their exceptions. A tally that breaks a turn is worse than a tally that
 misses a row, and none of this is load-bearing for the work itself.
 
-The deliberate exception is version skew: a stale CLI would stop firing the gate while
-everything still looked installed. That is the failure shape this project keeps paying for,
-so it is the one thing a hook says out loud.
+The deliberate exception is version skew, in **both** directions — that is the failure shape
+this project keeps paying for, so it is the one thing a hook says out loud, once, at session
+start.
+
+- **Plugin newer than the CLI** — the manifest dispatches `charter hook <name>` for a handler
+  this CLI does not have, so it errors. `doctor` FAILs, which is what makes the SessionStart
+  preflight print at all.
+- **Plugin older than the CLI** — the manifest never *names* the newer handlers, so they
+  simply do not run. Nothing errors; the tallies they would have written read as empty rather
+  than absent, which is the more expensive kind of wrong. charter compares what the installed
+  `hooks/hooks.json` invokes against what the CLI ships and names the handlers that are not
+  being dispatched.
+
+The second is measured by **handler sets, not version numbers**. A plugin one patch behind
+that adds no handler behaves identically, so it says nothing — a row that fires on every
+version lag is a row people learn to scroll past.
 
 Seeing what actually happened: `charter trace` reports guard denials, tool approvals, secret
 warnings and memory writes for the session.

--- a/docs/news/unreleased-plugin-behind-names-handlers.md
+++ b/docs/news/unreleased-plugin-behind-names-handlers.md
@@ -1,0 +1,31 @@
+---
+version: unreleased
+headline: charter says which hooks are not running when your plugin is behind
+check: doctor
+---
+
+charter ships as two artifacts with two version numbers, and they update through completely
+different channels: `uv tool install charter-cp --force` moves the CLI and touches no plugin,
+while the plugin moves only when its marketplace checkout is pulled. So the CLI running ahead
+of the plugin is the *default* drift, not the exotic one.
+
+Only the other direction was guarded. A plugin **newer** than the CLI hard-fails — it
+dispatches `charter hook <name>` for a handler that does not exist — and charter has always
+been loud about it. A plugin **behind** the CLI fails softly: `hooks/hooks.json` is what
+decides which handlers run at all, so the newer ones are never named and never run.
+
+Nothing errors, which is the problem. Observed on a real plane: plugin at 0.44.1, CLI at
+0.46.3, and a day's tally of **299 `ask` events and 0 `ask-approved`** — not because nothing
+was approved, but because `posttooluse-bash`, the handler that records approvals, was never
+dispatched. The honest reading of that data is the exact opposite of the truth.
+
+Session start now says so, naming the handlers rather than a version pair:
+
+> ⬢ charter plugin is behind this CLI (v0.46.3): its hooks.json does not dispatch
+> posttooluse-bash, posttooluse-message, so those handlers are not running here.
+
+`charter doctor` shows the same as a WARN on the `plugin` row.
+
+**Handler sets, not version numbers.** A plugin one patch behind that adds no handler
+dispatches everything and stays silent — a row that fires on every version lag is one people
+learn to scroll past. Nothing to adopt: if your plugin is current, you will never see it.

--- a/tests/test_stale_plugin_handlers.py
+++ b/tests/test_stale_plugin_handlers.py
@@ -1,0 +1,176 @@
+"""A plugin BEHIND the CLI leaves handlers undispatched, and nothing said so (#306).
+
+`skew_message` guards one direction only — a plugin NEWER than the CLI, which hard-fails
+because the manifest dispatches `charter hook <name>` for a handler the CLI does not have.
+The other direction fails softly and is the one that happens by default: `uv tool install
+charter-cp --force` moves the CLI and touches no plugin.
+
+`hooks/hooks.json` is what decides which handlers run at all, so an older manifest silently
+runs fewer of them. Observed: a plane on plugin 0.44.1 with CLI 0.46.3 recorded 299 `ask`
+events and 0 `ask-approved` — not because nothing was approved, but because
+`posttooluse-bash`, the handler that records approvals, was never dispatched. The tally read
+exactly like a guard that runs and finds nothing.
+
+**Handler sets, not version numbers.** A patch behind that adds no handler changes nothing
+about dispatch and must stay silent, or the row trains people to scroll past it. Comparing
+what the manifest actually invokes against what the CLI actually ships removes that
+judgement call entirely, and measures the thing that breaks instead of a proxy for it.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import hooks
+
+
+def _plugin(version: str, handlers: list[str]) -> Path:
+    root = Path(tempfile.mkdtemp(prefix="charter-plugin-")).resolve()
+    (root / ".claude-plugin").mkdir(parents=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "charter", "version": version}))
+    (root / ".claude-plugin" / "marketplace.json").write_text(
+        json.dumps({"name": "charter"}))
+    (root / "hooks").mkdir()
+    (root / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {"PostToolUse": [
+        {"hooks": [{"type": "command",
+                    "command": f"charter hook {h} --plugin-version {version}"}
+                   for h in handlers]}]}}))
+    return root
+
+
+class TestWhatTheManifestDispatches(unittest.TestCase):
+    def test_it_reads_the_handler_names_out_of_the_manifest(self):
+        root = _plugin("0.44.1", ["sessionstart", "posttooluse"])
+        self.assertEqual(hooks.dispatched_handlers(root),
+                         {"sessionstart", "posttooluse"})
+
+    def test_an_unreadable_manifest_is_not_an_answer(self):
+        """None, not an empty set. "I could not look" must not render as "it dispatches
+        nothing", which would report every handler in the CLI as missing."""
+        root = Path(tempfile.mkdtemp(prefix="charter-noplugin-"))
+        self.assertIsNone(hooks.dispatched_handlers(root))
+
+    def test_it_ignores_commands_that_are_not_hook_dispatches(self):
+        """The manifest also runs `charter workspace _autosave`, `charter doctor` and
+        friends. Only `charter hook <name>` decides which handler runs."""
+        root = _plugin("0.44.1", ["sessionstart"])
+        p = root / "hooks" / "hooks.json"
+        doc = json.loads(p.read_text())
+        doc["hooks"]["SessionStart"] = [{"hooks": [
+            {"type": "command", "command": "charter workspace _autosave >/dev/null 2>&1"}]}]
+        p.write_text(json.dumps(doc))
+        self.assertEqual(hooks.dispatched_handlers(root), {"sessionstart"})
+
+
+class TestTheMessage(unittest.TestCase):
+    def test_it_names_the_handlers_that_are_not_running(self):
+        """A version pair is not actionable; "posttooluse-bash is not being dispatched
+        here" is. Same standard `guardseen` sets by recording the harness and the age
+        rather than a boolean."""
+        root = _plugin("0.44.1", [h for h in hooks._HANDLERS if h != "posttooluse-bash"])
+        msg = hooks.stale_plugin_message(root)
+        self.assertIsNotNone(msg)
+        self.assertIn("posttooluse-bash", msg)
+
+    def test_a_plugin_that_dispatches_everything_is_silent(self):
+        """The property that makes this version-independent: a patch behind adding no
+        handler produces an empty diff, so nothing is said and the row keeps its meaning."""
+        root = _plugin("0.0.1", list(hooks._HANDLERS))
+        self.assertIsNone(hooks.stale_plugin_message(root))
+
+    def test_the_shipped_manifest_says_nothing_against_its_own_cli(self):
+        """The repo's own plugin must be in sync — this is the test that fails when a
+        handler is added to `_HANDLERS` and not wired into `hooks/hooks.json`."""
+        self.assertIsNone(hooks.stale_plugin_message(Path(__file__).resolve().parents[1]))
+
+    def test_an_extra_handler_the_cli_lacks_is_not_this_message(self):
+        """That is the NEWER-plugin case, and `skew_message` already hard-fails on it.
+        Reporting it twice, in two voices, with two different remedies, is worse than
+        either."""
+        root = _plugin("9.9.9", list(hooks._HANDLERS) + ["posttooluse-fromthefuture"])
+        self.assertIsNone(hooks.stale_plugin_message(root))
+
+    def test_an_unreadable_manifest_says_nothing(self):
+        self.assertIsNone(hooks.stale_plugin_message(
+            Path(tempfile.mkdtemp(prefix="charter-noplugin-"))))
+
+    def test_it_names_the_refresh_step_that_is_otherwise_a_no_op(self):
+        """`plugin update` alone finds the marketplace clone advertising what it last
+        fetched and correctly does nothing — the trap already recorded in doctor."""
+        root = _plugin("0.44.1", ["sessionstart"])
+        self.assertIn("marketplace update", hooks.stale_plugin_message(root))
+
+
+class TestItReachesTheSession(unittest.TestCase):
+    """The reason this is not simply a doctor WARN. `cmd_doctor` exits non-zero only on
+    FAIL, and that exit code is the whole trigger for the SessionStart wrapper
+    (`out=$(charter doctor) || printf …`) printing anything — so a WARN reaches nobody.
+    charter already wrote that down, in the branch above the one this fixes.
+
+    `systemMessage` is the channel that works: it renders at exit 0 and blocks nothing, and
+    the newer-plugin case already uses it.
+    """
+
+    def setUp(self):
+        hooks._pending_system.clear()
+        self.addCleanup(hooks._pending_system.clear)
+
+    def test_sessionstart_queues_it(self):
+        root = _plugin("0.44.1", ["sessionstart"])
+        with mock.patch.dict("os.environ", {"CLAUDE_PLUGIN_ROOT": str(root)}):
+            hooks._queue_plugin_notices("sessionstart", "0.44.1")
+        self.assertTrue(any("posttooluse-bash" in m for m in hooks._pending_system))
+
+    def test_other_hooks_do_not(self):
+        """`pretooluse` fires on every Bash call. Emitting there would print the same
+        warning dozens of times a session and teach people to scroll past it — the gate the
+        newer-plugin path already applies."""
+        root = _plugin("0.44.1", ["sessionstart"])
+        with mock.patch.dict("os.environ", {"CLAUDE_PLUGIN_ROOT": str(root)}):
+            hooks._queue_plugin_notices("pretooluse", "0.44.1")
+        self.assertEqual(hooks._pending_system, [])
+
+    def test_nothing_is_queued_outside_the_plugin(self):
+        """A bare `charter` from a terminal has no plugin to be behind."""
+        with mock.patch.dict("os.environ", {}, clear=True):
+            hooks._queue_plugin_notices("sessionstart", None)
+        self.assertEqual(hooks._pending_system, [])
+
+
+class TestDoctorAgrees(unittest.TestCase):
+    """`doctor` already named the version pair and the upgrade steps for an older plugin —
+    the issue's claim that it was silent does not hold. What it could not say was WHICH
+    handlers were not running, and it said all of it at OK, where a green tick is what gets
+    scanned.
+
+    WARN, not FAIL: nothing is broken and `cmd_doctor` exits non-zero only on FAIL, which
+    would turn a benign lag into a preflight failure. The reaching is the `systemMessage`'s
+    job; this row is for the developer who asks directly.
+    """
+
+    def _check(self, root):
+        from charter import doctor
+        with mock.patch.dict("os.environ", {"CLAUDE_PLUGIN_ROOT": str(root)}):
+            return doctor.check_plugin_skew()
+
+    def test_missing_handlers_warn_and_are_named(self):
+        from charter import doctor
+        root = _plugin("0.44.1", [h for h in hooks._HANDLERS if h != "posttooluse-bash"])
+        r = self._check(root)
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("posttooluse-bash", r.detail + (r.hint or ""))
+
+    def test_an_older_plugin_that_dispatches_everything_stays_ok(self):
+        """Version lag on its own is not a finding. Warning on it would train people to
+        ignore the row, which costs the case that matters."""
+        from charter import doctor
+        root = _plugin("0.0.1", list(hooks._HANDLERS))
+        self.assertEqual(self._check(root).status, doctor.OK)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #306.

## What the report got right

`hooks.py:2564` — `if plugin is None or cli is None or plugin <= cli: return None`. Quoted
exactly. And the manifest really is what gates dispatch: every entry is
`charter hook <name> --plugin-version 0.46.3`, so a 0.44.1 manifest never names
`posttooluse-bash` or `posttooluse-message` and they never run.

The evidence is the strongest part of it. **299 `ask` events, 0 `ask-approved`**, for a day —
not because nothing was approved, but because the handler that records approvals was never
dispatched. A tally that reads as *"the guard runs and finds nothing"* when the truth is
*"the guard never ran"* is worse than a crash.

## What it got wrong, and why it changes the fix

> `doctor.check_plugin_skew` delegates to it, so both surfaces are silent in the other
> direction

It isn't silent. `doctor.py` has a dedicated older-plugin branch printing the version pair
**and** the two-step upgrade command, added (per its own comment) because *"'matches' was
printed for a plugin many versions behind."* What it could not say was *which* handlers were
not running — and it said all of it at `OK`, where a green tick is what gets scanned.

**More importantly, the proposed remedy would not have worked.** #306 asks for a WARN.
charter already wrote down why that fails, two lines above the branch this changes:

> `cmd_doctor` exits 1 only on FAIL, and that exit code is what makes the SessionStart
> wrapper (`out=$(charter doctor) || printf …`) print anything at all; **at WARN the message
> reached nobody through either surface.**

Confirmed at `hooks/hooks.json:22`. A WARN would have closed the issue and left the symptom.

## The fix

**Handler sets, not version numbers.** `stale_plugin_message()` reads the installed
`hooks/hooks.json`, extracts every `charter hook <name>` it invokes, and diffs against
`_HANDLERS`.

That answers the issue's own open question — *"whether a plugin that is merely a PATCH behind
should say anything at all"* — without a judgement call. A patch that adds no handler produces
an empty diff and says nothing. A minor behind names `posttooluse-bash` and
`posttooluse-message` outright. It measures the thing that breaks instead of a proxy for it,
so it cannot drift as the version scheme changes.

**It reaches the session through the channel that works.** `_queue_plugin_notices` now carries
both directions, and the behind-plugin message rides out as `systemMessage` at sessionstart —
renders at exit 0, blocks nothing, and is exactly what the newer-plugin case already uses.
sessionstart only: `pretooluse` fires on every Bash call, and repeating a standing condition
per invocation is how a guard stops working once it is finally visible.

**doctor's row becomes WARN when handlers are actually missing**, naming them; an older plugin
that still dispatches everything stays `OK`. Warning on mere version lag would train people to
scroll past the row, which costs the case that matters.

`None` vs empty set is load-bearing in `dispatched_handlers()`: *"I could not read the
manifest"* rendered as *"it dispatches nothing"* would report every handler as missing — the
confidently-wrong output this check exists to prevent.

`plugin_ids` moved to `hooks.py`; `doctor._plugin_ids` delegates. Two copies of the upgrade
instructions could disagree about what to type, which is the one thing that string exists to
get right.

## Testing

`python3 -m unittest discover -s tests` — 2827 tests, green. 14 new, failing without the fix.
One is worth calling out: `test_the_shipped_manifest_says_nothing_against_its_own_cli` fails
the day someone adds a handler to `_HANDLERS` without wiring it into `hooks/hooks.json` —
which is the mistake that produces this bug in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)