### PR TITLE
Release 0.49.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.48.0"
+__version__ = "0.49.0"

--- a/docs/news/0.49.0-guard-says-what-it-wrote.md
+++ b/docs/news/0.49.0-guard-says-what-it-wrote.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.49.0
 headline: `charter guard` writes the rule you typed, and shows you all of them
 ---
 

--- a/docs/news/0.49.0-messages-that-match-the-failure.md
+++ b/docs/news/0.49.0-messages-that-match-the-failure.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.49.0
 headline: Three messages now name the failure you actually have
 ---
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.48.0",
+            "command": "charter hook sessionstart --plugin-version 0.49.0",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.48.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.49.0",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.48.0",
+            "command": "charter hook pretooluse --plugin-version 0.49.0",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.48.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.49.0",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.48.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.49.0"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.48.0",
+            "command": "charter hook pretooluse-edit --plugin-version 0.49.0",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-bash --plugin-version 0.48.0",
+            "command": "charter hook posttooluse-bash --plugin-version 0.49.0",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.48.0",
+            "command": "charter hook posttooluse --plugin-version 0.49.0",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.48.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.49.0",
             "timeout": 5
           }
         ]
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.48.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.49.0",
             "timeout": 5
           }
         ]
@@ -128,7 +128,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-message --plugin-version 0.48.0",
+            "command": "charter hook posttooluse-message --plugin-version 0.49.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.48.0"
+version = "0.49.0"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Carries everything merged since `v0.48.0`: three code PRs (#364, #377) and two
documentation PRs (#359, #362), closing eight issues — #360, #361, #363, #365, #366,
#367, #368, #369. All of it the tail of the authority audit rather than new work.

## The version call: minor

**0.49.0, not 0.48.1.** Two scripted paths move, not one:

| path | 0.48.0 | 0.49.0 |
|---|---|---|
| `charter guard ask 'mcp__…​ *'` | rc=0, writes a rule matching nothing | **rc=2**, refuses, writes nothing |
| `charter guard list` row format | `    <rule>` | `    <bucket> <rule>` + a second file section |

That the old `rc=0` was a lie does not make the change invisible to a caller — a script
branching on the exit code, or parsing the listing by column, breaks either way. This is
the same reading that made 0.48.0 a minor ("exit codes change… a previously-succeeding
`secret set` can now fail — those are changed defaults, not fixes that add no surface").

Nothing here adds a new config key, a new CLI flag or a changed default in the
surface-growing sense, which is the honest argument for a patch. It loses because a
version number is a promise to the caller about what an upgrade can do to their scripts,
and this upgrade can break one.

**What the patch reading would have cost:** an operator takes 0.48.1 as safe, and a
provisioning script that calls `charter guard ask` with an MCP wildcard starts exiting 2
mid-run, or one parsing `charter guard list` reads a bucket label as a rule name. The
second-order cost is worse: once a patch has broken a scripted path, no later patch can be
trusted, and that signal is the only thing the number buys.

## The asset gate did not decide it

`captured.json` was re-stamped to 0.48.0 by #362, so — confirmed by running
`tests/test_asset_freshness.py`'s own `_minor`/lag arithmetic rather than reasoning about
it — a patch computes **lag 0** and a minor **lag 1**, and `MAX_MINOR_LAG = 1` passes
both. The gate was checked and stayed silent; it did not bend the number.

⚠️ **Choosing the minor spends the gate's last slack.** At `captured.json` 0.48.0, the next
minor (0.50.0) computes lag 2 and **will fail the suite** until `demo.svg`, `personas.svg`
and `statusline.svg` are regenerated and the stamp updated. That is a real dated obligation
this PR creates, stated here so it is not later read as a surprise.

## Version points moved: 14

| file | points |
|---|---|
| `pyproject.toml` | 1 |
| `charter/__init__.py` | 1 |
| `.claude-plugin/plugin.json` | 1 |
| `hooks/hooks.json` (`--plugin-version`) | **11** |

Verified by re-grepping the **old** string to zero across all four, and by parsing
`hooks.json` for engine-hook commands: 11 found, 11 at `0.49.0`, 0 at `0.48.0`. The count
was read off the file, never remembered. `docs/assets/captured.json` is deliberately not a
version point — it is a capture stamp, and moving it by hand would defeat the gate.

News: both staged entries stamped by `charter news stamp 0.49.0` (rename + `version:`
rewrite), zero `unreleased-*` left.

## Verification

| check | result |
|---|---|
| Suite on `main` @ `99fe5dc` (baseline) | **3344 tests, OK**, 75.4s |
| Suite on this branch | **3344 tests, OK**, 75.1s — same count, so no tests were silently lost |
| Skips / expected failures | **0** in either run |
| `TestVersionsMoveInLockstep`, `TestTheCapturesAreNotStale` | confirmed *ran*, not skipped |
| `charter doctor`, subprocess, 60s bound | **1.19s, rc=0**, all 27 checks reported |
| Stamped entries arm a `check:` | **no** — both `check=''`, `adopt=''`, read back through `news.for_version` |
| Release guard, replayed verbatim | tag↔pyproject **PASS** (tag must be exactly `v0.49.0`); news entry **PASS** |
| `charter news --for 0.49.0` | renders both entries, rc=0 |

Branch and HEAD asserted identical on both sides of every long run.

### Smoke tests — real CLI in a subprocess, throwaway plane via `$CHARTER_ROOT`

The operator's own settings and `vaults.json` were never touched; isolation was asserted by
printing where the CLI resolves `SHARED_VAULTS` under the fixture, not assumed. Every test
asserts its precondition, because the audit produced vacuous passes before.

1. **Bare MCP rule written unwrapped (#365)** — `guard ask 'mcp__slack__send'` wrote
   `mcp__slack__send`; asserted `Bash(mcp__slack__send)` absent. Benign twins prove the fix
   did not over-correct into writing everything bare: `terraform apply *` →
   `Bash(terraform apply *)`, and the two prefix traps the PR names, `Globalprotect
   --connect` → `Bash(Globalprotect --connect)` and `Taskwarrior add x` →
   `Bash(Taskwarrior add x)`, plus `Read(./secrets/**)` kept verbatim.
2. **Wildcard MCP pattern refused (#365)** — `guard ask 'mcp__slack__send *'` → **rc=2**,
   every harness file **byte-identical** before and after (shasum), stderr carries the
   refusal sentence, and asserted *not* an argparse error — the exact vacuous pass that bit
   the last release.
3. **`guard list` shows both buckets, both files (#368)** — precondition asserted on disk
   (committed file holds `ask` **and** `allow`; a `settings.local.json` exists). v0.48.0's
   listing logic replayed against the same fixture for an A/B: **5 rows then, 7 now** — the
   `allow` rule and the entire machine-local block were invisible.
4. **Malformed `vaults.json` does not end the preflight (#363)** — precondition proved by
   replaying 0.48.0's line on the fixture entry and catching the real
   `AttributeError: 'str' object has no attribute 'get'`. With the malformed entry, doctor
   returned **rc=0 in 0.68s** and reported **28 checks — the identical set and count as the
   clean control**, reaching the summary line.
5. **Status line renders** — rc=0 on both the fixture and the real plane; every row asserted
   to the same visible width (76 cols, ANSI-stripped, East-Asian-width aware), and the
   fixture render shows `⬢ charter 0.49.0`, confirming the bump reaches the rendered surface.

## Nothing here should stop the release

One **separate, pre-existing** defect was found while smoke-testing #363 and is
deliberately **not** fixed in this PR — a release branch is the wrong place to smuggle one:

`registry.malformed_shared()` correctly returns the dropped entry, but `doctor`'s `vaults`
check assembles that note only on its final OK path. The `timed_out` / `no_identity` /
`bad` branches (`charter/doctor.py:1157-1173`) each return
`detail=f"{len(vs)} configured"` early, so when a plane has a malformed entry **and** an
unreachable vault, the ignored entry is never named. Observed: `! vaults 1 configured →
not reachable: forge` with no mention of `oops`. It is worth an upstream issue.

A **second** one, from the same smoke run, and the more interesting of the two: **#365 is
fixed for Claude Code only.** `charter guard ask 'mcp__slack__send'` prints two ticks —

```
✓ claude-code: asking for mcp__slack__send      → .claude/settings.json
✓ opencode:    asking for ('bash', 'mcp__slack__send') → opencode.json
```

— and the second one is the exact defect #365 describes, one harness over.
`opencode.ask_rule` (`charter/harness/opencode.py:394-403`) matches `Tool(...)`/`tool(...)`
and otherwise falls through to `return "bash", p`, so a bare MCP name lands as
`{"permission": {"bash": {"mcp__slack__send": "ask"}}}` — an MCP tool name in opencode's
**command-pattern** map, matching a bash command by that literal name and nothing else.
Verified byte-for-byte identical to `v0.48.0`, so this is **pre-existing, not a regression**,
and it does not block the release.

It is worth filing promptly for one reason: this same PR widened `charter guard`'s help to
advertise that the command writes *every* registered harness. The release therefore points
operators at a surface where the headline fix does not hold, and the refusal added for
`mcp__…​ *` runs before the harness loop — so charter now refuses the pattern it cannot
express while still ticking for one it expresses wrongly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo
