### PR TITLE
Carry the news probe guard across process boundaries (#314)

### DIFF
--- a/charter/commands_update.py
+++ b/charter/commands_update.py
@@ -131,6 +131,18 @@ def _handoff(target: str, baseline: str) -> tuple[bool, str]:
     `cmd_version_sync` already says out loud — and a binary that answers with the target
     version IS the proof the install took. Without that, an install that succeeded against
     a cached index reports success while leaving you where you started.
+
+    **This is the charter process that made #314 a loop**, and what used to bound it is
+    worth naming rather than leaving to be rediscovered. `charter news --since` probes, and
+    a probe can dispatch `update`, so the chain comes back here — in a new interpreter,
+    where a counter in `news` starts at zero again. It terminated only because `cmd_update`
+    stamps its baseline BEFORE it moves and hands the pre-install version down as *baseline*:
+    once the target is installed the child asks for `between(installed, installed)`, which
+    is empty because `news.between` is exclusive at the low end, so it probes nothing. True,
+    and an accident — arithmetic in another module, one refactor from silently going away.
+    The guard no longer rests on it: `news._ENV` marks the environment for the length of a
+    probe and the charter started here inherits it, so it declines to probe whatever its
+    range says. `tests/test_news_cross_process.py` pins both.
     """
     binary = shutil.which("charter")
     if not binary:
@@ -190,7 +202,21 @@ def _resolve_target(args, installed: str, locked: str | None) -> tuple[str | Non
 
 
 def cmd_update(args) -> int:
-    from . import doctor, harness, instance
+    from . import doctor, harness, instance, news
+
+    if news.probing():
+        # FIRST, before the checkout refusal below and before anything is read, because
+        # this one is true wherever it is typed. A news entry's `check:` is dispatched as a
+        # charter subcommand, so `check: update --to X` reaches the installer below and
+        # reinstalls the machine to answer a question about it (#314) — a probe that
+        # installs software is a worse bug than a probe that hangs. The environment marker
+        # cannot stop this: it only reaches processes charter SPAWNS, and this one is the
+        # probe itself, running at the depth the guard permits by design.
+        news.refuse_mutation()
+        util.err("refusing to update from inside a news probe — a `check:` asks whether "
+                 "this plane already has something; it cannot be the thing that gets it.")
+        util.info("  the entry naming `update` is the defect:  charter news --pending")
+        return 2
 
     if doctor._is_charter_checkout(config.ROOT):
         # `CONTRIBUTING.md` tells contributors to run `python3 -m charter …` from the

--- a/charter/news.py
+++ b/charter/news.py
@@ -18,11 +18,14 @@ entry forever. This is `doctor`'s ``_NOT_CHECKED_HINT`` in another costume: the 
 information is not evidence of health (ADR 0013).
 
 **Actions are charter subcommands, dispatched in-process.** No shell is ever involved and
-no argv is ever handed to one, so an entry cannot become an arbitrary-command primitive.
-`docsrc._TOPIC` keeps the same restraint for `docs show` — "must not be a file-read
-primitive wearing a documentation command" — and the stakes are higher here, because this
-one runs rather than prints. Being in-process is also what makes a dozen probes cheap
-enough for `doctor` to run on demand.
+no argv is ever handed to one, so an entry is meant not to be an arbitrary-command
+primitive. `docsrc._TOPIC` keeps the same restraint for `docs show` — "must not be a
+file-read primitive wearing a documentation command" — and the stakes are higher here,
+because this one runs rather than prints. Being in-process is also what makes a dozen
+probes cheap enough for `doctor` to run on demand. That restraint currently leaks: `secret
+exec` takes a pass-through argv, so a `check:` naming it reaches any binary, with a vault's
+credential in its environment (#317). Said out loud here rather than left as a claim this
+module does not keep.
 
 **A probe never runs from inside a probe.** Some charter commands probe every entry
 themselves — `doctor` does, and so does `charter news --pending` — so an entry naming one
@@ -30,11 +33,27 @@ puts the dispatcher inside itself, a full sweep at every level, forever (#311). 
 in :func:`_dispatch` refuses the nested call AND withholds the outer command's exit code,
 because the two halves fix different things: refusing bounds it, withholding is what keeps
 the answer honest.
+
+**And that guard has to survive `exec`.** Some charter commands start another charter —
+`commands_update._handoff` runs `charter news --since` in a fresh process of the newly
+installed binary — so re-entry does not have to come back up this module's stack. A depth
+counter is blind to that, which is why one also travels in the environment (:data:`_ENV`):
+a charter started underneath a probe is inside that probe, whatever spawned it (#314). Both
+halves cross with it — the refusal going down, and word of it coming back up, so an entry
+whose command spawned a charter that declined is unchecked rather than adopted.
+
+**A probe reads; it does not act.** The marker only ever reaches a CHILD, and the frightening
+half of #314 was never in the child: `check: update …` runs a real `uv tool install` in the
+process that IS the probe, at the depth the counter permits by design. So the mutation
+declines on its own account — :func:`probing` is public for exactly that, and refusing is
+only half of it, because a command that declined has no exit code worth reading.
 """
 
 from __future__ import annotations
 
 import io
+import os
+import tempfile
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import NamedTuple
@@ -59,16 +78,39 @@ _SHELLISH = set(";|&<>$`()\\\n\"'")
 _PACKAGED = Path(__file__).resolve().parent / "_news"
 _CHECKOUT = Path(__file__).resolve().parents[1] / "docs" / "news"
 
-#: How many :func:`_dispatch` calls are in flight, and whether one of them was refused for
-#: re-entry. Plain module state rather than a :class:`~contextvars.ContextVar`: a ContextVar
-#: reads its default in every new thread, so a probing command that fanned its own work out
-#: to a pool would walk straight past the guard — which is the one failure this exists to
-#: make impossible. The global's failure mode is the opposite and far cheaper: two probes
-#: racing in different threads would make each other `unknown`, which is wrong but bounded,
-#: honest, and not reachable today — `doctor` and `charter news` each walk their entries in
-#: one thread.
+#: How many :func:`_dispatch` calls are in flight, and — when the outermost one has no
+#: answer to give — why. Plain module state rather than a :class:`~contextvars.ContextVar`:
+#: a ContextVar reads its default in every new thread, so a probing command that fanned its
+#: own work out to a pool would walk straight past the guard — which is the one failure this
+#: exists to make impossible. The global's failure mode is the opposite and far cheaper: two
+#: probes racing in different threads would make each other `unknown`, which is wrong but
+#: bounded, honest, and not reachable today — `doctor` and `charter news` each walk their
+#: entries in one thread.
 _depth = 0
-_reentered = False
+_refused: str | None = None
+
+#: The same guard, in a form that survives `exec`. :func:`_dispatch` sets this for the
+#: length of a probe, so every process started underneath one inherits it and declines to
+#: probe: `commands_update._handoff` starts a fresh `charter news --since`, and `secret exec`
+#: will start whatever an entry names. A counter in this module's memory sees none of that.
+#:
+#: The value is ``<pid>:<path>``, and it carries both halves of the guard.
+#:
+#: **The PID** is the process running the probe, which is what keeps the marker from
+#: becoming the worse bug. An environment belongs to a process, so this cannot escape into
+#: the shell that started charter; it is restored in the same `finally` that releases the
+#: counter, so a probe that raises leaves nothing behind; and if a copy ever does turn up
+#: somewhere charter did not put it, it names a process — one that no longer exists guards
+#: nothing, and is ignored rather than believed. Believed, a scrap of stale environment
+#: would turn every probe on that machine into `unknown` for good and say nothing about why.
+#:
+#: **The path** is where a descendant that was refused leaves a mark, because bounding the
+#: loop is not the same as answering honestly. A child cannot reach into the memory of the
+#: process probing, and its exit code belongs to whatever it was actually asked to do — so
+#: without a way back up, a `check:` whose command exits 0 while the charter it spawned
+#: quietly declined would report the entry ADOPTED. That is #311's second half, one process
+#: further away.
+_ENV = "CHARTER_NEWS_PROBE"
 
 
 class Entry(NamedTuple):
@@ -210,6 +252,84 @@ def resolves(parser, argv: str) -> bool:
     return True
 
 
+def _outer_probe() -> int | None:
+    """The PID of a process ABOVE this one that is running a probe, or ``None``.
+
+    Three ways the marker means nothing, and each of them is a defect if believed. It is
+    not a PID at all — debris, or somebody's guess at the name. It is **this** process's:
+    :func:`_dispatch` sets the marker for its children to inherit, and a process that read
+    its own marker back as an ancestor's would refuse the very probe it is running. Or it
+    names a process that has exited, in which case the probe it stood for is gone too.
+    """
+    raw = os.environ.get(_ENV, "").partition(":")[0]
+    if not raw.isdigit():
+        return None
+    pid = int(raw)
+    if pid <= 0 or pid == os.getpid():
+        return None
+    if os.name != "posix":
+        # `os.kill(pid, 0)` is a question on POSIX and an ANSWER on Windows, where it maps
+        # to TerminateProcess and would kill whatever the marker named. So off POSIX the
+        # marker is taken at its word: a stale one costs `unknown` — which is loud, and
+        # says why — where getting this wrong costs somebody else's process.
+        return pid
+    try:
+        os.kill(pid, 0)   # signal 0 asks whether it exists; it sends nothing
+    except ProcessLookupError:
+        return None
+    except OSError:
+        pass              # alive, and not ours to signal — still a probe
+    return pid
+
+
+def probing() -> bool:
+    """Is an entry's ``check:`` running right now — here, or in a process above this one?
+
+    Public, because the answer is not only this module's business. A probe asks whether
+    this plane has something; anything that would answer by CHANGING the machine has to
+    decline, and say so through :func:`refuse_mutation` so the entry comes back unchecked
+    rather than pending. `commands_update.cmd_update` is the one that does today: its
+    installer is a real `uv tool install`, and it runs in the process that IS the probe —
+    at the depth the counter permits, where no marker in a child's environment reaches.
+    """
+    return _depth > 0 or _outer_probe() is not None
+
+
+def _mark_refusal() -> None:
+    """Leave word, for the process whose probe this is, that a descendant was refused.
+
+    The only channel there is. Never raises: a temporary directory that cannot be written
+    costs the outer probe its honesty — it falls back to reading an exit code — and must
+    not cost the caller anything at all, which is the rule `news` is held to on the
+    `doctor` and SessionStart paths.
+    """
+    if _outer_probe() is None:
+        # This process's own probe. It already knows — the flag it reads is in memory, and
+        # writing a file to tell ourselves would put the `doctor` path through the disk to
+        # learn what it just decided.
+        return
+    _, _, mark = os.environ.get(_ENV, "").partition(":")
+    if not mark:
+        return
+    try:
+        Path(mark).touch()
+    except OSError:
+        pass
+
+
+def refuse_mutation() -> None:
+    """Record that a command declined to run because a probe is in flight.
+
+    Stopping the mutation is the easy half. The command still has to return SOMETHING, and
+    whatever it returns is not an answer to "has this plane adopted this entry?" — so the
+    exit code is withheld here exactly as a re-entered one is, and the entry reports
+    `unknown`. Reporting `pending` instead would invent a chore on a plane that may well
+    have adopted the entry already.
+    """
+    global _refused
+    _refused = _MUTATES
+
+
 def _dispatch(argv: str) -> int | None:
     """Run ``charter <argv>`` in this process. Exit code, or ``None`` if there is no
     usable one.
@@ -224,22 +344,32 @@ def _dispatch(argv: str) -> int | None:
     outer probe that read that code would report the entry ADOPTED and never offer it
     again — the entry would be hidden by the very bug it triggers. Bounded is not the same
     as correct (ADR 0013).
+
+    Re-entry is refused by :func:`probing`, not by the counter alone, so it is refused the
+    same way whether it came back up this stack or through a process charter spawned on the
+    way (#314).
     """
-    global _depth, _reentered
+    global _depth, _refused
     if not _depth:
         # Cleared on the way IN, not on the way out, and before the early returns below:
         # every top-level dispatch has to start clean, or a refusal recorded while probing
         # the previous entry is read as this entry's answer.
-        _reentered = False
+        _refused = None
     tokens = _tokens(argv)
     if tokens is None:
         return None
-    if _depth:
-        _reentered = True
+    if probing():
+        _refused = _PROBES
+        _mark_refusal()
         return None
     from . import cli
 
     _depth += 1
+    outer = os.environ.get(_ENV)
+    mark = Path(tempfile.gettempdir()) / f"charter-probe-{os.getpid()}"
+    mark.unlink(missing_ok=True)   # a PID gets reused; a mark from its last owner is not
+                                   # this probe's answer
+    os.environ[_ENV] = f"{os.getpid()}:{mark}"
     try:
         with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
             args = cli.build_parser().parse_args(tokens)
@@ -255,12 +385,25 @@ def _dispatch(argv: str) -> int | None:
         # In a `finally` because this function swallows everything above: released only on
         # the happy path, the guard would stay armed for the life of the process the first
         # time a `check:` raised — and argparse raises `SystemExit` for every malformed
-        # one — turning every later probe into `unknown` with no way to tell why.
+        # one — turning every later probe into `unknown` with no way to tell why. The
+        # marker is put back rather than deleted, for the same reason: charter is not the
+        # only thing that may have set a variable in its own environment.
         _depth -= 1
-    return None if _reentered else code
+        if mark.exists():
+            # Some charter below this one declined to probe, so the exit code about to be
+            # returned is not this entry's answer — it is whatever the command did while a
+            # descendant of it was refused. Same withholding as an in-process re-entry, and
+            # for the same reason: bounded is not correct (ADR 0013).
+            _refused = _PROBES
+            mark.unlink(missing_ok=True)
+        if outer is None:
+            os.environ.pop(_ENV, None)
+        else:
+            os.environ[_ENV] = outer
+    return None if _refused else code
 
 
-#: Three ways to have no answer, said three ways. "Did not run here" points the reader at
+#: Four ways to have no answer, said four ways. "Did not run here" points the reader at
 #: their own machine, which is right for a check this CLI could not resolve and wrong for
 #: an entry whose `check:` can never run anywhere — folding those together hides the second
 #: behind the first, and the second is a defect in the entry that somebody has to fix.
@@ -271,19 +414,23 @@ _PROBES = ("`charter {check}` probes news itself, so its exit code answers a dif
            "`check:` has to name a command that does not probe")
 _IN_FLIGHT = ("`charter {check}` was not run: a probe is already in flight, and a probe "
               "never runs from inside a probe — unchecked here")
+_MUTATES = ("`charter {check}` changes this machine rather than reading it, so it was not "
+            "run — a `check:` asks whether this plane already has something and cannot be "
+            "the thing that goes and gets it. Unchecked, neither adopted nor pending")
 
 
 def probe(entry: Entry) -> tuple[str, str]:
     """Has this plane adopted *entry*? ``(status, why)``."""
     if not entry.check:
         return INFORMATIONAL, ""
-    # Read before dispatching: inside another probe, this one is refused before it runs,
-    # and blaming THIS entry's `check:` for probing would be a guess — the command already
-    # in flight is the one that probes, and it may not be this one.
-    in_flight = _depth > 0
+    # Read before dispatching: inside another probe — this process's, or one it was
+    # spawned by — this one is refused before it runs, and blaming THIS entry's `check:`
+    # for probing would be a guess. The command already in flight is the one that probes,
+    # and it may not be this one; across a process boundary it is not even in this list.
+    in_flight = probing()
     code = _dispatch(entry.check)
     if code is None:
-        why = _IN_FLIGHT if in_flight else (_PROBES if _reentered else _NOT_RUN)
+        why = _IN_FLIGHT if in_flight else (_refused or _NOT_RUN)
         return UNKNOWN, why.format(check=entry.check)
     return (ADOPTED if code == 0 else PENDING), ""
 

--- a/docs/news/unreleased-probe-crosses-processes.md
+++ b/docs/news/unreleased-probe-crosses-processes.md
@@ -1,0 +1,31 @@
+---
+version: unreleased
+headline: A news probe no longer re-enters charter through a process it spawned
+---
+
+0.47.1 stopped a `check:` from running inside another probe by counting how many were in
+flight. A counter lives in one process, and one re-entry path leaves the process: `charter
+update` finishes by starting a fresh charter to run `charter news --since`, which probes.
+Every hop was a new interpreter, so the count started at zero again and the guard never
+fired — measured here at four process boundaries and still going when the test's own cap
+stopped it.
+
+The reinstall was the worse half. `check: update --to X` reaches the installer in the
+process that IS the probe, so asking whether this plane had a version would have gone and
+installed it — a real `uv tool install`, run to answer a question. That is now refused on
+its own account: a probe reads, it does not act. The entry comes back **unchecked** rather
+than pending, because a command that declined to run has no exit code worth reading, and
+`pending` would invent a chore on a plane that may already have adopted the entry.
+
+The guard travels in the environment for the length of a probe, so any charter started
+underneath one declines to probe whatever started it — the update handoff today, and
+anything else that spawns charter tomorrow — and word of the refusal travels back, so the
+entry whose `check:` did the spawning is unchecked too rather than adopted on an exit code
+that answered something else. Nothing changes for a charter run normally: the marker exists
+only between the start and the end of a probe, it names the process running that probe, and
+one naming a process that has exited is ignored rather than believed.
+
+What used to keep this off the fire was arithmetic in another module — the update stamps
+its baseline before it moves, so the charter it spawns asks for an empty version range and
+probes nothing. That was true, and an accident. It is written down now, and it is the
+second line rather than the first.

--- a/tests/test_news_cross_process.py
+++ b/tests/test_news_cross_process.py
@@ -1,0 +1,400 @@
+"""A probe never runs from inside a probe — including across a process boundary.
+
+#311 bounded re-entry with a counter in :mod:`charter.news`. A counter is process-local,
+and one re-entry path leaves the process: `commands_update._handoff` spawns a FRESH charter
+running `charter news --since <baseline>`, which probes. Every hop is a new interpreter, so
+`_depth` is 0 again at each level and the in-process guard never fires (#314).
+
+Two failures live on that path and they are not the same size.
+
+**The loop.** Each hop is a whole charter start-up rather than a stack frame, so it is
+slower and less visible than #311's, and it terminates today only by arithmetic two modules
+away — `cmd_update` stamps its baseline before it moves, so a later hop's
+`between(installed, installed)` is empty. Nothing asserted that, which is what made it a
+defect rather than a design: incidental safety nobody wrote down.
+
+**The side effect.** `check: update …` reaches `_sync_to`, a real `uv tool install`, in the
+process that IS the probe — at depth 1, which the counter permits and which no marker in a
+child's environment can reach. A probe that installs software is worse than a probe that
+hangs, so the mutation is refused on its own account, by asking whether a probe is in
+flight rather than by naming commands.
+
+Every test here bounds itself. The cross-process case caps its own hop count and gives
+every subprocess an explicit timeout, so a real recursion ends in a failed assertion rather
+than a wedged runner — and each hop records how many entries it could see, because a probe
+that found nothing to probe passes every timing assertion while proving nothing.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import charter
+from charter import commands, commands_update, doctor, harness, instance, news
+
+#: What `charter update` would refuse for reasons that are not this test's. Left in place,
+#: they stop the command before it reaches an installer — which is indistinguishable from
+#: the guard working, and the suite runs inside exactly the charter checkout `cmd_update`
+#: declines to install over.
+_CLEAR_THE_WAY = (
+    (doctor, "_is_charter_checkout", lambda root: False),
+    (instance, "load", lambda root: {}),
+    (instance, "locked_version", lambda cfg: None),
+    (harness, "current", lambda: None),
+    (harness, "get", lambda name: None),
+)
+
+#: Hops a test tolerates before it stops the chain itself. One is the guarded answer: the
+#: probe's own command spawns one charter, and that charter refuses. The cap exists so an
+#: unguarded tree ends red instead of running until something else kills it.
+HOP_CAP = 3
+
+#: Seconds any one hop may take. Charter's start-up is ~0.3s; this is a wedge detector,
+#: not a performance budget.
+HOP_TIMEOUT = 60
+
+#: The repo this test is running from, so a spawned interpreter imports the tree under
+#: test rather than whatever `charter` happens to be installed on the machine.
+SRC = str(Path(charter.__file__).resolve().parents[1])
+
+#: One hop. Points a fresh charter at the same throwaway news directory, probes the same
+#: entry, appends what it saw, and — standing in for `cmd_update`'s handoff — spawns the
+#: next hop from inside the probe. `check: version` is dispatched to this, exactly as
+#: `check: update` is dispatched to a command that spawns charter.
+HOP = '''
+import json, os, subprocess, sys
+from pathlib import Path
+
+sys.path.insert(0, os.environ["PROBE_SRC"])
+from charter import commands, config, news
+
+news._PACKAGED = Path(os.environ["PROBE_NEWSDIR"])
+hop = int(os.environ["PROBE_HOP"])
+log = Path(os.environ["PROBE_LOG"])
+cap = int(os.environ["PROBE_CAP"])
+
+
+def spawn(args):
+    """`check:` lands here — a command that starts another charter, like `_handoff`."""
+    if hop >= cap:
+        log.write_text(log.read_text() + json.dumps({"hop": hop + 1, "capped": True}) + "\\n")
+        return 0
+    env = {**os.environ, "PROBE_HOP": str(hop + 1)}
+    done = subprocess.run([sys.executable, os.environ["PROBE_SCRIPT"]], env=env,
+                          timeout=float(os.environ["PROBE_TIMEOUT"]),
+                          capture_output=True, text=True)
+    return done.returncode
+
+
+commands.cmd_version = spawn
+entries = [e for e in news.released() if e.slug == "loop"]
+record = {"hop": hop, "released": len(news.released())}
+if entries:
+    status, why = news.probe(entries[0])
+    record.update(status=status, why=why)
+log.write_text(log.read_text() + json.dumps(record) + "\\n")
+'''
+
+
+class CrossProcessReentry(unittest.TestCase):
+    """The #314 reproduction, with the install replaced by a bare subprocess.
+
+    The real chain runs `uv tool install` on the way, so it is not something a test may
+    perform. What is reproduced is the part that matters: a `check:` whose command starts a
+    fresh charter that probes the same entry, and therefore re-enters where a process-local
+    counter cannot see it.
+    """
+
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        (self.dir / "0.44.0-loop.md").write_text(
+            "---\nversion: 0.44.0\nheadline: h\ncheck: version\nadopt: version\n---\nbody\n")
+        patch = mock.patch.object(news, "_PACKAGED", self.dir)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+        self.script = self.dir / "hop.py"
+        self.script.write_text(HOP)
+        self.log = self.dir / "hops.jsonl"
+        self.log.write_text("")
+
+        self.entry, = [e for e in news.released() if e.slug == "loop"]
+        # The counterfactual this suite has been burned by: a tree where `news.all()` comes
+        # back empty makes every unguarded run finish instantly and look guarded. Nothing
+        # below is trustworthy unless the planted entry is really there to be probed.
+        self.assertEqual(self.entry.check, "version")
+        self.assertEqual(len(news.released()), 1)
+
+    def _env(self, hop: int) -> dict:
+        return {**os.environ, "PROBE_SRC": SRC, "PROBE_NEWSDIR": str(self.dir),
+                "PROBE_SCRIPT": str(self.script), "PROBE_LOG": str(self.log),
+                "PROBE_HOP": str(hop), "PROBE_CAP": str(HOP_CAP),
+                "PROBE_TIMEOUT": str(HOP_TIMEOUT)}
+
+    def _spawn(self, args) -> int:
+        done = subprocess.run([sys.executable, str(self.script)], env=self._env(1),
+                              timeout=HOP_TIMEOUT, capture_output=True, text=True)
+        self.stderr = done.stderr
+        return done.returncode
+
+    def _hops(self) -> list[dict]:
+        return [json.loads(line) for line in self.log.read_text().splitlines() if line]
+
+    def _probe(self) -> tuple[str, str]:
+        with mock.patch.object(commands, "cmd_version", self._spawn):
+            started = time.monotonic()
+            status, why = news.probe(self.entry)
+            self.elapsed = time.monotonic() - started
+        return status, why
+
+    def test_the_chain_stops_at_the_first_spawned_charter(self):
+        self._probe()
+        hops = self._hops()
+        self.assertTrue(hops, f"no hop ran at all — the chain never started: {self.stderr}")
+        self.assertEqual(
+            [h["hop"] for h in hops], [1],
+            f"a probe re-entered across {len(hops)} process boundaries — the guard has to "
+            f"survive exec, not just recursion")
+
+    def test_the_spawned_charter_could_see_the_entry_it_refused(self):
+        """The vacuous pass this file exists to rule out. A hop that found no entries
+        probes nothing, spawns nothing, and reports a bounded chain — which is what a
+        broken guard and a missing news directory look like from the outside."""
+        self._probe()
+        hop, = self._hops()
+        self.assertEqual(hop["released"], 1,
+                         "the spawned charter saw no entries, so it proved nothing")
+        self.assertIn("status", hop, "the spawned charter never reached the probe")
+
+    def test_the_re_entered_probe_has_no_answer(self):
+        """Bounded is not correct (ADR 0013). The spawned charter's `check:` would exit 0
+        the moment the chain is cut, so a guard that only stopped the loop would hand the
+        entry back as **adopted** — hidden forever by the bug that hid it."""
+        self._probe()
+        hop, = self._hops()
+        self.assertEqual(hop["status"], news.UNKNOWN)
+        self.assertIn("probe", hop["why"])
+
+    def test_the_probe_that_spawned_it_has_no_answer_either(self):
+        """The same half, in the direction that needs a channel.
+
+        The entry the OUTER probe is asking about is the one whose `check:` spawned a
+        charter that had to be refused — so its exit code is not an answer, whatever it
+        says. Nothing in a child can reach its parent's memory, so a refused descendant
+        leaves a mark at the path the marker names and this is where it is read. Without
+        it the loop is bounded and the entry still comes back adopted, one process further
+        away than #311.
+        """
+        status, why = self._probe()
+        self.assertEqual(status, news.UNKNOWN)
+        self.assertIn("version", why)
+
+    def test_it_finishes_in_bounded_time(self):
+        """A wall clock is never the assertion — the hop count is — but a guard that let
+        the chain run to the cap would still be slow here, and slow is what the field
+        would report."""
+        self._probe()
+        self.assertLess(self.elapsed, HOP_TIMEOUT,
+                        f"one probe took {self.elapsed:.1f}s")
+
+
+class TheMarkerIsCleanedUp(unittest.TestCase):
+    """An environment variable that outlived its probe would disable probing for good, and
+    say nothing. That is a worse defect than the one being fixed."""
+
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        (self.dir / "0.44.0-x.md").write_text(
+            "---\nversion: 0.44.0\nheadline: h\ncheck: version\nadopt: version\n---\nbody\n")
+        patch = mock.patch.object(news, "_PACKAGED", self.dir)
+        patch.start()
+        self.addCleanup(patch.stop)
+        self.entry, = news.released()
+
+    def _probe_seeing(self, seen: list):
+        def cmd(args):
+            seen.append(os.environ.get(news._ENV))
+            return 0
+
+        with mock.patch.object(commands, "cmd_version", cmd):
+            return news.probe(self.entry)
+
+    def test_the_marker_names_this_process_while_the_probe_runs(self):
+        seen = []
+        self._probe_seeing(seen)
+        self.assertEqual(len(seen), 1)
+        pid, _, mark = seen[0].partition(":")
+        self.assertEqual(pid, str(os.getpid()),
+                         "the marker has to name the process running the probe — that is "
+                         "what makes a stale one recognisable as debris")
+        self.assertTrue(mark, "no way back up: a refused descendant could not report it")
+
+    def test_nothing_is_left_in_the_environment_afterwards(self):
+        self.assertNotIn(news._ENV, os.environ)
+        self._probe_seeing([])
+        self.assertNotIn(news._ENV, os.environ)
+
+    def test_a_value_that_was_already_there_is_put_back(self):
+        with mock.patch.dict(os.environ, {news._ENV: "already"}):
+            self._probe_seeing([])
+            self.assertEqual(os.environ[news._ENV], "already")
+
+    @unittest.skipUnless(os.name == "posix",
+                         "liveness is only asked on POSIX — `os.kill` off it would kill")
+    def test_a_marker_from_a_dead_process_does_not_disable_probing(self):
+        """The leak that would be silent. A marker names the process running the probe; a
+        process that is gone is running nothing, so the marker is debris — believed, it
+        would turn every probe on that machine into `unknown` until someone thought to look
+        at their environment."""
+        dead = _a_dead_pid()
+        with mock.patch.dict(os.environ, {news._ENV: str(dead)}):
+            self.assertEqual(self._probe_seeing([])[0], news.ADOPTED)
+
+    def test_a_marker_from_a_live_ancestor_refuses_the_probe(self):
+        ran = []
+        with mock.patch.dict(os.environ, {news._ENV: str(os.getppid())}):
+            status, why = self._probe_seeing(ran)
+        self.assertEqual(status, news.UNKNOWN)
+        self.assertEqual(ran, [], "the probe ran underneath another probe")
+        self.assertIn("in flight", why)
+
+    def test_the_mark_a_refused_descendant_leaves_is_read_and_removed(self):
+        """The marker's other half, and the other thing that could rot in a temp
+        directory. Left behind, the next probe in a process with the same PID would read
+        somebody else's refusal as its own answer."""
+        marks = []
+
+        def cmd(args):
+            _, _, mark = os.environ[news._ENV].partition(":")
+            Path(mark).touch()      # what a spawned charter does when it declines to probe
+            marks.append(mark)
+            return 0
+
+        with mock.patch.object(commands, "cmd_version", cmd):
+            status, why = news.probe(self.entry)
+        self.assertEqual(status, news.UNKNOWN, "an exit code from underneath a refusal is "
+                                               "not this entry's answer")
+        self.assertFalse(Path(marks[0]).exists(), "the mark outlived the probe that read it")
+
+    def test_a_garbled_marker_is_ignored_rather_than_believed(self):
+        with mock.patch.dict(os.environ, {news._ENV: "yes"}):
+            self.assertEqual(self._probe_seeing([])[0], news.ADOPTED)
+
+
+class AProbeDoesNotInstallSoftware(unittest.TestCase):
+    """The half no environment marker can reach.
+
+    `check: update …` runs `uv tool install` in the process that IS the probe — depth 1,
+    which the counter permits by design. The marker only ever reaches a CHILD, so it bounds
+    the loop and leaves the reinstall untouched. The mutation therefore refuses on its own
+    account.
+    """
+
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        (self.dir / "0.44.0-up.md").write_text(
+            "---\nversion: 0.44.0\nheadline: h\ncheck: update --to 9.9.9\n"
+            "adopt: update\n---\nbody\n")
+        patch = mock.patch.object(news, "_PACKAGED", self.dir)
+        patch.start()
+        self.addCleanup(patch.stop)
+        self.entry, = news.released()
+
+        # Recorded, never raised: `_dispatch` swallows every exception, so a `self.fail()`
+        # in here would be eaten and the test would pass while the machine was reinstalled.
+        self.did = []
+        for name in ("_sync_to", "_handoff", "_stamp_baseline", "_bump_pin"):
+            p = mock.patch.object(commands_update, name,
+                                  lambda *a, _n=name, **k: self.did.append(_n) or (True, ""))
+            p.start()
+            self.addCleanup(p.stop)
+        # Everything that would have stopped `update` for some OTHER reason, removed. A
+        # refusal this test did not ask for looks exactly like the guard working, and
+        # `cmd_update` declines to install over a charter checkout — which is what the
+        # suite is running in.
+        for target, name, value in _CLEAR_THE_WAY:
+            p = mock.patch.object(target, name, value)
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_the_probe_moves_nothing(self):
+        news.probe(self.entry)
+        self.assertEqual(self.did, [], f"a news probe ran {self.did}")
+
+    def test_the_entry_is_unchecked_rather_than_pending(self):
+        """`pending` would be a guess dressed as an answer — it invents work on a plane
+        that may well have adopted the entry already. The refusal produced no information,
+        so the entry reports none."""
+        status, why = news.probe(self.entry)
+        self.assertEqual(status, news.UNKNOWN)
+        self.assertIn("update --to 9.9.9", why)
+
+    def test_a_human_running_update_outside_a_probe_is_untouched(self):
+        """The guard must be invisible to everyone it is not for."""
+        self.assertFalse(news.probing())
+
+    def test_update_still_refuses_under_a_marker_it_inherited(self):
+        """A charter started underneath a probe is inside that probe, whoever spawned it.
+        `_handoff`'s child is the one that exists today."""
+        with mock.patch.dict(os.environ, {news._ENV: str(os.getppid())}):
+            self.assertTrue(news.probing())
+
+
+class TheHandoffBound(unittest.TestCase):
+    """What kept #314 off the fire, written down.
+
+    `cmd_update` stamps its baseline BEFORE anything moves and hands the pre-install
+    version to `_handoff`, so once the target is installed the child's range is empty and
+    the chain dies. That is real, and it is arithmetic sitting two modules from the call
+    site with nothing naming it — which is how it survived as an accident. It is a second
+    line now, not the first: the marker bounds the child whatever the range says.
+    """
+
+    def test_the_handoff_baseline_is_the_version_that_was_installed_before(self):
+        seen = {}
+
+        def handoff(target, baseline):
+            seen.update(target=target, baseline=baseline)
+            return True, ""
+
+        with contextlib.ExitStack() as stack:
+            for target, name, value in _CLEAR_THE_WAY:
+                stack.enter_context(mock.patch.object(target, name, value))
+            stack.enter_context(mock.patch.object(commands_update, "_stamp_baseline",
+                                                  lambda v: None))
+            stack.enter_context(mock.patch.object(commands_update, "_sync_to",
+                                                  lambda v: (True, v)))
+            stack.enter_context(mock.patch.object(commands_update, "_handoff", handoff))
+            stack.enter_context(contextlib.redirect_stdout(io.StringIO()))
+            stack.enter_context(contextlib.redirect_stderr(io.StringIO()))
+            installed = commands_update._installed_version()
+            commands_update.cmd_update(mock.Mock(to=installed, bump=False))
+        self.assertEqual(seen.get("baseline"), installed,
+                         "the handoff no longer carries the pre-install version")
+        self.assertEqual(seen.get("target"), installed)
+
+    def test_that_baseline_makes_the_spawned_charters_range_empty(self):
+        self.assertEqual(news.between("0.44.0", "0.44.0"), [],
+                         "`between` stopped being exclusive at the low end — the handoff's "
+                         "child would now probe the entries that sent it there")
+
+
+def _a_dead_pid() -> int:
+    """A PID that has certainly exited: start one, reap it, reuse its number."""
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    return proc.pid
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #314.

#313 bounded a news probe's re-entry with a depth counter in `news`. A counter lives in one
process, and one re-entry path leaves the process: `commands_update._handoff` starts a fresh
charter running `charter news --since`, which probes. Every hop is a new interpreter, so
`_depth` starts at zero again and the guard never fires.

## Measured, before and after

The test spawns real charter processes and caps its own hop count, so a real recursion ends
red instead of wedged.

| | processes spawned | hops | what each hop reported | outer probe | elapsed |
|---|---|---|---|---|---|
| 0.47.1 | 4 | `[4,3,2,1]` | `adopted` | `adopted` | 0.228s (stopped by the test's cap) |
| this branch | 1 | `[1]` | `unknown` | `unknown` | 0.086s |

Each hop records how many entries it could see (`released=1` in both runs). That is not
decoration: `news._is_checkout` needs a `pyproject.toml` two levels above `docs/news`, so a
scratch tree without one makes `news.all()` empty and an unguarded run finishes instantly
and looks guarded. The count is what tells the two apart.

## What changed

**The guard travels in `CHARTER_NEWS_PROBE`**, set for the length of a probe, and both
halves cross with it.

* *Down* — a charter started underneath a probe declines to probe, whatever spawned it: the
  update handoff today, `secret exec` (#317) or anything else tomorrow. Not a list of
  command names, which #313 already ruled out.
* *Back up* — a refused descendant leaves a mark at the path the marker names, so the entry
  whose `check:` did the spawning is unchecked rather than adopted on an exit code that
  answered something else. Bounded is not correct (ADR 0013), and that argument does not
  stop at a process boundary. Without this the loop is bounded and the entry still comes
  back `adopted`, one process further away than #311.

**A probe reads; it does not act.** The frightening half was never in the child.
`check: update --to X` reaches `_sync_to` — a real `uv tool install` — in the process that
IS the probe, at the depth the counter permits by design, where no marker in a child's
environment reaches. So `cmd_update` asks `news.probing()` first and declines, and says so
through `news.refuse_mutation()`: the entry reports `unknown`, not `pending`. A command
that declined has no exit code worth reading, and `pending` would invent a chore on a plane
that may already have adopted the entry.

**The marker does not become the worse bug.** Its value is the PID of the process running
the probe. An environment belongs to a process, so it cannot escape into the shell that
started charter; it is restored in the same `finally` that releases the counter, so a probe
that raises leaves nothing behind; and a copy naming a process that has exited is ignored
rather than believed — a stale marker taken at its word would turn every probe on that
machine into `unknown` for good and say nothing about why. Liveness is asked with
`os.kill(pid, 0)` **on POSIX only**, where that is a question; on Windows it maps to
TerminateProcess and would kill whatever the marker named.

**The accidental bound is written down.** `cmd_update` stamps its baseline before it moves,
so the charter it spawns asks for `between(installed, installed)` and probes nothing. True,
and an accident — arithmetic in another module, one refactor from silently going away. Now
named in `_handoff`'s docstring and pinned by `TheHandoffBound`, as the second line rather
than the first.

## Nothing changes for anyone outside a probe

`news.probing()` is false unless a `check:` is running, so a charter run by a human or a
hook takes exactly the path it took before — one dict lookup more. Smoke-tested on the
tree: `charter news --pending` unchanged at 0.4s; `charter update` under an inherited live
marker refuses with rc=2 and installs nothing.

## Tests

`tests/test_news_cross_process.py`, 18 tests, every one of which fails on 0.47.1 for the
reason it names. Full suite **2894 OK** (2876 on `main`).

## Not in this PR

The survey behind this turned up a second spawn path of the same shape, filed as **#317**:
`secret exec` takes a pass-through argv, so a `check:` naming it reaches any binary with a
vault's credential in its environment — contradicting `news.py`'s own docstring, which this
PR corrects to say so rather than leave the claim standing. The marker closes its
*re-entrancy* half already (the spawned charter declines to probe); the argv is #317's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo