### PR TITLE
Contain names charter reads out of committed files (#328)

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -7,7 +7,8 @@ import json
 import re
 from pathlib import Path
 
-from . import config, docsrc, doctor, inventory, render, util, workspace, worktree
+from . import (config, contain, docsrc, doctor, inventory, render, util, workspace,
+               worktree)
 # One committer for the control plane, in charter/planegit.py. Re-exported rather
 # than moved-and-updated so every existing caller and test keeps working — the point
 # of the extraction is that there is ONE implementation, not that callers churn.
@@ -45,7 +46,21 @@ def _https_url(r: dict) -> str:
     for prefix in ssh_forms:
         if ssh.startswith(prefix):
             return https_base + ssh[len(prefix):]
-    return ssh
+    # Returns NOTHING rather than the value it was handed (#335). The fallthrough used to
+    # be unconditional, so anything that matched no known SSH form went to `git clone`
+    # verbatim — and `inventory/repos.json` is a tracked file. `ext::sh -c '…'` is a
+    # transport that runs a command; `--upload-pack=…` is not a URL at all but an option
+    # git reads off the argv; `/etc/passwd` is a path git will happily try to clone.
+    # Confirmed on 0.47.2: all three came back unchanged.
+    #
+    # The only thing stopping the first one today is git's own `protocol.*.allow`, which
+    # charter neither sets nor owns — people relax it for `ext` helpers, and a plane that
+    # has is unprotected. A function whose entire purpose is producing a URL that uses the
+    # right credential should not be able to return something that is not a URL, so this
+    # is an allowlist: HTTPS, or an SSH form `insteadof()` actually recognised. Refusing
+    # the shape rather than blacklisting `ext::` also means the next transport, and the
+    # leading-dash argv case, need no further thought.
+    return ""
 
 
 def _build_repo(forge, p: dict, no_probe: bool) -> tuple[dict, bool]:
@@ -364,6 +379,13 @@ def cmd_clone(args) -> int:
     failures = 0
     for res in results:
         r, dest = res["repo"], res["dest"]
+        if res["status"] == "refused":
+            # Named, never silently skipped: a refusal here means a committed file in this
+            # plane carries something that is not a name, and the person who can fix it is
+            # reading this output.
+            failures += 1
+            util.err(f"{r['name']!r}: not cloned — {res['reason']}.")
+            continue
         if res["status"] == "exists":
             util.info(f"{r['name']}: already cloned in '{ws}'")
         elif res["status"] == "ok":
@@ -398,12 +420,28 @@ def _clone_one(r: dict, wd) -> dict:
     from . import gitpolicy
     from .forge import registry
 
-    dest = wd / r["name"]
+    # #325: the destination is a name out of `inventory/repos.json`, a TRACKED file, and
+    # this join had nothing between the two. A name with parent components put the clone
+    # — and `gitpolicy.apply`'s write to `.git/config` — outside the workspace entirely.
+    # `contain.child` rather than `workspace.valid_name`: a forge mints these names, and
+    # `org/.github` is a real repo GitHub tells organisations to create.
+    dest = contain.child(wd, r.get("name") or "")
+    if dest is None:
+        return {"repo": r, "dest": wd, "status": "refused",
+                "reason": contain.refusal(str(r.get("name") or ""))}
     if dest.exists():
         return {"repo": r, "dest": dest, "status": "exists"}
     forge = registry.for_repo(r)
+    # #335: refusing the URL has to mean refusing the clone. Handing "" to `git clone`
+    # would be the same defect wearing this fix.
+    url = _https_url(r)
+    if not url:
+        return {"repo": r, "dest": dest, "status": "refused",
+                "reason": "its inventory record carries no HTTPS clone URL, and the "
+                          "`ssh_url` it does carry is not a form this forge recognises — "
+                          "charter will not hand git a string it did not build"}
     proc = _git([*_cred_flag(forge), "clone", "--branch", r["default_branch"],
-                 _https_url(r), str(dest)])
+                 "--", url, str(dest)])
     if proc.returncode != 0:
         return {"repo": r, "dest": dest, "status": "failed", "forge": forge,
                 "stderr": (proc.stderr or "").strip()}

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -16,7 +16,7 @@ import sys
 import time
 from types import SimpleNamespace
 
-from . import config, gitpolicy, util, workspace, worktree
+from . import config, contain, gitpolicy, util, workspace, worktree
 from .commands import (_cred_flag, _git, _origin_https, cmd_clone, commit_memory_reactive,
                        commit_push)
 
@@ -517,13 +517,40 @@ def cmd_workspace_restore(args) -> int:
             util.info(f"  on-demand: {r['name']} @ {r['branch']} (clone when you enter it)")
         util.info("Enter the workspace and clone as you go: charter clone <repo> -w " + name)
         return 0
-    missing = [r["name"] for r in repos
-               if not workspace.is_git_repo(workspace.workspace_dir(name) / r["name"])]
+    # #325/#334/#328 all describe this join and each frames it as another's: #325 claims
+    # it as the clone-destination half, #334 disclaims it as "the join #325 already
+    # names", and #328's bullet assigns it to #334. Three issues, one line, nobody's — so
+    # it is fixed HERE, explicitly, rather than left for whichever ticket closes last.
+    #
+    # `workspace.json` is committed precisely so a teammate can restore someone else's
+    # workspace; that is the feature, and it is what makes every field in it untrusted.
+    # `is_git_repo` below is an existence check, never a containment one, so without this
+    # a name with parent components selected a repository the operator never named — and
+    # `git checkout` plus a CREDENTIALED `git pull` then ran inside it (#334, confirmed on
+    # 0.47.2 by the target repository's own reflog).
+    wd = workspace.workspace_dir(name)
+    contained, refused = [], []
+    for r in repos:
+        d = contain.child(wd, str(r.get("name") or ""))
+        if d is None:
+            refused.append(r)
+        else:
+            contained.append((r, d))
+    for r in refused:
+        util.err(f"  {str(r.get('name'))!r}: refused — {contain.refusal(str(r.get('name') or ''))}. "
+                 f"Fix workspaces/{name}/workspace.json.")
+    # Per-entry, never per-file: a manifest is shared and committed, so rejecting the whole
+    # thing would let one bad row deny the other eight repos to the whole team — an attack
+    # in its own right. `restore` already skips repos it cannot reach and says so.
+    repos = [r for r, _ in contained]
+    if not repos:
+        util.err(f"No usable repos in '{name}'s manifest.")
+        return 1
+    missing = [r["name"] for r, d in contained if not workspace.is_git_repo(d)]
     if missing:
         cmd_clone(SimpleNamespace(repos=missing, workspace=name))
     ok = 0
-    for r in repos:
-        d = workspace.workspace_dir(name) / r["name"]
+    for r, d in contained:
         if not workspace.is_git_repo(d):
             util.warn(f"  {r['name']}: not cloned (no access?) — skipped.")
             continue
@@ -534,7 +561,27 @@ def cmd_workspace_restore(args) -> int:
             util.warn(f"  {r['name']}: origin host isn't a known/declared forge — skipped.")
             continue
         cred = _cred_flag(forge)
-        if _git(["checkout", r["branch"]], cwd=d).returncode == 0:
+        # #334's second half. A branch is a REF, not a path segment — `feature/x` is the
+        # convention most teams use — so no name rule applies here and the treatment is
+        # argv position instead. Without a guard, a manifest branch beginning with a dash
+        # is read by `git checkout` as an option, and `checkout` has options that write:
+        # `-b`, `-B`, `--orphan`, `--pathspec-from-file`.
+        #
+        # A leading dash is the whole check, and `git check-ref-format` is deliberately
+        # NOT used: verified against git 2.50.1, `check-ref-format refs/heads/-b` ACCEPTS
+        # `-b`, because a leading dash is legal inside a ref. Ref grammar answers a
+        # different question than argv safety, and reaching for it here would have cost a
+        # subprocess per repo while closing nothing.
+        branch = str(r.get("branch") or "")
+        if branch.startswith("-"):
+            util.err(f"  {r['name']}: refused branch {branch!r} — a branch read from a "
+                     f"committed manifest may not begin with '-', which git would read as "
+                     f"an option rather than a ref. Fix workspaces/{name}/workspace.json.")
+            continue
+        # `--` after the ref, so git cannot reinterpret it as a pathspec even if the guard
+        # above is ever loosened. (`checkout -- <x>` means the opposite: it forces the
+        # PATHSPEC reading, which is why the separator goes after the branch, not before.)
+        if _git(["checkout", branch, "--"], cwd=d).returncode == 0:
             _git([*cred, "pull", "--ff-only"], cwd=d)  # latest of the recorded branch
             util.ok(f"  {r['name']} @ {r['branch']}")
             ok += 1

--- a/charter/contain.py
+++ b/charter/contain.py
@@ -1,0 +1,119 @@
+"""One name, one directory: the containment rule for names charter reads out of files.
+
+Charter validated a name when a human typed it and never when it read one from a
+committed file (#328). `valid_name` lives in :mod:`charter.persona` and
+:mod:`charter.workspace` and is called from six places, all of them commands. The reading
+side — `extends:`, `uses:`, `[persona] default`, a `workspace.json` repo name, an
+`inventory/repos.json` name — joined the value onto a path with nothing in between, so a
+committed file could name a target outside the directory charter meant to look in.
+
+:mod:`charter.docsrc` already had the answer and it was never reused: a topic is matched
+against a shape before it becomes a page, because ``charter docs show ../../etc/passwd``
+"must not be a file-read primitive wearing a documentation command". This module is that
+idea, extracted so the five reading sites share one implementation instead of four
+near-misses and a fifth that forgets.
+
+**Two questions, kept apart on purpose.**
+
+*Shape* — "could this string name one entry in a directory?" — is :func:`segment_ok`.
+*Containment* — "does joining it stay inside the base?" — is :func:`child`. Callers use
+both, and the pair is deliberate rather than redundant: the shape check belongs where an
+identity is decided (`inventory.merge`, beside the bare-name collision logic that already
+treats the name as load-bearing), and the containment assertion belongs at every join,
+because a hand-edited or PR-modified tracked file never passes through the code that
+decided the identity. An identity-layer check alone is a guard the attacker walks around.
+
+**Who gets which shape rule.** Charter mints persona and workspace names — `persona
+create` and `workspace create` enforce their own `valid_name` — so those keep answering
+to `valid_name`, and lint agrees with the resolver by construction rather than by a second
+check kept in step by hand. A **forge** mints repo names, and `org/.github` is a real repo
+GitHub itself tells organisations to create, while `MyRepo` is merely ordinary. Imposing
+charter's creation-time alphabet on someone else's forge would refuse to clone both.
+:func:`segment_ok` is therefore the permissive rule: it forbids traversal and separators
+and nothing else.
+
+**Containment is lexical, and does not follow symlinks.** :func:`docsrc.read` resolves its
+page precisely to catch a symlink pointing out of the directory, and copying that here
+would be a mistake in two directions. It would do half of #336 — whose containment half is
+about symlinks in *every* file charter reads, not only the ones named by a name — while
+claiming none of it; and it would refuse a plane that legitimately symlinks a persona
+directory today, which is a working plane broken in exchange for a hole that stays open
+anyway. Traversal and absoluteness are what these five issues are about. Symlinks are
+filed, and stay filed.
+
+**Nothing here raises.** These checks sit under `doctor`, the status line and SessionStart,
+where the rule is that a hook may cost a session its briefing and never its turn. A refused
+name is reported as data — see :data:`NOT_A_SEGMENT` and the vocabulary in
+:mod:`charter.news`, which says five kinds of "no answer" five different ways for the same
+reason: folding a defect in a file behind a generic message hides the defect, and somebody
+has to fix it.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+#: Said once, so every site refuses in the same words. A reader who hits this has a defect
+#: in a committed file, not a typo, and the sentence has to be enough to act on: "no such
+#: repo" would send them looking for a repo that was never the point.
+NOT_A_SEGMENT = ("'{name}' is not a name — it is a path. This is read from a committed "
+                 "file and joined onto a directory, so it may name one entry there and "
+                 "nothing else: no '/', no '\\', no '.' or '..', and nothing absolute")
+
+#: The separators every platform charter runs on will honour. Backslash is included on
+#: POSIX too: the file is committed and shared, so the machine that *wrote* the name is
+#: not necessarily the machine that resolves it.
+_SEPARATORS = ("/", "\\")
+
+
+def segment_ok(name: str) -> bool:
+    """True when *name* could name one entry inside some directory.
+
+    Deliberately a question about the *string*, never about the disk. Asking the
+    filesystem would make a traversal succeed exactly when the attacker's target happens
+    to exist, which is the one case where the answer must not change.
+    """
+    if not name or not isinstance(name, str):
+        return False
+    if name in (".", ".."):
+        return False
+    if "\x00" in name:
+        # A NUL terminates the string inside the C library, so the name Python checked and
+        # the name the kernel opened would be two different strings.
+        return False
+    if any(sep in name for sep in _SEPARATORS):
+        return False
+    # Catches a Windows drive-qualified name ("C:x") and anything else the running
+    # platform considers rooted, without charter maintaining its own list of what those
+    # look like.
+    if os.path.isabs(name) or os.path.splitdrive(name)[0]:
+        return False
+    return True
+
+
+def child(base, name: str) -> Path | None:
+    """``base / name`` when that is a direct child of *base*, else ``None``.
+
+    ``None`` rather than an exception because every caller is on a path that must not
+    crash, and rather than a sanitised name because silently rewriting a name invents a
+    second identity for the same thing and hides the defect in the file that somebody
+    still has to fix.
+
+    The normalised comparison is belt and braces over :func:`segment_ok` — which already
+    forbids every separator, so the join cannot escape today. It is kept because it is the
+    half that still holds if the shape rule is ever loosened to admit some new name, which
+    is exactly the drift `docsrc`'s own comment warns about.
+    """
+    if not segment_ok(name):
+        return None
+    base = Path(base)
+    joined = base / name
+    if Path(os.path.normpath(joined)).parent != Path(os.path.normpath(base)):
+        return None
+    return joined
+
+
+def refusal(name: str) -> str:
+    """The one sentence every site uses to say why *name* was refused."""
+    return NOT_A_SEGMENT.format(name=name)

--- a/charter/inventory.py
+++ b/charter/inventory.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import json
 import re
 
-from . import config
+from . import config, contain
 
 
 def classify_kind(name: str) -> str:
@@ -225,6 +225,19 @@ def merge(batches: list[list[dict]]) -> list[dict]:
     for batch in batches:
         for r in batch:
             name = r["name"]
+            # #325/#328: the bare name is already load-bearing here — that is why the
+            # collision logic below exists — and the on-disk clone path derives from it.
+            # A name that cannot be one directory entry is not an identity, so it is
+            # refused where identity is settled rather than only where a path is joined.
+            #
+            # This does NOT make the checks at the joins redundant, and neither one is
+            # safe to delete. `inventory/repos.json` is a tracked file: a hand-edited or
+            # PR-modified inventory never passes through this function, so an
+            # identity-layer check alone is a guard that gets walked around. The joins
+            # assert independently; this stops a bad identity from being carried in the
+            # inventory and reported by `status` and `discover` as though it were a repo.
+            if not contain.segment_ok(name):
+                continue        # per-entry: one bad row must not deny the rest
             identity = (r.get("forge"), r["path_with_namespace"])
             prev_identity = owner_of_name.get(name)
             if prev_identity is not None and prev_identity != identity:

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -33,7 +33,7 @@ import shutil
 import time
 from pathlib import Path
 
-from . import config
+from . import config, contain
 
 _NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 
@@ -41,6 +41,31 @@ _NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 def valid_name(name: str) -> bool:
     # A leading '_' is reserved (the shared namespace) and rejected by the regex.
     return bool(name) and _NAME_RE.match(name) is not None
+
+
+def reference_ok(ref: str) -> bool:
+    """Can *ref*, read out of a committed file, name a persona at all?
+
+    **The one place that answers this**, so the resolver and the operator's own check
+    cannot disagree — which they did, and that divergence is #328's tell rather than a
+    detail of it. `structural_errors` tested membership in a *name* set while `lineage`
+    resolved a *path*, so `charter persona lint` printed
+
+        ✗ frontdoor: uses: '<relative path>' — no such persona (dangling)
+
+    about a reference `resolve()` loaded without complaint and whose `tools:` the
+    PreToolUse gate then honoured. The signal an operator would actively check said the
+    grant was inert while it was live (#329, #337).
+
+    `valid_name` is the right rule here and a *forge* name would not be: charter mints
+    persona names itself — `persona create` already enforces exactly this — so a reference
+    outside that alphabet cannot name a persona this plane contains. That makes lint and
+    the resolver agree by construction instead of by two checks kept in step by hand.
+
+    The containment join is belt and braces on top, per :mod:`charter.contain`: it is the
+    half that still holds if `_NAME_RE` is ever widened.
+    """
+    return valid_name(ref) and contain.child(config.PERSONAS_DIR, ref) is not None
 
 
 # --------------------------------------------------------------------------- #
@@ -142,7 +167,18 @@ def parse(text: str) -> tuple[dict, str]:
 
 def load(name: str) -> dict | None:
     """The persona's OWN (unmerged) definition. For the effective persona with
-    inheritance applied, use :func:`resolve`."""
+    inheritance applied, use :func:`resolve`.
+
+    **The choke point for every reference read out of a file.** `lineage`, `resolve`,
+    `tools_of`, `vault_of` and `effective_tools` all reach a definition through here, so
+    refusing a non-name here is what stops `extends:`/`uses:`/`borrows:` naming a file
+    outside `personas/` — rather than four guards at four call sites, three of which stay
+    correct. Returns None for a refused reference exactly as it does for one that names
+    nothing: the caller has no reason to tell a typo from an escape, and
+    `structural_errors` is where the difference is spelled out for the human.
+    """
+    if not reference_ok(name):
+        return None
     p = def_path(name)
     if not p.exists():
         return None
@@ -370,7 +406,9 @@ def default_persona() -> str | None:
         val = (config.PERSONAS_DIR / ".default").read_text().strip()
     except OSError:
         return None
-    return val if val and def_path(val).exists() else None
+    # `reference_ok` before `.exists()`: this dotfile is committed, so the value is a
+    # teammate's, and "a path that exists" was never the question being asked (#337).
+    return val if val and reference_ok(val) and def_path(val).exists() else None
 
 
 #: The outbound postures a persona may declare, least → most insistent. `off` is what an
@@ -474,7 +512,11 @@ def declared_default() -> str | None:
         val = _instance.default_persona_of(_instance.load(config.ROOT))
     except Exception:
         return None
-    return val if val and def_path(val).exists() else None
+    # Same as `default_persona`: `charter.toml` is committed, so this rung picks the
+    # session's acting identity out of a teammate-authorable file. Existence of a path was
+    # the wrong question — a reference climbing out of `personas/` named a file the plane
+    # does not contain, and `resolve()` merged its `vault:`, `role:` and `tools:` (#337).
+    return val if val and reference_ok(val) and def_path(val).exists() else None
 
 
 def _pointer_files() -> tuple[Path | None, Path | None]:
@@ -799,6 +841,26 @@ def is_draft(name: str) -> bool:
     return str(d["meta"].get("draft", "")).strip().lower() in _DRAFT_TRUE
 
 
+def _reference_problem(field: str, ref: str, known: set[str]) -> tuple[str, str] | None:
+    """Why *ref* cannot be used as a persona reference, or None when it can.
+
+    Two failures, said two ways, because they send the reader to two different places. A
+    name that is simply absent is a typo or a rename — "dangling" is right, and hunting
+    for the persona is the fix. A reference that is a *path* is not a name at all: no
+    amount of looking for that persona will help, and the fix is in the file. #328's whole
+    shape is a distinction like this one being collapsed, so it gets its own sentence.
+
+    Shares :func:`reference_ok` with :func:`load`, which is what makes lint and the
+    resolver structurally unable to disagree again — the property whose absence let the
+    gate honour a grant `lint` was calling dangling in the same run.
+    """
+    if not reference_ok(ref):
+        return ("error", f"{field}: {contain.refusal(ref)}")
+    if ref not in known:
+        return ("error", f"{field}: '{ref}' — no such persona (dangling)")
+    return None
+
+
 def structural_errors(name: str, known: set[str] | None = None) -> list[tuple[str, str]]:
     """The ``error``-level half of :func:`lint`: references that do not resolve.
 
@@ -815,15 +877,19 @@ def structural_errors(name: str, known: set[str] | None = None) -> list[tuple[st
     allnames = known if known is not None else set(list_personas())
     issues: list[tuple[str, str]] = []
     for u in uses_of(name):
-        if u not in allnames:
-            issues.append(("error", f"uses: '{u}' — no such persona (dangling)"))
+        problem = _reference_problem("uses", u, allnames)
+        if problem:
+            issues.append(problem)
     for b in borrows_of(name) or ():
-        if b not in allnames:
-            issues.append(("error", f"borrows: '{b}' — no such persona (dangling)"))
+        problem = _reference_problem("borrows", b, allnames)
+        if problem:
+            issues.append(problem)
     d = load(name)
     ext = ((d["meta"] if d else {}).get("extends") or "").strip()
-    if ext and ext not in allnames:
-        issues.append(("error", f"extends: '{ext}' — no such persona (dangling)"))
+    if ext:
+        problem = _reference_problem("extends", ext, allnames)
+        if problem:
+            issues.append(problem)
     cycle = _inherits_cycle(name)
     if cycle:
         issues.append(("error", f"extends: inheritance cycle ({cycle})"))

--- a/docs/news/unreleased-contain-names-from-files.md
+++ b/docs/news/unreleased-contain-names-from-files.md
@@ -1,0 +1,53 @@
+---
+version: unreleased
+headline: A name charter reads out of a committed file can no longer point outside the plane
+---
+
+Charter validated a name when a human typed it and never when it read one out of a file.
+`valid_name` exists twice — once for personas, once for workspaces — and was called from
+six places, every one of them a command handling a name someone had just typed at the
+prompt. No parser called either function. On the reading side, the same kind of value was
+joined onto a path or handed to git with nothing in between.
+
+Five issues came out of that one omission. `extends:` and `[persona] default` resolved as
+paths, so a reference climbing out of `personas/` became the acting persona and
+contributed its `vault:`, `role:` and `tools:` from a file the plane does not contain.
+`uses:` and `borrows:` did the same through `effective_tools`, whose result the PreToolUse
+gate turns into an `allow` — so a persona could be granted a tool declared outside the
+plane. A repo name in a workspace manifest selected the directory that `git checkout` and
+a **credentialed** `git pull` then ran inside. The same field in `inventory/repos.json`
+became a clone destination. And an inventory `ssh_url` was handed to `git clone`
+unchanged, so `ext::sh -c '…'` — a transport that runs a command — was stopped only by
+git's own `protocol.*.allow` default, which charter neither sets nor owns.
+
+The tell that this was one omission and not five bugs is that charter already disagreed
+with itself about it. `charter persona lint` checked a reference by looking for the name in
+a set and reported `uses: '…' — no such persona (dangling)`, while the resolver joined the
+same string onto a path and loaded it. Both ran in one session: the operator's own check
+said the grant was inert while the gate was honouring it. The lint and the resolver now
+share one function, so they cannot answer differently again, and a reference that is a path
+rather than a name says so instead of being reported as a typo — those send you to two
+different places, and only one of them has the problem in it.
+
+**The rule is per-name-kind, because two different systems mint these names.** Charter
+mints persona and workspace names, and `persona create` already enforces the alphabet, so
+persona references answer to that same rule and agreement is structural rather than
+maintained by hand. A *forge* mints repo names, so those get a permissive rule that forbids
+traversal and separators and nothing else — `org/.github` is a repo GitHub itself tells
+organisations to create, and a fix that refused to clone it would have broken working
+planes in exchange for closing a hole.
+
+Two smaller things travelled with it. A branch name from a manifest can no longer reach git
+as an option: `git checkout` has options that write, and a manifest is a committed file
+anyone on the team can edit. `git check-ref-format` is deliberately not what does this —
+it *accepts* `refs/heads/-b`, because a leading dash is legal inside a ref, so ref grammar
+and argv safety turn out to be different questions. And `_https_url` now returns an HTTPS
+URL or nothing, rather than passing through whatever it could not classify.
+
+Containment here is lexical and does not follow symlinks. That is a deliberate limit rather
+than an oversight: symlinks in the files charter reads are a separate, filed problem that
+covers every plane file and not just the ones named by a name, and resolving links here
+would have claimed none of it while refusing planes that legitimately symlink a persona
+directory today. What is checked is covered by a table-driven test across every site that
+takes a name from a file, so the next join to skip containment fails in the suite rather
+than shipping.

--- a/tests/test_names_from_files_are_contained.py
+++ b/tests/test_names_from_files_are_contained.py
@@ -1,0 +1,525 @@
+"""A name charter reads OUT OF A FILE must name one entry inside its own base, or nothing.
+
+#328: `valid_name` exists in `charter/persona.py:41` and `charter/workspace.py:81` and is
+called from six places — `persona create`, `workspace create`/`rename`, the `--piece`
+argument, `workspace.ensure`. Every one of them is a command handling a name a human just
+typed. **No parser called either function.** On the reading side the same values were
+joined onto a path or handed to argv with nothing in between, so a committed file could
+name a target outside the directory charter meant to look in.
+
+The five instances this file covers, all one omission:
+
+* **#337** — `extends:` and `[persona] default` resolve through `def_path()`, which joins
+  onto `PERSONAS_DIR` and asks only whether the result exists. A reference with parent
+  components became the acting persona, contributing its `vault:`, `role:` and `tools:`.
+* **#329** — the same join reached from `uses:`/`borrows:` via `effective_tools`, whose
+  result the PreToolUse gate turns into an `allow`.
+* **#334** — a `workspace.json` repo name joined onto the workspace directory, then
+  `git checkout` and a **credentialed** `git pull` run in whatever that landed on.
+* **#325** — the same field from `inventory/repos.json` becoming a `git clone` destination.
+* **#335** — an inventory `ssh_url` returned unchanged into the `git clone` argv.
+
+**Two populations, two shape rules, one containment rule.** Charter mints persona names
+(`persona create` enforces `valid_name`), so a persona reference outside that alphabet
+cannot name a real persona and `valid_name` is exactly right there. A *forge* mints repo
+names, and `org/.github` is both real and common — so repo names get the more permissive
+`contain.segment_ok`, which forbids separators and traversal without inventing an
+alphabet charter has no business imposing on someone else's forge.
+
+**Containment here is lexical, not `realpath`-based, and that is deliberate.**
+`docsrc.read` resolves its page specifically to catch a symlink pointing out of the
+directory. Following that lead here would quietly do half of #336 — whose containment
+half is about symlinks in *every* file charter reads, not just names — and would refuse a
+plane that legitimately symlinks a persona directory today. Traversal and absoluteness are
+what these five issues are about; symlinks are filed separately and stay filed.
+
+**Preconditions are asserted, not assumed.** Each traversal case plants a real canary at
+the path the hostile name resolves to and asserts it is there *before* asking charter to
+refuse — a refusal because the file happened not to exist would prove nothing, and this
+audit produced four vacuous passes exactly that way. The benign half of every table is
+just as load-bearing: it is what catches a fix that contains names by refusing all of them.
+
+The tables are the point of the file. They cover every entry point that takes a name from
+a file, so the *next* parser to skip containment fails here rather than shipping — which
+is how #323's fix was made durable, and how this one omission came to wear five issue
+numbers.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import (commands, commands_workspace, config, contain, inventory, persona,
+                     workspace)
+from tests._isolation import PersonaIso
+
+#: Hostile references, by the shape that makes them hostile. Every entry point below is
+#: run against every one of these.
+#:
+#: `..` and `.` are here because they are the two names that traverse without containing a
+#: separator, so a check that only rejects `/` lets them through.
+_TRAVERSING = ("../outside", "../../beyond", "..", ".", "sub/dir", "sub\\dir", "")
+
+#: Names a real forge really produces. A containment fix that refuses these has broken a
+#: working plane, which is a worse outcome than the traversal it set out to prevent —
+#: `org/.github` is the special repo GitHub itself tells organisations to create.
+_REAL_REPO_NAMES = (".github", "MyRepo", "api", "a.b-c", "repo_1", "x")
+
+#: Names `charter persona create` accepts, and therefore the only ones a persona reference
+#: can legitimately carry.
+_REAL_PERSONA_NAMES = ("base", "front-door", "a.b_c", "steward2")
+
+
+class SegmentShapeTests(unittest.TestCase):
+    """The permissive shape rule, on its own. Repo names come from a forge, not charter."""
+
+    def test_accepts_the_names_a_forge_really_mints(self):
+        for name in _REAL_REPO_NAMES:
+            with self.subTest(name=name):
+                self.assertTrue(contain.segment_ok(name),
+                                f"{name!r} is a real repo name and must stay clonable")
+
+    def test_rejects_every_traversing_shape(self):
+        for name in _TRAVERSING:
+            with self.subTest(name=name):
+                self.assertFalse(contain.segment_ok(name),
+                                 f"{name!r} does not name one entry in a directory")
+
+    def test_rejects_an_absolute_path(self):
+        for name in ("/etc", "/etc/passwd", "//host/share"):
+            with self.subTest(name=name):
+                self.assertFalse(contain.segment_ok(name))
+
+    def test_rejects_a_nul_byte(self):
+        """A NUL truncates the name inside the C library, so what Python checked and what
+        the kernel opened would be two different strings."""
+        self.assertFalse(contain.segment_ok("api\x00/../../etc"))
+
+
+class ContainedJoinTests(unittest.TestCase):
+    """The containment rule, on its own — lexical, and it never touches the filesystem."""
+
+    def setUp(self):
+        self.base = Path(tempfile.mkdtemp(prefix="contain-test-"))
+
+    def test_a_good_name_joins_to_a_child_of_the_base(self):
+        got = contain.child(self.base, "api")
+        self.assertEqual(got, self.base / "api")
+
+    def test_a_traversing_name_yields_nothing(self):
+        for name in _TRAVERSING + ("/etc",):
+            with self.subTest(name=name):
+                self.assertIsNone(contain.child(self.base, name))
+
+    def test_it_does_not_consult_the_filesystem(self):
+        """A missing directory and a present one must give the same answer: this is a
+        question about the name, and making it a question about the disk would mean a
+        traversal succeeds exactly when the attacker's target happens to exist."""
+        self.assertEqual(contain.child(self.base / "does-not-exist", "api"),
+                         self.base / "does-not-exist" / "api")
+
+    def test_a_symlinked_base_is_not_refused(self):
+        """#336's containment half is symlinks, and it stays filed. A plane that symlinks
+        a persona directory works today and must keep working after this change."""
+        real = self.base / "real"
+        real.mkdir()
+        link = self.base / "link"
+        link.symlink_to(real, target_is_directory=True)
+        self.assertEqual(contain.child(link, "api"), link / "api")
+
+
+class PersonaReferenceTests(PersonaIso):
+    """#337 and #329: every rung that turns a persona *reference* into a persona."""
+
+    def setUp(self):
+        super().setUp()
+        # The canary that a traversing reference resolves to. Inside the tmp root but
+        # OUTSIDE `personas/`, which is the base being defended.
+        outside = self.tmp / "outside"
+        outside.mkdir(parents=True, exist_ok=True)
+        (outside / "persona.md").write_text(
+            "---\nname: outside\nrole: Outside The Base\nvault: outside-vault\n"
+            "tools: CanaryTool\n---\n\nCANARY-BODY-FROM-OUTSIDE-THE-BASE\n")
+        self.canary = outside / "persona.md"
+        # And one genuinely outside the plane, reached by an absolute reference.
+        beyond = Path(tempfile.mkdtemp(prefix="beyond-plane-"))
+        (beyond / "persona.md").write_text(
+            "---\nname: beyond\ntools: CanaryTool\n---\n\nCANARY-BEYOND-THE-PLANE\n")
+        self.beyond_ref = str(beyond)
+        self.addCleanup(lambda: __import__("shutil").rmtree(beyond, ignore_errors=True))
+
+    def _persona(self, name, body="body", **meta):
+        d = config.PERSONAS_DIR / name
+        d.mkdir(parents=True, exist_ok=True)
+        fm = "\n".join(f"{k}: {v}" for k, v in {"name": name, **meta}.items())
+        (d / "persona.md").write_text(f"---\n{fm}\n---\n\n{body}\n")
+
+    def _hostile_refs(self):
+        """Every hostile reference, each proven to reach a real file first."""
+        self.assertTrue(self.canary.is_file(),
+                        "PRECONDITION: the canary persona must exist outside the base")
+        rel = "../outside"
+        self.assertTrue((config.PERSONAS_DIR / rel / "persona.md").is_file(),
+                        "PRECONDITION: '../outside' must reach the canary from PERSONAS_DIR, "
+                        "or a refusal proves only that the file was missing")
+        self.assertTrue((Path(self.beyond_ref) / "persona.md").is_file(),
+                        "PRECONDITION: the absolute reference must reach a real persona file")
+        return (rel, self.beyond_ref)
+
+    # -- the parser itself ------------------------------------------------- #
+    def test_load_refuses_a_reference_that_is_not_a_persona_name(self):
+        for ref in self._hostile_refs():
+            with self.subTest(ref=ref):
+                self.assertIsNone(persona.load(ref),
+                                  f"load({ref!r}) read a definition outside PERSONAS_DIR")
+
+    def test_load_still_reads_every_name_charter_mints(self):
+        for name in _REAL_PERSONA_NAMES:
+            self._persona(name)
+            with self.subTest(name=name):
+                self.assertIsNotNone(persona.load(name))
+
+    def test_resolve_refuses_the_same_references(self):
+        for ref in self._hostile_refs():
+            with self.subTest(ref=ref):
+                self.assertIsNone(persona.resolve(ref))
+
+    # -- #337: extends: ----------------------------------------------------- #
+    def test_extends_does_not_pull_a_charter_from_outside_the_base(self):
+        for ref in self._hostile_refs():
+            with self.subTest(ref=ref):
+                self._persona("victim", "VICTIM BODY", extends=ref)
+                self.assertEqual(persona.lineage("victim"), ["victim"],
+                                 f"extends: {ref!r} joined a chain outside PERSONAS_DIR")
+                self.assertNotIn("CANARY", persona.resolve("victim")["charter"])
+
+    def test_extends_does_not_inherit_scalars_from_outside_the_base(self):
+        """`resolve` merges the parent's `vault:` and `role:`, so containment failing here
+        hands the child an identity out of a file the plane does not contain."""
+        self._persona("victim", "VICTIM BODY", vault="victim-vault", extends="../outside")
+        meta = persona.resolve("victim")["meta"]
+        self.assertEqual(meta["vault"], "victim-vault")
+        self.assertNotEqual(meta.get("role"), "Outside The Base")
+
+    # -- #329: uses:/borrows: → effective_tools → the PreToolUse gate -------- #
+    def test_uses_does_not_grant_tools_from_outside_the_base(self):
+        for ref in self._hostile_refs():
+            with self.subTest(ref=ref):
+                self._persona("front", "front door", tools="Read", uses=ref)
+                self.assertEqual(persona.effective_tools("front"), {"Read"},
+                                 f"uses: {ref!r} granted a tool declared outside PERSONAS_DIR")
+
+    def test_borrows_does_not_grant_tools_from_outside_the_base(self):
+        for ref in self._hostile_refs():
+            with self.subTest(ref=ref):
+                self._persona("front", "front door", tools="Read", borrows=ref)
+                self.assertEqual(persona.effective_tools("front"), {"Read"})
+
+    def test_uses_still_grants_tools_from_a_real_persona(self):
+        self._persona("helper", "helper", tools="Bash")
+        self._persona("front", "front", tools="Read", uses="helper")
+        self.assertEqual(persona.effective_tools("front"), {"Read", "Bash"})
+
+    # -- #337: the declared front door -------------------------------------- #
+    def test_charter_toml_default_cannot_name_a_file_outside_the_base(self):
+        for ref in self._hostile_refs():
+            with self.subTest(ref=ref):
+                (config.ROOT / "charter.toml").write_text(
+                    f'schema = 1\n\n[persona]\ndefault = "{ref}"\n')
+                self.assertIsNone(persona.declared_default(),
+                                  f"[persona] default = {ref!r} became the acting identity")
+                self.assertNotEqual(persona.resolve_active(), ref)
+
+    def test_charter_toml_default_still_resolves_a_real_persona(self):
+        self._persona("steward2")
+        (config.ROOT / "charter.toml").write_text(
+            'schema = 1\n\n[persona]\ndefault = "steward2"\n')
+        self.assertEqual(persona.declared_default(), "steward2")
+
+    def test_legacy_default_dotfile_cannot_name_a_file_outside_the_base(self):
+        for ref in self._hostile_refs():
+            with self.subTest(ref=ref):
+                (config.PERSONAS_DIR / ".default").write_text(ref + "\n")
+                self.assertIsNone(persona.default_persona())
+
+    def test_legacy_default_dotfile_still_resolves_a_real_persona(self):
+        self._persona("base")
+        (config.PERSONAS_DIR / ".default").write_text("base\n")
+        self.assertEqual(persona.default_persona(), "base")
+
+
+class LintAndResolverAgreeTests(PersonaIso):
+    """#328's tell: `structural_errors` tested membership in a name set while the resolver
+    resolved a path, so `lint` called a reference dangling that the gate honoured.
+
+    The rule this pins is not "both reject the same strings today" — it is that the
+    *operator's own check* can never say a reference is inert while the resolver acts on
+    it. That is the property whose absence produced all five issues.
+    """
+
+    def setUp(self):
+        super().setUp()
+        outside = self.tmp / "outside"
+        outside.mkdir(parents=True, exist_ok=True)
+        (outside / "persona.md").write_text("---\nname: outside\ntools: CanaryTool\n---\n\nx\n")
+
+    def _persona(self, name, **meta):
+        d = config.PERSONAS_DIR / name
+        d.mkdir(parents=True, exist_ok=True)
+        fm = "\n".join(f"{k}: {v}" for k, v in {"name": name, **meta}.items())
+        (d / "persona.md").write_text(f"---\n{fm}\n---\n\nbody\n")
+
+    def test_a_reference_lint_calls_broken_is_one_the_resolver_refuses(self):
+        refs = ("../outside", "..", "sub/dir", "no-such-persona")
+        for field in ("uses", "borrows", "extends"):
+            for ref in refs:
+                with self.subTest(field=field, ref=ref):
+                    self._persona("subject", **{field: ref})
+                    errs = persona.structural_errors("subject")
+                    self.assertTrue(errs, f"lint stayed silent about {field}: {ref!r}")
+                    self.assertIsNone(
+                        persona.load(ref),
+                        f"lint reports {field}: {ref!r} broken while the resolver loads it")
+
+    def test_a_traversing_reference_is_not_reported_as_a_typo(self):
+        """"no such persona (dangling)" sends whoever fixes the file hunting for a typo.
+        A reference that is not a name at all is a different defect and reads differently."""
+        self._persona("subject", uses="../outside")
+        messages = " ".join(m for _, m in persona.structural_errors("subject"))
+        self.assertIn("../outside", messages)
+        self.assertNotIn("dangling", messages,
+                         "a path-shaped reference is not a dangling name")
+
+    def test_lint_stays_silent_about_a_reference_that_resolves(self):
+        self._persona("helper")
+        self._persona("subject", uses="helper")
+        self.assertEqual(persona.structural_errors("subject"), [])
+
+
+class ManifestRepoNameTests(PersonaIso):
+    """#334: `workspace restore` reads repo names out of a committed `workspace.json`,
+    joins them onto the workspace directory and runs git — including a **credentialed**
+    `pull` — in whatever the join landed on.
+
+    Asserts the argv and the working directory charter builds, never what git does with
+    them: the invariant charter owns is that no git command runs outside the workspace,
+    and it is checkable without a network, a credential, or a real repository.
+    """
+
+    def _manifest(self, ws, rows):
+        workspace.ensure(ws)
+        workspace.write_manifest(ws, {"name": ws, "repos": rows})
+
+    def _run_restore(self, ws):
+        """Run restore with git stubbed; return every ``(argv, cwd)`` it attempted."""
+        calls = []
+
+        def fake_git(args, cwd=None):
+            calls.append((list(args), None if cwd is None else Path(cwd)))
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+        with mock.patch.object(commands_workspace, "_git", fake_git), \
+             mock.patch.object(commands_workspace, "cmd_clone", lambda *a, **k: 0), \
+             mock.patch.object(commands_workspace.gitpolicy, "forge_for",
+                               lambda d: SimpleNamespace(
+                                   cli="gh", credential_helper=lambda: "!gh auth git-credential")), \
+             mock.patch.object(commands_workspace.workspace, "is_git_repo", lambda d: True):
+            commands_workspace.cmd_workspace_restore(
+                SimpleNamespace(name=ws, on_demand=False))
+        return calls
+
+    def test_a_traversing_repo_name_runs_no_git_anywhere(self):
+        ws = "probe"
+        for name in _TRAVERSING:
+            with self.subTest(name=name):
+                self._manifest(ws, [{"name": name, "branch": "main"}])
+                wd = workspace.workspace_dir(ws)
+                for argv, cwd in self._run_restore(ws):
+                    self.assertIsNotNone(cwd, f"{argv!r} ran with no working directory")
+                    self.assertTrue(
+                        str(cwd.resolve()).startswith(str(wd.resolve())),
+                        f"git ran OUTSIDE the workspace: {argv!r} in {cwd}")
+
+    def test_a_real_repo_name_still_gets_checked_out_and_pulled(self):
+        """The precondition for every refusal above: this code path really does run git,
+        so 'no git ran' is a refusal rather than a command that never executed."""
+        ws = "probe"
+        self._manifest(ws, [{"name": ".github", "branch": "main"}])
+        calls = self._run_restore(ws)
+        verbs = [argv[0] if argv[0] != "-c" else argv[2] for argv, _ in calls]
+        self.assertIn("checkout", verbs, f"restore ran no checkout at all: {calls!r}")
+        self.assertTrue(any("pull" in argv for argv, _ in calls),
+                        f"restore ran no pull at all: {calls!r}")
+
+    def test_a_branch_cannot_reach_git_as_an_option(self):
+        """#334's second half. `git checkout -B x` writes; a manifest is a committed file
+        anyone on the team can edit, so a branch beginning with a dash must not be read as
+        a flag. Verified against git 2.50.1: `check-ref-format refs/heads/-b` *accepts*
+        `-b`, so ref grammar is not what closes this — argv position is."""
+        ws = "probe"
+        for branch in ("-B", "--orphan", "-b", "--pathspec-from-file=/etc/passwd"):
+            with self.subTest(branch=branch):
+                self._manifest(ws, [{"name": "api", "branch": branch}])
+                for argv, _ in self._run_restore(ws):
+                    self.assertNotIn(branch, argv,
+                                     f"a manifest branch reached git argv as {branch!r}: {argv!r}")
+
+    def test_a_branch_with_a_slash_still_reaches_git(self):
+        """The regression the careless fix causes: `feature/x` is the convention most
+        teams use, and it is not a traversal — the branch is a ref, not a path segment."""
+        ws = "probe"
+        self._manifest(ws, [{"name": "api", "branch": "feature/nested/branch"}])
+        argvs = [argv for argv, _ in self._run_restore(ws)]
+        self.assertTrue(any("feature/nested/branch" in argv for argv in argvs),
+                        f"the branch must reach git as written: {argvs!r}")
+
+
+class CloneDestinationTests(PersonaIso):
+    """#325: an `inventory/repos.json` name becoming a `git clone` destination."""
+
+    def test_a_traversing_repo_name_never_becomes_a_clone_destination(self):
+        wd = self.tmp / "workspaces" / "probe"
+        wd.mkdir(parents=True, exist_ok=True)
+        for name in _TRAVERSING:
+            with self.subTest(name=name):
+                calls = []
+
+                def fake_git(args, cwd=None):
+                    calls.append(list(args))
+                    return SimpleNamespace(stdout="", stderr="", returncode=1)
+
+                r = {"name": name, "default_branch": "main", "forge": "github",
+                     "web_url": "https://github.com/acme/api",
+                     "path_with_namespace": "acme/api"}
+                with mock.patch.object(commands, "_git", fake_git):
+                    commands._clone_one(r, wd)
+                for argv in calls:
+                    for element in argv:
+                        self.assertFalse(
+                            str(element).startswith(str(self.tmp)) and
+                            not str(Path(element).resolve()).startswith(str(wd.resolve())),
+                            f"clone destination escaped the workspace: {argv!r}")
+
+    def test_a_real_repo_name_still_clones(self):
+        wd = self.tmp / "workspaces" / "probe"
+        wd.mkdir(parents=True, exist_ok=True)
+        calls = []
+
+        def fake_git(args, cwd=None):
+            calls.append(list(args))
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+        r = {"name": ".github", "default_branch": "main", "forge": "github",
+             "web_url": "https://github.com/acme/.github",
+             "path_with_namespace": "acme/.github"}
+        with mock.patch.object(commands, "_git", fake_git), \
+             mock.patch.object(commands, "gitpolicy", SimpleNamespace(apply=lambda d: None),
+                               create=True):
+            res = commands._clone_one(r, wd)
+        self.assertEqual(res["status"], "ok", f"a real repo name must still clone: {res!r}")
+        self.assertTrue(any("clone" in argv for argv in calls))
+        self.assertEqual(res["dest"], wd / ".github")
+
+
+class InventoryIdentityTests(unittest.TestCase):
+    """The other half of the defence in depth, per #325's own fix direction.
+
+    `inventory.merge` is where a repo's *identity* is decided — its bare name is already
+    load-bearing there, which is why it carries collision logic that refuses two repos
+    sharing one. A name with a separator in it is not a valid identity, so it is refused
+    where identity is settled, not only where a path is joined.
+
+    Both layers exist deliberately and neither is redundant. `inventory/repos.json` is a
+    tracked file: a hand-edited or PR-modified inventory never passes through `merge`, so
+    the identity check alone is a guard an attacker walks straight around — which is why
+    every join asserts independently. And a join-only check would let a bad identity sit
+    in the inventory being reported by `status` and `discover` as though it were a repo.
+    """
+
+    def _record(self, name):
+        return {"name": name, "path_with_namespace": f"acme/{name}", "forge": "github",
+                "default_branch": "main", "web_url": f"https://github.com/acme/{name}"}
+
+    def test_a_name_that_is_not_a_segment_is_not_given_an_identity(self):
+        for name in _TRAVERSING:
+            with self.subTest(name=name):
+                got = inventory.merge([[self._record(name)]])
+                self.assertEqual([r["name"] for r in got], [],
+                                 f"{name!r} was recorded as a repo identity")
+
+    def test_real_repo_names_keep_their_identity(self):
+        got = inventory.merge([[self._record(n) for n in _REAL_REPO_NAMES]])
+        self.assertEqual(sorted(r["name"] for r in got), sorted(_REAL_REPO_NAMES))
+
+    def test_a_bad_name_does_not_take_the_good_ones_with_it(self):
+        """Per-entry, never per-file — the same rule `restore` follows. One bad row in a
+        shared, committed file must not deny the whole inventory to the team."""
+        rows = [self._record("api"), self._record("../escape"), self._record(".github")]
+        got = inventory.merge([rows])
+        self.assertEqual(sorted(r["name"] for r in got), [".github", "api"])
+
+
+class CloneUrlTests(unittest.TestCase):
+    """#335: `_https_url` returned whatever the inventory said when no SSH form matched.
+
+    The bound today is git's own `protocol.*.allow`, which charter neither sets nor owns —
+    a plane on a git where `ext` has been enabled has no bound at all. A function whose
+    entire purpose is normalising a URL so the right credential is used should not be able
+    to return something that is not a URL.
+    """
+
+    #: Every shape the fallthrough returned verbatim on 0.47.2, confirmed by calling it.
+    _HOSTILE_URLS = (
+        "ext::sh -c 'touch /tmp/charter-pwned'",   # a transport that runs a command
+        "--upload-pack=touch /tmp/charter-pwned",  # not a URL at all — a git option
+        "/etc/passwd",                             # a local path git will happily clone
+        "file:///etc",
+        "-",
+        "",
+    )
+
+    def test_a_url_that_is_not_https_is_refused(self):
+        for url in self._HOSTILE_URLS:
+            with self.subTest(url=url):
+                got = commands._https_url({"ssh_url": url, "forge": "github",
+                                           "path_with_namespace": "acme/api"})
+                self.assertFalse(
+                    got, f"_https_url returned a non-HTTPS value into the clone argv: {got!r}")
+
+    def test_a_web_url_still_becomes_a_clone_url(self):
+        got = commands._https_url({"web_url": "https://github.com/acme/api",
+                                   "forge": "github", "path_with_namespace": "acme/api"})
+        self.assertEqual(got, "https://github.com/acme/api.git")
+
+    def test_a_known_ssh_form_is_still_rewritten(self):
+        got = commands._https_url({"ssh_url": "git@github.com:acme/api.git",
+                                   "forge": "github", "path_with_namespace": "acme/api"})
+        self.assertTrue(got.startswith("https://"), got)
+        self.assertIn("acme/api", got)
+
+    def test_a_repo_whose_url_cannot_be_classified_is_not_cloned(self):
+        """Refusing the URL has to mean refusing the clone — returning "" and then handing
+        "" to `git clone` would be a different bug wearing the same fix."""
+        calls = []
+
+        def fake_git(args, cwd=None):
+            calls.append(list(args))
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+        wd = Path(tempfile.mkdtemp(prefix="clone-url-test-"))
+        r = {"name": "api", "default_branch": "main", "forge": "github",
+             "path_with_namespace": "acme/api",
+             "ssh_url": "ext::sh -c 'touch /tmp/charter-pwned'"}
+        with mock.patch.object(commands, "_git", fake_git):
+            res = commands._clone_one(r, wd)
+        self.assertNotEqual(res["status"], "ok")
+        self.assertEqual(calls, [], f"a refused URL still reached git: {calls!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Charter validated a name when a human typed it and never when it read one out of a committed file. `valid_name` exists in `charter/persona.py` and `charter/workspace.py` and was called from six places — `persona create`, `workspace create`/`rename`, `--piece`, `workspace.ensure` — every one of them a command handling a name someone had just typed. **No parser called either function.** On the reading side the same values were joined onto a path, or handed to git argv, with nothing in between.

This is one omission wearing five issue numbers.

## What changed

One helper — `charter/contain.py` — with two questions kept apart on purpose:

- **`segment_ok(name)`** — could this string name one entry in a directory?
- **`child(base, name)`** — does joining it stay inside the base?

Called at every site that reads a name out of a file:

| Site | Issue |
| --- | --- |
| `persona.reference_ok`, shared by `load()` and `structural_errors` | #337, #329 |
| `commands_workspace.cmd_workspace_restore` — both manifest joins | #325 / #334 / #328 |
| `commands._clone_one` — the clone destination | #325 |
| `commands._https_url` — HTTPS or nothing | #335 |
| `inventory.merge` — the shape rule at the identity layer | #325 |

### The divergence was the finding, more than the traversal

`structural_errors` tested membership in a *name set* while `lineage`/`resolve` resolved a *path*, so `charter persona lint` printed `uses: '…' — no such persona (dangling)` about a reference the resolver loaded and the PreToolUse gate then honoured. Reproduced before the fix, in one run:

```
effective_tools('front')   → {'Read', 'Bash'}     ← Bash declared OUTSIDE the plane
structural_errors('front') → uses: '…' — no such persona (dangling)
```

Both now share `persona.reference_ok`, so they cannot answer differently again. A reference that is a *path* rather than a *name* now says so instead of being reported as dangling — a typo and a traversal send the reader to two different places, and only one of them has the problem in it.

### Two populations, two shape rules, one containment rule

Charter mints persona and workspace names (`persona create` already enforces the alphabet), so persona references keep answering to `valid_name` and lint agrees with the resolver *by construction*. A **forge** mints repo names, so those get the permissive rule. This is load-bearing: `org/.github` is a repo GitHub itself tells organisations to create, and both existing `valid_name`s reject it —

```
'.github'   workspace.valid_name=False   persona.valid_name=False
'MyRepo'    workspace.valid_name=True    persona.valid_name=False
```

— so reusing `valid_name` for repo names would have broken working planes in exchange for closing a hole.

### Why both the identity layer and the joins

Per #325's own fix direction, and neither is safe to delete as redundant. The shape rule belongs at `inventory.merge`, where identity is decided and the bare name is already load-bearing. The containment assertion belongs at every join, because `inventory/repos.json` is a **tracked file** — a hand-edited or PR-modified inventory never passes through `merge`, so an identity-layer check alone is a guard that gets walked around.

### The `commands_workspace.py:521,526` orphan

#325 claims this join, #334 disclaims it as "the join #325 already names", and #328's bullet assigns it to #334's framing. Three issues, one line, each assuming another covers it. **It is fixed here**, stated so no ticket later closes on that assumption.

### Two smaller things

A manifest `branch` can no longer reach git as an option — `git checkout` has options that write (`-b`, `-B`, `--orphan`, `--pathspec-from-file`) and a manifest is committed. **`git check-ref-format` is deliberately not what does this**: verified against git 2.50.1, `check-ref-format refs/heads/-b` *accepts* `-b`, because a leading dash is legal inside a ref. Ref grammar and argv safety are different questions, and reaching for it would have cost a subprocess per repo while closing nothing.

`_https_url` returns an HTTPS URL or nothing. Confirmed on the pre-fix function, all returned verbatim into the clone argv: `ext::sh -c '…'` (a transport that runs a command), `--upload-pack=…` (not a URL — an option git reads off argv), `/etc/passwd`. The only bound today is git's own `protocol.*.allow`, which charter neither sets nor owns.

## A stated limit

**Containment is lexical and does not follow symlinks.** `docsrc.read` resolves its page precisely to catch a symlink, and copying that here would be wrong in two directions: it would do half of #336 while claiming none of it, and it would refuse a plane that legitimately symlinks a persona directory today. #336 is untouched in **both** halves — its containment half is symlink-shaped and covers every file charter reads, not only the ones named by a name.

`#331` is untouched: the vault-path instance is the same shape but needs a non-mutating `health()`, not a path check.

## Closes

- **Closes #328** — in full, as its own body scopes it: all four reading sites it enumerates are covered.
- **Closes #325** — in full (join + identity layer).
- **Closes #334** — in full (both the join and the branch argv).
- **Closes #335** — in full.
- **Closes #337** — in full (all three rungs: `extends:`, `[persona] default`, `personas/.default`).
- **#329 — in part.** Its path-resolution half closes. The `tools:` → PreToolUse `allow` grant itself is by design and stays, and its suggested direction (2) — the gate ignoring a persona with non-empty `structural_errors` — is filed separately rather than ridden in here, because a persona with a typo'd `uses:` silently losing every tool grant it declared itself is a real regression traded for a hole this PR already closes.

## Verification

`python3 -m unittest discover -s tests` — **2914 → 2950, all green.** The 36 new tests are table-driven across every entry point that takes a name from a file, so the next join to skip containment fails in the suite rather than shipping — #327 fixed #323 inline at each site, which is the option #328 itself names as "most likely to grow a fifth site that forgets".

Every traversal case plants a real canary at the path the hostile name resolves to and **asserts it is present before asking charter to refuse** — a refusal because the file happened not to exist would prove nothing. The benign half of every table is equally load-bearing: it is what catches a fix that contains names by refusing all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo
