### PR TITLE
Two diagnostics that reported the wrong thing, in the direction that hid a problem (#321, #322)

### DIFF
--- a/charter/news.py
+++ b/charter/news.py
@@ -240,6 +240,17 @@ def _parser():
     return cli.build_parser()
 
 
+def _shell_syntax(argv: str) -> bool:
+    """Would a shell read anything in *argv* as syntax?
+
+    Its own function because two callers need the same answer and they need it for
+    different purposes: :func:`_tokens` refuses on it, and :func:`_dispatch` has to know
+    *which* of `_tokens`' two refusals fired to say whose defect it is (#321). A second
+    ``set(argv) & _SHELLISH`` at the second call site is how the two would drift.
+    """
+    return bool(argv) and bool(set(argv) & _SHELLISH)
+
+
 def _tokens(argv: str, parser=None) -> list[str] | None:
     """*argv* as a charter subcommand's tokens, or ``None`` if it is not one.
 
@@ -247,10 +258,15 @@ def _tokens(argv: str, parser=None) -> list[str] | None:
     syntax, and any first token that is not a registered subcommand. `charter` is implied
     and must not be written, so an entry cannot reach a different binary.
 
+    They are not the same defect, and :func:`_dispatch` tells them apart before it reports
+    one. Shell syntax can never run on any machine in any version; an unregistered first
+    token is a command *this* charter does not have. ``None`` is the right answer to both,
+    which is exactly why the reason cannot be read off it.
+
     *parser* is optional and is threaded through rather than rebuilt because building one
     is ~6ms and this module runs on the `doctor` and SessionStart paths, once per entry.
     """
-    if not argv or set(argv) & _SHELLISH:
+    if not argv or _shell_syntax(argv):
         return None
     tokens = argv.split()
     if not tokens:
@@ -513,6 +529,11 @@ def _dispatch(argv: str) -> int | None:
     command a ``check:`` may name at all (:func:`probeable`, #317). Each returns ``None``,
     and each records its own reason, because the entry a reader has to go and fix is a
     different entry in each case.
+
+    The first of those is really two, and reading its bare ``None`` as one was #321.
+    Shell syntax is the entry's defect and reports as such; an unregistered first token is
+    this machine's news about itself and keeps ``_NOT_RUN``. So the reason is taken from
+    :func:`_shell_syntax` rather than from the ``None``, which cannot carry it.
     """
     global _depth, _refused
     if not _depth:
@@ -525,6 +546,18 @@ def _dispatch(argv: str) -> int | None:
     parser = _parser()
     tokens = _tokens(argv, parser)
     if tokens is None:
+        if _shell_syntax(argv):
+            # `_tokens` refuses two things and this is the one that is the ENTRY's defect:
+            # a `check:` carrying shell syntax can never run — not here, not on any machine,
+            # not in any version — so "did not run here" sends its author to look at a
+            # laptop that has nothing wrong with it (#321). The other refusal, a first
+            # token this CLI does not register, really is a fact about here: an entry
+            # written against a charter this one is not. It keeps `_NOT_RUN`.
+            #
+            # Same reason as an unlisted command rather than a sixth string, because it is
+            # the same finding — the entry names something a probe cannot run — and the fix
+            # is the same one: pick from the short list.
+            _refused = _UNLISTED
         return None
     if probing():
         _refused = _PROBES

--- a/charter/secrets/onepassword.py
+++ b/charter/secrets/onepassword.py
@@ -60,6 +60,14 @@ _DIAGNOSES: tuple[tuple[str, str], ...] = (
      "1Password refused this as unauthorised. For a service-account token that usually "
      "means it has no WRITE access to this vault — the same token reads perfectly well, "
      "which is what makes the failure look like a charter bug."),
+    # Reported in #322: an agent invoking the path charter invokes saw "Too many requests.
+    # Your client has been rate-limited." across ~17 attempts with backoff. `op` still
+    # exits 1 — the same code as "no such item" — which is precisely why the exit status
+    # cannot classify this, and why it read as four empty vaults. The advice is the part
+    # the operator did not get: wait, and do not conclude anything about the contents.
+    ("rate-limited",
+     "1Password rate-limited this client. Its contents are UNKNOWN — this is not an empty "
+     "vault. Wait and retry rather than re-provisioning secrets that are probably there."),
     # Reported in #78 against op 2.34.0: `op` says this when it never parsed the JSON
     # template, which DOES declare a category. The flag it asks for is a red herring,
     # and supplying it is actively destructive, so the hint has to say so.
@@ -250,13 +258,29 @@ class OnePasswordProvider(VaultProvider):
         self._write(fields, creating=False)
 
     def keys(self) -> list[str]:
-        """The item's field names. Empty when the item does not exist yet."""
+        """The item's field names. Empty when the item PROVABLY does not exist yet.
+
+        Raises rather than returning ``[]`` when charter could not read the vault, because
+        the caller renders the two differently and cannot tell them apart from a list
+        (#322): `cmd_secret_list` prints "has no secrets" and exits 0 for the first, and
+        must report and exit non-zero for the second.
+        """
         return sorted(self._fields())
 
     # --- helpers ----------------------------------------------------------- #
-    def _list_items(self) -> list[str]:
-        proc = self._run(self._argv("item", "list", "--vault", self.op_vault,
-                                    "--tags", self._vault_tag(), "--format", "json"))
+    def _list_items(self, tagged: bool = True) -> list[str]:
+        """Item titles in the op-vault. Tagged as charter's by default.
+
+        ``tagged=False`` is for the one question the tag cannot answer: is this vault's
+        item *there*? An item charter adopted rather than created carries no charter tag —
+        that is the whole point of `op-item` — so a tagged listing would report it absent
+        and :meth:`_fields` would call an unreadable vault empty for exactly the vaults
+        most likely to be somebody's hand-curated item.
+        """
+        argv = ["item", "list", "--vault", self.op_vault]
+        if tagged:
+            argv += ["--tags", self._vault_tag()]
+        proc = self._run(self._argv(*argv, "--format", "json"))
         if proc.returncode != 0:
             raise self._fail(f"listing vault '{self.name}'", proc)
         try:
@@ -274,7 +298,8 @@ class OnePasswordProvider(VaultProvider):
         return proc.returncode == 0
 
     def _fields(self, reveal: bool = False) -> dict:
-        """This vault's secrets as ``{field: value}``. ``{}`` if there is no item yet.
+        """This vault's secrets as ``{field: value}``. ``{}`` if there is no item yet, and
+        a :class:`VaultError` if charter could not tell — never ``{}`` for a failed read.
 
         ``reveal`` is **off by default and belongs only to the write path.** With it, `op`
         returns real values — which is what makes the read-modify-write safe, since writing
@@ -290,6 +315,30 @@ class OnePasswordProvider(VaultProvider):
             argv.append("--reveal")
         proc = self._run(self._argv(*argv))
         if proc.returncode != 0:
+            # A vault charter could not READ is not a vault with no secrets (#322).
+            #
+            # `op item get` exits non-zero for "there is no item yet" and for every way the
+            # read can fail — rate limit, expired session, a token that cannot see this
+            # vault, the wrong `op-vault` name — and this used to return `{}` for all of
+            # them. So a failure arrived everywhere as a benign state: `secret list` said
+            # "has no secrets" about a populated vault, `health()` called it fine, and the
+            # read-modify-write in `set` piped back an item holding only the key being
+            # written, silently dropping every sibling secret. An operator lost an hour to
+            # re-provisioning credentials that were already there, and could not verify the
+            # result because the same mask was still in place.
+            #
+            # The two diagnoses demand opposite responses — go and populate it, versus
+            # check the identity and treat the contents as unknown — so absence is now
+            # PROVEN rather than assumed, and proven by this vault's own identity: if
+            # `op item list` can read the vault and the item is not in it, there is no
+            # item. If that read fails too, the failure IS the answer and it propagates.
+            #
+            # Untagged, because an adopted `op-item` carries no charter tag. And no
+            # matching of `op`'s English on this path, unlike `_diagnose`, which only
+            # sharpens a message: here a missed signature would turn a failure back into
+            # an empty vault, which is the bug.
+            if self.op_item in self._list_items(tagged=False):
+                raise self._fail(f"reading vault '{self.name}'", proc)
             return {}
         try:
             doc = json.loads(proc.stdout or "{}")

--- a/tests/test_news_reason_names_the_entry.py
+++ b/tests/test_news_reason_names_the_entry.py
@@ -1,0 +1,157 @@
+"""A refused `check:` blames whatever is actually at fault — the entry, or this machine.
+
+`news.py` keeps five reasons for having no answer, and the split between two of them is
+the whole of #321. Its own comment states it:
+
+    "Did not run here" points the reader at their own machine, which is right for a check
+    this CLI could not resolve and wrong for an entry whose `check:` can never run
+    anywhere — folding those together hides the second behind the first.
+
+A `check:` containing shell syntax is the second kind. It cannot run on any machine, in
+any version, ever; the entry is broken and somebody has to go and fix it. It was reported
+as the first kind, because `_tokens` refuses shell syntax and an unregistered first token
+in one breath and both arrive at `_dispatch` as a bare ``None`` — so the maintainer who
+wrote the bad entry was told to go and look at their own laptop.
+
+The pair that must stay apart is the pair this file tests, and it is not shell-syntax vs
+unlisted — both of those are the entry's defect and say so. It is **entry-side** vs
+**machine-side**: a command this CLI does not have is genuinely "did not run here" (an
+entry written against a charter this one is not), and folding *that* into the entry-side
+reason would be the same bug pointing the other way. Both directions are asserted here.
+
+Nothing is dispatched by any test below: every `check:` used is refused before a command
+function is reached, which is asserted rather than assumed.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import cli, news
+
+#: A `check:` that can never run anywhere: `&` is shell syntax, so `_tokens` refuses it.
+#: Its first token is a real, listed subcommand on purpose — that is what makes the
+#: refusal attributable to the shell syntax and to nothing else.
+SHELLISH_CHECK = "doctor && echo adopted"
+
+#: A `check:` naming a command that exists and is registered, but that a probe may not
+#: run (`_PROBEABLE`). The entry-side reason charter already gets right.
+UNLISTED_CHECK = "secret exec devops -- true"
+
+#: A `check:` this CLI cannot resolve at all. Machine-side: an entry written against a
+#: charter that has the command, read by one that does not.
+UNRESOLVED_CHECK = "frobnicate --hard"
+
+
+class NewsDir(unittest.TestCase):
+    """Entries read from a throwaway directory, so no test depends on what shipped."""
+
+    def setUp(self) -> None:
+        self.dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.dir, ignore_errors=True)
+        patch = mock.patch.object(news, "_PACKAGED", self.dir)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def write(self, check: str, *, slug: str = "x") -> news.Entry:
+        (self.dir / f"0.44.0-{slug}.md").write_text(
+            f"---\nversion: 0.44.0\nheadline: h\ncheck: {check}\nadopt: version\n---\nbody\n")
+        entries = [e for e in news.released() if e.slug == slug]
+        # Really released, or `probe` is being handed something no caller would reach and
+        # every assertion below is vacuous.
+        self.assertEqual(len(entries), 1, "the planted entry is not released")
+        self.assertEqual(entries[0].check, check, "the frontmatter did not survive parsing")
+        return entries[0]
+
+    def why(self, check: str) -> str:
+        status, why = news.probe(self.write(check))
+        self.assertEqual(status, news.UNKNOWN, f"`{check}` was not refused at all")
+        return why
+
+
+class ThePreconditionsTheseTestsRestOn(NewsDir):
+    """Assert the gate under test is the gate that fires.
+
+    Every assertion in this file is about *which* refusal happened. If the shellish check
+    were refused for being an unregistered command, or the unresolved one for containing
+    shell syntax, the tests below would still pass and would prove nothing.
+    """
+
+    def test_the_shellish_check_is_refused_by_the_shell_gate_and_not_the_other_one(self):
+        parser = cli.build_parser()
+        self.assertTrue(set(SHELLISH_CHECK) & news._SHELLISH,
+                        "the check under test contains no shell syntax")
+        self.assertIn(SHELLISH_CHECK.split()[0], cli._subcommand_names(parser),
+                      "its first token is not a subcommand, so `_tokens` would refuse it "
+                      "for the machine-side reason and this file would test nothing")
+        self.assertIsNone(news._tokens(SHELLISH_CHECK, parser),
+                          "`_tokens` accepted it, so no refusal is under test")
+
+    def test_the_shell_gate_is_what_stands_between_this_check_and_a_dispatch(self):
+        """Without the shell refusal this entry would REACH `doctor`: `_command_path`
+        stops at `&&` and reports `("doctor",)`, which is listed. So the gate is load
+        bearing, and the reason it records is the only thing #321 changes."""
+        parser = cli.build_parser()
+        tokens = SHELLISH_CHECK.split()
+        self.assertIn(news._command_path(tokens, parser), news._PROBEABLE)
+
+    def test_the_unresolved_check_is_refused_for_naming_no_command_here(self):
+        parser = cli.build_parser()
+        self.assertFalse(set(UNRESOLVED_CHECK) & news._SHELLISH,
+                         "it contains shell syntax, so it is the other case")
+        self.assertNotIn(UNRESOLVED_CHECK.split()[0], cli._subcommand_names(parser))
+
+    def test_the_unlisted_check_names_a_real_command_a_probe_may_not_run(self):
+        parser = cli.build_parser()
+        self.assertFalse(set(UNLISTED_CHECK) & news._SHELLISH)
+        self.assertIsNotNone(news._tokens(UNLISTED_CHECK, parser),
+                             "it never reaches the `_PROBEABLE` gate")
+        self.assertFalse(news.probeable(UNLISTED_CHECK, parser))
+
+
+class AShellSyntaxCheckBlamesTheEntry(NewsDir):
+    def test_it_does_not_point_the_reader_at_their_own_machine(self):
+        """The sentence #321 is about. Nothing on the reader's machine is wrong, and
+        every machine that installs this entry gets the same refusal."""
+        self.assertNotIn("did not run here", self.why(SHELLISH_CHECK))
+
+    def test_it_says_the_entry_is_not_something_a_check_may_name(self):
+        """Same defect class as an unlisted command — the entry names something a probe
+        cannot run — so it reuses that reason rather than inventing a sixth."""
+        self.assertIn("is not a command a `check:` may name", self.why(SHELLISH_CHECK))
+
+    def test_it_names_the_entrys_own_check(self):
+        """A sweep prints a list. A reason that does not quote the broken `check:` is one
+        nobody can act on."""
+        self.assertIn(SHELLISH_CHECK, self.why(SHELLISH_CHECK))
+
+    def test_it_reads_the_same_as_an_unlisted_command(self):
+        """Both are the entry's defect, so they are the same diagnosis. This is the
+        assertion that would break if a sixth string were added for shell syntax."""
+        self.assertEqual(self.why(SHELLISH_CHECK).replace(SHELLISH_CHECK, ""),
+                         self.why(UNLISTED_CHECK).replace(UNLISTED_CHECK, ""))
+
+
+class ACheckThisCliCannotResolveStillBlamesTheMachine(NewsDir):
+    """The other direction, and the reason the two gates inside `_tokens` cannot simply
+    both be folded onto the entry. A `check:` naming a command this charter does not have
+    is an entry written against a charter this one is not — which IS a fact about here."""
+
+    def test_it_says_the_probe_did_not_run_here(self):
+        self.assertIn("did not run here", self.why(UNRESOLVED_CHECK))
+
+    def test_it_does_not_blame_the_entry(self):
+        self.assertNotIn("is not a command a `check:` may name", self.why(UNRESOLVED_CHECK))
+
+    def test_a_listed_command_with_a_flag_this_cli_lacks_also_did_not_run_here(self):
+        """The same machine-side shape one gate further in: the command exists and is
+        listed, and only the flag is gone. `doctor` is real and probeable, so this is
+        refused by the parser rather than by either gate in `_tokens`."""
+        check = "doctor --a-flag-no-charter-ever-had"
+        self.assertTrue(news.probeable(check, cli.build_parser()),
+                        "it was refused before the parser, so this tests the wrong gate")
+        self.assertIn("did not run here", self.why(check))

--- a/tests/test_op_unreadable_vault_is_not_empty.py
+++ b/tests/test_op_unreadable_vault_is_not_empty.py
@@ -1,0 +1,341 @@
+"""A 1Password vault charter could not read is not a vault with no secrets (#322).
+
+Reported through `charter report bug` by an operator whose four populated vaults all
+printed::
+
+    • Vault 'devops' has no secrets.
+
+The vaults were fine. `op` was rate-limiting the client — an earlier agent on the same
+path saw *Too many requests. Your client has been rate-limited.* across ~17 attempts —
+and `OnePasswordProvider._fields` turned every non-zero exit of `op item get` into `{}`:
+
+    if proc.returncode != 0:
+        return {}
+
+`keys()` sorts that into `[]` and `cmd_secret_list` prints "has no secrets". The failure
+arrived as a benign state, which is the same species as `doctor`'s `_NOT_CHECKED_HINT`
+(ADR 0013) and #55's "0 secrets, all fine" over a vault whose credentials charter had
+simply stopped being able to see.
+
+The two diagnoses demand opposite responses — *go and populate it* versus *check the
+token, and the contents are unknown* — so an hour went into re-provisioning secrets that
+were already there, and the re-provisioning could not be verified afterwards because the
+same masked failure was still masking it. It also inverts the guardrail in charter's own
+guidance, "do not reach past charter to raw `op` because a vault is empty": that
+instruction assumes *empty* is true, and when empty is a lie the pressure to bypass
+charter goes up rather than down.
+
+**Absence is proven here, not assumed.** `op item get` exits non-zero both for "there is
+no such item yet" and for every way a read can fail, so the exit code cannot tell them
+apart and neither can charter. What can: ask this vault's *own identity* to list the
+vault. A listing that succeeds and does not contain the item proves there is no item. A
+listing that fails is the answer — the read failed, and it propagates. No matching of
+`op`'s English anywhere on this path, so a reworded error cannot quietly turn a failure
+back into an empty vault.
+
+Every test below asserts its own precondition, because the one way this file could pass
+while proving nothing is a fixture whose vault is genuinely empty.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_secrets
+from charter.secrets import base
+from charter.secrets.onepassword import OnePasswordProvider
+
+#: What `op` writes when a service account has been rate-limited. Quoted from the session
+#: in #322 — the operator's own `op` output, from an agent invoking the path charter
+#: invokes. The process still exits 1, the same code as "no such item", which is exactly
+#: why the exit status cannot classify this.
+RATE_LIMITED = "[ERROR] 2026/08/20 11:02:31 Too many requests. Your client has been rate-limited."
+
+#: What `op` writes for an item that is not there. charter deliberately does **not** match
+#: on this text — absence is proven by a successful listing instead — so this string is
+#: here for realism and nothing depends on its wording.
+NO_SUCH_ITEM = '[ERROR] 2026/08/20 11:02:31 "charter-devops" isn\'t an item.'
+
+ITEM = "charter-devops"
+
+
+class FakeOp:
+    """`op`, with each subcommand's outcome settable on its own.
+
+    Separate from the fake in `test_onepassword_single_item`, whose `fail_on` fails
+    whatever a substring matches. The distinction under test is precisely *which* `op`
+    call failed, so it has to be set per subcommand.
+    """
+
+    def __init__(self, *, fields=None, titles=(ITEM,), fails=(), stderr=RATE_LIMITED):
+        self.calls: list[dict] = []
+        self.fields = dict(fields or {})
+        #: Item titles the vault holds, as this identity can see them.
+        self.titles = list(titles)
+        #: Subcommands that fail, e.g. ``{"item get", "item list"}``.
+        self.fails = set(fails)
+        self.stderr = stderr
+
+    @staticmethod
+    def _sub(argv) -> str:
+        words = [w for w in argv[1:] if not w.startswith("-")]
+        if words[:1] == ["item"]:
+            return " ".join(words[:2])
+        return words[0] if words else ""
+
+    def _item_json(self) -> str:
+        return json.dumps({
+            "id": "itm1", "title": ITEM, "category": "PASSWORD",
+            "fields": [{"id": k, "label": k, "type": "CONCEALED", "value": v}
+                       for k, v in self.fields.items()],
+        })
+
+    def __call__(self, argv, input=None, check=False, env=None, **kw):
+        sub = self._sub(argv)
+        self.calls.append({"argv": list(argv), "sub": sub, "input": input})
+        if sub in self.fails:
+            return SimpleNamespace(returncode=1, stdout="", stderr=self.stderr)
+        if sub == "item get":
+            if ITEM not in self.titles:
+                return SimpleNamespace(returncode=1, stdout="", stderr=NO_SUCH_ITEM)
+            return SimpleNamespace(returncode=0, stdout=self._item_json(), stderr="")
+        if sub == "item list":
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"title": t} for t in self.titles]), stderr="")
+        if sub in ("item create", "item edit"):
+            # A write replaces the item with exactly the template it was piped, which is
+            # what makes a dropped sibling observable here rather than only in 1Password.
+            self.fields = {f.get("label") or f["id"]: f.get("value", "")
+                           for f in json.loads(input or "{}").get("fields", [])}
+            if ITEM not in self.titles:
+                self.titles.append(ITEM)
+            return SimpleNamespace(returncode=0, stdout=self._item_json(), stderr="")
+        if sub == "read":
+            key = [w for w in argv if w.startswith("op://")][0].rsplit("/", 1)[1]
+            if key not in self.fields:
+                return SimpleNamespace(returncode=1, stdout="", stderr=NO_SUCH_ITEM)
+            return SimpleNamespace(returncode=0, stdout=self.fields[key], stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def subs(self) -> list[str]:
+        return [c["sub"] for c in self.calls]
+
+
+class OpCase(unittest.TestCase):
+    """`op` is not on CI's PATH and the provider checks before running, so PATH is pinned
+    rather than inherited — the same reason `test_onepassword_single_item` does it."""
+
+    def setUp(self) -> None:
+        import charter.secrets.onepassword as mod
+        real = mod.shutil.which
+        mod.shutil.which = lambda n: "/usr/local/bin/op" if n == "op" else None
+        self.addCleanup(lambda: setattr(mod.shutil, "which", real))
+
+    def make(self, **kw):
+        op = FakeOp(**kw)
+        p = OnePasswordProvider("devops", {
+            "op-vault": "Eng",
+            # A per-scope identity, which is the setup #322 was reported from: four vaults,
+            # four service accounts. It is what `identity_note` names in the failure.
+            "env": {"OP_SERVICE_ACCOUNT_TOKEN": "OP_ENG_DEVOPS_TOKEN"},
+        })
+        p.runner = op
+        return op, p
+
+    def setenv(self, value: str = "ops-not-a-real-token") -> None:
+        """`env_overlay` raises when a declared identity variable is unset, which would
+        refuse every call below before `op` was reached."""
+        patch = mock.patch.dict("os.environ", {"OP_ENG_DEVOPS_TOKEN": value})
+        patch.start()
+        self.addCleanup(patch.stop)
+
+
+class ThePopulatedVaultIsReallyPopulated(OpCase):
+    """The precondition the whole file rests on.
+
+    Same construction as every failing case below, minus the failure. If this returned
+    `[]` the fixture's vault would be genuinely empty and "has no secrets" would be the
+    truth, so every assertion about a *masked failure* would be vacuous.
+    """
+
+    def test_the_fixture_vault_holds_secrets_when_op_answers(self):
+        self.setenv()
+        op, p = self.make(fields={"AWS_ACCESS_KEY_ID": "a", "GITHUB_TOKEN": "b"})
+        self.assertEqual(p.keys(), ["AWS_ACCESS_KEY_ID", "GITHUB_TOKEN"])
+        self.assertIn("item get", op.subs(), "`op item get` was never reached")
+
+
+class AFailedReadIsReported(OpCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.setenv()
+        # Rate limiting is not per-subcommand: the client is limited, so the listing that
+        # would prove absence fails too. That is what makes absence unprovable and the
+        # failure the only honest answer.
+        self.op, self.p = self.make(fields={"AWS_ACCESS_KEY_ID": "a"},
+                                    fails={"item get", "item list"})
+
+    def test_the_precondition_the_read_actually_failed(self):
+        """Not "the vault was empty". `op item get` ran and exited non-zero."""
+        with self.assertRaises(base.VaultError):
+            self.p.keys()
+        self.assertIn("item get", self.op.subs(), "`op item get` was never reached")
+        got = [c for c in self.op.calls if c["sub"] == "item get"][0]
+        self.assertEqual(self.op._sub(got["argv"]), "item get")
+
+    def test_keys_raises_rather_than_returning_an_empty_list(self):
+        with self.assertRaises(base.VaultError):
+            self.p.keys()
+
+    def test_the_failure_names_the_rate_limit_rather_than_guessing_at_tokens(self):
+        """`_fail`'s unrecognised-failure fallback sends the reader to check the identity
+        variable and the sign-in — which is where #322's operator went, and rotated a
+        token that was fine. A recognised signature says what actually happened."""
+        with self.assertRaises(base.VaultError) as raised:
+            self.p.keys()
+        self.assertIn("rate-limit", str(raised.exception).lower())
+
+    def test_the_failure_never_carries_ops_own_output(self):
+        """`op`'s stderr can echo an assignment, and on a read path its stdout IS the
+        secret. The error class is separable from the value and only the class travels."""
+        with self.assertRaises(base.VaultError) as raised:
+            self.p.keys()
+        self.assertNotIn(RATE_LIMITED, str(raised.exception))
+        self.assertNotIn("AWS_ACCESS_KEY_ID", str(raised.exception))
+
+    def test_the_failure_names_the_identity_the_read_was_made_under(self):
+        """Four vaults, four service accounts: which one failed is the first thing the
+        operator needs and the last thing they can guess."""
+        with self.assertRaises(base.VaultError) as raised:
+            self.p.keys()
+        self.assertIn("OP_ENG_DEVOPS_TOKEN", str(raised.exception))
+
+    def test_health_does_not_report_the_vault_as_fine(self):
+        """`vault list` and `doctor` read this. A green line over an unreadable vault is
+        #55 in a new place."""
+        healthy, detail = self.p.health()
+        self.assertFalse(healthy)
+        self.assertNotIn("no secrets", detail)
+
+    def test_a_write_does_not_replace_the_item_with_what_it_could_not_read(self):
+        """The same swallow on the write path, and the expensive half. `set` is a
+        read-modify-write; `{}` for the read means the template it pipes back holds only
+        the new key, and every sibling secret in the item is dropped."""
+        with self.assertRaises(base.VaultError):
+            self.p.set("NEW_KEY", "v")
+        self.assertNotIn("item create", self.op.subs())
+        self.assertNotIn("item edit", self.op.subs())
+
+
+class AGenuinelyEmptyVaultStillReadsAsEmpty(OpCase):
+    """The other direction, and the reason a failed read cannot simply always raise.
+
+    A vault whose item has not been created yet is the ordinary state of a freshly
+    registered vault. `op item get` fails for it too, so the fix has to tell it apart —
+    and it does, by the listing this identity can still perform.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.setenv()
+        self.op, self.p = self.make(fields={}, titles=())
+
+    def test_the_precondition_the_read_failed_and_the_vault_is_readable(self):
+        self.p.keys()
+        self.assertIn("item get", self.op.subs())
+        self.assertIn("item list", self.op.subs(),
+                      "absence was assumed from the failed get rather than proven")
+
+    def test_keys_are_empty(self):
+        self.assertEqual(self.p.keys(), [])
+
+    def test_health_says_there_is_nothing_in_it_yet(self):
+        healthy, detail = self.p.health()
+        self.assertTrue(healthy)
+        self.assertIn("no secrets", detail)
+
+    def test_the_first_write_still_creates_the_item(self):
+        self.p.set("FIRST", "v")
+        self.assertIn("item create", self.op.subs())
+
+
+class AnUnreadableItemInAReadableVaultIsReported(OpCase):
+    """The item is right there in the listing and `op item get` still failed. Absence is
+    disproven, so this cannot be reported as empty either."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.setenv()
+        self.op, self.p = self.make(fields={"A": "1"}, fails={"item get"})
+
+    def test_the_precondition_the_item_is_visible_to_this_identity(self):
+        self.assertIn(ITEM, self.p._list_items(tagged=False))
+
+    def test_keys_raises(self):
+        with self.assertRaises(base.VaultError):
+            self.p.keys()
+
+
+class TheCommandSaysWhichOfTheTwoItIs(OpCase):
+    """What the operator in #322 actually saw. `_provider` is stubbed rather than the
+    registry populated, so this is about `cmd_secret_list`'s contract with a provider."""
+
+    def _list(self, p) -> tuple[int, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with mock.patch.object(commands_secrets, "_provider", lambda _n: p), \
+             redirect_stdout(out), redirect_stderr(err):
+            code = commands_secrets.cmd_secret_list(SimpleNamespace(vault="devops"))
+        return code, out.getvalue() + err.getvalue()
+
+    def test_an_unreadable_vault_is_not_reported_as_empty(self):
+        self.setenv()
+        op, p = self.make(fields={"AWS_ACCESS_KEY_ID": "a"},
+                          fails={"item get", "item list"})
+        code, text = self._list(p)
+        self.assertNotIn("has no secrets", text)
+        self.assertIn("rate-limit", text.lower())
+        self.assertNotEqual(code, 0,
+                            "a scripted caller would proceed against an apparently-empty "
+                            "vault")
+        self.assertIn("item get", op.subs(), "the read never happened")
+
+    def test_an_empty_vault_is_still_reported_as_empty(self):
+        self.setenv()
+        _, p = self.make(fields={}, titles=())
+        code, text = self._list(p)
+        self.assertIn("has no secrets", text)
+        self.assertEqual(code, 0)
+
+    def test_a_populated_vault_still_lists_its_keys(self):
+        """The feature, unchanged. A fix that reported every vault as unreadable would
+        satisfy every assertion above and tell nobody anything."""
+        self.setenv()
+        _, p = self.make(fields={"AWS_ACCESS_KEY_ID": "value-of-the-aws-key",
+                                 "GITHUB_TOKEN": "value-of-the-github-token"})
+        code, text = self._list(p)
+        self.assertEqual(code, 0)
+        self.assertIn("AWS_ACCESS_KEY_ID", text)
+        self.assertIn("GITHUB_TOKEN", text)
+        # Names, never values: redacting the value is right, and it is what makes
+        # redacting the *failure* separable from it.
+        self.assertNotIn("value-of-the-aws-key", text)
+        self.assertNotIn("value-of-the-github-token", text)
+
+
+class AnUnsetIdentityIsNotAnEmptyVaultEither(OpCase):
+    """The failure mode `env_overlay` already refuses, pinned from this end: it must not
+    come back as an empty listing through the path #322 opened."""
+
+    def test_a_declared_identity_that_is_unset_reports_rather_than_listing_nothing(self):
+        _, p = self.make(fields={"AWS_ACCESS_KEY_ID": "a"})
+        with mock.patch.dict("os.environ", {}, clear=False):
+            import os
+            os.environ.pop("OP_ENG_DEVOPS_TOKEN", None)
+            with self.assertRaises(base.VaultError):
+                p.keys()


### PR DESCRIPTION
Closes #321. Closes #322.

Both are the same species: a failure rendered as a benign state. One is cosmetic in effect, one cost an operator an hour and a rotated credential. Neither was visible to the suite — both were found by running the commands a human runs.

## #321 — a shell-syntax `check:` blamed the machine

`news._tokens` refuses two different things and returns the same bare `None` for both: argv a shell would read as syntax, and a first token this CLI does not register. `_dispatch` read that `None` as one refusal and reported `_NOT_RUN` — *"did not run **here**"* — which sends the reader to audit a laptop with nothing wrong with it.

Right for the second (an entry written against a charter this one is not). Wrong for the first: a `check:` carrying shell syntax can never run, anywhere, in any version. `news.py`'s own comment above `_NOT_RUN` already said these two must not be folded.

The reason cannot be read off the `None`, so it is read off a new `_shell_syntax` predicate — one function, called by `_tokens` to refuse and by `_dispatch` to attribute, rather than a second `set(argv) & _SHELLISH` that would drift. Shell syntax now reports `_UNLISTED`: same finding as an unlisted command, same fix, no sixth string. The unregistered-first-token half keeps `_NOT_RUN`, and that direction is asserted too — folding both onto the entry would be the same bug reversed.

No behavioural change beyond the sentence. No process starts either way.

## #322 — `charter secret list` said "no secrets" when the read had FAILED

`OnePasswordProvider._fields` turned every non-zero exit of `op item get` into `{}`:

```python
if proc.returncode != 0:
    return {}
```

`op` exits non-zero for *"no such item yet"* and for every way a read can fail — rate limit, expired session, a token that cannot see the vault, the wrong `op-vault` name. `keys()` sorts `{}` into `[]`, and `cmd_secret_list` prints "has no secrets" and exits 0. `cmd_secret_list` already handles `VaultError` correctly; it was never given one.

The same swallow ran the **write** path, which is the expensive half. `set` is a read-modify-write, so `{}` for the read means the template piped back to `op` holds only the key being written. Observed on `main`, against a populated vault whose read was rate-limited:

```
keys() -> []
TEMPLATE PIPED TO op: [{"id": "NEW_KEY", "label": "NEW_KEY", …}]
```

Every sibling secret dropped, from a masked read.

**Absence is now proven, not assumed.** Neither the exit code nor charter can tell the two apart from that one call. What can: ask this vault's own identity to list the vault. A listing that succeeds without the item proves there is no item; a listing that fails *is* the answer and propagates. Untagged, because an adopted `op-item` carries no charter tag and a tagged listing would report exactly those vaults absent. No matching of `op`'s English on this path — unlike `_diagnose`, where a missed signature costs only precision, here it would turn a failure back into an empty vault.

`_DIAGNOSES` gains the rate-limit signature (provenance: #322, per this module's rule). Without it `_fail` falls back to candidates that send the reader to check the identity variable and the sign-in — which is where #322's operator went, and rotated a token that was fine.

**One source of truth, recovered.** `vault list` was already honest about these vaults, because `health()` reaches `_list_items`, which raises, while `secret list` reached `_fields`, which did not. Two paths, one question, opposite answers.

## Verification

Both fixes were driven test-first and watched fail. Every #322 test asserts its own precondition — the same fixture with the failure removed lists its keys, so "the vault was simply empty" cannot be why any of them pass.

Against the real CLI, `charter news --pending` with two throwaway packaged entries:

```
! shellcheck:  `charter doctor && echo adopted` is not a command a `check:` may name. …
! unknowncmd:  `charter frobnicate --hard` did not run here, …
```

Against the real CLI, a throwaway plane with a real `op` that genuinely fails:

```
before:  • Vault 'eng' has no secrets.                                          exit 0
after:   ✗ listing vault 'eng' failed (op exit 1). `op` has no account
           configured on this machine. Sign in (`op signin`), … then retry.     exit 1
```

Full suite: **3197 passed** — the 3168 baseline plus exactly the 29 tests added here (11 for #321, 18 for #322).

No version bump, no tag, no documentation touched.

## Noted, not fixed

`_existing_ids` carries the same `return {}`-on-failure shape as `_fields` did. It is only reached from `_write` after `_fields` succeeded, so this PR closes the path that made it reachable with a broken read — but a transient failure there would still renumber the field ids of an adopted item. Same species, different symptom (silent mutation rather than a false diagnosis), so it is left for its own issue rather than widened into this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo