### PR TITLE
Keep a stuck dispatch on screen instead of deleting it

### DIFF
--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -1965,7 +1965,12 @@ def pretooluse_dispatch() -> int:
         return 0
     try:
         from . import inflight, persona
-        others = inflight.live()
+        # `still_running`, not `live`: a record past the presumed-dead threshold is kept
+        # now (#308) so a stuck dispatch stays on screen, but this nudge asserts a peer
+        # "is already running" — which charter stops knowing at exactly that threshold.
+        # Nudging on one would nag for a day after a killed process, and a warning people
+        # learn to dismiss is worse than the overlap it reports.
+        others = inflight.still_running()
         token = inflight.start(agent)
         if not others:
             return 0

--- a/charter/inflight.py
+++ b/charter/inflight.py
@@ -25,10 +25,22 @@ import tempfile
 import time
 from pathlib import Path
 
-#: A dispatch still marked in-flight after this long is assumed dead — the process
-#: was killed, or PostToolUse never fired. Long enough not to prune a genuinely slow
-#: sub-agent mid-run; short enough that strays cannot accumulate into a false warning.
-TTL_SECONDS = 30 * 60
+# One number used to do both jobs, and doing both is what made it wrong (#308). A record
+# past the old TTL was DELETED, so the single most interesting thing this tracker can hold
+# — a dispatch that has outlived every reasonable expectation — rendered as nothing at all,
+# and irreversibly: "presumed dead" and "never happened" were the same picture. The two
+# jobs want opposite horizons, so they get their own numbers.
+
+#: A dispatch still marked in-flight after this long is **presumed dead** — the process was
+#: killed, or PostToolUse never fired. Still returned, flagged, and drawn (`45m?`); charter
+#: cannot know whether it died or is genuinely still working, only that nobody should still
+#: be expecting it. Long enough not to doubt a genuinely slow sub-agent mid-run.
+PRESUMED_DEAD_SECONDS = 30 * 60
+
+#: When a record is finally discarded. Far out, because everything before it is a thing a
+#: human might still be looking at — but finite, so a stray from a killed process cannot
+#: accumulate into a permanent false warning.
+PRUNE_SECONDS = 24 * 60 * 60
 
 
 def _dir() -> Path:
@@ -40,8 +52,8 @@ def _safe_name(agent: str) -> str:
     return "".join(c if c.isalnum() or c in "._-" else "_" for c in agent)[:64]
 
 
-def live_records(exclude_token: str | None = None) -> list[tuple[str, float]]:
-    """``(agent, started_at)`` per live dispatch, duplicates preserved, stale pruned.
+def live_records(exclude_token: str | None = None) -> list[tuple[str, float, bool]]:
+    """``(agent, started_at, presumed_dead)`` per record, duplicates preserved.
 
     The start time is what separates "two agents are out" from "two agents have been
     out for forty minutes", and only the second is worth interrupting for. It is read
@@ -49,39 +61,58 @@ def live_records(exclude_token: str | None = None) -> list[tuple[str, float]]:
     and the only answer available for a record written by a charter that predates the
     field.
 
+    ``presumed_dead`` is measured from that same start time, not from the mtime the
+    pruning reads: it is the flag on the age a caller draws, so the two can never
+    disagree about which side of the threshold a record sits on. Pruning stays on the
+    mtime because it happens *before* the parse — which is what lets a corrupt stray be
+    cleaned up at all.
+
     :func:`live` is a projection of this rather than a second walk of the directory:
-    one glob, one pruning rule. A caller that wants the names only should keep calling
-    it — the extra element is a cost the aggregate has no use for.
+    one glob, one set of rules. A caller that wants the names only should keep calling
+    it — the extra elements are a cost the aggregate has no use for.
     """
     d = _dir()
     if not d.exists():
         return []
-    out: list[tuple[str, float]] = []
+    out: list[tuple[str, float, bool]] = []
     now = time.time()
     for p in d.glob("*.json"):
         try:
             mtime = p.stat().st_mtime
-            if now - mtime > TTL_SECONDS:
-                p.unlink(missing_ok=True)      # dead: killed process, or no PostToolUse
+            if now - mtime > PRUNE_SECONDS:
+                p.unlink(missing_ok=True)      # a stray, long past anyone watching for it
                 continue
             if exclude_token and p.stem == exclude_token:
                 continue
             rec = json.loads(p.read_text())
             ts = rec.get("ts")
-            out.append((rec.get("agent") or p.stem,
-                        float(ts) if isinstance(ts, (int, float)) else mtime))
+            started = float(ts) if isinstance(ts, (int, float)) else mtime
+            out.append((rec.get("agent") or p.stem, started,
+                        now - started > PRESUMED_DEAD_SECONDS))
         except (OSError, TypeError, ValueError):
             continue
     return out
 
 
 def live(exclude_token: str | None = None) -> list[str]:
-    """Agent names currently in flight, stale entries pruned.
+    """Agent names the tracker holds — presumed-dead ones included, since the aggregate
+    this feeds counts records and the distinction is drawn per chip.
 
     ``exclude_token`` drops one specific record — the caller's own, so a dispatch
     never reports itself as a concurrent peer.
     """
-    return sorted(name for name, _ in live_records(exclude_token))
+    return sorted(name for name, _, _ in live_records(exclude_token))
+
+
+def still_running(exclude_token: str | None = None) -> list[str]:
+    """Agent names charter can still claim are *running* — presumed-dead ones dropped.
+
+    For the callers that assert liveness rather than display it. The dispatch nudge says
+    a peer "is already running", which stops being true at the presumed-dead threshold;
+    keeping the record so a stuck dispatch stays visible must not turn that nudge into a
+    nag that outlives the process by a day.
+    """
+    return sorted(name for name, _, dead in live_records(exclude_token) if not dead)
 
 
 def start(agent: str) -> str | None:
@@ -105,15 +136,26 @@ def start(agent: str) -> str | None:
 
 
 def finish(agent: str) -> None:
-    """Clear one in-flight record for *agent* — the oldest, since a repeat dispatch
-    of the same persona should retire the run that started first."""
+    """Clear one in-flight record for *agent* — the oldest **still-running** one, since a
+    repeat dispatch of the same persona should retire the run that started first.
+
+    "Still running" is the qualification records surviving past the presumed-dead
+    threshold made necessary. Oldest-first alone would hand a finishing dispatch the
+    stuck record to retire and leave its own behind — deleting exactly what #308 exists
+    to keep, and leaving a false live one in its place. Presumed-dead records are still
+    eligible when there is nothing else, because a genuinely long dispatch does finish
+    eventually and its record has to go when it does.
+    """
     agent = (agent or "").strip()
     if not agent:
         return
     try:
+        now = time.time()
         matches = sorted(_dir().glob(f"{_safe_name(agent)}.*.json"),
                          key=lambda p: p.stat().st_mtime)
-        if matches:
-            matches[0].unlink(missing_ok=True)
+        running = [p for p in matches
+                   if now - p.stat().st_mtime <= PRESUMED_DEAD_SECONDS]
+        for p in (running or matches)[:1]:
+            p.unlink(missing_ok=True)
     except OSError:
         return

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1127,8 +1127,8 @@ def _mem_badge(persistent: int, ephemeral: int = 0) -> str:
     return (" " + " ".join(parts)) if parts else ""
 
 
-def _inflight_by_persona() -> dict[str, tuple[int, float]]:
-    """``persona → (dispatches in flight, epoch start of the OLDEST)``.
+def _inflight_by_persona() -> dict[str, tuple[int, float, bool]]:
+    """``persona → (dispatches held, epoch start of the OLDEST, oldest presumed dead)``.
 
     Computed once per render and handed to every chip: `inflight.live_records` is a
     directory glob, which is affordable on a surface that draws every turn, but not
@@ -1136,21 +1136,26 @@ def _inflight_by_persona() -> dict[str, tuple[int, float]]:
 
     The oldest wins because the newest answers nothing. Three dispatches out, the
     freshest a minute old, is not news; three out with one at ``2h`` is the whole
-    reason the age is on screen.
+    reason the age is on screen. The flag rides with the oldest for the same reason:
+    it qualifies the age that gets drawn, and the oldest is the record that crosses
+    the presumed-dead threshold first.
     """
     try:
         from . import inflight
-        out: dict[str, tuple[int, float]] = {}
-        for name, started in inflight.live_records():
-            n, oldest = out.get(name, (0, started))
-            out[name] = (n + 1, min(oldest, started))
+        out: dict[str, tuple[int, float, bool]] = {}
+        for name, started, dead in inflight.live_records():
+            n, oldest, oldest_dead = out.get(name, (0, started, dead))
+            if started < oldest:
+                oldest, oldest_dead = started, dead
+            out[name] = (n + 1, oldest, oldest_dead)
         return out
     except Exception:
         return {}
 
 
-def _inflight_badge(entry: tuple[int, float] | None) -> str:
-    """``⚡2 4m`` for a persona with dispatches in flight, '' for one without.
+def _inflight_badge(entry: tuple[int, float, bool] | None) -> str:
+    """``⚡2 4m`` for a persona with dispatches in flight, ``⚡ 45m?`` when the oldest has
+    outlived every expectation, '' for a persona with none.
 
     **Count only above one.** A lone ``⚡1`` is the same non-fact as `todo 0` or `✎0`,
     both of which render as nothing here: presence is the signal, and the digit only
@@ -1161,16 +1166,29 @@ def _inflight_badge(entry: tuple[int, float] | None) -> str:
     correct, reads as broken) renders as ``now`` for the same reason it does there.
     Coarse on purpose: this line refreshes every ten seconds, so a seconds figure would
     be a number nobody could trust to be current.
+
+    **``?`` past the presumed-dead threshold** (#308). The age keeps climbing — the record
+    is no longer deleted, so this is where `2h` and `3d` become reachable at all — and the
+    mark says *presumed dead, not confirmed*, which is the whole of what charter knows: it
+    cannot tell a killed process from a sub-agent still grinding. Hence a question mark and
+    not `✗`, and hence no colour escalation: it stays in the age's dim, because a red mark
+    would claim the certainty the mark exists to disclaim. ``?`` is ASCII and East-Asian
+    *Narrow*, unlike the Ambiguous glyphs that have broken this column twice.
+
+    It reads with the only other `?` on this line rather than against it: `pieces` draws a
+    bare `?` where a presence age is unreadable, and both mean *charter cannot vouch for
+    this number*. They are never confusable — that one replaces an age, this one trails one.
     """
     if not entry:
         return ""
     try:
         from datetime import datetime, timezone
         from . import pieces
-        n, started = entry
+        n, started, presumed_dead = entry
         age = pieces._presence_age(datetime.fromtimestamp(started, timezone.utc),
                                    datetime.now(timezone.utc))
-        return f" {_YELLOW}⚡{n if n > 1 else ''}{_R} {_DIM}{age}{_R}"
+        mark = "?" if presumed_dead else ""
+        return f" {_YELLOW}⚡{n if n > 1 else ''}{_R} {_DIM}{age}{mark}{_R}"
     except Exception:
         return ""
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -391,9 +391,10 @@ ctx 22% · cache 90% · ⚡ 1 · ⛊1 denied · ✎1 recorded  ⬢ charter 0.10.
   when the count is zero, like everything else that would otherwise render every turn.
 - **Columns — the Role × Task axes.** Left is the *task* (repos cloned into this
   workspace, their branch, CI and MRs); right is the *role* (the persona roster, each
-  chip carrying its memory counts, a `⚡` while it has sub-agents running, and a vault
-  mark only when its vault cannot be used). Personas are global, repos are
-  workspace-scoped — two independent axes, two columns.
+  chip carrying its memory counts, a `⚡` while it has sub-agents running — with a `?`
+  once one has outlived every reasonable expectation — and a vault mark only when its
+  vault cannot be used). Personas are global, repos are workspace-scoped — two
+  independent axes, two columns.
 - **Bottom — this session.** Context and prompt-cache health (`ctx NN%`, `cache NN%`),
   plus counters for what has happened: in-flight sub-agents, guard denials, memories
   recorded, dispatches. Absent entirely when there is nothing to report, so a denial

--- a/docs/news/unreleased-presumed-dead-dispatches.md
+++ b/docs/news/unreleased-presumed-dead-dispatches.md
@@ -1,0 +1,48 @@
+---
+version: unreleased
+headline: A stuck sub-agent now says so instead of disappearing
+---
+
+The in-flight tracker deleted any record older than thirty minutes, on every read. So the
+single most interesting thing it could ever hold — a dispatch that has outlived every
+reasonable expectation — was the one case it rendered as *nothing at all*. "Presumed dead"
+and "never happened" were the same picture, and the deletion was irreversible: the first
+render past the threshold was the last one that could mention it.
+
+That threshold was doing two jobs at once, and they want opposite horizons. It is now two:
+
+* **presumed dead at thirty minutes** — the record is kept and flagged, not deleted;
+* **pruned after a day** — so a stray from a killed process still cannot accumulate into a
+  permanent false warning, but nothing vanishes while a human might still be looking at it.
+
+On screen the chip appends a `?` to the age:
+
+```
+▫ statusline ✎9 ⚡ 3m
+▫ forge ◦ ✎3 ⚡2 47m?
+```
+
+The age keeps climbing — which is also what finally makes the badge's `2h` and `3d`
+reachable, since nothing used to survive long enough to render them. The mark says
+*presumed dead, not confirmed*, because that is the whole of what charter knows: it cannot
+tell a killed process from a sub-agent still grinding away. Hence a question mark rather
+than a cross, and hence no colour escalation — it stays in the age's dim, since a red mark
+would claim exactly the certainty the mark exists to disclaim.
+
+The session strip's `⚡ N` counts every record, presumed-dead ones included. The chips are
+where the distinction lives; the aggregate is what survives a narrow pane, and a total that
+shrank when a dispatch got *more* worrying would be the original bug in miniature.
+
+Two rules follow the record now that it outlives the threshold:
+
+* `finish` retires the oldest **still-running** record for a persona, not simply the oldest.
+  Oldest-first alone would hand a finishing dispatch the stuck record to retire and leave
+  its own behind — deleting the thing this change exists to keep. A presumed-dead record is
+  still eligible when there is nothing else, because a genuinely long dispatch does finish
+  eventually.
+* The overlap nudge at dispatch time asks only about records charter can still call
+  *running*. It claims a peer "is already running", which stops being true at the
+  presumed-dead threshold, and a warning that nags for a day after a killed process is one
+  people learn to dismiss.
+
+Closes #308.

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -434,3 +434,11 @@ A persona with sub-agents in flight carries `⚡` on its own chip, with the coun
 there is more than one and the age of the oldest dispatch always — `▸ devops ⚡2 12m`.
 The session strip keeps the bare total (`⚡ 3`), because the persona column caps at
 fourteen rows and disappears on a narrow pane.
+
+After thirty minutes a dispatch is **presumed dead** and the age takes a `?` —
+`▫ forge ✎3 ⚡ 45m?`. The age keeps climbing; the mark says *presumed dead, not
+confirmed*, which is all charter can honestly claim — it cannot tell a killed process
+from a sub-agent that is genuinely still working. The record itself survives for a day
+before it is discarded, so a stuck dispatch escalates instead of quietly vanishing. It
+still counts on the strip's total; the chip is where live and presumed-dead are told
+apart.

--- a/tests/test_inflight_dispatch.py
+++ b/tests/test_inflight_dispatch.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import time
 import unittest
 from contextlib import redirect_stdout
@@ -24,6 +25,29 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from charter import config, hooks, inflight
+
+
+def _age(path: Path, seconds: float) -> Path:
+    """Backdate one record by *seconds* — both its ``ts`` and its mtime.
+
+    The two thresholds read different fields on purpose (the prune horizon reads mtime
+    before parsing, so a corrupt stray is still cleaned; presumed-dead reads the ``ts``
+    the age is rendered from, so the mark and the number can never disagree). A fixture
+    that moved only one of them could therefore pass a test that a real record fails.
+    """
+    when = time.time() - seconds
+    try:
+        rec = json.loads(path.read_text())
+        rec["ts"] = when
+        path.write_text(json.dumps(rec))
+    except (OSError, ValueError):
+        pass
+    os.utime(path, (when, when))
+    return path
+
+
+def _only_record() -> Path:
+    return next((config.STATE_DIR / "dispatch-inflight").glob("*.json"))
 
 
 class _Stdin:
@@ -72,19 +96,95 @@ class InflightStore(unittest.TestCase):
         inflight.finish("coder")
         self.assertEqual(inflight.live(), ["coder"])
 
-    def test_a_stale_record_is_pruned(self):
-        """A killed process leaves a record behind; it must not warn forever."""
+    def test_a_record_past_the_prune_horizon_is_removed(self):
+        """A killed process leaves a record behind; it must not accumulate forever."""
         inflight.start("coder")
-        p = next((config.STATE_DIR / "dispatch-inflight").glob("*.json"))
-        old = time.time() - inflight.TTL_SECONDS - 60
-        import os
-        os.utime(p, (old, old))
+        p = _age(_only_record(), inflight.PRUNE_SECONDS + 60)
         self.assertEqual(inflight.live(), [])
-        self.assertFalse(p.exists(), "a stale record should be removed, not just ignored")
+        self.assertFalse(p.exists(), "a stray should be removed, not just ignored")
 
     def test_a_fresh_record_is_not_pruned(self):
         inflight.start("coder")
         self.assertEqual(inflight.live(), ["coder"])
+
+
+class PresumedDead(unittest.TestCase):
+    """The record outliving every reasonable expectation is the *most* interesting thing
+    this tracker can hold, and deleting it rendered it as nothing at all — "presumed dead"
+    and "never happened" were indistinguishable, irreversibly (#308).
+
+    So one threshold became two: past `PRESUMED_DEAD_SECONDS` a record is still returned,
+    flagged; only past `PRUNE_SECONDS` does it go away.
+    """
+
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self._orig = config.STATE_DIR
+        config.STATE_DIR = Path(self._td.name)
+        self.addCleanup(self._td.cleanup)
+        self.addCleanup(lambda: setattr(config, "STATE_DIR", self._orig))
+
+    def test_a_fresh_record_is_not_flagged(self):
+        inflight.start("coder")
+        self.assertEqual([r[2] for r in inflight.live_records()], [False])
+
+    def test_a_record_past_the_threshold_is_kept_and_flagged(self):
+        inflight.start("coder")
+        p = _age(_only_record(), inflight.PRESUMED_DEAD_SECONDS + 60)
+        recs = inflight.live_records()
+        self.assertEqual([(r[0], r[2]) for r in recs], [("coder", True)])
+        self.assertTrue(p.exists(), "a presumed-dead record must survive being read")
+
+    def test_reading_twice_does_not_consume_it(self):
+        """The old deletion was irreversible: the first render after the threshold was
+        the last one that could ever mention it."""
+        inflight.start("coder")
+        _age(_only_record(), inflight.PRESUMED_DEAD_SECONDS + 60)
+        inflight.live_records()
+        self.assertEqual([r[2] for r in inflight.live_records()], [True])
+
+    def test_the_age_keeps_climbing_past_the_threshold(self):
+        inflight.start("coder")
+        _age(_only_record(), 3 * 60 * 60)
+        started = inflight.live_records()[0][1]
+        self.assertAlmostEqual(started, time.time() - 3 * 60 * 60, delta=5)
+
+    def test_live_still_names_a_presumed_dead_dispatch(self):
+        """`_session_news` counts what `live()` returns, and the strip's aggregate counts
+        every record the tracker holds — the chips are where the distinction lives."""
+        inflight.start("coder")
+        _age(_only_record(), inflight.PRESUMED_DEAD_SECONDS + 60)
+        self.assertEqual(inflight.live(), ["coder"])
+
+    def test_the_prune_horizon_is_the_far_one(self):
+        self.assertGreater(inflight.PRUNE_SECONDS, inflight.PRESUMED_DEAD_SECONDS)
+
+    def test_finish_retires_a_live_record_before_a_presumed_dead_one(self):
+        """`finish` retires the OLDEST record for a name. Once the oldest can be a
+        presumed-dead stray, that rule alone would clear the stuck record and leave the
+        one that just finished behind — re-creating #308 through the back door."""
+        inflight.start("coder")
+        stuck = _age(_only_record(), inflight.PRESUMED_DEAD_SECONDS + 60)
+        inflight.start("coder")
+        inflight.finish("coder")
+        self.assertTrue(stuck.exists(), "the stuck record must survive a peer finishing")
+        self.assertEqual([r[2] for r in inflight.live_records()], [True])
+
+    def test_finish_retires_a_presumed_dead_record_when_nothing_else_is_live(self):
+        """A genuinely long dispatch does finish eventually, and when it does its record
+        must go — otherwise every run over the threshold leaks one."""
+        inflight.start("coder")
+        _age(_only_record(), inflight.PRESUMED_DEAD_SECONDS + 60)
+        inflight.finish("coder")
+        self.assertEqual(inflight.live(), [])
+
+    def test_finish_still_retires_the_oldest_of_several_live_records(self):
+        inflight.start("coder")
+        first = _age(_only_record(), 5 * 60)
+        inflight.start("coder")
+        inflight.finish("coder")
+        self.assertFalse(first.exists())
+        self.assertEqual(len(inflight.live_records()), 1)
 
     def test_an_agent_name_with_path_characters_is_made_safe(self):
         inflight.start("../../etc/passwd")
@@ -151,6 +251,16 @@ class DispatchNudge(unittest.TestCase):
     def test_silent_again_once_the_peer_finishes(self):
         self._run("coder")
         inflight.finish("coder")
+        self.assertEqual(self._run("coder").strip(), "")
+
+    def test_a_presumed_dead_peer_does_not_nudge(self):
+        """The nudge claims a peer *is already running*, and past the presumed-dead
+        threshold charter no longer knows that. Keeping the record so a stuck dispatch
+        stays visible (#308) must not turn into a nag that outlives the process by a day
+        — the window this asserts on is the one the old TTL pruning gave it.
+        """
+        self._run("coder")
+        _age(_only_record(), inflight.PRESUMED_DEAD_SECONDS + 60)
         self.assertEqual(self._run("coder").strip(), "")
 
     def test_an_unknown_agent_does_not_raise(self):

--- a/tests/test_statusline_inflight_chips.py
+++ b/tests/test_statusline_inflight_chips.py
@@ -82,14 +82,7 @@ class Chips(PersonaIso):
 
     def test_the_age_is_the_oldest_dispatch(self):
         """The newest is the least interesting: what a reader wants to know is how long
-        the longest-running one has been out.
-
-        Aged in minutes rather than hours because nothing older than
-        `inflight.TTL_SECONDS` can be observed at all — `live_records` prunes it as a
-        killed process. That the *most* alarming dispatch is the one that vanishes is
-        real and deliberately not fixed here (diazoxide/charter#308): it changes what
-        `inflight` means, not what this line draws.
-        """
+        the longest-running one has been out."""
         _start_aged("devops", 60)
         _start_aged("devops", 25 * 60)
         _start_aged("devops", 6 * 60)
@@ -113,6 +106,45 @@ class Chips(PersonaIso):
         `pieces._presence_age` already made, reused rather than re-litigated."""
         inflight.start("devops")
         self.assertIn("now", self._chip("devops"))
+
+    def test_a_live_dispatch_carries_no_question_mark(self):
+        _start_aged("devops", 4 * 60)
+        self.assertNotIn("?", self._chip("devops"))
+
+    def test_a_presumed_dead_dispatch_is_marked_after_its_age(self):
+        """`?` is the honest claim: charter cannot know whether the process died or is
+        genuinely still working, only that it has outlived every expectation (#308)."""
+        _start_aged("devops", inflight.PRESUMED_DEAD_SECONDS + 15 * 60)
+        self.assertIn("45m?", self._chip("devops"))
+
+    def test_the_age_can_now_reach_hours(self):
+        """Before #308 the badge's `2h`/`3d` vocabulary was unreachable: the record was
+        pruned at thirty minutes, so nothing older could ever be drawn."""
+        _start_aged("devops", 3 * 60 * 60)
+        self.assertIn("3h?", self._chip("devops"))
+
+    def test_one_presumed_dead_among_the_live_marks_the_chip(self):
+        """The count covers both, the age is the oldest — which is the presumed-dead one
+        by definition — so the mark belongs to the number beside it."""
+        _start_aged("devops", 60)
+        _start_aged("devops", inflight.PRESUMED_DEAD_SECONDS + 15 * 60)
+        chip = self._chip("devops")
+        self.assertIn("⚡2", chip)
+        self.assertIn("45m?", chip)
+
+    def test_a_presumed_dead_dispatch_still_counts_on_the_strip(self):
+        """The strip's aggregate counts every record the tracker holds; the chips are
+        where live and presumed-dead are told apart."""
+        _start_aged("devops", inflight.PRESUMED_DEAD_SECONDS + 60)
+        _start_aged("release", 60)
+        self.assertIn("⚡ 2", _plain(" ".join(statusline._session_news(None))))
+
+    def test_the_mark_is_the_only_new_character(self):
+        """`?` is ASCII and narrow. Every glyph this line already speaks is East-Asian
+        Neutral or Wide by deliberate choice — an Ambiguous one has broken the column
+        twice, so a new mark has to be checked, not assumed."""
+        import unicodedata
+        self.assertEqual(unicodedata.east_asian_width("?"), "Na")
 
     def test_a_broken_inflight_store_never_breaks_the_chips(self):
         orig = inflight.live_records
@@ -148,10 +180,13 @@ class RowsStayTrue(PersonaIso):
         self.addCleanup(lambda: setattr(update, "maybe_spawn", spawn))
         # A roster where every conditional badge is both present and absent: `flying`
         # declares a vault this machine has never registered (`◦`) and is in flight;
-        # `quiet` declares no vault at all (nothing) and is not.
+        # `stuck` is in flight past the presumed-dead threshold, so it carries the `?`
+        # too; `quiet` declares no vault at all (nothing) and is not in flight.
         self.make_persona("flying", role="F", vault="nowhere", **{"delegate-when": "x"})
+        self.make_persona("stuck", role="S", **{"delegate-when": "x"})
         self.make_persona("quiet", role="Q", **{"delegate-when": "x"})
         _start_aged("flying", 4 * 60)
+        _start_aged("stuck", 3 * 60 * 60)
 
     def _rendered(self, width=200):
         os.environ["COLUMNS"] = str(width)
@@ -193,12 +228,13 @@ class RowsStayTrue(PersonaIso):
         self.assertEqual(len(starts), 1,
                          f"right-column text starts at differing columns: {sorted(starts)}")
 
-    def test_the_column_shows_both_signals_at_once(self):
+    def test_the_column_shows_every_signal_at_once(self):
         """Guards the fixture: a width assertion over rows that carry no badges proves
         nothing."""
         col = "\n".join(_plain(c) for c in statusline._persona_chips())
         self.assertIn("◦", col)
         self.assertIn("⚡", col)
+        self.assertIn("3h?", col)
 
 
 class Records(PersonaIso):
@@ -208,7 +244,7 @@ class Records(PersonaIso):
     def test_records_carry_a_start_time(self):
         _start_aged("devops", 90)
         recs = inflight.live_records()
-        self.assertEqual([n for n, _ in recs], ["devops"])
+        self.assertEqual([n for n, _, _ in recs], ["devops"])
         self.assertAlmostEqual(recs[0][1], time.time() - 90, delta=5)
 
     def test_records_preserve_duplicates(self):
@@ -217,7 +253,7 @@ class Records(PersonaIso):
         self.assertEqual(len(inflight.live_records()), 2)
 
     def test_records_prune_the_stale_like_live_does(self):
-        _start_aged("devops", inflight.TTL_SECONDS + 60)
+        _start_aged("devops", inflight.PRUNE_SECONDS + 60)
         self.assertEqual(inflight.live_records(), [])
 
     def test_live_still_answers_with_names(self):
@@ -226,8 +262,10 @@ class Records(PersonaIso):
         self.assertEqual(inflight.live(), ["devops", "release"])
 
     def test_a_record_written_without_a_timestamp_falls_back_to_mtime(self):
-        """Records written by an older charter carry no ``ts``. A chip that renders `?`
-        for one is worse than one that uses the mtime, which is the same instant."""
+        """Records written by an older charter carry no ``ts``. Dropping one, or drawing
+        it with no age at all, would be worse than using the mtime — the same instant.
+        And since the presumed-dead flag is measured from whatever start time comes back,
+        a two-minute-old record still reads as live."""
         token = _start_aged("devops", 120)
         p = Path(config.STATE_DIR) / "dispatch-inflight" / f"{token}.json"
         when = p.stat().st_mtime
@@ -235,6 +273,7 @@ class Records(PersonaIso):
         os.utime(p, (when, when))
         recs = inflight.live_records()
         self.assertAlmostEqual(recs[0][1], when, delta=5)
+        self.assertFalse(recs[0][2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #308.

`inflight` deleted every record older than `TTL_SECONDS` (30 min) on each read. So the one
state the tracker exists to catch — a dispatch that has outlived every reasonable
expectation — rendered as *nothing at all*, permanently. "Presumed dead" and "never
happened" were the same picture, and the deletion was irreversible.

## Keep the record, mark it presumed-dead

One threshold was doing two jobs that want opposite horizons, so it becomes two:

| | |
|---|---|
| `PRESUMED_DEAD_SECONDS` = 30 min | the record is **kept** and flagged, not deleted |
| `PRUNE_SECONDS` = 24 h | when it is finally discarded, so a stray from a killed process still cannot accumulate forever |

`live_records` gains the flag as a third element. `live()` keeps its contract (`_session_news`
calls it) and still counts presumed-dead records: the strip's aggregate is what survives a
narrow pane, and a total that *shrank* as a dispatch got more worrying would be this bug in
miniature. The chips are where live and presumed-dead are told apart.

## On screen

The chip appends `?` after the age. Same fixture, both branches — `forge` has a 47-minute
dispatch and a 6-minute one, `statusline` has a 3-minute one:

**before** — the 47-minute record is deleted on read, so `forge` reads as a single
six-minute dispatch and the total says 2:

```
│ ▫ forge ◦ ✎3 ⚡ 6m                 │
│ ▫ statusline ✎9 ⚡ 3m              │
├───────────────────────────────────┤
│ ⚡ 2                               │
```

**after**:

```
│ ▫ forge ◦ ✎3 ⚡2 47m?              │
│ ▫ statusline ✎9 ⚡ 3m              │
├───────────────────────────────────┤
│ ⚡ 3                               │
```

The age keeps climbing — which is also what finally makes the badge's `2h`/`3d` vocabulary
reachable, since nothing used to survive long enough to render it. `?` says *presumed dead,
not confirmed*, which is the whole of what charter knows: it cannot tell a killed process
from a sub-agent still grinding. Hence a question mark rather than a cross, and no colour
escalation — it stays in the age's dim, because a red mark would claim exactly the certainty
the mark exists to disclaim.

`?` is ASCII and East-Asian **Narrow** (asserted in a test), unlike the Ambiguous glyphs that
have broken this column twice. Rendered at 80 / 140 / 200 columns: every row measures one
width in each (76 / 136 / 196), including the stacked single-column fallback at 80.

## Two rules follow the longer-lived record

* **`finish` retires the oldest *still-running* record for a name**, not simply the oldest.
  Oldest-first alone would hand a finishing dispatch the stuck record to retire and leave its
  own behind — deleting exactly what this change exists to keep, and leaving a false live one
  in its place. A presumed-dead record stays eligible when there is nothing else, because a
  genuinely long dispatch does finish eventually.
* **The dispatch overlap nudge reads `still_running`, not `live`.** It asserts a peer "is
  already running", which stops being true at the presumed-dead threshold; nudging on a
  presumed-dead record would nag for a day after a killed process, and a warning people learn
  to dismiss is worse than the overlap it reports. The window it acts on is exactly the one
  the old TTL pruning gave it.

## Cost and safety

Unchanged: one directory glob, no subprocess, no network. Pruning still reads the mtime
*before* the parse, which is what lets a corrupt stray be cleaned up at all; the presumed-dead
flag reads the same start time the age is drawn from, so the mark and the number can never
disagree about which side of the threshold a record sits on. Everything still degrades to
empty, and `render()`'s no-crash guarantee is unchanged.

## Tests

2864 pass, up from 2848 on `main` (+16, watched failing first). Docs updated
(`docs/personas.md`, `docs/control-plane.md`) plus an unreleased news entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo