### PR TITLE
Hold a news `check:` to a list of commands a probe may run (#317)

### DIFF
--- a/charter/news.py
+++ b/charter/news.py
@@ -17,15 +17,27 @@ not "pending". Reporting it as pending invents work; reporting it as adopted hid
 entry forever. This is `doctor`'s ``_NOT_CHECKED_HINT`` in another costume: the absence of
 information is not evidence of health (ADR 0013).
 
-**Actions are charter subcommands, dispatched in-process.** No shell is ever involved and
-no argv is ever handed to one, so an entry is meant not to be an arbitrary-command
-primitive. `docsrc._TOPIC` keeps the same restraint for `docs show` — "must not be a
-file-read primitive wearing a documentation command" — and the stakes are higher here,
-because this one runs rather than prints. Being in-process is also what makes a dozen
-probes cheap enough for `doctor` to run on demand. That restraint currently leaks: `secret
-exec` takes a pass-through argv, so a `check:` naming it reaches any binary, with a vault's
-credential in its environment (#317). Said out loud here rather than left as a claim this
-module does not keep.
+**A probe reads, and its argv is charter's rather than the entry's.** That is the whole
+restraint, and it is a property of the *command* — being dispatched in-process is not it.
+`_tokens` refusing shell syntax and an unregistered first token was, and the claim built on
+it was false for as long as it stood: `secret exec` takes the rest of the line as a
+pass-through argv, so a `check:` naming it reached any binary on the machine with a vault's
+credential in the child's environment, on every plane that upgraded, from a SessionStart
+hook (#317). So an entry now chooses from :data:`_PROBEABLE` — command paths a human has
+confirmed — rather than from the whole CLI.
+
+A list, and not a rule derived from the parser, because only one half of the restraint is
+derivable. argparse can be asked whether a command takes a pass-through positional; it
+cannot be asked whether the command writes to the disk, and `check: update …` reaching a
+real `uv tool install` is the same defect wearing no argv at all. What the parser can
+answer is asserted over the list instead of at runtime — entries, list and parser ship in
+one wheel, so a test across the three is a proof rather than a sample, and the SessionStart
+path stays free of a walk through argparse's internals.
+
+`docsrc._TOPIC` keeps the same restraint for `docs show` — "must not be a file-read
+primitive wearing a documentation command" — and the stakes are higher here, because this
+one runs rather than prints. Being in-process is what makes a dozen probes cheap enough for
+`doctor` to run on demand; it was never what made them safe.
 
 **A probe never runs from inside a probe.** Some charter commands probe every entry
 themselves — `doctor` does, and so does `charter news --pending` — so an entry naming one
@@ -47,10 +59,16 @@ half of #314 was never in the child: `check: update …` runs a real `uv tool in
 process that IS the probe, at the depth the counter permits by design. So the mutation
 declines on its own account — :func:`probing` is public for exactly that, and refusing is
 only half of it, because a command that declined has no exit code worth reading.
+
+`update` is not in :data:`_PROBEABLE`, so an entry naming it is now refused before any of
+that. Both stay, because they answer different questions: the list says what an entry may
+*name*, and :func:`probing` says what a command does when it finds itself inside a probe —
+which a command reached from a listed one still is.
 """
 
 from __future__ import annotations
 
+import argparse
 import io
 import os
 import tempfile
@@ -214,12 +232,23 @@ def render_body(version: str) -> str:
     return "\n\n".join(parts)
 
 
-def _tokens(argv: str) -> list[str] | None:
+def _parser():
+    """A fresh parser. Never cached: the suite replaces command functions and every call
+    site here has to see the replacement, which a parser built once at import would not."""
+    from . import cli
+
+    return cli.build_parser()
+
+
+def _tokens(argv: str, parser=None) -> list[str] | None:
     """*argv* as a charter subcommand's tokens, or ``None`` if it is not one.
 
     Two refusals, both structural rather than advisory: anything a shell would read as
     syntax, and any first token that is not a registered subcommand. `charter` is implied
     and must not be written, so an entry cannot reach a different binary.
+
+    *parser* is optional and is threaded through rather than rebuilt because building one
+    is ~6ms and this module runs on the `doctor` and SessionStart paths, once per entry.
     """
     if not argv or set(argv) & _SHELLISH:
         return None
@@ -228,9 +257,132 @@ def _tokens(argv: str) -> list[str] | None:
         return None
     from . import cli
 
-    if tokens[0] not in cli._subcommand_names(cli.build_parser()):
+    if tokens[0] not in cli._subcommand_names(parser if parser is not None else _parser()):
         return None
     return tokens
+
+
+#: Every command path a ``check:`` may name.
+#:
+#: An entry chooses from here rather than from the whole CLI, because what makes a probe
+#: safe is a property of the command: it reads rather than acts, and any argv it hands to
+#: another program is charter's rather than the entry's. Neither half can be read off the
+#: parser — argparse cannot be asked whether a command writes — so this is a list a human
+#: keeps, and `tests/test_news_probeable.py` pins the half the parser *can* answer: nothing
+#: listed here takes a pass-through positional, and everything listed here is a command
+#: that exists.
+#:
+#: A path is the subcommand tokens and nothing else. Flags are the entry's to choose; a
+#: deeper subcommand is a different command and needs its own line, or listing ``news``
+#: would silently list ``news stamp``, which renames files.
+#:
+#: Adding one is a deliberate act with two questions to answer, and the second is the one
+#: that gets skipped: does it change this machine, and does its exit code actually mean
+#: "this plane has the thing?". ``version`` fails the second — it always exits 0, so an
+#: entry naming it would report adopted everywhere, forever — which is why the most
+#: obviously harmless command in the CLI is not here.
+_PROBEABLE = frozenset({
+    ("doctor",),           # reads the plane and reports on it
+    ("news",),             # reads entries; the ones that probe are #311's guard to answer
+    ("persona", "lint"),   # reads the persona files — every shipped probe today
+})
+
+
+def _subparsers(parser) -> argparse._SubParsersAction | None:
+    """*parser*'s subcommands, or ``None`` if it is a leaf.
+
+    ``_SubParsersAction`` is nominally private and has been stable for the life of
+    argparse; `cli._subcommand_names` reads it the same way and for the same reason.
+    """
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return action
+    return None
+
+
+def _parser_at(path: tuple[str, ...], parser=None):
+    """The parser ``charter <path>`` reaches, or ``None`` when there is no such command."""
+    parser = _parser() if parser is None else parser
+    for name in path:
+        sub = _subparsers(parser)
+        if sub is None or name not in sub.choices:
+            return None
+        parser = sub.choices[name]
+    return parser
+
+
+def _pass_through(parser) -> list[str]:
+    """*parser*'s positionals that swallow an open-ended list of words.
+
+    The shape #317 was: ``secret exec``'s ``command`` is ``nargs="*"``, so everything after
+    the vault name became an argv for :func:`subprocess.run`. Read off the parser rather
+    than named, so it cannot come back under a different command's name.
+    """
+    if parser is None:
+        return []
+    return [a.dest for a in parser._actions
+            if not a.option_strings and a.nargs in ("*", argparse.REMAINDER)]
+
+
+def _all_command_paths(parser=None, path: tuple[str, ...] = ()) -> list[tuple[str, ...]]:
+    """Every subcommand path the CLI accepts, depth first. For the suite, not the hot path."""
+    parser = _parser() if parser is None else parser
+    sub = _subparsers(parser)
+    if sub is None:
+        return [path] if path else []
+    found = [path] if path else []
+    for name, child in sub.choices.items():
+        found.extend(_all_command_paths(child, path + (name,)))
+    return found
+
+
+def _command_path(tokens: list[str], parser=None) -> tuple[str, ...] | None:
+    """The subcommand path *tokens* names, or ``None`` when it cannot be read off.
+
+    Leading tokens are consumed while they name a subcommand at the level reached so far,
+    which is where argparse would find them too. The walk then stops at the first token
+    that does not — a flag, or an argument — and that is the case worth stating: argparse
+    reads *past* a flag to find the subcommand behind it, so `news --pending stamp 9.9.9`
+    runs `news stamp`. A walk that just stopped would score it as plain `news` and let a
+    rename through a list that never named it. So a subcommand sighted anywhere further
+    along means this walk cannot say what the tokens name, and ``None`` is the honest
+    answer — refused, because every caller reads ``None`` as "not probeable".
+    """
+    parser = _parser() if parser is None else parser
+    path: list[str] = []
+    rest = list(tokens)
+    while rest:
+        sub = _subparsers(parser)
+        if sub is None:
+            break
+        if rest[0] in sub.choices:
+            parser = sub.choices[rest[0]]
+            path.append(rest.pop(0))
+            continue
+        if any(t in sub.choices for t in rest):
+            return None
+        break
+    return tuple(path)
+
+
+def probeable(argv: str, parser=None) -> bool:
+    """May a ``check:`` name ``charter <argv>``?
+
+    Public because it is the entry author's rule, not only the dispatcher's: the suite
+    holds every shipped ``check:`` to it, so an entry naming a command a probe may not run
+    fails the PR that adds it rather than the machine that installs it.
+
+    ``adopt:`` is deliberately NOT held to this. It is the line a human is told to run,
+    once, on purpose — `adopt: browser install` installs a browser, which is the point —
+    where ``check:`` runs unprompted on every plane that upgrades. Same grammar, opposite
+    rules, and reading one as the other is how the restraint gets widened back out.
+    """
+    parser = _parser() if parser is None else parser
+    tokens = _tokens(argv, parser)
+    if tokens is None:
+        return False
+    path = _command_path(tokens, parser)
+    return path is not None and path in _PROBEABLE
 
 
 def resolves(parser, argv: str) -> bool:
@@ -238,8 +390,15 @@ def resolves(parser, argv: str) -> bool:
 
     Used by the suite over every shipped entry, so a flag removed by some future PR fails
     that PR's tests rather than degrading a probe to permanent `unknown` in the field.
+
+    Parsing only — whether a ``check:`` is *allowed* to name the command is
+    :func:`probeable`, and the two are kept apart because this one also runs over
+    ``adopt:``, where a mutating command is correct.
     """
-    tokens = _tokens(argv)
+    # The caller's parser, not another one: it was passed in so that the answer is about
+    # THAT parser, and a first-token check against a freshly built one would quietly
+    # disagree with it.
+    tokens = _tokens(argv, parser)
     if tokens is None:
         return False
     try:
@@ -348,6 +507,12 @@ def _dispatch(argv: str) -> int | None:
     Re-entry is refused by :func:`probing`, not by the counter alone, so it is refused the
     same way whether it came back up this stack or through a process charter spawned on the
     way (#314).
+
+    Three refusals now, and they are not the same question. Is this a charter subcommand at
+    all (:func:`_tokens`); is a probe already running (:func:`probing`); and is this a
+    command a ``check:`` may name at all (:func:`probeable`, #317). Each returns ``None``,
+    and each records its own reason, because the entry a reader has to go and fix is a
+    different entry in each case.
     """
     global _depth, _refused
     if not _depth:
@@ -355,14 +520,23 @@ def _dispatch(argv: str) -> int | None:
         # every top-level dispatch has to start clean, or a refusal recorded while probing
         # the previous entry is read as this entry's answer.
         _refused = None
-    tokens = _tokens(argv)
+    # One parser, threaded through every use below. Building it is ~6ms and this runs once
+    # per entry on the `doctor` and SessionStart paths.
+    parser = _parser()
+    tokens = _tokens(argv, parser)
     if tokens is None:
         return None
     if probing():
         _refused = _PROBES
         _mark_refusal()
         return None
-    from . import cli
+    if not probeable(argv, parser):
+        # After the re-entrancy guard rather than before it, so #318's marking is reached
+        # on exactly the paths it was reached on before. Which of the two speaks first only
+        # decides which reason is recorded, and inside a nested sweep `probe` prefers
+        # `_IN_FLIGHT` over either.
+        _refused = _UNLISTED
+        return None
 
     _depth += 1
     outer = os.environ.get(_ENV)
@@ -372,7 +546,7 @@ def _dispatch(argv: str) -> int | None:
     os.environ[_ENV] = f"{os.getpid()}:{mark}"
     try:
         with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
-            args = cli.build_parser().parse_args(tokens)
+            args = parser.parse_args(tokens)
             func = getattr(args, "func", None)
             if func is None:
                 return None
@@ -403,7 +577,7 @@ def _dispatch(argv: str) -> int | None:
     return None if _refused else code
 
 
-#: Four ways to have no answer, said four ways. "Did not run here" points the reader at
+#: Five ways to have no answer, said five ways. "Did not run here" points the reader at
 #: their own machine, which is right for a check this CLI could not resolve and wrong for
 #: an entry whose `check:` can never run anywhere — folding those together hides the second
 #: behind the first, and the second is a defect in the entry that somebody has to fix.
@@ -417,6 +591,10 @@ _IN_FLIGHT = ("`charter {check}` was not run: a probe is already in flight, and 
 _MUTATES = ("`charter {check}` changes this machine rather than reading it, so it was not "
             "run — a `check:` asks whether this plane already has something and cannot be "
             "the thing that goes and gets it. Unchecked, neither adopted nor pending")
+_UNLISTED = ("`charter {check}` is not a command a `check:` may name. A probe reads, and "
+             "the argv it hands anything else is charter's rather than this entry's, so an "
+             "entry picks from a short list of read-only commands instead of from the whole "
+             "CLI. Unchecked, neither adopted nor pending")
 
 
 def probe(entry: Entry) -> tuple[str, str]:

--- a/docs/news/unreleased-check-argv-restraint.md
+++ b/docs/news/unreleased-check-argv-restraint.md
@@ -1,0 +1,33 @@
+---
+version: unreleased
+headline: A news entry's `check:` can only name a command a probe is allowed to run
+---
+
+A news entry carries a `check:` — a charter command whose exit code answers "does this
+plane already have this?". `charter doctor` runs every released entry's `check:` unprompted,
+on a SessionStart hook, so those commands run on every machine that upgrades.
+
+What kept that safe was supposed to be that a `check:` names a charter subcommand and
+nothing else: no shell, no argv handed to one. It did not. `charter secret exec` takes the
+rest of its line as a command to run, with a vault's credential in that command's
+environment, so a `check:` naming it reached any program on the machine — and the entry
+would have reported itself **adopted** on that program's exit code. The same for `charter
+persona secret exec`. Only a charter maintainer could write such an entry, since entries
+ship inside the wheel, and none ever did; it was a restraint the code claimed and did not
+keep.
+
+An entry now picks its `check:` from a short list of commands — `doctor`, `news`, and
+`persona lint` today — instead of from the whole CLI. The rule it encodes is the one that
+was being claimed: **a probe reads, and the argv it hands anything else is charter's rather
+than the entry's.** A `check:` naming anything off that list is refused, and the entry
+reports **unchecked** with a reason naming the command, rather than adopted or pending.
+
+A list rather than something derived from the command line parser, because only half of the
+rule is derivable: the parser can be asked whether a command takes a pass-through argv, and
+cannot be asked whether it writes to your disk — `check: update` reaching a real reinstall
+was the same defect with no argv in sight. The half the parser *can* answer is now asserted
+across the whole list on every test run, so a command that later grows a pass-through argv
+fails the change that added it.
+
+`adopt:` is deliberately unaffected. That line is one a human is told to run, once, on
+purpose — installing something is exactly what it is for.

--- a/tests/test_news_cross_process.py
+++ b/tests/test_news_cross_process.py
@@ -40,7 +40,14 @@ from pathlib import Path
 from unittest import mock
 
 import charter
-from charter import commands, commands_update, doctor, harness, instance, news
+from charter import (commands, commands_persona, commands_update, doctor, harness,
+                     instance, news)
+
+#: The `check:` every test here plants, and the handler it stands on. A `check:` may
+#: only name a command `news._PROBEABLE` lists (#317), so the stand-in has to be one
+#: an entry could really carry; each test replaces the handler with whatever it needs
+#: the probe to do.
+STAND_IN, STAND_IN_FN = "persona lint", "cmd_persona_lint"
 
 #: What `charter update` would refuse for reasons that are not this test's. Left in place,
 #: they stop the command before it reaches an installer — which is indistinguishable from
@@ -69,14 +76,14 @@ SRC = str(Path(charter.__file__).resolve().parents[1])
 
 #: One hop. Points a fresh charter at the same throwaway news directory, probes the same
 #: entry, appends what it saw, and — standing in for `cmd_update`'s handoff — spawns the
-#: next hop from inside the probe. `check: version` is dispatched to this, exactly as
+#: next hop from inside the probe. The entry's `check:` is dispatched to this, exactly as
 #: `check: update` is dispatched to a command that spawns charter.
 HOP = '''
 import json, os, subprocess, sys
 from pathlib import Path
 
 sys.path.insert(0, os.environ["PROBE_SRC"])
-from charter import commands, config, news
+from charter import commands_persona, config, news
 
 news._PACKAGED = Path(os.environ["PROBE_NEWSDIR"])
 hop = int(os.environ["PROBE_HOP"])
@@ -96,7 +103,7 @@ def spawn(args):
     return done.returncode
 
 
-commands.cmd_version = spawn
+commands_persona.cmd_persona_lint = spawn
 entries = [e for e in news.released() if e.slug == "loop"]
 record = {"hop": hop, "released": len(news.released())}
 if entries:
@@ -118,7 +125,7 @@ class CrossProcessReentry(unittest.TestCase):
     def setUp(self):
         self.dir = Path(tempfile.mkdtemp())
         (self.dir / "0.44.0-loop.md").write_text(
-            "---\nversion: 0.44.0\nheadline: h\ncheck: version\nadopt: version\n---\nbody\n")
+            "---\nversion: 0.44.0\nheadline: h\ncheck: persona lint\nadopt: version\n---\nbody\n")
         patch = mock.patch.object(news, "_PACKAGED", self.dir)
         patch.start()
         self.addCleanup(patch.stop)
@@ -132,7 +139,7 @@ class CrossProcessReentry(unittest.TestCase):
         # The counterfactual this suite has been burned by: a tree where `news.all()` comes
         # back empty makes every unguarded run finish instantly and look guarded. Nothing
         # below is trustworthy unless the planted entry is really there to be probed.
-        self.assertEqual(self.entry.check, "version")
+        self.assertEqual(self.entry.check, STAND_IN)
         self.assertEqual(len(news.released()), 1)
 
     def _env(self, hop: int) -> dict:
@@ -151,7 +158,7 @@ class CrossProcessReentry(unittest.TestCase):
         return [json.loads(line) for line in self.log.read_text().splitlines() if line]
 
     def _probe(self) -> tuple[str, str]:
-        with mock.patch.object(commands, "cmd_version", self._spawn):
+        with mock.patch.object(commands_persona, STAND_IN_FN, self._spawn):
             started = time.monotonic()
             status, why = news.probe(self.entry)
             self.elapsed = time.monotonic() - started
@@ -197,7 +204,7 @@ class CrossProcessReentry(unittest.TestCase):
         """
         status, why = self._probe()
         self.assertEqual(status, news.UNKNOWN)
-        self.assertIn("version", why)
+        self.assertIn(STAND_IN, why)
 
     def test_it_finishes_in_bounded_time(self):
         """A wall clock is never the assertion — the hop count is — but a guard that let
@@ -215,7 +222,7 @@ class TheMarkerIsCleanedUp(unittest.TestCase):
     def setUp(self):
         self.dir = Path(tempfile.mkdtemp())
         (self.dir / "0.44.0-x.md").write_text(
-            "---\nversion: 0.44.0\nheadline: h\ncheck: version\nadopt: version\n---\nbody\n")
+            "---\nversion: 0.44.0\nheadline: h\ncheck: persona lint\nadopt: version\n---\nbody\n")
         patch = mock.patch.object(news, "_PACKAGED", self.dir)
         patch.start()
         self.addCleanup(patch.stop)
@@ -226,7 +233,7 @@ class TheMarkerIsCleanedUp(unittest.TestCase):
             seen.append(os.environ.get(news._ENV))
             return 0
 
-        with mock.patch.object(commands, "cmd_version", cmd):
+        with mock.patch.object(commands_persona, STAND_IN_FN, cmd):
             return news.probe(self.entry)
 
     def test_the_marker_names_this_process_while_the_probe_runs(self):
@@ -280,7 +287,7 @@ class TheMarkerIsCleanedUp(unittest.TestCase):
             marks.append(mark)
             return 0
 
-        with mock.patch.object(commands, "cmd_version", cmd):
+        with mock.patch.object(commands_persona, STAND_IN_FN, cmd):
             status, why = news.probe(self.entry)
         self.assertEqual(status, news.UNKNOWN, "an exit code from underneath a refusal is "
                                                "not this entry's answer")
@@ -298,6 +305,12 @@ class AProbeDoesNotInstallSoftware(unittest.TestCase):
     which the counter permits by design. The marker only ever reaches a CHILD, so it bounds
     the loop and leaves the reinstall untouched. The mutation therefore refuses on its own
     account.
+
+    Since #317 there is a layer in front: `update` is not a command a `check:` may name, so
+    the shipped configuration never reaches `cmd_update` at all. That is asserted in
+    `test_news_probeable.py`. Here the list is opened deliberately, because a class that
+    passed only because something else refused first would be a guard nobody is testing —
+    which is how `refuse_mutation` would quietly rot into dead code.
     """
 
     def setUp(self):
@@ -309,6 +322,13 @@ class AProbeDoesNotInstallSoftware(unittest.TestCase):
         patch.start()
         self.addCleanup(patch.stop)
         self.entry, = news.released()
+
+        # The layer in front, stood down for the length of this class. Left in place it
+        # refuses the entry before `cmd_update` runs, and every assertion below would pass
+        # with the guard they are about never reached.
+        p = mock.patch.object(news, "_PROBEABLE", news._PROBEABLE | {("update",)})
+        p.start()
+        self.addCleanup(p.stop)
 
         # Recorded, never raised: `_dispatch` swallows every exception, so a `self.fail()`
         # in here would be eaten and the test would pass while the machine was reinstalled.
@@ -338,6 +358,10 @@ class AProbeDoesNotInstallSoftware(unittest.TestCase):
         status, why = news.probe(self.entry)
         self.assertEqual(status, news.UNKNOWN)
         self.assertIn("update --to 9.9.9", why)
+        # Which refusal, not just that there was one: the reason separates "the mutation
+        # declined" from "the entry named a command it may not name", and the second one
+        # arriving here would mean this class had stopped testing the first.
+        self.assertIn("changes this machine", why)
 
     def test_a_human_running_update_outside_a_probe_is_untouched(self):
         """The guard must be invisible to everyone it is not for."""

--- a/tests/test_news_probeable.py
+++ b/tests/test_news_probeable.py
@@ -1,0 +1,242 @@
+"""A `check:` may name only a command a probe is allowed to run (#317).
+
+`news.py` claimed that dispatching in-process was enough to keep an entry from becoming an
+arbitrary-command primitive. It was not: `_tokens` refused shell syntax and an unregistered
+first token, and `secret exec` takes the rest of the line as a pass-through argv — so the
+tail of a `check:` reached `subprocess.run`, with a vault's credential in the child's
+environment. `charter doctor` runs every released entry's `check:` unprompted on a
+SessionStart hook, so the reach was every machine that upgraded, not only one that ran a
+command.
+
+The restraint that actually holds is a property of the command, not of the string:
+**a probe reads, and its argv is charter's rather than the entry's.** Neither half is
+derivable from the parser — argparse knows nothing about whether a command writes — so the
+rule is a list of command paths a human has confirmed, and the parser is used to pin the
+half it *can* answer (see `TheListIsPinnedToTheParser`).
+
+The spawn is observed rather than inferred. A returned status is what the bug would have
+lied about, so the assertion is on a file that only a real child process could have
+created.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import cli, commands_persona, commands_secrets, commands_update, news
+
+
+class _StubProvider:
+    """A vault that resolves, so nothing but the guard under test can stop the spawn.
+
+    Without this `_provider` raises and `cmd_secret_exec` returns 1 before reaching
+    `subprocess.run` — which is a refusal this test did not ask for and would look exactly
+    like the guard working.
+    """
+
+    def get(self, key: str) -> str:
+        return "not-a-real-secret"
+
+
+class NewsDir(unittest.TestCase):
+    """Entries read from a throwaway directory, so no test depends on what shipped."""
+
+    def setUp(self) -> None:
+        self.dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.dir, ignore_errors=True)
+        patch = mock.patch.object(news, "_PACKAGED", self.dir)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def write(self, check: str, *, slug: str = "x") -> news.Entry:
+        (self.dir / f"0.44.0-{slug}.md").write_text(
+            f"---\nversion: 0.44.0\nheadline: h\ncheck: {check}\nadopt: version\n---\nbody\n")
+        entries = [e for e in news.released() if e.slug == slug]
+        # The entry has to be REALLY released, or `probe` is being handed something no
+        # caller would reach and every assertion below is vacuous.
+        self.assertEqual(len(entries), 1, "the planted entry is not released")
+        return entries[0]
+
+
+class AProbeSpawnsNothing(NewsDir):
+    """The #317 reproduction: a `check:` whose tail is an argv for another program."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.sentinel = self.dir / "a-child-ran"
+        self.script = self.dir / "child.py"
+        self.script.write_text(f"open({str(self.sentinel)!r}, 'w').close()\n")
+
+        p = mock.patch.object(commands_secrets, "_provider", lambda _name: _StubProvider())
+        p.start()
+        self.addCleanup(p.stop)
+        # `persona secret exec` is the same function behind a proxy that resolves the
+        # persona's vault first. Resolving it here for the same reason as the provider.
+        p = mock.patch.object(commands_persona, "_resolve_vault", lambda _args: "probe-vault")
+        p.start()
+        self.addCleanup(p.stop)
+
+    #: `secret exec` names the vault; `persona secret exec` takes it from the persona, so
+    #: its whole tail is the command. Spelled out per test rather than shared, because a
+    #: vault token left in front of the persona form is read as the program to run — which
+    #: fails as "command not found" and looks exactly like a guard that works.
+    def _check(self, *lead: str) -> str:
+        argv = " ".join([*lead, sys.executable, str(self.script)])
+        # Two ways this test could pass while proving nothing, both checked rather than
+        # assumed: a path containing a character `_tokens` reads as shell syntax, and a
+        # command line the live parser does not accept. Either would refuse the entry for
+        # a reason that has nothing to do with #317.
+        self.assertFalse(set(argv) & news._SHELLISH, f"{argv} was refused as shell syntax")
+        self.assertTrue(news.resolves(cli.build_parser(), argv),
+                        f"`charter {argv}` does not parse, so nothing would have run")
+        return argv
+
+    def test_a_check_naming_secret_exec_starts_no_process(self):
+        entry = self.write(self._check("secret", "exec", "probe-vault"))
+        news.probe(entry)
+        self.assertFalse(self.sentinel.exists(),
+                         "a news probe started a process of the entry's choosing")
+
+    def test_a_check_naming_persona_secret_exec_starts_no_process(self):
+        entry = self.write(self._check("persona", "secret", "exec"))
+        news.probe(entry)
+        self.assertFalse(self.sentinel.exists(),
+                         "a news probe started a process of the entry's choosing")
+
+    def test_the_entry_is_unchecked_rather_than_adopted(self):
+        """Refusing is half of it. `cmd_secret_exec` returns the child's exit code, and a
+        refusal that let the outer call read an exit code would report the entry ADOPTED —
+        bounded is not correct (ADR 0013)."""
+        entry = self.write(self._check("secret", "exec", "probe-vault"))
+        self.assertEqual(news.probe(entry)[0], news.UNKNOWN)
+
+    def test_the_reason_names_the_entrys_own_check(self):
+        """During a sweep the reader is looking at a list. A reason that does not name the
+        command is a reason nobody can act on."""
+        entry = self.write(self._check("secret", "exec", "probe-vault"))
+        _, why = news.probe(entry)
+        self.assertIn("secret exec", why)
+        self.assertIn(str(self.script), why)
+
+
+class OnlyAListedCommandIsProbeable(unittest.TestCase):
+    """What the list says, said directly — `probeable` is the whole rule."""
+
+    def test_a_pass_through_command_is_refused(self):
+        self.assertFalse(news.probeable("secret exec v ls"))
+        self.assertFalse(news.probeable("persona secret exec v ls"))
+
+    def test_the_shipped_probes_are_allowed(self):
+        self.assertTrue(news.probeable("persona lint"))
+        self.assertTrue(news.probeable("persona lint --only delegate-when"))
+
+    def test_a_command_that_probes_news_is_still_allowed_here(self):
+        """`news --pending` re-enters, and #311's guard is what answers that — a separate
+        question, answered later and with its own reason. Folding the two together would
+        report the wrong fact for whichever one this rule reached first."""
+        self.assertTrue(news.probeable("news --pending"))
+        self.assertTrue(news.probeable("doctor"))
+
+    def test_a_subcommand_below_a_listed_one_needs_its_own_listing(self):
+        """`news` is probeable; `news stamp` renames files. Allowing a prefix would allow
+        every command beneath it, which is how a read-only list acquires a writer."""
+        self.assertFalse(news.probeable("news stamp 9.9.9"))
+
+    def test_a_flag_cannot_hide_the_subcommand_that_follows_it(self):
+        """argparse reads past `--pending` and finds `stamp`. A walk that stopped at the
+        first flag would score this as plain `news` and let the rename through."""
+        self.assertEqual(cli.build_parser().parse_args(
+            ["news", "--pending", "stamp", "9.9.9"]).func.__name__, "cmd_news_stamp")
+        self.assertFalse(news.probeable("news --pending stamp 9.9.9"))
+
+    def test_an_unregistered_command_is_refused(self):
+        self.assertFalse(news.probeable("not-a-charter-command"))
+        self.assertFalse(news.probeable(""))
+
+
+class TheListIsPinnedToTheParser(unittest.TestCase):
+    """The half the parser CAN answer, asserted over the whole list.
+
+    A list alone would drift: a listed command that later grows a pass-through positional
+    reopens #317 with nothing failing. Deriving the refusal at runtime instead would only
+    move the same check somewhere more expensive and less complete — entries, list and
+    parser ship in one wheel, so a test over the three is a proof rather than a sample.
+    """
+
+    def test_every_listed_path_is_a_command_the_parser_has(self):
+        """A rename that left the list behind would turn a probe into permanent `unknown`
+        in the field, and say nothing about why."""
+        for path in sorted(news._PROBEABLE):
+            with self.subTest(path=" ".join(path)):
+                self.assertIsNotNone(news._parser_at(path),
+                                     f"`charter {' '.join(path)}` is listed but not a command")
+
+    def test_no_listed_command_takes_a_pass_through_argv(self):
+        """#317's shape, refused structurally so it cannot come back under a new name."""
+        for path in sorted(news._PROBEABLE):
+            with self.subTest(path=" ".join(path)):
+                self.assertEqual(
+                    news._pass_through(news._parser_at(path)), [],
+                    f"`charter {' '.join(path)}` takes an argv from the entry")
+
+    def test_the_commands_that_carry_a_pass_through_today_are_not_listed(self):
+        """Read the parser, not a memory of it: whatever takes a pass-through argv now is
+        exactly what may not be probeable, however the list is later edited."""
+        offenders = [p for p in news._all_command_paths()
+                     if news._pass_through(news._parser_at(p))]
+        self.assertTrue(offenders, "no pass-through command found — the walk is broken")
+        for path in offenders:
+            with self.subTest(path=" ".join(path)):
+                self.assertNotIn(path, news._PROBEABLE)
+
+
+class TheShippedEntriesStillProbe(unittest.TestCase):
+    """A rule that quietly refused everything would pass every test above.
+
+    Held against what actually ships, on the real parser, running the real commands.
+    """
+
+    def setUp(self) -> None:
+        self.entries = [e for e in news.released() if e.check]
+        self.assertTrue(self.entries, "no shipped entry carries a `check:` — nothing pinned")
+
+    def test_every_shipped_check_is_probeable(self):
+        for e in self.entries:
+            with self.subTest(entry=e.slug):
+                self.assertTrue(news.probeable(e.check),
+                                f"{e.path.name}: `charter {e.check}` may no longer be probed")
+
+    def test_every_shipped_check_still_reaches_an_answer(self):
+        """Not `unknown`: the probe has to RUN. Adopted or pending are both fine — which
+        one depends on the plane the suite happens to be running on."""
+        for e in self.entries:
+            with self.subTest(entry=e.slug):
+                status, why = news.probe(e)
+                self.assertIn(status, (news.ADOPTED, news.PENDING),
+                              f"{e.path.name}: `charter {e.check}` stopped probing — {why}")
+
+
+class TheMutationGuardIsBehindThisOne(NewsDir):
+    """#318's `refuse_mutation` and this rule answer different questions; both stay.
+
+    `update` is not probeable, so a `check:` naming it is refused here and never reaches
+    the installer. That is the outer layer, asserted below. The inner one — `cmd_update`
+    declining on its own account because a probe is in flight — is exercised by
+    `test_news_cross_process.py`, which opens this list deliberately to reach it.
+    """
+
+    def test_a_check_naming_update_is_refused_before_the_installer(self):
+        entry = self.write("update --to 9.9.9")
+        with mock.patch.object(commands_update, "cmd_update") as run:
+            status, _ = news.probe(entry)
+        run.assert_not_called()
+        self.assertEqual(status, news.UNKNOWN)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_news_reentrancy.py
+++ b/tests/test_news_reentrancy.py
@@ -34,7 +34,13 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-from charter import commands, config, doctor, news
+from charter import commands, commands_persona, config, doctor, news
+
+#: A `check:` a probe is allowed to run, standing in for whatever an entry names
+#: (#317: an entry picks from `news._PROBEABLE`, not from the whole CLI). Its
+#: handler is replaced per test, so what it does here is the test's business and
+#: not `persona lint`'s — what matters is that a real entry could name it.
+STAND_IN, STAND_IN_FN = "persona lint", "cmd_persona_lint"
 
 #: How many doctor sweeps a test tolerates before it breaks the loop itself. Two is the
 #: guarded answer (the outer sweep, plus the one nested dispatch that is then refused);
@@ -158,8 +164,8 @@ class ARefusedProbe(NewsDir):
     def test_pending_still_ticks_when_every_probe_did_answer(self):
         """And the tick survives where it is true — a guard that removed the good news
         along with the false claim would be a worse trade than the bug."""
-        e = self.write("version", slug="fine")
-        with mock.patch.object(commands, "cmd_version", lambda args: 0):
+        e = self.write(STAND_IN, slug="fine")
+        with mock.patch.object(commands_persona, STAND_IN_FN, lambda args: 0):
             self.assertEqual(news.probe(e)[0], news.ADOPTED)
             self.assertIn("every entry with a probe reports adopted", self._pending())
 
@@ -169,14 +175,14 @@ class TheGuardDoesNotBreakProbing(NewsDir):
     would pass every test above and report nothing to anybody."""
 
     def _probe(self, code: int):
-        e = self.write("version")
+        e = self.write(STAND_IN)
         ran = []
 
         def cmd(args):
             ran.append(True)
             return code
 
-        with mock.patch.object(commands, "cmd_version", cmd):
+        with mock.patch.object(commands_persona, STAND_IN_FN, cmd):
             status, why = news.probe(e)
         self.assertEqual(len(ran), 1, "the probe did not actually run the subcommand")
         return status, why
@@ -200,29 +206,29 @@ class TheGuardIsReleasedOnFailure(NewsDir):
         """`_dispatch` swallows every exception, so a command that blows up is a normal
         outcome here — and the one path where a guard set outside a `finally` stays armed
         for the life of the process, turning every later probe into `unknown`."""
-        e = self.write("version")
+        e = self.write(STAND_IN)
 
         def boom(args):
             raise RuntimeError("probe exploded")
 
-        with mock.patch.object(commands, "cmd_version", boom):
+        with mock.patch.object(commands_persona, STAND_IN_FN, boom):
             self.assertEqual(news.probe(e)[0], news.UNKNOWN)
 
-        with mock.patch.object(commands, "cmd_version", lambda args: 0):
+        with mock.patch.object(commands_persona, STAND_IN_FN, lambda args: 0):
             self.assertEqual(news.probe(e)[0], news.ADOPTED)
 
     def test_a_probe_that_exits_leaves_nothing_armed(self):
         """`SystemExit` is not an `Exception`, so it takes a different path out of
         `_dispatch` — and argparse raises it for every malformed `check:`."""
-        e = self.write("version")
+        e = self.write(STAND_IN)
 
         def bail(args):
             raise SystemExit(2)
 
-        with mock.patch.object(commands, "cmd_version", bail):
+        with mock.patch.object(commands_persona, STAND_IN_FN, bail):
             self.assertEqual(news.probe(e)[0], news.UNKNOWN)
 
-        with mock.patch.object(commands, "cmd_version", lambda args: 0):
+        with mock.patch.object(commands_persona, STAND_IN_FN, lambda args: 0):
             self.assertEqual(news.probe(e)[0], news.ADOPTED)
 
 


### PR DESCRIPTION
Closes #317.

## The defect

`news.py`'s module docstring stated the restraint that made a `check:` safe:

> Actions are charter subcommands, dispatched in-process. No shell is ever involved and no argv is ever handed to one, so an entry cannot become an arbitrary-command primitive.

False. `_tokens` refused shell metacharacters and an unregistered first token, but `secret exec` registers `command` as a bare `nargs="*"` positional, so the tail of a `check:` was passed to `subprocess.run(command, env=env)` — with the vault's secret in the child's environment. `charter persona secret exec` is the same function.

`charter doctor` runs every **released** entry's `check:` unprompted, on a SessionStart hook, so the blast radius was every machine that upgraded. Bounded in practice by needing a vault that really resolves on the reading machine and by entries shipping in the wheel — the author is a charter maintainer. A stated restraint the code did not keep, not an exploited hole.

## The ruling: an allow-list, with the structural rule asserted across it

`_PROBEABLE` — `doctor`, `news`, `persona lint` — is what a `check:` may name. The invariant it encodes is the real one, and it is now what the docstring says:

> **A probe reads, and the argv it hands anything else is charter's rather than the entry's.**

**Why not derive it from the parser (option 3).** Only half the invariant is derivable. argparse can be asked whether a command takes a pass-through positional; it cannot be asked whether a command *writes*. `check: update --to X` reaching a real `uv tool install` is the same defect wearing no argv at all, and a structural rule waves it through — it has no pass-through positional. A rule that enforces one clause of a two-clause invariant cannot be the primary rule.

It is also weaker than it looks in the direction it does cover: a command can forward an entry-supplied string without a `nargs="*"` positional at all.

So option 3's mechanism is kept, and moved to where it is *total* rather than partial: a test asserting that no command on the list takes a pass-through positional, plus one asserting that every command that takes one today is off the list. Entries, list and parser ship in one wheel, so a test across the three is a proof rather than a sample. It fails the PR that adds the drift instead of the machine that installs it, and the SessionStart path stays free of a walk through argparse internals.

**Why not a deny-list (option 1).** Named in the issue as whack-a-mole and it is: the next subcommand with pass-through argv reopens the hole silently. It also cannot express "reads rather than acts".

**What the allow-list costs.** A maintenance point — a new probe-worthy command has to be added, and a forgotten one costs an honest `unknown` with a reason. It also refuses commands that are read-only but useless as probes, and that is the second question the list's comment asks: `version` is not listed, because it always exits 0, so an entry naming it would report adopted everywhere forever.

## Details worth reviewing

- **A path is the subcommand tokens only.** Listing `news` must not list `news stamp`, which renames files. `_command_path` returns `None` — refuse — when a subcommand hides behind a flag, because `charter news --pending stamp 9.9.9` really does reach `cmd_news_stamp`.
- **`adopt:` is deliberately not held to this rule.** It is the line a human is told to run, once, on purpose; `adopt: browser install` installs a browser, which is the point. `resolves` therefore stays parse-only — it runs over both fields.
- **#318's `probing()` / `refuse_mutation()` stay**, ahead of this rule in the call order so their marking is reached on exactly the paths it was before. They answer a different question: the list says what an entry may *name*; `probing()` says what a command does on finding itself inside a probe.
- **One vacuous test, caught and fixed.** `update` is now refused before `cmd_update` runs, so `AProbeDoesNotInstallSoftware` passed without ever reaching the guard it is about. That class now opens `_PROBEABLE` deliberately and asserts *which* refusal it got (`"changes this machine"`), so it cannot rot back into a pass. Verified by counterfactual: closing the list turns it red.
- **Five reason strings, not four.** A refused `check:` reports `unknown` naming its own command.
- **The stand-in command in the #311/#314 tests moved** from `version` to `persona lint` — a command an entry can really name — rather than patching the list in eleven places.
- **`_dispatch` is now cheaper than before this change**: it built the parser twice and now builds one and threads it through, so a probe drops ~6ms even with the extra check.

## Verification

TDD. The essential test was RED on `main` **at the process level** — not on a return value: it plants a `check:` whose tail starts a real interpreter that creates a sentinel file, and asserts the file does not exist.

```
FAIL: test_a_check_naming_secret_exec_starts_no_process
AssertionError: True is not false : a news probe started a process of the entry's choosing
FAIL: test_a_check_naming_persona_secret_exec_starts_no_process
AssertionError: True is not false : a news probe started a process of the entry's choosing
FAIL: test_the_entry_is_unchecked_rather_than_adopted
AssertionError: 'adopted' != 'unknown'
```

The test guards its own counterfactual: it asserts the command line contains no character `_tokens` reads as shell syntax and that it parses against the live parser, so a refusal for some unrelated reason cannot pass as the guard working. (One first draft *did* pass vacuously — `persona secret exec` takes its vault from the persona, so a vault token in front was read as the program name and died as "command not found".)

Also pinned: every shipped entry's `check:` is still probeable and still reaches `adopted`/`pending` rather than `unknown` — a fix that silently stopped probing everything would pass a naive test.

- `python3 -m unittest discover -s tests` — **2910 OK** (2894 on `main`; +16 all new)
- `python3 -m charter news --pending` → `nothing pending`, 0.25s
- `python3 -m charter doctor --json` → news row `ok | nothing to adopt`, 1.17s

No version bump; news entry staged at `version: unreleased` with no `check:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo