### PR TITLE
Bound every forge call, and stop trusting what a forge sends (#324, #326)

### DIFF
--- a/charter/forge/base.py
+++ b/charter/forge/base.py
@@ -19,6 +19,40 @@ from typing import Protocol, runtime_checkable
 CI_STATES = frozenset({"success", "failed", "running", "pending",
                        "manual", "canceled", "skipped"})
 
+# --------------------------------------------------------------------------------- #
+# How long one forge CLI invocation may take                                          #
+# --------------------------------------------------------------------------------- #
+# `util.run` has taken a `timeout` since the day its docstring named `gh api` and
+# `glab api` as paths that "could hang indefinitely", and no forge call site passed one
+# (#324). The bound lives here rather than at each site so a new backend inherits it.
+#
+# #324 left the number open, on the grounds that a status refresh, a `discover` paging
+# through hundreds of repos and a `doctor` preflight have different budgets. They do —
+# but that is a difference in TOTAL, not per call. Every site below is one CLI
+# invocation making one API request; `discover`'s hundreds of repos are hundreds of
+# separate invocations, each of which should still answer promptly. So the split that
+# earns two numbers is not caller-by-caller, it is the permissive/strict split both
+# backends already draw, because the two differ in what being WRONG costs.
+
+#: The best-effort path (`_api`, `ci_status`) — what the status line renders from.
+#: Being wrong is nearly free: a blank column, retried at the next `REFRESH_TTL`. This
+#: is also the path that runs detached, holding the forge credential, on a surface that
+#: asks for another refresh every two minutes, so a generous bound here is the expensive
+#: mistake. Ten seconds is roughly an order of magnitude over a healthy call (a CLI
+#: start plus one HTTPS round trip) and still covers a cold handshake to a self-hosted
+#: instance over a VPN. It sits in charter's existing scale for a network call on a
+#: rendering path — `doctor.CHECK_TIMEOUT` is 5s, `update.NET_TIMEOUT` 5s — and below
+#: `glstate.SPAWN_COOLDOWN`, so one call can never on its own outlive the cooldown.
+STATUS_TIMEOUT = 10.0
+
+#: The strict path (`_paged_strict`, `_api_strict`, `repo_tree_strict`) — human-invoked,
+#: and a failure aborts the whole `discover` rather than blanking a cell, so a bound
+#: tight enough for the status line would trade a cheap wrong answer for an expensive
+#: one. One page here is a hundred records with descriptions and topics, not a single
+#: `per_page=1` lookup. Sixty seconds is the same number `secrets.reference` already
+#: uses for "a human is waiting and this is allowed to be slow".
+LIST_TIMEOUT = 60.0
+
 
 class ForgeError(Exception):
     """A forge CLI is missing, unauthenticated, or returned something unusable."""

--- a/charter/forge/github.py
+++ b/charter/forge/github.py
@@ -24,7 +24,7 @@ import json
 import urllib.parse
 
 from .. import util
-from .base import CI_STATES, ForgeError
+from .base import CI_STATES, LIST_TIMEOUT, STATUS_TIMEOUT, ForgeError
 
 #: GitHub rollup state → the neutral vocabulary. Anything unlisted becomes None.
 _CI_MAP = {
@@ -60,8 +60,16 @@ class GitHubForge:
     # --- plumbing -----------------------------------------------------------------
     def _api(self, path: str):
         """Best-effort JSON GET. Returns None on any failure — callers feed the status
-        line, which renders every turn and must never crash."""
-        p = util.run([self.cli, "api", "--hostname", self.host, path], check=False)
+        line, which renders every turn and must never crash.
+
+        A timeout is one of those failures. `ProcTimeout` is a `RuntimeError`, so left
+        to escape it would reach `cli.main` — which catches only `KeyboardInterrupt` —
+        as a traceback, from the one path documented never to crash (#324)."""
+        try:
+            p = util.run([self.cli, "api", "--hostname", self.host, path],
+                         check=False, timeout=STATUS_TIMEOUT)
+        except util.ProcTimeout:
+            return None
         if p.returncode != 0:
             return None
         try:
@@ -88,7 +96,14 @@ class GitHubForge:
         out, page = [], 1
         while True:
             path = f"{base_path}?per_page=100&page={page}"
-            p = util.run([self.cli, "api", "--hostname", self.host, path], check=False)
+            try:
+                p = util.run([self.cli, "api", "--hostname", self.host, path],
+                             check=False, timeout=LIST_TIMEOUT)
+            except util.ProcTimeout as e:
+                # Reported in this path's own vocabulary rather than let a RuntimeError
+                # traceback stand in for "the forge did not answer" (#324).
+                raise ForgeError(
+                    f"listing repos for GitHub owner '{owner}' {e}") from e
             if p.returncode != 0:
                 if org_probe and page == 1 and self._is_not_found(p):
                     raise _NotAnOrg()
@@ -113,7 +128,11 @@ class GitHubForge:
 
     # --- protocol -----------------------------------------------------------------
     def check_auth(self) -> None:
-        p = util.run([self.cli, "auth", "status", "--hostname", self.host], check=False)
+        try:
+            p = util.run([self.cli, "auth", "status", "--hostname", self.host],
+                         check=False, timeout=STATUS_TIMEOUT)
+        except util.ProcTimeout as e:
+            raise ForgeError(f"gh did not answer for {self.host}: {e}") from e
         if p.returncode != 0:
             raise ForgeError(
                 f"gh is not authenticated for {self.host}. Run: gh auth login")
@@ -164,8 +183,12 @@ class GitHubForge:
         ref = ref or repo.get("default_branch") or "HEAD"
         enc_owner, enc_name = urllib.parse.quote(owner, safe=""), urllib.parse.quote(name, safe="")
         enc_ref = urllib.parse.quote(ref, safe="")
-        p = util.run([self.cli, "api", "--hostname", self.host,
-                      f"repos/{enc_owner}/{enc_name}/git/trees/{enc_ref}"], check=False)
+        try:
+            p = util.run([self.cli, "api", "--hostname", self.host,
+                          f"repos/{enc_owner}/{enc_name}/git/trees/{enc_ref}"],
+                         check=False, timeout=LIST_TIMEOUT)
+        except util.ProcTimeout as e:
+            raise ForgeError(f"listing tree for {path}@{ref} {e}") from e
         if p.returncode != 0:
             detail = (p.stderr or p.stdout or "").strip() or f"gh exited {p.returncode}"
             raise ForgeError(f"listing tree for {path}@{ref} failed: {detail}")
@@ -203,10 +226,14 @@ class GitHubForge:
         # Encoding here would send `feature%2Fx` for `feature/x`, match no ref, and blank
         # the CI column for every branch with a slash in it. The flag is the fix, not the
         # value.
-        p = util.run([self.cli, "api", "graphql", "--hostname", self.host,
-                      "-f", f"query={_ROLLUP_QUERY}",
-                      "-f", f"owner={owner}", "-f", f"name={name}",
-                      "-f", f"ref={branch}"], check=False)
+        try:
+            p = util.run([self.cli, "api", "graphql", "--hostname", self.host,
+                          "-f", f"query={_ROLLUP_QUERY}",
+                          "-f", f"owner={owner}", "-f", f"name={name}",
+                          "-f", f"ref={branch}"],
+                         check=False, timeout=STATUS_TIMEOUT)
+        except util.ProcTimeout:
+            return None      # status-line path: a blank CI cell, never a raise (#324)
         if p.returncode != 0:
             return None
         try:

--- a/charter/forge/gitlab.py
+++ b/charter/forge/gitlab.py
@@ -5,7 +5,7 @@ import json
 import urllib.parse
 
 from .. import util
-from .base import CI_STATES, ForgeError
+from .base import CI_STATES, LIST_TIMEOUT, STATUS_TIMEOUT, ForgeError
 
 #: GitLab pipeline status → the neutral vocabulary. Anything unlisted becomes None
 #: rather than being invented, so a new upstream state degrades to "unknown", not a lie.
@@ -27,19 +27,30 @@ class GitLabForge:
         self.host = host
 
     # --- plumbing -----------------------------------------------------------------
-    def _glab(self, args, check: bool = True):
+    def _glab(self, args, check: bool = True, timeout: float = STATUS_TIMEOUT):
         """Every invocation is explicit about ITS OWN host (``--hostname``) — mirrors
         `GitHubForge`, which has always passed `--hostname self.host` on every call.
         Before this, a declared self-hosted GitLab (``host = "git.internal"``) silently
         queried gitlab.com instead (glab's ambient default host), and `check_auth`
         reported success for `git.internal` merely because gitlab.com happened to be
-        logged in — a false green on the auth axis (FINDING I2)."""
-        return util.run([self.cli, "--hostname", self.host, *args], check=check)
+        logged in — a false green on the auth axis (FINDING I2).
+
+        Bounded by ``timeout`` at every caller, defaulting to the tighter of the two
+        budgets: this is the single chokepoint for `glab`, so an unbounded default here
+        would be an unbounded call anywhere a future method forgets to say otherwise
+        (#324)."""
+        return util.run([self.cli, "--hostname", self.host, *args],
+                        check=check, timeout=timeout)
 
     def _api(self, path: str):
         """Best-effort JSON GET. Returns None on any failure — callers feed the status
-        line, which renders every turn and must never crash."""
-        p = self._glab(["api", path], check=False)
+        line, which renders every turn and must never crash. A timeout is one of those
+        failures: `ProcTimeout` is a `RuntimeError` and would otherwise escape this path
+        as a traceback (#324)."""
+        try:
+            p = self._glab(["api", path], check=False, timeout=STATUS_TIMEOUT)
+        except util.ProcTimeout:
+            return None
         if p.returncode != 0:
             return None
         try:
@@ -53,8 +64,12 @@ class GitLabForge:
         never look the same, because collapsing them is how a `list_repos` failure
         silently wipes the inventory. Raises :class:`ForgeError` (naming the failing path
         and glab's own error text) on a non-zero exit or unparsable JSON; a clean empty
-        body is returned as ``[]``, which is a legal, successful result."""
-        p = self._glab(["api", path], check=False)
+        body is returned as ``[]``, which is a legal, successful result. A timeout is
+        reported the same way, for the same reason (#324)."""
+        try:
+            p = self._glab(["api", path], check=False, timeout=LIST_TIMEOUT)
+        except util.ProcTimeout as e:
+            raise ForgeError(f"GitLab API call ({path}) {e}") from e
         if p.returncode != 0:
             detail = (p.stderr or p.stdout or "").strip() or f"glab exited {p.returncode}"
             raise ForgeError(f"GitLab API call failed ({path}): {detail}")
@@ -67,7 +82,10 @@ class GitLabForge:
 
     # --- protocol -----------------------------------------------------------------
     def check_auth(self) -> None:
-        p = self._glab(["auth", "status"], check=False)
+        try:
+            p = self._glab(["auth", "status"], check=False, timeout=STATUS_TIMEOUT)
+        except util.ProcTimeout as e:
+            raise ForgeError(f"glab did not answer for {self.host}: {e}") from e
         blob = (p.stdout or "") + (p.stderr or "")
         if p.returncode != 0 or "Logged in" not in blob:
             raise ForgeError(

--- a/charter/glstate.py
+++ b/charter/glstate.py
@@ -23,6 +23,13 @@ from . import config, util
 DISPLAY_TTL = 7200    # show a cached value for up to 2h
 REFRESH_TTL = 300     # try to refresh entries older than 5 min
 SPAWN_COOLDOWN = 120  # at most one background refresh per this many seconds
+#: How long a refresh may claim to be in flight before it is presumed wedged and
+#: replaced. Three times `REFRESH_TTL`: a refresh still running after this would land
+#: data that was already stale several times over, so waiting on it is worse than
+#: starting a fresh one even if it IS alive. This is also what stops a recycled pid from
+#: suppressing refreshes indefinitely — the failure it bounds is a slightly stale CI
+#: column, never a stuck status line, since `read_for` keeps serving up to `DISPLAY_TTL`.
+STUCK_AFTER = 900
 
 _EMPTY = {"change": None, "ci": None, "sigil": ""}
 
@@ -63,7 +70,72 @@ def _cache_file() -> Path:
 
 
 def _lock_file() -> Path:
+    """The spawn lock: its CONTENT is the pid of an in-flight refresh (empty when none),
+    and its MTIME is when that last changed — spawned, or finished.
+
+    Two facts rather than one because #324 needed both and the file carried neither. The
+    mtime alone said "a refresh was STARTED 120s ago", which is not a reason to start
+    another; what suppresses a second refresh is that the first is still running, and
+    what starts the cooldown is that it stopped.
+    """
     return config.STATE_DIR / "cache" / "glstate.refreshing"
+
+
+def _write_lock(pid: int | None) -> None:
+    """Record an in-flight refresh (*pid*), or that none is (``None``). Bumps the mtime
+    either way. Never raises — every caller is on a path that must not fail."""
+    try:
+        lock = _lock_file()
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        lock.write_text(str(pid) if pid else "")
+    except Exception:
+        pass
+
+
+def _read_lock():
+    """``(pid_or_None, age_in_seconds)``, or ``None`` when there is no lock at all.
+
+    Deliberately tolerant of the content: a truncated write, a hand edit or a pid from
+    another machine all read as "no pid", which degrades to the plain cooldown rather
+    than to an exception on the render path.
+    """
+    lock = _lock_file()
+    try:
+        age = max(0.0, time.time() - lock.stat().st_mtime)
+    except OSError:
+        return None
+    try:
+        txt = lock.read_text().strip()
+    except OSError:
+        txt = ""
+    return (int(txt) if txt.isdigit() else None), age
+
+
+def _alive(pid: int | None) -> bool:
+    """Whether *pid* is a live process. Signal 0 checks for existence without delivering
+    anything; ``PermissionError`` means it exists and belongs to somebody else, which is
+    still "in flight" for our purposes."""
+    if not pid or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except Exception:
+        return False
+    return True
+
+
+def _mark_done() -> None:
+    """Called by the refresh itself when the work is OVER.
+
+    This is what moves the cooldown from the spawn to the completion. `maybe_spawn`
+    cannot do it — it returns the instant `Popen` forks, which is precisely the mistake
+    #324 records — so the process that knows the work finished is the one that says so.
+    """
+    _write_lock(None)
 
 
 def load() -> dict:
@@ -121,11 +193,24 @@ def maybe_spawn(dirs, workspace: str | None = None) -> None:
     session's active workspace on its own.
     """
     now = time.time()
-    lock = _lock_file()
     try:
-        if lock.exists() and now - lock.stat().st_mtime < SPAWN_COOLDOWN:
-            return
+        state = _read_lock()
+        if state is not None:
+            pid, age = state
+            # Cooled down since the last spawn OR the last completion, whichever the
+            # mtime records.
+            if age < SPAWN_COOLDOWN:
+                return
+            # Past the cooldown, but the previous refresh is STILL RUNNING. This is the
+            # case #324 is about: the old code had already forgotten the child existed,
+            # so a wedged refresh invited a replacement every 120s for as long as the
+            # session stayed open, each one holding the forge credential.
+            if _alive(pid) and age < STUCK_AFTER:
+                return
     except Exception:
+        # Suppress rather than spawn on an unreadable lock: the cost of skipping a
+        # refresh is a stale column, and the cost of getting this wrong is the pile-up
+        # this function exists to prevent.
         return
     cache = load()
     stale = any(
@@ -142,8 +227,7 @@ def maybe_spawn(dirs, workspace: str | None = None) -> None:
     if workspace:
         cmd += ["--workspace", workspace]
     try:
-        lock.parent.mkdir(parents=True, exist_ok=True)
-        subprocess.Popen(
+        proc = subprocess.Popen(
             cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL, start_new_session=True, env=os.environ.copy(),
         )
@@ -151,10 +235,15 @@ def maybe_spawn(dirs, workspace: str | None = None) -> None:
         # Spawn never happened — don't start the cooldown, so a transient failure
         # (rather than a real refresh) doesn't suppress the next render's retry.
         return
+    # Record WHICH process is refreshing, not merely that one was started. The child
+    # rewrites this to empty when it finishes (`_mark_done`), which is what makes the
+    # cooldown run from completion. A `Popen` stand-in that reports no usable pid still
+    # arms the cooldown — a spawn that happened must never invite another in 120s.
     try:
-        lock.touch()
+        pid = int(proc.pid)
     except Exception:
-        pass
+        pid = None
+    _write_lock(pid)
 
 
 # --------------------------------------------------------------------------- #
@@ -170,6 +259,10 @@ def refresh(dirs) -> dict:
         state = state_for_repo(d, branch) if branch and branch != "?" else dict(_EMPTY)
         cache[str(d)] = {"branch": branch, "ts": now, **state}
     _save(cache)
+    # The work is over — start the cooldown from HERE, and stop claiming to be in
+    # flight (#324). Last, so a refresh that dies partway leaves its pid behind and is
+    # recognised as crashed rather than as finished.
+    _mark_done()
     return cache
 
 

--- a/charter/glstate.py
+++ b/charter/glstate.py
@@ -27,6 +27,37 @@ SPAWN_COOLDOWN = 120  # at most one background refresh per this many seconds
 _EMPTY = {"change": None, "ci": None, "sigil": ""}
 
 
+def _change_or_none(v):
+    """A change identifier as :meth:`base.Forge.open_change` promises it — ``int`` or
+    ``None`` — whatever the forge actually returned.
+
+    ``change`` was the one forge field that reached the rendered status line unchecked
+    (#326). ``ci`` is pinned to seven literals by each backend's ``_CI_MAP`` and
+    ``sigil`` is a class constant, so both are safe by construction; this was whatever
+    the JSON ``number`` (GitHub) or ``iid`` (GitLab) field happened to hold, stored
+    verbatim, cached verbatim, and interpolated into a line a terminal interprets. A
+    self-hosted or compromised instance, an altered response, or an edit to the cache
+    file — which nothing signs — could put an escape sequence there.
+
+    Coerced rather than type-checked, because a forge that serialises its id as ``"42"``
+    is answering the question and only its JSON type is off; dropping that would blank a
+    real change number over a detail. Anything `int()` refuses, and anything that is not
+    a positive identifier on any forge charter speaks to, becomes ``None`` — the same
+    thing "no open change" already looks like, which the render path draws as an empty
+    cell.
+
+    Never raises: this runs under `state_for_repo`, whose contract is that a status line
+    rendering every turn cannot be given a way to fail.
+    """
+    if v is None or isinstance(v, bool):
+        return None
+    try:
+        n = int(v)
+    except (TypeError, ValueError):
+        return None
+    return n if n > 0 else None
+
+
 def _cache_file() -> Path:
     return config.STATE_DIR / "cache" / "glstate.json"
 
@@ -60,6 +91,12 @@ def read_for(dirs, branches: dict) -> dict:
     are read with a fallback so a stale on-disk cache still renders after an upgrade
     rather than raising a ``KeyError``. ``sigil`` falls back to ``""`` here; the render
     path is what turns an absent sigil into the display default (``!``).
+
+    ``change`` is re-validated here and not only where it was written: an entry written
+    by the charter that had #326 renders for up to ``DISPLAY_TTL`` (two hours) after the
+    upgrade that fixed it, and the cache is an ordinary writable JSON file that nothing
+    signs. Same reason `charter.contain` asserts at every join rather than trusting the
+    identity layer — a check the value can be written past is not a check.
     """
     cache = load()
     now = time.time()
@@ -70,7 +107,7 @@ def read_for(dirs, branches: dict) -> dict:
             continue
         if now - ent.get("ts", 0) > DISPLAY_TTL:
             continue
-        out[d] = {"change": ent.get("change", ent.get("mr")),
+        out[d] = {"change": _change_or_none(ent.get("change", ent.get("mr"))),
                   "ci": ent.get("ci"),
                   "sigil": ent.get("sigil") or ""}
     return out
@@ -160,7 +197,7 @@ def state_for_repo(d: Path, branch: str) -> dict:
         forge = registry.resolve_host(url, config.ROOT)
         if forge is None:
             return dict(_EMPTY)
-        return {"change": forge.open_change(path, branch),
+        return {"change": _change_or_none(forge.open_change(path, branch)),
                 "ci": forge.ci_status(path, branch),
                 "sigil": forge.change_sigil}
     except Exception:

--- a/charter/tui.py
+++ b/charter/tui.py
@@ -12,8 +12,15 @@ zero). Overflow is truncated with an ellipsis, never wrapped — a single
 wrapped line shears every column below it. Rendered lines also never carry
 trailing whitespace, even when it hides behind trailing colour escapes.
 
+That guarantee is about the terminal, so it cannot be computed from a string the
+terminal reads differently: **SGR is the only escape this module passes through**, and
+`sanitize` drops everything else — a cursor move, an erase, an OSC title string, a bare
+control character — before anything is measured or clamped. Charter's markup is charter's
+own; the values interpolated into it (a forge's JSON, a directory name) are not (#326).
+
 Vocabulary::
 
+    sanitize                  drop everything that is not charter's own markup
     width / truncate / pad    ANSI-aware string primitives
     Text                      markup line(s), clamped at render time
     Cell + Row                one line of fixed/natural-width cells
@@ -38,13 +45,78 @@ _SGR = re.compile(r"\x1b\[[0-9;]*m")
 #: Trailing whitespace hiding *behind* trailing SGR escapes ("a \x1b[0m").
 _HIDDEN_TRAIL = re.compile(r"[ \t]+((?:\x1b\[[0-9;]*m)+)$")
 
+#: Everything this module may be handed, split into "charter's own markup" and "not".
+#: Alternation order is the whole design: SGR is matched FIRST and handed back
+#: untouched, so the catch-all `\x1b` at the end can delete a stray introducer without
+#: decapitating a colour span and spilling `[32m` onto the screen as text.
+#:
+#: The rest, in the order a terminal would parse it. The *string* sequences (OSC, DCS,
+#: APC, PM, SOS) come before the single-character forms because they must go whole: drop
+#: only the introducer and the payload — `0;pwned` — prints as ordinary text, which is
+#: worse than the escape because it looks like data. An unterminated one is removed to
+#: the end of the string for that same reason.
+#:
+#: `\x1b[^\x1b]` catches every remaining two-character escape, `ESC c` (RIS, a full
+#: terminal reset) among them, and stops short of a following ESC so that `ESC ESC [32m`
+#: loses the stray introducer and keeps the colour — which is what a terminal does with
+#: it too.
+_MARKUP_OR_CONTROL = re.compile(
+    r"(\x1b\[[0-9;]*m)"                            # 1 — SGR: charter's own, kept
+    r"|\x1b[\]P^_X][^\x1b\x07]*(?:\x07|\x1b\\|$)"  # OSC/DCS/APC/PM/SOS … ST | BEL | end
+    r"|\x1b\[[0-?]*[ -/]*[@-~]"                    # any other CSI (cursor, erase, …)
+    r"|\x1b[^\x1b]"                                # other two-character escapes
+    r"|\x1b"                                       # a lone/trailing ESC
+    r"|([\t\n\r\v\f])"                             # 2 — whitespace controls → a space
+    r"|[\x00-\x1f\x7f-\x9f]"                       # other C0, DEL, C1: removed
+)
+
+
+def _keep(m: "re.Match[str]") -> str:
+    if m.group(1):
+        return m.group(1)
+    # A tab jumps to the next tab stop and a newline ends the line — both shear the
+    # columns below, which is the one thing this module promises not to do. They keep
+    # their separation as a single space rather than vanishing, so `a\tb` stays two
+    # words instead of becoming one.
+    return " " if m.group(2) else ""
+
 
 # --------------------------------------------------------------------------
 # String primitives
 # --------------------------------------------------------------------------
 
+def sanitize(s: str) -> str:
+    """Return *s* with everything that is not charter's own colour markup removed.
+
+    `tui` measures and clamps *markup*, and its contract has always been that markup
+    is charter's: SGR escapes, which cost zero columns, and text, which costs one
+    column per character. Nothing enforced that. A forge's JSON, a directory name off
+    the filesystem — anything that reaches a `Cell` — could carry an erase-in-display,
+    an OSC title string or a bare BEL, and the module would count it as visible
+    columns, pad around a width the terminal disagreed with, and copy it to a surface
+    that repaints every ten seconds with no human in the loop (#326).
+
+    Deliberately kept as a *narrow* removal rather than a whitelist of printable text.
+    This module exists to emit SGR — a blanket strip would fight the colour it is built
+    to produce — so SGR is matched first and passed through untouched, and only what a
+    terminal would interpret as a command rather than as content is dropped. Sanitising
+    here rather than at each call site is what makes the guarantee hold for a value
+    nobody has thought about yet, including the next field somebody adds.
+
+    Not a substitute for validating at the boundary: `glstate` still refuses a change
+    identifier that is not a number, because a value with the wrong *type* is a defect
+    worth catching where it enters, not a rendering detail. This is the second half.
+    """
+    # `isprintable()` is a C-level scan and false only for a control character (ASCII
+    # space excepted), so the overwhelmingly common case never touches the regex.
+    return s if s.isprintable() else _MARKUP_OR_CONTROL.sub(_keep, s)
+
+
 def strip_ansi(s: str) -> str:
-    """Return *s* with ANSI SGR (colour/style) escapes removed."""
+    """Return *s* as the plain text a terminal would show: SGR escapes removed, and —
+    since anything else that claims to be an escape is not charter's markup either —
+    :func:`sanitize` applied first."""
+    s = sanitize(s)
     return _SGR.sub("", s) if "\x1b" in s else s
 
 
@@ -75,6 +147,9 @@ def truncate(s: str, w: int, ellipsis: str = ELLIPSIS) -> str:
     """
     if w <= 0:
         return ""
+    # Before the fits-already fast path, not after: returning *s* unchanged is exactly
+    # how an escape reached the screen without anything ever having looked at it (#326).
+    s = sanitize(s)
     if width(s) <= w:
         return s
     keep = max(0, w - width(ellipsis))

--- a/charter/util.py
+++ b/charter/util.py
@@ -131,6 +131,9 @@ def run(
 
     ``input`` is written to the child's stdin. That is how a secret reaches a CLI
     without ever appearing in argv — where `ps` and the shell's history can see it.
+    Without it the child gets ``DEVNULL``: charter's own stdin is never inherited, so a
+    CLI that reads it gets EOF instead of blocking on a descriptor nobody will write to
+    (#324). See the comment on the ``stdin`` argument below for the audit behind that.
 
     ``timeout`` bounds the child in seconds, raising :class:`ProcTimeout` — a *charter*
     error, so a caller can render it rather than let `subprocess.TimeoutExpired` reach the
@@ -149,8 +152,10 @@ def run(
     overlay = dict(env or {})
     if cmd and cmd[0] == "git":
         # git falls back to prompting on the TERMINAL when a credential helper produces
-        # nothing — and this function captures stdout/stderr while leaving stdin
-        # INHERITED, so that prompt is invisible and the call simply waits, forever.
+        # nothing — and this function captures stdout/stderr, so that prompt is invisible
+        # and the call simply waits, forever. (Stdin is `DEVNULL` now too, which stops
+        # git READING an answer; this stops it ASKING, so the failure is reported as an
+        # auth error rather than as whatever git makes of an empty response.)
         #
         # charter's auth design (see `planegit`) says a prompt is never the path: every
         # git operation authenticates with its forge CLI's token over HTTPS. So this
@@ -175,6 +180,34 @@ def run(
             timeout=timeout,
             stdout=subprocess.PIPE if capture else None,
             stderr=subprocess.PIPE if capture else None,
+            # A child charter runs never inherits charter's stdin. This function
+            # redirected stdout and stderr and left stdin alone, so a CLI that decided to
+            # read it blocked on whatever the parent had — forever, and invisibly, since
+            # its output was captured out of sight (#324). `gh api` does exactly that for
+            # a field value naming standard input (#323), which is how a status refresh
+            # was observed still running after 10s.
+            #
+            # For EVERY caller, not just the forge path, because "who reads stdin" is not
+            # a property of the caller — it is a property of a CLI's argv, which is
+            # sometimes built from a forge response. The audit that makes this safe:
+            # nothing passes `capture=False`, so every call already captures stdout AND
+            # stderr, and a child whose output nobody sees cannot conduct a dialogue with
+            # the terminal anyway. Its prompt would be buffered out of sight and the call
+            # would simply wait — which is the failure, not a feature. charter's one
+            # genuinely interactive path, `secret --exec`, replaces this process with
+            # `os.execvpe` and never comes through here.
+            #
+            # This generalises a rule this function already applied to one CLI:
+            # `GIT_TERMINAL_PROMPT=0` above says a prompt is never charter's path. That
+            # covered git's own prompts and, as its comment notes, not "a GUI credential
+            # manager, [or] an SSH signing agent, which is a separate way for a captured
+            # git call to hang". Closing the descriptor closes those too.
+            #
+            # Conditional because `subprocess.run` opens the pipe itself when `input` is
+            # given and rejects being handed both — and that is the correct semantics as
+            # well as the required one: `input=` is how a secret reaches a CLI without
+            # passing through argv, and it must still arrive.
+            stdin=subprocess.DEVNULL if input is None else None,
         )
     except subprocess.TimeoutExpired:
         raise ProcTimeout(cmd, timeout) from None

--- a/docs/news/unreleased-bound-and-sanitise-forge-data.md
+++ b/docs/news/unreleased-bound-and-sanitise-forge-data.md
@@ -1,0 +1,95 @@
+---
+version: unreleased
+headline: Forge calls are bounded, and forge data can no longer repaint your terminal
+---
+
+Two defects on the same short path — a forge's answer, through a cache, onto the status
+line. That surface renders on every turn and repaints every ten seconds, unprompted, for
+as long as a session is open, and nothing on it waits for a human to ask.
+
+**Every forge CLI call now has a time limit.** `util.run` has taken a `timeout` since the
+day its own docstring named `gh api` and `glab api` as paths that "could hang
+indefinitely". Not one forge call site passed one. So a status refresh — detached,
+holding the forge credential, and asked for again every two minutes — had no bound on its
+life at all, and a slow network or a wedged CLI was a process that stayed.
+
+The number was the part worth arguing about, and the answer is two numbers rather than
+one. A status-line refresh and a `discover` paging through hundreds of repos do have
+different budgets, but that difference is in the *total*, not the call: every site is one
+CLI invocation making one API request, and `discover`'s hundreds of repos are hundreds of
+separate invocations, each of which should still answer promptly. What actually differs is
+what being wrong costs. On the best-effort path that feeds the status line, giving up is
+nearly free — a blank column, retried at the next refresh — and it is the path that piles
+up, so it gets **ten seconds**, about ten times a healthy call and in line with what
+`doctor` and the update check already allow a network call on a rendering path. The strict
+path is human-invoked, pulls a hundred records at a time, and aborts a whole `discover`
+when it gives up, so it gets **sixty**. A timeout is now reported in each path's own
+vocabulary instead of surfacing as a traceback from code documented never to crash.
+
+**Charter no longer hands a child its own stdin.** `util.run` redirected stdout and
+stderr and left stdin inherited, so a CLI that decided to read it blocked on whatever the
+parent had — forever, and invisibly, because its output was captured out of sight. That
+is not hypothetical: `gh` reads standard input for a field value that names it, which is
+how a status refresh was seen still running after ten seconds with nobody at the keyboard.
+
+The fix is in `util.run` for every caller, not just the forge path, because "who reads
+stdin" is not a property of the caller — it is a property of a CLI's argv, which is
+sometimes built out of a forge response. What makes that safe is that no caller was ever
+interactive: every one of them already captured both stdout and stderr, and a child whose
+output nobody can see cannot hold a conversation with the terminal anyway. Its prompt is
+buffered out of sight and the call simply waits, which is the failure rather than a
+feature. Charter's one genuinely interactive path replaces the process outright and never
+came through here. Writing *to* a child is untouched — that is how a credential reaches a
+CLI without passing through argv, where `ps` and shell history can read it.
+
+This generalises a rule the same function already applied to git alone, whose comment had
+named exactly what it did not cover: not a GUI credential manager, and not a signing
+agent, "which is a separate way for a captured git call to hang". Both are closed now.
+
+**A refresh that is still running suppresses the next one.** The spawn cooldown was
+measured from the spawn. A child that never finished left the cache stale, so the moment
+the cooldown lapsed the next render started another, and another, with no bound on how
+many detached processes could accumulate — each holding the forge credential. The lock
+now records *which* process is refreshing rather than merely that one was started, and
+the refresh marks itself done when the work is over, so the cooldown runs from completion.
+At most one refresh is ever in flight. A refresh still running after fifteen minutes is
+presumed wedged and replaced, since its answer would already be stale several times over
+by the time it landed.
+
+Fixed separately from the timeout on purpose. With a bound in place a hung child does
+eventually die — but "eventually" is not the same as "not stacking", and only one of those
+two is a guarantee.
+
+**And forge data is no longer trusted to be text.** Charter's little layout kit measures
+markup and clamps it to a column width, and its contract has always been that the markup is
+charter's own: colour escapes, which cost zero columns, and text, which costs one column
+per character. Nothing enforced that. It recognised colour escapes and nothing else, so a
+cursor move, a screen erase, a terminal-title string or a bare control character survived
+every strip, was counted as visible columns, and was copied through onto the screen. A
+line could measure ninety-four columns while several of its characters occupied none of
+them — and that arithmetic is what every row below it aligns against.
+
+Two independent halves, because the two ways in are different. The open-change number was
+the one forge field passed through as-is: the CI status is pinned to seven known words and
+the `!`/`#` sigil is a constant, but the change identifier was whatever the response's
+`number` or `iid` field held, stored, cached and interpolated without anyone asking what it
+was. It is now what the protocol always said it was — a number or nothing — checked both
+where it is written and where it is read back, since a cache entry written by the version
+that had the bug renders for two hours after the upgrade that fixed it, and nothing signs
+that file. The other half is a clone's directory name, which comes off the filesystem and
+never passes through any of that, so the layout kit itself now drops everything that is
+not charter's own markup before measuring or clamping anything.
+
+Deliberately a narrow removal rather than a whitelist of printable text: this is the module
+that *emits* colour, so a blanket strip would fight the thing it exists to produce. Colour
+is matched first and passed through untouched; only what a terminal would act on as a
+command is dropped. A tab or a newline becomes a single space rather than vanishing,
+because both shear the columns below them, which is the one thing the module promises not
+to do.
+
+On a public forge none of the display half is reachable — a pull request number is an
+integer and repo names are ordinary — and it needs a self-hosted or compromised instance,
+an altered response, or a hand-edited inventory. Worth recording what turned out *not* to
+be reachable, since it was the first thing checked: a branch name cannot carry this. Git's
+own ref format rejects control characters, so that column was already clean. The guard is
+git's rather than charter's, but it is real and it holds.

--- a/tests/test_forge_timeout.py
+++ b/tests/test_forge_timeout.py
@@ -1,0 +1,157 @@
+"""#324 — no forge CLI call may be unbounded.
+
+`util.run` has taken a ``timeout`` since the day its docstring named ``gh api`` and
+``glab api`` as paths that "could hang indefinitely". Not one forge call site passed
+one. On the status-line path that is a detached process holding the forge credential
+with no bound on its life, on a surface that asks for another every two minutes.
+
+Two numbers, not one, and the split is the one that already exists in both backends.
+The permissive path (`_api`, `ci_status`) feeds the status line: failing is nearly free
+— a blank column, retried on the next refresh — and it is the path that stacks. The
+strict path (`_paged_strict`, `_api_strict`, `repo_tree_strict`) is human-invoked, costs
+a whole `discover` run when it gives up, and pulls a hundred records at a time.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import glstate, util
+from charter.forge import base
+from charter.forge.github import GitHubForge
+from charter.forge.gitlab import GitLabForge
+
+
+#: `{}` rather than `[]`: it parses as a legal, empty response for every shape these
+#: backends read — a page of records, a tree, and GitHub's GraphQL rollup object.
+def _proc(stdout="{}", rc=0, stderr=""):
+    return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=rc)
+
+
+def _drive_everything(forge, response):
+    """Call every method on *forge* that shells out, and return the recorded
+    `util.run` calls. Nothing here asserts — the tests do."""
+    repo = {"path_with_namespace": "acme/api", "default_branch": "main", "id": 7}
+    with mock.patch("charter.util.run", return_value=response) as m:
+        forge.check_auth()
+        forge.list_repos("acme")
+        forge.repo_tree(repo)
+        forge.repo_tree_strict(repo)
+        forge.open_change("acme/api", "main")
+        forge.ci_status("acme/api", "main")
+    return m.call_args_list
+
+
+class TheBoundsAreSane(unittest.TestCase):
+    def test_both_bounds_exist_and_are_positive(self):
+        for name in ("STATUS_TIMEOUT", "LIST_TIMEOUT"):
+            v = getattr(base, name)
+            self.assertIsInstance(v, (int, float), name)
+            self.assertGreater(v, 0, name)
+
+    def test_the_status_bound_is_the_tighter_of_the_two(self):
+        self.assertLess(base.STATUS_TIMEOUT, base.LIST_TIMEOUT)
+
+    def test_a_status_call_cannot_outlive_the_respawn_cooldown(self):
+        """The number has to mean something against the surface it serves. A single
+        status call that could run longer than `SPAWN_COOLDOWN` would be asking the
+        cooldown to be the only thing standing between a hung CLI and a second one."""
+        self.assertLess(base.STATUS_TIMEOUT, glstate.SPAWN_COOLDOWN)
+
+
+class NoForgeCallIsUnbounded(unittest.TestCase):
+    """The sweep. Written as "every recorded call" rather than a list of the four
+    known sites, because the defect in #324 was not that one site forgot — it was that
+    the parameter existed and nobody reached for it."""
+
+    def _assert_all_bounded(self, calls):
+        # Precondition: something was actually invoked. Without this the loop below is
+        # vacuously true over an empty list, which is the shape of a test that passes
+        # while proving nothing.
+        self.assertGreater(len(calls), 0, "no CLI call was recorded at all")
+        for c in calls:
+            argv = " ".join(c.args[0])
+            self.assertIn("timeout", c.kwargs, f"unbounded call: {argv}")
+            self.assertIsNotNone(c.kwargs["timeout"], f"unbounded call: {argv}")
+            self.assertGreater(c.kwargs["timeout"], 0, argv)
+
+    def test_github(self):
+        self._assert_all_bounded(_drive_everything(GitHubForge(), _proc()))
+
+    def test_gitlab(self):
+        self._assert_all_bounded(
+            _drive_everything(GitLabForge(), _proc(stderr="Logged in")))
+
+
+class EachCallGetsTheBudgetForItsJob(unittest.TestCase):
+    def _timeout_of(self, forge, call, response=_proc()):
+        with mock.patch("charter.util.run", return_value=response) as m:
+            call(forge)
+        self.assertTrue(m.call_args_list, "nothing was invoked")
+        return {c.kwargs.get("timeout") for c in m.call_args_list}
+
+    def test_github_status_calls_use_the_status_bound(self):
+        for call in (lambda f: f.open_change("acme/api", "main"),
+                     lambda f: f.ci_status("acme/api", "main")):
+            self.assertEqual(self._timeout_of(GitHubForge(), call),
+                             {base.STATUS_TIMEOUT})
+
+    def test_gitlab_status_calls_use_the_status_bound(self):
+        for call in (lambda f: f.open_change("acme/api", "main"),
+                     lambda f: f.ci_status("acme/api", "main")):
+            self.assertEqual(self._timeout_of(GitLabForge(), call),
+                             {base.STATUS_TIMEOUT})
+
+    def test_github_listing_uses_the_listing_bound(self):
+        self.assertEqual(self._timeout_of(GitHubForge(), lambda f: f.list_repos("acme")),
+                         {base.LIST_TIMEOUT})
+
+    def test_gitlab_listing_uses_the_listing_bound(self):
+        self.assertEqual(self._timeout_of(GitLabForge(), lambda f: f.list_repos("acme")),
+                         {base.LIST_TIMEOUT})
+
+
+class ATimeoutIsReportedInEachPathSVocabulary(unittest.TestCase):
+    """`ProcTimeout` is a `RuntimeError`. Left to escape, it reaches `cli.main` — which
+    catches only `KeyboardInterrupt` — as a traceback. Each path already says how it
+    reports a failure, and a timeout is a failure."""
+
+    def _timing_out(self):
+        return mock.patch("charter.util.run",
+                          side_effect=util.ProcTimeout(["gh", "api"], 10.0))
+
+    def test_a_status_call_degrades_to_none_rather_than_raising(self):
+        """`_api`'s own docstring: "callers feed the status line, which renders every
+        turn and must never crash"."""
+        for forge in (GitHubForge(), GitLabForge()):
+            with self.subTest(forge.kind), self._timing_out():
+                self.assertIsNone(forge.open_change("acme/api", "main"))
+                self.assertIsNone(forge.ci_status("acme/api", "main"))
+
+    def test_a_listing_call_raises_forge_error_not_a_bare_runtime_error(self):
+        for forge in (GitHubForge(), GitLabForge()):
+            with self.subTest(forge.kind), self._timing_out():
+                with self.assertRaises(base.ForgeError) as caught:
+                    forge.list_repos("acme")
+                self.assertIn("10", str(caught.exception),
+                              "the report must name the bound that was hit")
+
+    def test_check_auth_raises_forge_error_on_a_timeout(self):
+        for forge in (GitHubForge(), GitLabForge()):
+            with self.subTest(forge.kind), self._timing_out():
+                with self.assertRaises(base.ForgeError):
+                    forge.check_auth()
+
+    def test_repo_tree_still_degrades_to_empty_on_a_timeout(self):
+        """The permissive tree read is documented to "degrade to [] on any failure,
+        never raise"."""
+        for forge in (GitHubForge(), GitLabForge()):
+            with self.subTest(forge.kind), self._timing_out():
+                self.assertEqual(forge.repo_tree({"path_with_namespace": "a/b", "id": 1}),
+                                 [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_glstate_change_shape.py
+++ b/tests/test_glstate_change_shape.py
@@ -1,0 +1,139 @@
+"""#326 — the open-change identifier is the one forge field passed through as-is.
+
+`ci` is pinned to seven literals by each backend's `_CI_MAP`, and `sigil` is a class
+constant, so both are safe by construction. `change` was whatever the forge's JSON
+`number` (GitHub) or `iid` (GitLab) field held: `state_for_repo` stored it, the cache
+kept it, `read_for` returned it, and `statusline` interpolated it into the rendered row.
+
+`base.Forge.open_change` is annotated ``int | None`` and both implementations `.get()` a
+field documented as a number, so the protocol already says what this is. These tests
+hold the boundary to it — at BOTH ends, because a cache entry survives an upgrade by two
+hours (`DISPLAY_TTL`) and a hand-edited or already-poisoned cache never passes through
+`state_for_repo` at all.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import glstate
+
+from tests._isolation import PersonaIso
+
+#: The demonstration in #326: a change "number" that is an escape sequence.
+ERASE_DISPLAY = "\x1b[2J"
+OSC_TITLE = "\x1b]0;pwned\x07"
+
+
+class _Forge:
+    """A forge whose open_change returns whatever it was handed — the shim `gh` from
+    #326, without the subprocess."""
+
+    kind, host, cli, change_sigil = "github", "github.com", "gh", "#"
+
+    def __init__(self, change):
+        self.change = change
+        self.calls = []
+
+    def open_change(self, path, branch):
+        self.calls.append((path, branch))
+        return self.change
+
+    def ci_status(self, path, branch):
+        return "success"
+
+
+def _state_for(change):
+    """Drive `state_for_repo` with a forge returning *change*. Returns (state, forge)
+    so a test can assert the call actually happened before trusting the result."""
+    forge = _Forge(change)
+    with mock.patch("charter.forge.registry.resolve_host", return_value=forge), \
+         mock.patch("charter.glstate._remote_url",
+                    return_value="https://github.com/acme/api.git"), \
+         mock.patch("charter.glstate._remote_path", return_value="acme/api"):
+        return glstate.state_for_repo(Path("/tmp/acme-api"), "main"), forge
+
+
+class ChangeIsWhatTheProtocolSaysItIs(unittest.TestCase):
+    def test_an_escape_sequence_never_becomes_a_change_number(self):
+        state, forge = _state_for(f"{ERASE_DISPLAY}31")
+        # Precondition: the hostile value really did cross the forge boundary. Without
+        # this the assertion below passes just as well when nothing was ever called.
+        self.assertEqual(forge.calls, [("acme/api", "main")],
+                         "open_change was never reached — the test proves nothing")
+        self.assertIsNone(state["change"])
+
+    def test_an_osc_string_never_becomes_a_change_number(self):
+        state, forge = _state_for(OSC_TITLE)
+        self.assertEqual(forge.calls, [("acme/api", "main")])
+        self.assertIsNone(state["change"])
+
+    def test_a_dict_never_becomes_a_change_number(self):
+        """`arr[0].get("number")` returns whatever the JSON held — an object, a list and
+        a null are all things a forge response can put there."""
+        state, _ = _state_for({"number": 1})
+        self.assertIsNone(state["change"])
+
+    def test_a_genuine_number_is_kept(self):
+        state, forge = _state_for(42)
+        self.assertEqual(forge.calls, [("acme/api", "main")])
+        self.assertEqual(state["change"], 42)
+        self.assertEqual(state["ci"], "success")
+        self.assertEqual(state["sigil"], "#")
+
+    def test_a_numeric_string_is_coerced_rather_than_dropped(self):
+        """A forge that serialises its id as a string is answering the question; only
+        the type is off. Dropping it would blank a real PR number over a JSON detail."""
+        self.assertEqual(_state_for("42")[0]["change"], 42)
+
+    def test_no_open_change_stays_none(self):
+        self.assertIsNone(_state_for(None)[0]["change"])
+
+    def test_a_nonsense_number_is_dropped(self):
+        """Zero and negatives are not change identifiers on any forge charter speaks to,
+        and a value that is *shaped* like a number but cannot be one is the same defect
+        as a value that is not a number at all."""
+        for bad in (0, -7, "-7"):
+            self.assertIsNone(_state_for(bad)[0]["change"], bad)
+
+
+class AnAlreadyPoisonedCacheDoesNotRender(PersonaIso):
+    """`state_for_repo` guards what is written from now on. `read_for` guards what is
+    already on disk — an entry written by the charter that had the bug renders for two
+    hours after the upgrade, and the cache file is an ordinary writable JSON file that
+    nothing signs."""
+
+    def _write(self, entry: dict) -> Path:
+        d = self.tmp / "poisoned"
+        d.mkdir(parents=True, exist_ok=True)
+        f = glstate._cache_file()
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(json.dumps({str(d): {"ts": time.time(), "branch": "main", **entry}}))
+        return d
+
+    def test_an_escape_in_a_cached_change_is_dropped_on_read(self):
+        d = self._write({"change": f"{ERASE_DISPLAY}31", "ci": "success"})
+        got = glstate.read_for([d], {d: "main"})
+        # Precondition: the entry was fresh and branch-matching, so it really was read.
+        self.assertIn(d, got, "the cache entry was skipped — the test proves nothing")
+        self.assertIsNone(got[d]["change"])
+        self.assertEqual(got[d]["ci"], "success")
+
+    def test_an_escape_in_the_legacy_mr_key_is_dropped_too(self):
+        d = self._write({"mr": OSC_TITLE, "ci": None})
+        got = glstate.read_for([d], {d: "main"})
+        self.assertIn(d, got)
+        self.assertIsNone(got[d]["change"])
+
+    def test_a_good_cached_change_still_renders(self):
+        d = self._write({"change": 9, "ci": "running", "sigil": "#"})
+        got = glstate.read_for([d], {d: "main"})
+        self.assertEqual(got[d], {"change": 9, "ci": "running", "sigil": "#"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_glstate_respawn.py
+++ b/tests/test_glstate_respawn.py
@@ -1,0 +1,159 @@
+"""#324 — the spawn cooldown was measured from the wrong end.
+
+`maybe_spawn` touched the lock immediately after `Popen`, so `SPAWN_COOLDOWN` ran from
+SPAWN time. If the child never finished, the cache entries were still stale when the
+cooldown lapsed and the next render spawned another — with no bound on how many detached
+forge processes could accumulate, each holding the forge credential.
+
+Fixed independently of the timeout, and these tests are why: with a bound in place a hung
+child eventually dies, but "eventually" is not "not stacking". A refresh that is still
+RUNNING must suppress the next one however long it has been running, and the cooldown
+must start when the previous one FINISHED.
+
+Nothing here spawns a real refresh — `Popen` is faked, and the one real process is a
+`python -c pass` used to obtain a pid that is definitely dead.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+import unittest
+from unittest import mock
+
+from charter import glstate
+
+from tests._isolation import PersonaIso
+
+
+def _fake_popen(pid):
+    """A `Popen` stand-in reporting *pid*, and a record of every call made."""
+    calls = []
+
+    def popen(cmd, **kw):
+        calls.append(cmd)
+        return mock.MagicMock(pid=pid)
+
+    return popen, calls
+
+
+def _a_definitely_dead_pid() -> int:
+    """A real pid that has exited and been reaped. Preferred over a large made-up
+    number, which is a guess about the machine rather than a fact about it."""
+    p = subprocess.Popen([sys.executable, "-c", "pass"])
+    p.wait()
+    return p.pid
+
+
+class RespawnTests(PersonaIso):
+    def _dirs(self):
+        d = self.tmp / "somerepo"
+        d.mkdir(parents=True, exist_ok=True)
+        return [d]
+
+    def _age_lock(self, seconds: float) -> None:
+        """Backdate the lock as if it had been written *seconds* ago."""
+        lock = glstate._lock_file()
+        t = time.time() - seconds
+        os.utime(lock, (t, t))
+
+    def _spawn_once(self, pid):
+        """Drive one successful spawn and assert it happened — the precondition every
+        test below depends on."""
+        popen, calls = _fake_popen(pid)
+        with mock.patch.object(glstate.subprocess, "Popen", side_effect=popen):
+            glstate.maybe_spawn(self._dirs())
+        self.assertEqual(len(calls), 1, "the first spawn did not happen — proves nothing")
+        self.assertTrue(glstate._lock_file().exists(), "the lock was not armed")
+        return calls
+
+    def _try_spawn_again(self):
+        popen, calls = _fake_popen(os.getpid())
+        with mock.patch.object(glstate.subprocess, "Popen", side_effect=popen):
+            glstate.maybe_spawn(self._dirs())
+        return calls
+
+    # --- the defect ----------------------------------------------------------------
+
+    def test_a_running_refresh_suppresses_the_next_one_past_the_cooldown(self):
+        """The core of #324. `os.getpid()` is this process — unambiguously alive — so
+        the recorded refresh is genuinely still running when the cooldown lapses."""
+        self._spawn_once(os.getpid())
+        self._age_lock(glstate.SPAWN_COOLDOWN + 60)
+        self.assertEqual(self._try_spawn_again(), [],
+                         "a second refresh was spawned while the first was still running")
+
+    def test_a_finished_refresh_stops_suppressing_once_the_cooldown_lapses(self):
+        """The other side: suppression must not become permanent. A refresh that
+        finished and marked itself done frees the next one after `SPAWN_COOLDOWN`."""
+        self._spawn_once(os.getpid())
+        glstate._mark_done()
+        self._age_lock(glstate.SPAWN_COOLDOWN + 1)
+        self.assertEqual(len(self._try_spawn_again()), 1)
+
+    def test_a_crashed_refresh_does_not_suppress_forever(self):
+        """A child that died without marking itself done leaves its pid behind. Once it
+        is gone, the cooldown is all that stands in the way."""
+        self._spawn_once(_a_definitely_dead_pid())
+        self._age_lock(glstate.SPAWN_COOLDOWN + 1)
+        self.assertEqual(len(self._try_spawn_again()), 1)
+
+    def test_a_wedged_refresh_is_eventually_replaced(self):
+        """The ceiling. A refresh still running after `STUCK_AFTER` would produce data
+        already stale several times over, so waiting on it is worse than replacing it —
+        and this is also what keeps a recycled pid from suppressing refreshes forever."""
+        self._spawn_once(os.getpid())
+        self._age_lock(glstate.STUCK_AFTER + 1)
+        self.assertEqual(len(self._try_spawn_again()), 1)
+
+    # --- the cooldown now runs from completion --------------------------------------
+
+    def test_the_refresh_marks_the_lock_when_it_finishes(self):
+        """`refresh` is what the detached child runs, so it is what knows the work is
+        over. Called with no trees, it touches nothing on the network."""
+        self._spawn_once(os.getpid())
+        self._age_lock(glstate.SPAWN_COOLDOWN + 60)
+        glstate.refresh([])
+        lock = glstate._lock_file()
+        self.assertLess(time.time() - lock.stat().st_mtime, 5,
+                        "the lock's mtime is still the SPAWN time, not the completion")
+        self.assertEqual(lock.read_text().strip(), "",
+                         "a finished refresh must not still claim to be in flight")
+
+    def test_completion_restarts_the_cooldown(self):
+        """The behaviour that mtime carries: after a refresh finishes, the next spawn
+        waits a full `SPAWN_COOLDOWN` from THAT moment."""
+        self._spawn_once(os.getpid())
+        self._age_lock(glstate.SPAWN_COOLDOWN + 60)
+        glstate.refresh([])                      # finishes now
+        self.assertEqual(self._try_spawn_again(), [],
+                         "the cooldown did not restart when the refresh completed")
+
+    # --- the render path may never raise --------------------------------------------
+
+    def test_a_corrupt_lock_never_raises(self):
+        """`maybe_spawn` runs on the status line. Whatever is in this file — a truncated
+        write, a hand edit, a pid from another machine — it renders."""
+        lock = glstate._lock_file()
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        for junk in ("", "   ", "not-a-pid", "-1", "0", "99999999999999999999", "\x00"):
+            lock.write_text(junk)
+            self._age_lock(glstate.SPAWN_COOLDOWN + 1)
+            with mock.patch.object(glstate.subprocess, "Popen",
+                                   return_value=mock.MagicMock(pid=os.getpid())):
+                glstate.maybe_spawn(self._dirs())   # must not raise
+
+    def test_a_popen_that_reports_no_usable_pid_still_arms_the_cooldown(self):
+        """A `Popen` stand-in — or a platform quirk — may not give an int. The cooldown
+        must still arm, or a spawn that DID happen invites another in 120s."""
+        with mock.patch.object(glstate.subprocess, "Popen",
+                               return_value=mock.MagicMock(pid=object())):
+            glstate.maybe_spawn(self._dirs())
+        self.assertTrue(glstate._lock_file().exists())
+        self.assertEqual(self._try_spawn_again(), [], "the cooldown was not armed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_statusline_hostile_forge_values.py
+++ b/tests/test_statusline_hostile_forge_values.py
@@ -1,0 +1,74 @@
+"""#326 end to end — a repo row drawn from hostile forge data.
+
+The two demonstrations in the issue were a change "number" that was an escape sequence
+and a clone directory name carrying an OSC string, both "rendered byte for byte" into
+the status line. They enter by different doors: the change comes off a forge's JSON and
+is guarded at the boundary (`glstate._change_or_none`), while the directory name comes
+off the filesystem and never passes through `glstate` at all — so it is `tui` that has
+to hold, and this is the test that says so.
+
+The alignment assertion is the point of the whole issue, not a nicety: #326 measured a
+rendered line at 94 columns "while the escape occupied none of them", which is the
+column arithmetic every row below it inherits.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from charter import statusline, tui
+
+OSC_TITLE = "\x1b]0;pwned\x07"
+ERASE_DISPLAY = "\x1b[2J"
+
+#: Everything a terminal would act on. SGR is charter's own and is expected to be here,
+#: so ESC (0x1b) is exempted from the control-character class and matched only by the
+#: first branch, where the lookahead lets a colour escape past.
+_NON_SGR_ESCAPE = re.compile(
+    r"\x1b(?!\[[0-9;]*m)|[\x00-\x08\x0b-\x1a\x1c-\x1f\x7f-\x9f]")
+
+
+def _row(label, change, d=Path("/tmp/plain-repo")):
+    return statusline._tree_cells(
+        "", label, d, states={}, branches={d: "main"},
+        gl={d: {"ci": "success", "change": change, "sigil": "#"}},
+    )
+
+
+class AHostileValueCannotReachTheTerminal(unittest.TestCase):
+    WIDTH = 100
+
+    def _render(self, label, change):
+        lines = _row(label, change).render(self.WIDTH)
+        self.assertEqual(len(lines), 1, "a repo row is one line, always")
+        return lines[0]
+
+    def test_a_directory_name_carrying_an_osc_string_is_not_rendered(self):
+        line = self._render(f"api{OSC_TITLE}", 7)
+        # Precondition: the hostile label really is what was drawn, not a fallback.
+        self.assertIn("api", line, "the label never reached the row — proves nothing")
+        self.assertIsNone(_NON_SGR_ESCAPE.search(line), repr(line))
+
+    def test_a_change_number_carrying_an_escape_is_not_rendered(self):
+        line = self._render("api", f"{ERASE_DISPLAY}31")
+        self.assertIsNone(_NON_SGR_ESCAPE.search(line), repr(line))
+
+    def test_the_row_still_fits_its_width(self):
+        line = self._render(f"api{OSC_TITLE}{ERASE_DISPLAY}", f"{OSC_TITLE}31")
+        self.assertLessEqual(tui.width(line), self.WIDTH)
+
+    def test_an_escape_costs_no_columns_so_the_row_below_stays_aligned(self):
+        """The strongest form: a row drawn from a poisoned name is byte-identical to the
+        one drawn from the same name with the escapes taken out. Nothing shifts."""
+        self.assertEqual(self._render(f"api{OSC_TITLE}", 7), self._render("api", 7))
+
+    def test_a_clean_row_is_unchanged(self):
+        line = self._render("api", 7)
+        self.assertIn("api", line)
+        self.assertIn("#7", tui.strip_ansi(line))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tui_control_chars.py
+++ b/tests/test_tui_control_chars.py
@@ -1,0 +1,150 @@
+"""#326 — `tui` must measure and clamp only ITS OWN markup.
+
+`_SGR` matched `\\x1b[…m` and nothing else, so an erase-in-display, an OSC title
+sequence, a bare BEL or a backspace survived `strip_ansi`, were counted as visible
+columns by `width()`, and were copied through verbatim by `truncate()`. The module's
+one hard guarantee — "no rendered line ever exceeds the requested width" — was being
+computed from a string the terminal does not render the way `tui` measured it.
+
+The tension these tests pin down: `tui` *emits* SGR deliberately, so the fix must
+remove everything that is not SGR and leave SGR alone. Both halves are asserted here;
+a blanket strip would pass the first half and fail the second.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import tui
+
+#: The demonstrations named in #326, plus the C0 cases the same gap lets through.
+ERASE_DISPLAY = "\x1b[2J"          # CSI, non-SGR final byte
+OSC_TITLE = "\x1b]0;pwned\x07"     # OSC … BEL — repaints the terminal's title bar
+CURSOR_HOME = "\x1b[H"             # CSI with no parameters at all
+BEL = "\x07"
+BACKSPACE = "\x08"
+DEL = "\x7f"
+
+
+class WidthCountsOnlyVisibleColumns(unittest.TestCase):
+    """`width()` must not count a control character as a column.
+
+    #326 measured a rendered line at 94 columns "while the escape occupied none of
+    them" — the arithmetic every `Cell` and `Row` uses to stay aligned was reading a
+    number the terminal disagreed with.
+    """
+
+    def test_a_non_sgr_csi_is_not_counted(self):
+        self.assertEqual(tui.width(f"a{ERASE_DISPLAY}b"), 2)
+
+    def test_a_parameterless_csi_is_not_counted(self):
+        self.assertEqual(tui.width(f"a{CURSOR_HOME}b"), 2)
+
+    def test_an_osc_sequence_is_not_counted(self):
+        self.assertEqual(tui.width(f"a{OSC_TITLE}b"), 2)
+
+    def test_bare_c0_controls_are_not_counted(self):
+        self.assertEqual(tui.width(f"a{BEL}{BACKSPACE}{DEL}b"), 2)
+
+    def test_sgr_colour_is_still_zero_width(self):
+        """The pre-existing guarantee, restated so a broader strip cannot quietly
+        change what SGR costs."""
+        self.assertEqual(tui.width("\x1b[32mok\x1b[0m"), 2)
+
+
+class SanitiseKeepsCharterSOwnMarkup(unittest.TestCase):
+    """The half a blanket strip would break."""
+
+    def test_sgr_survives_sanitising(self):
+        self.assertEqual(tui.sanitize("\x1b[32mok\x1b[0m"), "\x1b[32mok\x1b[0m")
+
+    def test_a_multi_parameter_sgr_survives(self):
+        self.assertEqual(tui.sanitize("\x1b[1;38;5;208mx\x1b[0m"),
+                         "\x1b[1;38;5;208mx\x1b[0m")
+
+    def test_an_escape_that_is_not_sgr_is_removed(self):
+        self.assertEqual(tui.sanitize(f"a{ERASE_DISPLAY}b"), "ab")
+
+    def test_an_osc_string_is_removed_whole(self):
+        """Removing only the introducer would leave `0;pwned` as visible text — worse
+        than the escape, because it looks like data."""
+        self.assertEqual(tui.sanitize(f"a{OSC_TITLE}b"), "ab")
+
+    def test_an_unterminated_osc_string_is_still_removed(self):
+        self.assertEqual(tui.sanitize("a\x1b]0;no-terminator"), "a")
+
+    def test_a_lone_escape_is_removed_without_eating_the_text_after_it(self):
+        self.assertEqual(tui.sanitize("a\x1bb"), "a")   # ESC b is a two-char escape
+        self.assertEqual(tui.sanitize("ab\x1b"), "ab")
+
+    def test_whitespace_controls_become_a_space_not_a_deletion(self):
+        """A tab jumps to the next tab stop, which is the column-shearing this module
+        exists to prevent; a newline breaks the one-line contract outright. Both keep
+        their separation as a single, measurable space."""
+        self.assertEqual(tui.sanitize("a\tb\nc"), "a b c")
+
+    def test_c1_controls_are_removed(self):
+        self.assertEqual(tui.sanitize("a\x9bb"), "ab")
+
+    def test_ordinary_text_is_returned_unchanged(self):
+        for s in ("", "plain", "wide 日本語", "non-breaking\xa0space", "…"):
+            self.assertEqual(tui.sanitize(s), s, s)
+
+
+class TruncateAndPadDoNotCopyControlsThrough(unittest.TestCase):
+    def test_truncate_drops_a_non_sgr_escape_that_already_fits(self):
+        """The fast path — `truncate` returns *s* unchanged when it fits — was the way
+        an escape reached the screen without ever being looked at."""
+        out = tui.truncate(f"a{ERASE_DISPLAY}b", 40)
+        self.assertNotIn("\x1b", out)
+        self.assertEqual(out, "ab")
+
+    def test_truncate_drops_an_osc_when_it_also_has_to_cut(self):
+        out = tui.truncate(f"{OSC_TITLE}abcdefghij", 4)
+        self.assertNotIn("\x1b]", out)
+        self.assertLessEqual(tui.width(out), 4)
+
+    def test_truncate_still_carries_sgr_through_a_cut(self):
+        out = tui.truncate("\x1b[32mabcdefghij\x1b[0m", 4)
+        self.assertIn("\x1b[32m", out)
+        self.assertLessEqual(tui.width(out), 4)
+
+    def test_pad_produces_exactly_the_requested_columns(self):
+        out = tui.pad(f"a{OSC_TITLE}b", 8)
+        self.assertNotIn("\x1b", out)
+        self.assertEqual(tui.width(out), 8)
+        self.assertEqual(len(out), 8, "padded to 8 columns but not 8 characters")
+
+
+class NoNodeRendersAControlCharacter(unittest.TestCase):
+    """The module-level guarantee, asserted at the node boundary rather than the
+    primitive — a natural-width `Cell` is copied into the row verbatim, so it is the
+    one shape that could route round a fix applied only where padding happens."""
+
+    HOSTILE = f"repo{OSC_TITLE}{ERASE_DISPLAY}{BEL}"
+
+    def _assert_clean(self, lines, limit):
+        for ln in lines:
+            self.assertNotIn("\x1b]", ln)
+            self.assertNotIn(ERASE_DISPLAY, ln)
+            self.assertNotIn(BEL, ln)
+            self.assertLessEqual(tui.width(ln), limit)
+
+    def test_text(self):
+        self._assert_clean(tui.Text(self.HOSTILE).render(40), 40)
+
+    def test_row_with_a_fixed_width_cell(self):
+        row = tui.Row(tui.Cell(self.HOSTILE, 12), tui.Cell("main", 10))
+        self._assert_clean(row.render(40), 40)
+
+    def test_row_with_a_natural_width_cell(self):
+        row = tui.Row(tui.Cell(self.HOSTILE), tui.Cell("main", 10))
+        self._assert_clean(row.render(40), 40)
+
+    def test_columns(self):
+        node = tui.Columns([(tui.Text(self.HOSTILE), 20), ([self.HOSTILE], None)])
+        self._assert_clean(node.render(60), 60)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_util_run_stdin.py
+++ b/tests/test_util_run_stdin.py
@@ -1,0 +1,125 @@
+"""#324 — `util.run` redirects stdout and stderr, and leaves stdin INHERITED.
+
+`test_clone_parallel` already wrote the diagnosis down, one defect early: "`util.run`
+captures stdout and stderr but leaves stdin INHERITED, so when git falls back to
+prompting for credentials the prompt is invisible and the call waits forever." That was
+answered for git alone, with `GIT_TERMINAL_PROMPT=0`. Every other CLI charter runs kept
+the descriptor — and `gh api` will read stdin for a field value naming standard input
+(#323), which is how `glstate.state_for_repo` was observed still running after 10s.
+
+**Never reproduced in this process.** A test that blocks on its own stdin does not fail,
+it hangs, and a suite with nobody at the keyboard hangs with it. Everything below runs in
+a child under an explicit timeout, and the hostile stdin is a pipe this test constructs
+rather than whatever the machine happened to hand the runner — the "your machine is not
+the runner" rule in CONTRIBUTING, applied to a file descriptor.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+import charter
+
+#: So the helper below can `from charter import util` whatever the cwd is.
+_REPO_ROOT = Path(charter.__file__).resolve().parent.parent
+
+#: Reads stdin to EOF. Handed a descriptor that never reaches EOF, it blocks until
+#: something kills it — which is the whole point.
+_READER = "import sys; sys.stdout.write(sys.stdin.read())"
+
+_INNER_BOUND = 5.0    # what the helper gives the child before calling it stuck
+_OUTER_BOUND = 60.0   # the backstop on the helper itself; never reached in practice
+
+#: Runs `_READER` through `util.run` and reports the outcome as JSON. Run as a child so
+#: that if `util.run` does block, it blocks *here* and this process reaps it.
+_HELPER = f"""
+import json, sys
+from charter import util
+try:
+    p = util.run([sys.executable, "-c", {_READER!r}], check=False,
+                 timeout={_INNER_BOUND})
+    print(json.dumps({{"outcome": "returned", "rc": p.returncode, "out": p.stdout}}))
+except util.ProcTimeout as e:
+    print(json.dumps({{"outcome": "blocked", "seconds": e.seconds}}))
+"""
+
+
+class _NeverEofStdin:
+    """A pipe whose write end nobody ever writes to and this process holds open, so a
+    reader of the read end waits forever. Closed on exit."""
+
+    def __enter__(self):
+        self.r, self.w = os.pipe()
+        return self.r
+
+    def __exit__(self, *exc):
+        os.close(self.r)
+        os.close(self.w)
+        return False
+
+
+class TheFixtureIsRealBeforeAnythingIsConcludedFromIt(unittest.TestCase):
+    """Assert the precondition rather than assume it.
+
+    If this pipe were at EOF — because a descriptor got closed, or because the runner's
+    stdin was already `/dev/null` — the test below would pass with `util.run` having
+    done nothing at all. That is the vacuous shape this audit produced five of.
+    """
+
+    def test_an_inheriting_child_really_does_block_on_it(self):
+        with _NeverEofStdin() as stdin:
+            with self.assertRaises(subprocess.TimeoutExpired):
+                subprocess.run([sys.executable, "-c", _READER], stdin=stdin,
+                               capture_output=True, timeout=3)
+
+
+class AChildNeverInheritsCharterSStdin(unittest.TestCase):
+    def _report(self) -> dict:
+        with _NeverEofStdin() as stdin:
+            proc = subprocess.run(
+                [sys.executable, "-c", _HELPER], stdin=stdin,
+                capture_output=True, text=True, timeout=_OUTER_BOUND,
+                env={**os.environ, "PYTHONPATH": str(_REPO_ROOT)},
+            )
+        # Precondition: the helper ran and reported. An ImportError or a traceback here
+        # must be loud, not silently read as "did not block".
+        self.assertEqual(proc.returncode, 0,
+                         f"helper failed:\n{proc.stdout}\n{proc.stderr}")
+        return json.loads(proc.stdout)
+
+    def test_a_cli_waiting_on_stdin_gets_eof_instead_of_charter_s_descriptor(self):
+        got = self._report()
+        self.assertEqual(got["outcome"], "returned",
+                         f"util.run blocked on inherited stdin: {got}")
+        self.assertEqual(got["rc"], 0)
+        self.assertEqual(got["out"], "", "the child read something — stdin was inherited")
+
+
+class WritingToTheChildStillWorks(unittest.TestCase):
+    """The half that must NOT change. `input=` is how every credential reaches `op`,
+    `gh` and `vault` without appearing in argv, and `subprocess.run` opens the pipe for
+    it itself — handing it `stdin=` as well is a `ValueError`, so the guard has to be
+    conditional. `test_secrets_travel_by_pipe` owns this contract; asserted here too so
+    a change to the stdin line fails next to the line that caused it.
+    """
+
+    def test_input_still_reaches_the_child(self):
+        proc = util_run_reader(input="s3cret-alpha")
+        self.assertEqual(proc.stdout, "s3cret-alpha")
+
+    def test_passing_input_does_not_raise_value_error(self):
+        self.assertEqual(util_run_reader(input="").returncode, 0)
+
+
+def util_run_reader(**kw):
+    from charter import util
+    return util.run([sys.executable, "-c", _READER], check=False, **kw)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two defects on one short path — a forge's answer, through a cache, onto the status line.
That surface renders every turn and repaints every ten seconds with no human in the loop.

**Closes #324 in full. Closes #326 in full.**

## #324 — unbounded calls, inherited stdin, a cooldown measured from the wrong end

Three separable defects, three commits.

**A bound on every forge CLI call.** `util.run` has taken a `timeout` since the day its
own docstring named `gh api`/`glab api` as paths that "could hang indefinitely"; no forge
call site passed one.

#324 left the *number* open, on the grounds that a status refresh, a `discover` and a
`doctor` preflight have different budgets. They do — but that difference is in the
**total, not the call**. Every site here is one CLI invocation making one API request;
`discover`'s hundreds of repos are hundreds of separate invocations. So the split that
earns two numbers is not caller-by-caller, it is the permissive/strict split both backends
already draw, because the two differ in **what being wrong costs**:

| | bound | why |
|---|---|---|
| `_api`, `ci_status`, `check_auth` | **10s** | Best-effort, feeds the status line. Failing costs a blank column until the next `REFRESH_TTL`. ~10x a healthy call (CLI start + one HTTPS round trip); matches charter's existing scale for a network call on a rendering path (`doctor.CHECK_TIMEOUT` 5s, `update.NET_TIMEOUT` 5s); below `SPAWN_COOLDOWN`, so one call can never outlive the cooldown on its own. This is also the path that stacks, so a generous bound here is the expensive mistake. |
| `_paged_strict`, `_api_strict`, `repo_tree_strict` | **60s** | Human-invoked; a failure aborts a whole `discover` rather than blanking a cell, and one page is a hundred records with descriptions and topics. Same number `secrets.reference` already uses for "a human is waiting". |

Each path reports a timeout in its own vocabulary rather than letting `ProcTimeout` — a
`RuntimeError` — reach `cli.main`, which catches only `KeyboardInterrupt`, as a traceback.
Best-effort paths degrade to `None`/`[]`; strict paths raise `ForgeError` naming the bound.

**Stdin, in `util.run`, for every caller.** This is the risky half, so here is the audit.
23 production call sites across 12 modules:

* **Nothing passes `capture=False`.** Every call already captures stdout *and* stderr, so
  no call site is interactive — a child whose output nobody sees cannot conduct a dialogue
  with the terminal. Its prompt is buffered out of sight and the call waits, which is the
  failure, not a feature.
* **The one caller that writes to a child's stdin** does it through `input=`
  (`secrets/onepassword.py`), for which `subprocess.run` opens the pipe itself and rejects
  being handed `stdin` as well. The guard is conditional — correct semantics as well as
  required, since `input=` is how a secret reaches a CLI without passing through argv.
  `test_secrets_travel_by_pipe` owns that contract and stays green.
* **Charter's one genuinely interactive path**, `secret --exec`, replaces the process with
  `os.execvpe` and never comes through `util.run`.
* The rest: git (13), forge CLIs (7), non-interactive installers and `charter
  --version`/`news` (4).

Fixed for everyone rather than the forge path alone because *who reads stdin* is not a
property of the caller — it is a property of a CLI's argv, which is sometimes built from a
forge response. It also generalises a rule this function already applied to git, whose own
comment named what it did not cover: "not a GUI credential manager, and not an SSH signing
agent, which is a separate way for a captured git call to hang."

`test_clone_parallel`'s docstring had already written the diagnosis down one defect
earlier — "leaves stdin INHERITED, so … the call waits forever" — and it was answered for
git alone.

**The respawn, fixed independently of the timeout.** With a bound in place a hung child
eventually dies, but "eventually" is not "not stacking". The lock now carries two facts:
its *content* is the pid of an in-flight refresh, its *mtime* is when that last changed.
`maybe_spawn` suppresses while that pid is alive however long it has been; `refresh` calls
`_mark_done()` when the work is over, which is what moves the cooldown from the spawn to
the completion. `STUCK_AFTER` (900s, 3x `REFRESH_TTL`) replaces a presumed-wedged refresh
whose answer would already be stale several times over — which also stops a recycled pid
suppressing refreshes indefinitely. A crashed child reads as crashed, not finished, so the
plain cooldown applies rather than a hammer.

## #326 — control characters reached the rendered line, and `width()` miscounted them

Two halves, because the two ways in are different — and neither alone is sufficient.

**At the boundary.** The open-change number was the one forge field passed through as-is
(`ci` is pinned to seven literals, `sigil` is a class constant). It is now what
`base.Forge.open_change` always said it was — `int | None` — validated at **both** ends:
where it is written *and* where it is read back, because a cache entry written by the
charter that had this bug renders for two hours after the upgrade that fixed it, and
nothing signs that file. Same reasoning `charter.contain` uses for asserting at every join.

**In `tui`.** A clone's directory name comes off the filesystem and never passes through
`glstate` at all, so the boundary fix cannot reach it. `sanitize` drops everything that is
not charter's own markup before anything is measured or clamped — and it runs *before*
`truncate`'s fits-already fast path, which is exactly how an escape reached the screen
without anything ever looking at it.

Deliberately a narrow removal, not a whitelist of printable text: this module *emits* SGR,
so a blanket strip would fight the colour it exists to produce. SGR is matched **first**
and passed through untouched, so the catch-all can drop a stray introducer without
decapitating a colour span and spilling `[32m` onto the screen as text. Writing the tests
turned up two cases the issue did not name: `ESC c` (RIS — a full terminal reset) and the
DCS/APC/PM/SOS string sequences, which must be removed *whole* or their payload prints as
ordinary text, which is worse than the escape because it looks like data. Tabs and
newlines become a single space rather than vanishing, since both shear the columns below
them.

The strongest assertion in the set: a row drawn from a poisoned name is byte-identical to
the same row drawn from the name with the escapes removed. Nothing shifts.

## Verification

* **3012 tests, green.** Baseline 2950 on `main` + 62 new.
* Every fix is TDD — each test watched failing first, for the right reason. The stdin hang
  was reproduced (`{'outcome': 'blocked', 'seconds': 5.0}`), never in the test process: a
  child under an explicit bound, against a pipe the test constructs rather than whatever
  the machine handed the runner.
* **Preconditions asserted before trusting a negative**, given this audit's five vacuous
  passes. `test_util_run_stdin` proves its own pipe blocks an inheriting child *before*
  concluding anything from `util.run` not blocking; the respawn tests assert the first
  spawn happened before concluding a later suppression means anything; the `#326` boundary
  tests assert the fake forge was actually called. That discipline paid: it caught a stale
  local in `maybe_spawn` whose `NameError` was being swallowed by the never-raise guard.
* Nothing added reads the network, walks a repo, or can raise on the render path.
* One `docs/news/` entry covers both, `version: unreleased`, no `check:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo
