### PR TITLE
Release 0.48.0 — the authority audit

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.47.2",
+  "version": "0.48.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.47.2"
+__version__ = "0.48.0"

--- a/docs/news/0.48.0-bound-and-sanitise-forge-data.md
+++ b/docs/news/0.48.0-bound-and-sanitise-forge-data.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.48.0
 headline: Forge calls are bounded, and forge data can no longer repaint your terminal
 ---
 

--- a/docs/news/0.48.0-committed-config-and-credentials.md
+++ b/docs/news/0.48.0-committed-config-and-credentials.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.48.0
 headline: Committed configuration no longer chooses what a credential is handed to
 ---
 

--- a/docs/news/0.48.0-committed-settings-are-validated.md
+++ b/docs/news/0.48.0-committed-settings-are-validated.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.48.0
 headline: Committed settings are checked where they act, and a persona's `role:` is quoted rather than obeyed
 ---
 

--- a/docs/news/0.48.0-contain-names-from-files.md
+++ b/docs/news/0.48.0-contain-names-from-files.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.48.0
 headline: A name charter reads out of a committed file can no longer point outside the plane
 ---
 

--- a/docs/news/0.48.0-contain-plane-writes.md
+++ b/docs/news/0.48.0-contain-plane-writes.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.48.0
 headline: A committed symlink can no longer redirect charter's own writes into your vault
 ---
 

--- a/docs/news/0.48.0-forge-argv-encoding.md
+++ b/docs/news/0.48.0-forge-argv-encoding.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.48.0
 headline: A branch name can no longer make `gh` open a file on your machine
 ---
 

--- a/docs/news/0.48.0-resolve-and-bound-plane-reads.md
+++ b/docs/news/0.48.0-resolve-and-bound-plane-reads.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.48.0
 headline: A committed symlink can no longer point charter's own reads at your vault, or stop them finishing
 ---
 

--- a/docs/news/0.48.0-unreadable-vault-is-not-empty.md
+++ b/docs/news/0.48.0-unreadable-vault-is-not-empty.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.48.0
 headline: A 1Password vault charter could not read is no longer reported as empty
 ---
 

--- a/docs/news/0.48.0-version-lock-direction.md
+++ b/docs/news/0.48.0-version-lock-direction.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.48.0
 headline: A committed version pin can no longer downgrade the guard binary behind your back
 ---
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.47.2",
+            "command": "charter hook sessionstart --plugin-version 0.48.0",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.47.2",
+            "command": "charter hook userpromptsubmit --plugin-version 0.48.0",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.47.2",
+            "command": "charter hook pretooluse --plugin-version 0.48.0",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.47.2",
+            "command": "charter hook pretooluse-read --plugin-version 0.48.0",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.47.2"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.48.0"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.47.2",
+            "command": "charter hook pretooluse-edit --plugin-version 0.48.0",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-bash --plugin-version 0.47.2",
+            "command": "charter hook posttooluse-bash --plugin-version 0.48.0",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.47.2",
+            "command": "charter hook posttooluse --plugin-version 0.48.0",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.47.2",
+            "command": "charter hook posttooluse-skill --plugin-version 0.48.0",
             "timeout": 5
           }
         ]
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.47.2",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.48.0",
             "timeout": 5
           }
         ]
@@ -128,7 +128,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-message --plugin-version 0.47.2",
+            "command": "charter hook posttooluse-message --plugin-version 0.48.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.47.2"
+version = "0.48.0"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Carries the whole authority audit: **ten merged PRs, eighteen issues, nine news entries**.

The through-line: **charter validated a name when a human typed it and never when it read one out of a committed file** — and separately trusted what a forge sent. The fixes are one containment vocabulary (`charter/contain.py`) applied at every reading *and* writing site, argv discipline on the forge calls, bounds on every read, and a set of diagnostics that stopped rendering failures as benign states.

## What operators will feel

- `charter secret set` now **fails loudly** where it previously returned success; `charter secret list` **errors** instead of reporting "no secrets" for an unreadable vault. A masked 1Password read had been dropping sibling secrets on the read-modify-write path.
- `[charter] version` now takes an exact `X.Y.Z`, and a **downgrade is reported, never performed unattended**.
- A persona's `role:` is **quoted under a data label** rather than spliced into an instruction.
- Reads of plane data are **bounded to a regular file and 1 MiB**, and refuse a symlink that escapes the data roots.

## Why minor, not patch — and not 1.0.0

Behaviour changes are real: exit codes change, a committed pin shape is now refused, a previously-succeeding `secret set` can now fail. Those are **changed defaults**, which the release charter puts squarely in minor territory — a patch says "no new surface", and shipping these behind one would hand them to anyone on auto-update unannounced.

Not 1.0.0 either: nothing here removes a documented feature or changes an API signature, and 1.0.0 is a claim about API stability that an audit still moving this much surface should not make. Under 0.x semver the minor *is* the breaking-change bump.

## Version points

All four files move together — **14 points**, verified by re-grepping the old string to zero:

| file | points |
|---|---|
| `pyproject.toml` | 1 |
| `charter/__init__.py` | 1 |
| `.claude-plugin/plugin.json` | 1 |
| `hooks/hooks.json` | **11** `--plugin-version` flags |

## Verification

- **Suite: 3227 tests, OK** on this branch (75.3s) — identical count to the `main` baseline (74.2s), so no tests were lost. 236 test files before and after; worktree hash asserted unchanged across both runs.
- **`charter doctor` terminates** in 1.37s, exit 0, run as a subprocess under an explicit 120s cap. The stamped entries arm **no `check:`** — `doctor` reports `news · nothing to adopt`.
- **`charter news --for 0.48.0`** renders all nine entries, exit 0 — the same call the release workflow's `guard` job makes, so guard and notes cannot disagree.
- **Asset-freshness gate**: `docs/assets/captured.json` is stamped `0.47.1`; the gate's own arithmetic gives lag **1** at `0.48.0`, which passes (`MAX_MINOR_LAG = 1`).
- **Behavioural smoke tests** against the stamped branch, each with its precondition asserted and a benign twin as a positive control: an unreadable vault errors with the new rate-limit diagnostic (exit 1) while a readable one still lists keys; a traversing `[persona] default`, `extends:`, and `workspace.json` repo name are each refused while their legitimate twins resolve; a symlinked `MEMORY.md` leaks nothing while a real memory reads back; the status line renders and shows `0.48.0`.

## Heads-up for the next release

`0.48.0` consumes the asset gate's **last slack**. With `captured.json` still at `0.47.1`, the next minor (`0.49.0`) computes lag 2 and **fails the suite** — the three SVG captures must be regenerated before then. (A hypothetical `1.0.0` would compute lag 953 and fail outright; that constraint did not decide this version, which stands on its own merits.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo
