### PR TITLE
Rules that match what you typed, counters with a denominator (#365, #366, #367, #368, #369)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -255,10 +255,23 @@ def build_parser() -> argparse.ArgumentParser:
     vsub = ver.add_subparsers(dest="version_cmd")
     ver.set_defaults(func=commands.cmd_version)     # bare `charter version` = show
 
+    # The harness names are DERIVED, never written down. `charter guard` writes every
+    # registered harness — there is no `detect()` gate on purpose, because `detect()`
+    # answers "am I running inside this harness right now" rather than "does this team use
+    # it", and gating on it would make a rule's reach depend on which harness happened to
+    # type the command (ADR 0014: no sync step, nothing that can drift). The help said one
+    # file while the command wrote three, so the claim moved to match (#369) — and reading
+    # the registry rather than listing it here keeps this from being one more place to
+    # remember the day a harness is added, which `harness/registry.py` warns about.
+    from .harness import registry as _harness_registry
+
     gd = sub.add_parser("guard",
-                        help="Force-prompt rules for this plane. Written as Claude Code "
-                             "`permissions.ask` rules in .claude/settings.json — charter "
-                             "keeps no list of its own (ADR 0014).")
+                        help="Force-prompt and stop-prompting rules for this plane. "
+                             "Written in each harness's own syntax, into the file each "
+                             "one reads — every harness charter knows ("
+                             + ", ".join(_harness_registry.KINDS)
+                             + "), not only the one you are running. charter keeps no "
+                               "list of its own (ADR 0014).")
     gsub = gd.add_subparsers(dest="guard_cmd")
     gd.set_defaults(func=commands.cmd_guard_list)
     ga = gsub.add_parser("ask", help="Always prompt before this command runs.")

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1170,23 +1170,69 @@ def cmd_guard_ask(args) -> int:
     return rc
 
 
+#: The buckets `charter guard` writes, in the host's own evaluation order.
+#:
+#: `deny` is deliberately absent. Charter never writes it, and it answers neither question
+#: an operator opens this command with — "what has charter put in my permissions" and "what
+#: is currently not prompting me".
+_LISTED_BUCKETS = ("ask", "allow")
+
+
+def _rules_in(doc, bucket: str) -> list[str]:
+    """The string rules in ``permissions.<bucket>``, tolerating every other shape.
+
+    A `permissions` block or a bucket of the wrong type is somebody's deliberate structure,
+    which `add_permission_rule` refuses to write into. A *reader* has less standing still:
+    it reports what it can read and never raises over what it cannot.
+    """
+    perms = doc.get("permissions") if isinstance(doc, dict) else None
+    entries = perms.get(bucket) if isinstance(perms, dict) else None
+    return [r for r in entries if isinstance(r, str)] if isinstance(entries, list) else []
+
+
 def cmd_guard_list(args) -> int:
-    """Show the plane's force-prompt rules — read from the host's file, not a charter one."""
+    """Show the plane's guard rules — read from the host's files, not a charter one.
+
+    Both buckets, from both files. This read `permissions.ask` alone, and bare `charter
+    guard` defaults to it, so the command an operator reaches for to answer "what has
+    charter put in my permissions" showed the conservative half and hid the widening one
+    (#368). An ask rule narrows what happens without a human; an allow rule widens it, which
+    is why `cmd_guard_allow` shouts `COMMITTED` when it writes one — and why that half being
+    the invisible one was the wrong way round.
+
+    **Grouped by file, because the file a rule lives in IS its blast radius.** A flat list
+    with a label would ask the reader to trust the label; a heading makes it structural. The
+    machine-local file was invisible here for the same reason the allow bucket was — the
+    reader only ever opened one — so `--local` rules had no reader at all.
+
+    Read through the same two loaders `add_permission_rule` writes through, so the reader
+    and the writer cannot come to different conclusions about what a file contains. A
+    malformed file is named and does not suppress the other: reporting nothing because one
+    of two files is unparseable would hide rules that are in force, which is the silent
+    direction this command was already failing in.
+    """
     root = Path(config.ROOT)
-    settings, path = _load_settings(root)
-    if settings is None:
-        util.err(f"{path} is not valid JSON.")
-        return 1
-    perms = settings.get("permissions")
-    ask = (perms or {}).get("ask") if isinstance(perms, dict) else None
-    if not ask:
-        util.info("No force-prompt rules in this plane. "
+    committed, committed_path = _load_settings(root)
+    local, local_path = _load_json_settings(Path(root) / LOCAL_SETTINGS)
+    files = ((committed, committed_path, "committed — everyone on this repo"),
+             (local, local_path, "machine-local — yours alone, on this machine"))
+    rc, shown = 0, False
+    for doc, path, blast_radius in files:
+        if doc is None:
+            util.err(f"{path} is not valid JSON — skipped, so this listing is incomplete.")
+            rc = 1
+            continue
+        rules = [(b, r) for b in _LISTED_BUCKETS for r in _rules_in(doc, b)]
+        if not rules:
+            continue
+        print(f"  {path}  ({blast_radius})")
+        for bucket, rule in rules:
+            print(f"    {bucket:<6} {rule}")
+        shown = True
+    if not shown and rc == 0:
+        util.info("No guard rules in this plane. "
                   "Add one: charter guard ask 'terraform apply *'")
-        return 0
-    print(f"  {path}")
-    for rule in ask:
-        print(f"    {rule}")
-    return 0
+    return rc
 
 
 def _warn_if_shadowing(rule: str) -> None:

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -921,6 +921,26 @@ def _as_rule(pattern: str) -> str:
     return f"Bash({p})"
 
 
+def _say_if_uneven(wrote: bool, refused: bool) -> None:
+    """Say so when one command left the rule in force under some harnesses and not others.
+
+    The refusal to touch a malformed file is per-harness, not per-command: the caller goes
+    on to the next harness, so a `✗` beside a `✓` means one invocation left the plane
+    holding the rule under opencode and not under Claude Code. An operator who sees the `✗`
+    reads it as "nothing was written" (#369), and a re-run after the fix then makes the
+    other harness's copy a duplicate write rather than a first one.
+
+    Making the command all-or-nothing is a two-phase apply across three file formats with
+    no rollback primitive — a design change, and not this one. Naming what actually
+    happened costs nothing and is true today. Shared by both verbs so `ask` and `allow`
+    cannot come to describe the same half-write differently.
+    """
+    if wrote and refused:
+        util.warn("  The rule landed UNEVENLY — it is in force under the harnesses ticked "
+                  "above and NOT under the one refused, from this one command. Fix that "
+                  "file and re-run; the harnesses that already have it will say so.")
+
+
 def _refuse_unexpressible(pattern: str) -> str | None:
     """Why *pattern* cannot be written as a rule at all, or ``None``.
 
@@ -982,7 +1002,13 @@ def add_permission_rule(root: Path, rule: str, bucket: str,
     command now asks each registered harness to write its own file in its own syntax,
     and this is Claude Code's half. Refuses a malformed file rather than repairing it,
     and a `permissions` or bucket of the wrong type is somebody's deliberate structure —
-    charter reports it and stops.
+    charter reports it and writes nothing HERE.
+
+    "Writes nothing here" is the whole of the promise, and the docstring used to overstate
+    it as "reports it and stops" (#369). The refusal is per-harness: the caller goes on to
+    the next one, so a malformed Claude Code file leaves the rule in force under opencode
+    and absent under Claude Code from a single command. That is worth knowing at this level
+    because it is what the callers have to say out loud.
 
     Parameterised over the bucket when `guard allow` arrived: `ask` and `allow` are the
     same job with opposite verbs, and two copies of this function would eventually
@@ -1110,6 +1136,7 @@ def cmd_guard_allow(args) -> int:
                       "just you. Use `--local` for a rule that is yours alone.")
         util.info("  charter's own guards are unaffected: an allow rule relaxes the HOST's "
                   "prompt, never the secret, credential or plane-root denials.")
+    _say_if_uneven(wrote, rc == 1)
     return rc
 
 
@@ -1167,6 +1194,7 @@ def cmd_guard_ask(args) -> int:
             util.info("  These files are committed, so the rule applies to everyone on this "
                       "repo — no sync step, and nothing that can drift (ADR 0014).")
         _warn_if_shadowing(registry.get(registry.CLAUDE_CODE).ask_rule(pattern))
+    _say_if_uneven(wrote, rc == 1)
     return rc
 
 

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -873,15 +873,67 @@ def _json_style(text: str) -> tuple[str | None, tuple[str, str]]:
 #: naming another tool must survive untouched — wrapping `Read(./secrets/**)` would produce
 #: `Bash(Read(./secrets/**))`, which matches nothing and fails in the silent direction.
 _RULE_TOOLS = ("Bash", "Read", "Edit", "Write", "Grep", "Glob", "WebFetch", "NotebookEdit",
-               "Task", "mcp__")
+               "Task")
+
+#: A rule already in the host's ``Tool(pattern)`` form.
+_TOOL_RULE_RE = re.compile(r"^(?:%s)\(.*\)$" % "|".join(_RULE_TOOLS), re.DOTALL)
+
+#: An MCP rule: a whole server (``mcp__slack``) or one of its tools (``mcp__slack__send``).
+#: Claude Code's MCP permission syntax is exactly this — a bare name, never parenthesised
+#: and never wildcarded — which is why it needs a shape of its own here.
+_MCP_RULE_RE = re.compile(r"^mcp__[A-Za-z0-9_-]+$")
+
+
+class UnexpressibleRule(ValueError):
+    """A pattern that names a rule syntax and then asks for something it cannot say.
+
+    Raised rather than guessed because both guesses fail silently: wrapping produces
+    `Bash(mcp__slack__send *)`, which matches a bash command by that literal name, and
+    writing it bare produces an MCP rule the host will not match either. A rule charter
+    cannot express is the one case where refusing beats writing something.
+    """
 
 
 def _as_rule(pattern: str) -> str:
-    """A permission rule for *pattern*, wrapping a bare command in ``Bash(...)``."""
+    """A permission rule for *pattern*, wrapping a bare command in ``Bash(...)``.
+
+    Tests the **shape** of the rule, never the prefix of the string. The prefix test this
+    replaces required a parenthesis (`"(" in p`), which excluded the one family that cannot
+    carry one: `charter guard ask 'mcp__slack__send'` wrote `Bash(mcp__slack__send)` and
+    printed a tick (#365).
+
+    Dropping the parenthesis requirement would have mirrored the bug rather than fixed it.
+    `str.startswith` matches raw prefixes, so `Globalprotect --connect` starts with `Glob`
+    and `Taskwarrior add x` starts with `Task`; both are ordinary binaries, and writing
+    either bare would produce a rule matching nothing in the other direction. The three
+    shapes below are what a rule can actually be — `Tool(pattern)`, a bare tool name, a bare
+    MCP name — and everything else is a command.
+    """
     p = (pattern or "").strip()
-    if p.startswith(_RULE_TOOLS) and ("(" in p or p in ("Bash",)):
+    if _TOOL_RULE_RE.match(p) or p in _RULE_TOOLS or _MCP_RULE_RE.match(p):
         return p
+    if p.startswith("mcp__"):
+        raise UnexpressibleRule(
+            f"charter cannot write {p!r} as a permission rule. An MCP rule names a server "
+            f"(`mcp__slack`) or one of its tools (`mcp__slack__send`) exactly — no "
+            f"wildcard and no arguments. Wrapping it as `Bash(...)` would write a rule "
+            f"that matches nothing, so charter writes nothing.")
     return f"Bash({p})"
+
+
+def _refuse_unexpressible(pattern: str) -> str | None:
+    """Why *pattern* cannot be written as a rule at all, or ``None``.
+
+    Asked once, BEFORE the harness loop, so a pattern charter cannot express never lands
+    under one harness and not another — the split #369 records for the malformed-file case.
+    `_as_rule` stays the single authority on what is expressible; this only decides when to
+    ask it, so the command and the translator cannot come to different answers.
+    """
+    try:
+        _as_rule(pattern)
+    except UnexpressibleRule as e:
+        return str(e)
+    return None
 
 
 def _settings_path(root: Path) -> Path:
@@ -1022,6 +1074,10 @@ def cmd_guard_allow(args) -> int:
     if not pattern:
         util.err("Nothing to add. Example: charter guard allow 'git status *'")
         return 2
+    unexpressible = _refuse_unexpressible(pattern)
+    if unexpressible:
+        util.err(unexpressible)
+        return 2
     from .harness import registry
 
     root = Path(config.ROOT)
@@ -1076,6 +1132,10 @@ def cmd_guard_ask(args) -> int:
     local = bool(getattr(args, "local", False))
     if not pattern:
         util.err("Nothing to add. Example: charter guard ask 'terraform apply *'")
+        return 2
+    unexpressible = _refuse_unexpressible(pattern)
+    if unexpressible:
+        util.err(unexpressible)
         return 2
     from .harness import registry
 

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -2131,11 +2131,21 @@ def pretooluse_dispatch() -> int:
         if ((d.get("meta") or {}).get("dispatch-isolation") or "").strip() != "worktree":
             return 0  # not a code-writer: overlapping is fine
         peers = ", ".join(f"`{o}`" for o in others)
-        _ask("PreToolUse",
-             f"`{agent}` writes code and {peers} "
-             f"{'is' if len(others) == 1 else 'are'} already running. They share one "
-             f"working tree, so parallel edits interleave silently. Dispatch this one "
-             f"with `isolation: worktree`, or let the other finish first.", data)
+        if _ask("PreToolUse",
+                f"`{agent}` writes code and {peers} "
+                f"{'is' if len(others) == 1 else 'are'} already running. They share one "
+                f"working tree, so parallel edits interleave silently. Dispatch this one "
+                f"with `isolation: worktree`, or let the other finish first.", data):
+            # The ask half of the tally. Passing `data` above already leaves the marker
+            # `posttooluse_bash` turns into an `ask-approved`, so without this row those
+            # approvals counted against a denominator nothing ever incremented — the exact
+            # shape #290 was filed to remove, left behind at the third of three sites.
+            #
+            # Its own event name, not `ask`: every historical `ask` row means the
+            # clone-commit guard, and folding this in would corrupt the series a judgement
+            # about that guard has to rest on. Counts and names only, like the rest of the
+            # tally — the agent, and how many peers, never the prompt.
+            _trace("dispatch-ask", data.get("session_id"), agent=agent, peers=len(others))
         del token
     except Exception:
         return 0  # a nudge must never break a turn

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -417,17 +417,38 @@ def reconcile(session_id: str | None = None, terminal_id: str | None = None) -> 
 
 
 def _prune() -> None:
+    """Drop every per-session pointer past the cutoff — the DIRECTORY, not a list of names.
+
+    This enumerated five suffixes (`*.workspace`, `*.lock`, `*.configver`, `*.memnudge`,
+    `*.usage`) and read as an exhaustive list of the marker family while being nothing of
+    the kind. Three families were missing by the time anyone looked: `*.ask-pending`,
+    `*.route-pending` (`hooks`) and `*.persona` (`persona`, in both directories). The
+    allowlist drifted three times, and a reader adding a fourth marker type had nothing
+    telling them this list needed editing.
+
+    The list is gone rather than three names longer, because a fourth drift is otherwise
+    just a matter of time — a family added tomorrow is now covered the day it is written.
+    Both directories are charter's own state and hold nothing but per-session and
+    per-terminal pointers, so there is no member for which keeping it past the cutoff is
+    the right answer. Files only: a directory in here is not a pointer, and unlinking is
+    not the tool for one.
+
+    Pruning `*.ask-pending` was checked against its readers rather than assumed safe — a
+    declined ask deliberately leaves its marker behind, and that asymmetry is what makes
+    "asked N, approved M" countable (#290). Nothing globs these suffixes: every reader
+    (`_ask_mark_take`, `_route_mark_take`, `_route_mark_clear`) addresses one file by exact
+    ids, and the tally itself lives in the trace store, which this does not touch.
+    """
     cutoff = time.time() - _SESSION_MAX_AGE
     for d in (config.SESSIONS_DIR, config.TERMINALS_DIR):
         if not d.exists():
             continue
-        for pattern in ("*.workspace", "*.lock", "*.configver", "*.memnudge", "*.usage"):
-            for f in d.glob(pattern):
-                try:
-                    if f.stat().st_mtime < cutoff:
-                        f.unlink()
-                except OSError:
-                    pass
+        for f in d.iterdir():
+            try:
+                if f.is_file() and f.stat().st_mtime < cutoff:
+                    f.unlink()
+            except OSError:
+                pass
 
 
 def list_workspaces() -> list[str]:

--- a/docs/news/unreleased-guard-says-what-it-wrote.md
+++ b/docs/news/unreleased-guard-says-what-it-wrote.md
@@ -1,0 +1,64 @@
+---
+version: unreleased
+headline: `charter guard` writes the rule you typed, and shows you all of them
+---
+
+Three defects in `charter guard`, all of one species: the command did something wider or
+narrower than it said, and said it convincingly. A guard whose output cannot be trusted is
+worse than no guard, because the tick is what stops you checking.
+
+**An MCP rule is no longer wrapped into a rule that matches nothing.** `_RULE_TOOLS` lists
+the tools whose rules charter writes verbatim and deliberately includes `mcp__`, but the
+condition consulting it also demanded a parenthesis. Claude Code's MCP permission syntax is
+the bare `mcp__<server>__<tool>` and never has one, so `charter guard ask 'mcp__slack__send'`
+wrote `Bash(mcp__slack__send)` — a rule matching a *bash command* by that literal name,
+which is to say nothing at all — printed a tick, and committed it. The operator was never
+prompted. Bare whole-tool rules like `Read` and `Task` went the same way.
+
+The obvious fix mirrors the bug. `str.startswith` matches raw prefixes, so
+`Globalprotect --connect` starts with `Glob` and `Taskwarrior add x` starts with `Task`;
+dropping the parenthesis requirement would have written both bare, matching nothing in the
+other direction. That requirement was load-bearing by accident. So the test is now on the
+shape a rule can actually take — `Tool(pattern)`, a bare tool name, or a bare MCP name — and
+everything else is a command to be wrapped.
+
+One shape is refused rather than guessed. `mcp__slack__send *` names the MCP syntax and then
+asks for a wildcard it does not have, and both available guesses fail silently, so charter
+writes nothing and says why. That refusal happens before any harness is touched, so a
+pattern charter cannot express never lands under one harness and not another.
+
+**`charter guard` shows both halves of what it wrote.** The listing read `permissions.ask`
+alone, and bare `charter guard` defaults to the listing — so the command you reach for to
+answer "what has charter put in my permissions" showed the conservative half and hid the
+widening one. An ask rule narrows what happens without a human; an allow rule widens it,
+which is why `guard allow` shouts `COMMITTED` when it writes one. That being the invisible
+half was the wrong way round. Rules written with `--local` had no reader at all.
+
+The output is grouped by file rather than labelled per row, because the file a rule lives in
+*is* its blast radius: a label asks you to trust it, a heading makes it structural.
+`permissions.deny` stays unlisted — charter never writes it, and it answers neither question
+you open this command with.
+
+**And the help now names every harness the command writes.** It said rules go into Claude
+Code's `.claude/settings.json` while both verbs write every registered harness, so a plane
+that only uses Claude Code gained a tracked `opencode.json` from a command whose help named
+one file. The behaviour is right and did not change: gating on `Harness.detect()` would make
+a rule's reach depend on which harness happened to type the command, and a teammate on
+opencode would silently not get it — the drift ADR 0014 exists to remove. The names are read
+from the registry rather than written into the help, so the sentence cannot go stale the day
+a harness is added.
+
+The same command has a second, smaller gap in the same direction. A malformed settings file
+is refused per harness rather than per command, so a `✗` beside a `✓` means one invocation
+left the rule in force under one harness and absent under another — while the `✗` reads as
+"nothing was written". `charter guard` now says so at the moment it happens. Making the
+write all-or-nothing is a two-phase apply across three file formats and is filed separately
+rather than smuggled in here.
+
+Two further fixes are invisible from the outside and worth recording anyway: the dispatch
+nudge now records the ask as well as its approval, so those approvals stop counting against
+a denominator nothing incremented; and the session-marker sweep now covers the directory
+rather than a list of suffixes that had drifted three times, which puts a floor under the
+`ask-pending` markers every declined nudge leaves behind.
+
+Found during the third pass of an authority audit (#365, #366, #367, #368, #369).

--- a/tests/test_dispatch_ask_is_counted.py
+++ b/tests/test_dispatch_ask_is_counted.py
@@ -1,0 +1,176 @@
+"""Every nudge charter emits is countable, including the dispatch one (#367).
+
+`_ask` leaves an `ask-pending` marker so the outcome can be tallied: `posttooluse_bash`
+clears it when the tool actually runs, and that clearing is recorded as `ask-approved`. It
+deliberately does not trace the ask itself — "callers trace their own event name, so they
+must not also record an 'ask' that never reached anybody".
+
+Three sites call it. `pretooluse` traces `ask`, `pretooluse_edit` traces `routing-ask`, and
+`pretooluse_dispatch` traced nothing while still passing `data` — so its approvals were
+recorded against a denominator that never counted the ask. That is the exact shape #290 was
+filed to remove, applied to two sites of three.
+
+**This cannot be observed on a plane that does not use worktree isolation**, which is every
+plane the audit had: the nudge fires only when a peer declaring `dispatch-isolation:
+worktree` is already in flight, so a test could pass by never reaching the handler at all.
+Every counting assertion below is therefore paired with a precondition assertion that the
+nudge actually fired — the emitted decision — so a fixture that stops reaching the `_ask`
+fails loudly instead of passing vacuously.
+
+The event is `dispatch-ask`, not `ask`. `routing-ask` set that precedent, and folding this
+into `ask` would corrupt a series whose every historical row means the clone-commit guard —
+the evidence a judgement about that guard has to rest on.
+"""
+
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+from charter import config, hooks, inflight, trace
+from tests._isolation import PersonaIso, run_hook
+
+SESSION = "s-dispatch"
+
+
+class DispatchAskCase(PersonaIso):
+    """A plane that DOES use worktree isolation — the fixture this defect needs."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.make_persona("coder", **{"dispatch-isolation": "worktree"})
+        self.make_persona("explorer")
+
+    def dispatch(self, agent: str = "coder", **extra):
+        """One Task dispatch through the handler; returns the emitted JSON or None."""
+        payload = {"tool_name": "Task", "tool_input": {"subagent_type": agent},
+                   "session_id": SESSION, "tool_use_id": f"toolu_{agent}", **extra}
+        return run_hook(hooks.pretooluse_dispatch, payload)
+
+    def events(self, name: str) -> list[dict]:
+        return [e for e in trace.read(SESSION) if e.get("event") == name]
+
+    def assert_nudged(self, out) -> None:
+        """The precondition every count below depends on: the handler REACHED the ask."""
+        self.assertIsNotNone(out, "fixture never reached the nudge — the count proves nothing")
+        decision = out["hookSpecificOutput"]["permissionDecision"]
+        self.assertEqual(decision, "ask", "must nudge, never deny")
+
+
+class TestTheFixtureItself(DispatchAskCase):
+    """Asserted separately so a broken fixture is diagnosed as a broken fixture."""
+
+    def test_a_first_dispatch_does_not_nudge(self):
+        self.assertIsNone(self.dispatch())
+
+    def test_an_overlapping_code_writer_does_nudge(self):
+        self.dispatch()
+        self.assert_nudged(self.dispatch())
+
+    def test_the_peer_really_is_recorded_in_flight(self):
+        self.dispatch()
+        self.assertEqual(inflight.live(), ["coder"])
+
+
+class TestTheAskIsCounted(DispatchAskCase):
+    def test_an_overlapping_dispatch_records_a_dispatch_ask(self):
+        self.dispatch()
+        self.assert_nudged(self.dispatch())
+        self.assertEqual(len(self.events("dispatch-ask")), 1)
+
+    def test_the_ask_is_recorded_alongside_the_marker_that_counts_its_approval(self):
+        """The two halves of one tally. The marker was already being left; the row that
+        gives it a denominator was not."""
+        self.dispatch()
+        self.assert_nudged(self.dispatch())
+        markers = list(config.SESSIONS_DIR.glob("*.ask-pending"))
+        self.assertEqual(len(markers), 1, "the approval half was already being recorded")
+        self.assertEqual(len(self.events("dispatch-ask")), 1, "so the ask half must be too")
+
+    def test_it_does_not_pollute_the_clone_commit_ask_series(self):
+        """`ask` rows all mean the clone-commit guard. This one says what it is."""
+        self.dispatch()
+        self.assert_nudged(self.dispatch())
+        self.assertEqual(self.events("ask"), [])
+
+    def test_the_row_names_the_dispatched_agent(self):
+        self.dispatch()
+        self.assert_nudged(self.dispatch())
+        self.assertEqual(self.events("dispatch-ask")[0].get("agent"), "coder")
+
+
+class TestWhatIsNotCounted(DispatchAskCase):
+    def test_a_first_dispatch_records_no_ask(self):
+        self.assertIsNone(self.dispatch(), "precondition: nothing was asked")
+        self.assertEqual(self.events("dispatch-ask"), [])
+
+    def test_a_read_only_peer_overlapping_records_no_ask(self):
+        self.dispatch()
+        self.assertIsNone(self.dispatch("explorer"), "precondition: nothing was asked")
+        self.assertEqual(self.events("dispatch-ask"), [])
+
+    def test_an_unattended_nudge_is_not_counted_as_an_ask(self):
+        """Nobody was there to answer, so it is `ask-unattended` — the distinction
+        `_ask` keeps, and the double count it exists to prevent."""
+        self.dispatch()
+        out = self.dispatch(permission_mode=hooks.UNATTENDED_MODE)
+        self.assertIsNotNone(out, "fixture never reached the nudge")
+        self.assertEqual(out["hookSpecificOutput"]["permissionDecision"], "allow",
+                         "an unattended nudge allows rather than floors the run at a prompt")
+        self.assertEqual(len(self.events("ask-unattended")), 1)
+        self.assertEqual(self.events("dispatch-ask"), [], "counted once, under one name")
+
+
+class TestEveryAskSiteRecordsAnAsk(unittest.TestCase):
+    """The structural half: a fourth call site cannot quietly forget.
+
+    `_ask`'s docstring defends keeping the trace OUTSIDE it — callers name their own event —
+    and that reasoning is sound, so the fix is not to move the trace inward. This asserts the
+    property that reasoning assumes instead: any function that asks also records an
+    ask-shaped event. `test_guards_that_must_not_be_refactored_away.py` is the precedent for
+    holding a rule the type system cannot.
+    """
+
+    @staticmethod
+    def _functions_that_ask() -> dict[str, ast.FunctionDef]:
+        src = Path(hooks.__file__).read_text()
+        tree = ast.parse(src)
+        out = {}
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef) or node.name == "_ask":
+                continue
+            for call in ast.walk(node):
+                if (isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+                        and call.func.id == "_ask"):
+                    out[node.name] = node
+                    break
+        return out
+
+    @staticmethod
+    def _ask_shaped_events(fn: ast.FunctionDef) -> list[str]:
+        names = []
+        for call in ast.walk(fn):
+            if (isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+                    and call.func.id == "_trace" and call.args
+                    and isinstance(call.args[0], ast.Constant)
+                    and isinstance(call.args[0].value, str)
+                    and "ask" in call.args[0].value):
+                names.append(call.args[0].value)
+        return names
+
+    def test_the_known_sites_are_all_found(self):
+        """Precondition: the scan sees the real call sites, so a pass means something."""
+        self.assertEqual(set(self._functions_that_ask()),
+                         {"pretooluse", "pretooluse_dispatch", "pretooluse_edit"})
+
+    def test_every_function_that_asks_also_traces_an_ask(self):
+        for name, fn in sorted(self._functions_that_ask().items()):
+            with self.subTest(handler=name):
+                self.assertTrue(self._ask_shaped_events(fn),
+                                f"{name} calls _ask but records no ask-shaped event, so its "
+                                f"approvals count against a denominator nothing incremented")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_guard_claims_its_reach.py
+++ b/tests/test_guard_claims_its_reach.py
@@ -1,0 +1,159 @@
+"""`charter guard` says how far it reaches, and says when it only got half way (#369).
+
+Two claims, both understating reach, both documentation-shaped rather than behaviour-shaped.
+
+**The help named one file.** It said rules are written as Claude Code `permissions.ask`
+rules in `.claude/settings.json`, while `cmd_guard_ask` and `cmd_guard_allow` iterate
+`registry.all()` and write every registered harness — so a plane whose settings declare
+`CHARTER_HARNESS: claude-code` gains a tracked `opencode.json` from a command whose help
+named one file.
+
+The behaviour is right and is not what changed. `registry.all()` has no `detect()` gate on
+purpose: `detect()` answers "am I running inside this harness right now", not "does this
+team use it", so gating on it would make a rule's reach depend on which harness happened to
+type the command — and a teammate on opencode would silently not get it. That is exactly
+the drift ADR 0014 exists to remove ("no sync step, and nothing that can drift"). The claim
+is what was wrong, so the claim is what moved.
+
+The names are derived from `registry.KINDS` rather than written into the help string.
+`registry.py`'s own docstring says why: a hardcoded literal is the thing that goes stale the
+day a harness is added, and this help would be one more place to remember.
+
+**A `✗` read as "nothing was written".** The refusal to touch a malformed file is
+per-harness, so with `.claude/settings.json` corrupted the rule still landed in
+`opencode.json`: one invocation, rule in force under one harness and absent under the other,
+and a re-run after the fix makes opencode's copy a duplicate write rather than a first one.
+`add_permission_rule`'s docstring said charter "reports it and stops"; it reports and
+continues.
+
+Making it all-or-nothing is a two-phase apply across three file formats with no rollback
+primitive, which is a design change and not this one. What is fixed here is the claim: the
+output now says a rule landed unevenly, at the moment it happens.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import cli, commands, config
+from charter.harness import registry
+from tests._isolation import PersonaIso
+
+
+def _guard_help() -> str:
+    """The `guard` subcommand's help, as `charter --help` renders it."""
+    parser = cli.build_parser()
+    for action in parser._actions:
+        if getattr(action, "choices", None) and "guard" in (action.choices or {}):
+            return action.choices["guard"].format_help() + (
+                action._choices_actions and "" or "")
+    raise AssertionError("no `guard` subcommand found")
+
+
+def _guard_summary() -> str:
+    """The one-line help shown beside `guard` in the top-level command list."""
+    parser = cli.build_parser()
+    for action in parser._actions:
+        for sub in getattr(action, "_choices_actions", []) or []:
+            if sub.dest == "guard":
+                return sub.help or ""
+    raise AssertionError("no `guard` entry in the command list")
+
+
+class TestTheHelpNamesEveryHarnessItWrites(unittest.TestCase):
+    def test_the_registered_harnesses_are_named(self):
+        said = _guard_summary().lower()
+        for name in registry.KINDS:
+            with self.subTest(harness=name):
+                self.assertIn(name.lower(), said)
+
+    def test_more_than_one_harness_is_registered(self):
+        """Precondition: naming them all is only a claim worth testing while there are
+        several. A one-harness registry would make this test vacuous."""
+        self.assertGreater(len(registry.KINDS), 1)
+
+    def test_the_names_are_derived_not_written_down(self):
+        """A harness added to the registry must appear without editing the help string —
+        the staleness `registry.py`'s docstring warns about."""
+        extended = dict(registry.KINDS)
+        extended["zzz-fictional"] = registry.KINDS[registry.CLAUDE_CODE]
+        with mock.patch.object(registry, "KINDS", extended):
+            self.assertIn("zzz-fictional", _guard_summary())
+
+    def test_it_no_longer_claims_a_single_file(self):
+        said = _guard_summary()
+        self.assertNotIn(".claude/settings.json — charter keeps no list", said)
+
+    def test_adr_0014_is_still_cited(self):
+        """The reasoning did not change; only the count of files did."""
+        self.assertIn("0014", _guard_summary())
+
+
+class GuardCase(PersonaIso):
+    def settings(self) -> Path:
+        return Path(config.ROOT) / ".claude" / "settings.json"
+
+    def opencode(self) -> Path:
+        return Path(config.ROOT) / "opencode.json"
+
+    def invoke(self, fn, **kw) -> tuple[int, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = fn(SimpleNamespace(**kw))
+        return rc, out.getvalue() + err.getvalue()
+
+    def corrupt_claude_settings(self) -> None:
+        self.settings().parent.mkdir(parents=True, exist_ok=True)
+        self.settings().write_text("{not json")
+
+
+class TestAPartialWriteSaysSo(GuardCase):
+    def test_the_precondition_that_one_harness_refuses_and_another_writes(self):
+        """Asserted on its own, so the message test below cannot pass in a world where
+        nothing was written at all."""
+        rc, _ = self.invoke(commands.cmd_guard_ask, pattern="foo *", local=False)
+        self.assertEqual(rc, 0)
+        self.corrupt_claude_settings()
+        rc, said = self.invoke(commands.cmd_guard_ask, pattern="bar *", local=False)
+        self.assertEqual(rc, 1, "the malformed file is still refused")
+        self.assertEqual(self.settings().read_text(), "{not json",
+                         "and left byte-identical")
+        self.assertIn("bar *", json.dumps(json.loads(self.opencode().read_text())),
+                      "while another harness took the rule")
+
+    def test_an_uneven_landing_is_named(self):
+        self.corrupt_claude_settings()
+        _, said = self.invoke(commands.cmd_guard_ask, pattern="bar *", local=False)
+        self.assertIn("opencode", said)
+        self.assertRegex(said.lower(), r"in force|not in force|unevenly|some harnesses")
+
+    def test_guard_allow_says_it_too(self):
+        self.corrupt_claude_settings()
+        _, said = self.invoke(commands.cmd_guard_allow, pattern="bar *", local=False)
+        self.assertRegex(said.lower(), r"in force|not in force|unevenly|some harnesses")
+
+    def test_a_clean_write_says_nothing_about_uneven_landing(self):
+        """The message must be the exception, or it stops carrying information."""
+        _, said = self.invoke(commands.cmd_guard_ask, pattern="foo *", local=False)
+        self.assertNotRegex(said.lower(), r"unevenly|not in force")
+
+    def test_the_docstring_says_the_refusal_is_per_harness(self):
+        """`add_permission_rule` said charter "reports it and stops". It reports and
+        continues to the next harness, and the next reader deserves the true sentence.
+
+        Asserted on the true claim rather than the absence of the old phrase, because the
+        docstring now quotes that phrase in order to correct it — and a test that greps for
+        a string would forbid the correction along with the error.
+        """
+        doc = commands.add_permission_rule.__doc__ or ""
+        self.assertIn("per-harness", doc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_guard_list_both_buckets.py
+++ b/tests/test_guard_list_both_buckets.py
@@ -1,0 +1,188 @@
+"""`charter guard list` shows both buckets, from both files (#368).
+
+`charter guard` writes two buckets — `cmd_guard_ask` into `permissions.ask`,
+`cmd_guard_allow` into `permissions.allow` — through one `add_permission_rule`, into one
+file. The listing read one of them, and bare `charter guard` defaults to the listing, so it
+is the command an operator reaches for to answer "what has charter put in my permissions".
+
+The half it hid is the half with the wider blast radius. `cmd_guard_allow` shouts
+`COMMITTED — this stops the prompt for everyone on this repo, not just you` precisely
+because an allow rule widens what happens without a human, and its own comment records the
+asymmetry: an ask rule narrows, so sharing it is conservative; an allow rule widens, and
+sharing extends one person's trust decision to everyone who clones the repo. The listing
+showed the conservative half and hid the widening one.
+
+`--local` rules were invisible for the same reason — the reader only opened the committed
+file — so no command answered "what is currently not prompting me, and who decided that".
+
+**The file a rule lives in IS its blast radius**, so the output groups by file rather than
+labelling rows: the committed file, then the machine-local one, each named for what it
+means. `permissions.deny` is deliberately not shown; charter never writes it, and it
+answers neither operator question.
+
+A malformed file is named and does not suppress the other. Reporting nothing because one of
+two files is unparseable would hide rules that are in force — the same silent direction the
+defect itself pointed in.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import commands, config
+from tests._isolation import PersonaIso
+
+
+class GuardListCase(PersonaIso):
+    def settings(self) -> Path:
+        return Path(config.ROOT) / ".claude" / "settings.json"
+
+    def local_settings(self) -> Path:
+        return Path(config.ROOT) / ".claude" / "settings.local.json"
+
+    def write(self, path: Path, body: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(body, indent=2))
+
+    def invoke(self, fn, **kw) -> tuple[int, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = fn(SimpleNamespace(**kw))
+        return rc, out.getvalue() + err.getvalue()
+
+    def listing(self) -> tuple[int, str]:
+        return self.invoke(commands.cmd_guard_list)
+
+
+class TestBothBucketsAreShown(GuardListCase):
+    def test_an_allow_rule_appears(self):
+        """The reported case: written by `charter guard allow`, absent from the listing."""
+        self.write(self.settings(), {"permissions": {"allow": ["Bash(gh pr merge *)"]}})
+        _, said = self.listing()
+        self.assertIn("gh pr merge", said)
+
+    def test_an_ask_rule_still_appears(self):
+        self.write(self.settings(), {"permissions": {"ask": ["Bash(terraform apply *)"]}})
+        _, said = self.listing()
+        self.assertIn("terraform apply", said)
+
+    def test_both_appear_together_and_are_told_apart(self):
+        self.write(self.settings(), {"permissions": {
+            "ask": ["Bash(terraform apply *)"], "allow": ["Bash(gh pr merge *)"]}})
+        _, said = self.listing()
+        self.assertIn("terraform apply", said)
+        self.assertIn("gh pr merge", said)
+        self.assertIn("ask", said)
+        self.assertIn("allow", said)
+
+    def test_the_deny_bucket_is_not_shown(self):
+        """charter never writes it, and it answers neither operator question."""
+        self.write(self.settings(), {"permissions": {
+            "ask": ["Bash(terraform apply *)"], "deny": ["Bash(rm -rf /)"]}})
+        _, said = self.listing()
+        self.assertNotIn("rm -rf", said)
+
+
+class TestBlastRadiusIsOnScreen(GuardListCase):
+    def test_a_machine_local_rule_is_listed(self):
+        """Written by `guard allow --local`, and invisible to every reader until now."""
+        self.write(self.local_settings(), {"permissions": {"allow": ["Bash(git status *)"]}})
+        _, said = self.listing()
+        self.assertIn("git status", said)
+
+    def test_the_local_file_is_named_as_this_machine_only(self):
+        self.write(self.local_settings(), {"permissions": {"allow": ["Bash(git status *)"]}})
+        _, said = self.listing()
+        self.assertIn("settings.local.json", said)
+        self.assertIn("machine", said.lower())
+
+    def test_the_committed_file_is_named_as_everyone(self):
+        self.write(self.settings(), {"permissions": {"ask": ["Bash(terraform apply *)"]}})
+        _, said = self.listing()
+        self.assertIn("committed", said.lower())
+
+    def test_rules_from_both_files_appear_in_one_listing(self):
+        self.write(self.settings(), {"permissions": {"ask": ["Bash(terraform apply *)"]}})
+        self.write(self.local_settings(), {"permissions": {"allow": ["Bash(git status *)"]}})
+        _, said = self.listing()
+        self.assertIn("terraform apply", said)
+        self.assertIn("git status", said)
+
+    def test_each_rule_is_listed_under_the_file_that_holds_it(self):
+        """Grouping IS the blast radius. A flat list would need the reader to trust a
+        label; this makes the file the heading the rule sits under."""
+        self.write(self.settings(), {"permissions": {"ask": ["Bash(committed-rule *)"]}})
+        self.write(self.local_settings(), {"permissions": {"ask": ["Bash(local-rule *)"]}})
+        _, said = self.listing()
+        lines = [ln for ln in said.splitlines() if ln.strip()]
+        committed_at = next(i for i, ln in enumerate(lines) if "settings.json" in ln
+                            and "settings.local.json" not in ln)
+        local_at = next(i for i, ln in enumerate(lines) if "settings.local.json" in ln)
+        committed_rule = next(i for i, ln in enumerate(lines) if "committed-rule" in ln)
+        local_rule = next(i for i, ln in enumerate(lines) if "local-rule" in ln)
+        self.assertTrue(committed_at < committed_rule < local_at,
+                        "the committed rule belongs under the committed file")
+        self.assertTrue(local_at < local_rule, "the local rule belongs under the local file")
+
+
+class TestTheEmptyPlane(GuardListCase):
+    def test_no_rules_anywhere_says_so(self):
+        rc, said = self.listing()
+        self.assertEqual(rc, 0)
+        self.assertTrue(said.strip())
+
+    def test_an_empty_bucket_is_not_a_rule(self):
+        self.write(self.settings(), {"permissions": {"ask": [], "allow": []}})
+        rc, said = self.listing()
+        self.assertEqual(rc, 0)
+        self.assertIn("No", said)
+
+
+class TestAMalformedFile(GuardListCase):
+    def test_a_malformed_committed_file_is_named(self):
+        self.settings().parent.mkdir(parents=True, exist_ok=True)
+        self.settings().write_text("{not json")
+        rc, said = self.listing()
+        self.assertEqual(rc, 1)
+        self.assertIn("settings.json", said)
+
+    def test_a_malformed_local_file_does_not_hide_the_committed_rules(self):
+        """Reporting nothing because one file is unparseable would hide rules that ARE in
+        force — the same silent direction this issue is about."""
+        self.write(self.settings(), {"permissions": {"ask": ["Bash(terraform apply *)"]}})
+        self.local_settings().write_text("{not json")
+        rc, said = self.listing()
+        self.assertEqual(rc, 1)
+        self.assertIn("terraform apply", said)
+        self.assertIn("settings.local.json", said)
+
+    def test_a_malformed_committed_file_does_not_hide_the_local_rules(self):
+        self.settings().parent.mkdir(parents=True, exist_ok=True)
+        self.settings().write_text("{not json")
+        self.write(self.local_settings(), {"permissions": {"allow": ["Bash(git status *)"]}})
+        rc, said = self.listing()
+        self.assertEqual(rc, 1)
+        self.assertIn("git status", said)
+
+
+class TestOddShapes(GuardListCase):
+    """Somebody's deliberate structure, or somebody's mistake — never a crash."""
+
+    def test_a_permissions_block_of_the_wrong_type_does_not_raise(self):
+        self.write(self.settings(), {"permissions": "nope"})
+        rc, _ = self.listing()
+        self.assertEqual(rc, 0)
+
+    def test_a_bucket_of_the_wrong_type_does_not_raise(self):
+        self.write(self.settings(), {"permissions": {"ask": "nope"}})
+        rc, _ = self.listing()
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_guard_rule_shapes.py
+++ b/tests/test_guard_rule_shapes.py
@@ -1,0 +1,164 @@
+"""`_as_rule` tests the SHAPE of a rule, not the prefix of a string (#365).
+
+`_RULE_TOOLS` lists the tools whose rules charter must write verbatim, and deliberately
+includes `mcp__`. The condition that consulted it did not: it also required
+`("(" in p or p in ("Bash",))`, and Claude Code's MCP permission syntax is the bare
+`mcp__<server>__<tool>` — it never carries parentheses. So `charter guard ask
+'mcp__slack__send'` wrote `Bash(mcp__slack__send)`: a rule matching a *bash command*
+literally named `mcp__slack__send`, which is to say nothing at all. A tick was printed and
+a committed rule was written, and the operator was never prompted.
+
+That is the exact failure `_RULE_TOOLS`' own docstring exists to prevent, in its own words —
+"which matches nothing and fails in the silent direction" — landing on the one tool family
+that cannot carry the parenthesis the carve-out demanded.
+
+**The parenthesis requirement was load-bearing, though, and dropping it would mirror the
+bug.** `str.startswith` is a raw prefix match, so `Globalprotect --connect` starts with
+`Glob` and `Taskwarrior add x` starts with `Task`. Under a prefix test with no parenthesis
+requirement, both would stop being wrapped and become bare rules matching nothing — the same
+silent failure pointing the other way. So the test is on the shape a rule can actually take:
+`Tool(pattern)`, a bare tool name, or a bare MCP name. Everything else is a command.
+
+**And one shape is refused rather than written.** `mcp__slack__send *` names Claude Code's
+MCP syntax and then asks for a wildcard it does not have. There is no string charter can
+write that means it: wrapping produces `Bash(mcp__slack__send *)` and writing it bare
+produces a rule that matches nothing, so both directions fail silently. `mcp__` is the one
+family where wrapping is provably wrong rather than merely suspicious, so the command
+refuses before any harness writes — which also keeps the plane from ending up with the rule
+under one harness and not another (#369).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import commands, config
+from tests._isolation import PersonaIso
+
+
+class TestBareToolRulesSurvive(unittest.TestCase):
+    """A rule naming a tool is written verbatim whether or not it carries parentheses."""
+
+    def test_a_bare_mcp_tool_rule_is_not_wrapped(self):
+        """The reported case. `Bash(mcp__slack__send)` matches nothing."""
+        self.assertEqual(commands._as_rule("mcp__slack__send"), "mcp__slack__send")
+
+    def test_a_whole_mcp_server_rule_is_not_wrapped(self):
+        self.assertEqual(commands._as_rule("mcp__slack"), "mcp__slack")
+
+    def test_a_bare_tool_name_is_not_wrapped(self):
+        """`Read` alone is a whole-tool rule in the host's syntax, like `Bash` already was."""
+        self.assertEqual(commands._as_rule("Read"), "Read")
+
+    def test_task_is_not_wrapped(self):
+        self.assertEqual(commands._as_rule("Task"), "Task")
+
+    def test_bash_alone_is_still_not_wrapped(self):
+        self.assertEqual(commands._as_rule("Bash"), "Bash")
+
+
+class TestParenthesisedRulesStillSurvive(unittest.TestCase):
+    """The half that already worked, kept working."""
+
+    def test_a_read_rule_survives(self):
+        self.assertEqual(commands._as_rule("Read(./secrets/**)"), "Read(./secrets/**)")
+
+    def test_a_webfetch_rule_survives(self):
+        self.assertEqual(commands._as_rule("WebFetch(domain:x.com)"),
+                         "WebFetch(domain:x.com)")
+
+    def test_a_bash_rule_survives(self):
+        self.assertEqual(commands._as_rule("Bash(git push *)"), "Bash(git push *)")
+
+
+class TestCommandsThatMerelySTARTWithAToolName(unittest.TestCase):
+    """The mirror-image silent failure, which a prefix test would have introduced.
+
+    These are ordinary binaries. Under `startswith(_RULE_TOOLS)` with the parenthesis
+    requirement dropped they would have been written bare, matching nothing.
+    """
+
+    def test_globalprotect_is_a_command_not_a_glob_rule(self):
+        self.assertEqual(commands._as_rule("Globalprotect --connect"),
+                         "Bash(Globalprotect --connect)")
+
+    def test_taskwarrior_is_a_command_not_a_task_rule(self):
+        self.assertEqual(commands._as_rule("Taskwarrior add x"), "Bash(Taskwarrior add x)")
+
+    def test_an_ordinary_command_is_wrapped(self):
+        self.assertEqual(commands._as_rule("terraform apply *"), "Bash(terraform apply *)")
+
+    def test_a_tool_name_with_arguments_is_a_command(self):
+        """`Read the manual` is not a whole-tool rule; the tool rule is `Read` exactly."""
+        self.assertEqual(commands._as_rule("Read the manual"), "Bash(Read the manual)")
+
+
+class TestARuleCharterCannotExpress(unittest.TestCase):
+    """`mcp__` plus a wildcard: no string means it, so charter writes neither."""
+
+    def test_a_wildcarded_mcp_rule_is_refused(self):
+        with self.assertRaises(commands.UnexpressibleRule):
+            commands._as_rule("mcp__slack__send *")
+
+    def test_the_refusal_names_the_pattern_and_the_reason(self):
+        try:
+            commands._as_rule("mcp__slack__send *")
+        except commands.UnexpressibleRule as e:
+            self.assertIn("mcp__slack__send *", str(e))
+            self.assertIn("wildcard", str(e).lower())
+        else:
+            self.fail("expected UnexpressibleRule")
+
+    def test_a_valid_mcp_name_with_dashes_is_still_accepted(self):
+        self.assertEqual(commands._as_rule("mcp__my-server__do_thing"),
+                         "mcp__my-server__do_thing")
+
+
+class GuardCase(PersonaIso):
+    def settings(self) -> Path:
+        return Path(config.ROOT) / ".claude" / "settings.json"
+
+    def invoke(self, fn, **kw) -> tuple[int, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = fn(SimpleNamespace(**kw))
+        return rc, out.getvalue() + err.getvalue()
+
+
+class TestEndToEndThroughTheCommand(GuardCase):
+    def test_guard_ask_writes_the_mcp_rule_verbatim(self):
+        rc, _ = self.invoke(commands.cmd_guard_ask, pattern="mcp__slack__send", local=False)
+        self.assertEqual(rc, 0)
+        rules = json.loads(self.settings().read_text())["permissions"]["ask"]
+        self.assertIn("mcp__slack__send", rules)
+        self.assertNotIn("Bash(mcp__slack__send)", rules)
+
+    def test_guard_allow_writes_the_mcp_rule_verbatim(self):
+        rc, _ = self.invoke(commands.cmd_guard_allow, pattern="mcp__slack__send", local=False)
+        self.assertEqual(rc, 0)
+        rules = json.loads(self.settings().read_text())["permissions"]["allow"]
+        self.assertIn("mcp__slack__send", rules)
+
+    def test_an_unexpressible_pattern_writes_nothing_anywhere(self):
+        """Refused before the harness loop, so no harness gets a half of it (#369)."""
+        rc, out = self.invoke(commands.cmd_guard_ask, pattern="mcp__slack__send *",
+                              local=False)
+        self.assertEqual(rc, 2)
+        self.assertFalse(self.settings().exists())
+        self.assertFalse((Path(config.ROOT) / "opencode.json").exists())
+        self.assertIn("mcp__slack__send *", out)
+
+    def test_guard_allow_refuses_the_same_pattern(self):
+        rc, _ = self.invoke(commands.cmd_guard_allow, pattern="mcp__slack__send *",
+                            local=False)
+        self.assertEqual(rc, 2)
+        self.assertFalse(self.settings().exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_marker_prune.py
+++ b/tests/test_session_marker_prune.py
@@ -1,0 +1,155 @@
+"""`_prune` sweeps the session directories, not an allowlist of suffixes (#366).
+
+`_prune` keeps `SESSIONS_DIR` and `TERMINALS_DIR` bounded by unlinking per-session pointers
+past `_SESSION_MAX_AGE`. It enumerated the families by glob — `*.workspace`, `*.lock`,
+`*.configver`, `*.memnudge`, `*.usage` — and read as an exhaustive list of the family while
+being nothing of the kind.
+
+**Three families were missing, not two.** `*.ask-pending` (`hooks._ask_mark`) and
+`*.route-pending` (`hooks._route_mark`) were the two reported; `*.persona`
+(`persona._pointer_files`, in BOTH directories) is a third the report did not find. The
+allowlist has drifted three times, and a reader adding a fourth marker type has nothing
+telling them this list needs editing — which is the shape that repeats.
+
+So the sweep is now the directory, not a list of names: any file in those two directories
+past the cutoff goes. A marker family added tomorrow is covered the day it is written rather
+than the day somebody remembers this function. Both directories are charter's own state and
+hold nothing but per-session and per-terminal pointers, so there is no member for which
+"keep past the cutoff" is the right answer.
+
+**Nothing countable is lost.** `*.ask-pending` is deliberately left behind by a declined ask
+— that asymmetry is what makes "asked N, approved M" countable (#290) — so pruning it had to
+be checked against its readers rather than assumed safe. Nothing anywhere globs these
+suffixes: `_ask_mark_take`, `_route_mark_take` and `_route_mark_clear` all address one file
+by an exact session id and tool-use id. The tally itself lives in the trace store, which
+`_prune` does not touch. What ages out at thirty days is an inode whose session ended a
+month ago.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import unittest
+from pathlib import Path
+
+from charter import config, workspace
+from tests._isolation import PersonaIso
+
+
+def _age(p: Path, days: float) -> Path:
+    """Backdate *p* so `_prune`'s cutoff sees it as *days* old."""
+    when = time.time() - days * 86400
+    os.utime(p, (when, when))
+    return p
+
+
+class PruneCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        config.SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+        config.TERMINALS_DIR.mkdir(parents=True, exist_ok=True)
+
+    def marker(self, name: str, days: float, terminals: bool = False) -> Path:
+        d = config.TERMINALS_DIR if terminals else config.SESSIONS_DIR
+        p = d / name
+        p.write_text("")
+        return _age(p, days)
+
+
+class TestTheFamiliesThatWereMissing(PruneCase):
+    def test_a_stale_ask_pending_marker_is_pruned(self):
+        m = self.marker("sid.toolu_x.ask-pending", days=40)
+        workspace._prune()
+        self.assertFalse(m.exists())
+
+    def test_a_stale_route_pending_marker_is_pruned(self):
+        m = self.marker("sid.route-pending", days=40)
+        workspace._prune()
+        self.assertFalse(m.exists())
+
+    def test_a_stale_session_persona_pointer_is_pruned(self):
+        """The third family, which the report did not find."""
+        m = self.marker("sid.persona", days=40)
+        workspace._prune()
+        self.assertFalse(m.exists())
+
+    def test_a_stale_terminal_persona_pointer_is_pruned(self):
+        m = self.marker("tid.persona", days=40, terminals=True)
+        workspace._prune()
+        self.assertFalse(m.exists())
+
+
+class TestTheFloorDoesNotEatLiveState(PruneCase):
+    """Thirty days is the floor under the growth, not a cap on a live session."""
+
+    def test_a_fresh_ask_pending_marker_survives(self):
+        m = self.marker("sid.toolu_x.ask-pending", days=1)
+        workspace._prune()
+        self.assertTrue(m.exists())
+
+    def test_a_fresh_route_pending_marker_survives(self):
+        m = self.marker("sid.route-pending", days=3)
+        workspace._prune()
+        self.assertTrue(m.exists())
+
+    def test_a_fresh_persona_pointer_survives(self):
+        m = self.marker("sid.persona", days=29)
+        workspace._prune()
+        self.assertTrue(m.exists())
+
+
+class TestAFamilyNobodyHasWrittenYet(PruneCase):
+    """The reason the allowlist went rather than growing by three names.
+
+    A marker family added tomorrow is covered the day it is written. This test fails on
+    any return to an allowlist, which is the point of writing it.
+    """
+
+    def test_an_unknown_marker_suffix_is_pruned_when_stale(self):
+        m = self.marker("sid.some-marker-invented-later", days=40)
+        workspace._prune()
+        self.assertFalse(m.exists())
+
+    def test_an_unknown_marker_suffix_survives_while_fresh(self):
+        m = self.marker("sid.some-marker-invented-later", days=1)
+        workspace._prune()
+        self.assertTrue(m.exists())
+
+
+class TestTheFamiliesThatAlreadyWorked(PruneCase):
+    """Regression: the five the allowlist did cover still go."""
+
+    def test_stale_pointers_of_every_listed_family_are_pruned(self):
+        names = ["sid.workspace", "sid.lock", "sid.configver", "sid.memnudge", "sid.usage"]
+        made = [self.marker(n, days=40) for n in names]
+        workspace._prune()
+        for m in made:
+            with self.subTest(marker=m.name):
+                self.assertFalse(m.exists())
+
+    def test_a_fresh_workspace_pointer_survives(self):
+        m = self.marker("sid.workspace", days=1)
+        workspace._prune()
+        self.assertTrue(m.exists())
+
+
+class TestItOnlyRemovesFiles(PruneCase):
+    def test_a_stale_subdirectory_is_left_alone(self):
+        """Sweeping the directory means meeting whatever is in it. A directory is not a
+        per-session pointer, and unlinking is not the tool for one."""
+        d = config.SESSIONS_DIR / "somedir"
+        d.mkdir()
+        _age(d, 40)
+        workspace._prune()
+        self.assertTrue(d.exists())
+
+    def test_it_survives_a_missing_directory(self):
+        import shutil
+
+        shutil.rmtree(config.SESSIONS_DIR)
+        workspace._prune()  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Five mechanical defects from the third authority-audit sweep. #370 and #371 are excluded on purpose — they are the operator's judgement, not defects with one right answer.

Closes #365, closes #366, closes #367, closes #368, closes #369.

One commit per issue, plus a `docs/news/` entry for the three an operator can see. Baseline **3274 passed** on `main`, confirmed by running it after the pull rather than trusted; **3344 passed, 6208 subtests, 0 failed** on this branch (+70 tests), with branch and HEAD asserted identical either side of the run.

## Each issue ended with numbered options and no pick. What was chosen, and why

**#365 — `_as_rule` drops its own carve-out.** Took option 2 (split the shapes), made precise, plus the narrow slice of option 3.

The reported half: `_RULE_TOOLS` lists `mcp__` so an MCP rule survives untouched, but the condition also demanded a parenthesis, and Claude Code's MCP syntax never has one — so `charter guard ask 'mcp__slack__send'` wrote `Bash(mcp__slack__send)`, printed a tick, and committed a rule matching nothing.

The half that was **not** in the issue, and that option 1 would have shipped: `str.startswith` is a raw prefix match. `Globalprotect --connect` starts with `Glob`; `Taskwarrior add x` starts with `Task`. Dropping the parenthesis requirement would have written both bare — the identical silent failure, mirrored. That requirement was load-bearing by accident, so the fix tests the *shape* a rule can take (`Tool(pattern)`, a bare tool name, a bare MCP name) rather than the prefix of a string. Both binaries have regression tests that passed before the change and still do.

Option 3 taken only for `mcp__` patterns that parse as neither shape (`mcp__slack__send *`): no harness can express a wildcarded MCP rule, both available guesses fail silently, so charter refuses — before the harness loop, so nothing lands unevenly.

```
BEFORE  ✓ claude-code: asking for Bash(mcp__slack__send) → …/.claude/settings.json
AFTER   ✓ claude-code: asking for mcp__slack__send → …/.claude/settings.json

BEFORE  $ charter guard ask 'mcp__slack__send *'   → rc=0, written to both files
AFTER   ✗ charter cannot write 'mcp__slack__send *' as a permission rule. An MCP rule
          names a server (`mcp__slack`) or one of its tools (`mcp__slack__send`) exactly
          — no wildcard and no arguments. …  → rc=2, nothing written anywhere
```

**#366 — `_prune` sweeps five marker families of seven.** Took option 2 (sweep the directory).

**The issue undercounts: three families were missing, not two.** `*.ask-pending` and `*.route-pending` were reported; `*.persona` (`persona.py`, written into *both* `SESSIONS_DIR` and `TERMINALS_DIR`) is a third nobody had found. The allowlist has now drifted three times, which is why it is gone rather than three names longer — a family added tomorrow is covered the day it is written. Files only, so a directory in there is not unlinked.

The brief asked whether pruning loses a signal something else reads. **Checked, not assumed: it does not.** Nothing anywhere globs those suffixes — `_ask_mark_take`, `_route_mark_take` and `_route_mark_clear` each address one file by exact session and tool-use id, and #290's countability lives in the trace store, which `_prune` does not touch. What ages out at thirty days is an inode whose session ended a month ago.

**#367 — `pretooluse_dispatch` asks without tracing.** Took option 1 (trace the return) **plus a structural test**, and declined option 3.

Option 2 (move the trace inside `_ask`) would overturn a contract `_ask`'s docstring defends on the record, and the three sites pass different trace fields. So the fix is mechanical, and the guarantee option 2 was after is bought by a test that parses `hooks.py` and asserts every function calling `_ask` also records an ask-shaped event — a fourth site cannot quietly forget. `test_guards_that_must_not_be_refactored_away.py` is the precedent.

Event name `dispatch-ask`, not `ask`: every historical `ask` row means the clone-commit guard, and folding this in would corrupt the series a judgement about that guard has to rest on.

**This has no live data behind it and the fixture is the deliverable.** The nudge fires only when a peer declaring `dispatch-isolation: worktree` is in flight, so a test here can pass by never reaching the handler. Every counting assertion is paired with a precondition assertion on the emitted decision; the fixture is asserted separately; and the AST scan asserts it finds exactly the three real call sites before concluding anything about them. In the RED run the marker assertion passed (1 marker — the approval half already worked) while the ask assertion read 0, which is the defect stated exactly.

Option 3 declined: a `reason` on `ask-approved` means putting content into a marker whose comment says it holds *"nothing but the correlation key"*, on a path documented as a stat() on every Bash call. Filed as #375.

**#368 — `guard list` reads only the `ask` bucket.** Took options 1 and 2, rejected option 3.

Rejected 3 because bare `charter guard` is the command an operator actually reaches for; keeping the ask-only view as the default and hiding the full picture behind a subcommand nobody types is the same defect wearing a flag. Grouped by file rather than labelled per row, because the file a rule lives in *is* its blast radius — a label asks the reader to trust it, a heading makes it structural. `deny` stays unlisted: charter never writes it and it answers neither operator question. A malformed file is named and does not suppress the other.

```
BEFORE    …/.claude/settings.json
            Bash(terraform apply *)
            Read(./secrets/**)

AFTER     …/.claude/settings.json  (committed — everyone on this repo)
            ask    Bash(terraform apply *)
            ask    Read(./secrets/**)
            allow  Bash(gh pr merge *)
          …/.claude/settings.local.json  (machine-local — yours alone, on this machine)
            allow  Bash(git status *)
```

The two allow rules are in those files in both runs. Only the second shows them.

**#369 — the help names one file; the command writes every harness.** Ruled against option 4, took option 1, declined option 2, took option 3 as claim-only.

**`detect()` gate rejected.** `detect()` answers "am I running inside this harness right now", not "does this team use it", so gating on it makes a rule's reach depend on which harness happened to type the command — and a teammate on opencode silently does not get it. That is the drift ADR 0014 exists to remove. Behaviour unchanged; the claim moved.

The harness names are derived from `registry.KINDS`, not written into the help string — a literal is what goes stale the day a harness is added, which `harness/registry.py`'s own docstring warns about. There is a test that adds a fictional harness to the registry and asserts it appears.

```
BEFORE  guard   Force-prompt rules for this plane. Written as Claude Code
                `permissions.ask` rules in .claude/settings.json — charter keeps
                no list of its own (ADR 0014).

AFTER   guard   Force-prompt and stop-prompting rules for this plane. Written in
                each harness's own syntax, into the file each one reads — every
                harness charter knows (claude-code, opencode, codex), not only
                the one you are running. charter keeps no list of its own (ADR 0014).
```

**The non-atomic write: claim in scope, behaviour out.** All-or-nothing is a two-phase apply across three file formats with no rollback primitive — a design change, filed as #376. What is fixed is that a `✗` read as "nothing was written":

```
AFTER (new final line, with .claude/settings.json malformed)
  !   The rule landed UNEVENLY — it is in force under the harnesses ticked above and
      NOT under the one refused, from this one command. Fix that file and re-run;
      the harnesses that already have it will say so.
```

`add_permission_rule`'s docstring said charter "reports it and stops". It reports and continues, and now says so.

## Deferred, on the record rather than in a transcript

- #374 — opencode's `ask_rule` mistranslates an MCP pattern into a bash rule that matches nothing. Found while fixing #365; not fixed there because it needs opencode's MCP syntax established rather than inferred.
- #375 — `ask-approved` carries no reason, so approvals cannot be attributed to the nudge that earned them.
- #376 — `charter guard` is not all-or-nothing across harnesses.

## Contradicting the brief

- **#366 says two missing families; there are three.** `*.persona` is written into both directories by `persona.py` and was not in the allowlist either.
- **#365 has a second half in `opencode.py`** that the issue does not mention — the same pattern still mistranslates there. Filed as #374 rather than fixed here.
- **The before/after for #365 shows the rule charter writes, not the host matching it.** That bare `Read` and `mcp__server__tool` are valid rules rests on Claude Code's documented permission syntax, not on anything run here; charter's own behaviour is what these tests and outputs demonstrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo