### PR TITLE
Release 0.47.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.47.0",
+  "version": "0.47.1",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.47.0"
+__version__ = "0.47.1"

--- a/docs/news/0.47.1-probe-reentrancy.md
+++ b/docs/news/0.47.1-probe-reentrancy.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.47.1
 headline: A news entry can no longer hang `charter doctor`
 ---
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.47.0",
+            "command": "charter hook sessionstart --plugin-version 0.47.1",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.47.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.47.1",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.47.0",
+            "command": "charter hook pretooluse --plugin-version 0.47.1",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.47.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.47.1",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.47.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.47.1"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.47.0",
+            "command": "charter hook pretooluse-edit --plugin-version 0.47.1",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-bash --plugin-version 0.47.0",
+            "command": "charter hook posttooluse-bash --plugin-version 0.47.1",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.47.0",
+            "command": "charter hook posttooluse --plugin-version 0.47.1",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.47.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.47.1",
             "timeout": 5
           }
         ]
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.47.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.47.1",
             "timeout": 5
           }
         ]
@@ -128,7 +128,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-message --plugin-version 0.47.0",
+            "command": "charter hook posttooluse-message --plugin-version 0.47.1",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.47.0"
+version = "0.47.1"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bumps the four version points in lockstep and stamps the one staged news entry onto `0.47.1`.

Ships exactly one change since `v0.47.0` — everything else on `main` is control-plane `charter save` noise:

- **#313** (closes **#311**) — a probe never runs from inside a probe.

## Patch, not minor

Both halves are fixes and neither adds surface: no new flag, no new config key, no changed default.

`charter news --pending` does print differently, but only in the state that was already wrong — it no longer follows *"this entry could not be checked"* with a green ✓ claiming every probe reported adopted. Correcting a contradiction is not a changed default.

Worth stating explicitly, because it looks like a convenient answer: `docs/assets/captured.json` is stamped `0.46.0`, and `tests/test_asset_freshness.py` fails only when lag **exceeds** one minor. `0.47.1` sits at exactly one and passes; a `0.48.0` would have failed it and needed the SVG captures regenerated first. That gate did not pick the number — it would have been a patch either way.

## Version points moved

| Point | 0.47.0 → 0.47.1 |
|---|---|
| `pyproject.toml` | 1 |
| `charter/__init__.py` | 1 |
| `.claude-plugin/plugin.json` | 1 |
| `hooks/hooks.json` `--plugin-version` | 11 |
| `docs/news/` | `unreleased-probe-reentrancy.md` → `0.47.1-probe-reentrancy.md` |

Verified by re-grepping for the **old** string across the tree rather than by counting: no `0.47.0` remains outside `personas/` and `workspaces/` memory prose, where it is a historical fact.

## Verification

- **Full suite green on this branch**: `Ran 2876 tests in 71.867s — OK`, exit 0. Matches the `main` baseline exactly; the bump adds no tests.
- **`charter doctor` under a hard 90s cap, after stamping**: rc=0 in **1.27s**, `news: nothing to adopt`. The stamped entry carries **no `check:`** — verified, not assumed. The only three `check:` lines in `docs/news/` are all `persona lint`, which does not probe news.
- **The guard does what it says, checked against real behaviour.** The same self-referential `check: doctor` entry planted in two scratch trees:

  | | v0.47.0 `news.py` | this branch |
  |---|---|---|
  | `charter doctor` | **killed at a 45s cap, still running** | rc=0 in **1.33s**, `news: 1 unchecked` |

  and `charter news --pending` on this branch names the entry and why, with no ✓ beneath it:

  > `! landmine: `charter doctor` probes news itself, so its exit code answers a different question than this entry's — unchecked, neither adopted nor pending. A `check:` has to name a command that does not probe`
  > `! nothing pending, but 1 entry could not be checked — which is not the same as nothing to adopt.`

  Reported `unknown`, not `adopted` — the honesty half, which is what keeps the entry from being hidden by the bug it triggers.
- Probing the landmine does not poison the next entry (`adopted` still `adopted`), `_depth` returns to 0, and a malformed `check:` that raises `SystemExit` leaves the guard unarmed.
- `python -m charter news --for 0.47.1` — the exact call CI's `guard` job makes and the source of the Release body — exits 0 and renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo