### PR TITLE
Messages that match the failure (#360, #361, #363)

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1591,8 +1591,16 @@ def check_vault_registry_divergence() -> Result:
     from .secrets import base, registry
 
     try:
-        shared = registry.load_shared().get("vaults", {})
-        local = registry.load_local().get("vaults", {})
+        # Through `usable_vaults`, which is the same drop rule `load_registry` applies —
+        # not a raw read. Reading the halves raw did two wrong things at once (#363): it
+        # counted entries the merged view had already dropped, one line below the `vaults`
+        # check that named them as ignored, and it handed this loop the malformed entry
+        # itself. A non-empty string is truthy, so `shared[name] or {}` did not catch it
+        # and `.get` raised `AttributeError` — out of a preflight that has no per-check
+        # guard, so one hand-edited line in a committed file cost the whole briefing.
+        # That is #347's mechanism exactly, in the check next door to the one it fixed.
+        shared = registry.usable_vaults(registry.load_shared())
+        local = registry.usable_vaults(registry.load_local())
     except base.VaultError as e:
         return Result("vault registry", WARN, hint=str(e))
 
@@ -1616,9 +1624,14 @@ def check_vault_registry_divergence() -> Result:
             # warns about in this file ("it must not claim agreement it hasn't checked").
             return Result("vault registry", OK,
                           detail="no vaults registered — nothing to compare")
+        # DISTINCT vaults, not entries summed. A vault declared in both halves — the very
+        # case this check is about — is one vault, and `len(shared) + len(local)` called
+        # it two. "Entries" was the word doing the hiding: a reader looking at a vault
+        # registry counts vaults, so the plural has to be the thing being counted (#363).
+        n = len(set(shared) | set(local))
         return Result("vault registry", OK,
-                      detail=f"shared and local halves agree ({len(shared) + len(local)} "
-                             f"entr{'y' if len(shared) + len(local) == 1 else 'ies'})")
+                      detail=f"shared and local halves agree "
+                             f"({n} vault{'' if n == 1 else 's'})")
     shown = "; ".join(clashes[:3])
     if len(clashes) > 3:
         shown += f" (+{len(clashes) - 3} more)"

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -37,10 +37,81 @@ from . import config, contain, mcpseen
 
 _NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 
+#: The characters :data:`_NAME_RE` admits anywhere after the first. Kept beside it so the
+#: rule and the sentence that reports the rule cannot drift apart.
+_NAME_CHARS = re.compile(r"[a-z0-9._-]")
+
+#: Why a reference is not a persona name when its **alphabet** is what it violated, rather
+#: than its shape. Said here, next to :func:`valid_name`, because that is the rule broken.
+#:
+#: `contain.NOT_A_SEGMENT` describes a *different* violation and enumerates separators,
+#: dots and absolute paths — none of which is true of ``"parent"`` (quoted). Rendering it
+#: for either half of :func:`reference_ok` sent the operator looking for a slash that is
+#: not there, which is #328's own defect, a distinction collapsed, reappearing three lines
+#: below the docstring that names it (#361).
+NOT_A_NAME = ("'{name}' is not a persona name{detail}. Charter mints these itself — "
+              "`persona create` enforces exactly this — so a reference can only name one: "
+              "a lowercase letter or digit first, then lowercase letters, digits, '.', "
+              "'_' or '-'")
+
+#: The one refused reference that is neither a path nor a bad character: nothing at all.
+#: ``extends:`` with an empty value parses to ``""``, and "'' is not a name — it is a path"
+#: would be wrong twice over.
+EMPTY_REFERENCE = "is empty — remove the key, or name a persona"
+
 
 def valid_name(name: str) -> bool:
     # A leading '_' is reserved (the shared namespace) and rejected by the regex.
     return bool(name) and _NAME_RE.match(name) is not None
+
+
+def _alphabet_detail(ref: str) -> str:
+    """The clause naming *which* part of the alphabet *ref* broke.
+
+    Three cases, because they are three different fixes. A disallowed character is deleted
+    or replaced; a bad *first* character means the name is otherwise fine and only starts
+    wrong; and quotes mean the frontmatter was written as YAML by someone who reasonably
+    expected YAML.
+    """
+    bad = sorted({c for c in ref if not _NAME_CHARS.fullmatch(c)})
+    if bad and set(bad) <= {'"', "'"}:
+        # The live case from #361, and worth its own sentence because the generic one
+        # ("'\"' cannot appear in one") is true and still leaves the reader guessing.
+        # charter's frontmatter parser does not strip quotes, so the value really does
+        # carry them — the fix is in the file, and it is two characters.
+        return (" — the quotes are part of the value. charter's frontmatter parser does "
+                "not strip them, so `extends: \"parent\"` asks for a persona whose name "
+                "includes the quote marks; remove them")
+    if bad:
+        return f" — {', '.join(repr(c) for c in bad)} cannot appear in one"
+    # Every character is in the alphabet, so the FIRST one is what is wrong. Listing '_'
+    # as a disallowed character here would be its own small lie: it is allowed, just not
+    # in front.
+    if ref[0] == "_":
+        return " — a leading '_' is reserved for the shared namespace"
+    return f" — it starts with {ref[0]!r}"
+
+
+def reference_refusal(ref: str) -> str | None:
+    """Why *ref*, read out of a committed file, cannot name a persona — or ``None``.
+
+    **The one place that answers this**, verdict *and* sentence together, which is the
+    property :func:`reference_ok` already claimed for itself and did not have: it decided
+    the verdict here while the caller picked the message somewhere else, and the message
+    it picked described the other failure (#361).
+
+    The two halves are asked in this order deliberately. Where a reference is both a path
+    and outside the alphabet, "it is a path" is the more serious and the more useful thing
+    to say — the alphabet is a naming rule, containment is what stops a committed file
+    naming a target outside the directory charter meant to look in.
+    """
+    if not ref:
+        return EMPTY_REFERENCE
+    if contain.child(config.PERSONAS_DIR, ref) is None:
+        return contain.refusal(ref)
+    if not valid_name(ref):
+        return NOT_A_NAME.format(name=ref, detail=_alphabet_detail(ref))
+    return None
 
 
 def reference_ok(ref: str) -> bool:
@@ -64,8 +135,12 @@ def reference_ok(ref: str) -> bool:
 
     The containment join is belt and braces on top, per :mod:`charter.contain`: it is the
     half that still holds if `_NAME_RE` is ever widened.
+
+    Delegates to :func:`reference_refusal` rather than re-testing the two halves, so the
+    verdict and the sentence an operator reads cannot describe different failures — which
+    they did, and which is what #361 is (see that function).
     """
-    return valid_name(ref) and contain.child(config.PERSONAS_DIR, ref) is not None
+    return reference_refusal(ref) is None
 
 
 # --------------------------------------------------------------------------- #
@@ -910,18 +985,27 @@ def is_draft(name: str) -> bool:
 def _reference_problem(field: str, ref: str, known: set[str]) -> tuple[str, str] | None:
     """Why *ref* cannot be used as a persona reference, or None when it can.
 
-    Two failures, said two ways, because they send the reader to two different places. A
-    name that is simply absent is a typo or a rename — "dangling" is right, and hunting
-    for the persona is the fix. A reference that is a *path* is not a name at all: no
-    amount of looking for that persona will help, and the fix is in the file. #328's whole
-    shape is a distinction like this one being collapsed, so it gets its own sentence.
+    Three failures, said three ways, because they send the reader to three different
+    places. A name that is simply absent is a typo or a rename — "dangling" is right, and
+    hunting for the persona is the fix. A reference that is a *path* is not a name at all:
+    no amount of looking for that persona will help, and the fix is in the file. And a
+    reference that is neither — ``"parent"``, quoted — is refused by the *alphabet*, where
+    the fix is two characters. #328's whole shape is a distinction like these being
+    collapsed, so each gets its own sentence.
+
+    It said two, and that is #361: this line rendered `contain.refusal` for either half of
+    :func:`reference_ok`, so a quoted reference — no separator, no dot, not absolute — was
+    answered with a sentence enumerating separators, dots and absolute paths. The
+    distinction this docstring exists to draw was collapsed on the line below it.
+    :func:`reference_refusal` now decides the verdict and the sentence together.
 
     Shares :func:`reference_ok` with :func:`load`, which is what makes lint and the
     resolver structurally unable to disagree again — the property whose absence let the
     gate honour a grant `lint` was calling dangling in the same run.
     """
-    if not reference_ok(ref):
-        return ("error", f"{field}: {contain.refusal(ref)}")
+    refused = reference_refusal(ref)
+    if refused:
+        return ("error", f"{field}: {refused}")
     if ref not in known:
         return ("error", f"{field}: '{ref}' — no such persona (dangling)")
     return None

--- a/charter/report.py
+++ b/charter/report.py
@@ -510,14 +510,73 @@ def gh_available() -> bool:
     return p.returncode == 0
 
 
+#: A Markdown ATX heading opening the first line of a described report. Stripped before
+#: that line becomes an issue title, because a heading marker is a **block** marker — it
+#: was never part of the reporter's sentence — where backticks and bold are inline markup
+#: the reporter chose. Charter un-marks the line; it does not rewrite the words.
+#:
+#: The body of a report *is* Markdown, so opening with a heading is the natural thing to
+#: write, and #322 on this tracker is titled ``# `charter secret list` reports …`` because
+#: nothing removed it. The trailing group is CommonMark's *closed* form (``## Title ##``).
+#: The whitespace CommonMark requires after the marker is load-bearing here: without it,
+#: "#331 is still open" — an issue reference in the reporter's own sentence — would be
+#: read as a heading and silently lose the number.
+_ATX_HEADING = re.compile(r"^#{1,6}[ \t]+(.*?)[ \t]*#*[ \t]*$")
+
+#: The longest an issue title may be, ellipsis included. A forge allows far more; this is
+#: about the maintainer's issue list, where a title that wraps stops being scannable.
+_TITLE_MAX = 72
+
+#: The earliest index at which a word break is worth taking. Below it, breaking throws away
+#: more of the sentence than a tidy ending is worth, so charter cuts mid-word instead.
+#:
+#: Hand-rolled rather than :func:`textwrap.shorten` for exactly that case: `shorten`
+#: returns **only** the placeholder when the first word exceeds the width, so a first line
+#: that is one long unbroken token — a URL, a path, a stack frame — would arrive on the
+#: tracker as an issue titled "…". The obvious helper is wrong in the one case a floor is
+#: for, and it would have looked right in review.
+_BREAK_FLOOR = 40
+
+
 def title(rec: dict) -> str:
     """The upstream issue title. Crashes lead with exception type and subcommand so
-    duplicates collide visually in the issue list."""
+    duplicates collide visually in the issue list.
+
+    A *described* report has no exception to lead with, so its title is its first line —
+    un-marked and bounded at a word. That line is also what :func:`search_duplicates`
+    searches on, so a marker left in place degrades duplicate detection as well as the
+    title (#360).
+
+    The heading is deliberately **not** removed from the body. :func:`render` serves both
+    the Reporter's review and the issue body so that what is shown and what is sent cannot
+    drift (docs/adr/0003); dropping a line here would make the sent thing differ from the
+    approved thing, and would need `render` and this function to agree about which line
+    became the title. One repeated heading is the cheaper failure.
+    """
     p = rec["payload"]
     if p.get("exception_type"):
         return f"{p['exception_type']} in `charter {p.get('subcommand', '?')}`"
-    first = (p.get("text") or "").strip().splitlines()[0]
-    return first[:72] + ("…" if len(first) > 72 else "")
+    lines = (p.get("text") or "").strip().splitlines()
+    if not lines:
+        # `splitlines()` on empty or whitespace-only text is the EMPTY list, and the
+        # verbatim `[0]` raised `IndexError`. `commands_report._draft` refuses an empty
+        # body one layer up, so no CLI path reaches this — but `title` is called on stored
+        # records, and the one function whose job is to describe a report must never be the
+        # thing that raises.
+        return ""
+    first = lines[0].strip()
+    heading = _ATX_HEADING.match(first)
+    if heading:
+        first = heading.group(1).strip()
+    # Measured AFTER the marker is stripped: a line whose words fit once the "# " is gone
+    # must not be truncated for two characters charter itself removed.
+    if len(first) <= _TITLE_MAX:
+        return first
+    cut = first[:_TITLE_MAX - 1]                       # leave room for the ellipsis
+    space = cut.rfind(" ")
+    if space >= _BREAK_FLOOR:
+        cut = cut[:space]
+    return cut.rstrip() + "…"
 
 
 def search_duplicates(rec: dict) -> list[dict]:

--- a/charter/secrets/registry.py
+++ b/charter/secrets/registry.py
@@ -69,6 +69,29 @@ def load_local() -> dict:
     return _read(config.VAULTS_REGISTRY)
 
 
+def usable_vaults(half: dict) -> dict:
+    """The entries in one half of the registry that are vault entries at all.
+
+    A vault entry that is not an object is not a vault entry. `vaults.json` is COMMITTED
+    and hand-editable, and `provider_for` reached straight for `entry.get("provider")` —
+    so a string there raised `AttributeError` out of `doctor.check_vaults`, which runs
+    from the SessionStart hook and catches only `VaultError` (#347).
+
+    **The one place that decides what a half contains**, so a reader that *counts* entries
+    and a reader that *resolves* them cannot disagree about which ones exist. They did:
+    `load_registry` dropped the malformed entry while `doctor.check_vault_registry_
+    divergence` read the halves raw — which is both why it counted an entry the line above
+    it had just called ignored, and why it was handed the string it crashed on (#363).
+    Defending here rather than in each reader is the same single-source rule that put the
+    drop in `load_registry` in the first place; the mistake was having two implementations
+    of "what is in this file", not where the first one lived.
+
+    Nothing is hidden by the drop: `doctor` names what was dropped (see
+    :func:`malformed_shared`).
+    """
+    return {n: e for n, e in (half or {}).get("vaults", {}).items() if isinstance(e, dict)}
+
+
 def load_registry() -> dict:
     """The merged view every reader gets: shared as the base, local layered over it.
 
@@ -78,20 +101,9 @@ def load_registry() -> dict:
     """
     merged = {}
     shared, local = load_shared(), load_local()
-    for name, entry in shared.get("vaults", {}).items():
-        # A vault entry that is not an object is not a vault entry. `vaults.json` is
-        # COMMITTED and hand-editable, and `provider_for` reached straight for
-        # `entry.get("provider")` — so a string there raised `AttributeError` out of
-        # `doctor.check_vaults`, which runs from the SessionStart hook and catches only
-        # `VaultError`. Dropping it here rather than defending in each reader is the
-        # single-source rule: this function IS the merged view every reader gets.
-        # `doctor` names what was dropped (see `malformed_shared`), so nothing is hidden.
-        if not isinstance(entry, dict):
-            continue
+    for name, entry in usable_vaults(shared).items():
         merged[name] = json.loads(json.dumps(entry))          # deep copy, no aliasing
-    for name, entry in local.get("vaults", {}).items():
-        if not isinstance(entry, dict):
-            continue
+    for name, entry in usable_vaults(local).items():
         if name not in merged:
             merged[name] = json.loads(json.dumps(entry))
             continue
@@ -106,10 +118,15 @@ def load_registry() -> dict:
 
 def malformed_shared() -> list[str]:
     """Names in the COMMITTED half whose entry is not an object, and was therefore
-    dropped from the merged view. Never raises — a corrupt file reads as none."""
+    dropped from the merged view. Never raises — a corrupt file reads as none.
+
+    The complement of :func:`usable_vaults` rather than its own `isinstance` test, so the
+    names `doctor` reports as ignored are exactly the ones the merged view left out.
+    """
     try:
-        return sorted(n for n, e in load_shared().get("vaults", {}).items()
-                      if not isinstance(e, dict))
+        half = load_shared()
+        kept = usable_vaults(half)
+        return sorted(n for n in half.get("vaults", {}) if n not in kept)
     except VaultError:
         return []
 

--- a/docs/news/unreleased-messages-that-match-the-failure.md
+++ b/docs/news/unreleased-messages-that-match-the-failure.md
@@ -1,0 +1,59 @@
+---
+version: unreleased
+headline: Three messages now name the failure you actually have
+---
+
+Three defects of one species: a message that told the reader something other than what
+happened. Each was cheap to fix and expensive to read, because the whole value of a
+diagnostic is that it points at the thing that is wrong.
+
+**An issue title is the reporter's sentence, not their markup.** `charter report` took a
+described report's first line verbatim and cut it at 72 characters. The body of a report is
+Markdown, so opening with a heading is the natural thing to write — and the `#` travelled
+to the tracker in the title, cut mid-word. #322 on charter's own tracker is titled
+``# `charter secret list` reports "no secrets" when the 1Password read act…``. The same
+string feeds duplicate detection, so the marker and the mid-word cut went into the search
+too.
+
+A heading marker is a **block** marker: it was never part of the sentence. Backticks and
+bold are inline markup the reporter chose, and are left alone — charter un-marks the line,
+it does not rewrite the words. Truncation now prefers a word boundary, with a floor below
+which it cuts mid-word instead, because a break too near the start throws away more of the
+sentence than a tidy ending is worth.
+
+The heading is deliberately **not** removed from the body, and that was the open question.
+`render` serves both the Reporter's review and the issue body on purpose, so that what is
+shown and what is sent cannot drift (`docs/adr/0003`). Dropping the line once it became the
+title would make the sent thing differ from the approved thing in the one place the design
+forbids it, and would need two functions to agree about which line that was. An issue that
+opens with its own title repeated is a cosmetic cost; an approval that stops meaning
+anything is not.
+
+**A bad character in a persona reference is no longer called a path.** `extends: "parent"`
+— quoted, because charter's frontmatter parser does not strip quotes — was refused with a
+sentence enumerating "no '/', no '\', no '.' or '..', nothing absolute". Every one of those
+conditions is false for it. The operator was sent looking for a separator that is not there
+when the fix was to delete two quote marks, and a quoted reference produced output
+identical to `extends: ../evil`.
+
+`persona lint` now says which rule was broken. A reference that really is a path keeps the
+containment sentence, and is still checked first — where a reference is both, "it is a
+path" is the more serious thing to say. A reference refused by the alphabet gets a sentence
+about the alphabet, naming the character, and saying so plainly when that character is a
+quote mark. A name that is simply absent is still "dangling", which is still the right
+place to go looking.
+
+**A malformed `vaults.json` entry no longer takes the whole preflight with it.** One entry
+that is not an object — a string where a vault should be — made `doctor`'s registry check
+raise `AttributeError`, and `charter doctor` ended with `charter preflight:` and nothing
+after it. Not one check reported, including the dozen that had already passed and the
+`vaults` check that would have named the bad entry. `vaults.json` is committed and shared,
+so that line arrives from a teammate's machine or a bad merge.
+
+The same raw read is why the check counted an entry the line above it had just called
+ignored — the contradiction noted in #347 and left as cosmetic. One drop rule now answers
+both readers, so a reader that counts entries and a reader that resolves them cannot
+disagree about which ones exist. The total also counts distinct **vaults** rather than
+summing the two halves, which reported "2 entries" for one vault declared in both.
+
+Found while auditing 0.48.0 (#360, #361, #363).

--- a/tests/test_doctor_vault_registry_malformed.py
+++ b/tests/test_doctor_vault_registry_malformed.py
@@ -1,0 +1,180 @@
+"""`doctor`'s registry check, against a `vaults.json` entry that is not an object (#363).
+
+#346 taught `load_registry` to drop such an entry and `check_vaults` to name what it
+dropped (#347). `check_vault_registry_divergence` was not part of that change and still
+read the two halves raw, so it
+
+* **crashed** — a malformed entry is a *string*, a non-empty string is truthy, so
+  ``shared[name] or {}`` handed a `str` to ``.get`` — taking the entire preflight with it,
+  because `_checks()` is eager and `cmd_doctor` has no per-check guard; and
+* **counted** an entry `load_registry` had already dropped, one line below the check that
+  said it was ignored.
+
+Every test here **proves the drop happened first**. A test that asserted a count without
+establishing that the entry was malformed *and* dropped would pass against a fixture that
+was never malformed at all — which is the vacuous pass this module exists to avoid.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import doctor
+from charter.secrets import registry
+from tests._isolation import PersonaIso
+
+#: Not an object. The shape #347 found in the field.
+MALFORMED = "op://Team/devops"
+
+
+class MalformedEntryCase(PersonaIso):
+    def assert_dropped(self, name: str) -> None:
+        """Precondition: *name*'s committed entry really is malformed, and really was
+        dropped from the merged view every reader gets.
+
+        Deliberately **not** ``assertNotIn(name, registry.vaults())``. When the same name
+        is also declared in the local half — which is the shape that reached the crash —
+        the name survives into the merged view carrying the *local* entry, and the shared
+        string is what was dropped. Asserting the name's absence looked right and was
+        wrong for exactly the case this module is about; what has to be true is that the
+        malformed VALUE never reaches a reader.
+        """
+        raw = registry.load_shared().get("vaults", {})
+        self.assertIn(name, raw, f"precondition: {name} is not in the shared half at all")
+        self.assertNotIsInstance(
+            raw[name], dict,
+            f"precondition: {name} is a well-formed entry, so nothing would drop it")
+        self.assertIn(name, registry.malformed_shared(),
+                      f"precondition: {name} is not reported as malformed, so nothing "
+                      f"dropped it and this test would assert against an intact registry")
+        self.assertNotEqual(registry.vaults().get(name), raw[name],
+                            f"precondition: the malformed value for {name} survived into "
+                            f"the merged view")
+
+    def assert_absent_from_merged(self, name: str) -> None:
+        """The stronger form, for a name the local half does not rescue."""
+        self.assert_dropped(name)
+        self.assertNotIn(name, registry.vaults())
+
+
+class TestItNoLongerCrashes(MalformedEntryCase):
+    def test_a_malformed_shared_entry_also_named_locally_does_not_raise(self):
+        """The crash, exactly: the name has to be in BOTH halves to reach the `.get`, and
+        a shared vault with a local `account` pin is the ordinary shape of that."""
+        registry.save_shared({"vaults": {"devops": MALFORMED}})
+        registry.save_registry({"vaults": {"devops": {"config": {"account": "me@corp"}}}})
+        self.assert_dropped("devops")
+        r = doctor.check_vault_registry_divergence()          # must not raise
+        self.assertEqual(r.status, doctor.OK)
+
+    def test_the_rest_of_the_preflight_still_runs(self):
+        """What the crash actually cost: `_checks()` is eager, so one raising check ended
+        the command before a single line was printed — including the twelve that passed."""
+        registry.save_shared({"vaults": {"devops": MALFORMED}})
+        registry.save_registry({"vaults": {"devops": {"config": {"account": "me@corp"}}}})
+        results = doctor.run_all()
+        self.assertGreater(len(results), 12)
+        self.assertIn("vault registry", [r.name for r in results])
+
+    def test_a_malformed_entry_in_the_local_half_does_not_raise_either(self):
+        registry.save_shared({"vaults": {"devops": {"config": {"op-item": "x"}}}})
+        registry.save_registry({"vaults": {"devops": MALFORMED}})
+        self.assertEqual(doctor.check_vault_registry_divergence().status, doctor.OK)
+
+    def test_a_malformed_entry_in_both_halves_does_not_raise(self):
+        registry.save_shared({"vaults": {"devops": MALFORMED}})
+        registry.save_registry({"vaults": {"devops": MALFORMED}})
+        self.assertEqual(doctor.check_vault_registry_divergence().status, doctor.OK)
+
+
+class TestTheCountMatchesWhatWasKept(MalformedEntryCase):
+    def test_a_dropped_entry_is_not_counted(self):
+        registry.save_shared({"vaults": {"devops": MALFORMED,
+                                         "media": {"config": {"op-item": "m"}}}})
+        self.assert_absent_from_merged("devops")
+        detail = doctor.check_vault_registry_divergence().detail
+        self.assertIn("1", detail)
+        self.assertNotIn("2", detail)
+
+    def test_one_vault_declared_in_both_halves_counts_once(self):
+        """`len(shared) + len(local)` reported "2 entries" for one vault — and "entries"
+        was the word doing the hiding, because a reader of a vault registry counts vaults."""
+        registry.save_shared({"vaults": {"ops": {"config": {"op-item": "same"}}}})
+        registry.save_registry({"vaults": {"ops": {"config": {"op-item": "same"}}}})
+        detail = doctor.check_vault_registry_divergence().detail
+        self.assertIn("1", detail)
+        self.assertNotIn("2", detail)
+
+    def test_the_count_says_vaults(self):
+        registry.save_shared({"vaults": {"a": {}, "b": {}}})
+        detail = doctor.check_vault_registry_divergence().detail
+        self.assertIn("2 vaults", detail)
+
+    def test_one_vault_is_singular(self):
+        registry.save_shared({"vaults": {"a": {}}})
+        self.assertIn("1 vault", doctor.check_vault_registry_divergence().detail)
+
+    def test_distinct_vaults_across_the_halves_are_counted_once_each(self):
+        registry.save_shared({"vaults": {"team": {"config": {"op-item": "x"}}}})
+        registry.save_registry({"vaults": {"solo": {"config": {"op-item": "y"}}}})
+        self.assertIn("2 vaults", doctor.check_vault_registry_divergence().detail)
+
+    def test_no_vaults_at_all_still_says_nothing_to_compare(self):
+        """The existing wording, which must survive: claiming the halves agree when
+        neither holds anything is an agreement nothing was compared to reach."""
+        self.assertIn("nothing to compare",
+                      doctor.check_vault_registry_divergence().detail)
+
+    def test_a_registry_that_holds_only_a_malformed_entry_has_nothing_to_compare(self):
+        registry.save_shared({"vaults": {"devops": MALFORMED}})
+        self.assert_absent_from_merged("devops")
+        self.assertIn("nothing to compare",
+                      doctor.check_vault_registry_divergence().detail)
+
+
+class TestTheTwoVaultLinesNoLongerContradict(MalformedEntryCase):
+    """#347's actual complaint: one line says the entry was ignored, the next counts it.
+
+    `check_vaults` reaches its notes only on the OK path, which needs a reachable vault —
+    so the provider is stubbed. Nothing here touches a real 1Password.
+    """
+
+    def _healthy(self):
+        prov = mock.Mock()
+        prov.env_overlay.return_value = None
+        prov.health.return_value = (True, 1)
+        return mock.patch.object(registry, "provider_for", return_value=prov)
+
+    def test_ignored_and_counted_agree(self):
+        registry.save_shared({"vaults": {"devops": MALFORMED,
+                                         "media": {"provider": "op", "persona": "ed"}}})
+        self.assert_absent_from_merged("devops")
+        with self._healthy():
+            vaults_line = doctor.check_vaults()
+        registry_line = doctor.check_vault_registry_divergence()
+
+        self.assertIn("devops", vaults_line.detail)
+        self.assertIn("ignored", vaults_line.detail)
+        # The contradiction: the line above ignored one of two, so the line below must not
+        # report two.
+        self.assertIn("1 vault", registry_line.detail)
+        self.assertNotIn("2", registry_line.detail)
+
+
+class TestDivergenceIsStillDetected(MalformedEntryCase):
+    """The check must not be made quiet by the fix — a malformed entry beside a real
+    disagreement still has to report the disagreement."""
+
+    def test_a_real_clash_is_still_found_next_to_a_malformed_entry(self):
+        registry.save_shared({"vaults": {"junk": MALFORMED,
+                                         "ops": {"config": {"op-item": "charter-ops"}}}})
+        registry.save_registry({"vaults": {"ops": {"config": {"op-item": "SECRET"}}}})
+        self.assert_absent_from_merged("junk")
+        r = doctor.check_vault_registry_divergence()
+        self.assertEqual(r.status, doctor.FAIL)
+        for expected in ("op-item", "SECRET", "charter-ops"):
+            self.assertIn(expected, r.detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_persona_reference_message.py
+++ b/tests/test_persona_reference_message.py
@@ -1,0 +1,159 @@
+"""A refused persona reference is told apart from a refused *path* (#361).
+
+`reference_ok` is two checks — `valid_name` and `contain.child` — and `_reference_problem`
+rendered `contain.refusal` for either. That message enumerates "no '/', no '\\', no '.' or
+'..', nothing absolute". For ``extends: "parent"`` — quoted, because charter's frontmatter
+parser does not strip quotes — **every one of those conditions is false**. The operator was
+sent looking for a slash that is not there when the fix is to delete two quote marks.
+
+The irony is the point: `_reference_problem`'s own docstring says "#328's whole shape is a
+distinction like this one being collapsed", three lines above the line that collapsed one.
+
+Each test asserts its **precondition** — which half of `reference_ok` actually failed —
+because a message test that passes while the other branch produced the string proves
+nothing about the branch it names.
+"""
+from __future__ import annotations
+
+import unittest
+
+from charter import config, contain, persona
+from tests._isolation import PersonaIso
+
+#: The live case from #361, exactly as a frontmatter parser hands it over.
+QUOTED = '"parent"'
+
+
+class ReferenceRefusalCase(PersonaIso):
+    def assert_containment_passed(self, ref: str) -> None:
+        """Precondition: the *containment* half is satisfied, so anything this reference
+        is refused for is the alphabet — and `contain.refusal` would be a false sentence."""
+        self.assertIsNotNone(
+            contain.child(config.PERSONAS_DIR, ref),
+            f"precondition failed: {ref!r} does not survive containment, so this test "
+            f"would be asserting about the wrong half of reference_ok")
+
+    def assert_containment_failed(self, ref: str) -> None:
+        self.assertIsNone(
+            contain.child(config.PERSONAS_DIR, ref),
+            f"precondition failed: {ref!r} survives containment, so the containment "
+            f"message is not the one under test")
+
+
+class TestTheQuotedReferenceFromIssue361(ReferenceRefusalCase):
+    def test_precondition_only_the_alphabet_half_rejects_it(self):
+        """The whole basis of the issue, asserted rather than assumed: the quoted name is
+        not a path by any of the tests the old message listed."""
+        self.assert_containment_passed(QUOTED)
+        self.assertFalse(persona.valid_name(QUOTED))
+        self.assertFalse(persona.reference_ok(QUOTED))
+        self.assertTrue(persona.reference_ok("parent"))
+
+    def test_the_message_does_not_call_it_a_path(self):
+        msg = persona.reference_refusal(QUOTED)
+        self.assertNotIn("it is a path", msg)
+
+    def test_the_message_does_not_send_the_reader_looking_for_a_separator(self):
+        """Every condition the old sentence enumerated is false for this reference."""
+        msg = persona.reference_refusal(QUOTED)
+        for absent in ("no '/'", "no '\\'", "nothing absolute", "'.' or '..'"):
+            self.assertNotIn(absent, msg)
+
+    def test_the_message_names_the_quotes_and_says_to_remove_them(self):
+        msg = persona.reference_refusal(QUOTED)
+        self.assertIn("quote", msg)
+        self.assertIn("remove", msg)
+
+
+class TestAReferenceThatReallyIsAPath(ReferenceRefusalCase):
+    """The containment half keeps its own sentence, and is asked first — where a reference
+    is both a path and outside the alphabet, "it is a path" is the more serious and more
+    useful thing to say."""
+
+    def test_a_relative_path_still_gets_the_containment_message(self):
+        self.assert_containment_failed("../evil")
+        self.assertEqual(persona.reference_refusal("../evil"), contain.refusal("../evil"))
+
+    def test_a_separator_still_gets_the_containment_message(self):
+        self.assert_containment_failed("team/parent")
+        self.assertIn("it is a path", persona.reference_refusal("team/parent"))
+
+    def test_dot_dot_still_gets_the_containment_message(self):
+        self.assert_containment_failed("..")
+        self.assertIn("it is a path", persona.reference_refusal(".."))
+
+
+class TestTheAlphabetMessageNamesWhatWasViolated(ReferenceRefusalCase):
+    def test_a_leading_underscore_is_named_as_the_reserved_namespace(self):
+        """`_` IS in the alphabet — it is only the FIRST character that is wrong, so
+        listing it as a disallowed character would be its own small lie."""
+        self.assert_containment_passed("_shared")
+        msg = persona.reference_refusal("_shared")
+        self.assertIn("_", msg)
+        self.assertIn("reserved", msg)
+
+    def test_an_uppercase_reference_names_the_character(self):
+        self.assert_containment_passed("Frontdoor")
+        self.assertIn("'F'", persona.reference_refusal("Frontdoor"))
+
+    def test_a_space_is_named(self):
+        self.assert_containment_passed("front door")
+        self.assertIn("' '", persona.reference_refusal("front door"))
+
+    def test_an_empty_reference_is_neither_a_path_nor_a_bad_character(self):
+        msg = persona.reference_refusal("")
+        self.assertNotIn("it is a path", msg)
+        self.assertIn("empty", msg)
+
+
+class TestOneFunctionDecidesVerdictAndSentence(ReferenceRefusalCase):
+    """`reference_ok`'s docstring claims to be "the one place that answers this". It was
+    for the verdict and not for the message — which is how the message came to describe a
+    different failure from the one that happened."""
+
+    CASES = ("parent", QUOTED, "../evil", "team/parent", "..", "", "_shared",
+             "Frontdoor", "front door", "front.door", "front-door_2")
+
+    def test_ok_is_exactly_the_absence_of_a_refusal(self):
+        for ref in self.CASES:
+            with self.subTest(ref=ref):
+                self.assertEqual(persona.reference_ok(ref),
+                                 persona.reference_refusal(ref) is None)
+
+    def test_a_good_reference_has_no_refusal(self):
+        self.assertIsNone(persona.reference_refusal("parent"))
+        self.assertIsNone(persona.reference_refusal("front.door"))
+        self.assertIsNone(persona.reference_refusal("front-door_2"))
+
+
+class TestWhatLintPrints(ReferenceRefusalCase):
+    """The message an operator actually reads. `structural_errors` is what `persona lint`
+    and the status line both go through."""
+
+    def test_lint_names_the_quotes_rather_than_a_missing_slash(self):
+        self.make_persona("parent", role="Parent", vault="none")
+        self.make_persona("child", role="Child", vault="none", extends=QUOTED)
+        errs = persona.structural_errors("child")
+        self.assertTrue(errs, "precondition: the quoted extends must be a lint error")
+        text = " ".join(m for _, m in errs)
+        self.assertIn("extends:", text)
+        self.assertIn("quote", text)
+        self.assertNotIn("it is a path", text)
+
+    def test_lint_still_calls_a_real_path_a_path(self):
+        self.make_persona("child", role="Child", vault="none", extends="../evil")
+        text = " ".join(m for _, m in persona.structural_errors("child"))
+        self.assertIn("it is a path", text)
+
+    def test_a_dangling_but_well_formed_reference_is_still_dangling(self):
+        """The third distinction, unchanged: a name that is a name and simply absent sends
+        the reader hunting for the persona, which is the right place to look."""
+        self.make_persona("child", role="Child", vault="none", extends="nosuchpersona")
+        text = " ".join(m for _, m in persona.structural_errors("child"))
+        self.assertIn("dangling", text)
+        self.assertNotIn("quote", text)
+        self.assertNotIn("it is a path", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_report_title.py
+++ b/tests/test_report_title.py
@@ -1,0 +1,159 @@
+"""`report.title` — the one line of a report a maintainer reads before anything else.
+
+The free-text branch took the report's first line verbatim and cut it at 72 (#360). A
+reporter opening with a Markdown heading — which is natural, the body *is* Markdown — got
+the `#` in the issue title, truncated mid-word. Live example: #322 on this tracker.
+
+Every test here asserts its **precondition** first: that the record has no
+``exception_type``, so the free-text branch is the one that ran. The crash branch above it
+never touches this code, and a test that silently exercised it would pass while proving
+nothing.
+"""
+from __future__ import annotations
+
+import unittest
+
+from charter import report
+
+#: #322's first line, as the reporter wrote it. The defect this module exists for.
+_322 = '`charter secret list` reports "no secrets" when the 1Password read actually failed'
+
+
+def rec(text: str) -> dict:
+    return {"payload": {"text": text}}
+
+
+class TitleCase(unittest.TestCase):
+    def title_of(self, text: str) -> str:
+        """The title, having first proved the free-text branch is what produced it."""
+        r = rec(text)
+        self.assertNotIn("exception_type", r["payload"],
+                         "precondition: this must be the free-text branch, not the crash "
+                         "branch, which builds its title from the exception type instead")
+        return report.title(r)
+
+    def assert_broke_at_a_word(self, first: str, title: str) -> None:
+        """The title is a prefix of *first* that ends where a word ends."""
+        self.assertTrue(title.endswith("…"), title)
+        kept = title[:-1]
+        self.assertTrue(first.startswith(kept), f"{title!r} is not a prefix of {first!r}")
+        self.assertEqual(first[len(kept)], " ",
+                         f"{title!r} cut mid-word — the next character is not a space")
+
+
+class TestAHeadingMarkerIsNotPartOfTheTitle(TitleCase):
+    def test_the_issue_322_line_loses_its_marker_and_keeps_its_words(self):
+        self.assertEqual(
+            self.title_of(f"# {_322}\n\nBody follows."),
+            '`charter secret list` reports "no secrets" when the 1Password read…')
+
+    def test_every_atx_depth_is_stripped(self):
+        for depth in range(1, 7):
+            with self.subTest(depth=depth):
+                self.assertEqual(self.title_of(f"{'#' * depth} A gap in clone"),
+                                 "A gap in clone")
+
+    def test_a_closed_atx_heading_loses_the_trailing_markers_too(self):
+        self.assertEqual(self.title_of("## A gap in clone ##"), "A gap in clone")
+
+    def test_a_hash_that_is_not_a_heading_marker_is_left_alone(self):
+        """CommonMark needs whitespace after the marker. `#331` is an issue reference in
+        the reporter's own sentence, and deleting it would change what they said."""
+        self.assertEqual(self.title_of("#331 is still open"), "#331 is still open")
+
+    def test_a_hash_inside_the_line_is_left_alone(self):
+        self.assertEqual(self.title_of("clone fails on #331"), "clone fails on #331")
+
+
+class TestInlineMarkupIsTheReportersOwnWords(TitleCase):
+    """A heading marker is a *block* marker — it was never part of the sentence. Backticks
+    and bold are inline markup the reporter chose. Charter un-marks the line; it does not
+    rewrite the words."""
+
+    def test_backticks_survive(self):
+        self.assertEqual(self.title_of("# `charter clone` fails"), "`charter clone` fails")
+
+    def test_bold_survives(self):
+        self.assertEqual(self.title_of("**clone** fails"), "**clone** fails")
+
+
+class TestTruncationPrefersAWordBoundary(TitleCase):
+    def test_a_long_line_is_not_cut_mid_word(self):
+        self.assert_broke_at_a_word(_322, self.title_of(_322))
+
+    def test_a_long_unbroken_token_is_hard_cut_rather_than_collapsed(self):
+        """The `textwrap.shorten` trap, and why this rule is hand-rolled: `shorten`
+        returns ONLY the placeholder when the first word exceeds the width, which would
+        leave the issue titled `…`. A word break too near the start is worth less than the
+        characters it throws away, so below the floor charter cuts mid-word instead."""
+        first = "ab " + "x" * 80
+        got = self.title_of(first)
+        self.assertEqual(got, "ab " + "x" * 68 + "…")
+        self.assertNotEqual(got, "…")
+        self.assertNotEqual(got, "ab…")
+
+    def test_a_break_at_or_past_the_floor_is_taken(self):
+        first = "y" * 45 + " " + "z" * 40
+        self.assertEqual(self.title_of(first), "y" * 45 + "…")
+
+    def test_the_whole_title_including_the_ellipsis_fits_the_bound(self):
+        for first in (_322, "ab " + "x" * 80, "y" * 45 + " " + "z" * 40, "w" * 200):
+            with self.subTest(first=first[:20]):
+                self.assertLessEqual(len(self.title_of(first)), 72)
+
+    def test_a_line_that_already_fits_is_untouched_and_unmarked(self):
+        got = self.title_of("clone fails on a private repo")
+        self.assertEqual(got, "clone fails on a private repo")
+        self.assertFalse(got.endswith("…"))
+
+    def test_the_marker_is_stripped_before_the_bound_is_measured(self):
+        """Not after: a line whose words fit in 72 once the `# ` is gone must not be
+        truncated for the two characters charter itself removed."""
+        first = "c" * 71
+        self.assertEqual(self.title_of(f"# {first}"), first)
+
+
+class TestEmptyTextIsNotACrash(TitleCase):
+    """Defence in depth, not a live bug: `commands_report._draft` refuses an empty body
+    before a record is ever written, so no CLI path reaches this. It is asserted because
+    `title` is called on stored records and must never be the thing that raises — the
+    verbatim `splitlines()[0]` raised `IndexError` here."""
+
+    def test_empty_text_is_an_empty_title(self):
+        self.assertEqual(self.title_of(""), "")
+
+    def test_whitespace_only_text_is_an_empty_title(self):
+        self.assertEqual(self.title_of("   \n  \n"), "")
+
+    def test_a_line_that_is_only_a_marker_is_an_empty_title(self):
+        self.assertEqual(self.title_of("###"), "###")
+
+
+class TestTheHeadingStaysInTheBody(TitleCase):
+    """The ruling on #360's open question, held by a test so it cannot be quietly reversed.
+
+    `render` serves both the Reporter's review and the issue body **deliberately**, so that
+    what is shown and what is sent cannot drift (docs/adr/0003). Dropping the heading line
+    once it became the title would make the sent thing differ from the approved thing in
+    the one place the codebase forbids it, and would need `render` and `title` to agree
+    about which line that was — two code paths answering one question, which is the defect
+    this repo keeps paying for. One repeated Markdown heading is the cheaper failure.
+    """
+
+    def test_render_still_contains_the_heading_line_verbatim(self):
+        r = rec(f"# {_322}\n\nBody follows.")
+        self.assertNotIn("exception_type", r["payload"])
+        body = report.render(r)
+        self.assertIn(f"# {_322}", body)
+        self.assertIn("Body follows.", body)
+
+    def test_the_title_is_not_the_heading_line(self):
+        """Both halves of the ruling in one place: the body keeps the marker, the title
+        does not."""
+        r = rec(f"# {_322}\n\nBody follows.")
+        self.assertIn(f"# {_322}", report.render(r))
+        self.assertFalse(report.title(r).startswith("#"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three defects of one species: a message that told the reader something other than what happened. One commit each, plus a staged news entry.

Closes #360. Closes #361. Closes #363.

## #360 — an issue title is the reporter's sentence, not their markup

`report.title` took a described report's first line verbatim and cut it at 72. The body of a report is Markdown, so opening with a heading is the natural thing to write, and the `#` went to the tracker. Rendered by `charter report send --dry-run`:

```
before   diazoxide/charter: # `charter secret list` reports "no secrets" when the 1Password read act…
after    diazoxide/charter: `charter secret list` reports "no secrets" when the 1Password read…
```

ATX markers only — opening `#{1,6}` plus CommonMark's closed trailing `#`s. Backticks and bold are inline markup the reporter chose and are left alone: charter un-marks the line, it does not rewrite the words. The marker is stripped *before* the bound is measured, so a line that fits once the `# ` is gone is not truncated for two characters charter removed. `#331 is still open` keeps its number, because CommonMark requires the whitespace.

Truncation prefers the last space in the first 71 characters, with a floor at index 40. The floor is why this is hand-rolled rather than `textwrap.shorten`, which returns **only** the placeholder when the first word exceeds the width — a first line of one long unbroken token would have arrived as an issue titled `…`.

**Ruling on the open question: the heading stays in the body.** `render` serves both the Reporter's review and the issue body deliberately, so that what is shown and what is sent cannot drift (ADR 0003). Dropping the line once it became the title would make the sent thing differ from the approved thing in the one place the design forbids it, and would need `render` and `title` to agree about which line that was — two code paths answering one question. An issue that opens with its own title repeated is cosmetic; an approval that stops meaning anything is not. Held by a test and stated in the news entry.

Also fixed in passing: `splitlines()[0]` raised `IndexError` on whitespace-only text. `_draft` refuses an empty body one layer up, so no CLI path reached it — defence in depth, not a live bug, and labelled as such.

## #361 — a bad character is not a path

`reference_ok` is `valid_name and contain.child`, and `_reference_problem` rendered `contain.refusal` for either. From `charter persona lint`, with `child` carrying `extends: "parent"` and `wanderer` carrying `extends: ../evil`:

```
before
  ✗ child:    extends: '"parent"' is not a name — it is a path. … no '/', no '\', no '.' or '..', and nothing absolute
  ✗ wanderer: extends: '../evil'  is not a name — it is a path. … no '/', no '\', no '.' or '..', and nothing absolute

after
  ✗ child:    extends: '"parent"' is not a persona name — the quotes are part of the value. charter's
              frontmatter parser does not strip them, so `extends: "parent"` asks for a persona whose
              name includes the quote marks; remove them. …
  ✗ wanderer: extends: '../evil' is not a name — it is a path. … no '/', no '\', no '.' or '..', and nothing absolute
```

Two references with nothing in common produced byte-identical output, and the one that was not a path got the sentence about paths — no separator, no dot, not absolute, every enumerated condition false.

`reference_refusal` now decides the verdict **and** the sentence, and `reference_ok` is `reference_refusal(ref) is None` — the "one place that answers this" property its docstring already claimed, extended to the message so the two cannot describe different failures. Containment is asked first: where a reference is both a path and outside the alphabet, "it is a path" is the more serious and more useful thing to say.

The alphabet message lives beside `valid_name`, whose rule it reports, and separates three cases because they are three different fixes — a disallowed character, a bad *first* character (a leading `_` is **reserved**, not disallowed, so listing it as a bad character would be its own small lie), and quotes, which get their own sentence because the generic one is true and still leaves the reader guessing. "Dangling" is untouched.

Whether the frontmatter parser should strip quotes is out of scope; the message is right either way.

## #363 — a malformed vault entry no longer costs the whole preflight

Filed as part of this work. #346 taught `load_registry` to drop a `vaults.json` entry that is not an object; `check_vault_registry_divergence` was not part of that change and read the halves raw. From `charter doctor` against a plane with one string entry:

```
before   charter preflight:
         AttributeError: 'str' object has no attribute 'get'
         exit 1 — 0 checks reported

after    charter preflight:
           !  vaults           2 configured
           ✓  vault registry   shared and local halves agree (2 vaults)
         exit 0 — 28 checks reported
```

A malformed entry is a string, a non-empty string is truthy, so `shared[name] or {}` handed a `str` to `.get`. `_checks()` is eager and `cmd_doctor` has no per-check guard, so the whole briefing went with it — #347's own mechanism ("one bad entry should cost you that entry, not the session's briefing") surviving in the check next door to the one it fixed.

The same raw read is why the check counted an entry the line above had just called ignored — the contradiction #347 recorded and left as cosmetic. `registry.usable_vaults` is now the one place that decides what a half contains, asked by `load_registry`, by `malformed_shared` (as its complement, so the names reported as ignored are exactly the ones left out) and by `doctor`. The mistake was having two implementations of "what is in this file".

The total counts **distinct vaults** rather than summing the halves: a vault declared in both — the case this check exists for — is one vault, and `len(shared) + len(local)` called it two. "Entries" was the word doing the hiding.

## Verification

- Full suite: **3274 pass**, from a measured baseline of **3227** on `main` after pulling. 18 + 16 + 13 = 47 new tests, and the arithmetic reconciles exactly.
- Branch and working tree asserted **identical before and after** the suite run.
- Every test watched fail first, for the right reason: the #360 and #363 crashes as errors, the message defects as assertions printing the wrong sentence verbatim.
- Preconditions asserted throughout. For #361, that `contain.child` **succeeds** for `"parent"` — so the old message was false rather than merely unhelpful. For #363, that the entry is malformed in the raw half *and* named by `malformed_shared` *and* absent from the merged view, before any count is asserted.
- All three before/afters above are real CLI output, not unit-test rendering.

## Two findings outside this PR's scope, reported not fixed

1. **`_checks()` is eager, so `iter_all`'s streaming does not hold.** `iter_all`'s docstring says it exists so "a preflight killed by its hook timeout" still names where it stopped — but `_checks()` builds the whole list before yielding, so nothing is emitted. That is why #363's crash lost all 28 lines rather than stopping at the vault check. Fixing #363 removes today's trigger; any other raising check still empties the preflight. Worth its own issue.
2. **`check_vaults` reaches its notes only on the OK path.** The "entries ignored" note requires a *reachable* vault, so on a plane where the vault is unreachable the malformed entry is never named at all. Not a regression and not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo
