### PR TITLE
Contain plane writes, and say when a broken persona still grants (#349, #329, #343)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -16,6 +16,7 @@ from . import (
     commands_secrets,
     commands_workspace,
     commands_worktree,
+    contain,
     hooks,
     statusline,
     toolgate,
@@ -1109,6 +1110,13 @@ def main(argv=None) -> int:
             except Exception:  # noqa: BLE001 - a best-effort tidy-up, never the story
                 pass
         return 141  # 128 + SIGPIPE, matching the 128 + SIGINT returned below
+    except contain.Refused as e:
+        # A committed file that redirects a write is a defect in the PLANE's data, not in
+        # charter — the same distinction `ProcTimeout` draws below, one noun over. Falling
+        # through to the crash reporter would file a report against charter for it and
+        # send whoever reads it looking in the wrong repository (#349).
+        util.err(str(e))
+        return 1
     except util.ProcTimeout as e:
         # A child that outlived its budget is a condition, not a bug. Only
         # KeyboardInterrupt was caught here, so a timeout reached the user as a traceback

--- a/charter/contain.py
+++ b/charter/contain.py
@@ -53,8 +53,10 @@ and break a plane that legitimately links a persona directory. Resolving keeps t
 working, and #342's reason for staying lexical was never that symlinks are acceptable —
 only that doing half of this while claiming all of it would be worse than filing it.
 
-**Nothing here raises.** These checks sit under `doctor`, the status line and SessionStart,
-where the rule is that a hook may cost a session its briefing and never its turn. A refused
+**No refusal function here raises.** These checks sit under `doctor`, the status line and
+SessionStart, where the rule is that a hook may cost a session its briefing and never its
+turn. The single exception is :func:`writable`, which exists to raise and says so: a write
+that refuses has no fallback the way a skipped read does. A refused
 name is reported as data — see :data:`NOT_A_SEGMENT` and the vocabulary in
 :mod:`charter.news`, which says five kinds of "no answer" five different ways for the same
 reason: folding a defect in a file behind a generic message hides the defect, and somebody
@@ -136,13 +138,37 @@ def refusal(name: str) -> str:
 # the resolving layer — a PATH charter is about to read (#336)                 #
 # --------------------------------------------------------------------------- #
 
+class Refused(Exception):
+    """A path charter declined to write to, carrying the sentence that says why.
+
+    Deliberately **not** a `ValueError`. The write sites sit under `except ValueError`
+    handlers that already mean "the text you passed was empty", and three more swallow it
+    bare — inheriting from it would let a containment refusal be caught by a clause
+    written about something else and disappear, which is the one outcome worse than the
+    corruption this exists to stop.
+
+    Caught once, in `cli.main`, beside `util.ProcTimeout` and for the same stated reason:
+    *a child that outlived its budget is a condition, not a bug*. So is a committed file
+    that redirects a write. Reaching the `except Exception` below it would file a crash
+    report against charter for a defect in the plane's own data, and send the reader
+    looking for the bug in the wrong repository.
+
+    The refusal functions themselves still never raise — this is thrown by *callers* that
+    have nothing useful to do with a refusal except stop.
+    """
+
+
 #: Said once, like :data:`NOT_A_SEGMENT`, and for the same reason: the reader has a defect
 #: in a committed file. It names both ends because "refused" without the target is
 #: unactionable — the whole point is that the path charter opened is not the path it read.
+#:
+#: ``{verb}`` is read/write rather than two near-identical constants: which operation was
+#: redirected is the one word that differs, and it is the word that tells the reader
+#: whether they are looking at a leak or at corruption.
 NOT_PLANE_DATA = ("'{name}' resolves to '{target}', outside the directories a control "
                   "plane keeps its data in ({roots}). A committed symlink there redirects "
-                  "the read, so charter follows a link that lands inside them and refuses "
-                  "one that leaves")
+                  "the {verb}, so charter follows a link that lands inside them and "
+                  "refuses one that leaves")
 
 #: A path charter cannot examine at all (vanished mid-listing, a broken link, no
 #: permission). Refused rather than raised — every caller here is on a path that must not
@@ -152,9 +178,13 @@ UNREADABLE = "'{name}' cannot be examined ({error})"
 #: Not a file at all: a FIFO, a device, a socket, a directory. Named for what it is,
 #: because "could not be read" would send the reader looking for a permissions problem
 #: when what they have is a path that blocks for ever or yields for ever.
-NOT_A_FILE = ("'{name}' is not a regular file (it is {kind}). Charter reads plane data by "
-              "listing a directory and opening what it finds, so an entry that blocks or "
-              "never ends would take the read with it")
+#:
+#: A FIFO blocks a *writer* just as completely as a reader — ``open(fifo, "a")`` waits for
+#: a reader to appear and never stops waiting — so this is one sentence for both sides,
+#: and the write side has no `hooks.json` timeout above it to end the wait.
+NOT_A_FILE = ("'{name}' is not a regular file (it is {kind}). Charter opens plane data at "
+              "names a committed file can occupy, so an entry that blocks or never ends "
+              "would take the {verb} with it")
 
 #: The bound on one plane file charter reads whole. **1 MiB, and it is meant never to fire
 #: on anything a human wrote**: the largest persona charter in charter's own plane is
@@ -226,25 +256,31 @@ def within_data(path) -> bool:
     return False
 
 
-def _not_plane_data(path) -> str:
+def _not_plane_data(path, verb: str = "read") -> str:
     roots = ", ".join(sorted(Path(r).name for r in data_roots()))
     try:
         target = os.path.realpath(path)
     except (OSError, ValueError):
         target = path            # unresolvable — say what was asked for, never raise here
-    return NOT_PLANE_DATA.format(name=path, target=target, roots=roots)
+    return NOT_PLANE_DATA.format(name=path, target=target, roots=roots, verb=verb)
 
 
-def dir_refusal(directory) -> str | None:
-    """Why charter must not list *directory*, or ``None``.
+def dir_refusal(directory, verb: str = "read") -> str | None:
+    """Why charter must not list — or write inside — *directory*, or ``None``.
 
     Separate from :func:`file_refusal` because a listing pays this **once** while paying
     the per-file check N times, and because it is what catches the variant the file check
     structurally cannot see: when the *directory* is the link, every file inside it is an
     ordinary regular file that no per-file check has anything to object to.
+
+    That variant is worse on the write side, where charter creates the directory it is
+    about to write into: ``mkdir(parents=True, exist_ok=True)`` accepts a symlink to an
+    existing directory without complaint, so a committed link at ``memory/`` silently
+    relocates every file written under it. Hence *verb* — the same question, asked before
+    the ``mkdir`` rather than before the listing.
     """
     if not within_data(directory):
-        return _not_plane_data(directory)
+        return _not_plane_data(directory, verb)
     return None
 
 
@@ -268,14 +304,84 @@ def file_refusal(path) -> str | None:
     Not a TOCTOU guard, and not sold as one: the attacker here holds a commit, not a
     process racing the read.
     """
+    return _path_refusal(path, missing_ok=False, verb="read")
+
+
+def write_refusal(path) -> str | None:
+    """Why charter must not **write** to *path*, or ``None``.
+
+    #348 gated every read of plane data and left the write side untouched, so a committed
+    link at a name charter writes redirected the write instead of the read (#349). The
+    same three questions apply — is this link contained, is it a file at all, is it a
+    sane size — and each of them matters *more* here: an append to a credential store
+    corrupts it where a read merely leaked it, ``write_text`` through a **dangling** link
+    creates the target wherever it points, and ``open(fifo, "a")`` blocks for ever with a
+    human sitting at the command rather than a hook timeout overhead.
+
+    **One rule differs, and it is the whole reason this is a second function.** On a read,
+    a path that is not there is a refusal. On a write it is the ordinary case — the file
+    is about to be created — so ENOENT answers ``None``. Getting that backwards refuses
+    every first write on a fresh plane, and getting it *too* right (treating "not there"
+    as "nothing to check" before the link is resolved) misses the dangling-link case
+    entirely, because ``exists()`` is false for exactly the link that is most dangerous.
+    Both halves are held by tests that fail in opposite directions.
+
+    **The parent is checked here, not by the caller.** On the read side that split is
+    right — a listing pays :func:`dir_refusal` once and the per-file check N times. A
+    write has no such loop, and the directory variant is the one a per-file check
+    structurally cannot see: when ``memory/`` is the link, ``MEMORY.md`` inside it is an
+    ordinary regular file with nothing to object to, and every ``mkdir(exist_ok=True)`` in
+    charter accepts a symlink to a directory without complaint. Folding it in costs one
+    resolve on a path nobody writes in a loop, and makes it impossible for the fifteenth
+    caller to remember the file and forget the directory.
+
+    What this is not: a check on whether the *value* being written belongs there. It
+    answers where the bytes will land, nothing more.
+    """
+    return (dir_refusal(Path(path).parent, "write")
+            or _path_refusal(path, missing_ok=True, verb="write"))
+
+
+def writable(path) -> Path:
+    """*path*, when charter may write there — else raise :class:`Refused`.
+
+    The one place in this module that raises, and the exception is deliberate rather than
+    an oversight in the "nothing here raises" promise above: that promise is about the
+    *refusal* functions, which run under `doctor`, the status line and SessionStart and
+    must return data. This is for callers on a command path, where a refusal has no
+    sensible fallback — a read that refuses can skip the file, but a write that refuses
+    and carries on leaves `charter persona remember` printing ✓ over a fact it never
+    recorded, which is the same class of lie as the corruption being prevented.
+
+    Callers that must *not* raise — the hook-driven tallies, which already promise a hook
+    may never break a turn — ask :func:`write_refusal` directly and decline to write.
+    """
+    refusal = write_refusal(path)
+    if refusal:
+        raise Refused(refusal)
+    return Path(path)
+
+
+def _path_refusal(path, *, missing_ok: bool, verb: str) -> str | None:
+    """The body :func:`file_refusal` and :func:`write_refusal` share.
+
+    One implementation with the difference named, rather than two functions kept in step
+    by hand — the divergence between two checks that read the same file and answered
+    differently is what #328 and #342 were both about, and it is not a mistake worth
+    making again inside the module that exists to stop it.
+    """
+    if not str(path):
+        # ENOENT means "about to be created" only for a path that COULD be created, and
+        # the empty path never can. Without this the write side answered "nothing to
+        # object to" for it and handed the caller an unhandled `OSError` one line later —
+        # a refusal turned back into a crash, which is the bug #348 shipped and fixed.
+        return UNREADABLE.format(name=path, error="empty path")
     try:
         st = os.lstat(path)
-        if stat.S_ISLNK(st.st_mode):
-            if not within_data(path):
-                return _not_plane_data(path)
-            # Follows the link. Still a `stat`, so a FIFO on the other end answers here
-            # rather than blocking; a broken link raises and is refused as unreadable.
-            st = os.stat(path)
+    except FileNotFoundError:
+        if missing_ok:
+            return None       # about to be created — there is nothing there to object to
+        return UNREADABLE.format(name=path, error="No such file or directory")
     except OSError as e:
         return UNREADABLE.format(name=path, error=e.strerror or e)
     except ValueError as e:
@@ -283,9 +389,27 @@ def file_refusal(path) -> str | None:
         # input shaped to get past a check (`segment_ok` refuses it for the same reason).
         # "Nothing here raises" is this module's promise; catching only OSError broke it.
         return UNREADABLE.format(name=path, error=e)
+    if stat.S_ISLNK(st.st_mode):
+        # Asked BEFORE `os.stat`, and that order is load-bearing on the write side: a
+        # dangling link has no target to stat, so a containment check placed after the
+        # stat would never run on the one link that can create a file out of nothing.
+        if not within_data(path):
+            return _not_plane_data(path, verb)
+        try:
+            # Follows the link. Still a `stat`, so a FIFO on the other end answers here
+            # rather than blocking.
+            st = os.stat(path)
+        except FileNotFoundError:
+            if missing_ok:
+                return None   # a contained link naming a file charter is about to create
+            return UNREADABLE.format(name=path, error="No such file or directory")
+        except OSError as e:
+            return UNREADABLE.format(name=path, error=e.strerror or e)
+        except ValueError as e:
+            return UNREADABLE.format(name=path, error=e)
     if not stat.S_ISREG(st.st_mode):
         kind = next((k for test, k in _KINDS if test(st.st_mode)), "not a file")
-        return NOT_A_FILE.format(name=path, kind=kind)
+        return NOT_A_FILE.format(name=path, kind=kind, verb=verb)
     if st.st_size > MAX_BYTES:
         return TOO_LARGE.format(name=path, size=st.st_size, cap=MAX_BYTES)
     return None

--- a/charter/curate.py
+++ b/charter/curate.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import datetime
 from pathlib import Path
 
-from . import memstore
+from . import contain, memstore
 
 # Durable-RULE language worth promoting to the charter. Weighted toward IMPERATIVE,
 # time-invariant phrasing ("standing rule", "always/never") and deliberately EXCLUDING
@@ -95,10 +95,18 @@ def apply_safe(mem_dir: Path) -> list[str]:
     missing = report(mem_dir)["index"]["missing"]  # recompute after archiving
     if missing:
         idx = memstore.index_path(mem_dir)
-        for p, title, _text in memstore.entries(mem_dir):
-            if p.name in missing:
-                memstore.index_append(idx, p.name, title)
-        actions.append(f"repaired index: linked {len(missing)} unindexed memory(ies)")
+        # `apply_safe` returns a LOG the operator reads, and by here it may already have
+        # archived files. A refusal is therefore reported into that log rather than raised
+        # out of a half-finished batch — and reported rather than swallowed, because a
+        # linked index turns this one command into N appends into whatever it points at,
+        # which is the largest single write charter performs unprompted (#349).
+        try:
+            for p, title, _text in memstore.entries(mem_dir):
+                if p.name in missing:
+                    memstore.index_append(idx, p.name, title)
+            actions.append(f"repaired index: linked {len(missing)} unindexed memory(ies)")
+        except contain.Refused as e:
+            actions.append(f"index NOT repaired — {e}")
     return actions
 
 

--- a/charter/dispatch.py
+++ b/charter/dispatch.py
@@ -36,7 +36,7 @@ from collections import Counter
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from . import config
+from . import config, contain
 
 DIR_NAME = "_dispatch"
 #: Agents that aren't personas — tallied so the persona-vs-generic ratio stays visible.
@@ -70,6 +70,8 @@ def record(agent: str, when: datetime | None = None) -> Path | None:
         return None
     when = when or _now()
     p = path_for(when)
+    if contain.write_refusal(p):
+        return None  # a committed link at this fixed name — see contain.write_refusal
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
         line = json.dumps({"ts": when.isoformat(timespec="seconds"), "agent": agent},
@@ -97,6 +99,8 @@ def record_advice(when: datetime | None = None) -> Path | None:
     """Append one 'routing advice was shown' event. Best-effort, like :func:`record`."""
     when = when or _now()
     p = path_for(when)
+    if contain.write_refusal(p):
+        return None  # a committed link at this fixed name — see contain.write_refusal
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
         line = json.dumps({"event": ADVICE, "ts": when.isoformat(timespec="seconds")},
@@ -140,6 +144,8 @@ def record_resume(agent: str, when: datetime | None = None) -> Path | None:
         return None
     when = when or _now()
     p = path_for(when)
+    if contain.write_refusal(p):
+        return None  # a committed link at this fixed name — see contain.write_refusal
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
         line = json.dumps({"agent": agent, "event": RESUME,

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1435,6 +1435,64 @@ def check_front_door() -> Result:
     return Result(name, OK, detail="none declared")
 
 
+def check_persona_grant() -> Result:
+    """The ACTIVE persona is broken, and is still auto-approving tools (#343).
+
+    `toolgate.decide` asks the active persona what its tools are and never asks whether
+    the persona is well-formed. `charter persona lint` calls it broken; the gate honours
+    it anyway. Two checks read one file, answer different questions about it, and only one
+    of them sits on the path that removes a prompt.
+
+    **Why this reports rather than revokes.** #343's own suggested direction (1) — have
+    the gate ignore a persona with non-empty ``structural_errors`` — was measured before
+    being declined, in `tests/test_broken_persona_still_grants.py`. After #342 it closes
+    nothing: `load()` returns None for a reference that is not a name, so a broken
+    reference contributes no tools at all, and what survives is the persona's own
+    ``tools:`` plus what a reader of those same files would compute. Revoking that would
+    take away a grant the operator wrote by hand and give back no containment.
+
+    It would also take it away **silently**, which is the part that decided it. The gate's
+    production output path emits nothing when `decide` declines — a lost grant looks
+    exactly like a persona that never declared the tool, and the operator gets an
+    unexplained prompt with nothing to connect it to the typo that caused it. Reporting is
+    the half that can be done without that cost, and the half that was actually missing.
+
+    Deliberately separate from :func:`check_personas`, which reports the roster's health
+    and would say "4 with error(s)" whether or not any of them were the acting identity.
+    The pairing is this check's whole content: *this* persona, *these* binaries, right
+    now. Silent when the active persona is well-formed — the `tools:` grant is the
+    designed behaviour (#329) and a check that fired on it would be noise on every plane.
+
+    The mirror of :func:`check_ask_rules`, which names the case where a persona's tools
+    quietly *stop* being pre-approved. This one names where they quietly keep going.
+    """
+    name = "persona grant"
+    from . import persona
+    try:
+        active = persona.resolve_active()
+        if not active:
+            return Result(name, OK, detail="no active persona")
+        issues = persona.structural_errors(active)
+        if not issues:
+            return Result(name, OK, detail=f"'{active}' is well-formed")
+        tools = sorted(persona.effective_tools(active))
+        if not tools:
+            # Broken but granting nothing — `check_personas` already reports the break,
+            # and saying it twice in different words is how a preflight stops being read.
+            return Result(name, OK, detail=f"'{active}' is broken but grants no tools")
+    except Exception as e:
+        # Only ever advisory. A check that crashes the preflight over a persona file is
+        # worse than the divergence it reports.
+        return Result(name, WARN, detail=f"not checked ({e})", hint=_NOT_CHECKED_HINT)
+    why = "; ".join(m for _level, m in issues[:2])
+    return Result(name, WARN,
+                  detail=f"'{active}' is broken and still auto-approves "
+                         f"{', '.join(tools)}",
+                  hint=f"{why}  → charter persona lint {active}  (the gate reads this "
+                       f"persona's tools whether or not it loads cleanly, so a prompt you "
+                       f"expected to see may not appear)")
+
+
 def check_personas() -> Result:
     """Roster config health — `persona lint` across every persona, summarised.
 
@@ -1894,7 +1952,8 @@ def _checks():
                 check_workspace_clones(),
                 check_inventory(), check_vaults(),
                 check_vault_registry_divergence(), check_version_lock(),
-                check_memory_indexes(), check_personas(), check_front_door(),
+                check_memory_indexes(), check_personas(), check_persona_grant(),
+                check_front_door(),
                 check_news_adoption(),
                 check_ask_rules(),
                 check_shadowed_knowledge(),

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1322,8 +1322,17 @@ def check_memory_indexes() -> Result:
     # repaired. A remediation hint that silently no-ops is worse than no hint at all.
     unindexed_kinds: set[str] = set()
     large_kinds: set[str] = set()
+    refused = []
     for label, mem_dir in bases:
         if not mem_dir.exists():
+            continue
+        # Asked FIRST, and reported on its own terms. A refused index answers "nothing is
+        # listed", which is what an empty base answers too — so without this the drift
+        # numbers below describe a store charter is declining to touch as though it were
+        # merely untidy, and point `optimize` at a repair that cannot run (#349).
+        why = memstore.index_refusal(mem_dir)
+        if why:
+            refused.append(f"{label}: {why}")
             continue
         d = memstore.index_drift(mem_dir)
         if d["dangling"] or d["unindexed"]:
@@ -1341,6 +1350,15 @@ def check_memory_indexes() -> Result:
         if n >= _INDEX_LINES_WARN:
             large.append(f"{label} ({n} entries)")
             large_kinds.add("workspace" if label.startswith("ws:") else "persona")
+    if refused:
+        # Ahead of drift and growth because it outranks them: those are hygiene, this is a
+        # committed file redirecting charter's own writes, and the remedy is to fix that
+        # file rather than to run any curation command.
+        return Result("memory indexes", WARN,
+                      detail=f"{len(refused)} index(es) charter will not touch",
+                      hint="; ".join(refused[:2]) + (", …" if len(refused) > 2 else "")
+                           + "  → this is a defect in a committed file: replace the link "
+                             "with a real MEMORY.md")
     if not worst and not large:
         return Result("memory indexes", OK, detail=f"{len(bases)} base(s) consistent")
     hint = ", ".join(worst[:4]) + (", …" if len(worst) > 4 else "")

--- a/charter/memstore.py
+++ b/charter/memstore.py
@@ -36,10 +36,22 @@ def _now() -> datetime.datetime:
     return datetime.datetime.now()
 
 
+#: **The one gate on the write side**, the mirror of :func:`files` on the read side and
+#: for the same stated reason: containment asserted once rather than at four callers,
+#: three of which stay correct. Every write this module performs goes through it, and it
+#: checks both the file and the directory holding it — ``MEMORY.md`` is a fixed name, so
+#: an attacker needs no guess and wins no race, and a linked ``memory/`` hides the file
+#: check entirely (#349).
+writable = contain.writable
+
+
 def ensure_index(mem_dir: Path, header: str) -> Path:
     """Create the dir + MEMORY.md (with *header*) if missing; return the index path."""
+    # Gated BEFORE the mkdir: `mkdir(exist_ok=True)` accepts a committed symlink to a
+    # directory outside the plane, and would then create that directory's missing parents
+    # for the attacker on the way past.
+    idx = writable(index_path(mem_dir))
     mem_dir.mkdir(parents=True, exist_ok=True)
-    idx = index_path(mem_dir)
     if not idx.exists():
         idx.write_text(header if header.endswith("\n") else header + "\n")
     return idx
@@ -55,6 +67,12 @@ def write(mem_dir: Path, text: str, title: str | None = None, *, timestamped: bo
     if not text:
         raise ValueError("empty memory")
     title = (title or text.splitlines()[0]).strip()[:72]
+    # Before the mkdir, and before a byte is written: both targets are checked up front so
+    # a refusal leaves the store exactly as it was, rather than a memory file on disk that
+    # nothing indexes.
+    refusal = contain.dir_refusal(mem_dir, "write")
+    if refusal:
+        raise contain.Refused(refusal)
     mem_dir.mkdir(parents=True, exist_ok=True)
     now = stamp or _now()
     prefix = now.strftime("%Y%m%d-%H%M%S-") if timestamped else ""
@@ -64,6 +82,11 @@ def write(mem_dir: Path, text: str, title: str | None = None, *, timestamped: bo
     while p.exists():  # same title (and same second) → keep both
         p = mem_dir / f"{prefix}{base}-{i}.md"
         i += 1
+    # `exists()` is false for a DANGLING link, so the loop above stops on exactly the
+    # entry that would create a file wherever it points. `writable` resolves it.
+    writable(p)
+    if index:
+        writable(index_path(mem_dir))
     p.write_text(f"# {title}\n\n_{now.strftime('%Y-%m-%d %H:%M')} · {kind}_\n\n{text}\n")
     if index:
         index_append(index_path(mem_dir), p.name, title)
@@ -71,6 +94,7 @@ def write(mem_dir: Path, text: str, title: str | None = None, *, timestamped: bo
 
 
 def index_append(idx: Path, filename: str, title: str) -> None:
+    idx = writable(idx)
     if not idx.exists():
         idx.parent.mkdir(parents=True, exist_ok=True)
         idx.write_text("# Memory Index\n\n")
@@ -141,9 +165,54 @@ def index_drift(mem_dir: Path) -> dict[str, list[str]]:
     for every memory base, and runs from the SessionStart hook.
     """
     actual = {p.name for p in files(mem_dir)}
-    idx = index_path(mem_dir)
-    listed = set(_INDEX_LINK_RE.findall(idx.read_text())) if idx.exists() else set()
+    listed = _listed(mem_dir)
     return {"dangling": sorted(listed - actual), "unindexed": sorted(actual - listed)}
+
+
+def index_refusal(mem_dir: Path) -> str | None:
+    """Why charter will not touch this base's ``MEMORY.md``, or ``None``.
+
+    Public because a refusal here is the one that hides. A refused *memory* still leaves
+    the other memories to list, so the store visibly shrinks; a refused *index* answers
+    with an empty set, which a base that simply has no memories yet answers with too. On
+    a store whose files were also refused, `doctor` reported "consistent" over an index
+    pointing at a credential file.
+
+    So the reason is exported rather than swallowed, and `doctor` prints it. ADR 0009:
+    name what was actually checked. "1 unindexed" is true and sends the operator to
+    `charter persona optimize`, which cannot repair an index charter declines to write.
+
+    **The write-side rule, deliberately, even though `_listed` reads.** An index that is
+    simply *absent* is not a defect — `charter init` scaffolds a front door whose
+    `memory/` holds a `.gitkeep` and no `MEMORY.md` — so the read-side gate's "not there
+    is a refusal" reported every fresh plane as broken. `write_refusal` still catches the
+    case `exists()` cannot see: a **dangling** link that escapes, which is absent and
+    hostile at the same time. `_listed` is unaffected either way, because a missing file
+    and a refused one both leave it with nothing listed.
+    """
+    return (contain.dir_refusal(mem_dir, "write")
+            or contain.write_refusal(index_path(mem_dir)))
+
+
+def _listed(mem_dir: Path) -> set[str]:
+    """The filenames MEMORY.md links to — ``set()`` when charter may not read it.
+
+    **The one read `files()` never covered**, because ``MEMORY.md`` is the single name it
+    filters out (`p.name != "MEMORY.md"`). So the file with the most predictable name in
+    the store was the only one with no gate on either side (#336, #349). `doctor` reads
+    this for every memory base on every SessionStart, where a FIFO costs the briefing and
+    a link reads whatever it points at.
+
+    An unreadable index answers ``set()`` rather than raising, matching `files()`: the
+    drift report then shows every file as unindexed, which is true — nothing charter is
+    willing to read indexes them — and is what surfaces the defect to the operator.
+    """
+    if index_refusal(mem_dir):
+        return set()
+    try:
+        return set(_INDEX_LINK_RE.findall(index_path(mem_dir).read_text()))
+    except OSError:
+        return set()
 
 
 def index_size(mem_dir: Path) -> int:
@@ -299,10 +368,24 @@ def forget(mem_dir: Path, ident: str) -> Path | None:
 
 
 def _drop_index_line(mem_dir: Path, filename: str) -> None:
+    """Remove *filename*'s line from the index — the store's only **truncating** write.
+
+    Where `index_append` adds two lines to whatever a link points at, this replaces the
+    target with what survived a filter, so pointed at a credential store it destroys it
+    outright rather than corrupting it. `file_refusal` is the right gate here rather than
+    `write_refusal`: the file must already exist for there to be a line to drop, so ENOENT
+    is genuinely "nothing to do" on both sides of the question.
+
+    Refuses by doing nothing, deliberately — unlike `write`, this runs *after* `forget`
+    and `archive` have already moved the memory file, so raising would report a failure
+    for work that succeeded. The index left holding a stale line is a file charter has
+    declined to read, which `index_drift` reports as drift on the next `doctor`.
+    """
     idx = index_path(mem_dir)
-    if idx.exists():
-        keep = [ln for ln in idx.read_text().splitlines() if f"({filename})" not in ln]
-        idx.write_text("\n".join(keep) + ("\n" if keep else ""))
+    if not idx.exists() or contain.dir_refusal(mem_dir, "write") or contain.file_refusal(idx):
+        return
+    keep = [ln for ln in idx.read_text().splitlines() if f"({filename})" not in ln]
+    idx.write_text("\n".join(keep) + ("\n" if keep else ""))
 
 
 def body(text: str) -> str:
@@ -323,6 +406,13 @@ def archive(mem_dir: Path, ident: str) -> Path | None:
     if not p or not p.exists():
         return None
     dest_dir = mem_dir / "archive"
+    # The fifth fixed name in the store, and the one #349 did not list. `rename` follows a
+    # link on the destination directory exactly as `open` follows one on a file, so a
+    # committed `archive` → elsewhere turns a retire into a move out of the plane. Answers
+    # None like every other "nothing was archived", rather than raising into `curate`'s
+    # batch.
+    if contain.dir_refusal(dest_dir, "write"):
+        return None
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest = dest_dir / p.name
     i = 2

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -1165,9 +1165,13 @@ def vault_of(name: str) -> str | None:
 def scaffold_memory(name: str, shared: bool = False) -> None:
     """Create the committed memory/ and refs/ dirs with keep-files so git tracks
     them and the persona always has an index to read."""
+    # Two fixed names under a directory a commit controls, written HERE rather than
+    # through `memstore.ensure_index` — so gating the store alone would have left the
+    # scaffolder holding the same hole one function over (#349). Both checked before the
+    # `mkdir`, which happily accepts a committed link to a directory outside the plane.
     mem = memory_dir(name, shared)
+    idx = contain.writable(index_of(mem))
     mem.mkdir(parents=True, exist_ok=True)
-    idx = index_of(mem)
     if not idx.exists():
         who = "shared (all personas)" if shared else name
         idx.write_text(
@@ -1176,8 +1180,8 @@ def scaffold_memory(name: str, shared: bool = False) -> None:
             "Written by the persona as it learns; committed and shared.\n"
         )
     refs = refs_dir(name, shared)
+    readme = contain.writable(refs / "README.md")
     refs.mkdir(parents=True, exist_ok=True)
-    readme = refs / "README.md"
     if not readme.exists():
         who = "shared (all personas)" if shared else name
         readme.write_text(

--- a/charter/pieces.py
+++ b/charter/pieces.py
@@ -44,7 +44,7 @@ import socket
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from . import persona, session, workspace
+from . import contain, persona, session, workspace
 
 #: Directory under a workspace holding its piece records. Deliberately absent from
 #: ``workspace._live_block`` — see the module docstring.
@@ -113,6 +113,8 @@ def record(ws: str, event: str, repo: str, piece: str, reason: str | None = None
     if reason:
         line["reason"] = reason
     p = log_path(ws)
+    if contain.write_refusal(p):
+        return None  # a committed link at this fixed name — see contain.write_refusal
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
         blob = (json.dumps(line, sort_keys=True) + "\n").encode()
@@ -267,6 +269,8 @@ def seen(ws: str, repo: str, piece: str | None, session: str | None = None,
     if persona:
         blob["persona"] = persona
         blob["by"] = by
+    if contain.write_refusal(p):
+        return None  # a committed link at this fixed name — see contain.write_refusal
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(json.dumps(blob, sort_keys=True) + "\n")

--- a/charter/skilluse.py
+++ b/charter/skilluse.py
@@ -38,7 +38,7 @@ import socket
 from datetime import datetime, timezone
 from pathlib import Path
 
-from . import config
+from . import config, contain
 
 #: Directory under ``personas/`` holding the tally. Leading underscore so it can never
 #: collide with a persona name — the same convention ``_dispatch`` and ``_shared`` use.
@@ -73,6 +73,8 @@ def record(skill: str, persona_name: str | None = None,
         return None
     when = when or _now()
     p = path_for(when)
+    if contain.write_refusal(p):
+        return None  # a committed link at this fixed name — see contain.write_refusal
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
         line = json.dumps({"ts": when.isoformat(timespec="seconds"),

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -211,7 +211,10 @@ def declared_default() -> str | None:
 
 
 def set_declared_default(name: str) -> None:
-    d = default_file()
+    # A fixed name directly under `workspaces/`, which the default ignore rule
+    # (`/workspaces/*/*`) does not match — so it is an ordinarily committable path, and a
+    # link there redirects this write (#349).
+    d = contain.writable(default_file())
     d.parent.mkdir(parents=True, exist_ok=True)
     d.write_text(name.strip() + "\n")
 
@@ -659,7 +662,7 @@ def read_manifest(name: str) -> dict:
 
 def write_manifest(name: str, data: dict) -> None:
     ensure(name)
-    manifest_path(name).write_text(json.dumps(data, indent=2) + "\n")
+    contain.writable(manifest_path(name)).write_text(json.dumps(data, indent=2) + "\n")
 
 
 def merge_repo_rows(manifest_rows, disk_rows) -> tuple[list[dict], list[str]]:
@@ -872,7 +875,10 @@ def _replace_md_section(text: str, header: str, body: str) -> str:
 
 def scaffold_charter(name: str, vision: str | None = None) -> None:
     """Create workspace.md from the template if missing; if a vision is given, set it."""
-    cf = charter_file(name)
+    # `read_charter` below already refuses a `workspace.md` that resolves out of the
+    # plane; this is the same file, written. A guard on one side of one name is how the
+    # write half of #336 stayed open after the read half closed (#349).
+    cf = contain.writable(charter_file(name))
     if not cf.exists():
         cf.parent.mkdir(parents=True, exist_ok=True)
         cf.write_text(_CHARTER_TEMPLATE.format(
@@ -884,7 +890,7 @@ def scaffold_charter(name: str, vision: str | None = None) -> None:
 def set_vision(name: str, text: str) -> None:
     """Set/replace the charter's ## Vision section (creating the charter if needed)."""
     scaffold_charter(name)
-    cf = charter_file(name)
+    cf = contain.writable(charter_file(name))
     cf.write_text(_replace_md_section(cf.read_text(), "Vision", text))
 
 

--- a/docs/news/unreleased-contain-plane-writes.md
+++ b/docs/news/unreleased-contain-plane-writes.md
@@ -1,0 +1,64 @@
+---
+version: unreleased
+headline: A committed symlink can no longer redirect charter's own writes into your vault
+---
+
+The previous release closed the read half of this: charter resolves every path it reads on
+a plane and refuses one that lands outside the directories a plane keeps data in. The
+**write** paths were never in that change, and they inherited none of it.
+
+So the write went somewhere else. With `personas/<name>/memory/MEMORY.md` committed as a
+link to `.charter/vaults/devops.json`, `charter persona remember` appended its index line
+*through* the link:
+
+```
+$ charter persona remember devops "the cluster is in eu-west-1"
+✓ Remembered (persistent) → personas/devops/memory/the-cluster-is-in-eu-west-1.md
+```
+
+— and the vault was two lines long and no longer parsed as JSON.
+
+**This is sharper than the read half in two ways.** `MEMORY.md` is a *fixed* name, so there
+is nothing to guess and no race to win: the file charter will write to is known before the
+attacker commits, and it is the one they replace. And the target need not be a charter file
+at all. Where a redirected read leaked a secret, a redirected write destroys one —
+`charter persona forget` rewrites the index whole, so pointed at a credential store it
+replaces the file rather than appending to it.
+
+**One rule differs from the read side, and it is the whole reason this needed its own
+check.** On a read, a path that is not there is a refusal. On a write it is the ordinary
+case — the file is about to be created. So charter answers "nothing to object to" for a
+path that does not exist, and still refuses a *dangling* link that escapes: `write_text`
+through one of those **creates** the target wherever it points, and it is invisible to any
+check that asks whether the file exists first.
+
+The gate now covers every write charter aims at a name it chose rather than a name you
+typed, wherever the target already sits inside the plane's data: the memory and todo stores
+(including `archive/`, where a rename follows a link on the destination directory just as an
+open follows one on a file), persona and workspace scaffolding, a workspace's `workspace.md`
+and `workspace.json`, and the three unattended tallies charter keeps for dispatches, skill
+use and pieces. Those last three are driven by a hook with nobody typing, so they decline
+and carry on rather than failing your turn — the same thing they already did for a full
+disk.
+
+`MEMORY.md` turned out to be the one file with no gate on the **read** side either. The
+store's one reader filters it out by name, so the index — which `charter doctor` reads for
+every memory base on every session start — was still opened wherever it pointed, and a FIFO
+there hung the check. It is gated now, and `doctor` names an index it will not touch
+instead of reporting the base consistent: a refused index answers "nothing is listed", which
+is exactly what an empty one answers too.
+
+**Writes to committed names outside the plane's data directories are not covered**, and
+that is deliberate rather than an oversight. `charter.toml`, `.gitignore`,
+`.claude/settings.json`, `inventory/repos.json` and `vaults.json` have the same shape, and
+the boundary the read half draws — which deliberately excludes `.charter/` — has nothing to
+say about them. Extending it is a decision in its own right, and inventing one quietly here
+would have been the worse answer.
+
+Separately, `charter doctor` now says when your **active** persona is structurally broken
+*and still auto-approving tools*. The roster check already reported that a persona had
+errors; it never connected that to the fact that this one is the acting identity and is
+still removing prompts. The grant itself is unchanged and stays as designed — a broken
+reference already contributes nothing, so the tools that survive are the ones the persona
+declares for itself, which is what someone reading the file would expect. What was missing
+was anybody saying so.

--- a/tests/test_broken_persona_still_grants.py
+++ b/tests/test_broken_persona_still_grants.py
@@ -1,0 +1,143 @@
+"""A broken persona that still auto-approves tools must SAY so (#343, #329).
+
+`toolgate.decide` asks the active persona what its tools are and never asks whether the
+persona is well-formed. `charter persona lint` calls it broken; the PreToolUse gate honours
+it anyway. Two checks read the same file, answer different questions about it, and only one
+of them sits on the path that removes a prompt.
+
+**#343's direction (1) — have the gate ignore such a persona — is deliberately NOT what
+this file holds, and the reason is measured rather than assumed.** After #342 that gate
+buys no containment at all. `verify` runs below in three shapes (a `uses:` that is a path
+out of the plane, a `uses:` that is a plain typo, an `extends:` cycle) and in every one the
+surviving grant is exactly the persona's own `tools:` plus what a reader of those same
+files would compute. The only tool reachable *through* a broken reference is refused
+already, because `load()` returns None for a reference that is not a name and contributes
+nothing. So gating on `structural_errors` would revoke a grant the operator wrote by hand,
+in exchange for closing nothing — and it would revoke it silently, because the gate's
+production output path (`hooks.pretooluse`) emits nothing at all when `decide` declines.
+
+What was actually missing is the sentence. `doctor` reported "4 with error(s)" about the
+roster and, separately, nothing about the fact that one of those broken personas was the
+*active* one and was still pre-approving binaries. `check_ask_rules` is the precedent and
+the mirror image — *"the persona's tools quietly stop being pre-approved, with nothing
+naming the cause"* — pointed the other way: here they quietly keep working.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import config, doctor, persona, toolgate
+from tests._isolation import PersonaIso
+
+
+class BrokenPersonaStillGrants(PersonaIso):
+
+    def broken(self, name: str, **meta) -> str:
+        """A persona with a real structural error and a real tool grant."""
+        self.make_persona(name, role="front door", **{"delegate-when": "everything"},
+                          **meta)
+        self.assertTrue(persona.structural_errors(name),
+                        f"precondition: '{name}' must actually be broken")
+        return name
+
+    def activate(self, name: str) -> None:
+        (config.PERSONAS_DIR / ".default").write_text(name + "\n")
+        self.assertEqual(name, persona.resolve_active(),
+                         "precondition: the broken persona must be the ACTIVE one")
+
+    # ------------------------------------------------------- the measured claim
+    def test_a_broken_reference_contributes_no_tools(self):
+        """The evidence #343 is closed on. Three shapes of breakage; in each the gate
+        grants the persona's OWN tools and nothing the broken reference names.
+
+        `curl` is in every case for the same reason a benign half is: a gate that allowed
+        everything would pass every other assertion here.
+        """
+        self.make_persona("lender", tools="sh")
+        for label, meta in (
+            ("uses: a path out of the plane", {"uses": "../../elsewhere/lender"}),
+            ("uses: a plain typo", {"uses": "lendr"}),
+            ("extends: a dangling parent", {"extends": "nobody"}),
+        ):
+            with self.subTest(shape=label):
+                name = f"front-{len(label)}"
+                self.broken(name, tools="gh", **meta)
+                tools = persona.effective_tools(name)
+                self.assertIn("gh", tools, "its own grant must survive")
+                self.assertNotIn("sh", tools,
+                                 "a broken reference must contribute nothing")
+                self.activate(name)
+                self.assertIsNotNone(toolgate.decide("gh --version"))
+                self.assertIsNone(toolgate.decide("curl example.com"),
+                                  "the gate is not simply allowing everything")
+
+    def test_an_inheritance_cycle_grants_no_more_than_the_files_read(self):
+        """The one shape where `lineage` truncates rather than refusing, so it is the
+        one that could plausibly grant something unexpected. It does not: `a extends b`
+        and `b extends a` gives each the other's tools, which is what the two files say.
+        """
+        self.make_persona("cyc-a", tools="gh", extends="cyc-b")
+        self.make_persona("cyc-b", tools="kubectl", extends="cyc-a")
+        self.assertTrue(any("cycle" in m for _l, m in persona.structural_errors("cyc-a")),
+                        "precondition: this must be reported as a cycle")
+        self.assertEqual({"gh", "kubectl"}, persona.effective_tools("cyc-a"))
+        self.activate("cyc-a")
+        self.assertIsNone(toolgate.decide("curl example.com"))
+
+    # ------------------------------------------------------------ the legibility
+    def test_doctor_says_the_active_persona_is_broken_and_still_granting(self):
+        """The divergence, closed where it can be: not by revoking the grant, but by
+        refusing to leave the two answers unconnected.
+
+        `check_personas` already reports "N with error(s)" about the roster. It does not
+        say that one of them is the ACTIVE persona and is still pre-approving binaries,
+        which is the half that decides whether a prompt appears.
+        """
+        self.broken("front", tools="gh, kubectl", uses="lendr")
+        self.activate("front")
+
+        r = doctor.check_persona_grant()
+        self.assertNotEqual(doctor.OK, r.status,
+                            "doctor left a broken persona granting silently")
+        said = f"{r.detail} {r.hint or ''}"
+        self.assertIn("front", said, "it must name the persona")
+        self.assertIn("gh", said, "it must name what is still auto-approved")
+        self.assertIn("lint", said, "it must point at the command that explains the break")
+
+    def test_doctor_is_quiet_when_the_active_persona_is_well_formed(self):
+        """The half that catches a check which warns about every plane. A persona with a
+        `tools:` grant and no structural errors is the *designed* configuration — #329
+        settled that the grant itself stays — and must not be reported as a problem."""
+        self.make_persona("clean", role="front door", tools="gh",
+                          **{"delegate-when": "everything"})
+        self.assertEqual([], persona.structural_errors("clean"), "precondition")
+        self.activate("clean")
+        self.assertEqual(doctor.OK, doctor.check_persona_grant().status)
+
+    def test_doctor_is_quiet_when_a_broken_persona_grants_nothing(self):
+        """Breakage alone is `check_personas`' business. This check earns its line only
+        when a broken persona is also removing prompts — otherwise it is a second, louder
+        copy of a report that already exists."""
+        self.broken("front", uses="lendr")           # no tools: at all
+        self.activate("front")
+        self.assertEqual(set(), persona.effective_tools("front"), "precondition")
+        self.assertEqual(doctor.OK, doctor.check_persona_grant().status)
+
+    def test_doctor_is_quiet_with_no_active_persona(self):
+        (config.PERSONAS_DIR / ".default").unlink(missing_ok=True)
+        self.assertIsNone(persona.resolve_active(), "precondition")
+        self.assertEqual(doctor.OK, doctor.check_persona_grant().status)
+
+    def test_the_check_is_wired_into_the_preflight(self):
+        """A check nobody runs is the shape this repo has paid for twice (#177, #197),
+        and `check_personas`' own docstring says so: it *"was in no hook and in no other
+        command, so it reported drift only to someone who already suspected drift"*."""
+        self.broken("front", tools="gh", uses="lendr")
+        self.activate("front")
+        names = [r.name for r in doctor.run_all()]
+        self.assertIn(doctor.check_persona_grant().name, names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plane_writes_are_contained.py
+++ b/tests/test_plane_writes_are_contained.py
@@ -1,0 +1,673 @@
+"""A committed symlink must not redirect a WRITE charter performs on its own.
+
+#349, the other half of #336. #348 gated every *read* of plane data behind
+`contain.file_refusal`/`dir_refusal`; the write side never went through `memstore.files`
+and inherited none of it. `ensure_index`, `write`, `index_append` and `_drop_index_line`
+opened their target directly, and `Path.write_text` / `open(…, "a")` follow a symlink.
+
+**Two properties make this sharper than the read half.**
+
+``MEMORY.md`` is a **fixed name**, so there is nothing to guess and no race to win: the
+file charter will write to is known before the attacker commits, and it is the one they
+replace with a link. And the target need not be a charter file — pointed at
+``.charter/vaults/<name>.json`` an append *corrupts* a credential store, where the read
+half merely leaked one. Reproduced against the real CLI on 0.47.2 and on #348's branch:
+
+    $ charter persona remember victim "the sky is blue"
+    ✓ Remembered (persistent) → personas/victim/memory/the-sky-is-blue.md
+    # …and the vault is now two lines and no longer parses as JSON.
+
+**ENOENT is the one thing the write side must read differently.** On a read, a path that
+is not there is a refusal. On a write it is the *normal* case — the file is about to be
+created — so `contain.write_refusal` answers ``None`` for it. Getting that backwards
+breaks every first write on a fresh plane, which is why
+:meth:`test_a_first_write_on_a_fresh_plane_is_not_refused` and
+:meth:`test_a_dangling_link_that_escapes_does_not_create_its_target` are both here: they
+fail in opposite directions, and no single mistake passes both.
+
+**Preconditions are asserted, not assumed.** Every case plants a real link or FIFO,
+proves the OS follows or blocks on it, and records the target's exact bytes *before*
+asking charter to refuse. A test that passed because the fixture was a copy, or because
+the target happened not to exist, would prove nothing — this audit has produced seven
+vacuous passes already.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+from charter import config, contain, curate, memstore, persona, todos, workspace
+from tests._isolation import PersonaIso
+
+#: The value an append must never reach. Same shape as the read half's canary so a grep
+#: from either report lands in both files.
+CANARY = "CANARY-VAULT-SECRET-9f31"
+
+#: Long enough that a block is unambiguous, short enough that a regression does not look
+#: like a wedged machine. Every case here returns in microseconds when the gate holds.
+WATCHDOG = 5.0
+
+
+class WriteFixtures(PersonaIso):
+    """Plane, vault canary and link/FIFO fixtures — shared, so neither case class
+    inherits the other's tests and runs them twice."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # A plain-file vault at the fixed place relative to the plane — what makes the
+        # attack portable to a machine whose layout the attacker does not know.
+        self.vault = config.VAULTS_DIR / "devops.json"
+        self.vault.parent.mkdir(parents=True, exist_ok=True)
+        # Two properties, both load-bearing, both learned from a vacuous pass.
+        #
+        # It carries an index-shaped `(…md)` link, so `index_drift` reading this file
+        # *shows up* in what it returns. Without one the drift assertion passed against
+        # unfixed code: a vault with no links yields no links whether charter read it or
+        # not, which proves only that JSON is not markdown.
+        #
+        # It has **no trailing newline**, so `_drop_index_line`'s rewrite
+        # (`"\n".join(keep) + "\n"`) is visible in the bytes. With one, a single-line
+        # target round-trips through that filter unchanged and `forget` also passed
+        # against unfixed code — the write happened and the file looked untouched.
+        self.vault.write_text(
+            '{"token": "%s", "note": "rotate: - [stolen](outside-canary.md)"}' % CANARY)
+        self.vault_bytes = self.vault.read_bytes()
+        self.vault_mtime = self.vault.stat().st_mtime_ns
+        self.outside = Path(tempfile.mkdtemp(prefix="edm-test-outside-"))
+        self.addCleanup(shutil.rmtree, self.outside, ignore_errors=True)
+
+    # ------------------------------------------------------------------ helpers
+    def link(self, link: Path, target: Path) -> str:
+        """Plant *link* → *target* as a **relative** symlink and prove it is one."""
+        link.parent.mkdir(parents=True, exist_ok=True)
+        rel = os.path.relpath(target, link.parent)
+        if link.is_symlink() or link.exists():
+            link.unlink()
+        os.symlink(rel, link)
+        self.assertTrue(link.is_symlink(), f"fixture must be a symlink, not a copy: {link}")
+        return rel
+
+    def escaping_link(self, link: Path, target: Path) -> str:
+        rel = self.link(link, target)
+        self.assertTrue(rel.startswith(".."),
+                        f"fixture must escape its own directory, got {rel!r}")
+        return rel
+
+    def live_vault_link(self, link: Path) -> Path:
+        """*link* → the vault, proven live: the OS reads the secret through it.
+
+        This is the precondition that separates "charter refused" from "the fixture never
+        worked". Without it a passing test proves only that `os.symlink` was misspelled.
+        """
+        self.escaping_link(link, self.vault)
+        self.assertIn(CANARY, link.read_text(),
+                      "precondition: the OS must follow the link to the vault")
+        return link
+
+    def assertVaultIntact(self, why: str) -> None:
+        """The vault must be untouched: same bytes, same mtime, still valid JSON.
+
+        `mtime` is here because content equality is not proof that nothing was written —
+        `_drop_index_line` rewrites the file whole, and a target it happens to reproduce
+        byte for byte looks identical to one charter never opened. That is precisely how
+        this file's first draft passed against unfixed code.
+        """
+        self.assertEqual(self.vault_bytes, self.vault.read_bytes(), why)
+        self.assertEqual(self.vault_mtime, self.vault.stat().st_mtime_ns,
+                         f"{why} (the bytes survived, but the file was rewritten)")
+        json.loads(self.vault.read_text())          # raises if an append corrupted it
+
+    def _fifo(self, path: Path) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.is_symlink() or path.exists():
+            path.unlink()
+        os.mkfifo(path)
+        self.assertTrue(stat.S_ISFIFO(os.lstat(path).st_mode),
+                        f"precondition: {path} must be a FIFO")
+        return path
+
+    def write_blocking_fifo(self, path: Path) -> Path:
+        """A FIFO with **no reader**, proven to block a writer.
+
+        Deliberately not the same fixture as :meth:`read_blocking_fifo`, and the two
+        cannot be merged: a FIFO blocks a writer only while nobody is reading and blocks
+        a reader only while nobody is writing, so the thread that *proves* one case is
+        exactly what makes the other case fail to block. A single shared helper here
+        passed the read case against unfixed code, because its own blocked writer had
+        already satisfied the reader.
+        """
+        self._fifo(path)
+        started = threading.Event()
+
+        def _write():
+            started.set()
+            with open(path, "a") as f:              # blocks here until a reader appears
+                f.write("x")
+        writer = threading.Thread(target=_write, daemon=True)
+        writer.start()
+        started.wait(1.0)
+        writer.join(0.3)
+        self.assertTrue(writer.is_alive(),
+                        f"precondition: writing to {path} must block — it did not")
+        self.addCleanup(self._release, path, os.O_RDONLY)
+        return path
+
+    def read_blocking_fifo(self, path: Path) -> Path:
+        """A FIFO with **no writer**, proven to block a reader."""
+        self._fifo(path)
+        started = threading.Event()
+
+        def _read():
+            started.set()
+            with open(path) as f:                   # blocks here until a writer appears
+                f.read()
+        reader = threading.Thread(target=_read, daemon=True)
+        reader.start()
+        started.wait(1.0)
+        reader.join(0.3)
+        self.assertTrue(reader.is_alive(),
+                        f"precondition: reading {path} must block — it did not")
+        self.addCleanup(self._release, path, os.O_WRONLY)
+        return path
+
+    @staticmethod
+    def _release(path: Path, how: int) -> None:
+        try:
+            os.close(os.open(path, how | os.O_NONBLOCK))
+        except OSError:
+            pass                                 # nobody waiting — nothing to release
+
+    def completes(self, fn, label: str):
+        """Call *fn* on a watchdog. Fails if it is still running when the clock runs out."""
+        box = {}
+
+        def _run():
+            try:
+                box["r"] = fn()
+            except BaseException as e:            # noqa: BLE001 — the watchdog wants the
+                box["e"] = e                      # outcome, whatever shape it arrived in
+        t = threading.Thread(target=_run, daemon=True)
+        t.start()
+        t.join(WATCHDOG)
+        self.assertFalse(t.is_alive(), f"{label} blocked for more than {WATCHDOG}s")
+        return box
+
+
+class PlaneWritesAreContained(WriteFixtures):
+
+    # --------------------------------------- contain.write_refusal, on its own
+    def test_a_path_that_is_not_there_is_not_a_refusal(self):
+        """The one rule the write side does not share with the read side.
+
+        Every first write on a fresh plane lands on a path that does not exist. Reading
+        ENOENT as a refusal — which `file_refusal` correctly does — would refuse all of
+        them, so the two functions have to answer this differently and deliberately.
+        """
+        fresh = persona.memory_dir("nobody") / "MEMORY.md"
+        self.assertFalse(fresh.exists(), "precondition: nothing is there yet")
+        self.assertIsNone(contain.write_refusal(fresh))
+        self.assertIsNotNone(contain.file_refusal(fresh),
+                             "the READ side must still refuse a path that is not there")
+
+    def test_an_ordinary_file_inside_the_data_roots_is_writable(self):
+        self.make_persona("real")
+        idx = persona.index_of(persona.memory_dir("real"))
+        self.assertTrue(idx.is_file(), "precondition: scaffolding wrote a real index")
+        self.assertIsNone(contain.write_refusal(idx))
+
+    def test_a_link_that_escapes_the_data_roots_is_refused(self):
+        self.make_persona("victim")
+        idx = self.live_vault_link(persona.index_of(persona.memory_dir("victim")))
+        refusal = contain.write_refusal(idx)
+        self.assertIsNotNone(refusal, "an escaping link must be refused on the write side")
+        self.assertIn("outside the directories", refusal)
+        self.assertIn("write", refusal,
+                      "the refusal must say a WRITE was redirected, not a read")
+
+    def test_a_link_that_lands_inside_the_data_roots_is_followed(self):
+        """The benign half — what catches a "fix" that contains writes by refusing all
+        of them. #342 stayed lexical partly so a plane that legitimately links a persona
+        directory keeps working, and resolving must not take that away."""
+        self.make_persona("real")
+        self.make_persona("alias")
+        target = persona.memory_dir("real") / "MEMORY.md"
+        self.assertTrue(target.is_file(), "precondition: the target is a real index")
+        link = persona.memory_dir("alias") / "MEMORY.md"
+        self.link(link, target)
+        self.assertIsNone(contain.write_refusal(link),
+                          "a link landing inside the data roots must still be written")
+
+    def test_a_dangling_link_inside_the_data_roots_is_writable(self):
+        """A contained link whose target is not there **yet** is the ENOENT case one
+        level down: charter is about to create the file the link names, and it names a
+        place charter may write."""
+        self.make_persona("real")
+        link = persona.memory_dir("real") / "later.md"
+        self.link(link, persona.memory_dir("real") / "not-yet.md")
+        self.assertTrue(link.is_symlink() and not link.exists(),
+                        "precondition: a live link to a file that does not exist")
+        self.assertIsNone(contain.write_refusal(link))
+
+    def test_a_fifo_is_refused_before_anything_opens_it(self):
+        self.make_persona("victim")
+        idx = self.write_blocking_fifo(persona.index_of(persona.memory_dir("victim")))
+        self.assertIsNotNone(contain.write_refusal(idx))
+
+    def test_a_directory_is_not_a_writable_plane_file(self):
+        self.make_persona("victim")
+        d = persona.memory_dir("victim") / "archive"
+        d.mkdir(parents=True, exist_ok=True)
+        self.assertIsNotNone(contain.write_refusal(d))
+
+    def test_a_write_refusal_never_raises(self):
+        """`contain`'s standing promise, extended to the new function. `os.lstat` answers
+        a path holding a NUL with `ValueError`, not `OSError` — the one input shaped to
+        reach past a check, and the bug that survived #348's first push."""
+        for bad in ("a\x00b", ""):
+            with self.subTest(path=bad):
+                self.assertIsNotNone(contain.write_refusal(bad))
+
+    # ------------------------------------------------- the flagship: remember
+    def test_remember_does_not_append_through_a_linked_index(self):
+        """#349's demonstration, end to end. `MEMORY.md` is a fixed name, so this needs
+        no guess: the attacker commits the link and waits for the next `remember`."""
+        self.make_persona("victim")
+        self.live_vault_link(persona.index_of(persona.memory_dir("victim")))
+
+        with self.assertRaises(contain.Refused):
+            persona.remember("victim", "the sky is blue")
+        self.assertVaultIntact("charter appended its index line through the link")
+
+    def test_remember_says_why_it_refused(self):
+        """A refusal is data. The operator ran a command that did not do what it said;
+        "✓ Remembered" over a corrupted vault is the failure, and silence is only
+        marginally better. The sentence has to name both ends — the path charter opened
+        is not the path it was given, which is the whole defect."""
+        self.make_persona("victim")
+        idx = self.live_vault_link(persona.index_of(persona.memory_dir("victim")))
+        try:
+            persona.remember("victim", "the sky is blue")
+            self.fail("the write was not refused")
+        except contain.Refused as e:
+            said = str(e)
+        self.assertIn(str(idx), said)
+        self.assertIn(str(self.vault.resolve()), said,
+                      "the refusal must name where the link actually goes")
+
+    def test_remember_does_not_write_its_memory_file_through_a_linked_directory(self):
+        """The variant a per-file check structurally cannot see: when the *directory* is
+        the link, every path inside it is an ordinary name with nothing to object to."""
+        self.make_persona("victim")
+        mem = persona.memory_dir("victim")
+        shutil.rmtree(mem, ignore_errors=True)
+        elsewhere = self.outside / "stolen"
+        elsewhere.mkdir(parents=True)
+        self.link(mem, elsewhere)
+        self.assertTrue(mem.is_dir() and mem.is_symlink(),
+                        "precondition: a live directory link")
+
+        with self.assertRaises(contain.Refused):
+            persona.remember("victim", "the sky is blue")
+        self.assertEqual([], sorted(p.name for p in elsewhere.iterdir()),
+                         "charter wrote a memory into a directory outside the plane")
+
+    def test_a_dangling_link_that_escapes_does_not_create_its_target(self):
+        """The half that fails if ENOENT is read as "nothing to object to" *before* the
+        link is resolved. `write_text` through a dangling link **creates the target**, so
+        a link at a predictable name is a write-anywhere primitive with attacker-chosen
+        content — strictly worse than the append, and invisible to `exists()`."""
+        self.make_persona("victim")
+        victim_file = self.outside / "not-yet-there.json"
+        self.assertFalse(victim_file.exists(), "precondition: the target does not exist")
+        link = persona.index_of(persona.memory_dir("victim"))
+        self.escaping_link(link, victim_file)
+        self.assertTrue(link.is_symlink() and not link.exists(),
+                        "precondition: a live link to a file that is not there")
+
+        with self.assertRaises(contain.Refused):
+            persona.remember("victim", "the sky is blue")
+        self.assertFalse(victim_file.exists(),
+                         "charter created a file outside the plane through a dangling link")
+
+    def test_a_fifo_index_does_not_block_remember(self):
+        """The liveness half on the write side. `open(fifo, "a")` waits for a reader for
+        ever, and unlike the read half there is no `hooks.json` timeout above this — a
+        human is sitting at the command."""
+        self.make_persona("victim")
+        self.write_blocking_fifo(persona.index_of(persona.memory_dir("victim")))
+        box = self.completes(lambda: persona.remember("victim", "the sky is blue"),
+                             "persona.remember onto a FIFO index")
+        self.assertIsInstance(box.get("e"), contain.Refused)
+
+    # ---------------------------------------------------- the benign half, end to end
+    def test_a_first_write_on_a_fresh_plane_is_not_refused(self):
+        """The case that breaks if ENOENT is treated as a refusal. Deliberately the
+        whole path — scaffold, write, index — because each step lands on something that
+        is not there yet."""
+        self.make_persona("fresh")
+        p = persona.remember("fresh", "the sky is blue")
+        self.assertTrue(p.is_file(), "the memory file must be written")
+        idx = persona.index_of(persona.memory_dir("fresh"))
+        self.assertIn("the sky is blue", idx.read_text(),
+                      "the index line must be appended")
+
+    def test_a_second_write_still_appends(self):
+        """A guard that refuses an *existing* regular file would pass every test above
+        and break the plane on its second memory."""
+        self.make_persona("fresh")
+        persona.remember("fresh", "the sky is blue")
+        persona.remember("fresh", "water is wet")
+        idx = persona.index_of(persona.memory_dir("fresh")).read_text()
+        self.assertIn("the sky is blue", idx)
+        self.assertIn("water is wet", idx)
+
+    def test_an_index_linked_inside_the_plane_is_still_appended(self):
+        """The benign link, end to end: a plane that shares one index between two
+        personas keeps working, because the link lands inside `personas/`."""
+        self.make_persona("real")
+        self.make_persona("alias")
+        target = persona.index_of(persona.memory_dir("real"))
+        self.link(persona.index_of(persona.memory_dir("alias")), target)
+        persona.remember("alias", "the sky is blue")
+        self.assertIn("the sky is blue", target.read_text(),
+                      "a contained link must still be followed")
+
+    # ------------------------------------------------------ the other write paths
+    def test_forget_does_not_truncate_through_a_linked_index(self):
+        """`_drop_index_line` **rewrites** the index whole, so this is the destructive
+        variant: where `remember` appends two lines to a vault, `forget` replaces it with
+        whatever survived a filter for one filename."""
+        self.make_persona("victim")
+        persona.remember("victim", "the sky is blue")
+        self.live_vault_link(persona.index_of(persona.memory_dir("victim")))
+
+        self.completes(lambda: persona.forget("victim", "the-sky-is-blue"),
+                       "persona.forget onto a linked index")
+        self.assertVaultIntact("charter truncated the vault through the index link")
+
+    def test_index_drift_does_not_read_a_linked_index(self):
+        """The read `files()` never covered, because it is the one file `files()` filters
+        out by name. `doctor` calls `index_drift` for every memory base on every
+        SessionStart, so a FIFO here hangs the briefing and a link here reads whatever it
+        points at."""
+        self.make_persona("victim")
+        self.live_vault_link(persona.index_of(persona.memory_dir("victim")))
+        drift = memstore.index_drift(persona.memory_dir("victim"))
+        self.assertEqual([], drift["dangling"],
+                         "charter parsed a file outside the plane as its index")
+
+    def test_a_fifo_index_does_not_block_the_session_briefing(self):
+        self.make_persona("victim")
+        self.read_blocking_fifo(persona.index_of(persona.memory_dir("victim")))
+        self.completes(lambda: memstore.index_drift(persona.memory_dir("victim")),
+                       "index_drift over a FIFO index")
+
+    def test_a_todo_is_not_recorded_through_a_linked_index(self):
+        """The todo store is the same `memstore` with a different base, so one gate must
+        cover it — asserted rather than assumed, which is what caught `curate` on the
+        read side."""
+        workspace.ensure("task")
+        todos.scaffold("task")
+        self.live_vault_link(memstore.index_path(todos.todos_dir("task")))
+        with self.assertRaises(contain.Refused):
+            todos.add("task", "ship the thing")
+        self.assertVaultIntact("a todo was appended into the vault")
+
+    def test_a_workspace_note_is_not_recorded_through_a_linked_index(self):
+        workspace.ensure("task")
+        workspace.scaffold_memory("task")
+        self.live_vault_link(memstore.index_path(workspace.memory_dir("task")))
+        with self.assertRaises(contain.Refused):
+            workspace.note("task", "the sky is blue")
+        self.assertVaultIntact("a workspace note was appended into the vault")
+
+    def test_curate_does_not_repair_an_index_through_a_link(self):
+        """`curate --apply` re-appends every unindexed file, so a linked index turns one
+        operator command into N appends. It must refuse, and — because `apply_safe`
+        returns a log the operator reads — it must say so there rather than raise out of
+        a batch that has already archived files."""
+        self.make_persona("victim")
+        mem = persona.memory_dir("victim")
+        memstore.write(mem, "a real memory", "kept", index=False)
+        self.live_vault_link(persona.index_of(mem))
+
+        actions = self.completes(lambda: curate.apply_safe(mem), "curate.apply_safe")
+        self.assertIsNone(actions.get("e"),
+                          f"apply_safe must not raise out of a batch: {actions.get('e')}")
+        self.assertVaultIntact("curate repaired the index into the vault")
+        self.assertTrue(any("outside the directories" in a for a in actions.get("r") or []),
+                        f"the refusal must reach the operator's log, got {actions.get('r')}")
+
+    def test_archive_does_not_move_a_memory_out_through_a_linked_directory(self):
+        """`archive/` is the fourth fixed name in the store, and `rename` follows a link
+        on the destination directory exactly as `open` does on a file."""
+        self.make_persona("victim")
+        mem = persona.memory_dir("victim")
+        persona.remember("victim", "the sky is blue")
+        elsewhere = self.outside / "stolen"
+        elsewhere.mkdir(parents=True)
+        self.link(mem / "archive", elsewhere)
+
+        self.completes(lambda: memstore.archive(mem, "the-sky-is-blue"),
+                       "memstore.archive into a linked directory")
+        self.assertEqual([], sorted(p.name for p in elsewhere.iterdir()),
+                         "charter moved a memory out of the plane")
+
+    def test_doctor_says_when_it_will_not_touch_an_index(self):
+        """A refusal nobody can see is how #337 happened, and the store is the one place
+        where refusing is *quiet*: `files()` and `_listed` both answer "nothing", which a
+        base with no memories is indistinguishable from. `doctor` reported
+        "3 base(s) consistent" over an index pointing at a vault.
+
+        ADR 0009 — name what was actually checked. "1 unindexed" would send the operator
+        to `charter persona optimize`, which cannot repair an index charter refuses to
+        write, so the hint that looked helpful would be the one that wasted their time.
+        """
+        from charter import doctor
+        self.make_persona("victim")
+        memstore.write(persona.memory_dir("victim"), "a real memory", "kept", index=False)
+        self.live_vault_link(persona.index_of(persona.memory_dir("victim")))
+
+        r = doctor.check_memory_indexes()
+        self.assertNotEqual(doctor.OK, r.status,
+                            "doctor reported a refused index as consistent")
+        said = f"{r.detail} {r.hint or ''}"
+        self.assertIn("victim", said, "the refusal must name WHICH base")
+        self.assertIn("outside the directories", said,
+                      f"doctor must say why charter will not touch it, got {said!r}")
+
+    def test_doctor_does_not_flag_a_base_whose_index_is_simply_absent(self):
+        """The ENOENT rule again, one layer up — and the regression the first draft of
+        this check shipped. `charter init` scaffolds `personas/<front-door>/memory/` with
+        a `.gitkeep` and **no MEMORY.md**, so asking the READ-side gate here ("a path that
+        is not there is a refusal") reported every fresh plane as holding an index charter
+        refuses to touch. Found against the real CLI, not in the suite.
+        """
+        from charter import doctor
+        self.make_persona("fresh")
+        idx = persona.index_of(persona.memory_dir("fresh"))
+        idx.unlink(missing_ok=True)
+        self.assertTrue(idx.parent.is_dir() and not idx.exists(),
+                        "precondition: the base exists, its index does not")
+
+        r = doctor.check_memory_indexes()
+        self.assertEqual(doctor.OK, r.status,
+                         f"an absent index is not a defect, got {r.detail!r} {r.hint!r}")
+
+
+class FixedNameWritesAreContained(WriteFixtures):
+    """Every other write charter aims at a name an attacker can predict.
+
+    #349 names four functions in `memstore`; the shape is not theirs. Any write to a name
+    charter chooses, inside a directory a commit controls, can be pre-replaced with a link
+    — and `git checkout` materialises symlinks. Table-driven for the reason #342 gave:
+    the next fixed-name write that skips containment should fail here rather than ship.
+
+    **The boundary is `contain.data_roots()`.** These are the sites whose targets already
+    sit inside the directories the read half defends — `personas/` and `workspaces/`.
+    Charter writes to plenty of committed names *outside* them (`charter.toml`,
+    `.gitignore`, `.claude/settings.json`, `inventory/repos.json`, `vaults.json`), and
+    those have the same defect but no boundary to check against: `data_roots()` excludes
+    them by design, because `.charter/` sits under ROOT and must stay excluded. Extending
+    the boundary is a separate decision, and inventing one here would have drawn it
+    silently.
+
+    **Two contracts, and mixing them up would be the bug.** A write on a CLI path raises,
+    so nothing is lost silently. A write from a *hook* — `dispatch`, `skilluse`, `pieces`
+    — is a tally that already promises "best-effort: never break a turn", so it refuses by
+    declining to write and answering None, exactly as it already does for `OSError`.
+    """
+
+    def outside_target(self, name: str) -> Path:
+        """A file outside the plane, with known bytes, to catch a redirected write."""
+        t = self.outside / name
+        t.write_text("UNTOUCHED")
+        return t
+
+    def assertRedirectRefused(self, target: Path, label: str) -> None:
+        self.assertEqual("UNTOUCHED", target.read_text(),
+                         f"{label} was redirected through a committed link")
+
+    # ------------------------------------------------- unattended: refuse, never raise
+    def test_a_dispatch_tally_is_not_appended_through_a_link(self):
+        """The highest-reachability site in the audit: driven by the PostToolUse hook on
+        every sub-agent dispatch, with nobody typing anything. The filename is not even a
+        guess — `personas/_dispatch/<YYYY-MM>.<host>.jsonl` is a committed file, so the
+        attacker edits the one already in the repo."""
+        from charter import dispatch
+        target = self.outside_target("dispatch-victim.json")
+        self.escaping_link(dispatch.path_for(), target)
+        self.assertIsNone(dispatch.record("forge"), "a refused tally answers None")
+        self.assertRedirectRefused(target, "dispatch.record")
+
+    def test_dispatch_advice_is_not_appended_through_a_link(self):
+        from charter import dispatch
+        target = self.outside_target("advice-victim.json")
+        self.escaping_link(dispatch.path_for(), target)
+        self.assertIsNone(dispatch.record_advice())
+        self.assertRedirectRefused(target, "dispatch.record_advice")
+
+    def test_a_skill_tally_is_not_appended_through_a_link(self):
+        from charter import skilluse
+        target = self.outside_target("skills-victim.json")
+        self.escaping_link(skilluse.path_for(), target)
+        self.assertIsNone(skilluse.record("brainstorming"))
+        self.assertRedirectRefused(target, "skilluse.record")
+
+    def test_a_piece_event_is_not_appended_through_a_link(self):
+        from charter import pieces
+        workspace.ensure("task")
+        target = self.outside_target("pieces-victim.json")
+        self.escaping_link(pieces.log_path("task"), target)
+        self.assertIsNone(pieces.record("task", "claimed", "repo", "p1"))
+        self.assertRedirectRefused(target, "pieces.record")
+
+    def test_a_presence_beat_is_not_written_through_a_link(self):
+        """`seen` **overwrites** rather than appends, so a redirect here destroys the
+        target outright — and it is hook-driven too."""
+        from charter import pieces
+        workspace.ensure("task")
+        target = self.outside_target("seen-victim.json")
+        self.escaping_link(pieces.seen_path("task", "repo", None), target)
+        self.assertIsNone(pieces.seen("task", "repo", None, session="s"))
+        self.assertRedirectRefused(target, "pieces.seen")
+
+    def test_an_unattended_tally_never_raises_on_a_refusal(self):
+        """The contract these three already carry, asserted rather than assumed: a hook
+        may cost a session its briefing and never its turn. `contain.Refused` escaping
+        into `hooks.pretooluse` would break every dispatch on a plane with one bad link."""
+        from charter import dispatch, pieces, skilluse
+        workspace.ensure("task")
+        for label, path, call in (
+            ("dispatch", dispatch.path_for(), lambda: dispatch.record("forge")),
+            ("skilluse", skilluse.path_for(), lambda: skilluse.record("s")),
+            ("pieces", pieces.log_path("task"), lambda: pieces.record("task", "claimed", "r", "p1")),
+        ):
+            with self.subTest(site=label):
+                self.escaping_link(path, self.vault)
+                try:
+                    self.assertIsNone(call())
+                except contain.Refused as e:
+                    self.fail(f"{label} raised into a hook path: {e}")
+                self.assertVaultIntact(f"{label} wrote into the vault")
+
+    # ------------------------------------------------------ CLI paths: refuse loudly
+    def test_persona_scaffolding_does_not_write_through_a_link(self):
+        """`persona.scaffold_memory` writes `MEMORY.md` itself rather than through
+        `memstore.ensure_index`, so gating the store alone leaves this one open — the same
+        fixed name, one function over."""
+        d = config.PERSONAS_DIR / "victim"
+        d.mkdir(parents=True, exist_ok=True)
+        target = self.outside_target("scaffold-victim.json")
+        self.escaping_link(persona.memory_dir("victim") / "MEMORY.md", target)
+        with self.assertRaises(contain.Refused):
+            persona.scaffold_memory("victim")
+        self.assertRedirectRefused(target, "persona.scaffold_memory")
+
+    def test_persona_refs_readme_is_not_written_through_a_link(self):
+        d = config.PERSONAS_DIR / "victim"
+        d.mkdir(parents=True, exist_ok=True)
+        target = self.outside_target("refs-victim.json")
+        self.escaping_link(persona.refs_dir("victim") / "README.md", target)
+        with self.assertRaises(contain.Refused):
+            persona.scaffold_memory("victim")
+        self.assertRedirectRefused(target, "persona.scaffold_memory refs/README.md")
+
+    def test_a_workspace_vision_is_not_written_through_a_link(self):
+        """`workspace.read_charter` already calls `contain.file_refusal`; `set_vision`
+        reads *and* rewrites the same file with nothing in between. One file, one name,
+        a guard on one side of it."""
+        workspace.ensure("task")
+        target = self.outside_target("vision-victim.json")
+        self.escaping_link(workspace.charter_file("task"), target)
+        with self.assertRaises(contain.Refused):
+            workspace.set_vision("task", "ship it")
+        self.assertRedirectRefused(target, "workspace.set_vision")
+
+    def test_a_workspace_manifest_is_not_written_through_a_link(self):
+        workspace.ensure("task")
+        target = self.outside_target("manifest-victim.json")
+        self.escaping_link(workspace.manifest_path("task"), target)
+        with self.assertRaises(contain.Refused):
+            workspace.write_manifest("task", {"repos": []})
+        self.assertRedirectRefused(target, "workspace.write_manifest")
+
+    def test_the_declared_default_workspace_is_not_written_through_a_link(self):
+        workspace.ensure("task")
+        target = self.outside_target("default-victim.json")
+        self.escaping_link(config.WORKSPACES_DIR / ".default", target)
+        with self.assertRaises(contain.Refused):
+            workspace.set_declared_default("task")
+        self.assertRedirectRefused(target, "workspace.set_declared_default")
+
+    # ------------------------------------------------------------- the benign half
+    def test_every_gated_site_still_works_on_an_ordinary_plane(self):
+        """The half that catches a fix which contains writes by refusing them all —
+        every site above, with nothing planted."""
+        from charter import dispatch, pieces, skilluse
+        self.make_persona("real")
+        workspace.ensure("task")
+        self.assertIsNotNone(dispatch.record("real"))
+        self.assertIsNotNone(dispatch.record_advice())
+        self.assertIsNotNone(skilluse.record("brainstorming"))
+        self.assertIsNotNone(pieces.record("task", "claimed", "repo", "p1"))
+        self.assertIsNotNone(pieces.seen("task", "repo", None, session="s"))
+        persona.scaffold_memory("real")
+        self.assertTrue(persona.index_of(persona.memory_dir("real")).is_file())
+        workspace.set_vision("task", "ship it")
+        self.assertIn("ship it", workspace.charter_file("task").read_text())
+        workspace.write_manifest("task", {"repos": []})
+        self.assertTrue(workspace.manifest_path("task").is_file())
+        workspace.set_declared_default("task")
+        self.assertEqual("task", (config.WORKSPACES_DIR / ".default").read_text().strip())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #349. Closes #329. Closes #343 as **won't-fix on the revocation**, with the divergence it names closed by reporting instead — argued below.

## #349 — a committed symlink redirected charter's writes

#348 gated every *read* of plane data. The write side never went through `memstore.files()` and inherited none of it.

Reproduced against the **real CLI on `main`** (post-#348), with `personas/victim/memory/MEMORY.md` committed as a link to `.charter/vaults/devops.json`:

```
$ charter persona remember victim "the sky is blue"
✓ Remembered (persistent) → personas/victim/memory/the-sky-is-blue.md

vault grew                : True (38 -> 78 bytes)
vault still parses as JSON: NO -- JSONDecodeError: Extra data: line 2 column 1
```

After:

```
✗ '…/personas/victim/memory/MEMORY.md' resolves to '…/.charter/vaults/devops.json',
  outside the directories a control plane keeps its data in (persona-state, personas,
  workspaces). A committed symlink there redirects the write, …          (rc=1)
```

No orphan memory file, no crash report filed, benign path unaffected.

### `contain.write_refusal`

`file_refusal`'s twin over one shared body, with the single difference **named** rather than kept in step by hand — the divergence between two checks that read the same file is what #328 and #342 were both about.

**ENOENT is that difference.** On a read, a path that is not there is a refusal; on a write it is the normal case. Both directions are held by tests that fail in opposite directions:

- read it as a refusal → every first write on a fresh plane breaks;
- skip the check because `exists()` is false → a **dangling** link still creates its target wherever it points, which is strictly worse than the append and invisible to any `exists()`-gated write.

It checks the **parent directory** itself rather than leaving that to callers: a write has no listing loop to amortise it over, and a linked `memory/` is precisely the case a per-file check cannot see — every file inside it is an ordinary regular file.

`Refused` is deliberately **not** a `ValueError`: three bare `except ValueError` clauses in the command layer would have swallowed it. Caught once in `cli.main`, beside `ProcTimeout` and for its stated reason — *a child that outlived its budget is a condition, not a bug*. So is a committed file that redirects a write, and reaching the `except Exception` below would file a crash report against charter for a defect in the plane's data.

### The fixed-name-write audit

Swept every write site in `charter/`. Fixed here: every one whose target already sits inside `contain.data_roots()`.

- **memstore** — the four named in the issue, plus two the issue did not: `archive` (a fifth fixed name; `rename` follows a link on the destination directory) and `_drop_index_line`, the only **truncating** write — where `remember` corrupts a vault, `forget` replaces it.
- **`MEMORY.md` had no gate on the READ side either.** `files()` filters it out *by name*, so the one file with the most predictable name in the store was the only one gated on neither side. `index_drift` — which `doctor` runs per base at SessionStart — opened whatever it pointed at, and a FIFO there hung the briefing.
- **`persona.scaffold_memory`** writes `MEMORY.md` itself rather than through `ensure_index` — gating the store alone left the same hole one function over.
- **`workspace`** — `set_vision`, `scaffold_charter`, `write_manifest`, `set_declared_default`. `read_charter` already called `contain.file_refusal`; `set_vision` read *and* rewrote that same file with nothing in between.
- **`dispatch`, `skilluse`, `pieces`** — the highest-reachability sites found: driven by the PostToolUse hook with nobody typing, at filenames already committed in the repo. These **decline and answer `None`**, matching the "best-effort, never break a turn" contract they already carry for `OSError`. A test asserts they never raise into a hook path.

**Not fixed, and deliberately so:** `charter.toml`, `.gitignore`, `.claude/settings.json`, `inventory/repos.json`, `vaults.json` — same shape, but all *outside* `data_roots()`, which excludes them by design because `.charter/` sits under ROOT. Extending that boundary is its own decision; inventing one quietly inside this PR would have been the worse answer. Full site list in the report on the issue.

## #329 — verified closed, not re-fixed

Its path-resolution half closed in #342; the issue was never updated. Confirmed against the **real gate** (`charter persona tool-gate` over stdin, as the hook drives it), with an out-of-plane definition declaring `sh`:

```
lint  ✗ uses: '../../outside-personas/evil' is not a name — it is a path
gate  gh --version -> allow    ← its own tools:, so the gate IS consulted
gate  sh -c x      -> None     ← the out-of-plane grant contributes nothing
gate  curl x       -> None     ← so it is not simply allowing everything
```

The `tools:` → `allow` grant itself is by design and stays.

## #343 — measured, then declined; the divergence closed by saying it

Direction (1) — gate ignores a persona with non-empty `structural_errors` — was measured before being declined. In all three shapes of breakage (a `uses:` that is a path, a `uses:` that is a typo, an `extends:` cycle) the surviving grant is **exactly** the persona's own `tools:` plus what a reader of those same files would compute. `load()` returns `None` for a reference that is not a name, so a broken reference already contributes nothing. **Gating buys no containment and costs a grant the operator wrote by hand.**

It would also cost it *silently*, which is what decided it: `hooks.pretooluse` emits nothing when `decide` declines, so a revoked grant is indistinguishable from a tool never declared — an unexplained prompt with nothing connecting it to the typo. The two channels that could say otherwise at the moment it happens are `hooks.py` and `statusline.py`, both outside this change.

So the divergence closes by being said out loud:

```
!  persona grant   'typo' is broken and still auto-approves gh
     → uses: 'forge-typoed' — no such persona (dangling)
       → charter persona lint typo  (the gate reads this persona's tools whether or not
         it loads cleanly, so a prompt you expected to see may not appear)
```

The mirror of `check_ask_rules`, which names where a persona's tools quietly *stop* being pre-approved. Separate from `check_personas`, which would say "4 with error(s)" whether or not any of them were the acting identity — the pairing is the content. Silent when the active persona is well-formed, when it grants nothing, and when there is none.

## Verification

**3065 → 3109**, all green, 86s. Plus the real CLI at every step — three of the last four defects on this audit were found that way and none of them in the suite.

Every case plants a live link or FIFO and proves the OS follows or blocks on it **before** charter is asked to refuse. Two fixtures were rebuilt after passing against *unfixed* code, and both are now documented in the file so they are not simplified back:

- a one-line vault round-tripped `_drop_index_line`'s rewrite byte-identically — mtime is asserted too;
- one shared FIFO helper cannot prove both directions, because the blocked *writer* that proves the write case is exactly what satisfies the reader the read case needs blocked.

Two real-CLI findings the suite did not produce:
- `doctor` reported a base whose index points at a vault as **"consistent"** — a refused index answers "nothing listed", which an empty base answers too;
- the first version of that fix flagged **every fresh plane**, because `charter init`'s own front door has `memory/` with a `.gitkeep` and no `MEMORY.md`, and the read-side gate calls a missing file a refusal.

Untouched as instructed: `tui.py`, `statusline.py`, `util.py`, `forge/`, `glstate.py`, and the sibling agent's `hooks.py`, `instance.py`, `config.py`, `news.py`. No version bump, tag, or release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo