### PR TITLE
Persona chips: silence when the vault is fine, ⚡ when a persona is running

### DIFF
--- a/charter/inflight.py
+++ b/charter/inflight.py
@@ -40,27 +40,48 @@ def _safe_name(agent: str) -> str:
     return "".join(c if c.isalnum() or c in "._-" else "_" for c in agent)[:64]
 
 
+def live_records(exclude_token: str | None = None) -> list[tuple[str, float]]:
+    """``(agent, started_at)`` per live dispatch, duplicates preserved, stale pruned.
+
+    The start time is what separates "two agents are out" from "two agents have been
+    out for forty minutes", and only the second is worth interrupting for. It is read
+    from the record's own ``ts``, falling back to the file's mtime — the same instant,
+    and the only answer available for a record written by a charter that predates the
+    field.
+
+    :func:`live` is a projection of this rather than a second walk of the directory:
+    one glob, one pruning rule. A caller that wants the names only should keep calling
+    it — the extra element is a cost the aggregate has no use for.
+    """
+    d = _dir()
+    if not d.exists():
+        return []
+    out: list[tuple[str, float]] = []
+    now = time.time()
+    for p in d.glob("*.json"):
+        try:
+            mtime = p.stat().st_mtime
+            if now - mtime > TTL_SECONDS:
+                p.unlink(missing_ok=True)      # dead: killed process, or no PostToolUse
+                continue
+            if exclude_token and p.stem == exclude_token:
+                continue
+            rec = json.loads(p.read_text())
+            ts = rec.get("ts")
+            out.append((rec.get("agent") or p.stem,
+                        float(ts) if isinstance(ts, (int, float)) else mtime))
+        except (OSError, TypeError, ValueError):
+            continue
+    return out
+
+
 def live(exclude_token: str | None = None) -> list[str]:
     """Agent names currently in flight, stale entries pruned.
 
     ``exclude_token`` drops one specific record — the caller's own, so a dispatch
     never reports itself as a concurrent peer.
     """
-    d = _dir()
-    if not d.exists():
-        return []
-    out, now = [], time.time()
-    for p in d.glob("*.json"):
-        try:
-            if now - p.stat().st_mtime > TTL_SECONDS:
-                p.unlink(missing_ok=True)      # dead: killed process, or no PostToolUse
-                continue
-            if exclude_token and p.stem == exclude_token:
-                continue
-            out.append(json.loads(p.read_text()).get("agent") or p.stem)
-        except (OSError, ValueError):
-            continue
-    return sorted(out)
+    return sorted(name for name, _ in live_records(exclude_token))
 
 
 def start(agent: str) -> str | None:

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -939,7 +939,10 @@ def _persona_line() -> str | None:
         seg = f"{_MAGENTA}◆{_R} {_BOLD}{active}{_R}"
         vault = persona.vault_of(active)
         if vault:
-            seg += f"{_DIM} · vault {_R}{vault}{_vault_glyph(vault)}"
+            # Same mark as the chips, from the same function rather than a second one
+            # applying "the same" rule: this renderer is the fallback, so a divergence
+            # here would only ever be seen on the day the layout is already broken.
+            seg += f"{_DIM} · vault {_R}{vault}{_vault_dot(vault)}"
         # The other personas, on the same line — each dispatchable as a sub-agent.
         others = [n for n in names if n != active]
         if others:
@@ -1001,42 +1004,44 @@ def _vault_health(vault: str) -> tuple[bool, str]:
     return ok, detail
 
 
-def _vault_glyph(vault: str) -> str:
-    try:
-        from .secrets import registry
-        if vault not in registry.vaults():
-            return f" {_YELLOW}(set up){_R}"
-        ok, _ = _vault_health(vault)
-        return f" {_GREEN}✓{_R}" if ok else f" {_YELLOW}!{_R}"
-    except Exception:
-        return ""
-
-
 def _vault_dot(vault: str | None) -> str:
-    """Compact vault mark for persona chips — four states, matching what
-    ``charter persona list`` reports in words:
+    """Compact vault mark for persona chips — **only when the vault cannot be used**.
 
-    * ``✓`` healthy — registered, readable, holding secrets;
-    * ``◦`` registered, but the file does not exist yet;
-    * ``!`` registered and unhealthy (unreadable, bad provider config);
-    * ``·`` not set up locally at all — the *normal* state across most of a committed
-      roster, since personas are committed and vaults are private.
+    * nothing — no vault declared, or one that is registered and healthy;
+    * ``◦`` dim — declared but not usable *here*: this machine has no vault by that
+      name, or it has one whose file does not exist yet;
+    * ``!`` yellow — registered and unhealthy (unreadable, bad provider config).
 
-    The ``◦`` state used to render as a green ``✓``: ``plain-file.health()`` returns
-    ``ok=True`` with the detail "not created yet (<path>)", and this read only ``ok``.
-    `persona list` prints the detail and so was honest; the status line was claiming a
-    vault existed when it did not.
+    Silence is the point, and it is the same argument :func:`_health_mark` is built on:
+    a ✓ on every chip on every turn is furniture within a day, after which a real fault
+    inside the column reads like a zero. The four-state version spent a character per
+    persona per render to say "fine".
+
+    Worse, its two dim ``·`` states were different facts wearing one glyph — a persona
+    that needs no vault, and a persona *declaring* ``vault: X`` that this machine has
+    never registered. The second is the only vault fact worth a character, and it was
+    the one you could not see.
+
+    The two unusable reasons deliberately collapse into one ``◦``. Their fixes differ
+    (`charter vault add` vs `charter secret set`), a chip can carry neither, and
+    `charter persona list` already prints both in words — so a third glyph would buy a
+    distinction the reader still has to leave the status line to act on.
     """
     try:
         from .secrets import registry
-        if not vault or vault not in registry.vaults():
-            return f" {_DIM}·{_R}"
+        if not vault:
+            return ""
+        if vault not in registry.vaults():
+            return f" {_DIM}◦{_R}"
         ok, detail = _vault_health(vault)
         if not ok:
             return f" {_YELLOW}!{_R}"
+        # `plain-file.health()` returns ok=True with "not created yet (<path>)" for a
+        # registered vault holding nothing. Reading only `ok` once painted a green ✓ on
+        # a vault that did not exist; it now reads as unusable, which it is.
         if "not created yet" in (detail or ""):
             return f" {_DIM}◦{_R}"
-        return f" {_GREEN}✓{_R}"
+        return ""
     except Exception:
         return ""
 
@@ -1114,6 +1119,54 @@ def _mem_badge(persistent: int, ephemeral: int = 0) -> str:
     return (" " + " ".join(parts)) if parts else ""
 
 
+def _inflight_by_persona() -> dict[str, tuple[int, float]]:
+    """``persona → (dispatches in flight, epoch start of the OLDEST)``.
+
+    Computed once per render and handed to every chip: `inflight.live_records` is a
+    directory glob, which is affordable on a surface that draws every turn, but not
+    once per persona on a thirty-persona roster.
+
+    The oldest wins because the newest answers nothing. Three dispatches out, the
+    freshest a minute old, is not news; three out with one at ``2h`` is the whole
+    reason the age is on screen.
+    """
+    try:
+        from . import inflight
+        out: dict[str, tuple[int, float]] = {}
+        for name, started in inflight.live_records():
+            n, oldest = out.get(name, (0, started))
+            out[name] = (n + 1, min(oldest, started))
+        return out
+    except Exception:
+        return {}
+
+
+def _inflight_badge(entry: tuple[int, float] | None) -> str:
+    """``⚡2 4m`` for a persona with dispatches in flight, '' for one without.
+
+    **Count only above one.** A lone ``⚡1`` is the same non-fact as `todo 0` or `✎0`,
+    both of which render as nothing here: presence is the signal, and the digit only
+    starts carrying information once there is more than one of them.
+
+    **Age always**, in `pieces._presence_age`'s vocabulary — so a dispatch ages in the
+    same units as the `silent 12m` a couple of rows away, and so ``0m`` (technically
+    correct, reads as broken) renders as ``now`` for the same reason it does there.
+    Coarse on purpose: this line refreshes every ten seconds, so a seconds figure would
+    be a number nobody could trust to be current.
+    """
+    if not entry:
+        return ""
+    try:
+        from datetime import datetime, timezone
+        from . import pieces
+        n, started = entry
+        age = pieces._presence_age(datetime.fromtimestamp(started, timezone.utc),
+                                   datetime.now(timezone.utc))
+        return f" {_YELLOW}⚡{n if n > 1 else ''}{_R} {_DIM}{age}{_R}"
+    except Exception:
+        return ""
+
+
 def _persona_chips(session: str | None = None) -> list[str]:
     """One chip per persona (active first) for the status-line right column, each
     tagged with its memory counts (``✎`` persistent + ``◌`` ephemeral). Every
@@ -1126,12 +1179,14 @@ def _persona_chips(session: str | None = None) -> list[str]:
         active = persona.resolve_active()
         order = ([active] if active in names else []) + [n for n in names if n != active]
         known = set(names)   # computed once for the whole column, not once per persona
+        flying = _inflight_by_persona()   # one glob for the column, not one per chip
         chips = []
         flagged_names: set[str] = set()
         for n in order:
             dot = _vault_dot(persona.vault_of(n))
             badge = _mem_badge(_mem_count(n), _mem_count(n, ephemeral=True, session=session))
             health = _health_mark(n, known=known)
+            flight = _inflight_badge(flying.get(n))
             if health:
                 # `_health_mark` speaks ONLY when something is wrong, so its presence is
                 # the signal — recorded here rather than recovered from the rendered chip,
@@ -1142,10 +1197,17 @@ def _persona_chips(session: str | None = None) -> list[str]:
             # header carries `_MARK_HEAD` for exactly that reason. All three markers are
             # East-Asian Neutral, so no font gets to disagree about that width. Badges
             # trail the name, where nothing after them has to line up.
+            #
+            # `flight` goes LAST of the badges because it is the only one that changes
+            # while you watch: its count moves and its age ticks, and every character
+            # after a badge that changes moves with it. Behind it there is nothing to
+            # move. `⚡` is East-Asian *Wide* — two cells, unambiguously, unlike the
+            # Ambiguous glyphs that have broken this layout twice — and it is trailing,
+            # so its width never reaches a name.
             if n == active:
-                chips.append(f"{_MAGENTA}{_MARK_ACTIVE} {_BOLD}{n}{_R}{dot}{badge}{health}")
+                chips.append(f"{_MAGENTA}{_MARK_ACTIVE} {_BOLD}{n}{_R}{dot}{badge}{health}{flight}")
             else:
-                chips.append(f"{_DIM}{_MARK_IDLE} {n}{_R}{dot}{badge}{health}")
+                chips.append(f"{_DIM}{_MARK_IDLE} {n}{_R}{dot}{badge}{health}{flight}")
         if len(chips) > _MAX_PERSONA_LINES:
             # Which ones survive matters more than how many. Keeping the first N
             # alphabetically would drop exactly the personas worth seeing, so the order is
@@ -1190,8 +1252,15 @@ def _session_news(sid: str | None) -> list[str]:
         from . import inflight
         live = inflight.live()
         if live:
-            who = ", ".join(live[:3]) + (", …" if len(live) > 3 else "")
-            out.append(f"{_YELLOW}⚡{_R}{_DIM}in flight{_R} {len(live)} {_DIM}· {who}{_R}")
+            # A bare count. The names moved onto the persona chips, beside the personas
+            # they are about — here they made the reader match a name against a roster
+            # ten rows above to learn anything, and cost the width to do it.
+            #
+            # The aggregate stays because the chips are croppable: that column caps at
+            # `_MAX_PERSONA_LINES` and disappears entirely below `_LEFT_W + _RIGHT_MIN_W`,
+            # so this is what survives a narrow pane — the same contract `_repo_rows`
+            # keeps with its own "(+N more)" row.
+            out.append(f"{_YELLOW}⚡ {len(live)}{_R}")
     except Exception:
         pass
 

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -283,9 +283,15 @@ def _context_gauge(payload: dict) -> list[str]:
     stable; if cache *creation* stays high turn after turn, something keeps changing the prefix
     (a model/effort switch, an MCP server connecting, a plugin toggle, `/compact`).
 
-    Renders ``ctx NN%`` (context window used) and ``⚡NN%`` (share of this turn's input served
-    from cache). Both are absent early in a session and right after `/compact`, when the payload
-    has no usage yet — we simply show nothing rather than a misleading 0."""
+    Renders ``ctx NN%`` (context window used) and ``cache NN%`` (share of this turn's input
+    served from cache). Both are absent early in a session and right after `/compact`, when the
+    payload has no usage yet — we simply show nothing rather than a misleading 0.
+
+    The cache figure wore a ``⚡`` until the persona chips gave that glyph a meaning of its own
+    — *a dispatch is running* — which then rendered on the same strip as the chips' aggregate,
+    two bolts apart only by a ``%``. The bolt went to the fact that has two rendering sites and
+    needs them to read as one thing; the gauge took a word, which is what its sibling ``ctx``
+    already had and what a rate nobody can guess from a symbol always wanted."""
     cw = (payload or {}).get("context_window") or {}
     out: list[str] = []
     pct = cw.get("used_percentage")
@@ -299,7 +305,9 @@ def _context_gauge(payload: dict) -> list[str]:
         hit = round(100 * read / (read + write))
         # <50% sustained = the prefix is churning; that's the expensive failure mode.
         col = _GREEN if hit >= 80 else (_YELLOW if hit >= 50 else _RED)
-        out.append(f"{col}⚡{hit}%{_R}")
+        # Dim label, coloured number — the exact shape `ctx NN%` above uses, so the two
+        # session gauges read as a pair rather than as a word and a symbol.
+        out.append(f"{_DIM}cache{_R} {col}{hit}%{_R}")
         try:
             sid = payload.get("session_id") or ""
             trend = _record_turn(sid, hit, read, write)
@@ -1584,10 +1592,15 @@ def _root_marker() -> str:
 def _session_strip(payload: dict, sid: str | None) -> str:
     """The bottom zone: everything true of **this session**, on one line.
 
-    ``ctx``/``⚡`` (context + cache health) sit here rather than in the top line
-    because they describe the session, not the workspace — the top line answers
-    *where am I*, and mixing a session gauge into it was most of why the old header
-    read as unrelated items in a row.
+    ``ctx``/``cache`` (context window + prompt-cache health) sit here rather than in
+    the top line because they describe the session, not the workspace — the top line
+    answers *where am I*, and mixing a session gauge into it was most of why the old
+    header read as unrelated items in a row.
+
+    Every gauge here carries a word; the one glyph on the strip is ``⚡``, and it means
+    exactly what it means on a persona chip — a dispatch is running. That is the whole
+    reason the cache rate gave the bolt up: a fact rendered in two places has to read
+    the same in both, and a second meaning beside it on one line erases both.
 
     Empty string when there is nothing to report (a fresh session or one just past
     ``/compact`` has no usage yet): the brand alone does not justify a row.
@@ -1764,7 +1777,7 @@ def render(payload: dict | None = None) -> str:
         reinit = f"{_YELLOW}⚠ reinit: {_BOLD}charter ws reinit{_R}" if _stale_structure(active) else None
         # Zone 1 — WHERE I am. Identity and navigation only: which workspace is active,
         # what it still means to do, and how many others exist to switch to. Everything
-        # that used to ride along here (repo count, vault count, ctx/⚡) described
+        # that used to ride along here (repo count, vault count, ctx/cache) described
         # something else and now sits with the thing it describes.
         #
         # Open todos are a property of the ACTIVE WORKSPACE, so the layout's one rule —

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -102,7 +102,7 @@ Three things in that command are load-bearing, and the previous capture had none
   inner columns. At 110 the layout correctly falls back to stacking personas as rows, so
   the capture showed charter's narrow-terminal behaviour while the prose described the
   wide one.
-* **`context_window` in the payload.** `ctx 38% · ⚡92%` is read from there and from
+* **`context_window` in the payload.** `ctx 38% · cache 92%` is read from there and from
   nowhere else. Without it `_session_strip` is empty, the whole bottom row disappears, and
   the brand collapses onto the last persona row.
 * **`--compose`.** The status line never appears alone — it renders directly beneath

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -378,9 +378,9 @@ always sits next to the thing it counts:
 ```
 ⬢ umbrella-improvements · todo 3 · ws 9                           ← WHERE am I
 ◫ repos 2/38                    │ ◈ personas 13 · vaults 6 · shared ✎130
-├─ easysender-ui-workspace  main  ✗ failed │ ◆ steward · ✎2       ← WHAT I'm on × WHO I am
-└─ iam-service ⑂2           main  ✓ passed │ ○ devops ✓ ✎192
-ctx 22% · ⚡90% · ⛊1 denied · ✎1 recorded            ⬢ charter 0.10.0   ← THIS session
+├─ easysender-ui-workspace  main  ✗ failed │ ◆ steward ✎2         ← WHAT I'm on × WHO I am
+└─ iam-service ⑂2           main  ✓ passed │ ○ devops ✎192 ⚡ 4m
+ctx 22% · cache 90% · ⚡ 1 · ⛊1 denied · ✎1 recorded  ⬢ charter 0.10.0   ← THIS session
 ```
 
 - **Top — identity and navigation.** The active workspace, how many todos it still has
@@ -391,12 +391,17 @@ ctx 22% · ⚡90% · ⛊1 denied · ✎1 recorded            ⬢ charter 0.10.0 
   when the count is zero, like everything else that would otherwise render every turn.
 - **Columns — the Role × Task axes.** Left is the *task* (repos cloned into this
   workspace, their branch, CI and MRs); right is the *role* (the persona roster, each
-  chip carrying its vault state and memory counts). Personas are global, repos are
+  chip carrying its memory counts, a `⚡` while it has sub-agents running, and a vault
+  mark only when its vault cannot be used). Personas are global, repos are
   workspace-scoped — two independent axes, two columns.
-- **Bottom — this session.** Context and prompt-cache health, plus counters for what has
-  happened: in-flight sub-agents, guard denials, memories recorded, dispatches. Absent
-  entirely when there is nothing to report, so a denial appearing there is *news*.
-  The brand and version sit at its right edge.
+- **Bottom — this session.** Context and prompt-cache health (`ctx NN%`, `cache NN%`),
+  plus counters for what has happened: in-flight sub-agents, guard denials, memories
+  recorded, dispatches. Absent entirely when there is nothing to report, so a denial
+  appearing there is *news*. The brand and version sit at its right edge.
+
+  `⚡` is the one glyph left on that strip and it means one thing — a dispatch is
+  running — the same thing it means on a persona chip. The gauges carry words for
+  exactly that reason: the bolt belongs to the fact that renders in two places.
 - **Alerts** (a pinned-version mismatch, workspaces needing `reinit`) get their own
   full-width lines above the strip — actionable problems carrying the command that
   fixes them, not telemetry.

--- a/docs/news/unreleased-persona-chip-signals.md
+++ b/docs/news/unreleased-persona-chip-signals.md
@@ -1,0 +1,43 @@
+---
+version: unreleased
+headline: The persona chips go quiet when nothing is wrong, and say who is running
+---
+
+Two changes to the persona column, both applying a rule the status line already lives by:
+**a mark that renders every turn is furniture, and a real fault inside a row of furniture
+reads like a zero.**
+
+**Vault state is silent when it is fine.** The chip used to carry one of four marks on
+every persona on every render, and on a healthy roster three of them meant "nothing to do
+here". A healthy vault now renders nothing at all. What remains is the state worth a
+character:
+
+* `◦` dim — the persona *declares* a vault that cannot be used here: this machine has no
+  vault by that name, or it has one whose file does not exist yet;
+* `!` yellow — registered, and unhealthy.
+
+The first of those was previously invisible. A persona declaring `vault: forge` on a
+machine where no `forge` vault is registered rendered as the same dim `·` as a persona that
+needs no vault at all — so "required and missing", the one vault fact that changes what you
+should do next, was the one the line could not say. The two unusable cases share a glyph on
+purpose: their fixes differ (`charter vault add` versus `charter secret set`), a chip can
+carry neither, and `charter persona list` already prints both in words.
+
+**A running persona says so on its own row.** `charter` has always known which personas
+have sub-agents in flight, and spent it on one aggregate at the bottom of the screen —
+`⚡in flight 2 · devops, devops` — where reading it meant matching a name against a roster
+ten rows further up. The count now sits next to what it counts:
+
+```
+▸ devops ⚡2 12m
+▫ forge ✎3 ⚡ 4m
+```
+
+The count appears only above one (a lone `⚡1` is the same non-fact as `todo 0`), and the
+age — of the *oldest* dispatch, since the newest answers nothing — is always there, because
+"has this been stuck for twelve minutes?" is the actual question and only the age answers
+it. It is coarse (`4m`, `2h`) for the same reason every other age on this line is: at a
+ten-second refresh, a seconds figure would be a number nobody could trust.
+
+The session strip keeps a bare `⚡ 3`. The persona column caps at fourteen rows and
+disappears entirely on a narrow pane, so the aggregate is what survives cropping.

--- a/docs/news/unreleased-persona-chip-signals.md
+++ b/docs/news/unreleased-persona-chip-signals.md
@@ -41,3 +41,13 @@ ten-second refresh, a seconds figure would be a number nobody could trust.
 
 The session strip keeps a bare `⚡ 3`. The persona column caps at fourteen rows and
 disappears entirely on a narrow pane, so the aggregate is what survives cropping.
+
+**The prompt-cache gauge now reads `cache NN%`, not `⚡NN%`.** With the chips speaking, the
+bolt means *a dispatch is running* in two places at once — on the chip that owns it and as
+the strip's aggregate — and the cache rate was sitting on the same strip wearing the same
+glyph, the two told apart only by a `%`. The bolt stays with the fact that renders twice
+and has to read the same in both. The gauge takes a word, which is what its neighbour
+`ctx NN%` always had and what a ratio nobody can guess from a symbol always wanted; its
+colour thresholds and every diagnostic behind it (`↻N`, the rebuild warning) are unchanged.
+
+The strip now reads `ctx 22% · cache 100% · ⚡ 3`.

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -418,7 +418,19 @@ Two rules keep this honest:
   zero. Soft findings (no role, no `delegate-when`) stay in `lint`/`doctor`, which have
   room to explain them.
 
-The vault dot beside each chip has four states, matching what `persona list` says in
-words: `✓` healthy · `◦` registered but not created yet · `!` unhealthy · `·` not set
-up locally (the *normal* state for most of a committed roster — personas are committed,
-vaults are private).
+The vault mark beside each chip follows the same rule, so it appears only when the vault
+**cannot be used**: `◦` dim — declared but not usable here (no vault of that name is
+registered on this machine, or one is and its file does not exist yet) · `!` yellow —
+registered and unhealthy. A persona that needs no vault, or whose vault is registered and
+healthy, gets no mark at all.
+
+The two unusable cases share one glyph deliberately. Their fixes differ (`charter vault
+add` versus `charter secret set`), a chip can carry neither, and `charter persona list`
+prints both in words. What the chip is for is the distinction that used to be missing:
+a persona *declaring* a vault this machine has never registered is not the same as a
+persona that needs none, and both used to render as a dim `·`.
+
+A persona with sub-agents in flight carries `⚡` on its own chip, with the count when
+there is more than one and the age of the oldest dispatch always — `▸ devops ⚡2 12m`.
+The session strip keeps the bare total (`⚡ 3`), because the persona column caps at
+fourteen rows and disappears on a narrow pane.

--- a/tests/test_statusline_gauge.py
+++ b/tests/test_statusline_gauge.py
@@ -51,11 +51,11 @@ class ContextGaugeCase(unittest.TestCase):
 
     def test_cache_hit_rate_is_read_over_total_input(self):
         # 48000 read / (48000 + 1200 written) ≈ 98%
-        self.assertIn("⚡98%", _plain(statusline._context_gauge(_payload(read=48000, write=1200))))
+        self.assertIn("cache 98%", _plain(statusline._context_gauge(_payload(read=48000, write=1200))))
 
     def test_churning_prefix_reads_low(self):
         # cache creation dominating = the expensive failure mode
-        self.assertIn("⚡11%", _plain(statusline._context_gauge(_payload(read=5000, write=40000))))
+        self.assertIn("cache 11%", _plain(statusline._context_gauge(_payload(read=5000, write=40000))))
 
     def test_silent_before_first_api_call(self):
         # current_usage is null at session start and right after /compact — show nothing
@@ -68,15 +68,15 @@ class ContextGaugeCase(unittest.TestCase):
             {"context_window": {"current_usage": {}}}), [])
 
     def test_full_cache_hit_is_100(self):
-        self.assertIn("⚡100%", _plain(statusline._context_gauge(_payload(read=10000, write=0))))
+        self.assertIn("cache 100%", _plain(statusline._context_gauge(_payload(read=10000, write=0))))
 
     def test_cold_cache_is_zero_not_a_crash(self):
-        self.assertIn("⚡0%", _plain(statusline._context_gauge(_payload(read=0, write=10000))))
+        self.assertIn("cache 0%", _plain(statusline._context_gauge(_payload(read=0, write=10000))))
 
     def test_context_and_cache_are_independent(self):
         # a payload with only cache data still renders the cache part
         out = _plain(statusline._context_gauge(_payload(read=100, write=100)))
-        self.assertIn("⚡50%", out)
+        self.assertIn("cache 50%", out)
         self.assertNotIn("ctx", out)
 
     def test_gauge_appears_on_the_session_strip(self):
@@ -90,8 +90,38 @@ class ContextGaugeCase(unittest.TestCase):
         # the frame's own verticals.
         lines = [l.strip("│ ") for l in lines if set(l) - set("┌─┐└┘├┤")]
         self.assertIn("ctx 42%", lines[-1])
-        self.assertIn("⚡90%", lines[-1])
+        self.assertIn("cache 90%", lines[-1])
         self.assertNotIn("ctx", lines[0])
+
+    def test_the_cache_gauge_is_labelled_not_a_glyph(self):
+        """`⚡` used to mean "prompt-cache hit rate" here — a meaning nobody could guess
+        from the character, on a strip where its labelled sibling `ctx NN%` sits two
+        items away. The word was always the consistent choice; the bolt became actively
+        wrong once the persona chips gave it a meaning of their own."""
+        out = _plain(statusline._context_gauge(_payload(pct=42, read=900, write=100)))
+        self.assertIn("cache 90%", out)
+        self.assertNotIn("⚡", out)
+
+    def test_the_bolt_on_the_strip_means_a_dispatch_and_nothing_else(self):
+        """The assertion that keeps the rename from silently regressing.
+
+        `⚡` is one fact — *a dispatch is running* — rendered in two places: on the
+        persona chip that owns it, and as the aggregate here, which is what survives
+        when the chip column is cropped away. Two of them on one line, told apart only
+        by a `%`, and neither reads as anything.
+        """
+        from charter import inflight, update
+        spawn = update.maybe_spawn          # never fork a network child from the suite
+        update.maybe_spawn = lambda: None
+        self.addCleanup(lambda: setattr(update, "maybe_spawn", spawn))
+        inflight.start("coder")
+        out = statusline.render({"session_id": "t", **_payload(pct=42, read=900, write=100)})
+        lines = [re.sub(r"\033\[[0-9;]*m", "", l) for l in out.splitlines() if l.strip()]
+        strip = [l.strip("│ ") for l in lines if set(l) - set("┌─┐└┘├┤")][-1]
+        self.assertIn("ctx 42%", strip)
+        self.assertIn("cache 90%", strip)
+        self.assertIn("⚡ 1", strip)
+        self.assertEqual(strip.count("⚡"), 1, strip)
 
     def test_render_survives_a_malformed_payload(self):
         # the status line must never crash the footer

--- a/tests/test_statusline_inflight_chips.py
+++ b/tests/test_statusline_inflight_chips.py
@@ -1,0 +1,241 @@
+"""In-flight dispatches on the persona chips.
+
+`inflight` has always known which personas are running right now, and the status line
+spent that knowledge on one aggregate at the bottom of the screen — `⚡in flight 2 ·
+devops, devops` — where the reader had to match a name against a roster ten rows above
+to learn anything. The count now lives next to the thing it counts.
+
+Two rules, both borrowed from surfaces already on this line:
+
+* **count only when >1** — `⚡1` is the same non-fact as `todo 0` or `✎0`, which render
+  as nothing. Presence is the signal; the number is only interesting once it is a
+  number.
+* **age always** — the question a human asks a running dispatch is *"has this been
+  stuck for four minutes?"*, and only the age answers it. Coarse, in
+  `pieces._presence_age`'s vocabulary, so it ages in the same units as the `silent 12m`
+  a couple of rows away — and because at a 10s refresh, seconds would be a lie.
+
+The aggregate stays on the session strip (as a bare count) precisely because this
+column is croppable: it caps at `_MAX_PERSONA_LINES` and disappears entirely on a
+narrow pane.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+import unittest
+from pathlib import Path
+
+from charter import config, inflight, statusline
+from tests._isolation import PersonaIso
+
+
+def _plain(s: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+def _start_aged(agent: str, seconds: float) -> str:
+    """Start a dispatch and backdate that ONE record by *seconds*.
+
+    Both the JSON ``ts`` and the file's mtime move: `inflight` prunes on mtime, so a
+    record aged only in its payload would be a fixture that could never occur.
+    """
+    token = inflight.start(agent)
+    when = time.time() - seconds
+    p = config.STATE_DIR / "dispatch-inflight" / f"{token}.json"
+    rec = json.loads(p.read_text())
+    rec["ts"] = when
+    p.write_text(json.dumps(rec))
+    os.utime(p, (when, when))
+    return token
+
+
+class Chips(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        for n in ("devops", "release"):
+            self.make_persona(n, role=n.title(), **{"delegate-when": f"{n} work"})
+
+    def _chip(self, name: str) -> str:
+        for c in statusline._persona_chips():
+            if re.search(rf"\b{re.escape(name)}\b", _plain(c)):
+                return _plain(c)
+        raise AssertionError(f"no chip for {name}")
+
+    def test_a_persona_not_in_flight_carries_no_bolt(self):
+        self.assertNotIn("⚡", self._chip("devops"))
+
+    def test_one_dispatch_shows_a_bolt_and_an_age_but_no_count(self):
+        _start_aged("devops", 4 * 60)
+        chip = self._chip("devops")
+        self.assertIn("⚡", chip)
+        self.assertIn("4m", chip)
+        self.assertNotIn("⚡1", chip)
+
+    def test_more_than_one_dispatch_shows_the_count(self):
+        _start_aged("devops", 4 * 60)
+        _start_aged("devops", 60)
+        self.assertIn("⚡2", self._chip("devops"))
+
+    def test_the_age_is_the_oldest_dispatch(self):
+        """The newest is the least interesting: what a reader wants to know is how long
+        the longest-running one has been out.
+
+        Aged in minutes rather than hours because nothing older than
+        `inflight.TTL_SECONDS` can be observed at all — `live_records` prunes it as a
+        killed process. That the *most* alarming dispatch is the one that vanishes is
+        real and deliberately not fixed here (diazoxide/charter#308): it changes what
+        `inflight` means, not what this line draws.
+        """
+        _start_aged("devops", 60)
+        _start_aged("devops", 25 * 60)
+        _start_aged("devops", 6 * 60)
+        chip = self._chip("devops")
+        self.assertIn("⚡3", chip)
+        self.assertIn("25m", chip)
+        self.assertNotIn("6m", chip)
+
+    def test_only_the_dispatched_persona_is_marked(self):
+        _start_aged("devops", 60)
+        self.assertIn("⚡", self._chip("devops"))
+        self.assertNotIn("⚡", self._chip("release"))
+
+    def test_a_finished_dispatch_takes_its_bolt_with_it(self):
+        _start_aged("devops", 60)
+        inflight.finish("devops")
+        self.assertNotIn("⚡", self._chip("devops"))
+
+    def test_a_dispatch_under_a_minute_says_now(self):
+        """`0m` is technically correct and reads as broken — the same call
+        `pieces._presence_age` already made, reused rather than re-litigated."""
+        inflight.start("devops")
+        self.assertIn("now", self._chip("devops"))
+
+    def test_a_broken_inflight_store_never_breaks_the_chips(self):
+        orig = inflight.live_records
+        inflight.live_records = lambda *a, **k: 1 / 0
+        try:
+            self.assertTrue(statusline._persona_chips())
+        finally:
+            inflight.live_records = orig
+
+    def test_the_marker_stays_two_columns_wide(self):
+        """The bolt trails the name, so it must not move where a name starts — the
+        chips line up with the column header on exactly that promise."""
+        _start_aged("devops", 4 * 60)
+        for chip in statusline._persona_chips():
+            self.assertRegex(_plain(chip), r"^[▸▫] \S")
+
+
+class RowsStayTrue(PersonaIso):
+    """Both changes make a chip's badges *conditional*, which is the exact shape that has
+    broken this layout before: a glyph on some rows and not others moves one row and not
+    its neighbour, and a header has no sibling to reveal the drift.
+
+    The frame is the ruler that catches it. A row whose real width disagrees with what
+    `tui.width` believes pushes its own `│` out of line, so "every line is the same width"
+    is a stronger assertion than it looks.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        from charter import update
+        spawn = update.maybe_spawn          # never fork a network child from the suite
+        update.maybe_spawn = lambda: None
+        self.addCleanup(lambda: setattr(update, "maybe_spawn", spawn))
+        # A roster where every conditional badge is both present and absent: `flying`
+        # declares a vault this machine has never registered (`◦`) and is in flight;
+        # `quiet` declares no vault at all (nothing) and is not.
+        self.make_persona("flying", role="F", vault="nowhere", **{"delegate-when": "x"})
+        self.make_persona("quiet", role="Q", **{"delegate-when": "x"})
+        _start_aged("flying", 4 * 60)
+
+    def _rendered(self, width=200):
+        os.environ["COLUMNS"] = str(width)
+        self.addCleanup(os.environ.pop, "COLUMNS", None)
+        return [_plain(ln) for ln in statusline.render({}).split("\n") if ln.strip()]
+
+    def _content(self, width=200):
+        """Rendered rows with the frame peeled off — the frame's own right border is a
+        `│` too, and this test is about the divider *between* the columns."""
+        out = []
+        for ln in self._rendered(width):
+            if set(ln.strip()) <= set("┌─┐└┘├┤"):
+                continue
+            if ln.startswith("│ ") and ln.rstrip().endswith("│"):
+                ln = ln[2:].rstrip()[:-1].rstrip()
+            out.append(ln)
+        return out
+
+    def test_a_chip_with_badges_is_no_wider_than_one_without(self):
+        from charter import tui
+        for width in (80, 140, 200):
+            with self.subTest(columns=width):
+                rows = self._rendered(width)
+                self.assertGreater(len(rows), 4, rows)   # not vacuous: real rows measured
+                widths = {tui.width(ln) for ln in rows}
+                self.assertEqual(len(widths), 1, f"rows disagree on width: {sorted(widths)}")
+
+    def test_names_still_start_where_the_header_says_they_do(self):
+        """The vault mark disappearing must not move a name: the marker before it is
+        exactly two columns and the badges all trail."""
+        rows = [ln for ln in self._content() if ln.find("│", 40) > 0]
+        self.assertGreater(len(rows), 2, rows)   # header + both chips, or it proves nothing
+        starts = set()
+        for ln in rows:
+            right = ln[ln.find("│", 40) + 1:]
+            m = re.search(r"[A-Za-z]", right)
+            self.assertIsNotNone(m, right)
+            starts.add(m.start())
+        self.assertEqual(len(starts), 1,
+                         f"right-column text starts at differing columns: {sorted(starts)}")
+
+    def test_the_column_shows_both_signals_at_once(self):
+        """Guards the fixture: a width assertion over rows that carry no badges proves
+        nothing."""
+        col = "\n".join(_plain(c) for c in statusline._persona_chips())
+        self.assertIn("◦", col)
+        self.assertIn("⚡", col)
+
+
+class Records(PersonaIso):
+    """`live()` answers "who", which is all the aggregate ever needed. The chip needs
+    "since when" too, and must not learn to read the state directory itself to get it."""
+
+    def test_records_carry_a_start_time(self):
+        _start_aged("devops", 90)
+        recs = inflight.live_records()
+        self.assertEqual([n for n, _ in recs], ["devops"])
+        self.assertAlmostEqual(recs[0][1], time.time() - 90, delta=5)
+
+    def test_records_preserve_duplicates(self):
+        _start_aged("devops", 60)
+        _start_aged("devops", 30)
+        self.assertEqual(len(inflight.live_records()), 2)
+
+    def test_records_prune_the_stale_like_live_does(self):
+        _start_aged("devops", inflight.TTL_SECONDS + 60)
+        self.assertEqual(inflight.live_records(), [])
+
+    def test_live_still_answers_with_names(self):
+        _start_aged("devops", 60)
+        _start_aged("release", 60)
+        self.assertEqual(inflight.live(), ["devops", "release"])
+
+    def test_a_record_written_without_a_timestamp_falls_back_to_mtime(self):
+        """Records written by an older charter carry no ``ts``. A chip that renders `?`
+        for one is worse than one that uses the mtime, which is the same instant."""
+        token = _start_aged("devops", 120)
+        p = Path(config.STATE_DIR) / "dispatch-inflight" / f"{token}.json"
+        when = p.stat().st_mtime
+        p.write_text(json.dumps({"agent": "devops"}))
+        os.utime(p, (when, when))
+        recs = inflight.live_records()
+        self.assertAlmostEqual(recs[0][1], when, delta=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_statusline_layout_scope.py
+++ b/tests/test_statusline_layout_scope.py
@@ -11,7 +11,7 @@ Four zones now, each answering one question:
     ⬢ umbrella-improvements · ws 9                      WHERE I am
     ◫ repos 2/38            │ ◈ personas 13 · vaults 6  what each column holds
     ├─ …repo rows…          │ …persona chips…           WHAT I'm on × WHO I am
-    ctx 22% · ⚡100% · ⛊1 denied            ⬢ charter    THIS session · the tool
+    ctx 22% · cache 100% · ⛊1 denied         ⬢ charter    THIS session · the tool
 
 The rule to keep: a count lives next to what it counts.
 """
@@ -121,7 +121,10 @@ class Zones(PersonaIso):
     def test_session_gauges_live_on_the_last_content_line(self):
         ls = [ln for ln in _lines(_USAGE) if ln.strip()]
         self.assertIn("ctx", ls[-1])
-        self.assertIn("⚡", ls[-1])
+        # `cache`, not `⚡`: the bolt belongs to a running dispatch now, and the two
+        # gauges read as a pair because both carry a word.
+        self.assertIn("cache", ls[-1])
+        self.assertNotIn("⚡", ls[-1])
 
     def test_the_brand_sits_at_the_end_of_the_session_strip(self):
         ls = [ln for ln in _lines(_USAGE) if ln.strip()]
@@ -135,7 +138,7 @@ class Zones(PersonaIso):
         last = max(i for i, ln in enumerate(ls) if ln.strip())
         for ln in ls[head:last]:
             left = ln.split("│", 1)[0] if "│" in ln[40:] else ln
-            for token in ("denied", "recorded", "dispatched", "ctx", "⚡"):
+            for token in ("denied", "recorded", "dispatched", "ctx", "cache", "⚡"):
                 self.assertNotIn(token, left, f"session news leaked into the repo column: {ln}")
 
 
@@ -320,7 +323,10 @@ class Framed(PersonaIso):
     def test_session_gauges_live_on_the_last_content_line(self):
         ls = [ln for ln in _lines(_USAGE) if ln.strip()]
         self.assertIn("ctx", ls[-1])
-        self.assertIn("⚡", ls[-1])
+        # `cache`, not `⚡`: the bolt belongs to a running dispatch now, and the two
+        # gauges read as a pair because both carry a word.
+        self.assertIn("cache", ls[-1])
+        self.assertNotIn("⚡", ls[-1])
 
     def test_the_brand_sits_at_the_end_of_the_session_strip(self):
         ls = [ln for ln in _lines(_USAGE) if ln.strip()]
@@ -334,7 +340,7 @@ class Framed(PersonaIso):
         last = max(i for i, ln in enumerate(ls) if ln.strip())
         for ln in ls[head:last]:
             left = ln.split("│", 1)[0] if "│" in ln[40:] else ln
-            for token in ("denied", "recorded", "dispatched", "ctx", "⚡"):
+            for token in ("denied", "recorded", "dispatched", "ctx", "cache", "⚡"):
                 self.assertNotIn(token, left, f"session news leaked into the repo column: {ln}")
 
 

--- a/tests/test_statusline_persona_health.py
+++ b/tests/test_statusline_persona_health.py
@@ -110,10 +110,18 @@ class NeverExpensive(PersonaIso):
 
 
 class VaultDot(PersonaIso):
-    """Three states, not two. `plain-file.health()` returns ``ok=True`` with the detail
-    "not created yet (<path>)" for a vault that is registered but has no file — so
-    reading only ``ok`` painted a green ✓ on a vault that does not exist, while
-    `charter persona list` (which prints the detail) correctly said otherwise.
+    """Silence means fine — three states, two glyphs.
+
+    The four-state version painted a mark on every chip on every turn, and on a healthy
+    roster three of the four were ✓ or ·: furniture, by the same argument `_health_mark`
+    is built on. Worse, the two dim `·` states were *different facts wearing one glyph* —
+    a persona needing no vault at all, and a persona DECLARING ``vault: X`` that this
+    machine has never registered. "Required and absent" was the one thing the chip could
+    not say, and it is the only one worth a character.
+
+    The two unusable reasons collapse into one ``◦`` on purpose: their fixes differ
+    (`charter vault add` vs `charter secret set`), a chip cannot carry either, and
+    `charter persona list` already prints both in words.
     """
 
     def _dot(self, ok, detail, registered=True):
@@ -132,22 +140,35 @@ class VaultDot(PersonaIso):
         finally:
             registry.vaults, registry.provider_for = vaults, provider_for
 
-    def test_healthy_vault_is_a_check(self):
-        self.assertIn("✓", self._dot(True, "3 secret(s)"))
+    def test_a_healthy_vault_renders_nothing(self):
+        self.assertEqual("", self._dot(True, "3 secret(s)"))
 
-    def test_registered_but_absent_is_distinct_from_healthy(self):
-        dot = self._dot(True, "not created yet (/x/y.json)")
-        self.assertNotIn("✓", dot)
-        self.assertIn("◦", dot)
+    def test_no_vault_declared_renders_nothing(self):
+        self.assertEqual("", _plain(statusline._vault_dot(None)))
+
+    def test_declared_but_unregistered_is_a_ring(self):
+        """The state that used to be invisible: the persona says it needs a vault and
+        this machine has none by that name."""
+        self.assertIn("◦", self._dot(True, "", registered=False))
+
+    def test_registered_but_never_created_is_a_ring(self):
+        """`plain-file.health()` returns ``ok=True`` with "not created yet (<path>)" —
+        reading only ``ok`` once painted a green ✓ on a vault that does not exist."""
+        self.assertIn("◦", self._dot(True, "not created yet (/x/y.json)"))
+
+    def test_both_unusable_reasons_share_one_glyph(self):
+        self.assertEqual(self._dot(True, "", registered=False),
+                         self._dot(True, "not created yet (/x/y.json)"))
 
     def test_unhealthy_vault_is_a_bang(self):
         self.assertIn("!", self._dot(False, "unreadable"))
 
-    def test_unregistered_vault_is_a_dim_dot(self):
-        self.assertIn("·", self._dot(True, "", registered=False))
-
-    def test_no_vault_named_is_a_dim_dot(self):
-        self.assertIn("·", _plain(statusline._vault_dot(None)))
+    def test_an_unusable_vault_never_borrows_a_health_glyph(self):
+        """`⚑` (draft) and `✗` (broken config) already sit on this chip and mean
+        something else entirely."""
+        for dot in (self._dot(True, "", registered=False), self._dot(False, "unreadable")):
+            self.assertNotIn("⚑", dot)
+            self.assertNotIn("✗", dot)
 
 
 if __name__ == "__main__":

--- a/tests/test_statusline_session_block.py
+++ b/tests/test_statusline_session_block.py
@@ -46,18 +46,24 @@ class Silence(unittest.TestCase):
     def test_no_session_id_renders_nothing(self):
         self.assertEqual(statusline._session_news(None), [])
 
-    def test_in_flight_dispatch_appears(self):
+    def test_in_flight_dispatch_appears_as_a_bare_count(self):
         from charter import inflight
         inflight.start("coder")
+        inflight.start("coder")
         out = _plain(statusline._session_news(None))
-        self.assertTrue(any("in flight" in l and "coder" in l for l in out), out)
+        self.assertIn("⚡ 2", out)
 
-    def test_many_in_flight_are_truncated_not_wrapped(self):
+    def test_the_strip_no_longer_names_who_is_in_flight(self):
+        """The names moved onto the persona chips, next to the personas they describe.
+        What stays here is the aggregate — the chips cap at `_MAX_PERSONA_LINES` and
+        vanish altogether on a narrow pane, so the count is what survives cropping,
+        the same contract `_repo_rows` keeps with its "(+N more)" row."""
         from charter import inflight
         for n in ("a", "b", "c", "d", "e"):
             inflight.start(n)
         out = _plain(statusline._session_news(None))
-        self.assertTrue(any("…" in l for l in out), out)
+        bolt = [l for l in out if "⚡" in l]
+        self.assertEqual(bolt, ["⚡ 5"])
 
     def test_version_drift_appears_with_its_fix(self):
         from charter import instance

--- a/tests/test_statusline_todo_count.py
+++ b/tests/test_statusline_todo_count.py
@@ -258,7 +258,7 @@ class AlignmentSurvivesIt(TodoIso):
         """The count is about the workspace named on this row. Nothing else may follow
         it in — the repo count describes the left column, the gauges the session."""
         top = _top(_USAGE)
-        for foreign in ("repos", "vaults", "personas", "ctx", "⚡"):
+        for foreign in ("repos", "vaults", "personas", "ctx", "cache", "⚡"):
             self.assertNotIn(foreign, top, top)
 
 


### PR DESCRIPTION
Three changes to the status line's vocabulary. All apply one rule the line already
lives by: **a mark that renders every turn is furniture, and a real fault inside a row
of furniture reads like a zero** — plus its corollary, that a glyph may mean exactly
one thing.

## 1. Vault state: silence means fine

`_vault_dot` rendered four states on every chip on every turn, and on a healthy roster
three of them meant "nothing to do here". Worse, its two dim `·` states were different
facts wearing one glyph — a persona that needs no vault, and a persona *declaring*
`vault: X` that this machine has never registered. **Required-but-absent was the only
vault fact that changes what you do next, and it was the one the chip could not say.**

| case | before | after |
| --- | --- | --- |
| no vault declared | `·` | *(nothing)* |
| registered + healthy | `✓` | *(nothing)* |
| declared, not registered here | `·` | `◦` dim |
| registered, file not created yet | `◦` | `◦` dim |
| registered, unhealthy | `!` | `!` yellow |

The two unusable reasons collapse into one glyph deliberately: their fixes differ
(`charter vault add` vs `charter secret set`), a chip can carry neither, and
`charter persona list` already prints both in words — a third glyph would buy a
distinction the reader still has to leave the status line to act on.

`_vault_glyph` is deleted; the fallback `_persona_line` now calls `_vault_dot`. One
function applies the rule instead of two agreeing by hand.

## 2. Running personas on their own chip

`inflight` has always known which personas have sub-agents out, and the line spent it
on one aggregate at the bottom — `⚡in flight 2 · devops, devops` — where reading it
meant matching a name against a roster ten rows up. The count now sits next to what it
counts:

```
▸ devops ⚡2 12m
▫ forge ✎3 ⚡ 4m
```

- **Count only above one.** A lone `⚡1` is the same non-fact as `todo 0` or `✎0`,
  which already render as nothing.
- **Age always, from the OLDEST live record** — the newest answers nothing; three out
  with one at `25m` is the whole reason the age is on screen. Coarse, in
  `pieces._presence_age`'s vocabulary, so it ages in the same units as the `silent 12m`
  two rows away, and because at a 10s refresh a seconds figure would be a lie. A
  dispatch under a minute reads `now`, not `0m`, for the reason that function already
  documents.
- `inflight.live_records()` carries `(agent, started_at)` (from the record's `ts`,
  falling back to mtime for records written by an older charter). `live()` is now a
  projection of it — one glob, one pruning rule, and the aggregate keeps working.
- **The session strip keeps a bare `⚡ 3`.** The chip column caps at
  `_MAX_PERSONA_LINES` and disappears below `_LEFT_W + _RIGHT_MIN_W`, so the aggregate
  is what survives cropping — the contract `_repo_rows` keeps with its "(+N more)".

## 3. The cache gauge gives up the bolt: `⚡NN%` → `cache NN%`

Found while building #2. `_context_gauge` renders the prompt-cache hit rate on the
*same strip*, one item before the in-flight aggregate — so the line read
`ctx 22% · ⚡100% · ⚡ 3`: two meanings for one glyph, told apart only by a `%`.

`⚡` now means one thing, *a dispatch is running*, and it keeps the glyph because that
fact renders in **two** places (the chip and the aggregate) which have to read as the
same thing. The cache rate takes a word — `{_DIM}cache{_R} {col}{hit}%{_R}`, the exact
shape `ctx NN%` beside it already uses — and it is the one whose symbol was never
guessable anyway. Colour thresholds, `↻N`, the rebuild-prefix warning and `_cache_hint`
are untouched.

The strip now reads `ctx 22% · cache 100% · ⚡ 3`.

## Width, which is what breaks this layout

The flight badge trails every other badge: it is the only one whose value changes while
you watch (count moves, age ticks), and behind it there is nothing to move. `⚡` is
East-Asian **Wide** — unambiguously two cells, unlike the *Ambiguous* glyphs that have
broken this column twice — and `tui.width` agrees with the tables, so the frame stays a
true ruler. `◦` is Neutral.

`RowsStayTrue` renders a roster where every conditional badge is both present and
absent (one persona `◦` + in flight, one with neither) and asserts at 80/140/200
columns that every emitted row has the same `tui.width`, and that every right-column
name still starts in the same column as the `personas` header. Mutation-checked:
moving the badge ahead of the marker on idle chips only fails it.

## Cost

No new subprocess, no network. One extra directory glob per render, computed once for
the whole column rather than once per chip. `_vault_health` keeps its 60s disk cache
and per-process memo. Measured ~90–130ms per render, unchanged.

## Verification

- `python3 -m unittest discover -s tests` → **2848 tests, OK** (2827 on `main`).
- Rendered against a real plane at 80, 140 and 200 columns; every line one width at
  each:

```
│ ▪ repos 1/1                     │ ▪ personas 5 · vaults 3 · shared … │
│   ├─ charter    …               │ ▸ steward ✎31                      │
│   │                             │ ▫ forge ◦ ✎3 ⚡2 12m               │
│   │                             │ ▫ reddit ✎7                        │
│   │                             │ ▫ release ✎14                      │
│   │                             │ ▫ statusline ✎8 ⚡ 4m              │
├─────────────────────────────────────────────────────────────────────┤
│ ctx 22% · cache 100% · ⚡ 3                        ⬢ charter 0.46.3 │
```

## Out of scope, deliberately

- `refreshInterval` / render cadence — a separate piece of work.
- `inflight.TTL_SECONDS` pruning a stuck agent at 30 minutes (so a chip can never show
  `2h` today) — filed as #308; it changes what `inflight` means, not what this line
  draws.
- `docs/assets/*.svg` still show `⚡92%` and the pre-`▪`/`▸`/`▫` markers. They are
  captured renders and were already stale before this PR; regenerating them is a
  capture run against a specific plane, not a text edit — the hand-positioned per-glyph
  `x` coordinates cannot be edited safely. `docs/assets/README.md`, which describes what
  the capture produces, is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo
