### PR TITLE
A failed read on the write path is not an item with no ids (#354)

### DIFF
--- a/charter/secrets/onepassword.py
+++ b/charter/secrets/onepassword.py
@@ -239,6 +239,14 @@ class OnePasswordProvider(VaultProvider):
         and drop this field, and silently losing a credential somebody believes they
         stored is worse than failing.
         """
+        # Three `op item get` calls happen below — here, in `_item_present`, and in
+        # `_existing_ids` — all fetching the SAME document, which the first one already
+        # holds in full. That redundancy is why #354 was reachable at all: three chances
+        # to be rate-limited on the path where being rate-limited is most expensive, and
+        # ids that come from a different fetch than the values they are paired with.
+        # Collapsing them into one read is #355; it is deliberately not done here, because
+        # its correctness lives in the `op item edit`/`item create` round trip that no
+        # machine in this project can exercise against a real vault.
         fields = self._fields(reveal=True)
         fields[key] = value
         self._write(fields, creating=fields is not None and not self._item_present())
@@ -293,8 +301,25 @@ class OnePasswordProvider(VaultProvider):
         return title in self._list_items()
 
     def _item_present(self) -> bool:
+        """Whether the item exists — ``False`` only when that is PROVEN (#354).
+
+        This chooses between `op item create` and `op item edit`, and it used to be
+        `return proc.returncode == 0`. `op item get` exits non-zero both for "there is no
+        such item" and for every way a read can fail, so a rate limit read as *absent* and
+        charter created an item whose title was already taken. 1Password permits duplicate
+        titles, so nothing refused it: the vault ends up holding two items called
+        `charter-<vault>`, `op item get <title>` can no longer say which one is meant, and
+        the vault stays unreadable until a human deletes one. Worse than the renumbering
+        in :meth:`_existing_ids`, and from the same swallow.
+
+        Absence is proven the way #322 taught: ask this vault's own identity to list the
+        vault, untagged because an adopted item carries no charter tag. Not in the listing
+        means not there. A listing that fails is the answer, and propagates.
+        """
         proc = self._run(self._argv("item", "get", self.op_item,
                                     "--vault", self.op_vault, "--format", "json"))
+        if proc.returncode != 0 and self.op_item in self._list_items(tagged=False):
+            raise self._fail(f"reading vault '{self.name}'", proc)
         return proc.returncode == 0
 
     def _fields(self, reveal: bool = False) -> dict:
@@ -367,15 +392,32 @@ class OnePasswordProvider(VaultProvider):
         Adoption must be non-destructive: a field charter did not create carries an id
         1Password generated, and rewriting it to the key name on the next write would
         mutate an identifier the user never chose on an item charter does not own.
+
+        Both failures below used to `return {}` (#354). That is the swallow #322 was about,
+        arriving as a silent MUTATION rather than a false diagnosis: `{}` here does not
+        report anything, it tells :meth:`_write` there are no ids to keep, and every field
+        of the adopted item is renumbered on the next write while `set` returns success.
+        A rate limit is enough — no race with another writer required.
+
+        Unlike :meth:`_fields` and :meth:`_item_present`, there is nothing to prove here
+        and so no listing to make. This runs only from `_write(creating=False)`, which
+        means presence was just established, so no non-zero exit is a legitimate "no item"
+        — every one of them is a failed read. If the item did vanish in between, raising
+        names the read that failed instead of letting the `item edit` fail more obscurely.
+
+        The parse is refused for the same reason and not a weaker one: `_fields` already
+        raises on a document it cannot read, and the same bytes must not get two different
+        answers. That the failure is charter's inability to READ the answer rather than
+        1Password's inability to give one still makes it a failure, never an absence.
         """
         proc = self._run(self._argv("item", "get", self.op_item, "--vault", self.op_vault,
                                     "--format", "json"))
         if proc.returncode != 0:
-            return {}
+            raise self._fail(f"reading vault '{self.name}'", proc)
         try:
             doc = json.loads(proc.stdout or "{}")
-        except json.JSONDecodeError:
-            return {}
+        except json.JSONDecodeError as e:
+            raise VaultError(f"could not parse 1Password item '{self.op_item}': {e}")
         out = {}
         for f in doc.get("fields") or []:
             name = _field_name(f)

--- a/docs/news/unreleased-unreadable-vault-is-not-empty.md
+++ b/docs/news/unreleased-unreadable-vault-is-not-empty.md
@@ -1,0 +1,60 @@
+---
+version: unreleased
+headline: A 1Password vault charter could not read is no longer reported as empty
+---
+
+A vault that could not be read used to look exactly like a vault with nothing in it. It no
+longer does.
+
+`op item get` exits non-zero for *there is no item yet* and for every way a read can
+fail — a rate limit, an expired session, a token that cannot see the vault, the wrong
+`op-vault` name — and charter treated all of it as "no secrets here". So the failure
+arrived as a benign state:
+
+```
+$ charter secret list devops
+  • Vault 'devops' has no secrets.
+$ echo $?
+0
+```
+
+The vault was populated throughout. Absence is now **proven** rather than assumed: charter
+asks the vault's own identity to list the vault, and only a listing that succeeds *without*
+the item proves there is no item. A listing that fails is itself the answer, and it is
+reported.
+
+**The same swallow ran the write path, which is the expensive half.** `charter secret set`
+is a read-modify-write, so a masked read meant the template piped back to 1Password held
+only the key being written — every sibling secret in that item dropped, from a read that
+had merely been rate-limited. Not mis-reported: gone from the current version of the item.
+The write path had two more of these, so a failure landing mid-write could also renumber
+the fields of an item you curated by hand, or create a second item with the same title and
+leave the vault ambiguous to `op item get`. All of them now stop and report.
+
+**`charter vault list` was already telling you the truth about these same vaults**, because
+it reached a code path that raises while `secret list` reached one that did not. If the two
+have ever disagreed for you — `vault list` unhappy about a vault `secret list` called
+empty — that disagreement was this bug, and it is gone.
+
+## What to do about it
+
+**If charter now reports a read failure where it used to print "no secrets", nothing has
+broken.** You are seeing a failure that was always happening. The message names the cause
+where charter recognises it — a rate limit says so explicitly, and says the contents are
+unknown. Wait and retry rather than re-provisioning credentials that are almost certainly
+still there. That re-provisioning is the expensive mistake this prevents: it cost the
+operator who reported it an hour and a rotated token that had been fine all along.
+
+**Scripts that check an exit code will notice.** A masked read exited 0; a reported failure
+exits non-zero. That is the intended change — a command that could not answer no longer
+claims it did — but if you have automation branching on `charter secret list`, this is the
+release where a broken 1Password read starts failing it instead of silently returning
+nothing.
+
+**If you ran `charter secret set` against a 1Password vault while its reads were failing,
+check that item's history.** 1Password keeps previous versions, and a write made through a
+masked read may have replaced the item with one holding only the key you set. The values
+are recoverable there; charter cannot recover them for you.
+
+Vaults on the `plain-file` and `op://` reference providers are unaffected — this was in the
+native 1Password provider, the one where charter owns the item.

--- a/tests/test_op_unreadable_item_is_not_renumbered.py
+++ b/tests/test_op_unreadable_item_is_not_renumbered.py
@@ -1,0 +1,346 @@
+"""A read that failed on the WRITE path is not "the item has no ids" (#354).
+
+#352 fixed `OnePasswordProvider._fields`, where `if proc.returncode != 0: return {}` turned
+every kind of read failure into an empty vault. It deliberately did not widen into the two
+sibling helpers carrying the same shape, and this file is that follow-up.
+
+The write path is worse in kind. `_fields` failing produced a false *diagnosis* — "has no
+secrets" about a populated vault — which is visible the moment somebody looks. These fail
+as a silent *mutation*, and `set()` still returns successfully:
+
+* `_existing_ids` exists to keep an adopted item's field ids stable across a write. `{}`
+  means charter believes there are no existing ids and assigns fresh ones, so a transient
+  failure renumbers the fields of an item charter did not create.
+* `_item_present` answers "does the item exist" with `return proc.returncode == 0`, and
+  `op item get` exits non-zero both for *no such item* and for every way a read can fail.
+  A failure therefore reads as *absent*, which flips `_write` from `item edit` to `item
+  create` against a title that is already there — leaving two same-titled items, after
+  which `op item get <title>` is ambiguous and the vault is unreadable until a human
+  deletes one by hand. That is the worst outcome of the set, and it is not a `return {}`.
+
+None of this needs an attacker or a race with another writer. A rate limit is enough, and
+rate limiting is what #322 was actually reported from.
+
+**The window is the whole point, and it is what makes these tests non-vacuous.** `set()`
+issues *three* separate `op item get` calls — `_fields`, then `_item_present`, then
+`_existing_ids` — all fetching the same document (#355). So the failure under test is not
+"op is broken", which #352 already covers and which would make `_fields` raise before any
+of this is reached. It is the second or third call failing after the first SUCCEEDED. Every
+test below therefore asserts that the first `op item get` returned 0 before the one that
+failed; a fixture where op fails from the start would prove nothing here, and neither would
+an item that genuinely had no fields to renumber.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter.secrets import base
+from charter.secrets.onepassword import OnePasswordProvider
+
+#: What `op` writes when a service account has been rate-limited. Quoted from #322 — the
+#: operator's own output, from an agent invoking the path charter invokes. The process
+#: exits 1, the same code as "no such item", which is why the exit status cannot classify
+#: it and why a rate limit is enough to trigger everything below.
+RATE_LIMITED = "[ERROR] 2026/08/20 11:02:31 Too many requests. Your client has been rate-limited."
+
+#: What `op` writes for an item that is not there. charter deliberately does not match on
+#: this text — absence is proven by a successful listing — so nothing depends on its wording.
+NO_SUCH_ITEM = '[ERROR] 2026/08/20 11:02:31 "charter-devops" isn\'t an item.'
+
+ITEM = "charter-devops"
+
+#: A field charter did NOT create: 1Password generated the id, and the human chose only the
+#: label. Renumbering this to "PROD_KUBECONFIG" is the silent mutation under test, so the
+#: id has to be one no key name could coincidentally equal.
+ADOPTED_ID = "27r3gphb4fnsonx5ikcaw3cxwq"
+
+
+class FakeOp:
+    """`op`, with failure injectable **per `item get` call index**.
+
+    Distinct from the fakes in `test_onepassword_single_item` (fails whatever a substring
+    matches) and `test_op_unreadable_vault_is_not_empty` (fails a whole subcommand). Neither
+    can express the distinction this file exists for: `item get` is the subcommand of all
+    three reads, so failing "item get" wholesale makes `_fields` raise and the window is
+    never entered. What matters here is *which* of the three failed.
+    """
+
+    def __init__(self, *, raw_fields=None, titles=(ITEM,), fail_get_from=None,
+                 bad_json_from=None, fail_subs=(), stderr=RATE_LIMITED):
+        self.calls: list[dict] = []
+        #: Fields as 1Password returns them, ids and all.
+        self.raw_fields = list(raw_fields or [])
+        self.titles = list(titles)
+        #: `item get` calls at this index and beyond exit non-zero. A rate limit does not
+        #: clear itself between two calls a moment apart, so "from" models it better than
+        #: a single-call blip — and it still leaves call 0 green, which is the precondition.
+        self.fail_get_from = fail_get_from
+        #: `item get` calls at this index and beyond exit 0 with output charter cannot parse.
+        self.bad_json_from = bad_json_from
+        self.fail_subs = set(fail_subs)
+        self.stderr = stderr
+        self.n_get = 0
+        #: The template piped to `op item create`/`item edit`, if a write was reached.
+        self.template = None
+
+    @staticmethod
+    def _sub(argv) -> str:
+        words = [w for w in argv[1:] if not w.startswith("-")]
+        if words[:1] == ["item"]:
+            return " ".join(words[:2])
+        return words[0] if words else ""
+
+    def _item_json(self) -> str:
+        return json.dumps({"id": "itm1", "title": ITEM, "category": "PASSWORD",
+                           "fields": self.raw_fields})
+
+    def _record(self, sub, proc, input=None):
+        self.calls.append({"sub": sub, "ok": proc.returncode == 0, "input": input})
+        return proc
+
+    def __call__(self, argv, input=None, check=False, env=None, **kw):
+        sub = self._sub(argv)
+        if sub in self.fail_subs:
+            return self._record(sub, SimpleNamespace(
+                returncode=1, stdout="", stderr=self.stderr))
+        if sub == "item get":
+            i, self.n_get = self.n_get, self.n_get + 1
+            if self.fail_get_from is not None and i >= self.fail_get_from:
+                return self._record(sub, SimpleNamespace(
+                    returncode=1, stdout="", stderr=self.stderr))
+            if ITEM not in self.titles:
+                return self._record(sub, SimpleNamespace(
+                    returncode=1, stdout="", stderr=NO_SUCH_ITEM))
+            if self.bad_json_from is not None and i >= self.bad_json_from:
+                # op exited 0 and produced something charter cannot read: a truncated
+                # body, a proxy's error page. charter's inability to READ the answer is
+                # still not evidence about the item's contents.
+                return self._record(sub, SimpleNamespace(
+                    returncode=0, stdout="{not json at all", stderr=""))
+            return self._record(sub, SimpleNamespace(
+                returncode=0, stdout=self._item_json(), stderr=""))
+        if sub == "item list":
+            return self._record(sub, SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"title": t} for t in self.titles]), stderr=""))
+        if sub in ("item create", "item edit"):
+            self.template = json.loads(input or "{}")
+            self.raw_fields = list(self.template.get("fields", []))
+            if ITEM not in self.titles:
+                self.titles.append(ITEM)
+            return self._record(sub, SimpleNamespace(
+                returncode=0, stdout=self._item_json(), stderr=""), input=input)
+        if sub == "read":
+            key = [w for w in argv if w.startswith("op://")][0].rsplit("/", 1)[1]
+            vals = {f.get("label") or f.get("id"): f.get("value", "")
+                    for f in self.raw_fields}
+            if key not in vals:
+                return self._record(sub, SimpleNamespace(
+                    returncode=1, stdout="", stderr=NO_SUCH_ITEM))
+            return self._record(sub, SimpleNamespace(
+                returncode=0, stdout=vals[key], stderr=""))
+        return self._record(sub, SimpleNamespace(returncode=0, stdout="", stderr=""))
+
+    def subs(self) -> list[str]:
+        return [c["sub"] for c in self.calls]
+
+    def gets(self) -> list[dict]:
+        return [c for c in self.calls if c["sub"] == "item get"]
+
+    def written_ids(self) -> dict:
+        """`{label: id}` from the template op was actually piped."""
+        return {f.get("label"): f.get("id") for f in (self.template or {}).get("fields", [])}
+
+
+class OpCase(unittest.TestCase):
+    """`op` is not on CI's PATH and the provider checks before running, so PATH is pinned
+    rather than inherited — same reason as the two sibling op test modules."""
+
+    ADOPTED = [{"id": ADOPTED_ID, "label": "PROD_KUBECONFIG",
+                "type": "CONCEALED", "value": "body"}]
+
+    def setUp(self) -> None:
+        import charter.secrets.onepassword as mod
+        real = mod.shutil.which
+        mod.shutil.which = lambda n: "/usr/local/bin/op" if n == "op" else None
+        self.addCleanup(lambda: setattr(mod.shutil, "which", real))
+        patch = mock.patch.dict("os.environ", {"OP_ENG_DEVOPS_TOKEN": "ops-not-a-real-token"})
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def make(self, **kw):
+        kw.setdefault("raw_fields", [dict(f) for f in self.ADOPTED])
+        op = FakeOp(**kw)
+        p = OnePasswordProvider("devops", {
+            "op-vault": "Eng",
+            "env": {"OP_SERVICE_ACCOUNT_TOKEN": "OP_ENG_DEVOPS_TOKEN"},
+        })
+        p.runner = op
+        return op, p
+
+    def assertFirstReadSucceeded(self, op):
+        """The precondition every assertion in this file rests on.
+
+        Without it a test could pass because `op` failed from the very first call — which
+        is #352's case, already fixed, and would make these assertions vacuous.
+        """
+        gets = op.gets()
+        self.assertGreaterEqual(len(gets), 2,
+                                "precondition: the write path must reach a SECOND "
+                                "`op item get`; only one was made")
+        self.assertTrue(gets[0]["ok"],
+                        "precondition: the FIRST `op item get` must succeed, otherwise "
+                        "_fields raises and the window under test is never entered")
+        self.assertFalse(gets[-1]["ok"],
+                         "precondition: a LATER `op item get` must fail")
+
+
+class TheFixtureReallyHasAnIdToLose(OpCase):
+    """The control. Same construction as every failing case below, minus the failure.
+
+    If the adopted id were not preserved here, or the item had no fields, then "the ids
+    were not renumbered" would be true of an empty item and every assertion below would
+    be vacuous.
+    """
+
+    def test_the_adopted_id_survives_a_write_when_op_answers(self):
+        op, p = self.make()
+        p.set("GITHUB_TOKEN", "ghp_new")
+        self.assertEqual(op.written_ids()["PROD_KUBECONFIG"], ADOPTED_ID)
+
+    def test_a_new_field_still_takes_the_key_as_its_id(self):
+        op, p = self.make()
+        p.set("GITHUB_TOKEN", "ghp_new")
+        self.assertEqual(op.written_ids()["GITHUB_TOKEN"], "GITHUB_TOKEN")
+
+    def test_the_write_path_really_makes_three_item_get_calls(self):
+        """The window exists. If this ever drops to one (#355), the `fail_get_from`
+        indices below stop meaning what their comments say and must be revisited."""
+        op, p = self.make()
+        p.set("GITHUB_TOKEN", "ghp_new")
+        self.assertEqual(len(op.gets()), 3, op.subs())
+
+
+class AFailedIdReadIsReportedRatherThanRenumbering(OpCase):
+    """`_existing_ids` — the defect #354 was filed for."""
+
+    def test_set_raises_rather_than_returning_successfully(self):
+        # Calls 0 (_fields) and 1 (_item_present) succeed; call 2 (_existing_ids) fails.
+        op, p = self.make(fail_get_from=2)
+        with self.assertRaises(base.VaultError):
+            p.set("GITHUB_TOKEN", "ghp_new")
+        self.assertFirstReadSucceeded(op)
+
+    def test_no_write_reaches_op_with_renumbered_ids(self):
+        op, p = self.make(fail_get_from=2)
+        with self.assertRaises(base.VaultError):
+            p.set("GITHUB_TOKEN", "ghp_new")
+        self.assertIsNone(op.template,
+                          "a write was piped to op despite the id read having failed")
+        self.assertNotIn("item edit", op.subs())
+
+    def test_the_failure_names_the_rate_limit_rather_than_guessing_at_tokens(self):
+        op, p = self.make(fail_get_from=2)
+        with self.assertRaises(base.VaultError) as raised:
+            p.set("GITHUB_TOKEN", "ghp_new")
+        self.assertIn("rate-limited", str(raised.exception))
+
+    def test_delete_raises_too(self):
+        # delete() has no presence check, so _existing_ids is `item get` call 1 there.
+        op, p = self.make(fail_get_from=1)
+        with self.assertRaises(base.VaultError):
+            p.delete("PROD_KUBECONFIG")
+        self.assertFirstReadSucceeded(op)
+        self.assertIsNone(op.template)
+
+
+class AnUnparseableItemIsNotReadAsNoIds(OpCase):
+    """`op` exited 0 and charter could not parse what it said.
+
+    `_fields` raises `VaultError` for exactly this condition eight lines up. `_existing_ids`
+    swallowed it, so the same bytes got two different answers. That charter cannot READ the
+    answer is not evidence about the item's contents either.
+    """
+
+    def test_set_raises_rather_than_renumbering(self):
+        op, p = self.make(bad_json_from=2)
+        with self.assertRaises(base.VaultError):
+            p.set("GITHUB_TOKEN", "ghp_new")
+        gets = op.gets()
+        self.assertTrue(gets[0]["ok"] and gets[-1]["ok"],
+                        "precondition: every `op item get` here EXITS 0 — the failure "
+                        "under test is the parse, not the process")
+        self.assertIsNone(op.template)
+
+
+class AFailedPresenceCheckIsNotAnAbsentItem(OpCase):
+    """`_item_present` — the fourth site, and the worst consequence of the set.
+
+    A failed read reading as *absent* flips `_write` to `item create` against a title that
+    already exists, leaving two same-titled items in the vault.
+    """
+
+    def test_set_raises_rather_than_creating_a_duplicate_item(self):
+        # Call 0 (_fields) succeeds; call 1 (_item_present) fails.
+        op, p = self.make(fail_get_from=1)
+        with self.assertRaises(base.VaultError):
+            p.set("GITHUB_TOKEN", "ghp_new")
+        self.assertFirstReadSucceeded(op)
+
+    def test_no_second_item_is_created(self):
+        op, p = self.make(fail_get_from=1)
+        with self.assertRaises(base.VaultError):
+            p.set("GITHUB_TOKEN", "ghp_new")
+        self.assertNotIn("item create", op.subs(),
+                         "charter created a second item titled the same as the one that "
+                         "is already there — the vault is now ambiguous to `op item get`")
+        self.assertEqual(op.titles, [ITEM])
+
+
+class AProvenAbsentItemIsStillCreated(OpCase):
+    """The legitimate absence path, which the fix must not break.
+
+    On a vault's first write there is genuinely no item: `op item get` exits non-zero and
+    that is the truth. Absence is proven the way #352 proves it — this vault's own identity
+    lists the vault, and the item is not in the listing — rather than assumed from an exit
+    code that cannot tell absence from failure.
+    """
+
+    def test_a_first_write_creates_the_item(self):
+        op, p = self.make(raw_fields=[], titles=[])
+        p.set("GITHUB_TOKEN", "ghp_new")
+        self.assertIn("item create", op.subs(), op.subs())
+        self.assertEqual(op.written_ids(), {"GITHUB_TOKEN": "GITHUB_TOKEN"})
+
+    def test_the_precondition_op_really_refused_the_read(self):
+        """Not "op answered with an empty item" — `op item get` exited NON-ZERO, and the
+        listing is what proved the item absent."""
+        op, p = self.make(raw_fields=[], titles=[])
+        p.set("GITHUB_TOKEN", "ghp_new")
+        self.assertFalse(op.gets()[0]["ok"], "`op item get` was expected to refuse")
+        self.assertIn("item list", op.subs(), "absence was assumed, not proven")
+
+
+class AVaultThatCannotBeListedIsNotAnAbsentItem(OpCase):
+    """Absence must be *proven*, and a listing that fails is not proof.
+
+    This is #352's rule applied to the presence check: under a real rate limit the listing
+    that would prove absence is limited too, which is exactly what makes absence unprovable
+    and the failure the only honest answer.
+    """
+
+    def test_set_raises_when_neither_the_read_nor_the_listing_answers(self):
+        op, p = self.make(fail_get_from=1, fail_subs={"item list"})
+        with self.assertRaises(base.VaultError):
+            p.set("GITHUB_TOKEN", "ghp_new")
+        self.assertTrue(op.gets()[0]["ok"],
+                        "precondition: the first read succeeded, so this is not #352")
+        self.assertIsNone(op.template)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #354. Files #355.

#352 fixed `OnePasswordProvider._fields`, where `if proc.returncode != 0: return {}` turned
every kind of read failure into an empty vault, and deliberately did not widen into the
siblings carrying the same shape. This is that follow-up.

The write path is **worse in kind**. `_fields` failing produced a false *diagnosis* — "has
no secrets" about a populated vault — visible the moment somebody looks. These fail as a
silent *mutation*, and `set()` still returns successfully. A rate limit is enough; no race
with another writer is required.

## The window, which is the whole finding

`set()` issues **three separate `op item get` calls**, all fetching the same document.
Traced on `main` with a recording runner:

```
set() op calls, in order:
  0: item get --reveal      <- _fields
  1: item get               <- _item_present
  2: item get               <- _existing_ids
  3: item edit
  4: read                   <- the read-back in set()
```

Failing each one *alone* — every earlier call green — on `main`:

| # | Call site | Failing it alone, before |
| --- | --- | --- |
| 0 | `_fields(reveal=True)` | ✅ raises — #352's fix working |
| 1 | `_item_present()` | ❌ **silent**: `item edit` → `item create`, ids renumbered |
| 2 | `_existing_ids()` | ❌ **silent**: ids renumbered (#354) |

So the failure under test is *not* "op is broken" — that is #352's case, and it makes
`_fields` raise before any of this is reached. It is the second or third call failing
**after the first succeeded**.

## The four sites, decided explicitly

**`_fields`, the proven-absence `return {}` — unchanged.** It is reached only after
`_list_items(tagged=False)` *succeeded* without the item. That is #352's proof, not an
assumption, and it is genuinely "nothing there". Correct as it stands.

**`_existing_ids`, non-zero exit — now raises.** `{}` did not report anything; it told
`_write` there were no ids to keep, so every field of an adopted item was renumbered on
the next write while `set` returned success. Unlike the other two there is nothing to
prove and so no listing to make: this runs only from `_write(creating=False)`, where
presence was just established, so no non-zero exit is a legitimate "no item". If the item
did vanish in between, raising names the read that failed instead of letting the
`item edit` fail more obscurely.

**`_existing_ids`, `JSONDecodeError` — now raises**, matching `_fields` eight lines up.
The same bytes were getting two different answers. That the failure is charter's inability
to *read* the answer rather than 1Password's inability to give one still makes it a
failure, never an absence.

**`_item_present` — the fourth site.** Not a `return {}`, so not in the issue's count of
three, and the worst consequence of the set. `return proc.returncode == 0` read a failed
read as *absent*, flipping `_write` to `item create` against a title that already exists.
1Password permits duplicate titles, so nothing refuses it: the vault ends up holding two
items called `charter-<vault>`, `op item get <title>` can no longer say which is meant, and
the vault stays unreadable until a human deletes one. Absence is now proven by an untagged
listing, exactly as #352 proves it — untagged because an adopted `op-item` carries no
charter tag.

Four lines of logic change. `_fail` and the existing `_DIAGNOSES` vocabulary are reused, so
the rate-limit signature #352 added carries straight through:

```
reading vault 'devops' failed (op exit 1) (identity from $OP_ENG_DEVOPS_TOKEN). 1Password
rate-limited this client. Its contents are UNKNOWN — this is not an empty vault. Wait and
retry rather than re-provisioning secrets that are probably there.
```

`cmd_secret_*` already handles `VaultError`; it was simply never given one.

## Verification

Test-first, and watched fail: **8 failures out of 13, every one `VaultError not raised`.**

**Preconditions asserted, because a vacuous pass is the way this fix could be wrong and
look right.** Three controls pass on `main` unchanged and would make everything else
meaningless if they did not:

- the fixture's item really holds an adopted id (`27r3gph…`) that a write preserves — so
  "the ids were not renumbered" is not true of an empty item;
- the write path really makes three `op item get` calls — so the injected failure indices
  mean what their comments say;
- a genuinely absent item is still created, and its absence is *proven* by a listing.

And every failure test asserts the window directly: the **first** `op item get` returned 0
and a **later** one did not. A fixture where `op` fails from the start proves nothing here.

**No real-`op` run.** With zero accounts configured on this machine, `op` fails at *every*
call, so `_fields` raises first and calls 1–2 are never reached — the real binary cannot
produce this window. It can only re-confirm the failure class and message that #352 already
demonstrated against the same `_fail`/`_DIAGNOSES` code. Relying on that evidence.

Full suite: **3227 passed** — the 3214 baseline (#352's 3197 plus #353's 17) plus exactly
the 13 tests added here.

## Deliberately not done

Collapsing the three reads into one is **#355**, referenced from a comment in `set()` so
the next person meets the reasoning where the redundancy is. It is the better end state —
fewer round trips on the path where rate limiting is most expensive, and ids that cannot
disagree with the values they are paired with — but its correctness lives in the
`op item edit`/`item create` round trip, and there is no 1Password vault on any machine in
this project to exercise it against. `0.46.2` shipped broken with sixteen green tests
because a smoke test was skipped; restructuring the secret-write path against a fake
immediately before a release is that shape again. This PR leaves no defect open.

## News

Ships **one** entry covering the class — `docs/news/unreleased-unreadable-vault-is-not-empty.md`,
`version: unreleased`, no `check:` — rather than two about mechanics. #352 shipped none, and
that was the gap rather than the precedent: the other eight unreleased entries cover the
audit's other work, and a release generates its notes from these files, so the version that
changes what `charter secret list` and `charter secret set` *do* would otherwise have
shipped saying nothing about it.

It is written for an operator, because there is a behaviour change they can be bitten by: a
masked read exited 0 and a reported failure does not, so automation branching on
`charter secret list` will notice — "charter started failing" with no note is how a good fix
reads as a regression. It also tells them to check 1Password item history if a `set` ran
while reads were failing, since that write may have replaced the item with one holding only
the key being set.

Verified it parses and lands: `news._read` returns the headline with an empty `check`, and
`news.render_body("unreleased")` now lists nine entries with this one among them.

No version bump, no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo
