### PR TITLE
Resolve and bound every read of plane data (#336)

### DIFF
--- a/charter/contain.py
+++ b/charter/contain.py
@@ -212,7 +212,7 @@ def within_data(path) -> bool:
         roots = [os.path.abspath(r) for r in data_roots()]
         if os.path.dirname(target) in roots and not stat.S_ISLNK(os.lstat(target).st_mode):
             return True
-    except OSError:
+    except (OSError, ValueError):
         pass                                   # vanished or unreadable — ask the slow path
     try:
         target = os.path.realpath(path)
@@ -221,14 +221,18 @@ def within_data(path) -> bool:
             # `+ os.sep` so a sibling named like a root ("personas-old") is not a child.
             if target == root or target.startswith(root + os.sep):
                 return True
-    except OSError:
+    except (OSError, ValueError):
         return False
     return False
 
 
 def _not_plane_data(path) -> str:
     roots = ", ".join(sorted(Path(r).name for r in data_roots()))
-    return NOT_PLANE_DATA.format(name=path, target=os.path.realpath(path), roots=roots)
+    try:
+        target = os.path.realpath(path)
+    except (OSError, ValueError):
+        target = path            # unresolvable — say what was asked for, never raise here
+    return NOT_PLANE_DATA.format(name=path, target=target, roots=roots)
 
 
 def dir_refusal(directory) -> str | None:
@@ -274,6 +278,11 @@ def file_refusal(path) -> str | None:
             st = os.stat(path)
     except OSError as e:
         return UNREADABLE.format(name=path, error=e.strerror or e)
+    except ValueError as e:
+        # `os.lstat` raises ValueError, NOT OSError, on a path holding a NUL — the one
+        # input shaped to get past a check (`segment_ok` refuses it for the same reason).
+        # "Nothing here raises" is this module's promise; catching only OSError broke it.
+        return UNREADABLE.format(name=path, error=e)
     if not stat.S_ISREG(st.st_mode):
         kind = next((k for test, k in _KINDS if test(st.st_mode)), "not a file")
         return NOT_A_FILE.format(name=path, kind=kind)

--- a/charter/contain.py
+++ b/charter/contain.py
@@ -32,14 +32,26 @@ charter's creation-time alphabet on someone else's forge would refuse to clone b
 :func:`segment_ok` is therefore the permissive rule: it forbids traversal and separators
 and nothing else.
 
-**Containment is lexical, and does not follow symlinks.** :func:`docsrc.read` resolves its
-page precisely to catch a symlink pointing out of the directory, and copying that here
-would be a mistake in two directions. It would do half of #336 — whose containment half is
-about symlinks in *every* file charter reads, not only the ones named by a name — while
-claiming none of it; and it would refuse a plane that legitimately symlinks a persona
-directory today, which is a working plane broken in exchange for a hole that stays open
-anyway. Traversal and absoluteness are what these five issues are about. Symlinks are
-filed, and stay filed.
+**Two layers, and the second one resolves.** :func:`segment_ok` and :func:`child` stay
+lexical: they answer a question about a *string*, and asking the filesystem would make a
+traversal succeed exactly when the attacker's target happens to exist. That left every
+read charter performs — not only the ones named by a name — open to a committed symlink,
+which is #336 and is now :func:`file_refusal` / :func:`dir_refusal` below. The two are
+deliberately separate functions: a name is refused before anything is opened, and a *path*
+is refused before it is read, and neither can stand in for the other.
+
+**What "inside the plane" had to mean.** The obvious rule — refuse a path whose `realpath`
+leaves ROOT — admits #336's own demonstration unchanged, because ``.charter/`` sits
+*under* ROOT (:func:`config._migrate_state_dir`), so ``personas/x/persona.md`` →
+``../../.charter/vaults/devops.json`` never leaves the plane while doing precisely what the
+`pretooluse-read` guard exists to stop. The boundary is therefore the directories a plane
+keeps its **data** in — :func:`data_roots` — which excludes the secrets home and includes
+the one part of it that is data (ephemeral memory, which lives inside ``.charter/``).
+
+**Links are followed; escapes are refused.** Refusing every symlink would close the hole
+and break a plane that legitimately links a persona directory. Resolving keeps that plane
+working, and #342's reason for staying lexical was never that symlinks are acceptable —
+only that doing half of this while claiming all of it would be worse than filing it.
 
 **Nothing here raises.** These checks sit under `doctor`, the status line and SessionStart,
 where the rule is that a hook may cost a session its briefing and never its turn. A refused
@@ -52,6 +64,7 @@ has to fix it.
 from __future__ import annotations
 
 import os
+import stat
 from pathlib import Path
 
 #: Said once, so every site refuses in the same words. A reader who hits this has a defect
@@ -117,3 +130,112 @@ def child(base, name: str) -> Path | None:
 def refusal(name: str) -> str:
     """The one sentence every site uses to say why *name* was refused."""
     return NOT_A_SEGMENT.format(name=name)
+
+
+# --------------------------------------------------------------------------- #
+# the resolving layer — a PATH charter is about to read (#336)                 #
+# --------------------------------------------------------------------------- #
+
+#: Said once, like :data:`NOT_A_SEGMENT`, and for the same reason: the reader has a defect
+#: in a committed file. It names both ends because "refused" without the target is
+#: unactionable — the whole point is that the path charter opened is not the path it read.
+NOT_PLANE_DATA = ("'{name}' resolves to '{target}', outside the directories a control "
+                  "plane keeps its data in ({roots}). A committed symlink there redirects "
+                  "the read, so charter follows a link that lands inside them and refuses "
+                  "one that leaves")
+
+#: A path charter cannot examine at all (vanished mid-listing, a broken link, no
+#: permission). Refused rather than raised — every caller here is on a path that must not
+#: crash — and said in its own words so it is not read as a containment failure.
+UNREADABLE = "'{name}' cannot be examined ({error})"
+
+
+def data_roots() -> tuple[Path, ...]:
+    """The directories a control plane keeps readable data in.
+
+    Read from :mod:`charter.config` **at call time**, never captured at import: the test
+    harness re-points the plane with `config.use`, and a root captured at import would
+    quietly contain against the developer's real checkout.
+
+    ``PERSONA_STATE_DIR`` is here because ephemeral memory is data charter is *supposed* to
+    read, and it lives under the secrets home. That is the whole reason this is a list of
+    data directories rather than "the plane, minus ``.charter/``".
+    """
+    from . import config
+    return (config.PERSONAS_DIR, config.WORKSPACES_DIR, config.PERSONA_STATE_DIR)
+
+
+def within_data(path) -> bool:
+    """True when *path* **resolves** inside one of :func:`data_roots`.
+
+    Both ends are resolved. The roots have to be too: on macOS a temp plane lives under
+    ``/var/folders/…``, which is itself a link to ``/private/var/…``, so comparing a
+    resolved path against an unresolved root refuses every read in the test harness and
+    on any plane behind a linked mount. Resolving the roots is also what keeps a plane
+    that *relocates* ``personas/`` or ``workspaces/`` behind a link working, which is the
+    same legitimate case :func:`file_refusal` preserves one level down.
+
+    **The fast path is one ``lstat``, and it is exact.** ``persona.load`` asks this of
+    ``personas/<name>`` on every call, and four ``realpath``s (20µs) there doubled a
+    status-line sweep. When a path's own parent *is* a data root and the path itself is
+    not a link, it cannot have moved relative to that root — whatever the root resolves
+    to, this resolves inside it — so the answer is already known. Anything else (a deeper
+    base, a link, a lexical outsider) still pays the full resolve.
+    """
+    try:
+        target = os.path.abspath(path)
+        roots = [os.path.abspath(r) for r in data_roots()]
+        if os.path.dirname(target) in roots and not stat.S_ISLNK(os.lstat(target).st_mode):
+            return True
+    except OSError:
+        pass                                   # vanished or unreadable — ask the slow path
+    try:
+        target = os.path.realpath(path)
+        for r in data_roots():
+            root = os.path.realpath(r)
+            # `+ os.sep` so a sibling named like a root ("personas-old") is not a child.
+            if target == root or target.startswith(root + os.sep):
+                return True
+    except OSError:
+        return False
+    return False
+
+
+def _not_plane_data(path) -> str:
+    roots = ", ".join(sorted(Path(r).name for r in data_roots()))
+    return NOT_PLANE_DATA.format(name=path, target=os.path.realpath(path), roots=roots)
+
+
+def dir_refusal(directory) -> str | None:
+    """Why charter must not list *directory*, or ``None``.
+
+    Separate from :func:`file_refusal` because a listing pays this **once** while paying
+    the per-file check N times, and because it is what catches the variant the file check
+    structurally cannot see: when the *directory* is the link, every file inside it is an
+    ordinary regular file that no per-file check has anything to object to.
+    """
+    if not within_data(directory):
+        return _not_plane_data(directory)
+    return None
+
+
+def file_refusal(path) -> str | None:
+    """Why charter must not read *path*, or ``None``.
+
+    One ``lstat`` in the common case, and that is deliberate — these run under the status
+    line and SessionStart, where the read is already the cheapest thing in the frame and a
+    guard that costs more than it guards would be reverted the first time somebody
+    profiles it. The expensive answer (:func:`within_data`, which resolves) is only asked
+    when the entry **is** a link, because a path that is not a link cannot have moved
+    relative to the directory it was listed from — which the caller checked once.
+
+    Not a TOCTOU guard, and not sold as one: the attacker here holds a commit, not a
+    process racing the read.
+    """
+    try:
+        st = os.lstat(path)
+    except OSError as e:
+        return UNREADABLE.format(name=path, error=e.strerror or e)
+    if stat.S_ISLNK(st.st_mode) and not within_data(path):
+        return _not_plane_data(path)
+    return None

--- a/charter/contain.py
+++ b/charter/contain.py
@@ -149,6 +149,31 @@ NOT_PLANE_DATA = ("'{name}' resolves to '{target}', outside the directories a co
 #: crash — and said in its own words so it is not read as a containment failure.
 UNREADABLE = "'{name}' cannot be examined ({error})"
 
+#: Not a file at all: a FIFO, a device, a socket, a directory. Named for what it is,
+#: because "could not be read" would send the reader looking for a permissions problem
+#: when what they have is a path that blocks for ever or yields for ever.
+NOT_A_FILE = ("'{name}' is not a regular file (it is {kind}). Charter reads plane data by "
+              "listing a directory and opening what it finds, so an entry that blocks or "
+              "never ends would take the read with it")
+
+#: The bound on one plane file charter reads whole. **1 MiB, and it is meant never to fire
+#: on anything a human wrote**: the largest persona charter in charter's own plane is
+#: 6.8 KB, its largest memory index 5 KB, its largest document under `docs/` 34 KB. The
+#: number is not tuned to those — a cap sitting just above real content fires on the first
+#: long runbook somebody curates — it is set where nothing an editor produces can reach it
+#: and no single read can cost anything. `os.lstat` reports it in the syscall the
+#: containment check already makes, so the bound is free.
+MAX_BYTES = 1_048_576
+
+TOO_LARGE = ("'{name}' is {size} bytes, over the {cap}-byte bound on one plane file. "
+             "Nothing a memory, todo, ref or persona charter is meant to hold comes near "
+             "that, so this is a defect in the file rather than a limit to raise")
+
+#: `stat` module names for the shapes that are not files, so a refusal says which.
+_KINDS = ((stat.S_ISDIR, "a directory"), (stat.S_ISFIFO, "a FIFO"),
+          (stat.S_ISSOCK, "a socket"), (stat.S_ISCHR, "a character device"),
+          (stat.S_ISBLK, "a block device"))
+
 
 def data_roots() -> tuple[Path, ...]:
     """The directories a control plane keeps readable data in.
@@ -222,20 +247,36 @@ def dir_refusal(directory) -> str | None:
 def file_refusal(path) -> str | None:
     """Why charter must not read *path*, or ``None``.
 
-    One ``lstat`` in the common case, and that is deliberate — these run under the status
-    line and SessionStart, where the read is already the cheapest thing in the frame and a
-    guard that costs more than it guards would be reverted the first time somebody
-    profiles it. The expensive answer (:func:`within_data`, which resolves) is only asked
-    when the entry **is** a link, because a path that is not a link cannot have moved
-    relative to the directory it was listed from — which the caller checked once.
+    Three questions, **one syscall**, and that is why both halves of #336 close at the
+    same gate. ``lstat`` says whether this is a link (containment), whether it is a
+    regular file (a FIFO blocks the read for ever, a device never ends) and how big it is
+    (the bound) — and it says all of it *without opening anything*, which is the property
+    a deadline around the read could never have given: there is nothing to time out,
+    because nothing is opened.
+
+    Cheap on purpose. These run under the status line and SessionStart, where the read is
+    already the cheapest thing in the frame and a guard costing more than it guards gets
+    reverted the first time somebody profiles it. The expensive answer
+    (:func:`within_data`, which resolves) is asked only when the entry **is** a link — a
+    path that is not one cannot have moved relative to the directory it was listed from,
+    which the caller checked once with :func:`dir_refusal`.
 
     Not a TOCTOU guard, and not sold as one: the attacker here holds a commit, not a
     process racing the read.
     """
     try:
         st = os.lstat(path)
+        if stat.S_ISLNK(st.st_mode):
+            if not within_data(path):
+                return _not_plane_data(path)
+            # Follows the link. Still a `stat`, so a FIFO on the other end answers here
+            # rather than blocking; a broken link raises and is refused as unreadable.
+            st = os.stat(path)
     except OSError as e:
         return UNREADABLE.format(name=path, error=e.strerror or e)
-    if stat.S_ISLNK(st.st_mode) and not within_data(path):
-        return _not_plane_data(path)
+    if not stat.S_ISREG(st.st_mode):
+        kind = next((k for test, k in _KINDS if test(st.st_mode)), "not a file")
+        return NOT_A_FILE.format(name=path, kind=kind)
+    if st.st_size > MAX_BYTES:
+        return TOO_LARGE.format(name=path, size=st.st_size, cap=MAX_BYTES)
     return None

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -1498,7 +1498,10 @@ def _other_workspaces_digest(session_id: str | None) -> str:
             except Exception:
                 vision = ""
             try:
-                n = len(todos.open_todos(w))
+                # `count_open`, not `len(open_todos(...))`: the same question the status
+                # line asks, answered by the same function. The other spelling read every
+                # todo of every workspace in full to print a number, at SessionStart.
+                n = todos.count_open(w)
             except Exception:
                 n = 0
             rows.append((workspace.last_active(w) or 0, w, vision, n))

--- a/charter/memstore.py
+++ b/charter/memstore.py
@@ -18,6 +18,8 @@ import datetime
 import re
 from pathlib import Path
 
+from . import contain
+
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 
 
@@ -99,10 +101,25 @@ def memory_date(text: str, filename: str = ""):
 
 
 def files(mem_dir: Path) -> list[Path]:
-    """Every memory file in *mem_dir* (sorted — chronological when timestamped)."""
-    if not mem_dir.exists():
+    """Every memory file in *mem_dir* charter may read (sorted — chronological when
+    timestamped).
+
+    **The one gate.** Everything that reaches a memory, a todo or a ref goes through here
+    — :func:`entries`, :func:`search`, :func:`resolve`, `index_drift`, `curate.report`,
+    `todos.count_open` — so containment is asserted once rather than at six callers, five
+    of which stay correct. A file this refuses is not "a memory that failed to load": it
+    is not a memory, and the count, the index-drift report and the search all agree about
+    that because they ask the same function (#336).
+
+    Two questions, both from :mod:`charter.contain`: the *directory* must resolve inside
+    the plane's data (paid once — it is what catches a linked ``memory/`` whose contents
+    are all ordinary files), and each entry must be a plain contained file (one ``lstat``
+    each).
+    """
+    if not mem_dir.exists() or contain.dir_refusal(mem_dir):
         return []
-    return sorted(p for p in mem_dir.glob("*.md") if p.name != "MEMORY.md")
+    return sorted(p for p in mem_dir.glob("*.md")
+                  if p.name != "MEMORY.md" and not contain.file_refusal(p))
 
 
 #: A memory FILENAME is a bare slug — no slash, space or colon. Matching only that
@@ -252,7 +269,10 @@ def resolve(mem_dir: Path, ident: str) -> Path | None:
     timestamped store, ``<prefix>-<slug>.md``. First match wins."""
     name = ident if ident.endswith(".md") else f"{ident}.md"
     p = mem_dir / name
-    if p.exists():
+    # The direct hit asks the filesystem rather than the listing, so it needs the listing's
+    # gate spelled out: without it `forget`/`show` would reach a file `files()` refuses,
+    # which is the same read arriving by a shorter route (#336).
+    if p.exists() and not (contain.dir_refusal(mem_dir) or contain.file_refusal(p)):
         return p
     hits = [q for q in files(mem_dir) if q.name == name or q.name.endswith(f"-{name}")]
     return hits[0] if hits else None

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -165,6 +165,26 @@ def parse(text: str) -> tuple[dict, str]:
     return meta, body.strip()
 
 
+def definition_refusal(name: str) -> str | None:
+    """Why this persona's definition file must not be read, or ``None``.
+
+    The path half of what :func:`reference_ok` does for the name half, and split out for
+    the same reason: :func:`load` and :func:`structural_errors` must not be able to
+    disagree about it. When they did — lint calling a live grant dangling — the signal an
+    operator would actively check was the one that lied (#329, #337).
+
+    Both questions are asked, because they catch different links. The *directory* resolving
+    out of the plane's data is the case where `persona.md` is an ordinary file and there is
+    nothing about it to object to; the *file* resolving out is #336's demonstration,
+    ``persona.md`` → ``../../.charter/vaults/…``, which `sync-agents` then writes into a
+    sub-agent's system prompt while `pretooluse-read` denies the agent that same read.
+    """
+    p = def_path(name)
+    if not p.exists():
+        return None
+    return contain.dir_refusal(p.parent) or contain.file_refusal(p)
+
+
 def load(name: str) -> dict | None:
     """The persona's OWN (unmerged) definition. For the effective persona with
     inheritance applied, use :func:`resolve`.
@@ -180,7 +200,7 @@ def load(name: str) -> dict | None:
     if not reference_ok(name):
         return None
     p = def_path(name)
-    if not p.exists():
+    if not p.exists() or definition_refusal(name):
         return None
     meta, charter = parse(p.read_text())
     meta.setdefault("name", name)
@@ -914,6 +934,13 @@ def structural_errors(name: str, known: set[str] | None = None) -> list[tuple[st
     """
     allnames = known if known is not None else set(list_personas())
     issues: list[tuple[str, str]] = []
+    refused = definition_refusal(name)
+    if refused:
+        # First, and on its own terms: every check below reads through `load`, which
+        # returns None for this persona, so without this line a definition charter
+        # DECLINED to read is indistinguishable from one that says nothing — and the
+        # operator is looking straight at the signal that would have told them (#336).
+        issues.append(("error", f"persona.md: {refused}"))
     for u in uses_of(name):
         problem = _reference_problem("uses", u, allnames)
         if problem:

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -1046,7 +1046,12 @@ def lint(name: str, deep: bool = True) -> list[tuple[str, str]]:
     """
     d = load(name)
     if not d:
-        return [("error", f"persona '{name}' does not load")]
+        # WHY, when there is a why. "does not load" about a `persona.md` sitting right
+        # there sends the reader looking for a missing file; the refusal names the path
+        # charter actually resolved to, which is the whole defect (#336).
+        refused = definition_refusal(name)
+        return [("error", f"persona.md: {refused}" if refused
+                 else f"persona '{name}' does not load")]
     meta = d["meta"]
     issues: list[tuple[str, str]] = []
     if deep:

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -305,8 +305,11 @@ def mcp_servers(name: str) -> dict:
     # the child's entry was parsed and applied and then thrown away, so `sync-agents`
     # succeeded and the generated agent simply carried somebody else's server.
     for anc in reversed(lineage(name)):
+        declaration = dir_of(anc) / MCP_FILE
+        if contain.file_refusal(declaration):
+            continue          # same promise as the `except` below, kept before the open
         try:
-            doc = json.loads((dir_of(anc) / MCP_FILE).read_text())
+            doc = json.loads(declaration.read_text())
             servers = doc.get("mcpServers") or {}
         except (OSError, ValueError, AttributeError):
             continue
@@ -460,8 +463,13 @@ def default_persona() -> str | None:
     """The committed, team-wide default persona (``personas/.default``) — adopted when
     nothing else is selected. Shared/versioned (unlike the local ``.charter/active-persona``);
     ignored if it names a persona that no longer exists."""
+    p = config.PERSONAS_DIR / ".default"
+    # Gated like every other committed file charter reads: this one answers "who am I" on
+    # every turn, so a FIFO here hangs the status line rather than costing a briefing.
+    if contain.file_refusal(p):
+        return None
     try:
-        val = (config.PERSONAS_DIR / ".default").read_text().strip()
+        val = p.read_text().strip()
     except OSError:
         return None
     # `reference_ok` before `.exists()`: this dotfile is committed, so the value is a

--- a/charter/recall.py
+++ b/charter/recall.py
@@ -18,7 +18,7 @@ import re
 from pathlib import Path
 from typing import NamedTuple
 
-from . import config, memstore
+from . import config, contain, memstore
 
 #: The selectable scopes, in the order they're assembled/displayed.
 SCOPES = ("workspace", "persona", "shared", "ephemeral", "refs")
@@ -133,11 +133,19 @@ def _ref_dirs(base: Path) -> list[Path]:
     searches), each subdirectory is offered as its own source. `memstore.search` already
     takes a list of dirs, so recursion falls out of the assembly step where the shape
     difference actually lives.
+
+    Every directory offered here is one `memstore.files` will list, so each is contained
+    first. ``rglob`` does not descend *into* a symlinked directory, but it still yields the
+    link itself and ``is_dir()`` follows it — so an escape needs no depth: one committed
+    link at the top of `refs/` is enough, and the label this module derives for anything
+    read out of it degrades to ``?``, which is the provenance the reader would most want to
+    be right (#336).
     """
-    if not base.exists():
+    if not base.exists() or contain.dir_refusal(base):
         return []
     try:
-        return [base, *(d for d in sorted(base.rglob("*")) if d.is_dir())]
+        return [base, *(d for d in sorted(base.rglob("*"))
+                        if d.is_dir() and not contain.dir_refusal(d))]
     except OSError:
         return [base]
 

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -30,7 +30,7 @@ import re
 import time
 from pathlib import Path
 
-from . import config, util
+from . import config, contain, util
 
 _NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 _SESSION_MAX_AGE = 30 * 86400  # prune per-session pointers older than this
@@ -890,6 +890,11 @@ def set_vision(name: str, text: str) -> None:
 
 def read_charter(name: str) -> str:
     cf = charter_file(name)
+    # `workspace.md` is committed, and the SessionStart digest reads one per workspace on
+    # this plane for its vision line — so an entry that blocks costs every session its
+    # briefing, and one that never ends costs more than that (#336).
+    if contain.file_refusal(cf):
+        return ""
     return cf.read_text() if cf.exists() else ""
 
 

--- a/docs/news/unreleased-resolve-and-bound-plane-reads.md
+++ b/docs/news/unreleased-resolve-and-bound-plane-reads.md
@@ -1,0 +1,54 @@
+---
+version: unreleased
+headline: A committed symlink can no longer point charter's own reads at your vault, or stop them finishing
+---
+
+Charter reads the data on a plane by listing a directory and opening what it finds:
+`personas/<name>/persona.md`, every `*.md` in a `memory/`, every directory under a `refs/`.
+Nothing on any of those paths called `is_symlink`, `lstat` or `realpath`, and nothing
+bounded what came back. Git stores symlinks, so both properties belonged to whoever last
+committed to the plane.
+
+The read went somewhere else. With `personas/reader/persona.md` a link to
+`../../.charter/vaults/devops.json` — a plane-relative path, so it needs no knowledge of
+your home directory — `persona.load()` returned the vault's contents as that persona's
+charter, and `charter persona sync-agents` wrote them into `.claude/agents/reader.md`,
+which is a sub-agent's system prompt. Charter's own `pretooluse-read` guard denies an agent
+reading that same file and says so in `SECURITY.md`. The link walked around it, and the
+same shape worked through `memory/` and `refs/`, where the provenance label on out-of-plane
+content degraded to `?`.
+
+And the read did not have to finish. A link to a FIFO at the active persona's `persona.md`
+hung `doctor`, `statusline`, `hook sessionstart` and `persona show` — indefinitely for the
+last two, which have no charter-side bound at all. A device that yields for ever is the
+memory variant. Nothing here needed a subprocess, so #324's subprocess timeouts could not
+see it.
+
+**Both halves close at one syscall.** `os.lstat` says whether a path is a link, whether it
+is a regular file, and how big it is — and it says all of that *without opening anything*,
+which is what a deadline around the read could never have offered: there is nothing to time
+out, because nothing is opened. A FIFO is not a regular file. Neither is `/dev/zero`.
+Charter now asks that question before every read of plane data, once per directory and once
+per file, and reports a refusal as data the way a refused name already was.
+
+**Links still work; escapes do not.** A link that lands inside the plane's data is
+followed, so a plane that symlinks a persona directory, or relocates `personas/` or
+`workspaces/` behind a link, keeps working. What "inside" means took a correction: the
+obvious rule — refuse a path whose `realpath` leaves the plane — would have admitted the
+demonstration above unchanged, because `.charter/` sits *under* the plane root, so a link
+into your vault directory never leaves the plane. The boundary is the directories a plane
+keeps data in: `personas/`, `workspaces/`, and the per-developer persona state that holds
+ephemeral memory. Your vaults, your browser state and your unreviewed report drafts are on
+the other side of it, and charter's readers no longer look there.
+
+The bound on one file is 1 MiB. It is set where nothing an editor produces can reach it —
+the largest persona charter in charter's own plane is 6.8 KB — rather than close to real
+content, where the first long runbook somebody curates would trip it.
+
+Two smaller things came along, both the same omission wearing different names.
+`personas/.default` and a persona's `mcp.json` are committed files read on the same paths,
+now gated the same way; so is a workspace's `workspace.md`, which the session briefing reads
+once per workspace on the plane. And that briefing counted another workspace's todos by
+reading every one of them in full, while the status line counted the same todos from the
+directory listing. One question with two implementations, and the expensive one ran at
+session start.

--- a/tests/test_curate.py
+++ b/tests/test_curate.py
@@ -6,20 +6,21 @@ No LLM, fully deterministic — the semantic judgment stays in the steward agent
 from __future__ import annotations
 
 import datetime
-import shutil
-import tempfile
 import unittest
-from pathlib import Path
 
-from charter import curate, memstore
+from charter import curate, memstore, persona
+from tests._isolation import PersonaIso
 
 TODAY = datetime.date(2026, 7, 24)
 
 
-class CurateCase(unittest.TestCase):
+class CurateCase(PersonaIso):
     def setUp(self):
-        self.d = Path(tempfile.mkdtemp(prefix="charter-curate-"))
-        self.addCleanup(lambda: shutil.rmtree(self.d, ignore_errors=True))
+        # Inside a plane, because `memstore.files` refuses a store that resolves outside
+        # the plane's data since #336 — see the header of `tests/test_memstore.py`.
+        super().setUp()
+        self.d = persona.memory_dir("curatetest")
+        self.d.mkdir(parents=True, exist_ok=True)
 
     def _w(self, title, body, days_ago=0):
         stamp = datetime.datetime(2026, 7, 24, 12, 0) - datetime.timedelta(days=days_ago)

--- a/tests/test_forget_is_reactive.py
+++ b/tests/test_forget_is_reactive.py
@@ -52,21 +52,21 @@ class TestMemstoreReportsWhatItRemoved(PersonaIso):
     """The commands can only stage a deletion they are told about."""
 
     def test_it_returns_the_removed_path(self):
-        d = self.tmp / "mem"
-        d.mkdir()
+        d = persona.memory_dir("forgettest")
+        d.mkdir(parents=True, exist_ok=True)
         (d / "a-fact.md").write_text("x")
         self.assertEqual(memstore.forget(d, "a-fact.md"), d / "a-fact.md")
 
     def test_a_miss_is_still_falsy(self):
         """Callers test the result for truthiness; a Path is truthy and None is not, so
         the change of type must not change the branch anyone takes."""
-        d = self.tmp / "mem"
-        d.mkdir()
+        d = persona.memory_dir("forgettest")
+        d.mkdir(parents=True, exist_ok=True)
         self.assertFalse(memstore.forget(d, "nope"))
 
     def test_the_file_is_actually_gone(self):
-        d = self.tmp / "mem"
-        d.mkdir()
+        d = persona.memory_dir("forgettest")
+        d.mkdir(parents=True, exist_ok=True)
         (d / "a-fact.md").write_text("x")
         memstore.forget(d, "a-fact.md")
         self.assertFalse((d / "a-fact.md").exists())

--- a/tests/test_memory_index_health.py
+++ b/tests/test_memory_index_health.py
@@ -16,17 +16,19 @@ from the SessionStart hook, which must never block a session.
 from __future__ import annotations
 
 import unittest
-from pathlib import Path
-from tempfile import TemporaryDirectory
 
-from charter import doctor, memstore
+from charter import doctor, memstore, persona
+from tests._isolation import PersonaIso
 
 
-class IndexDrift(unittest.TestCase):
+class IndexDrift(PersonaIso):
     def setUp(self) -> None:
-        self._td = TemporaryDirectory()
-        self.d = Path(self._td.name)
-        self.addCleanup(self._td.cleanup)
+        # A memory base is a directory inside a plane; since #336 `memstore.files`
+        # refuses one that resolves outside the plane's data, so the fixture is a real
+        # base rather than a bare temp dir (see the header of `tests/test_memstore.py`).
+        super().setUp()
+        self.d = persona.memory_dir("indexhealth")
+        self.d.mkdir(parents=True, exist_ok=True)
 
     def _mem(self, name: str, body: str = "a fact") -> Path:
         p = self.d / name
@@ -104,7 +106,7 @@ class DoctorCheck(unittest.TestCase):
 
 
 
-class IndexGrowthSignal(unittest.TestCase):
+class IndexGrowthSignal(PersonaIso):
     """#2: an index only ever appends, and nothing said when it got long.
 
     Not a truncation guard — charter injects a bounded digest at SessionStart, so a
@@ -113,9 +115,12 @@ class IndexGrowthSignal(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self._td = TemporaryDirectory()
-        self.d = Path(self._td.name)
-        self.addCleanup(self._td.cleanup)
+        # A memory base is a directory inside a plane; since #336 `memstore.files`
+        # refuses one that resolves outside the plane's data, so the fixture is a real
+        # base rather than a bare temp dir (see the header of `tests/test_memstore.py`).
+        super().setUp()
+        self.d = persona.memory_dir("indexhealth")
+        self.d.mkdir(parents=True, exist_ok=True)
 
     def test_index_size_counts_memories_not_index_lines(self):
         """Files are the truth: a base mid-drift must not report a number that

--- a/tests/test_memstore.py
+++ b/tests/test_memstore.py
@@ -1,22 +1,31 @@
 """The shared per-file memory engine: one file per fact + MEMORY.md index, optional
 timestamp-prefixed filenames for chronological ordering, keyword search, near-dup
-detection, and forget-by-slug (matching the timestamp prefix too)."""
+detection, and forget-by-slug (matching the timestamp prefix too).
+
+**The store lives inside a plane, and that is not incidental.** These cases used to run
+against a bare `mkdtemp`, which no production caller ever produces — every one of them
+derives its directory from `persona.memory_dir`, `workspace.memory_dir`, `todos_dir` or
+`refs_dir`. Since #336 `memstore.files` refuses a directory that resolves outside the
+plane's data (a linked `memory/` is how a read of memory becomes a read of a vault), so a
+store in an unrelated temp directory now lists nothing. Keep the fixture inside
+`config.PERSONAS_DIR`: reverting it to `mkdtemp` makes every case here fail on an empty
+listing, which reads like a search bug and is not one.
+"""
 
 from __future__ import annotations
 
 import datetime
-import shutil
-import tempfile
 import unittest
-from pathlib import Path
 
-from charter import memstore
+from charter import memstore, persona
+from tests._isolation import PersonaIso
 
 
-class MemstoreCase(unittest.TestCase):
+class MemstoreCase(PersonaIso):
     def setUp(self):
-        self.d = Path(tempfile.mkdtemp(prefix="edm-memstore-"))
-        self.addCleanup(lambda: shutil.rmtree(self.d, ignore_errors=True))
+        super().setUp()
+        self.d = persona.memory_dir("memtest")
+        self.d.mkdir(parents=True, exist_ok=True)
 
     def _stamp(self, s):
         return datetime.datetime.strptime(s, "%Y-%m-%d %H:%M:%S")
@@ -82,7 +91,7 @@ class MemstoreCase(unittest.TestCase):
         self.assertFalse(memstore.forget(self.d, "nope"))
 
 
-class SearchFindsShortAndDistinctiveTerms(unittest.TestCase):
+class SearchFindsShortAndDistinctiveTerms(PersonaIso):
     """`_terms` discarded every token of two characters or fewer.
 
     So `recall "S3"`, `"CI"`, `"db"`, `"PR"`, `"TZ"`, `"v2"` each returned a confident
@@ -93,8 +102,9 @@ class SearchFindsShortAndDistinctiveTerms(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self.d = Path(tempfile.mkdtemp(prefix="memsearch-"))
-        self.addCleanup(shutil.rmtree, self.d, ignore_errors=True)
+        super().setUp()
+        self.d = persona.memory_dir("memsearch")
+        self.d.mkdir(parents=True, exist_ok=True)
 
     def _write(self, name: str, title: str, body: str = "") -> None:
         (self.d / f"{name}.md").write_text(f"# {title}\n\n{body}\n")

--- a/tests/test_names_from_files_are_contained.py
+++ b/tests/test_names_from_files_are_contained.py
@@ -26,12 +26,13 @@ names, and `org/.github` is both real and common — so repo names get the more 
 `contain.segment_ok`, which forbids separators and traversal without inventing an
 alphabet charter has no business imposing on someone else's forge.
 
-**Containment here is lexical, not `realpath`-based, and that is deliberate.**
-`docsrc.read` resolves its page specifically to catch a symlink pointing out of the
-directory. Following that lead here would quietly do half of #336 — whose containment
-half is about symlinks in *every* file charter reads, not just names — and would refuse a
-plane that legitimately symlinks a persona directory today. Traversal and absoluteness are
-what these five issues are about; symlinks are filed separately and stay filed.
+**Containment here is lexical, not `realpath`-based, and that is deliberate.** A name is
+refused for its *shape*, before anything is opened; asking the filesystem would make a
+traversal succeed exactly when the attacker's target happens to exist. The resolving half
+— every *path* charter reads, whether or not a name chose it — is #336, and lives in
+`contain.file_refusal`/`dir_refusal` with its own cases in
+`tests/test_plane_reads_are_contained.py`. The two are complements, not alternatives:
+neither file's cases pass under the other's rule.
 
 **Preconditions are asserted, not assumed.** Each traversal case plants a real canary at
 the path the hostile name resolves to and asserts it is there *before* asking charter to

--- a/tests/test_plane_reads_are_bounded.py
+++ b/tests/test_plane_reads_are_bounded.py
@@ -1,0 +1,208 @@
+"""A read of plane data must finish, and must not grow without limit.
+
+#336(b): nothing bounded these reads — no size cap, no deadline, and no check that the
+thing being opened is a file at all. A committed symlink to a FIFO at
+`personas/<active>/persona.md` hung `doctor`, `statusline`, `hook sessionstart` and
+`persona show` on 0.47.2; `/dev/zero` is the memory-exhaustion variant of the same
+omission. `hooks/hooks.json` caps the SessionStart hooks at 5s and 20s, so a session
+degrades to a lost briefing — the status line and `persona show` have no charter-side
+bound at all.
+
+**One check kills both, and it is the check that was already there for containment.**
+`os.lstat` says regular-or-not and how big in the same syscall, and — this is the part
+that matters — `stat` never *opens* anything, so it answers about a FIFO without
+blocking on it. A FIFO is not `S_ISREG`; neither is a character device; neither is a
+directory. The hang, the endless yield and the oversized read all die at the gate the
+redirection check already pays for, which is why this half costs no new syscall.
+
+**The cap is 1 MiB, and it is meant never to fire on anything a human wrote.** The
+largest persona charter in charter's own plane is 6.8 KB, the largest memory index 5 KB,
+the largest document under `docs/` 34 KB. 1 MiB is ~150× the first and still small
+enough that one read cannot exhaust anything. A cap tuned close to real content would
+fire on the first long runbook somebody curates, and a cap that never fires on anything
+at all is decoration — this one fires only on a file no editor produced.
+
+**Preconditions are asserted, not assumed.** Each hang case proves the fixture really
+blocks a reader — a thread that opens it is still alive when charter has already
+returned — before asserting that charter did not block on it. Without that, a passing
+test proves only that `mkfifo` was spelled wrong.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import threading
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import config, contain, hooks, memstore, persona, recall, todos, workspace
+from tests._isolation import PersonaIso
+
+#: Long enough that a hang is unambiguous, short enough that a regression does not look
+#: like a wedged machine. Every case here returns in microseconds when the gate holds.
+WATCHDOG = 5.0
+
+
+class PlaneReadsAreBounded(PersonaIso):
+
+    # ------------------------------------------------------------------ helpers
+    def fifo(self, path: Path) -> Path:
+        """A FIFO at *path*, proven to be one and proven to block a reader.
+
+        The proof is a live reader: a thread that opens it is still running when the
+        assertions below say charter came back. Cleanup opens the write end, which is
+        what releases that reader — a blocked `open()` on a FIFO waits for a writer.
+        """
+        path.parent.mkdir(parents=True, exist_ok=True)
+        os.mkfifo(path)
+        self.assertTrue(stat.S_ISFIFO(os.lstat(path).st_mode),
+                        f"precondition: {path} must be a FIFO")
+
+        opened = threading.Event()
+        def _read():
+            opened.set()
+            with open(path) as f:               # blocks here until a writer appears
+                f.read()
+        reader = threading.Thread(target=_read, daemon=True)
+        reader.start()
+        opened.wait(1.0)
+        reader.join(0.3)
+        self.assertTrue(reader.is_alive(),
+                        f"precondition: reading {path} must block — it did not")
+        self.addCleanup(self._release, path)
+        return path
+
+    @staticmethod
+    def _release(path: Path) -> None:
+        try:
+            os.close(os.open(path, os.O_WRONLY | os.O_NONBLOCK))
+        except OSError:
+            pass                                 # nobody waiting — nothing to release
+
+    def completes(self, fn, label: str):
+        """Call *fn* on a watchdog. Fails if it is still running when the clock runs out."""
+        box = {}
+        t = threading.Thread(target=lambda: box.update(r=fn()), daemon=True)
+        t.start()
+        t.join(WATCHDOG)
+        self.assertFalse(t.is_alive(), f"{label} blocked for more than {WATCHDOG}s")
+        return box.get("r")
+
+    def oversized(self, path: Path) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("# big\n\nbadger " * ((contain.MAX_BYTES // 7) + 1))
+        self.assertGreater(path.stat().st_size, contain.MAX_BYTES, "precondition")
+        return path
+
+    # ---------------------------------------------------------- (b) it must finish
+    def test_a_fifo_persona_charter_does_not_block_the_read(self):
+        d = config.PERSONAS_DIR / "blocked"
+        d.mkdir(parents=True)
+        self.fifo(d / "persona.md")
+        self.assertIn("blocked", persona.list_personas(),
+                      "precondition: charter still finds this persona")
+
+        self.assertIsNone(self.completes(lambda: persona.load("blocked"),
+                                         "persona.load on a FIFO charter"))
+        self.completes(lambda: persona.resolve("blocked"), "persona.resolve on a FIFO")
+        self.completes(lambda: persona.structural_errors("blocked"), "lint on a FIFO")
+
+    def test_a_fifo_memory_does_not_block_recall(self):
+        self.make_persona("reader")
+        mem = persona.memory_dir("reader")
+        (mem / "kept.md").write_text("# a real memory\n\nbadger\n")
+        self.fifo(mem / "blocked.md")
+
+        hits = self.completes(
+            lambda: recall.recall("badger", persona_name="reader", scopes=("persona",)).hits,
+            "recall over a FIFO memory")
+        self.assertEqual(["kept.md"], [h.path.name for h in hits])
+
+    def test_a_fifo_todo_does_not_block_the_count(self):
+        workspace.ensure("other")
+        self.fifo(todos.todos_dir("other") / "blocked.md")
+        self.assertEqual(0, self.completes(lambda: todos.count_open("other"),
+                                           "todos.count_open over a FIFO"))
+        self.assertEqual([], self.completes(lambda: todos.open_todos("other"),
+                                            "todos.open_todos over a FIFO"))
+
+    def test_a_fifo_default_persona_pointer_does_not_block(self):
+        """`personas/.default` is committed, and `resolve_active` reads it on every turn
+        to answer "who am I" — the status line's first question."""
+        self.fifo(config.PERSONAS_DIR / ".default")
+        self.completes(persona.resolve_active, "resolve_active on a FIFO .default")
+
+    def test_a_fifo_workspace_charter_does_not_block_the_session_briefing(self):
+        """The SessionStart neighbour digest reads every other workspace's `workspace.md`
+        for its vision line. `hooks.json` caps that hook at 5s, so a block here costs the
+        session its briefing rather than the turn — a bound, but not charter's."""
+        workspace.ensure("other")
+        charter_file = workspace.charter_file("other")
+        charter_file.unlink(missing_ok=True)
+        self.fifo(charter_file)
+        self.assertEqual("", self.completes(lambda: workspace.read_vision("other"),
+                                            "read_vision on a FIFO workspace.md"))
+
+    def test_a_fifo_mcp_declaration_does_not_block_sync_agents(self):
+        """`personas/<name>/mcp.json` is the third committed file `persona.py` opens by
+        listing rather than by asking. `mcp_servers` already refuses to raise on a stray
+        comma; blocking for ever is the same promise broken a different way."""
+        self.make_persona("reader")
+        self.fifo(persona.dir_of("reader") / persona.MCP_FILE)
+        self.assertEqual({}, self.completes(lambda: persona.mcp_servers("reader"),
+                                            "mcp_servers on a FIFO mcp.json"))
+
+    @unittest.skipUnless(os.path.exists("/dev/zero"), "no /dev/zero on this platform")
+    def test_a_character_device_is_not_a_plane_file(self):
+        """The memory-exhaustion variant: a link to a device that yields for ever. It is
+        refused by the same S_ISREG test that stops the FIFO, without reading a byte."""
+        self.assertTrue(stat.S_ISCHR(os.stat("/dev/zero").st_mode), "precondition")
+        self.assertIsNotNone(contain.file_refusal(Path("/dev/zero")))
+
+    # -------------------------------------------------------- (b) it must stay small
+    def test_an_oversized_memory_is_not_read(self):
+        self.make_persona("reader")
+        mem = persona.memory_dir("reader")
+        (mem / "kept.md").write_text("# a real memory\n\nbadger\n")
+        self.oversized(mem / "huge.md")
+
+        self.assertEqual(["kept.md"], [p.name for p in memstore.files(mem)])
+        hits = recall.recall("badger", persona_name="reader", scopes=("persona",)).hits
+        self.assertEqual(["kept.md"], [h.path.name for h in hits])
+
+    def test_a_file_just_under_the_cap_is_still_read(self):
+        """The half that catches a cap so tight it refuses real content."""
+        self.make_persona("reader")
+        big = persona.memory_dir("reader") / "long.md"
+        big.write_text("# long\n\n" + "badger " * ((contain.MAX_BYTES // 7) - 2))
+        self.assertLess(big.stat().st_size, contain.MAX_BYTES, "precondition")
+        self.assertGreater(big.stat().st_size, contain.MAX_BYTES // 2, "precondition")
+
+        hits = recall.recall("badger", persona_name="reader", scopes=("persona",)).hits
+        self.assertEqual(["long.md"], [h.path.name for h in hits])
+
+    def test_an_oversized_persona_charter_is_not_loaded(self):
+        d = config.PERSONAS_DIR / "huge"
+        d.mkdir(parents=True)
+        self.oversized(d / "persona.md")
+        self.assertIsNone(persona.load("huge"))
+
+    def test_the_session_briefing_counts_todos_without_reading_them(self):
+        """`hooks` read every todo of every workspace in full to print a number, while
+        `todos.count_open` — which the status line already uses — counts the listing. One
+        question, two implementations, and the expensive one ran at SessionStart."""
+        workspace.ensure("other")
+        todos.add("other", "something this workspace still means to do")
+
+        with mock.patch.object(memstore, "entries", wraps=memstore.entries) as spy:
+            digest = hooks._other_workspaces_digest("s1")
+        read_dirs = [str(c.args[0]) for c in spy.call_args_list]
+        self.assertEqual([], [d for d in read_dirs if d.endswith("todos")],
+                         f"the digest read todo bodies to count them: {read_dirs}")
+        self.assertIn("1 todo", digest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plane_reads_are_contained.py
+++ b/tests/test_plane_reads_are_contained.py
@@ -43,7 +43,8 @@ import unittest
 from pathlib import Path
 from types import SimpleNamespace
 
-from charter import commands_persona, config, contain, memstore, persona, recall
+from charter import (commands_persona, config, contain, curate, memstore, persona,
+                     recall)
 from tests._isolation import PersonaIso
 
 #: The issue's own canary, kept verbatim so a grep from the report lands here.
@@ -118,6 +119,21 @@ class PlaneReadsAreContained(PersonaIso):
 
         hits = recall.recall("canary", persona_name="reader", scopes=("persona",)).hits
         self.assertEqual([], [h.path.name for h in hits])
+
+    def test_curation_does_not_read_a_memory_that_escapes(self):
+        """`curate` never calls the filesystem itself — it reads through `memstore.entries`,
+        which is why one gate in `files()` covers it. Asserted rather than reasoned: this
+        is the module in #336's list with no reader of its own, and "it inherits it" is
+        exactly the claim that stops being true when somebody adds a glob here."""
+        self.make_persona("reader")
+        mem = persona.memory_dir("reader")
+        (mem / "kept.md").write_text("# a real memory\n\nbadger\n")
+        self.escaping_link(mem / "leak.md", self.vault)
+        self.assertIn(CANARY, (mem / "leak.md").read_text(), "precondition: link is live")
+
+        rep = curate.report(mem)
+        self.assertEqual(1, rep["total"])
+        self.assertNotIn("leak.md", str(rep))
 
     def test_a_ref_directory_symlinked_out_of_the_plane_is_not_a_source(self):
         self.make_persona("reader")

--- a/tests/test_plane_reads_are_contained.py
+++ b/tests/test_plane_reads_are_contained.py
@@ -43,7 +43,7 @@ import unittest
 from pathlib import Path
 from types import SimpleNamespace
 
-from charter import commands_persona, config, memstore, persona, recall
+from charter import commands_persona, config, contain, memstore, persona, recall
 from tests._isolation import PersonaIso
 
 #: The issue's own canary, kept verbatim so a grep from the report lands here.
@@ -178,6 +178,17 @@ class PlaneReadsAreContained(PersonaIso):
         self.assertTrue(
             any("outside the directories" in msg for _level, msg in printed),
             f"lint must say WHY it did not load, got {printed}")
+
+    def test_a_refusal_never_raises(self):
+        """`contain`'s standing promise — "Nothing here raises", because these run under
+        `doctor`, the status line and SessionStart. `os.lstat` answers a bad path with
+        `ValueError`, not `OSError`, so catching only the latter turned a refusal into a
+        crash on the one input designed to reach past a check (`segment_ok` refuses NUL
+        for exactly this reason, and it is not on this path)."""
+        for bad in ("a\x00b", ""):
+            with self.subTest(path=bad):
+                self.assertIsNotNone(contain.file_refusal(bad))
+                self.assertIsNotNone(contain.dir_refusal(bad))
 
     # ------------------------------------------------------------ (a) the benign half
     def test_a_persona_directory_symlinked_inside_the_plane_still_loads(self):

--- a/tests/test_plane_reads_are_contained.py
+++ b/tests/test_plane_reads_are_contained.py
@@ -171,6 +171,14 @@ class PlaneReadsAreContained(PersonaIso):
             any(level == "error" and "persona.md" in msg for level, msg in issues),
             f"lint must report the refused definition, got {issues}")
 
+        # And through `lint`, which is what `charter persona lint` actually prints. Its
+        # early return said only "persona 'reader' does not load" — true, and it sends the
+        # reader to look for a file that is right there.
+        printed = persona.lint("reader", deep=False)
+        self.assertTrue(
+            any("outside the directories" in msg for _level, msg in printed),
+            f"lint must say WHY it did not load, got {printed}")
+
     # ------------------------------------------------------------ (a) the benign half
     def test_a_persona_directory_symlinked_inside_the_plane_still_loads(self):
         """#342 kept containment lexical partly to avoid breaking this plane. A resolving

--- a/tests/test_plane_reads_are_contained.py
+++ b/tests/test_plane_reads_are_contained.py
@@ -1,0 +1,222 @@
+"""A committed symlink must not redirect a read of plane data out of the plane's data.
+
+#336(a): charter reads plane data by listing a directory and opening what it finds, and
+**nothing called `is_symlink`, `lstat` or `realpath`** on the way — in `persona.py`,
+`memstore.py`, `recall.py`, and therefore in `curate.py` and `todos.py`, which read
+through the store. Git commits symlinks, so the target of every one of those reads is
+attacker-controlled from a commit.
+
+The demonstration that matters is the one that walks around a guard charter already
+ships: `personas/reader/persona.md` → `../../.charter/vaults/devops.json` makes charter
+read a vault file and `sync-agents` write its contents into a sub-agent's system prompt,
+while `pretooluse-read` (`hooks._VAULT_PATH_RE`) denies the agent reading that same file
+directly. The path is **plane-relative** and needs no knowledge of the victim's home.
+
+**The boundary is the plane's DATA roots, not the plane root.** `.charter/` sits *under*
+`ROOT` (`config._migrate_state_dir` → `root / ".charter"`), so the obvious rule — "refuse
+a path whose realpath leaves the plane" — admits the flagship demonstration unchanged:
+`../../.charter/vaults/devops.json` never leaves the plane. What charter may read is
+`personas/`, `workspaces/` and `PERSONA_STATE_DIR` (ephemeral memory, which lives *inside*
+`.charter/` and must keep working). `test_a_refs_directory_symlinked_into_the_state_dir…`
+and `test_ephemeral_memory_under_the_state_dir…` are the two halves of that correction,
+and they fail in opposite directions if the boundary is drawn at ROOT or at `.charter`.
+
+**Escaping links are refused; links are not.** `contain`'s lexical containment was chosen
+in #342 partly so it would not refuse a plane that legitimately symlinks a persona
+directory. Resolving preserves that case — a link landing inside the data roots is
+followed, and the benign half of this file is what catches a "fix" that contains reads by
+refusing all of them.
+
+**Preconditions are asserted, not assumed.** Every case plants a real canary behind a real
+symlink and asserts the OS follows it *before* asking charter to refuse — a refusal
+because the fixture was a copy, or the target was missing, would prove nothing. This audit
+has produced six vacuous passes already.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import commands_persona, config, memstore, persona, recall
+from tests._isolation import PersonaIso
+
+#: The issue's own canary, kept verbatim so a grep from the report lands here.
+CANARY = "CANARY-LOCAL-VAULT-SECRET-4d8e"
+
+
+class PlaneReadsAreContained(PersonaIso):
+
+    def setUp(self) -> None:
+        super().setUp()
+        # A plain-file vault, at the fixed place relative to the plane that makes the
+        # attack portable. `.charter/vaults/` is exactly what `_VAULT_PATH_RE` denies the
+        # agent, and exactly what charter itself walked into.
+        self.vault = config.VAULTS_DIR / "devops.json"
+        self.vault.parent.mkdir(parents=True, exist_ok=True)
+        self.vault.write_text(json.dumps({"token": CANARY}))
+        self.outside = Path(tempfile.mkdtemp(prefix="edm-test-outside-"))
+        self.addCleanup(shutil.rmtree, self.outside, ignore_errors=True)
+
+    # ------------------------------------------------------------------ helpers
+    def link(self, link: Path, target: Path) -> str:
+        """Plant *link* → *target* as a **relative** symlink and prove it is one.
+
+        Relative because that is what makes a committed link portable to a machine whose
+        layout the author does not know — and asserting `is_symlink` is what stops this
+        file passing on a fixture that is quietly a copy.
+        """
+        link.parent.mkdir(parents=True, exist_ok=True)
+        rel = os.path.relpath(target, link.parent)
+        os.symlink(rel, link)
+        self.assertTrue(link.is_symlink(), f"fixture must be a symlink, not a copy: {link}")
+        return rel
+
+    def escaping_link(self, link: Path, target: Path) -> str:
+        rel = self.link(link, target)
+        self.assertTrue(rel.startswith(".."),
+                        f"fixture must escape its own directory, got {rel!r}")
+        return rel
+
+    # ------------------------------------------------------- (a) the redirection
+    def test_a_persona_charter_symlinked_to_a_vault_is_not_read_into_an_agent(self):
+        d = config.PERSONAS_DIR / "reader"
+        d.mkdir(parents=True)
+        rel = self.escaping_link(d / "persona.md", self.vault)
+
+        # Preconditions: the link is live, plane-relative, followed by the OS, and charter
+        # still SEES the persona — so a refusal below is charter's, not the filesystem's.
+        self.assertIn(CANARY, (d / "persona.md").read_text(),
+                      f"precondition: the OS must follow {rel!r} to the vault")
+        self.assertIn("reader", persona.list_personas())
+
+        self.assertIsNone(persona.load("reader"),
+                          "a definition resolving outside the plane's data must not load")
+
+        commands_persona.cmd_persona_sync_agents(
+            SimpleNamespace(persona="reader", approve_mcp=False))
+        generated = config.ROOT / ".claude" / "agents" / "reader.md"
+        body = generated.read_text() if generated.exists() else ""
+        self.assertNotIn(CANARY, body,
+                         "sync-agents wrote a vault into a sub-agent's system prompt")
+
+    def test_a_memory_symlinked_to_a_vault_is_not_recalled(self):
+        self.make_persona("reader")
+        mem = persona.memory_dir("reader")
+        (mem / "kept.md").write_text("# a real memory\n\nbadger badger\n")
+        self.escaping_link(mem / "leak.md", self.vault)
+        self.assertIn(CANARY, (mem / "leak.md").read_text(), "precondition: link is live")
+
+        listed = [p.name for p in memstore.files(mem)]
+        self.assertNotIn("leak.md", listed)
+        self.assertIn("kept.md", listed, "the store must still list its real memories")
+
+        hits = recall.recall("canary", persona_name="reader", scopes=("persona",)).hits
+        self.assertEqual([], [h.path.name for h in hits])
+
+    def test_a_ref_directory_symlinked_out_of_the_plane_is_not_a_source(self):
+        self.make_persona("reader")
+        elsewhere = self.outside / "notes"
+        elsewhere.mkdir(parents=True)
+        (elsewhere / "elsewhere.md").write_text(f"# elsewhere\n\n{CANARY}\n")
+        refs = persona.refs_dir("reader")
+        refs.mkdir(parents=True, exist_ok=True)
+        self.link(refs / "linked", elsewhere)
+        self.assertIn(CANARY, (refs / "linked" / "elsewhere.md").read_text(),
+                      "precondition: rglob's is_dir() follows this link")
+
+        self.assertNotIn(refs / "linked", recall._ref_dirs(refs))
+        hits = recall.recall("elsewhere", persona_name="reader", scopes=("refs",)).hits
+        self.assertEqual([], [h.path.name for h in hits])
+
+    def test_a_refs_directory_symlinked_into_the_state_dir_is_refused(self):
+        """The case a "must not leave the plane" rule would wave through.
+
+        `.charter/reports/` holds drafted upstream reports — "a draft may quote an
+        exception message that has not been redacted yet" (`config.derive`) — and it sits
+        *under* ROOT. Containment drawn at the plane root admits this whole directory.
+        """
+        reports = config.STATE_DIR / "reports"
+        reports.mkdir(parents=True, exist_ok=True)
+        (reports / "draft.md").write_text(f"# draft\n\n{CANARY}\n")
+        self.assertTrue(str(reports).startswith(str(config.ROOT)),
+                        "precondition: the state dir is INSIDE the plane root")
+
+        self.make_persona("reader")
+        refs = persona.refs_dir("reader")
+        shutil.rmtree(refs, ignore_errors=True)
+        self.escaping_link(refs, reports)
+        self.assertIn(CANARY, (refs / "draft.md").read_text(), "precondition: link is live")
+
+        hits = recall.recall("draft", persona_name="reader", scopes=("refs",)).hits
+        self.assertEqual([], [h.path.name for h in hits])
+
+    def test_lint_says_why_a_refused_definition_did_not_load(self):
+        """A refusal nobody can see is how #337 happened: `lint` called a grant dangling
+        while the resolver honoured it. A definition charter declines to read has to say
+        so in the signal an operator actually checks, not silently become an empty
+        persona."""
+        d = config.PERSONAS_DIR / "reader"
+        d.mkdir(parents=True)
+        self.escaping_link(d / "persona.md", self.vault)
+        self.assertIn(CANARY, (d / "persona.md").read_text(), "precondition: link is live")
+
+        issues = persona.structural_errors("reader")
+        self.assertTrue(
+            any(level == "error" and "persona.md" in msg for level, msg in issues),
+            f"lint must report the refused definition, got {issues}")
+
+    # ------------------------------------------------------------ (a) the benign half
+    def test_a_persona_directory_symlinked_inside_the_plane_still_loads(self):
+        """#342 kept containment lexical partly to avoid breaking this plane. A resolving
+        check keeps it working: the link lands inside `personas/`."""
+        self.make_persona("real")
+        self.link(config.PERSONAS_DIR / "alias", config.PERSONAS_DIR / "real")
+        d = persona.load("alias")
+        self.assertIsNotNone(d, "a link landing inside the plane's data must be followed")
+        self.assertIn("charter body", d["charter"])
+
+    def test_a_persona_directory_symlinked_out_of_the_plane_is_refused(self):
+        """The other side of the fast path in `contain.within_data`: a directory whose
+        parent IS a data root skips the resolve **only** when it is not a link. This one
+        is, so it must fall through and be refused — every file inside it is an ordinary
+        regular file that the per-file check has nothing to object to."""
+        elsewhere = self.outside / "borrowed"
+        elsewhere.mkdir(parents=True)
+        (elsewhere / "persona.md").write_text(f"---\nname: borrowed\n---\n\n{CANARY}\n")
+        self.link(config.PERSONAS_DIR / "borrowed", elsewhere)
+        self.assertIn(CANARY, (config.PERSONAS_DIR / "borrowed" / "persona.md").read_text(),
+                      "precondition: the link is live and the file inside it is ordinary")
+
+        self.assertIsNone(persona.load("borrowed"))
+
+    def test_a_memory_symlinked_to_another_in_plane_memory_is_still_recalled(self):
+        self.make_persona("a")
+        self.make_persona("b")
+        (persona.memory_dir("b") / "fact.md").write_text("# shared fact\n\nbadger\n")
+        self.link(persona.memory_dir("a") / "fact.md", persona.memory_dir("b") / "fact.md")
+        hits = recall.recall("badger", persona_name="a", scopes=("persona",)).hits
+        self.assertEqual(["fact.md"], [h.path.name for h in hits])
+
+    def test_ephemeral_memory_under_the_state_dir_is_still_read(self):
+        """Ephemeral memory lives in `PERSONA_STATE_DIR`, i.e. *inside* `.charter/`. A
+        boundary drawn by banning the state directory silently empties this scope."""
+        self.make_persona("a")
+        eph = persona.ephemeral_dir("a", session="s1")
+        eph.mkdir(parents=True, exist_ok=True)
+        (eph / "scratch.md").write_text("# scratch\n\nbadger\n")
+        self.assertTrue(str(eph).startswith(str(config.STATE_DIR)),
+                        "precondition: ephemeral memory is inside the state dir")
+
+        hits = recall.recall("badger", persona_name="a", session_id="s1",
+                             scopes=("ephemeral",)).hits
+        self.assertEqual(["scratch.md"], [h.path.name for h in hits])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #336 — both boxes, and the reachable variants of each.

## What was open

Charter read plane data by listing a directory and opening what it found. Nothing on any of those paths called `is_symlink`, `lstat` or `realpath`, and nothing bounded what came back. Git commits symlinks, so both properties belonged to whoever last committed to the plane.

Verified A/B on a throwaway plane, installed 0.47.2 against this branch:

| | 0.47.2 | this branch |
|---|---|---|
| `persona.md` → `../../.charter/vaults/devops.json`, then `sync-agents` | canary in `.claude/agents/reader.md` | no agent file, `✗ no persona 'reader'` |
| FIFO at the active `persona.md` → `charter statusline` | **hung >10s** | renders |
| … → `charter doctor` | **hung >10s** | reports |
| … → `charter persona show reader` | **hung >10s** | `✗ no persona 'reader'` |

The vault case is the one that matters: charter's own `pretooluse-read` guard denies an agent reading that file — it denied *me* mid-investigation, when a `cat` of the fixture tripped it — and the link walked around it into a sub-agent's system prompt.

## (a) Containment — closes in full

`contain.py` grows the resolving layer beside its lexical one: `dir_refusal` (a listing) and `file_refusal` (a read). Callers: `memstore.files` (so `entries`, `search`, `resolve`, `index_drift`, `count_open`, `curate` and `todos` all inherit one gate), `memstore.resolve`'s direct hit, `persona.load` via a new `definition_refusal`, and `recall._ref_dirs`.

**One correction to the issue's suggested direction.** "Refuse a path whose `realpath` leaves the plane" would have admitted the flagship demonstration unchanged: `.charter/` sits *under* ROOT (`config._migrate_state_dir`), so `../../.charter/vaults/devops.json` never leaves the plane. The boundary is the plane's **data** roots — `personas/`, `workspaces/`, `PERSONA_STATE_DIR` — which excludes the secrets home and includes the one part of it that is data. Two tests hold that line from opposite sides: a `refs/` linked into `.charter/reports/` is refused, and ephemeral memory (which lives *inside* `.charter/`) is still read. Drawing the boundary at ROOT fails the first; drawing it by banning `.charter/` fails the second.

**Links are followed, escapes are refused** — #342's reason for staying lexical was that it would break a plane legitimately symlinking a persona directory. Resolving keeps that working: a link landing inside the data roots is followed, and a plane that relocates `personas/` or `workspaces/` behind a link keeps working because the roots are resolved too. Four of the nine cases in `test_plane_reads_are_contained.py` are that benign half.

## (b) Liveness — closes in full

The brief's hypothesis held, and it is the whole reason this half is cheap: **`os.lstat` answers regular-or-not, how big, and link-or-not in one syscall — the syscall containment already pays for — and it answers without opening anything.** A read deadline would have had nothing to time out, because nothing is opened. A FIFO is not `S_ISREG`; neither is `/dev/zero`.

The cap is **1 MiB**, set where nothing an editor produces can reach it (largest persona charter on this plane: 6.8 KB; largest `docs/` page: 34 KB) rather than close to real content, where the first long runbook somebody curates would trip it. The just-under-cap case is a test, because a cap that never fires is decoration and one that fires on real content is worse.

Three more committed files read on the same paths get the same gate — `personas/.default` (answers "who am I" every turn), a persona's `mcp.json` (which already promised never to raise on a bad file), and a workspace's `workspace.md` (read once per workspace at SessionStart). And the session briefing counted another workspace's todos with `len(open_todos(w))` — every todo of every workspace, read in full, for a number — while the status line counted the same todos with `todos.count_open`. One question, two implementations, the expensive one at session start.

## Cost, measured on this plane

`file_refusal` 1.2µs (one `lstat`); `dir_refusal` 5.5µs on a persona directory via a fast path that is exact — a path whose parent *is* a data root and which is not itself a link cannot have moved relative to that root — and 20µs on a deeper base, paid once per listing. End to end: a 5-persona `structural_errors` sweep 1.22ms → 1.38ms, `recall(query)` 4.97ms → 5.06ms.

## Tests

20 new cases in two files, one per half. Every case asserts its preconditions: the escaping links assert `is_symlink` and that the OS follows the link to the canary *before* charter is asked to refuse; every hang case proves a thread that opens the fixture is still blocked when charter has already returned. The RED run of the liveness file spent 21s in watchdog timeouts; it now runs in 1.9s.

Five existing test files built a memory store in a bare `mkdtemp`, which no production caller produces — every one derives its base from `memory_dir`/`todos_dir`/`refs_dir`. They now build it in a plane, and their headers say why so nobody reverts it and reads the empty listing as a search bug.

Full suite: **3065 passed** (3043 on `main` + 22), 82s — green locally and in CI on 3.11, 3.12, 3.13 and 3.14.

## Found while here, not fixed here

**A committed link redirects charter's *writes* too, and `MEMORY.md` is a fixed name.** With `personas/x/memory/MEMORY.md` a link to a file outside the memory directory, `charter persona remember` appends its index line *through* the link. Demonstrated on 0.47.2 **and on this branch** — the write paths (`ensure_index`, `index_append`, `_drop_index_line`, `write`) do not go through `files()`, so this PR does not close it. Pointed at `.charter/vaults/<name>.json` it corrupts a credential store from a commit, with no guessing required, and `file_refusal` is the same helper it would need (ENOENT would have to read as "nothing to object to" rather than a refusal, since a write's target usually does not exist yet). Reported rather than folded in: this workspace's rule is findings before fixes, with a stop in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo
