### PR TITLE
A probe never runs from inside a probe (#311)

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1995,7 +1995,7 @@ def cmd_news(args) -> int:
         if planeless:
             util.warn(_NO_PLANE)
             return 0
-        shown = 0
+        shown, unchecked = 0, 0
         for e in news.released():
             status, why = news.probe(e)
             if status == news.PENDING:
@@ -2006,8 +2006,17 @@ def cmd_news(args) -> int:
                 # silence would be read as "nothing to adopt" — the shape ADR 0013 and
                 # `doctor`'s not-checked hint both exist to refuse.
                 util.warn(f"{e.slug}: {why}")
+                unchecked += 1
         if not shown:
-            util.ok("nothing pending — every entry with a probe reports adopted.")
+            if unchecked:
+                # NOT the ✓ line, which claims every probe reported adopted — the one
+                # thing an unchecked entry did not say. A green tick printed under the
+                # warning it contradicts is how the warning stops being read.
+                util.warn(f"nothing pending, but {unchecked} entr"
+                          f"{'y' if unchecked == 1 else 'ies'} could not be checked — "
+                          f"which is not the same as nothing to adopt.")
+            else:
+                util.ok("nothing pending — every entry with a probe reports adopted.")
         return 0
 
     since = (getattr(args, "since", None) or "").strip()

--- a/charter/news.py
+++ b/charter/news.py
@@ -4,7 +4,7 @@ A *news entry* is a shipped, per-item note that a version introduced something, 
 an optional probe for whether this plane has adopted it. Not a changelog: an entry exists
 to be **acted on**, and one with nothing to adopt is one line.
 
-Three properties are load-bearing.
+Four properties are load-bearing.
 
 **It ships in the wheel.** Entries travel with the code that implements them, resolved the
 way :mod:`charter.docsrc` resolves documentation — packaged copy first, the repo's
@@ -23,6 +23,13 @@ no argv is ever handed to one, so an entry cannot become an arbitrary-command pr
 primitive wearing a documentation command" — and the stakes are higher here, because this
 one runs rather than prints. Being in-process is also what makes a dozen probes cheap
 enough for `doctor` to run on demand.
+
+**A probe never runs from inside a probe.** Some charter commands probe every entry
+themselves — `doctor` does, and so does `charter news --pending` — so an entry naming one
+puts the dispatcher inside itself, a full sweep at every level, forever (#311). The guard
+in :func:`_dispatch` refuses the nested call AND withholds the outer command's exit code,
+because the two halves fix different things: refusing bounds it, withholding is what keeps
+the answer honest.
 """
 
 from __future__ import annotations
@@ -51,6 +58,17 @@ _SHELLISH = set(";|&<>$`()\\\n\"'")
 
 _PACKAGED = Path(__file__).resolve().parent / "_news"
 _CHECKOUT = Path(__file__).resolve().parents[1] / "docs" / "news"
+
+#: How many :func:`_dispatch` calls are in flight, and whether one of them was refused for
+#: re-entry. Plain module state rather than a :class:`~contextvars.ContextVar`: a ContextVar
+#: reads its default in every new thread, so a probing command that fanned its own work out
+#: to a pool would walk straight past the guard — which is the one failure this exists to
+#: make impossible. The global's failure mode is the opposite and far cheaper: two probes
+#: racing in different threads would make each other `unknown`, which is wrong but bounded,
+#: honest, and not reachable today — `doctor` and `charter news` each walk their entries in
+#: one thread.
+_depth = 0
+_reentered = False
 
 
 class Entry(NamedTuple):
@@ -193,37 +211,80 @@ def resolves(parser, argv: str) -> bool:
 
 
 def _dispatch(argv: str) -> int | None:
-    """Run ``charter <argv>`` in this process. Exit code, or ``None`` if it could not run.
+    """Run ``charter <argv>`` in this process. Exit code, or ``None`` if there is no
+    usable one.
 
     ``None`` is the whole reason this returns an Optional rather than an int: a probe that
-    did not run must not be reported as an answer.
+    did not run — or that ran and answered a different question — must not be reported as
+    an answer.
+
+    **The guard is two halves, and only one of them is about the loop.** Refusing the
+    nested call bounds the recursion; clearing the outer call's exit code is what keeps the
+    result honest. A `doctor` inside a `doctor` exits 0 whenever nothing is broken, so an
+    outer probe that read that code would report the entry ADOPTED and never offer it
+    again — the entry would be hidden by the very bug it triggers. Bounded is not the same
+    as correct (ADR 0013).
     """
+    global _depth, _reentered
+    if not _depth:
+        # Cleared on the way IN, not on the way out, and before the early returns below:
+        # every top-level dispatch has to start clean, or a refusal recorded while probing
+        # the previous entry is read as this entry's answer.
+        _reentered = False
     tokens = _tokens(argv)
     if tokens is None:
         return None
+    if _depth:
+        _reentered = True
+        return None
     from . import cli
 
+    _depth += 1
     try:
         with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
             args = cli.build_parser().parse_args(tokens)
             func = getattr(args, "func", None)
             if func is None:
                 return None
-            return int(func(args) or 0)
+            code = int(func(args) or 0)
     except SystemExit:
         return None
     except Exception:
         return None
+    finally:
+        # In a `finally` because this function swallows everything above: released only on
+        # the happy path, the guard would stay armed for the life of the process the first
+        # time a `check:` raised — and argparse raises `SystemExit` for every malformed
+        # one — turning every later probe into `unknown` with no way to tell why.
+        _depth -= 1
+    return None if _reentered else code
+
+
+#: Three ways to have no answer, said three ways. "Did not run here" points the reader at
+#: their own machine, which is right for a check this CLI could not resolve and wrong for
+#: an entry whose `check:` can never run anywhere — folding those together hides the second
+#: behind the first, and the second is a defect in the entry that somebody has to fix.
+_NOT_RUN = ("`charter {check}` did not run here, so this entry is unchecked — neither "
+            "adopted nor pending")
+_PROBES = ("`charter {check}` probes news itself, so its exit code answers a different "
+           "question than this entry's — unchecked, neither adopted nor pending. A "
+           "`check:` has to name a command that does not probe")
+_IN_FLIGHT = ("`charter {check}` was not run: a probe is already in flight, and a probe "
+              "never runs from inside a probe — unchecked here")
 
 
 def probe(entry: Entry) -> tuple[str, str]:
     """Has this plane adopted *entry*? ``(status, why)``."""
     if not entry.check:
         return INFORMATIONAL, ""
+    # Read before dispatching: inside another probe, this one is refused before it runs,
+    # and blaming THIS entry's `check:` for probing would be a guess — the command already
+    # in flight is the one that probes, and it may not be this one.
+    in_flight = _depth > 0
     code = _dispatch(entry.check)
     if code is None:
-        return UNKNOWN, (f"`charter {entry.check}` did not run here, so this entry is "
-                         f"unchecked — neither adopted nor pending")
+        why = _IN_FLIGHT if in_flight else (_PROBES if _reentered else _NOT_RUN)
+        return UNKNOWN, why.format(check=entry.check)
     return (ADOPTED if code == 0 else PENDING), ""
 
 

--- a/docs/news/unreleased-probe-reentrancy.md
+++ b/docs/news/unreleased-probe-reentrancy.md
@@ -1,0 +1,23 @@
+---
+version: unreleased
+headline: A news entry can no longer hang `charter doctor`
+---
+
+A `check:` runs a charter subcommand in-process to answer "does this plane already have
+it?". Two charter commands probe every entry themselves — `charter doctor` and `charter
+news --pending` — so an entry naming one put the dispatcher inside itself: `doctor` →
+`check_news_adoption` → `probe` → `doctor`, a full preflight sweep at every level, without
+end. Measured here: killed at a 20-second cap, still going, against 1.8s healthy.
+
+It was dormant until the release that shipped it. A staged entry says `version:
+unreleased` and is never probed, so it passes review, CI and merge untouched and arms
+itself at `charter news stamp` — inside the bump PR, whose next step is the tag that
+publishes. `charter news --for <version>` answers in a tenth of a second and the release
+guard passes on it.
+
+A probe now never runs from inside a probe, and — the half that a depth counter alone does
+not fix — the entry is reported **unchecked** rather than adopted. A nested `doctor` exits
+0 whenever nothing is broken, so an outer probe that trusted that exit code would mark the
+entry taken up and never offer it again: the entry would be hidden by the very bug it
+caused. `charter doctor` counts it under "N unchecked" and `charter news --pending` names
+the entry, its `check:`, and why that `check:` can never answer.

--- a/tests/test_news_reentrancy.py
+++ b/tests/test_news_reentrancy.py
@@ -1,0 +1,230 @@
+"""A probe never runs from inside a probe.
+
+`check:` is dispatched in-process, so an entry naming a command that itself probes news
+puts `doctor` inside `doctor`: `doctor` → `check_news_adoption` → `probe` → `_dispatch`
+→ `doctor` … Each level runs a full sweep, so it does not finish (#311).
+
+Two properties made it worse than an ordinary bug, and both are what these tests pin:
+
+**It was dormant until release.** `version: unreleased` entries are never probed, so the
+landmine survived review, CI and merge untouched and armed itself at `charter news stamp`.
+
+**CI could not catch it before the tag burned.** `charter news --for <v>` answers in 0.1s
+and the release guard passes on it; only the `test` job fails — after the tag push has
+already fired the irreversible PyPI upload.
+
+So the fix is a guard rather than a rule about entries: whatever a `check:` names, the
+probe is bounded and its answer is honest. "Honest" is the harder half — a nested `doctor`
+exits 0 whenever nothing is broken, and taking that as the probe's answer would report the
+entry **adopted**, which hides it forever. A re-entered probe therefore has no answer at
+all: `unknown`, the ADR 0013 shape, and the reason names the entry rather than the machine.
+
+Every test here bounds itself. A real recursion must fail CI, not wedge it, so the sweep
+count is capped inside the test and asserted on — never left to a wall clock.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands, config, doctor, news
+
+#: How many doctor sweeps a test tolerates before it breaks the loop itself. Two is the
+#: guarded answer (the outer sweep, plus the one nested dispatch that is then refused);
+#: anything beyond that is the bug. The cap exists so an unguarded tree ends in a failed
+#: assertion instead of a hung runner.
+SWEEP_CAP = 6
+
+
+class NewsDir(unittest.TestCase):
+    """Entries read from a throwaway directory, so no test depends on what shipped."""
+
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        patch = mock.patch.object(news, "_PACKAGED", self.dir)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def write(self, check: str, *, slug: str = "x", version: str = "0.44.0") -> news.Entry:
+        (self.dir / f"{version}-{slug}.md").write_text(
+            f"---\nversion: {version}\nheadline: h\ncheck: {check}\nadopt: version\n---\nbody\n")
+        return [e for e in news.all() if e.slug == slug][0]
+
+
+class CheckDoctor(NewsDir):
+    """The reproduction from #311, with the network-bound checks removed.
+
+    `doctor._checks` is replaced by one that runs the real `check_news_adoption` — the real
+    probe, the real `_dispatch`, the real parser, the real `cmd_doctor` — and nothing else.
+    What is removed is only what makes a full sweep slow and machine-dependent; the loop
+    itself is the shipped one.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.sweeps = 0
+
+        def sweep():
+            self.sweeps += 1
+            if self.sweeps > SWEEP_CAP:
+                # Break the loop rather than recursing on. Without this an unguarded tree
+                # runs until the interpreter's recursion limit, through a full sweep at
+                # every level — which is a hung CI job, not a red one.
+                return []
+            return [doctor.check_news_adoption()]
+
+        patch = mock.patch.object(doctor, "_checks", sweep)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def _doctor(self) -> list[dict]:
+        out = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(io.StringIO()):
+            commands.cmd_doctor(SimpleNamespace(json=True))
+        return json.loads(out.getvalue())
+
+    def test_doctor_finishes_when_an_entry_checks_doctor(self):
+        self.write("doctor")
+        self._doctor()
+        self.assertLessEqual(
+            self.sweeps, 2,
+            f"`check: doctor` re-entered doctor {self.sweeps} times — a probe must not "
+            f"run from inside a probe")
+
+    def test_the_entry_is_reported_unchecked_never_adopted(self):
+        """The half a depth guard alone does not fix.
+
+        Refusing only the *nested* dispatch leaves the outer one reading the nested
+        `doctor`'s exit code, which is 0 on a healthy plane — so the entry would report
+        **adopted** and never be offered again. A re-entered probe has no answer.
+        """
+        self.write("doctor")
+        row, = [r for r in self._doctor() if r["name"] == "news"]
+        self.assertEqual(row["status"], doctor.WARN)
+        self.assertIn("unchecked", row["detail"])
+
+
+class ARefusedProbe(NewsDir):
+    def test_a_check_that_probes_news_is_unknown(self):
+        """`news --pending` is the other surface that probes, so the guard is about the
+        shape and not about `doctor` — any command that probes is one a probe cannot use."""
+        e = self.write("news --pending")
+        with mock.patch.object(config, "HAS_CONTROL_PLANE", True):
+            status, why = news.probe(e)
+        self.assertEqual(status, news.UNKNOWN)
+        self.assertTrue(why.strip())
+
+    def test_the_reason_blames_the_entry_and_not_this_machine(self):
+        """A probe that could not run *here* and a probe that can never run are both
+        `unknown`, and folding them into one sentence hides the second behind the first.
+        "did not run here" invites the reader to check their machine; nothing about their
+        machine is wrong."""
+        e = self.write("news --pending")
+        with mock.patch.object(config, "HAS_CONTROL_PLANE", True):
+            _, why = news.probe(e)
+        self.assertNotIn("did not run here", why)
+        self.assertIn("news --pending", why)
+
+    def _pending(self) -> str:
+        err = io.StringIO()
+        args = SimpleNamespace(pending=True, since=None, until=None, for_version=None)
+        with mock.patch.object(config, "HAS_CONTROL_PLANE", True), \
+             redirect_stdout(io.StringIO()), redirect_stderr(err):
+            commands.cmd_news(args)
+        return err.getvalue()
+
+    def test_charter_news_pending_prints_the_reason(self):
+        """The one line that makes the next instance self-evident. `doctor` counts it as
+        "1 unchecked" and points here; here is where the entry is named as the defect."""
+        self.write("news --pending", slug="broken")
+        self.assertIn("broken", self._pending())
+
+    def test_pending_does_not_then_tick_every_probe_as_answered(self):
+        """The closing ✓ claims *every entry with a probe reports adopted* — which is the
+        one thing an unchecked entry did not say. Printed under the warning it contradicts,
+        it is how the warning stops being read: the eye takes the tick as the summary."""
+        self.write("news --pending", slug="broken")
+        err = self._pending()
+        self.assertNotIn("every entry with a probe reports adopted", err)
+        self.assertIn("could not be checked", err)
+
+    def test_pending_still_ticks_when_every_probe_did_answer(self):
+        """And the tick survives where it is true — a guard that removed the good news
+        along with the false claim would be a worse trade than the bug."""
+        e = self.write("version", slug="fine")
+        with mock.patch.object(commands, "cmd_version", lambda args: 0):
+            self.assertEqual(news.probe(e)[0], news.ADOPTED)
+            self.assertIn("every entry with a probe reports adopted", self._pending())
+
+
+class TheGuardDoesNotBreakProbing(NewsDir):
+    """The feature still works. A guard that quietly turned every probe into `unknown`
+    would pass every test above and report nothing to anybody."""
+
+    def _probe(self, code: int):
+        e = self.write("version")
+        ran = []
+
+        def cmd(args):
+            ran.append(True)
+            return code
+
+        with mock.patch.object(commands, "cmd_version", cmd):
+            status, why = news.probe(e)
+        self.assertEqual(len(ran), 1, "the probe did not actually run the subcommand")
+        return status, why
+
+    def test_a_check_that_exits_zero_still_reports_adopted(self):
+        self.assertEqual(self._probe(0)[0], news.ADOPTED)
+
+    def test_a_check_that_exits_non_zero_still_reports_pending(self):
+        self.assertEqual(self._probe(1)[0], news.PENDING)
+
+    def test_two_probes_in_a_row_both_run(self):
+        """A guard set on the way in and never released would refuse everything after the
+        first probe — the whole feature, broken by its own fix, and only on the second
+        entry so a single-entry test would not see it."""
+        self.assertEqual(self._probe(0)[0], news.ADOPTED)
+        self.assertEqual(self._probe(1)[0], news.PENDING)
+
+
+class TheGuardIsReleasedOnFailure(NewsDir):
+    def test_a_probe_that_raises_leaves_nothing_armed(self):
+        """`_dispatch` swallows every exception, so a command that blows up is a normal
+        outcome here — and the one path where a guard set outside a `finally` stays armed
+        for the life of the process, turning every later probe into `unknown`."""
+        e = self.write("version")
+
+        def boom(args):
+            raise RuntimeError("probe exploded")
+
+        with mock.patch.object(commands, "cmd_version", boom):
+            self.assertEqual(news.probe(e)[0], news.UNKNOWN)
+
+        with mock.patch.object(commands, "cmd_version", lambda args: 0):
+            self.assertEqual(news.probe(e)[0], news.ADOPTED)
+
+    def test_a_probe_that_exits_leaves_nothing_armed(self):
+        """`SystemExit` is not an `Exception`, so it takes a different path out of
+        `_dispatch` — and argparse raises it for every malformed `check:`."""
+        e = self.write("version")
+
+        def bail(args):
+            raise SystemExit(2)
+
+        with mock.patch.object(commands, "cmd_version", bail):
+            self.assertEqual(news.probe(e)[0], news.UNKNOWN)
+
+        with mock.patch.object(commands, "cmd_version", lambda args: 0):
+            self.assertEqual(news.probe(e)[0], news.ADOPTED)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A `check:` runs a charter subcommand in-process to answer "does this plane already have
it?". Two charter commands probe every entry themselves — `charter doctor` and `charter
news --pending` — so an entry naming one puts `news._dispatch` inside itself:

```
doctor → check_news_adoption → probe → _dispatch → doctor → …
```

a full preflight sweep at every level, without end.

## Why a guard and not a rule about entries

Two properties make an entry-level rule insufficient, and both are what the tests pin:

* **Dormant until release.** A staged entry says `version: unreleased` and is never
  probed, so the landmine passes review, CI and merge untouched and arms itself at
  `charter news stamp` — inside the bump PR, whose next step is the tag.
* **CI cannot catch it before the tag burns.** `charter news --for <v>` answers in 0.1s
  and the release guard passes on it; only the `test` job fails, after the tag push has
  already fired the irreversible PyPI upload. 0.47.0 shipped this exact class of entry and
  had to strip its `check:` in the release commit.

## The guard is two halves, and only one is about the loop

1. A module-level **depth counter** refuses the nested dispatch, decremented in a
   `finally` — `_dispatch` swallows every exception and argparse raises `SystemExit` for
   every malformed `check:`, so a guard released only on the happy path would stay armed
   for the life of the process and turn every later probe into `unknown`.
2. The outer dispatch then **withholds its exit code**. This is the half a depth counter
   alone does not fix: a nested `doctor` exits 0 whenever nothing is broken, so an outer
   probe that believed that code would report the entry **adopted** and never offer it
   again — the entry hidden by the very bug it caused. It reports `unknown` instead, with
   a reason naming the entry's `check:` rather than the reader's machine (ADR 0013).

A plain global rather than a `ContextVar`: a ContextVar reads its default in every new
thread, so a probing command that fanned its work out to a pool would walk straight past
the guard — the one failure this exists to make impossible. The global's failure mode is
the opposite and far cheaper (two probes racing in different threads make each other
`unknown`), and nothing probes concurrently today.

## Evidence

A fabricated, stamped `check: doctor` entry, run as a subprocess under a hard 20s cap
against a real `charter doctor --json` sweep. The entry lives in a throwaway directory only
that process is told about, so no shipped entry is touched:

```
before (HEAD, unguarded):   TIMEOUT after 20.00s — killed, still sweeping
after  (guarded):           finished in 3.71s, exit 0
healthy baseline:           1.81s   (no self-referential entry at all)
```

3.71s is the bound the tests assert: the outer sweep plus exactly one nested dispatch,
which is then refused. The `news` row from the guarded run:

```json
{ "name": "news", "status": "warn", "detail": "1 unchecked",
  "hint": "See them: charter news --pending" }
```

And the honesty half, with `check: news --pending` — which on `main` reports **nothing at
all**, because the nested run exits 0:

```
before:  ✓ nothing pending — every entry with a probe reports adopted.   (4.39s)
after:   ! repro: `charter news --pending` probes news itself, so its exit code answers a
           different question than this entry's — unchecked, neither adopted nor pending.
           A `check:` has to name a command that does not probe
         ! nothing pending, but 1 entry could not be checked — which is not the same as
           nothing to adopt.                                              (0.03s)
```

## Tests

`tests/test_news_reentrancy.py`, 12 tests. Every one bounds itself — the doctor sweep
count is capped inside the test and asserted on, never left to a wall clock, so a
regression fails CI instead of wedging it. They cover the loop, the `unknown` answer, the
reason's wording, that ordinary probing still reports adopted/pending, that two probes in a
row both run, and that a `check:` which raises or exits leaves nothing armed.

```
main:        Ran 2864 tests — OK
this branch: Ran 2876 tests — OK   (2864 + 12)
```

## Rulings the issue asked for

**Does a surface warn?** No new surface. `charter doctor` already counts the entry under
"N unchecked" and points at `charter news --pending`, which already names it — the work was
in the message, not a new line. One line *was* removed: `--pending` used to close with
"nothing pending — every entry with a probe reports adopted" directly beneath the warning
saying one entry did not, which is how a warning stops being read. It now names the
unchecked count instead.

**A static check on shipped entries?** Ruled against. The set of probing commands cannot be
stated statically without drifting into a lie: `news --pending` and `news --since` probe,
`news --for` does not, so a blanket ban on `news` would refuse a legitimate `check:` and a
precise list is a lint pass that rots. With the guard in place a miss now costs an honest
`unknown` instead of a hang.

**The same shape elsewhere.** `news._dispatch` is the only place outside `cli.main` that
builds the parser and calls `args.func`. One related gap found and **not** fixed here,
because it is a different mechanism: `commands_update._handoff` spawns a *fresh charter
process* running `charter news --since <baseline>`, which probes. `check: update …` would
therefore reach a probe across a process boundary, where this process-local counter cannot
see it. It terminates today only by accident of version arithmetic — `_stamp_baseline`
runs first, so the child's `between(installed, installed)` is empty — and no shipped entry
names `update`. Filed as #314 rather than folded in.

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo
