### PR TITLE
Stop a branch name from making `gh` open a file (#323)

### DIFF
--- a/charter/forge/github.py
+++ b/charter/forge/github.py
@@ -119,12 +119,18 @@ class GitHubForge:
                 f"gh is not authenticated for {self.host}. Run: gh auth login")
 
     def list_repos(self, owner: str) -> list[dict]:
+        # Encoded like every other URL segment here (#323). `owner` comes from a
+        # `[[forge]]` block rather than from a forge response, so this is the ordinary
+        # discipline rather than a fix for a reachable hole — but "which values happen to
+        # be trusted today" is exactly the distinction that let `ci_status` drift away
+        # from `open_change`, so the treatment is uniform instead of case-by-case.
+        enc = urllib.parse.quote(owner, safe="")
         try:
-            out = self._paged_strict(f"orgs/{owner}/repos", owner, org_probe=True)
+            out = self._paged_strict(f"orgs/{enc}/repos", owner, org_probe=True)
         except _NotAnOrg:
             # A 404 on the org endpoint is expected for a personal account — not a
             # ForgeError. A failure of *this* call, though, is a genuine failure.
-            out = self._paged_strict(f"users/{owner}/repos", owner)
+            out = self._paged_strict(f"users/{enc}/repos", owner)
         return [self._normalize(r) for r in out]
 
     def _normalize(self, r: dict) -> dict:
@@ -182,10 +188,25 @@ class GitHubForge:
 
     def ci_status(self, path: str, branch: str) -> str | None:
         owner, _, name = path.partition("/")
+        # `-f/--raw-field`, never `-F/--field` (#323). These three values are not charter's:
+        # `branch` is read out of the tree's `.git/HEAD` and `path` out of `git remote
+        # get-url origin`, so both are written by whoever wrote the repo. `-F` gives a
+        # value magic meaning — from `gh api --help`, "if the value starts with `@`, the
+        # rest of the value is interpreted as a filename to read the value from. Pass `-`
+        # to read from standard input" — which turned a status refresh into an arbitrary
+        # local file read by a process holding the forge token, on a surface that renders
+        # every 10s with no human in the loop. `-f` sends the value as a literal string.
+        #
+        # NOT percent-encoded, deliberately, and this is the one place that differs from
+        # `open_change` above. Those are URL path/query segments, which the server decodes
+        # again; these are GraphQL variables, which are JSON strings GitHub never decodes.
+        # Encoding here would send `feature%2Fx` for `feature/x`, match no ref, and blank
+        # the CI column for every branch with a slash in it. The flag is the fix, not the
+        # value.
         p = util.run([self.cli, "api", "graphql", "--hostname", self.host,
                       "-f", f"query={_ROLLUP_QUERY}",
-                      "-F", f"owner={owner}", "-F", f"name={name}",
-                      "-F", f"ref={branch}"], check=False)
+                      "-f", f"owner={owner}", "-f", f"name={name}",
+                      "-f", f"ref={branch}"], check=False)
         if p.returncode != 0:
             return None
         try:

--- a/charter/forge/gitlab.py
+++ b/charter/forge/gitlab.py
@@ -105,7 +105,9 @@ class GitLabForge:
         }
 
     def repo_tree(self, repo: dict, ref: str | None = None) -> list[str]:
-        rid = repo.get("id")
+        # `id` comes off a forge response, same as `ref` beside it — encoded for the same
+        # reason (#323), rather than trusted because it is "normally an integer".
+        rid = urllib.parse.quote(str(repo.get("id")), safe="")
         ref_q = f"&ref={urllib.parse.quote(str(ref), safe='')}" if ref else ""
         out, page = [], 1
         while True:
@@ -123,7 +125,7 @@ class GitLabForge:
         """See :meth:`base.Forge.repo_tree_strict` — same pagination as :meth:`repo_tree`,
         but through :meth:`_api_strict` so a failure raises instead of degrading (FINDING
         I5)."""
-        rid = repo.get("id")
+        rid = urllib.parse.quote(str(repo.get("id")), safe="")
         ref_q = f"&ref={urllib.parse.quote(str(ref), safe='')}" if ref else ""
         out, page = [], 1
         while True:

--- a/docs/news/unreleased-forge-argv-encoding.md
+++ b/docs/news/unreleased-forge-argv-encoding.md
@@ -1,0 +1,35 @@
+---
+version: unreleased
+headline: A branch name can no longer make `gh` open a file on your machine
+---
+
+`gh api`'s `-F/--field` flag is not a string pass-through. From its own help: "if the value
+starts with `@`, the rest of the value is interpreted as a filename to read the value from.
+Pass `-` to read from standard input." Charter used `-F` to send three values to GitHub's
+CI rollup query — the repo owner, the repo name and the branch — and it did not write any of
+them. The branch is read out of the tree's `.git/HEAD`; the owner and name are parsed out of
+`git remote get-url origin`. Both are written by whoever wrote the repo.
+
+So a value shaped like a path made `gh` open that file and put its contents in the body of
+an authenticated request. One naming standard input made it block on the terminal. One
+naming something that never ends made it allocate without bound — 12 GB in four seconds,
+measured, still climbing. None of this needed anyone to type a command: the status line
+renders every ten seconds, forks a refresh every two minutes, and `charter gl-refresh` runs
+at session start. Checking out a branch from someone else's pull request was enough.
+
+The fix is the flag, not the value. `-f/--raw-field` sends what it is given and interprets
+nothing, so the same values now travel as literal strings. Percent-encoding — the treatment
+`open_change` eight lines above already applied, and the obvious thing to reach for — would
+have been wrong here and quietly expensive: a GraphQL variable is a JSON string GitHub never
+decodes, so `feature/x` would have gone out as `feature%2Fx`, matched no ref, and emptied
+the CI column for every team that puts a slash in a branch name. A URL path gets encoded; a
+variable gets a flag with no magic. Both are now covered by a test that reads the argv
+charter builds, across every backend call that takes a value from outside, so the next one
+to drift fails in the suite rather than on someone's machine.
+
+Two neighbours got the encoding they were missing while the rule was being written down: a
+GitHub owner and a GitLab repo id, both interpolated raw into an API path. Neither was
+reachable — one comes from your own `charter.toml`, the other is an integer — and that is
+the point. "Which values happen to be trusted today" is the distinction that let `ci_status`
+drift away from `open_change` in the first place, so the treatment is uniform now instead of
+argued case by case.

--- a/tests/test_forge_argv_encoding.py
+++ b/tests/test_forge_argv_encoding.py
@@ -1,0 +1,201 @@
+"""Every value a forge backend interpolates into a CLI argument must be percent-encoded.
+
+#323: `GitHubForge.ci_status` passed `owner`, `name` and `branch` to `gh api` as bare
+``-F key=value`` fields, while `open_change` — eight lines above, on the identical values —
+encoded them. That asymmetry mattered because `-F` is not a string pass-through. From
+``gh api --help``:
+
+    if the value starts with `@`, the rest of the value is interpreted as a
+    filename to read the value from. Pass `-` to read from standard input.
+
+So a field value is a *filename gh dereferences*, and those values are not charter's: a
+branch name comes from the tree's ``.git/HEAD`` and a repo path from ``git remote get-url
+origin``. A leading ``@`` turned a status refresh into an arbitrary local file read by a
+process holding the forge token.
+
+These tests assert **the argv charter builds**, never what `gh` or `glab` do with it — the
+CLIs are stubbed. That is deliberate: the invariant charter owns is "nothing external
+reaches an argument the CLI gives magic meaning to", and it is checkable without a network,
+a credential, or a real CLI.
+
+**There are two correct treatments, and the context picks which.** Percent-encoding is right
+for a value going into a URL path or query string, where the server decodes it again — that
+is what `open_change` does. It is *wrong* for a `gh` GraphQL variable, which is a JSON
+string GitHub never percent-decodes: encoding a branch there would turn ``feature/x`` into
+``feature%2Fx``, match no ref, and blank the CI column for every team that puts a slash in a
+branch name. The fix for a variable is the flag, not the value — ``-f/--raw-field`` has no
+magic, verified against gh 2.83.2, where ``-F name=@path`` sends the file's contents and
+``-f name=@path`` sends the literal string.
+
+The table below is the point of the file. It covers every backend method that takes a value
+charter did not write, so the *next* one to reach argv uninterpreted fails here rather than
+shipping — which is exactly how #323 got in, one method treating its inputs and its
+neighbour not.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter.forge.github import GitHubForge
+from charter.forge.gitlab import GitLabForge
+
+#: Starts with the character that makes `gh` read a file, and is otherwise inert — it names
+#: nothing on any filesystem. The test asserts it never survives into argv intact, so its
+#: only job is to be recognisable and to begin with ``@``.
+_HOSTILE = "@sentinel-not-a-path"
+
+#: The flags whose values `gh` gives magic meaning to: a leading ``@`` names a file to read,
+#: ``@-`` names stdin. `-f/--raw-field` is deliberately NOT here — it is the escape hatch,
+#: and the fix for #323 is to use it.
+_MAGIC_FIELD_FLAGS = ("-F", "--field")
+
+#: Every flag that carries a ``key=value`` payload, magic or not.
+_FIELD_FLAGS = _MAGIC_FIELD_FLAGS + ("-f", "--raw-field")
+
+
+def _stub_run(captured):
+    """Record argv and answer with an empty JSON object.
+
+    ``{}`` rather than ``[]``: it parses as "no result" through every caller here —
+    pagination stops, `arr[0]` is never reached, `.get()` chains bottom out — so no method
+    raises and none of them needs a bespoke stub.
+    """
+    def run(cmd, *a, **k):
+        captured.append(list(cmd))
+        return SimpleNamespace(stdout="{}", stderr="", returncode=0)
+    return run
+
+
+def _call_sites(forge, value):
+    """Every backend method that receives a value charter did not write.
+
+    ``(label, thunk)``. New forge methods taking external data belong here; that is what
+    makes this file a guard rather than a snapshot of the two methods #323 happened to be
+    about.
+    """
+    repo = {
+        "id": value,
+        "path_with_namespace": f"{value}/{value}",
+        "default_branch": value,
+    }
+    return [
+        ("open_change", lambda: forge.open_change(f"{value}/{value}", value)),
+        ("ci_status", lambda: forge.ci_status(f"{value}/{value}", value)),
+        ("repo_tree", lambda: forge.repo_tree(repo, value)),
+        ("repo_tree_strict", lambda: forge.repo_tree_strict(repo, value)),
+        ("list_repos", lambda: forge.list_repos(value)),
+    ]
+
+
+def _field_values(argv, flags=_FIELD_FLAGS):
+    """The ``value`` half of every ``key=value`` element that follows one of *flags*."""
+    out = []
+    for flag, element in zip(argv, argv[1:]):
+        if flag in flags and "=" in element:
+            out.append(element.split("=", 1)[1])
+    return out
+
+
+def _non_field_elements(argv):
+    """Everything that is not a field flag or its payload — the URL paths and positionals,
+    where percent-encoding is the treatment that applies."""
+    out, skip = [], False
+    for i, element in enumerate(argv):
+        if skip:
+            skip = False
+            continue
+        if element in _FIELD_FLAGS:
+            skip = True
+            continue
+        out.append(element)
+    return out
+
+
+class ForgeArgvEncodingTests(unittest.TestCase):
+    """Run each call site against each backend with a hostile value in every slot."""
+
+    def _argvs(self, forge, label_filter=None):
+        """``{label: [argv, ...]}`` for one backend, with the CLI stubbed."""
+        out = {}
+        for label, thunk in _call_sites(forge, _HOSTILE):
+            if label_filter and label != label_filter:
+                continue
+            captured = []
+            with mock.patch("charter.util.run", _stub_run(captured)):
+                try:
+                    thunk()
+                except Exception as e:      # a backend may reject the value outright —
+                    pass                    # refusing to build the argv is also compliant
+                    del e
+            out[label] = captured
+        return out
+
+    def _forges(self):
+        return (("github", GitHubForge()), ("gitlab", GitLabForge()))
+
+    def test_no_magic_field_value_begins_with_an_at_sign(self):
+        """#323's exact shape: a `-F` value starting with `@` is a file gh will open."""
+        for kind, forge in self._forges():
+            for label, argvs in self._argvs(forge).items():
+                for argv in argvs:
+                    for value in _field_values(argv, _MAGIC_FIELD_FLAGS):
+                        with self.subTest(forge=kind, call=label, value=value):
+                            self.assertFalse(
+                                value.startswith("@"),
+                                f"{kind}.{label} builds a field value gh would read as a "
+                                f"filename: {value!r} in {argv!r}")
+
+    def test_external_value_never_carried_by_a_magic_flag(self):
+        """Stronger than "must not begin with `@`", and the rule that actually holds.
+
+        `-F`'s magic is unconditional — it applies to whatever the value turns out to be,
+        and charter does not get to know that in advance. So no value charter did not write
+        may ride a magic flag at all, whatever it happens to start with today.
+        """
+        for kind, forge in self._forges():
+            for label, argvs in self._argvs(forge).items():
+                for argv in argvs:
+                    with self.subTest(forge=kind, call=label):
+                        self.assertNotIn(
+                            _HOSTILE, " ".join(_field_values(argv, _MAGIC_FIELD_FLAGS)),
+                            f"{kind}.{label} hands an external value to a flag that gives "
+                            f"it magic meaning: {argv!r}")
+
+    def test_external_value_percent_encoded_in_every_url_position(self):
+        """The other half: anything landing in a URL path or query must be encoded.
+
+        This is the treatment `open_change` already applies and the one #323's neighbours
+        were missing — a repo id and an owner interpolated raw into an API path.
+        """
+        for kind, forge in self._forges():
+            for label, argvs in self._argvs(forge).items():
+                for argv in argvs:
+                    with self.subTest(forge=kind, call=label):
+                        self.assertNotIn(
+                            _HOSTILE, " ".join(_non_field_elements(argv)),
+                            f"{kind}.{label} interpolated an external value into a URL "
+                            f"position unencoded: {argv!r}")
+
+    def test_a_slash_in_a_branch_survives_to_the_graphql_variable(self):
+        """The regression the *wrong* fix for #323 would have caused.
+
+        Percent-encoding is right for a URL and wrong for a GraphQL variable: GitHub does
+        not decode ``qualifiedName``, so an encoded ``feature/x`` matches no ref and the CI
+        column silently empties — for the branch-naming convention most teams use. This
+        pins the value as sent, so a future "just quote it" fails here.
+        """
+        forge = GitHubForge()
+        captured = []
+        with mock.patch("charter.util.run", _stub_run(captured)):
+            forge.ci_status("acme/api", "feature/nested/branch")
+        self.assertTrue(captured, "ci_status must reach the CLI")
+        values = _field_values(captured[0])
+        self.assertIn("feature/nested/branch", values,
+                      f"the branch must reach GitHub as written: {captured[0]!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #323.

`gh api`'s `-F/--field` is not a string pass-through — a value starting with `@` names a
file `gh` opens, and `@-` names stdin. `GitHubForge.ci_status` sent three values through it
that charter did not write: the owner and repo name parsed out of `git remote get-url
origin`, and the branch read out of the tree's `.git/HEAD`. `open_change`, eight lines
above on the identical values, treated them; `ci_status` did not.

## The change

**`ci_status` uses `-f/--raw-field`, which interprets nothing.**

```
before:  -F owner=<owner>  -F name=<name>  -F ref=<branch>
after:   -f owner=<owner>  -f name=<name>  -f ref=<branch>
```

**Deliberately not percent-encoded, and that is the one place this differs from
`open_change`.** Those are URL path and query segments, which the server decodes again.
These are GraphQL variables — JSON strings GitHub never percent-decodes. Encoding them
would send `feature%2Fx` for `feature/x`, match no ref, and silently blank the CI column for
every team that puts a slash in a branch name. The flag is the fix, not the value.

Verified against gh 2.83.2, same argv shape both times, pointed at a non-resolving host so
nothing left the machine:

| flag | what reaches the request body |
|---|---|
| `-F name=@<path>` | the file's contents |
| `-f name=@<path>` | the literal string `@<path>` |

The same flag change closes all three shapes the issue describes — file read, stdin block,
and the unbounded read that took `gh` to 12 GB in four seconds (it now exits immediately).

**Two neighbours got the encoding they were missing**, found by the test rather than by
reading: `GitHubForge.list_repos` interpolated an owner into `orgs/{owner}/repos` raw, and
`GitLabForge.repo_tree`/`repo_tree_strict` interpolated a repo id into `projects/{id}/…`
raw. Neither is reachable — the owner comes from `charter.toml`, the id is an integer — and
that is the reason to fix them anyway. "Which values happen to be trusted today" is exactly
the distinction that let `ci_status` drift away from `open_change` in the first place.

## The test

`tests/test_forge_argv_encoding.py` asserts **the argv charter builds**, never what `gh` or
`glab` do with it — the CLIs are stubbed, so it needs no network, no credential and no real
CLI. It is table-driven over every backend method that takes a value charter did not write
(`open_change`, `ci_status`, `repo_tree`, `repo_tree_strict`, `list_repos`) × both
backends, and encodes the rule in two halves, because there are two correct treatments and
the context picks which:

* no external value may ride a flag the CLI gives magic meaning to (`-F`/`--field`);
* any external value landing in a URL position must be percent-encoded.

Plus a fence against the wrong fix: a slash-bearing branch must survive to the GraphQL
variable intact. That one passes on `main` — it is there so a future "just quote it" fails.

Adding a forge method that takes outside data means adding a row to `_call_sites`, which is
what makes this a guard rather than a snapshot of the two methods this issue was about.

## Verification

* Suite: **2914 pass, 0 failures** (2910 on `main` + 4 new).
* Red→green confirmed by reverting only the `ci_status` flag change: 4 failures, all naming
  `ci_status`; restored → OK.
* Re-ran the original end-to-end reproduction through the real `charter gl-refresh` against
  a throwaway clone: the hostile values still reach argv (they are data, and that is fine),
  but on `-f`, where `gh` sends them as literal strings instead of opening them.

No version bump, no tag. News entry is `version: unreleased`, with no `check:`.

Leaves #324 (no timeout / inherited stdin / re-spawn), #325 (repo name → path) and #326
(control characters in rendered forge data) filed and unfixed, as sequenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo
