### PR TITLE
Release 0.47.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.46.3",
+  "version": "0.47.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.46.3"
+__version__ = "0.47.0"

--- a/docs/news/0.47.0-persona-chip-signals.md
+++ b/docs/news/0.47.0-persona-chip-signals.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.47.0
 headline: The persona chips go quiet when nothing is wrong, and say who is running
 ---
 

--- a/docs/news/0.47.0-plugin-behind-names-handlers.md
+++ b/docs/news/0.47.0-plugin-behind-names-handlers.md
@@ -1,7 +1,6 @@
 ---
-version: unreleased
+version: 0.47.0
 headline: charter says which hooks are not running when your plugin is behind
-check: doctor
 ---
 
 charter ships as two artifacts with two version numbers, and they update through completely

--- a/docs/news/0.47.0-presumed-dead-dispatches.md
+++ b/docs/news/0.47.0-presumed-dead-dispatches.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.47.0
 headline: A stuck sub-agent now says so instead of disappearing
 ---
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.46.3",
+            "command": "charter hook sessionstart --plugin-version 0.47.0",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.46.3",
+            "command": "charter hook userpromptsubmit --plugin-version 0.47.0",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.46.3",
+            "command": "charter hook pretooluse --plugin-version 0.47.0",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.46.3",
+            "command": "charter hook pretooluse-read --plugin-version 0.47.0",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.46.3"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.47.0"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.46.3",
+            "command": "charter hook pretooluse-edit --plugin-version 0.47.0",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-bash --plugin-version 0.46.3",
+            "command": "charter hook posttooluse-bash --plugin-version 0.47.0",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.46.3",
+            "command": "charter hook posttooluse --plugin-version 0.47.0",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.46.3",
+            "command": "charter hook posttooluse-skill --plugin-version 0.47.0",
             "timeout": 5
           }
         ]
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.46.3",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.47.0",
             "timeout": 5
           }
         ]
@@ -128,7 +128,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-message --plugin-version 0.46.3",
+            "command": "charter hook posttooluse-message --plugin-version 0.47.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.46.3"
+version = "0.47.0"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only — no shipped-code changes beyond the news entries this stamps.

## What ships

- **#309** — the persona chips go quiet when nothing is wrong, and say who is running (`◦`/`!` vault marks, `⚡N age`, and the prompt-cache gauge becomes `cache NN%`).
- **#310** — a stuck sub-agent now says so instead of disappearing (`⚡2 47m?`, 24h prune, and the strip total no longer undercounts).
- **#307** — charter says which hooks are not running when your plugin is behind. Merged and unreleased, so it ships here regardless.

Minor rather than patch: two of the three change default rendering or add a diagnostic surface, and patch is reserved for fixes that add no surface. No breaking API changes.

## Version points moved

`pyproject.toml`, `charter/__init__.py`, `.claude-plugin/plugin.json`, 11 `--plugin-version` flags in `hooks/hooks.json`, and three `docs/news/` entries stamped. `docs/assets/captured.json` deliberately untouched — the asset-freshness gate passes at lag exactly 1, but **0.48.0 will fail it** until the captures are regenerated. `charter.toml` has no version pin, so there is nothing to move there.

## One fix rode along, and it is the reason this PR matters

`docs/news/0.47.0-plugin-behind-names-handlers.md` carried `check: doctor`. `charter doctor` runs every *released* entry's `check:` in-process through `news._dispatch`, which has no re-entrancy guard — so stamping that entry turned `doctor` into unbounded recursion, each level running a full check sweep.

It was invisible on `main` (`version: unreleased` entries are never probed) and **CI would not have caught it before the tag was burned**: `charter news --for 0.47.0` returns in 0.1s rc=0 and the tag/version guard passes, so only the `test` job fails — after a tag push has already fired the publish.

Reproduced: `charter doctor` still running after a 20s cap with the entry stamped; 2.1s with the line removed. The entry's own text says "Nothing to adopt", so carrying no probe was always correct.

The underlying defect — the missing guard, which lets any future entry re-arm this — is filed as #311 and deliberately not fixed here.

## Verification

- Full suite: 2864 tests, OK.
- `charter doctor` 2.1s rc=0, `doctor --json` 1.7s rc=0, `news --pending` 0.2s rc=0.
- Smoke tests of the shipped render functions: `⚡2 47m?`, `⚡2 12m`, `⚡ 3m`, `⚡ 3d?`; vault silent when healthy, `◦` when unusable; strip reads `ctx 38% · cache 92%`.