### PR TITLE
A guard that earns its prompt, and a denial that says what to do when it is wrong (#371, #370)

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,8 @@ copy wins, is compared to nothing, and drifts unwatched in both directions.
 - [docs/git-policy.md](docs/git-policy.md) — the one-credential rule, and why a denial from
   the plugin's guard is the rule working rather than a bug.
 - [docs/hooks.md](docs/hooks.md) — everything the plugin does without being asked: what
-  fires when, the four guards, what gets injected, and what gets counted.
+  fires when, the five guards, what to do when one of them is wrong, what gets injected,
+  and what gets counted.
 - [docs/mcp.md](docs/mcp.md) — giving an MCP server a persona's vault credentials without
   the value entering the model, and what the per-persona tool allowlist does and does not
   constrain.

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1134,8 +1134,14 @@ def cmd_guard_allow(args) -> int:
             # who clones the repo, on machines and under identities they did not choose.
             util.warn("  COMMITTED — this stops the prompt for everyone on this repo, not "
                       "just you. Use `--local` for a rule that is yours alone.")
+        # The claim is accurate and stays. What was missing is the next sentence: a reader
+        # who has just been told this command cannot reach charter's denials is exactly the
+        # reader about to go looking for something that can, and until #370 there was
+        # nothing to find and nowhere saying so.
         util.info("  charter's own guards are unaffected: an allow rule relaxes the HOST's "
-                  "prompt, never the secret, credential or plane-root denials.")
+                  "prompt, never the secret, credential, plane-root or release denials.")
+        util.info("  Nothing lifts those — by design. `charter docs show hooks` → *When a "
+                  "guard is wrong* for what to do when one of them is wrong about you.")
     _say_if_uneven(wrote, rc == 1)
     return rc
 

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -153,6 +153,36 @@ def _ask_mark_take(sid, tuid) -> bool:
         return False
 
 
+def _ask_approved(data: dict) -> None:
+    """Record that an `ask` was APPROVED — the other half of every nudge charter emits.
+
+    A hook `ask` blocks the tool, so a ``PostToolUse`` carrying the same ``tool_use_id`` is
+    proof it ran, which is proof somebody said yes. A declined ask never produces one and
+    its marker simply stays behind; that asymmetry is what makes "asked N, approved M"
+    countable at all (#290).
+
+    **One function, called from every PostToolUse family, because an ask can be raised on
+    every tool family.** This lived inside `posttooluse_bash` and nowhere else, which was
+    correct only for as long as the one nudge on the **Bash** tool existed. #371 deleted it,
+    and the two nudges that remain raise on ``Task|Agent`` and on ``Write|Edit|MultiEdit``
+    — so every approval either of them ever received was already uncountable, and the
+    deletion would have pinned the numerator at zero for good. Two code paths answering
+    "was this nudge approved?" is how that stayed invisible; there is now one.
+
+    **Kept to a stat() on the common path.** Every caller is registered against every call
+    of its tool, so the overwhelming majority of invocations must find no marker and return
+    having written nothing — no trace line, no read of the trace, no import beyond what is
+    already loaded.
+    """
+    try:
+        sid, tuid = data.get("session_id"), data.get("tool_use_id")
+        if not _ask_mark_take(sid, tuid):
+            return
+        _trace("ask-approved", sid)
+    except Exception:
+        return  # bookkeeping must never break a turn
+
+
 # --------------------------------------------------------------------------- #
 # secret detection (shared): report the KIND, never the value                  #
 # --------------------------------------------------------------------------- #
@@ -938,32 +968,32 @@ def _release_floor_reason(cmd: str, data: dict) -> str | None:
 
 
 # --------------------------------------------------------------------------- #
-# B: clone-boundary guard — deny git-write inside a clone from the control plane #
+# B: the clone-commit nudge — REMOVED in #371                                   #
 # --------------------------------------------------------------------------- #
-_GIT_WRITE_RE = re.compile(r"\bgit\b[^|;&]*?\b(?:commit|push|add|am|cherry-pick|tag|rebase|merge)\b")
-# Matches a clone path under the workspaces root (or the legacy `repos/` name, for a
-# teammate mid-migration): `cd workspaces/<ws>/<repo>`, `git -C …/workspaces/…`, etc.
-_CLONE = r"(?:repos|workspaces)"
-_REPOS_REF_RE = re.compile(
-    rf"(?:\bcd\s+\S*{_CLONE}/|-C\s+\S*{_CLONE}/|(?:^|[\s'\"]){_CLONE}/[^/\s]+/[^/\s]+)")
-
-
-def _clone_commit_reason(cmd: str, cwd: str) -> str | None:
-    if not _GIT_WRITE_RE.search(cmd):
-        return None
-    in_repos = bool(_REPOS_REF_RE.search(cmd))
-    if not in_repos and cwd:
-        try:
-            Path(cwd).resolve().relative_to(config.WORKSPACES_DIR.resolve())
-            in_repos = True
-        except Exception:
-            in_repos = False
-    if in_repos:
-        return ("you're committing inside a clone from the control-plane session. A repo-rooted "
-                "session (`cd workspaces/<ws>/<name> && claude`) applies the repo's own "
-                "hooks/skills/conventions — usually better for real repo work. Proceed if it's "
-                "intentional (the clone is its own git repo; the control plane's is untouched).")
-    return None
+# It asked before a git write inside a workspace clone, recommending a repo-rooted session.
+# Deleted rather than narrowed, for a reason worth keeping written down because the same
+# argument will be made for the next nudge somebody wants to add:
+#
+#   * **Its trigger was the prescribed workflow.** `charter clone` puts every repo under
+#     `workspaces/`, and `skills/working-in-a-clone` says "Commit to the repo you are in".
+#     A guard whose firing condition is the intended state is not miscalibrated, it is
+#     inverted — no amount of narrowing fixes that.
+#   * **Measured, not assumed.** 471 asks in one plane over two weeks, every `ask` row in
+#     the store this one rule, 97 of 98 approved on the first day approvals were countable.
+#     Against it, the persona tool-gate — the mechanism whose whole job is to REMOVE
+#     prompts — fired 16 times in the same window.
+#   * **It could not be justified even in principle.** Keeping it meant committing to show
+#     it earns its interruptions, and the evidence for that is a DECLINE. A declined ask
+#     produces no `PostToolUse`, so it is indistinguishable from an interrupted turn or an
+#     ended session (see `posttooluse_bash`). A guard that can only ever be defended with
+#     evidence the protocol cannot yield is a guard that will be re-argued forever.
+#   * **It was safe to remove.** It is not a safety rule and never claimed to be — the
+#     clone is its own repository and the plane's git is untouched either way. The one
+#     thing it covered by ACCIDENT, an unattended release (#299), has been covered on
+#     purpose by A4 since 0.46.1, and A4 runs BEFORE this ever did.
+#
+# The advice itself is not lost; it lives in prose in `skills/working-in-a-clone`, which is
+# one source of truth rather than two, and interrupts nobody.
 
 
 def _trace(event, session, **f):
@@ -1208,24 +1238,17 @@ def pretooluse() -> int:
         _deny("PreToolUse", branch)
         _trace("deny", sid, reason="plane-root-branch", cmd=head)
         return 0
-    # A4: an unattended run may not publish (#299). Checked BEFORE the clone nudge, which
-    # is where the hole was: that nudge matches `tag`/`push`, and 0.46.0 turned its
-    # unattended `ask` into an `allow` — so a release walked straight through it.
+    # A4: an unattended run may not publish (#299). It used to matter that this ran before
+    # the clone nudge — that nudge matched `tag`/`push` and stopped releases by accident
+    # until 0.46.0 turned its unattended `ask` into an `allow`. The nudge is gone (#371);
+    # this guard stands on its own, which is what "on purpose" was always supposed to mean.
     pub = _release_floor_reason(cmd, data) if _cfg.HAS_CONTROL_PLANE else None
     if pub:
         _deny("PreToolUse", pub)
         _trace("deny", sid, reason="release-floor", cmd=head)
         return 0
-    # B: committing inside a clone → ASK, not deny. A repo-rooted session is usually better
-    # (the repo's own hooks/conventions apply), but it's a preference, not a safety rule —
-    # the clone is its own git repo, so the control plane's is untouched either way.
-    # Same gate: "you are committing inside a clone rather than at the plane" is advice
-    # about a plane, so it has nothing to say where there is none.
-    clone = _clone_commit_reason(cmd, cwd) if _cfg.HAS_CONTROL_PLANE else None
-    if clone:
-        if _ask("PreToolUse", clone, data):
-            _trace("ask", sid, reason=clone[:70], cmd=head)
-        return 0
+    # B WAS HERE: the clone-commit nudge, removed in #371 — see the note where it lived.
+    # Nothing on this handler asks any more; every remaining verdict is a deny or an allow.
     # fall through to the allow-only persona tool-gate (unchanged behaviour)
     try:
         from . import toolgate
@@ -1960,6 +1983,10 @@ def memory_share_note() -> str:
 def posttooluse() -> int:
     data = _read_stdin()
     _touch_piece(data)
+    # The approval half of the `routing: require` edit nudge (`pretooluse_edit`), which asks
+    # on THIS tool family. Before the file-path checks below, because an approval is a fact
+    # about the tool call and not about what it wrote.
+    _ask_approved(data)
     if (data.get("tool_name") or "") not in ("Write", "Edit", "MultiEdit"):
         return 0
     ti = data.get("tool_input") or {}
@@ -2153,28 +2180,26 @@ def pretooluse_dispatch() -> int:
 
 
 def posttooluse_bash() -> int:
-    """Record that an `ask` was APPROVED — the other half of every nudge charter emits.
+    """The approval half of any nudge raised on the **Bash** tool — see `_ask_approved`.
 
-    A hook `ask` blocks the tool, so a `PostToolUse` for the same ``tool_use_id`` is proof
-    it ran, which is proof a human said yes. A declined ask never produces one, and its
-    marker simply stays behind; that asymmetry is what makes "asked N times, approved M"
-    countable at all (#290).
+    **charter currently raises none.** The clone-commit nudge was the only one and #371
+    deleted it, so on today's code this handler finds no marker and returns, every time.
+    That is deliberate rather than an oversight worth cleaning up:
 
-    **Kept to a stat() on the common path.** This is registered against every Bash call, so
-    the overwhelming majority of invocations must find no marker and return having written
-    nothing — no trace line, no read of the trace, no import beyond what is already loaded.
-    The cost that remains is the process spawn itself; narrowing the matcher with the host's
-    `if:` condition (e.g. ``Bash(git *)``) is the obvious next reduction, deferred only
-    because it would raise charter's minimum supported host version.
+    * A handler the shipped `hooks/hooks.json` dispatches cannot be removed from the CLI
+      without breaking every install whose plugin is a version behind — `charter hook
+      posttooluse-bash` would simply error, on every Bash call. Version skew in either
+      direction is the failure shape this project keeps paying for (`docs/hooks.md`), and
+      it is not worth re-entering to delete a `stat()`.
+    * `pretooluse` is where a Bash-tool guard would go, and the next one that wants to be a
+      nudge rather than a deny needs its approval counted from the day it ships — which is
+      the lesson #371 cost 471 prompts to learn.
+
+    The residual cost is the process spawn, already noted before this became a no-op:
+    narrowing the matcher with the host's `if:` condition (e.g. ``Bash(git *)``) is the
+    obvious reduction, deferred only because it would raise charter's minimum host version.
     """
-    data = _read_stdin()
-    try:
-        sid, tuid = data.get("session_id"), data.get("tool_use_id")
-        if not _ask_mark_take(sid, tuid):
-            return 0
-        _trace("ask-approved", sid)
-    except Exception:
-        return 0  # bookkeeping must never break a turn
+    _ask_approved(_read_stdin())
     return 0
 
 
@@ -2289,6 +2314,10 @@ def posttooluse_message() -> int:
 
 def posttooluse_dispatch() -> int:
     data = _read_stdin()
+    # The approval half of the overlapping-dispatch nudge (`pretooluse_dispatch`). Before
+    # the `subagent_type` check: an ask that was approved was approved whatever the tally
+    # below can make of the payload.
+    _ask_approved(data)
     if (data.get("tool_name") or "") not in ("Task", "Agent"):
         return 0
     agent = ((data.get("tool_input") or {}).get("subagent_type") or "").strip()

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -59,11 +59,40 @@ def _emit(obj: dict) -> None:
     print(json.dumps(obj))
 
 
+#: What to do when a guard is WRONG about your case (#370).
+#:
+#: Every denial named a remedy for the workflow the operator was supposed to be doing, and
+#: none named this. Nothing else did either — no config key, no environment variable, no
+#: per-guard switch — so the only route past a denial charter got wrong was to delete the
+#: hook or disable the plugin, taking every guard, both injections and all the tallies with
+#: it. Every guard is eventually wrong about something, and when the only move is nuclear,
+#: the guard that was wrong once is off for ever along with the ones that were not.
+#:
+#: **The answer is that there is no switch, and that is the design.** charter's guards exist
+#: because committed data must not reach a credential or make something run. A key in
+#: `charter.toml` would be a key a teammate's pull request could flip; an environment
+#: variable sits on a command line the agent itself writes. An override charter can READ is
+#: an override the AGENT controls, which is exactly the party being bound. What remains is
+#: the operator's own shell, which was never inside the boundary: these are `PreToolUse`
+#: hooks on the harness's tools, so running the command yourself works around nothing.
+#:
+#: Appended in :func:`_deny` rather than at the five call sites, for two reasons that are
+#: both about the next guard rather than these five: a sixth carries it without anyone
+#: remembering to, and the trace tally keys — derived from the reason BEFORE it gets here —
+#: cannot drift. Appended, never prepended, for the same reason.
+_OVERRIDE_NOTE = (
+    " — Wrong about this case? There is deliberately no config key, environment variable or "
+    "switch that lifts a charter denial: one charter could read is one a committed file could "
+    "flip. Run it yourself, in your own terminal — these guards bound what an AGENT does with "
+    "your authority, never what you do. See `docs/hooks.md` → When a guard is wrong."
+)
+
+
 def _deny(event: str, reason: str) -> None:
     _emit({"hookSpecificOutput": {
         "hookEventName": event,
         "permissionDecision": "deny",
-        "permissionDecisionReason": f"charter guard: {reason}",
+        "permissionDecisionReason": f"charter guard: {reason}{_OVERRIDE_NOTE}",
     }})
 
 

--- a/docs/adr/0014-policy-that-fits-a-pattern-belongs-to-the-host.md
+++ b/docs/adr/0014-policy-that-fits-a-pattern-belongs-to-the-host.md
@@ -39,9 +39,15 @@ standing or who you are?
 | --- | --- | --- |
 | `_leak_reason` | argv, and the plane's vault paths | no |
 | `_plane_root_branch_reason` | the working directory | no |
-| `_clone_commit_reason` | the working directory | no |
+| `_clone_commit_reason` ⁺ | the working directory | no |
 | `toolgate.decide` | the active persona's declared tools | no |
 | `_single_credential_reason` | the command alone | **yes** |
+
+⁺ Removed in #371 — not because the line drawn here moved, but because that particular
+guard failed a different test: it asked 471 times in one plane, was approved 97 times out of
+98, and its trigger condition was the workflow `skills/working-in-a-clone` prescribes. "Not
+expressible as a host rule" answers *where a guard lives*. It never answered *whether the
+guard should exist*, and this table was read as if it did.
 
 Only the last is static, and it deliberately stays in the hook anyway. A native `deny` rule
 prints no reason, and the reason is most of what that guard is for: a developer who reads

--- a/docs/adr/0015-the-boundary-moves-with-the-harness.md
+++ b/docs/adr/0015-the-boundary-moves-with-the-harness.md
@@ -36,7 +36,7 @@ Code* table.
 | --- | --- | --- | --- |
 | `_leak_reason` | no | no | no |
 | `_plane_root_branch_reason` | no | no | no |
-| `_clone_commit_reason` | no | no | no |
+| `_clone_commit_reason` (removed, #371) | no | no | no |
 | `toolgate.decide` | no | **yes** | no |
 | `_single_credential_reason` | yes | yes | yes |
 

--- a/docs/git-policy.md
+++ b/docs/git-policy.md
@@ -40,6 +40,12 @@ the fix, which is usually nothing at all — `charter git-policy --apply` has al
 configured the repo correctly. Check the credential with `glab auth status` or `gh auth
 status`, never `ssh -T`.
 
+**And when it is not the rule working** — a repo that genuinely needs something this guard
+refuses — see [hooks.md](hooks.md) → *When a guard is wrong*. Short version: nothing in
+`charter.toml` or the environment lifts a denial, deliberately, and you run the command in
+your own terminal. If the guard is wrong about you *every time*, that is charter holding a
+policy your organisation does not, and it belongs in an issue rather than a local switch.
+
 The same guard covers the vault: it refuses `--reveal` on a non-interactive stdout and
 refuses file-reading tools pointed at a vault file, so a secret cannot reach the transcript
 by way of `cat`. See [secrets.md](secrets.md).

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -17,7 +17,7 @@ one thing a hook is allowed to shout about.
 | --- | --- | --- |
 | `SessionStart` | — | reconcile workspace state, GC persona scratch, inject context, run `doctor`, refresh forge state |
 | `UserPromptSubmit` | — | the commitment gate (below) |
-| `PreToolUse` | `Bash` | the four guards (below) |
+| `PreToolUse` | `Bash` | four of the five guards (below) |
 | `PreToolUse` | `Read\|Grep` | keeps a vault file from being read into context |
 | `PreToolUse` | `Task\|Agent` | notes a dispatch about to happen |
 | `PostToolUse` | `Write\|Edit\|MultiEdit` | the record-memory nudge |
@@ -27,12 +27,17 @@ one thing a hook is allowed to shout about.
 
 ## The guards
 
+Every one of them **denies**. None of them asks — charter holds no nudge on the Bash tool,
+and that is a deliberate position, not an accident (see *What charter stopped asking*).
+
 A denial from these is **the rule working, not a bug** — the single most common thing
 mistaken for a defect. Each prints why, because a developer who reads the reason learns the
 rule while one who reads a bare refusal files an issue.
 
 - **Secret leak.** A command whose argv would put a vault's contents into the transcript.
   Needs argv *and* the plane's vault paths, so it cannot be expressed as a static rule.
+- **Vault read.** The same invariant on the `Read`/`Grep` tools, which never reach the Bash
+  matcher at all.
 - **Plane-root branch move.** The plane is not a work tree (ADR 0008); a branch switch there
   is almost always meant for a clone.
 - **One credential.** SSH to a forge, `GIT_SSH_COMMAND`, `-S`/`--gpg-sign`, and the
@@ -40,11 +45,31 @@ rule while one who reads a bare refusal files an issue.
   `--config-env`, `GIT_CONFIG_KEY_n`, and a `git config` write of it). This one *is*
   expressible as a pattern and stays in the hook anyway, so it can explain itself — see
   [git-policy.md](git-policy.md) and ADR 0014.
-- **Commit inside a clone.** Asks rather than denies: committing there is usually intended,
-  and only the working directory reveals which case it is.
+- **Release floor.** A run the harness reports as `bypassPermissions` may not create a tag,
+  push tags, or `gh release create` / `gh pr merge`. `bypassPermissions` means *stop asking
+  me*, not *stop knowing things*, and a published version number can never be reused.
 
-A fifth path is not a guard but an allowance: a binary the **active persona** declares in
+A sixth path is not a guard but an allowance: a binary the **active persona** declares in
 `tools:` runs without a prompt while that persona is active, and only then.
+
+## What charter stopped asking
+
+charter used to nudge before a git write inside a workspace clone, suggesting a repo-rooted
+session. It is gone, and the measurement is why: in one plane it asked **471 times in two
+weeks and was approved 97 times out of 98** — while the persona tool-gate, the mechanism
+whose whole job is to *remove* prompts, fired 16 times over the same window. Its trigger was
+also charter's own prescribed workflow: `charter clone` puts every repo under `workspaces/`,
+and the `working-in-a-clone` skill says *commit to the repo you are in*. The advice the
+nudge carried still exists there, in prose, interrupting nobody.
+
+The rule that came out of it, and the one a new nudge has to pass:
+
+> **A prompt is worth its interruption only if it changes what happens.** If the evidence
+> that it does cannot be collected, the prompt cannot be justified — and a declined `ask`
+> produces no `PostToolUse`, so charter can never tell a decline from an interrupted turn.
+
+An approved ask *is* countable, and every nudge charter still has records both halves. See
+*What gets counted*.
 
 Policy that *can* be written as a command pattern belongs in Claude Code's own
 `permissions`, not here — `charter guard ask <pattern>` writes it there. Charter keeps only

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -52,6 +52,43 @@ rule while one who reads a bare refusal files an issue.
 A sixth path is not a guard but an allowance: a binary the **active persona** declares in
 `tools:` runs without a prompt while that persona is active, and only then.
 
+## When a guard is wrong
+
+Every guard is eventually wrong about something, and the response a design invites at that
+moment is the response it gets. So this is written down rather than left to be discovered.
+
+**There is no config key, environment variable or `charter guard` verb that lifts a
+denial, and there will not be one.** That is the answer, not an omission:
+
+- charter's guards exist because **committed data must not be able to reach a credential or
+  make something run**. A switch charter read from `charter.toml` would be a switch a
+  committed file could flip — a teammate's pull request turning off the guard that keeps a
+  vault out of the transcript. An environment variable is no better: the agent writes the
+  command line the variable would sit on.
+- So an override charter can read is an override the *agent* controls, which is precisely
+  the party the guards bound.
+
+**The override is that you run the command yourself.** The guards are `PreToolUse` hooks on
+the harness's tools — they govern what an agent does with your authority inside a session.
+Your own shell is on the other side of that boundary and always was. Open a terminal and run
+it. Nothing is being worked around: the rule never applied to you.
+
+Two guards name a narrower move first, and it is usually the one you want:
+
+- **Release floor** — re-run the step **attended**. This is a mode, and it is yours to set.
+- **One credential** — `charter git-policy --apply` configures every clone for the token
+  transport, which is what most denials of it are actually asking for.
+
+**If a guard is wrong about you *every time*, that is not an override problem.** It means
+charter is holding a policy your organisation does not — an org that mandates signed
+commits, say. Switching the guard off locally hides that; the fix belongs in the rule.
+[Open an issue](https://github.com/diazoxide/charter/issues).
+
+**The thing that is not an override**, named here so nobody finds it by accident and
+believes they found the switch: removing charter's hooks from `.claude/settings.json`, or
+disabling the plugin. That takes out every guard, both injections and every tally together,
+because one of them was wrong once. It is an uninstall.
+
 ## What charter stopped asking
 
 charter used to nudge before a git write inside a workspace clone, suggesting a repo-rooted

--- a/docs/news/unreleased-the-clone-commit-nudge-is-gone.md
+++ b/docs/news/unreleased-the-clone-commit-nudge-is-gone.md
@@ -1,0 +1,51 @@
+---
+version: unreleased
+headline: The clone-commit nudge is gone — it asked 471 times and changed nothing
+---
+
+If you have been answering *"you're committing inside a clone from the control-plane
+session… proceed if it's intentional"* for the last few weeks, that prompt is gone. It was
+charter's only nudge on the Bash tool, and the reason it was removed is a number rather than
+a preference.
+
+**471 asks, 97 approved out of 98.** In one plane over two weeks, every single `ask` row in
+the trace store was this one rule. On 08-22 — the first day approvals were countable at all,
+after the counter shipped — it fired 98 times and was approved 97. Over the same window the
+persona tool-gate, the mechanism whose entire job is to *remove* prompts, fired 16 times.
+charter's net effect on prompt volume in that plane was roughly −16 / +471.
+
+**Its trigger was the workflow charter itself prescribes.** `charter clone` puts every repo
+under `workspaces/`, and the `working-in-a-clone` skill says *"Commit to the repo you are
+in"*. So the nudge fired on the intended state, not on a deviation from it. That is not a
+guard that needs narrowing; it is one pointed the wrong way.
+
+**It also fired on commands that were not commits.** It scanned the raw command string, so
+anything that merely *mentioned* the workflow reproduced as a prompt:
+
+```
+grep -rn 'git commit' workspaces/demo/repo                     -> ask
+gh issue comment 5 --body '… git rebase workspaces/demo/repo'  -> ask
+echo 'next: git push from workspaces/demo/repo'                -> ask
+```
+
+Two sibling guards had already been moved off that technique for causing exactly this — the
+secret-leak guard's own notes name `git commit -m "docs: document the --reveal flag"` as a
+false denial it had to fix. This nudge never got the rewrite.
+
+**Nothing you relied on went with it.** It was never a safety rule and never claimed to be:
+a clone is its own git repository and the plane's git was untouched either way. The one
+thing it covered *by accident* — an unattended `git tag` — has been covered on purpose by
+the release floor since 0.46.1, and that guard runs before this one ever did.
+
+**What replaces it is a rule for the next nudge**, written into `docs/hooks.md`:
+
+> A prompt is worth its interruption only if it changes what happens. If the evidence that
+> it does cannot be collected, the prompt cannot be justified.
+
+For an `ask`, that evidence is a *decline* — and a declined ask produces no `PostToolUse`,
+so charter can never tell one from an interrupted turn or a closed session. An **approved**
+ask is countable, and the two nudges charter still has (an overlapping code-writing dispatch,
+and editing after the roster fired at `routing: require`) now both record their approvals.
+They did not before: the approval half was wired to the Bash tool alone, so every dispatch
+and routing approval was landing against a denominator nothing incremented. Fixed here,
+because deleting the nudge would otherwise have pinned that count at zero for good.

--- a/docs/news/unreleased-when-a-guard-is-wrong.md
+++ b/docs/news/unreleased-when-a-guard-is-wrong.md
@@ -1,0 +1,46 @@
+---
+version: unreleased
+headline: Every denial now says what to do when the guard is wrong about you
+---
+
+charter denies five things, and a hook `deny` is the strongest thing it does to a session:
+no permission mode lifts it, `charter guard` cannot relax it, and it says so. Each denial
+named a remedy — for the workflow you were *supposed* to be doing. None of them named what
+to do when the guard is simply wrong about this case, and nothing else did either.
+
+So the only route past a denial charter got wrong was to delete the hook from
+`.claude/settings.json` or disable the plugin: every guard, both injections and all the
+tallies, gone together, because one of them was wrong once. Nuclear, and undiscoverable at
+the exact moment you need it.
+
+**The answer, now printed on every denial and written up in `docs/hooks.md`:**
+
+> Wrong about this case? There is deliberately no config key, environment variable or switch
+> that lifts a charter denial: one charter could read is one a committed file could flip.
+> Run it yourself, in your own terminal — these guards bound what an AGENT does with your
+> authority, never what you do.
+
+**Why no switch, rather than a narrow one.** charter's guards exist because committed data
+must not reach a credential or make something run. A `[guards]` key in `charter.toml` would
+be a key a teammate's pull request could flip — a committed file turning off the guard that
+keeps a vault out of your transcript. An environment variable is no better: the agent writes
+the command line the variable would sit on. **An override charter can read is an override the
+agent controls**, which is exactly the party the guards bound. The operator's own shell is
+the one place that was never inside the boundary, and it needs no feature.
+
+**Two guards name something narrower first**, and it is usually what you actually want: the
+release floor asks you to re-run **attended** (a mode, and yours to set), and the
+one-credential rule points at `charter git-policy --apply`, which is what most of its
+denials are really asking for.
+
+**If a guard is wrong about you every time**, that is not an override problem — it means
+charter is holding a policy your organisation does not, an org that mandates signed commits
+say. A local switch would hide that. Open an issue; the fix belongs in the rule.
+
+The note is appended in one place, so a guard added later carries it without anyone
+remembering to, and the trace tally keys are untouched — `charter trace` series that span
+this release still add up.
+
+While counting them: `docs/hooks.md` listed **four** guards and there are five. The
+`Read`/`Grep` vault denial never appeared, because it fires on a different tool and the list
+had been written from the Bash matcher.

--- a/tests/test_a_denial_names_its_override.py
+++ b/tests/test_a_denial_names_its_override.py
@@ -1,0 +1,212 @@
+"""A guard with no documented override is a guard people uninstall (#370).
+
+A hook `deny` is the strongest thing charter does to a session: no permission mode lifts it,
+`charter guard` cannot relax it, and it says so. Every denial named a remedy for the workflow
+the operator was *supposed* to be doing, and not one named what to do when the guard is
+simply wrong about this case. Nothing else named it either — no config key, no environment
+variable, no per-guard switch anywhere in `charter/config.py`.
+
+So the only route past a denial charter got wrong was to delete the hook from
+`.claude/settings.json` or disable the plugin, which removes every guard, both injections and
+all the tallies together. Nuclear, and undiscoverable at the moment it is needed. Every guard
+is eventually wrong about something, and the response a design invites at that moment is the
+response it gets: when the only move is nuclear, the guard that was wrong once is off for
+ever, along with the ones that were not.
+
+**The ruling this file pins.** The override is that you run the command yourself, outside
+the agent — and there is deliberately no switch charter can read. That is not a dodge:
+
+* charter's guards exist because committed data must not reach a credential or make
+  something run. A key in `charter.toml` would be a key a committed file could flip, and an
+  environment variable sits on a command line the agent writes. An override charter can read
+  is an override the AGENT controls, which is exactly the party being bound.
+* A `PreToolUse` hook governs the harness's tools. The operator's own shell was never on
+  that side of the line, so running it there works around nothing.
+
+**Appended in `_deny`, not at the five call sites**, which is the assertion with the most
+value here: a sixth guard added tomorrow carries the override without anyone remembering to,
+and the trace tally keys — computed from the reason BEFORE it reaches `_deny` — cannot drift.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import unittest
+from pathlib import Path
+
+from tests._isolation import PersonaIso, run_hook
+from tests.test_hooks import InAControlPlane
+from charter import hooks, trace
+
+DOC = Path(__file__).resolve().parents[1] / "docs" / "hooks.md"
+SECTION = "## When a guard is wrong"
+
+#: Every denial charter can emit, driven end to end through the real handler.
+DENIALS = {
+    "secret-leak": (hooks.pretooluse,
+                    {"tool_input": {"command": "charter secret get v K --reveal"}}),
+    "vault-read": (hooks.pretooluse_read,
+                   {"tool_name": "Read", "tool_input": {"file_path": ".charter/vaults/d.json"}}),
+    "single-credential": (hooks.pretooluse,
+                          {"tool_input": {"command": "git clone git@github.com:a/b.git"}}),
+    "plane-root-branch": (hooks.pretooluse,
+                          {"tool_input": {"command": "git checkout -b feature"}}),
+    "release-floor": (hooks.pretooluse,
+                      {"tool_input": {"command": "gh release create v9.9.9"},
+                       "permission_mode": "bypassPermissions"}),
+}
+
+
+class DenialCase(InAControlPlane):
+    def reason(self, name: str, sid: str = "s") -> str:
+        handler, payload = DENIALS[name]
+        r = run_hook(handler, {"cwd": str(self.tmp), "session_id": sid, **payload})
+        self.assertIsNotNone(r, f"{name}: fixture never reached the guard")
+        out = r["hookSpecificOutput"]
+        self.assertEqual("deny", out["permissionDecision"],
+                         f"{name}: precondition — this fixture must DENY, not {out}")
+        return out["permissionDecisionReason"]
+
+
+class TestEveryDenialNamesTheOverride(DenialCase):
+    def test_all_five_of_them(self):
+        """The precondition is the count: five guards deny, and all five must say it."""
+        self.assertEqual(5, len(DENIALS))
+        for name in DENIALS:
+            with self.subTest(guard=name):
+                self.assertIn(hooks._OVERRIDE_NOTE, self.reason(name))
+
+
+class TestWhatTheOverrideActuallySays(DenialCase):
+    """The wording is the deliverable. A pointer to a section that answers nothing, or a
+    hint that reads as "ask charter nicely", would leave the operator exactly where #370
+    found them."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.note = hooks._OVERRIDE_NOTE
+
+    def test_it_says_there_is_no_switch(self):
+        self.assertRegex(self.note, r"no .*(config|switch)")
+
+    def test_it_says_why_there_is_no_switch(self):
+        """Not a refusal — a reason. "A file could flip it" is the whole argument."""
+        self.assertIn("committed", self.note)
+
+    def test_it_names_the_move_that_works(self):
+        self.assertIn("your own terminal", self.note)
+
+    def test_it_points_at_the_section_that_explains_it(self):
+        self.assertIn("docs/hooks.md", self.note)
+        self.assertIn("When a guard is wrong", self.note)
+
+    def test_it_does_not_read_as_a_bypass_the_agent_can_take(self):
+        """An override an agent can act on is not an override, it is a hole. The note must
+        not name a flag, variable or command that would lift the denial."""
+        for bait in ("CHARTER_", "--force", "--no-verify", "charter guard allow"):
+            self.assertNotIn(bait, self.note)
+
+
+class TestTheTallyKeysAreUnchanged(DenialCase):
+    """The trace `reason` is a tally key, and two guards derive it from the first 70
+    characters of their prose. Appending in `_deny` keeps that prefix bit-identical;
+    prepending would have silently restarted every series in every existing store."""
+
+    KEYS = {"secret-leak": "would reveal a secret value into the conversation (--reveal)",
+            "vault-read": "reads a vault/secret file directly (would print plaintext)",
+            "single-credential": "single-credential",
+            "plane-root-branch": "plane-root-branch",
+            "release-floor": "release-floor"}
+
+    def test_each_guard_still_traces_the_key_it_always_did(self):
+        for name, key in self.KEYS.items():
+            with self.subTest(guard=name):
+                sid = f"s-{name}"
+                self.reason(name, sid=sid)
+                rows = [e for e in trace.read(sid) if e.get("event") == "deny"]
+                self.assertEqual(1, len(rows), f"{name}: precondition — one deny row")
+                self.assertTrue(rows[0]["reason"].startswith(key),
+                                f"{name}: tally key moved to {rows[0]['reason']!r}")
+
+    def test_no_tally_key_carries_the_override_text(self):
+        for name in DENIALS:
+            with self.subTest(guard=name):
+                sid = f"k-{name}"
+                self.reason(name, sid=sid)
+                for row in trace.read(sid):
+                    self.assertNotIn("your own terminal", row.get("reason", ""))
+
+
+class TestANewGuardCannotForgetIt(PersonaIso):
+    """Structural, because remembering is what fails. Every denial goes through `_deny`,
+    so the override rides along with a guard nobody has written yet."""
+
+    @staticmethod
+    def _source() -> str:
+        return Path(hooks.__file__).read_text()
+
+    @staticmethod
+    def _emits_a_denial(fn: ast.FunctionDef) -> bool:
+        """An `_emit(...)` call whose literal payload carries `permissionDecision: deny`.
+        Deliberately not "the word `deny` appears": `_trace("deny", …)` records a denial
+        that `_deny` already emitted, and flagging those would make this test noise."""
+        for node in ast.walk(fn):
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                    and node.func.id == "_emit"):
+                continue
+            for d in ast.walk(node):
+                if not isinstance(d, ast.Dict):
+                    continue
+                for k, v in zip(d.keys, d.values):
+                    if (isinstance(k, ast.Constant) and k.value == "permissionDecision"
+                            and isinstance(v, ast.Constant) and v.value == "deny"):
+                        return True
+        return False
+
+    def test_deny_is_the_only_thing_that_emits_a_denial(self):
+        tree = ast.parse(self._source())
+        fns = [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)]
+        emitters = [f.name for f in fns if self._emits_a_denial(f)]
+        self.assertEqual(["_deny"], emitters,
+                         "a denial is emitted outside `_deny`, so it carries no override")
+
+    def test_every_deny_call_passes_prose_and_not_a_prebuilt_message(self):
+        """Precondition for the test above: the call sites really do exist and route here."""
+        calls = re.findall(r"_deny\(\s*\"PreToolUse\"", self._source())
+        self.assertGreaterEqual(len(calls), 5, "precondition: the guards were not found")
+
+
+class TestTheDocumentationExists(unittest.TestCase):
+    """"Undocumented override" and "no override" are the same thing to the person hitting
+    one, so the denial's pointer must land somewhere real."""
+
+    def setUp(self) -> None:
+        self.text = DOC.read_text()
+
+    def test_hooks_md_has_the_section(self):
+        self.assertIn(SECTION, self.text)
+
+    def test_the_section_rules_out_a_config_key_and_says_why(self):
+        body = self.text.split(SECTION, 1)[1].split("\n## ", 1)[0]
+        self.assertIn("charter.toml", body)
+        self.assertIn("committed", body)
+
+    def test_the_section_names_the_move_that_works(self):
+        body = self.text.split(SECTION, 1)[1].split("\n## ", 1)[0]
+        self.assertIn("terminal", body)
+
+    def test_the_section_names_the_narrower_moves_that_come_first(self):
+        """Two guards have a real, narrower answer. Sending someone to a terminal when
+        `--apply` or an attended re-run is the actual fix would be a worse doc than none."""
+        body = self.text.split(SECTION, 1)[1].split("\n## ", 1)[0]
+        self.assertIn("attended", body)
+        self.assertIn("git-policy --apply", body)
+
+    def test_the_section_names_the_nuclear_option_as_not_an_override(self):
+        body = self.text.split(SECTION, 1)[1].split("\n## ", 1)[0]
+        self.assertIn("uninstall", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ask_outcome_is_recorded.py
+++ b/tests/test_ask_outcome_is_recorded.py
@@ -8,43 +8,78 @@ argument for keeping or deleting it could only be made from irritation. Same fai
 The signal is deterministic and already in the protocol: a hook `ask` blocks the tool, so a
 `PostToolUse` for that same `tool_use_id` means it ran, which means it was approved. An ask
 that is declined simply never gets one — its marker is still there, which is what makes
-"asked 231 times, approved 231 times" countable.
+"asked N times, approved M times" countable.
+
+**Why this file no longer drives the clone-commit nudge.** That nudge is gone (#371): it was
+counted, and the count is what deleted it — 471 asks, all one rule, 97 of 98 approved. It
+was also the only ask charter raised on the **Bash** tool, and `_ask_mark_take` was wired to
+`posttooluse_bash` alone. Removing the producer therefore left the take half with no reachable
+caller at all: the two surviving nudges raise on `Task|Agent` (`pretooluse_dispatch`) and on
+`Write|Edit|MultiEdit` (`pretooluse_edit`), and *those* PostToolUse handlers never took the
+marker. Every one of their approvals was already uncountable, and deleting the clone nudge
+would have made "asked N, approved M" permanently `M = 0` — the exact defect #290 was filed
+to remove, arriving by the back door.
+
+So the take half now lives in one helper (`_ask_approved`) called from all three PostToolUse
+handlers, and the cases below assert it on each tool family. The fixtures are real nudges on
+real committed frontmatter, and each one asserts the ask actually fired before asserting
+anything about the count — a fixture that stops reaching `_ask` must fail loudly rather than
+report zero approvals of zero asks.
 """
 
 import unittest
 
 from tests._isolation import run_hook
 from tests.test_hooks import InAControlPlane
-from charter import hooks, trace
-
-ASKED = {"tool_input": {"command": "cd workspaces/default/x && git commit -m y"},
-         "cwd": "", "session_id": "s", "tool_use_id": "tu_1"}
+from charter import config, hooks, trace
 
 
 class AskOutcomeCase(InAControlPlane):
-    def ask(self, **over):
-        payload = {**ASKED, **over}
-        payload["cwd"] = str(self.tmp / "workspaces" / "default" / "x")
-        (self.tmp / "workspaces" / "default" / "x").mkdir(parents=True, exist_ok=True)
-        r = run_hook(hooks.pretooluse, payload)
+    """The overlapping-dispatch nudge: `Task` in, `Task` out, same `tool_use_id`."""
+
+    SID = "s"
+    TUID = "tu_1"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.make_persona("coder", **{"dispatch-isolation": "worktree"})
+
+    def ask(self, tuid: str | None = None) -> dict:
+        """Raise one real nudge; returns the payload whose approval can now be recorded."""
+        first = {"tool_name": "Task", "tool_input": {"subagent_type": "coder"},
+                 "session_id": self.SID, "tool_use_id": "tu_0"}
+        run_hook(hooks.pretooluse_dispatch, first)
+        payload = {**first, "tool_use_id": tuid or self.TUID}
+        r = run_hook(hooks.pretooluse_dispatch, payload)
+        self.assertIsNotNone(r, "fixture never reached `_ask` — the count proves nothing")
         self.assertEqual("ask", r["hookSpecificOutput"]["permissionDecision"], r)
         return payload
 
-    def events(self, sid="s"):
-        return [e["event"] for e in trace.read(sid)]
+    def approve(self, payload: dict) -> None:
+        run_hook(hooks.posttooluse_dispatch, {**payload, "tool_response": ""})
+
+    def events(self, sid=None):
+        return [e["event"] for e in trace.read(sid or self.SID)]
+
+    def markers(self):
+        return list(config.SESSIONS_DIR.glob("*.ask-pending"))
 
 
 class TestAnApprovedAskIsRecorded(AskOutcomeCase):
     def test_the_tool_running_marks_it_approved(self):
-        p = self.ask()
-        run_hook(hooks.posttooluse_bash,
-                 {"tool_name": "Bash", "session_id": p["session_id"],
-                  "tool_use_id": p["tool_use_id"]})
+        self.approve(self.ask())
         self.assertIn("ask-approved", self.events())
 
     def test_the_ask_itself_is_still_traced(self):
+        """Both halves, or the ratio has no denominator."""
         self.ask()
-        self.assertIn("ask", self.events())
+        self.assertIn("dispatch-ask", self.events())
+
+    def test_the_marker_is_consumed(self):
+        p = self.ask()
+        self.assertEqual(1, len(self.markers()), "precondition: an ask was pending")
+        self.approve(p)
+        self.assertEqual([], self.markers())
 
 
 class TestAnUnansweredAskIsNotRecordedAsApproved(AskOutcomeCase):
@@ -54,54 +89,55 @@ class TestAnUnansweredAskIsNotRecordedAsApproved(AskOutcomeCase):
         self.assertNotIn("ask-approved", self.events())
 
     def test_a_different_tool_call_does_not_resolve_it(self):
-        """The correlation is per `tool_use_id` — another Bash call in the same session
-        must not be mistaken for the answer to this one."""
-        self.ask()
-        run_hook(hooks.posttooluse_bash,
-                 {"tool_name": "Bash", "session_id": "s", "tool_use_id": "tu_OTHER"})
+        p = self.ask()
+        self.approve({**p, "tool_use_id": "tu_other"})
         self.assertNotIn("ask-approved", self.events())
 
 
 class TestItIsCheapAndSafeOnTheHotPath(AskOutcomeCase):
-    def test_an_ordinary_bash_call_traces_nothing(self):
-        """The overwhelmingly common case: no ask was pending, so the handler is a stat()
-        and a return. It must not write a trace line per Bash call."""
-        run_hook(hooks.posttooluse_bash,
-                 {"tool_name": "Bash", "session_id": "quiet", "tool_use_id": "tu_x"})
-        self.assertEqual([], self.events("quiet"))
-
-    def test_a_missing_tool_use_id_is_survivable(self):
-        self.assertIsNone(run_hook(hooks.posttooluse_bash,
-                                   {"tool_name": "Bash", "session_id": "s"}))
-
-    def test_garbage_input_never_raises(self):
-        self.assertIsNone(run_hook(hooks.posttooluse_bash, {}))
+    def test_a_post_tool_use_with_no_pending_ask_records_nothing(self):
+        """The overwhelmingly common case: no marker, so the handler is a stat() and a
+        return. It must never invent a row."""
+        self.approve({"tool_name": "Task", "tool_input": {"subagent_type": "coder"},
+                      "session_id": self.SID, "tool_use_id": "tu_never_asked"})
+        self.assertNotIn("ask-approved", self.events())
 
     def test_it_resolves_only_once(self):
-        """A replayed PostToolUse must not inflate the approval count."""
+        """The unlink IS the idempotency — a replayed PostToolUse cannot inflate the count."""
         p = self.ask()
-        for _ in range(3):
-            run_hook(hooks.posttooluse_bash,
-                     {"tool_name": "Bash", "session_id": p["session_id"],
-                      "tool_use_id": p["tool_use_id"]})
+        self.approve(p)
+        self.approve(p)
         self.assertEqual(1, self.events().count("ask-approved"))
 
 
-class TestItIsWired(unittest.TestCase):
-    """A handler the manifest does not dispatch is a handler that does not run — the lesson
-    `test_vault_read_guard` already had to learn once."""
+class TestEveryToolFamilyThatCanAskCanAlsoRecordTheApproval(InAControlPlane):
+    """The gap #371 exposed: `_ask_mark_take` lived only in `posttooluse_bash`, so an ask
+    raised on `Task|Agent` or on `Write|Edit|MultiEdit` could be approved and never counted.
 
-    def test_the_manifest_registers_a_bash_posttooluse(self):
-        import json
-        from pathlib import Path
-        root = Path(__file__).resolve().parent.parent
-        hooks_json = json.loads((root / "hooks" / "hooks.json").read_text())["hooks"]
-        cmds = [h["command"] for e in hooks_json["PostToolUse"] for h in e["hooks"]]
-        named = {c.split("charter hook ")[1].split()[0] for c in cmds if "charter hook " in c}
-        self.assertIn("posttooluse-bash", named)
+    Asserted directly on the marker rather than through a nudge fixture, because the claim
+    is about the HANDLER — that each PostToolUse family consumes a pending ask — and a
+    per-family nudge fixture would make three different preconditions carry one assertion.
+    """
 
-    def test_the_engine_knows_the_handler(self):
-        self.assertIn("posttooluse-bash", hooks._HANDLERS)
+    HANDLERS = (("posttooluse_bash", {"tool_name": "Bash"}),
+                ("posttooluse", {"tool_name": "Edit", "tool_input": {"file_path": "/x/y.py"}}),
+                ("posttooluse_dispatch", {"tool_name": "Task",
+                                          "tool_input": {"subagent_type": "coder"},
+                                          "tool_response": ""}))
+
+    def test_each_one_consumes_a_pending_ask_and_records_it(self):
+        for name, payload in self.HANDLERS:
+            with self.subTest(handler=name):
+                sid, tuid = f"s-{name}", "tu_1"
+                hooks._ask_mark_set(sid, tuid)
+                self.assertTrue(hooks._ask_mark(sid, tuid).exists(),
+                                "precondition: an ask is pending")
+                run_hook(getattr(hooks, name), {**payload, "session_id": sid,
+                                                "tool_use_id": tuid})
+                self.assertFalse(hooks._ask_mark(sid, tuid).exists(),
+                                 f"{name} left the marker behind")
+                self.assertIn("ask-approved", [e["event"] for e in trace.read(sid)],
+                              f"{name} consumed the marker without recording the approval")
 
 
 if __name__ == "__main__":

--- a/tests/test_asks_do_not_hang_bypass_permissions.py
+++ b/tests/test_asks_do_not_hang_bypass_permissions.py
@@ -13,6 +13,16 @@ Two deliberate boundaries, both asserted here:
   the prompt.
 * **The floor is untouched.** `bypassPermissions` is the operator saying *stop asking me*,
   not *stop knowing things*. Every `deny` still denies.
+
+The nudge these cases drive used to be the clone-commit one, on `pretooluse`. #371 deleted
+it, so the fixture moved to the overlapping-dispatch nudge on `pretooluse_dispatch` — a real
+nudge on real committed frontmatter (`dispatch-isolation: worktree`), which is the shape
+that matters here: the payload has to reach `_ask` for the downgrade to happen at all.
+
+That fixture only fires when a code-writing peer is already in flight, so it can stop firing
+silently. Every mode assertion below is therefore paired with `assert_reached`, which fails
+if the handler emitted nothing — otherwise "no ask under bypassPermissions" would pass for a
+plane where nothing could ever have asked.
 """
 
 import unittest
@@ -21,15 +31,36 @@ from tests._isolation import run_hook
 from tests.test_hooks import InAControlPlane
 from charter import hooks, trace
 
-CLONE_COMMIT = "cd workspaces/default/x && git commit -m y"
 SSH_CLONE = "git clone git@github.com:acme/x.git"
 
 
 class ModeCase(InAControlPlane):
+    """Two decision paths: the NUDGE (dispatch) and the FLOOR (Bash guards)."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.make_persona("coder", **{"dispatch-isolation": "worktree"})
+
+    def _dispatch(self, mode, sid, tuid):
+        payload = {"tool_name": "Task", "tool_input": {"subagent_type": "coder"},
+                   "session_id": sid, "tool_use_id": tuid}
+        if mode is not None:
+            payload["permission_mode"] = mode
+        return run_hook(hooks.pretooluse_dispatch, payload)
+
+    def nudge(self, mode: str | None, sid="s"):
+        """One overlapping dispatch — the first puts `coder` in flight, the second nudges."""
+        self._dispatch(mode, sid, "tu_0")
+        r = self._dispatch(mode, sid, "tu_1")
+        self.assert_reached(r)
+        return r["hookSpecificOutput"]["permissionDecision"]
+
+    def assert_reached(self, r):
+        self.assertIsNotNone(r, "fixture never reached `_ask` — this assertion proves nothing")
+
     def decide(self, cmd: str, mode: str | None, sid="s"):
-        (self.tmp / "workspaces" / "default" / "x").mkdir(parents=True, exist_ok=True)
-        payload = {"tool_input": {"command": cmd},
-                   "cwd": str(self.tmp / "workspaces" / "default" / "x"),
+        """The FLOOR path: a Bash command through the guards."""
+        payload = {"tool_input": {"command": cmd}, "cwd": str(self.tmp),
                    "session_id": sid, "tool_use_id": "tu_1"}
         if mode is not None:
             payload["permission_mode"] = mode
@@ -39,31 +70,31 @@ class ModeCase(InAControlPlane):
 
 class TestBypassPermissionsTurnsAnAskIntoAnAllow(ModeCase):
     def test_the_nudge_no_longer_blocks(self):
-        self.assertEqual("allow", self.decide(CLONE_COMMIT, "bypassPermissions"))
+        self.assertEqual("allow", self.nudge("bypassPermissions"))
 
     def test_it_is_still_counted(self):
         """Suppressed is not the same as invisible — the tally must still show it fired."""
-        self.decide(CLONE_COMMIT, "bypassPermissions")
+        self.nudge("bypassPermissions")
         self.assertIn("ask-unattended", [e["event"] for e in trace.read("s")])
 
 
 class TestEveryOtherModeStillAsks(ModeCase):
     def test_auto_still_asks(self):
         """`auto` usually HAS a human watching. Fail toward the prompt."""
-        self.assertEqual("ask", self.decide(CLONE_COMMIT, "auto"))
+        self.assertEqual("ask", self.nudge("auto"))
 
     def test_default_still_asks(self):
-        self.assertEqual("ask", self.decide(CLONE_COMMIT, "default"))
+        self.assertEqual("ask", self.nudge("default"))
 
     def test_plan_still_asks(self):
-        self.assertEqual("ask", self.decide(CLONE_COMMIT, "plan"))
+        self.assertEqual("ask", self.nudge("plan"))
 
     def test_an_absent_mode_still_asks(self):
         """Hosts that send no `permission_mode` must not be read as unattended."""
-        self.assertEqual("ask", self.decide(CLONE_COMMIT, None))
+        self.assertEqual("ask", self.nudge(None))
 
     def test_an_unknown_mode_still_asks(self):
-        self.assertEqual("ask", self.decide(CLONE_COMMIT, "some-future-mode"))
+        self.assertEqual("ask", self.nudge("some-future-mode"))
 
 
 class TestTheFloorIsNotAPermission(ModeCase):
@@ -160,9 +191,9 @@ class TestASuppressedAskIsCountedExactlyOnce(ModeCase):
         return [e["event"] for e in trace.read(sid)]
 
     def test_unattended_records_only_the_suppression(self):
-        self.decide(CLONE_COMMIT, "bypassPermissions", sid="u")
+        self.nudge("bypassPermissions", sid="u")
         self.assertEqual(["ask-unattended"], self.events("u"))
 
     def test_attended_records_only_the_ask(self):
-        self.decide(CLONE_COMMIT, "default", sid="d")
-        self.assertEqual(["ask"], self.events("d"))
+        self.nudge("default", sid="d")
+        self.assertEqual(["dispatch-ask"], self.events("d"))

--- a/tests/test_committed_settings_are_validated.py
+++ b/tests/test_committed_settings_are_validated.py
@@ -240,7 +240,10 @@ class TheGuardsThatWereAlreadyThere(PersonaIso):
         import re as _re
         src = inspect.getsource(hooks)
         calls = _re.findall(r"_ask\(\s*\"[^\"]+\",(?:[^()]|\([^()]*\))*?\)", src)
-        self.assertGreaterEqual(len(calls), 3, "precondition: no _ask calls were found")
+        # Two since #371 removed the clone-commit nudge: `pretooluse_dispatch` and
+        # `pretooluse_edit`. The number is a PRECONDITION, not the claim — without it a
+        # regex that stopped matching would make the loop below pass over nothing.
+        self.assertGreaterEqual(len(calls), 2, "precondition: no _ask calls were found")
         for call in calls:
             self.assertRegex(call, r",\s*data\s*[,)]",
                              f"an _ask site does not pass the payload:\n{call}")

--- a/tests/test_dispatch_ask_is_counted.py
+++ b/tests/test_dispatch_ask_is_counted.py
@@ -5,10 +5,12 @@ clears it when the tool actually runs, and that clearing is recorded as `ask-app
 deliberately does not trace the ask itself — "callers trace their own event name, so they
 must not also record an 'ask' that never reached anybody".
 
-Three sites call it. `pretooluse` traces `ask`, `pretooluse_edit` traces `routing-ask`, and
-`pretooluse_dispatch` traced nothing while still passing `data` — so its approvals were
+Three sites called it. `pretooluse` traced `ask`, `pretooluse_edit` traces `routing-ask`,
+and `pretooluse_dispatch` traced nothing while still passing `data` — so its approvals were
 recorded against a denominator that never counted the ask. That is the exact shape #290 was
-filed to remove, applied to two sites of three.
+filed to remove, applied to two sites of three. Two sites remain: `pretooluse`'s
+clone-commit nudge was deleted in #371, and `_functions_that_ask` below is what will notice
+if a third is ever added without an ask-shaped row to count it.
 
 **This cannot be observed on a plane that does not use worktree isolation**, which is every
 plane the audit had: the nudge fires only when a peer declaring `dispatch-isolation:
@@ -18,8 +20,10 @@ nudge actually fired — the emitted decision — so a fixture that stops reachi
 fails loudly instead of passing vacuously.
 
 The event is `dispatch-ask`, not `ask`. `routing-ask` set that precedent, and folding this
-into `ask` would corrupt a series whose every historical row means the clone-commit guard —
-the evidence a judgement about that guard has to rest on.
+into `ask` would have corrupted a series whose every historical row means the clone-commit
+guard — the evidence the judgement about that guard rested on, and did: 471 rows, all one
+rule, 97 of 98 approved, and the guard was deleted (#371). Keeping the series clean is what
+made that answerable, so the separation stays.
 """
 
 from __future__ import annotations
@@ -88,8 +92,9 @@ class TestTheAskIsCounted(DispatchAskCase):
         self.assertEqual(len(markers), 1, "the approval half was already being recorded")
         self.assertEqual(len(self.events("dispatch-ask")), 1, "so the ask half must be too")
 
-    def test_it_does_not_pollute_the_clone_commit_ask_series(self):
-        """`ask` rows all mean the clone-commit guard. This one says what it is."""
+    def test_it_does_not_pollute_the_bare_ask_series(self):
+        """Historical `ask` rows all mean the clone-commit guard, which no longer exists.
+        This one says what it is, so a store holding both stays readable."""
         self.dispatch()
         self.assert_nudged(self.dispatch())
         self.assertEqual(self.events("ask"), [])
@@ -162,7 +167,7 @@ class TestEveryAskSiteRecordsAnAsk(unittest.TestCase):
     def test_the_known_sites_are_all_found(self):
         """Precondition: the scan sees the real call sites, so a pass means something."""
         self.assertEqual(set(self._functions_that_ask()),
-                         {"pretooluse", "pretooluse_dispatch", "pretooluse_edit"})
+                         {"pretooluse_dispatch", "pretooluse_edit"})
 
     def test_every_function_that_asks_also_traces_an_ask(self):
         for name, fn in sorted(self._functions_that_ask().items()):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -30,7 +30,7 @@ class TestLeakGuard(PersonaIso):  # A
 class InAControlPlane(PersonaIso):
     """A tmp plane that actually IS one.
 
-    `pretooluse` gates the single-credential and clone-commit guards on
+    `pretooluse` gates the single-credential and plane-root guards on
     `config.HAS_CONTROL_PLANE`: the plugin installs per user or per project but the handler
     ran everywhere, so `git clone git@…`, `git commit -S` and `ssh -T git@github.com` were
     denied in every unrelated repo on the machine, explaining a control plane that did not
@@ -48,31 +48,75 @@ class InAControlPlane(PersonaIso):
         config.HAS_CONTROL_PLANE = True
 
 
-class TestCloneGuard(InAControlPlane):  # B — a nudge ('ask'), not a hard block
-    def test_cd_into_clone_commit_asks(self):
-        r = run_hook(hooks.pretooluse, {"tool_input": {"command": "cd workspaces/default/x && git commit -m y"},
-                                        "cwd": str(self.tmp)})
-        self.assertEqual(_decision(r), "ask")
+class TestCommittingInACloneIsNotNudged(InAControlPlane):
+    """Guard B is gone (#371). Committing in a clone is charter's OWN prescribed workflow.
 
-    def test_git_dash_C_clone_asks(self):
-        r = run_hook(hooks.pretooluse, {"tool_input": {"command": "git -C workspaces/default/x push"},
-                                        "cwd": str(self.tmp)})
-        self.assertEqual(_decision(r), "ask")
+    `charter clone` puts every repo under `workspaces/`, and `skills/working-in-a-clone`
+    says *"Commit to the repo you are in"* — so the nudge's trigger condition was the
+    intended state, not a deviation from it. Measured: 471 asks in one plane over two weeks,
+    every one of them this rule, 97 of 98 approved on the first day approvals were countable.
 
-    def test_legacy_repos_path_still_asks(self):  # back-compat mid-migration
-        r = run_hook(hooks.pretooluse, {"tool_input": {"command": "cd repos/default/x && git commit -m y"},
-                                        "cwd": str(self.tmp)})
-        self.assertEqual(_decision(r), "ask")
+    These cases are the ones that USED to ask. They are kept, inverted, because "the nudge
+    is gone" has to be asserted at the shapes that produced it — a bare `assertIsNone` on
+    some unrelated command would pass whether or not the code came out.
+    """
 
-    def test_commit_with_cwd_inside_repos_asks(self):
+    def test_cd_into_a_clone_then_commit_is_silent(self):
+        self.assertIsNone(run_hook(hooks.pretooluse, {
+            "tool_input": {"command": "cd workspaces/default/x && git commit -m y"},
+            "cwd": str(self.tmp)}))
+
+    def test_git_dash_C_into_a_clone_is_silent(self):
+        self.assertIsNone(run_hook(hooks.pretooluse, {
+            "tool_input": {"command": "git -C workspaces/default/x push"}, "cwd": str(self.tmp)}))
+
+    def test_the_legacy_repos_path_is_silent(self):
+        self.assertIsNone(run_hook(hooks.pretooluse, {
+            "tool_input": {"command": "cd repos/default/x && git commit -m y"},
+            "cwd": str(self.tmp)}))
+
+    def test_a_commit_with_cwd_inside_a_clone_is_silent(self):
         cwd = config.WORKSPACES_DIR / "ws" / "repo"
         cwd.mkdir(parents=True)
-        r = run_hook(hooks.pretooluse, {"tool_input": {"command": "git commit -m x"}, "cwd": str(cwd)})
-        self.assertEqual(_decision(r), "ask")
-
-    def test_umbrella_root_commit_silent(self):
         self.assertIsNone(run_hook(hooks.pretooluse,
-                                   {"tool_input": {"command": "git commit -q -F m.txt"}, "cwd": str(self.tmp)}))
+                                   {"tool_input": {"command": "git commit -m x"}, "cwd": str(cwd)}))
+
+    def test_a_command_that_merely_mentions_a_clone_path_is_silent(self):
+        """The false-positive half. `_REPOS_REF_RE` scanned the raw command string, so a
+        `grep`, an `echo`, a commit message or a `gh` comment body all reproduced as `ask`
+        — the technique this file abandoned twice elsewhere (`_leak_reason`,
+        `_single_credential_hit`) for causing exactly this."""
+        for cmd in ("grep -rn 'git commit' workspaces/demo/repo",
+                    "gh issue comment 5 --body 'we should git rebase workspaces/demo/repo'",
+                    "echo 'next: git push from workspaces/demo/repo'"):
+            with self.subTest(cmd=cmd):
+                self.assertIsNone(run_hook(hooks.pretooluse,
+                                           {"tool_input": {"command": cmd}, "cwd": "/tmp"}))
+
+    def test_no_ask_row_is_traced_for_a_clone_commit(self):
+        """The trace event went with it: `ask` had exactly one producer."""
+        from charter import trace
+        cwd = config.WORKSPACES_DIR / "ws" / "repo"
+        cwd.mkdir(parents=True)
+        run_hook(hooks.pretooluse, {"tool_input": {"command": "git commit -m x"},
+                                    "cwd": str(cwd), "session_id": "s-371"})
+        self.assertEqual([e for e in trace.read("s-371") if e.get("event") == "ask"], [])
+
+    def test_no_pending_ask_marker_is_left_behind(self):
+        cwd = config.WORKSPACES_DIR / "ws" / "repo"
+        cwd.mkdir(parents=True)
+        run_hook(hooks.pretooluse, {"tool_input": {"command": "git commit -m x"}, "cwd": str(cwd),
+                                    "session_id": "s-371", "tool_use_id": "tu-371"})
+        self.assertEqual(list(config.SESSIONS_DIR.glob("*.ask-pending")), [])
+
+    def test_the_release_floor_still_stops_an_unattended_tag(self):
+        """The one thing the nudge covered by ACCIDENT (#299) is covered on purpose by A4,
+        which runs BEFORE it did — so removing B cannot reopen it."""
+        cwd = config.WORKSPACES_DIR / "ws" / "repo"
+        cwd.mkdir(parents=True)
+        r = run_hook(hooks.pretooluse, {"tool_input": {"command": "git tag v9.9.9"},
+                                        "cwd": str(cwd), "permission_mode": "bypassPermissions"})
+        self.assertEqual(_decision(r), "deny")
 
     def test_secret_leak_still_hard_denied(self):  # A stays a hard block
         r = run_hook(hooks.pretooluse, {"tool_input": {"command": "cat .charter/vaults/dev.json"}})
@@ -380,8 +424,10 @@ class TestGuardsAreScopedToAPlane(PersonaIso):
     def test_signing_is_not_denied_without_a_plane(self):
         self.assertIsNone(self._decide("git commit -S -m 'signed'"))
 
-    def test_the_clone_commit_nudge_is_silent_without_a_plane(self):
-        self.assertIsNone(self._decide("cd workspaces/default/x && git commit -m y"))
+    # The clone-commit nudge used to be asserted silent here too. Removed rather than kept
+    # when #371 deleted the guard: it is now silent in EVERY plane, so the case could no
+    # longer distinguish "scoped to a plane" from "gone", and a test that passes for a
+    # reason other than the one it names is worse than no test.
 
     def test_the_same_command_is_denied_once_a_plane_exists(self):
         """The other half of the claim: this is scoping, not removal."""

--- a/tests/test_release_floor.py
+++ b/tests/test_release_floor.py
@@ -8,10 +8,13 @@ was there:
     git tag v9.9.9  (default)            -> ask     # a hook `ask` floors at a prompt in
     git tag v9.9.9  (bypassPermissions)  -> allow   # EVERY mode, so this used to stop
 
-`_clone_commit_reason` matches `_GIT_WRITE_RE`, which includes `tag` and `push`. It was never
-designed to guard releases; it just did, and pushing a tag fires `release.yml` → an
-irreversible PyPI publish (Trusted Publishing, no token, nothing to retract). `gh pr merge`
-and `gh release create` were never covered at all, being no kind of `git`.
+The cover was the clone-commit nudge, whose git-write pattern happened to include `tag` and
+`push`. It was never designed to guard releases; it just did, and pushing a tag fires
+`release.yml` → an irreversible PyPI publish (Trusted Publishing, no token, nothing to
+retract). `gh pr merge` and `gh release create` were never covered at all, being no kind of
+`git`. That nudge has since been deleted outright (#371) — which is exactly why this guard
+had to stop depending on it, and why the cases below assert the floor directly rather than
+through anything the nudge happens to catch.
 
 Two properties carry the whole design and are asserted with equal weight:
 
@@ -64,7 +67,7 @@ class TestUnattendedCannotCutARelease(FloorCase):
             self.assertEqual("deny", self.decide(cmd, UNATTENDED), cmd)
 
     def test_forge_release_and_merge_are_denied(self):
-        """Never covered before — no kind of `git`, so `_GIT_WRITE_RE` never saw them."""
+        """Never covered before — no kind of `git`, so the old nudge never saw them."""
         for cmd in ("gh release create v9.9.9",
                     "gh pr merge 1 --squash",
                     "glab release create v9.9.9",
@@ -90,8 +93,11 @@ class TestAttendedIsCompletelyUnchanged(FloorCase):
     def test_a_person_tagging_at_the_plane_is_not_stopped(self):
         self.assertIsNone(self.decide("git tag v9.9.9", "default"))
 
-    def test_a_person_tagging_in_a_clone_still_only_gets_the_old_nudge(self):
-        self.assertEqual("ask", self.decide("git tag v9.9.9", "default", in_clone=True))
+    def test_a_person_tagging_in_a_clone_is_not_stopped_either(self):
+        """Was `ask` while the clone-commit nudge existed; that nudge is gone (#371), so
+        this is now silent for the same reason the plane-root case is. The floor is what
+        matters here and it is asserted directly above — attended tagging never denies."""
+        self.assertIsNone(self.decide("git tag v9.9.9", "default", in_clone=True))
 
     def test_auto_mode_is_attended(self):
         """`auto` usually has a human watching — same boundary `_ask` already draws."""


### PR DESCRIPTION
Closes #371. Closes #370.

Both were left as the operator's judgement by the third audit sweep. Both are now decided.

## #371 — the clone-commit nudge: **deleted**

Not narrowed. The standard applied was *a guard is worth a prompt only if the prompt changes what happens*, and four things decided it:

1. **Its trigger was the prescribed workflow.** `charter clone` puts every repo under `workspaces/`, and `skills/working-in-a-clone` says *"Commit to the repo you are in"*. A guard whose firing condition is the intended state is not miscalibrated, it is inverted — narrowing does not fix that.
2. **It could not be justified even in principle.** Keeping it in any form meant committing to show it earns its interruptions, and that evidence is a **decline**. A declined `ask` produces no `PostToolUse`, so it is indistinguishable from an interrupted turn or an ended session. The brief asked that the evidence be made collectable; for this guard it cannot be, and a guard that can only ever be defended with evidence the protocol will not yield is one that gets re-argued forever.
3. **It was not a safety rule and never claimed to be.** A clone is its own git repository; the plane's git was untouched either way. The one thing it covered *by accident* — an unattended release (#299) — has been covered on purpose by the release floor since 0.46.1, and that guard already ran first. Pinned by a new test.
4. **It scanned the raw command string.** A `grep`, an `echo`, a commit message or a `gh` comment body all reproduced as `ask`. Two sibling guards had already been moved off that technique for exactly this; this one never got the rewrite.

Measured: **471 asks in one plane over two weeks, every `ask` row in the store this one rule, 97 approved of 98** on the first clean day. Over the same window the persona tool-gate — whose whole job is to *remove* prompts — fired 16 times.

The advice survives in `skills/working-in-a-clone`, in prose, interrupting nobody. One source of truth rather than two.

### The `_ask_mark` machinery, which the brief put in scope

`_ask_mark_take` was wired to `posttooluse_bash` **alone** — correct only while the clone nudge existed, because it was charter's only ask on the Bash tool. The two surviving nudges raise on `Task|Agent` and `Write|Edit|MultiEdit`, whose PostToolUse handlers never took the marker. So every approval either of them ever received was *already* uncountable, and deleting the clone nudge would have pinned "asked N, approved M" at `M = 0` for good — #290's defect arriving by the back door.

The take half now lives in one `_ask_approved` helper called from all three PostToolUse handlers. `posttooluse_bash` stays (it is a no-op on today's code): removing a handler the shipped `hooks.json` dispatches breaks every install a version behind, and version skew is the failure shape this project keeps paying for.

## #370 — the override: **there is none charter can read, and that is the design**

The honest answer, now printed on every denial:

> Wrong about this case? There is deliberately no config key, environment variable or switch that lifts a charter denial: one charter could read is one a committed file could flip. Run it yourself, in your own terminal — these guards bound what an **agent** does with your authority, never what you do. See `docs/hooks.md` → *When a guard is wrong*.

Why not the `charter.toml` opt-out the issue floated: charter's guards exist because committed data must not reach a credential or make something run. A `[guards]` key would be a key a teammate's pull request could flip — the guard keeping a vault out of your transcript, turned off by a file. An environment variable is no better; the agent writes the command line it would sit on. **An override charter can read is an override the agent controls**, which is exactly the party being bound. It would be an authority finding of the same shape as #333/#338/#339, handed over voluntarily.

Weighed against the brief's two failure modes: an override that is easy to reach is a guard that stops working — the operator's own terminal is *structurally* unreachable by the agent, so it cannot be. An override that does not exist is a guard people disable wholesale — so `docs/hooks.md` names the narrower first moves (`charter git-policy --apply`, re-run attended), the escalation when a guard is wrong about you *every* time (an issue, not a local switch), and the nuclear option explicitly as **an uninstall**, so nobody finds it by accident and believes they found the switch.

**Appended in `_deny`, not at the five call sites.** A sixth guard carries it without anyone remembering to, and the trace tally keys — derived from the reason *before* it reaches `_deny` — cannot drift. Both pinned by tests, including that no tally key carries the new text.

### Contradicting the brief, worth reporting

- **There are five denials, not four.** The `Read`/`Grep` vault denial (`pretooluse_read`) was never in `docs/hooks.md`'s list, because the list had been written from the Bash matcher. It denies, it named no override, and it now does.
- **`_ask_mark` was not orphaned by the deletion** — its *set* half has two other callers. Its *take* half had none that could reach them, which is the worse version of the same problem.

## Verification

- Baseline on `main` (`cb51f8f`): **3344 tests, OK** — confirmed by running, not assumed.
- Final: **3359 tests, OK**. Branch and HEAD identical around the run (`guard-that-earns-its-prompt` @ `d4a655d`).
- Every claim checked against the **real CLI** with throwaway fixtures in a scratch plane — never the operator's `.claude/settings.json`. The nudge was proved to fire *before* asserting it stopped; all five denials were proved to deny before asserting they explain themselves. Issue #370's own reproduction (`charter guard allow 'gh pr merge *'`, then the matching command) replayed clean.
- Two `docs/news/` entries, staged `unreleased-*` — no version named, nothing bumped or tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeoNSEaQceHHvn4AhP8xo