### PR TITLE
Release 0.47.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.47.1",
+  "version": "0.47.2",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.47.1"
+__version__ = "0.47.2"

--- a/docs/news/0.47.2-check-argv-restraint.md
+++ b/docs/news/0.47.2-check-argv-restraint.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.47.2
 headline: A news entry's `check:` can only name a command a probe is allowed to run
 ---
 

--- a/docs/news/0.47.2-probe-crosses-processes.md
+++ b/docs/news/0.47.2-probe-crosses-processes.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.47.2
 headline: A news probe no longer re-enters charter through a process it spawned
 ---
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.47.1",
+            "command": "charter hook sessionstart --plugin-version 0.47.2",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.47.1",
+            "command": "charter hook userpromptsubmit --plugin-version 0.47.2",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.47.1",
+            "command": "charter hook pretooluse --plugin-version 0.47.2",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.47.1",
+            "command": "charter hook pretooluse-read --plugin-version 0.47.2",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.47.1"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.47.2"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.47.1",
+            "command": "charter hook pretooluse-edit --plugin-version 0.47.2",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-bash --plugin-version 0.47.1",
+            "command": "charter hook posttooluse-bash --plugin-version 0.47.2",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.47.1",
+            "command": "charter hook posttooluse --plugin-version 0.47.2",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.47.1",
+            "command": "charter hook posttooluse-skill --plugin-version 0.47.2",
             "timeout": 5
           }
         ]
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.47.1",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.47.2",
             "timeout": 5
           }
         ]
@@ -128,7 +128,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-message --plugin-version 0.47.1",
+            "command": "charter hook posttooluse-message --plugin-version 0.47.2",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.47.1"
+version = "0.47.2"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Cuts **0.47.2** — the two probe fixes merged since `v0.47.1`.

## What ships

* **#318** (`7c059f4`, closes #314) — the probe guard crosses process boundaries. A `<pid>:<markpath>` environment marker, refusal travelling back up through a mark file so an outer probe stops reading a spawner's exit code as `adopted`, and `cmd_update` asking `news.probing()` itself so a probe cannot reach a real `uv tool install`.
* **#319** (`021c239`, closes #317) — a `check:` is held to `_PROBEABLE` (`doctor`, `news`, `persona lint`). Closes the `secret exec` path, which handed an entry-controlled argv to `subprocess.run` **with a vault credential in the child's environment**, and the `news --pending stamp X` path, where argparse reads past the flag and finds a subcommand that renames files.

**#316** (`a4bde1b`, the regenerated README captures) ships with no news entry, deliberately: its diff touches `docs/assets/` only — no `charter/`, `tests/`, `hooks/` or `pyproject.toml`.

## Why patch, not minor

Neither change adds a config key, a CLI flag, or a changed default — grepping the diff over `charter/` for `add_argument`/config reads returns nothing. Both are fixes to a stated restraint.

#319 does narrow what a `check:` may name, so an entry legal before is refused now. But entries ship inside the wheel, so the only authors are charter maintainers, and no shipped entry breaks: all three `check:` lines in the tree name `persona lint`, and `_PROBEABLE` matches on the subcommand path only, so `persona lint --only delegate-when` still resolves. All three probe **adopted** on this machine.

Taking the minor would also have spent capture-freshness slack for nothing: `MAX_MINOR_LAG = 1` against captures stamped 0.47.1 puts 0.48.0 at exactly the limit, where 0.47.2 sits at 0.

## Version points moved — 14, verified by re-grepping the old string

| File | Points |
|---|---|
| `pyproject.toml` | 1 |
| `charter/__init__.py` | 1 |
| `.claude-plugin/plugin.json` | 1 |
| `hooks/hooks.json` | **11** `--plugin-version` flags |

`grep -rn '0\.47\.1'` across the four returns nothing; the new string counts 14. `docs/assets/captured.json` stays at 0.47.1 by design — it records when the captures were taken, not the shipping version.

Both entries stamped onto 0.47.2 (renamed, and `version:` rewritten). Neither carries a `check:` or an `adopt:`.

## Verification

* **Full suite: `Ran 2910 tests ... OK`, exit code 0** — matches the `main` baseline exactly. Run after the bump and stamp, on this branch, with `__pycache__` cleared first (0.47.1 → 0.47.2 is the same byte length, so stale bytecode reads as real drift).
* `TestVersionsMoveInLockstep` (3 tests) and `test_asset_freshness` (5) pass individually.
* **`charter doctor` under an explicit 120s timeout: rc=0 in 1.52s.**
* **`charter news --for 0.47.2` (the CI guard's own call): rc=0**, both entries render.

### Behavioural confirmation, old code vs new

Both fixes confirmed against the stamped branch with a planted entry **asserted present in `news.released()` first**, so the timing is not vacuous. The old side runs from a throwaway `v0.47.1` worktree; the vault named does not exist, so no credential is resolved on either side.

`check: secret exec nosuchvault-zz -- true`

| | status | spawns during probe |
|---|---|---|
| v0.47.1 | `pending` — dispatched, exit code read | 0 (vault lookup failed first) |
| **0.47.2** | **`unknown`** — refused at the gate | **0** |

`check: news --pending stamp 9.9.9`, with a canary `unreleased-*.md` beside it:

| | status | canary |
|---|---|---|
| v0.47.1 | **`adopted`** | **renamed to `9.9.9-zzcanary.md`** |
| **0.47.2** | **`unknown`** | untouched |

Cross-process, with two real processes: a charter child started under `CHARTER_NEWS_PROBE` declines to probe and touches the mark file, and an outer probe whose descendant was refused reports **`unknown`, not `adopted`**.

## Not blocking, worth an issue

A `check:` containing shell syntax (quotes) is refused one gate earlier, by `_tokens`, and reports `_NOT_RUN` — "did not run here", which points the reader at their own machine — rather than `_UNLISTED`, which points at the entry as the defect. `news.py`'s own comment above `_NOT_RUN` says those two must not be folded together. Pre-existing (`_tokens`' shell refusal is unchanged by this release; only its signature moved), and the security property holds either way: no process starts.

## After merge

Tag from `main`, `v0.47.2` matching `pyproject.toml` exactly. Then CLI before plugin: `uv tool install --force --refresh charter-cp==0.47.2`, then `claude plugin marketplace update charter` and `claude plugin update charter@charter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo