### PR TITLE
charter runs the harness: a composed frame around the agent (#345)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,14 @@ you use. The browser lane additionally shells out to `npx`. That is the whole li
   (`charter harness install codex`) because nothing in a plugin can tell a shell which
   harness it is.
   → [docs/harnesses.md](docs/harnesses.md)
+- **A status line only one of your three harnesses has.** `charter claude` (or `codex`,
+  or `opencode`) runs the harness inside a frame charter composes: the agent in the middle,
+  charter's own panels on the edges — the active workspace, open todos, what wants
+  attention — repainting when charter's hooks say the plane changed. tmux composes and
+  owns the rectangles; charter fills the edges and never draws in the agent's own pane.
+  `charter frame -- <cmd>` does it for a command charter has never met, and `--no-frame`
+  (or piping the output anywhere) skips the frame entirely and carries the real exit code.
+  → [docs/frame.md](docs/frame.md)
 - **An unattended run that stops to ask a question.** Every git operation authenticates
   with that repo's own forge CLI token over HTTPS — never an SSH key, never signing —
   because a passphrase prompt hangs an agent until it times out.
@@ -345,6 +353,9 @@ copy wins, is compared to nothing, and drifts unwatched in both directions.
   against, `secret exec`, and feeding a tool that wants a dotenv file.
 - [docs/harnesses.md](docs/harnesses.md) — Claude Code, opencode and Codex: how each is
   wired, what each cannot carry, and the one command Codex needs.
+- [docs/frame.md](docs/frame.md) — `charter claude` and the frame: what tmux it needs,
+  what changes inside it (scrollback, mouse, the hotkey menu), how exit codes get out,
+  what happens when the terminal is too small, and every `[frame]` setting.
 - [docs/git-policy.md](docs/git-policy.md) — the one-credential rule, and why a denial from
   the plugin's guard is the rule working rather than a bug.
 - [docs/hooks.md](docs/hooks.md) — everything the plugin does without being asked: what

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -620,7 +620,16 @@ def _add_frame_parsers(sub) -> None:
     for h in harness.all():
         if not h.cli_name:
             continue
-        if h.cli_name in sub.choices:
+        # `"frame"` itself is reserved even though its OWN `add_parser` call below has
+        # not run yet: the loop finishes and registers every harness BEFORE `frame` is
+        # added, so a harness with `cli_name == "frame"` would pass a check against
+        # `sub.choices` alone (nothing there is named `frame` yet) and only collide once
+        # `sub.add_parser("frame", ...)` runs a few lines down — where, on argparse
+        # versions that raise for a conflicting name, the error names `frame` instead of
+        # the harness that actually caused it, and on versions that do not raise (this
+        # repo's own 3.11 floor — see `_split_frame_argv`'s docstring for the same
+        # version gap elsewhere), the escape hatch silently shadows the harness instead.
+        if h.cli_name in sub.choices or h.cli_name == "frame":
             raise ValueError(
                 f"harness {h.name!r} wants `charter {h.cli_name}`, which is already a "
                 f"charter command — rename the harness's cli_name or the command before "
@@ -1071,6 +1080,61 @@ def _split_exec_command(argv: list[str]) -> tuple[list[str], list[str] | None]:
     return argv, None
 
 
+def _frame_command_names() -> set[str]:
+    """Every subcommand `_add_frame_parsers` registers: each harness's `cli_name`, plus
+    the `frame` escape hatch. Read at call time (`harness.all()`, never cached) for the
+    same reason `_add_frame_parsers` itself iterates live rather than listing — a harness
+    added to `KINDS` is covered the moment it is registered."""
+    return {h.cli_name for h in harness.all() if h.cli_name} | {"frame"}
+
+
+#: The ONLY tokens `_split_frame_argv` ever keeps for `argparse` itself, and only in the
+#: fixed leading run described there. `-h`/`--help` are included deliberately: leaving
+#: them out was tried first and broke `charter claude --help` outright — REMAINDER
+#: absorbs `--help` just like any other harness token once it is past `argparse`'s own
+#: matching, so `cmd_launch` received `rest=["--help"]`, found no harness named `""`
+#: (bare `frame`) or treated it as a literal argv element otherwise, and the bypass path
+#: (non-tty in that reproduction) called `os.execvp("--help", ...)` — a real crash
+#: (`FileNotFoundError`, uncaught), not merely a UX regression. Keeping `-h`/`--help`
+#: recognized here restores the working behaviour: `charter claude --help` shows
+#: charter's OWN thin help for that subcommand (`usage: charter claude [-h]
+#: [--no-frame] ...`) exactly as before this fix, and a harness's own `--help` is still
+#: reachable — just as `-p`/`--continue` are — by putting it anywhere OTHER than this
+#: fixed leading run (`charter claude --continue --help`, or explicitly `charter claude
+#: -- --help`).
+_OWN_FLAGS = ("--no-frame", "-h", "--help")
+
+
+def _split_frame_argv(argv: list[str]) -> tuple[list[str], list[str] | None]:
+    """Peel a harness's own arguments off before `argparse` ever sees them.
+
+    `nargs=argparse.REMAINDER` cannot hold a positional whose very FIRST token looks
+    like an option `argparse` does not itself recognize: `charter claude -p hi` has
+    `argparse` try to match `-p` against `claude`'s own options (`-h`, `--no-frame`),
+    fail, and refuse the whole command with "unrecognized arguments: -p" — before
+    REMAINDER ever gets a chance to absorb anything. Confirmed identical on 3.9, 3.12 and
+    3.14, so unlike `_split_exec_command` above this is not something a Python-version
+    split could route around: it is `argparse`'s documented behaviour on every version
+    this repo supports, not drift on the 3.11 floor.
+
+    Splitting here — the same shape `_split_exec_command` uses for `secret exec` —
+    sidesteps the mechanism entirely: only `charter <name>` and a leading run of
+    `_OWN_FLAGS` immediately after it are ever handed to `argparse`; everything past
+    that point is captured here and grafted onto `args.rest` untouched by `argparse`'s
+    own option matching, dashes and all. `_OWN_FLAGS` is recognized only in that one
+    fixed leading position — anywhere else, a token that happens to spell `--no-frame`
+    or `--help` is just more of the harness's own verbatim argv, which is the one
+    unambiguous rule available once the harness's own flags (`-p`, `--continue`,
+    anything) are indistinguishable from ours by shape alone.
+    """
+    if not argv or argv[0] not in _frame_command_names():
+        return argv, None
+    i = 1
+    while i < len(argv) and argv[i] in _OWN_FLAGS:
+        i += 1
+    return argv[:i], argv[i:]
+
+
 def _subcommand_names(parser: argparse.ArgumentParser) -> set[str]:
     """Every top-level subcommand the parser accepts.
 
@@ -1134,6 +1198,7 @@ def main(argv=None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     argv = _hoist_persona_memory(argv)
     argv, exec_command = _split_exec_command(argv)
+    argv, frame_rest = _split_frame_argv(argv)
     parser = build_parser()
     try:
         args = parser.parse_args(argv)
@@ -1144,6 +1209,8 @@ def main(argv=None) -> int:
         raise
     if exec_command is not None:
         args.command = exec_command
+    if frame_rest is not None:
+        args.rest = frame_rest
     try:
         return args.func(args) or 0
     except KeyboardInterrupt:

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -616,28 +616,42 @@ def _add_frame_parsers(sub) -> None:
                             help="Passed to the harness verbatim.")
         parser.add_argument("--no-frame", action="store_true",
                             help="Run the harness bare, with no charter frame.")
+        # Read-only, and shares `--no-frame`'s own `_OWN_FLAGS` treatment below so
+        # `charter claude --probe` reaches `cmd_launch` as a flag rather than being
+        # grafted onto the harness's own verbatim argv. `cmd_launch` checks this FIRST,
+        # before resolving a harness or touching the workspace — see its own docstring.
+        # A `charter frame-probe` sibling also exists (registered further down) for the
+        # one caller this flag cannot serve: a news `check:`, which `news._PROBEABLE`
+        # refuses for any command whose parser carries a pass-through positional — every
+        # parser `_wire` builds has one (`rest`, above) — so `frame --probe` itself can
+        # never be listed there. See `commands_frame.cmd_probe`'s own docstring.
+        parser.add_argument("--probe", action="store_true",
+                            help="Read-only: can a frame run here? Prints one line, "
+                                 "starts nothing, never launches the harness.")
         parser.set_defaults(harness=name, func=commands_frame.cmd_launch)
 
     for h in harness.all():
         if not h.cli_name:
             continue
-        # `"frame"`, `"panel"`, `"frame-menu"` and `"frame-action"` are all reserved even
-        # though none of their OWN `add_parser` calls below has run yet: the loop
-        # finishes and registers every harness BEFORE any of them are added, so a
-        # harness with `cli_name` equal to one of these would pass a check against
-        # `sub.choices` alone (nothing there is named any of them yet) and only collide
-        # once THAT `add_parser` call runs a few lines down — where, on argparse versions
-        # that raise for a conflicting name, the error names the reserved command instead
-        # of the harness that actually caused it, and on versions that do not raise (this
-        # repo's own 3.11 floor — see `_split_frame_argv`'s docstring for the same
-        # version gap elsewhere), the later `add_parser` call silently shadows the
-        # harness instead — `frame`'s own escape hatch disappearing, every panel pane
+        # `"frame"`, `"panel"`, `"frame-menu"`, `"frame-action"` and `"frame-probe"` are
+        # all reserved even though none of their OWN `add_parser` calls below has run
+        # yet: the loop finishes and registers every harness BEFORE any of them are
+        # added, so a harness with `cli_name` equal to one of these would pass a check
+        # against `sub.choices` alone (nothing there is named any of them yet) and only
+        # collide once THAT `add_parser` call runs a few lines down — where, on argparse
+        # versions that raise for a conflicting name, the error names the reserved
+        # command instead of the harness that actually caused it, and on versions that do
+        # not raise (this repo's own 3.11 floor — see `_split_frame_argv`'s docstring for
+        # the same version gap elsewhere), the later `add_parser` call silently shadows
+        # the harness instead — `frame`'s own escape hatch disappearing, every panel pane
         # failing to start because `charter panel` now means something else
-        # (`layout.panel_argvs` emits exactly that argv; see `frame/panel.py`), or the
+        # (`layout.panel_argvs` emits exactly that argv; see `frame/panel.py`), the
         # hotkey menu silently opening a harness launch instead of a menu because
-        # `charter frame-menu`/`charter frame-action` now mean something else too.
+        # `charter frame-menu`/`charter frame-action` now mean something else too, or a
+        # news `check:` naming `frame-probe` silently launching a harness instead of
+        # reading tmux's own version (see `commands_frame.cmd_probe`'s own docstring).
         if h.cli_name in sub.choices or h.cli_name in ("frame", "panel", "frame-menu",
-                                                       "frame-action"):
+                                                       "frame-action", "frame-probe"):
             raise ValueError(
                 f"harness {h.name!r} wants `charter {h.cli_name}`, which is already a "
                 f"charter command — rename the harness's cli_name or the command before "
@@ -681,6 +695,21 @@ def _add_frame_parsers(sub) -> None:
     act = sub.add_parser("frame-action")
     act.add_argument("action_id")
     act.set_defaults(func=commands_frame.cmd_action)
+
+    # A TOP-LEVEL sibling of `frame` for a DIFFERENT reason than `frame-menu`/
+    # `frame-action` above: those two exist because `_split_frame_argv` eats everything
+    # after `argv[0] == "frame"`. This one exists because `news._PROBEABLE` (charter's
+    # `check:` allowlist, #317) refuses any command whose parser carries a pass-through
+    # positional, and every parser `_wire` builds carries one (`rest`, the harness's own
+    # verbatim argv) — so `("frame",)` can never be added there, `--probe` on it or not.
+    # `frame-probe` takes no arguments at all, so it is not that shape and CAN be listed
+    # (see `news._PROBEABLE` and `commands_frame.cmd_probe`'s own docstring). Unlike
+    # `panel`/`frame-menu`/`frame-action`, an operator can also type this one directly —
+    # it is the same read-only check `--probe` runs, just reachable without a launcher.
+    pb = sub.add_parser("frame-probe",
+                        help="Read-only: can a frame run here? (same check as "
+                             "`--probe` on any launcher above.)")
+    pb.set_defaults(func=commands_frame.cmd_probe)
 
 
 def _add_harness_parser(sub) -> None:
@@ -1142,7 +1171,14 @@ def _frame_command_names() -> set[str]:
 #: reachable — just as `-p`/`--continue` are — by putting it anywhere OTHER than this
 #: fixed leading run (`charter claude --continue --help`, or explicitly `charter claude
 #: -- --help`).
-_OWN_FLAGS = ("--no-frame", "-h", "--help")
+#:
+#: `--probe` joined for the identical reason `--no-frame` is here at all: without it,
+#: `charter frame --probe` has `argparse` never see `--probe` as `frame`'s own flag —
+#: `_split_frame_argv` grafts it onto `args.rest` instead, and `cmd_launch` (finding no
+#: harness named `""`, bare `frame`) hands `["--probe"]` to `bypass`, which
+#: `os.execvp("--probe", ...)` turns into a `FileNotFoundError` — confirmed by running
+#: `charter frame --probe` with this entry left out before adding it.
+_OWN_FLAGS = ("--no-frame", "--probe", "-h", "--help")
 
 
 def _split_frame_argv(argv: list[str]) -> tuple[list[str], list[str] | None]:

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -621,19 +621,23 @@ def _add_frame_parsers(sub) -> None:
     for h in harness.all():
         if not h.cli_name:
             continue
-        # `"frame"` and `"panel"` are reserved even though neither's OWN `add_parser`
-        # call below has run yet: the loop finishes and registers every harness BEFORE
-        # either is added, so a harness with `cli_name == "frame"` or `"panel"` would
-        # pass a check against `sub.choices` alone (nothing there is named either yet)
-        # and only collide once THAT `add_parser` call runs a few lines down — where, on
-        # argparse versions that raise for a conflicting name, the error names `frame`/
-        # `panel` instead of the harness that actually caused it, and on versions that
-        # do not raise (this repo's own 3.11 floor — see `_split_frame_argv`'s docstring
-        # for the same version gap elsewhere), the later `add_parser` call silently
-        # shadows the harness instead — `frame`'s own escape hatch disappearing, or every
-        # panel pane failing to start because `charter panel` now means something else
-        # (`layout.panel_argvs` emits exactly that argv; see `frame/panel.py`).
-        if h.cli_name in sub.choices or h.cli_name in ("frame", "panel"):
+        # `"frame"`, `"panel"`, `"frame-menu"` and `"frame-action"` are all reserved even
+        # though none of their OWN `add_parser` calls below has run yet: the loop
+        # finishes and registers every harness BEFORE any of them are added, so a
+        # harness with `cli_name` equal to one of these would pass a check against
+        # `sub.choices` alone (nothing there is named any of them yet) and only collide
+        # once THAT `add_parser` call runs a few lines down — where, on argparse versions
+        # that raise for a conflicting name, the error names the reserved command instead
+        # of the harness that actually caused it, and on versions that do not raise (this
+        # repo's own 3.11 floor — see `_split_frame_argv`'s docstring for the same
+        # version gap elsewhere), the later `add_parser` call silently shadows the
+        # harness instead — `frame`'s own escape hatch disappearing, every panel pane
+        # failing to start because `charter panel` now means something else
+        # (`layout.panel_argvs` emits exactly that argv; see `frame/panel.py`), or the
+        # hotkey menu silently opening a harness launch instead of a menu because
+        # `charter frame-menu`/`charter frame-action` now mean something else too.
+        if h.cli_name in sub.choices or h.cli_name in ("frame", "panel", "frame-menu",
+                                                       "frame-action"):
             raise ValueError(
                 f"harness {h.name!r} wants `charter {h.cli_name}`, which is already a "
                 f"charter command — rename the harness's cli_name or the command before "

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -669,7 +669,13 @@ def _add_frame_parsers(sub) -> None:
     # alone and ordinary top-level dispatch applies. Both are fired by tmux via
     # `run-shell` (the hotkey bind in `conf_text`, and one menu item's own action built
     # by `charter.frame.menu.menu_argv`) — never typed by an operator.
+    #
+    # `frame-menu`'s own `client` argument is `#{client_name}`, expanded by tmux INSIDE
+    # the bind's `run-shell` text before this process starts — never queried after the
+    # fact (see `cmd_menu`'s own docstring for why: `list-clients` cannot tell WHO
+    # pressed the key, only who is attached, and picking among several guessed wrong).
     mn = sub.add_parser("frame-menu")
+    mn.add_argument("client")
     mn.set_defaults(func=commands_frame.cmd_menu)
 
     act = sub.add_parser("frame-action")

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -26,6 +26,7 @@ from . import (
 )
 from .browser import PINNED as _PLAYWRIGHT_PIN
 from .forge.registry import KINDS as _FORGE_KINDS
+from .frame import panel as frame_panel
 from .secrets.registry import PROVIDERS
 
 
@@ -620,16 +621,19 @@ def _add_frame_parsers(sub) -> None:
     for h in harness.all():
         if not h.cli_name:
             continue
-        # `"frame"` itself is reserved even though its OWN `add_parser` call below has
-        # not run yet: the loop finishes and registers every harness BEFORE `frame` is
-        # added, so a harness with `cli_name == "frame"` would pass a check against
-        # `sub.choices` alone (nothing there is named `frame` yet) and only collide once
-        # `sub.add_parser("frame", ...)` runs a few lines down — where, on argparse
-        # versions that raise for a conflicting name, the error names `frame` instead of
-        # the harness that actually caused it, and on versions that do not raise (this
-        # repo's own 3.11 floor — see `_split_frame_argv`'s docstring for the same
-        # version gap elsewhere), the escape hatch silently shadows the harness instead.
-        if h.cli_name in sub.choices or h.cli_name == "frame":
+        # `"frame"` and `"panel"` are reserved even though neither's OWN `add_parser`
+        # call below has run yet: the loop finishes and registers every harness BEFORE
+        # either is added, so a harness with `cli_name == "frame"` or `"panel"` would
+        # pass a check against `sub.choices` alone (nothing there is named either yet)
+        # and only collide once THAT `add_parser` call runs a few lines down — where, on
+        # argparse versions that raise for a conflicting name, the error names `frame`/
+        # `panel` instead of the harness that actually caused it, and on versions that
+        # do not raise (this repo's own 3.11 floor — see `_split_frame_argv`'s docstring
+        # for the same version gap elsewhere), the later `add_parser` call silently
+        # shadows the harness instead — `frame`'s own escape hatch disappearing, or every
+        # panel pane failing to start because `charter panel` now means something else
+        # (`layout.panel_argvs` emits exactly that argv; see `frame/panel.py`).
+        if h.cli_name in sub.choices or h.cli_name in ("frame", "panel"):
             raise ValueError(
                 f"harness {h.name!r} wants `charter {h.cli_name}`, which is already a "
                 f"charter command — rename the harness's cli_name or the command before "
@@ -641,6 +645,15 @@ def _add_frame_parsers(sub) -> None:
     fr = sub.add_parser("frame",
                         help="Run any command inside charter's frame — `charter frame -- <cmd>`.")
     _wire(fr, "")
+
+    # Internal: one pane of a running frame, spawned by `layout.panel_argvs` — never
+    # typed by an operator. The argv shape here (`panel <slot> --session <fid>`) must
+    # match what that function emits EXACTLY: it is the only thing standing between a
+    # tmux pane and a process that fails at startup, leaving a hole in the frame.
+    pn = sub.add_parser("panel")
+    pn.add_argument("slot")
+    pn.add_argument("--session", dest="session", required=True)
+    pn.set_defaults(func=lambda args: frame_panel.run(args.slot, args.session))
 
 
 def _add_harness_parser(sub) -> None:

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -655,6 +655,23 @@ def _add_frame_parsers(sub) -> None:
     pn.add_argument("--session", dest="session", required=True)
     pn.set_defaults(func=lambda args: frame_panel.run(args.slot, args.session))
 
+    # Internal, same reason `panel` above is a TOP-LEVEL sibling of `frame` rather than
+    # nested under it: `_split_frame_argv` (below) treats `argv[0] == "frame"` as the
+    # launcher's own escape hatch and grafts EVERYTHING past it onto the harness's own
+    # verbatim argv before `argparse` ever gets a chance to route a subcommand — a
+    # `frsub = fr.add_subparsers(...)` nested under `fr` would never be reached, because
+    # `_split_frame_argv` runs first and unconditionally. `frame-menu` and
+    # `frame-action` are different literal tokens, so `_split_frame_argv` leaves them
+    # alone and ordinary top-level dispatch applies. Both are fired by tmux via
+    # `run-shell` (the hotkey bind in `conf_text`, and one menu item's own action built
+    # by `charter.frame.menu.menu_argv`) — never typed by an operator.
+    mn = sub.add_parser("frame-menu")
+    mn.set_defaults(func=commands_frame.cmd_menu)
+
+    act = sub.add_parser("frame-action")
+    act.add_argument("action_id")
+    act.set_defaults(func=commands_frame.cmd_action)
+
 
 def _add_harness_parser(sub) -> None:
     h = sub.add_parser("harness",

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -10,6 +10,7 @@ from . import (
     commands_update,
     __version__,
     commands,
+    commands_frame,
     commands_harness,
     commands_persona,
     commands_report,
@@ -17,6 +18,7 @@ from . import (
     commands_workspace,
     commands_worktree,
     contain,
+    harness,
     hooks,
     statusline,
     toolgate,
@@ -332,6 +334,11 @@ def build_parser() -> argparse.ArgumentParser:
     _add_secret_parser(sub)
     _add_persona_parser(sub)
     _add_report_parser(sub)
+    # Last: the collision guard below refuses a harness `cli_name` that shadows an
+    # already-registered command, so it needs the FULL set of `charter`'s own commands
+    # already in `sub.choices` — not just the ones defined above this line — to check
+    # against. Placed after every other `_add_*_parser` call for that reason.
+    _add_frame_parsers(sub)
 
     return p
 
@@ -584,6 +591,47 @@ def _add_workspace_parser(sub) -> None:
     aus.set_defaults(func=commands_workspace.cmd_workspace_autosave)
     pbg = wsub.add_parser("_pushbg")    # internal: background push half of autosave
     pbg.set_defaults(func=commands_workspace.cmd_workspace_pushbg)
+
+
+def _add_frame_parsers(sub) -> None:
+    """One launcher per registered harness, plus the escape hatch (`charter frame --`).
+
+    Generated from `harness.all()` rather than listed, which is the reason `registry.py`
+    exists: a harness added to `KINDS` gets a launcher the day it is registered, with no
+    second place to remember to update. That same automatism is exactly what makes a
+    name collision dangerous — a harness registered with `cli_name = "status"` would
+    otherwise silently take `charter status` away from the operator, with nothing
+    printing so much as a warning, because nothing forced the two registries (core
+    commands here, harnesses in `harness.KINDS`) to stay disjoint. `sub.choices` is
+    `argparse`'s own record of every subcommand name already claimed, so the check below
+    asks the same authority the CLI itself will dispatch through, rather than keeping a
+    second list of "known" command names that could itself drift. Raised, not printed:
+    this runs at import/parser-construction time, before any command line is parsed, so
+    there is no operator turn to spend a warning on — the fix is a code change, not
+    something to work around at runtime.
+    """
+    def _wire(parser, name):
+        parser.add_argument("rest", nargs=argparse.REMAINDER,
+                            help="Passed to the harness verbatim.")
+        parser.add_argument("--no-frame", action="store_true",
+                            help="Run the harness bare, with no charter frame.")
+        parser.set_defaults(harness=name, func=commands_frame.cmd_launch)
+
+    for h in harness.all():
+        if not h.cli_name:
+            continue
+        if h.cli_name in sub.choices:
+            raise ValueError(
+                f"harness {h.name!r} wants `charter {h.cli_name}`, which is already a "
+                f"charter command — rename the harness's cli_name or the command before "
+                f"this can ship")
+        p = sub.add_parser(h.cli_name,
+                           help=f"Run {h.cli_name} inside charter's frame.")
+        _wire(p, h.cli_name)
+
+    fr = sub.add_parser("frame",
+                        help="Run any command inside charter's frame — `charter frame -- <cmd>`.")
+    _wire(fr, "")
 
 
 def _add_harness_parser(sub) -> None:

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -603,13 +603,37 @@ def _add_frame_parsers(sub) -> None:
     name collision dangerous — a harness registered with `cli_name = "status"` would
     otherwise silently take `charter status` away from the operator, with nothing
     printing so much as a warning, because nothing forced the two registries (core
-    commands here, harnesses in `harness.KINDS`) to stay disjoint. `sub.choices` is
-    `argparse`'s own record of every subcommand name already claimed, so the check below
-    asks the same authority the CLI itself will dispatch through, rather than keeping a
-    second list of "known" command names that could itself drift. Raised, not printed:
-    this runs at import/parser-construction time, before any command line is parsed, so
-    there is no operator turn to spend a warning on — the fix is a code change, not
-    something to work around at runtime.
+    commands here, harnesses in `harness.KINDS`) to stay disjoint.
+
+    **Two collisions, two different hazards, two different responses.** A `cli_name` that
+    shadows a CORE command (anything registered before this function runs — see
+    `build_parser`'s own comment about calling this last — plus the names this function
+    reserves for itself: `frame`, `panel`, `frame-menu`, `frame-action`, `frame-probe`)
+    raises, loudly, at parser-construction time: `build_parser()` is called by every
+    single `charter` invocation, so a registry mistake here breaks `charter --help`,
+    `charter doctor`, everything — the failure has to happen in CI, not in an operator's
+    terminal. A `cli_name` shared between two HARNESSES is a narrower problem: it costs
+    one harness a launcher, not the whole CLI, and `harness.registry.all()` instantiating
+    by dict VALUE rather than by key (`tests/test_guard_claims_its_reach.py`'s own
+    `KINDS["zzz-fictional"] = KINDS[CLAUDE_CODE]` reproduces this directly) makes it
+    reachable by a registry mistake that has nothing to do with `_add_frame_parsers` at
+    all. Raising there would take down every command over a defect in a DIFFERENT
+    module's registry — so the first registration wins the word and every later one is
+    skipped, reported (not silently), and `build_parser()` keeps going.
+
+    "First" is `harness.all()`'s own order, which is `KINDS`'s dict-insertion order —
+    stable, and `registry.all`'s own docstring already calls it "registration order" — not
+    an alphabetical or otherwise inferred one. Worth stating here rather than leaving a
+    reader to work it out from `KINDS` being a dict at all.
+
+    `sub.choices` is `argparse`'s own record of every subcommand name already claimed, so
+    the CORE-collision check asks the same authority the CLI itself will dispatch
+    through, rather than keeping a second list of "known" command names that could itself
+    drift — but it is read as a SNAPSHOT taken before the harness loop starts, not live
+    inside it: the loop's own `sub.add_parser(h.cli_name, ...)` calls grow `sub.choices`
+    as they run, and reading it live would conflate "this collides with a core command"
+    with "this collides with an earlier harness in this very loop" — exactly the two
+    cases this docstring just said get different responses.
     """
     def _wire(parser, name):
         parser.add_argument("rest", nargs=argparse.REMAINDER,
@@ -630,32 +654,60 @@ def _add_frame_parsers(sub) -> None:
                                  "starts nothing, never launches the harness.")
         parser.set_defaults(harness=name, func=commands_frame.cmd_launch)
 
+    # Snapshot, not a live read of `sub.choices` inside the loop — see this function's
+    # own docstring for why the two must be kept apart. `_add_frame_parsers` runs LAST
+    # (`build_parser`'s own comment), so `sub.choices` here already holds every CORE
+    # command: init, doctor, workspace, worktree, vault, secret, persona, report,
+    # harness, hook, trace, all of it. `"frame"`, `"panel"`, `"frame-menu"`,
+    # `"frame-action"` and `"frame-probe"` join it even though none of their OWN
+    # `add_parser` calls below has run yet: the loop finishes and registers every
+    # harness BEFORE any of them are added, so a harness with `cli_name` equal to one of
+    # these would pass a check against `sub.choices` alone (nothing there is named any of
+    # them yet) and only collide once THAT `add_parser` call runs a few lines down —
+    # where, on argparse versions that raise for a conflicting name, the error names the
+    # reserved command instead of the harness that actually caused it, and on versions
+    # that do not raise (this repo's own 3.11 floor — see `_split_frame_argv`'s docstring
+    # for the same version gap elsewhere), the later `add_parser` call silently shadows
+    # the harness instead — `frame`'s own escape hatch disappearing, every panel pane
+    # failing to start because `charter panel` now means something else
+    # (`layout.panel_argvs` emits exactly that argv; see `frame/panel.py`), the hotkey
+    # menu silently opening a harness launch instead of a menu because `charter
+    # frame-menu`/`charter frame-action` now mean something else too, or a news `check:`
+    # naming `frame-probe` silently launching a harness instead of reading tmux's own
+    # version (see `commands_frame.cmd_probe`'s own docstring).
+    _core_commands = set(sub.choices) | {"frame", "panel", "frame-menu", "frame-action",
+                                         "frame-probe"}
+
+    # Which harness (by `.name`, never `.cli_name` — that's the dict key below) has
+    # already claimed each word, so a SECOND harness wanting it is told who got there
+    # first rather than merely "already taken". Scoped to this one loop, never `sub
+    # .choices`: after the first `sub.add_parser(h.cli_name, ...)` call below, that name
+    # IS in `sub.choices` too, and reading it there would make a harness-vs-harness
+    # collision indistinguishable from a harness-vs-core one — the exact conflation this
+    # function's own docstring says the two checks below exist to avoid.
+    _claimed_by: dict[str, str] = {}
     for h in harness.all():
         if not h.cli_name:
             continue
-        # `"frame"`, `"panel"`, `"frame-menu"`, `"frame-action"` and `"frame-probe"` are
-        # all reserved even though none of their OWN `add_parser` calls below has run
-        # yet: the loop finishes and registers every harness BEFORE any of them are
-        # added, so a harness with `cli_name` equal to one of these would pass a check
-        # against `sub.choices` alone (nothing there is named any of them yet) and only
-        # collide once THAT `add_parser` call runs a few lines down — where, on argparse
-        # versions that raise for a conflicting name, the error names the reserved
-        # command instead of the harness that actually caused it, and on versions that do
-        # not raise (this repo's own 3.11 floor — see `_split_frame_argv`'s docstring for
-        # the same version gap elsewhere), the later `add_parser` call silently shadows
-        # the harness instead — `frame`'s own escape hatch disappearing, every panel pane
-        # failing to start because `charter panel` now means something else
-        # (`layout.panel_argvs` emits exactly that argv; see `frame/panel.py`), the
-        # hotkey menu silently opening a harness launch instead of a menu because
-        # `charter frame-menu`/`charter frame-action` now mean something else too, or a
-        # news `check:` naming `frame-probe` silently launching a harness instead of
-        # reading tmux's own version (see `commands_frame.cmd_probe`'s own docstring).
-        if h.cli_name in sub.choices or h.cli_name in ("frame", "panel", "frame-menu",
-                                                       "frame-action", "frame-probe"):
+        if h.cli_name in _core_commands:
             raise ValueError(
                 f"harness {h.name!r} wants `charter {h.cli_name}`, which is already a "
                 f"charter command — rename the harness's cli_name or the command before "
                 f"this can ship")
+        if h.cli_name in _claimed_by:
+            # Two REGISTERED harnesses, not a harness against a core command — a
+            # narrower hazard (one harness loses a launcher, not the whole CLI; see the
+            # docstring), so this is reported rather than raised. "First" is
+            # `harness.all()`'s own order — `KINDS`'s dict-insertion order, per
+            # `registry.all`'s own docstring ("registration order") — so the harness
+            # registered EARLIER in `registry.KINDS` keeps `charter <cli_name>` and this
+            # one simply gets no launcher of its own.
+            util.warn(f"harness {h.name!r} also wants `charter {h.cli_name}`, already "
+                      f"claimed by {_claimed_by[h.cli_name]!r} — {h.name!r} has no "
+                      f"`charter <harness>` launcher of its own until the collision is "
+                      f"fixed in the registry.")
+            continue
+        _claimed_by[h.cli_name] = h.name
         p = sub.add_parser(h.cli_name,
                            help=f"Run {h.cli_name} inside charter's frame.")
         _wire(p, h.cli_name)

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -72,6 +72,17 @@ it REPLACES THE WHOLE ARRAY, silently deleting `[1]` if it was already there. In
 the write hook second would wipe out the teardown hook the moment it lands — reproduced
 end to end by swapping the two `cmd_launch` calls: the session hung exactly the way it
 did before either hook existed. See `_pane_died_teardown_hook_argv`'s own docstring.
+
+**Every tmux command here goes through `frame/tmuxctl.py`, and the timeout is the
+reason.** `cmd_launch` used to issue eleven `subprocess.run(…, timeout=15)` calls of its
+own with nothing catching `subprocess.TimeoutExpired`. Ten of them run AFTER
+`new-session` has already started the harness detached, so a wedged tmux server did not
+merely fail one command: it raised a traceback out of the launcher, `cli.main` filed a
+charter crash report for it, and the operator was left with a live agent session, no
+reattach line, and a bug report pointing at the wrong repository. `tmuxctl.run` folds a
+timeout into a return code (`tmuxctl.TIMED_OUT`) so all eleven degrade down the paths
+they already had for a tmux that merely says no, and `tmuxctl.report_failure` is called
+for each by default rather than remembered at each call site.
 """
 
 from __future__ import annotations
@@ -121,6 +132,12 @@ _PLACEHOLDER_CONF = "set -g remain-on-exit on\n"
 #: path is delivered this way instead of being embedded in the hook's own action text.
 _EXIT_PATH_ENV = "CHARTER_FRAME_EXIT"
 
+#: The second value carried the same out-of-band way, for the same reason: the
+#: interpreter the hotkey bind and every menu action run charter with. Owned by
+#: `tmuxctl` so `frame/menu.py` — which cannot import this module without a cycle —
+#: spells the same name; see `_charter_py_env_argv` and `conf_text`.
+_CHARTER_PY_ENV = tmuxctl.CHARTER_PY_ENV
+
 #: What `_query_pane_dead_status` returns for a pane confirmed dead (`#{pane_dead}` is
 #: `1`) whose `#{pane_dead_status}` tmux itself could not report — measured against tmux
 #: 3.7c: EMPTY, not negative, for a harness killed by SIGKILL/SIGTERM/SIGSEGV. `None`
@@ -139,37 +156,92 @@ def bypass(argv: list[str]) -> int:
     `tmux new-session` returns 0 regardless of what ran inside it (see the module
     docstring) — but there is no tmux in the way on this path, so the exit code an exec'd
     process carries out is already the real one.
+
+    **A missing harness binary is a condition, not a charter bug.** `os.execvp` raises
+    `FileNotFoundError` for a `claude` that is not installed — the most likely FIRST-RUN
+    state of this whole feature — and an uncaught one reached `cli.main`'s `except
+    Exception`, which files a crash report against charter and re-raises a traceback.
+    `cli.main` already carves out exactly this class twice (`contain.Refused`,
+    `util.ProcTimeout`), both noting that filing such a condition as a bug "sends whoever
+    reads it looking in the wrong repository"; a harness charter was asked to start and
+    could not find belongs in the same set. Caught HERE rather than as a third clause up
+    there, because this is the only place in charter that execs an operator-named binary
+    and the message can name what is missing.
+
+    127 and 126 are the shell's own numbers for the two cases, so `charter claude &&
+    …` behaves the way `claude && …` would have.
     """
-    os.execvp(argv[0], argv)
+    try:
+        os.execvp(argv[0], argv)
+    except FileNotFoundError:
+        util.err(f"charter: {argv[0]} is not installed, or not on $PATH.\n"
+                 f"  charter cannot start a harness it cannot find — install {argv[0]}, "
+                 f"or run a different one: charter harness list")
+        return 127
+    except PermissionError:
+        util.err(f"charter: {argv[0]} is not executable — check its permissions")
+        return 126
     return 127  # unreachable; execvp either replaces this process or raises
 
 
+def no_renderer_message(missing: list[str]) -> str:
+    """The one sentence for `[frame] slots` naming a slot charter cannot draw yet.
+
+    Shared by `frame_ready` and `doctor.check_frame` rather than written twice, for the
+    same reason both of them exist: this is a standing property of the configuration and
+    the build, and two copies of a standing fact drift into two different facts.
+    """
+    return (f"no renderer yet for {', '.join(missing)} — charter sizes and accepts "
+            f"{'it' if len(missing) == 1 else 'them'} in `[frame] slots` but draws "
+            f"nothing there, so the harness pane keeps that space")
+
+
 def frame_ready() -> tuple[int, str, str]:
-    """Can a frame run on this machine right now? ``(exit code, util.* level, one line)``
-    — read-only, and the only thing this asks is `tmuxctl.version()`.
+    """Can a frame run on this machine right now, and what will it not be able to do?
+    ``(exit code, util.* level, text)`` — read-only: `tmuxctl.version()` and
+    `config.FRAME`, nothing started, nothing written.
 
     Mirrors `cmd_launch`'s own gate exactly, not a stricter one: a few lines into
-    `cmd_launch`, tmux below `tmuxctl.FLOOR` gets a warning and the launch CONTINUES —
-    only its hotkey menu is disabled (`tmuxctl.below_floor_message`) — and only `tmux`
-    being entirely absent (`version() is None`) makes `cmd_launch` refuse outright.
-    Refusing here on anything short of that would report a frame this same launcher
-    goes on to draw regardless — a probe that lies about `cmd_launch`'s own behaviour is
-    worse than one that runs nothing at all.
+    `cmd_launch`, tmux below `tmuxctl.FLOOR` warns and the launch CONTINUES, and only
+    `tmux` being entirely absent (`version() is None`) makes `cmd_launch` refuse
+    outright. Refusing here on anything short of that would report a frame this same
+    launcher goes on to draw regardless — a probe that lies about `cmd_launch`'s own
+    behaviour is worse than one that runs nothing at all.
+
+    **The two STANDING conditions are reported here and nowhere else.** Both used to be
+    `util.warn` calls inside `cmd_launch` itself, and both were measured to be
+    unreadable there: `util.warn` for an unimplemented slot lands 86 bytes before tmux's
+    own `\\x1b[?1049h`, so the operator's terminal switches to the alternate screen
+    milliseconds later and the line is restored to view only when the frame EXITS. A
+    warning printed where it cannot be read is worse than silence, because it creates a
+    record that the operator was told. Neither is per-launch news anyway — a tmux below
+    the floor, and a configured slot with no renderer, are true on every launch on this
+    machine and this plane until something changes. They are capability ceilings, so
+    they belong to the two surfaces built to report ceilings on demand: this one, and
+    `doctor.check_frame`. (A per-launch notice mechanism, for conditions specific to one
+    launch, is deliberately NOT built here.)
 
     Two callers share this, both read-only for the same reason `charter/news.py`
-    requires of a `check:` (reads, never acts; and this module's own subprocess calls
-    already carry timeouts, so neither can hang): `--probe` on every `charter
-    <harness>`/`charter frame` launcher (`cmd_launch` below), for an operator to run by
-    hand, and the top-level `charter frame-probe` (`cmd_probe`) that a news `check:`
-    names — see `cmd_probe`'s own docstring for why the check cannot simply be `frame
-    --probe` itself.
+    requires of a `check:` (reads, never acts; and this module's own tmux calls all go
+    through `tmuxctl.run`, which is time-boxed, so neither can hang): `--probe` on every
+    `charter <harness>`/`charter frame` launcher (`cmd_launch` below), for an operator
+    to run by hand, and the top-level `charter frame-probe` (`cmd_probe`) that a news
+    `check:` names — see `cmd_probe`'s own docstring for why the check cannot simply be
+    `frame --probe` itself.
     """
     v = tmuxctl.version()
     if v is None:
         return 1, "err", tmuxctl.absent_message()
+    head = f"charter frame: tmux {v[0]}.{v[1]} — a frame can run on this machine"
+    ceilings = []
     if v < tmuxctl.FLOOR:
-        return 0, "warn", tmuxctl.below_floor_message(v)
-    return 0, "ok", f"charter frame: tmux {v[0]}.{v[1]} — a frame can run on this machine"
+        ceilings.append(tmuxctl.below_floor_message(v))
+    missing = frame_slots.unimplemented(config.FRAME["slots"])
+    if missing:
+        ceilings.append(no_renderer_message(missing))
+    if not ceilings:
+        return 0, "ok", head
+    return 0, "warn", "\n".join([head, *(f"  ↳ {c}" for c in ceilings)])
 
 
 def _report_probe(code: int, level: str, line: str) -> int:
@@ -221,8 +293,8 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
     plain `set -t <session> ...` config text, never into a shell command string, so it
     carries none of the risk `_EXIT_PATH_ENV`'s docstring describes for `status_path`.
 
-    `hotkey` opens this frame's own menu: `bind -n {hotkey} run-shell 'charter
-    frame-menu "#{client_name}"'`. A key BINDING has no per-session form the way
+    `hotkey` opens this frame's own menu: `bind -n {hotkey} run-shell '"$CHARTER_PY" -m
+    charter frame-menu "#{client_name}"'`. A key BINDING has no per-session form the way
     `status`/`mouse`/`history-limit` above do — key tables are server-wide in tmux, so
     every frame on `SOCKET` ends up sharing this exact bind text, "last launched wins"
     exactly like `escape-time`/`remain-on-exit`/the `WheelUpPane` bind two lines down
@@ -262,6 +334,23 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
     OMITTING `-t` entirely does. `-t =` resolves for FORMAT evaluation (`if-shell -F`,
     which never spawns a process); it is not the same mechanism a spawned shell's
     environment goes through, and the two do not behave alike.
+
+    **`"$CHARTER_PY" -m charter`, never a bare `charter`.** The panels already launch
+    charter as `[sys.executable, "-m", "charter"]` (see `cmd_launch`'s `panel_argvs`
+    call) precisely because the `charter` an operator's `$PATH` resolves may be a
+    different install, or no install at all — a `uv tool` shim not on the tmux server's
+    own PATH, a checkout run as `python -m charter`. This line had kept the bare name,
+    and the failure lands in the worst possible place: `run-shell` reports a non-zero
+    command by printing `'charter frame-menu "/dev/ttys020"' returned 127` INTO THE
+    HARNESS PANE and dropping it into copy-mode — charter drawing in the one rectangle
+    ADR 0018 says it never draws. The interpreter is carried out of band via
+    `set-environment` (`_charter_py_env_argv`) rather than interpolated here, for the
+    same reason `status_path` is (see `_EXIT_PATH_ENV`): an absolute path re-embedded
+    inside this nested tmux-quote layer is one apostrophe away from the silent
+    corruption the module docstring measures. Verified against tmux 3.7c that a
+    session-scoped `CHARTER_PY` reaches the shell this bind spawns and expands there,
+    and that this exact bind text survives `source-file` intact (`list-keys` reads it
+    back byte for byte).
     """
     return "\n".join([
         f"set -t {session} status off",
@@ -269,11 +358,31 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
         f"set -t {session} history-limit {int(history_limit)}",
         "set -g escape-time 0",
         "set -g remain-on-exit on",
-        f"bind -n {hotkey} run-shell 'charter frame-menu \"#{{client_name}}\"'",
+        f"bind -n {hotkey} run-shell "
+        f"'\"${_CHARTER_PY_ENV}\" -m charter frame-menu \"#{{client_name}}\"'",
         "bind -n WheelUpPane if-shell -F -t = '#{mouse_any_flag}'"
         " 'send-keys -M' 'copy-mode -e; send-keys -M'",
         "",
     ])
+
+
+def _charter_py_env_argv(*, socket: str, session: str) -> list[str]:
+    """`set-environment`: the interpreter the hotkey and every menu action run charter
+    with.
+
+    `sys.executable`, delivered the same out-of-band way `_exit_path_env_argv` delivers
+    `status_path` and for the same two reasons — a single argv value nothing re-parses,
+    and a bind/action TEMPLATE that stays free of per-machine text. See `conf_text`'s
+    own docstring for what a bare `charter` cost, and `frame/menu.py`'s `menu_argv` for
+    the second consumer.
+
+    Session-scoped, not `-g`: two planes on one laptop can be two different charter
+    installs (`docs/control-plane.md`'s version pin exists for exactly that), and a `-g`
+    write would hand frame N's interpreter to frame N-1 — the same "last launched wins"
+    trap `conf_text`'s docstring already names for `mouse`/`history-limit`.
+    """
+    return ["tmux", "-L", socket, "set-environment", "-t", session, _CHARTER_PY_ENV,
+           sys.executable]
 
 
 def _exit_path_env_argv(*, socket: str, session: str, status_path: str) -> list[str]:
@@ -397,7 +506,7 @@ _PANE_ID_RE = re.compile(r"%\d+")
 #: attempt for a version already KNOWN too old, not the only thing standing between an
 #: operator and a loud, recurring error if that constant ever turns out to be wrong —
 #: this is what makes the mechanism safe BY CONSTRUCTION rather than by the constant
-#: being right (see `_report_tmux_failure`'s call site below for how the two combine).
+#: being right (see `tmuxctl.report_failure`'s call site below for how the two combine).
 _INVALID_HOOK_NAME = "invalid option"
 
 
@@ -443,28 +552,16 @@ def _live_sessions(socket: str) -> set[str]:
 
     Empty rather than raised when nothing has ever run on *socket* — `list-sessions`
     exits non-zero with nothing on stdout in that case, which the plain `splitlines()`
-    below already turns into an empty set with no special-casing needed. The `except`
-    guards the rarer case: tmux vanishing between `tmuxctl.available()`'s own check and
-    this call, not the ordinary "no server yet" one.
+    below already turns into an empty set with no special-casing needed. That ordinary
+    "no server yet" answer is also why this is the one caller besides
+    `_query_pane_dead_status` that asks `tmuxctl.run` NOT to report: a failure here is
+    normally not a fault at all, and reporting it would print an error on every launch
+    that happens to be the first one on this machine.
     """
-    try:
-        out = subprocess.run(["tmux", "-L", socket, "list-sessions", "-F", "#{session_name}"],
-                             capture_output=True, text=True, timeout=5)
-    except (OSError, subprocess.SubprocessError):
-        return set()
+    out = tmuxctl.run("listing the frames already running",
+                      ["tmux", "-L", socket, "list-sessions", "-F", "#{session_name}"],
+                      timeout=5, report=False)
     return {line.strip() for line in out.stdout.splitlines() if line.strip()}
-
-
-def _report_tmux_failure(action: str, cmd: list[str], proc: subprocess.CompletedProcess) -> None:
-    """Name the command that failed and tmux's own stderr. Never silent.
-
-    This is what correction 2 exists to force: `subprocess.run(cmd, env=env)` with the
-    result thrown away is exactly how the pane-index bug `frame/layout.py`'s own module
-    docstring describes would have shipped — a frame missing a panel, and nothing
-    anywhere saying why.
-    """
-    stderr = (proc.stderr or "").strip() or "(tmux printed nothing to stderr)"
-    util.err(f"charter frame: {action} failed — `{' '.join(cmd)}`: {stderr}")
 
 
 def _query_pane_dead_status(socket: str, harness_pane: str) -> int | None:
@@ -489,13 +586,15 @@ def _query_pane_dead_status(socket: str, harness_pane: str) -> int | None:
     dead — the exact hang the eager check exists to close, reopened by a signal instead
     of a timing race. See `_UNKNOWN_DEATH_CODE`.
     """
-    try:
-        dm = subprocess.run(["tmux", "-L", socket, "display-message", "-p", "-t", harness_pane,
-                             "#{pane_dead}:#{pane_dead_status}"],
-                            capture_output=True, text=True, timeout=5)
-    except (OSError, subprocess.SubprocessError):
-        return None
+    dm = tmuxctl.run("asking whether the harness pane died",
+                     ["tmux", "-L", socket, "display-message", "-p", "-t", harness_pane,
+                      "#{pane_dead}:#{pane_dead_status}"],
+                     timeout=5, report=False)
     if dm.returncode != 0:
+        # Includes the timeout and could-not-run cases `tmuxctl.run` folds into a
+        # return code (see its own docstring): all three mean the same thing here —
+        # "cannot tell" — and `report=False` keeps a query that answers `None` from
+        # printing an error for a question `cmd_launch` is about to handle either way.
         return None
     dead, _, status = dm.stdout.strip().partition(":")
     if dead != "1":
@@ -531,17 +630,19 @@ def cmd_launch(args) -> int:
     if args.no_frame or not sys.stdout.isatty():
         return bypass(argv)
 
-    # ONE call (correction 5): `available()`, `version()` and `meets_floor()` each shell
-    # out to `tmux -V` independently, so calling all three in sequence would spawn three
-    # subprocesses to ask the same unchanging question on every single launch.
+    # ONE call (correction 5): asking `tmux -V` twice on a path that branches on the
+    # answer once is two subprocesses for one unchanging fact.
     v = tmuxctl.version()
     if v is None:
         util.err(tmuxctl.absent_message())
         return 1
-    if v < tmuxctl.FLOOR:
-        # Below the floor: degrade (the hotkey menu, not yet wired to anything by this
-        # task, would be unusable anyway), never refuse — the frame itself still works.
-        util.warn(tmuxctl.below_floor_message(v))
+    # Below `tmuxctl.FLOOR` the frame still launches — degrade, never refuse. Nothing is
+    # printed here, deliberately: this is a STANDING condition, true on every launch on
+    # this machine, and `util.warn` was measured landing 86 bytes before tmux's own
+    # `\x1b[?1049h` — the operator's terminal switches to the alternate screen
+    # milliseconds later and the line only comes back into view once the frame exits.
+    # It is reported by `frame_ready` (`--probe`, `charter frame-probe`) and by
+    # `doctor.check_frame` instead; see `frame_ready`'s own docstring.
 
     ws = workspace.resolve()
     fid = state.frame_id(ws, os.getpid())
@@ -566,11 +667,8 @@ def cmd_launch(args) -> int:
         # deterministically — not a hang, since the session simply vanishes with it, but
         # still wrong, and worth closing the same way the placeholder closes the
         # first-frame-ever case.
-        arm_cmd = ["tmux", "-L", SOCKET, "set", "-g", "remain-on-exit", "on"]
-        arm = subprocess.run(arm_cmd, capture_output=True, text=True, timeout=15)
-        if arm.returncode != 0:
-            _report_tmux_failure("arming remain-on-exit ahead of an already-running server",
-                                 arm_cmd, arm)
+        tmuxctl.run("arming remain-on-exit ahead of an already-running server",
+                    ["tmux", "-L", SOCKET, "set", "-g", "remain-on-exit", "on"])
     state.reap(live_before)
 
     fdir = state.frame_dir(fid, create=True)
@@ -601,14 +699,17 @@ def cmd_launch(args) -> int:
     # alive, the operator is left with a permanently dead, wrapped-error 22-column
     # pane and no explanation at the point the frame actually came up. Skipping an
     # unimplemented slot here instead means the harness pane simply keeps that space —
-    # the same degrade `visible_slots` itself already makes under a tight terminal —
-    # and one message, printed once, says why up front rather than leaving the operator
-    # to puzzle out a dead pane's own stderr.
-    unimplemented = sorted({s for s in slots if s not in frame_slots.SLOTS})
+    # the same degrade `visible_slots` itself already makes under a tight terminal.
+    #
+    # Silently, and that is the deliberate half: which slots have a renderer is a
+    # property of THIS BUILD, not of this launch, so a warning here repeats an
+    # unchanging fact on every single start — and repeats it into a terminal that is
+    # about to switch to tmux's alternate screen, where nobody reads it (measured; see
+    # `frame_ready`'s own docstring). `--probe`, `charter frame-probe` and `charter
+    # doctor` all name it on demand instead, from the same `frame_slots.unimplemented`
+    # this line filters on.
+    unimplemented = frame_slots.unimplemented(slots)
     if unimplemented:
-        util.warn(f"charter frame: no renderer yet for {', '.join(unimplemented)} — "
-                  f"not drawing {'it' if len(unimplemented) == 1 else 'them'}; "
-                  f"the harness pane keeps that space instead")
         slots = [s for s in slots if s not in unimplemented]
 
     env = dict(os.environ, CHARTER_SESSION_ID=fid)
@@ -632,9 +733,8 @@ def cmd_launch(args) -> int:
 
     session_cmd = layout.session_argv(session=fid, conf=str(conf_path), socket=SOCKET,
                                       cols=cols, rows=rows, harness_argv=argv)
-    proc = subprocess.run(session_cmd, env=env, capture_output=True, text=True, timeout=15)
+    proc = tmuxctl.run("starting the frame", session_cmd, env=env)
     if proc.returncode != 0:
-        _report_tmux_failure("starting the frame", session_cmd, proc)
         return 1
     harness_pane = proc.stdout.strip()
     if not harness_pane:
@@ -644,17 +744,17 @@ def cmd_launch(args) -> int:
 
     conf_path.write_text(conf_text(hotkey=frame["hotkey"], mouse=frame["mouse"],
                                    history_limit=frame["history_limit"], session=fid))
-    src_cmd = ["tmux", "-L", SOCKET, "source-file", str(conf_path)]
-    src = subprocess.run(src_cmd, env=env, capture_output=True, text=True, timeout=15)
+    src = tmuxctl.run("loading the frame's config",
+                      ["tmux", "-L", SOCKET, "source-file", str(conf_path)], env=env)
     if src.returncode != 0:
-        _report_tmux_failure("loading the frame's config", src_cmd, src)
         util.warn("charter frame: continuing without it — mouse/history-limit/hotkey "
                   "settings may not be in effect for this frame")
 
-    env_cmd = _exit_path_env_argv(socket=SOCKET, session=fid, status_path=str(status_path))
-    env_set = subprocess.run(env_cmd, env=env, capture_output=True, text=True, timeout=15)
+    env_set = tmuxctl.run(
+        "carrying the exit-status path",
+        _exit_path_env_argv(socket=SOCKET, session=fid, status_path=str(status_path)),
+        env=env)
     if env_set.returncode != 0:
-        _report_tmux_failure("carrying the exit-status path", env_cmd, env_set)
         util.warn("charter frame: continuing without it — the exit code may not be "
                   "recorded for this frame")
 
@@ -664,12 +764,21 @@ def cmd_launch(args) -> int:
     # process's environment, and without this call a frame beyond the first sharing
     # `SOCKET` would silently resolve the FIRST frame's id instead of its own (see
     # `_session_id_env_argv`'s own docstring for what was verified by hand).
-    sid_cmd = _session_id_env_argv(socket=SOCKET, session=fid)
-    sid_set = subprocess.run(sid_cmd, env=env, capture_output=True, text=True, timeout=15)
+    sid_set = tmuxctl.run("carrying the frame id to its own hotkey menu",
+                          _session_id_env_argv(socket=SOCKET, session=fid), env=env)
     if sid_set.returncode != 0:
-        _report_tmux_failure("carrying the frame id to its own hotkey menu", sid_cmd, sid_set)
         util.warn("charter frame: continuing without it — the hotkey menu may not find "
                   "this frame's own actions")
+
+    # The second value the same mechanism carries: which interpreter runs charter when
+    # the hotkey (or a menu item) fires. Without it both fall back to a bare `charter`
+    # on the tmux server's own `$PATH`, and `run-shell` reports the resulting 127 by
+    # printing it INTO THE HARNESS PANE — see `conf_text`'s own docstring.
+    py_set = tmuxctl.run("carrying charter's own interpreter to the hotkey menu",
+                         _charter_py_env_argv(socket=SOCKET, session=fid), env=env)
+    if py_set.returncode != 0:
+        util.warn("charter frame: continuing without it — the hotkey menu may not open "
+                  "on this frame")
 
     # The menu itself: what the hotkey actually opens. A single "Detach" entry — the
     # spec's own words, "Detach is allowed and prints how to reattach" — proves the
@@ -682,19 +791,16 @@ def cmd_launch(args) -> int:
         ("Detach", ["tmux", "-L", SOCKET, "detach-client", "-s", fid]),
     ])
 
-    write_hook_cmd = _pane_died_write_hook_argv(socket=SOCKET, harness_pane=harness_pane)
-    write_hook = subprocess.run(write_hook_cmd, env=env, capture_output=True, text=True, timeout=15)
+    write_hook = tmuxctl.run(
+        "installing the exit-status hook",
+        _pane_died_write_hook_argv(socket=SOCKET, harness_pane=harness_pane), env=env)
     if write_hook.returncode != 0:
-        _report_tmux_failure("installing the exit-status hook", write_hook_cmd, write_hook)
         util.warn("charter frame: continuing without it — the exit code may not be "
                   "recorded for this frame")
 
-    teardown_hook_cmd = _pane_died_teardown_hook_argv(socket=SOCKET, harness_pane=harness_pane)
-    teardown_hook = subprocess.run(teardown_hook_cmd, env=env, capture_output=True, text=True,
-                                   timeout=15)
-    if teardown_hook.returncode != 0:
-        _report_tmux_failure("installing the session-teardown hook", teardown_hook_cmd,
-                             teardown_hook)
+    teardown_hook = tmuxctl.run(
+        "installing the session-teardown hook",
+        _pane_died_teardown_hook_argv(socket=SOCKET, harness_pane=harness_pane), env=env)
 
     # Closes the install race directly, rather than merely working around its symptom. A
     # harness that died in the window between `new-session` starting it and the hooks
@@ -710,10 +816,8 @@ def cmd_launch(args) -> int:
     code = _query_pane_dead_status(SOCKET, harness_pane)
     if code is not None:
         state.record_exit(fid, code)
-        kill_cmd = ["tmux", "-L", SOCKET, "kill-session", "-t", fid]
-        kill = subprocess.run(kill_cmd, env=env, capture_output=True, text=True, timeout=15)
-        if kill.returncode != 0:
-            _report_tmux_failure("ending the frame after an early death", kill_cmd, kill)
+        tmuxctl.run("ending the frame after an early death",
+                    ["tmux", "-L", SOCKET, "kill-session", "-t", fid], env=env)
 
     attach = None
     attach_cmd = None
@@ -742,13 +846,12 @@ def cmd_launch(args) -> int:
             # slot, in the same order (see its own docstring).
             panes: dict[str, str] = {}
             for slot, cmd in zip(slots, panel_cmds):
-                p = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=15)
+                # Reported by `tmuxctl.run` but not fatal: one decorative panel failing
+                # to draw must not take down a harness pane that is already up and
+                # running (correction 2 asks for every return code to be CHECKED, not
+                # every failure refused).
+                p = tmuxctl.run("drawing a panel", cmd, env=env)
                 if p.returncode != 0:
-                    # Reported, not fatal: one decorative panel failing to draw must not
-                    # take down a harness pane that is already up and running (correction
-                    # 2 asks for every return code to be CHECKED, not every failure
-                    # refused).
-                    _report_tmux_failure("drawing a panel", cmd, p)
                     continue
                 pane_id = p.stdout.strip()
                 if pane_id and _PANE_ID_RE.fullmatch(pane_id):
@@ -775,8 +878,13 @@ def cmd_launch(args) -> int:
                 # geometry upkeep, not something a launch's correctness depends on.
                 resize_cmd = _resize_hook_argv(socket=SOCKET, harness_pane=harness_pane,
                                                panes=panes)
-                resize = subprocess.run(resize_cmd, env=env, capture_output=True, text=True,
-                                        timeout=15)
+                # `report=False`: this is the one call site that reads a failure's own
+                # stderr before deciding whether it IS one — an unrecognised hook name
+                # here is a capability ceiling to note quietly, not an integration to
+                # report loudly, and `tmuxctl.run`'s default would have printed the loud
+                # version first regardless of which branch runs below.
+                resize = tmuxctl.run("installing the resize hook", resize_cmd, env=env,
+                                     report=False)
                 if resize.returncode != 0:
                     if _INVALID_HOOK_NAME in (resize.stderr or ""):
                         # RESIZE_HOOK_FLOOR believed this tmux would recognise the
@@ -791,7 +899,8 @@ def cmd_launch(args) -> int:
                                  "resize-recovery hook — panels may drift out of "
                                  "shape if this terminal is resized")
                     else:
-                        _report_tmux_failure("installing the resize hook", resize_cmd, resize)
+                        tmuxctl.report_failure("installing the resize hook", resize_cmd,
+                                               resize)
                         util.warn("charter frame: continuing without it — panels may "
                                  "drift out of shape if this terminal is resized")
 
@@ -802,16 +911,14 @@ def cmd_launch(args) -> int:
             # `layout.panel_argvs`'s own split ordering, not something this diff
             # introduced, but leaving the frame in a state the operator can actually type
             # into is this launcher's job.
-            select_cmd = ["tmux", "-L", SOCKET, "select-pane", "-t", harness_pane]
-            select = subprocess.run(select_cmd, env=env, capture_output=True, text=True,
-                                    timeout=15)
-            if select.returncode != 0:
-                _report_tmux_failure("focusing the harness pane", select_cmd, select)
+            tmuxctl.run("focusing the harness pane",
+                        ["tmux", "-L", SOCKET, "select-pane", "-t", harness_pane], env=env)
 
-            # No capture_output: this is the operator's own terminal for as long as the
-            # harness runs, not an admin command whose output charter should own.
+            # `tmuxctl.interact`, not `tmuxctl.run`: no capture and no timeout — this
+            # IS the operator's own terminal for as long as the harness runs, not an
+            # admin command whose output (or lifetime) charter should own.
             attach_cmd = ["tmux", "-L", SOCKET, "attach", "-t", fid]
-            attach = subprocess.run(attach_cmd, env=env)
+            attach = tmuxctl.interact(attach_cmd, env=env)
 
             code = state.exit_code(fid)
             if code is None:
@@ -843,7 +950,7 @@ def cmd_launch(args) -> int:
         # Nothing was recorded, tmux is not still tracking this session, AND `attach`
         # itself reported trouble — surfaced rather than folded into a bare 0, which is
         # precisely the failure this whole module exists to stop happening silently.
-        _report_tmux_failure("attaching to the frame", attach_cmd, attach)
+        tmuxctl.report_failure("attaching to the frame", attach_cmd, attach)
         return attach.returncode
     return 0
 
@@ -882,7 +989,8 @@ def cmd_menu(args) -> int:
     was invoked some other way) is a quiet no-op: there is no screen to draw on, and no
     screen left to report that on either. So is an EMPTY menu (`not menu.build(fid)`):
     `display-menu` requires at least one `name key command` triple and fails outright
-    ("too few arguments") without one — reachable with a genuine `$CHARTER_SESSION_ID`
+    (rc 1, `not enough arguments` — tmux's own text, confirmed against 3.7c with a real
+    attached client) without one — reachable with a genuine `$CHARTER_SESSION_ID`
     whose frame has recorded nothing yet, and, before this guard, WOULD have been
     reachable with none at all (`menu.build("")` is always empty — `state.frame_dir`
     refuses an empty id — so a keypress arriving with no session id would otherwise
@@ -892,7 +1000,11 @@ def cmd_menu(args) -> int:
     fid = os.environ.get("CHARTER_SESSION_ID", "")
     if not args.client or not menu.build(fid):
         return 0
-    return subprocess.run(menu.menu_argv(fid, SOCKET, client=args.client)).returncode
+    # `tmuxctl.interact`: `display-menu` draws on an attached client and does not return
+    # until the operator chooses or dismisses it, so it belongs with `attach` on the
+    # no-capture, no-timeout side of `tmuxctl` — time-boxing it would close a menu for
+    # the crime of being read slowly.
+    return tmuxctl.interact(menu.menu_argv(fid, SOCKET, client=args.client)).returncode
 
 
 def cmd_action(args) -> int:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -89,6 +89,7 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 import subprocess
 import sys
 
@@ -628,6 +629,31 @@ def cmd_launch(args) -> int:
         return 2
 
     if args.no_frame or not sys.stdout.isatty():
+        return bypass(argv)
+
+    # A REGISTERED harness whose binary is not installed never reaches tmux — and the
+    # irony is worth recording, because it is what hid this for a whole review round:
+    # `--no-frame` and piped output, the two paths that bypass the frame, already
+    # printed charter's own message and exited 127 correctly. Only the terminal path —
+    # the NORMAL one, the first thing a new operator types — was silent, and silent in
+    # the most complete way available: `new-session` starts, the exec fails instantly,
+    # the eager `_query_pane_dead_status` below catches the dead pane and runs
+    # `kill-session`, and because `code is not None` from that moment on, the entire
+    # `if code is None:` block — panels, `select-pane`, and `attach` — is skipped. There
+    # is no pane left and no attach, so nothing is ever drawn. Measured against a real
+    # tmux 3.7c under a pty, with `claude` genuinely off `$PATH`: **zero bytes** of
+    # output, exit 127, no alternate-screen switch. `charter claude` before installing
+    # `claude` returned instantly with no explanation of any kind.
+    #
+    # Scoped to `if h` deliberately, and this is the whole reason the check sits here
+    # rather than over `argv[0]`. A registered harness's binary comes from charter's own
+    # registry (`harness.base.binary`), so `shutil.which` is asking about a name charter
+    # chose. `charter frame -- <cmd>` is the opposite: `argv[0]` is the operator's own
+    # verbatim word, and it is allowed to be a shell builtin, a relative path, or
+    # anything else tmux's own resolution accepts — a `which` check over THAT would
+    # narrow what the escape hatch accepts, which is a design change and not this fix.
+    # So the escape hatch keeps its current behaviour exactly, unchanged.
+    if h and not shutil.which(h.binary):
         return bypass(argv)
 
     # ONE call (correction 5): asking `tmux -V` twice on a path that branches on the

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -171,18 +171,32 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
     carries none of the risk `_EXIT_PATH_ENV`'s docstring describes for `status_path`.
 
     `hotkey` opens this frame's own menu: `bind -n {hotkey} run-shell 'charter
-    frame-menu'`. A key BINDING has no per-session form the way `status`/`mouse`/
-    `history-limit` above do — key tables are server-wide in tmux, so every frame on
-    `SOCKET` ends up sharing this exact bind text, "last launched wins" exactly like
-    `escape-time`/`remain-on-exit`/the `WheelUpPane` bind two lines down already do. That
-    is only safe here because the action itself carries no frame identity: `charter
-    frame-menu` (`cmd_menu`) resolves the CURRENT session from `$CHARTER_SESSION_ID` —
-    carried out of band via `set-environment`, see `_session_id_env_argv` — at the moment
-    the key actually fires, never from anything baked into this text. A bind that
-    embedded one frame's own id here would start opening the WRONG frame's menu the
-    instant a second frame launched, the same trap this function's own docstring already
-    names for `mouse`/`history-limit`, just reached through a binding instead of a
-    session-scoped `set`.
+    frame-menu "#{client_name}"'`. A key BINDING has no per-session form the way
+    `status`/`mouse`/`history-limit` above do — key tables are server-wide in tmux, so
+    every frame on `SOCKET` ends up sharing this exact bind text, "last launched wins"
+    exactly like `escape-time`/`remain-on-exit`/the `WheelUpPane` bind two lines down
+    already do. That is only safe here because the action itself carries no frame
+    identity: `charter frame-menu` (`cmd_menu`) resolves the CURRENT session from
+    `$CHARTER_SESSION_ID` — carried out of band via `set-environment`, see
+    `_session_id_env_argv` — at the moment the key actually fires, never from anything
+    baked into this text. A bind that embedded one frame's own id here would start
+    opening the WRONG frame's menu the instant a second frame launched, the same trap
+    this function's own docstring already names for `mouse`/`history-limit`, just
+    reached through a binding instead of a session-scoped `set`.
+
+    `"#{client_name}"` is a SECOND thing this same bind carries, for a DIFFERENT
+    reason: which of possibly several clients attached to one frame should see the
+    menu. Format expansion resolves `#{client_name}` in the context of whoever's
+    keypress is firing the bind — verified by hand with two real ptys attached to one
+    session, pressing the hotkey from each in turn: each press's own `run-shell`
+    resolved its OWN presser's client name, never the other one's, regardless of which
+    was attached first. `charter frame-menu` receives it as a plain argv value (`args
+    .client` in `cmd_menu`) and hands it straight to `display-menu -c`. Earlier, this
+    module queried `list-clients` and guessed the first one reported when several
+    clients were attached — confirmed wrong: pressing the hotkey on the SECOND-attached
+    client drew the menu on the FIRST client's screen, worse than tmux's own unscoped
+    default single-client guess this module was replacing. Carrying the presser by name
+    removes the guess entirely rather than making it a better one.
 
     This also satisfies correction 2's "only in charter's own server" rule by
     construction rather than by discipline at each call site: `conf_text`'s only caller
@@ -204,7 +218,7 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
         f"set -t {session} history-limit {int(history_limit)}",
         "set -g escape-time 0",
         "set -g remain-on-exit on",
-        f"bind -n {hotkey} run-shell 'charter frame-menu'",
+        f"bind -n {hotkey} run-shell 'charter frame-menu \"#{{client_name}}\"'",
         "bind -n WheelUpPane if-shell -F -t = '#{mouse_any_flag}'"
         " 'send-keys -M' 'copy-mode -e; send-keys -M'",
         "",
@@ -388,25 +402,6 @@ def _live_sessions(socket: str) -> set[str]:
     except (OSError, subprocess.SubprocessError):
         return set()
     return {line.strip() for line in out.stdout.splitlines() if line.strip()}
-
-
-def _menu_clients(socket: str, session: str) -> list[str]:
-    """Every client `tmux -L socket list-clients -t session` reports for *session*, now.
-
-    `cmd_menu`'s own query for `-c`'s answer (see `menu.menu_argv`'s docstring for why
-    `-t` alone cannot choose the client) — same shape as `_live_sessions` above, and for
-    the same reason: `list-clients` exits non-zero with nothing on stdout for the
-    ordinary "nothing attached right now" case, which `splitlines()` already turns into
-    an empty list with no special-casing needed. The `except` guards tmux vanishing
-    between calls, not that ordinary case.
-    """
-    try:
-        out = subprocess.run(["tmux", "-L", socket, "list-clients", "-t", session,
-                              "-F", "#{client_name}"],
-                             capture_output=True, text=True, timeout=5)
-    except (OSError, subprocess.SubprocessError):
-        return []
-    return [line.strip() for line in out.stdout.splitlines() if line.strip()]
 
 
 def _report_tmux_failure(action: str, cmd: list[str], proc: subprocess.CompletedProcess) -> None:
@@ -795,34 +790,50 @@ def cmd_launch(args) -> int:
 
 
 def cmd_menu(args) -> int:
-    """Open this frame's own menu. The hotkey bind's only action — see `conf_text`.
+    """Open this frame's own menu, on the screen of whoever actually pressed the hotkey.
 
-    `args` is unused; this exists purely so `cli.py` has a handler to point `charter
-    frame-menu` (registered as a top-level command — see `menu.py`'s own docstring for
-    why not `frame menu`) at. `fid` is resolved from `$CHARTER_SESSION_ID`, carried
-    session-scoped via `_session_id_env_argv` rather than baked into the bind's own text
-    (see `conf_text`'s docstring for why that split is load-bearing, not incidental):
-    the SAME bind text is shared by every frame on `SOCKET`, so the frame it opens a menu
+    `fid` is resolved from `$CHARTER_SESSION_ID`, carried session-scoped via
+    `_session_id_env_argv` rather than baked into the bind's own text (see
+    `conf_text`'s docstring for why that split is load-bearing, not incidental): the
+    SAME bind text is shared by every frame on `SOCKET`, so the frame it opens a menu
     FOR has to be resolved here, at the moment the key actually fires, never earlier.
 
-    Resolves the CLIENT to draw the menu on before ever calling `display-menu` — `-t`
-    alone does not choose it (verified by hand against tmux 3.7c with two frames attached
-    in two terminals: `-t fid` rendered the WRONG frame's menu on the wrong screen; see
-    `menu.menu_argv`'s own docstring). `_menu_clients` asks `list-clients` directly,
-    scoped to this session, rather than ever falling back to tmux's own "most recently
-    active" default. Zero clients (nothing attached right now — a keypress landing mid
-    detach, say) is a quiet no-op: `display-menu` would just fail with tmux's own "no
-    current client", and there is no screen left to report that failure on anyway.
-    Several clients (the same session open in two terminals at once) picks the FIRST one
-    reported — any client actually watching THIS session is correct by construction,
-    `display-menu -c` only ever accepts one, and there is no way to show a menu on two
-    screens at the same time.
+    `args.client` is `#{client_name}`, expanded by tmux INSIDE the bind's own
+    `run-shell` text before this process ever starts (see `conf_text`'s docstring) — not
+    queried here. An earlier version queried `list-clients` and picked the first client
+    reported when several were attached to one frame; confirmed WRONG by observation,
+    not merely suboptimal: with two real ptys attached to one session, pressing the
+    hotkey on the SECOND-attached client drew the menu on the FIRST client's screen,
+    and the presser saw nothing — worse than tmux's own unscoped single-client default
+    this module was built to replace, which happened to guess right in that same
+    two-client, one-frame setup when given no `-c` at all (also verified by hand,
+    separately). Carrying the presser's own name through the bind removes the guess
+    rather than making it a better one — confirmed against the same two-pty setup:
+    each press now resolves to its OWN presser, never the other one's, regardless of
+    attach order (see `tests/test_frame_tmux_integration.py`'s
+    `MenuClientIntegration`). This is the one property actually verified for the
+    ORIGINAL single-frame bug this whole mechanism exists to fix: nobody ever directly
+    reproduced tmux's default guess failing for a single frame with several clients —
+    only the two-FRAME case (`display-menu -t <session>` alone, no `-c`, resolving to
+    whichever session was "current" server-wide) was. `#{client_name}` closes both
+    regardless, by construction, rather than leaving the single-frame case resting on
+    an inference.
+
+    A missing client (`args.client` empty — `#{client_name}` failed to expand, or this
+    was invoked some other way) is a quiet no-op: there is no screen to draw on, and no
+    screen left to report that on either. So is an EMPTY menu (`not menu.build(fid)`):
+    `display-menu` requires at least one `name key command` triple and fails outright
+    ("too few arguments") without one — reachable with a genuine `$CHARTER_SESSION_ID`
+    whose frame has recorded nothing yet, and, before this guard, WOULD have been
+    reachable with none at all (`menu.build("")` is always empty — `state.frame_dir`
+    refuses an empty id — so a keypress arriving with no session id would otherwise
+    have gone on to build a zero-item `display-menu` call and fail loudly for no
+    reason the operator could see).
     """
     fid = os.environ.get("CHARTER_SESSION_ID", "")
-    clients = _menu_clients(SOCKET, fid)
-    if not clients:
+    if not args.client or not menu.build(fid):
         return 0
-    return subprocess.run(menu.menu_argv(fid, SOCKET, client=clients[0])).returncode
+    return subprocess.run(menu.menu_argv(fid, SOCKET, client=args.client)).returncode
 
 
 def cmd_action(args) -> int:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -269,6 +269,17 @@ _RESIZE_FLAG = {"top": "-y", "bottom": "-y", "left": "-x", "right": "-x"}
 #: that whatever the string actually was cannot corrupt the action tmux re-parses.
 _PANE_ID_RE = re.compile(r"%\d+")
 
+#: tmux's own answer, verbatim, for a `set-hook` call naming an event this binary does
+#: not recognise at all — confirmed by hand against a real tmux 3.7c with a fabricated
+#: hook name (`invalid option: <name>`, generic `set-hook` argument-parsing text, not
+#: specific to any one hook's name). Checked against a FAILED install's own stderr
+#: rather than trusted only up front: `RESIZE_HOOK_FLOOR` is a fast path to skip the
+#: attempt for a version already KNOWN too old, not the only thing standing between an
+#: operator and a loud, recurring error if that constant ever turns out to be wrong —
+#: this is what makes the mechanism safe BY CONSTRUCTION rather than by the constant
+#: being right (see `_report_tmux_failure`'s call site below for how the two combine).
+_INVALID_HOOK_NAME = "invalid option"
+
 
 def _resize_hook_argv(*, socket: str, harness_pane: str, panes: dict[str, str]) -> list[str]:
     """`window-resized`: re-asserts every fixed-size panel's dimension after a resize.
@@ -615,9 +626,22 @@ def cmd_launch(args) -> int:
                 resize = subprocess.run(resize_cmd, env=env, capture_output=True, text=True,
                                         timeout=15)
                 if resize.returncode != 0:
-                    _report_tmux_failure("installing the resize hook", resize_cmd, resize)
-                    util.warn("charter frame: continuing without it — panels may "
-                             "drift out of shape if this terminal is resized")
+                    if _INVALID_HOOK_NAME in (resize.stderr or ""):
+                        # RESIZE_HOOK_FLOOR believed this tmux would recognise the
+                        # hook name and it does not — the constant is wrong, not the
+                        # launch. Trust what THIS tmux just said over the constant and
+                        # degrade the same quiet way the version-gate above already
+                        # does, rather than report it as a broken integration (a
+                        # capability ceiling, not a failure — see the module's own
+                        # "belt and braces" framing and `harness.base.Deficit`'s same
+                        # philosophy for a harness-level capability gap).
+                        util.warn("charter frame: this tmux does not support the "
+                                 "resize-recovery hook — panels may drift out of "
+                                 "shape if this terminal is resized")
+                    else:
+                        _report_tmux_failure("installing the resize hook", resize_cmd, resize)
+                        util.warn("charter frame: continuing without it — panels may "
+                                 "drift out of shape if this terminal is resized")
 
             # `split-window` makes the newly created pane the ACTIVE one by default, so
             # after every slot has been drawn, the LAST panel drawn — not the harness —

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -77,6 +77,7 @@ did before either hook existed. See `_pane_died_teardown_hook_argv`'s own docstr
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 
@@ -254,6 +255,19 @@ def _pane_died_teardown_hook_argv(*, socket: str, harness_pane: str) -> list[str
 #: own `-v`/`-h` split direction already encodes for the same slots, read here rather
 #: than re-derived a third way.
 _RESIZE_FLAG = {"top": "-y", "bottom": "-y", "left": "-x", "right": "-x"}
+
+#: Every real pane id tmux's own `-P -F '#{pane_id}'` has ever reported (`%<digits>`,
+#: confirmed against tmux 3.7c and never observed otherwise). Checked before a value
+#: read off `split-window`'s stdout is trusted as a pane id, because `_resize_hook_argv`
+#: interpolates it directly into a hook ACTION STRING tmux later re-parses as a command
+#: line — the exact construction the module docstring's "constant string" section bans
+#: for `status_path`, for the same reason: something interpolated into an action must be
+#: safe BY CONSTRUCTION, not merely safe because the one program that currently produces
+#: it (tmux itself) happens to be well-behaved. A value that fails this check is treated
+#: the same as `split-window` reporting no id at all (see the empty-string check right
+#: below this) — that one panel simply gets no resize-hook entry, rather than gambling
+#: that whatever the string actually was cannot corrupt the action tmux re-parses.
+_PANE_ID_RE = re.compile(r"%\d+")
 
 
 def _resize_hook_argv(*, socket: str, harness_pane: str, panes: dict[str, str]) -> list[str]:
@@ -574,10 +588,23 @@ def cmd_launch(args) -> int:
                     _report_tmux_failure("drawing a panel", cmd, p)
                     continue
                 pane_id = p.stdout.strip()
-                if pane_id:
+                if pane_id and _PANE_ID_RE.fullmatch(pane_id):
                     panes[slot] = pane_id
 
-            if panes:
+            if panes and v < tmuxctl.RESIZE_HOOK_FLOOR:
+                # Below RESIZE_HOOK_FLOOR, `window-resized` is not a hook name THIS
+                # tmux recognises at all — `set-hook` fails with `invalid option:
+                # <name>` for any name it does not know (see RESIZE_HOOK_FLOOR's own
+                # docstring for exactly what was, and was not, confirmed by hand) —
+                # skip the attempt rather than printing that confusing text on every
+                # single launch. One quiet, honest note instead, naming the real
+                # consequence (item 4's own standard: every degrade in this launcher
+                # says what it costs).
+                util.warn(f"charter frame: tmux {v[0]}.{v[1]} predates the "
+                         f"resize-recovery hook (needs "
+                         f"{tmuxctl.RESIZE_HOOK_FLOOR[0]}.{tmuxctl.RESIZE_HOOK_FLOOR[1]}+)"
+                         f" — panels may drift out of shape if this terminal is resized")
+            elif panes:
                 # Only once any panel actually exists — a resize hook with nothing to
                 # resize would just be a wasted `set-hook` call, and (per the module
                 # docstring's "belt and braces" framing) every pane already measures its
@@ -589,6 +616,8 @@ def cmd_launch(args) -> int:
                                         timeout=15)
                 if resize.returncode != 0:
                     _report_tmux_failure("installing the resize hook", resize_cmd, resize)
+                    util.warn("charter frame: continuing without it — panels may "
+                             "drift out of shape if this terminal is resized")
 
             # `split-window` makes the newly created pane the ACTIVE one by default, so
             # after every slot has been drawn, the LAST panel drawn — not the harness —

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -82,7 +82,7 @@ import subprocess
 import sys
 
 from . import config, harness, util, workspace
-from .frame import layout, state, tmuxctl
+from .frame import layout, menu, state, tmuxctl
 # Aliased: `cmd_launch` already has a local variable named `slots` (the VISIBLE slot
 # list `layout.visible_slots` returns) — importing the renderer registry under its own
 # name would be shadowed by that local the moment it's assigned, and a `slots.SLOTS`
@@ -170,9 +170,33 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
     plain `set -t <session> ...` config text, never into a shell command string, so it
     carries none of the risk `_EXIT_PATH_ENV`'s docstring describes for `status_path`.
 
-    `hotkey` is accepted and never bound to anything here on purpose: binding the key AND
-    populating the menu it opens both belong to the task that makes the menu reachable,
-    and half of that wiring (a key bound to nothing) would be worse than none of it.
+    `hotkey` opens this frame's own menu: `bind -n {hotkey} run-shell 'charter
+    frame-menu'`. A key BINDING has no per-session form the way `status`/`mouse`/
+    `history-limit` above do — key tables are server-wide in tmux, so every frame on
+    `SOCKET` ends up sharing this exact bind text, "last launched wins" exactly like
+    `escape-time`/`remain-on-exit`/the `WheelUpPane` bind two lines down already do. That
+    is only safe here because the action itself carries no frame identity: `charter
+    frame-menu` (`cmd_menu`) resolves the CURRENT session from `$CHARTER_SESSION_ID` —
+    carried out of band via `set-environment`, see `_session_id_env_argv` — at the moment
+    the key actually fires, never from anything baked into this text. A bind that
+    embedded one frame's own id here would start opening the WRONG frame's menu the
+    instant a second frame launched, the same trap this function's own docstring already
+    names for `mouse`/`history-limit`, just reached through a binding instead of a
+    session-scoped `set`.
+
+    This also satisfies correction 2's "only in charter's own server" rule by
+    construction rather than by discipline at each call site: `conf_text`'s only caller
+    (`cmd_launch`) sources this text against `SOCKET`, charter's own private server —
+    never the operator's own default socket (see this module's own docstring, "Never the
+    operator's own default socket").
+
+    No `-t` on the `run-shell` itself, unlike `_exit_path_env_argv`'s callers (which
+    target a session by NAME): verified by hand against tmux 3.7c that `run-shell -t =`
+    — the idiom the `WheelUpPane` bind below already uses for `if-shell -F` — does NOT
+    carry a session's own `set-environment` values into the shell it spawns, while
+    OMITTING `-t` entirely does. `-t =` resolves for FORMAT evaluation (`if-shell -F`,
+    which never spawns a process); it is not the same mechanism a spawned shell's
+    environment goes through, and the two do not behave alike.
     """
     return "\n".join([
         f"set -t {session} status off",
@@ -180,6 +204,7 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
         f"set -t {session} history-limit {int(history_limit)}",
         "set -g escape-time 0",
         "set -g remain-on-exit on",
+        f"bind -n {hotkey} run-shell 'charter frame-menu'",
         "bind -n WheelUpPane if-shell -F -t = '#{mouse_any_flag}'"
         " 'send-keys -M' 'copy-mode -e; send-keys -M'",
         "",
@@ -197,6 +222,36 @@ def _exit_path_env_argv(*, socket: str, session: str, status_path: str) -> list[
     """
     return ["tmux", "-L", socket, "set-environment", "-t", session, _EXIT_PATH_ENV,
            status_path]
+
+
+def _session_id_env_argv(*, socket: str, session: str) -> list[str]:
+    """`set-environment`: makes *session* resolvable from its own `run-shell` calls.
+
+    `cmd_menu` and `cmd_action` (the hotkey bind's own action, and every menu item's own
+    action) both read `$CHARTER_SESSION_ID` back out of a `run-shell`-spawned process's
+    environment — the same out-of-band shape `_exit_path_env_argv` already uses for
+    `status_path`, and for the identical reason: this is what lets `conf_text`'s bind
+    stay a single, frame-agnostic line shared by every session on `SOCKET` (see its own
+    docstring) while still resolving the RIGHT frame at the moment the key fires.
+
+    Without this call, `run-shell` fired from a LATER frame sharing `SOCKET` does not
+    fall back to "no id" — it falls back to the FIRST frame's own id, silently. Verified
+    by hand against tmux 3.7c: a second session started on an already-running server,
+    `run-shell`'d with no override of its own, reported the FIRST frame's
+    `$CHARTER_SESSION_ID` (present in the SERVER's own starting process environment,
+    inherited from whichever `new-session` call happened to start it) rather than an
+    empty string — `show-environment -t <session>` confirmed the value was never tracked
+    per-session at all until a call exactly like this one ties it there explicitly. Left
+    unfixed, every frame after the first would open the FIRST frame's own menu and run
+    its actions against the wrong session's state.
+
+    The value IS the session's own name (`state.frame_id`'s own restricted alphabet —
+    see its docstring — so there is nothing here for this call's own text to sanitise),
+    which is why this hands the session right back to itself rather than taking a
+    separate value the way `_exit_path_env_argv` takes `status_path`.
+    """
+    return ["tmux", "-L", socket, "set-environment", "-t", session, "CHARTER_SESSION_ID",
+           session]
 
 
 def _pane_died_write_hook_argv(*, socket: str, harness_pane: str) -> list[str]:
@@ -530,6 +585,30 @@ def cmd_launch(args) -> int:
         util.warn("charter frame: continuing without it — the exit code may not be "
                   "recorded for this frame")
 
+    # Ties this session to its own id BEFORE anything else can ask for it — the hotkey
+    # bind's action (`charter frame-menu`) and every menu item's own action (`charter
+    # frame-action <id>`) both resolve `$CHARTER_SESSION_ID` from a `run-shell`-spawned
+    # process's environment, and without this call a frame beyond the first sharing
+    # `SOCKET` would silently resolve the FIRST frame's id instead of its own (see
+    # `_session_id_env_argv`'s own docstring for what was verified by hand).
+    sid_cmd = _session_id_env_argv(socket=SOCKET, session=fid)
+    sid_set = subprocess.run(sid_cmd, env=env, capture_output=True, text=True, timeout=15)
+    if sid_set.returncode != 0:
+        _report_tmux_failure("carrying the frame id to its own hotkey menu", sid_cmd, sid_set)
+        util.warn("charter frame: continuing without it — the hotkey menu may not find "
+                  "this frame's own actions")
+
+    # The menu itself: what the hotkey actually opens. A single "Detach" entry — the
+    # spec's own words, "Detach is allowed and prints how to reattach" — proves the
+    # mechanism end to end (bind → menu → opaque id → real command) without inventing a
+    # feature this task was never asked to build. `-s fid` (not `-t`): `detach-client`'s
+    # `-s` targets every client attached to a SESSION, `-t` a single CLIENT — this frame
+    # normally has exactly one attached client, but `-s` is correct even if it ever has
+    # more than one.
+    menu.record(fid=fid, entries=[
+        ("Detach", ["tmux", "-L", SOCKET, "detach-client", "-s", fid]),
+    ])
+
     write_hook_cmd = _pane_died_write_hook_argv(socket=SOCKET, harness_pane=harness_pane)
     write_hook = subprocess.run(write_hook_cmd, env=env, capture_output=True, text=True, timeout=15)
     if write_hook.returncode != 0:
@@ -694,3 +773,36 @@ def cmd_launch(args) -> int:
         _report_tmux_failure("attaching to the frame", attach_cmd, attach)
         return attach.returncode
     return 0
+
+
+def cmd_menu(args) -> int:
+    """Open this frame's own menu. The hotkey bind's only action — see `conf_text`.
+
+    `args` is unused; this exists purely so `cli.py` has a handler to point `charter
+    frame-menu` (registered as a top-level command — see `menu.py`'s own docstring for
+    why not `frame menu`) at. `fid` is resolved from `$CHARTER_SESSION_ID`, carried
+    session-scoped via `_session_id_env_argv` rather than baked into the bind's own text
+    (see `conf_text`'s docstring for why that split is load-bearing, not incidental):
+    the SAME bind text is shared by every frame on `SOCKET`, so the frame it opens a menu
+    FOR has to be resolved here, at the moment the key actually fires, never earlier.
+    """
+    fid = os.environ.get("CHARTER_SESSION_ID", "")
+    return subprocess.run(menu.menu_argv(fid, SOCKET)).returncode
+
+
+def cmd_action(args) -> int:
+    """Run one menu entry by its opaque id. The only path from a menu to a real command.
+
+    `args.action_id` is never anything but `a<N>` shaped text arriving on `charter
+    frame-action`'s own command line (see `menu.py`'s module docstring for why that is a
+    top-level command rather than `frame action`) — `menu.resolve` is the one place an id
+    turns back into the argv it names, and `subprocess.run` below takes that argv as a
+    LIST, never a shell string, so nothing an id could ever resolve to is re-parsed by
+    anything on the way to running.
+    """
+    fid = os.environ.get("CHARTER_SESSION_ID", "")
+    argv = menu.resolve(fid, args.action_id)
+    if not argv:
+        util.err(f"charter frame-action: unknown action {args.action_id!r}")
+        return 2
+    return subprocess.run(argv).returncode

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -64,6 +64,14 @@ teardown hook — sharing no text with it — still fired and ended the session 
 Belt and braces over the constant-action fix above: it means a *future* bug in the write
 hook's own construction can degrade to "the wrong exit code was recorded" and never
 regress all the way back to "the session never ends."
+
+**The two hooks must be installed in this order — write, then teardown — and that is
+load-bearing, not incidental.** Verified against tmux 3.7c: an UNINDEXED `set-hook -p -t
+<pane> pane-died '<action>'` call does not overwrite index 0 of an existing hook array;
+it REPLACES THE WHOLE ARRAY, silently deleting `[1]` if it was already there. Installing
+the write hook second would wipe out the teardown hook the moment it lands — reproduced
+end to end by swapping the two `cmd_launch` calls: the session hung exactly the way it
+did before either hook existed. See `_pane_died_teardown_hook_argv`'s own docstring.
 """
 
 from __future__ import annotations
@@ -215,7 +223,22 @@ def _pane_died_write_hook_argv(*, socket: str, harness_pane: str) -> list[str]:
 def _pane_died_teardown_hook_argv(*, socket: str, harness_pane: str) -> list[str]:
     """`pane-died[1]`: ends the session. Nothing else — see the module docstring's
     "Teardown is its own hook" section for why this is never combined with the write
-    hook above."""
+    hook above.
+
+    **Must be installed AFTER `_pane_died_write_hook_argv`, never before — this is not
+    a style preference, it is the entire fix.** Verified by hand against tmux 3.7c: an
+    UNINDEXED `set-hook -p -t <pane> pane-died '<action>'` call does not merely overwrite
+    index 0 of an existing array — it REPLACES THE WHOLE ARRAY, silently deleting any
+    `[1]` that was already there. So installing this hook first and the write hook
+    second wipes teardown before the harness ever runs, and the exact hang this pair of
+    hooks exists to close comes back — reproduced end to end (`RESULT: TIMEOUT`, session
+    left attached) by swapping the two calls in `cmd_launch`. `cmd_launch`'s own call
+    order (write, then this one) is the only thing enforcing the requirement; nothing in
+    the type system does, which is why it is pinned by a dedicated ordering test
+    (`Launch.test_the_write_hook_is_installed_before_the_teardown_hook`) as well as by
+    `tests/test_frame_tmux_integration.py`'s own test of this exact array-replacement
+    behaviour against a real server.
+    """
     return ["tmux", "-L", socket, "set-hook", "-p", "-t", harness_pane, "pane-died[1]",
            "kill-session"]
 
@@ -438,6 +461,7 @@ def cmd_launch(args) -> int:
 
     attach = None
     attach_cmd = None
+    refused_to_attach = False
     if code is None:
         if teardown_hook.returncode != 0:
             # Refuse to attach rather than risk it: without the teardown hook, a crash
@@ -446,6 +470,7 @@ def cmd_launch(args) -> int:
             # exists to close, just moved later and made permanent for this frame. The
             # harness keeps running (it was already started, detached); the operator can
             # still attach manually and accept that risk themselves.
+            refused_to_attach = True
             util.err("charter frame: refusing to attach — the session-teardown hook "
                      "failed to install, so a crash later would block `attach` forever "
                      "with nothing to end the session. The harness is still running, "
@@ -493,6 +518,12 @@ def cmd_launch(args) -> int:
     state.reap(live_after)
     if code is not None:
         return code
+    if refused_to_attach:
+        # Nonzero, deliberately distinct from the `still live` detach path below: the
+        # harness never ran interactively and charter has no way to learn its real exit
+        # code, so a script or `&&` chain must see this as a failure rather than the
+        # quiet success an operator's own deliberate detach is allowed to be.
+        return 1
     if fid in live_after:
         # Detach, not completion — the session tmux still lists is this frame's own.
         # Silence here is exactly what the spec calls out: "an agent surviving a closed

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -144,6 +144,57 @@ def bypass(argv: list[str]) -> int:
     return 127  # unreachable; execvp either replaces this process or raises
 
 
+def frame_ready() -> tuple[int, str, str]:
+    """Can a frame run on this machine right now? ``(exit code, util.* level, one line)``
+    — read-only, and the only thing this asks is `tmuxctl.version()`.
+
+    Mirrors `cmd_launch`'s own gate exactly, not a stricter one: a few lines into
+    `cmd_launch`, tmux below `tmuxctl.FLOOR` gets a warning and the launch CONTINUES —
+    only its hotkey menu is disabled (`tmuxctl.below_floor_message`) — and only `tmux`
+    being entirely absent (`version() is None`) makes `cmd_launch` refuse outright.
+    Refusing here on anything short of that would report a frame this same launcher
+    goes on to draw regardless — a probe that lies about `cmd_launch`'s own behaviour is
+    worse than one that runs nothing at all.
+
+    Two callers share this, both read-only for the same reason `charter/news.py`
+    requires of a `check:` (reads, never acts; and this module's own subprocess calls
+    already carry timeouts, so neither can hang): `--probe` on every `charter
+    <harness>`/`charter frame` launcher (`cmd_launch` below), for an operator to run by
+    hand, and the top-level `charter frame-probe` (`cmd_probe`) that a news `check:`
+    names — see `cmd_probe`'s own docstring for why the check cannot simply be `frame
+    --probe` itself.
+    """
+    v = tmuxctl.version()
+    if v is None:
+        return 1, "err", tmuxctl.absent_message()
+    if v < tmuxctl.FLOOR:
+        return 0, "warn", tmuxctl.below_floor_message(v)
+    return 0, "ok", f"charter frame: tmux {v[0]}.{v[1]} — a frame can run on this machine"
+
+
+def _report_probe(code: int, level: str, line: str) -> int:
+    getattr(util, level)(line)
+    return code
+
+
+def cmd_probe(args=None) -> int:
+    """`charter frame-probe` — read-only, one line, starts nothing. The command a news
+    `check:` names.
+
+    A TOP-LEVEL command, not `frame --probe` reached through the escape hatch (which
+    also exists — see `cmd_launch`'s own `args.probe` branch): `news._PROBEABLE`
+    refuses any command whose parser carries a pass-through positional (#317), and
+    every parser `cli._wire` builds — `frame` included — carries `rest`
+    (`nargs=argparse.REMAINDER`, the harness's own verbatim argv, the entire point of
+    `charter frame -- <cmd>`). That makes `("frame",)` exactly the shape #317 fixed,
+    `--probe` or not, so it can never be added to `news._PROBEABLE` no matter what flag
+    reaches it. This command takes no arguments at all — nothing here could ever carry
+    an argv from a caller — so it is not that shape, and can be (see
+    `tests/test_news_probeable.py`).
+    """
+    return _report_probe(*frame_ready())
+
+
 def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> str:
     """The private tmux config for one frame's own settings. Never `~/.tmux.conf`.
 
@@ -457,6 +508,14 @@ def _query_pane_dead_status(socket: str, harness_pane: str) -> int | None:
 
 def cmd_launch(args) -> int:
     """One launcher, shared by every registered harness and by `charter frame --`."""
+    if getattr(args, "probe", False):
+        # First, and read-only: nothing below this line — resolving a harness, touching
+        # the workspace, reaping a sibling frame's state, ever calling `subprocess.run` —
+        # may run before a `--probe` caller gets its one-line answer and nothing else.
+        # `getattr` rather than `args.probe`: every other caller of `cmd_launch` in this
+        # codebase (tests included) constructs its own `args` without a `probe` field,
+        # and none of them means "probe".
+        return _report_probe(*frame_ready())
     h = next((x for x in harness.all() if x.cli_name == args.harness), None)
     rest = list(args.rest or [])
     # `nargs=argparse.REMAINDER` keeps a literal leading `--` when the operator typed

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -82,6 +82,12 @@ import sys
 
 from . import config, harness, util, workspace
 from .frame import layout, state, tmuxctl
+# Aliased: `cmd_launch` already has a local variable named `slots` (the VISIBLE slot
+# list `layout.visible_slots` returns) — importing the renderer registry under its own
+# name would be shadowed by that local the moment it's assigned, and a `slots.SLOTS`
+# lookup after that point would silently resolve to the wrong thing (an `AttributeError`
+# on a `list`, not a helpful one).
+from .frame import slots as frame_slots
 
 #: One shared tmux server for every frame this machine runs, sessions (not servers) told
 #: apart by name — the frame id. Never the operator's own default socket: a frame's
@@ -243,6 +249,50 @@ def _pane_died_teardown_hook_argv(*, socket: str, harness_pane: str) -> list[str
            "kill-session"]
 
 
+#: Which `resize-pane` flag re-asserts a slot's fixed dimension: `-y` (rows) for the
+#: horizontal strips, `-x` (columns) for the side columns — the same axis `layout.py`'s
+#: own `-v`/`-h` split direction already encodes for the same slots, read here rather
+#: than re-derived a third way.
+_RESIZE_FLAG = {"top": "-y", "bottom": "-y", "left": "-x", "right": "-x"}
+
+
+def _resize_hook_argv(*, socket: str, harness_pane: str, panes: dict[str, str]) -> list[str]:
+    """`window-resized`: re-asserts every fixed-size panel's dimension after a resize.
+
+    Measured against tmux 3.7c (see `layout.panel_argvs`'s own docstring): tmux's layout
+    engine redistributes EVERY pane proportionally whenever the window's size changes,
+    `-l size` notwithstanding — a 120x30 frame grown to 200x50 stretched two one-row
+    panels to 8 and 7 rows apiece, and only snapped back to 1 row because that particular
+    shrink happened to be an exact round trip of the same grow. `resize-pane -t <pane>
+    -y/-x <size>` re-applies the intended size directly and was verified by hand to hold
+    across repeated grows AND shrinks to arbitrary sizes, not just a round trip.
+
+    Installed as a WINDOW hook (`-w`, scoped via *harness_pane* — tmux resolves its
+    containing window from the pane), not a session or global one, so a sibling frame's
+    own window is left untouched. Fires on EVERY resize for the life of the window, not
+    only the first, since an operator's terminal can be grown and shrunk any number of
+    times.
+
+    *panes* maps each slot that was actually split to the pane id tmux reported for it —
+    never a slot whose `split-window` itself failed, since there is nothing there to
+    resize. Pane ids are tmux's own (`%<digits>`), never operator- or plane-derived, so
+    this action is safe to build directly: there is no hostile string here for a nested
+    tmux-quote layer to mangle, unlike `status_path` (see `_EXIT_PATH_ENV`'s own
+    docstring).
+
+    A SINGLE `set-hook` call, not one per slot: nothing else in this codebase installs a
+    `window-resized` hook, so there is no existing index to collide with — contrast
+    `pane-died`, which needed two INDEXED hooks specifically because two independent
+    actions shared one event (see `_pane_died_teardown_hook_argv`'s own docstring). One
+    action string chaining every slot's `resize-pane` with `;` covers all of them.
+    """
+    action = " ; ".join(
+        f"resize-pane -t {pane} {_RESIZE_FLAG[slot]} {layout.SLOT_SIZE[slot]}"
+        for slot, pane in panes.items())
+    return ["tmux", "-L", socket, "set-hook", "-w", "-t", harness_pane,
+           "window-resized", action]
+
+
 def _live_sessions(socket: str) -> set[str]:
     """Every session name `tmux -L socket list-sessions` currently reports.
 
@@ -390,7 +440,36 @@ def cmd_launch(args) -> int:
     frame = config.FRAME
     slots = layout.visible_slots(frame["slots"], cols, rows, frame["min_cols"], frame["min_rows"])
 
+    # `[frame] slots` accepts `left`/`right` (`instance.FRAME_SLOTS`, sized by
+    # `layout.SLOT_SIZE`) even though `frame.slots.SLOTS` — the RENDERER registry —
+    # does not implement either one yet. Left unfiltered, `panel_argvs` below would
+    # still split a real pane for it; `panel.run` correctly refuses or exits 2 (Task
+    # 7's own "no empty pane" rule), but with `remain-on-exit on` keeping that pane
+    # alive, the operator is left with a permanently dead, wrapped-error 22-column
+    # pane and no explanation at the point the frame actually came up. Skipping an
+    # unimplemented slot here instead means the harness pane simply keeps that space —
+    # the same degrade `visible_slots` itself already makes under a tight terminal —
+    # and one message, printed once, says why up front rather than leaving the operator
+    # to puzzle out a dead pane's own stderr.
+    unimplemented = sorted({s for s in slots if s not in frame_slots.SLOTS})
+    if unimplemented:
+        util.warn(f"charter frame: no renderer yet for {', '.join(unimplemented)} — "
+                  f"not drawing {'it' if len(unimplemented) == 1 else 'them'}; "
+                  f"the harness pane keeps that space instead")
+        slots = [s for s in slots if s not in unimplemented]
+
     env = dict(os.environ, CHARTER_SESSION_ID=fid)
+    # Belt and braces, not the fix itself: every pane (harness or panel) measures its
+    # OWN tty rather than trusting these (`frame/slots.py`, `frame/panel.py`), so a
+    # stale value here cannot mislay anything charter draws. But `env` is inherited
+    # WHOLE by every process tmux starts on this launch — the harness's shell among
+    # them — and COLUMNS/LINES describe the LAUNCHING terminal, not any pane this frame
+    # creates. Left in place, a shell inside a pane that echoes them back (or a
+    # program, charter's own or not, still reading `$COLUMNS` the way `tui.term_width`
+    # deliberately does for the status line) would report the wrong size for no reason
+    # charter needs to accept.
+    env.pop("COLUMNS", None)
+    env.pop("LINES", None)
     if h:
         env["CHARTER_HARNESS"] = h.name
 
@@ -477,9 +556,15 @@ def cmd_launch(args) -> int:
                      f"detached; reattach manually if you must: "
                      f"tmux -L {SOCKET} attach -t {fid}")
         else:
-            for cmd in layout.panel_argvs(slots=slots, session=fid, socket=SOCKET,
-                                          charter_argv=[sys.executable, "-m", "charter"],
-                                          harness_pane=harness_pane):
+            panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=SOCKET,
+                                            charter_argv=[sys.executable, "-m", "charter"],
+                                            harness_pane=harness_pane)
+            # Zipped with `slots`, not just iterated: `_resize_hook_argv` below needs to
+            # know WHICH slot each successfully-created pane belongs to (for its size and
+            # its resize-pane flag), and `panel_argvs` returns exactly one command per
+            # slot, in the same order (see its own docstring).
+            panes: dict[str, str] = {}
+            for slot, cmd in zip(slots, panel_cmds):
                 p = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=15)
                 if p.returncode != 0:
                     # Reported, not fatal: one decorative panel failing to draw must not
@@ -487,6 +572,23 @@ def cmd_launch(args) -> int:
                     # 2 asks for every return code to be CHECKED, not every failure
                     # refused).
                     _report_tmux_failure("drawing a panel", cmd, p)
+                    continue
+                pane_id = p.stdout.strip()
+                if pane_id:
+                    panes[slot] = pane_id
+
+            if panes:
+                # Only once any panel actually exists — a resize hook with nothing to
+                # resize would just be a wasted `set-hook` call, and (per the module
+                # docstring's "belt and braces" framing) every pane already measures its
+                # own tty on every repaint regardless, so this hook is purely cosmetic
+                # geometry upkeep, not something a launch's correctness depends on.
+                resize_cmd = _resize_hook_argv(socket=SOCKET, harness_pane=harness_pane,
+                                               panes=panes)
+                resize = subprocess.run(resize_cmd, env=env, capture_output=True, text=True,
+                                        timeout=15)
+                if resize.returncode != 0:
+                    _report_tmux_failure("installing the resize hook", resize_cmd, resize)
 
             # `split-window` makes the newly created pane the ACTIVE one by default, so
             # after every slot has been drawn, the LAST panel drawn — not the harness —

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -2,50 +2,73 @@
 
 The launcher does NOT exec tmux, and that is measured rather than stylistic: an attached
 `tmux new-session` returns 0 whatever its command exited with (tmux 3.7c). So the status
-is carried out of band — normally by a pane-scoped `pane-died` hook, with a direct query
-as a fallback for the race described below — and this process waits for tmux, reads the
+is carried out of band — normally by a pair of `pane-died` hooks, with a direct query as
+a fallback for the race described below — and this process waits for tmux, reads the
 recorded (or queried) code, and exits with it. `exec` survives only on the bypass path,
 where there is no frame in the way.
 
 **Every frame shares one tmux server (`SOCKET`), told apart by session name (the frame
 id), not one server per frame.** That single choice is what makes the rest of this module
 non-obvious, and it is why the session-scoped/hook-installing config reaches tmux through
-`source-file`/a direct `set-hook` command rather than through the `-f` flag
-`layout.session_argv` also carries. Measured against tmux 3.7c: `-f` is read only at the
-moment a client's connection actually STARTS the server — a later `new-session -f`
+`source-file`/direct `set-hook`/`set-environment` commands rather than through the `-f`
+flag `layout.session_argv` also carries. Measured against tmux 3.7c: `-f` is read only at
+the moment a client's connection actually STARTS the server — a later `new-session -f`
 against a server that is already running (the ordinary case, once a first frame is up) is
 silently ignored. A frame launched second, third, or fifty-first would then never get its
-own config applied at all if it relied on `-f` alone. `source-file` and a direct
-`set-hook` invocation both re-apply against whatever server already answers on the
-socket, so they work identically for the first frame and the fifty-first (verified by
-hand against tmux 3.7c: a hook installed this way for a SECOND session on an
-already-running server fires correctly, and its `kill-session` tears down only that
-session, leaving a sibling frame's session untouched).
+own config applied at all if it relied on `-f` alone. `source-file` and direct commands
+both re-apply against whatever server already answers on the socket, so they work
+identically for the first frame and the fifty-first (verified by hand against tmux 3.7c: a
+hook installed this way for a SECOND session on an already-running server fires correctly,
+and its `kill-session` tears down only that session, leaving a sibling frame untouched).
 
 **A second, narrower race survives even that fix.** `new-session` starts the harness
-running immediately; the hook that would record its exit code is not installed until a
-separate `set-hook` call some milliseconds later (measured 8.2-10.5ms). A harness that
-dies inside that window is never caught by the hook — hooks do not fire retroactively for
-an event that already happened, so it never existed yet to catch anything — and this is
-worse than `state.exit_code` merely reading back `None`: with nothing left to run the
-hook's own `kill-session`, an `attach` against that session BLOCKS FOREVER (verified by
-hand against a real tmux 3.7c — `remain-on-exit`, armed for exactly this reason, is
-legitimately keeping the dead pane's session alive; the module never called anything to
-end it). `remain-on-exit on` in the placeholder `-f` config is still necessary — it is
-what keeps the pane around long enough to be askable at all — but is not sufficient on
-its own. What actually closes the race is asking tmux directly, `display-message -p -t
-<harness_pane> '#{pane_dead}:#{pane_dead_status}'`, IMMEDIATELY after the `set-hook` call
-returns and BEFORE ever calling `attach`: if the pane is already dead at that point, this
-launcher finishes the hook's job itself (records the code, runs `kill-session`) and skips
-`attach` entirely, rather than block on a session that will never end on its own. The
-same query runs again as a fallback after `attach` DOES return, for whatever gap the
-eager check could not have seen yet.
+running immediately; the hooks that would record its exit code and end the session are
+not installed until separate `set-hook` calls a few milliseconds later (measured
+8.2-10.5ms). A harness that dies inside that window is never caught by them — hooks do
+not fire retroactively for an event that already happened — and this is worse than
+`state.exit_code` merely reading back `None`: with nothing left to run `kill-session`, an
+`attach` against that session BLOCKS FOREVER (verified by hand against a real tmux 3.7c,
+via a Python `pty` driving the real launcher end to end — `remain-on-exit`, armed for
+exactly this reason, is legitimately keeping the dead pane's session alive; nothing else
+was ever going to end it). `remain-on-exit on` in the placeholder `-f` config is still
+necessary — it is what keeps the pane around long enough to be askable at all — but is
+not sufficient on its own. What actually closes the race is asking tmux directly,
+`display-message -p -t <harness_pane> '#{pane_dead}:#{pane_dead_status}'`, IMMEDIATELY
+after the hooks are installed and BEFORE ever calling `attach`: if the pane is already
+dead at that point, this launcher finishes the hooks' own job itself (records the code,
+runs `kill-session`) and skips `attach` entirely, rather than block on a session that
+will never end on its own. The same query runs again as a fallback after `attach` DOES
+return, for whatever gap the eager check could not have seen yet.
+
+**The exit-code hook's action text is a CONSTANT string, on purpose — status_path is
+never embedded in it.** An earlier version of this module interpolated the path directly
+into the hook's `run-shell "echo ... > <path>"` action. That action is TEXT tmux
+re-parses as a fresh command line when the hook fires — one tmux-quote layer nested
+inside the `source-file`/`set-hook` install call that wrote it — and `shlex.quote()`
+cannot escape a path containing a literal `'` correctly across that nesting: verified by
+hand against tmux 3.7c that the install call still reported success (`set-hook` returned
+0) while the stored action was silently corrupted (`; kill-session` disappeared into a
+mangled argument), so a plane root with an apostrophe in it hung the exact same way the
+install race does, with SUCCESS printed on the way in. Fixed by delivering the path out
+of band instead — `set-environment -t <session> CHARTER_FRAME_EXIT <path>`, a single
+argv value, no shell involved — and writing a hook action that never varies by frame at
+all (`_pane_died_write_hook_argv`): nothing in it depends on plane state, so there is
+nothing left for any path, however hostile, to corrupt (verified against tmux 3.7c with
+a path containing a space, a literal `'`, and a `$(...)` injection attempt: the exact
+byte string reaches the file and nothing embedded in it runs).
+
+**Teardown is its own hook, `pane-died[1]`, entirely separate from the write hook
+(`pane-died[0]`).** `kill-session` alone, a constant string with no interpolated data at
+all. Verified by hand: even with the write hook's own action deliberately mangled, the
+teardown hook — sharing no text with it — still fired and ended the session correctly.
+Belt and braces over the constant-action fix above: it means a *future* bug in the write
+hook's own construction can degrade to "the wrong exit code was recorded" and never
+regress all the way back to "the session never ends."
 """
 
 from __future__ import annotations
 
 import os
-import shlex
 import subprocess
 import sys
 
@@ -67,14 +90,31 @@ _FALLBACK_SIZE = (80, 24)
 
 #: The placeholder loaded via `session_argv`'s `-f`, in effect ONLY if this call happens
 #: to start a brand-new tmux server on `SOCKET` (see the module docstring: `-f` is
-#: ignored otherwise). `remain-on-exit` alone, deliberately global (`-g`, not scoped to
-#: this one session): every frame wants the same value, so there is nothing to leak by
-#: sharing it, and this is what has to be in effect from the instant the harness's
-#: process starts — before this launcher has even read the pane id back off tmux's
-#: stdout, let alone had a chance to `source-file` the rest of the config — or a harness
-#: that dies in that opening window tears its own pane down before anything downstream
-#: (the hook, this launcher's fallback query) has a pane left to learn anything from.
+#: ignored otherwise — which is also why `cmd_launch` arms this same setting a second,
+#: direct way when a server is already running; see the "by construction" comment
+#: there). `remain-on-exit` alone, deliberately global (`-g`, not scoped to this one
+#: session): every frame wants the same value, so there is nothing to leak by sharing
+#: it, and this is what has to be in effect from the instant the harness's process
+#: starts — before this launcher has even read the pane id back off tmux's stdout, let
+#: alone had a chance to install anything else — or a harness that dies in that opening
+#: window tears its own pane down before anything downstream (the hooks, this
+#: launcher's fallback query) has a pane left to learn anything from.
 _PLACEHOLDER_CONF = "set -g remain-on-exit on\n"
+
+#: The session-scoped environment variable the write hook's shell reads the exit-status
+#: path back from — see the module docstring's "constant string" section for why the
+#: path is delivered this way instead of being embedded in the hook's own action text.
+_EXIT_PATH_ENV = "CHARTER_FRAME_EXIT"
+
+#: What `_query_pane_dead_status` returns for a pane confirmed dead (`#{pane_dead}` is
+#: `1`) whose `#{pane_dead_status}` tmux itself could not report — measured against tmux
+#: 3.7c: EMPTY, not negative, for a harness killed by SIGKILL/SIGTERM/SIGSEGV. `None`
+#: means "cannot tell" everywhere in this module (see `_query_pane_dead_status`'s own
+#: docstring) and must never be confused with "dead, but the real number isn't known" —
+#: the pane genuinely IS gone either way, so returning `None` here would send
+#: `cmd_launch` on to `attach` a session with nothing left to end it, recreating the
+#: exact hang the eager check exists to close, just from a signal instead of a race.
+_UNKNOWN_DEATH_CODE = 1
 
 
 def bypass(argv: list[str]) -> int:
@@ -106,8 +146,14 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
     identical binding anyway, so nothing is lost by sharing it the same way
     `remain-on-exit` is (see `_PLACEHOLDER_CONF`).
 
-    The `pane-died` hook does NOT live here — see `_pane_died_hook_argv` for why it is
-    issued as its own tmux command instead of text baked into this string.
+    Neither `pane-died` hook lives here — see `_pane_died_write_hook_argv` and
+    `_pane_died_teardown_hook_argv` for why they are issued as their own tmux commands
+    instead of text baked into this string.
+
+    *session* is the frame id, which `state.frame_id` already sanitises (see
+    `charter/frame/state.py`) before this function ever sees it — interpolated into
+    plain `set -t <session> ...` config text, never into a shell command string, so it
+    carries none of the risk `_EXIT_PATH_ENV`'s docstring describes for `status_path`.
 
     `hotkey` is accepted and never bound to anything here on purpose: binding the key AND
     populating the menu it opens both belong to the task that makes the menu reachable,
@@ -125,36 +171,53 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
     ])
 
 
-def _pane_died_hook_argv(*, socket: str, harness_pane: str, status_path: str) -> list[str]:
-    """The `set-hook` command that records the harness's real exit code.
+def _exit_path_env_argv(*, socket: str, session: str, status_path: str) -> list[str]:
+    """`set-environment`: carries *status_path* to the write hook's shell out of band.
 
-    Scoped to *harness_pane* — the id `cmd_launch` read off tmux's own stdout after
-    creating the session, never a guess. Unscoped, `pane-died` fires for ANY pane, and a
-    crashed side panel would be reported to the operator as the agent's own exit code.
-
-    Issued as its OWN tmux command — never embedded as text inside `conf_text`'s output
-    the way an earlier version of this module did — because the hook's action is itself
-    a shell command string that needs its own quoting, and nesting THAT inside a second,
-    text-file level of tmux quoting (`source-file`'s config syntax) breaks even
-    `shlex.quote`'s own escaping for a path containing a literal single quote: verified
-    against tmux 3.7c that the two nested quote layers corrupt each other's boundaries
-    (the outer layer's quote character terminates early on a quote character that only
-    means something to the inner one). Passed as one clean argv element instead —
-    matching every other command `frame/layout.py` builds, and the reason its own module
-    docstring gives for never joining argv (`gh -F`, #328) — `shlex.quote` then needs no
-    help and was verified, by hand against the same tmux 3.7c, to round-trip a path
-    containing a space, a literal single quote, and a `$(...)` injection attempt
-    correctly: the exact byte string reaches the file, and nothing embedded in it runs.
-
-    *status_path* reaches here from `STATE_DIR` (the plane root, or `$CHARTER_HOME`) —
-    never operator argv — but it is still handed to `/bin/sh -c` inside `run-shell`, the
-    one place this module hands tmux a STRING rather than an argv list, so it is quoted
-    like any other value that reaches a shell: a plane root with a space in it must not
-    silently write to the wrong file, and one shaped like `$(...)` must not run.
+    One argv value, no shell parsing at all on this side — the whole point (see the
+    module docstring). `run-shell`'s own spawned shell later reads it back from its
+    inherited environment via `$CHARTER_FRAME_EXIT`, verified by hand to work for a
+    SESSION-scoped `set-environment` (no `-g`) reaching a hook fired for a pane in that
+    session.
     """
-    action = (f'run-shell "echo #{{pane_dead_status}} > {shlex.quote(status_path)}" '
-             f'; kill-session')
+    return ["tmux", "-L", socket, "set-environment", "-t", session, _EXIT_PATH_ENV,
+           status_path]
+
+
+def _pane_died_write_hook_argv(*, socket: str, harness_pane: str) -> list[str]:
+    """`pane-died[0]`: writes the harness's real exit status, out of band.
+
+    A CONSTANT action — no operator- or plane-derived string is ever embedded in this
+    text (see the module docstring's "constant string" section for the bug that fixes).
+    `\\"` before a literal `"` or `$` is load-bearing, not decorative: verified by hand
+    that an UNESCAPED `$` inside this tmux double-quoted argument is consumed by tmux's
+    OWN parsing before the shell ever sees it (a first draft came out with the variable
+    reference silently missing, and a SECOND unescaped `$` — inside `${v:-1}` — made
+    `set-hook` itself fail outright with "invalid environment variable"); the escaped
+    form is what reaches `/bin/sh -c` as literal text for the SHELL to interpret.
+
+    `v=#{pane_dead_status}; echo "${v:-N}" > ...` rather than a bare `echo
+    #{pane_dead_status} > ...`: `#{pane_dead_status}` is EMPTY, not present as some
+    fallback digit, for a harness killed by a signal (SIGKILL/SIGTERM/SIGSEGV; measured
+    against tmux 3.7c) — an unqualified `echo` would then write an empty line, which
+    `state.exit_code`'s `int(...)` cannot parse, silently reading back as `None` exactly
+    like "nothing was ever recorded." The shell's own `${v:-N}` (not `${v-N}`, which only
+    substitutes for UNSET, not empty) closes that at the point of writing, so the file
+    this hook produces is always a parseable integer — `_UNKNOWN_DEATH_CODE` on a signal
+    death, the real status otherwise. Verified against tmux 3.7c for both.
+    """
+    action = ('run-shell "v=#{pane_dead_status}; echo '
+             f'\\"\\${{v:-{_UNKNOWN_DEATH_CODE}}}\\" > '
+             f'\\"\\${_EXIT_PATH_ENV}\\""')
     return ["tmux", "-L", socket, "set-hook", "-p", "-t", harness_pane, "pane-died", action]
+
+
+def _pane_died_teardown_hook_argv(*, socket: str, harness_pane: str) -> list[str]:
+    """`pane-died[1]`: ends the session. Nothing else — see the module docstring's
+    "Teardown is its own hook" section for why this is never combined with the write
+    hook above."""
+    return ["tmux", "-L", socket, "set-hook", "-p", "-t", harness_pane, "pane-died[1]",
+           "kill-session"]
 
 
 def _live_sessions(socket: str) -> set[str]:
@@ -189,22 +252,31 @@ def _report_tmux_failure(action: str, cmd: list[str], proc: subprocess.Completed
 def _query_pane_dead_status(socket: str, harness_pane: str) -> int | None:
     """Ask tmux directly whether *harness_pane* died, and with what status.
 
-    Called twice by `cmd_launch`, for two different gaps a hook alone cannot cover: once
-    EAGERLY, right after `set-hook` returns, to close the install race the module
-    docstring measures (a harness that died before the hook existed is never caught by
-    it, because a hook only fires for a death AFTER it exists); and again as a fallback
-    after `attach` returns, for whatever the eager check could not have seen yet.
-    `remain-on-exit` (armed from the very first moment via `_PLACEHOLDER_CONF`) is what
-    keeps the pane around long enough to still be askable either time — without it, this
-    query would simply find no such pane, exactly like the hook found no such event.
+    Called twice by `cmd_launch`, for two different gaps the hooks alone cannot cover:
+    once EAGERLY, right after both hooks are installed, to close the install race the
+    module docstring measures (a harness that died before the hooks existed is never
+    caught by them, because a hook only fires for a death AFTER it exists); and again as
+    a fallback after `attach` returns, for whatever the eager check could not have seen
+    yet. `remain-on-exit` (armed from the very first moment via `_PLACEHOLDER_CONF`, or
+    directly when a server is already running — see `cmd_launch`) is what keeps the pane
+    around long enough to still be askable either time — without it, this query would
+    simply find no such pane, exactly like the hooks found no such event.
 
-    ``None`` for "cannot tell" (the pane is alive, or the query itself failed) — never a
-    fabricated 0, which is the exact silent-success failure this whole module exists to
-    rule out.
+    ``None`` means "cannot tell" (the pane is alive, or the query itself failed) — never
+    a fabricated 0. An EMPTY `#{pane_dead_status}` is a THIRD case, distinct from both:
+    the pane is confirmed dead (`#{pane_dead}` is `1`) but tmux itself has no status to
+    report — measured against tmux 3.7c for a harness killed by a signal
+    (SIGKILL/SIGTERM/SIGSEGV), not merely a hypothetical. Returning `None` for THAT case
+    would tell `cmd_launch` "alive, go ahead and attach" for a pane that is provably
+    dead — the exact hang the eager check exists to close, reopened by a signal instead
+    of a timing race. See `_UNKNOWN_DEATH_CODE`.
     """
-    dm = subprocess.run(["tmux", "-L", socket, "display-message", "-p", "-t", harness_pane,
-                         "#{pane_dead}:#{pane_dead_status}"],
-                        capture_output=True, text=True, timeout=5)
+    try:
+        dm = subprocess.run(["tmux", "-L", socket, "display-message", "-p", "-t", harness_pane,
+                             "#{pane_dead}:#{pane_dead_status}"],
+                            capture_output=True, text=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return None
     if dm.returncode != 0:
         return None
     dead, _, status = dm.stdout.strip().partition(":")
@@ -213,7 +285,7 @@ def _query_pane_dead_status(socket: str, harness_pane: str) -> int | None:
     status = status.strip()
     if status.lstrip("-").isdigit():
         return int(status)
-    return None
+    return _UNKNOWN_DEATH_CODE
 
 
 def cmd_launch(args) -> int:
@@ -255,7 +327,25 @@ def cmd_launch(args) -> int:
     # also narrows (though does not close) the same race for a sibling frame's `exit`
     # file: less time between "session gone" and "directory removed" for a sibling's own
     # launcher to lose the read.
-    state.reap(_live_sessions(SOCKET))
+    live_before = _live_sessions(SOCKET)
+    if live_before:
+        # Arm `remain-on-exit` by construction here, not by coincidence. The placeholder
+        # `-f` config above only takes effect if THIS `new-session` call is what starts
+        # the tmux server — but a server on `SOCKET` may already be running for a reason
+        # that has nothing to do with charter (an operator's own `tmux -L charter
+        # new-session`, say), in which case `-f` is silently ignored and remain-on-exit
+        # stays at tmux's own default (off) until SOME charter frame happens to
+        # `source-file` it. Verified by hand: without this, a harness that dies in the
+        # race window against such a server returns the wrong code (1, not its own)
+        # deterministically — not a hang, since the session simply vanishes with it, but
+        # still wrong, and worth closing the same way the placeholder closes the
+        # first-frame-ever case.
+        arm_cmd = ["tmux", "-L", SOCKET, "set", "-g", "remain-on-exit", "on"]
+        arm = subprocess.run(arm_cmd, capture_output=True, text=True, timeout=15)
+        if arm.returncode != 0:
+            _report_tmux_failure("arming remain-on-exit ahead of an already-running server",
+                                 arm_cmd, arm)
+    state.reap(live_before)
 
     fdir = state.frame_dir(fid, create=True)
     if fdir is None:
@@ -306,56 +396,98 @@ def cmd_launch(args) -> int:
         util.warn("charter frame: continuing without it — mouse/history-limit/hotkey "
                   "settings may not be in effect for this frame")
 
-    hook_cmd = _pane_died_hook_argv(socket=SOCKET, harness_pane=harness_pane,
-                                    status_path=str(status_path))
-    hook = subprocess.run(hook_cmd, env=env, capture_output=True, text=True, timeout=15)
-    if hook.returncode != 0:
-        _report_tmux_failure("installing the exit-code hook", hook_cmd, hook)
+    env_cmd = _exit_path_env_argv(socket=SOCKET, session=fid, status_path=str(status_path))
+    env_set = subprocess.run(env_cmd, env=env, capture_output=True, text=True, timeout=15)
+    if env_set.returncode != 0:
+        _report_tmux_failure("carrying the exit-status path", env_cmd, env_set)
         util.warn("charter frame: continuing without it — the exit code may not be "
                   "recorded for this frame")
 
-    # Closes the install race, rather than merely working around its symptom. A harness
-    # that died in the window between `new-session` starting it and the `set-hook` call
-    # above actually registering leaves the hook registered for an event that ALREADY
-    # happened — hooks do not fire retroactively, so it never fires at all, and nothing
-    # is left to run the hook's own `kill-session`. Verified by hand against a real tmux
-    # 3.7c: `attach` below then blocks FOREVER on a session `remain-on-exit` is legitimately
-    # keeping alive, not merely returns 0 early — a worse failure than the one the module
+    write_hook_cmd = _pane_died_write_hook_argv(socket=SOCKET, harness_pane=harness_pane)
+    write_hook = subprocess.run(write_hook_cmd, env=env, capture_output=True, text=True, timeout=15)
+    if write_hook.returncode != 0:
+        _report_tmux_failure("installing the exit-status hook", write_hook_cmd, write_hook)
+        util.warn("charter frame: continuing without it — the exit code may not be "
+                  "recorded for this frame")
+
+    teardown_hook_cmd = _pane_died_teardown_hook_argv(socket=SOCKET, harness_pane=harness_pane)
+    teardown_hook = subprocess.run(teardown_hook_cmd, env=env, capture_output=True, text=True,
+                                   timeout=15)
+    if teardown_hook.returncode != 0:
+        _report_tmux_failure("installing the session-teardown hook", teardown_hook_cmd,
+                             teardown_hook)
+
+    # Closes the install race directly, rather than merely working around its symptom. A
+    # harness that died in the window between `new-session` starting it and the hooks
+    # above actually registering leaves them registered for an event that ALREADY
+    # happened — hooks do not fire retroactively, so neither fires at all, and nothing is
+    # left to run `kill-session`. Verified by hand against a real tmux 3.7c: `attach`
+    # below then blocks FOREVER on a session `remain-on-exit` is legitimately keeping
+    # alive, not merely returns 0 early — a worse failure than the one the module
     # docstring describes, because there is no return to read a code from at all. Asking
-    # directly, immediately, closes it: if the pane is already dead, the job the hook
+    # directly, immediately, closes it: if the pane is already dead, the job the hooks
     # would have done (record the code, end the session) is finished right here, and
     # `attach` is never even called against a session already known to be over.
     code = _query_pane_dead_status(SOCKET, harness_pane)
     if code is not None:
         state.record_exit(fid, code)
-        subprocess.run(["tmux", "-L", SOCKET, "kill-session", "-t", fid], env=env,
-                       capture_output=True, text=True, timeout=15)
+        kill_cmd = ["tmux", "-L", SOCKET, "kill-session", "-t", fid]
+        kill = subprocess.run(kill_cmd, env=env, capture_output=True, text=True, timeout=15)
+        if kill.returncode != 0:
+            _report_tmux_failure("ending the frame after an early death", kill_cmd, kill)
 
     attach = None
     attach_cmd = None
     if code is None:
-        for cmd in layout.panel_argvs(slots=slots, session=fid, socket=SOCKET,
-                                      charter_argv=[sys.executable, "-m", "charter"],
-                                      harness_pane=harness_pane):
-            p = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=15)
-            if p.returncode != 0:
-                # Reported, not fatal: one decorative panel failing to draw must not
-                # take down a harness pane that is already up and running (correction 2
-                # asks for every return code to be CHECKED, not every failure refused).
-                _report_tmux_failure("drawing a panel", cmd, p)
+        if teardown_hook.returncode != 0:
+            # Refuse to attach rather than risk it: without the teardown hook, a crash
+            # ANY time later in the harness's life would leave `attach` blocked forever
+            # with nothing to end the session — the same hang the eager check above
+            # exists to close, just moved later and made permanent for this frame. The
+            # harness keeps running (it was already started, detached); the operator can
+            # still attach manually and accept that risk themselves.
+            util.err("charter frame: refusing to attach — the session-teardown hook "
+                     "failed to install, so a crash later would block `attach` forever "
+                     "with nothing to end the session. The harness is still running, "
+                     f"detached; reattach manually if you must: "
+                     f"tmux -L {SOCKET} attach -t {fid}")
+        else:
+            for cmd in layout.panel_argvs(slots=slots, session=fid, socket=SOCKET,
+                                          charter_argv=[sys.executable, "-m", "charter"],
+                                          harness_pane=harness_pane):
+                p = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=15)
+                if p.returncode != 0:
+                    # Reported, not fatal: one decorative panel failing to draw must not
+                    # take down a harness pane that is already up and running (correction
+                    # 2 asks for every return code to be CHECKED, not every failure
+                    # refused).
+                    _report_tmux_failure("drawing a panel", cmd, p)
 
-        # No capture_output: this is the operator's own terminal for as long as the
-        # harness runs, not an admin command whose output charter should own.
-        attach_cmd = ["tmux", "-L", SOCKET, "attach", "-t", fid]
-        attach = subprocess.run(attach_cmd, env=env)
+            # `split-window` makes the newly created pane the ACTIVE one by default, so
+            # after every slot has been drawn, the LAST panel drawn — not the harness —
+            # has focus, and an interactive harness never receives a keystroke (measured:
+            # `%2 active=1, %0 active=0` after two splits). Pre-existing in
+            # `layout.panel_argvs`'s own split ordering, not something this diff
+            # introduced, but leaving the frame in a state the operator can actually type
+            # into is this launcher's job.
+            select_cmd = ["tmux", "-L", SOCKET, "select-pane", "-t", harness_pane]
+            select = subprocess.run(select_cmd, env=env, capture_output=True, text=True,
+                                    timeout=15)
+            if select.returncode != 0:
+                _report_tmux_failure("focusing the harness pane", select_cmd, select)
 
-        code = state.exit_code(fid)
-        if code is None:
-            # A second ask, for whatever gap the eager check above could not have seen
-            # yet (the harness was still alive at that point and died later — the
-            # ordinary case, caught here by the hook, or a rarer one where the hook
-            # itself never actually reached the server despite reporting success).
-            code = _query_pane_dead_status(SOCKET, harness_pane)
+            # No capture_output: this is the operator's own terminal for as long as the
+            # harness runs, not an admin command whose output charter should own.
+            attach_cmd = ["tmux", "-L", SOCKET, "attach", "-t", fid]
+            attach = subprocess.run(attach_cmd, env=env)
+
+            code = state.exit_code(fid)
+            if code is None:
+                # A second ask, for whatever gap the eager check above could not have
+                # seen yet (the harness was still alive at that point and died later —
+                # the ordinary case, caught here by the hooks, or a rarer one where they
+                # never actually reached the server despite reporting success).
+                code = _query_pane_dead_status(SOCKET, harness_pane)
 
     live_after = _live_sessions(SOCKET)
     state.reap(live_after)

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -2,31 +2,50 @@
 
 The launcher does NOT exec tmux, and that is measured rather than stylistic: an attached
 `tmux new-session` returns 0 whatever its command exited with (tmux 3.7c). So the status
-is carried out of band by a pane-scoped `pane-died` hook, and this process waits for tmux,
-reads the recorded code, and exits with it. `exec` survives only on the bypass path, where
-there is no frame in the way.
+is carried out of band — normally by a pane-scoped `pane-died` hook, with a direct query
+as a fallback for the race described below — and this process waits for tmux, reads the
+recorded (or queried) code, and exits with it. `exec` survives only on the bypass path,
+where there is no frame in the way.
 
 **Every frame shares one tmux server (`SOCKET`), told apart by session name (the frame
 id), not one server per frame.** That single choice is what makes the rest of this module
-non-obvious, and it is why `conf_text`'s output reaches tmux through `source-file` rather
-than through the `-f` flag `layout.session_argv` also carries. Measured against tmux
-3.7c: `-f` is read only at the moment a client's connection actually STARTS the server —
-a later `new-session -f` against a server that is already running (the ordinary case,
-once a first frame is up) is silently ignored. A frame launched second, third, or fifty-
-first would then never get its OWN `pane-died` hook installed, because the config that
-would have installed it was never read at all — and with no hook, `state.exit_code`
-never gets written, so this launcher would report exit 0 for a harness that actually
-crashed, which is the exact failure the module docstring above describes tmux itself
-committing. `source-file` re-reads the same text against whatever server already
-answers on the socket, so it is applied identically for the first frame and the
-fifty-first (verified by hand against tmux 3.7c: a hook installed this way for a SECOND
-session on an already-running server fires correctly, and its `kill-session` tears down
-only that session, leaving a sibling frame's session untouched).
+non-obvious, and it is why the session-scoped/hook-installing config reaches tmux through
+`source-file`/a direct `set-hook` command rather than through the `-f` flag
+`layout.session_argv` also carries. Measured against tmux 3.7c: `-f` is read only at the
+moment a client's connection actually STARTS the server — a later `new-session -f`
+against a server that is already running (the ordinary case, once a first frame is up) is
+silently ignored. A frame launched second, third, or fifty-first would then never get its
+own config applied at all if it relied on `-f` alone. `source-file` and a direct
+`set-hook` invocation both re-apply against whatever server already answers on the
+socket, so they work identically for the first frame and the fifty-first (verified by
+hand against tmux 3.7c: a hook installed this way for a SECOND session on an
+already-running server fires correctly, and its `kill-session` tears down only that
+session, leaving a sibling frame's session untouched).
+
+**A second, narrower race survives even that fix.** `new-session` starts the harness
+running immediately; the hook that would record its exit code is not installed until a
+separate `set-hook` call some milliseconds later (measured 8.2-10.5ms). A harness that
+dies inside that window is never caught by the hook — hooks do not fire retroactively for
+an event that already happened, so it never existed yet to catch anything — and this is
+worse than `state.exit_code` merely reading back `None`: with nothing left to run the
+hook's own `kill-session`, an `attach` against that session BLOCKS FOREVER (verified by
+hand against a real tmux 3.7c — `remain-on-exit`, armed for exactly this reason, is
+legitimately keeping the dead pane's session alive; the module never called anything to
+end it). `remain-on-exit on` in the placeholder `-f` config is still necessary — it is
+what keeps the pane around long enough to be askable at all — but is not sufficient on
+its own. What actually closes the race is asking tmux directly, `display-message -p -t
+<harness_pane> '#{pane_dead}:#{pane_dead_status}'`, IMMEDIATELY after the `set-hook` call
+returns and BEFORE ever calling `attach`: if the pane is already dead at that point, this
+launcher finishes the hook's job itself (records the code, runs `kill-session`) and skips
+`attach` entirely, rather than block on a session that will never end on its own. The
+same query runs again as a fallback after `attach` DOES return, for whatever gap the
+eager check could not have seen yet.
 """
 
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 import sys
 
@@ -46,6 +65,17 @@ SOCKET = "charter"
 #: might not fit the terminal that is actually there.
 _FALLBACK_SIZE = (80, 24)
 
+#: The placeholder loaded via `session_argv`'s `-f`, in effect ONLY if this call happens
+#: to start a brand-new tmux server on `SOCKET` (see the module docstring: `-f` is
+#: ignored otherwise). `remain-on-exit` alone, deliberately global (`-g`, not scoped to
+#: this one session): every frame wants the same value, so there is nothing to leak by
+#: sharing it, and this is what has to be in effect from the instant the harness's
+#: process starts — before this launcher has even read the pane id back off tmux's
+#: stdout, let alone had a chance to `source-file` the rest of the config — or a harness
+#: that dies in that opening window tears its own pane down before anything downstream
+#: (the hook, this launcher's fallback query) has a pane left to learn anything from.
+_PLACEHOLDER_CONF = "set -g remain-on-exit on\n"
+
 
 def bypass(argv: list[str]) -> int:
     """Run the harness with no frame at all — `exec`, so the exit code needs no help.
@@ -59,35 +89,72 @@ def bypass(argv: list[str]) -> int:
     return 127  # unreachable; execvp either replaces this process or raises
 
 
-def conf_text(*, hotkey: str, mouse: bool, history_limit: int,
-              status_path: str, harness_pane: str) -> str:
-    """The private tmux config for one frame. Never the operator's ~/.tmux.conf.
+def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> str:
+    """The private tmux config for one frame's own settings. Never `~/.tmux.conf`.
 
-    The `pane-died` hook is scoped to *harness_pane* — the id `cmd_launch` read off
-    tmux's own stdout after creating the session, never the literal `"%0"`. Unscoped
-    (or scoped to a guess) it either fires for any pane or never fires for the right one,
-    and a crashed side panel — or a frame whose harness landed on some other pane id —
-    would be reported to the operator as the agent's own exit code.
+    `status`, `mouse` and `history-limit` are SESSION-scoped (`set -t <session>`, no
+    `-g`) — not global. `source-file` applies whatever this returns to the one shared
+    server every frame runs on, so a `-g` write here would rewrite every OTHER frame's
+    settings too: the second frame launched turns the first frame's mouse/scrollback
+    into its own, "last launched wins" for both, silently, even across planes with
+    different `[frame]` config (verified by hand against tmux 3.7c — a session-scoped
+    `set -t` sibling session does NOT pick up a value set this way for another session).
+    `escape-time` stays `-g`: verified against tmux 3.7c that it is a genuine SERVER
+    option (`show-options -s`, not `-g`), so there is no per-session form to move it to.
+    The `WheelUpPane` bind is likewise left global — key tables are server-wide in tmux,
+    there being no such thing as a per-session keymap, and every frame wants the
+    identical binding anyway, so nothing is lost by sharing it the same way
+    `remain-on-exit` is (see `_PLACEHOLDER_CONF`).
+
+    The `pane-died` hook does NOT live here — see `_pane_died_hook_argv` for why it is
+    issued as its own tmux command instead of text baked into this string.
 
     `hotkey` is accepted and never bound to anything here on purpose: binding the key AND
     populating the menu it opens both belong to the task that makes the menu reachable,
     and half of that wiring (a key bound to nothing) would be worse than none of it.
     """
     return "\n".join([
-        "set -g status off",
-        f"set -g mouse {'on' if mouse else 'off'}",
-        f"set -g history-limit {int(history_limit)}",
+        f"set -t {session} status off",
+        f"set -t {session} mouse {'on' if mouse else 'off'}",
+        f"set -t {session} history-limit {int(history_limit)}",
         "set -g escape-time 0",
-        # Without this, the pane (and often the whole session) is torn down the instant
-        # the harness exits — before the hook below has a pane left to read
-        # `#{pane_dead_status}` from, and the exit code is lost with it.
         "set -g remain-on-exit on",
         "bind -n WheelUpPane if-shell -F -t = '#{mouse_any_flag}'"
         " 'send-keys -M' 'copy-mode -e; send-keys -M'",
-        f"set-hook -p -t {harness_pane} pane-died "
-        f"'run-shell \"echo #{{pane_dead_status}} > {status_path}\" ; kill-session'",
         "",
     ])
+
+
+def _pane_died_hook_argv(*, socket: str, harness_pane: str, status_path: str) -> list[str]:
+    """The `set-hook` command that records the harness's real exit code.
+
+    Scoped to *harness_pane* — the id `cmd_launch` read off tmux's own stdout after
+    creating the session, never a guess. Unscoped, `pane-died` fires for ANY pane, and a
+    crashed side panel would be reported to the operator as the agent's own exit code.
+
+    Issued as its OWN tmux command — never embedded as text inside `conf_text`'s output
+    the way an earlier version of this module did — because the hook's action is itself
+    a shell command string that needs its own quoting, and nesting THAT inside a second,
+    text-file level of tmux quoting (`source-file`'s config syntax) breaks even
+    `shlex.quote`'s own escaping for a path containing a literal single quote: verified
+    against tmux 3.7c that the two nested quote layers corrupt each other's boundaries
+    (the outer layer's quote character terminates early on a quote character that only
+    means something to the inner one). Passed as one clean argv element instead —
+    matching every other command `frame/layout.py` builds, and the reason its own module
+    docstring gives for never joining argv (`gh -F`, #328) — `shlex.quote` then needs no
+    help and was verified, by hand against the same tmux 3.7c, to round-trip a path
+    containing a space, a literal single quote, and a `$(...)` injection attempt
+    correctly: the exact byte string reaches the file, and nothing embedded in it runs.
+
+    *status_path* reaches here from `STATE_DIR` (the plane root, or `$CHARTER_HOME`) —
+    never operator argv — but it is still handed to `/bin/sh -c` inside `run-shell`, the
+    one place this module hands tmux a STRING rather than an argv list, so it is quoted
+    like any other value that reaches a shell: a plane root with a space in it must not
+    silently write to the wrong file, and one shaped like `$(...)` must not run.
+    """
+    action = (f'run-shell "echo #{{pane_dead_status}} > {shlex.quote(status_path)}" '
+             f'; kill-session')
+    return ["tmux", "-L", socket, "set-hook", "-p", "-t", harness_pane, "pane-died", action]
 
 
 def _live_sessions(socket: str) -> set[str]:
@@ -117,6 +184,36 @@ def _report_tmux_failure(action: str, cmd: list[str], proc: subprocess.Completed
     """
     stderr = (proc.stderr or "").strip() or "(tmux printed nothing to stderr)"
     util.err(f"charter frame: {action} failed — `{' '.join(cmd)}`: {stderr}")
+
+
+def _query_pane_dead_status(socket: str, harness_pane: str) -> int | None:
+    """Ask tmux directly whether *harness_pane* died, and with what status.
+
+    Called twice by `cmd_launch`, for two different gaps a hook alone cannot cover: once
+    EAGERLY, right after `set-hook` returns, to close the install race the module
+    docstring measures (a harness that died before the hook existed is never caught by
+    it, because a hook only fires for a death AFTER it exists); and again as a fallback
+    after `attach` returns, for whatever the eager check could not have seen yet.
+    `remain-on-exit` (armed from the very first moment via `_PLACEHOLDER_CONF`) is what
+    keeps the pane around long enough to still be askable either time — without it, this
+    query would simply find no such pane, exactly like the hook found no such event.
+
+    ``None`` for "cannot tell" (the pane is alive, or the query itself failed) — never a
+    fabricated 0, which is the exact silent-success failure this whole module exists to
+    rule out.
+    """
+    dm = subprocess.run(["tmux", "-L", socket, "display-message", "-p", "-t", harness_pane,
+                         "#{pane_dead}:#{pane_dead_status}"],
+                        capture_output=True, text=True, timeout=5)
+    if dm.returncode != 0:
+        return None
+    dead, _, status = dm.stdout.strip().partition(":")
+    if dead != "1":
+        return None
+    status = status.strip()
+    if status.lstrip("-").isdigit():
+        return int(status)
+    return None
 
 
 def cmd_launch(args) -> int:
@@ -150,6 +247,16 @@ def cmd_launch(args) -> int:
 
     ws = workspace.resolve()
     fid = state.frame_id(ws, os.getpid())
+
+    # Reap BEFORE this frame's own directory exists, not after: `frame_dir(create=True)`
+    # below makes that directory, and a `reap()` run afterward — but still before
+    # `session_argv` starts this frame's OWN tmux session — would see a directory with
+    # no live session yet and delete it out from under this very launch. Reaping first
+    # also narrows (though does not close) the same race for a sibling frame's `exit`
+    # file: less time between "session gone" and "directory removed" for a sibling's own
+    # launcher to lose the read.
+    state.reap(_live_sessions(SOCKET))
+
     fdir = state.frame_dir(fid, create=True)
     if fdir is None:
         # `frame_dir` refuses rather than raises (see charter/frame/state.py) — an id
@@ -157,8 +264,6 @@ def cmd_launch(args) -> int:
         # ENAMETOOLONG) must not be treated as a Path here just because it usually is one.
         util.err(f"charter frame: could not create state for frame {fid!r}")
         return 1
-
-    state.reap(_live_sessions(SOCKET))
     state.bump(fid)
 
     try:
@@ -178,12 +283,7 @@ def cmd_launch(args) -> int:
 
     conf_path = fdir / "tmux.conf"
     status_path = fdir / "exit"
-    # A placeholder. `session_argv`'s `-f` reads it ONLY if this call is what starts a
-    # brand-new tmux server on SOCKET — content here is never load-bearing (tmux
-    # tolerates the path not existing at all), because the config that actually matters
-    # is `source-file`d in below, once the harness pane id is known. See the module
-    # docstring for the measured reason a *second* frame cannot rely on `-f` at all.
-    conf_path.write_text("")
+    conf_path.write_text(_PLACEHOLDER_CONF)
 
     session_cmd = layout.session_argv(session=fid, conf=str(conf_path), socket=SOCKET,
                                       cols=cols, rows=rows, harness_argv=argv)
@@ -198,38 +298,81 @@ def cmd_launch(args) -> int:
         return 1
 
     conf_path.write_text(conf_text(hotkey=frame["hotkey"], mouse=frame["mouse"],
-                                   history_limit=frame["history_limit"],
-                                   status_path=str(status_path), harness_pane=harness_pane))
+                                   history_limit=frame["history_limit"], session=fid))
     src_cmd = ["tmux", "-L", SOCKET, "source-file", str(conf_path)]
     src = subprocess.run(src_cmd, env=env, capture_output=True, text=True, timeout=15)
     if src.returncode != 0:
         _report_tmux_failure("loading the frame's config", src_cmd, src)
         util.warn("charter frame: continuing without it — mouse/history-limit/hotkey "
-                  "settings and the exit-code hook may not be in effect for this frame")
+                  "settings may not be in effect for this frame")
 
-    for cmd in layout.panel_argvs(slots=slots, session=fid, socket=SOCKET,
-                                  charter_argv=[sys.executable, "-m", "charter"],
-                                  harness_pane=harness_pane):
-        p = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=15)
-        if p.returncode != 0:
-            # Reported, not fatal: one decorative panel failing to draw must not take
-            # down a harness pane that is already up and running (correction 2 asks for
-            # every return code to be CHECKED, not for every failure to be a refusal).
-            _report_tmux_failure("drawing a panel", cmd, p)
+    hook_cmd = _pane_died_hook_argv(socket=SOCKET, harness_pane=harness_pane,
+                                    status_path=str(status_path))
+    hook = subprocess.run(hook_cmd, env=env, capture_output=True, text=True, timeout=15)
+    if hook.returncode != 0:
+        _report_tmux_failure("installing the exit-code hook", hook_cmd, hook)
+        util.warn("charter frame: continuing without it — the exit code may not be "
+                  "recorded for this frame")
 
-    # No capture_output: this is the operator's own terminal for as long as the harness
-    # runs, not an admin command whose output charter should own.
-    attach_cmd = ["tmux", "-L", SOCKET, "attach", "-t", fid]
-    attach = subprocess.run(attach_cmd, env=env)
+    # Closes the install race, rather than merely working around its symptom. A harness
+    # that died in the window between `new-session` starting it and the `set-hook` call
+    # above actually registering leaves the hook registered for an event that ALREADY
+    # happened — hooks do not fire retroactively, so it never fires at all, and nothing
+    # is left to run the hook's own `kill-session`. Verified by hand against a real tmux
+    # 3.7c: `attach` below then blocks FOREVER on a session `remain-on-exit` is legitimately
+    # keeping alive, not merely returns 0 early — a worse failure than the one the module
+    # docstring describes, because there is no return to read a code from at all. Asking
+    # directly, immediately, closes it: if the pane is already dead, the job the hook
+    # would have done (record the code, end the session) is finished right here, and
+    # `attach` is never even called against a session already known to be over.
+    code = _query_pane_dead_status(SOCKET, harness_pane)
+    if code is not None:
+        state.record_exit(fid, code)
+        subprocess.run(["tmux", "-L", SOCKET, "kill-session", "-t", fid], env=env,
+                       capture_output=True, text=True, timeout=15)
 
-    code = state.exit_code(fid)
-    state.reap(_live_sessions(SOCKET))
+    attach = None
+    attach_cmd = None
+    if code is None:
+        for cmd in layout.panel_argvs(slots=slots, session=fid, socket=SOCKET,
+                                      charter_argv=[sys.executable, "-m", "charter"],
+                                      harness_pane=harness_pane):
+            p = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=15)
+            if p.returncode != 0:
+                # Reported, not fatal: one decorative panel failing to draw must not
+                # take down a harness pane that is already up and running (correction 2
+                # asks for every return code to be CHECKED, not every failure refused).
+                _report_tmux_failure("drawing a panel", cmd, p)
+
+        # No capture_output: this is the operator's own terminal for as long as the
+        # harness runs, not an admin command whose output charter should own.
+        attach_cmd = ["tmux", "-L", SOCKET, "attach", "-t", fid]
+        attach = subprocess.run(attach_cmd, env=env)
+
+        code = state.exit_code(fid)
+        if code is None:
+            # A second ask, for whatever gap the eager check above could not have seen
+            # yet (the harness was still alive at that point and died later — the
+            # ordinary case, caught here by the hook, or a rarer one where the hook
+            # itself never actually reached the server despite reporting success).
+            code = _query_pane_dead_status(SOCKET, harness_pane)
+
+    live_after = _live_sessions(SOCKET)
+    state.reap(live_after)
     if code is not None:
         return code
-    if attach.returncode != 0:
-        # The hook never recorded anything AND tmux itself reported trouble attaching —
-        # surfaced rather than folded into a bare 0, which is precisely the failure this
-        # whole module exists to stop happening silently.
+    if fid in live_after:
+        # Detach, not completion — the session tmux still lists is this frame's own.
+        # Silence here is exactly what the spec calls out: "an agent surviving a closed
+        # lid is a feature, and returning silently to a shell with it still running is
+        # not."
+        util.info(f"charter frame: detached — the harness is still running.\n"
+                 f"  reattach with: tmux -L {SOCKET} attach -t {fid}")
+        return 0
+    if attach is not None and attach.returncode != 0:
+        # Nothing was recorded, tmux is not still tracking this session, AND `attach`
+        # itself reported trouble — surfaced rather than folded into a bare 0, which is
+        # precisely the failure this whole module exists to stop happening silently.
         _report_tmux_failure("attaching to the frame", attach_cmd, attach)
         return attach.returncode
     return 0

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1,0 +1,235 @@
+"""`charter <harness>` — run the harness inside charter's frame.
+
+The launcher does NOT exec tmux, and that is measured rather than stylistic: an attached
+`tmux new-session` returns 0 whatever its command exited with (tmux 3.7c). So the status
+is carried out of band by a pane-scoped `pane-died` hook, and this process waits for tmux,
+reads the recorded code, and exits with it. `exec` survives only on the bypass path, where
+there is no frame in the way.
+
+**Every frame shares one tmux server (`SOCKET`), told apart by session name (the frame
+id), not one server per frame.** That single choice is what makes the rest of this module
+non-obvious, and it is why `conf_text`'s output reaches tmux through `source-file` rather
+than through the `-f` flag `layout.session_argv` also carries. Measured against tmux
+3.7c: `-f` is read only at the moment a client's connection actually STARTS the server —
+a later `new-session -f` against a server that is already running (the ordinary case,
+once a first frame is up) is silently ignored. A frame launched second, third, or fifty-
+first would then never get its OWN `pane-died` hook installed, because the config that
+would have installed it was never read at all — and with no hook, `state.exit_code`
+never gets written, so this launcher would report exit 0 for a harness that actually
+crashed, which is the exact failure the module docstring above describes tmux itself
+committing. `source-file` re-reads the same text against whatever server already
+answers on the socket, so it is applied identically for the first frame and the
+fifty-first (verified by hand against tmux 3.7c: a hook installed this way for a SECOND
+session on an already-running server fires correctly, and its `kill-session` tears down
+only that session, leaving a sibling frame's session untouched).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+from . import config, harness, util, workspace
+from .frame import layout, state, tmuxctl
+
+#: One shared tmux server for every frame this machine runs, sessions (not servers) told
+#: apart by name — the frame id. Never the operator's own default socket: a frame's
+#: config (`conf_text`) is charter's, not something to lay over `~/.tmux.conf`.
+SOCKET = "charter"
+
+#: Terminal size assumed when `os.get_terminal_size()` cannot report one even though
+#: `sys.stdout.isatty()` said yes (seen from a harness invoked under a test/CI wrapper
+#: that fakes a tty for capture but backs it with nothing `TIOCGWINSZ` can answer). The
+#: same floor `shutil.get_terminal_size()` itself falls back to — small enough that
+#: `layout.visible_slots` degrades the frame to a bare harness instead of a guess that
+#: might not fit the terminal that is actually there.
+_FALLBACK_SIZE = (80, 24)
+
+
+def bypass(argv: list[str]) -> int:
+    """Run the harness with no frame at all — `exec`, so the exit code needs no help.
+
+    Correct ONLY here. `cmd_launch`'s frame path never execs tmux, because an attached
+    `tmux new-session` returns 0 regardless of what ran inside it (see the module
+    docstring) — but there is no tmux in the way on this path, so the exit code an exec'd
+    process carries out is already the real one.
+    """
+    os.execvp(argv[0], argv)
+    return 127  # unreachable; execvp either replaces this process or raises
+
+
+def conf_text(*, hotkey: str, mouse: bool, history_limit: int,
+              status_path: str, harness_pane: str) -> str:
+    """The private tmux config for one frame. Never the operator's ~/.tmux.conf.
+
+    The `pane-died` hook is scoped to *harness_pane* — the id `cmd_launch` read off
+    tmux's own stdout after creating the session, never the literal `"%0"`. Unscoped
+    (or scoped to a guess) it either fires for any pane or never fires for the right one,
+    and a crashed side panel — or a frame whose harness landed on some other pane id —
+    would be reported to the operator as the agent's own exit code.
+
+    `hotkey` is accepted and never bound to anything here on purpose: binding the key AND
+    populating the menu it opens both belong to the task that makes the menu reachable,
+    and half of that wiring (a key bound to nothing) would be worse than none of it.
+    """
+    return "\n".join([
+        "set -g status off",
+        f"set -g mouse {'on' if mouse else 'off'}",
+        f"set -g history-limit {int(history_limit)}",
+        "set -g escape-time 0",
+        # Without this, the pane (and often the whole session) is torn down the instant
+        # the harness exits — before the hook below has a pane left to read
+        # `#{pane_dead_status}` from, and the exit code is lost with it.
+        "set -g remain-on-exit on",
+        "bind -n WheelUpPane if-shell -F -t = '#{mouse_any_flag}'"
+        " 'send-keys -M' 'copy-mode -e; send-keys -M'",
+        f"set-hook -p -t {harness_pane} pane-died "
+        f"'run-shell \"echo #{{pane_dead_status}} > {status_path}\" ; kill-session'",
+        "",
+    ])
+
+
+def _live_sessions(socket: str) -> set[str]:
+    """Every session name `tmux -L socket list-sessions` currently reports.
+
+    Empty rather than raised when nothing has ever run on *socket* — `list-sessions`
+    exits non-zero with nothing on stdout in that case, which the plain `splitlines()`
+    below already turns into an empty set with no special-casing needed. The `except`
+    guards the rarer case: tmux vanishing between `tmuxctl.available()`'s own check and
+    this call, not the ordinary "no server yet" one.
+    """
+    try:
+        out = subprocess.run(["tmux", "-L", socket, "list-sessions", "-F", "#{session_name}"],
+                             capture_output=True, text=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    return {line.strip() for line in out.stdout.splitlines() if line.strip()}
+
+
+def _report_tmux_failure(action: str, cmd: list[str], proc: subprocess.CompletedProcess) -> None:
+    """Name the command that failed and tmux's own stderr. Never silent.
+
+    This is what correction 2 exists to force: `subprocess.run(cmd, env=env)` with the
+    result thrown away is exactly how the pane-index bug `frame/layout.py`'s own module
+    docstring describes would have shipped — a frame missing a panel, and nothing
+    anywhere saying why.
+    """
+    stderr = (proc.stderr or "").strip() or "(tmux printed nothing to stderr)"
+    util.err(f"charter frame: {action} failed — `{' '.join(cmd)}`: {stderr}")
+
+
+def cmd_launch(args) -> int:
+    """One launcher, shared by every registered harness and by `charter frame --`."""
+    h = next((x for x in harness.all() if x.cli_name == args.harness), None)
+    rest = list(args.rest or [])
+    # `nargs=argparse.REMAINDER` keeps a literal leading `--` when the operator typed
+    # one (`charter frame -- claude -p hi` → `rest == ["--", "claude", "-p", "hi"]`); it
+    # is the separator that told argparse to stop parsing, not part of the command.
+    if rest and rest[0] == "--":
+        rest = rest[1:]
+    argv = h.launch_argv(rest) if h else rest
+    if not argv:
+        util.err("charter frame: nothing to run — `charter frame -- <command>`")
+        return 2
+
+    if args.no_frame or not sys.stdout.isatty():
+        return bypass(argv)
+
+    # ONE call (correction 5): `available()`, `version()` and `meets_floor()` each shell
+    # out to `tmux -V` independently, so calling all three in sequence would spawn three
+    # subprocesses to ask the same unchanging question on every single launch.
+    v = tmuxctl.version()
+    if v is None:
+        util.err(tmuxctl.absent_message())
+        return 1
+    if v < tmuxctl.FLOOR:
+        # Below the floor: degrade (the hotkey menu, not yet wired to anything by this
+        # task, would be unusable anyway), never refuse — the frame itself still works.
+        util.warn(tmuxctl.below_floor_message(v))
+
+    ws = workspace.resolve()
+    fid = state.frame_id(ws, os.getpid())
+    fdir = state.frame_dir(fid, create=True)
+    if fdir is None:
+        # `frame_dir` refuses rather than raises (see charter/frame/state.py) — an id
+        # `contain.child` cannot shape into a directory (or a name so long `mkdir` hits
+        # ENAMETOOLONG) must not be treated as a Path here just because it usually is one.
+        util.err(f"charter frame: could not create state for frame {fid!r}")
+        return 1
+
+    state.reap(_live_sessions(SOCKET))
+    state.bump(fid)
+
+    try:
+        cols, rows = os.get_terminal_size()
+    except OSError:
+        # `os.get_terminal_size()` raises even when `isatty()` said yes — a tty with
+        # nothing behind it to answer `TIOCGWINSZ`. Falling back rather than propagating
+        # is the deliberate choice; see `_FALLBACK_SIZE`'s own docstring for why 80x24.
+        cols, rows = _FALLBACK_SIZE
+
+    frame = config.FRAME
+    slots = layout.visible_slots(frame["slots"], cols, rows, frame["min_cols"], frame["min_rows"])
+
+    env = dict(os.environ, CHARTER_SESSION_ID=fid)
+    if h:
+        env["CHARTER_HARNESS"] = h.name
+
+    conf_path = fdir / "tmux.conf"
+    status_path = fdir / "exit"
+    # A placeholder. `session_argv`'s `-f` reads it ONLY if this call is what starts a
+    # brand-new tmux server on SOCKET — content here is never load-bearing (tmux
+    # tolerates the path not existing at all), because the config that actually matters
+    # is `source-file`d in below, once the harness pane id is known. See the module
+    # docstring for the measured reason a *second* frame cannot rely on `-f` at all.
+    conf_path.write_text("")
+
+    session_cmd = layout.session_argv(session=fid, conf=str(conf_path), socket=SOCKET,
+                                      cols=cols, rows=rows, harness_argv=argv)
+    proc = subprocess.run(session_cmd, env=env, capture_output=True, text=True, timeout=15)
+    if proc.returncode != 0:
+        _report_tmux_failure("starting the frame", session_cmd, proc)
+        return 1
+    harness_pane = proc.stdout.strip()
+    if not harness_pane:
+        util.err("charter frame: tmux started the session but did not report a pane id "
+                 "— cannot scope the exit-code hook to it")
+        return 1
+
+    conf_path.write_text(conf_text(hotkey=frame["hotkey"], mouse=frame["mouse"],
+                                   history_limit=frame["history_limit"],
+                                   status_path=str(status_path), harness_pane=harness_pane))
+    src_cmd = ["tmux", "-L", SOCKET, "source-file", str(conf_path)]
+    src = subprocess.run(src_cmd, env=env, capture_output=True, text=True, timeout=15)
+    if src.returncode != 0:
+        _report_tmux_failure("loading the frame's config", src_cmd, src)
+        util.warn("charter frame: continuing without it — mouse/history-limit/hotkey "
+                  "settings and the exit-code hook may not be in effect for this frame")
+
+    for cmd in layout.panel_argvs(slots=slots, session=fid, socket=SOCKET,
+                                  charter_argv=[sys.executable, "-m", "charter"],
+                                  harness_pane=harness_pane):
+        p = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=15)
+        if p.returncode != 0:
+            # Reported, not fatal: one decorative panel failing to draw must not take
+            # down a harness pane that is already up and running (correction 2 asks for
+            # every return code to be CHECKED, not for every failure to be a refusal).
+            _report_tmux_failure("drawing a panel", cmd, p)
+
+    # No capture_output: this is the operator's own terminal for as long as the harness
+    # runs, not an admin command whose output charter should own.
+    attach_cmd = ["tmux", "-L", SOCKET, "attach", "-t", fid]
+    attach = subprocess.run(attach_cmd, env=env)
+
+    code = state.exit_code(fid)
+    state.reap(_live_sessions(SOCKET))
+    if code is not None:
+        return code
+    if attach.returncode != 0:
+        # The hook never recorded anything AND tmux itself reported trouble attaching —
+        # surfaced rather than folded into a bare 0, which is precisely the failure this
+        # whole module exists to stop happening silently.
+        _report_tmux_failure("attaching to the frame", attach_cmd, attach)
+        return attach.returncode
+    return 0

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -390,6 +390,25 @@ def _live_sessions(socket: str) -> set[str]:
     return {line.strip() for line in out.stdout.splitlines() if line.strip()}
 
 
+def _menu_clients(socket: str, session: str) -> list[str]:
+    """Every client `tmux -L socket list-clients -t session` reports for *session*, now.
+
+    `cmd_menu`'s own query for `-c`'s answer (see `menu.menu_argv`'s docstring for why
+    `-t` alone cannot choose the client) — same shape as `_live_sessions` above, and for
+    the same reason: `list-clients` exits non-zero with nothing on stdout for the
+    ordinary "nothing attached right now" case, which `splitlines()` already turns into
+    an empty list with no special-casing needed. The `except` guards tmux vanishing
+    between calls, not that ordinary case.
+    """
+    try:
+        out = subprocess.run(["tmux", "-L", socket, "list-clients", "-t", session,
+                              "-F", "#{client_name}"],
+                             capture_output=True, text=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return []
+    return [line.strip() for line in out.stdout.splitlines() if line.strip()]
+
+
 def _report_tmux_failure(action: str, cmd: list[str], proc: subprocess.CompletedProcess) -> None:
     """Name the command that failed and tmux's own stderr. Never silent.
 
@@ -785,9 +804,25 @@ def cmd_menu(args) -> int:
     (see `conf_text`'s docstring for why that split is load-bearing, not incidental):
     the SAME bind text is shared by every frame on `SOCKET`, so the frame it opens a menu
     FOR has to be resolved here, at the moment the key actually fires, never earlier.
+
+    Resolves the CLIENT to draw the menu on before ever calling `display-menu` — `-t`
+    alone does not choose it (verified by hand against tmux 3.7c with two frames attached
+    in two terminals: `-t fid` rendered the WRONG frame's menu on the wrong screen; see
+    `menu.menu_argv`'s own docstring). `_menu_clients` asks `list-clients` directly,
+    scoped to this session, rather than ever falling back to tmux's own "most recently
+    active" default. Zero clients (nothing attached right now — a keypress landing mid
+    detach, say) is a quiet no-op: `display-menu` would just fail with tmux's own "no
+    current client", and there is no screen left to report that failure on anyway.
+    Several clients (the same session open in two terminals at once) picks the FIRST one
+    reported — any client actually watching THIS session is correct by construction,
+    `display-menu -c` only ever accepts one, and there is no way to show a menu on two
+    screens at the same time.
     """
     fid = os.environ.get("CHARTER_SESSION_ID", "")
-    return subprocess.run(menu.menu_argv(fid, SOCKET)).returncode
+    clients = _menu_clients(SOCKET, fid)
+    if not clients:
+        return 0
+    return subprocess.run(menu.menu_argv(fid, SOCKET, client=clients[0])).returncode
 
 
 def cmd_action(args) -> int:

--- a/charter/config.py
+++ b/charter/config.py
@@ -252,6 +252,10 @@ def derive(root: Path, start: Path | None = None) -> dict:
     #: How far a written memory travels — see charter.instance.SHARE_MODES.
     d["MEMORY_SHARE"] = _instance.share_of(cfg)
 
+    #: How `charter <harness>` composes its frame. Defaults live in
+    #: `instance.FRAME_DEFAULTS`; an absent or malformed section yields them whole.
+    d["FRAME"] = _instance.frame_of(cfg)
+
     #: Root for worktrees, or ``None`` for the per-workspace ``.worktrees/`` default.
     d["WORKTREES_ROOT"] = worktrees_root_for(root, cfg)
 

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -715,8 +715,17 @@ def check_frame() -> Result:
     core work; discover, clone, and run any harness with `--no-frame`. Only `charter
     <harness>` without that flag is affected, and both remedies are named here rather
     than left to be discovered in `docs/frame.md`.
+
+    This row and `charter frame-probe` are also the ONLY places the frame's standing
+    capability ceilings are reported at all. They used to be `util.warn` calls inside
+    `cmd_launch`, printed microseconds before tmux switched the operator's terminal to
+    the alternate screen, where nobody could read them — see
+    `commands_frame.frame_ready`'s own docstring for the measurement and the argument.
+    Both facts are answerable without starting anything: `tmuxctl.version()` and
+    `config.FRAME["slots"]`.
     """
-    from .frame import tmuxctl
+    from . import config
+    from .frame import slots as frame_slots, tmuxctl
 
     name = "frame"
     v = tmuxctl.version()
@@ -725,12 +734,33 @@ def check_frame() -> Result:
                       hint="charter <harness> needs tmux to compose a frame — brew "
                            "install tmux (or your package manager). Without it, "
                            "charter <harness> --no-frame still runs the harness bare.")
+    missing = frame_slots.unimplemented(config.FRAME["slots"])
     if v < tmuxctl.FLOOR:
+        # Not "the hotkey menu is disabled" — nothing disables it. `cmd_launch` warns
+        # and continues, and `conf_text` emits the bind unchanged; what is actually at
+        # risk below the floor is that the bind opens nothing and that the pane-scoped
+        # exit-code hooks may not install. `below_floor_message` is the one place that
+        # sentence lives, so this row and `--probe` cannot drift apart.
+        hint = tmuxctl.below_floor_message(v)
+        if missing:
+            hint += " " + commands_frame_no_renderer(missing)
+        return Result(name, WARN, detail=f"tmux {v[0]}.{v[1]}", hint=hint)
+    if missing:
         return Result(name, WARN, detail=f"tmux {v[0]}.{v[1]}",
-                      hint=f"below the frame's floor (tmux {tmuxctl.FLOOR[0]}."
-                           f"{tmuxctl.FLOOR[1]}+) — a frame still starts, with its "
-                           f"hotkey menu disabled.")
+                      hint=commands_frame_no_renderer(missing))
     return Result(name, OK, detail=f"tmux {v[0]}.{v[1]}")
+
+
+def commands_frame_no_renderer(missing: list[str]) -> str:
+    """`commands_frame.no_renderer_message`, imported lazily.
+
+    A module-level `from .commands_frame import no_renderer_message` would make every
+    `charter doctor` import the whole launcher (and, through it, `harness`, `workspace`
+    and `frame.menu`) to print one row; the import lives inside a function for the same
+    reason `check_frame`'s own `tmuxctl` import does.
+    """
+    from .commands_frame import no_renderer_message
+    return no_renderer_message(missing)
 
 
 def _read_text(p) -> str:

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -699,6 +699,40 @@ def check_harness() -> Result:
     return Result(name, OK, detail=f"{current} — {len(gaps)} capability ceiling{plural}\n{listed}")
 
 
+def check_frame() -> Result:
+    """Can `charter <harness>` compose a frame here? (ADR 0018)
+
+    Its own check, sitting beside `check_harness` rather than inside its deficit list:
+    tmux is a prerequisite of the FRAME, not a ceiling of any harness, and filing it
+    under `check_harness` would tell the reader their harness is limited when it is not
+    — `tests/test_doctor_absent_is_not_health.py` already draws exactly that line for a
+    check that renders green over something it never actually looked at, and the
+    opposite error (naming a harness limit that is not real) is the one `check_harness`'s
+    own docstring guards against.
+
+    WARN, never FAIL: `cmd_doctor` exits non-zero only on FAIL, and a machine with no
+    tmux — or one too old to meet `tmuxctl.FLOOR` — can still do every bit of charter's
+    core work; discover, clone, and run any harness with `--no-frame`. Only `charter
+    <harness>` without that flag is affected, and both remedies are named here rather
+    than left to be discovered in `docs/frame.md`.
+    """
+    from .frame import tmuxctl
+
+    name = "frame"
+    v = tmuxctl.version()
+    if v is None:
+        return Result(name, WARN, detail="tmux not found",
+                      hint="charter <harness> needs tmux to compose a frame — brew "
+                           "install tmux (or your package manager). Without it, "
+                           "charter <harness> --no-frame still runs the harness bare.")
+    if v < tmuxctl.FLOOR:
+        return Result(name, WARN, detail=f"tmux {v[0]}.{v[1]}",
+                      hint=f"below the frame's floor (tmux {tmuxctl.FLOOR[0]}."
+                           f"{tmuxctl.FLOOR[1]}+) — a frame still starts, with its "
+                           f"hotkey menu disabled.")
+    return Result(name, OK, detail=f"tmux {v[0]}.{v[1]}")
+
+
 def _read_text(p) -> str:
     """A settings file's text, or ``""`` when it cannot be read. A file charter is not
     allowed to open is not evidence of anything, and a preflight row must render whatever
@@ -1980,7 +2014,7 @@ def _checks():
         results.append(check_forge_cli(forge))
         results.append(check_forge_auth(forge))
     results += [check_ssh(), check_control_plane_config(), check_control_plane_schema(),
-                check_plane_root(), check_harness(), check_guard_wired(), check_guard_seen(), check_nested_plane(),
+                check_plane_root(), check_harness(), check_frame(), check_guard_wired(), check_guard_seen(), check_nested_plane(),
                 check_workspace_clones(),
                 check_inventory(), check_vaults(),
                 check_vault_registry_divergence(), check_version_lock(),

--- a/charter/frame/__init__.py
+++ b/charter/frame/__init__.py
@@ -1,0 +1,12 @@
+"""charter's own frame: the harness runs inside it, charter draws around it.
+
+tmux composes the rectangles and owns every part of terminal emulation — alt-screen,
+resize, scrollback, the lot. Charter fills the edges with its own processes and never
+parses or draws the harness's pane. ADR 0018.
+"""
+
+from __future__ import annotations
+
+from . import layout
+
+__all__ = ["layout"]

--- a/charter/frame/__init__.py
+++ b/charter/frame/__init__.py
@@ -8,5 +8,6 @@ parses or draws the harness's pane. ADR 0018.
 from __future__ import annotations
 
 from . import layout
+from . import tmuxctl
 
-__all__ = ["layout"]
+__all__ = ["layout", "tmuxctl"]

--- a/charter/frame/__init__.py
+++ b/charter/frame/__init__.py
@@ -8,6 +8,7 @@ parses or draws the harness's pane. ADR 0018.
 from __future__ import annotations
 
 from . import layout
+from . import state
 from . import tmuxctl
 
-__all__ = ["layout", "tmuxctl"]
+__all__ = ["layout", "state", "tmuxctl"]

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -88,6 +88,18 @@ def panel_argvs(*, slots: list[str], session: str, socket: str,
     split below targets that same id — never a `session:0.0`-style index, and never a
     target derived from an earlier split in this same list. Both are the mistake the
     module docstring measures: indices move under every split tmux runs, pane ids don't.
+
+    Also asks tmux to PRINT the new pane's id (`-P -F '#{pane_id}'`, the same flags
+    `session_argv` uses for the harness pane, placed the same way — before `--`, so they
+    are `split-window`'s own options and never touch the `charter panel …` argv after
+    it). A caller that keeps the id for each fixed-size slot can re-assert its size on a
+    `window-resized` hook (see `commands_frame._resize_hook_argv`): tmux's own layout
+    engine redistributes EVERY pane proportionally on a resize, `-l size` notwithstanding
+    — measured against tmux 3.7c, growing a 120x30 frame to 200x50 stretched two
+    one-row panels to 8 and 7 rows, snapping back only because the resize happened to be
+    an exact round trip. Without the id, nothing later could target the RIGHT pane to
+    correct that (an index would renumber under the very next split, same failure the
+    module docstring already measures for the harness pane).
     """
     cmds: list[list[str]] = []
     for slot in slots:
@@ -95,6 +107,7 @@ def panel_argvs(*, slots: list[str], session: str, socket: str,
         direction = "-v" if slot in ("top", "bottom") else "-h"
         before = ["-b"] if slot in ("top", "left") else []
         cmds.append(_tmux(socket, "split-window", "-t", harness_pane,
-                          direction, *before, "-l", str(size), "--",
+                          direction, *before, "-l", str(size),
+                          "-P", "-F", "#{pane_id}", "--",
                           *charter_argv, "panel", slot, "--session", session))
     return cmds

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -1,0 +1,100 @@
+"""The frame's shape, decided before tmux is involved at all.
+
+Pure on purpose. Everything that decides *what the frame looks like* lives here and
+returns plain lists of strings, so the whole shape is under test on a machine with no
+tmux, and so the argv rule below is enforced mechanically instead of by review.
+
+**Nothing here ever joins argv.** Pinned against tmux 3.7c: `new-session … printf
+'hello;touch INJ'` passed as separate arguments creates no file, and the same text as one
+string creates it. Workspace, repo, branch and persona names all reach a frame from
+committed files or `.git/HEAD`, so a joined string would be the `gh -F` bug again.
+
+**Every split targets the harness pane's id — never a `session:0.0`-style index.**
+Measured against tmux 3.7c, and the reason this module has two entry points instead of
+one `plan()` that emits every command up front: tmux renumbers pane INDICES on every
+split. Starting a session whose only pane is the harness (`%0`, index 0) and running
+`split-window -t session:0.0 -v -b -l 1` leaves the layout as index 0 = the new one-row
+panel (`%1`) and index 1 = the harness (`%0`) — the split moved, the harness didn't, and
+now sits at the index the split just vacated. A second split still targeting
+`session:0.0` therefore divides the FIRST PANEL, not the harness, and once that panel is
+down to a single row tmux refuses outright: `size or position no space for a new pane`.
+The bottom panel is never built. Silently — nothing downstream currently checks a split's
+return code — so a four-slot frame ships with one panel and no error.
+
+Pane IDs don't have this problem: tmux never reuses or renumbers a pane's `%N` id for its
+lifetime, index churn or not. `session_argv` asks tmux to print the harness's id at
+creation time (`-P -F '#{pane_id}'`); the caller reads it off stdout and hands it to
+`panel_argvs`, which targets it — and only it — for every split.
+"""
+
+from __future__ import annotations
+
+#: The order slots are dropped in as the terminal shrinks. Sides first — a side panel
+#: costs the harness columns, so it goes as soon as space is tight in EITHER dimension,
+#: not only when columns themselves are the short one — then the top, whose row is worth
+#: less than the bottom's alerts, and which only goes when rows are the tight dimension.
+_DROP_ORDER = ("left", "right", "top", "bottom")
+
+#: Rows a horizontal panel occupies, and columns a vertical one does.
+SLOT_SIZE = {"top": 1, "bottom": 1, "left": 22, "right": 22}
+
+
+def visible_slots(slots: list[str], cols: int, rows: int,
+                  min_cols: int, min_rows: int) -> list[str]:
+    """Which of *slots* fit in a *cols* x *rows* terminal.
+
+    Degradation, not refusal: below the floor the harness simply gets the whole terminal,
+    which is the same choice `statusline.render` makes when it runs out of width. Follows
+    `_DROP_ORDER`: `left`/`right` are the first to go, on ANY shortage — a terminal that is
+    short on rows cannot spare a side panel's own divider any more than a narrow one can
+    spare its columns — then `top`, only when rows specifically are the tight dimension.
+    """
+    keep = list(slots)
+    if cols < min_cols or rows < min_rows:
+        keep = [s for s in keep if s not in ("left", "right")]
+    if rows < min_rows:
+        keep = [s for s in keep if s != "top"]
+    if cols < min_cols // 2 or rows < min_rows // 2:
+        keep = []
+    return [s for s in slots if s in keep]
+
+
+def _tmux(socket: str, *args: str) -> list[str]:
+    return ["tmux", "-L", socket, *args]
+
+
+def session_argv(*, session: str, conf: str, socket: str, cols: int, rows: int,
+                 harness_argv: list[str]) -> list[str]:
+    """The `new-session` command that starts the frame's tmux server, harness inside it.
+
+    Detached (`-d`): this is launched from a script with no tty to hand tmux, not typed
+    interactively, and without `-d` tmux would attach and the call would never return.
+
+    Asks tmux to PRINT the new pane's id (`-P -F '#{pane_id}'`) rather than assuming one.
+    That id is the whole fix the module docstring describes: the caller must capture it
+    off stdout and pass it to `panel_argvs`, because a `session:0.0`-style index stops
+    naming the harness after the very first split.
+    """
+    return _tmux(socket, "-f", conf, "new-session", "-d", "-s", session,
+                "-x", str(cols), "-y", str(rows), "-P", "-F", "#{pane_id}",
+                "--", *harness_argv)
+
+
+def panel_argvs(*, slots: list[str], session: str, socket: str,
+                charter_argv: list[str], harness_pane: str) -> list[list[str]]:
+    """One `split-window` per slot in *slots*, each carving its rectangle off *harness_pane*.
+
+    *harness_pane* is the id `session_argv`'s caller read off tmux's stdout, and every
+    split below targets that same id — never a `session:0.0`-style index, and never a
+    target derived from an earlier split in this same list. Both are the mistake the
+    module docstring measures: indices move under every split tmux runs, pane ids don't.
+    """
+    cmds: list[list[str]] = []
+    for slot in slots:
+        size = SLOT_SIZE[slot]
+        direction = "-v" if slot in ("top", "bottom") else "-h"
+        before = ["-b"] if slot in ("top", "left") else []
+        cmds.append(_tmux(socket, "split-window", "-t", harness_pane,
+                          direction, *before, "-l", str(size), "--",
+                          *charter_argv, "panel", slot, "--session", session))
+    return cmds

--- a/charter/frame/menu.py
+++ b/charter/frame/menu.py
@@ -8,9 +8,19 @@ tmux would be an arms race against a parser with `;` separation, `#{}` expansion
 quote styles.
 
 So the command tmux runs is always `charter frame-action a<N>`, and charter looks the real
-argv up in its own state — never re-derives it, never re-quotes it. Labels are still
-shown — a label is drawn, never executed — but they are sanitised of the one thing that
-could confuse the menu's own layout: newlines.
+argv up in its own state — never re-derives it, never re-quotes it.
+
+**A label is a tmux FORMAT, not inert text — it is drawn, but "drawn" still means
+tmux expands it first.** `display-menu`'s own docs: "The name and command are formats,
+see the FORMATS and STYLES sections." `#(shell command)` runs the command and substitutes
+its output; `#{variable}` substitutes a value — both fire the moment tmux RENDERS the
+menu, no selection needed. Verified by hand against tmux 3.7c, in a real frame: a label of
+`#(touch CANARY)` created `CANARY` the instant the menu was drawn, and the hostile row
+itself was invisible in the rendered menu — nothing about the menu LOOKED wrong. An
+earlier version of this module's docstring said "a label is drawn, never executed"; that
+was false, and a wrong invariant asserted by a passing test is worse than no test at all
+— see `_safe_label` for the fix (`#` -> `##`, tmux's own escape for a literal `#`) and
+`tests/test_frame_menu.py` for the canary that proves it closed.
 
 **`charter frame-action`, not `charter frame action`.** `charter/cli.py`'s
 `_split_frame_argv` treats every `charter frame ...` invocation as the launcher's own
@@ -26,6 +36,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 
 from . import state
 
@@ -34,6 +45,15 @@ from . import state
 #: merely look ugly — the same "safe by construction" standard this module's other
 #: sanitisation (stripping newlines) already applies.
 _MAX_LABEL = 60
+
+#: What `record` ever mints — `a0`, `a1`, … — and the ONLY shape `build` will hand back to
+#: a caller that turns it into a command (`menu_argv`). Checked again here, at the point
+#: an id is about to reach an argv, rather than trusted because `record` is the only
+#: writer TODAY: the guard belongs at the join, not at whichever writer happens to exist
+#: first — a hand-edited or otherwise corrupted `actions.json` key of `a0'; run-shell
+#: "..."` would otherwise reach `menu_argv`'s f-string untouched and become exactly the
+#: injection this whole module exists to refuse.
+_ACTION_ID_RE = re.compile(r"^a[0-9]+$")
 
 
 def _table(fid: str, *, create: bool = False):
@@ -58,16 +78,27 @@ def record(*, fid: str, entries: list[tuple[str, list[str]]]) -> None:
     atomic-write shape: `build`/`resolve` are read from a `run-shell` fired by an
     operator's own keypress, which has no way to retry a table caught mid-write.
 
-    A label is drawn by tmux, never executed — see the module docstring — but it is still
-    operator-visible text read from a committed file, so newlines are stripped (a menu row
+    A label is still operator-visible text read from a committed file (see the module
+    docstring for why "drawn" does not mean "inert"), so newlines are stripped (a menu row
     cannot hold one without corrupting the menu's own layout) and the length is bounded
-    (`_MAX_LABEL`) for the same reason.
+    (`_MAX_LABEL`) for the same reason. The tmux-format escaping (`#` -> `##`) and the
+    leading-`-`/trailing-`#` guards live in `menu_argv` instead, at the point a label
+    actually reaches tmux's argv — this function's own job is making the STORED text
+    sane, not making it safe for a parser it has not met yet.
+
+    An empty result (the label was empty, or entirely newlines) falls back to a
+    placeholder rather than an empty string: `display-menu` treats an empty NAME as a
+    separator line, which desynchronises every `label key command` triple after it and
+    fails the whole menu outright with "not enough arguments" — the hotkey would then
+    silently do nothing, for a reason with no message anywhere to explain it.
     """
     path = _table(fid, create=True)
     if path is None:
         return
-    data = {f"a{i}": {"label": label.replace("\n", " ")[:_MAX_LABEL], "argv": list(argv)}
-            for i, (label, argv) in enumerate(entries)}
+    data = {}
+    for i, (label, argv) in enumerate(entries):
+        clean = label.replace("\n", " ")[:_MAX_LABEL] or "(untitled)"
+        data[f"a{i}"] = {"label": clean, "argv": list(argv)}
     tmp = path.with_name(path.name + ".tmp")
     try:
         tmp.write_text(json.dumps(data))
@@ -86,6 +117,10 @@ def build(fid: str) -> list[tuple[str, str]]:
     the same order `record`'s own dict comprehension wrote them in — no `sorted()` here on
     purpose: sorting the id STRINGS lexicographically would put ``"a10"`` before ``"a2"``,
     silently reordering the menu the moment a frame ever grows past nine entries.
+
+    Any key not shaped `a<N>` is dropped rather than passed through — see
+    `_ACTION_ID_RE`'s own docstring for why this is checked here, at the join, and not
+    only trusted from `record`.
     """
     path = _table(fid)
     if path is None:
@@ -96,7 +131,8 @@ def build(fid: str) -> list[tuple[str, str]]:
         return []
     if not isinstance(data, dict):
         return []
-    return [(v.get("label", ""), k) for k, v in data.items() if isinstance(v, dict)]
+    return [(v.get("label", ""), k) for k, v in data.items()
+            if isinstance(v, dict) and _ACTION_ID_RE.fullmatch(k)]
 
 
 def resolve(fid: str, action_id: str) -> list[str] | None:
@@ -104,7 +140,10 @@ def resolve(fid: str, action_id: str) -> list[str] | None:
 
     Reads the same table `build` does and nothing more — no name, hostile or not, is ever
     on the path from a menu selection to this return value; `cmd_action` runs whatever
-    comes back through `subprocess.run` as a list, never a shell.
+    comes back through `subprocess.run` as a list, never a shell. `action_id` is not
+    re-checked against `_ACTION_ID_RE` here: a `dict.get` lookup is safe against a key of
+    any shape (there is no parser downstream of it to confuse), unlike `menu_argv`, which
+    interpolates the id into text tmux re-parses and is where that check actually matters.
     """
     path = _table(fid)
     if path is None:
@@ -122,26 +161,64 @@ def resolve(fid: str, action_id: str) -> list[str] | None:
     return argv if isinstance(argv, list) and all(isinstance(a, str) for a in argv) else None
 
 
-def menu_argv(fid: str, socket: str) -> list[str]:
+def _safe_label(label: str) -> str:
+    """*label*, made inert against tmux's own format/style parsing. Three transforms:
+
+    1. **`#` -> `##`.** The fix for the format-expansion hole the module docstring
+       describes: `#(...)`/`#{...}` in an unescaped label execute/substitute the moment
+       tmux draws the menu. `##` is tmux's own escape for a literal `#` — doubling every
+       occurrence closes it the same way `_pane_died_write_hook_argv` closes `$`/`"` in a
+       hook action: escape every occurrence, not a scan for "looks like a format".
+
+    2. **A leading `-` disables the item.** `display-menu`'s own docs: a name starting
+       with `-` is "shown dim and may not be chosen" — the whole row, not merely its
+       first character, becomes something else. That is exactly correction 4's "truncated
+       into something misleading" failure, reached through a menu instead of a status
+       line. A leading space keeps the text intact and un-disables the row.
+
+    3. **A label ending in `#` gets a trailing space.** Cosmetic only — nothing here
+       executes either way — but worth closing: verified by hand that a label doubled
+       from a single trailing `#` (`"trailing#"` -> `"trailing##"`) collides with a
+       style-reset sequence tmux appends after every item's own name, rendering as
+       literal `trailing#[default]` garbage in the menu. A label with no trailing hash
+       never showed it. A trailing space breaks the adjacency.
+    """
+    label = label.replace("#", "##")
+    if label.startswith("-"):
+        label = " " + label
+    if label.endswith("#"):
+        label = label + " "
+    return label
+
+
+def menu_argv(fid: str, socket: str, client: str) -> list[str]:
     """The `display-menu` invocation for this frame. Ids only — never a name.
 
-    `-t fid` targets THIS frame's own session explicitly, always. Without it,
-    `display-menu` defaults to "the client that fired this command" — exactly right the
-    instant a bind's own action runs `display-menu` directly, but nothing about that
-    default survives being invoked a second time removed, which is what actually happens
-    here: the hotkey bind runs `charter frame-menu` (see `commands_frame.cmd_menu`), and
-    THAT process is what calls this function and runs its result as a brand-new `tmux`
-    client invocation — a different process from whichever client's keypress triggered
-    it. `fid` is the one thing this function is always trusted to carry (it is the
-    session's own name, minted by `state.frame_id`'s restricted alphabet — see its
-    docstring), so passing it explicitly is free and removes an ambiguity that would
-    otherwise only show up with two frames attached in two terminals at once.
+    `-c client` is what selects WHICH ATTACHED TERMINAL the menu is drawn on —
+    `display-menu`'s own docs: "Display a menu on target-client. target-pane gives the
+    target for any commands run from the menu." `-t` (kept below) never did that; it only
+    scopes FORMAT EVALUATION for the item's own command text. Verified by hand against
+    tmux 3.7c with two frames attached in two separate terminals: `-t fid` alone rendered
+    frame B's menu on frame A's screen when B's own hotkey was pressed — B's operator saw
+    nothing, and selecting the item there would have run B's action from A's terminal.
+    *client* is resolved by `commands_frame.cmd_menu` (via `list-clients -t fid`) before
+    this function is ever called — `menu.py` makes no subprocess calls of its own (every
+    other function here is pure file/state access), so the one query `-c` needs lives in
+    `commands_frame.py` and the answer is simply handed in.
 
-    Every item's own action is the fixed template ``run-shell 'charter frame-action
-    a<N>'`` — the opaque id is the only thing that varies, and it is never derived from
-    the label sitting right next to it in this same argv.
+    `-t fid` stays for a DIFFERENT reason: it is what scopes the ITEM's own `run-shell`
+    command to this session's `$CHARTER_SESSION_ID` (verified by hand: an item fired from
+    `display-menu -t <session>` inherits that session's own `set-environment` values even
+    though its own `run-shell` text carries no `-t` — see `_session_id_env_argv`'s own
+    docstring in `commands_frame.py` for why that value has to be there at all).
+
+    Every label passes through `_safe_label` — see its own docstring and the module
+    docstring for why a label is not inert text. Every item's own ACTION is the fixed
+    template ``run-shell 'charter frame-action a<N>'`` — the opaque id is the only thing
+    that varies, and `build` already refuses anything not shaped `a<N>` before it ever
+    reaches here.
     """
-    cmd = ["tmux", "-L", socket, "display-menu", "-t", fid, "-T", "charter"]
+    cmd = ["tmux", "-L", socket, "display-menu", "-t", fid, "-c", client, "-T", "charter"]
     for i, (label, action_id) in enumerate(build(fid)):
-        cmd += [label, str(i + 1), f"run-shell 'charter frame-action {action_id}'"]
+        cmd += [_safe_label(label), str(i + 1), f"run-shell 'charter frame-action {action_id}'"]
     return cmd

--- a/charter/frame/menu.py
+++ b/charter/frame/menu.py
@@ -1,0 +1,147 @@
+"""The frame's menu, built so no name ever reaches tmux's parser.
+
+`display-menu` and `display-popup -E` take commands **tmux** parses and executes. Every
+interesting label in charter — a workspace, a repo, a branch, a persona — is read out of a
+committed file or `.git/HEAD`, which is exactly the input class that made `gh -F` open a
+file on someone's machine (`docs/news/unreleased-forge-argv-encoding.md`). Quoting it for
+tmux would be an arms race against a parser with `;` separation, `#{}` expansion and two
+quote styles.
+
+So the command tmux runs is always `charter frame-action a<N>`, and charter looks the real
+argv up in its own state — never re-derives it, never re-quotes it. Labels are still
+shown — a label is drawn, never executed — but they are sanitised of the one thing that
+could confuse the menu's own layout: newlines.
+
+**`charter frame-action`, not `charter frame action`.** `charter/cli.py`'s
+`_split_frame_argv` treats every `charter frame ...` invocation as the launcher's own
+escape hatch and grafts everything past `frame` onto the harness's verbatim argv *before*
+`argparse` ever sees a subcommand to dispatch on — exactly the reason `charter panel` is
+already registered as a top-level sibling of `frame` rather than nested under it. A
+`frame action` subcommand would never be reached for the identical reason; `frame-action`
+is a different literal token, so it passes through untouched. See `cli.py`'s own
+`_add_frame_parsers` for where this is wired.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from . import state
+
+#: The bound on one label's length, and the reason for it: a `display-menu` row is one
+#: line, and a label long enough to wrap would corrupt the menu's own layout rather than
+#: merely look ugly — the same "safe by construction" standard this module's other
+#: sanitisation (stripping newlines) already applies.
+_MAX_LABEL = 60
+
+
+def _table(fid: str, *, create: bool = False):
+    """Path to *fid*'s menu table, or ``None`` when `state.frame_dir` refuses *fid*.
+
+    Delegates entirely to `state.frame_dir`, which resolves through `contain.child`
+    rather than sanitising a hostile id (see its own docstring) — rewriting one here
+    instead would invent a second identity for exactly the id `frame_dir` exists to
+    refuse, and silently write this frame's menu somewhere no other part of the frame
+    would ever look for it.
+    """
+    d = state.frame_dir(fid, create=create)
+    return None if d is None else d / "actions.json"
+
+
+def record(*, fid: str, entries: list[tuple[str, list[str]]]) -> None:
+    """Store this frame's menu as ``{id: {label, argv}}``. The only place ids are minted.
+
+    Ids are ``a0``, ``a1``, … — insertion order, never re-derived from the label — so
+    `resolve` can answer purely from the id with no dependency on what a label happens to
+    say. Written via a temp file + `os.replace`, matching `state.bump`/`record_exit`'s own
+    atomic-write shape: `build`/`resolve` are read from a `run-shell` fired by an
+    operator's own keypress, which has no way to retry a table caught mid-write.
+
+    A label is drawn by tmux, never executed — see the module docstring — but it is still
+    operator-visible text read from a committed file, so newlines are stripped (a menu row
+    cannot hold one without corrupting the menu's own layout) and the length is bounded
+    (`_MAX_LABEL`) for the same reason.
+    """
+    path = _table(fid, create=True)
+    if path is None:
+        return
+    data = {f"a{i}": {"label": label.replace("\n", " ")[:_MAX_LABEL], "argv": list(argv)}
+            for i, (label, argv) in enumerate(entries)}
+    tmp = path.with_name(path.name + ".tmp")
+    try:
+        tmp.write_text(json.dumps(data))
+        os.replace(tmp, path)
+    except OSError:
+        # Same "must not raise" promise `state.py` makes for its own writes: this can run
+        # from `cmd_launch`, where a menu the operator never opens is not worth losing the
+        # frame over.
+        return
+
+
+def build(fid: str) -> list[tuple[str, str]]:
+    """``(label, opaque id)`` for each entry, in the order `record` stored them.
+
+    `json.loads` rebuilds the dict in the order its keys appeared in the text, which is
+    the same order `record`'s own dict comprehension wrote them in — no `sorted()` here on
+    purpose: sorting the id STRINGS lexicographically would put ``"a10"`` before ``"a2"``,
+    silently reordering the menu the moment a frame ever grows past nine entries.
+    """
+    path = _table(fid)
+    if path is None:
+        return []
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    return [(v.get("label", ""), k) for k, v in data.items() if isinstance(v, dict)]
+
+
+def resolve(fid: str, action_id: str) -> list[str] | None:
+    """The real argv for *action_id*, or ``None``. The only place an id becomes a command.
+
+    Reads the same table `build` does and nothing more — no name, hostile or not, is ever
+    on the path from a menu selection to this return value; `cmd_action` runs whatever
+    comes back through `subprocess.run` as a list, never a shell.
+    """
+    path = _table(fid)
+    if path is None:
+        return None
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    entry = data.get(action_id)
+    if not isinstance(entry, dict):
+        return None
+    argv = entry.get("argv")
+    return argv if isinstance(argv, list) and all(isinstance(a, str) for a in argv) else None
+
+
+def menu_argv(fid: str, socket: str) -> list[str]:
+    """The `display-menu` invocation for this frame. Ids only — never a name.
+
+    `-t fid` targets THIS frame's own session explicitly, always. Without it,
+    `display-menu` defaults to "the client that fired this command" — exactly right the
+    instant a bind's own action runs `display-menu` directly, but nothing about that
+    default survives being invoked a second time removed, which is what actually happens
+    here: the hotkey bind runs `charter frame-menu` (see `commands_frame.cmd_menu`), and
+    THAT process is what calls this function and runs its result as a brand-new `tmux`
+    client invocation — a different process from whichever client's keypress triggered
+    it. `fid` is the one thing this function is always trusted to carry (it is the
+    session's own name, minted by `state.frame_id`'s restricted alphabet — see its
+    docstring), so passing it explicitly is free and removes an ambiguity that would
+    otherwise only show up with two frames attached in two terminals at once.
+
+    Every item's own action is the fixed template ``run-shell 'charter frame-action
+    a<N>'`` — the opaque id is the only thing that varies, and it is never derived from
+    the label sitting right next to it in this same argv.
+    """
+    cmd = ["tmux", "-L", socket, "display-menu", "-t", fid, "-T", "charter"]
+    for i, (label, action_id) in enumerate(build(fid)):
+        cmd += [label, str(i + 1), f"run-shell 'charter frame-action {action_id}'"]
+    return cmd

--- a/charter/frame/menu.py
+++ b/charter/frame/menu.py
@@ -1,6 +1,7 @@
 """The frame's menu, built so no name ever reaches tmux's parser.
 
-`display-menu` and `display-popup -E` take commands **tmux** parses and executes. Every
+`display-menu` takes commands **tmux** itself parses and executes (so does `display-popup
+-E`, which charter does not use). Every
 interesting label in charter — a workspace, a repo, a branch, a persona — is read out of a
 committed file or `.git/HEAD`, which is exactly the input class that made `gh -F` open a
 file on someone's machine (`docs/news/unreleased-forge-argv-encoding.md`). Quoting it for
@@ -18,18 +19,27 @@ successfully. Verified through the real production path (`bind` -> `run-shell` -
 `charter frame-menu` -> `display-menu`), not a lab stand-in, including with a real git
 branch literally named `#(id>/tmp/...)` — a shape `git checkout -b` accepts without
 complaint and `.git/HEAD` holds unchanged: the job ran and the branch name itself never
-appeared anywhere in the rendered menu. A label that is ENTIRELY a silent `#(...)` job
-(nothing visible before or after it, and the command itself writes no stdout — `touch`,
-say) expands to an EMPTY string, and `display-menu` treats an empty name as a separator
-line, which desyncs this module's own `label key command` triples and REFUSES THE WHOLE
-MENU outright ("too few arguments") — but the job still ran; that refusal is decided
-only after evaluation, not instead of it, so it is not a defence, only a different-
-looking failure mode. An earlier version of this module's docstring said "a label is
-drawn, never executed"; that was false, and a wrong invariant asserted by a passing test
-is worse than no test at all — see `_safe_label` for the fix (`#` -> `##`, tmux's own
-escape for a literal `#`, applied before tmux ever sees the label, which closes it
-regardless of how many times it is later collapsed for display — pre-doubled payloads
-(`##(...)`, `####(...)`) were tried by hand against the fix and found no hole) and
+appeared anywhere in the rendered menu.
+
+**There is no accidental defence anywhere in that path.** An earlier version of this
+docstring claimed a label that is ENTIRELY a silent `#(...)` job (nothing visible before
+or after it, and the command writing no stdout — `touch`, say) expands to an empty
+string and so REFUSES THE WHOLE MENU. Re-measured against tmux 3.7c through a real bind,
+with a real attached client: `display-menu` returned **0**, the menu **opened**, the
+sibling item stayed **selectable**, and the canary **fired**. The mechanism is that tmux
+counts a command's arguments BEFORE expanding formats, so a name that expands to nothing
+still occupies its own slot and nothing desynchronises. The refusal is real for a
+LITERALLY empty name (`""` — rc 1, tmux's own text is `not enough arguments`, see
+`record`), and that is a different case from a name that merely expands to empty. Both
+claims mattered: this one was cited as a reason the hole was partly self-limiting, and
+it never was.
+
+An earlier version of this docstring also said "a label is drawn, never executed"; that
+was false too, and a wrong invariant asserted by a passing test is worse than no test at
+all — see `_safe_label` for the fix (`#` -> `##`, tmux's own escape for a literal `#`,
+applied before tmux ever sees the label, which closes it regardless of how many times it
+is later collapsed for display — pre-doubled payloads (`##(...)`, `####(...)`) were
+tried by hand against the fix and found no hole) and
 `tests/test_frame_menu.py`/`tests/test_frame_tmux_integration.py` for the canaries that
 prove it closed.
 
@@ -49,7 +59,7 @@ import json
 import os
 import re
 
-from . import state
+from . import state, tmuxctl
 
 #: The bound on one label's length, and the reason for it: a `display-menu` row is one
 #: line, and a label long enough to wrap would corrupt the menu's own layout rather than
@@ -98,10 +108,16 @@ def record(*, fid: str, entries: list[tuple[str, list[str]]]) -> None:
     sane, not making it safe for a parser it has not met yet.
 
     An empty result (the label was empty, or entirely newlines) falls back to a
-    placeholder rather than an empty string: `display-menu` treats an empty NAME as a
-    separator line, which desynchronises every `label key command` triple after it and
-    fails the whole menu outright with "not enough arguments" — the hotkey would then
+    placeholder rather than an empty string: `display-menu` treats a LITERALLY empty NAME
+    as a separator line, which desynchronises every `label key command` triple after it
+    and fails the whole menu outright — rc 1, tmux's own text `not enough arguments`,
+    re-confirmed against tmux 3.7c with a real attached client. The hotkey would then
     silently do nothing, for a reason with no message anywhere to explain it.
+
+    Distinct from a name that merely EXPANDS to empty (`#(touch x)`, `#{no_such_thing}`),
+    which does NOT refuse: tmux counts a command's arguments before expanding formats, so
+    such a name still occupies its slot and the menu opens normally. See the module
+    docstring — that difference used to be recorded the wrong way round.
     """
     path = _table(fid, create=True)
     if path is None:
@@ -232,24 +248,42 @@ def menu_argv(fid: str, socket: str, client: str) -> list[str]:
     tmux 3.7c with two frames attached in two separate terminals: `-t fid` alone rendered
     frame B's menu on frame A's screen when B's own hotkey was pressed — B's operator saw
     nothing, and selecting the item there would have run B's action from A's terminal.
-    *client* is resolved by `commands_frame.cmd_menu` (via `list-clients -t fid`) before
-    this function is ever called — `menu.py` makes no subprocess calls of its own (every
-    other function here is pure file/state access), so the one query `-c` needs lives in
-    `commands_frame.py` and the answer is simply handed in.
+
+    *client* arrives as `#{client_name}`, expanded by tmux inside the hotkey BIND's own
+    `run-shell` text and handed to `charter frame-menu` as a plain argv value, which
+    `commands_frame.cmd_menu` passes straight here (see `conf_text`'s own docstring).
+    Nothing queries it: an earlier version of this module said the client was resolved
+    "via `list-clients -t fid`", and that command was removed from charter entirely when
+    the guess it fed turned out to pick the wrong client with two attached. `menu.py`
+    still makes no subprocess calls of its own — every function here is pure file/state
+    access — but that is now true because there is no query left anywhere, not because
+    one was moved next door.
 
     `-t fid` stays for a DIFFERENT reason: it is what scopes the ITEM's own `run-shell`
-    command to this session's `$CHARTER_SESSION_ID` (verified by hand: an item fired from
-    `display-menu -t <session>` inherits that session's own `set-environment` values even
-    though its own `run-shell` text carries no `-t` — see `_session_id_env_argv`'s own
-    docstring in `commands_frame.py` for why that value has to be there at all).
+    command to this session's `$CHARTER_SESSION_ID` and `$CHARTER_PY` (verified by hand:
+    an item fired from `display-menu -t <session>` inherits that session's own
+    `set-environment` values even though its own `run-shell` text carries no `-t` — see
+    `_session_id_env_argv`'s own docstring in `commands_frame.py` for why those values
+    have to be there at all).
 
     Every label passes through `_safe_label` — see its own docstring and the module
     docstring for why a label is not inert text. Every item's own ACTION is the fixed
-    template ``run-shell 'charter frame-action a<N>'`` — the opaque id is the only thing
-    that varies, and `build` already refuses anything not shaped `a<N>` before it ever
-    reaches here.
+    template ``run-shell '"$CHARTER_PY" -m charter frame-action a<N>'`` — the opaque id
+    is the only thing that varies, and `build` already refuses anything not shaped `a<N>`
+    before it ever reaches here.
+
+    `"$CHARTER_PY" -m charter`, never a bare `charter`: the `charter` on the tmux
+    server's own `$PATH` may be a different install or none at all, and `run-shell`
+    reports a 127 by printing it INTO THE HARNESS PANE and dropping that pane into
+    copy-mode — charter drawing in the one rectangle ADR 0018 says it never draws. The
+    interpreter is carried session-scoped by `commands_frame._charter_py_env_argv`, which
+    keeps this template free of any per-machine path; embedding `sys.executable` here
+    instead would put an absolute path back inside a nested tmux-quote layer, the exact
+    construction the `commands_frame` module docstring bans for `status_path`.
     """
     cmd = ["tmux", "-L", socket, "display-menu", "-t", fid, "-c", client, "-T", "charter"]
     for i, (label, action_id) in enumerate(build(fid)):
-        cmd += [_safe_label(label), str(i + 1), f"run-shell 'charter frame-action {action_id}'"]
+        cmd += [_safe_label(label), str(i + 1),
+                f'run-shell \'"${tmuxctl.CHARTER_PY_ENV}" -m charter '
+                f'frame-action {action_id}\'']
     return cmd

--- a/charter/frame/menu.py
+++ b/charter/frame/menu.py
@@ -10,17 +10,28 @@ quote styles.
 So the command tmux runs is always `charter frame-action a<N>`, and charter looks the real
 argv up in its own state — never re-derives it, never re-quotes it.
 
-**A label is a tmux FORMAT, not inert text — it is drawn, but "drawn" still means
-tmux expands it first.** `display-menu`'s own docs: "The name and command are formats,
-see the FORMATS and STYLES sections." `#(shell command)` runs the command and substitutes
-its output; `#{variable}` substitutes a value — both fire the moment tmux RENDERS the
-menu, no selection needed. Verified by hand against tmux 3.7c, in a real frame: a label of
-`#(touch CANARY)` created `CANARY` the instant the menu was drawn, and the hostile row
-itself was invisible in the rendered menu — nothing about the menu LOOKED wrong. An
-earlier version of this module's docstring said "a label is drawn, never executed"; that
-was false, and a wrong invariant asserted by a passing test is worse than no test at all
-— see `_safe_label` for the fix (`#` -> `##`, tmux's own escape for a literal `#`) and
-`tests/test_frame_menu.py` for the canary that proves it closed.
+**A label is a tmux FORMAT, not inert text.** `display-menu`'s own docs: "The name and
+command are formats, see the FORMATS and STYLES sections." `#(shell command)` runs the
+command and substitutes its output; `#{variable}` substitutes a value — both fire during
+FORMAT EVALUATION, which happens whether or not the resulting menu goes on to display
+successfully. Verified through the real production path (`bind` -> `run-shell` ->
+`charter frame-menu` -> `display-menu`), not a lab stand-in, including with a real git
+branch literally named `#(id>/tmp/...)` — a shape `git checkout -b` accepts without
+complaint and `.git/HEAD` holds unchanged: the job ran and the branch name itself never
+appeared anywhere in the rendered menu. A label that is ENTIRELY a silent `#(...)` job
+(nothing visible before or after it, and the command itself writes no stdout — `touch`,
+say) expands to an EMPTY string, and `display-menu` treats an empty name as a separator
+line, which desyncs this module's own `label key command` triples and REFUSES THE WHOLE
+MENU outright ("too few arguments") — but the job still ran; that refusal is decided
+only after evaluation, not instead of it, so it is not a defence, only a different-
+looking failure mode. An earlier version of this module's docstring said "a label is
+drawn, never executed"; that was false, and a wrong invariant asserted by a passing test
+is worse than no test at all — see `_safe_label` for the fix (`#` -> `##`, tmux's own
+escape for a literal `#`, applied before tmux ever sees the label, which closes it
+regardless of how many times it is later collapsed for display — pre-doubled payloads
+(`##(...)`, `####(...)`) were tried by hand against the fix and found no hole) and
+`tests/test_frame_menu.py`/`tests/test_frame_tmux_integration.py` for the canaries that
+prove it closed.
 
 **`charter frame-action`, not `charter frame action`.** `charter/cli.py`'s
 `_split_frame_argv` treats every `charter frame ...` invocation as the launcher's own
@@ -121,6 +132,16 @@ def build(fid: str) -> list[tuple[str, str]]:
     Any key not shaped `a<N>` is dropped rather than passed through — see
     `_ACTION_ID_RE`'s own docstring for why this is checked here, at the join, and not
     only trusted from `record`.
+
+    A label that is missing, not a string, or empty gets `record`'s own `"(untitled)"`
+    placeholder rather than being passed through as-is: `record` only writes a `str`
+    today (`or "(untitled)"` already guards the empty case there), but `build` reads
+    whatever is actually on disk, and a hand-edited or otherwise corrupted table is not
+    bound by what `record` would have written. `{"label": 123}` reaching `menu_argv`
+    unguarded raised `AttributeError` there (`int` has no `.replace`) — the SAME class
+    of defect `_ACTION_ID_RE` exists to close for the key, applied consistently to the
+    value next to it, so a corrupted label degrades the one row it belongs to rather
+    than crashing the hotkey for the whole menu.
     """
     path = _table(fid)
     if path is None:
@@ -131,8 +152,13 @@ def build(fid: str) -> list[tuple[str, str]]:
         return []
     if not isinstance(data, dict):
         return []
-    return [(v.get("label", ""), k) for k, v in data.items()
-            if isinstance(v, dict) and _ACTION_ID_RE.fullmatch(k)]
+    out = []
+    for k, v in data.items():
+        if not isinstance(v, dict) or not _ACTION_ID_RE.fullmatch(k):
+            continue
+        label = v.get("label")
+        out.append((label if isinstance(label, str) and label else "(untitled)", k))
+    return out
 
 
 def resolve(fid: str, action_id: str) -> list[str] | None:
@@ -170,11 +196,16 @@ def _safe_label(label: str) -> str:
        occurrence closes it the same way `_pane_died_write_hook_argv` closes `$`/`"` in a
        hook action: escape every occurrence, not a scan for "looks like a format".
 
-    2. **A leading `-` disables the item.** `display-menu`'s own docs: a name starting
-       with `-` is "shown dim and may not be chosen" — the whole row, not merely its
-       first character, becomes something else. That is exactly correction 4's "truncated
-       into something misleading" failure, reached through a menu instead of a status
-       line. A leading space keeps the text intact and un-disables the row.
+    2. **A leading `-` refuses the WHOLE menu, not just that row.** `display-menu`'s
+       own docs describe a name starting with `-` as merely "shown dim and may not be
+       chosen" — verified by hand that this is not what actually happens: tmux's own
+       argument parser reads a name beginning with `-` as an unrecognised FLAG of its
+       own (`command display-menu: unknown flag -m` for a label starting `-my-branch`,
+       confirmed against a real, attached client), and refuses the entire `display-menu`
+       call outright (rc 1) — no item in the menu opens, not only the one whose name
+       triggered it. Worse than the docs suggest, and this guard is correspondingly more
+       necessary than its own comment once claimed. A leading space keeps the text
+       intact and stops it from ever reaching tmux's own flag position.
 
     3. **A label ending in `#` gets a trailing space.** Cosmetic only — nothing here
        executes either way — but worth closing: verified by hand that a label doubled

--- a/charter/frame/notify.py
+++ b/charter/frame/notify.py
@@ -1,0 +1,57 @@
+"""Telling a running frame that the plane changed.
+
+Called from `charter/hooks.py`, where the posture is absolute (see that module's own
+docstring, and `contain.py`'s): a hook may cost a session its briefing, never its turn.
+`posttooluse` fires on every single tool call, so this has two jobs, not one — never
+raise, and never cost the hot path anything worth measuring.
+
+A FIFO was considered and rejected: opening one for write blocks until a reader exists,
+which would put a hang directly in the hook path the first time no panel was listening.
+`state.bump`'s plain version-file-plus-`stat` shape exists because it cannot hang, and
+this module rides on top of it rather than inventing a second channel.
+
+The debounce is a plain module-level dict rather than a `threading.Lock`-guarded
+counter: each hook invocation is a fresh short-lived `python3 -m charter hook ...`
+process (see `hooks.dispatch`), so there is never a second thread in here to race —
+only ever a second *call*, later in the same process, when a handler is exercised
+directly (as the tests below do).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+from . import state
+
+#: At most one bump per this many seconds. A panel ticks at 0.2s (`panel.TICK`), so a
+#: tighter debounce buys nothing a reader could ever see — it would only add cost to a
+#: hot path (`posttooluse`, once per tool call) for no visible benefit.
+DEBOUNCE = 0.25
+
+#: Mutable through a dict, not a bare module global, so a test can reset it
+#: (`notify._last["at"] = 0.0`) without `global` statements on both sides.
+_last = {"at": 0.0}
+
+
+def plane_changed() -> None:
+    """Bump the frame this process is running inside, if any. Never raises.
+
+    A no-op outside a frame (`$CHARTER_SESSION_ID` unset — the common case, most
+    sessions run with no frame at all) and a no-op inside the debounce window. The
+    `except Exception` is not defensive boilerplate: `state.bump` already swallows its
+    own `OSError`s, but this also guards `os.environ.get`/`time.monotonic` and any
+    future change to either — the one rule this module exists to keep is that NOTHING
+    reaching it from a hook ever turns into a raised exception.
+    """
+    try:
+        fid = os.environ.get("CHARTER_SESSION_ID")
+        if not fid:
+            return
+        now = time.monotonic()
+        if now - _last["at"] < DEBOUNCE:
+            return
+        _last["at"] = now
+        state.bump(fid)
+    except Exception:
+        return

--- a/charter/frame/notify.py
+++ b/charter/frame/notify.py
@@ -2,8 +2,22 @@
 
 Called from `charter/hooks.py`, where the posture is absolute (see that module's own
 docstring, and `contain.py`'s): a hook may cost a session its briefing, never its turn.
-`posttooluse` fires on every single tool call, so this has two jobs, not one — never
-raise, and never cost the hot path anything worth measuring.
+
+**Every `posttooluse*` handler calls this, not just the bare-named `posttooluse`.**
+`hooks/hooks.json` scopes `posttooluse` itself to `Write|Edit|MultiEdit` — Bash, Skill,
+Task/Agent and SendMessage each route to their own handler (`posttooluse-bash`,
+`-skill`, `-dispatch`, `-message`). Relying on `posttooluse` alone would leave the frame
+blind to Bash specifically, which is where most plane-state changes that matter to a
+panel actually happen — commits, branch moves, worktree edits — none of them a
+Write/Edit/MultiEdit call. Every handler bumping, rather than picking the ones that seem
+to matter today, is the one rule simple enough that a future sixth `posttooluse-*`
+handler has an unambiguous answer for whether it should call this too (yes). Each call
+site sits behind the same 250ms debounce below, so calling from five handlers instead of
+one costs nothing extra on the common path — it only changes which single call in a
+quiet stretch is the one that survives the debounce and actually writes.
+
+Being called from five hot paths instead of one changes nothing about what this module
+owes them: never raise, and never cost any of them anything worth measuring.
 
 A FIFO was considered and rejected: opening one for write blocks until a reader exists,
 which would put a hang directly in the hook path the first time no panel was listening.
@@ -26,7 +40,8 @@ from . import state
 
 #: At most one bump per this many seconds. A panel ticks at 0.2s (`panel.TICK`), so a
 #: tighter debounce buys nothing a reader could ever see — it would only add cost to a
-#: hot path (`posttooluse`, once per tool call) for no visible benefit.
+#: hot path (every `posttooluse*` handler, so once per Bash/Write/Edit/MultiEdit/Skill/
+#: Task/Agent/SendMessage call) for no visible benefit.
 DEBOUNCE = 0.25
 
 #: Mutable through a dict, not a bare module global, so a test can reset it

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -26,10 +26,12 @@ downstream of it knows how many ROWS the pane it is about to overwrite actually 
 `top`/`bottom` panel is one row today (`layout.SLOT_SIZE`), but `left`/`right` are
 full-height panes the layout module already supports — assuming "one line" here would
 silently clip a future multi-line renderer to its first row, or (the opposite failure)
-let it emit more lines than the pane holds and scroll the frame's own top row out of
-view, corruption of the same shape a stale-width repaint causes. `_rows` measures the
-pane the same way `slots._width` measures it, and `_paint` clamps the LINE COUNT to that
-measurement the way `tui.truncate` already clamps each line's WIDTH.
+let it emit more lines than the pane holds and scroll THAT PANEL'S OWN rows — measured
+against real tmux: each pane keeps its own scroll region, so an over-height paint pushes
+only its own top line out of view and leaves every sibling pane untouched, not the whole
+frame. `_rows` measures the pane the same way `slots._width` measures it, and `_paint`
+clamps the LINE COUNT to that measurement the way `tui.truncate` already clamps each
+line's WIDTH.
 
 **SIGWINCH matters because a resize does not bump the frame's version.** Only charter's
 own hooks call `state.bump`; the operator resizing their terminal does not. Without a
@@ -116,25 +118,33 @@ def _tick(resized: dict, seen: str, slot: str, fid: str) -> str:
     `while True`/`time.sleep`, which a test cannot call directly without either hanging
     or racing real wall-clock time.
 
-    A resize repaints even when the frame's own version has not moved: `should_redraw`
+    Reads `state.version` exactly once (`should_redraw`'s own version read is not
+    reused here — it takes *seen* and *fid*, not a precomputed current value, so calling
+    it as well would mean two `stat`s to decide one repaint). `should_redraw` stays the
+    public, standalone answer to "has the frame changed", exercised directly by its own
+    tests; this inlines the same comparison against the ALREADY-read *now* instead of
+    calling it a second time.
+
+    A resize repaints even when the frame's own version has not moved: comparing versions
     alone would leave a pane showing content laid out for a size that no longer exists
     until the next unrelated version bump happened to come along — see the module
     docstring's SIGWINCH section.
 
-    The version is read BEFORE `_paint` runs, not after — deliberately the direction
-    that errs safe. `_paint` calls `slots.render`, which reads several independent
-    pieces of live state (workspace, todos, alerts) one at a time, not atomically; a
-    second bump landing while that read is in flight could leave the painted content
-    reflecting only the OLDER state. Recording the version from after the paint would
-    then mark that newer version "seen" even though nothing on screen actually reflects
-    it, and the next tick's `should_redraw` would see no difference and stay silent —
-    a missed repaint with nothing left to trigger a correction. Reading first means
-    `seen` can only lag behind (or exactly match) what was actually painted, so any
-    bump during or after the paint is still visible to the next comparison.
+    *now* is read BEFORE `_paint` runs, not after — deliberately the direction that errs
+    safe. `_paint` calls `slots.render`, which reads several independent pieces of live
+    state (workspace, todos, alerts) one at a time, not atomically; a second bump landing
+    while that read is in flight could leave the painted content reflecting only the
+    OLDER state. Recording the version from after the paint would then mark that newer
+    version "seen" even though nothing on screen actually reflects it, and the next
+    tick's comparison would see no difference and stay silent — a missed repaint with
+    nothing left to trigger a correction. Reading first means `seen` can only lag behind
+    (or exactly match) what was actually painted, so any bump during or after the paint
+    is still visible to the next comparison — pinned directly by
+    `Tick.test_a_bump_landing_during_the_paint_is_not_marked_seen`.
     """
-    if resized["flag"] or should_redraw(seen, fid):
+    now = state.version(fid)
+    if resized["flag"] or now != seen:
         resized["flag"] = False
-        now = state.version(fid)
         _paint(slot, fid)
         return now
     return seen

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -1,0 +1,168 @@
+"""One charter panel, owning one tmux pane.
+
+Repaints whole, never diffed: a five-row pane is a few hundred cells, so diffing would be
+optimising something that is already free, and `tui.py` already truncates rather than
+wraps when the pane is narrow — there is no partial-line state to reconcile between one
+paint and the next.
+
+**Liveness is a poll, not a push.** A panel does not learn charter did something; it
+notices `state.version(fid)` changed. `version` is a `stat`, which is why watching a
+frame costs nothing at idle (see `state.py`'s own docstring). A FIFO was designed and
+rejected for the same job: opening one for write blocks until a reader exists, which
+would put a hang inside the hook path that calls `state.bump` — a cost this feature must
+never impose on the agent turn that triggers a redraw.
+
+**Width is `slots.py`'s job, not this module's.** `slots.render` already measures the
+pane's own tty (`os.get_terminal_size(sys.stdout.fileno())`) rather than trusting
+`$COLUMNS` — which a panel process, started as a tmux pane command, inherits WHOLE from
+the launching shell (measured: a 22-column pane whose launcher had exported
+`COLUMNS=200` saw `COLUMNS='200'` in its own environment). See `charter/frame/slots.py`'s
+module docstring for the full measurement. Duplicating that logic here would just be a
+second place to get it wrong; `_paint` below calls `slots.render` and trusts its output
+is already clamped to the pane's width.
+
+**Height is this module's job.** `render()`'s contract is a single string, so nothing
+downstream of it knows how many ROWS the pane it is about to overwrite actually has. A
+`top`/`bottom` panel is one row today (`layout.SLOT_SIZE`), but `left`/`right` are
+full-height panes the layout module already supports — assuming "one line" here would
+silently clip a future multi-line renderer to its first row, or (the opposite failure)
+let it emit more lines than the pane holds and scroll the frame's own top row out of
+view, corruption of the same shape a stale-width repaint causes. `_rows` measures the
+pane the same way `slots._width` measures it, and `_paint` clamps the LINE COUNT to that
+measurement the way `tui.truncate` already clamps each line's WIDTH.
+
+**SIGWINCH matters because a resize does not bump the frame's version.** Only charter's
+own hooks call `state.bump`; the operator resizing their terminal does not. Without a
+handler, a pane sits with content painted for the OLD size until some unrelated activity
+happens to bump the version next — on an idle agent, that could be a long wait, and the
+pane looks broken for all of it. The handler only sets a flag; a signal handler runs
+between bytecodes on the main thread, wherever the run loop happens to be, so it must not
+itself call anything that could block or recurse.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import sys
+import time
+
+from . import slots, state
+
+#: How often the version file is checked when nothing else has woken this panel. A
+#: `stat` at this rate is indistinguishable from zero cost (see `state.version`'s own
+#: docstring) — and unlike a FIFO, polling cannot hang the hook that writes the version
+#: file waiting for a reader that may never arrive.
+TICK = 0.2
+
+#: Rows assumed when this pane's own tty cannot be measured at all — stdout piped to
+#: something with no tty behind it (`charter panel top --session x > /tmp/log`, run by
+#: hand for debugging, or a test). Matches `commands_frame._FALLBACK_SIZE`'s own row
+#: count: the same "traditional default screen" charter already falls back to elsewhere
+#: when a terminal's real size is unknowable.
+_DEFAULT_ROWS = 24
+
+
+def should_redraw(seen: str, fid: str) -> bool:
+    """Has the frame changed since *seen*? Never raises: a panel that dies checking a
+    version file leaves a hole in the frame — the same failure `state.version` and
+    `slots.render` are already built not to cause, so this must not reintroduce it on
+    top of them.
+    """
+    try:
+        return state.version(fid) != seen
+    except Exception:
+        return True
+
+
+def _rows() -> int:
+    """This pane's own height, measured the way `slots._width` measures its own width:
+    `os.get_terminal_size(sys.stdout.fileno())` asks the file descriptor this process is
+    actually writing to, which for a panel launched as a tmux pane command IS the pane —
+    not a pipe, not the launching terminal. Only when that raises (no tty behind the fd
+    at all) does this fall back to `_DEFAULT_ROWS`.
+    """
+    try:
+        return os.get_terminal_size(sys.stdout.fileno()).lines
+    except OSError:
+        return _DEFAULT_ROWS
+
+
+def _paint(slot: str, fid: str) -> None:
+    """Clear the pane and draw *slot* whole, clamped to this pane's real row count.
+
+    `slots.render` already clamps every line to the pane's WIDTH; clamping the line
+    COUNT to the pane's HEIGHT is what this function adds on top, because `render`'s
+    contract (one string) carries no notion of height at all — see the module
+    docstring's "Height is this module's job" section.
+    """
+    lines = slots.render(slot, fid).split("\n")[:_rows()]
+    sys.stdout.write("\x1b[H\x1b[2J" + "\n".join(lines))
+    sys.stdout.flush()
+
+
+def _install_sigwinch(resized: dict) -> object:
+    """Arm the resize handler, returning whatever was installed before it so `run` can
+    put it back rather than leaking a handler past this process's own lifetime — a
+    real concern here specifically because `run(once=True)` is called in-process by
+    tests, not only as a subprocess's whole life.
+    """
+    return signal.signal(signal.SIGWINCH, lambda *_a: resized.__setitem__("flag", True))
+
+
+def _tick(resized: dict, seen: str, slot: str, fid: str) -> str:
+    """One loop iteration's decision AND its effect — split out of `run` so the
+    DECISION (paint now, or wait) can be exercised without also exercising `run`'s
+    `while True`/`time.sleep`, which a test cannot call directly without either hanging
+    or racing real wall-clock time.
+
+    A resize repaints even when the frame's own version has not moved: `should_redraw`
+    alone would leave a pane showing content laid out for a size that no longer exists
+    until the next unrelated version bump happened to come along — see the module
+    docstring's SIGWINCH section.
+
+    The version is read BEFORE `_paint` runs, not after — deliberately the direction
+    that errs safe. `_paint` calls `slots.render`, which reads several independent
+    pieces of live state (workspace, todos, alerts) one at a time, not atomically; a
+    second bump landing while that read is in flight could leave the painted content
+    reflecting only the OLDER state. Recording the version from after the paint would
+    then mark that newer version "seen" even though nothing on screen actually reflects
+    it, and the next tick's `should_redraw` would see no difference and stay silent —
+    a missed repaint with nothing left to trigger a correction. Reading first means
+    `seen` can only lag behind (or exactly match) what was actually painted, so any
+    bump during or after the paint is still visible to the next comparison.
+    """
+    if resized["flag"] or should_redraw(seen, fid):
+        resized["flag"] = False
+        now = state.version(fid)
+        _paint(slot, fid)
+        return now
+    return seen
+
+
+def run(slot: str, fid: str, *, once: bool = False) -> int:
+    """Run one panel: refuse an unknown slot, then paint on every version bump or
+    resize until killed (`once=True` — never passed by `charter panel` itself, only by
+    tests — paints exactly once and returns).
+
+    Refuses rather than drawing an empty pane for a *slot* not in `slots.SLOTS`: an
+    empty pane reads as a broken frame, and `layout.panel_argvs` can in principle be
+    handed a slot name `slots.py` does not (yet) implement a renderer for (`left`/
+    `right` today — see `layout.SLOT_SIZE`).
+    """
+    if slot not in slots.SLOTS:
+        print(f"charter panel: unknown slot {slot!r} "
+              f"(known: {', '.join(sorted(slots.SLOTS))})", file=sys.stderr)
+        return 2
+
+    resized = {"flag": True}  # the first pass always paints, resized or not
+    old_handler = _install_sigwinch(resized)
+    try:
+        seen = ""
+        while True:
+            seen = _tick(resized, seen, slot, fid)
+            if once:
+                return 0
+            time.sleep(TICK)
+    finally:
+        signal.signal(signal.SIGWINCH, old_handler)

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -66,15 +66,31 @@ _DEFAULT_ROWS = 24
 
 
 def should_redraw(seen: str, fid: str) -> bool:
-    """Has the frame changed since *seen*? Never raises: a panel that dies checking a
-    version file leaves a hole in the frame — the same failure `state.version` and
-    `slots.render` are already built not to cause, so this must not reintroduce it on
-    top of them.
+    """Has the frame changed since *seen*?
+
+    The plain, PUBLIC form of the question this module's whole run loop answers — part
+    of `panel.py`'s own interface (the plan's Task 7 contract names it alongside `run`)
+    and the direct oracle several tests assert against, including the one pinning
+    `_tick`'s read-before-paint ordering (`Tick.test_a_bump_landing_during_the_paint_is_
+    not_marked_seen`). `_tick` itself does NOT call this: it needs the actual current
+    version anyway, to remember as the next `seen`, and calling this first would mean
+    two `state.version` reads to answer one question — see `_tick`'s own docstring for
+    why it inlines the equivalent comparison against a value it already has. This
+    function exists for every OTHER caller: tests that want a yes/no without needing
+    the value, and any future one with the same need.
+
+    Trusts `state.version` never to raise, the same way `_paint` trusts `slots.render`
+    — no `try/except` here duplicating a guarantee the callee already makes. That
+    guarantee used to be incomplete (a non-UTF-8 version file escaped `state.version`'s
+    own `except OSError` and crashed whichever caller reached it) and this function's
+    own `try/except Exception: return True` was, for a while, the only thing standing
+    between that bug and a live panel — which is exactly the kind of promise this
+    module must not make unless the production path actually goes through it. Fixed at
+    the source instead (`state.version`'s own docstring), so every caller — this
+    function, `_tick`, anything future — is safe without needing its own copy of the
+    guard.
     """
-    try:
-        return state.version(fid) != seen
-    except Exception:
-        return True
+    return state.version(fid) != seen
 
 
 def _rows() -> int:

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -65,34 +65,6 @@ TICK = 0.2
 _DEFAULT_ROWS = 24
 
 
-def should_redraw(seen: str, fid: str) -> bool:
-    """Has the frame changed since *seen*?
-
-    The plain, PUBLIC form of the question this module's whole run loop answers — part
-    of `panel.py`'s own interface (the plan's Task 7 contract names it alongside `run`)
-    and the direct oracle several tests assert against, including the one pinning
-    `_tick`'s read-before-paint ordering (`Tick.test_a_bump_landing_during_the_paint_is_
-    not_marked_seen`). `_tick` itself does NOT call this: it needs the actual current
-    version anyway, to remember as the next `seen`, and calling this first would mean
-    two `state.version` reads to answer one question — see `_tick`'s own docstring for
-    why it inlines the equivalent comparison against a value it already has. This
-    function exists for every OTHER caller: tests that want a yes/no without needing
-    the value, and any future one with the same need.
-
-    Trusts `state.version` never to raise, the same way `_paint` trusts `slots.render`
-    — no `try/except` here duplicating a guarantee the callee already makes. That
-    guarantee used to be incomplete (a non-UTF-8 version file escaped `state.version`'s
-    own `except OSError` and crashed whichever caller reached it) and this function's
-    own `try/except Exception: return True` was, for a while, the only thing standing
-    between that bug and a live panel — which is exactly the kind of promise this
-    module must not make unless the production path actually goes through it. Fixed at
-    the source instead (`state.version`'s own docstring), so every caller — this
-    function, `_tick`, anything future — is safe without needing its own copy of the
-    guard.
-    """
-    return state.version(fid) != seen
-
-
 def _rows() -> int:
     """This pane's own height, measured the way `slots._width` measures its own width:
     `os.get_terminal_size(sys.stdout.fileno())` asks the file descriptor this process is
@@ -134,12 +106,13 @@ def _tick(resized: dict, seen: str, slot: str, fid: str) -> str:
     `while True`/`time.sleep`, which a test cannot call directly without either hanging
     or racing real wall-clock time.
 
-    Reads `state.version` exactly once (`should_redraw`'s own version read is not
-    reused here — it takes *seen* and *fid*, not a precomputed current value, so calling
-    it as well would mean two `stat`s to decide one repaint). `should_redraw` stays the
-    public, standalone answer to "has the frame changed", exercised directly by its own
-    tests; this inlines the same comparison against the ALREADY-read *now* instead of
-    calling it a second time.
+    Reads `state.version` exactly once, and the comparison is inline. A separate
+    `should_redraw(seen, fid)` predicate lived beside this for a while — the plan's own
+    Task 7 contract named it — but it took *seen* and *fid* rather than a precomputed
+    current value, so this function could never use it without paying a second `stat` to
+    decide one repaint, and nothing in production ever called it. It has been deleted
+    rather than documented: a public helper with no caller is a claim about an interface
+    nobody has.
 
     A resize repaints even when the frame's own version has not moved: comparing versions
     alone would leave a pane showing content laid out for a size that no longer exists

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -56,7 +56,14 @@ def _top(fid: str) -> str:
 
 
 def _bottom(fid: str) -> str:
-    """What still wants attention, and how to act on it."""
+    """What still wants attention, and how to act on it.
+
+    Only the first alert, deliberately: bottom is a fixed single-row pane, and
+    `_alerts()` already returns its entries in priority order, so this picks which one
+    survives rather than leaving it to whichever one happens to fit before
+    `tui.truncate`'s ellipsis — the same truncation-order reasoning `statusline.py`
+    names inline wherever a row has to choose what to drop.
+    """
     from .. import statusline, workspace
     ws = workspace.resolve()
     todos = statusline._todo_count(ws)

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -1,0 +1,88 @@
+"""What each edge of the frame says.
+
+Content comes from the renderers `statusline.py` already has — they are composed here,
+never rewritten, so a fix to a repo row or an alert lands in both surfaces at once.
+
+**A panel measures its own pane, never `$COLUMNS`.** A panel process is started as a
+tmux pane command, which inherits the *launching* shell's environment whole. Measured: a
+tmux pane 22 columns wide, launched from a shell that had exported `COLUMNS=200`, ran a
+probe that saw `COLUMNS env='200'` while its real tty was 22 columns.
+`charter.tui.term_width()` reads `$COLUMNS` first — correctly, for the status line, where
+stdout is a pipe and the environment is the only source of the truth. That order is
+exactly wrong here: trusting it would lay every panel out at the OUTER terminal's width
+and wrap catastrophically inside its own narrow pane. `tui.term_width()` itself is left
+alone (the status line depends on its env-first order); `_width` below asks the pane's
+own tty directly instead, and only reaches for `tui.term_width()` as a last resort, when
+there is no tty to measure at all.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from .. import tui
+
+
+def _width() -> int:
+    """The pane's own width in columns — measured, never read out of `$COLUMNS`.
+
+    `os.get_terminal_size(sys.stdout.fileno())` asks the file descriptor this process is
+    actually writing to, which for a panel launched as a tmux pane command IS the pane —
+    not a pipe, not the launching terminal. Only when that raises (stdout redirected to
+    something with no tty behind it at all, e.g. a test, or a panel run for debugging
+    with its output piped to a file) does this fall back to `tui.term_width()`, which is
+    the env-first helper the status line also uses. The measured value is returned as
+    reported, with no artificial floor clamped over it: a pane that really is 10 columns
+    wide getting reported as 20 would be exactly the theorising this function exists to
+    avoid — it would tell every caller here there is room that the real pane does not have.
+    """
+    try:
+        return os.get_terminal_size(sys.stdout.fileno()).columns
+    except OSError:
+        return tui.term_width(default=80, floor=20)
+
+
+def _top(fid: str) -> str:
+    """Identity: where you are, pinned or not, and who you are being."""
+    from .. import __version__, statusline, workspace
+    ws = workspace.resolve()
+    src = workspace.source()
+    pin = "*" if src == "$CHARTER_WORKSPACE" else ""
+    persona = statusline._persona_line() or ""
+    left = f" ⬢ {ws}{pin}"
+    right = f"{persona}  charter {__version__} "
+    return tui.truncate(f"{left}  {right}", _width())
+
+
+def _bottom(fid: str) -> str:
+    """What still wants attention, and how to act on it."""
+    from .. import statusline, workspace
+    ws = workspace.resolve()
+    todos = statusline._todo_count(ws)
+    alerts = statusline._alerts(ws)
+    parts = [f"{todos} todo" + ("s" if todos != 1 else "")]
+    parts.extend(alerts[:1])
+    parts.append("F2 menu")
+    return tui.truncate(" · ".join(p for p in parts if p), _width())
+
+
+#: Every slot charter can draw. `panel.run` refuses a name that is not in here rather
+#: than painting an empty pane, because an empty pane reads as a broken frame.
+SLOTS = {"top": _top, "bottom": _bottom}
+
+
+def render(slot: str, fid: str) -> str:
+    """Draw *slot*, or a one-line explanation of why it could not be drawn.
+
+    Never raises. A panel that dies leaves a hole in the frame, which is worse than a
+    line saying what went wrong — the same promise `statusline.render` already makes and
+    documents.
+    """
+    fn = SLOTS.get(slot)
+    if fn is None:
+        return tui.truncate(f" charter: unknown slot {slot}", _width())
+    try:
+        return fn(fid)
+    except Exception as e:
+        return tui.truncate(f" charter: {slot} unavailable ({type(e).__name__})", _width())

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -63,20 +63,40 @@ def _bottom(fid: str) -> str:
     survives rather than leaving it to whichever one happens to fit before
     `tui.truncate`'s ellipsis — the same truncation-order reasoning `statusline.py`
     names inline wherever a row has to choose what to drop.
+
+    The hotkey is READ, not spelled out: `[frame] hotkey` is configurable, and this row
+    hardcoded `F2 menu` — so a plane on `hotkey = "F1"` had its own panel telling every
+    operator the wrong key, on every repaint, forever. `config.FRAME` is the resolved
+    value `commands_frame.conf_text` binds, so there is one source for what the panel
+    says and what the frame actually does.
     """
-    from .. import statusline, workspace
+    from .. import config, statusline, workspace
     ws = workspace.resolve()
     todos = statusline._todo_count(ws)
     alerts = statusline._alerts(ws)
     parts = [f"{todos} todo" + ("s" if todos != 1 else "")]
     parts.extend(alerts[:1])
-    parts.append("F2 menu")
+    parts.append(f"{config.FRAME['hotkey']} menu")
     return tui.truncate(" · ".join(p for p in parts if p), _width())
 
 
 #: Every slot charter can draw. `panel.run` refuses a name that is not in here rather
 #: than painting an empty pane, because an empty pane reads as a broken frame.
 SLOTS = {"top": _top, "bottom": _bottom}
+
+
+def unimplemented(configured) -> list[str]:
+    """Which of *configured* charter sizes and accepts but has no renderer for.
+
+    `left`/`right` today: `instance.FRAME_SLOTS` accepts both and `layout.SLOT_SIZE`
+    sizes both, while :data:`SLOTS` implements neither. Three callers need exactly this
+    list and must agree — `commands_frame.cmd_launch` (to skip splitting a pane that
+    would be permanently dead under `remain-on-exit on`), `commands_frame.frame_ready`
+    (`--probe`) and `doctor.check_frame` (both to SAY so, which is the only place it is
+    said at all now) — so the question is answered here, next to the registry that
+    answers it, rather than three times over.
+    """
+    return sorted({s for s in configured if s not in SLOTS})
 
 
 def render(slot: str, fid: str) -> str:

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -23,6 +23,15 @@ charter's hooks, where an exception costs a session its turn; ``version()`` is p
 several times a second by a panel, where a write-on-read would fight ``reap()`` over
 whether a dead frame's directory should exist. A missing frame answers with a sentinel
 ("0", ``None``, ``[]``) rather than an exception or a side effect.
+
+An id can be shaped correctly and still be unusable: ``contain.child`` bounds shape, not
+length, so a multi-thousand-character ``$CHARTER_SESSION_ID`` passes it and then hits
+``mkdir``'s own limit (``ENAMETOOLONG``) — reachable in practice, since
+``session.py``'s id-safety regex strips characters but never bounds length. The read
+paths (``version``, ``exit_code``) were already safe here, because a failing read was
+already inside a ``try/except OSError``; ``frame_dir``'s ``mkdir`` and the writes in
+``bump``/``record_exit`` needed the same guard to make the claim true rather than
+aspirational.
 """
 
 from __future__ import annotations
@@ -71,12 +80,28 @@ def frame_dir(fid: str, *, create: bool = False) -> Path | None:
     polling the version of a frame that ``reap()`` already removed must see it stay gone,
     not have its own read resurrect it; the two write paths (``bump``, ``record_exit``)
     pass ``create=True`` because minting state IS their job.
+
+    **The length guard lives here, not in `frame_id`.** `contain.child` bounds *shape*
+    (no traversal, no separators) but not *length* — an id thousands of characters long
+    still passes it — and `$CHARTER_SESSION_ID` reaches `bump()` without ever going
+    through `frame_id`'s minting, so a cap there would guard some callers and not others.
+    `mkdir` is the one place every caller's id necessarily passes through, so it is the
+    one place a length cap protects all of them: an oversized-but-otherwise-valid id
+    degrades to "no directory" (``ENAMETOOLONG``, caught below) exactly like a hostile
+    one does above, rather than raising out of a hook that cannot afford it.
     """
     d = contain.child(_root(), fid)
     if d is None:
         return None
     if create:
-        d.mkdir(parents=True, exist_ok=True)
+        try:
+            d.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            # Shaped correctly (no traversal, no separators) but unusable anyway —
+            # ENAMETOOLONG is the case this exists for, but any mkdir failure here
+            # (permissions, a full filesystem) gets the same treatment: the caller
+            # asked for a directory it cannot have, not for an exception.
+            return None
     return d
 
 
@@ -93,8 +118,14 @@ def bump(fid: str) -> None:
     if d is None:
         return
     tmp = d / "version.tmp"
-    tmp.write_text(f"{time.time_ns()}\n")
-    os.replace(tmp, d / "version")
+    try:
+        tmp.write_text(f"{time.time_ns()}\n")
+        os.replace(tmp, d / "version")
+    except OSError:
+        # The directory existing doesn't guarantee the write does too (a filesystem
+        # that fills up between the two calls above, say) — same must-not-raise
+        # promise as the mkdir guard in frame_dir, covering the step after it.
+        return
 
 
 def version(fid: str) -> str:
@@ -121,8 +152,11 @@ def record_exit(fid: str, code: int) -> None:
     if d is None:
         return
     tmp = d / "exit.tmp"
-    tmp.write_text(f"{int(code)}\n")
-    os.replace(tmp, d / "exit")
+    try:
+        tmp.write_text(f"{int(code)}\n")
+        os.replace(tmp, d / "exit")
+    except OSError:
+        return
 
 
 def exit_code(fid: str) -> int | None:

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -140,13 +140,26 @@ def version(fid: str) -> str:
     rather than creating one by calling :func:`bump`. Doing that on a read would make
     every panel's poll resurrect a directory :func:`reap` had just deleted, and the two
     would fight forever over whether the frame still exists.
+
+    ``except (OSError, ValueError)``, not just ``OSError``: a version file holding bytes
+    that are not valid UTF-8 makes ``read_text()`` raise ``UnicodeDecodeError`` — a
+    ``ValueError`` subclass, never caught by ``OSError`` alone — and this module's own
+    docstring already promises "nothing here raises... a missing frame answers with the
+    sentinel rather than an exception." A panel polls this function several times a
+    second and has nothing of its own guarding the call (`panel._tick` reads it
+    directly); an uncaught decode error here used to reach the run loop uncaught and
+    kill the pane it was drawn in — precisely the hole this whole module exists to
+    close, just reached through content corruption rather than a missing file.
+    ``exit_code`` below already caught this shape (``int()`` raises ``ValueError`` for
+    unparseable text, which happens to catch a decode error too); this brings
+    ``version`` in line with it rather than leaving the two read paths inconsistent.
     """
     d = frame_dir(fid)
     if d is None:
         return "0"
     try:
         return (d / "version").read_text().strip() or "0"
-    except OSError:
+    except (OSError, ValueError):
         return "0"
 
 

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -1,0 +1,155 @@
+"""What one frame knows about itself, on disk.
+
+Under ``<STATE_DIR>/frame/<frame-id>/`` — per frame, never global, because two frames may
+run at once (one per session, named by workspace and pid) and a shared version file would
+make each frame's panels redraw for the other's activity.
+
+``config.STATE_DIR`` is read as an attribute at call time, everywhere below, and never
+imported as a bare name (``from ..config import STATE_DIR``) — the test harness repoints
+it with ``config.use()`` after this module has already been imported, and a name bound at
+import time would keep pointing at whatever ``STATE_DIR`` was when Python first loaded
+this file, which on a developer's machine is the real plane.
+
+**Minting an id is not resolving one.** :func:`frame_id` sanitises, because it is
+producing a name from scratch — the same thing a slug generator does. :func:`frame_dir`
+does the opposite: it is handed an id from a caller and must not invent a second identity
+for a bad one by rewriting it into a good one. A later caller (``notify.plane_changed``)
+reads its id out of ``$CHARTER_SESSION_ID`` rather than minting it here, so the id
+``frame_dir`` resolves is not always one this module produced — it goes through
+:func:`charter.contain.child`, which refuses a hostile name outright (see #328, #348).
+
+**Nothing here raises, and nothing here mutates on a read.** ``bump()`` runs from
+charter's hooks, where an exception costs a session its turn; ``version()`` is polled
+several times a second by a panel, where a write-on-read would fight ``reap()`` over
+whether a dead frame's directory should exist. A missing frame answers with a sentinel
+("0", ``None``, ``[]``) rather than an exception or a side effect.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import time
+from pathlib import Path
+
+from .. import config, contain
+
+#: Anything outside this becomes an underscore. Only used to MINT an id in
+#: :func:`frame_id` — never to rewrite one handed to :func:`frame_dir`, which resolves
+#: through :func:`charter.contain.child` instead and refuses rather than rewrites.
+_UNSAFE = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def frame_id(workspace: str, pid: int) -> str:
+    """A stable id for one frame: the workspace it is for, and the launcher's pid.
+
+    The same pair the tmux session and socket are named for, so a directory on disk and a
+    session in `tmux list-sessions` can always be matched up by eye. *workspace* is a name
+    read out of ``workspace.json`` or a directory listing rather than typed by an operator
+    (#328), so it is sanitised here rather than trusted — this is the one place in the
+    module that mints an identity instead of resolving one handed to it.
+    """
+    safe = _UNSAFE.sub("_", workspace).strip("._-") or "frame"
+    return f"{safe}-{int(pid)}"
+
+
+def _root() -> Path:
+    return Path(config.STATE_DIR) / "frame"
+
+
+def frame_dir(fid: str, *, create: bool = False) -> Path | None:
+    """The directory *fid* owns, or ``None`` when *fid* cannot name one there.
+
+    Resolves through :func:`charter.contain.child` rather than sanitising: *fid* may have
+    come from ``$CHARTER_SESSION_ID`` rather than from :func:`frame_id`, and rewriting a
+    hostile value into a safe-looking one would silently invent a second identity for it
+    instead of surfacing the defect (the exact failure ``contain.child`` documents).
+
+    ``create`` defaults to ``False`` so every READ in this module — ``version``,
+    ``exit_code`` — never creates the directory it is only trying to look at. A panel
+    polling the version of a frame that ``reap()`` already removed must see it stay gone,
+    not have its own read resurrect it; the two write paths (``bump``, ``record_exit``)
+    pass ``create=True`` because minting state IS their job.
+    """
+    d = contain.child(_root(), fid)
+    if d is None:
+        return None
+    if create:
+        d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def bump(fid: str) -> None:
+    """Record that the frame changed. A caller on a must-not-crash path (a hook).
+
+    Written to a temp file and moved into place with ``os.replace``, which is atomic on
+    the same filesystem, so a panel reading mid-bump gets the previous value whole rather
+    than a half-written one. Silently does nothing for an *fid* :func:`frame_dir` refuses
+    — this runs from charter's hooks, where raising costs a session its turn, so a hostile
+    or malformed id is a no-op here rather than an exception.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    tmp = d / "version.tmp"
+    tmp.write_text(f"{time.time_ns()}\n")
+    os.replace(tmp, d / "version")
+
+
+def version(fid: str) -> str:
+    """The frame's version, cheap enough to poll several times a second.
+
+    A probe, not a mutation: a frame with no version file yet — or no directory at all,
+    because it was never bumped or was just reaped — answers with the sentinel ``"0"``
+    rather than creating one by calling :func:`bump`. Doing that on a read would make
+    every panel's poll resurrect a directory :func:`reap` had just deleted, and the two
+    would fight forever over whether the frame still exists.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return "0"
+    try:
+        return (d / "version").read_text().strip() or "0"
+    except OSError:
+        return "0"
+
+
+def record_exit(fid: str, code: int) -> None:
+    """Record the harness's exit code. Same atomic-write shape as :func:`bump`."""
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    tmp = d / "exit.tmp"
+    tmp.write_text(f"{int(code)}\n")
+    os.replace(tmp, d / "exit")
+
+
+def exit_code(fid: str) -> int | None:
+    """The recorded exit code, or ``None`` when the frame has not finished (or exist)."""
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        return int((d / "exit").read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def reap(live: set[str]) -> list[str]:
+    """Remove state for frames whose tmux session is gone. Returns what was removed.
+
+    Never by age: a frame open for two days is exactly a working frame, and an age
+    heuristic would delete precisely that one. *live* names the sessions `tmux
+    list-sessions` still reports, so the only frames removed are ones nothing is watching
+    any more.
+    """
+    root = _root()
+    if not root.is_dir():
+        return []
+    removed = []
+    for d in sorted(root.iterdir()):
+        if d.is_dir() and d.name not in live:
+            shutil.rmtree(d, ignore_errors=True)
+            removed.append(d.name)
+    return removed

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -108,11 +108,15 @@ def frame_dir(fid: str, *, create: bool = False) -> Path | None:
 def bump(fid: str) -> None:
     """Record that the frame changed. A caller on a must-not-crash path (a hook).
 
-    Written to a temp file and moved into place with ``os.replace``, which is atomic on
-    the same filesystem, so a panel reading mid-bump gets the previous value whole rather
-    than a half-written one. Silently does nothing for an *fid* :func:`frame_dir` refuses
-    — this runs from charter's hooks, where raising costs a session its turn, so a hostile
-    or malformed id is a no-op here rather than an exception.
+    Written to a temp file and moved into place with ``os.replace``. A failed write is
+    swallowed (see below), not raised — which is exactly why the atomic replace matters
+    more here than it would if a failure were still visible: ``os.replace`` only ever
+    touches the target file by fully replacing it, never partially, so a write that
+    cannot complete leaves the previous version exactly as a reader last saw it rather
+    than corrupting it silently. Does nothing for an *fid* :func:`frame_dir` refuses, and
+    nothing for a write that fails after the directory exists (a full filesystem, say) —
+    this runs from charter's hooks, where raising costs a session its turn, so every
+    failure here is a no-op rather than an exception.
     """
     d = frame_dir(fid, create=True)
     if d is None:

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -1,7 +1,19 @@
 """The only module in charter that runs tmux.
 
-Kept alone so everything else — layout, panels, slots — is testable on a machine with no
-tmux installed, and so there is exactly one place where the argv rule can be broken.
+Kept alone so everything else — layout, panels, slots, the menu table — is testable on a
+machine with no tmux installed, and so there is exactly one place where the argv rule can
+be broken. That sentence was aspirational for a while: `commands_frame.py` called
+`subprocess.run(["tmux", …])` at thirteen separate call sites of its own, each repeating
+`capture_output=True, text=True, timeout=15` and each catching nothing, so a wedged tmux
+raised `subprocess.TimeoutExpired` straight out of the launcher. :func:`run` and
+:func:`interact` below are what the sentence needed to become true: every tmux command
+charter issues goes through one of them.
+
+One honest exception remains, and it is not a tmux call by construction:
+`commands_frame.cmd_action` runs whatever argv a menu entry resolved to. That argv is a
+LIST out of charter's own state — a tmux command today (`detach-client`), but nothing in
+`menu.record`'s contract says it has to be one — so it is run as a plain child process
+rather than pushed through a tmux-shaped helper that would have to lie about what it is.
 """
 
 from __future__ import annotations
@@ -10,8 +22,30 @@ import re
 import shutil
 import subprocess
 
-#: `display-menu` arrived in 3.0 and `display-popup` in 3.2, and the frame's interaction
-#: model uses both. Floor at the higher one and degrade below it rather than refuse.
+from .. import util
+
+#: The tmux the frame is known to work on, and the version charter warns below.
+#:
+#: **Not `display-popup`.** An earlier version of this constant justified 3.2 by naming
+#: `display-popup` (3.2) as part of "the frame's interaction model" — that command
+#: appears nowhere in shipped code, in any form; only in two comments. The number is
+#: right for a different reason, so the reason is written down rather than the number
+#: lowered to match a justification that was never real:
+#:
+#: * `display-menu` — what the hotkey actually opens — arrived in 3.0.
+#: * The exit-code mechanism rests on PANE-scoped hooks (`set-hook -p`, see
+#:   `commands_frame._pane_died_write_hook_argv`), which followed pane options into tmux
+#:   some time after 3.0. If those do not install, `cmd_launch` does not merely lose the
+#:   exit code: a failed TEARDOWN hook makes it refuse to attach at all, which is a far
+#:   worse outcome than the warning this floor produces.
+#:
+#: No tmux older than 3.7c exists on the machine this was written on, so where exactly
+#: `set-hook -p` first appeared could not be confirmed by running it — and an unverified
+#: reading of tmux's CHANGES is not a good enough reason to lower a floor whose only cost
+#: when it is too high is one accurate warning, and whose cost when it is too low is a
+#: frame that starts and then refuses to attach. Kept at 3.2, conservatively, with the
+#: real reason recorded. Below it charter WARNS and launches anyway — nothing refuses,
+#: and nothing disables the hotkey either; see :func:`below_floor_message`.
 FLOOR = (3, 2)
 
 #: The first tmux release with a `window-resized` hook AT ALL — the VERSION is read
@@ -31,7 +65,35 @@ FLOOR = (3, 2)
 #: two constants.
 RESIZE_HOOK_FLOOR = (3, 3)
 
+#: The session-scoped tmux environment variable carrying the interpreter that runs
+#: charter from inside a frame — `"$CHARTER_PY" -m charter …`, never a bare `charter`
+#: off `$PATH`. Defined HERE, not in either of the two modules that build text around it
+#: (`commands_frame.conf_text`'s hotkey bind and `menu.menu_argv`'s per-item action), so
+#: the name the writer sets and the name both readers spell cannot drift apart —
+#: `commands_frame` imports `menu`, so there is no direction in which those two could
+#: have shared it between themselves. See `commands_frame._charter_py_env_argv` for why
+#: the value travels out of band at all.
+CHARTER_PY_ENV = "CHARTER_PY"
+
+#: How long any one tmux ADMIN command may take before charter stops waiting for it.
+#: Every command the launcher issues is a local, in-process request to a server on a
+#: unix socket; none of them is supposed to take measurable time at all, so a command
+#: still unanswered after this is a wedged server, not a slow one. See :func:`run`.
+TIMEOUT = 15
+
 _VERSION = re.compile(r"^tmux (\d+)\.(\d+)")
+
+#: What :func:`run` reports as the return code of a command that never answered.
+#: `timeout(1)`'s own convention, and deliberately not `1`: every caller in
+#: `commands_frame` already branches on "nonzero", so a timeout degrades exactly the
+#: way a refusal does, but the number still tells a reader which of the two happened.
+TIMED_OUT = 124
+
+#: What :func:`run` reports when tmux could not be started at all (`OSError` — the
+#: binary vanished between `version()` and this call, a fork failure). 127 is the
+#: shell's own "command not found", the same code `commands_frame.bypass` returns for a
+#: missing harness binary.
+COULD_NOT_RUN = 127
 
 
 def _probe() -> str | None:
@@ -58,15 +120,6 @@ def version() -> tuple[int, int] | None:
     return (int(m.group(1)), int(m.group(2))) if m else None
 
 
-def available() -> bool:
-    return version() is not None
-
-
-def meets_floor() -> bool:
-    v = version()
-    return bool(v and v >= FLOOR)
-
-
 def absent_message() -> str:
     return ("charter's frame needs tmux, which is not on this machine.\n"
             "  install:  brew install tmux   (or your package manager)\n"
@@ -74,12 +127,84 @@ def absent_message() -> str:
 
 
 def below_floor_message(v: tuple[int, int]) -> str:
-    return (f"tmux {v[0]}.{v[1]} composes the frame, but its menu needs "
-            f"tmux {FLOOR[0]}.{FLOOR[1]} — the frame starts with the hotkey disabled.")
+    """What an operator below :data:`FLOOR` is actually in for.
+
+    An earlier wording said "the frame starts with the hotkey disabled". Nothing
+    disables the hotkey — `commands_frame.cmd_launch` warns and continues, and
+    `conf_text` still emits the bind unchanged — so that sentence described a mechanism
+    that does not exist, in the one message an operator reads to find out what they are
+    losing. What actually happens is written instead.
+    """
+    return (f"tmux {v[0]}.{v[1]} composes the frame, and charter still launches it — "
+            f"nothing here is disabled. Below tmux {FLOOR[0]}.{FLOOR[1]} charter has "
+            f"not verified two things it relies on: the hotkey stays bound but may open "
+            f"nothing (`display-menu`), and the pane-scoped hooks that carry the "
+            f"harness's real exit code may fail to install, in which case charter says "
+            f"so and declines to attach rather than risk a session nothing can end.")
 
 
-def run(cmd: list[str]) -> int:
-    """Run one tmux command. *cmd* is a LIST; this module never joins argv."""
-    if not isinstance(cmd, list):
-        raise TypeError(f"tmux argv must be a list, got {type(cmd).__name__}: {cmd!r} — see frame/layout.py")
-    return subprocess.run(cmd).returncode
+def report_failure(action: str, cmd: list[str], proc: subprocess.CompletedProcess) -> None:
+    """Name the command that failed and tmux's own stderr. Never silent.
+
+    Correction 2's rule, in one place: `subprocess.run(cmd, env=env)` with the result
+    thrown away is exactly how the pane-index bug `frame/layout.py`'s own module
+    docstring describes would have shipped — a frame missing a panel, and nothing
+    anywhere saying why. :func:`run` calls this for every non-zero return by default, so
+    a caller has to opt OUT of reporting (and say why) rather than remember to opt in.
+    """
+    stderr = (proc.stderr or "").strip() or "(tmux printed nothing to stderr)"
+    util.err(f"charter frame: {action} failed — `{' '.join(cmd)}`: {stderr}")
+
+
+def run(action: str, argv: list[str], *, env: dict | None = None,
+        timeout: float = TIMEOUT, report: bool = True) -> subprocess.CompletedProcess:
+    """Run one tmux ADMIN command, captured and time-boxed. Never raises.
+
+    *action* is the human-readable phrase :func:`report_failure` prints ("installing the
+    exit-status hook") — required, not optional, because the failure message is the whole
+    reason this wrapper exists and a call site that has not decided what to call itself
+    has not decided what it is doing either.
+
+    **A timeout comes back as a return code, not an exception.** Ten of the launcher's
+    eleven admin commands run AFTER `new-session` has already started the harness
+    detached; a `subprocess.TimeoutExpired` propagating out of one of them gave the
+    operator a traceback, a filed charter crash report, an orphaned agent session and no
+    reattach line. Every caller already branches on a non-zero return, so a wedged server
+    now degrades down the same path a refusal does — see :data:`TIMED_OUT`.
+
+    *report* is opt-out for the two callers that read the failure themselves: a query
+    whose whole answer is "cannot tell" (`_query_pane_dead_status`), and one whose
+    non-zero return is the ORDINARY case rather than a fault (`_live_sessions` against a
+    socket no server has ever run on).
+    """
+    if not isinstance(argv, list):
+        raise TypeError(f"tmux argv must be a list, got {type(argv).__name__}: {argv!r} "
+                        "— see frame/layout.py")
+    try:
+        proc = subprocess.run(argv, env=env, capture_output=True, text=True,
+                              timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc = subprocess.CompletedProcess(
+            argv, TIMED_OUT, stdout="",
+            stderr=f"tmux did not answer within {timeout:g}s")
+    except OSError as e:
+        proc = subprocess.CompletedProcess(argv, COULD_NOT_RUN, stdout="", stderr=str(e))
+    if proc.returncode != 0 and report:
+        report_failure(action, argv, proc)
+    return proc
+
+
+def interact(argv: list[str], *, env: dict | None = None) -> subprocess.CompletedProcess:
+    """Run one tmux command that OWNS the operator's terminal — no capture, no timeout.
+
+    `attach` and `display-menu` are not admin commands: the first IS the session for as
+    long as the harness runs, and the second draws on an attached client and waits for a
+    keypress. Capturing either would swallow the operator's own screen, and time-boxing
+    either would kill a frame for the crime of being used. Split from :func:`run` rather
+    than expressed as flags on it, so "this one has no timeout" is a visible property of
+    the call site instead of a keyword argument easily copied to a command that needs one.
+    """
+    if not isinstance(argv, list):
+        raise TypeError(f"tmux argv must be a list, got {type(argv).__name__}: {argv!r} "
+                        "— see frame/layout.py")
+    return subprocess.run(argv, env=env)

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -63,5 +63,6 @@ def below_floor_message(v: tuple[int, int]) -> str:
 
 def run(cmd: list[str]) -> int:
     """Run one tmux command. *cmd* is a LIST; this module never joins argv."""
-    assert isinstance(cmd, list), "tmux argv must be a list — see frame/layout.py"
+    if not isinstance(cmd, list):
+        raise TypeError(f"tmux argv must be a list, got {type(cmd).__name__}: {cmd!r} — see frame/layout.py")
     return subprocess.run(cmd).returncode

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -14,6 +14,23 @@ import subprocess
 #: model uses both. Floor at the higher one and degrade below it rather than refuse.
 FLOOR = (3, 2)
 
+#: The first tmux release with a `window-resized` hook AT ALL — the VERSION is read
+#: from tmux's own published CHANGES file (github.com/tmux/tmux, "CHANGES FROM 3.2a
+#: TO 3.3"): "Add a window-resized hook which is fired when the window is actually
+#: resized which may be later than the client resize." (No pre-3.3 tmux binary was
+#: available on this machine to install one directly and confirm it refuses the name;
+#: the ERROR SHAPE below — "invalid option: <name>", rc 1 — WAS confirmed by hand
+#: against a real tmux 3.7c, using a fabricated hook name it does not recognise, which
+#: is generic `set-hook` argument-parsing text rather than anything specific to this
+#: one hook's name.) HIGHER than `FLOOR` itself — not folded into it — because an
+#: operator on 3.2 or 3.2a is explicitly still allowed to launch (`below_floor_message`
+#: warns, does not refuse) and would otherwise see `set-hook … window-resized …` fail
+#: with that same "invalid option" text on every single launch. Raising `FLOOR` itself
+#: would refuse the whole frame over a gap that only costs cosmetic resize-drift, not
+#: the menu `FLOOR` protects — the two floors mean two different things and must stay
+#: two constants.
+RESIZE_HOOK_FLOOR = (3, 3)
+
 _VERSION = re.compile(r"^tmux (\d+)\.(\d+)")
 
 

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -1,0 +1,67 @@
+"""The only module in charter that runs tmux.
+
+Kept alone so everything else — layout, panels, slots — is testable on a machine with no
+tmux installed, and so there is exactly one place where the argv rule can be broken.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+
+#: `display-menu` arrived in 3.0 and `display-popup` in 3.2, and the frame's interaction
+#: model uses both. Floor at the higher one and degrade below it rather than refuse.
+FLOOR = (3, 2)
+
+_VERSION = re.compile(r"^tmux (\d+)\.(\d+)")
+
+
+def _probe() -> str | None:
+    """`tmux -V`'s output, or ``None`` when there is no tmux to ask."""
+    if not shutil.which("tmux"):
+        return None
+    try:
+        out = subprocess.run(["tmux", "-V"], capture_output=True, text=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.stdout.strip() or None
+
+
+def version() -> tuple[int, int] | None:
+    """``(major, minor)``, or ``None`` when tmux is absent or unparseable.
+
+    ``None`` is not "version zero": it says charter could not find out, which reads
+    differently from "too old" and is answered with a different message.
+    """
+    raw = _probe()
+    if not raw:
+        return None
+    m = _VERSION.match(raw)
+    return (int(m.group(1)), int(m.group(2))) if m else None
+
+
+def available() -> bool:
+    return version() is not None
+
+
+def meets_floor() -> bool:
+    v = version()
+    return bool(v and v >= FLOOR)
+
+
+def absent_message() -> str:
+    return ("charter's frame needs tmux, which is not on this machine.\n"
+            "  install:  brew install tmux   (or your package manager)\n"
+            "  without:  charter <harness> --no-frame  runs the harness bare")
+
+
+def below_floor_message(v: tuple[int, int]) -> str:
+    return (f"tmux {v[0]}.{v[1]} composes the frame, but its menu needs "
+            f"tmux {FLOOR[0]}.{FLOOR[1]} — the frame starts with the hotkey disabled.")
+
+
+def run(cmd: list[str]) -> int:
+    """Run one tmux command. *cmd* is a LIST; this module never joins argv."""
+    assert isinstance(cmd, list), "tmux argv must be a list — see frame/layout.py"
+    return subprocess.run(cmd).returncode

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -41,6 +41,25 @@ class Harness:
     #: harness carries everything, and `doctor` prints that as a clean row.
     deficits: tuple[Deficit, ...] = ()
 
+    #: The word an operator types after ``charter`` to run this harness in a frame.
+    #: Distinct from :attr:`name`, which is the harness's own identity in
+    #: ``$CHARTER_HARNESS``: ``claude-code`` names the harness, ``claude`` is the binary
+    #: and what a hand types. Empty means charter cannot launch this harness.
+    cli_name: str = ""
+
+    #: The binary to exec. Separate from :attr:`cli_name` because they differ.
+    binary: str = ""
+
+    def launch_argv(self, extra: list[str]) -> list[str]:
+        """Argv for starting this harness, with the operator's arguments appended.
+
+        A **list**, never a joined string, and that is a security property rather than a
+        style preference: tmux does not shell-interpret separate arguments and does
+        interpret a joined one (pinned against 3.7c). Returning a string here would put
+        command injection back into every launch.
+        """
+        return [self.binary, *extra]
+
     def detect(self) -> bool:
         """Is this harness live, judged by its own native evidence?
 

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -53,7 +53,15 @@ class Harness:
     #: and what a hand types. Empty means charter cannot launch this harness.
     cli_name: str = ""
 
-    #: The binary to exec. Separate from :attr:`cli_name` because they differ.
+    #: The binary to exec. All three shipped harnesses set this to the SAME string as
+    #: :attr:`cli_name` — the split is not there because they differ today, and saying
+    #: so was a lie a reader could check in thirty seconds. It is kept because the two
+    #: answer to different owners: `cli_name` is charter's own command surface, checked
+    #: for collisions against every core `charter` command at parser-construction time
+    #: (see `cli._wire`), while `binary` is whatever the harness's vendor happens to
+    #: install. Either can move without the other — a harness renaming its binary, or
+    #: charter having to rename a subcommand that collided — and collapsing them into
+    #: one attribute would make each of those a change to the other's meaning.
     binary: str = ""
 
     def launch_argv(self, extra: list[str]) -> list[str]:

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -4,9 +4,15 @@ A *harness* is the agent runtime charter runs inside — Claude Code, opencode, 
 whatever comes next — as distinct from a *host*, which in this codebase is a forge
 (``github.com``, a self-hosted GitLab). ADR 0015.
 
-The interface is deliberately three members wide. Charter does not model a harness; it
-models the three things it needs from one: what it calls itself, what it cannot carry,
-and what has to be written on disk for charter to work inside it.
+Charter does not model a harness; it models what it needs from one, and the interface
+grows only when that need does. Three members answered while charter only lived inside a
+harness: what it calls itself, what it cannot carry, and what has to be written on disk
+for charter to work inside it. `charter <harness>` adds a fourth, because charter now
+runs the harness rather than only living inside it, so it also needs to know how to
+start one — what an operator types, and what argv to exec (ADR 0018, issue #345). That
+fact lives here, on the harness, for the same reason the first three do: anywhere else
+it is a hardcoded literal per harness, the exact failure `registry.py` iterating
+``KINDS`` exists to end. A fifth member needs the same kind of argument, not just a use.
 """
 
 from __future__ import annotations

--- a/charter/harness/claude_code.py
+++ b/charter/harness/claude_code.py
@@ -23,6 +23,9 @@ class ClaudeCodeHarness(Harness):
     #: that happens to have no gaps recorded yet.
     deficits = ()
 
+    cli_name = "claude"
+    binary = "claude"
+
     def detect(self) -> bool:
         """``$CLAUDE_PLUGIN_ROOT`` is set for the plugin's own processes.
 

--- a/charter/harness/codex.py
+++ b/charter/harness/codex.py
@@ -140,6 +140,9 @@ class CodexHarness(Harness):
                 "`session_id` directly."),
     )
 
+    cli_name = "codex"
+    binary = "codex"
+
     def upgrade(self, root: Path) -> tuple[str, str]:
         """Codex's own config block never needs moving; its PLUGIN does.
 

--- a/charter/harness/opencode.py
+++ b/charter/harness/opencode.py
@@ -321,6 +321,9 @@ class OpenCodeHarness(Harness):
                 "effectful tools (write/edit/bash) instead of arriving beside them."),
     )
 
+    cli_name = "opencode"
+    binary = "opencode"
+
     def stale_wiring(self) -> str:
         """The version that wrote the installed plugin, when it is not this one.
 

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -1864,6 +1864,8 @@ def context_block(cwd=None) -> str:
 
 
 def sessionstart() -> int:
+    from .frame import notify
+    notify.plane_changed()
     data = _read_stdin()
     # Read the piece's existing state BEFORE recording this session as alive — the write
     # below would otherwise replace the holder's mark with ours and hide the collision.
@@ -2010,6 +2012,8 @@ def memory_share_note() -> str:
 
 
 def posttooluse() -> int:
+    from .frame import notify
+    notify.plane_changed()
     data = _read_stdin()
     _touch_piece(data)
     # The approval half of the `routing: require` edit nudge (`pretooluse_edit`), which asks
@@ -2710,6 +2714,8 @@ def _commitment_nudge(prompt: str, sid: str | None, unattended: bool = False) ->
 
 
 def userpromptsubmit() -> int:
+    from .frame import notify
+    notify.plane_changed()
     data = _read_stdin()
     _touch_piece(data)
     sid = data.get("session_id")

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -2232,6 +2232,8 @@ def posttooluse_bash() -> int:
     narrowing the matcher with the host's `if:` condition (e.g. ``Bash(git *)``) is the
     obvious reduction, deferred only because it would raise charter's minimum host version.
     """
+    from .frame import notify
+    notify.plane_changed()
     _ask_approved(_read_stdin())
     return 0
 
@@ -2248,6 +2250,8 @@ def posttooluse_skill() -> int:
     workspace or client name would travel. `skilluse.record` swallows its own failures: a
     tally must never break a turn.
     """
+    from .frame import notify
+    notify.plane_changed()
     data = _read_stdin()
     _touch_piece(data)
     try:
@@ -2327,6 +2331,8 @@ def posttooluse_message() -> int:
     created — `main`, another session, a teammate's agent. Attributing those would be
     inventing a delegation that did not happen.
     """
+    from .frame import notify
+    notify.plane_changed()
     data = _read_stdin()
     if (data.get("tool_name") or "") != "SendMessage":
         return 0
@@ -2346,6 +2352,8 @@ def posttooluse_message() -> int:
 
 
 def posttooluse_dispatch() -> int:
+    from .frame import notify
+    notify.plane_changed()
     data = _read_stdin()
     # The approval half of the overlapping-dispatch nudge (`pretooluse_dispatch`). Before
     # the `subagent_type` check: an ask that was approved was approved whatever the tally

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -320,34 +320,32 @@ def drift(root: Path) -> list[str]:
 #: reach a tmux argv — so an unknown one is dropped rather than passed through.
 FRAME_SLOTS = ("top", "bottom", "left", "right")
 
-FRAME_DEFAULTS = {
-    "slots": ["top", "bottom"],
+#: Every ``[frame]`` setting, keyed by the name :func:`frame_of` returns it under
+#: (underscore — reads better at the call site, e.g. ``frame["history_limit"]``) and
+#: paired with ``(default, toml_key)``: the shipped default, and the name charter.toml
+#: actually spells it with. Three of the six differ — ``history-limit``, ``min-cols``,
+#: ``min-rows`` use a hyphen, per docs/frame.md — so the TOML spelling travels right next
+#: to the default it belongs to instead of living in a second dict a reader has to keep
+#: in sync by hand. Two dicts keyed apart, as an earlier draft of this had it, meant a key
+#: added to one and not the other was a ``KeyError`` raised from inside :func:`frame_of` —
+#: in a module every charter command imports. One structure makes that failure mode
+#: impossible by construction rather than merely unlikely. Only the ``toml_key`` spelling
+#: is ever honoured — the underscore form is not accepted as a second, undocumented alias.
+FRAME_FIELDS = {
+    "slots": (["top", "bottom"], "slots"),
     #: Off by default: tmux's `set -g mouse on` takes over drag-select, so turning this on
     #: trades the operator's terminal text-selection for clickable panels. That trade
     #: belongs to a later release that actually ships clickable panels, not this one.
-    "mouse": False,
-    "hotkey": "F2",
-    "history_limit": 50000,
-    "min_cols": 100,
-    "min_rows": 20,
+    "mouse": (False, "mouse"),
+    "hotkey": ("F2", "hotkey"),
+    "history_limit": (50000, "history-limit"),
+    "min_cols": (100, "min-cols"),
+    "min_rows": (20, "min-rows"),
 }
 
-#: charter.toml spells these three with a hyphen (``history-limit``, ``min-cols``,
-#: ``min-rows`` — the spelling documented in docs/frame.md), while the dict this module
-#: returns uses an underscore, which reads better at the call site
-#: (``frame["history_limit"]``). The mapping is written out explicitly, one
-#: operator-facing name per dict key, rather than derived by swapping characters: the
-#: TOML names are a published interface and belong in the source where a reader can see
-#: them. Only the spelling listed here is ever honoured — the underscore form is not
-#: accepted in charter.toml as a second, undocumented alias.
-FRAME_TOML_KEYS = {
-    "slots": "slots",
-    "mouse": "mouse",
-    "hotkey": "hotkey",
-    "history_limit": "history-limit",
-    "min_cols": "min-cols",
-    "min_rows": "min-rows",
-}
+#: The plain ``{key: default}`` view of :data:`FRAME_FIELDS`, for callers (and the
+#: ``config.FRAME`` docstring) that only want the shipped defaults, not the TOML mapping.
+FRAME_DEFAULTS = {key: default for key, (default, _toml_key) in FRAME_FIELDS.items()}
 
 
 def frame_of(cfg: dict) -> dict:
@@ -361,8 +359,7 @@ def frame_of(cfg: dict) -> dict:
     section = cfg.get("frame")
     if not isinstance(section, dict):
         return out
-    for key, default in FRAME_DEFAULTS.items():
-        toml_key = FRAME_TOML_KEYS[key]
+    for key, (default, toml_key) in FRAME_FIELDS.items():
         if toml_key not in section:
             continue
         value = section[toml_key]
@@ -372,12 +369,15 @@ def frame_of(cfg: dict) -> dict:
                 if kept:
                     out[key] = kept
             continue
-        # `bool` is a subclass of `int` in Python, so `isinstance(1, int)` is True even
-        # though `1` was never meant to stand in for a bool default, and
-        # `isinstance(True, int)` is True even though `True` was never meant to stand in
-        # for an int default. Both directions have to be ruled out explicitly, or
-        # `mouse = 1` and `history-limit = true` would silently pass as valid instead of
-        # being dropped.
+        # `bool` is a subclass of `int` in Python, so `isinstance(True, int)` is True even
+        # though `True` was never meant to stand in for an int default — without this
+        # guard, `history-limit = true` would silently pass `isinstance(True, int)` and be
+        # accepted as a (nonsensical) history limit. The reverse can't happen through
+        # plain `isinstance` alone (an `int` like `1` is never an instance of `bool`, so
+        # `mouse = 1` is already rejected without this line) but the check is written to
+        # cover both directions, since "a value must be an instance of the default's own
+        # type" is the contract this function documents, not "…unless int and bool are
+        # involved, in which case it depends which one is the default."
         if isinstance(value, bool) != isinstance(default, bool):
             continue
         if isinstance(value, type(default)):

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -314,3 +314,72 @@ def drift(root: Path) -> list[str]:
         else:
             out.append(f"missing directory: {d}/")
     return out
+
+
+#: The edges a frame may occupy. A slot outside this set is a typo, and a typo must not
+#: reach a tmux argv — so an unknown one is dropped rather than passed through.
+FRAME_SLOTS = ("top", "bottom", "left", "right")
+
+FRAME_DEFAULTS = {
+    "slots": ["top", "bottom"],
+    #: Off by default: tmux's `set -g mouse on` takes over drag-select, so turning this on
+    #: trades the operator's terminal text-selection for clickable panels. That trade
+    #: belongs to a later release that actually ships clickable panels, not this one.
+    "mouse": False,
+    "hotkey": "F2",
+    "history_limit": 50000,
+    "min_cols": 100,
+    "min_rows": 20,
+}
+
+#: charter.toml spells these three with a hyphen (``history-limit``, ``min-cols``,
+#: ``min-rows`` — the spelling documented in docs/frame.md), while the dict this module
+#: returns uses an underscore, which reads better at the call site
+#: (``frame["history_limit"]``). The mapping is written out explicitly, one
+#: operator-facing name per dict key, rather than derived by swapping characters: the
+#: TOML names are a published interface and belong in the source where a reader can see
+#: them. Only the spelling listed here is ever honoured — the underscore form is not
+#: accepted in charter.toml as a second, undocumented alias.
+FRAME_TOML_KEYS = {
+    "slots": "slots",
+    "mouse": "mouse",
+    "hotkey": "hotkey",
+    "history_limit": "history-limit",
+    "min_cols": "min-cols",
+    "min_rows": "min-rows",
+}
+
+
+def frame_of(cfg: dict) -> dict:
+    """The ``[frame]`` section merged over :data:`FRAME_DEFAULTS`.
+
+    Every value is type-checked against its default and discarded if it disagrees. This
+    module is imported by every command, including ``charter --version``, so a
+    hand-edited charter.toml must degrade to the defaults rather than raise.
+    """
+    out = dict(FRAME_DEFAULTS)
+    section = cfg.get("frame")
+    if not isinstance(section, dict):
+        return out
+    for key, default in FRAME_DEFAULTS.items():
+        toml_key = FRAME_TOML_KEYS[key]
+        if toml_key not in section:
+            continue
+        value = section[toml_key]
+        if key == "slots":
+            if isinstance(value, list):
+                kept = [s for s in value if s in FRAME_SLOTS]
+                if kept:
+                    out[key] = kept
+            continue
+        # `bool` is a subclass of `int` in Python, so `isinstance(1, int)` is True even
+        # though `1` was never meant to stand in for a bool default, and
+        # `isinstance(True, int)` is True even though `True` was never meant to stand in
+        # for an int default. Both directions have to be ruled out explicitly, or
+        # `mouse = 1` and `history-limit = true` would silently pass as valid instead of
+        # being dropped.
+        if isinstance(value, bool) != isinstance(default, bool):
+            continue
+        if isinstance(value, type(default)):
+            out[key] = value
+    return out

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -372,9 +372,28 @@ FRAME_DEFAULTS = {key: default for key, (default, _toml_key) in FRAME_FIELDS.ite
 #: ``a``, ``7``) or a single punctuation key. Whitespace, newlines, quotes, ``;``, ``#``,
 #: ``$``, ``\\`` and braces are all absent from that alphabet, so nothing matching this
 #: can end the ``bind`` line, start a second command, open a quote, or introduce a tmux
-#: format. A key this refuses that tmux would have accepted costs the operator their
-#: preferred hotkey and a line in `charter frame-probe`; a key this accepted that tmux
+#: format.
+#:
+#: The asymmetry is what justifies erring narrow: a key this refuses that tmux would have
+#: accepted costs the operator their preferred hotkey; a key this accepted that tmux
 #: parses as a command costs them the machine.
+#:
+#: **A refusal is currently SILENT — nothing anywhere names it.** :func:`frame_of`
+#: discards the value and the shipped ``F2`` takes its place, and neither
+#: ``charter frame-probe`` nor ``charter doctor``'s frame row says a word: measured with
+#: the newline payload above sitting in charter.toml, both render a clean green tick.
+#: An earlier version of this comment claimed the probe reported it, which it never did —
+#: the same class of false claim this branch removed from `frame/menu.py` and
+#: `frame/tmuxctl.py`, so it is written down here rather than quietly deleted.
+#:
+#: Left silent deliberately, not overlooked. The gap is real but it is not this
+#: constant's: NO refused ``[frame]`` value is reported anywhere — a dropped ``slots``
+#: entry and a rejected ``history-limit`` are exactly as quiet — so the fix is one
+#: surface for the whole section, not a special case for the one key that happens to have
+#: a security story. It also would NOT catch the neighbouring hazard it looks like it
+#: should: a key such as ``Fn2`` MATCHES this pattern, so :func:`frame_of` accepts it and
+#: has nothing to report, and it is tmux that refuses it later, at ``source-file`` time.
+#: Those are two mechanisms needing two answers. Both are filed as follow-ups.
 _HOTKEY_RE = re.compile(r"^(?:[CMS]-){0,3}(?:[A-Za-z0-9]{1,20}|[!%&()*+,./:<=>?@\[\]^_|~-])$")
 
 

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -347,6 +347,36 @@ FRAME_FIELDS = {
 #: ``config.FRAME`` docstring) that only want the shipped defaults, not the TOML mapping.
 FRAME_DEFAULTS = {key: default for key, (default, _toml_key) in FRAME_FIELDS.items()}
 
+#: The shape of a tmux key name, and the ONE thing standing between ``[frame] hotkey``
+#: and arbitrary code execution at launch.
+#:
+#: ``commands_frame.conf_text`` interpolates this value into tmux CONFIG TEXT that
+#: ``source-file`` parses and runs (``bind -n {hotkey} run-shell …``). Verified against
+#: tmux 3.7c: ``hotkey = "F2\\nrun-shell 'touch /tmp/PWNED'"`` makes ``source-file``
+#: return **0**, silently, and the file appears **at launch, with no keypress** — the
+#: newline simply ends the ``bind`` line and starts a second command. `charter.toml` is
+#: committed and shared, which is precisely what makes it untrusted input (see the
+#: containment rule in README.md): it arrives from someone else's machine.
+#:
+#: Checked HERE, at the config boundary, rather than as a fifth ad-hoc guard inside the
+#: frame. Every other ``[frame]`` value is already constrained where it enters —
+#: ``slots`` is set-filtered, ``mouse`` is a bool, the three numbers are int-checked —
+#: and ``hotkey`` was the one free string in the section, and the one that reaches a
+#: parser. The branch already carries four separate sanitisers added after four separate
+#: incidents (``frame.state._UNSAFE``, ``frame.menu._ACTION_ID_RE``,
+#: ``commands_frame._PANE_ID_RE``, ``contain.child``); this defect existed because a
+#: fifth input arrived through a fifth door.
+#:
+#: Deliberately narrower than tmux's own key grammar: optional ``C-``/``M-``/``S-``
+#: modifiers, then either a key NAME (``F2``, ``Up``, ``PPage``, ``BSpace``, ``Escape``,
+#: ``a``, ``7``) or a single punctuation key. Whitespace, newlines, quotes, ``;``, ``#``,
+#: ``$``, ``\\`` and braces are all absent from that alphabet, so nothing matching this
+#: can end the ``bind`` line, start a second command, open a quote, or introduce a tmux
+#: format. A key this refuses that tmux would have accepted costs the operator their
+#: preferred hotkey and a line in `charter frame-probe`; a key this accepted that tmux
+#: parses as a command costs them the machine.
+_HOTKEY_RE = re.compile(r"^(?:[CMS]-){0,3}(?:[A-Za-z0-9]{1,20}|[!%&()*+,./:<=>?@\[\]^_|~-])$")
+
 
 def frame_of(cfg: dict) -> dict:
     """The ``[frame]`` section merged over :data:`FRAME_DEFAULTS`.
@@ -354,6 +384,13 @@ def frame_of(cfg: dict) -> dict:
     Every value is type-checked against its default and discarded if it disagrees. This
     module is imported by every command, including ``charter --version``, so a
     hand-edited charter.toml must degrade to the defaults rather than raise.
+
+    Two keys need more than a type check, and both get it here rather than downstream:
+    ``slots`` is filtered against :data:`FRAME_SLOTS`, and ``hotkey`` against
+    :data:`_HOTKEY_RE` — see that constant for the injection a bare ``isinstance(value,
+    str)`` let through. Both degrade to the shipped default, which is the contract every
+    other key in this function already keeps: a charter.toml charter cannot make sense
+    of never stops charter from running.
     """
     out = dict(FRAME_DEFAULTS)
     section = cfg.get("frame")
@@ -368,6 +405,10 @@ def frame_of(cfg: dict) -> dict:
                 kept = [s for s in value if s in FRAME_SLOTS]
                 if kept:
                     out[key] = kept
+            continue
+        if key == "hotkey":
+            if isinstance(value, str) and _HOTKEY_RE.fullmatch(value):
+                out[key] = value
             continue
         # `bool` is a subclass of `int` in Python, so `isinstance(True, int)` is True even
         # though `True` was never meant to stand in for an int default — without this

--- a/charter/news.py
+++ b/charter/news.py
@@ -301,6 +301,11 @@ _PROBEABLE = frozenset({
     ("doctor",),           # reads the plane and reports on it
     ("news",),             # reads entries; the ones that probe are #311's guard to answer
     ("persona", "lint"),   # reads the persona files — every shipped probe today
+    ("frame-probe",),      # reads tmux's own version (charter.commands_frame.cmd_probe);
+                            # a TOP-LEVEL command rather than `frame --probe` precisely so
+                            # it carries no pass-through positional — `frame` itself always
+                            # does (`rest`, its harness's verbatim argv) and so can never be
+                            # listed here, `--probe` or not.
 })
 
 

--- a/docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md
+++ b/docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md
@@ -1,0 +1,102 @@
+# Charter may run the harness, but never draws it
+
+ADR 0015 settled where charter sits relative to a harness it lives *inside*: "Charter
+targets harnesses, not one host. It keeps only the policy the current harness cannot
+express… where a harness's ceiling is lower, `charter doctor` names the deficit by name."
+That ADR's whole shape assumes charter is a guest — a hook, a status line, a plugin —
+running inside a process someone else started.
+
+`charter <harness>` inverts the relationship it describes. Charter is no longer only the
+guest; for this command it is the process that **starts** the harness, in a frame it
+composes around it — the harness in the middle, charter's own panels on the edges. That is
+a second question ADR 0015 never had to answer, and answering it wrong twice — first by
+guessing wrong about what the boundary even is — is why it gets its own record rather than
+a paragraph appended to that one.
+
+## The candidate that looked obvious
+
+The natural instinct, having already built `charter/tui.py` and a status line, is to keep
+going: read the harness's own stdout, parse its escape sequences, draw the whole frame with
+one renderer charter owns end to end. A spike built exactly that — a Textual widget backed
+by `pyte`, a terminal-in-a-terminal, running `claude` and `opencode` inside it.
+
+It worked. Both harnesses rendered correctly. That is precisely why this had to be settled
+by measurement rather than argument: a design that fails outright is easy to reject, and
+this one did not fail.
+
+## What was measured
+
+darwin, Python 3.14.4, `textual` 8.2.8, `pyte` 0.8.2, tmux 3.7c, a 150×42 frame, one
+agent-shaped corpus (an ordinary Claude Code session's own output, replayed).
+
+| | Textual + pyte | tmux, end to end |
+| --- | --- | --- |
+| throughput | **1.85 MB/s** | **25.2 MB/s** |
+| parse alone | 2.4 MB/s (0.9 MB/s with scrollback enabled) | ~37 MB/s |
+
+Rendering itself was never the bottleneck on either side — Textual's own paint measured
+7.2 ms/frame, a 138 fps ceiling nowhere close to being reached. The gap is the parse:
+`pyte` interpreting the harness's escape sequences in Python, against tmux's own C parser
+doing the identical job roughly fifteen times faster, and scrollback made `pyte` alone
+almost three times slower again. Two implementations of the same well-specified problem —
+one already correct and shipped in every environment charter runs on, one freshly written
+in the language charter happens to be written in.
+
+**Both arms rendered `claude` and `opencode` correctly.** This was a cost decision, not a
+feasibility one — the kind of decision measurement resolves and argument alone does not,
+because "which one is faster" and "which one is right" are different questions and only
+the spike could answer the first.
+
+## The half a benchmark cannot show
+
+Speed is the half that is measurable in an afternoon. The half that is not: what the
+Textual/pyte widget was, and was not, at the moment it was measured. It drew text. It did
+not draw a cursor. Still owed, unwritten: mouse, scrollback beyond raw buffer access,
+bracketed paste, OSC sequences, wide characters, and `?2026` (synchronized output) — each
+one a real terminal behaviour a real coding-agent session produces, and each one a place
+`pyte` could silently render something subtly wrong rather than fail loudly. `pyte` itself
+was last released 2023-11-12 — a terminal parser is exactly the kind of code where a
+one-cell drift in cursor math shows up as a garbled screen months later, on somebody else's
+terminal, and the library that would need patching is not actively maintained.
+
+This project ships `dependencies = []` — every dependency is a promise to keep re-checking,
+by hand, forever. Owning a terminal emulator would mean owning the correctness of
+`\x1b[?2026h`, of double-width CJK glyphs, of an OSC 8 hyperlink escape, indefinitely,
+in a widget that at 120 lines had implemented perhaps a third of what a real one needs —
+against tmux, which has already solved this problem, ships on every machine charter already
+requires, and needs nothing from charter to keep solving it.
+
+## The decision
+
+**tmux composes the rectangles and does every part of terminal emulation. Charter draws
+only its own panels — the edges — and never touches the harness's own pane: never reads
+its output, never parses its escape sequences, never decides what a cursor or a colour
+means inside it.** `charter/frame/tmuxctl.py` is the one module in the codebase allowed to
+shell out to `tmux`, precisely so this boundary has exactly one place it could be crossed
+by accident.
+
+Read the other direction, the same rule is ADR 0015's boundary, moved: that ADR drew the
+line at what a harness can express and let charter's own reach change harness by harness.
+This one draws a line at what charter *runs*, and keeps that line fixed regardless of which
+harness is on the other side of it — the frame is identical whether the pane inside it is
+`claude`, `codex`, or a command charter has never met (`charter frame -- <cmd>`), because
+charter never has to understand what is in that pane to draw around it.
+
+## Consequences
+
+* Charter's frame code needs no terminal-emulation dependency at all — `dependencies = []`
+  survives this feature.
+* The floor for `charter <harness>` is tmux's own version (3.2 for the frame's menu, 3.3
+  for its resize-recovery hook — `charter/frame/tmuxctl.py`), not a Python library's
+  release cadence.
+* Charter's panels stay simple by construction: a top/bottom strip is one line, measuring
+  its own pane and repainting whole on every change charter's own hooks report — there is
+  no cursor, no scrollback, no input focus for charter's own code to get subtly wrong,
+  because none of that is charter's to draw.
+* The harness's own pane keeps every terminal behaviour it already has, including ones
+  charter has never heard of, because tmux is already handling it and charter never gets
+  between the harness and the terminal it is actually talking to.
+* A future feature that genuinely needs to read the harness's own output (say, to react to
+  what it printed) needs its own measurement and its own ADR — this one settles rendering,
+  not observation, and conflating the two is how a boundary like this erodes one convenient
+  exception at a time.

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -1,0 +1,99 @@
+# The frame
+
+`charter claude` runs the harness inside a frame charter composes: the harness in the
+middle, charter's own panels on the edges. It works on every harness, which is the point —
+a status line is Claude Code's own surface, and Codex and opencode have none at all.
+
+    charter claude               # or codex, opencode
+    charter frame -- <cmd>       # anything charter has never met
+    charter claude --no-frame    # bare, no frame at all
+
+`claude`, `codex` and `opencode` are top-level commands (`charter claude`), never nested
+under `frame` (`charter frame claude`) — `charter frame` is its own, separate escape hatch
+for a command charter has no launcher for at all. That is not just naming: once `charter
+frame` is on the command line, everything after it is grafted onto the harness's own argv
+verbatim, before charter's own argument parser ever sees it, so `frame claude -p hi` would
+hand `claude -p hi` to the `frame --` mechanism rather than route anywhere. The same reason
+keeps `frame-menu`, `frame-action` and `frame-probe` — one command tmux's hotkey calls
+back into, one every menu action calls back into, and the read-only probe — as top-level
+names rather than nested under `frame` too.
+
+## What it needs
+
+tmux 3.2 or newer composes the rectangles and does every part of terminal emulation;
+charter fills the edges and never draws or parses the harness's own pane (ADR 0018). Below
+3.2, `charter <harness>` still starts — the frame's hotkey menu is what needs 3.2, not the
+frame itself — with one warning naming the gap. The resize-recovery hook needs a further
+3.3; below that a resize still works, panels can just drift out of their fixed size until
+the next one, again with a single warning rather than a failure.
+
+`charter <harness> --probe` (or the standalone `charter frame-probe`) answers "can a frame
+run here" without starting anything: one line, exit 0 if it can, non-zero if tmux is
+missing entirely. `charter doctor` carries the same fact as its own `frame` row.
+
+## What changes inside the frame
+
+**Scrollback is tmux's own copy-mode, not your terminal's — the difference people notice
+first.** The frame raises tmux's `history-limit` (50 000 lines, configurable) and binds the
+mouse wheel to enter copy-mode, but it is tmux's buffer you are scrolling, not the
+terminal emulator's.
+
+**Mouse is off by default.** `set -g mouse on` takes over drag-select, so turning it on
+trades your terminal's own text-selection for clickable panels — a trade this release does
+not make for you. `[frame] mouse = true` opts in.
+
+**Panels repaint when charter's own hooks say something changed**, not by reaching out for
+anything themselves: every `posttooluse*` hook bumps a version marker charter already
+writes, and each panel notices the bump with a cheap local check (a `stat`, a few times a
+second) — never a poll of anything outside the plane, and never work while nothing has
+changed.
+
+**Panels measure their own pane**, never `$COLUMNS` — a tmux pane inherits the *launching*
+shell's environment whole, so trusting `$COLUMNS` there would lay a panel out at the outer
+terminal's width and wrap inside its own much narrower one.
+
+Charter never touches `~/.tmux.conf`. Outside tmux it starts its own private server;
+inside tmux it opens a new window in your own server instead, so there is no nesting and no
+second prefix key to learn.
+
+## Exit codes
+
+The launcher does not `exec` tmux — an attached `tmux new-session` reports 0 regardless of
+what actually ran inside it (measured against tmux 3.7c), so a frame's exit code would
+otherwise always read as success. Instead charter waits for the session, then reads back
+the harness's real status and exits with that. `--no-frame` and the automatic bypass when
+stdout is not a terminal both skip the frame entirely and `exec` straight into the harness,
+so a pipe (`charter claude -p … | jq`) carries the real exit code with no help needed.
+
+## When the terminal is too small
+
+Below `[frame]`'s `min-cols`/`min-rows`, the side panels (`left`/`right`) are the first to
+drop — any shortage costs them, since neither can spare its own divider. A further shortage
+in rows drops `top` too. Below half of either floor, every panel drops and the harness
+simply gets the whole terminal, the same choice `charter`'s own status line makes when it
+runs out of width. `left`/`right` are accepted in configuration and sized, but nothing
+renders in them yet — asking for one prints a single warning and leaves the harness pane
+holding that space instead of a dead, unwritten-to pane.
+
+## Configuring it
+
+```toml
+[frame]
+slots = ["top", "bottom"]
+mouse = false
+hotkey = "F2"
+history-limit = 50000
+min-cols = 100
+min-rows = 20
+```
+
+`slots`/`mouse`/`hotkey` are spelled the same on both sides. `history-limit`, `min-cols`
+and `min-rows` are the three that are not: charter.toml spells them with a hyphen: the
+resolved settings charter's own code reads back use an underscore
+(`config.FRAME["history_limit"]`) instead. A key typed the underscored way in charter.toml
+is silently not recognized — the hyphenated spelling above is the one that is read.
+
+The hotkey (`F2` by default) opens a small menu on whichever frame you are attached to —
+today, a single "Detach" entry. However you detach — that entry, or tmux's own prefix key
+— charter notices the session is still running and prints how to get back in
+(`tmux -L charter attach -t <frame-id>`) rather than leaving you to remember the flags.

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -20,16 +20,27 @@ names rather than nested under `frame` too.
 
 ## What it needs
 
-tmux 3.2 or newer composes the rectangles and does every part of terminal emulation;
-charter fills the edges and never draws or parses the harness's own pane (ADR 0018). Below
-3.2, `charter <harness>` still starts — the frame's hotkey menu is what needs 3.2, not the
-frame itself — with one warning naming the gap. The resize-recovery hook needs a further
-3.3; below that a resize still works, panels can just drift out of their fixed size until
-the next one, again with a single warning rather than a failure.
+tmux composes the rectangles and does every part of terminal emulation; charter fills the
+edges and never draws or parses the harness's own pane (ADR 0018). Only tmux being
+*missing* stops a launch. tmux 3.2 is the version charter has checked its own
+requirements against — the hotkey's `display-menu`, and the pane-scoped hooks that carry
+the harness's exit code back out. Below 3.2 `charter <harness>` still starts and nothing
+is switched off: the hotkey stays bound but may open nothing, and if the exit-code hooks
+fail to install charter says so and declines to attach rather than risk a session nothing
+can end. The resize-recovery hook needs a further 3.3; below that a resize still works,
+panels can just drift out of their fixed size until the next one.
 
 `charter <harness> --probe` (or the standalone `charter frame-probe`) answers "can a frame
-run here" without starting anything: one line, exit 0 if it can, non-zero if tmux is
-missing entirely. `charter doctor` carries the same fact as its own `frame` row.
+run here, and what will it not be able to do" without starting anything: exit 0 if a frame
+can run, non-zero if tmux is missing entirely, plus a line for each standing limit — a
+tmux below 3.2, and any `[frame] slots` entry charter sizes but has no renderer for.
+`charter doctor` carries the same facts as its own `frame` row.
+
+Those two limits are deliberately **not** printed when a frame launches. A warning
+written to your terminal microseconds before tmux switches to the alternate screen is not
+readable — measured at 86 bytes ahead of the switch — and it comes back into view only
+once the frame exits. Both are standing properties of this machine and this plane rather
+than news about one launch, so they live on the two surfaces you can ask on demand.
 
 ## What changes inside the frame
 
@@ -52,9 +63,15 @@ changed.
 shell's environment whole, so trusting `$COLUMNS` there would lay a panel out at the outer
 terminal's width and wrap inside its own much narrower one.
 
-Charter never touches `~/.tmux.conf`. Outside tmux it starts its own private server;
-inside tmux it opens a new window in your own server instead, so there is no nesting and no
-second prefix key to learn.
+Charter never touches `~/.tmux.conf` — the frame's settings go into a private server of
+charter's own (`tmux -L charter`), one server shared by every frame on the machine, with
+each frame a session on it.
+
+**Run from inside an existing tmux session, the frame nests.** charter starts its own
+server regardless, so you end up with two tmux layers and two prefix keys — charter's
+frame does not currently read `$TMUX` or open a window in your own server instead. That
+non-nesting path is not built. If you already live in tmux, `charter <harness> --no-frame`
+is the honest answer for now.
 
 ## Exit codes
 
@@ -72,8 +89,8 @@ drop — any shortage costs them, since neither can spare its own divider. A fur
 in rows drops `top` too. Below half of either floor, every panel drops and the harness
 simply gets the whole terminal, the same choice `charter`'s own status line makes when it
 runs out of width. `left`/`right` are accepted in configuration and sized, but nothing
-renders in them yet — asking for one prints a single warning and leaves the harness pane
-holding that space instead of a dead, unwritten-to pane.
+renders in them yet — asking for one leaves the harness pane holding that space instead of
+a dead, unwritten-to pane, and `charter frame-probe`/`charter doctor` name it.
 
 ## Configuring it
 
@@ -86,6 +103,13 @@ history-limit = 50000
 min-cols = 100
 min-rows = 20
 ```
+
+`hotkey` is checked against the shape of a tmux key name — optional `C-`/`M-`/`S-`
+modifiers and then a key (`F2`, `Up`, `PPage`, `a`, `/`). Anything else falls back to
+`F2`, the same way every other key in `[frame]` falls back to its default when charter
+cannot make sense of it. That check is not cosmetic: this value is interpolated into tmux
+configuration that `source-file` *executes*, and `charter.toml` is a committed, shared
+file that arrives from someone else's machine.
 
 `slots`/`mouse`/`hotkey` are spelled the same on both sides. `history-limit`, `min-cols`
 and `min-rows` are the three that are not: charter.toml spells them with a hyphen: the

--- a/docs/news/unreleased-charter-runs-the-harness.md
+++ b/docs/news/unreleased-charter-runs-the-harness.md
@@ -1,0 +1,24 @@
+---
+version: unreleased
+headline: charter can run the harness, and draw around it
+check: frame-probe
+---
+
+`charter claude` (or `codex`, or `opencode`) now runs the harness inside a frame charter
+composes: the harness in the middle, charter's own panels on the edges — a status line for
+harnesses that have none of their own, updated from charter's own hooks rather than by
+polling anything. `charter frame -- <cmd>` runs the same frame around a command charter has
+no launcher for at all, and `--no-frame` skips it entirely when you want the harness bare.
+
+tmux does every part of terminal emulation — charter never reads or parses the harness's
+own pane, only draws its own edges around it (ADR 0018). That is a cost decision, not a
+feasibility one: a hand-rolled terminal widget worked in testing and ran roughly 14× slower
+than tmux end to end, with a cursor and a list of terminal behaviours (mouse, bracketed
+paste, wide characters) still unimplemented. tmux needs no new dependency and has already
+solved the problem.
+
+`charter <harness> --probe` (or the standalone `charter frame-probe`) answers "can a frame
+run here" without starting one — read-only, one line, and it is what `charter doctor`'s new
+`frame` row checks too. See `docs/frame.md` for what tmux version this needs, what changes
+inside the frame (scrollback is tmux's own copy-mode, and the mouse stays off by default so
+it does not take over your terminal's own text-selection), and how `[frame]` is configured.

--- a/docs/superpowers/plans/2026-08-22-harness-frame.md
+++ b/docs/superpowers/plans/2026-08-22-harness-frame.md
@@ -1,0 +1,1907 @@
+# Harness Frame Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `charter claude` (and `codex`, `opencode`, `frame -- <cmd>`) runs the harness inside a tmux-composed frame with charter panels on the edges, giving every harness the surface only Claude Code's status line provides today.
+
+**Architecture:** tmux composes the rectangles and owns all terminal emulation; charter fills them. Each panel is a charter process that owns its pane, drawing with `charter/tui.py` primitives and waking on a version file the existing hooks bump. Charter never parses or draws the harness's pane.
+
+**Tech Stack:** Python 3.11+, stdlib only. tmux ≥ 3.2 as an external binary. Tests are stdlib `unittest`, run with `python -m unittest discover -s tests -v`.
+
+**Spec:** `docs/superpowers/specs/2026-08-21-harness-wrapper-design.md`
+
+## Global Constraints
+
+- **Zero runtime dependencies.** `pyproject.toml` ships `dependencies = []`. Nothing in this feature may add one.
+- **tmux floor is 3.2** — `display-menu` needs 3.0, `display-popup` needs 3.2. Probe `tmux -V`; below the floor, start the frame with the hotkey disabled and say which feature needs which version.
+- **Never join argv.** Pinned against tmux 3.7c: separate arguments are not shell-interpreted, a joined string is. Every tmux invocation passes a list; no `" ".join` anywhere in `charter/frame/`.
+- **Names never enter a tmux command string.** Workspace, repo, branch and persona names come from committed files and `.git/HEAD`. Menu items carry opaque ids resolved in-process.
+- **`_PANE_ID_VARS` is not reordered.** The frame mints its own id; existing sessions keep their behaviour.
+- **`CHARTER_WORKSPACE` is never exported** by the frame — `statusline._active()` prefers it over the pointer file, so exporting it would make `charter ws use` inside the frame appear to do nothing.
+- **The status line path is untouched.** No edits to `charter/statusline.py`'s render path; slots *call* its helpers.
+- **Tests never require tmux.** Anything needing the binary skips when it is absent, and asserts on probed capability rather than a version string.
+
+---
+
+### Task 1: A harness knows how to start itself
+
+**Files:**
+- Modify: `charter/harness/base.py` (add two members to `Harness`)
+- Modify: `charter/harness/claude_code.py`, `charter/harness/codex.py`, `charter/harness/opencode.py`
+- Test: `tests/test_harness_launch.py`
+
+**Interfaces:**
+- Consumes: `charter.harness.registry.KINDS`, `charter.harness.base.Harness`
+- Produces: `Harness.cli_name: str` (the word after `charter`), `Harness.launch_argv(extra: list[str]) -> list[str]`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""A harness that charter can run has to say what to type and what to exec.
+
+`registry.KINDS` exists so a harness added to it is covered everywhere the day it is
+registered. That only holds if the launcher reads these two facts off the harness rather
+than keeping its own table — the hardcoded-literal problem the registry was built to end.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import cli, harness
+
+
+class HarnessLaunchIdentity(unittest.TestCase):
+    def test_every_registered_harness_says_what_to_type(self):
+        for h in harness.all():
+            with self.subTest(harness=h.name):
+                self.assertTrue(h.cli_name, f"{h.name} has no cli_name")
+
+    def test_cli_names_are_distinct(self):
+        names = [h.cli_name for h in harness.all()]
+        self.assertEqual(len(names), len(set(names)), f"colliding cli_names: {names}")
+
+    def test_a_cli_name_never_shadows_a_core_command(self):
+        """A harness called `status` would take `charter status` from the operator.
+        Failing here is the point: the collision is caught in CI, not in a terminal."""
+        parser = cli.build_parser()
+        core = set()
+        for action in parser._subparsers._group_actions:
+            core.update(action.choices)
+        for h in harness.all():
+            with self.subTest(harness=h.name):
+                self.assertNotIn(h.cli_name, core - {h.cli_name},
+                                 f"{h.name}'s cli_name shadows a core command")
+
+    def test_launch_argv_passes_the_operators_arguments_through_verbatim(self):
+        h = harness.get(harness.CLAUDE_CODE)
+        self.assertEqual(h.launch_argv(["--resume", "a;b"]),
+                         ["claude", "--resume", "a;b"])
+
+    def test_launch_argv_returns_a_list_never_a_string(self):
+        """Pinned against tmux 3.7c: separate argv is not shell-interpreted, a joined
+        string is. A harness returning a string would put the injection back."""
+        for h in harness.all():
+            with self.subTest(harness=h.name):
+                self.assertIsInstance(h.launch_argv([]), list)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `python -m unittest tests.test_harness_launch -v`
+Expected: FAIL — `AttributeError: 'ClaudeCodeHarness' object has no attribute 'cli_name'`
+
+- [ ] **Step 3: Add the two members to the base class**
+
+In `charter/harness/base.py`, inside `class Harness`, after `deficits`:
+
+```python
+    #: The word an operator types after ``charter`` to run this harness in a frame.
+    #: Distinct from :attr:`name`, which is the harness's own identity in
+    #: ``$CHARTER_HARNESS``: ``claude-code`` names the harness, ``claude`` is the binary
+    #: and what a hand types. Empty means charter cannot launch this harness.
+    cli_name: str = ""
+
+    #: The binary to exec. Separate from :attr:`cli_name` because they differ.
+    binary: str = ""
+
+    def launch_argv(self, extra: list[str]) -> list[str]:
+        """Argv for starting this harness, with the operator's arguments appended.
+
+        A **list**, never a joined string, and that is a security property rather than a
+        style preference: tmux does not shell-interpret separate arguments and does
+        interpret a joined one (pinned against 3.7c). Returning a string here would put
+        command injection back into every launch.
+        """
+        return [self.binary, *extra]
+```
+
+- [ ] **Step 4: Give each harness its two values**
+
+`charter/harness/claude_code.py`, in `class ClaudeCodeHarness` after `deficits = ()`:
+
+```python
+    cli_name = "claude"
+    binary = "claude"
+```
+
+`charter/harness/codex.py`, in `class CodexHarness`:
+
+```python
+    cli_name = "codex"
+    binary = "codex"
+```
+
+`charter/harness/opencode.py`, in `class OpenCodeHarness`:
+
+```python
+    cli_name = "opencode"
+    binary = "opencode"
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `python -m unittest tests.test_harness_launch -v`
+Expected: PASS, 5 tests
+
+- [ ] **Step 6: Run the whole suite for regressions**
+
+Run: `python -m unittest discover -s tests -v 2>&1 | tail -5`
+Expected: OK
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add charter/harness/ tests/test_harness_launch.py
+git commit -m "A harness says what to type and what to exec (#345)"
+```
+
+---
+
+### Task 2: The `[frame]` config section
+
+**Files:**
+- Modify: `charter/instance.py` (add `frame_of`)
+- Modify: `charter/config.py:derive` (add `d["FRAME"]`)
+- Test: `tests/test_frame_config.py`
+
+**Interfaces:**
+- Consumes: `charter.instance.load`
+- Produces: `instance.frame_of(cfg: dict) -> dict` and `config.FRAME` with keys `slots: list[str]`, `mouse: bool`, `hotkey: str`, `history_limit: int`, `min_cols: int`, `min_rows: int`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""`[frame]` in charter.toml, with defaults that hold when it is absent.
+
+Defaults are the shipped behaviour, so they are asserted rather than assumed: `mouse` is
+off because `set -g mouse on` takes over drag-select, and breaking the operator's copy to
+enable a feature v1 does not ship is a bad trade.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import instance
+
+
+class FrameDefaults(unittest.TestCase):
+    def test_an_absent_section_yields_the_shipped_defaults(self):
+        f = instance.frame_of({})
+        self.assertEqual(f["slots"], ["top", "bottom"])
+        self.assertIs(f["mouse"], False)
+        self.assertEqual(f["hotkey"], "F2")
+        self.assertEqual(f["history_limit"], 50000)
+        self.assertEqual(f["min_cols"], 100)
+        self.assertEqual(f["min_rows"], 20)
+
+    def test_a_section_overrides_only_what_it_names(self):
+        f = instance.frame_of({"frame": {"mouse": True, "hotkey": "F5"}})
+        self.assertIs(f["mouse"], True)
+        self.assertEqual(f["hotkey"], "F5")
+        self.assertEqual(f["slots"], ["top", "bottom"])
+
+    def test_an_unknown_slot_is_dropped_rather_than_carried(self):
+        """A typo must not reach a tmux argv. Dropping is louder than it looks: the slot
+        simply does not appear, and `doctor` has the config to report."""
+        f = instance.frame_of({"frame": {"slots": ["top", "sideways", "bottom"]}})
+        self.assertEqual(f["slots"], ["top", "bottom"])
+
+    def test_a_malformed_section_falls_back_instead_of_raising(self):
+        """`config` is imported by every command including `charter --version`, so a bad
+        value must never crash import."""
+        f = instance.frame_of({"frame": {"slots": "top", "history_limit": "lots"}})
+        self.assertEqual(f["slots"], ["top", "bottom"])
+        self.assertEqual(f["history_limit"], 50000)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `python -m unittest tests.test_frame_config -v`
+Expected: FAIL — `AttributeError: module 'charter.instance' has no attribute 'frame_of'`
+
+- [ ] **Step 3: Implement `frame_of`**
+
+Append to `charter/instance.py`:
+
+```python
+#: The edges a frame may occupy. A slot outside this set is a typo, and a typo must not
+#: reach a tmux argv — so an unknown one is dropped rather than passed through.
+FRAME_SLOTS = ("top", "bottom", "left", "right")
+
+FRAME_DEFAULTS = {
+    "slots": ["top", "bottom"],
+    "mouse": False,
+    "hotkey": "F2",
+    "history_limit": 50000,
+    "min_cols": 100,
+    "min_rows": 20,
+}
+
+
+def frame_of(cfg: dict) -> dict:
+    """The ``[frame]`` section merged over :data:`FRAME_DEFAULTS`.
+
+    Every value is type-checked against its default and discarded if it disagrees. This
+    module is imported by every command, including ``charter --version``, so a
+    hand-edited charter.toml must degrade to the defaults rather than raise.
+    """
+    out = dict(FRAME_DEFAULTS)
+    section = cfg.get("frame")
+    if not isinstance(section, dict):
+        return out
+    for key, default in FRAME_DEFAULTS.items():
+        if key not in section:
+            continue
+        value = section[key]
+        if key == "slots":
+            if isinstance(value, list):
+                kept = [s for s in value if s in FRAME_SLOTS]
+                if kept:
+                    out[key] = kept
+        elif isinstance(value, type(default)) and not isinstance(value, bool) ^ isinstance(default, bool):
+            out[key] = value
+    return out
+```
+
+- [ ] **Step 4: Expose it on `config`**
+
+In `charter/config.py`, inside `derive()`, after the `MEMORY_SHARE` line:
+
+```python
+    #: How `charter <harness>` composes its frame. Defaults live in
+    #: `instance.FRAME_DEFAULTS`; an absent or malformed section yields them whole.
+    d["FRAME"] = _instance.frame_of(cfg)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `python -m unittest tests.test_frame_config tests.test_config -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add charter/instance.py charter/config.py tests/test_frame_config.py
+git commit -m "The [frame] section, with defaults that survive a bad edit (#345)"
+```
+
+---
+
+### Task 3: `frame/layout.py` — the frame's shape, as a pure function
+
+**Files:**
+- Create: `charter/frame/__init__.py`
+- Create: `charter/frame/layout.py`
+- Test: `tests/test_frame_layout.py`
+
+**Interfaces:**
+- Consumes: nothing (deliberately — this module imports no tmux and no charter state)
+- Produces:
+  - `visible_slots(slots: list[str], cols: int, rows: int, min_cols: int, min_rows: int) -> list[str]`
+  - `Pane = NamedTuple("Pane", [("slot", str), ("argv", list[str]), ("size", int)])`
+  - `plan(*, slots, cols, rows, harness_argv, session, conf, socket, charter_argv) -> list[list[str]]`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""The frame's whole shape, decided without tmux.
+
+Layout is pure so the feature is testable on a machine that has never installed tmux, and
+so the argv rule is enforced by a unit test rather than by review: every element of every
+command is a separate string, because tmux shell-interprets a joined one (pinned against
+3.7c) and workspace, repo and branch names all reach here from committed files.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter.frame import layout
+
+
+BASE = dict(cols=200, rows=50, harness_argv=["claude", "--resume", "a;b"],
+            session="charter-demo-1234", conf="/tmp/f/tmux.conf",
+            socket="charter", charter_argv=["charter"])
+
+
+class VisibleSlots(unittest.TestCase):
+    def test_a_wide_tall_terminal_keeps_every_slot(self):
+        self.assertEqual(
+            layout.visible_slots(["top", "bottom", "left", "right"], 200, 50, 100, 20),
+            ["top", "bottom", "left", "right"])
+
+    def test_side_panels_go_first_when_the_terminal_is_narrow(self):
+        self.assertEqual(
+            layout.visible_slots(["top", "bottom", "left", "right"], 80, 50, 100, 20),
+            ["top", "bottom"])
+
+    def test_the_top_goes_next_when_the_terminal_is_short(self):
+        self.assertEqual(
+            layout.visible_slots(["top", "bottom", "left", "right"], 200, 12, 100, 20),
+            ["bottom"])
+
+    def test_a_tiny_terminal_keeps_nothing(self):
+        """Below the floor the harness gets the whole terminal. Degrading to a bare
+        harness is the same move `statusline.render` makes when it runs out of width."""
+        self.assertEqual(layout.visible_slots(["top", "bottom"], 40, 8, 100, 20), [])
+
+
+class Plan(unittest.TestCase):
+    def test_the_harness_argv_survives_as_separate_elements(self):
+        cmds = layout.plan(slots=[], **BASE)
+        joined = [c for c in cmds if any("claude --resume" in part for part in c)]
+        self.assertEqual(joined, [], "harness argv was joined into one string")
+        flat = [part for c in cmds for part in c]
+        self.assertIn("--resume", flat)
+        self.assertIn("a;b", flat)
+
+    def test_every_command_is_a_list_of_separate_strings(self):
+        for cmd in layout.plan(slots=["top", "bottom"], **BASE):
+            self.assertIsInstance(cmd, list)
+            for part in cmd:
+                self.assertIsInstance(part, str)
+
+    def test_each_visible_slot_gets_one_panel_command(self):
+        cmds = layout.plan(slots=["top", "bottom"], **BASE)
+        panels = [c for c in cmds if "panel" in c]
+        self.assertEqual(len(panels), 2)
+        slots = {c[c.index("panel") + 1] for c in panels}
+        self.assertEqual(slots, {"top", "bottom"})
+
+    def test_the_socket_is_named_on_every_command(self):
+        """One private server, never the operator's. Every command carries `-L`."""
+        for cmd in layout.plan(slots=["top"], **BASE):
+            self.assertEqual(cmd[:3], ["tmux", "-L", "charter"])
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `python -m unittest tests.test_frame_layout -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'charter.frame'`
+
+- [ ] **Step 3: Create the package and the layout module**
+
+`charter/frame/__init__.py`:
+
+```python
+"""charter's own frame: the harness runs inside it, charter draws around it.
+
+tmux composes the rectangles and owns every part of terminal emulation — alt-screen,
+resize, scrollback, the lot. Charter fills the edges with its own processes and never
+parses or draws the harness's pane. ADR 0018.
+"""
+
+from __future__ import annotations
+
+from . import layout
+
+__all__ = ["layout"]
+```
+
+`charter/frame/layout.py`:
+
+```python
+"""The frame's shape, decided before tmux is involved at all.
+
+Pure on purpose. Everything that decides *what the frame looks like* lives here and
+returns plain lists of strings, so the whole shape is under test on a machine with no
+tmux, and so the argv rule below is enforced mechanically instead of by review.
+
+**Nothing here ever joins argv.** Pinned against tmux 3.7c: `new-session … printf
+'hello;touch INJ'` passed as separate arguments creates no file, and the same text as one
+string creates it. Workspace, repo, branch and persona names all reach a frame from
+committed files or `.git/HEAD`, so a joined string would be the `gh -F` bug again.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+#: The order slots are dropped in as the terminal shrinks. Sides first — they cost the
+#: harness columns, which is what a narrow terminal has none of — then the top, whose row
+#: is worth less than the bottom's alerts.
+_DROP_ORDER = ("left", "right", "top", "bottom")
+
+#: Rows a horizontal panel occupies, and columns a vertical one does.
+SLOT_SIZE = {"top": 1, "bottom": 1, "left": 22, "right": 22}
+
+
+class Pane(NamedTuple):
+    slot: str
+    argv: list[str]
+    size: int
+
+
+def visible_slots(slots: list[str], cols: int, rows: int,
+                  min_cols: int, min_rows: int) -> list[str]:
+    """Which of *slots* fit in a *cols* x *rows* terminal.
+
+    Degradation, not refusal: below the floor the harness simply gets the whole terminal,
+    which is the same choice `statusline.render` makes when it runs out of width.
+    """
+    keep = list(slots)
+    if cols < min_cols:
+        keep = [s for s in keep if s not in ("left", "right")]
+    if rows < min_rows:
+        keep = [s for s in keep if s != "top"]
+    if cols < min_cols // 2 or rows < min_rows // 2:
+        keep = []
+    return [s for s in slots if s in keep]
+
+
+def _tmux(socket: str, *args: str) -> list[str]:
+    return ["tmux", "-L", socket, *args]
+
+
+def plan(*, slots: list[str], cols: int, rows: int, harness_argv: list[str],
+         session: str, conf: str, socket: str, charter_argv: list[str]) -> list[list[str]]:
+    """Every tmux command needed to build the frame, in order.
+
+    Returns commands rather than running them, which is what makes the frame's shape
+    assertable without a tmux binary anywhere near the test.
+    """
+    cmds: list[list[str]] = [
+        _tmux(socket, "-f", conf, "new-session", "-d", "-s", session,
+              "-x", str(cols), "-y", str(rows), "--", *harness_argv),
+    ]
+    for slot in slots:
+        size = SLOT_SIZE[slot]
+        direction = "-v" if slot in ("top", "bottom") else "-h"
+        before = ["-b"] if slot in ("top", "left") else []
+        cmds.append(_tmux(socket, "split-window", "-t", f"{session}:0.0",
+                          direction, *before, "-l", str(size), "--",
+                          *charter_argv, "panel", slot, "--session", session))
+    return cmds
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python -m unittest tests.test_frame_layout -v`
+Expected: PASS, 8 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add charter/frame/ tests/test_frame_layout.py
+git commit -m "The frame's shape as a pure function, testable without tmux (#345)"
+```
+
+---
+
+### Task 4: `frame/tmuxctl.py` — the only module that touches the binary
+
+**Files:**
+- Create: `charter/frame/tmuxctl.py`
+- Test: `tests/test_frame_tmuxctl.py`
+
+**Interfaces:**
+- Consumes: `charter.frame.layout`
+- Produces: `FLOOR: tuple[int, int]`, `version() -> tuple[int, int] | None`, `available() -> bool`, `meets_floor() -> bool`, `absent_message() -> str`, `below_floor_message(v) -> str`, `run(cmd: list[str]) -> int`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Everything that touches the tmux binary, in one module, so the rest is testable.
+
+The messages are asserted because `Deficit` already settled what an absent capability has
+to read like: naming the limit and the command that closes it, never a guess, because "a
+remedy that does not exist costs more than an honest gap".
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter.frame import tmuxctl
+
+
+class Version(unittest.TestCase):
+    def test_a_release_version_parses(self):
+        with mock.patch.object(tmuxctl, "_probe", return_value="tmux 3.7c"):
+            self.assertEqual(tmuxctl.version(), (3, 7))
+
+    def test_a_two_part_version_parses(self):
+        with mock.patch.object(tmuxctl, "_probe", return_value="tmux 3.2"):
+            self.assertEqual(tmuxctl.version(), (3, 2))
+
+    def test_an_absent_binary_is_none_not_zero(self):
+        """None is 'charter has nothing to say', which reads differently from 'version
+        0.0' — the distinction `registry.deficits` makes for an unknown harness."""
+        with mock.patch.object(tmuxctl, "_probe", return_value=None):
+            self.assertIsNone(tmuxctl.version())
+
+    def test_unparseable_output_is_none_rather_than_a_crash(self):
+        with mock.patch.object(tmuxctl, "_probe", return_value="tmux next-3.9"):
+            self.assertIsNone(tmuxctl.version())
+
+
+class Floor(unittest.TestCase):
+    def test_the_floor_is_the_version_display_popup_needs(self):
+        self.assertEqual(tmuxctl.FLOOR, (3, 2))
+
+    def test_a_new_enough_tmux_meets_the_floor(self):
+        with mock.patch.object(tmuxctl, "version", return_value=(3, 7)):
+            self.assertTrue(tmuxctl.meets_floor())
+
+    def test_an_old_tmux_does_not(self):
+        with mock.patch.object(tmuxctl, "version", return_value=(3, 0)):
+            self.assertFalse(tmuxctl.meets_floor())
+
+
+class Messages(unittest.TestCase):
+    def test_the_absent_message_names_the_command_that_fixes_it(self):
+        msg = tmuxctl.absent_message()
+        self.assertIn("tmux", msg)
+        self.assertIn("--no-frame", msg)
+
+    def test_the_below_floor_message_names_both_versions(self):
+        msg = tmuxctl.below_floor_message((3, 0))
+        self.assertIn("3.0", msg)
+        self.assertIn("3.2", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `python -m unittest tests.test_frame_tmuxctl -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'charter.frame.tmuxctl'`
+
+- [ ] **Step 3: Implement it**
+
+`charter/frame/tmuxctl.py`:
+
+```python
+"""The only module in charter that runs tmux.
+
+Kept alone so everything else — layout, panels, slots — is testable on a machine with no
+tmux installed, and so there is exactly one place where the argv rule can be broken.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+
+#: `display-menu` arrived in 3.0 and `display-popup` in 3.2, and the frame's interaction
+#: model uses both. Floor at the higher one and degrade below it rather than refuse.
+FLOOR = (3, 2)
+
+_VERSION = re.compile(r"^tmux (\d+)\.(\d+)")
+
+
+def _probe() -> str | None:
+    """`tmux -V`'s output, or ``None`` when there is no tmux to ask."""
+    if not shutil.which("tmux"):
+        return None
+    try:
+        out = subprocess.run(["tmux", "-V"], capture_output=True, text=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.stdout.strip() or None
+
+
+def version() -> tuple[int, int] | None:
+    """``(major, minor)``, or ``None`` when tmux is absent or unparseable.
+
+    ``None`` is not "version zero": it says charter could not find out, which reads
+    differently from "too old" and is answered with a different message.
+    """
+    raw = _probe()
+    if not raw:
+        return None
+    m = _VERSION.match(raw)
+    return (int(m.group(1)), int(m.group(2))) if m else None
+
+
+def available() -> bool:
+    return version() is not None
+
+
+def meets_floor() -> bool:
+    v = version()
+    return bool(v and v >= FLOOR)
+
+
+def absent_message() -> str:
+    return ("charter's frame needs tmux, which is not on this machine.\n"
+            "  install:  brew install tmux   (or your package manager)\n"
+            "  without:  charter <harness> --no-frame  runs the harness bare")
+
+
+def below_floor_message(v: tuple[int, int]) -> str:
+    return (f"tmux {v[0]}.{v[1]} composes the frame, but its menu needs "
+            f"tmux {FLOOR[0]}.{FLOOR[1]} — the frame starts with the hotkey disabled.")
+
+
+def run(cmd: list[str]) -> int:
+    """Run one tmux command. *cmd* is a LIST; this module never joins argv."""
+    assert isinstance(cmd, list), "tmux argv must be a list — see frame/layout.py"
+    return subprocess.run(cmd).returncode
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python -m unittest tests.test_frame_tmuxctl -v`
+Expected: PASS, 9 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add charter/frame/tmuxctl.py tests/test_frame_tmuxctl.py
+git commit -m "One module runs tmux, so the rest needs none to test (#345)"
+```
+
+---
+
+### Task 5: `frame/state.py` — frame id, state directory, version file, reaping
+
+**Files:**
+- Create: `charter/frame/state.py`
+- Test: `tests/test_frame_state.py`
+
+**Interfaces:**
+- Consumes: `charter.config.STATE_DIR`
+- Produces: `frame_id(workspace: str, pid: int) -> str`, `frame_dir(fid: str) -> Path`, `bump(fid: str) -> None`, `version(fid: str) -> str`, `record_exit(fid: str, code: int) -> None`, `exit_code(fid: str) -> int | None`, `reap(live: set[str]) -> list[str]`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""The frame's own state: who it is, when it last changed, how it ended.
+
+Per frame rather than global, because two frames may run at once (one session each, named
+by workspace and pid) and a shared version file would make each frame's panels redraw for
+the other's activity.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from charter.frame import state
+
+from _isolation import IsolatedPaths
+
+
+class FrameId(unittest.TestCase):
+    def test_the_id_carries_the_workspace_and_the_pid(self):
+        fid = state.frame_id("harness-wrapper", 4242)
+        self.assertIn("harness-wrapper", fid)
+        self.assertIn("4242", fid)
+
+    def test_a_hostile_workspace_name_cannot_escape_the_state_directory(self):
+        """The id becomes a directory name. `contain.py` exists because a name read out
+        of a file used to be joined onto a path with nothing in between."""
+        fid = state.frame_id("../../etc", 1)
+        self.assertNotIn("/", fid)
+        self.assertNotIn("..", fid)
+
+
+class Version(IsolatedPaths, unittest.TestCase):
+    def test_a_fresh_frame_has_a_version(self):
+        self.assertTrue(state.version("f-1"))
+
+    def test_bumping_changes_it(self):
+        before = state.version("f-1")
+        state.bump("f-1")
+        self.assertNotEqual(before, state.version("f-1"))
+
+    def test_a_reader_never_sees_a_half_written_version(self):
+        """Written with os.replace, so a panel reading mid-bump gets the old value whole
+        rather than a torn one."""
+        for _ in range(50):
+            state.bump("f-1")
+            self.assertTrue(state.version("f-1").strip())
+
+
+class ExitCode(IsolatedPaths, unittest.TestCase):
+    def test_an_unfinished_frame_has_no_exit_code(self):
+        self.assertIsNone(state.exit_code("f-1"))
+
+    def test_the_recorded_code_comes_back(self):
+        state.record_exit("f-1", 42)
+        self.assertEqual(state.exit_code("f-1"), 42)
+
+
+class Reap(IsolatedPaths, unittest.TestCase):
+    def test_a_directory_whose_session_is_gone_is_removed(self):
+        state.bump("dead-1")
+        state.bump("live-1")
+        removed = state.reap({"live-1"})
+        self.assertEqual(removed, ["dead-1"])
+        self.assertFalse(state.frame_dir("dead-1").exists())
+        self.assertTrue(state.frame_dir("live-1").exists())
+
+    def test_a_live_frame_is_never_reaped_by_age(self):
+        """A long-lived frame is exactly what an age heuristic would eat."""
+        state.bump("old-1")
+        self.assertEqual(state.reap({"old-1"}), [])
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `python -m unittest tests.test_frame_state -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'charter.frame.state'`
+
+- [ ] **Step 3: Implement it**
+
+`charter/frame/state.py`:
+
+```python
+"""What one frame knows about itself, on disk.
+
+Under ``.charter/frame/<frame-id>/`` — per frame, never global, because two frames may run
+at once and a shared version file would make each one's panels redraw for the other's work.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import time
+from pathlib import Path
+
+from .. import config
+
+#: Anything outside this becomes an underscore. The id becomes a directory name, and
+#: `contain.py` exists because a name read out of a file was once joined onto a path with
+#: nothing in between.
+_UNSAFE = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def frame_id(workspace: str, pid: int) -> str:
+    """A stable id for one frame: the workspace it is for, and the launcher's pid.
+
+    The same pair the tmux session is named for, so a directory on disk and a session in
+    `tmux list-sessions` can always be matched up by eye.
+    """
+    safe = _UNSAFE.sub("_", workspace).strip("._-") or "frame"
+    return f"{safe}-{int(pid)}"
+
+
+def _root() -> Path:
+    return Path(config.STATE_DIR) / "frame"
+
+
+def frame_dir(fid: str) -> Path:
+    d = _root() / _UNSAFE.sub("_", fid)
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def bump(fid: str) -> None:
+    """Record that the plane changed. Written whole, then moved into place.
+
+    ``os.replace`` is atomic on the same filesystem, so a panel reading mid-bump gets the
+    previous value entire rather than a truncated one.
+    """
+    d = frame_dir(fid)
+    tmp = d / "version.tmp"
+    tmp.write_text(f"{time.time_ns()}\n")
+    os.replace(tmp, d / "version")
+
+
+def version(fid: str) -> str:
+    f = frame_dir(fid) / "version"
+    try:
+        return f.read_text().strip()
+    except OSError:
+        bump(fid)
+        try:
+            return (frame_dir(fid) / "version").read_text().strip()
+        except OSError:
+            return "0"
+
+
+def record_exit(fid: str, code: int) -> None:
+    d = frame_dir(fid)
+    tmp = d / "exit.tmp"
+    tmp.write_text(f"{int(code)}\n")
+    os.replace(tmp, d / "exit")
+
+
+def exit_code(fid: str) -> int | None:
+    try:
+        return int((frame_dir(fid) / "exit").read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def reap(live: set[str]) -> list[str]:
+    """Remove state for frames whose tmux session is gone. Returns what was removed.
+
+    Never by age: a frame open for two days is a working frame, and an age heuristic
+    would delete exactly that one.
+    """
+    root = _root()
+    if not root.is_dir():
+        return []
+    removed = []
+    for d in sorted(root.iterdir()):
+        if d.is_dir() and d.name not in live:
+            shutil.rmtree(d, ignore_errors=True)
+            removed.append(d.name)
+    return removed
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python -m unittest tests.test_frame_state -v`
+Expected: PASS, 9 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add charter/frame/state.py tests/test_frame_state.py
+git commit -m "A frame's own state: id, version, exit code, reaping (#345)"
+```
+
+---
+
+### Task 6: The launcher — `charter <harness>`, bypass, and the exit code
+
+**Files:**
+- Create: `charter/commands_frame.py`
+- Modify: `charter/cli.py` (import, `_add_frame_parsers(sub)`, call site near line 314)
+- Test: `tests/test_frame_launcher.py`
+
+**Interfaces:**
+- Consumes: `harness.all()`, `frame.layout.plan`, `frame.tmuxctl`, `frame.state`, `config.FRAME`
+- Produces: `cmd_launch(args) -> int`, `conf_text(*, hotkey, mouse, history_limit, status_path, harness_pane) -> str`, `bypass(argv: list[str]) -> int`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Starting a harness inside a frame, and the three ways that must not go wrong.
+
+The exit code is asserted because it was measured wrong once: an attached
+`tmux new-session` returns 0 whatever its command exited with (pinned against 3.7c), so
+the launcher waits and reads a recorded status instead of exec'ing and hoping.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import commands_frame
+
+
+class Bypass(unittest.TestCase):
+    def test_a_pipe_gets_no_frame(self):
+        """`charter claude -p "…" | jq` must be `claude -p "…" | jq`. A frame around a
+        pipe is wrong, and exec keeps the exit code without any help."""
+        with mock.patch("sys.stdout.isatty", return_value=False), \
+             mock.patch("os.execvp") as ex:
+            commands_frame.bypass(["claude", "-p", "hi"])
+        ex.assert_called_once_with("claude", ["claude", "-p", "hi"])
+
+
+class Conf(unittest.TestCase):
+    def test_the_pane_died_hook_is_scoped_to_the_harness_pane(self):
+        """pane-died fires for ANY pane. Unscoped, a dead panel would be reported as the
+        agent's exit code."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=50000,
+                                        status_path="/tmp/f/exit", harness_pane="%3")
+        self.assertIn("%3", text)
+        self.assertIn("pane_dead_status", text)
+
+    def test_remain_on_exit_is_set_or_the_status_never_exists(self):
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=50000,
+                                        status_path="/tmp/f/exit", harness_pane="%3")
+        self.assertIn("remain-on-exit on", text)
+
+    def test_mouse_is_off_unless_asked_for(self):
+        off = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
+                                       status_path="/x", harness_pane="%0")
+        self.assertIn("set -g mouse off", off)
+        on = commands_frame.conf_text(hotkey="F2", mouse=True, history_limit=1,
+                                      status_path="/x", harness_pane="%0")
+        self.assertIn("set -g mouse on", on)
+
+    def test_history_limit_is_raised_above_the_tmux_default(self):
+        """tmux ships 2000 lines, which becomes the harness's entire scrollback."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=50000,
+                                        status_path="/x", harness_pane="%0")
+        self.assertIn("history-limit 50000", text)
+
+
+class MissingTmux(unittest.TestCase):
+    def test_an_absent_tmux_names_the_remedy_and_does_not_start_a_frame(self):
+        args = mock.Mock(harness="claude", rest=[], no_frame=False)
+        with mock.patch("charter.frame.tmuxctl.available", return_value=False), \
+             mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("builtins.print") as p:
+            rc = commands_frame.cmd_launch(args)
+        self.assertNotEqual(rc, 0)
+        printed = " ".join(str(c) for c in p.call_args_list)
+        self.assertIn("--no-frame", printed)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `python -m unittest tests.test_frame_launcher -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'charter.commands_frame'`
+
+- [ ] **Step 3: Implement the launcher**
+
+`charter/commands_frame.py`:
+
+```python
+"""`charter <harness>` — run the harness inside charter's frame.
+
+The launcher does NOT exec tmux, and that is measured rather than stylistic: an attached
+`tmux new-session` returns 0 whatever its command exited with (tmux 3.7c). So the status
+is carried out of band by a pane-scoped `pane-died` hook, and this process waits for tmux,
+reads the recorded code, and exits with it. `exec` survives only on the bypass path, where
+there is no frame in the way.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+from . import config, harness
+from .frame import layout, state, tmuxctl
+
+
+def bypass(argv: list[str]) -> int:
+    """Run the harness with no frame at all — `exec`, so the exit code needs no help."""
+    os.execvp(argv[0], argv)
+    return 127  # unreachable; execvp either replaces this process or raises
+
+
+def conf_text(*, hotkey: str, mouse: bool, history_limit: int,
+              status_path: str, harness_pane: str) -> str:
+    """The private tmux config for one frame. Never the operator's ~/.tmux.conf.
+
+    The `pane-died` hook is scoped to the harness pane. Unscoped it fires for any pane,
+    and a crashed panel would be reported to the operator as the agent's exit code.
+    """
+    return "\n".join([
+        "set -g status off",
+        f"set -g mouse {'on' if mouse else 'off'}",
+        f"set -g history-limit {int(history_limit)}",
+        "set -g escape-time 0",
+        "set -g remain-on-exit on",
+        "bind -n WheelUpPane if-shell -F -t = '#{mouse_any_flag}'"
+        " 'send-keys -M' 'copy-mode -e; send-keys -M'",
+        f"set-hook -p -t {harness_pane} pane-died "
+        f"'run-shell \"echo #{{pane_dead_status}} > {status_path}\" ; kill-session'",
+        "",
+    ])
+
+
+def _live_sessions(socket: str) -> set[str]:
+    try:
+        out = subprocess.run(["tmux", "-L", socket, "list-sessions", "-F", "#{session_name}"],
+                             capture_output=True, text=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    return {line.strip() for line in out.stdout.splitlines() if line.strip()}
+
+
+def cmd_launch(args) -> int:
+    """One launcher, shared by every registered harness and by `charter frame --`."""
+    h = next((x for x in harness.all() if x.cli_name == args.harness), None)
+    argv = h.launch_argv(list(args.rest)) if h else list(args.rest)
+    if not argv:
+        print("charter frame: nothing to run — `charter frame -- <command>`", file=sys.stderr)
+        return 2
+
+    if getattr(args, "no_frame", False) or not sys.stdout.isatty():
+        return bypass(argv)
+
+    if not tmuxctl.available():
+        print(tmuxctl.absent_message(), file=sys.stderr)
+        return 1
+    v = tmuxctl.version()
+    if not tmuxctl.meets_floor():
+        print(tmuxctl.below_floor_message(v), file=sys.stderr)
+
+    frame = config.FRAME
+    from . import workspace
+    ws = workspace.resolve()
+    fid = state.frame_id(ws, os.getpid())
+    fdir = state.frame_dir(fid)
+    state.reap(_live_sessions("charter"))
+    state.bump(fid)
+
+    cols, rows = os.get_terminal_size()
+    slots = layout.visible_slots(frame["slots"], cols, rows,
+                                 frame["min_cols"], frame["min_rows"])
+    conf = fdir / "tmux.conf"
+    conf.write_text(conf_text(hotkey=frame["hotkey"], mouse=frame["mouse"],
+                              history_limit=frame["history_limit"],
+                              status_path=str(fdir / "exit"), harness_pane="%0"))
+
+    env = dict(os.environ, CHARTER_SESSION_ID=fid)
+    if h:
+        env["CHARTER_HARNESS"] = h.name
+    for cmd in layout.plan(slots=slots, cols=cols, rows=rows, harness_argv=argv,
+                           session=fid, conf=str(conf), socket="charter",
+                           charter_argv=[sys.argv[0]]):
+        subprocess.run(cmd, env=env)
+
+    subprocess.run(["tmux", "-L", "charter", "attach", "-t", fid], env=env)
+    code = state.exit_code(fid)
+    state.reap(_live_sessions("charter"))
+    return code if code is not None else 0
+```
+
+- [ ] **Step 4: Wire it into the CLI**
+
+In `charter/cli.py`, add `commands_frame` to the `from . import (…)` block (line 9), then add this function beside `_add_harness_parser`:
+
+```python
+def _add_frame_parsers(sub) -> None:
+    """One launcher per registered harness, plus the escape hatch.
+
+    Generated from `harness.KINDS` rather than listed, which is the reason that registry
+    exists: a harness added to it gets a launcher the day it is registered.
+    """
+    from . import commands_frame
+
+    def _wire(parser, name):
+        parser.add_argument("rest", nargs=argparse.REMAINDER,
+                            help="Passed to the harness verbatim.")
+        parser.add_argument("--no-frame", action="store_true",
+                            help="Run the harness bare, with no charter frame.")
+        parser.set_defaults(harness=name, func=commands_frame.cmd_launch)
+
+    for h in harness.all():
+        if not h.cli_name:
+            continue
+        p = sub.add_parser(h.cli_name,
+                           help=f"Run {h.cli_name} inside charter's frame.")
+        _wire(p, h.cli_name)
+
+    fr = sub.add_parser("frame",
+                        help="Run any command inside charter's frame — `charter frame -- <cmd>`.")
+    _wire(fr, "")
+```
+
+Then call it in `build_parser()` beside the others (near line 314):
+
+```python
+    _add_frame_parsers(sub)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `python -m unittest tests.test_frame_launcher tests.test_harness_launch tests.test_cli_smoke -v`
+Expected: PASS
+
+- [ ] **Step 6: Check the CLI actually grew the commands**
+
+Run: `python -m charter frame --help` and `python -m charter claude --help`
+Expected: both print help; `--no-frame` listed
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add charter/commands_frame.py charter/cli.py tests/test_frame_launcher.py
+git commit -m "charter <harness> starts the frame, and carries the real exit code (#345)"
+```
+
+---
+
+### Task 7: `frame/panel.py` — the panel runtime
+
+**Files:**
+- Create: `charter/frame/panel.py`
+- Modify: `charter/cli.py` (add the internal `panel` parser)
+- Test: `tests/test_frame_panel.py`
+
+**Interfaces:**
+- Consumes: `charter.frame.state.version`, `charter.frame.slots.render`
+- Produces: `run(slot: str, fid: str, *, once: bool = False) -> int`, `should_redraw(seen: str, fid: str) -> bool`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""A panel wakes because the agent did something, not because a timer went off.
+
+The version file is a `stat` per tick, which is why the frame costs nothing at idle. A
+FIFO was designed and rejected: opening one for write blocks until a reader exists, which
+would put a hang inside the hook path.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter.frame import panel, state
+
+from _isolation import IsolatedPaths
+
+
+class Redraw(IsolatedPaths, unittest.TestCase):
+    def test_an_unchanged_version_does_not_redraw(self):
+        seen = state.version("f-1")
+        self.assertFalse(panel.should_redraw(seen, "f-1"))
+
+    def test_a_bump_asks_for_a_redraw(self):
+        seen = state.version("f-1")
+        state.bump("f-1")
+        self.assertTrue(panel.should_redraw(seen, "f-1"))
+
+    def test_a_missing_frame_redraws_rather_than_crashing(self):
+        """A panel outliving its state directory must show something, not die and leave
+        a hole in the frame."""
+        self.assertTrue(panel.should_redraw("nothing-like-a-version", "never-existed"))
+
+
+class Draw(IsolatedPaths, unittest.TestCase):
+    def test_one_pass_writes_the_slot_and_returns(self):
+        rc = panel.run("bottom", "f-1", once=True)
+        self.assertEqual(rc, 0)
+
+    def test_an_unknown_slot_is_refused_rather_than_drawn_blank(self):
+        rc = panel.run("sideways", "f-1", once=True)
+        self.assertNotEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `python -m unittest tests.test_frame_panel -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'charter.frame.panel'`
+
+- [ ] **Step 3: Implement the runtime**
+
+`charter/frame/panel.py`:
+
+```python
+"""One charter panel, owning one tmux pane.
+
+Repaints whole. A five-row pane is a few hundred cells, so diffing would be optimising
+something that is already free, and `tui.py` already truncates rather than wrapping when
+the pane is narrow.
+"""
+
+from __future__ import annotations
+
+import signal
+import sys
+import time
+
+from . import slots, state
+
+#: How often the version file is checked. A `stat` at this rate is indistinguishable from
+#: zero, and it cannot hang the hook that writes it — which a FIFO could.
+TICK = 0.2
+
+
+def should_redraw(seen: str, fid: str) -> bool:
+    try:
+        return state.version(fid) != seen
+    except Exception:
+        return True
+
+
+def _paint(slot: str, fid: str) -> None:
+    sys.stdout.write("\x1b[H\x1b[2J" + slots.render(slot, fid))
+    sys.stdout.flush()
+
+
+def run(slot: str, fid: str, *, once: bool = False) -> int:
+    if slot not in slots.SLOTS:
+        print(f"charter panel: unknown slot '{slot}' "
+              f"(known: {', '.join(sorted(slots.SLOTS))})", file=sys.stderr)
+        return 2
+
+    resized = {"flag": True}
+    signal.signal(signal.SIGWINCH, lambda *_: resized.__setitem__("flag", True))
+
+    seen = ""
+    while True:
+        if resized["flag"] or should_redraw(seen, fid):
+            resized["flag"] = False
+            seen = state.version(fid)
+            _paint(slot, fid)
+        if once:
+            return 0
+        time.sleep(TICK)
+```
+
+- [ ] **Step 4: Wire the internal command**
+
+In `charter/cli.py`, inside `_add_frame_parsers`, append:
+
+```python
+    pn = sub.add_parser("panel")          # internal: one pane of a running frame
+    pn.add_argument("slot")
+    pn.add_argument("--session", dest="session", required=True)
+    pn.set_defaults(func=lambda args: __import__(
+        "charter.frame.panel", fromlist=["panel"]).run(args.slot, args.session))
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `python -m unittest tests.test_frame_panel -v`
+Expected: PASS, 5 tests
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add charter/frame/panel.py charter/cli.py tests/test_frame_panel.py
+git commit -m "A panel owns its pane and wakes on a version bump (#345)"
+```
+
+---
+
+### Task 8: Liveness — the hooks bump the frame
+
+**Files:**
+- Modify: `charter/hooks.py` (one call in the `sessionstart`, `userpromptsubmit` and `posttooluse` handlers)
+- Create: `charter/frame/notify.py`
+- Test: `tests/test_frame_liveness.py`
+
+**Interfaces:**
+- Consumes: `charter.frame.state.bump`
+- Produces: `notify.plane_changed() -> None` (debounced, never raises)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""The frame updates because the agent did something.
+
+`posttooluse` runs on every tool call, and `hooks.py` already treats that path as hot, so
+the bump is debounced and swallows every error: a hook may cost a session its briefing,
+never its turn.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from charter.frame import notify, state
+
+from _isolation import IsolatedPaths
+
+
+class Notify(IsolatedPaths, unittest.TestCase):
+    def test_a_change_bumps_the_running_frame(self):
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
+            before = state.version("f-1")
+            notify._last["at"] = 0.0
+            notify.plane_changed()
+            self.assertNotEqual(before, state.version("f-1"))
+
+    def test_a_second_bump_inside_the_debounce_window_is_skipped(self):
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
+            notify._last["at"] = 0.0
+            notify.plane_changed()
+            first = state.version("f-1")
+            notify.plane_changed()
+            self.assertEqual(first, state.version("f-1"))
+
+    def test_outside_a_frame_it_does_nothing_at_all(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            notify.plane_changed()   # must not raise
+
+    def test_a_broken_state_directory_never_reaches_the_hook(self):
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}), \
+             mock.patch.object(state, "bump", side_effect=OSError("read-only")):
+            notify._last["at"] = 0.0
+            notify.plane_changed()   # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `python -m unittest tests.test_frame_liveness -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'charter.frame.notify'`
+
+- [ ] **Step 3: Implement it**
+
+`charter/frame/notify.py`:
+
+```python
+"""Telling a running frame that the plane changed.
+
+Called from hooks, so the two rules are absolute: it never raises, and it never costs the
+hot path anything. `posttooluse` fires on every tool call.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+from . import state
+
+#: At most one bump per this many seconds. A panel ticks at 0.2s, so a tighter debounce
+#: buys nothing a reader could see.
+DEBOUNCE = 0.25
+
+_last = {"at": 0.0}
+
+
+def plane_changed() -> None:
+    """Bump the frame this process is running inside, if any. Never raises."""
+    try:
+        fid = os.environ.get("CHARTER_SESSION_ID")
+        if not fid:
+            return
+        now = time.monotonic()
+        if now - _last["at"] < DEBOUNCE:
+            return
+        _last["at"] = now
+        state.bump(fid)
+    except Exception:
+        return
+```
+
+- [ ] **Step 4: Call it from the three handlers**
+
+In `charter/hooks.py`, at the top of the `sessionstart`, `userpromptsubmit` and `posttooluse` handler functions (the ones registered in `_HANDLERS`), add:
+
+```python
+    from .frame import notify
+    notify.plane_changed()
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `python -m unittest tests.test_frame_liveness -v && python -m unittest discover -s tests 2>&1 | tail -3`
+Expected: PASS, then OK
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add charter/frame/notify.py charter/hooks.py tests/test_frame_liveness.py
+git commit -m "The frame updates because the agent did something (#345)"
+```
+
+---
+
+### Task 9: `frame/slots.py` — what top and bottom actually say
+
+**Files:**
+- Create: `charter/frame/slots.py`
+- Test: `tests/test_frame_slots.py`
+
+**Interfaces:**
+- Consumes: `charter.statusline` helpers (`_todo_count`, `_alerts`, `_persona_line`), `charter.workspace.resolve`, `charter.tui`
+- Produces: `SLOTS: dict[str, callable]`, `render(slot: str, fid: str) -> str`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Panels compose the renderers the status line already has.
+
+Zones are not re-invented here: `statusline.py` already argues for identity in one place
+and alerts in another, and a frame that split them differently would be a second layout to
+keep in step with the first.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import tui
+from charter.frame import slots
+
+from _isolation import IsolatedPaths
+
+
+class Render(IsolatedPaths, unittest.TestCase):
+    def test_top_names_the_workspace(self):
+        out = slots.render("top", "f-1")
+        self.assertTrue(out.strip())
+
+    def test_bottom_renders(self):
+        self.assertTrue(slots.render("bottom", "f-1").strip())
+
+    def test_a_slot_never_exceeds_the_pane_width(self):
+        """`tui.width` counts display cells, not characters — a wide glyph that fits by
+        len() still wraps the pane and pushes the frame apart."""
+        for slot in ("top", "bottom"):
+            for line in slots.render(slot, "f-1").splitlines():
+                with self.subTest(slot=slot):
+                    self.assertLessEqual(tui.width(line), tui.term_width(default=80))
+
+    def test_a_failing_renderer_yields_a_line_rather_than_an_exception(self):
+        """A panel that raises leaves a hole in the frame; `statusline.render` makes the
+        same promise for the same reason."""
+        slots.SLOTS["boom"] = lambda fid: 1 / 0
+        try:
+            self.assertIn("charter", slots.render("boom", "f-1"))
+        finally:
+            del slots.SLOTS["boom"]
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `python -m unittest tests.test_frame_slots -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'charter.frame.slots'`
+
+- [ ] **Step 3: Implement it**
+
+`charter/frame/slots.py`:
+
+```python
+"""What each edge of the frame says.
+
+Content comes from the renderers `statusline.py` already has — they are composed here,
+never rewritten, so a fix to a repo row or an alert lands in both surfaces at once.
+"""
+
+from __future__ import annotations
+
+from .. import tui
+
+
+def _width() -> int:
+    return max(20, tui.term_width(default=80, floor=20))
+
+
+def _top(fid: str) -> str:
+    """Identity: where you are, pinned or not, and who you are being."""
+    from .. import __version__, statusline, workspace
+    ws = workspace.resolve()
+    src = workspace.source()
+    pin = "*" if src == "$CHARTER_WORKSPACE" else ""
+    persona = statusline._persona_line() or ""
+    left = f" ⬢ {ws}{pin}"
+    right = f"{persona}  charter {__version__} "
+    return tui.truncate(f"{left}  {right}", _width())
+
+
+def _bottom(fid: str) -> str:
+    """What still wants attention, and how to act on it."""
+    from .. import statusline, workspace
+    ws = workspace.resolve()
+    todos = statusline._todo_count(ws)
+    alerts = statusline._alerts(ws)
+    parts = [f"{todos} todo" + ("s" if todos != 1 else "")]
+    parts.extend(alerts[:1])
+    parts.append("F2 menu")
+    return tui.truncate(" · ".join(p for p in parts if p), _width())
+
+
+#: Every slot charter can draw. `panel.run` refuses a name that is not in here rather
+#: than painting an empty pane, because an empty pane reads as a broken frame.
+SLOTS = {"top": _top, "bottom": _bottom}
+
+
+def render(slot: str, fid: str) -> str:
+    """Draw *slot*, or a one-line explanation of why it could not be drawn.
+
+    Never raises. A panel that dies leaves a hole in the frame, which is worse than a
+    line saying what went wrong — the promise `statusline.render` already makes.
+    """
+    fn = SLOTS.get(slot)
+    if fn is None:
+        return tui.truncate(f" charter: unknown slot {slot}", _width())
+    try:
+        return fn(fid)
+    except Exception as e:
+        return tui.truncate(f" charter: {slot} unavailable ({type(e).__name__})", _width())
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python -m unittest tests.test_frame_slots -v`
+Expected: PASS, 4 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add charter/frame/slots.py tests/test_frame_slots.py
+git commit -m "Top and bottom compose the renderers the status line already has (#345)"
+```
+
+---
+
+### Task 10: The menu, and the boundary names never cross
+
+**Files:**
+- Create: `charter/frame/menu.py`
+- Modify: `charter/commands_frame.py` (add `cmd_action`), `charter/cli.py` (`frame action`)
+- Test: `tests/test_frame_menu.py`
+
+**Interfaces:**
+- Consumes: `charter.frame.state.frame_dir`
+- Produces: `build(fid: str) -> list[tuple[str, str]]` (label, opaque id), `menu_argv(fid, socket) -> list[str]`, `resolve(fid: str, action_id: str) -> list[str] | None`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""A workspace name must never reach a tmux command string.
+
+`display-menu` takes commands tmux parses and runs, and workspace, repo, branch and
+persona names all come from committed files or `.git/HEAD`. Charter shipped a fix for
+this exact shape one release ago — a branch name reaching `gh -F` and making it read a
+file — and its conclusion was that the fix is the mechanism, not the value. So menu items
+carry opaque ids and charter resolves them in-process.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter.frame import menu
+
+from _isolation import IsolatedPaths
+
+
+HOSTILE = 'x" ; run-shell "touch /tmp/pwned'
+
+
+class OpaqueIds(IsolatedPaths, unittest.TestCase):
+    def test_a_menu_item_carries_an_id_not_a_name(self):
+        menu.record(fid="f-1", entries=[(HOSTILE, ["charter", "ws", "use", HOSTILE])])
+        argv = menu.menu_argv("f-1", "charter")
+        flat = " ".join(argv)
+        self.assertNotIn("run-shell", flat)
+        self.assertNotIn("/tmp/pwned", flat)
+
+    def test_the_id_resolves_back_to_the_real_command_in_process(self):
+        menu.record(fid="f-1", entries=[(HOSTILE, ["charter", "ws", "use", HOSTILE])])
+        entries = menu.build("f-1")
+        self.assertEqual(len(entries), 1)
+        _label, action_id = entries[0]
+        self.assertEqual(menu.resolve("f-1", action_id),
+                         ["charter", "ws", "use", HOSTILE])
+
+    def test_an_unknown_id_resolves_to_nothing(self):
+        self.assertIsNone(menu.resolve("f-1", "not-an-id"))
+
+    def test_an_id_is_only_ever_id_shaped(self):
+        menu.record(fid="f-1", entries=[(HOSTILE, ["charter", "true"])])
+        for _label, action_id in menu.build("f-1"):
+            self.assertRegex(action_id, r"^a[0-9]+$")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `python -m unittest tests.test_frame_menu -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'charter.frame.menu'`
+
+- [ ] **Step 3: Implement it**
+
+`charter/frame/menu.py`:
+
+```python
+"""The frame's menu, built so no name ever reaches tmux's parser.
+
+`display-menu` and `display-popup -E` take commands **tmux** parses and executes. Every
+interesting label in charter — a workspace, a repo, a branch, a persona — is read out of a
+committed file or `.git/HEAD`, which is exactly the input class that made `gh -F` open a
+file on someone's machine. Quoting it for tmux would be an arms race against a parser with
+`;` separation, `#{}` expansion and two quote styles.
+
+So the command tmux runs is always `charter frame action a<N>`, and charter looks the real
+argv up in its own state. Labels are still shown — a label is drawn, never executed — but
+they are sanitised of the one thing that could confuse a menu: newlines.
+"""
+
+from __future__ import annotations
+
+import json
+
+from . import state
+
+
+def _table(fid: str):
+    return state.frame_dir(fid) / "actions.json"
+
+
+def record(*, fid: str, entries: list[tuple[str, list[str]]]) -> None:
+    """Store this frame's menu as ``{id: argv}``, and the labels beside it."""
+    data = {f"a{i}": {"label": label.replace("\n", " ")[:60], "argv": argv}
+            for i, (label, argv) in enumerate(entries)}
+    _table(fid).write_text(json.dumps(data))
+
+
+def build(fid: str) -> list[tuple[str, str]]:
+    """``(label, opaque id)`` for each entry, in order."""
+    try:
+        data = json.loads(_table(fid).read_text())
+    except (OSError, ValueError):
+        return []
+    return [(v["label"], k) for k, v in sorted(data.items())]
+
+
+def resolve(fid: str, action_id: str) -> list[str] | None:
+    """The real argv for an id, or ``None``. The only place an id becomes a command."""
+    try:
+        data = json.loads(_table(fid).read_text())
+    except (OSError, ValueError):
+        return None
+    entry = data.get(action_id)
+    if not isinstance(entry, dict):
+        return None
+    argv = entry.get("argv")
+    return argv if isinstance(argv, list) and all(isinstance(a, str) for a in argv) else None
+
+
+def menu_argv(fid: str, socket: str) -> list[str]:
+    """The `display-menu` invocation for this frame. Ids only — never a name."""
+    cmd = ["tmux", "-L", socket, "display-menu", "-T", "charter"]
+    for i, (label, action_id) in enumerate(build(fid)):
+        cmd += [label, str(i + 1), f"run-shell 'charter frame action {action_id}'"]
+    return cmd
+```
+
+- [ ] **Step 4: Add the action command**
+
+Append to `charter/commands_frame.py`:
+
+```python
+def cmd_action(args) -> int:
+    """Run a menu entry by its opaque id. The only path from a menu to a command."""
+    from .frame import menu
+
+    fid = os.environ.get("CHARTER_SESSION_ID", "")
+    argv = menu.resolve(fid, args.action_id)
+    if not argv:
+        print(f"charter frame action: unknown action '{args.action_id}'", file=sys.stderr)
+        return 2
+    return subprocess.run(argv).returncode
+```
+
+In `charter/cli.py`, inside `_add_frame_parsers`, after the `frame` parser:
+
+```python
+    frsub = fr.add_subparsers(dest="frame_command")
+    act = frsub.add_parser("action")   # internal: a menu entry, by opaque id
+    act.add_argument("action_id")
+    act.set_defaults(func=commands_frame.cmd_action)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `python -m unittest tests.test_frame_menu -v`
+Expected: PASS, 4 tests
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add charter/frame/menu.py charter/commands_frame.py charter/cli.py tests/test_frame_menu.py
+git commit -m "Menu entries carry opaque ids, so no name reaches tmux's parser (#345)"
+```
+
+---
+
+### Task 11: Docs, news, ADR, and the doctor row
+
+**Files:**
+- Create: `docs/frame.md`, `docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md`, `docs/news/unreleased-charter-runs-the-harness.md`
+- Modify: `pyproject.toml` (force-include `docs/frame.md`), `charter/doctor.py`
+- Test: `tests/test_frame_doctor.py` (the docs test already exists and will fail without the force-include)
+
+**Interfaces:**
+- Consumes: `charter.frame.tmuxctl`
+- Produces: a `doctor` row reporting tmux presence and version
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""tmux is a frame prerequisite, not a harness ceiling.
+
+Filing it under `harness.deficits` would claim claude-code cannot do something it does
+perfectly well — `tests/test_doctor_absent_is_not_health.py` already draws that line.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import doctor
+
+
+class FrameRow(unittest.TestCase):
+    def test_a_present_tmux_reports_its_version(self):
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)):
+            row = doctor.frame_row()
+        self.assertIn("3.7", row)
+
+    def test_an_absent_tmux_is_named_not_silent(self):
+        with mock.patch("charter.frame.tmuxctl.version", return_value=None):
+            row = doctor.frame_row()
+        self.assertIn("tmux", row)
+
+    def test_tmux_is_not_reported_as_a_harness_deficit(self):
+        from charter import harness
+        for h in harness.all():
+            with self.subTest(harness=h.name):
+                self.assertNotIn("tmux", " ".join(d.key for d in h.deficits))
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `python -m unittest tests.test_frame_doctor -v`
+Expected: FAIL — `AttributeError: module 'charter.doctor' has no attribute 'frame_row'`
+
+- [ ] **Step 3: Add the doctor row**
+
+Append to `charter/doctor.py`:
+
+```python
+def frame_row() -> str:
+    """One line on whether `charter <harness>` can compose a frame here.
+
+    Its own check rather than a `Deficit`: tmux is a prerequisite of the frame, not a
+    ceiling of any harness, and filing it as a deficit would tell the reader that their
+    harness is limited when it is not.
+    """
+    from .frame import tmuxctl
+
+    v = tmuxctl.version()
+    if v is None:
+        return "frame    tmux not found — `charter <harness>` needs it (brew install tmux)"
+    ok = "" if v >= tmuxctl.FLOOR else f" — menu needs {tmuxctl.FLOOR[0]}.{tmuxctl.FLOOR[1]}"
+    return f"frame    tmux {v[0]}.{v[1]}{ok}"
+```
+
+Call it from the same place the other rows are printed in `doctor`'s report body.
+
+- [ ] **Step 4: Write `docs/frame.md`**
+
+```markdown
+# The frame
+
+`charter claude` runs the harness inside a frame charter composes: the harness in the
+middle, charter's panels on the edges. It works on every harness, which is the point — a
+status line is Claude Code's surface, and Codex and opencode have none.
+
+    charter claude              # or codex, opencode
+    charter frame -- <cmd>      # anything charter has never met
+    charter claude --no-frame   # bare, no frame at all
+
+## What it needs
+
+tmux 3.2 or newer. tmux composes the rectangles and does every part of terminal emulation;
+charter fills the edges and never draws or parses the harness's pane (ADR 0018).
+
+## What changes inside the frame
+
+Scrollback is tmux's copy-mode rather than your terminal's. The frame raises
+`history-limit` to 50 000 and binds the wheel to copy-mode, but it is not the same thing
+as your terminal's own buffer, and it is the difference people notice first.
+
+Mouse is off by default: `set -g mouse on` takes over drag-select, so turning it on trades
+your terminal's copy behaviour for clickable panels. `[frame] mouse = true` when you want
+that trade.
+
+Charter never touches `~/.tmux.conf`. Outside tmux it starts a private server; inside tmux
+it builds the same layout as a new window in your own server, so there is no nesting and
+no second prefix key.
+
+## Configuring it
+
+```toml
+[frame]
+slots = ["top", "bottom"]
+mouse = false
+hotkey = "F2"
+history-limit = 50000
+min-cols = 100
+min-rows = 20
+```
+
+Below `min-cols`/`min-rows` the side panels drop, then the top, and below the floor the
+harness simply gets the whole terminal.
+```
+
+- [ ] **Step 5: Force-include the docs page**
+
+In `pyproject.toml`, in `[tool.hatch.build.targets.wheel.force-include]`, add in alphabetical order:
+
+```toml
+"docs/frame.md" = "charter/_docs/frame.md"
+```
+
+- [ ] **Step 6: Write ADR 0018 and the news entry**
+
+`docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md` records the measurement (1.85 MB/s against 25.2 MB/s end to end, 2.4 MB/s pyte parse against ~37 MB/s tmux), that both arms worked so feasibility was never the question, and the maintenance argument (a 120-line widget with no cursor, on a parser last released 2023-11-12, in a project shipping `dependencies = []`).
+
+`docs/news/unreleased-charter-runs-the-harness.md` uses the existing entry format, with a `check:` probe that is read-only, uses charter's own argv, and cannot hang:
+
+```markdown
+---
+version: unreleased
+headline: charter can run the harness, and draw around it
+check: frame --probe
+---
+```
+
+- [ ] **Step 7: Run the whole suite**
+
+Run: `python -m unittest discover -s tests -v 2>&1 | tail -5`
+Expected: OK — including `tests/test_docs_show.py`, which fails on a `docs/*.md` that is not force-included
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/ pyproject.toml charter/doctor.py tests/test_frame_doctor.py
+git commit -m "Document the frame, record ADR 0018, and report tmux in doctor (#345)"
+```
+
+---
+
+## Self-review notes
+
+**Spec coverage.** Command surface → Task 6. Non-TTY bypass → Task 6. Missing tmux → Tasks 4, 6. `cli_name`/`launch_argv` → Task 1. Collision test → Task 1. Process model and private conf → Task 6. Inside-tmux new window → **not yet covered; see below.** Identity and `CHARTER_SESSION_ID` → Task 6. `CHARTER_WORKSPACE` never exported → Task 6 (asserted in Task 1's constraint list, worth its own test when the inside-tmux path lands). Liveness → Task 8. Slots → Task 9. Focus pinned, menu, opaque ids → Task 10. Mouse default → Tasks 2, 6. Scrollback → Task 6. Degradation → Task 3. Exit code → Task 6. Panel crash policy → **not yet covered; see below.** Config → Task 2. Docs/news/ADR/doctor → Task 11.
+
+**Two gaps this plan leaves open, deliberately, as the v1.1 slice:**
+
+1. **The inside-tmux path** (`$TMUX` set → new window in the operator's server, prefix-scoped keys). Every piece it needs exists after Task 6; it is one branch in `cmd_launch` plus its own test file, and it is the first thing to add.
+2. **Panel respawn with backoff** (`remain-on-exit` already keeps a dead panel visible with its error, which is the half that matters; three-attempt respawn is the other half).
+
+Both are named here rather than silently dropped, because a plan that omits them reads as if the spec were fully covered.

--- a/docs/superpowers/plans/2026-08-22-harness-frame.md
+++ b/docs/superpowers/plans/2026-08-22-harness-frame.md
@@ -1641,7 +1641,9 @@ file on someone's machine. Quoting it for tmux would be an arms race against a p
 `;` separation, `#{}` expansion and two quote styles.
 
 So the command tmux runs is always `charter frame action a<N>`, and charter looks the real
-argv up in its own state. Labels are still shown — a label is drawn, never executed — but
+argv up in its own state. Labels are still shown — and a label is NOT merely drawn:
+tmux runs item names through its format engine, so `#(cmd)` in a label executes `cmd`
+(measured; see the execution notes below). Labels are escaped, not trusted — but
 they are sanitised of the one thing that could confuse a menu: newlines.
 """
 
@@ -1905,3 +1907,50 @@ git commit -m "Document the frame, record ADR 0018, and report tmux in doctor (#
 2. **Panel respawn with backoff** (`remain-on-exit` already keeps a dead panel visible with its error, which is the half that matters; three-attempt respawn is the other half).
 
 Both are named here rather than silently dropped, because a plan that omits them reads as if the spec were fully covered.
+
+---
+
+## What execution changed (2026-08-22)
+
+This plan was written before any of it ran. Eleven tasks, twenty reviews and several
+hundred mutations later, a number of its claims turned out to be wrong. They are corrected
+here rather than quietly left, because a plan read later is evidence about the design, and
+a wrong one is worse than none.
+
+**Defects in this plan, found by building it:**
+
+| where | what the plan said | what is true |
+| --- | --- | --- |
+| Task 3 | every `split-window` targets `{session}:0.0` | tmux renumbers panes on each split, so the second split divides the *first panel* and fails with `size or position no space for a new pane` — the frame came up with one panel instead of four, silently. Fixed by capturing the harness pane id (`-P -F '#{pane_id}'`) and targeting it. |
+| Task 3 | `visible_slots` as written | contradicted its own test: at 200x12 it returned `['bottom','left','right']` where the test asserted `['bottom']`. |
+| Task 2 | `[frame]` keys read from TOML | `FRAME_DEFAULTS` was keyed with underscores while the documented TOML spelling is hyphenated, so `history-limit`, `min-cols` and `min-rows` were silently ignored — and the plan's own tests only covered the three hyphen-free keys. |
+| Task 5 | `frame_dir()` creates on every call | a read path that writes: reading a version created the frame's directory, and a panel could resurrect a directory `reap()` had just deleted. |
+| Task 6 | the launcher `exec`s tmux and re-raises the harness's status | an attached `tmux new-session` returns 0 whatever its command exited with. The launcher must fork, wait, and read a recorded status. |
+| Task 6 | `charter claude [args…]` | `argparse.REMAINDER` does not capture leading option-like tokens, so `charter claude -p hi` errored. |
+| Task 10 | `charter frame action <id>` | unreachable — `_split_frame_argv` swallows everything after `frame` so the harness gets its argv verbatim. `frame-action` is a top-level sibling. |
+| Task 10 | "a label is drawn, never executed" | false, and the most serious finding in the plan. See below. |
+| Task 11 | `check: frame --probe` | `news._PROBEABLE` refuses any command whose parser carries a pass-through positional, which `frame` always does. A separate `charter frame-probe` carries the news probe. |
+| Task 1/6 | the collision guard raises on any duplicate `cli_name` | raising from `build_parser()` breaks *every* charter command. It now raises only for a collision with a core command; a duplicate between harnesses skips. |
+
+**The one that mattered most.** `display-menu` item names pass through tmux's format
+engine, so a label containing `#(cmd)` **executes** `cmd` the moment the menu renders. It
+was reproduced end to end in a real frame — two labels, two canary files — and the payload
+needs no space, because `#(id>/tmp/x)` is a legal git branch name. That is the same
+delivery vehicle `docs/news/unreleased-forge-argv-encoding.md` describes, where "checking
+out a branch from someone else's pull request was enough". Labels are now escaped (`#` →
+`##`), and the module comment and test that had certified the opposite were inverted.
+
+**Behaviours pinned against tmux 3.7c**, each by rejection rather than by documentation:
+
+- separate argv is not shell-interpreted; a joined string is;
+- an attached `new-session` returns 0 regardless of its command's status;
+- `-f <conf>` is honoured only when the call actually *starts* the server, so a second
+  frame on a shared socket silently never got its own hooks;
+- a bare `set-hook pane-died` replaces the **whole array**, deleting `[1]` — so swapping
+  two adjacent lines reintroduces an infinite hang with a green suite;
+- tmux reports an **empty** `pane_dead_status` for signal deaths, not a negative one;
+- `-t` scopes format state; `-c` selects the client, so the menu rendered on the wrong
+  operator's screen until the presser was carried through the bind via `#{client_name}`;
+- `window-resized` needs tmux 3.3, and without it panels drift to 15 of 50 rows on resize.
+
+**What is still open** is recorded in the branch's final review, not here.

--- a/docs/superpowers/specs/2026-08-21-harness-wrapper-design.md
+++ b/docs/superpowers/specs/2026-08-21-harness-wrapper-design.md
@@ -1,0 +1,238 @@
+# charter runs the harness: a composed frame around the agent
+
+Charter's status line exists because a control plane has state a developer needs at a
+glance — which workspace is active, what the repos are doing, what is still open. It is
+also the one surface charter cannot offer everywhere: Claude Code renders a status line,
+Codex and opencode do not, and no amount of care in `statusline.py` changes that.
+
+**So charter stops asking the harness for a surface and brings its own.** `charter claude`
+starts the harness inside a frame charter composes, with charter's panels on the edges.
+The status line path is untouched; this is a second way to run charter, not a replacement.
+
+## The decision that cost the most to make
+
+The obvious reading of "charter's own frame" is that charter becomes the app: one program,
+a component tree, the harness as a widget. It was built and measured rather than argued
+about, against a second arm where tmux composes and charter fills the rectangles.
+
+Measured on darwin 25.2.0, Python 3.14.4, textual 8.2.8, pyte 0.8.2, tmux 3.7c, a 150x42
+frame, one corpus shaped like an agent streaming (coloured text, full repaint every 40
+lines):
+
+| | charter is the app (Textual + pyte) | tmux composes |
+| --- | --- | --- |
+| end-to-end burst | **1.85 MB/s** | **25.2 MB/s** |
+| 2 MB log | 1.08 s frozen | 0.08 s |
+| 13 MB build log | ~7 s frozen | 0.51 s |
+| VT parse alone | 2.4 MB/s, 0.9 with scrollback | ~37 MB/s |
+| screen to pixels | 7.2 ms/frame (138 fps ceiling) | n/a, it is C |
+
+Both arms work: the Textual arm rendered claude's trust prompt and opencode's alt-screen
+TUI correctly, so this was never a feasibility question. Rendering was never the
+bottleneck either — **parsing is**, and a pure-Python VT emulator is the whole cost.
+
+The maintenance side decided it as firmly as the numbers. The spike's terminal widget was
+120 lines and did not draw a cursor. Still owed: mouse forwarding, scrollback, bracketed
+paste, focus reporting, OSC titles, wide-character widths, and synchronized output —
+`?2026`, which Claude Code was measured emitting. All of it permanent, on `pyte`, whose
+last release was 2023-11-12, in a project that ships `dependencies = []`.
+
+**tmux composes the rectangles. Charter fills them, and owns no terminal emulation.** The
+only thing given up is drawing on top of the harness pane, which is the one rectangle
+charter has no reason to draw. Recorded as ADR 0018, *charter may run the harness, but
+never draws it*.
+
+Charter still gets a component model everywhere it actually draws: each panel is a charter
+process owning its pane, built on `tui.py`'s existing `Node`/`Row`/`Stack`/`Columns`.
+
+## Command surface
+
+```
+charter claude [args…]          # one launcher per harness in registry.KINDS
+charter codex [args…]
+charter opencode [args…]
+charter frame -- <cmd> [args…]  # any harness charter has never met
+```
+
+Arguments after the name reach the harness verbatim.
+
+- **Not a TTY, no frame.** `charter claude -p "…" | jq` `execvp`s the harness directly.
+  A frame around a pipe is wrong, and `exec` preserves the exit code for free.
+- **No tmux, name the gap.** `Deficit` already states the rule — inventing a remedy
+  "sends somebody off to configure something that does not exist" — so charter states the
+  requirement, prints the install command, and offers `--no-frame`.
+- **`Harness` gains two members**, `cli_name` and `launch_argv()`. This widens an
+  interface whose docstring calls itself "deliberately three members wide", and it is
+  deliberate: charter now needs a fourth fact from a harness — how to start it — and
+  anywhere else recreates the hardcoded-literal problem `registry.py` exists to prevent.
+- **Core commands win a name collision**, and a colliding `cli_name` fails a test rather
+  than someone's terminal.
+
+## Process model
+
+```
+charter claude
+ ├─ resolve harness → argv, probe `tmux -V` (floor 3.2)
+ ├─ write .charter/frame/<frame-id>/tmux.conf   (never ~/.tmux.conf)
+ └─ exec tmux -L charter -f <conf> …
+      ├─ pane: charter panel top
+      ├─ pane: <harness>      ← charter never draws or parses this
+      ├─ pane: charter panel left / right
+      └─ pane: charter panel bottom
+```
+
+Inside an existing tmux (`$TMUX` set): the same layout as **a new window in the user's own
+server**. No nesting, no second prefix, their config untouched. Only key policy differs —
+prefix-scoped bindings there, because tmux bindings are server-wide and charter must not
+take a key from the user's other windows.
+
+Concurrent frames share the server and get one session each, named by workspace and pid.
+One session *per workspace* was rejected: two terminals silently sharing one agent is the
+same class of bug as the identity collision below.
+
+## Identity
+
+`session.terminal()` prefers `TERM_SESSION_ID` over `TMUX_PANE`, and tmux's
+`update-environment` does not scrub it — so under iTerm2 or Terminal.app **every pane in
+the frame inherits one terminal id**. That is exactly what `WINDOWID` was removed for:
+"two sessions in one window, one runs `charter ws use`, and the other silently moved with
+it."
+
+The launcher mints a frame id — the workspace name and its own pid, the same pair the
+session is named for — and exports it as `CHARTER_SESSION_ID`; panels take the harness
+pane's id as an argument and never resolve identity themselves. `_PANE_ID_VARS` is *not*
+reordered — that would change behaviour for every existing session to fix a problem only
+the frame has.
+
+`CHARTER_WORKSPACE` is deliberately **not** exported. `statusline._active()` prefers it
+over the pointer file, so exporting it would make `charter ws use` inside the frame appear
+to do nothing.
+
+## Liveness
+
+Panels do not poll charter's state; they wait on a version file and `stat` it every
+~200 ms. `sessionstart`, `userpromptsubmit` and `posttooluse` bump it, debounced to at
+most once per 250 ms, written with a single `os.replace` so a torn read is impossible.
+
+A FIFO was designed and rejected: opening one for write **blocks until a reader exists**,
+which would put a hang inside the hook path — and a hook may cost a session its briefing,
+never its turn.
+
+The frame therefore updates because the agent did something, costs a `stat` per panel at
+idle, and behaves identically on all three harnesses. This is why the wrapper is better
+than a status line rather than merely more portable.
+
+## Slots
+
+`top` is identity — workspace, pin marker, plane version, persona. `bottom` is alerts, the
+todo count and the hotkey hint. `left` is repo rows and `right` is todos and memory when
+they ship. The split follows the zones `statusline.py` already argues for, so the frame
+inherits a layout that has been thought about rather than inventing a second one. Content
+comes from the existing renderers — `_repo_rows`, `_persona_chips`, `_todo_count`,
+`_alerts` — composed, never rewritten.
+
+Panels repaint fully; a five-row pane is a few hundred cells and diffing would optimise
+something already free. No alt-screen in a panel: nothing there scrolls.
+
+## Interaction, and the boundary that keeps it safe
+
+Keyboard focus is pinned to the harness. Typing must always reach the agent; a mis-click
+that swallows half a prompt is the worst bug this feature could ship. Interaction is a
+single configurable hotkey (`bind -n` only in charter's own server) opening a
+`display-menu`, with `display-popup -E` for anything charter must render itself.
+
+**Names never cross into a tmux command string.** `display-menu` and `display-popup -E`
+take commands tmux parses and runs, and workspace names, repo names, branch names and
+persona names are all read from committed files or `.git/HEAD`. Charter shipped a fix for
+this exact shape one release ago — a branch name reaching `gh -F` and making it read a
+file, where "checking out a branch from someone else's pull request was enough" — and its
+conclusion was that the fix is the mechanism, not the value.
+
+So menu items invoke `charter frame action <opaque-id>`, where the id indexes a table
+charter holds in its own state and resolves in-process. The same rule covers the launch
+path: the harness is spawned as **separate argv, never a joined string**, with tmux's
+actual behaviour pinned by probing the binary the way `codex.py` pinned its config shapes.
+
+This is also an argument for panes over `status-format`: text a panel writes to its own
+pane is inert, where a status format would expand `#{}` inside a workspace name.
+
+Mouse is **off by default**. `set -g mouse on` takes over drag-select, and breaking the
+user's copy to enable a feature v1 does not ship is a bad trade; it turns on with the
+release that makes panels clickable.
+
+## Degradation
+
+Below `min-cols`/`min-rows`, side panels drop, then the top, then the frame falls back to
+a bare harness with a one-line note. `statusline.render` already budgets a width and
+truncates rather than wrapping; the frame degrades the same way rather than differently.
+
+Scrollback inside the frame is tmux copy-mode, not the terminal's, capped at 2000 lines by
+default. The frame raises `history-limit` to 50 000 and binds the wheel to copy-mode, and
+the docs name the difference regardless — it is the most likely "the frame broke my
+terminal" report.
+
+## Lifecycle
+
+- **Exit code.** `charter claude` must be a transparent substitute for `claude`, so the
+  harness's status is re-raised via `remain-on-exit` and `#{pane_dead_status}`.
+- **Detach** is allowed and prints how to reattach; an agent surviving a closed lid is a
+  feature, and returning silently to a shell with it still running is not.
+- **A dead panel** stays visible with its error, respawns with backoff, and gives up after
+  3 attempts. A panel must never be able to take the agent down with it.
+- **Teardown** removes the frame's own directory; launch reaps directories whose tmux
+  session is gone. Never by age — a long-lived frame is what an age heuristic would eat.
+- **Version skew** is named, not fixed: panels compare their version against the CLI's and
+  show "frame is stale — restart" rather than restarting under the user's agent.
+
+## Config
+
+```toml
+[frame]
+slots = ["top", "bottom"]
+mouse = false
+hotkey = "F2"
+history-limit = 50000
+min-cols = 100
+min-rows = 20
+```
+
+Plane-level only, with `--slots` and `--no-frame` overrides. No per-workspace override
+until something asks for one.
+
+## Layout
+
+| file | job |
+| --- | --- |
+| `charter/frame/layout.py` | pure: (slots, size, argv) → list of tmux argv. No tmux to test. |
+| `charter/frame/tmuxctl.py` | the only module that shells out to tmux; version probing |
+| `charter/frame/panel.py` | panel runtime — draw, wait, resize |
+| `charter/frame/slots.py` | per-slot renderers composed from statusline parts |
+| `charter/commands_frame.py` | CLI wiring, matching the `commands_*.py` convention |
+
+## v1
+
+Launchers plus `charter frame --`, private server, non-TTY bypass, missing-tmux message,
+**top and bottom panels**, version-file liveness, and one hotkey opening a menu. Left and
+right follow immediately — they are the same `split-window` and one config line, so
+shipping them in v1 proves nothing while delaying what can actually go wrong.
+
+Build order, test-first throughout: `layout.py` → `tmuxctl.py` → launcher → `panel.py` →
+slots → menu → docs/news/ADR. Layout being a pure function means the frame's whole shape
+is under test before a pane is ever created. The end-to-end test skips when tmux is absent
+rather than failing, and asserts on probed capability rather than a version string.
+
+Ships with `docs/frame.md` (force-included in `pyproject.toml`, which is not optional —
+`tests/test_docs_show.py` fails otherwise) and a news entry whose `check:` probe is
+read-only, uses charter's own argv, and cannot hang.
+
+## Not pinned yet
+
+Two facts are assumed and must be probed before the code depends on them, because this
+repo's rule is that only a rejection is evidence:
+
+1. Whether `tmux new-session` given separate argv ever hands the command to a shell.
+2. Whether `remain-on-exit` plus `#{pane_dead_status}` reliably carries the exit code out
+   through an attached client. Neither could be tested in a sandbox without a terminal.
+
+If either fails, the harness gets spawned through a small charter shim that owns both
+answers itself.

--- a/docs/superpowers/specs/2026-08-21-harness-wrapper-design.md
+++ b/docs/superpowers/specs/2026-08-21-harness-wrapper-design.md
@@ -74,7 +74,7 @@ Arguments after the name reach the harness verbatim.
 charter claude
  ├─ resolve harness → argv, probe `tmux -V` (floor 3.2)
  ├─ write .charter/frame/<frame-id>/tmux.conf   (never ~/.tmux.conf)
- └─ exec tmux -L charter -f <conf> …
+ └─ run (NOT exec — see Exit code) tmux -L charter -f <conf> …
       ├─ pane: charter panel top
       ├─ pane: <harness>      ← charter never draws or parses this
       ├─ pane: charter panel left / right
@@ -173,8 +173,14 @@ terminal" report.
 
 ## Lifecycle
 
-- **Exit code.** `charter claude` must be a transparent substitute for `claude`, so the
-  harness's status is re-raised via `remain-on-exit` and `#{pane_dead_status}`.
+- **Exit code.** `charter claude` must be a transparent substitute for `claude`. Probed:
+  an attached `tmux new-session` returns **0** whatever its command exited with, so the
+  status has to be carried out of band. `remain-on-exit on` plus a `pane-died` hook
+  writing `#{pane_dead_status}` records it correctly (42 in, 42 recorded). The launcher
+  therefore **forks and waits rather than `exec`ing** tmux, then exits with the recorded
+  status. `exec` remains correct only on the `--no-frame`/non-TTY bypass, where there is
+  no frame in the way. The hook must be scoped to the harness pane — `pane-died` fires for
+  any pane, and an unscoped hook would report a dead *panel* as the agent's exit.
 - **Detach** is allowed and prints how to reattach; an agent surviving a closed lid is a
   feature, and returning silently to a shell with it still running is not.
 - **A dead panel** stays visible with its error, respawns with backoff, and gives up after
@@ -225,14 +231,17 @@ Ships with `docs/frame.md` (force-included in `pyproject.toml`, which is not opt
 `tests/test_docs_show.py` fails otherwise) and a news entry whose `check:` probe is
 read-only, uses charter's own argv, and cannot hang.
 
-## Not pinned yet
+## Pinned against tmux 3.7c
 
-Two facts are assumed and must be probed before the code depends on them, because this
-repo's rule is that only a rejection is evidence:
+Both assumptions were probed rather than trusted, and one of them was wrong.
 
-1. Whether `tmux new-session` given separate argv ever hands the command to a shell.
-2. Whether `remain-on-exit` plus `#{pane_dead_status}` reliably carries the exit code out
-   through an attached client. Neither could be tested in a sandbox without a terminal.
+**Separate argv is not shell-interpreted; a joined string is.** `new-session … printf
+'hello;touch INJ1'` as separate arguments created no file; the same text as one string
+created it. The rejection is the evidence, so the safe form is confirmed safe *and* the
+unsafe form is confirmed unsafe — argv never gets joined anywhere in this feature.
 
-If either fails, the harness gets spawned through a small charter shim that owns both
-answers itself.
+**An attached tmux does not carry the exit code**, which the earlier draft of this spec
+assumed it could be made to. It returns 0 regardless. `remain-on-exit` plus a `pane-died`
+hook does record `#{pane_dead_status}` faithfully, so the status travels through the
+frame's state directory and the launcher waits rather than `exec`s. This is why the
+process model above says run, not exec.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ packages = ["charter"]
 "docs/browser.md" = "charter/_docs/browser.md"
 "docs/control-plane.md" = "charter/_docs/control-plane.md"
 "docs/forges.md" = "charter/_docs/forges.md"
+"docs/frame.md" = "charter/_docs/frame.md"
 "docs/git-policy.md" = "charter/_docs/git-policy.md"
 "docs/harnesses.md" = "charter/_docs/harnesses.md"
 "docs/hooks.md" = "charter/_docs/hooks.md"

--- a/tests/test_frame_config.py
+++ b/tests/test_frame_config.py
@@ -1,0 +1,69 @@
+"""`[frame]` in charter.toml, with defaults that hold when it is absent.
+
+Defaults are the shipped behaviour, so they are asserted rather than assumed: `mouse` is
+off because `set -g mouse on` takes over drag-select, and breaking the operator's copy to
+enable a feature v1 does not ship is a bad trade.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import instance
+
+
+class FrameDefaults(unittest.TestCase):
+    def test_an_absent_section_yields_the_shipped_defaults(self):
+        f = instance.frame_of({})
+        self.assertEqual(f["slots"], ["top", "bottom"])
+        self.assertIs(f["mouse"], False)
+        self.assertEqual(f["hotkey"], "F2")
+        self.assertEqual(f["history_limit"], 50000)
+        self.assertEqual(f["min_cols"], 100)
+        self.assertEqual(f["min_rows"], 20)
+
+    def test_a_section_overrides_only_what_it_names(self):
+        f = instance.frame_of({"frame": {"mouse": True, "hotkey": "F5"}})
+        self.assertIs(f["mouse"], True)
+        self.assertEqual(f["hotkey"], "F5")
+        self.assertEqual(f["slots"], ["top", "bottom"])
+
+    def test_an_unknown_slot_is_dropped_rather_than_carried(self):
+        """A typo must not reach a tmux argv. Dropping is louder than it looks: the slot
+        simply does not appear, and `doctor` has the config to report."""
+        f = instance.frame_of({"frame": {"slots": ["top", "sideways", "bottom"]}})
+        self.assertEqual(f["slots"], ["top", "bottom"])
+
+    def test_a_malformed_section_falls_back_instead_of_raising(self):
+        """`config` is imported by every command including `charter --version`, so a bad
+        value must never crash import."""
+        f = instance.frame_of({"frame": {"slots": "top", "history_limit": "lots"}})
+        self.assertEqual(f["slots"], ["top", "bottom"])
+        self.assertEqual(f["history_limit"], 50000)
+
+    def test_the_hyphenated_settings_are_actually_read(self):
+        """`history-limit`, `min-cols` and `min-rows` are the spellings charter.toml (and
+        docs/frame.md) document. A prior draft keyed the merge loop on the underscore
+        form, so these three settings matched nothing in a real `[frame]` section and
+        silently kept their defaults no matter what an operator wrote — this pins that
+        they are read, not merely defaulted."""
+        f = instance.frame_of({"frame": {
+            "history-limit": 999,
+            "min-cols": 42,
+            "min-rows": 7,
+        }})
+        self.assertEqual(f["history_limit"], 999)
+        self.assertEqual(f["min_cols"], 42)
+        self.assertEqual(f["min_rows"], 7)
+
+    def test_the_underscore_spelling_is_not_a_second_alias(self):
+        """Only the hyphenated TOML spelling is honoured. Accepting the underscore form
+        too would give one setting two undocumented spellings, with no rule for which
+        wins the day they disagree — so `history_limit` in charter.toml is inert and the
+        default holds."""
+        f = instance.frame_of({"frame": {"history_limit": 999}})
+        self.assertEqual(f["history_limit"], 50000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_config.py
+++ b/tests/test_frame_config.py
@@ -30,16 +30,60 @@ class FrameDefaults(unittest.TestCase):
 
     def test_an_unknown_slot_is_dropped_rather_than_carried(self):
         """A typo must not reach a tmux argv. Dropping is louder than it looks: the slot
-        simply does not appear, and `doctor` has the config to report."""
+        simply does not appear, and `doctor` has the config to report.
+
+        By itself this does not distinguish "filtered" from "ignored": `["top",
+        "sideways", "bottom"]` filters to `["top", "bottom"]`, which is byte-identical to
+        the default, so a stub that always returns the default would also pass this one.
+        `test_a_valid_slots_override_actually_takes_effect` below is what rules that out.
+        """
         f = instance.frame_of({"frame": {"slots": ["top", "sideways", "bottom"]}})
         self.assertEqual(f["slots"], ["top", "bottom"])
 
+    def test_a_valid_slots_override_actually_takes_effect(self):
+        """Companion to the test above: a *different* valid override must actually be
+        honoured, not just filtered. `["left", "right"]` shares no elements with the
+        default `["top", "bottom"]`, so a stub that always returns the default — which
+        would still pass the "unknown slot is dropped" test above — fails this one."""
+        f = instance.frame_of({"frame": {"slots": ["left", "right"]}})
+        self.assertEqual(f["slots"], ["left", "right"])
+
     def test_a_malformed_section_falls_back_instead_of_raising(self):
         """`config` is imported by every command including `charter --version`, so a bad
-        value must never crash import."""
-        f = instance.frame_of({"frame": {"slots": "top", "history_limit": "lots"}})
+        value must never crash import.
+
+        `history-limit` (hyphenated — the real charter.toml spelling; an earlier draft of
+        this test used the underscore key, which `frame_of`'s TOML-key mapping never looks
+        up, so the bad value was silently ignored as an unknown key rather than rejected
+        for its type, and the test passed for the wrong reason). This one fails if the
+        final `isinstance(value, type(default))` type check is deleted: without it, the
+        string `"lots"` would be assigned straight into `history_limit`."""
+        f = instance.frame_of({"frame": {"slots": "top", "history-limit": "lots"}})
         self.assertEqual(f["slots"], ["top", "bottom"])
         self.assertEqual(f["history_limit"], 50000)
+
+    def test_a_bool_does_not_satisfy_a_non_bool_default(self):
+        """Pins the bool/int subclass guard itself — the one whose own comment predicts a
+        future reader will "simplify it back" to a plain `isinstance(value, type(default))`
+        check. `bool` is a subclass of `int` in Python, so `isinstance(True, int)` is True;
+        without the guard, `history-limit = true` (and `min-cols = true`) would silently
+        pass that check and be accepted as a nonsensical int. Deleting the guard clause
+        flips `history_limit` and `min_cols` below from their defaults to `True` — that is
+        the assertion that actually fails under that mutation.
+
+        `mouse = 1` is included for completeness (a non-bool must not satisfy a bool
+        default, per the brief) but does NOT by itself distinguish guard-present from
+        guard-absent: `1` is never an instance of `bool`, so `isinstance(1, bool)` is False
+        and `mouse` falls back to its default via the plain type check alone, guard or no
+        guard. Confirmed empirically before writing this test, by running both versions."""
+        f = instance.frame_of({"frame": {
+            "mouse": 1,
+            "history-limit": True,
+            "min-cols": True,
+        }})
+        self.assertIs(f["mouse"], False)
+        self.assertEqual(f["history_limit"], 50000)
+        self.assertEqual(f["min_cols"], 100)
 
     def test_the_hyphenated_settings_are_actually_read(self):
         """`history-limit`, `min-cols` and `min-rows` are the spellings charter.toml (and

--- a/tests/test_frame_config.py
+++ b/tests/test_frame_config.py
@@ -109,5 +109,68 @@ class FrameDefaults(unittest.TestCase):
         self.assertEqual(f["history_limit"], 50000)
 
 
+class HotkeyIsNotAFreeString(unittest.TestCase):
+    """`hotkey` is the one `[frame]` value that reaches a PARSER, and it was the one
+    with no check beyond `isinstance(value, str)`.
+
+    `commands_frame.conf_text` interpolates it into tmux config text that `source-file`
+    parses and runs. Verified against a real tmux 3.7c, through the exact text
+    `conf_text` produces: `hotkey = "F2\\nrun-shell 'touch /tmp/PWNED'"` makes
+    `source-file` return **0**, silently, and the canary file appears **at launch, with
+    no keypress at all** — the newline ends the `bind` line and starts a second command.
+    `charter.toml` is committed and shared; it arrives from someone else's machine,
+    which is exactly the input class the containment rule exists for.
+
+    Checked at the config boundary rather than inside the frame, which is the point:
+    `slots` is set-filtered here, `mouse` is a bool here, the three numbers are
+    int-checked here — this was the fifth input arriving through a fifth door.
+    """
+
+    def test_a_newline_bearing_hotkey_degrades_to_the_default(self):
+        """The exploit itself, as an assertion. Fails if `_HOTKEY_RE` is deleted or
+        loosened to accept `\\n` — nothing else in `frame_of` would stop it."""
+        f = instance.frame_of({"frame": {"hotkey": "F2\nrun-shell 'touch /tmp/PWNED'"}})
+        self.assertEqual(f["hotkey"], "F2")
+
+    def test_every_shape_that_could_break_out_of_the_bind_line_is_refused(self):
+        """One case per escape route out of `bind -n {hotkey} run-shell '…'`: end the
+        line, end the command, open a quote, start a comment or a tmux format, reach the
+        shell, or split the argument. Each must fall back to `F2` — an `assertEqual`
+        per shape rather than one loop assertion, so a regression names which shape."""
+        for hostile in ["F2\nkill-server",
+                        "F2; kill-server",
+                        "F2 run-shell 'touch /tmp/x'",
+                        "F2'",
+                        'F2"',
+                        "F2#{client_name}",
+                        "F2$(touch /tmp/x)",
+                        "F2\\",
+                        "F2\tkill-server",
+                        "{}"]:
+            with self.subTest(hotkey=hostile):
+                f = instance.frame_of({"frame": {"hotkey": hostile}})
+                self.assertEqual(f["hotkey"], "F2",
+                                 f"{hostile!r} was accepted into a tmux config line")
+
+    def test_the_key_names_an_operator_actually_types_are_still_accepted(self):
+        """The other half, and the one that stops the fix being "reject everything":
+        a guard that only ever returned the default would pass every test above and
+        silently take `[frame] hotkey` away from everyone."""
+        for good in ["F2", "F12", "M-m", "C-b", "S-Left", "C-M-x", "Escape", "BSpace",
+                     "PPage", "Up", "a", "7", "/", "C-/"]:
+            with self.subTest(hotkey=good):
+                self.assertEqual(instance.frame_of({"frame": {"hotkey": good}})["hotkey"],
+                                 good)
+
+    def test_a_non_string_hotkey_still_degrades_the_way_it_always_did(self):
+        """The type check the regex sits behind must survive it: `_HOTKEY_RE.fullmatch`
+        raises `TypeError` on a non-`str`, and `frame_of` is imported by every command
+        including `charter --version`."""
+        for bad in [42, True, None, ["F2"], {"key": "F2"}]:
+            with self.subTest(hotkey=bad):
+                self.assertEqual(instance.frame_of({"frame": {"hotkey": bad}})["hotkey"],
+                                 "F2")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_frame_config.py
+++ b/tests/test_frame_config.py
@@ -8,6 +8,7 @@ enable a feature v1 does not ship is a bad trade.
 from __future__ import annotations
 
 import unittest
+from unittest import mock
 
 from charter import instance
 
@@ -161,6 +162,35 @@ class HotkeyIsNotAFreeString(unittest.TestCase):
             with self.subTest(hotkey=good):
                 self.assertEqual(instance.frame_of({"frame": {"hotkey": good}})["hotkey"],
                                  good)
+
+    def test_a_refused_hotkey_degrades_silently_and_no_surface_names_it(self):
+        """A CHARACTERIZATION test: this pins a known gap, not a desired behaviour.
+
+        `_HOTKEY_RE`'s own comment used to claim a refused key "costs the operator their
+        preferred hotkey and a line in `charter frame-probe`". It never did — measured
+        with the newline payload in charter.toml, `frame-probe` prints a clean green tick
+        and `doctor`'s frame row is green, while the hotkey silently becomes `F2`. That
+        false claim is the same class this branch removed from `frame/menu.py` and
+        `frame/tmuxctl.py`, so the truth is asserted here rather than only written down.
+
+        It is deliberately left this way for now: NO refused `[frame]` value is reported
+        anywhere — a dropped `slots` entry and a rejected `history-limit` are exactly as
+        quiet — so the fix is one surface for the whole section, filed as a follow-up. If
+        you are implementing that follow-up, this test SHOULD fail; update it, do not
+        route around it."""
+        from charter import commands_frame, config, doctor
+        hostile = "F2\nrun-shell 'touch /tmp/PWNED'"
+        resolved = instance.frame_of({"frame": {"hotkey": hostile}})
+        self.assertEqual(resolved["hotkey"], "F2")
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch.dict(config.FRAME, resolved):
+            code, level, line = commands_frame.frame_ready()
+            row = doctor.check_frame()
+        self.assertEqual((code, level), (0, "ok"),
+                         "the probe does not currently know a hotkey was refused")
+        self.assertNotIn("hotkey", line)
+        self.assertEqual(row.status, doctor.OK)
+        self.assertNotIn("hotkey", row.hint or "")
 
     def test_a_non_string_hotkey_still_degrades_the_way_it_always_did(self):
         """The type check the regex sits behind must survive it: `_HOTKEY_RE.fullmatch`

--- a/tests/test_frame_doctor.py
+++ b/tests/test_frame_doctor.py
@@ -1,0 +1,62 @@
+"""tmux is a frame prerequisite, not a harness ceiling.
+
+Filing it under `harness.deficits` would claim claude-code cannot do something it does
+perfectly well — `tests/test_doctor_absent_is_not_health.py` already draws that line, which
+is why this is `doctor.check_frame() -> Result`, registered in `doctor._checks()` beside
+`check_harness()` rather than a line inside its deficit list, and why every assertion below
+is on the `Result` — its `.status`, checked against `doctor.OK`/`doctor.WARN` — rather than
+on a string `doctor` never actually returns from a check function.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import doctor
+
+
+class FrameRow(unittest.TestCase):
+    def test_a_present_tmux_reports_its_version(self):
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)):
+            r = doctor.check_frame()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIn("3.7", r.detail)
+
+    def test_an_absent_tmux_is_named_not_silent(self):
+        with mock.patch("charter.frame.tmuxctl.version", return_value=None):
+            r = doctor.check_frame()
+        self.assertIn("tmux", r.detail)
+        # Not OK: "not checked" rendered as a tick is exactly the failure
+        # `tests/test_doctor_absent_is_not_health.py` was filed against (#171) — and this
+        # is not even "not checked", it's a confirmed absence, which is stronger evidence
+        # than that class covers, so it must not be weaker than WARN either.
+        self.assertNotEqual(r.status, doctor.OK)
+
+    def test_a_below_floor_tmux_still_warns_not_fails(self):
+        """`cmd_launch` itself does not refuse below `tmuxctl.FLOOR` — it warns and the
+        frame still starts, with its hotkey menu disabled (`tmuxctl.below_floor_message`).
+        A doctor row that FAILED here would tell the reader `charter <harness>` cannot run
+        when it, in fact, still can."""
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 0)):
+            r = doctor.check_frame()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertNotEqual(r.status, doctor.FAIL)
+
+    def test_tmux_is_not_reported_as_a_harness_deficit(self):
+        from charter import harness
+        for h in harness.all():
+            with self.subTest(harness=h.name):
+                self.assertNotIn("tmux", " ".join(d.key for d in h.deficits))
+
+    def test_cmd_doctor_never_fails_solely_on_a_missing_tmux(self):
+        """The behavioural half of "WARN, never FAIL": `cmd_doctor`'s own exit code is
+        1 only when a FAIL is among the results (`charter/commands.py:cmd_doctor`), so a
+        machine missing tmux entirely must still see `doctor` register this as WARN."""
+        with mock.patch("charter.frame.tmuxctl.version", return_value=None):
+            r = doctor.check_frame()
+        self.assertNotEqual(r.status, doctor.FAIL)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_doctor.py
+++ b/tests/test_frame_doctor.py
@@ -34,14 +34,45 @@ class FrameRow(unittest.TestCase):
         self.assertNotEqual(r.status, doctor.OK)
 
     def test_a_below_floor_tmux_still_warns_not_fails(self):
-        """`cmd_launch` itself does not refuse below `tmuxctl.FLOOR` — it warns and the
-        frame still starts, with its hotkey menu disabled (`tmuxctl.below_floor_message`).
-        A doctor row that FAILED here would tell the reader `charter <harness>` cannot run
-        when it, in fact, still can."""
+        """`cmd_launch` itself does not refuse below `tmuxctl.FLOOR` — the frame still
+        starts, and nothing is switched off (`tmuxctl.below_floor_message`). A doctor row
+        that FAILED here would tell the reader `charter <harness>` cannot run when it, in
+        fact, still can."""
         with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 0)):
             r = doctor.check_frame()
         self.assertEqual(r.status, doctor.WARN)
         self.assertNotEqual(r.status, doctor.FAIL)
+
+    def test_the_below_floor_hint_does_not_claim_the_hotkey_is_disabled(self):
+        """This hint used to say "a frame still starts, with its hotkey menu disabled".
+        Nothing disables it: `cmd_launch` warns and continues, and `conf_text` emits the
+        bind unchanged. The hint now comes from `tmuxctl.below_floor_message` — one
+        sentence shared with `--probe`, so the two cannot drift apart."""
+        from charter.frame import tmuxctl
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 0)):
+            r = doctor.check_frame()
+        self.assertNotIn("hotkey menu disabled", r.hint)
+        self.assertEqual(r.hint, tmuxctl.below_floor_message((3, 0)))
+
+    def test_a_slot_with_no_renderer_is_a_ceiling_this_row_names(self):
+        """The second standing condition that moved off the launch path (see
+        `commands_frame.frame_ready`): `[frame] slots` accepts `left`/`right`, charter
+        sizes them, and nothing draws in them. It used to be a `util.warn` printed
+        microseconds before tmux switched the terminal to the alternate screen."""
+        from charter import config
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch.dict(config.FRAME, {"slots": ["top", "right"]}):
+            r = doctor.check_frame()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("right", r.hint)
+
+    def test_an_ordinary_machine_still_renders_a_clean_row(self):
+        """What stops the two tests above from passing against a row that always warns."""
+        from charter import config
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch.dict(config.FRAME, {"slots": ["top", "bottom"]}):
+            r = doctor.check_frame()
+        self.assertEqual(r.status, doctor.OK)
 
     def test_tmux_is_not_reported_as_a_harness_deficit(self):
         from charter import harness

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1293,6 +1293,140 @@ class CollisionGuard(unittest.TestCase):
         self.assertIn("frame-probe-harness", str(ctx.exception))
 
 
+class TwoHarnessesCanShareAWord(unittest.TestCase):
+    """The genuine flaw a rebase onto charter 0.49.0 surfaced: `registry.all()`
+    instantiates by dict VALUE (`[cls() for cls in KINDS.values()]`), so two KEYS mapped
+    to the same class produce two harness objects sharing a `cli_name` —
+    `tests/test_guard_claims_its_reach.py::test_the_names_are_derived_not_written_down`
+    reaches exactly this shape (`KINDS["zzz-fictional"] = KINDS[CLAUDE_CODE]`) from a
+    module that owns no code here at all. `_add_frame_parsers` used to raise
+    `ValueError` for it — indistinguishable, until this fix, from a harness shadowing a
+    CORE command — which took down `build_parser()`, and with it every `charter`
+    command, over a registry mistake in a different module entirely. A harness-vs-
+    harness collision costs the LATER harness one launcher; it must not cost the whole
+    CLI, which is the whole reason `_add_frame_parsers` now tells the two apart.
+    """
+
+    def test_a_harness_colliding_with_a_core_command_still_raises(self):
+        """Enumerated against the REAL parser's own core commands, not one hardcoded
+        name (`CollisionGuard` above already pins `status` alone) — the rule has to hold
+        for core commands in general, not just the one example that happened to be
+        picked first."""
+        from charter import cli, harness
+        from charter.harness.base import Harness
+
+        core = cli._subcommand_names(cli.build_parser())
+        reserved = ({h.cli_name for h in harness.all() if h.cli_name} |
+                   {"frame", "panel", "frame-menu", "frame-action", "frame-probe"})
+        # Only genuinely CORE commands — colliding with the frame family itself is
+        # `CollisionGuard`'s own job, one dedicated test per reserved name.
+        sample = sorted(core - reserved)
+        self.assertTrue(sample, "no core (non-harness) command found to collide with")
+        for core_name in sample[:4]:
+            with self.subTest(core_command=core_name):
+                # Named `core_name`, not `name`: a class body assigning its OWN `name`
+                # attribute shadows an enclosing `name` when Python resolves names
+                # inside the class suite, which turns `name = f"...{name}"` into a
+                # `NameError` from inside the class body itself (confirmed by hand).
+                class _Colliding(Harness):
+                    name = f"colliding-with-{core_name}"
+                    cli_name = core_name
+                    binary = "colliding"
+
+                with mock.patch.dict("charter.harness.registry.KINDS",
+                                     {f"colliding-with-{core_name}": _Colliding},
+                                     clear=True):
+                    with self.assertRaises(ValueError) as ctx:
+                        cli.build_parser()
+                self.assertIn(f"colliding-with-{core_name}", str(ctx.exception))
+
+    def test_two_harnesses_sharing_a_cli_name_do_not_raise_and_the_first_wins(self):
+        """`build_parser()` must succeed, exactly one subcommand must exist for the
+        shared word, and running it must resolve to a REAL harness — the one registered
+        FIRST, `KINDS`'s own dict-insertion order (`registry.all`'s own docstring: "in
+        registration order"), asserted directly here rather than assumed.
+
+        This is the OUTCOME an operator would see, not a direct pin of
+        `_add_frame_parsers`'s own loop order: `_wire` stores only the plain STRING
+        `h.cli_name` on the parser (`set_defaults(harness=name, ...)`), so `cmd_launch`
+        re-resolves it against a FRESH `harness.all()` at run time regardless of which of
+        the two colliding classes happened to call `add_parser` first — confirmed by hand
+        by reversing `_add_frame_parsers`'s own iteration order and watching this test
+        stay green while `test_the_second_claimant_is_reported_not_silent` below (which
+        checks the warning's own wording) goes red. That test is what actually pins the
+        loop's choice of "first"; this one pins that the choice is never silently wrong
+        from an operator's seat.
+        """
+        from charter import cli, harness
+        from charter.harness import registry
+        from charter.harness.base import Harness
+
+        class _First(Harness):
+            name = "first-claimant"
+            cli_name = "shared-word"
+            binary = "first"
+
+        class _Second(Harness):
+            name = "second-claimant"
+            cli_name = "shared-word"   # same word, a DIFFERENT class
+            binary = "second"
+
+        kinds = {"first-claimant": _First, "second-claimant": _Second}
+        with mock.patch.dict("charter.harness.registry.KINDS", kinds, clear=True):
+            # What "first" means, pinned rather than assumed: dict-insertion order.
+            self.assertEqual([h.name for h in registry.all()],
+                             ["first-claimant", "second-claimant"])
+            parser = cli.build_parser()  # must NOT raise
+            names = cli._subcommand_names(parser)
+            self.assertIn("shared-word", names)
+            args = parser.parse_args(["shared-word", "--", "hi"])
+            self.assertEqual(args.harness, "shared-word")
+            # `cmd_launch` resolves `args.harness` back to a `Harness` this same way
+            # (`next((x for x in harness.all() if x.cli_name == args.harness), None)`)
+            # — the harness that actually RUNS for this word is the one that got the
+            # launcher, not merely the one this test expects by name.
+            resolved = next((h for h in harness.all() if h.cli_name == args.harness), None)
+        self.assertIsNotNone(resolved)
+        self.assertEqual(resolved.name, "first-claimant")
+
+    def test_the_second_claimant_is_reported_not_silent(self):
+        """"Make the skip observable": a second harness wanting a claimed word must say
+        so, not merely fail to get a launcher with nothing printed anywhere.
+
+        Roles are checked precisely, not just "both names appear somewhere": it is
+        `second-claimant` that must be named as the one left without a launcher, and
+        `first-claimant` as who already holds it — the same distinction
+        `test_two_harnesses_sharing_a_cli_name_do_not_raise_and_the_first_wins` pins from
+        the parser's own side. A version of this loop that iterated `harness.all()`
+        reversed would still call `util.warn` exactly once, mentioning both names, and
+        still pass a test that only checked for their presence — confirmed by hand: only
+        the STARTSWITH/`already claimed by` checks below actually go red under that
+        mutation.
+        """
+        from charter import cli
+        from charter.harness.base import Harness
+
+        class _First(Harness):
+            name = "first-claimant"
+            cli_name = "shared-word"
+            binary = "first"
+
+        class _Second(Harness):
+            name = "second-claimant"
+            cli_name = "shared-word"
+            binary = "second"
+
+        kinds = {"first-claimant": _First, "second-claimant": _Second}
+        with mock.patch.dict("charter.harness.registry.KINDS", kinds, clear=True), \
+             mock.patch("charter.util.warn") as warn:
+            cli.build_parser()
+        warn.assert_called_once()
+        said = warn.call_args[0][0]
+        self.assertTrue(said.startswith("harness 'second-claimant'"), said)
+        self.assertIn("already claimed by 'first-claimant'", said)
+        self.assertIn("shared-word", said)
+
+
 class FrameArgvSplit(unittest.TestCase):
     """Critical 2: `charter claude -p hi` — the documented, spec-named invocation — was
     refused outright by `argparse` before this fix (`nargs=argparse.REMAINDER` cannot

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -234,6 +234,84 @@ class MissingTmux(unittest.TestCase):
         run.assert_not_called()
 
 
+class Probe(unittest.TestCase):
+    """`--probe` (on `cmd_launch`) and `charter frame-probe` (`cmd_probe`) share one
+    read-only gate, `commands_frame.frame_ready` — mirroring `cmd_launch`'s OWN behaviour
+    below `tmuxctl.FLOOR` (warn, still runs), not a stricter refusal, is the whole point:
+    a probe that refused there would report a frame this same launcher goes on to draw.
+    """
+
+    def test_present_and_at_the_floor_exits_zero(self):
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch("charter.commands_frame.subprocess.run") as run, \
+             mock.patch("builtins.print") as p:
+            rc = commands_frame.cmd_probe()
+        self.assertEqual(rc, 0)
+        run.assert_not_called()
+        printed = " ".join(str(c) for c in p.call_args_list)
+        self.assertIn("3.7", printed)
+
+    def test_absent_tmux_exits_nonzero_and_names_it(self):
+        with mock.patch("charter.frame.tmuxctl.version", return_value=None), \
+             mock.patch("charter.commands_frame.subprocess.run") as run, \
+             mock.patch("builtins.print") as p:
+            rc = commands_frame.cmd_probe()
+        self.assertNotEqual(rc, 0)
+        run.assert_not_called()
+        printed = " ".join(str(c) for c in p.call_args_list)
+        self.assertIn("tmux", printed)
+
+    def test_below_the_floor_still_exits_zero(self):
+        """The mutation this pins: a naive `--probe` written as "refuse below the floor"
+        would flip this to non-zero — wrong, because `cmd_launch` itself still runs a
+        frame there (only the hotkey menu is disabled). A probe stricter than the thing
+        it is asked about lies about that thing."""
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 0)), \
+             mock.patch("charter.commands_frame.subprocess.run") as run, \
+             mock.patch("builtins.print"):
+            rc = commands_frame.cmd_probe()
+        self.assertEqual(rc, 0)
+        run.assert_not_called()
+
+    def test_cmd_launch_short_circuits_on_probe_before_touching_anything(self):
+        """`args.probe` is checked before `harness.all()`, `workspace.resolve()`, or any
+        `subprocess.run` — the read-only promise `charter/news.py` requires of a `check:`,
+        proven here by making every one of those raise if reached at all."""
+        args = SimpleNamespace(harness="claude", rest=["-p", "hi"], no_frame=False,
+                               probe=True)
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch("charter.harness.all", side_effect=AssertionError("harness "
+                        "resolved")), \
+             mock.patch("charter.workspace.resolve",
+                        side_effect=AssertionError("workspace touched")), \
+             mock.patch("charter.commands_frame.subprocess.run") as run, \
+             mock.patch("builtins.print"):
+            rc = commands_frame.cmd_launch(args)
+        self.assertEqual(rc, 0)
+        run.assert_not_called()
+
+    def test_a_missing_probe_attribute_means_launch_not_probe(self):
+        """`getattr(args, "probe", False)`, not `args.probe`: every OTHER `cmd_launch`
+        call in this file builds its own `args` with no `probe` field at all, and none of
+        them means "probe" — a bare `AttributeError` here would crash every one of them.
+
+        Distinguished from the probe path by what it REACHES, not by its return code —
+        with tmux present, `--probe` returns before `workspace.resolve()`
+        (`test_cmd_launch_short_circuits_on_probe_before_touching_anything` above); an
+        `args` with no `probe` field at all must reach it, exactly like an ordinary
+        launch always has.
+        """
+        args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
+        self.assertFalse(hasattr(args, "probe"))
+        sentinel = AssertionError("workspace resolved — the launch path was reached")
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("charter.workspace.resolve", side_effect=sentinel):
+            with self.assertRaises(AssertionError) as ctx:
+                commands_frame.cmd_launch(args)
+        self.assertIs(ctx.exception, sentinel)
+
+
 class QueryPaneDeadStatus(unittest.TestCase):
     """`_query_pane_dead_status` is the SAME function `cmd_launch` calls both eagerly
     (immediately after installing the hooks, to close the install race) and again as a
@@ -1193,6 +1271,27 @@ class CollisionGuard(unittest.TestCase):
                 cli.build_parser()
         self.assertIn("frame-action-harness", str(ctx.exception))
 
+    def test_a_harness_named_frame_probe_is_refused_too(self):
+        """`frame-probe` (this task) is reserved the same way, though for a different
+        reason than `frame-menu`/`frame-action`: it exists because `news._PROBEABLE`
+        cannot list `("frame",)` at all — every parser `_wire` builds carries a
+        pass-through `rest` — not because `_split_frame_argv` eats anything past
+        `frame`. A harness silently shadowing it would break the one command a news
+        `check:` can safely name for the frame feature at all."""
+        from charter import cli
+        from charter.harness.base import Harness
+
+        class _FrameProbeHarness(Harness):
+            name = "frame-probe-harness"
+            cli_name = "frame-probe"
+            binary = "frame-probe-harness"
+
+        with mock.patch.dict("charter.harness.registry.KINDS",
+                             {"frame-probe-harness": _FrameProbeHarness}, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                cli.build_parser()
+        self.assertIn("frame-probe-harness", str(ctx.exception))
+
 
 class FrameArgvSplit(unittest.TestCase):
     """Critical 2: `charter claude -p hi` — the documented, spec-named invocation — was
@@ -1226,6 +1325,17 @@ class FrameArgvSplit(unittest.TestCase):
     def test_a_bare_no_frame_is_still_recognized(self):
         ns = self._parse(["claude", "--no-frame"])
         self.assertTrue(ns.no_frame)
+        self.assertEqual(ns.rest, [])
+
+    def test_a_bare_probe_is_still_recognized(self):
+        """The exact trap this task's brief named: without `--probe` in `_OWN_FLAGS`,
+        `_split_frame_argv` grafts it onto `args.rest` instead of leaving it for
+        `argparse`, and `cmd_launch` (finding no harness named `""` for bare `frame`)
+        hands `["--probe"]` to `bypass`, which `os.execvp("--probe", ...)` turns into a
+        real `FileNotFoundError` — confirmed by hand by removing the entry and running
+        `charter frame --probe`."""
+        ns = self._parse(["frame", "--probe"])
+        self.assertTrue(ns.probe)
         self.assertEqual(ns.rest, [])
 
     def test_no_frame_followed_by_harness_flags(self):
@@ -1281,7 +1391,7 @@ class FrameArgvSplit(unittest.TestCase):
         matches, so `_split_frame_argv` leaves them alone — the same reason `panel` is
         already a top-level sibling of `frame` rather than nested under it."""
         from charter.cli import _split_frame_argv
-        for argv in (["frame-action", "a1"], ["frame-menu"]):
+        for argv in (["frame-action", "a1"], ["frame-menu"], ["frame-probe"]):
             with self.subTest(argv=argv):
                 rest, frame_rest = _split_frame_argv(list(argv))
                 self.assertEqual(rest, argv)
@@ -1323,6 +1433,29 @@ class MainDeliversFrameRest(unittest.TestCase):
             rc = cli.main(["frame-menu", "/dev/ttys7"])
         cm.assert_called_once()
         self.assertEqual(cm.call_args[0][0].client, "/dev/ttys7")
+        self.assertEqual(rc, 0)
+
+    def test_charter_frame_probe_reaches_cmd_probe_via_main(self):
+        """The delivery half of `frame-probe`'s own registration: a test that only
+        proves `_split_frame_argv` leaves it alone (`FrameArgvSplit` above) cannot catch
+        `_add_frame_parsers` never having registered a parser for it."""
+        from charter import cli
+        with mock.patch("charter.commands_frame.cmd_probe", return_value=0) as cp:
+            rc = cli.main(["frame-probe"])
+        cp.assert_called_once()
+        self.assertEqual(rc, 0)
+
+    def test_charter_frame_dash_dash_probe_reaches_cmd_launch_via_main(self):
+        """The delivery half of the `_OWN_FLAGS` fix: a test that only exercises
+        `_split_frame_argv` in isolation (`test_a_bare_probe_is_still_recognized` above)
+        cannot catch `main` failing to graft `args.probe` through, or `cmd_launch`
+        itself never checking it."""
+        from charter import cli
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch("charter.commands_frame.subprocess.run") as run, \
+             mock.patch("builtins.print"):
+            rc = cli.main(["frame", "--probe"])
+        run.assert_not_called()
         self.assertEqual(rc, 0)
 
 

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -724,6 +724,24 @@ class Launch(PersonaIso, unittest.TestCase):
         _launch(fake)
         self.assertFalse(any("window-resized" in c for c in fake.calls))
 
+    def test_a_pane_id_of_the_wrong_shape_is_never_interpolated_into_the_resize_hook(self):
+        """Fix round 2, item 3: `_resize_hook_argv` interpolates the pane id directly
+        into a hook ACTION STRING tmux later re-parses as a command line — the exact
+        construction the module docstring's "constant string" section bans for
+        `status_path`, for the same reason: something interpolated into an action must
+        be safe BY CONSTRUCTION, not merely safe because tmux happens to always report
+        `%<digits>` today. A value of any other shape must be treated the same as no id
+        at all — that one slot gets no resize-hook entry, and every OTHER (validly
+        shaped) slot still does."""
+        fake = _FakeTmux(exit_code=0,
+                         panel_pane_ids={"top": "not-a-pane-id", "bottom": "%12"})
+        rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        resize_cmd = next(c for c in fake.calls if "window-resized" in c)
+        action = resize_cmd[-1]
+        self.assertNotIn("not-a-pane-id", action)
+        self.assertIn("%12", action)
+
     def test_a_failed_resize_hook_install_is_reported_but_not_fatal(self):
         """Same "report, don't kill an already-running pane" treatment every other
         cosmetic tmux command in this launcher gets (correction 2) — every pane already
@@ -736,6 +754,38 @@ class Launch(PersonaIso, unittest.TestCase):
             rc = _launch(fake)
         self.assertEqual(rc, 0)
         self.assertTrue(any("resize hook" in m for m in buf), buf)
+
+    def test_a_failed_resize_hook_install_names_its_consequence(self):
+        """Fix round 2, item 4: `_report_tmux_failure` prints the command and tmux's
+        own stderr, but not what the failure COSTS the operator — every other degrade
+        in this launcher (`source-file`, `set-environment`) pairs its failure report
+        with a `util.warn` naming the consequence; the resize hook's own failure was
+        missing that second half."""
+        fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11", "bottom": "%12"},
+                         resize_hook_rc=1)
+        buf = []
+        with mock.patch("charter.util.warn", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        self.assertTrue(any("continuing without it" in m and "drift" in m for m in buf),
+                        buf)
+
+    def test_the_resize_hook_is_skipped_quietly_below_its_own_version_floor(self):
+        """Fix round 2, item 5: `window-resized` was added in tmux 3.3
+        (`tmuxctl.RESIZE_HOOK_FLOOR`) — ABOVE `tmuxctl.FLOOR` (3.2), a version this
+        launcher explicitly still allows to launch (degraded, not refused — see
+        `test_below_the_tmux_floor_degrades_instead_of_refusing`). Below
+        RESIZE_HOOK_FLOOR the hook must never even be ATTEMPTED — confirmed by hand
+        that installing it on an unrecognised hook name fails with `invalid option:
+        window-resized` — one quiet note instead, naming the real version gap."""
+        fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11", "bottom": "%12"})
+        buf = []
+        with mock.patch("charter.util.warn", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake, version=(3, 2))
+        self.assertEqual(rc, 0)
+        self.assertFalse(any("window-resized" in c for c in fake.calls),
+                         "the hook must not even be attempted below its own floor")
+        self.assertTrue(any("3.2" in m and "resize" in m for m in buf), buf)
         self.assertTrue(any("attach" in c for c in fake.calls))
 
     def test_below_the_tmux_floor_degrades_instead_of_refusing(self):

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -53,6 +54,49 @@ class Bypass(unittest.TestCase):
              mock.patch("os.execvp") as ex:
             commands_frame.bypass(["claude", "-p", "hi"])
         ex.assert_called_once_with("claude", ["claude", "-p", "hi"])
+
+
+class MissingHarnessBinary(unittest.TestCase):
+    """`charter claude` before `claude` is installed — the most likely FIRST-RUN state
+    of this whole feature.
+
+    `bypass` called `os.execvp` raw, so `FileNotFoundError` reached `cli.main`'s
+    `except Exception`, which files a charter crash report and re-raises a traceback.
+    `cli.main` already carves out this exact class twice (`contain.Refused`,
+    `util.ProcTimeout`), both noting that filing such a condition as a bug "sends
+    whoever reads it looking in the wrong repository"."""
+
+    def test_a_missing_binary_exits_127_and_names_what_is_missing(self):
+        buf = []
+        with mock.patch("os.execvp", side_effect=FileNotFoundError(2, "No such file")), \
+             mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = commands_frame.bypass(["claude", "-p", "hi"])
+        self.assertEqual(rc, 127, "127 is the shell's own 'command not found', so "
+                                  "`charter claude && ...` behaves like `claude && ...`")
+        self.assertTrue(any("claude" in m for m in buf),
+                        f"the message must name the binary charter could not find: {buf}")
+
+    def test_a_non_executable_binary_exits_126_rather_than_crashing(self):
+        buf = []
+        with mock.patch("os.execvp", side_effect=PermissionError(13, "Permission denied")), \
+             mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = commands_frame.bypass(["claude"])
+        self.assertEqual(rc, 126)
+        self.assertTrue(any("claude" in m for m in buf), buf)
+
+    def test_no_crash_report_is_filed_for_a_missing_binary(self):
+        """The half that actually mattered: not merely "does not traceback", but "does
+        not file a bug against charter". Driven through `cli.main`, because that is
+        where `_record_crash` lives — a test calling `bypass` directly could never
+        observe it."""
+        from charter import cli
+        with mock.patch("os.execvp", side_effect=FileNotFoundError(2, "No such file")), \
+             mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("charter.cli._record_crash") as crash, \
+             mock.patch("charter.util.err"):
+            rc = cli.main(["claude", "--no-frame"])
+        self.assertEqual(rc, 127)
+        crash.assert_not_called()
 
 
 class Conf(unittest.TestCase):
@@ -107,9 +151,36 @@ class Conf(unittest.TestCase):
         (a different literal token) is what `cli.py` actually registers."""
         text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
                                         session="x")
-        self.assertIn('bind -n F2 run-shell \'charter frame-menu "#{client_name}"\'',
-                      text)
+        self.assertIn('bind -n F2 run-shell \'"$CHARTER_PY" -m charter '
+                      'frame-menu "#{client_name}"\'', text)
         self.assertNotIn("frame menu", text)
+
+    def test_the_hotkey_never_invokes_a_bare_charter_off_the_path(self):
+        """The panels already launch `[sys.executable, "-m", "charter"]`; this bind kept
+        a bare `charter`. With charter not on the tmux server's own `$PATH` — a `uv
+        tool` shim, a checkout run as `python -m charter` — pressing the hotkey makes
+        `run-shell` print `'charter frame-menu "/dev/ttys020"' returned 127` INTO THE
+        HARNESS PANE and drop it into copy-mode: charter drawing in the one rectangle
+        ADR 0018 says it never draws.
+
+        Asserts the absence of the old shape, not merely the presence of the new one —
+        a fix that added `$CHARTER_PY` while leaving a second bare invocation behind
+        would satisfy an `assertIn` alone. `run-shell 'charter` is the exact byte
+        sequence that puts `charter` in the shell's own command position."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
+                                        session="x")
+        self.assertNotIn("run-shell 'charter", text)
+        self.assertIn('"$CHARTER_PY" -m charter frame-menu', text)
+
+    def test_the_interpreter_is_carried_out_of_band_not_baked_into_the_bind(self):
+        """The same reasoning `_exit_path_env_argv`'s own docstring records for
+        `status_path`: an absolute path re-embedded inside this nested tmux-quote layer
+        is one apostrophe away from silent corruption (verified against 3.7c that
+        `set-hook` still returns 0 while the stored action is mangled). So the bind
+        text must carry the VARIABLE, never the value."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
+                                        session="x")
+        self.assertNotIn(sys.executable, text)
 
     def test_the_hotkey_bind_is_global_not_session_scoped(self):
         """Key tables have no per-session form in tmux (unlike `status`/`mouse`/
@@ -216,11 +287,12 @@ class MissingTmux(unittest.TestCase):
     def test_an_absent_tmux_names_the_remedy_and_does_not_start_a_frame(self):
         """Adapted from the task brief's own draft, which mocked `tmuxctl.available()`.
         Correction 5 requires `cmd_launch` to call `tmuxctl.version()` exactly ONCE and
-        branch on it — `available()` is never called at all in the corrected launcher —
-        so a test that only patches `available()` would exercise the REAL `tmux -V` here
-        (whatever happens to be installed on the machine running the suite) instead of
-        the absent-tmux path it claims to test. Patching `version()` to return `None` (=
-        "absent", per `tmuxctl.version`'s own docstring) is what actually simulates it."""
+        branch on it, so a test that patched `available()` would exercise the REAL `tmux
+        -V` here (whatever happens to be installed on the machine running the suite)
+        instead of the absent-tmux path it claims to test. Patching `version()` to return
+        `None` (= "absent", per `tmuxctl.version`'s own docstring) is what actually
+        simulates it. `available()` has since been deleted outright — it never had a
+        production caller, which is exactly why the brief's draft could name it."""
         args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
         with mock.patch("charter.frame.tmuxctl.version", return_value=None), \
              mock.patch("sys.stdout.isatty", return_value=True), \
@@ -272,6 +344,47 @@ class Probe(unittest.TestCase):
             rc = commands_frame.cmd_probe()
         self.assertEqual(rc, 0)
         run.assert_not_called()
+
+    def test_below_the_floor_says_what_is_at_risk(self):
+        """Where the below-floor message went when it stopped printing at launch (see
+        `Launch.test_below_the_tmux_floor_degrades_instead_of_refusing`). This is the
+        surface an operator can actually read: nothing has switched their terminal to
+        tmux's alternate screen by the time it prints."""
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 0)), \
+             mock.patch("charter.commands_frame.subprocess.run") as run, \
+             mock.patch("builtins.print") as p:
+            rc = commands_frame.cmd_probe()
+        self.assertEqual(rc, 0)
+        run.assert_not_called()
+        printed = " ".join(str(c) for c in p.call_args_list)
+        self.assertIn("3.0", printed)
+        self.assertIn("3.2", printed)
+
+    def test_a_slot_with_no_renderer_is_named_by_probe(self):
+        """The second standing ceiling that moved off the launch path: `[frame] slots`
+        accepts `left`/`right` and `layout.SLOT_SIZE` sizes them, but `frame.slots.SLOTS`
+        implements neither, so the harness pane silently keeps that space. Read from
+        `config.FRAME` with nothing started — the probe's own read-only promise."""
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch.dict(config.FRAME, {"slots": ["top", "left", "right"]}), \
+             mock.patch("charter.commands_frame.subprocess.run") as run, \
+             mock.patch("builtins.print") as p:
+            rc = commands_frame.cmd_probe()
+        self.assertEqual(rc, 0, "an unimplemented slot is a ceiling, not a failure")
+        run.assert_not_called()
+        printed = " ".join(str(c) for c in p.call_args_list)
+        self.assertIn("left", printed)
+        self.assertIn("right", printed)
+
+    def test_an_ordinary_machine_gets_no_ceilings_at_all(self):
+        """The other direction, and what stops the two tests above from passing against
+        a probe that always warns: with a new-enough tmux and only implemented slots
+        configured, `frame_ready` reports `ok` and names no ceiling."""
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch.dict(config.FRAME, {"slots": ["top", "bottom"]}):
+            code, level, line = commands_frame.frame_ready()
+        self.assertEqual((code, level), (0, "ok"))
+        self.assertNotIn("\n", line)
 
     def test_cmd_launch_short_circuits_on_probe_before_touching_anything(self):
         """`args.probe` is checked before `harness.all()`, `workspace.resolve()`, or any
@@ -590,13 +703,31 @@ class Launch(PersonaIso, unittest.TestCase):
         """Ordering matters: the write hook's action reads `$CHARTER_FRAME_EXIT` back
         from the session's own environment, so `set-environment` must land before the
         hook that depends on it — otherwise the shell sees an unset variable the first
-        time the hook could possibly fire."""
+        time the hook could possibly fire.
+
+        Filtered on `CHARTER_FRAME_EXIT`, and that filter is the test. `cmd_launch`
+        issues THREE `set-environment` calls now (the exit path, the frame id, the
+        interpreter), and an unfiltered `next(... if "set-environment" in c)` was
+        satisfied by whichever landed first — so deleting the `_exit_path_env_argv`
+        block outright left this assertion, and the whole suite, green. No test
+        anywhere asserted the launcher issued the exit-path call at all. Copies the
+        shape `test_the_frame_id_is_carried_to_its_own_menu_before_the_write_hook`
+        below already had right: filter, assert exactly one, assert the VALUE."""
         fake = _FakeTmux(exit_code=0)
         _launch(fake)
-        env_idx = next(i for i, c in enumerate(fake.calls) if "set-environment" in c)
+        exit_calls = [c for c in fake.calls
+                      if "set-environment" in c and "CHARTER_FRAME_EXIT" in c]
+        self.assertEqual(len(exit_calls), 1,
+                         "the exit-status path must be carried out of band exactly "
+                         f"once: {fake.calls}")
+        cmd = exit_calls[0]
+        self.assertEqual(cmd[cmd.index("-t") + 1], fake.fid)
+        self.assertEqual(cmd[-1], str(state.frame_dir(fake.fid) / "exit"),
+                         "the path carried must be THIS frame's own `exit` file — the "
+                         "one `state.exit_code` reads back")
         hook_idx = next(i for i, c in enumerate(fake.calls)
                        if "set-hook" in c and "pane-died[1]" not in c)
-        self.assertLess(env_idx, hook_idx)
+        self.assertLess(fake.calls.index(cmd), hook_idx)
 
     def test_the_frame_id_is_carried_to_its_own_menu_before_the_write_hook(self):
         """Companion to the test above: `charter frame-menu`/`charter frame-action`
@@ -615,6 +746,62 @@ class Launch(PersonaIso, unittest.TestCase):
         hook_idx = next(i for i, c in enumerate(fake.calls)
                        if "set-hook" in c and "pane-died[1]" not in c)
         self.assertLess(sid_idx, hook_idx)
+
+    def test_charters_own_interpreter_is_carried_to_the_hotkey_menu(self):
+        """The delivery half of the bare-`charter` fix (`Conf` above pins the bind text
+        that READS it). Without this call the bind expands `$CHARTER_PY` to nothing and
+        `run-shell` runs ` -m charter frame-menu ...`, whose failure tmux prints into
+        the harness pane. Filtered and counted the way the `CHARTER_SESSION_ID` test
+        below is — an unfiltered "some set-environment happened" assertion is exactly
+        what let the exit-path call be deleted with the suite green."""
+        fake = _FakeTmux(exit_code=0)
+        _launch(fake)
+        py_calls = [c for c in fake.calls
+                    if "set-environment" in c and "CHARTER_PY" in c]
+        self.assertEqual(len(py_calls), 1,
+                         f"the interpreter must be carried exactly once: {fake.calls}")
+        cmd = py_calls[0]
+        self.assertEqual(cmd[cmd.index("-t") + 1], fake.fid,
+                         "session-scoped: two planes on one laptop can be two different "
+                         "charter installs, so a `-g` write would hand frame N's "
+                         "interpreter to frame N-1")
+        self.assertEqual(cmd[-1], sys.executable)
+
+    def test_the_harness_name_reaches_the_harness_environment(self):
+        """`harness.current()` reads `$CHARTER_HARNESS` FIRST, before any native
+        detection — so this export decides what every hook running inside the frame
+        thinks it is running in. Nothing asserted it: removing the two lines that set
+        it survived the entire suite.
+
+        The ambient value is deliberately overwritten with a sentinel first, and that is
+        the whole test. `cmd_launch` builds its environment as `dict(os.environ, ...)`,
+        and this suite is frequently RUN inside a charter frame, where the real
+        `$CHARTER_HARNESS` is already `claude-code` — so a straight assertion on the
+        expected value passes whether or not the launcher exports anything at all
+        (confirmed: the mutation that deletes the export left the first version of this
+        test green). Starting from a wrong value means only an actual export can make
+        this pass.
+
+        `claude` (`cli_name`, what a hand types) and `claude-code` (`name`, the harness's
+        own identity) are also different strings on purpose, so a launcher exporting the
+        wrong one of the two fails rather than passes."""
+        fake = _FakeTmux(exit_code=0)
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "stale-sentinel"}):
+            _launch(fake, harness="claude")
+        self.assertIsNotNone(fake.new_session_env)
+        self.assertEqual(fake.new_session_env.get("CHARTER_HARNESS"), "claude-code")
+
+    def test_a_bare_frame_command_leaves_the_harness_name_alone(self):
+        """`charter frame -- <cmd>` runs something charter has never met, so there is no
+        harness identity for the launcher to claim — it must not invent one. Same
+        sentinel trick, read the other way: whatever the launching environment already
+        said is what the harness inherits, and nothing charter made up."""
+        fake = _FakeTmux(exit_code=0)
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "stale-sentinel"}):
+            _launch(fake, harness="", rest=["--", "echo", "hi"])
+        self.assertIsNotNone(fake.new_session_env)
+        self.assertEqual(fake.new_session_env.get("CHARTER_HARNESS"), "stale-sentinel",
+                         "a bare `charter frame --` must not claim a harness identity")
 
     def test_the_menu_is_populated_with_a_detach_action(self):
         """`cmd_launch` must not merely bind the hotkey — the menu it opens has to have
@@ -800,11 +987,30 @@ class Launch(PersonaIso, unittest.TestCase):
         """`split-window` makes the newly created pane the ACTIVE one by default, so
         after every slot has been drawn, the LAST panel drawn — not the harness — has
         focus, and an interactive harness never receives a keystroke without this
-        (measured by hand: `%2 active=1, %0 active=0` after two splits)."""
+        (measured by hand: `%2 active=1, %0 active=0` after two splits).
+
+        The ORDER is the property, and it was the half nothing pinned: this test's own
+        name and docstring were about ordering while it asserted only the target, so
+        moving the `select-pane` call ABOVE the panel loop — which reintroduces exactly
+        the "the harness never receives a keystroke" defect, since every later split
+        steals the focus back — left the suite green. Compares indices, the way
+        `test_the_write_hook_is_installed_before_the_teardown_hook` already does."""
         fake = _FakeTmux(exit_code=0)
         _launch(fake)
-        select_cmd = next(c for c in fake.calls if "select-pane" in c)
+        select_idx = next(i for i, c in enumerate(fake.calls) if "select-pane" in c)
+        select_cmd = fake.calls[select_idx]
         self.assertEqual(select_cmd[select_cmd.index("-t") + 1], fake.pane_id)
+
+        split_idxs = [i for i, c in enumerate(fake.calls) if "split-window" in c]
+        self.assertTrue(split_idxs, "no panel was drawn — this test would be vacuous")
+        self.assertGreater(select_idx, max(split_idxs),
+                           "the harness pane must be selected AFTER every split, or "
+                           "the last panel drawn keeps the focus and the harness never "
+                           "receives a keystroke")
+        attach_idx = next(i for i, c in enumerate(fake.calls) if "attach" in c)
+        self.assertLess(select_idx, attach_idx,
+                        "selecting after `attach` returns is selecting after the "
+                        "operator has already stopped using the frame")
 
     def test_a_failed_pane_selection_is_reported_but_not_fatal(self):
         fake = _FakeTmux(exit_code=0, select_rc=1)
@@ -918,7 +1124,7 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertTrue(any("attach" in c for c in fake.calls))
 
     def test_a_failed_resize_hook_install_names_its_consequence(self):
-        """Fix round 2, item 4: `_report_tmux_failure` prints the command and tmux's
+        """Fix round 2, item 4: `tmuxctl.report_failure` prints the command and tmux's
         own stderr, but not what the failure COSTS the operator — every other degrade
         in this launcher (`source-file`, `set-environment`) pairs its failure report
         with a `util.warn` naming the consequence; the resize hook's own failure was
@@ -940,7 +1146,7 @@ class Launch(PersonaIso, unittest.TestCase):
         `invalid option: <name>` (confirmed by hand: generic `set-hook`
         argument-parsing text, not specific to this one hook) must degrade the SAME
         quiet way a known-too-old version already does: `util.warn`, never
-        `util.err`/`_report_tmux_failure`'s command-and-stderr dump."""
+        `util.err`/`tmuxctl.report_failure`'s command-and-stderr dump."""
         fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11", "bottom": "%12"},
                          resize_hook_rc=1,
                          resize_hook_stderr="invalid option: window-resized")
@@ -957,7 +1163,7 @@ class Launch(PersonaIso, unittest.TestCase):
         """Companion to the test above — the two paths must not collapse into each
         other. A resize-hook failure for some OTHER reason (a real bug, a permissions
         problem, anything that isn't tmux saying the hook name itself is unrecognised)
-        must still get the loud, specific `_report_tmux_failure` treatment; degrading
+        must still get the loud, specific `tmuxctl.report_failure` treatment; degrading
         every failure to a quiet warning would hide an actual regression behind the
         same wording a known compatibility gap uses."""
         fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11", "bottom": "%12"},
@@ -990,18 +1196,27 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertTrue(any("3.2" in m and "resize" in m for m in buf), buf)
 
     def test_below_the_tmux_floor_degrades_instead_of_refusing(self):
-        """Correction 5: a version below `tmuxctl.FLOOR` prints `below_floor_message`
-        and the frame still launches — only the (not-yet-wired) hotkey menu is
-        affected, not the frame itself."""
+        """Correction 5: a version below `tmuxctl.FLOOR` still launches — the frame
+        itself works there.
+
+        And it launches SILENTLY. The below-floor message used to be a `util.warn` on
+        this path; measured, `util.warn` lands 86 bytes before tmux's own
+        `\x1b[?1049h`, so the operator's terminal switches to the alternate screen
+        milliseconds later and the line is restored to view only when the frame EXITS.
+        It is a standing capability ceiling — true on every launch on this machine —
+        so it moved to the two surfaces built to answer on demand: `frame_ready`
+        (`--probe`, `charter frame-probe`) and `doctor.check_frame`. See
+        `Probe.test_below_the_floor_says_what_is_at_risk` for where it is asserted now."""
         fake = _FakeTmux(exit_code=0)
         buf = []
         with mock.patch("charter.util.warn", side_effect=lambda m: buf.append(m)):
             rc = _launch(fake, version=(3, 0))
         self.assertEqual(rc, 0)
-        self.assertTrue(any("3.0" in m and "3.2" in m for m in buf),
-                        f"the below-floor message was never printed: {buf}")
         self.assertTrue(any("new-session" in c for c in fake.calls),
                         "below-floor must degrade, not refuse to launch")
+        self.assertEqual(buf, [], "a standing ceiling must not be warned about into a "
+                                 "terminal that is about to switch to tmux's alternate "
+                                 "screen — see the docstring")
 
     def test_a_terminal_size_os_cannot_report_falls_back_rather_than_crashing(self):
         """`os.get_terminal_size()` raises `OSError` even on a tty that passes
@@ -1068,9 +1283,13 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertFalse(any("panel" in c and "left" in c for c in fake.calls),
                          "no pane may be spawned for a slot with no renderer")
-        self.assertTrue(any("left" in m for m in buf), buf)
         self.assertTrue(any("panel" in c and "bottom" in c for c in fake.calls),
                         "an IMPLEMENTED slot must still be drawn")
+        # Silently: which slots have a renderer is a property of this BUILD, not of
+        # this launch, and the warning it used to print landed 86 bytes before tmux
+        # switched the terminal to the alternate screen. `--probe` and `charter doctor`
+        # name it instead — see `Probe.test_a_slot_with_no_renderer_is_named_by_probe`.
+        self.assertEqual(buf, [], f"nothing standing may be warned at launch: {buf}")
 
     def test_a_frame_dir_the_state_module_refuses_does_not_crash(self):
         """`frame_dir` returns `None` rather than a `Path` for an id it cannot shape

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -29,6 +29,7 @@ start a real tmux server in this suite".
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 import unittest
@@ -39,6 +40,34 @@ from unittest import mock
 from tests._isolation import PersonaIso
 from charter import commands_frame, config
 from charter.frame import menu, state
+
+
+def _harness_binary_installed(resolver=None):
+    """Make "is the harness's binary installed?" deterministic for the framed path.
+
+    `cmd_launch` refuses to reach tmux for a REGISTERED harness whose binary is not on
+    `$PATH` (it hands off to `bypass`, which names it and exits 127). Every framed-path
+    test below therefore has to answer that question itself: left to the real
+    `shutil.which`, the entire `Launch` class would take the bypass branch on any machine
+    without `claude` installed — and `bypass` calls `os.execvp`, so a suite run there
+    would try to REPLACE THE TEST PROCESS rather than merely fail. Machine-dependent and
+    destructive, which is a worse combination than either alone.
+
+    `side_effect` over `return_value`: `shutil.which` is patched on the module object, so
+    this is global for the duration — `tmuxctl._probe`'s own `which("tmux")` goes through
+    it too — and answering every name with a plausible path keeps that honest rather than
+    special-casing one string.
+
+    *resolver* exists because the blanket "everything is installed" answer silently made a
+    test vacuous the first time this helper was written: `_launch` applies this patch
+    INSIDE its own `with`, so it overrides anything a caller set up outside, and
+    `test_the_frame_escape_hatch_is_not_narrowed_by_that_check` — whose entire point is a
+    binary that is NOT on `$PATH` — was answered "installed" along with everything else.
+    Caught by the mutation that widens the guard to `argv[0]`, which stayed green. A
+    caller that cares what `which` says must therefore say so.
+    """
+    return mock.patch("charter.commands_frame.shutil.which",
+                      side_effect=resolver or (lambda name, *a, **k: f"/usr/bin/{name}"))
 
 
 def _os_terminal_size(cols, rows):
@@ -83,6 +112,71 @@ class MissingHarnessBinary(unittest.TestCase):
             rc = commands_frame.bypass(["claude"])
         self.assertEqual(rc, 126)
         self.assertTrue(any("claude" in m for m in buf), buf)
+
+    def test_the_framed_path_refuses_before_tmux_and_says_why(self):
+        """The defect the `bypass` fix alone did not reach, and the one that mattered
+        most: `charter claude` in a TERMINAL — the normal path, the first thing a new
+        operator types — printed nothing at all.
+
+        `new-session` starts, the exec fails instantly, the eager
+        `_query_pane_dead_status` catches the dead pane and runs `kill-session`, and from
+        that moment `code is not None`, so the whole `if code is None:` block — panels,
+        `select-pane`, and `attach` — is skipped. No pane, no attach, nothing drawn.
+        Measured under a pty against a real tmux 3.7c with `claude` genuinely off
+        `$PATH`: **zero bytes** of output, exit 127, no alternate-screen switch. The
+        irony this test also pins: `--no-frame` and piped output, the two paths that
+        skip the frame, printed the right thing all along.
+
+        `run.assert_not_called()` is the half that says "before tmux": returning 127 by
+        going all the way through `new-session` and reading a dead pane's status would
+        satisfy the exit code while leaving the operator exactly as uninformed."""
+        args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
+        buf = []
+        with mock.patch("charter.commands_frame.shutil.which", return_value=None), \
+             mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch("os.execvp", side_effect=FileNotFoundError(2, "No such file")), \
+             mock.patch("charter.commands_frame.subprocess.run") as run, \
+             mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = commands_frame.cmd_launch(args)
+        self.assertEqual(rc, 127)
+        self.assertTrue(any("claude" in m for m in buf),
+                        f"the operator must be told what is missing: {buf}")
+        run.assert_not_called()
+
+    def test_the_frame_escape_hatch_is_not_narrowed_by_that_check(self):
+        """`charter frame -- <cmd>` must behave exactly as it did. `argv[0]` there is the
+        operator's own verbatim word and is allowed to be a shell builtin, a relative
+        path, or anything else tmux's own resolution accepts — so the check is scoped to
+        `if h`, a REGISTERED harness whose binary charter itself chose
+        (`harness.base.binary`), and never to `argv[0]`.
+
+        This is what fails if anyone "simplifies" the guard to `not
+        shutil.which(argv[0])`: a command charter has never met, provably not on `$PATH`,
+        must still reach `new-session`."""
+        fake = _FakeTmux(exit_code=0)
+        self.assertIsNone(shutil.which("charter-definitely-not-a-real-binary-xyz"))
+        # NOTHING resolves on `$PATH` for the duration — the strongest form of the
+        # question, and it has to be said explicitly: `_launch`'s default answers
+        # "installed" for every name, which made the first version of this test vacuous
+        # (see `_harness_binary_installed`).
+        with mock.patch("os.execvp", side_effect=AssertionError("bypassed the frame")):
+            rc = _launch(fake, harness="",
+                         rest=["--", "charter-definitely-not-a-real-binary-xyz"],
+                         which=lambda name, *a, **k: None)
+        self.assertEqual(rc, 0)
+        self.assertTrue(any("new-session" in c for c in fake.calls),
+                        "the `frame --` escape hatch must still reach tmux for a command "
+                        "that is not on $PATH")
+
+    def test_an_installed_harness_is_not_short_circuited(self):
+        """The other direction, and what stops the guard from being "always bypass": with
+        the binary present the launch proceeds into tmux exactly as before."""
+        fake = _FakeTmux(exit_code=0)
+        with mock.patch("os.execvp", side_effect=AssertionError("bypassed the frame")):
+            rc = _launch(fake, harness="claude")
+        self.assertEqual(rc, 0)
+        self.assertTrue(any("new-session" in c for c in fake.calls))
 
     def test_no_crash_report_is_filed_for_a_missing_binary(self):
         """The half that actually mattered: not merely "does not traceback", but "does
@@ -296,6 +390,7 @@ class MissingTmux(unittest.TestCase):
         args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
         with mock.patch("charter.frame.tmuxctl.version", return_value=None), \
              mock.patch("sys.stdout.isatty", return_value=True), \
+             _harness_binary_installed(), \
              mock.patch("charter.commands_frame.subprocess.run") as run, \
              mock.patch("builtins.print") as p:
             rc = commands_frame.cmd_launch(args)
@@ -419,6 +514,7 @@ class Probe(unittest.TestCase):
         sentinel = AssertionError("workspace resolved — the launch path was reached")
         with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
              mock.patch("sys.stdout.isatty", return_value=True), \
+             _harness_binary_installed(), \
              mock.patch("charter.workspace.resolve", side_effect=sentinel):
             with self.assertRaises(AssertionError) as ctx:
                 commands_frame.cmd_launch(args)
@@ -651,10 +747,11 @@ class _FakeTmux:
 
 
 def _launch(fake: _FakeTmux, *, cols=200, rows=50, version=(3, 7), harness="claude",
-           rest=()):
+           rest=(), which=None):
     args = SimpleNamespace(harness=harness, rest=list(rest), no_frame=False)
     with mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
          mock.patch("sys.stdout.isatty", return_value=True), \
+         _harness_binary_installed(which), \
          mock.patch("charter.frame.tmuxctl.version", return_value=version), \
          mock.patch("charter.workspace.resolve", return_value="demo"), \
          mock.patch("os.get_terminal_size", return_value=_os_terminal_size(cols, rows)):
@@ -916,6 +1013,7 @@ class Launch(PersonaIso, unittest.TestCase):
         args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
         with mock.patch("charter.commands_frame.subprocess.run", side_effect=_peek), \
              mock.patch("sys.stdout.isatty", return_value=True), \
+             _harness_binary_installed(), \
              mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
              mock.patch("charter.workspace.resolve", return_value="demo"), \
              mock.patch("os.get_terminal_size", return_value=_os_terminal_size(200, 50)):
@@ -1225,6 +1323,7 @@ class Launch(PersonaIso, unittest.TestCase):
         args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
         with mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
              mock.patch("sys.stdout.isatty", return_value=True), \
+             _harness_binary_installed(), \
              mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
              mock.patch("charter.workspace.resolve", return_value="demo"), \
              mock.patch("os.get_terminal_size", side_effect=OSError("no tty size")):
@@ -1298,6 +1397,7 @@ class Launch(PersonaIso, unittest.TestCase):
         args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
         with mock.patch("charter.commands_frame.subprocess.run") as run, \
              mock.patch("sys.stdout.isatty", return_value=True), \
+             _harness_binary_installed(), \
              mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
              mock.patch("charter.workspace.resolve", return_value="demo"), \
              mock.patch("charter.frame.state.frame_dir", return_value=None), \

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1,0 +1,301 @@
+"""Starting a harness inside a frame, and the three ways that must not go wrong.
+
+The exit code is asserted because it was measured wrong once: an attached
+`tmux new-session` returns 0 whatever its command exited with (pinned against 3.7c), so
+the launcher waits and reads a recorded status instead of exec'ing and hoping.
+
+**Every fake tmux command here returns a `subprocess.CompletedProcess`, never a real
+tmux process** — the point of `charter/frame/tmuxctl.py` splitting the binary out of
+everything else is that this module gets to keep that promise while still exercising the
+FULL launch sequence: session creation, reading the captured pane id back off stdout,
+loading the pane-scoped config, drawing the panels, and attaching.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from tests._isolation import PersonaIso
+from charter import commands_frame
+from charter.frame import state
+
+
+class Bypass(unittest.TestCase):
+    def test_a_pipe_gets_no_frame(self):
+        """`charter claude -p "…" | jq` must be `claude -p "…" | jq`. A frame around a
+        pipe is wrong, and exec keeps the exit code without any help."""
+        with mock.patch("sys.stdout.isatty", return_value=False), \
+             mock.patch("os.execvp") as ex:
+            commands_frame.bypass(["claude", "-p", "hi"])
+        ex.assert_called_once_with("claude", ["claude", "-p", "hi"])
+
+
+class Conf(unittest.TestCase):
+    def test_the_pane_died_hook_is_scoped_to_the_harness_pane(self):
+        """pane-died fires for ANY pane. Unscoped, a dead panel would be reported as the
+        agent's exit code."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=50000,
+                                        status_path="/tmp/f/exit", harness_pane="%3")
+        self.assertIn("%3", text)
+        self.assertIn("pane_dead_status", text)
+
+    def test_remain_on_exit_is_set_or_the_status_never_exists(self):
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=50000,
+                                        status_path="/tmp/f/exit", harness_pane="%3")
+        self.assertIn("remain-on-exit on", text)
+
+    def test_mouse_is_off_unless_asked_for(self):
+        off = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
+                                       status_path="/x", harness_pane="%0")
+        self.assertIn("set -g mouse off", off)
+        on = commands_frame.conf_text(hotkey="F2", mouse=True, history_limit=1,
+                                      status_path="/x", harness_pane="%0")
+        self.assertIn("set -g mouse on", on)
+
+    def test_history_limit_is_raised_above_the_tmux_default(self):
+        """tmux ships 2000 lines, which becomes the harness's entire scrollback."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=50000,
+                                        status_path="/x", harness_pane="%0")
+        self.assertIn("history-limit 50000", text)
+
+
+class MissingTmux(unittest.TestCase):
+    def test_an_absent_tmux_names_the_remedy_and_does_not_start_a_frame(self):
+        """Adapted from the task brief's own draft, which mocked `tmuxctl.available()`.
+        Correction 5 requires `cmd_launch` to call `tmuxctl.version()` exactly ONCE and
+        branch on it — `available()` is never called at all in the corrected launcher —
+        so a test that only patches `available()` would exercise the REAL `tmux -V` here
+        (whatever happens to be installed on the machine running the suite) instead of
+        the absent-tmux path it claims to test. Patching `version()` to return `None` (=
+        "absent", per `tmuxctl.version`'s own docstring) is what actually simulates it."""
+        args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
+        with mock.patch("charter.frame.tmuxctl.version", return_value=None), \
+             mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("charter.commands_frame.subprocess.run") as run, \
+             mock.patch("builtins.print") as p:
+            rc = commands_frame.cmd_launch(args)
+        self.assertNotEqual(rc, 0)
+        printed = " ".join(str(c) for c in p.call_args_list)
+        self.assertIn("--no-frame", printed)
+        # "does not start a frame": no tmux command of any kind was even attempted.
+        run.assert_not_called()
+
+
+class _FakeTmux:
+    """Every tmux invocation `cmd_launch` makes, keyed by which subcommand it carries.
+
+    Standing in for the real binary (never started in this suite — see the module
+    docstring) while still letting a test drive the FULL sequence: the launcher reads a
+    pane id off `new-session`'s stdout, and this fake hands one back the same way real
+    tmux does, so a test can assert what the launcher does with THAT VALUE rather than
+    with a hardcoded stand-in like `"%0"` (the exact bug correction 3 exists to catch).
+
+    `exit_code`, if given, is written via `state.record_exit` at the moment the fake
+    `attach` command runs — mimicking the real timing: `attach` blocks until the
+    session ends, and by the time it returns, the `pane-died` hook (fired on the real
+    server while attach was blocked) has already recorded the code.
+    """
+
+    def __init__(self, *, pane_id="%7", exit_code=None,
+                session_rc=0, source_rc=0, panel_rc=0, attach_rc=0):
+        self.pane_id = pane_id
+        self.exit_code = exit_code
+        self.session_rc = session_rc
+        self.source_rc = source_rc
+        self.panel_rc = panel_rc
+        self.attach_rc = attach_rc
+        self.calls: list[list[str]] = []
+        self.fid = None
+        self.sourced_conf_text = None
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append(list(cmd))
+        if "new-session" in cmd:
+            self.fid = cmd[cmd.index("-s") + 1]
+            return subprocess.CompletedProcess(cmd, self.session_rc,
+                                               stdout=(self.pane_id + "\n") if self.session_rc == 0 else "",
+                                               stderr="" if self.session_rc == 0 else "no space for a new pane")
+        if "source-file" in cmd:
+            conf_path = cmd[cmd.index("source-file") + 1]
+            self.sourced_conf_text = Path(conf_path).read_text()
+            return subprocess.CompletedProcess(cmd, self.source_rc, stdout="",
+                                               stderr="" if self.source_rc == 0 else "bad config line")
+        if "split-window" in cmd:
+            return subprocess.CompletedProcess(cmd, self.panel_rc, stdout="",
+                                               stderr="" if self.panel_rc == 0 else "no space for a new pane")
+        if "attach" in cmd:
+            if self.exit_code is not None and self.fid:
+                state.record_exit(self.fid, self.exit_code)
+            return subprocess.CompletedProcess(cmd, self.attach_rc, stdout="", stderr="")
+        if "list-sessions" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        raise AssertionError(f"unexpected tmux command in test: {cmd}")
+
+
+def _launch(fake: _FakeTmux, *, cols=200, rows=50, version=(3, 7), harness="claude"):
+    args = SimpleNamespace(harness=harness, rest=[], no_frame=False)
+    with mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
+         mock.patch("sys.stdout.isatty", return_value=True), \
+         mock.patch("charter.frame.tmuxctl.version", return_value=version), \
+         mock.patch("charter.workspace.resolve", return_value="demo"), \
+         mock.patch("os.get_terminal_size", return_value=os_terminal_size(cols, rows)):
+        return commands_frame.cmd_launch(args)
+
+
+def os_terminal_size(cols, rows):
+    import os as _os
+    return _os.terminal_size((cols, rows))
+
+
+class Launch(PersonaIso, unittest.TestCase):
+    def test_the_pane_scoped_hook_uses_the_pane_tmux_actually_reported(self):
+        """The regression correction 3 names directly: `conf_text`'s `harness_pane` must
+        be the id READ OFF tmux's stdout, never the literal `"%0"` that happens to be
+        right only for the very first pane ever created on a fresh server. `_FakeTmux`
+        reports `%7` — a value `"%0"` could never produce by accident — so this fails if
+        the launcher ever falls back to a hardcoded pane id."""
+        fake = _FakeTmux(pane_id="%7", exit_code=0)
+        rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        self.assertIsNotNone(fake.sourced_conf_text)
+        self.assertIn("%7", fake.sourced_conf_text)
+        self.assertNotIn("%0", fake.sourced_conf_text)
+
+    def test_the_config_is_loaded_with_source_file_not_only_dash_f(self):
+        """Measured against tmux 3.7c (module docstring of commands_frame.py): `-f` on
+        `new-session` is read only when that call starts a brand-new server, so a SECOND
+        frame sharing `SOCKET` would never get its own pane-scoped hook installed if the
+        launcher relied on `-f` alone. `source-file`, run after the pane id is known,
+        applies live regardless of whether the server was already running."""
+        fake = _FakeTmux(exit_code=0)
+        _launch(fake)
+        self.assertTrue(any("source-file" in c for c in fake.calls),
+                        "the real config was never loaded via `source-file`")
+
+    def test_the_recorded_exit_code_wins_over_a_zero_from_attach(self):
+        """The whole module's reason to exist: an attached `tmux attach` (like
+        `new-session`) returns 0 for the CLIENT's own detach, not for what ran inside —
+        so a real crash must still surface even though `attach`'s own returncode is 0."""
+        fake = _FakeTmux(exit_code=17, attach_rc=0)
+        rc = _launch(fake)
+        self.assertEqual(rc, 17)
+
+    def test_a_failed_session_start_is_fatal_and_reported(self):
+        """No harness pane exists — nothing to attach to, so this must not proceed to
+        try drawing panels or attaching, and correction 2 requires the failure to name
+        the command and tmux's stderr rather than vanish."""
+        fake = _FakeTmux(session_rc=1)
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake)
+        self.assertNotEqual(rc, 0)
+        self.assertTrue(any("no space for a new pane" in m for m in buf),
+                        f"tmux's own stderr was never surfaced: {buf}")
+        self.assertFalse(any("split-window" in c for c in fake.calls))
+        self.assertFalse(any("attach" in c for c in fake.calls))
+
+    def test_a_failed_panel_split_is_reported_but_not_fatal(self):
+        """Correction 2's target bug: the layout split that silently failed and shipped
+        a frame with a missing panel. Here it must be REPORTED (command + tmux's
+        stderr) — but the harness pane already exists and is already running, so the
+        launch must still finish and return the harness's real exit code."""
+        fake = _FakeTmux(panel_rc=1, exit_code=3)
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake)
+        self.assertEqual(rc, 3)
+        self.assertTrue(any("no space for a new pane" in m for m in buf),
+                        f"the panel failure's tmux stderr was never surfaced: {buf}")
+        self.assertTrue(any("attach" in c for c in fake.calls),
+                        "a decorative panel failing must not cancel the attach")
+
+    def test_below_the_tmux_floor_degrades_instead_of_refusing(self):
+        """Correction 5: a version below `tmuxctl.FLOOR` prints `below_floor_message`
+        and the frame still launches — only the (not-yet-wired) hotkey menu is
+        affected, not the frame itself."""
+        fake = _FakeTmux(exit_code=0)
+        buf = []
+        with mock.patch("charter.util.warn", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake, version=(3, 0))
+        self.assertEqual(rc, 0)
+        self.assertTrue(any("3.0" in m and "3.2" in m for m in buf),
+                        f"the below-floor message was never printed: {buf}")
+        self.assertTrue(any("new-session" in c for c in fake.calls),
+                        "below-floor must degrade, not refuse to launch")
+
+    def test_a_terminal_size_os_cannot_report_falls_back_rather_than_crashing(self):
+        """`os.get_terminal_size()` raises `OSError` even on a tty that passes
+        `isatty()` — a documented trap, not a hypothetical. Must not propagate."""
+        fake = _FakeTmux(exit_code=0)
+        args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
+             mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch("charter.workspace.resolve", return_value="demo"), \
+             mock.patch("os.get_terminal_size", side_effect=OSError("no tty size")):
+            rc = commands_frame.cmd_launch(args)
+        self.assertEqual(rc, 0)
+        session_cmd = next(c for c in fake.calls if "new-session" in c)
+        self.assertEqual(session_cmd[session_cmd.index("-x") + 1], "80")
+        self.assertEqual(session_cmd[session_cmd.index("-y") + 1], "24")
+
+    def test_a_double_dash_separator_is_stripped_before_reaching_the_harness(self):
+        """`nargs=argparse.REMAINDER` keeps a literal leading `--` when the operator
+        typed one (`charter frame -- claude -p hi`); it is the token that told argparse
+        to stop parsing, not part of what should run."""
+        fake = _FakeTmux(exit_code=0)
+        args = SimpleNamespace(harness="", rest=["--", "echo", "hi"], no_frame=False)
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
+             mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch("charter.workspace.resolve", return_value="demo"), \
+             mock.patch("os.get_terminal_size", return_value=os_terminal_size(200, 50)):
+            commands_frame.cmd_launch(args)
+        session_cmd = next(c for c in fake.calls if "new-session" in c)
+        self.assertEqual(session_cmd[session_cmd.index("--") + 1:], ["echo", "hi"])
+
+
+class CollisionGuard(unittest.TestCase):
+    def test_a_harness_cli_name_colliding_with_a_core_command_is_refused_at_build_time(self):
+        """The additional requirement carried from Task 1: a harness registered with a
+        `cli_name` that already names a `charter` command must be refused LOUDLY, at
+        parser-construction time — never silently letting the harness shadow it.
+
+        Patches `charter.harness.registry.KINDS` (the dict `harness.all()` actually
+        reads inside its own module — `charter.harness.KINDS` is a re-exported ALIAS of
+        the same object, but reassigning that alias via `mock.patch` would not touch
+        what `registry.all()` reads from its own globals; `mock.patch.dict` mutating the
+        real dict in place is what makes `harness.all()` see the fake entry).
+
+        Asserts on the GUARD'S OWN wording (`clashing-harness`), not merely "a
+        `ValueError` mentioning `status`" — on Python 3.12+, `argparse`'s own
+        `add_parser` already raises `ValueError: conflicting subparser: status` for a
+        second parser of the same name, which would make a weaker assertion pass even
+        with this module's own guard deleted entirely (verified by hand: disabling the
+        `if h.cli_name in sub.choices` check here still left this test green on 3.14,
+        for exactly that reason — the guard exists for 3.11, where `add_parser` accepts
+        a duplicate name silently). Checking for this guard's specific message is what
+        makes the test depend on THIS code rather than on which interpreter runs it."""
+        from charter import cli
+        from charter.harness import registry
+        from charter.harness.base import Harness
+
+        class _CollidingHarness(Harness):
+            name = "clashing-harness"
+            cli_name = "status"  # already a core `charter` command (see cli.py)
+            binary = "clashing"
+
+        with mock.patch.dict("charter.harness.registry.KINDS",
+                             {"clashing-harness": _CollidingHarness}, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                cli.build_parser()
+        self.assertIn("clashing-harness", str(ctx.exception))
+        self.assertIn("charter status", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -3,27 +3,31 @@
 The exit code is asserted because it was measured wrong once: an attached
 `tmux new-session` returns 0 whatever its command exited with (pinned against 3.7c), so
 the launcher waits and reads a recorded status instead of exec'ing and hoping. A second,
-narrower race survives even that fix — the hook that records the status is not installed
-until a moment after the harness starts running, so a harness that dies inside that
-window is never caught by it, and (verified by hand against a real tmux 3.7c) nothing is
-left to end the session either, so `attach` would block forever rather than merely return
-early. `Launch` below covers the EAGER `display-message` check `cmd_launch` runs right
-after installing the hook — before ever calling `attach` — that closes this.
+narrower race survives even that fix — the hooks that record the status and end the
+session are not installed until a moment after the harness starts running, so a harness
+that dies inside that window is never caught by them, and (verified by hand against a
+real tmux 3.7c) nothing is left to end the session either, so `attach` would block
+forever rather than merely return early. `Launch` below covers the EAGER
+`display-message` check `cmd_launch` runs right after installing both hooks — before
+ever calling `attach` — that closes this, and its harder cousin: a harness killed by a
+signal reports `#{pane_dead_status}` EMPTY, not negative, and treating empty as "cannot
+tell" reopens the same hang from a different angle (confirmed by hand:
+`charter frame -- bash -c 'kill -9 $$'` hung under an earlier version of this fix).
 
 **Every fake tmux command here returns a `subprocess.CompletedProcess`, never a real
 tmux process** — the point of `charter/frame/tmuxctl.py` splitting the binary out of
 everything else is that this module gets to keep that promise while still exercising the
 FULL launch sequence: session creation, reading the captured pane id back off stdout,
-loading the session-scoped config, installing the exit-code hook, drawing the panels,
-and attaching. The shell-quoting and multi-session-server properties `_pane_died_hook_argv`
-and `source-file` rely on were verified by hand against a real tmux 3.7c (see the
-fix-round section of the task report) — that verification cannot be a unit test without
-violating "never start a real tmux server in this suite".
+loading the session-scoped config, carrying the exit-status path out of band, installing
+the write and teardown hooks, drawing the panels, focusing the harness pane, and
+attaching. The shell-quoting, hook-independence, and multi-session-server properties this
+relies on were verified by hand against a real tmux 3.7c (see the fix-round sections of
+the task report) — that verification cannot be a unit test without violating "never
+start a real tmux server in this suite".
 """
 
 from __future__ import annotations
 
-import shlex
 import subprocess
 import unittest
 from pathlib import Path
@@ -51,14 +55,13 @@ class Bypass(unittest.TestCase):
 
 
 class Conf(unittest.TestCase):
-    """`conf_text` no longer carries the `pane-died` hook (see `PaneDiedHook` below) —
-    only the settings that are safe to bake into a text file `source-file` loads: no
-    untrusted path ever reaches this function."""
+    """Neither `pane-died` hook lives in `conf_text` — see `PaneDiedHooks` below — only
+    the settings that are safe to bake into a text file `source-file` loads."""
 
     def test_status_mouse_and_history_limit_are_session_scoped(self):
-        """Finding 4: `source-file` applies this text to the ONE shared server every
-        frame runs on. `-g` (global) here would rewrite every OTHER live frame's mouse
-        and scrollback the moment this frame's config loads — session-scoped (`-t
+        """`source-file` applies this text to the ONE shared server every frame runs
+        on. `-g` (global) here would rewrite every OTHER live frame's mouse and
+        scrollback the moment this frame's config loads — session-scoped (`-t
         <session>`, no `-g`) is what keeps frame N's settings from becoming frame
         (N-1)'s."""
         text = commands_frame.conf_text(hotkey="F2", mouse=True, history_limit=999,
@@ -95,52 +98,68 @@ class Conf(unittest.TestCase):
         self.assertIn("history-limit 50000", text)
 
 
-class PaneDiedHook(unittest.TestCase):
-    """`_pane_died_hook_argv` — issued as its OWN tmux command (clean argv), never text
-    baked into `conf_text`'s output. See the module docstring in `commands_frame.py` for
-    why: nesting a shell-quoted path inside a SECOND, text-file level of tmux quoting
-    (what `source-file`'s config syntax requires) breaks `shlex.quote`'s own escaping for
-    a path containing a literal single quote — verified by hand against tmux 3.7c."""
+class PaneDiedHooks(unittest.TestCase):
+    """The exit-status hook is now TWO separate tmux commands, not one — see
+    `commands_frame.py`'s module docstring ("Teardown is its own hook") for why a
+    write hook (`pane-died[0]`, carries the real status) and a teardown hook
+    (`pane-died[1]`, a constant `kill-session`) are installed independently: a bug in
+    the write hook's own construction must never be able to take teardown down with it.
+    The status path itself is delivered out of band (`_exit_path_env_argv`,
+    `set-environment`), never embedded in either hook's action text."""
 
-    def test_the_hook_targets_the_harness_pane(self):
-        cmd = commands_frame._pane_died_hook_argv(socket="charter", harness_pane="%9",
-                                                   status_path="/tmp/f/exit")
+    def test_the_write_hook_targets_the_harness_pane(self):
+        cmd = commands_frame._pane_died_write_hook_argv(socket="charter", harness_pane="%9")
         self.assertEqual(cmd[cmd.index("-t") + 1], "%9")
         self.assertIn("pane-died", cmd)
+        self.assertNotIn("pane-died[1]", cmd)
 
-    def test_it_is_a_clean_argv_list_naming_the_socket(self):
-        cmd = commands_frame._pane_died_hook_argv(socket="charter", harness_pane="%0",
-                                                   status_path="/x")
-        self.assertIsInstance(cmd, list)
-        for part in cmd:
-            self.assertIsInstance(part, str)
-        self.assertEqual(cmd[:3], ["tmux", "-L", "charter"])
+    def test_the_write_hook_action_is_constant(self):
+        """No operator- or plane-derived string is ever embedded in this text — the
+        exact bug that let a plane root with a literal `'` in it hang silently
+        (`set-hook` reported success while the stored action was corrupted). Two calls
+        with different `harness_pane`s produce IDENTICAL action text; only the `-t`
+        target differs."""
+        a = commands_frame._pane_died_write_hook_argv(socket="charter", harness_pane="%1")
+        b = commands_frame._pane_died_write_hook_argv(socket="charter", harness_pane="%2")
+        self.assertEqual(a[-1], b[-1])
 
-    def test_the_status_path_is_shell_quoted_against_a_space(self):
-        """Finding 5: `status_path` reaches `run-shell`, which hands it to `/bin/sh -c`.
-        A plane root (or `$CHARTER_HOME`) containing a space — ordinary on macOS — must
-        not silently truncate the write. `shlex.quote`'s exact output is asserted, not
-        merely "no error", because a test that only checks `set-hook` didn't crash would
-        pass even if the path were embedded completely unquoted."""
-        path = "/tmp/My Plane/exit"
-        cmd = commands_frame._pane_died_hook_argv(socket="charter", harness_pane="%0",
-                                                   status_path=path)
+    def test_the_write_hook_falls_back_to_the_unknown_death_sentinel_when_status_is_empty(self):
+        """Measured against tmux 3.7c: a harness killed by a signal
+        (SIGKILL/SIGTERM/SIGSEGV) reports `#{pane_dead_status}` EMPTY, not a negative
+        number. An unqualified `echo #{pane_dead_status} > ...` would write an empty,
+        unparseable line — `state.exit_code` cannot parse it and reads back `None`,
+        exactly like nothing was ever recorded. Confirmed by hand: `charter frame --
+        bash -c 'sleep 1.5; kill -9 $$'` (well past the install race, so the hooks ARE
+        installed) returned 0 — silent success for a crashed harness — before this
+        fix. `${v:-N}` in the shell fragment closes it at the point of writing."""
+        cmd = commands_frame._pane_died_write_hook_argv(socket="charter", harness_pane="%0")
         action = cmd[-1]
-        self.assertIn(shlex.quote(path), action)
-        # The raw, unquoted path must not appear on its own — only inside the quoted form.
-        self.assertNotIn(f"> {path}\"", action)
+        self.assertIn(f"${{v:-{commands_frame._UNKNOWN_DEATH_CODE}}}", action)
 
-    def test_a_dollar_paren_injection_attempt_is_neutralized(self):
-        """The sharper form of the same finding: a path shaped like a command
-        substitution must reach the shell as an inert literal, not run."""
-        path = "/tmp/inj $(touch pwned)/exit"
-        cmd = commands_frame._pane_died_hook_argv(socket="charter", harness_pane="%0",
-                                                   status_path=path)
-        action = cmd[-1]
-        self.assertIn(shlex.quote(path), action)
-        # Unquoted, "$(touch pwned)" would sit outside any quotes in the action string;
-        # quoted, it is wrapped in the shell-single-quoted form `shlex.quote` produces.
-        self.assertNotIn("> /tmp/inj $(touch pwned)/exit\"", action)
+    def test_the_teardown_hook_is_a_constant_kill_session_at_index_1(self):
+        cmd = commands_frame._pane_died_teardown_hook_argv(socket="charter", harness_pane="%9")
+        self.assertEqual(cmd[cmd.index("-t") + 1], "%9")
+        self.assertIn("pane-died[1]", cmd)
+        self.assertEqual(cmd[-1], "kill-session")
+
+    def test_both_hooks_are_clean_argv_lists_naming_the_socket(self):
+        for cmd in (commands_frame._pane_died_write_hook_argv(socket="charter", harness_pane="%0"),
+                   commands_frame._pane_died_teardown_hook_argv(socket="charter", harness_pane="%0")):
+            self.assertIsInstance(cmd, list)
+            for part in cmd:
+                self.assertIsInstance(part, str)
+            self.assertEqual(cmd[:3], ["tmux", "-L", "charter"])
+
+    def test_the_status_path_is_carried_out_of_band(self):
+        """`set-environment` takes the path as ONE argv value — no shell, no tmux
+        text-command parsing of it at all — verified by hand to round-trip a space, a
+        literal `'`, and a `$(...)` injection attempt correctly precisely because
+        nothing here ever re-parses it as text."""
+        path = "/tmp/My Plane's exit $(touch pwned)/exit"
+        cmd = commands_frame._exit_path_env_argv(socket="charter", session="demo-1",
+                                                 status_path=path)
+        self.assertEqual(cmd, ["tmux", "-L", "charter", "set-environment", "-t", "demo-1",
+                              "CHARTER_FRAME_EXIT", path])
 
 
 class MissingTmux(unittest.TestCase):
@@ -167,7 +186,7 @@ class MissingTmux(unittest.TestCase):
 
 class QueryPaneDeadStatus(unittest.TestCase):
     """`_query_pane_dead_status` is the SAME function `cmd_launch` calls both eagerly
-    (immediately after installing the hook, to close the install race) and again as a
+    (immediately after installing the hooks, to close the install race) and again as a
     fallback after `attach` returns — pinned directly here, not only indirectly through
     `Launch`'s race-recovery test, since either call site reuses this one function."""
 
@@ -179,6 +198,16 @@ class QueryPaneDeadStatus(unittest.TestCase):
     def test_a_dead_pane_returns_its_status(self):
         with self._dm("1:42"):
             self.assertEqual(commands_frame._query_pane_dead_status("charter", "%0"), 42)
+
+    def test_a_subprocess_error_returns_none_rather_than_raising(self):
+        """Correction 2's counterpart for a query rather than an action: `_live_sessions`
+        already wraps its `subprocess.run` call this way, and this function must too — a
+        `TimeoutExpired`/`OSError` escaping here would crash `cmd_launch` AFTER the
+        harness is already running, which is a worse failure than the one this whole
+        function exists to prevent (a fabricated answer)."""
+        with mock.patch("charter.commands_frame.subprocess.run",
+                        side_effect=OSError("no such tmux")):
+            self.assertIsNone(commands_frame._query_pane_dead_status("charter", "%0"))
 
     def test_a_live_pane_returns_none(self):
         with self._dm("0:"):
@@ -195,15 +224,39 @@ class QueryPaneDeadStatus(unittest.TestCase):
         with self._dm("1:99", rc=1):
             self.assertIsNone(commands_frame._query_pane_dead_status("charter", "%0"))
 
-    def test_unparseable_status_text_returns_none_rather_than_raising(self):
+    def test_unparseable_status_text_degrades_to_the_sentinel_rather_than_raising(self):
         """`#{pane_dead_status}` is tmux's own format variable, not operator input, but
-        this function must not assume its shape: a malformed or unexpected value must
-        degrade to "cannot tell", never raise `ValueError` out of `int(status)`."""
+        this function must not assume its shape: a malformed value must never raise
+        `ValueError` out of `int(status)`. It degrades to `_UNKNOWN_DEATH_CODE`, not
+        `None` — by the time `status` is even inspected, `dead == "1"` already confirmed
+        the pane IS dead (see `test_a_failed_query_returns_none_not_zero` above for the
+        one case that still answers `None`: the query itself failing, before `dead` is
+        even known). `None` would tell `cmd_launch` to go ahead and attach a pane
+        already known to be gone."""
         with self._dm("1:not-a-number"):
-            self.assertIsNone(commands_frame._query_pane_dead_status("charter", "%0"))
+            self.assertEqual(commands_frame._query_pane_dead_status("charter", "%0"),
+                             commands_frame._UNKNOWN_DEATH_CODE)
 
-    def test_a_negative_status_is_parsed(self):
-        """tmux reports a negative `pane_dead_status` for a process killed by a signal."""
+    def test_an_empty_status_is_dead_with_unknown_status_not_cannot_tell(self):
+        """Fix round 2, item 1/2: measured against tmux 3.7c, a harness killed by a
+        signal (SIGKILL/SIGTERM/SIGSEGV) reports `pane_dead=1` with an EMPTY
+        `pane_dead_status` — replaces an earlier version of this test class that wrongly
+        assumed a signal death produced a NEGATIVE number (see the test below, reworded
+        rather than deleted, for the parser's own handling of that shape). Treating
+        empty as `None` ("cannot tell") told `cmd_launch` "alive, go ahead and attach" —
+        confirmed by hand that this hung `charter frame -- bash -c 'kill -9 $$'`
+        forever, against a session `remain-on-exit` was correctly keeping alive with
+        nothing left to end it."""
+        with self._dm("1:"):
+            self.assertEqual(commands_frame._query_pane_dead_status("charter", "%0"),
+                             commands_frame._UNKNOWN_DEATH_CODE)
+
+    def test_a_negative_status_would_still_be_parsed_if_one_were_ever_reported(self):
+        """NOT a claim that tmux reports negative statuses for a signal death — verified
+        it does not (see the empty-status test above, which is what actually happens
+        and is what this test used to wrongly assert). Kept, reworded, to pin the
+        parser's own `-` handling defensively in case some other tmux version or
+        platform ever does report one."""
         with self._dm("1:-15"):
             self.assertEqual(commands_frame._query_pane_dead_status("charter", "%0"), -15)
 
@@ -222,35 +275,48 @@ class _FakeTmux:
 
     - `exit_code`: the ORDINARY path. Written via `state.record_exit` at the moment the
       fake `attach` command runs — mimicking real timing, where `attach` blocks until the
-      session ends and by the time it returns, the hook (fired on the real server while
-      attach was blocked) has already recorded the code.
+      session ends and by the time it returns, the write hook (fired on the real server
+      while attach was blocked) has already recorded the code.
     - `race_death_status`: the RACE `cmd_launch`'s eager `display-message` check exists
-      to close. Nothing is written via `state.record_exit` up front (the hook never got
+      to close. Nothing is written via `state.record_exit` up front (the hooks never got
       the chance to fire), but a fake `display-message` query answers `1:<status>` —
       what tmux would actually report for a pane that died before any hook existed but
       is still there to ask, thanks to `remain-on-exit`. `cmd_launch` asks this BEFORE
-      ever calling `attach` (verified by hand against a real tmux 3.7c that a `attach`
-      against exactly this state blocks forever otherwise, `remain-on-exit` legitimately
-      keeping the session alive with nothing left to end it), so a correct launcher
-      never reaches the fake `attach` handler at all in this scenario.
+      ever calling `attach` (verified by hand against a real tmux 3.7c that `attach`
+      against exactly this state blocks forever otherwise), so a correct launcher never
+      reaches the fake `attach` handler at all in this scenario.
     - `still_live` (with both of the above left `None`): the session is still running
       when `attach` returns (an operator detach, not a finish) — `list-sessions` reports
       the frame's own session id as still live.
+
+    `pre_existing_sessions` answers the FIRST `list-sessions` call (before this frame's
+    own session exists, i.e. `self.fid` is still `None`) — a separate knob from
+    `still_live`, which only answers the SECOND call (after this frame's session was
+    created), because they model two different questions: "was anything else already
+    running before this launch" versus "is THIS frame still running after `attach`".
     """
 
     def __init__(self, *, pane_id="%7", exit_code=None, race_death_status=None,
-                still_live=False, session_rc=0, source_rc=0, hook_rc=0, panel_rc=0,
-                attach_rc=0, dm_rc=0):
+                still_live=False, pre_existing_sessions=frozenset(),
+                session_rc=0, source_rc=0, env_set_rc=0, write_hook_rc=0,
+                teardown_hook_rc=0, panel_rc=0, select_rc=0, attach_rc=0, dm_rc=0,
+                kill_rc=0, arm_rc=0):
         self.pane_id = pane_id
         self.exit_code = exit_code
         self.race_death_status = race_death_status
         self.still_live = still_live
+        self.pre_existing_sessions = pre_existing_sessions
         self.session_rc = session_rc
         self.source_rc = source_rc
-        self.hook_rc = hook_rc
+        self.env_set_rc = env_set_rc
+        self.write_hook_rc = write_hook_rc
+        self.teardown_hook_rc = teardown_hook_rc
         self.panel_rc = panel_rc
+        self.select_rc = select_rc
         self.attach_rc = attach_rc
         self.dm_rc = dm_rc
+        self.kill_rc = kill_rc
+        self.arm_rc = arm_rc
         self.calls: list[list[str]] = []
         self.fid = None
         self.sourced_conf_text = None
@@ -270,9 +336,24 @@ class _FakeTmux:
             self.sourced_conf_text = Path(conf_path).read_text()
             return subprocess.CompletedProcess(cmd, self.source_rc, stdout="",
                                                stderr="" if self.source_rc == 0 else "bad config line")
+        if "remain-on-exit" in cmd:
+            # The direct "arm ahead of an already-running server" command — distinct
+            # from `source-file` (which carries `remain-on-exit` as text in a config
+            # file, never as a bare tmux argv command).
+            return subprocess.CompletedProcess(cmd, self.arm_rc, stdout="",
+                                               stderr="" if self.arm_rc == 0 else "cannot set")
+        if "set-environment" in cmd:
+            return subprocess.CompletedProcess(cmd, self.env_set_rc, stdout="",
+                                               stderr="" if self.env_set_rc == 0 else "bad session")
         if "set-hook" in cmd:
-            return subprocess.CompletedProcess(cmd, self.hook_rc, stdout="",
-                                               stderr="" if self.hook_rc == 0 else "bad hook target")
+            if "pane-died[1]" in cmd:
+                return subprocess.CompletedProcess(cmd, self.teardown_hook_rc, stdout="",
+                                                   stderr="" if self.teardown_hook_rc == 0 else "bad teardown target")
+            return subprocess.CompletedProcess(cmd, self.write_hook_rc, stdout="",
+                                               stderr="" if self.write_hook_rc == 0 else "bad hook target")
+        if "select-pane" in cmd:
+            return subprocess.CompletedProcess(cmd, self.select_rc, stdout="",
+                                               stderr="" if self.select_rc == 0 else "no such pane")
         if "split-window" in cmd:
             return subprocess.CompletedProcess(cmd, self.panel_rc, stdout="",
                                                stderr="" if self.panel_rc == 0 else "no space for a new pane")
@@ -281,13 +362,17 @@ class _FakeTmux:
             return subprocess.CompletedProcess(cmd, self.dm_rc, stdout=out, stderr="")
         if "kill-session" in cmd:
             self.kill_session_called = True
-            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            return subprocess.CompletedProcess(cmd, self.kill_rc, stdout="",
+                                               stderr="" if self.kill_rc == 0 else "no such session")
         if "attach" in cmd:
             if self.exit_code is not None and self.fid:
                 state.record_exit(self.fid, self.exit_code)
             return subprocess.CompletedProcess(cmd, self.attach_rc, stdout="", stderr="")
         if "list-sessions" in cmd:
-            live = {self.fid} if (self.still_live and self.fid) else set()
+            if self.fid is None:
+                live = set(self.pre_existing_sessions)
+            else:
+                live = {self.fid} if self.still_live else set()
             return subprocess.CompletedProcess(cmd, 0, stdout="\n".join(live), stderr="")
         raise AssertionError(f"unexpected tmux command in test: {cmd}")
 
@@ -304,7 +389,7 @@ def _launch(fake: _FakeTmux, *, cols=200, rows=50, version=(3, 7), harness="clau
 
 
 class Launch(PersonaIso, unittest.TestCase):
-    def test_the_pane_died_hook_targets_the_pane_tmux_actually_reported(self):
+    def test_the_write_hook_targets_the_pane_tmux_actually_reported(self):
         """The regression correction 3 names directly: the hook's target must be the id
         READ OFF tmux's stdout, never the literal `"%0"` that happens to be right only
         for the very first pane ever created on a fresh server. `_FakeTmux` reports
@@ -313,8 +398,9 @@ class Launch(PersonaIso, unittest.TestCase):
         fake = _FakeTmux(pane_id="%7", exit_code=0)
         rc = _launch(fake)
         self.assertEqual(rc, 0)
-        hook_cmd = next(c for c in fake.calls if "set-hook" in c)
-        self.assertEqual(hook_cmd[hook_cmd.index("-t") + 1], "%7")
+        write_hook_cmd = next(c for c in fake.calls
+                              if "set-hook" in c and "pane-died[1]" not in c)
+        self.assertEqual(write_hook_cmd[write_hook_cmd.index("-t") + 1], "%7")
 
     def test_the_config_is_loaded_with_source_file_not_only_dash_f(self):
         """Measured against tmux 3.7c (module docstring of commands_frame.py): `-f` on
@@ -328,17 +414,30 @@ class Launch(PersonaIso, unittest.TestCase):
                         "the real config was never loaded via `source-file`")
         self.assertIn("mouse", fake.sourced_conf_text)
 
-    def test_the_pane_died_hook_is_installed_as_its_own_command(self):
-        """Companion to the `source-file` test: the hook must not be missing from BOTH
-        places (baked into neither the sourced config nor issued separately)."""
+    def test_both_hooks_are_installed_as_their_own_commands(self):
+        """Companion to the `source-file` test: neither hook is missing from BOTH
+        places (baked into the sourced config nor issued separately)."""
         fake = _FakeTmux(exit_code=0)
         _launch(fake)
-        self.assertTrue(any("set-hook" in c and "pane-died" in " ".join(c)
-                           for c in fake.calls),
-                        "the pane-died hook was never installed")
-        # And NOT duplicated into the text file `source-file` loads (see `Conf`/
-        # `PaneDiedHook`'s own docstrings for why it moved out entirely).
+        write = [c for c in fake.calls if "set-hook" in c and "pane-died[1]" not in c]
+        teardown = [c for c in fake.calls if "pane-died[1]" in c]
+        self.assertEqual(len(write), 1, "the write hook was not installed exactly once")
+        self.assertEqual(len(teardown), 1, "the teardown hook was not installed exactly once")
+        # And NOT duplicated into the text file `source-file` loads.
         self.assertNotIn("pane-died", fake.sourced_conf_text or "")
+
+    def test_the_exit_status_path_is_carried_before_the_write_hook_is_installed(self):
+        """Ordering matters: the write hook's action reads `$CHARTER_FRAME_EXIT` back
+        from the session's own environment, so `set-environment` must land before the
+        hook that depends on it — otherwise the shell sees an unset variable the first
+        time the hook could possibly fire."""
+        fake = _FakeTmux(exit_code=0)
+        _launch(fake)
+        names = [c[3] if len(c) > 3 else "" for c in fake.calls]
+        env_idx = next(i for i, c in enumerate(fake.calls) if "set-environment" in c)
+        hook_idx = next(i for i, c in enumerate(fake.calls)
+                       if "set-hook" in c and "pane-died[1]" not in c)
+        self.assertLess(env_idx, hook_idx)
 
     def test_the_recorded_exit_code_wins_over_a_zero_from_attach(self):
         """The whole module's reason to exist: an attached `tmux attach` (like
@@ -349,17 +448,18 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertEqual(rc, 17)
 
     def test_a_death_that_races_the_hooks_own_install_is_recovered(self):
-        """Critical 1: `new-session` starts the harness immediately; the hook that would
-        record its exit code is not installed until a `set-hook` call some time later. A
-        harness that dies inside that window is never caught by the hook — nothing was
-        listening yet, and hooks do not fire retroactively.
+        """Critical 1: `new-session` starts the harness immediately; the hooks that
+        would record its exit code and end the session are not installed until a
+        `set-hook` call some time later. A harness that dies inside that window is
+        never caught by them — nothing was listening yet, and hooks do not fire
+        retroactively.
 
-        The check for this is EAGER — run immediately after `set-hook` returns, before
-        `attach` is ever called — not merely a fallback after `attach` returns. Verified
-        by hand against a real tmux 3.7c: with nothing left to run the hook's own
+        The check for this is EAGER — run immediately after both hooks are installed,
+        before `attach` is ever called — not merely a fallback after `attach` returns.
+        Verified by hand against a real tmux 3.7c: with nothing left to run
         `kill-session`, `remain-on-exit` legitimately keeps the session alive forever,
         so an `attach` reaching this state BLOCKS FOREVER rather than returning 0 early.
-        A correct launcher must therefore finish the hook's own job itself (record the
+        A correct launcher must therefore finish the hooks' own job itself (record the
         code, run `kill-session`) and skip `attach` entirely — this test fails if
         `attach` is ever reached in this scenario, not only if the wrong code comes
         back."""
@@ -382,12 +482,23 @@ class Launch(PersonaIso, unittest.TestCase):
                          "attach must never be reached against a session already known "
                          "to be over — reaching it here would hang against real tmux")
 
+    def test_a_failed_teardown_after_an_early_death_is_reported(self):
+        """`kill-session`, run directly after the eager check recovers an early death,
+        was the module's own last unchecked tmux return code — correction 2 applies to
+        it too."""
+        fake = _FakeTmux(race_death_status=9, kill_rc=1)
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake)
+        self.assertEqual(rc, 9)
+        self.assertTrue(any("ending the frame" in m for m in buf), buf)
+
     def test_remain_on_exit_is_armed_before_the_pane_id_is_even_known(self):
         """The other half of Critical 1: the placeholder loaded via `new-session`'s own
         `-f` — written and on disk BEFORE that command even runs — must already carry
         `remain-on-exit on`, because a harness that dies in the opening milliseconds
         (a missing binary is the sharpest case) needs its pane to survive before this
-        launcher has done anything else at all, config or hook alike."""
+        launcher has done anything else at all, config or hooks alike."""
         conf_snapshots = []
 
         def _peek(cmd, **kwargs):
@@ -408,12 +519,34 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertEqual(len(conf_snapshots), 1)
         self.assertIn("remain-on-exit on", conf_snapshots[0])
 
+    def test_remain_on_exit_is_armed_directly_when_a_server_is_already_running(self):
+        """The placeholder's `-f` is silently ignored once a server is already up
+        (measured; see the module docstring), regardless of who started it — an
+        operator's own `tmux -L charter new-session` included. Confirmed by hand:
+        without arming it directly in that case, a race-window death against such a
+        server returns the WRONG code (1, not its own) deterministically, rather than
+        hanging — still wrong, just a quieter failure than the hang."""
+        fake = _FakeTmux(exit_code=0, pre_existing_sessions=frozenset({"someone-elses"}))
+        rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        self.assertTrue(any("remain-on-exit" in c for c in fake.calls),
+                        "remain-on-exit was not armed directly ahead of a running server")
+
+    def test_remain_on_exit_is_not_armed_a_second_way_on_a_fresh_server(self):
+        """Companion: when nothing else is running, the placeholder `-f` is sufficient
+        (it IS what starts the server), so the direct arm command should not run —
+        pinning that the condition is actually checked, not that running it twice would
+        itself be wrong."""
+        fake = _FakeTmux(exit_code=0)  # pre_existing_sessions defaults to empty
+        _launch(fake)
+        self.assertFalse(any("remain-on-exit" in c for c in fake.calls))
+
     def test_a_still_live_session_after_attach_is_a_detach_not_a_silent_zero(self):
-        """Finding 6, and the spec's own words: "Detach is allowed and prints how to
-        reattach... returning silently to a shell with it still running is not." A
-        session `list-sessions` still reports after `attach` returns is this frame's
-        own — the harness is still running, so this must not read as success by
-        accident and must not stay silent about it."""
+        """The spec's own words: "Detach is allowed and prints how to reattach...
+        returning silently to a shell with it still running is not." A session
+        `list-sessions` still reports after `attach` returns is this frame's own — the
+        harness is still running, so this must not read as success by accident and must
+        not stay silent about it."""
         fake = _FakeTmux(still_live=True)
         buf = []
         with mock.patch("charter.util.info", side_effect=lambda m: buf.append(m)):
@@ -424,11 +557,47 @@ class Launch(PersonaIso, unittest.TestCase):
         # The frame's own directory must not be reaped while the session is still live.
         self.assertTrue(state.frame_dir(fake.fid).exists())
 
-    def test_a_failed_hook_install_is_reported_but_not_fatal(self):
+    def test_refuses_to_attach_when_the_teardown_hook_fails_to_install(self):
+        """Without the teardown hook, a crash ANY time later in the harness's life
+        would leave `attach` blocked forever with nothing to end the session — the same
+        hang the eager check exists to close, just moved later and made permanent for
+        this frame. Refusing to attach is the safe choice; the harness keeps running,
+        detached."""
+        fake = _FakeTmux(teardown_hook_rc=1, still_live=True)
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        self.assertTrue(any("refusing to attach" in m for m in buf),
+                        f"no refusal message: {buf}")
+        self.assertFalse(any("attach" in c for c in fake.calls),
+                         "attach must never be reached once teardown cannot be trusted")
+        self.assertTrue(state.frame_dir(fake.fid).exists())
+
+    def test_the_harness_pane_is_selected_after_the_splits(self):
+        """`split-window` makes the newly created pane the ACTIVE one by default, so
+        after every slot has been drawn, the LAST panel drawn — not the harness — has
+        focus, and an interactive harness never receives a keystroke without this
+        (measured by hand: `%2 active=1, %0 active=0` after two splits)."""
+        fake = _FakeTmux(exit_code=0)
+        _launch(fake)
+        select_cmd = next(c for c in fake.calls if "select-pane" in c)
+        self.assertEqual(select_cmd[select_cmd.index("-t") + 1], fake.pane_id)
+
+    def test_a_failed_pane_selection_is_reported_but_not_fatal(self):
+        fake = _FakeTmux(exit_code=0, select_rc=1)
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        self.assertTrue(any("focusing the harness pane" in m for m in buf), buf)
+        self.assertTrue(any("attach" in c for c in fake.calls))
+
+    def test_a_failed_write_hook_install_is_reported_but_not_fatal(self):
         """A harness pane already exists and is already running by the time the hook is
         installed — losing exit-code tracking for this one frame is a real degradation,
         but killing an already-live pane over it would be worse."""
-        fake = _FakeTmux(hook_rc=1, exit_code=5)
+        fake = _FakeTmux(write_hook_rc=1, exit_code=5)
         buf = []
         with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
             rc = _launch(fake)
@@ -528,16 +697,17 @@ class Launch(PersonaIso, unittest.TestCase):
              mock.patch("os.get_terminal_size", return_value=_os_terminal_size(200, 50)):
             rc = commands_frame.cmd_launch(args)
         self.assertNotEqual(rc, 0)
-        # `run` is reached once, for the pre-create `reap()` pass (see the reap-ordering
-        # test below) — but never for anything that needs a working state directory.
+        # `run` is reached at most for the pre-create `reap()`/arm pass (see the
+        # reap-ordering test below) — but never for anything that needs a working state
+        # directory.
         self.assertFalse(any("new-session" in c.args[0] for c in run.call_args_list))
 
     def test_reap_runs_before_this_frames_own_directory_is_created(self):
-        """Finding 12: `state.reap` compares live tmux sessions against directories
-        already on disk. Creating THIS frame's own directory first — before its tmux
-        session exists — would make it look exactly like an abandoned one, and the very
-        next `reap()` call would delete a directory this launch had not even started
-        using yet."""
+        """`state.reap` compares live tmux sessions against directories already on
+        disk. Creating THIS frame's own directory first — before its tmux session
+        exists — would make it look exactly like an abandoned one, and the very next
+        `reap()` call would delete a directory this launch had not even started using
+        yet."""
         order = []
         real_reap = state.reap
         real_frame_dir = state.frame_dir
@@ -565,8 +735,8 @@ class BypassRouting(unittest.TestCase):
     """`Bypass.test_a_pipe_gets_no_frame` pins `bypass()`'s OWN argv shape but never
     calls `cmd_launch` at all — it cannot catch a `cmd_launch` that stopped routing to
     `bypass()` in the first place (confirmed: deleting the routing check, or replacing
-    it with `if False:`, left the full 15-test suite green before this class existed).
-    These test the DECISION, not what `bypass()` does once reached."""
+    it with `if False:`, left the full suite green before this class existed). These
+    test the DECISION, not what `bypass()` does once reached."""
 
     def test_the_no_frame_flag_routes_to_bypass(self):
         args = SimpleNamespace(harness="claude", rest=[], no_frame=True)
@@ -633,7 +803,7 @@ class CollisionGuard(unittest.TestCase):
         self.assertIn("charter status", str(ctx.exception))
 
     def test_a_harness_named_frame_is_refused_too(self):
-        """Finding 11: the loop that registers every harness runs BEFORE `sub.add_parser
+        """The loop that registers every harness runs BEFORE `sub.add_parser
         ("frame", ...)` does, so a harness with `cli_name == "frame"` would pass a check
         against `sub.choices` alone (nothing is named `frame` there yet) and only
         collide once the escape hatch's own `add_parser` call runs a few lines later —
@@ -731,6 +901,22 @@ class FrameArgvSplit(unittest.TestCase):
                 rest, frame_rest = _split_frame_argv(list(argv))
                 self.assertEqual(rest, argv)
                 self.assertIsNone(frame_rest)
+
+
+class MainDeliversFrameRest(unittest.TestCase):
+    """The DELIVERY half of Critical 2. `FrameArgvSplit` above tests `_split_frame_argv`
+    in isolation, re-implementing in its own `_parse` helper the graft `cli.main` itself
+    performs (`args.rest = frame_rest`) — a test that only exercises the helper cannot
+    catch that graft line being deleted from `main`. Confirmed: deleting `args.rest =
+    frame_rest` from `main()` left the full suite green, while `charter claude -p hi`
+    silently ran with `rest=[]`, dropping `-p hi` entirely."""
+
+    def test_charter_claude_dash_p_hi_reaches_bypass_via_main(self):
+        from charter import cli
+        with mock.patch("charter.commands_frame.bypass", return_value=0) as byp:
+            rc = cli.main(["claude", "--no-frame", "-p", "hi"])
+        byp.assert_called_once_with(["claude", "-p", "hi"])
+        self.assertEqual(rc, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1,18 +1,29 @@
-"""Starting a harness inside a frame, and the three ways that must not go wrong.
+"""Starting a harness inside a frame, and the ways that must not go wrong.
 
 The exit code is asserted because it was measured wrong once: an attached
 `tmux new-session` returns 0 whatever its command exited with (pinned against 3.7c), so
-the launcher waits and reads a recorded status instead of exec'ing and hoping.
+the launcher waits and reads a recorded status instead of exec'ing and hoping. A second,
+narrower race survives even that fix — the hook that records the status is not installed
+until a moment after the harness starts running, so a harness that dies inside that
+window is never caught by it, and (verified by hand against a real tmux 3.7c) nothing is
+left to end the session either, so `attach` would block forever rather than merely return
+early. `Launch` below covers the EAGER `display-message` check `cmd_launch` runs right
+after installing the hook — before ever calling `attach` — that closes this.
 
 **Every fake tmux command here returns a `subprocess.CompletedProcess`, never a real
 tmux process** — the point of `charter/frame/tmuxctl.py` splitting the binary out of
 everything else is that this module gets to keep that promise while still exercising the
 FULL launch sequence: session creation, reading the captured pane id back off stdout,
-loading the pane-scoped config, drawing the panels, and attaching.
+loading the session-scoped config, installing the exit-code hook, drawing the panels,
+and attaching. The shell-quoting and multi-session-server properties `_pane_died_hook_argv`
+and `source-file` rely on were verified by hand against a real tmux 3.7c (see the
+fix-round section of the task report) — that verification cannot be a unit test without
+violating "never start a real tmux server in this suite".
 """
 
 from __future__ import annotations
 
+import shlex
 import subprocess
 import unittest
 from pathlib import Path
@@ -22,6 +33,11 @@ from unittest import mock
 from tests._isolation import PersonaIso
 from charter import commands_frame
 from charter.frame import state
+
+
+def _os_terminal_size(cols, rows):
+    import os as _os
+    return _os.terminal_size((cols, rows))
 
 
 class Bypass(unittest.TestCase):
@@ -35,32 +51,96 @@ class Bypass(unittest.TestCase):
 
 
 class Conf(unittest.TestCase):
-    def test_the_pane_died_hook_is_scoped_to_the_harness_pane(self):
-        """pane-died fires for ANY pane. Unscoped, a dead panel would be reported as the
-        agent's exit code."""
-        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=50000,
-                                        status_path="/tmp/f/exit", harness_pane="%3")
-        self.assertIn("%3", text)
-        self.assertIn("pane_dead_status", text)
+    """`conf_text` no longer carries the `pane-died` hook (see `PaneDiedHook` below) —
+    only the settings that are safe to bake into a text file `source-file` loads: no
+    untrusted path ever reaches this function."""
 
-    def test_remain_on_exit_is_set_or_the_status_never_exists(self):
-        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=50000,
-                                        status_path="/tmp/f/exit", harness_pane="%3")
-        self.assertIn("remain-on-exit on", text)
+    def test_status_mouse_and_history_limit_are_session_scoped(self):
+        """Finding 4: `source-file` applies this text to the ONE shared server every
+        frame runs on. `-g` (global) here would rewrite every OTHER live frame's mouse
+        and scrollback the moment this frame's config loads — session-scoped (`-t
+        <session>`, no `-g`) is what keeps frame N's settings from becoming frame
+        (N-1)'s."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=True, history_limit=999,
+                                        session="demo-42")
+        self.assertIn("set -t demo-42 status off", text)
+        self.assertIn("set -t demo-42 mouse on", text)
+        self.assertIn("set -t demo-42 history-limit 999", text)
+        self.assertNotIn("set -g mouse", text)
+        self.assertNotIn("set -g history-limit", text)
+        self.assertNotIn("set -g status", text)
+
+    def test_escape_time_and_remain_on_exit_stay_global(self):
+        """`escape-time` is a genuine SERVER option in tmux (verified by hand: it shows
+        under `show-options -s`, never `-g`/session scope), so there is no per-session
+        form to move it to. `remain-on-exit` is deliberately left global too — every
+        frame wants the identical value, so sharing it leaks nothing frame-specific."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
+                                        session="demo-42")
+        self.assertIn("set -g escape-time 0", text)
+        self.assertIn("set -g remain-on-exit on", text)
 
     def test_mouse_is_off_unless_asked_for(self):
         off = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
-                                       status_path="/x", harness_pane="%0")
-        self.assertIn("set -g mouse off", off)
+                                       session="x")
+        self.assertIn("mouse off", off)
         on = commands_frame.conf_text(hotkey="F2", mouse=True, history_limit=1,
-                                      status_path="/x", harness_pane="%0")
-        self.assertIn("set -g mouse on", on)
+                                      session="x")
+        self.assertIn("mouse on", on)
 
     def test_history_limit_is_raised_above_the_tmux_default(self):
         """tmux ships 2000 lines, which becomes the harness's entire scrollback."""
         text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=50000,
-                                        status_path="/x", harness_pane="%0")
+                                        session="x")
         self.assertIn("history-limit 50000", text)
+
+
+class PaneDiedHook(unittest.TestCase):
+    """`_pane_died_hook_argv` — issued as its OWN tmux command (clean argv), never text
+    baked into `conf_text`'s output. See the module docstring in `commands_frame.py` for
+    why: nesting a shell-quoted path inside a SECOND, text-file level of tmux quoting
+    (what `source-file`'s config syntax requires) breaks `shlex.quote`'s own escaping for
+    a path containing a literal single quote — verified by hand against tmux 3.7c."""
+
+    def test_the_hook_targets_the_harness_pane(self):
+        cmd = commands_frame._pane_died_hook_argv(socket="charter", harness_pane="%9",
+                                                   status_path="/tmp/f/exit")
+        self.assertEqual(cmd[cmd.index("-t") + 1], "%9")
+        self.assertIn("pane-died", cmd)
+
+    def test_it_is_a_clean_argv_list_naming_the_socket(self):
+        cmd = commands_frame._pane_died_hook_argv(socket="charter", harness_pane="%0",
+                                                   status_path="/x")
+        self.assertIsInstance(cmd, list)
+        for part in cmd:
+            self.assertIsInstance(part, str)
+        self.assertEqual(cmd[:3], ["tmux", "-L", "charter"])
+
+    def test_the_status_path_is_shell_quoted_against_a_space(self):
+        """Finding 5: `status_path` reaches `run-shell`, which hands it to `/bin/sh -c`.
+        A plane root (or `$CHARTER_HOME`) containing a space — ordinary on macOS — must
+        not silently truncate the write. `shlex.quote`'s exact output is asserted, not
+        merely "no error", because a test that only checks `set-hook` didn't crash would
+        pass even if the path were embedded completely unquoted."""
+        path = "/tmp/My Plane/exit"
+        cmd = commands_frame._pane_died_hook_argv(socket="charter", harness_pane="%0",
+                                                   status_path=path)
+        action = cmd[-1]
+        self.assertIn(shlex.quote(path), action)
+        # The raw, unquoted path must not appear on its own — only inside the quoted form.
+        self.assertNotIn(f"> {path}\"", action)
+
+    def test_a_dollar_paren_injection_attempt_is_neutralized(self):
+        """The sharper form of the same finding: a path shaped like a command
+        substitution must reach the shell as an inert literal, not run."""
+        path = "/tmp/inj $(touch pwned)/exit"
+        cmd = commands_frame._pane_died_hook_argv(socket="charter", harness_pane="%0",
+                                                   status_path=path)
+        action = cmd[-1]
+        self.assertIn(shlex.quote(path), action)
+        # Unquoted, "$(touch pwned)" would sit outside any quotes in the action string;
+        # quoted, it is wrapped in the shell-single-quoted form `shlex.quote` produces.
+        self.assertNotIn("> /tmp/inj $(touch pwned)/exit\"", action)
 
 
 class MissingTmux(unittest.TestCase):
@@ -85,6 +165,49 @@ class MissingTmux(unittest.TestCase):
         run.assert_not_called()
 
 
+class QueryPaneDeadStatus(unittest.TestCase):
+    """`_query_pane_dead_status` is the SAME function `cmd_launch` calls both eagerly
+    (immediately after installing the hook, to close the install race) and again as a
+    fallback after `attach` returns — pinned directly here, not only indirectly through
+    `Launch`'s race-recovery test, since either call site reuses this one function."""
+
+    def _dm(self, stdout, rc=0):
+        return mock.patch(
+            "charter.commands_frame.subprocess.run",
+            return_value=subprocess.CompletedProcess([], rc, stdout=stdout, stderr=""))
+
+    def test_a_dead_pane_returns_its_status(self):
+        with self._dm("1:42"):
+            self.assertEqual(commands_frame._query_pane_dead_status("charter", "%0"), 42)
+
+    def test_a_live_pane_returns_none(self):
+        with self._dm("0:"):
+            self.assertIsNone(commands_frame._query_pane_dead_status("charter", "%0"))
+
+    def test_a_failed_query_returns_none_not_zero(self):
+        """A query that fails outright (pane already gone, tmux error) must never be
+        read as "alive" OR as a fabricated "exit 0" — `None` is "cannot tell", not
+        either kind of answer. `stdout` here is deliberately made to LOOK like a dead
+        pane (`"1:99"`) alongside the nonzero return code: a test that failed the query
+        with empty stdout would pass even if the returncode check were deleted, since
+        empty stdout also fails the separate `dead != "1"` parse — this is what actually
+        pins the returncode check as its own, distinct guard."""
+        with self._dm("1:99", rc=1):
+            self.assertIsNone(commands_frame._query_pane_dead_status("charter", "%0"))
+
+    def test_unparseable_status_text_returns_none_rather_than_raising(self):
+        """`#{pane_dead_status}` is tmux's own format variable, not operator input, but
+        this function must not assume its shape: a malformed or unexpected value must
+        degrade to "cannot tell", never raise `ValueError` out of `int(status)`."""
+        with self._dm("1:not-a-number"):
+            self.assertIsNone(commands_frame._query_pane_dead_status("charter", "%0"))
+
+    def test_a_negative_status_is_parsed(self):
+        """tmux reports a negative `pane_dead_status` for a process killed by a signal."""
+        with self._dm("1:-15"):
+            self.assertEqual(commands_frame._query_pane_dead_status("charter", "%0"), -15)
+
+
 class _FakeTmux:
     """Every tmux invocation `cmd_launch` makes, keyed by which subcommand it carries.
 
@@ -94,28 +217,51 @@ class _FakeTmux:
     tmux does, so a test can assert what the launcher does with THAT VALUE rather than
     with a hardcoded stand-in like `"%0"` (the exact bug correction 3 exists to catch).
 
-    `exit_code`, if given, is written via `state.record_exit` at the moment the fake
-    `attach` command runs — mimicking the real timing: `attach` blocks until the
-    session ends, and by the time it returns, the `pane-died` hook (fired on the real
-    server while attach was blocked) has already recorded the code.
+    Three ways an exit code can reach `cmd_launch`, each selected by which constructor
+    argument is set (at most one at a time in any single test):
+
+    - `exit_code`: the ORDINARY path. Written via `state.record_exit` at the moment the
+      fake `attach` command runs — mimicking real timing, where `attach` blocks until the
+      session ends and by the time it returns, the hook (fired on the real server while
+      attach was blocked) has already recorded the code.
+    - `race_death_status`: the RACE `cmd_launch`'s eager `display-message` check exists
+      to close. Nothing is written via `state.record_exit` up front (the hook never got
+      the chance to fire), but a fake `display-message` query answers `1:<status>` —
+      what tmux would actually report for a pane that died before any hook existed but
+      is still there to ask, thanks to `remain-on-exit`. `cmd_launch` asks this BEFORE
+      ever calling `attach` (verified by hand against a real tmux 3.7c that a `attach`
+      against exactly this state blocks forever otherwise, `remain-on-exit` legitimately
+      keeping the session alive with nothing left to end it), so a correct launcher
+      never reaches the fake `attach` handler at all in this scenario.
+    - `still_live` (with both of the above left `None`): the session is still running
+      when `attach` returns (an operator detach, not a finish) — `list-sessions` reports
+      the frame's own session id as still live.
     """
 
-    def __init__(self, *, pane_id="%7", exit_code=None,
-                session_rc=0, source_rc=0, panel_rc=0, attach_rc=0):
+    def __init__(self, *, pane_id="%7", exit_code=None, race_death_status=None,
+                still_live=False, session_rc=0, source_rc=0, hook_rc=0, panel_rc=0,
+                attach_rc=0, dm_rc=0):
         self.pane_id = pane_id
         self.exit_code = exit_code
+        self.race_death_status = race_death_status
+        self.still_live = still_live
         self.session_rc = session_rc
         self.source_rc = source_rc
+        self.hook_rc = hook_rc
         self.panel_rc = panel_rc
         self.attach_rc = attach_rc
+        self.dm_rc = dm_rc
         self.calls: list[list[str]] = []
         self.fid = None
         self.sourced_conf_text = None
+        self.new_session_env = None
+        self.kill_session_called = False
 
     def __call__(self, cmd, **kwargs):
         self.calls.append(list(cmd))
         if "new-session" in cmd:
             self.fid = cmd[cmd.index("-s") + 1]
+            self.new_session_env = kwargs.get("env")
             return subprocess.CompletedProcess(cmd, self.session_rc,
                                                stdout=(self.pane_id + "\n") if self.session_rc == 0 else "",
                                                stderr="" if self.session_rc == 0 else "no space for a new pane")
@@ -124,57 +270,75 @@ class _FakeTmux:
             self.sourced_conf_text = Path(conf_path).read_text()
             return subprocess.CompletedProcess(cmd, self.source_rc, stdout="",
                                                stderr="" if self.source_rc == 0 else "bad config line")
+        if "set-hook" in cmd:
+            return subprocess.CompletedProcess(cmd, self.hook_rc, stdout="",
+                                               stderr="" if self.hook_rc == 0 else "bad hook target")
         if "split-window" in cmd:
             return subprocess.CompletedProcess(cmd, self.panel_rc, stdout="",
                                                stderr="" if self.panel_rc == 0 else "no space for a new pane")
+        if "display-message" in cmd:
+            out = f"1:{self.race_death_status}" if self.race_death_status is not None else "0:"
+            return subprocess.CompletedProcess(cmd, self.dm_rc, stdout=out, stderr="")
+        if "kill-session" in cmd:
+            self.kill_session_called = True
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
         if "attach" in cmd:
             if self.exit_code is not None and self.fid:
                 state.record_exit(self.fid, self.exit_code)
             return subprocess.CompletedProcess(cmd, self.attach_rc, stdout="", stderr="")
         if "list-sessions" in cmd:
-            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            live = {self.fid} if (self.still_live and self.fid) else set()
+            return subprocess.CompletedProcess(cmd, 0, stdout="\n".join(live), stderr="")
         raise AssertionError(f"unexpected tmux command in test: {cmd}")
 
 
-def _launch(fake: _FakeTmux, *, cols=200, rows=50, version=(3, 7), harness="claude"):
-    args = SimpleNamespace(harness=harness, rest=[], no_frame=False)
+def _launch(fake: _FakeTmux, *, cols=200, rows=50, version=(3, 7), harness="claude",
+           rest=()):
+    args = SimpleNamespace(harness=harness, rest=list(rest), no_frame=False)
     with mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
          mock.patch("sys.stdout.isatty", return_value=True), \
          mock.patch("charter.frame.tmuxctl.version", return_value=version), \
          mock.patch("charter.workspace.resolve", return_value="demo"), \
-         mock.patch("os.get_terminal_size", return_value=os_terminal_size(cols, rows)):
+         mock.patch("os.get_terminal_size", return_value=_os_terminal_size(cols, rows)):
         return commands_frame.cmd_launch(args)
 
 
-def os_terminal_size(cols, rows):
-    import os as _os
-    return _os.terminal_size((cols, rows))
-
-
 class Launch(PersonaIso, unittest.TestCase):
-    def test_the_pane_scoped_hook_uses_the_pane_tmux_actually_reported(self):
-        """The regression correction 3 names directly: `conf_text`'s `harness_pane` must
-        be the id READ OFF tmux's stdout, never the literal `"%0"` that happens to be
-        right only for the very first pane ever created on a fresh server. `_FakeTmux`
-        reports `%7` — a value `"%0"` could never produce by accident — so this fails if
-        the launcher ever falls back to a hardcoded pane id."""
+    def test_the_pane_died_hook_targets_the_pane_tmux_actually_reported(self):
+        """The regression correction 3 names directly: the hook's target must be the id
+        READ OFF tmux's stdout, never the literal `"%0"` that happens to be right only
+        for the very first pane ever created on a fresh server. `_FakeTmux` reports
+        `%7` — a value `"%0"` could never produce by accident — so this fails if the
+        launcher ever falls back to a hardcoded pane id."""
         fake = _FakeTmux(pane_id="%7", exit_code=0)
         rc = _launch(fake)
         self.assertEqual(rc, 0)
-        self.assertIsNotNone(fake.sourced_conf_text)
-        self.assertIn("%7", fake.sourced_conf_text)
-        self.assertNotIn("%0", fake.sourced_conf_text)
+        hook_cmd = next(c for c in fake.calls if "set-hook" in c)
+        self.assertEqual(hook_cmd[hook_cmd.index("-t") + 1], "%7")
 
     def test_the_config_is_loaded_with_source_file_not_only_dash_f(self):
         """Measured against tmux 3.7c (module docstring of commands_frame.py): `-f` on
         `new-session` is read only when that call starts a brand-new server, so a SECOND
-        frame sharing `SOCKET` would never get its own pane-scoped hook installed if the
-        launcher relied on `-f` alone. `source-file`, run after the pane id is known,
-        applies live regardless of whether the server was already running."""
+        frame sharing `SOCKET` would never get its own settings applied if the launcher
+        relied on `-f` alone. `source-file`, run after the pane id is known, applies
+        live regardless of whether the server was already running."""
         fake = _FakeTmux(exit_code=0)
         _launch(fake)
         self.assertTrue(any("source-file" in c for c in fake.calls),
                         "the real config was never loaded via `source-file`")
+        self.assertIn("mouse", fake.sourced_conf_text)
+
+    def test_the_pane_died_hook_is_installed_as_its_own_command(self):
+        """Companion to the `source-file` test: the hook must not be missing from BOTH
+        places (baked into neither the sourced config nor issued separately)."""
+        fake = _FakeTmux(exit_code=0)
+        _launch(fake)
+        self.assertTrue(any("set-hook" in c and "pane-died" in " ".join(c)
+                           for c in fake.calls),
+                        "the pane-died hook was never installed")
+        # And NOT duplicated into the text file `source-file` loads (see `Conf`/
+        # `PaneDiedHook`'s own docstrings for why it moved out entirely).
+        self.assertNotIn("pane-died", fake.sourced_conf_text or "")
 
     def test_the_recorded_exit_code_wins_over_a_zero_from_attach(self):
         """The whole module's reason to exist: an attached `tmux attach` (like
@@ -183,6 +347,95 @@ class Launch(PersonaIso, unittest.TestCase):
         fake = _FakeTmux(exit_code=17, attach_rc=0)
         rc = _launch(fake)
         self.assertEqual(rc, 17)
+
+    def test_a_death_that_races_the_hooks_own_install_is_recovered(self):
+        """Critical 1: `new-session` starts the harness immediately; the hook that would
+        record its exit code is not installed until a `set-hook` call some time later. A
+        harness that dies inside that window is never caught by the hook — nothing was
+        listening yet, and hooks do not fire retroactively.
+
+        The check for this is EAGER — run immediately after `set-hook` returns, before
+        `attach` is ever called — not merely a fallback after `attach` returns. Verified
+        by hand against a real tmux 3.7c: with nothing left to run the hook's own
+        `kill-session`, `remain-on-exit` legitimately keeps the session alive forever,
+        so an `attach` reaching this state BLOCKS FOREVER rather than returning 0 early.
+        A correct launcher must therefore finish the hook's own job itself (record the
+        code, run `kill-session`) and skip `attach` entirely — this test fails if
+        `attach` is ever reached in this scenario, not only if the wrong code comes
+        back."""
+        fake = _FakeTmux(race_death_status=42)
+        # `state.record_exit` is asserted on directly, mid-call, rather than by reading
+        # `state.exit_code` back after `_launch` returns: `reap()` legitimately deletes
+        # a frame's directory once its session is truly gone (which it is here, once
+        # `kill-session` runs), and this test's own `_FakeTmux` reports nothing live —
+        # so a post-hoc read would see the sentinel `None` regardless of whether the
+        # code was ever written, for a reason that has nothing to do with this test.
+        with mock.patch("charter.frame.state.record_exit",
+                        side_effect=state.record_exit) as rec:
+            rc = _launch(fake)
+        self.assertEqual(rc, 42)
+        rec.assert_called_once_with(fake.fid, 42)
+        self.assertTrue(any("display-message" in c for c in fake.calls))
+        self.assertTrue(fake.kill_session_called,
+                        "nothing else was ever going to end this session")
+        self.assertFalse(any("attach" in c for c in fake.calls),
+                         "attach must never be reached against a session already known "
+                         "to be over — reaching it here would hang against real tmux")
+
+    def test_remain_on_exit_is_armed_before_the_pane_id_is_even_known(self):
+        """The other half of Critical 1: the placeholder loaded via `new-session`'s own
+        `-f` — written and on disk BEFORE that command even runs — must already carry
+        `remain-on-exit on`, because a harness that dies in the opening milliseconds
+        (a missing binary is the sharpest case) needs its pane to survive before this
+        launcher has done anything else at all, config or hook alike."""
+        conf_snapshots = []
+
+        def _peek(cmd, **kwargs):
+            if "new-session" in cmd:
+                conf_path = Path(cmd[cmd.index("-f") + 1])
+                conf_snapshots.append(conf_path.read_text())
+            return fake_call(cmd, **kwargs)
+
+        fake = _FakeTmux(exit_code=0)
+        fake_call = fake.__call__
+        args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=_peek), \
+             mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch("charter.workspace.resolve", return_value="demo"), \
+             mock.patch("os.get_terminal_size", return_value=_os_terminal_size(200, 50)):
+            commands_frame.cmd_launch(args)
+        self.assertEqual(len(conf_snapshots), 1)
+        self.assertIn("remain-on-exit on", conf_snapshots[0])
+
+    def test_a_still_live_session_after_attach_is_a_detach_not_a_silent_zero(self):
+        """Finding 6, and the spec's own words: "Detach is allowed and prints how to
+        reattach... returning silently to a shell with it still running is not." A
+        session `list-sessions` still reports after `attach` returns is this frame's
+        own — the harness is still running, so this must not read as success by
+        accident and must not stay silent about it."""
+        fake = _FakeTmux(still_live=True)
+        buf = []
+        with mock.patch("charter.util.info", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        self.assertTrue(any("detach" in m.lower() and fake.fid in m for m in buf),
+                        f"no reattach message was printed: {buf}")
+        # The frame's own directory must not be reaped while the session is still live.
+        self.assertTrue(state.frame_dir(fake.fid).exists())
+
+    def test_a_failed_hook_install_is_reported_but_not_fatal(self):
+        """A harness pane already exists and is already running by the time the hook is
+        installed — losing exit-code tracking for this one frame is a real degradation,
+        but killing an already-live pane over it would be worse."""
+        fake = _FakeTmux(hook_rc=1, exit_code=5)
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake)
+        self.assertEqual(rc, 5)
+        self.assertTrue(any("bad hook target" in m for m in buf),
+                        f"the hook-install failure's tmux stderr was never surfaced: {buf}")
+        self.assertTrue(any("attach" in c for c in fake.calls))
 
     def test_a_failed_session_start_is_fatal_and_reported(self):
         """No harness pane exists — nothing to attach to, so this must not proceed to
@@ -248,15 +501,98 @@ class Launch(PersonaIso, unittest.TestCase):
         typed one (`charter frame -- claude -p hi`); it is the token that told argparse
         to stop parsing, not part of what should run."""
         fake = _FakeTmux(exit_code=0)
-        args = SimpleNamespace(harness="", rest=["--", "echo", "hi"], no_frame=False)
-        with mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
+        rc = _launch(fake, harness="", rest=["--", "echo", "hi"])
+        self.assertEqual(rc, 0)
+        session_cmd = next(c for c in fake.calls if "new-session" in c)
+        self.assertEqual(session_cmd[session_cmd.index("--") + 1:], ["echo", "hi"])
+
+    def test_charter_session_id_reaches_the_harness_environment(self):
+        """Task 8's `notify.plane_changed` reads `$CHARTER_SESSION_ID` back out of the
+        running harness's own environment — this is the one place it is ever set."""
+        fake = _FakeTmux(exit_code=0)
+        rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        self.assertIsNotNone(fake.new_session_env)
+        self.assertEqual(fake.new_session_env.get("CHARTER_SESSION_ID"), fake.fid)
+
+    def test_a_frame_dir_the_state_module_refuses_does_not_crash(self):
+        """`frame_dir` returns `None` rather than a `Path` for an id it cannot shape
+        into a directory (see charter/frame/state.py) — this launcher must treat that as
+        data, not assume it always gets a `Path` back."""
+        args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
+        with mock.patch("charter.commands_frame.subprocess.run") as run, \
              mock.patch("sys.stdout.isatty", return_value=True), \
              mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
              mock.patch("charter.workspace.resolve", return_value="demo"), \
-             mock.patch("os.get_terminal_size", return_value=os_terminal_size(200, 50)):
-            commands_frame.cmd_launch(args)
-        session_cmd = next(c for c in fake.calls if "new-session" in c)
-        self.assertEqual(session_cmd[session_cmd.index("--") + 1:], ["echo", "hi"])
+             mock.patch("charter.frame.state.frame_dir", return_value=None), \
+             mock.patch("os.get_terminal_size", return_value=_os_terminal_size(200, 50)):
+            rc = commands_frame.cmd_launch(args)
+        self.assertNotEqual(rc, 0)
+        # `run` is reached once, for the pre-create `reap()` pass (see the reap-ordering
+        # test below) — but never for anything that needs a working state directory.
+        self.assertFalse(any("new-session" in c.args[0] for c in run.call_args_list))
+
+    def test_reap_runs_before_this_frames_own_directory_is_created(self):
+        """Finding 12: `state.reap` compares live tmux sessions against directories
+        already on disk. Creating THIS frame's own directory first — before its tmux
+        session exists — would make it look exactly like an abandoned one, and the very
+        next `reap()` call would delete a directory this launch had not even started
+        using yet."""
+        order = []
+        real_reap = state.reap
+        real_frame_dir = state.frame_dir
+
+        def _track_reap(live):
+            order.append("reap")
+            return real_reap(live)
+
+        def _track_frame_dir(fid, **kw):
+            if kw.get("create"):
+                order.append("frame_dir_create")
+            return real_frame_dir(fid, **kw)
+
+        fake = _FakeTmux(exit_code=0)
+        with mock.patch("charter.frame.state.reap", side_effect=_track_reap), \
+             mock.patch("charter.frame.state.frame_dir", side_effect=_track_frame_dir):
+            _launch(fake)
+        self.assertIn("reap", order)
+        self.assertIn("frame_dir_create", order)
+        self.assertLess(order.index("reap"), order.index("frame_dir_create"),
+                        f"reap must run before this frame's own directory is created: {order}")
+
+
+class BypassRouting(unittest.TestCase):
+    """`Bypass.test_a_pipe_gets_no_frame` pins `bypass()`'s OWN argv shape but never
+    calls `cmd_launch` at all — it cannot catch a `cmd_launch` that stopped routing to
+    `bypass()` in the first place (confirmed: deleting the routing check, or replacing
+    it with `if False:`, left the full 15-test suite green before this class existed).
+    These test the DECISION, not what `bypass()` does once reached."""
+
+    def test_the_no_frame_flag_routes_to_bypass(self):
+        args = SimpleNamespace(harness="claude", rest=[], no_frame=True)
+        with mock.patch("charter.commands_frame.bypass", return_value=0) as byp, \
+             mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("charter.commands_frame.subprocess.run") as run:
+            rc = commands_frame.cmd_launch(args)
+        byp.assert_called_once_with(["claude"])
+        run.assert_not_called()
+        self.assertEqual(rc, 0)
+
+    def test_a_non_tty_stdout_routes_to_bypass_even_without_the_flag(self):
+        args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
+        with mock.patch("charter.commands_frame.bypass", return_value=0) as byp, \
+             mock.patch("sys.stdout.isatty", return_value=False), \
+             mock.patch("charter.commands_frame.subprocess.run") as run:
+            rc = commands_frame.cmd_launch(args)
+        byp.assert_called_once_with(["claude"])
+        run.assert_not_called()
+        self.assertEqual(rc, 0)
+
+    def test_a_tty_without_no_frame_does_not_bypass(self):
+        fake = _FakeTmux(exit_code=0)
+        with mock.patch("charter.commands_frame.bypass") as byp:
+            _launch(fake)
+        byp.assert_not_called()
 
 
 class CollisionGuard(unittest.TestCase):
@@ -295,6 +631,106 @@ class CollisionGuard(unittest.TestCase):
                 cli.build_parser()
         self.assertIn("clashing-harness", str(ctx.exception))
         self.assertIn("charter status", str(ctx.exception))
+
+    def test_a_harness_named_frame_is_refused_too(self):
+        """Finding 11: the loop that registers every harness runs BEFORE `sub.add_parser
+        ("frame", ...)` does, so a harness with `cli_name == "frame"` would pass a check
+        against `sub.choices` alone (nothing is named `frame` there yet) and only
+        collide once the escape hatch's own `add_parser` call runs a few lines later —
+        where, on the 3.11 floor (`argparse` does not raise for a re-added name there —
+        see `_split_frame_argv`'s docstring for the same version gap elsewhere), it
+        would silently shadow the harness instead of the other way around."""
+        from charter import cli
+        from charter.harness.base import Harness
+
+        class _FrameHarness(Harness):
+            name = "frame-harness"
+            cli_name = "frame"
+            binary = "frame-harness"
+
+        with mock.patch.dict("charter.harness.registry.KINDS",
+                             {"frame-harness": _FrameHarness}, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                cli.build_parser()
+        self.assertIn("frame-harness", str(ctx.exception))
+
+
+class FrameArgvSplit(unittest.TestCase):
+    """Critical 2: `charter claude -p hi` — the documented, spec-named invocation — was
+    refused outright by `argparse` before this fix (`nargs=argparse.REMAINDER` cannot
+    hold a positional whose first token looks like an option `argparse` itself does not
+    recognize; confirmed identical on 3.9, 3.12, 3.14). `_split_frame_argv` peels the
+    harness's own argv off before `argparse` ever parses it, the same shape
+    `_split_exec_command` already uses for `secret exec`."""
+
+    def _parse(self, argv):
+        from charter.cli import _split_exec_command, _split_frame_argv, build_parser
+        rest, tail = _split_exec_command(list(argv))
+        rest2, frame_rest = _split_frame_argv(rest)
+        ns = build_parser().parse_args(rest2)
+        if tail is not None:
+            ns.command = tail
+        if frame_rest is not None:
+            ns.rest = frame_rest
+        return ns
+
+    def test_a_leading_short_flag_reaches_the_harness(self):
+        """The exact case the coordinator reported: `charter claude -p hi`."""
+        ns = self._parse(["claude", "-p", "hi"])
+        self.assertEqual(ns.rest, ["-p", "hi"])
+        self.assertFalse(ns.no_frame)
+
+    def test_a_leading_long_flag_reaches_the_harness(self):
+        ns = self._parse(["claude", "--continue"])
+        self.assertEqual(ns.rest, ["--continue"])
+
+    def test_a_bare_no_frame_is_still_recognized(self):
+        ns = self._parse(["claude", "--no-frame"])
+        self.assertTrue(ns.no_frame)
+        self.assertEqual(ns.rest, [])
+
+    def test_no_frame_followed_by_harness_flags(self):
+        ns = self._parse(["claude", "--no-frame", "-p", "hi"])
+        self.assertTrue(ns.no_frame)
+        self.assertEqual(ns.rest, ["-p", "hi"])
+
+    def test_an_explicit_double_dash_still_works(self):
+        ns = self._parse(["claude", "--", "-p", "hi"])
+        self.assertEqual(ns.rest, ["--", "-p", "hi"])
+
+    def test_the_frame_escape_hatch_is_covered_too(self):
+        ns = self._parse(["frame", "--", "some-cmd", "--flag"])
+        self.assertEqual(ns.rest, ["--", "some-cmd", "--flag"])
+
+    def test_bare_help_still_shows_charters_own_help_not_a_crash(self):
+        """The regression a first draft of this fix introduced: treating `--help` as
+        just more harness argv left `charter claude --help` reaching the BYPASS path
+        with `rest=["--help"]`, which `os.execvp("--help", ...)` turned into an actual
+        `FileNotFoundError` — a crash, not merely a UX change. `-h`/`--help` are kept in
+        the same fixed-leading-position allowlist as `--no-frame` for exactly this
+        reason: `argparse` intercepts them itself and exits cleanly."""
+        from charter.cli import _split_frame_argv
+        rest, frame_rest = _split_frame_argv(["claude", "--help"])
+        self.assertEqual(rest, ["claude", "--help"])
+        self.assertEqual(frame_rest, [])
+        with self.assertRaises(SystemExit) as ctx:
+            self._parse(["claude", "--help"])
+        self.assertEqual(ctx.exception.code, 0)
+
+    def test_a_later_help_still_reaches_the_harness(self):
+        """`--help` loses its special status once it is not the immediate next token —
+        `charter claude --continue --help` means "run claude, tell IT to show its own
+        help", not charter's."""
+        ns = self._parse(["claude", "--continue", "--help"])
+        self.assertEqual(ns.rest, ["--continue", "--help"])
+
+    def test_unrelated_subcommands_are_untouched(self):
+        from charter.cli import _split_frame_argv
+        for argv in (["workspace", "list"], ["persona", "list"], ["status"]):
+            with self.subTest(argv=argv):
+                rest, frame_rest = _split_frame_argv(list(argv))
+                self.assertEqual(rest, argv)
+                self.assertIsNone(frame_rest)
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -107,7 +107,8 @@ class Conf(unittest.TestCase):
         (a different literal token) is what `cli.py` actually registers."""
         text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
                                         session="x")
-        self.assertIn("bind -n F2 run-shell 'charter frame-menu'", text)
+        self.assertIn('bind -n F2 run-shell \'charter frame-menu "#{client_name}"\'',
+                      text)
         self.assertNotIn("frame menu", text)
 
     def test_the_hotkey_bind_is_global_not_session_scoped(self):
@@ -1314,91 +1315,81 @@ class MainDeliversFrameRest(unittest.TestCase):
         self.assertEqual(rc, 0)
 
     def test_charter_frame_menu_reaches_cmd_menu_via_main(self):
+        """`client` (`#{client_name}`, expanded by tmux inside the bind's own text —
+        see `conf_text`'s docstring) is a required positional now, not queried after
+        the fact."""
         from charter import cli
         with mock.patch("charter.commands_frame.cmd_menu", return_value=0) as cm:
-            rc = cli.main(["frame-menu"])
+            rc = cli.main(["frame-menu", "/dev/ttys7"])
         cm.assert_called_once()
+        self.assertEqual(cm.call_args[0][0].client, "/dev/ttys7")
         self.assertEqual(rc, 0)
-
-
-def _fake_list_clients(*names: str):
-    """A `subprocess.run` `side_effect` distinguishing `list-clients` (answers *names*,
-    one per line, tmux's own `-F` output shape) from any other command (answers an empty,
-    successful `CompletedProcess`) — `cmd_menu` issues two DIFFERENT tmux commands now
-    (`_menu_clients`'s query, then `display-menu` itself), so a single flat mock return
-    value can no longer stand in for both."""
-    def _run(cmd, **kwargs):
-        if "list-clients" in cmd:
-            return SimpleNamespace(returncode=0, stdout="\n".join(names))
-        return SimpleNamespace(returncode=0)
-    return _run
 
 
 class MenuCommands(PersonaIso, unittest.TestCase):
     """`cmd_menu`/`cmd_action` — the handlers `charter frame-menu`/`charter frame-action`
-    dispatch to. Both resolve the frame purely from `$CHARTER_SESSION_ID`; neither ever
-    takes a frame id as an argument (see `menu.py`'s own docstring for why the id stays
-    out of the bind's own text)."""
+    dispatch to. `cmd_menu`'s `args.client` is `#{client_name}`, expanded by tmux INSIDE
+    the bind's own text before this process ever starts (see `conf_text`'s docstring) —
+    never queried here, so these tests supply it directly rather than mocking a
+    `list-clients` call that no longer exists. `fid` is still resolved purely from
+    `$CHARTER_SESSION_ID`; neither function ever takes a frame id as an argument (see
+    `menu.py`'s own docstring for why the id stays out of the bind's own text)."""
 
     def test_cmd_menu_opens_the_current_frames_own_menu_on_its_own_client(self):
         """`-c` — not merely `-t` — is what the fix for IMPORTANT-1 added: `-t fid`
         alone does not choose WHICH terminal sees the menu (verified by hand: it
-        rendered frame B's menu on frame A's screen). `cmd_menu` must ask `list-clients`
-        first and pass whatever it learns straight through to `-c`."""
+        rendered frame B's menu on frame A's screen). `cmd_menu` must pass
+        `args.client` straight through to `-c`, unmodified."""
         menu.record(fid="f-menu", entries=[("Detach", ["true"])])
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-menu"}), \
-             mock.patch("charter.commands_frame.subprocess.run",
-                        side_effect=_fake_list_clients("/dev/ttys7")) as run:
-            rc = commands_frame.cmd_menu(SimpleNamespace())
+             mock.patch("charter.commands_frame.subprocess.run") as run:
+            run.return_value = SimpleNamespace(returncode=0)
+            rc = commands_frame.cmd_menu(SimpleNamespace(client="/dev/ttys7"))
         self.assertEqual(rc, 0)
-        calls = [c.args[0] for c in run.call_args_list]
-        list_clients_cmd = next(c for c in calls if "list-clients" in c)
-        self.assertEqual(list_clients_cmd,
-                         ["tmux", "-L", "charter", "list-clients", "-t", "f-menu",
-                          "-F", "#{client_name}"])
-        menu_cmd = next(c for c in calls if "display-menu" in c)
+        run.assert_called_once()
+        menu_cmd = run.call_args[0][0]
         self.assertEqual(menu_cmd[:9],
                          ["tmux", "-L", "charter", "display-menu", "-t", "f-menu",
                           "-c", "/dev/ttys7", "-T"])
 
-    def test_cmd_menu_with_zero_clients_is_a_quiet_no_op(self):
-        """Nothing attached to this session right now (a keypress landing mid-detach,
-        say) — `display-menu` would just fail with tmux's own "no current client", and
-        there is no screen left to report that failure on anyway. `cmd_menu` must not
-        even attempt it."""
+    def test_cmd_menu_with_an_empty_client_is_a_quiet_no_op(self):
+        """`#{client_name}` failing to expand (or `charter frame-menu` invoked some
+        other way with nothing supplied) leaves no screen to draw on and none to
+        report that on either — `display-menu` must never even be attempted."""
         menu.record(fid="f-menu", entries=[("Detach", ["true"])])
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-menu"}), \
-             mock.patch("charter.commands_frame.subprocess.run",
-                        side_effect=_fake_list_clients()) as run:
-            rc = commands_frame.cmd_menu(SimpleNamespace())
+             mock.patch("charter.commands_frame.subprocess.run") as run:
+            rc = commands_frame.cmd_menu(SimpleNamespace(client=""))
         self.assertEqual(rc, 0)
-        self.assertFalse(any("display-menu" in c.args[0] for c in run.call_args_list),
-                         "display-menu must never be attempted with no client to draw on")
+        run.assert_not_called()
 
-    def test_cmd_menu_with_several_clients_picks_the_first_reported(self):
-        """The same session open in two terminals at once — `display-menu -c` only ever
-        accepts one, and there is no way to show a menu on two screens simultaneously;
-        picking the first `list-clients` reports is at least a client actually watching
-        THIS session, which a bare `-t fid` never guaranteed (see the test above)."""
-        menu.record(fid="f-menu", entries=[("Detach", ["true"])])
-        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-menu"}), \
-             mock.patch("charter.commands_frame.subprocess.run",
-                        side_effect=_fake_list_clients("/dev/ttys1", "/dev/ttys2")) as run:
-            rc = commands_frame.cmd_menu(SimpleNamespace())
-        self.assertEqual(rc, 0)
-        menu_cmd = next(c.args[0] for c in run.call_args_list if "display-menu" in c.args[0])
-        self.assertEqual(menu_cmd[menu_cmd.index("-c") + 1], "/dev/ttys1")
-
-    def test_cmd_menu_with_no_session_id_finds_no_clients_and_does_nothing(self):
-        """No `$CHARTER_SESSION_ID` at all (the frame died between the bind firing and
-        this process starting, say) must not raise — `list-clients -t ""` reports no
-        clients, and `cmd_menu` treats that the same as any other zero-clients case."""
+    def test_cmd_menu_with_no_session_id_is_a_quiet_no_op_not_a_failed_display_menu(self):
+        """Real tmux 3.7c: `list-clients -t ""` (the query an EARLIER version of this
+        module made) does NOT report zero clients — with a client attached it reports
+        the CURRENT session's client, same as an unscoped query would. The prior test
+        for this case asserted the opposite and passed anyway, because its mock hard
+        -coded the convenient wrong answer — the exact "wrong invariant pinned by a
+        passing test" this fix round exists to remove. `cmd_menu` no longer queries
+        `list-clients` at all, so that specific fiction cannot recur, but the SAME
+        real hazard remains from a different angle: `menu.build("")` is always empty
+        (`state.frame_dir` refuses an empty id), so a real `display-menu` call with no
+        `$CHARTER_SESSION_ID` would still have ZERO items and fail outright ("too few
+        arguments") if `cmd_menu` did not check for that deliberately."""
         with mock.patch.dict(os.environ, {}, clear=True), \
-             mock.patch("charter.commands_frame.subprocess.run",
-                        side_effect=_fake_list_clients()) as run:
-            rc = commands_frame.cmd_menu(SimpleNamespace())
+             mock.patch("charter.commands_frame.subprocess.run") as run:
+            rc = commands_frame.cmd_menu(SimpleNamespace(client="/dev/ttys7"))
         self.assertEqual(rc, 0)
-        self.assertFalse(any("display-menu" in c.args[0] for c in run.call_args_list))
+        run.assert_not_called()
+
+    def test_cmd_menu_with_a_real_session_but_an_empty_menu_is_also_a_quiet_no_op(self):
+        """The same empty-menu guard, reached a different way: a genuine
+        `$CHARTER_SESSION_ID` whose frame has recorded no entries yet (nothing has
+        called `menu.record` for it, or `cmd_launch` has not reached that point)."""
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-empty"}), \
+             mock.patch("charter.commands_frame.subprocess.run") as run:
+            rc = commands_frame.cmd_menu(SimpleNamespace(client="/dev/ttys7"))
+        self.assertEqual(rc, 0)
+        run.assert_not_called()
 
     def test_cmd_action_runs_the_resolved_argv_as_a_list_never_a_shell(self):
         menu.record(fid="f-act", entries=[("Detach", ["tmux", "-L", "charter",

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -37,7 +37,7 @@ from unittest import mock
 
 from tests._isolation import PersonaIso
 from charter import commands_frame, config
-from charter.frame import state
+from charter.frame import menu, state
 
 
 def _os_terminal_size(cols, rows):
@@ -97,6 +97,33 @@ class Conf(unittest.TestCase):
         text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=50000,
                                         session="x")
         self.assertIn("history-limit 50000", text)
+
+    def test_the_hotkey_opens_the_menu_via_frame_menu_not_frame_space_menu(self):
+        """`charter frame menu` (a space) would never be reached: `cli._split_frame_argv`
+        treats `argv[0] == "frame"` as the launcher's own escape hatch and grafts
+        everything past it onto the harness's own verbatim argv before `argparse` ever
+        sees a subcommand to route — the exact reason `charter panel` is already a
+        top-level sibling of `frame` rather than nested under it. `charter frame-menu`
+        (a different literal token) is what `cli.py` actually registers."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
+                                        session="x")
+        self.assertIn("bind -n F2 run-shell 'charter frame-menu'", text)
+        self.assertNotIn("frame menu", text)
+
+    def test_the_hotkey_bind_is_global_not_session_scoped(self):
+        """Key tables have no per-session form in tmux (unlike `status`/`mouse`/
+        `history-limit` above) — this is `-n`, not `-t <session>`, on purpose; see the
+        `conf_text` docstring for why sharing one bind text across every frame on
+        `SOCKET` is still safe."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
+                                        session="demo-42")
+        self.assertNotIn("bind -t demo-42", text)
+        self.assertIn("bind -n F2", text)
+
+    def test_a_different_hotkey_is_honoured(self):
+        text = commands_frame.conf_text(hotkey="M-m", mouse=False, history_limit=1,
+                                        session="x")
+        self.assertIn("bind -n M-m run-shell", text)
 
 
 class PaneDiedHooks(unittest.TestCase):
@@ -170,6 +197,18 @@ class PaneDiedHooks(unittest.TestCase):
                                                  status_path=path)
         self.assertEqual(cmd, ["tmux", "-L", "charter", "set-environment", "-t", "demo-1",
                               "CHARTER_FRAME_EXIT", path])
+
+    def test_the_frame_id_is_carried_to_its_own_hotkey_menu(self):
+        """Without this, `run-shell` fired from a LATER frame sharing `SOCKET` falls
+        back to the SERVER's own starting environment — the FIRST frame's
+        `CHARTER_SESSION_ID`, not this one's (verified by hand against tmux 3.7c: a
+        second session on an already-running server, `run-shell`'d with no override of
+        its own, reported the first frame's id). The value carried is the session's own
+        name — `_session_id_env_argv` hands a session its own id back, unlike
+        `_exit_path_env_argv`, which carries a SEPARATE value (`status_path`)."""
+        cmd = commands_frame._session_id_env_argv(socket="charter", session="demo-1")
+        self.assertEqual(cmd, ["tmux", "-L", "charter", "set-environment", "-t", "demo-1",
+                              "CHARTER_SESSION_ID", "demo-1"])
 
 
 class MissingTmux(unittest.TestCase):
@@ -479,6 +518,44 @@ class Launch(PersonaIso, unittest.TestCase):
         hook_idx = next(i for i, c in enumerate(fake.calls)
                        if "set-hook" in c and "pane-died[1]" not in c)
         self.assertLess(env_idx, hook_idx)
+
+    def test_the_frame_id_is_carried_to_its_own_menu_before_the_write_hook(self):
+        """Companion to the test above: `charter frame-menu`/`charter frame-action`
+        (fired later, from a live keypress) both resolve `$CHARTER_SESSION_ID` from a
+        `run-shell` environment the same way the write hook resolves
+        `$CHARTER_FRAME_EXIT` — so this `set-environment` call needs to exist by the
+        time ANYTHING could plausibly fire, same reasoning, different variable."""
+        fake = _FakeTmux(exit_code=0)
+        _launch(fake)
+        sid_calls = [c for c in fake.calls if "set-environment" in c and "CHARTER_SESSION_ID" in c]
+        self.assertEqual(len(sid_calls), 1,
+                         "the frame's own id must be carried out of band exactly once")
+        self.assertEqual(sid_calls[0][sid_calls[0].index("-t") + 1], fake.fid)
+        self.assertEqual(sid_calls[0][-1], fake.fid)
+        sid_idx = fake.calls.index(sid_calls[0])
+        hook_idx = next(i for i, c in enumerate(fake.calls)
+                       if "set-hook" in c and "pane-died[1]" not in c)
+        self.assertLess(sid_idx, hook_idx)
+
+    def test_the_menu_is_populated_with_a_detach_action(self):
+        """`cmd_launch` must not merely bind the hotkey — the menu it opens has to have
+        something real in it, or the mechanism this whole task exists to wire up is
+        reachable but empty. "Detach" is the spec's own words ("Detach is allowed and
+        prints how to reattach").
+
+        `still_live=True`, not `exit_code=0`: a launch that ends normally has its own
+        frame directory reaped by `cmd_launch` itself before returning (same reasoning
+        `test_a_still_live_session_after_attach_is_a_detach_not_a_silent_zero` already
+        documents for `state.frame_dir(...).exists()`) — this test needs the menu table
+        to still be there to read back, so it has to look at a still-running frame."""
+        fake = _FakeTmux(still_live=True)
+        _launch(fake)
+        entries = menu.build(fake.fid)
+        self.assertEqual(len(entries), 1)
+        label, action_id = entries[0]
+        self.assertEqual(label, "Detach")
+        argv = menu.resolve(fake.fid, action_id)
+        self.assertEqual(argv, ["tmux", "-L", "charter", "detach-client", "-s", fake.fid])
 
     def test_the_write_hook_is_installed_before_the_teardown_hook(self):
         """Load-bearing, not incidental — see `_pane_died_teardown_hook_argv`'s own
@@ -1157,6 +1234,22 @@ class FrameArgvSplit(unittest.TestCase):
                 self.assertEqual(rest, argv)
                 self.assertIsNone(frame_rest)
 
+    def test_frame_action_and_frame_menu_are_not_swallowed_by_the_frame_split(self):
+        """The bug this pins: `argv[0] == "frame"` is what `_split_frame_argv` matches
+        on, so `charter frame action a1` (a SPACE, as the task brief's own draft text
+        proposed) would have `"action"` and `"a1"` grafted onto `args.rest` — the SAME
+        path `charter frame -- <cmd>` uses — and `cmd_launch` would try to LAUNCH A NEW
+        FRAME running `["action", "a1"]` as a harness, never reaching `cmd_action` at
+        all. `frame-action`/`frame-menu` are different literal tokens `argv[0]` never
+        matches, so `_split_frame_argv` leaves them alone — the same reason `panel` is
+        already a top-level sibling of `frame` rather than nested under it."""
+        from charter.cli import _split_frame_argv
+        for argv in (["frame-action", "a1"], ["frame-menu"]):
+            with self.subTest(argv=argv):
+                rest, frame_rest = _split_frame_argv(list(argv))
+                self.assertEqual(rest, argv)
+                self.assertIsNone(frame_rest)
+
 
 class MainDeliversFrameRest(unittest.TestCase):
     """The DELIVERY half of Critical 2. `FrameArgvSplit` above tests `_split_frame_argv`
@@ -1172,6 +1265,73 @@ class MainDeliversFrameRest(unittest.TestCase):
             rc = cli.main(["claude", "--no-frame", "-p", "hi"])
         byp.assert_called_once_with(["claude", "-p", "hi"])
         self.assertEqual(rc, 0)
+
+    def test_charter_frame_action_reaches_cmd_action_via_main(self):
+        """The delivery half of the `_split_frame_argv` fix above: a test that only
+        proves `_split_frame_argv` leaves `frame-action` alone cannot catch `cli.py`
+        never having registered a parser for it in the first place."""
+        from charter import cli
+        with mock.patch("charter.commands_frame.cmd_action", return_value=0) as ca:
+            rc = cli.main(["frame-action", "a3"])
+        ca.assert_called_once()
+        self.assertEqual(ca.call_args[0][0].action_id, "a3")
+        self.assertEqual(rc, 0)
+
+    def test_charter_frame_menu_reaches_cmd_menu_via_main(self):
+        from charter import cli
+        with mock.patch("charter.commands_frame.cmd_menu", return_value=0) as cm:
+            rc = cli.main(["frame-menu"])
+        cm.assert_called_once()
+        self.assertEqual(rc, 0)
+
+
+class MenuCommands(PersonaIso, unittest.TestCase):
+    """`cmd_menu`/`cmd_action` — the handlers `charter frame-menu`/`charter frame-action`
+    dispatch to. Both resolve the frame purely from `$CHARTER_SESSION_ID`; neither ever
+    takes a frame id as an argument (see `menu.py`'s own docstring for why the id stays
+    out of the bind's own text)."""
+
+    def test_cmd_menu_opens_the_current_frames_own_menu(self):
+        menu.record(fid="f-menu", entries=[("Detach", ["true"])])
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-menu"}), \
+             mock.patch("charter.commands_frame.subprocess.run") as run:
+            run.return_value = SimpleNamespace(returncode=0)
+            rc = commands_frame.cmd_menu(SimpleNamespace())
+        self.assertEqual(rc, 0)
+        run.assert_called_once()
+        cmd = run.call_args[0][0]
+        self.assertEqual(cmd[:6], ["tmux", "-L", "charter", "display-menu", "-t", "f-menu"])
+
+    def test_cmd_menu_with_no_session_id_opens_an_empty_menu_rather_than_crashing(self):
+        """No `$CHARTER_SESSION_ID` at all (the frame died between the bind firing and
+        this process starting, say) must not raise — `menu.menu_argv("", socket)` is
+        still a valid, if useless, `display-menu` invocation with no items."""
+        with mock.patch.dict(os.environ, {}, clear=True), \
+             mock.patch("charter.commands_frame.subprocess.run") as run:
+            run.return_value = SimpleNamespace(returncode=0)
+            rc = commands_frame.cmd_menu(SimpleNamespace())
+        self.assertEqual(rc, 0)
+
+    def test_cmd_action_runs_the_resolved_argv_as_a_list_never_a_shell(self):
+        menu.record(fid="f-act", entries=[("Detach", ["tmux", "-L", "charter",
+                                                       "detach-client", "-s", "f-act"])])
+        entries = menu.build("f-act")
+        action_id = entries[0][1]
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-act"}), \
+             mock.patch("charter.commands_frame.subprocess.run") as run:
+            run.return_value = SimpleNamespace(returncode=0)
+            rc = commands_frame.cmd_action(SimpleNamespace(action_id=action_id))
+        self.assertEqual(rc, 0)
+        run.assert_called_once_with(["tmux", "-L", "charter", "detach-client",
+                                     "-s", "f-act"])
+
+    def test_cmd_action_on_an_unknown_id_is_a_clean_failure_not_a_crash(self):
+        buf = []
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-act"}), \
+             mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = commands_frame.cmd_action(SimpleNamespace(action_id="a99"))
+        self.assertEqual(rc, 2)
+        self.assertTrue(any("a99" in m for m in buf), buf)
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -864,6 +864,29 @@ class CollisionGuard(unittest.TestCase):
                 cli.build_parser()
         self.assertIn("frame-harness", str(ctx.exception))
 
+    def test_a_harness_named_panel_is_refused_too(self):
+        """`charter/frame/panel.py` (Task 7) is internal, spawned only by
+        `layout.panel_argvs` — never typed by an operator — but it is registered the
+        same way `frame` is: AFTER the harness loop, in `_add_frame_parsers`. A harness
+        claiming `cli_name == "panel"` would otherwise pass `sub.choices` (nothing is
+        named `panel` yet when the loop checks) and only collide once `charter/cli.py`'s
+        own `sub.add_parser("panel")` call runs — where a version-3.11 argparse would
+        silently let the harness shadow it, and every panel pane would then fail at
+        startup against a parser that no longer expects `--session`."""
+        from charter import cli
+        from charter.harness.base import Harness
+
+        class _PanelHarness(Harness):
+            name = "panel-harness"
+            cli_name = "panel"
+            binary = "panel-harness"
+
+        with mock.patch.dict("charter.harness.registry.KINDS",
+                             {"panel-harness": _PanelHarness}, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                cli.build_parser()
+        self.assertIn("panel-harness", str(ctx.exception))
+
 
 class FrameArgvSplit(unittest.TestCase):
     """Critical 2: `charter claude -p hi` — the documented, spec-named invocation — was

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -113,6 +113,15 @@ class PaneDiedHooks(unittest.TestCase):
         self.assertIn("pane-died", cmd)
         self.assertNotIn("pane-died[1]", cmd)
 
+    def test_the_write_hook_is_scoped_to_the_pane_not_the_whole_session(self):
+        """`-p` is what makes this a PANE hook rather than a session-wide one — verified
+        against tmux 3.7c what dropping it costs: without `-p`, `pane-died` fires for
+        EVERY pane in the session, so a decorative PANEL exiting (77, say) writes 77
+        into the harness's own exit-status file, and the operator sees a panel's exit
+        status reported as their agent's."""
+        cmd = commands_frame._pane_died_write_hook_argv(socket="charter", harness_pane="%9")
+        self.assertIn("-p", cmd)
+
     def test_the_write_hook_action_is_constant(self):
         """No operator- or plane-derived string is ever embedded in this text — the
         exact bug that let a plane root with a literal `'` in it hang silently
@@ -194,6 +203,13 @@ class QueryPaneDeadStatus(unittest.TestCase):
         return mock.patch(
             "charter.commands_frame.subprocess.run",
             return_value=subprocess.CompletedProcess([], rc, stdout=stdout, stderr=""))
+
+    def test_the_unknown_death_sentinel_is_not_zero(self):
+        """Every other test in this class refers to `_UNKNOWN_DEATH_CODE` symbolically,
+        which pins nothing about its actual VALUE — and `0` is precisely the fabricated
+        silent success this whole module exists to rule out. A pane confirmed dead with
+        no readable status must never be reported as if it exited cleanly."""
+        self.assertNotEqual(commands_frame._UNKNOWN_DEATH_CODE, 0)
 
     def test_a_dead_pane_returns_its_status(self):
         with self._dm("1:42"):
@@ -433,11 +449,30 @@ class Launch(PersonaIso, unittest.TestCase):
         time the hook could possibly fire."""
         fake = _FakeTmux(exit_code=0)
         _launch(fake)
-        names = [c[3] if len(c) > 3 else "" for c in fake.calls]
         env_idx = next(i for i, c in enumerate(fake.calls) if "set-environment" in c)
         hook_idx = next(i for i, c in enumerate(fake.calls)
                        if "set-hook" in c and "pane-died[1]" not in c)
         self.assertLess(env_idx, hook_idx)
+
+    def test_the_write_hook_is_installed_before_the_teardown_hook(self):
+        """Load-bearing, not incidental — see `_pane_died_teardown_hook_argv`'s own
+        docstring. Verified against tmux 3.7c: an UNINDEXED `set-hook pane-died ...`
+        call does not merely overwrite index 0 of an existing hook array, it REPLACES
+        THE WHOLE ARRAY — so installing the write hook (unindexed) AFTER the teardown
+        hook (`pane-died[1]`) silently deletes the teardown hook the moment it lands,
+        and the hang both hooks together exist to close comes back. Reproduced end to
+        end by swapping the two `cmd_launch` calls: `RESULT: TIMEOUT`, session left
+        attached. This test pins the ORDER `cmd_launch` issues the two commands in;
+        `tests/test_frame_tmux_integration.py` pins the real-tmux array-replacement
+        behaviour the order exists to work around."""
+        fake = _FakeTmux(exit_code=0)
+        _launch(fake)
+        write_idx = next(i for i, c in enumerate(fake.calls)
+                         if "set-hook" in c and "pane-died[1]" not in c)
+        teardown_idx = next(i for i, c in enumerate(fake.calls) if "pane-died[1]" in c)
+        self.assertLess(write_idx, teardown_idx,
+                        "the write hook must be installed BEFORE the teardown hook, or "
+                        "installing teardown wipes it out — see the docstring above")
 
     def test_the_recorded_exit_code_wins_over_a_zero_from_attach(self):
         """The whole module's reason to exist: an attached `tmux attach` (like
@@ -562,12 +597,17 @@ class Launch(PersonaIso, unittest.TestCase):
         would leave `attach` blocked forever with nothing to end the session — the same
         hang the eager check exists to close, just moved later and made permanent for
         this frame. Refusing to attach is the safe choice; the harness keeps running,
-        detached."""
+        detached.
+
+        The return code must be NONZERO, not the `0` a deliberate operator detach
+        returns below: the harness never ran interactively and charter has no way to
+        learn its real exit code, so a script or `&&` chain must see this launch as
+        having failed, not quietly succeeded."""
         fake = _FakeTmux(teardown_hook_rc=1, still_live=True)
         buf = []
         with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
             rc = _launch(fake)
-        self.assertEqual(rc, 0)
+        self.assertNotEqual(rc, 0)
         self.assertTrue(any("refusing to attach" in m for m in buf),
                         f"no refusal message: {buf}")
         self.assertFalse(any("attach" in c for c in fake.calls),

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -318,7 +318,8 @@ class _FakeTmux:
                 panel_pane_ids=None,
                 session_rc=0, source_rc=0, env_set_rc=0, write_hook_rc=0,
                 teardown_hook_rc=0, panel_rc=0, select_rc=0, attach_rc=0, dm_rc=0,
-                kill_rc=0, arm_rc=0, resize_hook_rc=0):
+                kill_rc=0, arm_rc=0, resize_hook_rc=0,
+                resize_hook_stderr="bad resize hook target"):
         self.pane_id = pane_id
         self.exit_code = exit_code
         self.race_death_status = race_death_status
@@ -340,6 +341,10 @@ class _FakeTmux:
         self.kill_rc = kill_rc
         self.arm_rc = arm_rc
         self.resize_hook_rc = resize_hook_rc
+        # Distinct from every other stderr string in this fake — a test needs to
+        # control it independently to exercise the "invalid option" degrade (fix
+        # round 3, item 2) separately from an ordinary resize-hook failure.
+        self.resize_hook_stderr = resize_hook_stderr
         self.calls: list[list[str]] = []
         self.fid = None
         self.sourced_conf_text = None
@@ -374,7 +379,7 @@ class _FakeTmux:
                                                    stderr="" if self.teardown_hook_rc == 0 else "bad teardown target")
             if "window-resized" in cmd:
                 return subprocess.CompletedProcess(cmd, self.resize_hook_rc, stdout="",
-                                                   stderr="" if self.resize_hook_rc == 0 else "bad resize hook target")
+                                                   stderr="" if self.resize_hook_rc == 0 else self.resize_hook_stderr)
             return subprocess.CompletedProcess(cmd, self.write_hook_rc, stdout="",
                                                stderr="" if self.write_hook_rc == 0 else "bad hook target")
         if "select-pane" in cmd:
@@ -754,6 +759,7 @@ class Launch(PersonaIso, unittest.TestCase):
             rc = _launch(fake)
         self.assertEqual(rc, 0)
         self.assertTrue(any("resize hook" in m for m in buf), buf)
+        self.assertTrue(any("attach" in c for c in fake.calls))
 
     def test_a_failed_resize_hook_install_names_its_consequence(self):
         """Fix round 2, item 4: `_report_tmux_failure` prints the command and tmux's
@@ -769,6 +775,46 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertTrue(any("continuing without it" in m and "drift" in m for m in buf),
                         buf)
+
+    def test_an_invalid_option_resize_hook_failure_warns_rather_than_errors(self):
+        """Fix round 3, item 2: `RESIZE_HOOK_FLOOR` is a fast path to skip a version
+        already KNOWN too old, not the only thing standing between an operator and a
+        LOUD, RECURRING error if that constant is ever wrong — safe by construction,
+        not by the constant being right. A failed install whose stderr is tmux's own
+        `invalid option: <name>` (confirmed by hand: generic `set-hook`
+        argument-parsing text, not specific to this one hook) must degrade the SAME
+        quiet way a known-too-old version already does: `util.warn`, never
+        `util.err`/`_report_tmux_failure`'s command-and-stderr dump."""
+        fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11", "bottom": "%12"},
+                         resize_hook_rc=1,
+                         resize_hook_stderr="invalid option: window-resized")
+        warned, errored = [], []
+        with mock.patch("charter.util.warn", side_effect=lambda m: warned.append(m)), \
+             mock.patch("charter.util.err", side_effect=lambda m: errored.append(m)):
+            rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        self.assertEqual(errored, [], f"an unsupported hook name must never reach "
+                                      f"util.err: {errored}")
+        self.assertTrue(any("resize" in m and "drift" in m for m in warned), warned)
+
+    def test_a_non_invalid_option_resize_hook_failure_still_errors(self):
+        """Companion to the test above — the two paths must not collapse into each
+        other. A resize-hook failure for some OTHER reason (a real bug, a permissions
+        problem, anything that isn't tmux saying the hook name itself is unrecognised)
+        must still get the loud, specific `_report_tmux_failure` treatment; degrading
+        every failure to a quiet warning would hide an actual regression behind the
+        same wording a known compatibility gap uses."""
+        fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11", "bottom": "%12"},
+                         resize_hook_rc=1,
+                         resize_hook_stderr="no space for a new pane")
+        warned, errored = [], []
+        with mock.patch("charter.util.warn", side_effect=lambda m: warned.append(m)), \
+             mock.patch("charter.util.err", side_effect=lambda m: errored.append(m)):
+            rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        self.assertTrue(any("resize hook" in m for m in errored), errored)
+        self.assertTrue(any("continuing without it" in m and "drift" in m
+                            for m in warned), warned)
 
     def test_the_resize_hook_is_skipped_quietly_below_its_own_version_floor(self):
         """Fix round 2, item 5: `window-resized` was added in tmux 3.3
@@ -786,7 +832,6 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertFalse(any("window-resized" in c for c in fake.calls),
                          "the hook must not even be attempted below its own floor")
         self.assertTrue(any("3.2" in m and "resize" in m for m in buf), buf)
-        self.assertTrue(any("attach" in c for c in fake.calls))
 
     def test_below_the_tmux_floor_degrades_instead_of_refusing(self):
         """Correction 5: a version below `tmuxctl.FLOOR` prints `below_floor_message`

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -28,6 +28,7 @@ start a real tmux server in this suite".
 
 from __future__ import annotations
 
+import os
 import subprocess
 import unittest
 from pathlib import Path
@@ -35,7 +36,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from tests._isolation import PersonaIso
-from charter import commands_frame
+from charter import commands_frame, config
 from charter.frame import state
 
 
@@ -314,14 +315,19 @@ class _FakeTmux:
 
     def __init__(self, *, pane_id="%7", exit_code=None, race_death_status=None,
                 still_live=False, pre_existing_sessions=frozenset(),
+                panel_pane_ids=None,
                 session_rc=0, source_rc=0, env_set_rc=0, write_hook_rc=0,
                 teardown_hook_rc=0, panel_rc=0, select_rc=0, attach_rc=0, dm_rc=0,
-                kill_rc=0, arm_rc=0):
+                kill_rc=0, arm_rc=0, resize_hook_rc=0):
         self.pane_id = pane_id
         self.exit_code = exit_code
         self.race_death_status = race_death_status
         self.still_live = still_live
         self.pre_existing_sessions = pre_existing_sessions
+        # slot -> pane id `split-window` reports for it. Empty by default (see
+        # `split-window`'s own handler below for why that matters for every other test
+        # in this class).
+        self.panel_pane_ids = panel_pane_ids or {}
         self.session_rc = session_rc
         self.source_rc = source_rc
         self.env_set_rc = env_set_rc
@@ -333,6 +339,7 @@ class _FakeTmux:
         self.dm_rc = dm_rc
         self.kill_rc = kill_rc
         self.arm_rc = arm_rc
+        self.resize_hook_rc = resize_hook_rc
         self.calls: list[list[str]] = []
         self.fid = None
         self.sourced_conf_text = None
@@ -365,13 +372,27 @@ class _FakeTmux:
             if "pane-died[1]" in cmd:
                 return subprocess.CompletedProcess(cmd, self.teardown_hook_rc, stdout="",
                                                    stderr="" if self.teardown_hook_rc == 0 else "bad teardown target")
+            if "window-resized" in cmd:
+                return subprocess.CompletedProcess(cmd, self.resize_hook_rc, stdout="",
+                                                   stderr="" if self.resize_hook_rc == 0 else "bad resize hook target")
             return subprocess.CompletedProcess(cmd, self.write_hook_rc, stdout="",
                                                stderr="" if self.write_hook_rc == 0 else "bad hook target")
         if "select-pane" in cmd:
             return subprocess.CompletedProcess(cmd, self.select_rc, stdout="",
                                                stderr="" if self.select_rc == 0 else "no such pane")
         if "split-window" in cmd:
-            return subprocess.CompletedProcess(cmd, self.panel_rc, stdout="",
+            # Real tmux, with `-P -F '#{pane_id}'` now always on this argv (see
+            # `layout.panel_argvs`), prints the new pane's id. Most tests leave
+            # `panel_pane_ids` empty (its default) and get the SAME "reports nothing"
+            # behaviour this fake always had — deliberately, so this addition doesn't
+            # ripple through every other test in this class, which are not ABOUT the
+            # resize hook. Keyed by slot (`cmd[cmd.index("panel") + 1]`, the literal
+            # argv element `panel_argvs` always emits right after `--`), not by call
+            # order, so a test can name exactly which slot(s) it wants a real id for.
+            slot = cmd[cmd.index("panel") + 1] if "panel" in cmd else None
+            pane_id = self.panel_pane_ids.get(slot, "") if self.panel_rc == 0 else ""
+            return subprocess.CompletedProcess(cmd, self.panel_rc,
+                                               stdout=f"{pane_id}\n" if pane_id else "",
                                                stderr="" if self.panel_rc == 0 else "no space for a new pane")
         if "display-message" in cmd:
             out = f"1:{self.race_death_status}" if self.race_death_status is not None else "0:"
@@ -675,6 +696,48 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertTrue(any("attach" in c for c in fake.calls),
                         "a decorative panel failing must not cancel the attach")
 
+    def test_a_resize_hook_is_installed_reasserting_every_drawn_panels_size(self):
+        """Cross-task fix round, item 3: tmux's own layout engine redistributes EVERY
+        pane proportionally on any resize, `-l size` notwithstanding — verified by hand
+        against real tmux 3.7c (`commands_frame._resize_hook_argv`'s own docstring): a
+        120x30 frame grown to 200x50 stretched two one-row panels to 8 and 7 rows.
+        `cmd_launch` must install a `window-resized` hook re-asserting each DRAWN
+        panel's fixed dimension, targeting the REAL pane id tmux reported for it — a
+        slot name alone is not a valid `resize-pane` target."""
+        fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11", "bottom": "%12"})
+        rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        resize_cmd = next(c for c in fake.calls if "window-resized" in c)
+        self.assertEqual(resize_cmd[resize_cmd.index("-t") + 1], fake.pane_id,
+                         "the hook must be scoped to the harness pane's own window")
+        action = resize_cmd[-1]
+        self.assertIn("%11", action)
+        self.assertIn("%12", action)
+        self.assertIn("-y 1", action)
+
+    def test_no_resize_hook_is_installed_when_no_panel_pane_id_was_learned(self):
+        """Companion: every OTHER test in this class leaves `split-window` reporting no
+        pane id (the fake's own default). With nothing valid to target, installing a
+        resize hook anyway would either fail outright or silently target nothing — this
+        pins that `cmd_launch` does not even attempt it in that case."""
+        fake = _FakeTmux(exit_code=0)
+        _launch(fake)
+        self.assertFalse(any("window-resized" in c for c in fake.calls))
+
+    def test_a_failed_resize_hook_install_is_reported_but_not_fatal(self):
+        """Same "report, don't kill an already-running pane" treatment every other
+        cosmetic tmux command in this launcher gets (correction 2) — every pane already
+        measures its own tty on every repaint regardless (the module docstring's "belt
+        and braces" framing), so a launch's correctness never depended on this hook."""
+        fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11", "bottom": "%12"},
+                         resize_hook_rc=1)
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        self.assertTrue(any("resize hook" in m for m in buf), buf)
+        self.assertTrue(any("attach" in c for c in fake.calls))
+
     def test_below_the_tmux_floor_degrades_instead_of_refusing(self):
         """Correction 5: a version below `tmuxctl.FLOOR` prints `below_floor_message`
         and the frame still launches — only the (not-yet-wired) hotkey menu is
@@ -723,6 +786,40 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertIsNotNone(fake.new_session_env)
         self.assertEqual(fake.new_session_env.get("CHARTER_SESSION_ID"), fake.fid)
+
+    def test_columns_and_lines_are_stripped_from_the_environment_handed_to_tmux(self):
+        """Belt and braces alongside every pane measuring its own tty (`frame/slots.py`,
+        `frame/panel.py`): `env` here is inherited WHOLE by every process tmux starts on
+        this launch, and `$COLUMNS`/`$LINES` describe the LAUNCHING terminal, not any
+        pane this frame creates — verified against a real panel pane by hand (`ps -E`
+        showed both inherited whole before this fix)."""
+        fake = _FakeTmux(exit_code=0)
+        with mock.patch.dict(os.environ, {"COLUMNS": "500", "LINES": "70"}):
+            rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        self.assertIsNotNone(fake.new_session_env)
+        self.assertNotIn("COLUMNS", fake.new_session_env)
+        self.assertNotIn("LINES", fake.new_session_env)
+
+    def test_a_configured_slot_with_no_renderer_is_skipped_not_spawned_dead(self):
+        """`[frame] slots` accepts `left`/`right` (`instance.FRAME_SLOTS`, sized by
+        `layout.SLOT_SIZE`) even though `frame.slots.SLOTS` — the renderer registry —
+        has no renderer for either yet. Spawning a real pane for one anyway would leave
+        the operator a permanently dead, wrapped-error pane under `remain-on-exit on`
+        (`panel.run` correctly refuses it, exit 2, but nothing then explains why at the
+        point the frame actually comes up). This pins that no such pane is even
+        attempted, one warning names it, and the implemented slots still draw."""
+        fake = _FakeTmux(exit_code=0)
+        buf = []
+        with mock.patch.dict(config.FRAME, {"slots": ["top", "bottom", "left"]}), \
+             mock.patch("charter.util.warn", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        self.assertFalse(any("panel" in c and "left" in c for c in fake.calls),
+                         "no pane may be spawned for a slot with no renderer")
+        self.assertTrue(any("left" in m for m in buf), buf)
+        self.assertTrue(any("panel" in c and "bottom" in c for c in fake.calls),
+                        "an IMPLEMENTED slot must still be drawn")
 
     def test_a_frame_dir_the_state_module_refuses_does_not_crash(self):
         """`frame_dir` returns `None` rather than a `Path` for an id it cannot shape

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1156,6 +1156,42 @@ class CollisionGuard(unittest.TestCase):
                 cli.build_parser()
         self.assertIn("panel-harness", str(ctx.exception))
 
+    def test_a_harness_named_frame_menu_is_refused_too(self):
+        """Same class of collision as `frame`/`panel` above, for the two commands this
+        task added: a harness claiming `cli_name == "frame-menu"` would pass the loop's
+        own `sub.choices` check (nothing is named that yet) and only collide once
+        `_add_frame_parsers`'s own `sub.add_parser("frame-menu")` call runs — silently
+        shadowing the hotkey menu's own handler on a 3.11 floor, with nothing telling
+        the operator why the hotkey stopped doing anything."""
+        from charter import cli
+        from charter.harness.base import Harness
+
+        class _FrameMenuHarness(Harness):
+            name = "frame-menu-harness"
+            cli_name = "frame-menu"
+            binary = "frame-menu-harness"
+
+        with mock.patch.dict("charter.harness.registry.KINDS",
+                             {"frame-menu-harness": _FrameMenuHarness}, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                cli.build_parser()
+        self.assertIn("frame-menu-harness", str(ctx.exception))
+
+    def test_a_harness_named_frame_action_is_refused_too(self):
+        from charter import cli
+        from charter.harness.base import Harness
+
+        class _FrameActionHarness(Harness):
+            name = "frame-action-harness"
+            cli_name = "frame-action"
+            binary = "frame-action-harness"
+
+        with mock.patch.dict("charter.harness.registry.KINDS",
+                             {"frame-action-harness": _FrameActionHarness}, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                cli.build_parser()
+        self.assertIn("frame-action-harness", str(ctx.exception))
+
 
 class FrameArgvSplit(unittest.TestCase):
     """Critical 2: `charter claude -p hi` — the documented, spec-named invocation — was
@@ -1285,32 +1321,84 @@ class MainDeliversFrameRest(unittest.TestCase):
         self.assertEqual(rc, 0)
 
 
+def _fake_list_clients(*names: str):
+    """A `subprocess.run` `side_effect` distinguishing `list-clients` (answers *names*,
+    one per line, tmux's own `-F` output shape) from any other command (answers an empty,
+    successful `CompletedProcess`) — `cmd_menu` issues two DIFFERENT tmux commands now
+    (`_menu_clients`'s query, then `display-menu` itself), so a single flat mock return
+    value can no longer stand in for both."""
+    def _run(cmd, **kwargs):
+        if "list-clients" in cmd:
+            return SimpleNamespace(returncode=0, stdout="\n".join(names))
+        return SimpleNamespace(returncode=0)
+    return _run
+
+
 class MenuCommands(PersonaIso, unittest.TestCase):
     """`cmd_menu`/`cmd_action` — the handlers `charter frame-menu`/`charter frame-action`
     dispatch to. Both resolve the frame purely from `$CHARTER_SESSION_ID`; neither ever
     takes a frame id as an argument (see `menu.py`'s own docstring for why the id stays
     out of the bind's own text)."""
 
-    def test_cmd_menu_opens_the_current_frames_own_menu(self):
+    def test_cmd_menu_opens_the_current_frames_own_menu_on_its_own_client(self):
+        """`-c` — not merely `-t` — is what the fix for IMPORTANT-1 added: `-t fid`
+        alone does not choose WHICH terminal sees the menu (verified by hand: it
+        rendered frame B's menu on frame A's screen). `cmd_menu` must ask `list-clients`
+        first and pass whatever it learns straight through to `-c`."""
         menu.record(fid="f-menu", entries=[("Detach", ["true"])])
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-menu"}), \
-             mock.patch("charter.commands_frame.subprocess.run") as run:
-            run.return_value = SimpleNamespace(returncode=0)
+             mock.patch("charter.commands_frame.subprocess.run",
+                        side_effect=_fake_list_clients("/dev/ttys7")) as run:
             rc = commands_frame.cmd_menu(SimpleNamespace())
         self.assertEqual(rc, 0)
-        run.assert_called_once()
-        cmd = run.call_args[0][0]
-        self.assertEqual(cmd[:6], ["tmux", "-L", "charter", "display-menu", "-t", "f-menu"])
+        calls = [c.args[0] for c in run.call_args_list]
+        list_clients_cmd = next(c for c in calls if "list-clients" in c)
+        self.assertEqual(list_clients_cmd,
+                         ["tmux", "-L", "charter", "list-clients", "-t", "f-menu",
+                          "-F", "#{client_name}"])
+        menu_cmd = next(c for c in calls if "display-menu" in c)
+        self.assertEqual(menu_cmd[:9],
+                         ["tmux", "-L", "charter", "display-menu", "-t", "f-menu",
+                          "-c", "/dev/ttys7", "-T"])
 
-    def test_cmd_menu_with_no_session_id_opens_an_empty_menu_rather_than_crashing(self):
-        """No `$CHARTER_SESSION_ID` at all (the frame died between the bind firing and
-        this process starting, say) must not raise — `menu.menu_argv("", socket)` is
-        still a valid, if useless, `display-menu` invocation with no items."""
-        with mock.patch.dict(os.environ, {}, clear=True), \
-             mock.patch("charter.commands_frame.subprocess.run") as run:
-            run.return_value = SimpleNamespace(returncode=0)
+    def test_cmd_menu_with_zero_clients_is_a_quiet_no_op(self):
+        """Nothing attached to this session right now (a keypress landing mid-detach,
+        say) — `display-menu` would just fail with tmux's own "no current client", and
+        there is no screen left to report that failure on anyway. `cmd_menu` must not
+        even attempt it."""
+        menu.record(fid="f-menu", entries=[("Detach", ["true"])])
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-menu"}), \
+             mock.patch("charter.commands_frame.subprocess.run",
+                        side_effect=_fake_list_clients()) as run:
             rc = commands_frame.cmd_menu(SimpleNamespace())
         self.assertEqual(rc, 0)
+        self.assertFalse(any("display-menu" in c.args[0] for c in run.call_args_list),
+                         "display-menu must never be attempted with no client to draw on")
+
+    def test_cmd_menu_with_several_clients_picks_the_first_reported(self):
+        """The same session open in two terminals at once — `display-menu -c` only ever
+        accepts one, and there is no way to show a menu on two screens simultaneously;
+        picking the first `list-clients` reports is at least a client actually watching
+        THIS session, which a bare `-t fid` never guaranteed (see the test above)."""
+        menu.record(fid="f-menu", entries=[("Detach", ["true"])])
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-menu"}), \
+             mock.patch("charter.commands_frame.subprocess.run",
+                        side_effect=_fake_list_clients("/dev/ttys1", "/dev/ttys2")) as run:
+            rc = commands_frame.cmd_menu(SimpleNamespace())
+        self.assertEqual(rc, 0)
+        menu_cmd = next(c.args[0] for c in run.call_args_list if "display-menu" in c.args[0])
+        self.assertEqual(menu_cmd[menu_cmd.index("-c") + 1], "/dev/ttys1")
+
+    def test_cmd_menu_with_no_session_id_finds_no_clients_and_does_nothing(self):
+        """No `$CHARTER_SESSION_ID` at all (the frame died between the bind firing and
+        this process starting, say) must not raise — `list-clients -t ""` reports no
+        clients, and `cmd_menu` treats that the same as any other zero-clients case."""
+        with mock.patch.dict(os.environ, {}, clear=True), \
+             mock.patch("charter.commands_frame.subprocess.run",
+                        side_effect=_fake_list_clients()) as run:
+            rc = commands_frame.cmd_menu(SimpleNamespace())
+        self.assertEqual(rc, 0)
+        self.assertFalse(any("display-menu" in c.args[0] for c in run.call_args_list))
 
     def test_cmd_action_runs_the_resolved_argv_as_a_list_never_a_shell(self):
         menu.record(fid="f-act", entries=[("Detach", ["tmux", "-L", "charter",

--- a/tests/test_frame_layout.py
+++ b/tests/test_frame_layout.py
@@ -106,6 +106,20 @@ class PanelArgvs(unittest.TestCase):
             for part in cmd:
                 self.assertIsInstance(part, str)
 
+    def test_it_asks_tmux_to_print_each_panels_pane_id(self):
+        """Mirrors `SessionArgv.test_it_asks_tmux_to_print_the_pane_id`: a caller needs
+        each panel's own pane id to re-assert its fixed size after tmux's own layout
+        engine redistributes every pane proportionally on a resize (measured against
+        tmux 3.7c — see this function's own docstring). `-P`/`-F` must land BEFORE the
+        `--` separator (tmux's own option, never part of the `charter panel …` argv
+        after it) — the same placement `session_argv` already uses."""
+        for cmd in layout.panel_argvs(slots=["top", "bottom"], **PANELS):
+            self.assertIn("-P", cmd)
+            i = cmd.index("-P")
+            self.assertEqual(cmd[i + 1:i + 3], ["-F", "#{pane_id}"])
+            self.assertLess(i, cmd.index("--"),
+                            "-P/-F must be split-window's own options, before --")
+
     def test_each_visible_slot_gets_one_panel_command(self):
         cmds = layout.panel_argvs(slots=["top", "bottom"], **PANELS)
         panels = [c for c in cmds if "panel" in c]

--- a/tests/test_frame_layout.py
+++ b/tests/test_frame_layout.py
@@ -26,6 +26,16 @@ PANELS = dict(session="charter-demo-1234", socket="charter",
               charter_argv=["charter"], harness_pane="%0")
 
 
+def _direction(cmd: list[str]) -> str:
+    """`-v` (splits along rows) or `-h` (splits along columns) — whichever is present."""
+    return "-v" if "-v" in cmd else "-h"
+
+
+def _size(cmd: list[str]) -> str:
+    """The value passed to `-l`, as the literal string tmux would see on argv."""
+    return cmd[cmd.index("-l") + 1]
+
+
 class VisibleSlots(unittest.TestCase):
     def test_a_wide_tall_terminal_keeps_every_slot(self):
         self.assertEqual(
@@ -129,6 +139,68 @@ class PanelArgvs(unittest.TestCase):
         cmds = layout.panel_argvs(slots=["top", "bottom", "left", "right"], **PANELS)
         targets = {cmd[cmd.index("-t") + 1] for cmd in cmds}
         self.assertEqual(targets, {"%0"})
+
+
+class PanelGeometry(unittest.TestCase):
+    """Pins the one property nothing else in this file checks: each slot's actual shape.
+
+    `visible_slots` decides WHICH slots appear and `panel_argvs`' targeting tests pin
+    WHERE the split lands, but nothing until now pinned the split itself — direction,
+    `-b`, and `-l <size>` are three independent pieces of code (a membership check, a
+    second membership check, and a dict lookup) that happen to agree with the intended
+    frame only because each was written correctly, not because anything forces them to
+    agree. Swap two `SLOT_SIZE` values, or transpose the two membership checks, and every
+    other test in this file stays green while the frame ships sideways.
+    """
+
+    def test_horizontal_edges_split_vertically_and_top_goes_before_the_harness(self):
+        """`top` and `bottom` are full-width, one-row strips, so both are cut with a
+        VERTICAL split (`-v` divides the terminal along its rows — the axis that makes a
+        one-row strip; `-h`, used by `left`/`right` below, divides it into side-by-side
+        columns instead, which is the wrong shape for either of these). `top` is placed
+        BEFORE the harness pane (`-b`); `bottom`, asserted right alongside it for
+        contrast, goes after (no `-b`) — that contrast is what makes this one test with
+        `bottom` in it rather than an isolated claim about `top`. Both are exactly
+        `SLOT_SIZE["top"] == SLOT_SIZE["bottom"] == 1` row, asserted as the literal
+        `"1"` rather than read back through `layout.SLOT_SIZE`: reading it back would
+        still pass after `SLOT_SIZE` is swapped to `{"top": 22, ...}`, since the emitted
+        `-l` always equals whatever the dict currently says — the literal is what makes
+        the swap visible.
+
+        Catches (verified by hand, see fix-round section of the task report): mutation 1
+        (direction inverted and `-b` membership swapped) — `top`'s direction flips to
+        `-h` and its `-b` disappears, both asserted here. Catches mutation 2 (`SLOT_SIZE`
+        rows/cols swapped to 22/1) via the literal `"1"`.
+        """
+        top, bottom = layout.panel_argvs(slots=["top", "bottom"], **PANELS)
+        self.assertEqual(_direction(top), "-v")
+        self.assertEqual(_direction(bottom), "-v")
+        self.assertIn("-b", top)
+        self.assertNotIn("-b", bottom)
+        self.assertEqual(_size(top), "1")
+        self.assertEqual(_size(bottom), "1")
+
+    def test_vertical_edges_split_horizontally_and_left_goes_before_the_harness(self):
+        """Mirror of the test above, for the other axis. `left` and `right` are the side
+        columns, so both are cut with a HORIZONTAL split (`-h` — the axis that makes a
+        column; `-v`, used by `top`/`bottom` above, would instead slice off a row).
+        `left` goes BEFORE the harness (`-b`); `right`, alongside it for the same
+        contrast, goes after (no `-b`). Both are `SLOT_SIZE["left"] == SLOT_SIZE["right"]
+        == 22` columns, again the literal `"22"` rather than read back through
+        `layout.SLOT_SIZE`, for the reason given above.
+
+        Catches: mutation 1 on `left` (direction flips to `-v`, `-b` disappears — both
+        asserted here) and, together with the test above, rules out a fix that inverts
+        direction correctly on one axis but not the other. Catches mutation 2 via the
+        literal `"22"`.
+        """
+        left, right = layout.panel_argvs(slots=["left", "right"], **PANELS)
+        self.assertEqual(_direction(left), "-h")
+        self.assertEqual(_direction(right), "-h")
+        self.assertIn("-b", left)
+        self.assertNotIn("-b", right)
+        self.assertEqual(_size(left), "22")
+        self.assertEqual(_size(right), "22")
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_layout.py
+++ b/tests/test_frame_layout.py
@@ -1,0 +1,135 @@
+"""The frame's whole shape, decided without tmux.
+
+Layout is pure so the feature is testable on a machine that has never installed tmux, and
+so the argv rule is enforced by a unit test rather than by review: every element of every
+command is a separate string, because tmux shell-interprets a joined one (pinned against
+3.7c) and workspace, repo and branch names all reach here from committed files.
+
+`session_argv` and `panel_argvs` are two functions rather than one `plan()` because the
+launcher must run the first, read the harness's pane id off its stdout, and only then
+build the splits — see `charter/frame/layout.py`'s module docstring for the measured tmux
+3.7c failure (pane-index renumbering) a single up-front plan cannot avoid.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter.frame import layout
+
+
+SESSION = dict(session="charter-demo-1234", conf="/tmp/f/tmux.conf",
+               socket="charter", cols=200, rows=50,
+               harness_argv=["claude", "--resume", "a;b"])
+
+PANELS = dict(session="charter-demo-1234", socket="charter",
+              charter_argv=["charter"], harness_pane="%0")
+
+
+class VisibleSlots(unittest.TestCase):
+    def test_a_wide_tall_terminal_keeps_every_slot(self):
+        self.assertEqual(
+            layout.visible_slots(["top", "bottom", "left", "right"], 200, 50, 100, 20),
+            ["top", "bottom", "left", "right"])
+
+    def test_side_panels_go_first_when_the_terminal_is_narrow(self):
+        self.assertEqual(
+            layout.visible_slots(["top", "bottom", "left", "right"], 80, 50, 100, 20),
+            ["top", "bottom"])
+
+    def test_the_top_goes_next_when_the_terminal_is_short(self):
+        self.assertEqual(
+            layout.visible_slots(["top", "bottom", "left", "right"], 200, 12, 100, 20),
+            ["bottom"])
+
+    def test_a_tiny_terminal_keeps_nothing(self):
+        """Below the floor the harness gets the whole terminal. Degrading to a bare
+        harness is the same move `statusline.render` makes when it runs out of width."""
+        self.assertEqual(layout.visible_slots(["top", "bottom"], 40, 8, 100, 20), [])
+
+
+class SessionArgv(unittest.TestCase):
+    def test_the_harness_argv_survives_as_separate_elements_after_the_separator(self):
+        """The security property: tmux does not shell-interpret separate argv elements
+        but does interpret a joined string (pinned against 3.7c), and harness arguments
+        come from the operator's own command line. Checking the exact tail — not just
+        membership of `"--resume"` and `"a;b"` — also catches a `--` dropped or moved,
+        and the harness argv reordered or truncated, none of which the brief's weaker
+        membership check would have caught."""
+        cmd = layout.session_argv(**SESSION)
+        joined = [part for part in cmd if "claude --resume" in part]
+        self.assertEqual(joined, [], "harness argv was joined into one string")
+        self.assertEqual(cmd[cmd.index("--") + 1:], SESSION["harness_argv"])
+
+    def test_the_command_is_a_list_of_separate_strings(self):
+        cmd = layout.session_argv(**SESSION)
+        self.assertIsInstance(cmd, list)
+        for part in cmd:
+            self.assertIsInstance(part, str)
+
+    def test_the_socket_is_named(self):
+        """One private server, never the operator's. Every command carries `-L`."""
+        self.assertEqual(layout.session_argv(**SESSION)[:3], ["tmux", "-L", "charter"])
+
+    def test_it_asks_tmux_to_print_the_pane_id(self):
+        """Pins that `session_argv` actually requests the pane id, not merely `-P` in
+        isolation: the whole two-function split depends on the launcher being able to
+        read a real pane id off stdout, and `-P` with the wrong (or missing) `-F` prints
+        something else just as silently as omitting the flag. Catches `-P` present but
+        `-F`/`'#{pane_id}'` dropped or misspelled."""
+        cmd = layout.session_argv(**SESSION)
+        self.assertIn("-P", cmd)
+        i = cmd.index("-P")
+        self.assertEqual(cmd[i + 1:i + 3], ["-F", "#{pane_id}"])
+
+    def test_the_session_is_created_detached(self):
+        """`-d`: launched from a script with no tty to hand tmux. Without it tmux
+        attaches and the call never returns, which a test would see as a hang rather
+        than a clean failure — so this is worth pinning explicitly."""
+        self.assertIn("-d", layout.session_argv(**SESSION))
+
+
+class PanelArgvs(unittest.TestCase):
+    def test_every_command_is_a_list_of_separate_strings(self):
+        for cmd in layout.panel_argvs(slots=["top", "bottom"], **PANELS):
+            self.assertIsInstance(cmd, list)
+            for part in cmd:
+                self.assertIsInstance(part, str)
+
+    def test_each_visible_slot_gets_one_panel_command(self):
+        cmds = layout.panel_argvs(slots=["top", "bottom"], **PANELS)
+        panels = [c for c in cmds if "panel" in c]
+        self.assertEqual(len(panels), 2)
+        slots = {c[c.index("panel") + 1] for c in panels}
+        self.assertEqual(slots, {"top", "bottom"})
+
+    def test_the_socket_is_named_on_every_command(self):
+        for cmd in layout.panel_argvs(slots=["top"], **PANELS):
+            self.assertEqual(cmd[:3], ["tmux", "-L", "charter"])
+
+    def test_every_split_targets_the_harness_pane_id_not_a_session_index(self):
+        """The bug this two-function design exists to prevent (measured against tmux
+        3.7c — see the module docstring): tmux renumbers pane INDICES on every split, so
+        a target like `f"{session}:0.0"` stops naming the harness after the first split
+        ever runs, and the next split divides the previous split's own panel instead —
+        which eventually fails outright once that panel is one row tall. Fails if any
+        split falls back to a `session:0.0`-style target instead of the pane id it was
+        given."""
+        cmds = layout.panel_argvs(slots=["top", "bottom", "left", "right"], **PANELS)
+        for cmd in cmds:
+            self.assertEqual(cmd[cmd.index("-t") + 1], "%0")
+            self.assertNotIn(f"{PANELS['session']}:0.0", cmd)
+
+    def test_every_slot_targets_the_same_pane_even_after_earlier_splits(self):
+        """Companion to the test above, guarding against a plausible half-fix: only the
+        FIRST split corrected to use the pane id, with later ones drifting back to some
+        target derived from loop position (e.g. incrementing an index, or chaining off
+        the pane an earlier split in this same list would have created). Every split must
+        name the one id `panel_argvs` was handed, regardless of its position in *slots*."""
+        cmds = layout.panel_argvs(slots=["top", "bottom", "left", "right"], **PANELS)
+        targets = {cmd[cmd.index("-t") + 1] for cmd in cmds}
+        self.assertEqual(targets, {"%0"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_liveness.py
+++ b/tests/test_frame_liveness.py
@@ -57,7 +57,20 @@ class Notify(PersonaIso, unittest.TestCase):
             notify.plane_changed()   # must not raise
 
 
-class EveryPostToolUseHandlerBumps(PersonaIso, unittest.TestCase):
+#: Every hook family the spec names as a liveness trigger, and what each one buys.
+#:
+#: `posttooluse*` alone is what this class used to enumerate, and the gap was real:
+#: removing `notify.plane_changed()` from `hooks.sessionstart` or
+#: `hooks.userpromptsubmit` left the whole suite green. The cost of the
+#: `userpromptsubmit` one in particular is the "agent is thinking, no tool calls yet"
+#: window — exactly when an operator looks at the panel and finds it stale, because the
+#: next repaint waits for a tool call that has not happened yet. `sessionstart` is the
+#: first paint of a frame's life: without it a panel opens showing whatever the
+#: previous session left behind until something else moves.
+_TRIGGERS = ("sessionstart", "userpromptsubmit", "posttooluse")
+
+
+class EveryLivenessTriggerBumps(PersonaIso, unittest.TestCase):
     """`hooks/hooks.json` scopes the bare-named `posttooluse` handler to
     `Write|Edit|MultiEdit` alone — Bash, Skill, Task/Agent and SendMessage each route to
     their OWN `posttooluse-*` handler (`posttooluse-bash`, `-skill`, `-dispatch`,
@@ -66,18 +79,25 @@ class EveryPostToolUseHandlerBumps(PersonaIso, unittest.TestCase):
     cares about actually happen — commits, branch moves, worktree edits, none of them a
     Write/Edit/MultiEdit call.
 
-    Enumerates `hooks._HANDLERS` rather than hardcoding today's five names, so a future
-    SIXTH `posttooluse-*` handler that forgets the call fails HERE, the same way it
-    would have caught the gap this class exists to close."""
+    Enumerates `hooks._HANDLERS` against :data:`_TRIGGERS` rather than hardcoding
+    today's names, so a future handler in any of the three families that forgets the
+    call fails HERE, the same way it would have caught the gap this class exists to
+    close."""
 
-    def test_every_posttooluse_handler_calls_plane_changed(self):
-        names = [n for n in hooks._HANDLERS if n.startswith("posttooluse")]
-        # A floor, not a fixed count — the whole point is that a sixth name added later
-        # is picked up automatically, not that exactly five exist today.
-        self.assertGreaterEqual(len(names), 5,
-                                "hooks.json's own five posttooluse* matchers "
-                                "(posttooluse, -bash, -skill, -dispatch, -message) "
-                                "should all be registered in _HANDLERS")
+    def test_every_liveness_trigger_calls_plane_changed(self):
+        names = [n for n in hooks._HANDLERS if n.startswith(_TRIGGERS)]
+        # A floor, not a fixed count — the whole point is that a name added later is
+        # picked up automatically, not that exactly seven exist today.
+        self.assertGreaterEqual(len(names), 7,
+                                "the three trigger families the spec names: "
+                                "sessionstart, userpromptsubmit, and hooks.json's own "
+                                "five posttooluse* matchers (posttooluse, -bash, "
+                                "-skill, -dispatch, -message)")
+        for family in _TRIGGERS:
+            self.assertTrue(any(n.startswith(family) for n in names),
+                            f"no handler at all for the {family!r} trigger family — "
+                            "an enumeration that silently covers two of three is how "
+                            "the gap this class closes got in")
         for name in names:
             with self.subTest(handler=name), \
                  mock.patch.object(notify, "plane_changed") as bumped:

--- a/tests/test_frame_liveness.py
+++ b/tests/test_frame_liveness.py
@@ -1,8 +1,8 @@
 """The frame updates because the agent did something.
 
-`posttooluse` runs on every tool call, and `hooks.py` already treats that path as hot, so
-the bump is debounced and swallows every error: a hook may cost a session its briefing,
-never its turn.
+Every `posttooluse*` handler runs on some tool call, and `hooks.py` already treats that
+family as hot, so the bump is debounced and swallows every error: a hook may cost a
+session its briefing, never its turn.
 """
 
 from __future__ import annotations
@@ -11,9 +11,10 @@ import os
 import unittest
 from unittest import mock
 
+from charter import hooks
 from charter.frame import notify, state
 
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, run_hook
 
 
 class Notify(PersonaIso, unittest.TestCase):
@@ -54,6 +55,34 @@ class Notify(PersonaIso, unittest.TestCase):
              mock.patch.object(state, "bump", side_effect=OSError("read-only")):
             notify._last["at"] = 0.0
             notify.plane_changed()   # must not raise
+
+
+class EveryPostToolUseHandlerBumps(PersonaIso, unittest.TestCase):
+    """`hooks/hooks.json` scopes the bare-named `posttooluse` handler to
+    `Write|Edit|MultiEdit` alone — Bash, Skill, Task/Agent and SendMessage each route to
+    their OWN `posttooluse-*` handler (`posttooluse-bash`, `-skill`, `-dispatch`,
+    `-message`). Wiring `plane_changed()` into `posttooluse` only would leave the frame
+    blind to Bash specifically, which is where most of the plane-state changes a panel
+    cares about actually happen — commits, branch moves, worktree edits, none of them a
+    Write/Edit/MultiEdit call.
+
+    Enumerates `hooks._HANDLERS` rather than hardcoding today's five names, so a future
+    SIXTH `posttooluse-*` handler that forgets the call fails HERE, the same way it
+    would have caught the gap this class exists to close."""
+
+    def test_every_posttooluse_handler_calls_plane_changed(self):
+        names = [n for n in hooks._HANDLERS if n.startswith("posttooluse")]
+        # A floor, not a fixed count — the whole point is that a sixth name added later
+        # is picked up automatically, not that exactly five exist today.
+        self.assertGreaterEqual(len(names), 5,
+                                "hooks.json's own five posttooluse* matchers "
+                                "(posttooluse, -bash, -skill, -dispatch, -message) "
+                                "should all be registered in _HANDLERS")
+        for name in names:
+            with self.subTest(handler=name), \
+                 mock.patch.object(notify, "plane_changed") as bumped:
+                run_hook(hooks._HANDLERS[name], {})
+                bumped.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_liveness.py
+++ b/tests/test_frame_liveness.py
@@ -1,0 +1,60 @@
+"""The frame updates because the agent did something.
+
+`posttooluse` runs on every tool call, and `hooks.py` already treats that path as hot, so
+the bump is debounced and swallows every error: a hook may cost a session its briefing,
+never its turn.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from charter.frame import notify, state
+
+from tests._isolation import PersonaIso
+
+
+class Notify(PersonaIso, unittest.TestCase):
+    def test_a_change_bumps_the_running_frame(self):
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
+            before = state.version("f-1")
+            notify._last["at"] = 0.0
+            notify.plane_changed()
+            self.assertNotEqual(before, state.version("f-1"))
+
+    def test_a_second_bump_inside_the_debounce_window_is_skipped(self):
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
+            notify._last["at"] = 0.0
+            notify.plane_changed()
+            first = state.version("f-1")
+            notify.plane_changed()
+            self.assertEqual(first, state.version("f-1"))
+
+    def test_outside_a_frame_it_does_nothing_at_all(self):
+        """Not just "does not raise" — `state.bump` is itself hardened against a bad id
+        (`contain.segment_ok` rejects a non-str/`None` name harmlessly), so a version of
+        this guard that forwarded a missing id to `state.bump` anyway would still not
+        raise. Spying on `state.bump` catches that the guard-removed version wouldn't:
+        it proves nothing was even attempted, not merely that nothing blew up.
+
+        `_last["at"]` is reset here too, same as the other cases — otherwise the
+        debounce window left over from a test that ran moments earlier (`_last["at"]`
+        being very recent) would return early and mask a missing/broken `fid` guard
+        just as effectively as a correct one, and this test would pass either way."""
+        with mock.patch.dict(os.environ, {}, clear=True), \
+             mock.patch.object(state, "bump") as bump:
+            notify._last["at"] = 0.0
+            notify.plane_changed()   # must not raise
+            bump.assert_not_called()
+
+    def test_a_broken_state_directory_never_reaches_the_hook(self):
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}), \
+             mock.patch.object(state, "bump", side_effect=OSError("read-only")):
+            notify._last["at"] = 0.0
+            notify.plane_changed()   # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_menu.py
+++ b/tests/test_frame_menu.py
@@ -20,6 +20,7 @@ cannot prove tmux's own format parser was actually defeated.
 
 from __future__ import annotations
 
+import json
 import unittest
 
 from charter.frame import menu, state
@@ -105,7 +106,6 @@ class OpaqueIds(PersonaIso, unittest.TestCase):
         write to, bypassing `record`'s own minting, to prove the guard is at `build`,
         not only at the one writer that happens to behave today."""
         d = state.frame_dir("f-1", create=True)
-        import json
         (d / "actions.json").write_text(json.dumps({
             "a0": {"label": "fine", "argv": ["true"]},
             "a0'; run-shell \"touch /tmp/pwned": {"label": "hostile key",
@@ -170,6 +170,27 @@ class OpaqueIds(PersonaIso, unittest.TestCase):
         (d / "actions.json").write_text("{not json")
         self.assertEqual(menu.build("f-1"), [])
         self.assertIsNone(menu.resolve("f-1", "a0"))
+
+    def test_a_non_string_label_in_a_corrupted_table_does_not_crash_the_hotkey(self):
+        """`build` used to return `v.get("label", "")` unvalidated — a value that
+        EXISTS but is the wrong type (`{"label": 123}`) is not caught by that default
+        (the default only ever applies when the KEY is missing), and `123.replace(...)`
+        inside `_safe_label` raised `AttributeError` the moment `menu_argv` tried to
+        escape it. Only `record` writes a `str` today, so this is defence in depth —
+        the same class of guard `_ACTION_ID_RE` already applies to the key next to it,
+        written directly to bypass `record`'s own minting, the same way that test
+        does."""
+        d = state.frame_dir("f-1", create=True)
+        (d / "actions.json").write_text(json.dumps({"a0": {"label": 123, "argv": ["true"]}}))
+        self.assertEqual(menu.build("f-1"), [("(untitled)", "a0")])
+        # Must not raise, and must not embed the id where the label was expected.
+        argv = menu.menu_argv("f-1", "charter", client="/dev/ttys0")
+        self.assertEqual(argv[-3], "(untitled)")
+
+    def test_a_missing_label_key_also_gets_the_placeholder(self):
+        d = state.frame_dir("f-1", create=True)
+        (d / "actions.json").write_text(json.dumps({"a0": {"argv": ["true"]}}))
+        self.assertEqual(menu.build("f-1"), [("(untitled)", "a0")])
 
 
 class LabelSafety(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_menu.py
+++ b/tests/test_frame_menu.py
@@ -1,0 +1,121 @@
+"""A workspace name must never reach a tmux command string.
+
+`display-menu` takes commands tmux parses and runs, and workspace, repo, branch and
+persona names all come from committed files or `.git/HEAD`. Charter shipped a fix for
+this exact shape one release ago — a branch name reaching `gh -F` and making it read a
+file — and its conclusion was that the fix is the mechanism, not the value. So menu items
+carry opaque ids and charter resolves them in-process.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter.frame import menu, state
+
+from tests._isolation import PersonaIso
+
+#: The task brief's own hostile string. Deliberately picked so it ALSO contains the
+#: literal substring "run-shell" — a menu label is drawn verbatim (never executed), so a
+#: label containing that text is exactly as harmless as one that doesn't, and any test
+#: that treated "the joined argv doesn't contain the substring run-shell" as the safety
+#: property would be testing the wrong thing (see `OpaqueIds`'s own docstring below).
+HOSTILE = 'x" ; run-shell "touch /tmp/pwned'
+
+
+class OpaqueIds(PersonaIso, unittest.TestCase):
+    def test_the_action_slot_never_carries_the_label(self):
+        """The property that actually matters, and the one the brief's own draft test
+        ('assertNotIn("run-shell", flat)') cannot check: `menu_argv`'s FIXED action
+        template is `run-shell 'charter frame-action a<N>'`, which legitimately contains
+        the substring "run-shell" for every entry, hostile label or not — asserting that
+        substring is absent from the whole joined argv fails against ANY correct
+        implementation the moment a label happens to echo it back, which this one does on
+        purpose. What must hold is narrower and stronger: the per-item COMMAND slot
+        (`display-menu`'s third element of each `label key command` triple) is always
+        that exact fixed string, independent of what the label next to it says — proven
+        here by checking the command slot in isolation, not the flattened text."""
+        menu.record(fid="f-1", entries=[(HOSTILE, ["charter", "ws", "use", HOSTILE])])
+        argv = menu.menu_argv("f-1", "charter")
+        label, key, command = argv[-3:]
+        self.assertEqual(label, HOSTILE, "a label is drawn verbatim, never executed")
+        self.assertEqual(key, "1")
+        self.assertEqual(command, "run-shell 'charter frame-action a0'")
+        self.assertNotIn(HOSTILE, command)
+        self.assertNotIn("/tmp/pwned", command)
+        self.assertNotIn(";", command)
+
+    def test_the_menu_targets_this_frames_own_session_explicitly(self):
+        """Without `-t fid`, `display-menu` defaults to "whichever client is most
+        recently active" — right the instant a bind's own action runs it directly, but
+        `charter frame-menu` (`commands_frame.cmd_menu`) is a SEPARATE process one hop
+        removed from that bind, so the default is no longer guaranteed once two frames
+        are attached in two terminals at once. `fid` is free to pass explicitly (it is
+        the session's own name, already restricted to a safe alphabet by
+        `state.frame_id` — see `charter/frame/state.py`), so there is no reason to lean
+        on an implicit default here."""
+        argv = menu.menu_argv("f-1", "charter")
+        self.assertEqual(argv[:6], ["tmux", "-L", "charter", "display-menu", "-t", "f-1"])
+
+    def test_the_id_resolves_back_to_the_real_command_in_process(self):
+        menu.record(fid="f-1", entries=[(HOSTILE, ["charter", "ws", "use", HOSTILE])])
+        entries = menu.build("f-1")
+        self.assertEqual(len(entries), 1)
+        label, action_id = entries[0]
+        self.assertEqual(label, HOSTILE)
+        self.assertEqual(menu.resolve("f-1", action_id),
+                         ["charter", "ws", "use", HOSTILE])
+
+    def test_an_unknown_id_resolves_to_nothing(self):
+        self.assertIsNone(menu.resolve("f-1", "not-an-id"))
+
+    def test_an_unrecorded_frame_resolves_to_nothing(self):
+        """No `record()` call for this fid at all — the ordinary case for a menu id
+        arriving after `reap()` already removed the frame's own directory."""
+        self.assertIsNone(menu.resolve("never-recorded", "a0"))
+        self.assertEqual(menu.build("never-recorded"), [])
+
+    def test_an_id_is_only_ever_id_shaped(self):
+        menu.record(fid="f-1", entries=[(HOSTILE, ["charter", "true"])])
+        for _label, action_id in menu.build("f-1"):
+            self.assertRegex(action_id, r"^a[0-9]+$")
+
+    def test_ids_stay_in_recorded_order_past_nine_entries(self):
+        """`build` must not sort the id STRINGS lexicographically — "a10" would then
+        land before "a2", silently reordering the menu the moment a frame grows past
+        nine entries. `record` mints ids by plain insertion order; `build` must return
+        them the same way."""
+        entries = [(f"item{i}", ["true"]) for i in range(12)]
+        menu.record(fid="f-1", entries=entries)
+        got = [label for label, _id in menu.build("f-1")]
+        self.assertEqual(got, [f"item{i}" for i in range(12)])
+
+    def test_a_hostile_workspace_named_fid_never_becomes_a_stray_directory(self):
+        """`frame_dir` refuses a hostile id rather than sanitising it (see its own
+        docstring) — `record`/`build`/`resolve` must all fall through to a no-op/`None`
+        for exactly that id, never invent a path of their own to write to instead."""
+        hostile_fid = "../../etc/passwd"
+        menu.record(fid=hostile_fid, entries=[("x", ["true"])])
+        self.assertIsNone(state.frame_dir(hostile_fid))
+        self.assertEqual(menu.build(hostile_fid), [])
+        self.assertIsNone(menu.resolve(hostile_fid, "a0"))
+
+    def test_a_label_with_a_newline_cannot_break_the_menus_own_layout(self):
+        menu.record(fid="f-1", entries=[("line one\nline two", ["true"])])
+        label, _id = menu.build("f-1")[0]
+        self.assertNotIn("\n", label)
+
+    def test_a_very_long_label_is_bounded(self):
+        menu.record(fid="f-1", entries=[("x" * 500, ["true"])])
+        label, _id = menu.build("f-1")[0]
+        self.assertLessEqual(len(label), 60)
+
+    def test_reading_a_corrupt_table_answers_empty_not_a_crash(self):
+        d = state.frame_dir("f-1", create=True)
+        (d / "actions.json").write_text("{not json")
+        self.assertEqual(menu.build("f-1"), [])
+        self.assertIsNone(menu.resolve("f-1", "a0"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_menu.py
+++ b/tests/test_frame_menu.py
@@ -1,10 +1,21 @@
-"""A workspace name must never reach a tmux command string.
+"""A workspace name must never reach a tmux command string — and a label is not inert.
 
 `display-menu` takes commands tmux parses and runs, and workspace, repo, branch and
 persona names all come from committed files or `.git/HEAD`. Charter shipped a fix for
 this exact shape one release ago — a branch name reaching `gh -F` and making it read a
 file — and its conclusion was that the fix is the mechanism, not the value. So menu items
 carry opaque ids and charter resolves them in-process.
+
+But a menu item's own NAME is also not inert: `display-menu`'s own docs say "The name and
+command are formats" — `#(shell command)` runs the moment tmux draws the menu, no
+selection needed, and `#{variable}` substitutes a value. This module's own first version
+claimed "a label is drawn, never executed" and pinned that with a test; both were wrong,
+confirmed by hand in a real frame (an unescaped `#(touch CANARY)` label created CANARY the
+instant the menu was drawn, and the hostile row was invisible — nothing about the RENDERED
+menu looked wrong). `OpaqueIds` below tests the id/argv boundary at the unit level;
+`tests/test_frame_tmux_integration.py`'s `MenuFormatIntegration` proves the label boundary
+against a real, rendered `display-menu`, with a canary — an argv-shape assertion alone
+cannot prove tmux's own format parser was actually defeated.
 """
 
 from __future__ import annotations
@@ -15,11 +26,10 @@ from charter.frame import menu, state
 
 from tests._isolation import PersonaIso
 
-#: The task brief's own hostile string. Deliberately picked so it ALSO contains the
-#: literal substring "run-shell" — a menu label is drawn verbatim (never executed), so a
-#: label containing that text is exactly as harmless as one that doesn't, and any test
-#: that treated "the joined argv doesn't contain the substring run-shell" as the safety
-#: property would be testing the wrong thing (see `OpaqueIds`'s own docstring below).
+#: The task brief's own hostile string, for the id/argv boundary below. Contains no `#`,
+#: no leading `-`, and does not end in `#` — none of `_safe_label`'s own transforms
+#: apply to it, so it round-trips through `menu_argv` unchanged, which is exactly what
+#: lets `test_the_action_slot_never_carries_the_label` assert on it byte for byte.
 HOSTILE = 'x" ; run-shell "touch /tmp/pwned'
 
 
@@ -36,26 +46,32 @@ class OpaqueIds(PersonaIso, unittest.TestCase):
         that exact fixed string, independent of what the label next to it says — proven
         here by checking the command slot in isolation, not the flattened text."""
         menu.record(fid="f-1", entries=[(HOSTILE, ["charter", "ws", "use", HOSTILE])])
-        argv = menu.menu_argv("f-1", "charter")
+        argv = menu.menu_argv("f-1", "charter", client="/dev/ttys0")
         label, key, command = argv[-3:]
-        self.assertEqual(label, HOSTILE, "a label is drawn verbatim, never executed")
+        # NOT "a label is drawn verbatim, never executed" — that was this module's own
+        # first, wrong claim (see the module docstring). HOSTILE happens to round-trip
+        # unchanged only because it triggers none of `_safe_label`'s own transforms (no
+        # `#`, no leading `-`, no trailing `#`); see `LabelSafety` below for labels that
+        # DO trigger them, and `MenuFormatIntegration` for the property that actually
+        # matters, proven against a real, rendered menu.
+        self.assertEqual(label, HOSTILE)
         self.assertEqual(key, "1")
         self.assertEqual(command, "run-shell 'charter frame-action a0'")
         self.assertNotIn(HOSTILE, command)
         self.assertNotIn("/tmp/pwned", command)
         self.assertNotIn(";", command)
 
-    def test_the_menu_targets_this_frames_own_session_explicitly(self):
-        """Without `-t fid`, `display-menu` defaults to "whichever client is most
-        recently active" — right the instant a bind's own action runs it directly, but
-        `charter frame-menu` (`commands_frame.cmd_menu`) is a SEPARATE process one hop
-        removed from that bind, so the default is no longer guaranteed once two frames
-        are attached in two terminals at once. `fid` is free to pass explicitly (it is
-        the session's own name, already restricted to a safe alphabet by
-        `state.frame_id` — see `charter/frame/state.py`), so there is no reason to lean
-        on an implicit default here."""
-        argv = menu.menu_argv("f-1", "charter")
-        self.assertEqual(argv[:6], ["tmux", "-L", "charter", "display-menu", "-t", "f-1"])
+    def test_the_menu_targets_this_frames_own_client_and_session(self):
+        """`-c client` is what selects WHICH ATTACHED TERMINAL sees the menu —
+        `display-menu`'s own docs: "Display a menu on target-client." `-t fid` alone
+        does NOT choose it (verified by hand against tmux 3.7c with two frames attached
+        in two terminals: `-t fid` rendered the wrong frame's menu on the wrong screen) —
+        it only scopes format evaluation for the item's own command text, which is why
+        both flags are asserted here rather than either alone."""
+        argv = menu.menu_argv("f-1", "charter", client="/dev/ttys3")
+        self.assertEqual(argv[:9],
+                         ["tmux", "-L", "charter", "display-menu", "-t", "f-1",
+                          "-c", "/dev/ttys3", "-T"])
 
     def test_the_id_resolves_back_to_the_real_command_in_process(self):
         menu.record(fid="f-1", entries=[(HOSTILE, ["charter", "ws", "use", HOSTILE])])
@@ -79,6 +95,26 @@ class OpaqueIds(PersonaIso, unittest.TestCase):
         menu.record(fid="f-1", entries=[(HOSTILE, ["charter", "true"])])
         for _label, action_id in menu.build("f-1"):
             self.assertRegex(action_id, r"^a[0-9]+$")
+
+    def test_a_key_not_shaped_a_n_is_refused_at_the_point_of_use(self):
+        """Only `record` mints ids today, so this is defence in depth rather than a live
+        hole — but `menu_argv` interpolates whatever `build` hands it directly into text
+        tmux re-parses (`f"run-shell 'charter frame-action {action_id}'"`), so a
+        corrupted or hand-edited table with a key like `a0'; run-shell "touch x` must
+        never reach that f-string. Written directly to the table `record` itself would
+        write to, bypassing `record`'s own minting, to prove the guard is at `build`,
+        not only at the one writer that happens to behave today."""
+        d = state.frame_dir("f-1", create=True)
+        import json
+        (d / "actions.json").write_text(json.dumps({
+            "a0": {"label": "fine", "argv": ["true"]},
+            "a0'; run-shell \"touch /tmp/pwned": {"label": "hostile key",
+                                                  "argv": ["touch", "/tmp/pwned"]},
+        }))
+        entries = menu.build("f-1")
+        self.assertEqual([label for label, _id in entries], ["fine"])
+        argv = menu.menu_argv("f-1", "charter", client="/dev/ttys0")
+        self.assertNotIn("pwned", " ".join(argv))
 
     def test_ids_stay_in_recorded_order_past_nine_entries(self):
         """`build` must not sort the id STRINGS lexicographically — "a10" would then
@@ -110,11 +146,83 @@ class OpaqueIds(PersonaIso, unittest.TestCase):
         label, _id = menu.build("f-1")[0]
         self.assertLessEqual(len(label), 60)
 
+    def test_an_empty_label_does_not_desync_the_menus_own_triples(self):
+        """`display-menu` treats an empty NAME as a separator line — both the key and
+        command are meant to be omitted for one, per its own docs. `record` still writes
+        a `label key command` triple regardless, so an empty label would silently
+        desync every triple after it and `display-menu` would fail outright with "not
+        enough arguments" — the hotkey doing nothing, with nothing anywhere saying why."""
+        menu.record(fid="f-1", entries=[("", ["true"]), ("second", ["true"])])
+        labels = [label for label, _id in menu.build("f-1")]
+        self.assertTrue(labels[0], "an empty label must become a non-empty placeholder")
+        self.assertEqual(labels[1], "second")
+
+    def test_a_label_of_only_newlines_also_gets_a_placeholder(self):
+        """Newline-stripping alone can turn a non-empty label into an all-space one but
+        never into an EMPTY one (`\\n` -> ` `, never -> `''`) — this pins the one input
+        shape that actually reaches record's own empty check: a literally empty string."""
+        menu.record(fid="f-1", entries=[("", ["true"])])
+        label, _id = menu.build("f-1")[0]
+        self.assertNotEqual(label, "")
+
     def test_reading_a_corrupt_table_answers_empty_not_a_crash(self):
         d = state.frame_dir("f-1", create=True)
         (d / "actions.json").write_text("{not json")
         self.assertEqual(menu.build("f-1"), [])
         self.assertIsNone(menu.resolve("f-1", "a0"))
+
+
+class LabelSafety(PersonaIso, unittest.TestCase):
+    """`_safe_label` and its use inside `menu_argv` — the fix for the CRITICAL finding:
+    a `display-menu` item name is a tmux FORMAT, not inert text. Argv-level assertions
+    only; the render-time proof (a real `#(...)` label creating no canary against a real,
+    attached client) lives in `test_frame_tmux_integration.py`'s `MenuFormatIntegration`."""
+
+    def _label_argv(self, label: str) -> str:
+        menu.record(fid="f-1", entries=[(label, ["true"])])
+        return menu.menu_argv("f-1", "charter", client="/dev/ttys0")[-3]
+
+    def test_a_shell_job_label_is_escaped_hash_by_hash(self):
+        """`#(cmd)` runs `cmd` the instant tmux draws the menu (confirmed by hand — see
+        the module docstring). `##` is tmux's own escape for a literal `#`; doubling
+        every occurrence is what closes it — checked here as an exact string match, not
+        merely "the substring #( is gone", since a partial escape (only the first #, say)
+        would still leave a working `#(...)` job one character later."""
+        rendered = self._label_argv("#(touch /tmp/pwned)")
+        self.assertEqual(rendered, "##(touch /tmp/pwned)")
+
+    def test_a_format_variable_label_is_escaped_too(self):
+        """`#{session_name}` substitutes a value rather than running a job, but it is the
+        SAME construction (an unescaped `#`) and the SAME fix closes it — no separate
+        mechanism needed for the two forms tmux's FORMATS section documents."""
+        rendered = self._label_argv("#{session_name}")
+        self.assertEqual(rendered, "##{session_name}")
+
+    def test_every_hash_is_doubled_not_only_the_first(self):
+        rendered = self._label_argv("##(a)##(b)#")
+        self.assertEqual(rendered.count("#"), 2 * "##(a)##(b)#".count("#"))
+
+    def test_a_leading_hyphen_no_longer_disables_the_row(self):
+        """`display-menu`'s own docs: a name starting with `-` is "shown dim and may not
+        be chosen" — the whole item becomes unselectable, not merely oddly labelled.
+        Exactly correction 4's "truncated into something misleading" failure, reached
+        through a menu row instead of a status line."""
+        rendered = self._label_argv("-my-branch")
+        self.assertFalse(rendered.startswith("-"))
+        self.assertIn("my-branch", rendered)
+
+    def test_a_trailing_hash_gets_a_trailing_space(self):
+        """Cosmetic, not a safety hole (the escape above already makes it inert either
+        way) — but a label doubled from a single trailing `#` collides with a style-reset
+        sequence tmux appends after every item's own name, rendering literal
+        `label#[default]` garbage (confirmed by hand; a label with no trailing hash never
+        showed it). A trailing space breaks the adjacency."""
+        rendered = self._label_argv("trailing#")
+        self.assertEqual(rendered, "trailing## ")
+
+    def test_a_label_with_none_of_the_special_shapes_is_unchanged(self):
+        rendered = self._label_argv("ordinary text")
+        self.assertEqual(rendered, "ordinary text")
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_menu.py
+++ b/tests/test_frame_menu.py
@@ -21,6 +21,7 @@ cannot prove tmux's own format parser was actually defeated.
 from __future__ import annotations
 
 import json
+import sys
 import unittest
 
 from charter.frame import menu, state
@@ -38,7 +39,8 @@ class OpaqueIds(PersonaIso, unittest.TestCase):
     def test_the_action_slot_never_carries_the_label(self):
         """The property that actually matters, and the one the brief's own draft test
         ('assertNotIn("run-shell", flat)') cannot check: `menu_argv`'s FIXED action
-        template is `run-shell 'charter frame-action a<N>'`, which legitimately contains
+        template is `run-shell '"$CHARTER_PY" -m charter frame-action a<N>'`, which
+        legitimately contains
         the substring "run-shell" for every entry, hostile label or not — asserting that
         substring is absent from the whole joined argv fails against ANY correct
         implementation the moment a label happens to echo it back, which this one does on
@@ -57,10 +59,27 @@ class OpaqueIds(PersonaIso, unittest.TestCase):
         # matters, proven against a real, rendered menu.
         self.assertEqual(label, HOSTILE)
         self.assertEqual(key, "1")
-        self.assertEqual(command, "run-shell 'charter frame-action a0'")
+        self.assertEqual(command,
+                         'run-shell \'"$CHARTER_PY" -m charter frame-action a0\'')
         self.assertNotIn(HOSTILE, command)
         self.assertNotIn("/tmp/pwned", command)
         self.assertNotIn(";", command)
+
+    def test_the_action_runs_charter_through_a_named_interpreter_not_off_the_path(self):
+        """Same defect as the hotkey bind's own (`test_frame_launcher.Conf`), one layer
+        down: every MENU ITEM ran a bare `charter` too. With charter not on the tmux
+        server's `$PATH`, selecting "Detach" makes `run-shell` print
+        `'charter frame-action a0' returned 127` INTO THE HARNESS PANE and drop it into
+        copy-mode — charter drawing in the one rectangle ADR 0018 says it never draws.
+
+        The interpreter is a VARIABLE the session carries, never `sys.executable` baked
+        in here: an absolute path re-embedded inside this nested tmux-quote layer is the
+        construction `commands_frame`'s module docstring bans for `status_path`."""
+        menu.record(fid="f-1", entries=[("Detach", ["true"])])
+        command = menu.menu_argv("f-1", "charter", client="/dev/ttys0")[-1]
+        self.assertNotIn("run-shell 'charter", command)
+        self.assertIn('"$CHARTER_PY" -m charter frame-action', command)
+        self.assertNotIn(sys.executable, command)
 
     def test_the_menu_targets_this_frames_own_client_and_session(self):
         """`-c client` is what selects WHICH ATTACHED TERMINAL sees the menu —
@@ -100,7 +119,7 @@ class OpaqueIds(PersonaIso, unittest.TestCase):
     def test_a_key_not_shaped_a_n_is_refused_at_the_point_of_use(self):
         """Only `record` mints ids today, so this is defence in depth rather than a live
         hole — but `menu_argv` interpolates whatever `build` hands it directly into text
-        tmux re-parses (`f"run-shell 'charter frame-action {action_id}'"`), so a
+        tmux re-parses (`run-shell '"$CHARTER_PY" -m charter frame-action <id>'`), so a
         corrupted or hand-edited table with a key like `a0'; run-shell "touch x` must
         never reach that f-string. Written directly to the table `record` itself would
         write to, bypassing `record`'s own minting, to prove the guard is at `build`,

--- a/tests/test_frame_panel.py
+++ b/tests/test_frame_panel.py
@@ -47,8 +47,14 @@ class Redraw(PersonaIso, unittest.TestCase):
 
 class Draw(PersonaIso, unittest.TestCase):
     def test_one_pass_writes_the_slot_and_returns(self):
-        rc = panel.run("bottom", "f-1", once=True)
+        """`rc == 0` alone survives `_paint` becoming a no-op — the "writes the slot"
+        half of this test's own name needs the actual painted content checked, not just
+        that `run` returned cleanly."""
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = panel.run("bottom", "f-1", once=True)
         self.assertEqual(rc, 0)
+        self.assertIn("todo", buf.getvalue())
 
     def test_an_unknown_slot_is_refused_rather_than_drawn_blank(self):
         rc = panel.run("sideways", "f-1", once=True)
@@ -73,11 +79,12 @@ class Height(unittest.TestCase):
 class PaintClampsToRealHeight(PersonaIso, unittest.TestCase):
     """`render()`'s contract is a single string with no notion of height — a future
     `left`/`right` slot could return more lines than a real pane holds, and painting all
-    of them would scroll the frame's own top row out of view, the same shape of
-    corruption a stale-width repaint causes. Every real slot today (`top`/`bottom`) only
-    ever emits one line, so this stands a fake multi-line slot in for a future renderer
-    the same way `test_frame_slots.py`'s own `boom` fixture stands in for a failing one —
-    restored via `finally`, not `addCleanup`, to match that file's own convention.
+    of them would scroll that PANEL'S OWN rows (each tmux pane keeps its own scroll
+    region — a sibling pane is untouched), the same shape of corruption a stale-width
+    repaint causes. Every real slot today (`top`/`bottom`) only ever emits one line, so
+    this stands a fake multi-line slot in for a future renderer the same way
+    `test_frame_slots.py`'s own `boom` fixture stands in for a failing one — restored via
+    `finally`, not `addCleanup`, to match that file's own convention.
     """
 
     def test_a_taller_than_the_pane_render_is_clamped_to_the_panes_rows(self):
@@ -151,6 +158,23 @@ class Tick(PersonaIso, unittest.TestCase):
         paint.assert_called_once_with("bottom", "f-1")
         self.assertEqual(result, state.version("f-1"))
         self.assertNotEqual(result, seen)
+
+    def test_a_bump_landing_during_the_paint_is_not_marked_seen(self):
+        """Pins the read-before-paint ordering `_tick`'s own docstring argues for,
+        deterministically rather than by argument alone: `_paint` is mocked to itself
+        call `state.bump` — standing in for a hook firing WHILE this tick's paint is in
+        flight — so the version has already moved again by the time `_paint` returns.
+        `_tick` must not report the version it read at the START of this tick as "seen"
+        in a way that satisfies `should_redraw` for the version that landed during it;
+        red on the one mutation (of thirteen) that swapped the read and the paint."""
+        fid = "f-race"
+        state.bump(fid)
+        seen = state.version(fid)
+        state.bump(fid)
+        with mock.patch("charter.frame.panel._paint",
+                        side_effect=lambda slot, f: state.bump(f)):
+            result = panel._tick({"flag": False}, seen, "bottom", fid)
+        self.assertTrue(panel.should_redraw(result, fid))
 
 
 class Sigwinch(unittest.TestCase):

--- a/tests/test_frame_panel.py
+++ b/tests/test_frame_panel.py
@@ -1,0 +1,215 @@
+"""A panel wakes because the agent did something, not because a timer went off.
+
+The version file is a `stat` per tick, which is why the frame costs nothing at idle. A
+FIFO was designed and rejected: opening one for write blocks until a reader exists, which
+would put a hang inside the hook path.
+
+Width is `slots.py`'s own responsibility, already pinned end to end in
+`test_frame_slots.py`; `RendersToItsOwnPaneWidth` below only re-proves it holds THROUGH
+`panel.run`, not that `slots._width` itself is correct. Height — the line COUNT painted,
+not just each line's width — is this module's own job: `render()`'s contract is a single
+string, so nothing downstream of it knows how tall the pane it is about to overwrite
+actually is. `PaintClampsToRealHeight` pins that directly against a fake multi-line slot,
+since every real slot today (`top`/`bottom`) only ever renders one line.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import signal
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+from charter import tui
+from charter.frame import panel, slots, state
+
+from tests._isolation import PersonaIso
+
+
+class Redraw(PersonaIso, unittest.TestCase):
+    def test_an_unchanged_version_does_not_redraw(self):
+        seen = state.version("f-1")
+        self.assertFalse(panel.should_redraw(seen, "f-1"))
+
+    def test_a_bump_asks_for_a_redraw(self):
+        seen = state.version("f-1")
+        state.bump("f-1")
+        self.assertTrue(panel.should_redraw(seen, "f-1"))
+
+    def test_a_missing_frame_redraws_rather_than_crashing(self):
+        """A panel outliving its state directory must show something, not die and leave
+        a hole in the frame."""
+        self.assertTrue(panel.should_redraw("nothing-like-a-version", "never-existed"))
+
+
+class Draw(PersonaIso, unittest.TestCase):
+    def test_one_pass_writes_the_slot_and_returns(self):
+        rc = panel.run("bottom", "f-1", once=True)
+        self.assertEqual(rc, 0)
+
+    def test_an_unknown_slot_is_refused_rather_than_drawn_blank(self):
+        rc = panel.run("sideways", "f-1", once=True)
+        self.assertNotEqual(rc, 0)
+
+
+class Height(unittest.TestCase):
+    """Mirrors `test_frame_slots.py`'s own `Width` class: `_rows` must measure the
+    pane's own tty, not assume one — `left`/`right` panels are full height while
+    `top`/`bottom` are one row (`layout.SLOT_SIZE`), and this is the one function that
+    has to be right for both."""
+
+    def test_rows_measures_the_panes_own_tty(self):
+        with mock.patch("os.get_terminal_size", return_value=os.terminal_size((80, 7))):
+            self.assertEqual(panel._rows(), 7)
+
+    def test_rows_falls_back_to_a_default_when_no_tty_is_available(self):
+        with mock.patch("os.get_terminal_size", side_effect=OSError("not a tty")):
+            self.assertEqual(panel._rows(), panel._DEFAULT_ROWS)
+
+
+class PaintClampsToRealHeight(PersonaIso, unittest.TestCase):
+    """`render()`'s contract is a single string with no notion of height — a future
+    `left`/`right` slot could return more lines than a real pane holds, and painting all
+    of them would scroll the frame's own top row out of view, the same shape of
+    corruption a stale-width repaint causes. Every real slot today (`top`/`bottom`) only
+    ever emits one line, so this stands a fake multi-line slot in for a future renderer
+    the same way `test_frame_slots.py`'s own `boom` fixture stands in for a failing one —
+    restored via `finally`, not `addCleanup`, to match that file's own convention.
+    """
+
+    def test_a_taller_than_the_pane_render_is_clamped_to_the_panes_rows(self):
+        slots.SLOTS["tall"] = lambda fid: "\n".join(f"line {i}" for i in range(10))
+        try:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                with mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+                     mock.patch("os.get_terminal_size", return_value=os.terminal_size((40, 3))):
+                    rc = panel.run("tall", "f-1", once=True)
+        finally:
+            del slots.SLOTS["tall"]
+        self.assertEqual(rc, 0)
+        painted = buf.getvalue().split("\x1b[2J", 1)[1]
+        self.assertEqual(len(painted.split("\n")), 3, painted)
+
+
+class RendersToItsOwnPaneWidth(PersonaIso, unittest.TestCase):
+    """The coordinator correction this task shipped under: a panel computes its width
+    from its own tty, never from `$COLUMNS`, which it inherits WHOLE from the launching
+    shell (measured: a 22-column pane whose launcher had exported `COLUMNS=200` saw
+    `COLUMNS='200'`). `test_frame_slots.py` already pins this against `slots._width`/
+    `slots.render` directly; this pins it end to end THROUGH `panel.run`, so a future
+    change to `panel.py` itself — capturing stdout before `slots.render` ever sees the
+    real fd, say — cannot quietly reopen it.
+    """
+
+    def test_panel_run_follows_the_pane_not_the_wider_columns_value(self):
+        buf = io.StringIO()
+        with mock.patch.dict(os.environ, {"COLUMNS": "500"}), redirect_stdout(buf):
+            with mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+                 mock.patch("os.get_terminal_size", return_value=os.terminal_size((18, 4))):
+                rc = panel.run("top", "f-1", once=True)
+        self.assertEqual(rc, 0)
+        painted = buf.getvalue().split("\x1b[2J", 1)[1]
+        for line in painted.split("\n"):
+            self.assertLessEqual(tui.width(line), 18)
+
+
+class Tick(PersonaIso, unittest.TestCase):
+    """`_tick` is `run`'s decision-and-effect for ONE iteration, split out so the
+    decision can be exercised without also exercising `run`'s `while True`/
+    `time.sleep`. A resize must win even when the frame's own version has not moved —
+    only charter's own hooks call `state.bump`; an operator resizing their terminal does
+    not, so `should_redraw` alone would leave a pane painted for a size that no longer
+    exists until unrelated agent activity happened to bump the version next.
+    """
+
+    def test_a_resize_paints_even_when_the_version_is_unchanged(self):
+        seen = state.version("f-1")
+        resized = {"flag": True}
+        with mock.patch("charter.frame.panel._paint") as paint:
+            panel._tick(resized, seen, "bottom", "f-1")
+        paint.assert_called_once_with("bottom", "f-1")
+        self.assertFalse(resized["flag"])
+
+    def test_no_resize_and_no_version_change_does_not_paint(self):
+        seen = state.version("f-1")
+        resized = {"flag": False}
+        with mock.patch("charter.frame.panel._paint") as paint:
+            result = panel._tick(resized, seen, "bottom", "f-1")
+        paint.assert_not_called()
+        self.assertEqual(result, seen)
+
+    def test_a_version_bump_paints_and_remembers_the_new_version(self):
+        seen = state.version("f-1")
+        state.bump("f-1")
+        resized = {"flag": False}
+        with mock.patch("charter.frame.panel._paint") as paint:
+            result = panel._tick(resized, seen, "bottom", "f-1")
+        paint.assert_called_once_with("bottom", "f-1")
+        self.assertEqual(result, state.version("f-1"))
+        self.assertNotEqual(result, seen)
+
+
+class Sigwinch(unittest.TestCase):
+    """A resize does not bump the frame's version — only charter's own hooks call
+    `state.bump` — so without this handler a pane would sit painted at the OLD size
+    until unrelated activity happened to bump the version next."""
+
+    def test_the_installed_handler_marks_the_resize_flag(self):
+        resized = {"flag": False}
+        old = panel._install_sigwinch(resized)
+        try:
+            signal.getsignal(signal.SIGWINCH)(signal.SIGWINCH, None)
+            self.assertTrue(resized["flag"])
+        finally:
+            signal.signal(signal.SIGWINCH, old)
+
+
+class RunOnceLoop(PersonaIso, unittest.TestCase):
+    """`run(once=True)` is called IN-PROCESS by every test above, not only spawned as a
+    subprocess's whole life — so it must leave nothing behind, and it must never so much
+    as touch the loop's own throttle."""
+
+    def test_once_true_restores_the_previous_sigwinch_handler(self):
+        original = signal.getsignal(signal.SIGWINCH)
+        panel.run("bottom", "f-1", once=True)
+        self.assertEqual(signal.getsignal(signal.SIGWINCH), original)
+
+    def test_once_true_returns_without_ever_sleeping(self):
+        with mock.patch("charter.frame.panel.time.sleep",
+                        side_effect=AssertionError("once=True must not sleep")):
+            rc = panel.run("bottom", "f-1", once=True)
+        self.assertEqual(rc, 0)
+
+
+class CliWiring(unittest.TestCase):
+    """`layout.panel_argvs` (Task 6, already merged and already spawning panel panes)
+    emits exactly `*charter_argv, "panel", slot, "--session", session` — a CLI that does
+    not accept that shape means every panel pane fails at startup and the frame comes up
+    empty."""
+
+    def test_the_launchers_argv_shape_parses(self):
+        from charter.cli import build_parser
+        ns = build_parser().parse_args(["panel", "bottom", "--session", "f-1"])
+        self.assertEqual(ns.slot, "bottom")
+        self.assertEqual(ns.session, "f-1")
+
+    def test_the_parsed_args_dispatch_to_panel_run(self):
+        from charter.cli import build_parser
+        ns = build_parser().parse_args(["panel", "top", "--session", "f-2"])
+        with mock.patch("charter.frame.panel.run", return_value=0) as run:
+            rc = ns.func(ns)
+        run.assert_called_once_with("top", "f-2")
+        self.assertEqual(rc, 0)
+
+    def test_session_is_required(self):
+        from charter.cli import build_parser
+        with self.assertRaises(SystemExit):
+            build_parser().parse_args(["panel", "bottom"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_panel.py
+++ b/tests/test_frame_panel.py
@@ -29,22 +29,6 @@ from charter.frame import panel, slots, state
 from tests._isolation import PersonaIso
 
 
-class Redraw(PersonaIso, unittest.TestCase):
-    def test_an_unchanged_version_does_not_redraw(self):
-        seen = state.version("f-1")
-        self.assertFalse(panel.should_redraw(seen, "f-1"))
-
-    def test_a_bump_asks_for_a_redraw(self):
-        seen = state.version("f-1")
-        state.bump("f-1")
-        self.assertTrue(panel.should_redraw(seen, "f-1"))
-
-    def test_a_missing_frame_redraws_rather_than_crashing(self):
-        """A panel outliving its state directory must show something, not die and leave
-        a hole in the frame."""
-        self.assertTrue(panel.should_redraw("nothing-like-a-version", "never-existed"))
-
-
 class Draw(PersonaIso, unittest.TestCase):
     def test_one_pass_writes_the_slot_and_returns(self):
         """`rc == 0` alone survives `_paint` becoming a no-op — the "writes the slot"
@@ -129,8 +113,8 @@ class Tick(PersonaIso, unittest.TestCase):
     decision can be exercised without also exercising `run`'s `while True`/
     `time.sleep`. A resize must win even when the frame's own version has not moved —
     only charter's own hooks call `state.bump`; an operator resizing their terminal does
-    not, so `should_redraw` alone would leave a pane painted for a size that no longer
-    exists until unrelated agent activity happened to bump the version next.
+    not, so a version comparison alone would leave a pane painted for a size that no
+    longer exists until unrelated agent activity happened to bump the version next.
     """
 
     def test_a_resize_paints_even_when_the_version_is_unchanged(self):
@@ -165,8 +149,11 @@ class Tick(PersonaIso, unittest.TestCase):
         call `state.bump` — standing in for a hook firing WHILE this tick's paint is in
         flight — so the version has already moved again by the time `_paint` returns.
         `_tick` must not report the version it read at the START of this tick as "seen"
-        in a way that satisfies `should_redraw` for the version that landed during it;
-        red on the one mutation (of thirteen) that swapped the read and the paint."""
+        in a way that satisfies "has the frame changed" for the version that landed
+        during it; red on the one mutation (of thirteen) that swapped the read and the
+        paint. Asserts against `state.version` directly — `panel.should_redraw`, the
+        predicate this used to ask, was deleted as dead (no production caller ever
+        reached it), and the question it answered is one `!=` either way."""
         fid = "f-race"
         state.bump(fid)
         seen = state.version(fid)
@@ -174,7 +161,7 @@ class Tick(PersonaIso, unittest.TestCase):
         with mock.patch("charter.frame.panel._paint",
                         side_effect=lambda slot, f: state.bump(f)):
             result = panel._tick({"flag": False}, seen, "bottom", fid)
-        self.assertTrue(panel.should_redraw(result, fid))
+        self.assertNotEqual(result, state.version(fid))
 
 
 class Sigwinch(unittest.TestCase):

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -100,5 +100,26 @@ class RenderFollowsThePane(PersonaIso, unittest.TestCase):
                         self.assertLessEqual(tui.width(line), 10)
 
 
+class WideGlyphs(PersonaIso, unittest.TestCase):
+    """`tui.width` counts display cells, not `len()` — every other test in this file
+    uses pure-ASCII content, where the two coincide, so none of them would notice a
+    future edit that swapped `tui.truncate` for character slicing (`x[:w]`). Caught in
+    review by a hand-built probe: a workspace name of CJK glyphs measuring 57 display
+    cells rendered untouched into a 30-cell pane. This pins the same shape with an
+    assertion, not a probe: 30 CJK characters are 60 display cells (two each) but only
+    30 *characters* — half the false margin `len()`-based slicing would report as safe
+    against a pane this narrow.
+    """
+
+    def test_a_cjk_workspace_name_still_fits_a_narrow_pane(self):
+        cjk = "測" * 30  # 30 characters, 60 display cells
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": cjk}), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+             mock.patch("os.get_terminal_size",
+                         return_value=os.terminal_size((20, 3))):
+            line = slots.render("top", "f-1")
+        self.assertLessEqual(tui.width(line), 20)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -1,0 +1,104 @@
+"""Panels compose the renderers the status line already has.
+
+Zones are not re-invented here: `statusline.py` already argues for identity in one place
+and alerts in another, and a frame that split them differently would be a second layout to
+keep in step with the first.
+
+Width is measured, not theorised (the coordinator correction this task shipped under): a
+panel process started as a tmux pane command inherits the *launching* shell's whole
+environment, so `$COLUMNS` can describe a completely different rectangle than the pane
+this process is actually drawing into. Measured against a real tmux 3.7c: a 22-column
+pane, launched from a shell exporting `COLUMNS=200`, saw `COLUMNS='200'` in its own
+environment. `Width` below pins that a panel lays out against its own tty instead.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+from charter import tui
+from charter.frame import slots
+
+from tests._isolation import PersonaIso
+
+
+class Render(PersonaIso, unittest.TestCase):
+    def test_top_names_the_workspace(self):
+        out = slots.render("top", "f-1")
+        self.assertTrue(out.strip())
+
+    def test_bottom_renders(self):
+        self.assertTrue(slots.render("bottom", "f-1").strip())
+
+    def test_a_slot_never_exceeds_the_pane_width(self):
+        """`tui.width` counts display cells, not characters — a wide glyph that fits by
+        len() still wraps the pane and pushes the frame apart."""
+        for slot in ("top", "bottom"):
+            for line in slots.render(slot, "f-1").splitlines():
+                with self.subTest(slot=slot):
+                    self.assertLessEqual(tui.width(line), tui.term_width(default=80))
+
+    def test_a_failing_renderer_yields_a_line_rather_than_an_exception(self):
+        """A panel that raises leaves a hole in the frame; `statusline.render` makes the
+        same promise for the same reason."""
+        slots.SLOTS["boom"] = lambda fid: 1 / 0
+        try:
+            self.assertIn("charter", slots.render("boom", "f-1"))
+        finally:
+            del slots.SLOTS["boom"]
+
+    def test_an_unknown_slot_is_named_rather_than_drawn_blank(self):
+        """`panel.run` (Task 7) refuses an unknown slot before ever spawning a pane for
+        it — but `render` is the one place that can explain *why*, so it must not answer
+        an unknown name with silence either."""
+        out = slots.render("sideways", "f-1")
+        self.assertIn("sideways", out)
+
+
+class Width(unittest.TestCase):
+    """Pins the coordinator correction directly against `_width`, independent of
+    whatever `_top`/`_bottom` happen to render — so a future change to panel *content*
+    can never accidentally paper over a regression in *how much room it thinks it has*.
+    """
+
+    def test_width_measures_the_panes_own_tty_ignoring_columns(self):
+        with mock.patch.dict(os.environ, {"COLUMNS": "200"}), \
+             mock.patch("os.get_terminal_size",
+                         return_value=os.terminal_size((22, 5))):
+            self.assertEqual(slots._width(), 22)
+
+    def test_width_falls_back_to_env_first_term_width_when_no_tty_is_available(self):
+        """The one case `tui.term_width()` is allowed to answer: no tty behind the fd at
+        all (stdout piped to a file, say), not merely a pane that disagrees with
+        `$COLUMNS`."""
+        with mock.patch.dict(os.environ, {"COLUMNS": "55"}), \
+             mock.patch("os.get_terminal_size", side_effect=OSError("not a tty")):
+            self.assertEqual(slots._width(), 55)
+
+
+class RenderFollowsThePane(PersonaIso, unittest.TestCase):
+    """The end-to-end version of `Width`, above: what a real panel process would see
+    with a launching shell's `COLUMNS` still in its environment and its own pane far
+    narrower. `PersonaIso` redirects `sys.stdout` to a `StringIO`, so `fileno()` is
+    patched back to something callable rather than left to raise — the isolation harness
+    would otherwise force every test onto the fallback branch and hide exactly the bug
+    this class exists to catch.
+    """
+
+    def test_render_wraps_to_the_pane_not_to_the_wider_columns_value(self):
+        with mock.patch.dict(os.environ, {"COLUMNS": "200"}), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+             mock.patch("os.get_terminal_size",
+                         return_value=os.terminal_size((10, 3))):
+            for slot in ("top", "bottom"):
+                out = slots.render(slot, "f-1")
+                with self.subTest(slot=slot):
+                    for line in out.splitlines():
+                        self.assertLessEqual(tui.width(line), 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -19,7 +19,7 @@ import sys
 import unittest
 from unittest import mock
 
-from charter import tui
+from charter import config, tui
 from charter.frame import slots
 
 from tests._isolation import PersonaIso
@@ -50,12 +50,52 @@ class Render(PersonaIso, unittest.TestCase):
         finally:
             del slots.SLOTS["boom"]
 
+    def test_the_bottom_row_names_the_configured_hotkey_not_a_hardcoded_one(self):
+        """`[frame] hotkey` is configurable and this row spelled `F2 menu` literally, so
+        a plane on `hotkey = "F1"` had its own panel telling every operator the wrong
+        key, on every repaint, forever.
+
+        `F1` is chosen precisely because it is NOT the default: asserting against `F2`
+        would pass against the hardcoded string this test exists to remove. The absence
+        assertion is the one that fails on the mutation."""
+        with mock.patch.dict(config.FRAME, {"hotkey": "F1"}):
+            out = slots.render("bottom", "f-1")
+        self.assertIn("F1 menu", out)
+        self.assertNotIn("F2", out)
+
+    def test_a_modifier_hotkey_reaches_the_panel_intact(self):
+        """A second, differently-shaped value — `F1` alone could be satisfied by a
+        one-character substitution. `M-m` shares no characters with `F2`."""
+        with mock.patch.dict(config.FRAME, {"hotkey": "M-m"}):
+            self.assertIn("M-m menu", slots.render("bottom", "f-1"))
+
     def test_an_unknown_slot_is_named_rather_than_drawn_blank(self):
         """`panel.run` (Task 7) refuses an unknown slot before ever spawning a pane for
         it — but `render` is the one place that can explain *why*, so it must not answer
         an unknown name with silence either."""
         out = slots.render("sideways", "f-1")
         self.assertIn("sideways", out)
+
+
+class Unimplemented(unittest.TestCase):
+    """Which configured slots charter sizes but cannot draw — asked in one place because
+    three callers need the same answer and must not drift: `cmd_launch` (to skip
+    splitting a pane that would be permanently dead under `remain-on-exit on`),
+    `frame_ready` (`--probe`) and `doctor.check_frame`."""
+
+    def test_the_two_sized_but_unrendered_slots_are_named(self):
+        self.assertEqual(slots.unimplemented(["top", "left", "bottom", "right"]),
+                         ["left", "right"])
+
+    def test_an_all_implemented_configuration_names_nothing(self):
+        self.assertEqual(slots.unimplemented(["top", "bottom"]), [])
+
+    def test_the_answer_comes_from_the_registry_not_a_hardcoded_pair(self):
+        """`left`/`right` are today's answer, not the rule. A renderer landing for one
+        of them must take it off this list without anybody remembering to edit a
+        literal — so the registry is patched and the answer must follow."""
+        with mock.patch.dict(slots.SLOTS, {"left": lambda fid: "drawn"}):
+            self.assertEqual(slots.unimplemented(["top", "left", "right"]), ["right"])
 
 
 class Width(unittest.TestCase):

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -37,16 +37,6 @@ class Version(PersonaIso, unittest.TestCase):
         state.bump("f-1")
         self.assertNotEqual(before, state.version("f-1"))
 
-    def test_a_reader_never_sees_a_half_written_version(self):
-        """Fifty sequential bump+read cycles in one thread, so this cannot actually
-        observe a torn read racing a writer — that guarantee rests on `os.replace`'s own
-        atomicity, not on anything asserted here. What this pins down is narrower: the
-        write path fails loudly (an exception, catchable by the caller) rather than
-        silently leaving a reader with an empty or missing value."""
-        for _ in range(50):
-            state.bump("f-1")
-            self.assertTrue(state.version("f-1").strip())
-
     def test_reading_an_unknown_frames_version_creates_nothing_on_disk(self):
         """A probe reads; it does not act (charter/news.py). `version()` on a frame that
         was never bumped must not create the directory it is only trying to look at —
@@ -120,6 +110,19 @@ class WriteFailureIsNotFatal(PersonaIso, unittest.TestCase):
         with mock.patch("charter.frame.state.os.replace", side_effect=OSError("disk full")):
             state.record_exit("f-1", 9)  # must not raise
         self.assertIsNone(state.exit_code("f-1"))
+
+    def test_a_failed_bump_leaves_the_previous_version_intact(self):
+        """This is the property the tmp-file + os.replace shape in `bump()` exists for,
+        and Finding 1 made it load-bearing: a failed write no longer raises, so the only
+        thing standing between it and a reader seeing a corrupted value is that
+        os.replace never touches the target file unless it fully succeeds. A bump that
+        fails must leave the version a reader already saw exactly as it was — not "0",
+        not empty, not some partial write of the new value."""
+        state.bump("f-1")
+        before = state.version("f-1")
+        with mock.patch("charter.frame.state.os.replace", side_effect=OSError("disk full")):
+            state.bump("f-1")  # the write fails silently (Finding 1)
+        self.assertEqual(state.version("f-1"), before)
 
 
 class ExitCode(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -1,0 +1,109 @@
+"""The frame's own state: who it is, when it last changed, how it ended.
+
+Per frame rather than global, because two frames may run at once (one session each, named
+by workspace and pid) and a shared version file would make each frame's panels redraw for
+the other's activity.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from tests._isolation import PersonaIso
+from charter.frame import state
+
+
+class FrameId(unittest.TestCase):
+    def test_the_id_carries_the_workspace_and_the_pid(self):
+        fid = state.frame_id("harness-wrapper", 4242)
+        self.assertIn("harness-wrapper", fid)
+        self.assertIn("4242", fid)
+
+    def test_a_hostile_workspace_name_cannot_escape_the_state_directory(self):
+        """The id becomes a directory name. `contain.py` exists because a name read out
+        of a file used to be joined onto a path with nothing in between."""
+        fid = state.frame_id("../../etc", 1)
+        self.assertNotIn("/", fid)
+        self.assertNotIn("..", fid)
+
+
+class Version(PersonaIso, unittest.TestCase):
+    def test_a_fresh_frame_has_a_version(self):
+        self.assertTrue(state.version("f-1"))
+
+    def test_bumping_changes_it(self):
+        before = state.version("f-1")
+        state.bump("f-1")
+        self.assertNotEqual(before, state.version("f-1"))
+
+    def test_a_reader_never_sees_a_half_written_version(self):
+        """Written with os.replace, so a panel reading mid-bump gets the old value whole
+        rather than a torn one."""
+        for _ in range(50):
+            state.bump("f-1")
+            self.assertTrue(state.version("f-1").strip())
+
+    def test_reading_an_unknown_frames_version_creates_nothing_on_disk(self):
+        """A probe reads; it does not act (charter/news.py). `version()` on a frame that
+        was never bumped must not create the directory it is only trying to look at —
+        that is the mistake correction 1 exists to rule out."""
+        self.assertEqual(state.version("never-bumped"), "0")
+        self.assertFalse(state.frame_dir("never-bumped").exists())
+
+    def test_reap_then_version_does_not_resurrect_the_directory(self):
+        """If `version()` ever called `bump()` on a miss, this would fight `reap()`
+        forever: reap deletes, the next poll recreates, reap deletes again."""
+        state.bump("gone-1")
+        state.reap(set())
+        self.assertEqual(state.version("gone-1"), "0")
+        self.assertFalse(state.frame_dir("gone-1").exists())
+
+
+class FrameDirContainment(PersonaIso, unittest.TestCase):
+    def test_a_hostile_fid_cannot_resolve_outside_the_frame_root(self):
+        """`fid` is not always minted by this module — a later caller reads it out of
+        $CHARTER_SESSION_ID, so a traversal, an absolute path, or an embedded separator
+        must be refused rather than silently rewritten into a safe-looking name."""
+        root = state._root()
+        for hostile in ("../../etc/passwd", "/etc/passwd", "a/b", "..", "."):
+            with self.subTest(hostile=hostile):
+                self.assertIsNone(state.frame_dir(hostile))
+                self.assertIsNone(state.frame_dir(hostile, create=True))
+
+    def test_no_directory_is_created_for_a_hostile_fid(self):
+        state.frame_dir("../../escaped", create=True)
+        self.assertFalse(state._root().exists())
+
+    def test_bump_on_a_hostile_fid_does_not_raise(self):
+        """bump() runs from charter's hooks, where an exception costs a session its
+        turn — a malformed $CHARTER_SESSION_ID must be a no-op, not a crash."""
+        state.bump("../../escaped")  # must not raise
+        self.assertFalse(state._root().exists())
+
+
+class ExitCode(PersonaIso, unittest.TestCase):
+    def test_an_unfinished_frame_has_no_exit_code(self):
+        self.assertIsNone(state.exit_code("f-1"))
+
+    def test_the_recorded_code_comes_back(self):
+        state.record_exit("f-1", 42)
+        self.assertEqual(state.exit_code("f-1"), 42)
+
+
+class Reap(PersonaIso, unittest.TestCase):
+    def test_a_directory_whose_session_is_gone_is_removed(self):
+        state.bump("dead-1")
+        state.bump("live-1")
+        removed = state.reap({"live-1"})
+        self.assertEqual(removed, ["dead-1"])
+        self.assertFalse(state.frame_dir("dead-1").exists())
+        self.assertTrue(state.frame_dir("live-1").exists())
+
+    def test_a_live_frame_is_never_reaped_by_age(self):
+        """A long-lived frame is exactly what an age heuristic would eat."""
+        state.bump("old-1")
+        self.assertEqual(state.reap({"old-1"}), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -44,6 +44,19 @@ class Version(PersonaIso, unittest.TestCase):
         self.assertEqual(state.version("never-bumped"), "0")
         self.assertFalse(state.frame_dir("never-bumped").exists())
 
+    def test_a_non_utf8_version_file_degrades_to_the_sentinel_rather_than_raising(self):
+        """Fix round 2, item 1: `read_text()` on bytes that are not valid UTF-8 raises
+        `UnicodeDecodeError` — a `ValueError` subclass, never caught by an `except
+        OSError` alone. `panel._tick` reads this function directly with nothing of its
+        own guarding the call, so an uncaught decode error here used to reach a real
+        panel's run loop and kill the pane — exactly the failure this module's own
+        docstring already promised could not happen ("nothing here raises... a missing
+        frame answers with the sentinel"). A corrupt file is treated the same as a
+        missing one: the sentinel, not an exception."""
+        d = state.frame_dir("f-1", create=True)
+        (d / "version").write_bytes(b"\xff\xfe not valid utf-8 \x80\x81")
+        self.assertEqual(state.version("f-1"), "0")
+
     def test_reap_then_version_does_not_resurrect_the_directory(self):
         """If `version()` ever called `bump()` on a miss, this would fight `reap()`
         forever: reap deletes, the next poll recreates, reap deletes again."""

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -8,6 +8,7 @@ the other's activity.
 from __future__ import annotations
 
 import unittest
+from unittest import mock
 
 from tests._isolation import PersonaIso
 from charter.frame import state
@@ -37,8 +38,11 @@ class Version(PersonaIso, unittest.TestCase):
         self.assertNotEqual(before, state.version("f-1"))
 
     def test_a_reader_never_sees_a_half_written_version(self):
-        """Written with os.replace, so a panel reading mid-bump gets the old value whole
-        rather than a torn one."""
+        """Fifty sequential bump+read cycles in one thread, so this cannot actually
+        observe a torn read racing a writer — that guarantee rests on `os.replace`'s own
+        atomicity, not on anything asserted here. What this pins down is narrower: the
+        write path fails loudly (an exception, catchable by the caller) rather than
+        silently leaving a reader with an empty or missing value."""
         for _ in range(50):
             state.bump("f-1")
             self.assertTrue(state.version("f-1").strip())
@@ -79,6 +83,43 @@ class FrameDirContainment(PersonaIso, unittest.TestCase):
         turn — a malformed $CHARTER_SESSION_ID must be a no-op, not a crash."""
         state.bump("../../escaped")  # must not raise
         self.assertFalse(state._root().exists())
+
+
+class OverlongFid(PersonaIso, unittest.TestCase):
+    """`contain.child` bounds shape, not length — a 5000-character fid passes it and
+    then hits `mkdir`'s own ENAMETOOLONG, which is reachable from a real
+    `$CHARTER_SESSION_ID` (`session.py`'s id-safety regex strips characters, never
+    bounds length). `bump`/`record_exit` run from hooks, where that has to degrade to a
+    no-op rather than propagate."""
+
+    def test_bump_on_an_overlong_fid_does_not_raise_or_create(self):
+        fid = "x" * 5000
+        state.bump(fid)  # must not raise
+        self.assertFalse(state._root().exists())
+        self.assertEqual(state.version(fid), "0")
+
+    def test_record_exit_on_an_overlong_fid_does_not_raise_or_create(self):
+        fid = "x" * 5000
+        state.record_exit(fid, 7)  # must not raise
+        self.assertFalse(state._root().exists())
+        self.assertIsNone(state.exit_code(fid))
+
+
+class WriteFailureIsNotFatal(PersonaIso, unittest.TestCase):
+    """The over-long-fid case above fails at `mkdir`, before any write is attempted.
+    This covers the other half: the directory exists, but the write into it fails
+    anyway (a filesystem that fills up between `mkdir` and `os.replace`, say) — still a
+    hook's-eye no-op, not a raise."""
+
+    def test_bump_survives_a_failing_replace(self):
+        with mock.patch("charter.frame.state.os.replace", side_effect=OSError("disk full")):
+            state.bump("f-1")  # must not raise
+        self.assertEqual(state.version("f-1"), "0")
+
+    def test_record_exit_survives_a_failing_replace(self):
+        with mock.patch("charter.frame.state.os.replace", side_effect=OSError("disk full")):
+            state.record_exit("f-1", 9)  # must not raise
+        self.assertIsNone(state.exit_code("f-1"))
 
 
 class ExitCode(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from unittest import mock
 
 from charter import commands_frame, hooks, todos
-from charter.frame import notify, state
+from charter.frame import menu, notify, state
 
 from tests._isolation import PersonaIso, run_hook
 
@@ -264,6 +264,61 @@ class TmuxIntegration(unittest.TestCase):
                              f"the panel drifted to {height} rows after resizing to "
                              f"{cols}x{rows} — the hook did not hold")
 
+    # -- 5. Session-scoped id delivery for the hotkey menu --------------------------- #
+
+    def test_a_second_frames_own_id_does_not_leak_the_firsts(self):
+        """The exact bug `_session_id_env_argv` exists to close, verified against a
+        real server rather than only asserted about: a `run-shell` with NO explicit
+        `-t` of its own, fired against a session sharing this class's server, does not
+        fall back to "unset" — it falls back to whatever tmux resolves as "the current
+        session" absent one, which is NOT necessarily the session the caller meant
+        (confirmed by hand: it tracked whichever session was created most recently, not
+        the one named in the failing call). `cmd_launch` calls this for EVERY frame it
+        launches, so both sessions below get their own call — mirroring that — and
+        `sid-one` is seeded with a THIRD value neither call is expected to produce, so a
+        version of `_session_id_env_argv` that dropped its own `-t` would show up as
+        `sid-one` and `sid-two` BOTH reporting whichever session tmux's un-targeted
+        default happened to prefer, not their own two distinct ids.
+
+        `run-shell`, unlike `if-shell -F -t = ...` (`WheelUpPane`'s own idiom), needs a
+        target NAME here to inherit a session's own tracked environment at all — `-t =`
+        does not carry it (also verified by hand; see `conf_text`'s own docstring) — so
+        this targets each session by its literal name, matching what firing from a live
+        keypress inside that session's own pane does."""
+        tmp = tempfile.mkdtemp(prefix="charter-integ-sid-")
+        self.addCleanup(shutil.rmtree, tmp, True)
+        first_out = os.path.join(tmp, "first")
+        second_out = os.path.join(tmp, "second")
+
+        r1 = _tmux("new-session", "-d", "-s", "sid-one", "-x", "80", "-y", "24", "cat",
+                  env=dict(os.environ, CHARTER_SESSION_ID="neither-frames-own-id"))
+        self.assertEqual(r1.returncode, 0, r1.stderr)
+        r2 = _tmux("new-session", "-d", "-s", "sid-two", "-x", "80", "-y", "24", "cat")
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+
+        # Both calls, in the order `cmd_launch` would issue them across two launches:
+        # the OLDER frame's own id first, seeded before the newer one ever existed.
+        self.assertEqual(_run(commands_frame._session_id_env_argv(
+            socket=SOCKET, session="sid-one")).returncode, 0)
+        self.assertEqual(_run(commands_frame._session_id_env_argv(
+            socket=SOCKET, session="sid-two")).returncode, 0)
+
+        _tmux("run-shell", "-t", "sid-one",
+             f"env | grep CHARTER_SESSION_ID > {first_out} 2>&1 || echo NONE > {first_out}")
+        _tmux("run-shell", "-t", "sid-two",
+             f"env | grep CHARTER_SESSION_ID > {second_out} 2>&1 || echo NONE > {second_out}")
+        time.sleep(0.5)
+
+        with open(first_out) as f:
+            self.assertEqual(f.read().strip(), "CHARTER_SESSION_ID=sid-one",
+                             "the OLDER frame's own hotkey menu must still resolve its "
+                             "own id after a second frame launches, not whichever "
+                             "session tmux would pick as \"current\" by default")
+        with open(second_out) as f:
+            self.assertEqual(f.read().strip(), "CHARTER_SESSION_ID=sid-two",
+                             "the second frame's own hotkey menu must resolve its own "
+                             "id, not fall through to whatever the server started with")
+
 
 @unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
 class PanelIntegration(PersonaIso, unittest.TestCase):
@@ -420,6 +475,89 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
                          f"(stderr: {after.stderr!r})")
         self.assertEqual(after.stdout.strip(), "0",
                          "the panel died reading a corrupt version file")
+
+
+@unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
+class MenuIntegration(PersonaIso, unittest.TestCase):
+    """`charter frame-action` end to end: a REAL subprocess, spawned by a REAL `tmux
+    run-shell` fired against a REAL session, resolving a menu entry whose LABEL is the
+    task brief's own hostile string — through `menu.menu_argv`'s exact id-lookup
+    mechanism, never a hand-simulated stand-in for it.
+
+    `display-menu` itself needs an ATTACHED CLIENT to render to at all (confirmed by
+    hand: `tmux display-menu -t <session> ...` against a session with none returns 1,
+    `"no current client"`, before ever looking at an item) — every other test in this
+    file, including this one, avoids attaching a client, so this drives the exact
+    command text `menu_argv` embeds for ONE item directly, the same way firing it from
+    inside a live `display-menu -t fid` would (see `menu_argv`'s own docstring for why
+    `-t fid` is what supplies that scoping normally).
+
+    Uses `sys.executable -m charter` rather than the bare `charter` text `menu_argv`
+    itself embeds: this developer machine's own `$PATH` may resolve `charter` to an
+    entirely different install than this checkout (confirmed on the machine this test
+    was written on), and `PanelIntegration` above avoids the identical trap the same
+    way, for `charter panel`."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.addCleanup(_tmux, "kill-server")
+        self.addCleanup(lambda: (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET)
+                        .unlink(missing_ok=True))
+        (self.tmp / "charter.toml").write_text("")
+        self.env = dict(os.environ, CHARTER_ROOT=str(self.tmp), CHARTER_WORKSPACE="demo")
+        self.env.pop("CHARTER_HOME", None)
+
+    def test_a_hostile_label_never_reaches_what_the_resolved_action_runs(self):
+        fid = state.frame_id("menu-integ", os.getpid())
+        r = _tmux("new-session", "-d", "-s", fid, "-x", "80", "-y", "24", "cat", env=self.env)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        # `_kill_pid` on the pane's OWN pid, not just `kill-server` (already in
+        # `setUp`): `_kill_pid`'s own docstring names the failure mode this closes —
+        # `kill-server` reliably ends the SERVER's acceptance of new commands but does
+        # not reliably reap a session's still-running pane process in time, which left
+        # this exact "cat" leaking past `kill-server` (confirmed by hand: `pgrep -f
+        # 'tmux -L charter-integration-test'` still matched after the first version of
+        # this test ran without this line).
+        pid = _tmux("display-message", "-p", "-t", fid, "#{pane_pid}").stdout.strip()
+        self.addCleanup(_kill_pid, pid)
+        self.assertEqual(_run(commands_frame._session_id_env_argv(
+            socket=SOCKET, session=fid)).returncode, 0)
+
+        tmp = tempfile.mkdtemp(prefix="charter-integ-menu-")
+        self.addCleanup(shutil.rmtree, tmp, True)
+        canary = os.path.join(tmp, "canary")
+        pwned = os.path.join(tmp, "pwned")
+        hostile_label = f'x" ; run-shell "touch {pwned}'
+
+        menu.record(fid=fid, entries=[
+            (hostile_label, [sys.executable, "-c",
+                             f"open({canary!r}, 'w').close()"]),
+        ])
+        action_id = menu.build(fid)[0][1]
+        self.assertRegex(action_id, r"^a[0-9]+$")
+
+        # The exact template `menu_argv` embeds for this item, `charter` swapped for
+        # `sys.executable -m charter` (see the class docstring) — everything else,
+        # including the absence of any label text, matches byte for byte.
+        real_command = menu.menu_argv(fid, SOCKET)[-1]
+        self.assertNotIn("pwned", real_command,
+                         "sanity: the hostile label must not have leaked into the "
+                         "action text this integration test is about to run for real")
+        action = f"{sys.executable} -m charter frame-action {action_id}"
+        r = _tmux("run-shell", "-t", fid, action)
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not os.path.exists(canary):
+            time.sleep(0.2)
+
+        self.assertTrue(os.path.exists(canary),
+                        "the real, opaque-id-resolved action never ran — a real "
+                        "`charter frame-action` subprocess, given the real id and a "
+                        "real $CHARTER_SESSION_ID, must resolve the real stored argv")
+        self.assertFalse(os.path.exists(pwned),
+                         "the hostile LABEL text must never execute, even though it "
+                         "sat right next to the real id in the same menu table")
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -1,0 +1,190 @@
+"""Integration tests against a REAL tmux server — the properties `commands_frame.py`'s
+exit-code hooks rest on, which a mock cannot observe: tmux's own hook-array replacement
+semantics, and whether a session-scoped `set-environment` value actually reaches a
+`run-shell`-spawned shell later. Both were hand-verified during development; this module
+turns that hand-verification into something that reruns and fails loudly if tmux's own
+behaviour (or this code) ever drifts.
+
+A SEPARATE module from `tests/test_frame_launcher.py` on purpose, so that module's own
+"no tmux, ever" promise stays literally true — this is the one place in the suite
+allowed to start a real server. Skipped when tmux is absent
+(`unittest.skipUnless(shutil.which("tmux"), ...)`), per this plane's Global Constraints:
+"Tests never require tmux. Anything needing the binary skips when it is absent, and
+asserts on probed capability rather than a version string." Every assertion below reads
+tmux's own reported state (`show-hooks`, `display-message`, a file a real hook wrote) —
+never a version string.
+
+Every test gets its own tmux SESSION (hooks are per-pane, so a shared session would let
+one test's hook leak into another's pane) on the ONE socket this module owns, and every
+test kills that socket's server on the way out via `addCleanup` — so a failing test
+can't leak a stale socket file into `/private/tmp/tmux-<uid>/` any more than a passing
+one does.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from charter import commands_frame
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: Unique per test PROCESS, not merely per class — a socket left behind by an earlier,
+#: interrupted run must never collide with (or be mistaken for) this one's.
+SOCKET = f"charter-integration-test-{os.getpid()}"
+
+
+def _tmux(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["tmux", "-L", SOCKET, *args], capture_output=True, text=True,
+                          timeout=10)
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess:
+    """Run one of `commands_frame`'s own argv-building functions' output — never a
+    hand-retyped command — so this module tests the exact bytes the launcher sends."""
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+
+
+@unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
+class TmuxIntegration(unittest.TestCase):
+    def setUp(self) -> None:
+        self.addCleanup(self._teardown_socket)
+        self._pane_counter = 0
+
+    def _teardown_socket(self) -> None:
+        """`kill-server` ends the SERVER but does not remove its own socket FILE —
+        confirmed by hand: `list-sessions` on it afterward correctly reports "no server
+        running", yet the file stays in `/tmp/tmux-<uid>/`. A cleanup that only killed
+        the server would still leak one stale entry per test run — which is exactly how
+        this module's own hand-verification sessions left 52 of them behind before this
+        fix. tmux computes this path itself from `-L SOCKET`; matched here rather than
+        asked of tmux because there is no query command for it, only observed behaviour
+        (`/tmp/tmux-<getuid()>/<socket name>` on every platform this repo runs on)."""
+        _tmux("kill-server")
+        (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET).unlink(missing_ok=True)
+
+    def _new_pane(self) -> str:
+        """A fresh session on `SOCKET`, `remain-on-exit` armed, its one pane's id."""
+        self._pane_counter += 1
+        name = f"p{self._pane_counter}"
+        r = _tmux("new-session", "-d", "-s", name, "-x", "80", "-y", "24",
+                  "-P", "-F", "#{pane_id}")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        # Global on this socket's server — cheap to repeat per pane, and every frame
+        # wants it regardless (see `commands_frame._PLACEHOLDER_CONF`'s own docstring).
+        _tmux("set", "-g", "remain-on-exit", "on")
+        return name, r.stdout.strip()
+
+    # -- 1. Append and the order trap ---------------------------------------------- #
+
+    def test_the_write_hook_must_be_installed_before_the_teardown_hook(self):
+        """The property `_pane_died_teardown_hook_argv`'s own docstring names as the
+        entire reason for `cmd_launch`'s call order: an UNINDEXED `set-hook -p -t <pane>
+        pane-died '<action>'` call does not overwrite index 0 of an existing hook array
+        — it REPLACES THE WHOLE ARRAY. Installed write-then-teardown (the order
+        `cmd_launch` actually uses), both indices survive. Installed teardown-then-write
+        (the trap), the teardown hook is silently deleted the moment the write hook
+        lands — which is precisely the mutation that reintroduced the original hang
+        when the two `cmd_launch` calls were swapped."""
+        _, pane_correct = self._new_pane()
+        write = commands_frame._pane_died_write_hook_argv(socket=SOCKET, harness_pane=pane_correct)
+        teardown = commands_frame._pane_died_teardown_hook_argv(socket=SOCKET, harness_pane=pane_correct)
+        self.assertEqual(_run(write).returncode, 0)
+        self.assertEqual(_run(teardown).returncode, 0)
+        hooks = _tmux("show-hooks", "-p", "-t", pane_correct).stdout
+        self.assertIn("pane-died[0]", hooks)
+        self.assertIn("pane-died[1]", hooks)
+
+        _, pane_wrong = self._new_pane()
+        write2 = commands_frame._pane_died_write_hook_argv(socket=SOCKET, harness_pane=pane_wrong)
+        teardown2 = commands_frame._pane_died_teardown_hook_argv(socket=SOCKET, harness_pane=pane_wrong)
+        self.assertEqual(_run(teardown2).returncode, 0)
+        self.assertEqual(_run(write2).returncode, 0)
+        hooks_wrong = _tmux("show-hooks", "-p", "-t", pane_wrong).stdout
+        self.assertIn("pane-died[0]", hooks_wrong)
+        self.assertNotIn("pane-died[1]", hooks_wrong,
+                         "installing the write hook AFTER the teardown hook must not "
+                         "silently wipe the teardown hook out — this array-replacement "
+                         "behaviour is the entire reason cmd_launch's install order is "
+                         "load-bearing")
+
+    # -- 2. Path delivery and injection ---------------------------------------------- #
+
+    def test_the_exit_status_path_round_trips_a_hostile_plane_path(self):
+        """`set-environment` (a single argv value, no shell involved) is how the
+        exit-status path reaches the write hook's shell — verified here against a path
+        containing a space, a literal `'`, and a `$(touch ...)` injection attempt all at
+        once: the file at that exact path must hold the harness's real exit code, and
+        nothing embedded in the path may execute."""
+        session, pane = self._new_pane()
+        tmp = tempfile.mkdtemp(prefix="charter-integ-inj-")
+        self.addCleanup(shutil.rmtree, tmp, True)
+        canary = os.path.join(tmp, "canary")
+        hostile_dir = os.path.join(tmp, "it's a $(touch " + canary + ") dir")
+        os.makedirs(hostile_dir, exist_ok=True)
+        status_path = os.path.join(hostile_dir, "exit")
+
+        env_cmd = commands_frame._exit_path_env_argv(socket=SOCKET, session=session,
+                                                      status_path=status_path)
+        self.assertEqual(_run(env_cmd).returncode, 0)
+        write_cmd = commands_frame._pane_died_write_hook_argv(socket=SOCKET, harness_pane=pane)
+        self.assertEqual(_run(write_cmd).returncode, 0)
+        teardown_cmd = commands_frame._pane_died_teardown_hook_argv(socket=SOCKET, harness_pane=pane)
+        self.assertEqual(_run(teardown_cmd).returncode, 0)
+
+        _tmux("send-keys", "-t", pane, "exit 42", "Enter")
+        time.sleep(1)
+
+        self.assertFalse(os.path.exists(canary),
+                         "the $(touch ...) inside the plane path must never execute")
+        with open(status_path) as f:
+            self.assertEqual(f.read().strip(), "42")
+
+    # -- 3. Signal death -------------------------------------------------------------- #
+
+    def test_a_signal_death_writes_the_unknown_death_sentinel_not_an_empty_line(self):
+        """Measured against tmux 3.7c: a pane killed by SIGKILL reports `#{pane_dead}`
+        `1` with `#{pane_dead_status}` EMPTY, not a number — `display-message` is
+        checked directly to confirm that is still what THIS tmux does, not merely
+        assumed. The write hook's own `${v:-N}` fallback must turn that empty value into
+        `_UNKNOWN_DEATH_CODE` at the point of writing, so the file it produces is always
+        a parseable integer; `state.exit_code` cannot parse an empty line and would
+        silently read it back as "nothing was ever recorded"."""
+        session, pane = self._new_pane()
+        tmp = tempfile.mkdtemp(prefix="charter-integ-sig-")
+        self.addCleanup(shutil.rmtree, tmp, True)
+        status_path = os.path.join(tmp, "exit")
+
+        env_cmd = commands_frame._exit_path_env_argv(socket=SOCKET, session=session,
+                                                      status_path=status_path)
+        self.assertEqual(_run(env_cmd).returncode, 0)
+        write_cmd = commands_frame._pane_died_write_hook_argv(socket=SOCKET, harness_pane=pane)
+        self.assertEqual(_run(write_cmd).returncode, 0)
+
+        _tmux("send-keys", "-t", pane, "kill -9 $$", "Enter")
+        time.sleep(1)
+
+        dead, _, status = _tmux("display-message", "-p", "-t", pane,
+                                "#{pane_dead}:#{pane_dead_status}").stdout.strip().partition(":")
+        self.assertEqual(dead, "1", "the pane must be confirmed dead before this test "
+                                    "means anything")
+        self.assertEqual(status, "", "this pins that tmux itself still reports an EMPTY "
+                                     "status for a signal death, not a negative number "
+                                     "— the wrong premise an earlier version of this "
+                                     "suite assumed")
+
+        with open(status_path) as f:
+            content = f.read().strip()
+        self.assertEqual(content, str(commands_frame._UNKNOWN_DEATH_CODE),
+                         f"expected the sentinel, got {content!r} (an empty string here "
+                         f"is exactly the bug: state.exit_code cannot parse it)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -31,11 +31,12 @@ import tempfile
 import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
-from charter import commands_frame, todos
-from charter.frame import state
+from charter import commands_frame, hooks, todos
+from charter.frame import notify, state
 
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, run_hook
 
 _HAS_TMUX = shutil.which("tmux") is not None
 
@@ -302,6 +303,56 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
         self.assertTrue(changed, f"the panel never repainted after a real state.bump; "
                                  f"still showing:\n{first!r}")
         self.assertEqual(_tmux("display-message", "-p", "-t", "panel-live",
+                               "#{pane_dead}").stdout.strip(), "0",
+                         "the pane died sometime after its first paint")
+
+    def test_a_real_hook_call_repaints_a_live_panel_without_a_direct_state_bump(self):
+        """Closes the gap the test above leaves open: that test calls `state.bump`
+        directly, which proves the PANEL half of the liveness story (Task 6/7) but says
+        nothing about the HOOK half (Task 8) — `notify.plane_changed`, wired into
+        `charter/hooks.py`'s `sessionstart`/`userpromptsubmit`/`posttooluse` handlers,
+        is the thing that is actually supposed to call `state.bump` in a running
+        session. This drives a REAL hook handler (`hooks.posttooluse`, via
+        `tests._isolation.run_hook` — the same stdin-JSON shape Claude Code itself
+        feeds it) with `$CHARTER_SESSION_ID` set to the live panel's own frame id, and
+        watches the SAME pane used above repaint from that call alone — no
+        `state.bump` call anywhere in this test. `notify._last` is reset first so a
+        debounce window left over from another test in this process can't mask a
+        broken hook wiring the way `test_frame_liveness.py`'s own docstring warns
+        about."""
+        fid = state.frame_id("panel-hook-integ", os.getpid())
+        argv = [sys.executable, "-m", "charter", "panel", "bottom", "--session", fid]
+        r = _tmux("new-session", "-d", "-s", "panel-hook-live", "-x", "40", "-y", "5",
+                  "-c", str(_REPO_ROOT), "--", *argv, env=self.env)
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+        time.sleep(1)
+        first = _tmux("capture-pane", "-p", "-t", "panel-hook-live").stdout
+        self.assertIn("todo", first, f"the pane never drew its content:\n{first!r}")
+        self.assertEqual(_tmux("display-message", "-p", "-t", "panel-hook-live",
+                               "#{pane_dead}").stdout.strip(), "0",
+                         "the pane died at startup")
+
+        todos.add("demo", "a todo a real hook call should surface")
+        notify._last["at"] = 0.0
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": fid}):
+            out = run_hook(hooks.posttooluse, {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "/nonexistent"},
+                "session_id": "hook-integ-session",
+            })
+        self.assertIsNone(out, "posttooluse should emit nothing for a plain Read")
+
+        deadline = time.monotonic() + 3
+        changed = False
+        while time.monotonic() < deadline:
+            if _tmux("capture-pane", "-p", "-t", "panel-hook-live").stdout != first:
+                changed = True
+                break
+            time.sleep(0.2)
+        self.assertTrue(changed, f"the panel never repainted after a real "
+                                 f"hooks.posttooluse() call; still showing:\n{first!r}")
+        self.assertEqual(_tmux("display-message", "-p", "-t", "panel-hook-live",
                                "#{pane_dead}").stdout.strip(), "0",
                          "the pane died sometime after its first paint")
 

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -26,12 +26,16 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
 from pathlib import Path
 
-from charter import commands_frame
+from charter import commands_frame, todos
+from charter.frame import state
+
+from tests._isolation import PersonaIso
 
 _HAS_TMUX = shutil.which("tmux") is not None
 
@@ -39,10 +43,23 @@ _HAS_TMUX = shutil.which("tmux") is not None
 #: interrupted run must never collide with (or be mistaken for) this one's.
 SOCKET = f"charter-integration-test-{os.getpid()}"
 
+#: `tests/_isolation.py`'s `PersonaIso` isolates the paths a Python IMPORT of `charter`
+#: reads inside THIS process; `PanelIntegration` below needs a SUBPROCESS to see the
+#: same throwaway plane, which only `$CHARTER_ROOT`/`$CHARTER_WORKSPACE` can hand it
+#: across a process boundary. `charter panel` never dies over a missing repo, `.git`,
+#: or any other plane furniture (this module's own `setUp` creates nothing beyond one
+#: empty `charter.toml` marker), so nothing here needs `PersonaIso`'s SIBLING classes
+#: (`ReportIso`, worktree scaffolding) — just its config-path redirection.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
 
-def _tmux(*args: str) -> subprocess.CompletedProcess:
+
+def _tmux(*args: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    """*env* is `None` by every existing call site (inherit this process's own
+    environment, unchanged) — `PanelIntegration` is the one caller that needs a
+    DIFFERENT environment for a `new-session` call, so tmux hands its spawned pane a
+    throwaway plane's `$CHARTER_ROOT` rather than this test process's real one."""
     return subprocess.run(["tmux", "-L", SOCKET, *args], capture_output=True, text=True,
-                          timeout=10)
+                          timeout=10, env=env)
 
 
 def _run(cmd: list[str]) -> subprocess.CompletedProcess:
@@ -184,6 +201,109 @@ class TmuxIntegration(unittest.TestCase):
         self.assertEqual(content, str(commands_frame._UNKNOWN_DEATH_CODE),
                          f"expected the sentinel, got {content!r} (an empty string here "
                          f"is exactly the bug: state.exit_code cannot parse it)")
+
+    # -- 4. Resize redistribution ----------------------------------------------------- #
+
+    def test_a_fixed_size_panels_dimension_survives_a_real_window_resize(self):
+        """Cross-task fix round, item 3: tmux's own layout engine redistributes EVERY
+        pane proportionally on ANY resize, `-l size` notwithstanding — hand-verified
+        against this exact tmux binary during development: a 120x30 frame grown to
+        200x50 stretched a one-row panel to 8 rows, and only snapped back to 1 row on
+        the way down because that particular shrink happened to be an exact round trip
+        of the same grow. This drives `commands_frame._resize_hook_argv` — the real
+        function, not a hand-retyped `resize-pane` — through three resizes (grow,
+        shrink smaller than the original, grow past the first grow) to rule out "only
+        works for a round trip" as the actual fix."""
+        r = _tmux("new-session", "-d", "-s", "rsz", "-x", "120", "-y", "30",
+                  "-P", "-F", "#{pane_id}")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness_pane = r.stdout.strip()
+        top = _tmux("split-window", "-t", harness_pane, "-v", "-b", "-l", "1",
+                   "-P", "-F", "#{pane_id}", "--", "sleep", "600")
+        self.assertEqual(top.returncode, 0, top.stderr)
+        top_pane = top.stdout.strip()
+
+        hook_cmd = commands_frame._resize_hook_argv(socket=SOCKET, harness_pane=harness_pane,
+                                                    panes={"top": top_pane})
+        self.assertEqual(_run(hook_cmd).returncode, 0, "installing the resize hook failed")
+
+        for cols, rows in ((200, 50), (90, 25), (300, 100)):
+            r = _tmux("resize-window", "-t", "rsz", "-x", str(cols), "-y", str(rows))
+            self.assertEqual(r.returncode, 0, r.stderr)
+            time.sleep(0.3)
+            height = _tmux("display-message", "-p", "-t", top_pane,
+                           "#{pane_height}").stdout.strip()
+            self.assertEqual(height, "1",
+                             f"the panel drifted to {height} rows after resizing to "
+                             f"{cols}x{rows} — the hook did not hold")
+
+
+@unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
+class PanelIntegration(PersonaIso, unittest.TestCase):
+    """`charter panel` end to end, closing the exact gap that let a launcher spawning
+    real panel panes (Task 6) and a `charter panel` command (Task 7) ship across two
+    whole tasks with a fully green suite even if the two had never actually agreed on
+    an argv shape — every OTHER test in this file, and in `test_frame_launcher.py`,
+    either builds argv without running it or runs tmux commands without a real
+    `charter panel` process on the other end. This is the one place both are true at
+    once: a real tmux pane running the REAL subprocess.
+
+    A THROWAWAY plane, not the real one this repo's own suite runs from — `todos.add`
+    below writes state, and PersonaIso's isolation (this class's own base) only covers
+    what a Python IMPORT of `charter` reads in THIS process; the SUBPROCESS needs the
+    same throwaway plane handed across the process boundary via `$CHARTER_ROOT`
+    (`root.py`'s own override, which requires a real `charter.toml` marker to exist at
+    that path or it silently falls back to the subprocess's own cwd instead) and
+    `$CHARTER_WORKSPACE` (`workspace.resolve`'s own override, checked before any
+    cwd-tree detection) — never the developer's real ``~/.charter`` or workspace data.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.addCleanup(_tmux, "kill-server")
+        self.addCleanup(lambda: (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET)
+                        .unlink(missing_ok=True))
+        (self.tmp / "charter.toml").write_text("")
+        self.env = dict(os.environ, CHARTER_ROOT=str(self.tmp), CHARTER_WORKSPACE="demo")
+        self.env.pop("CHARTER_HOME", None)  # let it derive under CHARTER_ROOT, like this
+                                            # process's own PersonaIso-isolated config
+
+    def test_a_bottom_panel_draws_and_repaints_on_a_real_state_bump(self):
+        """Minimal shape: a real pane running `charter panel bottom --session <fid>`
+        must (1) show real content rather than dying at startup — `capture-pane`
+        containing "todo" kills that, since a dead pane under `remain-on-exit` shows
+        nothing of the sort — and (2) actually repaint when the version file it polls
+        changes, not just once at launch — a fresh todo plus a real `state.bump` must
+        change what `capture-pane` reports within a few polls of `panel.TICK`."""
+        fid = state.frame_id("panel-integ", os.getpid())
+        argv = [sys.executable, "-m", "charter", "panel", "bottom", "--session", fid]
+        r = _tmux("new-session", "-d", "-s", "panel-live", "-x", "40", "-y", "5",
+                  "-c", str(_REPO_ROOT), "--", *argv, env=self.env)
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+        time.sleep(1)
+        first = _tmux("capture-pane", "-p", "-t", "panel-live").stdout
+        self.assertIn("todo", first, f"the pane never drew its content:\n{first!r}")
+        self.assertEqual(_tmux("display-message", "-p", "-t", "panel-live",
+                               "#{pane_dead}").stdout.strip(), "0",
+                         "the pane died at startup — exactly the launcher-days-of-a-"
+                         "green-suite gap this test exists to close")
+
+        todos.add("demo", "a fresh todo the live panel should pick up")
+        state.bump(fid)
+
+        deadline = time.monotonic() + 3
+        changed = False
+        while time.monotonic() < deadline:
+            if _tmux("capture-pane", "-p", "-t", "panel-live").stdout != first:
+                changed = True
+                break
+            time.sleep(0.2)
+        self.assertTrue(changed, f"the panel never repainted after a real state.bump; "
+                                 f"still showing:\n{first!r}")
+        self.assertEqual(_tmux("display-message", "-p", "-t", "panel-live",
+                               "#{pane_dead}").stdout.strip(), "0",
+                         "the pane died sometime after its first paint")
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -24,6 +24,7 @@ one does.
 from __future__ import annotations
 
 import os
+import pty
 import shutil
 import signal
 import subprocess
@@ -538,8 +539,10 @@ class MenuIntegration(PersonaIso, unittest.TestCase):
 
         # The exact template `menu_argv` embeds for this item, `charter` swapped for
         # `sys.executable -m charter` (see the class docstring) — everything else,
-        # including the absence of any label text, matches byte for byte.
-        real_command = menu.menu_argv(fid, SOCKET)[-1]
+        # including the absence of any label text, matches byte for byte. `client`
+        # (this test's own no-op stand-in) only affects `-c`, never the per-item
+        # action text this line inspects.
+        real_command = menu.menu_argv(fid, SOCKET, client="")[-1]
         self.assertNotIn("pwned", real_command,
                          "sanity: the hostile label must not have leaked into the "
                          "action text this integration test is about to run for real")
@@ -558,6 +561,212 @@ class MenuIntegration(PersonaIso, unittest.TestCase):
         self.assertFalse(os.path.exists(pwned),
                          "the hostile LABEL text must never execute, even though it "
                          "sat right next to the real id in the same menu table")
+
+
+@unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
+class MenuFormatIntegration(unittest.TestCase):
+    """The CRITICAL finding from the first review round, proved against a REAL,
+    RENDERED `display-menu` — not only the argv shape `tests/test_frame_menu.py`'s
+    `LabelSafety` checks. `display-menu`'s own docs: "The name and command are formats"
+    — a menu item's NAME is a tmux FORMAT, not inert text, and an unescaped `#(shell
+    command)` label runs the command the INSTANT tmux DRAWS the menu, no selection
+    needed (confirmed by hand: the hostile row was invisible in the rendered menu —
+    nothing about the menu LOOKED wrong, only the canary gave it away).
+
+    A REAL, ATTACHED client is unavoidable here — `display-menu` refuses outright ("no
+    current client") without one — which is why every OTHER test in this file avoids
+    attaching one at all. `_attach_pty` is the one place in the suite that does.
+    """
+
+    def setUp(self) -> None:
+        self.addCleanup(_tmux, "kill-server")
+        self.addCleanup(lambda: (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET)
+                        .unlink(missing_ok=True))
+
+    def _new_session(self, fid: str) -> None:
+        """A fresh `cat`-backed session named *fid*, with its pane's OWN pid registered
+        for cleanup — `kill-server` alone (already in `setUp`) is documented elsewhere in
+        this file (`_kill_pid`'s own docstring) as unreliable at reaping a still-running
+        pane's process in time; `PanelIntegration`/`MenuIntegration` above both work
+        around it the same way, and this class needs the identical fix (confirmed by
+        hand: without this, three "cat" processes were still alive under `pgrep -f
+        'tmux -L charter-integration-test'` after this class's own tests finished and
+        `kill-server` had already run)."""
+        r = _tmux("new-session", "-d", "-s", fid, "-x", "80", "-y", "24", "cat")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        pid = _tmux("display-message", "-p", "-t", fid, "#{pane_pid}").stdout.strip()
+        self.addCleanup(_kill_pid, pid)
+
+    def _attach_pty(self, session: str) -> tuple[str, int]:
+        """Forks a real `tmux attach -t session` under a pty — the one way to hand
+        `display-menu` a client it will actually accept for `-c`/`-t` targeting.
+        Registers the fork's own cleanup (SIGKILL, then reap — `_kill_pid` alone only
+        signals; a pty-forked child is THIS process's own, so it is also this process's
+        own zombie to reap, unlike a tmux-spawned pane's process, which reparents away)
+        before returning the attached client's name (`#{client_name}`, read back from
+        tmux itself once the attachment has had time to register) and the pty's own
+        master fd — writing a KEY to the fd (not `tmux send-keys`, confirmed by hand:
+        `send-keys` feeds a PANE's own input queue, which an active menu overlay never
+        reads from) is the only way found to actually select a menu item from here.
+        """
+        pid, fd = pty.fork()
+        if pid == 0:
+            os.execvp("tmux", ["tmux", "-L", SOCKET, "attach", "-t", session])
+
+        def _reap():
+            _kill_pid(str(pid))
+            try:
+                os.waitpid(pid, 0)
+            except OSError:
+                pass
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        self.addCleanup(_reap)
+
+        deadline = time.monotonic() + 3
+        name = ""
+        while time.monotonic() < deadline:
+            out = _tmux("list-clients", "-t", session, "-F", "#{client_name}")
+            name = out.stdout.strip()
+            if name:
+                break
+            time.sleep(0.1)
+        self.assertTrue(name, "the pty-attached client never registered with tmux")
+        return name, fd
+
+    def _drive_menu(self, fd: int, cmd: list[str]) -> None:
+        """Bind *cmd* (a real `display-menu` invocation) to a throwaway key and press
+        it through the attached pty — never issue *cmd* directly.
+
+        Confirmed by hand, twice, with the identical *cmd*: issued DIRECTLY (via
+        `subprocess.run` with a timeout, and separately via `Popen` with none) the menu
+        drew its visible text but an unescaped `#(touch CANARY)` label created no
+        canary either way — only firing the SAME command from a key binding did. This
+        is also the more honest test regardless of that quirk: a real operator's hotkey
+        never issues `display-menu` directly either, it always goes through a bind (see
+        `commands_frame.cmd_menu`).
+
+        `F2`'s own two escape sequences (`\\x1bOQ` application mode, `\\x1b[OQ` normal
+        mode) are written with a pause between them because this pty's terminal mode is
+        not otherwise known — sending both covers whichever one the attached client is
+        actually in, harmlessly duplicating the keypress if it is in neither exclusively
+        (redundant, not incorrect: two menus would just draw and one waits behind the
+        other, and only ONE F2 is ever ACTUALLY interpreted per mode in practice).
+        """
+        bind_cmd = ["tmux", "-L", SOCKET, "bind", "-n", "F2"] + cmd[3:]
+        r = subprocess.run(bind_cmd, capture_output=True, text=True, timeout=5)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        os.write(fd, b"\x1bOQ")
+        time.sleep(0.3)
+        os.write(fd, b"\x1b[OQ")
+        time.sleep(0.8)
+
+    def _short_canary(self, name: str) -> str:
+        """A canary path SHORT enough to survive `record`'s own `_MAX_LABEL` (60 chars)
+        truncation intact when embedded directly IN A LABEL.
+
+        `tempfile.mkdtemp()`'s own paths run 55-70+ characters before a filename is
+        even added on this platform (`/var/folders/<hash>/T/<prefix>-<random>/`) —
+        confirmed by hand that this silently truncates an embedded `#(touch ...)` job
+        mid-path, cutting off its closing `)` and neutralising the injection BY
+        ACCIDENT rather than by the escape this class exists to prove: the very first
+        version of these three tests passed even with `_safe_label`'s own `#` -> `##`
+        line deleted, for exactly this reason — a real bug in the test, not a real fix.
+        `/tmp` directly, not the plane's own scratch dir, and not cleaned up via
+        `shutil.rmtree` on a whole directory (there is no directory here to remove).
+        """
+        path = f"/tmp/chfi-{os.getpid()}-{name}"
+
+        def _cleanup():
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+        self.addCleanup(_cleanup)
+        return path
+
+    def test_a_shell_job_label_never_executes_when_the_menu_renders(self):
+        fid = f"menu-fmt-integ-{os.getpid()}"
+        self._new_session(fid)
+        client, fd = self._attach_pty(fid)
+
+        canary = self._short_canary("a")
+        hostile_label = f"#(touch {canary})"
+
+        menu.record(fid=fid, entries=[(hostile_label, ["true"])])
+        self._drive_menu(fd, menu.menu_argv(fid, SOCKET, client=client))
+
+        self.assertFalse(os.path.exists(canary),
+                         "an unescaped #(...) label executed the instant the menu was "
+                         "drawn — the exact hole this fix round closes")
+
+    def test_a_format_variable_label_also_never_executes(self):
+        """`#{session_name}` substitutes a value rather than running a shell job, but it
+        is the SAME `#`-triggered mechanism `_safe_label`'s escaping closes for both —
+        this pins that a label combining both shapes still creates no canary against a
+        real, rendered menu, not only in `menu_argv`'s own argv-shape unit test."""
+        fid = f"menu-fmt-integ2-{os.getpid()}"
+        self._new_session(fid)
+        client, fd = self._attach_pty(fid)
+
+        canary = self._short_canary("b")
+        hostile_label = f"#{{session_name}} #(touch {canary})"
+
+        menu.record(fid=fid, entries=[(hostile_label, ["true"])])
+        self._drive_menu(fd, menu.menu_argv(fid, SOCKET, client=client))
+
+        self.assertFalse(os.path.exists(canary),
+                         "#{session_name} and #(...) both reach the SAME escape — a "
+                         "label combining them must still create no canary")
+
+    def test_an_escaped_label_still_lets_the_real_action_run_when_selected(self):
+        """The other half of the property: `_safe_label` must not merely refuse to
+        execute — the row still has to be USABLE. After `_drive_menu` opens it (F2),
+        writes the bound key ('1') directly to the attached pty's own master fd — not
+        `tmux send-keys` (confirmed by hand: `send-keys -t <pane>` feeds the PANE's own
+        input queue, which an active menu overlay never reads from; a canary bound to
+        key '1' was never created that way) — and confirms the REAL argv (spawned via
+        the real id) is what runs, never anything derived from the label."""
+        fid = f"menu-fmt-integ3-{os.getpid()}"
+        self._new_session(fid)
+        client, fd = self._attach_pty(fid)
+        self.assertEqual(_run(commands_frame._session_id_env_argv(
+            socket=SOCKET, session=fid)).returncode, 0)
+
+        tmp = tempfile.mkdtemp(prefix="charter-integ-fmt3-")
+        self.addCleanup(shutil.rmtree, tmp, True)
+        real_canary = os.path.join(tmp, "REAL_CANARY")  # in the ARGV, not the label —
+                                                         # no length bound applies to it
+        format_canary = self._short_canary("c")  # in the LABEL — must stay short
+        hostile_label = f"#(touch {format_canary})"
+
+        menu.record(fid=fid, entries=[
+            (hostile_label, [sys.executable, "-c", f"open({real_canary!r}, 'w').close()"]),
+        ])
+        cmd = menu.menu_argv(fid, SOCKET, client=client)
+        # `charter` (bare, per `menu_argv`'s own text) may not be this checkout on
+        # `$PATH` — same substitution `MenuIntegration` above makes, for the same
+        # reason. The item's own action is the LAST argv element, a single string
+        # (`"run-shell 'charter frame-action a0'"`), not a separate "run-shell" token.
+        cmd[-1] = cmd[-1].replace("charter frame-action",
+                                 f"{sys.executable} -m charter frame-action")
+        self._drive_menu(fd, cmd)
+
+        self.assertFalse(os.path.exists(format_canary),
+                         "the hostile label must not have executed merely by being "
+                         "rendered")
+
+        os.write(fd, b"1")
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not os.path.exists(real_canary):
+            time.sleep(0.2)
+        self.assertTrue(os.path.exists(real_canary),
+                        "selecting the (escaped, still-usable) item must still run "
+                        "its real, opaque-id-resolved action")
+        self.assertFalse(os.path.exists(format_canary),
+                         "selecting the item must not retroactively execute the label")
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -648,19 +648,18 @@ class MenuFormatIntegration(unittest.TestCase):
         never issues `display-menu` directly either, it always goes through a bind (see
         `commands_frame.cmd_menu`).
 
-        `F2`'s own two escape sequences (`\\x1bOQ` application mode, `\\x1b[OQ` normal
-        mode) are written with a pause between them because this pty's terminal mode is
-        not otherwise known — sending both covers whichever one the attached client is
-        actually in, harmlessly duplicating the keypress if it is in neither exclusively
-        (redundant, not incorrect: two menus would just draw and one waits behind the
-        other, and only ONE F2 is ever ACTUALLY interpreted per mode in practice).
+        `\x1bOQ` (application-mode F2) is the ONLY sequence written — a second one
+        (`\x1b[OQ`, normal-mode F2) was tried "for safety" in an earlier version of
+        this helper and is exactly the mistake it looks like: its own leading ESC can
+        dismiss the menu the first sequence just opened, and the trailing `[OQ` then
+        leaks into the pane as literal text instead of being interpreted as a key at
+        all. It passed five runs in a row before this was caught — a single, correct
+        sequence is what actually works, not a second one "just in case".
         """
         bind_cmd = ["tmux", "-L", SOCKET, "bind", "-n", "F2"] + cmd[3:]
         r = subprocess.run(bind_cmd, capture_output=True, text=True, timeout=5)
         self.assertEqual(r.returncode, 0, r.stderr)
         os.write(fd, b"\x1bOQ")
-        time.sleep(0.3)
-        os.write(fd, b"\x1b[OQ")
         time.sleep(0.8)
 
     def _short_canary(self, name: str) -> str:
@@ -767,6 +766,211 @@ class MenuFormatIntegration(unittest.TestCase):
                         "its real, opaque-id-resolved action")
         self.assertFalse(os.path.exists(format_canary),
                          "selecting the item must not retroactively execute the label")
+
+
+@unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
+class MenuClientIntegration(unittest.TestCase):
+    """Fix round 2, IMPORTANT-1, proved with two real ptys attached to ONE frame at
+    once: the hotkey must open the menu on the PRESSER's own screen, never a
+    different attached client's — the defect an earlier version of this mechanism
+    introduced by picking `list-clients`'s first-reported client instead of asking
+    the bind itself who pressed. See `commands_frame.cmd_menu`'s own docstring for
+    what was, and was not, directly observed before the fix.
+
+    Drives the REAL production chain end to end — `conf_text`'s own bind text,
+    `source-file`'d for real, firing a REAL `charter frame-menu` subprocess via
+    `run-shell`, which calls the REAL `cmd_menu` -> `menu.menu_argv` ->
+    `display-menu`. Two things a hand-rolled stand-in could not exercise:
+
+    1. `commands_frame.SOCKET` is a hardcoded module constant ("charter", the real
+       production socket) — this suite never uses that socket (every OTHER class
+       here runs on its own pid-scoped one, precisely to avoid `kill-server` ever
+       reaching a real, unrelated frame). A subprocess spawned bare cannot be told
+       a different socket via any argv this module controls. `_charter_shim` is a
+       tiny executable Python script, standing in for `charter` on `$PATH`, that
+       monkeypatches `commands_frame.SOCKET` to this class's own socket before
+       dispatching to the real `cli.main` — the one substitution that has to happen
+       BEFORE `cmd_menu`/`cmd_action` run, not on a command string built inside
+       them (unlike `MenuIntegration`/`MenuFormatIntegration` above, which construct
+       the command themselves and can rewrite `charter` -> `sys.executable -m
+       charter` directly; `cmd_menu` builds ITS OWN `display-menu` call internally,
+       leaving no string here to rewrite after the fact).
+    2. `tmux display-menu`, issued directly rather than from a binding, does not
+       reliably wire itself to a target client's own key input the same way a
+       key-bound one does — confirmed by hand while building this: calling
+       `cmd_menu` in-process, in a background thread, with `SOCKET` mocked and no
+       subprocess involved at all, returned immediately, and no keypress from
+       either client could select anything afterward. The same "direct invocation
+       behaves differently from a bind" property `MenuFormatIntegration` above
+       already documents for label rendering, evidently not limited to format
+       expansion. The REAL bind is not a nicety here; it is the only path observed
+       to work at all.
+    """
+
+    def setUp(self) -> None:
+        self.addCleanup(_tmux, "kill-server")
+        self.addCleanup(lambda: (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET)
+                        .unlink(missing_ok=True))
+
+    def _charter_shim_env(self) -> dict:
+        """A `$PATH` entry standing in for `charter` — see the class docstring for
+        why a string substitution (as `MenuIntegration`/`MenuFormatIntegration`
+        above use) cannot reach the command `cmd_menu` builds internally. `#!` uses
+        `sys.executable` directly (not `/usr/bin/env python3`) so the shim runs
+        under the SAME interpreter this test process does, and `sys.path` is set
+        explicitly inside the shim rather than relied on from the environment: a
+        script executed by its own shebang gets ITS OWN directory as `sys.path[0]`,
+        not this checkout's, so `import charter` would otherwise fail
+        (`ModuleNotFoundError`) — confirmed by hand while building this.
+        """
+        repo_root = str(Path(__file__).resolve().parent.parent)
+        shim_dir = Path(tempfile.mkdtemp(prefix="charter-integ-shim-"))
+        self.addCleanup(shutil.rmtree, shim_dir, True)
+        shim = shim_dir / "charter"
+        shim.write_text(
+            f"#!{sys.executable}\n"
+            "import sys\n"
+            f"sys.path.insert(0, {repo_root!r})\n"
+            "import charter.commands_frame\n"
+            f"charter.commands_frame.SOCKET = {SOCKET!r}\n"
+            "from charter.cli import main\n"
+            "sys.exit(main(sys.argv[1:]))\n"
+        )
+        shim.chmod(0o755)
+        return dict(os.environ, PATH=f"{shim_dir}:{os.environ.get('PATH', '')}")
+
+    def _new_session(self, fid: str) -> None:
+        """The one `new-session` call that starts this class's fresh server —
+        carries the `charter` shim's `$PATH` (see `_charter_shim_env`). `run-shell`
+        (no explicit `-t`, matching both the bind's own action and every per-item
+        action) falls back to the SERVER's own starting process environment (see
+        `_session_id_env_argv`'s own docstring), so this is the only call in this
+        class that needs the special environment at all.
+
+        Kills both the pane's own process AND the server's own process directly
+        (`#{pid}`, tmux's own server-PID format) rather than relying on `setUp`'s
+        `kill-server` alone: confirmed by hand that this class's own heavier setup
+        (two attached ptys, a `charter` shim subprocess per keypress) left a bare,
+        childless, PPID-1 server behind `kill-server` more than once — the same
+        "kill-server does not reliably reap in time" property `_kill_pid`'s own
+        docstring already names for a session's PANE process, evidently reachable
+        for the SERVER process too under this class's own load. `kill-server`
+        stays in `setUp` as a harmless, already-a-no-op-by-then fallback."""
+        r = _tmux("new-session", "-d", "-s", fid, "-x", "80", "-y", "24", "cat",
+                 env=self._charter_shim_env())
+        self.assertEqual(r.returncode, 0, r.stderr)
+        server_pid = _tmux("display-message", "-p", "-t", fid, "#{pid}").stdout.strip()
+        self.addCleanup(_kill_pid, server_pid)
+        pid = _tmux("display-message", "-p", "-t", fid, "#{pane_pid}").stdout.strip()
+        self.addCleanup(_kill_pid, pid)
+
+    def _attach_pty(self, session: str, exclude: frozenset = frozenset()) -> tuple[str, int]:
+        """Same shape as `MenuFormatIntegration`'s own helper, extended for a SECOND
+        client on the same session: `list-clients -t session` lists every client
+        attached to it, not only the one just forked, so a second pty here has to
+        pick its OWN name out from among possibly several already there — *exclude*
+        names the ones a caller already knows about."""
+        pid, fd = pty.fork()
+        if pid == 0:
+            os.execvp("tmux", ["tmux", "-L", SOCKET, "attach", "-t", session])
+
+        def _reap():
+            _kill_pid(str(pid))
+            try:
+                os.waitpid(pid, 0)
+            except OSError:
+                pass
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        self.addCleanup(_reap)
+
+        deadline = time.monotonic() + 3
+        name = ""
+        while time.monotonic() < deadline:
+            out = _tmux("list-clients", "-t", session, "-F", "#{client_name}")
+            names = {n.strip() for n in out.stdout.splitlines() if n.strip()}
+            fresh = names - exclude
+            if fresh:
+                name = next(iter(fresh))
+                break
+            time.sleep(0.1)
+        self.assertTrue(name, "the pty-attached client never registered with tmux")
+        return name, fd
+
+    def _install_real_bind(self, fid: str) -> None:
+        """`conf_text`'s own bind line, `source-file`'d for real — no substitution
+        needed here (see the class docstring): the `charter` shim on `$PATH`
+        already makes the bare `charter` this embeds resolve correctly, against
+        THIS class's own socket."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
+                                        session=fid)
+        conf = Path(tempfile.mkdtemp(prefix="charter-integ-clientconf-")) / "tmux.conf"
+        self.addCleanup(shutil.rmtree, conf.parent, True)
+        conf.write_text(text)
+        r = _tmux("source-file", str(conf))
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def _short_canary(self, name: str) -> str:
+        path = f"/tmp/chci-{os.getpid()}-{name}"
+
+        def _cleanup():
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+        self.addCleanup(_cleanup)
+        return path
+
+    def test_each_presser_gets_their_own_menu_not_the_others(self):
+        fid = f"menu-client-integ-{os.getpid()}"
+        self._new_session(fid)
+        clientA, fdA = self._attach_pty(fid)
+        clientB, fdB = self._attach_pty(fid, exclude=frozenset({clientA}))
+        self.assertNotEqual(clientA, clientB)
+        self.assertEqual(_run(commands_frame._session_id_env_argv(
+            socket=SOCKET, session=fid)).returncode, 0)
+        self._install_real_bind(fid)
+
+        # -- A presses: only A's own keystream may select what A's own press opened --
+        canary_a = self._short_canary("a")
+        menu.record(fid=fid, entries=[
+            ("Detach", [sys.executable, "-c", f"open({canary_a!r}, 'w').close()"]),
+        ])
+        os.write(fdA, b"\x1bOQ")
+        time.sleep(0.8)
+        os.write(fdB, b"1")
+        time.sleep(0.8)
+        self.assertFalse(os.path.exists(canary_a),
+                         "client B's own keystream selected an item in the menu A's "
+                         "own hotkey opened — the menu did not open specifically on "
+                         "A's screen (the exact regression this round fixes)")
+        os.write(fdA, b"1")
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not os.path.exists(canary_a):
+            time.sleep(0.2)
+        self.assertTrue(os.path.exists(canary_a),
+                        "A's own hotkey press must open A's own, selectable menu")
+
+        # -- Now B presses: the reverse must hold too, not just one direction --
+        canary_b = self._short_canary("b")
+        menu.record(fid=fid, entries=[
+            ("Detach", [sys.executable, "-c", f"open({canary_b!r}, 'w').close()"]),
+        ])
+        os.write(fdB, b"\x1bOQ")
+        time.sleep(0.8)
+        os.write(fdA, b"1")
+        time.sleep(0.8)
+        self.assertFalse(os.path.exists(canary_b),
+                         "client A's own keystream selected an item in the menu B's "
+                         "own hotkey opened")
+        os.write(fdB, b"1")
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not os.path.exists(canary_b):
+            time.sleep(0.2)
+        self.assertTrue(os.path.exists(canary_b),
+                        "B's own hotkey press must open B's own, selectable menu")
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -305,6 +305,39 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
                                "#{pane_dead}").stdout.strip(), "0",
                          "the pane died sometime after its first paint")
 
+    def test_a_corrupt_version_file_does_not_kill_a_live_panel(self):
+        """Fix round 2, item 1: a non-UTF-8 `version` file used to reach a real panel's
+        run loop as an uncaught `UnicodeDecodeError` and kill the pane — confirmed by
+        hand before this fix (`#{pane_dead}` reported `1`, status `1`, the traceback
+        visible in the pane itself). `remain-on-exit` is deliberately NOT armed for
+        this session (see `setUp`): a crash here means the whole SESSION vanishes, not
+        just the pane, so the `display-message` calls below would fail outright
+        ("session not found") rather than merely answering `pane_dead=1` — a stronger
+        signal than checking the pane alone would give.
+        """
+        fid = state.frame_id("panel-integ-corrupt", os.getpid())
+        argv = [sys.executable, "-m", "charter", "panel", "bottom", "--session", fid]
+        r = _tmux("new-session", "-d", "-s", "panel-corrupt", "-x", "40", "-y", "5",
+                  "-c", str(_REPO_ROOT), "--", *argv, env=self.env)
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+        time.sleep(1)
+        alive = _tmux("display-message", "-p", "-t", "panel-corrupt", "#{pane_dead}")
+        self.assertEqual(alive.returncode, 0, "the panel never even started")
+        self.assertEqual(alive.stdout.strip(), "0")
+
+        frame_dir = state.frame_dir(fid, create=True)
+        (frame_dir / "version").write_bytes(b"\xff\xfe not valid utf-8 \x80\x81")
+
+        time.sleep(1)
+        after = _tmux("display-message", "-p", "-t", "panel-corrupt", "#{pane_dead}")
+        self.assertEqual(after.returncode, 0,
+                         "the session vanished — the panel crashed reading the "
+                         "corrupt version file, and remain-on-exit is not armed here "
+                         f"(stderr: {after.stderr!r})")
+        self.assertEqual(after.stdout.strip(), "0",
+                         "the panel died reading a corrupt version file")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -67,6 +68,31 @@ def _run(cmd: list[str]) -> subprocess.CompletedProcess:
     """Run one of `commands_frame`'s own argv-building functions' output — never a
     hand-retyped command — so this module tests the exact bytes the launcher sends."""
     return subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+
+
+def _kill_pid(pid_str: str) -> None:
+    """SIGKILL one process directly, tolerating it already being gone.
+
+    `tmux kill-server` is a fire-and-forget signal TO THE SERVER, not a wait for it to
+    actually finish tearing down and reaping every pane's process — confirmed by hand
+    (`PanelIntegration`'s three tests, run back to back on ONE shared socket, left THREE
+    separate orphaned `tmux` server processes behind, each with PPID 1 and each still
+    holding its own live `python3 -m charter panel ...` child, even though every test's
+    own `addCleanup(_tmux, "kill-server")` had already run and reported success — the
+    review that found this counted 52 such orphans after a full suite run). Once a
+    server has detached and reparented to init like that, no later `kill-server` call
+    from a DIFFERENT test can reach it — the socket path it was using may already have
+    rolled over to a fresh server for the next test's `new-session`. Killing the pane's
+    OWN pid (captured via `#{pane_pid}` right after the pane is created) sidesteps the
+    whole question of whether the server ever tears itself down cleanly."""
+    try:
+        pid = int(pid_str)
+    except (TypeError, ValueError):
+        return
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except OSError:
+        pass  # already dead — exactly what this cleanup is trying to ensure
 
 
 @unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
@@ -269,6 +295,21 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
         self.env.pop("CHARTER_HOME", None)  # let it derive under CHARTER_ROOT, like this
                                             # process's own PersonaIso-isolated config
 
+    def _spawn_panel(self, session: str, fid: str) -> None:
+        """One `charter panel bottom --session <fid>` pane, in a fresh session named
+        *session* on this class's socket. Registers `_kill_pid` as a cleanup — see its
+        own docstring for why `kill-server` alone leaves this process orphaned — using
+        the pane's OWN pid (`#{pane_pid}`), captured immediately, rather than the
+        session or pane id: those name tmux objects, not the OS process underneath
+        them, and killing the process is the actual guarantee this method exists to
+        give every caller."""
+        argv = [sys.executable, "-m", "charter", "panel", "bottom", "--session", fid]
+        r = _tmux("new-session", "-d", "-s", session, "-x", "40", "-y", "5",
+                  "-c", str(_REPO_ROOT), "--", *argv, env=self.env)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        pid = _tmux("display-message", "-p", "-t", session, "#{pane_pid}").stdout.strip()
+        self.addCleanup(_kill_pid, pid)
+
     def test_a_bottom_panel_draws_and_repaints_on_a_real_state_bump(self):
         """Minimal shape: a real pane running `charter panel bottom --session <fid>`
         must (1) show real content rather than dying at startup — `capture-pane`
@@ -277,10 +318,7 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
         changes, not just once at launch — a fresh todo plus a real `state.bump` must
         change what `capture-pane` reports within a few polls of `panel.TICK`."""
         fid = state.frame_id("panel-integ", os.getpid())
-        argv = [sys.executable, "-m", "charter", "panel", "bottom", "--session", fid]
-        r = _tmux("new-session", "-d", "-s", "panel-live", "-x", "40", "-y", "5",
-                  "-c", str(_REPO_ROOT), "--", *argv, env=self.env)
-        self.assertEqual(r.returncode, 0, r.stderr)
+        self._spawn_panel("panel-live", fid)
 
         time.sleep(1)
         first = _tmux("capture-pane", "-p", "-t", "panel-live").stdout
@@ -321,10 +359,7 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
         broken hook wiring the way `test_frame_liveness.py`'s own docstring warns
         about."""
         fid = state.frame_id("panel-hook-integ", os.getpid())
-        argv = [sys.executable, "-m", "charter", "panel", "bottom", "--session", fid]
-        r = _tmux("new-session", "-d", "-s", "panel-hook-live", "-x", "40", "-y", "5",
-                  "-c", str(_REPO_ROOT), "--", *argv, env=self.env)
-        self.assertEqual(r.returncode, 0, r.stderr)
+        self._spawn_panel("panel-hook-live", fid)
 
         time.sleep(1)
         first = _tmux("capture-pane", "-p", "-t", "panel-hook-live").stdout
@@ -367,10 +402,7 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
         signal than checking the pane alone would give.
         """
         fid = state.frame_id("panel-integ-corrupt", os.getpid())
-        argv = [sys.executable, "-m", "charter", "panel", "bottom", "--session", fid]
-        r = _tmux("new-session", "-d", "-s", "panel-corrupt", "-x", "40", "-y", "5",
-                  "-c", str(_REPO_ROOT), "--", *argv, env=self.env)
-        self.assertEqual(r.returncode, 0, r.stderr)
+        self._spawn_panel("panel-corrupt", fid)
 
         time.sleep(1)
         alive = _tmux("display-message", "-p", "-t", "panel-corrupt", "#{pane_dead}")

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -14,6 +14,24 @@ asserts on probed capability rather than a version string." Every assertion belo
 tmux's own reported state (`show-hooks`, `display-message`, a file a real hook wrote) —
 never a version string.
 
+**Presence is not capability, and that gap cost a whole CI matrix.** These tests were
+first written against tmux 3.7c on a developer's Mac, inside a real terminal, and gated
+on `shutil.which("tmux")` alone — so on `ubuntu-latest` (tmux 3.4, `TERM=dumb`, no
+controlling terminal) seven of them failed rather than skipped, and each failure
+described the environment rather than charter. Three capabilities are now PROBED, each
+where it is needed, each skipping with a message that names what was missing:
+
+* an attachable tmux CLIENT (`_NeedsAttachedClient`) — `tmux attach` refuses a terminal
+  that cannot clear, which is what a headless CI step's `TERM=dumb` is;
+* a `pane-died` hook that FIRES (`TmuxIntegration._require_pane_died_fires`) — the one
+  thing the two exit-status tests cannot substitute for;
+* a tmux parser that lets the hotkey injection through at all
+  (`test_the_hotkey_injection_this_guards_against_is_live_on_this_tmux`) — tmux 3.4's
+  refuses it outright, so on 3.4 there is no live exploit to control against.
+
+None of these weakens an assertion: every test that RUNS asserts exactly what it always
+did, and a machine that cannot run one says which capability it lacked.
+
 Every test gets its own tmux SESSION (hooks are per-pane, so a shared session would let
 one test's hook leak into another's pane) on the ONE socket this module owns, and every
 test kills that socket's server on the way out via `addCleanup` — so a failing test
@@ -96,11 +114,215 @@ def _kill_pid(pid_str: str) -> None:
         pass  # already dead — exactly what this cleanup is trying to ensure
 
 
+def _gate_argv(gate: str, dies_by: str) -> list[str]:
+    """A pane program that waits for the file *gate* and then dies by *dies_by*.
+
+    **Never tmux's default pane command, and never driven by `send-keys`.** Both of those
+    were how this module used to kill a pane, and both were measured wrong:
+
+    * tmux's default is `default-shell` run as a LOGIN shell, which charter never
+      launches — `frame/layout.session_argv` always ends `new-session … -- <harness
+      argv>`. On `ubuntu-latest` (tmux 3.4, Ubuntu 24.04) a login `bash` exiting runs the
+      runner's own `~/.bash_logout`, after which tmux reports the pane `#{pane_dead}` `1`
+      with `#{pane_dead_status}` EMPTY and **fires no `pane-died` hook at all** — so the
+      file these tests read was never written. Every CI job failed that way.
+    * `send-keys` into an INTERACTIVE shell, telling it to `exit 42` or `kill -9 $$`, is
+      not reliable: measured 30 trials per shape on tmux 3.4, `send-keys` shapes fired
+      the hook 26-28 times out of 30, while a pane whose own program died on its own
+      fired it 30/30 (`exit 42` through this gate, `kill -9 $$` through this gate, and an
+      external SIGKILL to `#{pane_pid}` — all three perfect). The failures all looked
+      identical: `#{pane_dead}` `1`, `#{pane_dead_status}` empty, no hook. That is tmux
+      3.4's own `server_destroy_pane` refusing to fire `pane-died` until `PANE_STATUSREADY`
+      is set, and an interactive shell's job-control handling of a keyed-in death
+      sometimes leaves it unset. It is also nothing charter does: a harness dies because
+      it exited or was signalled, never because someone typed at it.
+
+    So a pane here dies the way a harness dies — its own program reaching its own end —
+    and the test says WHEN by opening the gate. That is both the faithful shape and the
+    reliable one.
+
+    Three argv words, also deliberately: tmux runs a ONE-ARGUMENT pane command through a
+    shell (`$SHELL -c '<the argument>'`) and only `execvp`s it directly when there is
+    more than one, so a single-word command can leave the pane's own process a `sh -c`
+    WRAPPER with the real program as its child — measured in an Ubuntu 24.04 container,
+    where that wrapper turned a SIGKILLed child into a normal exit with status 137.
+    """
+    return ["/bin/sh", "-c", f"while [ ! -f '{gate}' ]; do sleep 0.05; done; {dies_by}"]
+
+#: Terminal types tried, in order, when this module forks a tmux CLIENT onto a pty.
+#:
+#: `tmux attach` REFUSES to start a client on an unsuitable terminal — "open terminal
+#: failed: terminal does not support clear" — and a headless CI step is exactly that:
+#: measured on `ubuntu-latest`, a workflow `run:` step has `TERM=dumb`. That is a
+#: property of the ENVIRONMENT, not of tmux's version and not of anything charter does:
+#: the same tmux 3.4 that refuses `TERM=dumb` attaches immediately when the forked
+#: client's own `TERM` names a terminal that can clear. A real operator's `charter
+#: <harness>` always has one; a test's forked client has to be given one.
+#:
+#: `$TERM` first when this process has a usable one (a developer's own terminal is the
+#: most faithful thing to attach with), then two entries carried by every terminfo
+#: database on a machine that has tmux at all. `dumb` is never tried — tmux's refusal of
+#: it is the measured fact above, so retrying it would only spend the timeout.
+_TERM_CANDIDATES = tuple(dict.fromkeys(
+    ([os.environ["TERM"]] if os.environ.get("TERM", "dumb") != "dumb" else [])
+    + ["xterm-256color", "screen", "vt100"]))
+
+#: Whether a pane-scoped `pane-died` hook FIRES on this machine — probed once per test
+#: process by `TmuxIntegration._require_pane_died_fires`, and a list rather than a bool
+#: so "not probed yet" and "probed, and the answer is False" stay distinguishable.
+_PANE_DIED_FIRES: list[bool] = []
+
+#: How long ONE forked client gets to register with tmux before this gives up on it.
+#:
+#: Generous on purpose, and NOT the thing that detects a refusal: a refused `tmux attach`
+#: EXITS, which `_await_client` notices immediately, so the next terminal type is tried
+#: without spending this at all. Cutting it short instead would abandon a client that was
+#: merely slow and move on to a terminal type whose KEY ENCODINGS differ — and every test
+#: using an attached client drives it by writing a raw key sequence to the pty, so a
+#: silently-substituted terminal type is a silently-broken test rather than an honest
+#: skip. (Measured: that is exactly what a 2s cap did on a loaded developer machine —
+#: `MenuClientIntegration` failed roughly one run in ten with the menu never opening.)
+_ATTACH_TIMEOUT = 10.0
+
+
+def _fork_attach(session: str, term: str) -> tuple[int, int]:
+    """`tmux attach -t session` under a fresh pty, with *term* as the client's `$TERM`.
+
+    Returns the child's pid and the pty's master fd. The child never returns — the
+    `finally` is there so a failed `execvp` cannot fall through into the test process's
+    own code as a second copy of the whole suite.
+    """
+    pid, fd = pty.fork()
+    if pid == 0:
+        try:
+            os.environ["TERM"] = term
+            os.execvp("tmux", ["tmux", "-L", SOCKET, "attach", "-t", session])
+        finally:
+            os._exit(127)
+    return pid, fd
+
+
+def _reap_pty(pid: int, fd: int) -> None:
+    """SIGKILL, reap, close — a pty-forked child is THIS process's own zombie to reap,
+    unlike a tmux-spawned pane's process, which reparents away (see `_kill_pid`)."""
+    _kill_pid(str(pid))
+    try:
+        os.waitpid(pid, 0)
+    except OSError:
+        pass
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
+
+def _refusal(fd: int) -> str:
+    """Whatever a refused `tmux attach` printed to its pty — tmux's own words, so a skip
+    can name the capability that was missing instead of guessing at it."""
+    try:
+        os.set_blocking(fd, False)
+        out = os.read(fd, 4096)
+    except OSError:
+        return ""
+    finally:
+        try:
+            os.set_blocking(fd, True)
+        except OSError:
+            pass
+    return out.decode("utf-8", "replace").strip()
+
+
+def _await_file(path: str, timeout: float = 5.0) -> bool:
+    """Wait for a hook-written file to appear, up to *timeout*.
+
+    A fixed `time.sleep(1)` here was a guess about how long a `run-shell` takes to fork a
+    shell and redirect one line — which is the wrong shape of question for a test whose
+    assertion is about the file's CONTENT. Polling makes a slow machine slow rather than
+    wrong, and a machine where the hook never fires still reaches the same assertion with
+    the same missing file (see `TmuxIntegration._require_pane_died_fires`, which is what
+    tells those two apart).
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline and not os.path.exists(path):
+        time.sleep(0.1)
+    return os.path.exists(path)
+
+
+def _await_client(session: str, exclude: frozenset, pid: int) -> str:
+    """The name of a client attached to *session* that the caller does not already know
+    about, or `""` when the forked client at *pid* will never register.
+
+    Two ways to learn that, and the fast one is watching the CHILD: a `tmux attach` that
+    the terminal type was wrong for exits at once, so `waitpid(WNOHANG)` reporting it gone
+    is a definitive refusal, available in milliseconds and independent of tmux's wording.
+    :data:`_ATTACH_TIMEOUT` is only the backstop for a client that neither registers nor
+    exits.
+    """
+    deadline = time.monotonic() + _ATTACH_TIMEOUT
+    while time.monotonic() < deadline:
+        out = _tmux("list-clients", "-t", session, "-F", "#{client_name}")
+        fresh = {n.strip() for n in out.stdout.splitlines() if n.strip()} - exclude
+        if fresh:
+            return next(iter(fresh))
+        try:
+            if os.waitpid(pid, os.WNOHANG)[0] == pid:
+                return ""   # the client exited rather than attaching — a refusal
+        except OSError:
+            return ""
+        time.sleep(0.1)
+    return ""
+
+
+class _NeedsAttachedClient:
+    """`_attach_pty` for the two classes that need a REAL, ATTACHED client, and the
+    capability probe that decides whether this machine can give them one.
+
+    `display-menu` refuses outright ("no current client") without an attached client, so
+    both classes below are unrunnable — not passable, not failable — where tmux will not
+    attach one. They skip, naming what they could not get and quoting tmux's own refusal,
+    rather than asserting anything about a menu nothing drew.
+    """
+
+    def _attach_pty(self, session: str, exclude: frozenset = frozenset()) -> tuple[str, int]:
+        """Forks a real `tmux attach -t session` under a pty — the one way to hand
+        `display-menu` a client it will actually accept for `-c`/`-t` targeting.
+
+        *exclude* names clients the caller already knows about: `list-clients -t session`
+        lists every client attached to it, not only the one just forked, so a SECOND pty
+        on the same session has to pick its own name out from among several.
+
+        Registers the fork's own cleanup (SIGKILL, then reap — see `_reap_pty`) before
+        returning the attached client's name (`#{client_name}`, read back from tmux
+        itself once the attachment has had time to register) and the pty's own master fd
+        — writing a KEY to the fd (not `tmux send-keys`, confirmed by hand: `send-keys`
+        feeds a PANE's own input queue, which an active menu overlay never reads from) is
+        the only way found to actually select a menu item from here.
+        """
+        refusals = []
+        for term in _TERM_CANDIDATES:
+            pid, fd = _fork_attach(session, term)
+            try:
+                name = _await_client(session, exclude, pid)
+            except Exception:
+                _reap_pty(pid, fd)
+                raise
+            if name:
+                self.addCleanup(_reap_pty, pid, fd)
+                return name, fd
+            refusals.append(f"TERM={term}: {_refusal(fd) or '(tmux printed nothing)'}")
+            _reap_pty(pid, fd)
+        self.skipTest(
+            "no tmux client can attach on this machine, and a rendered `display-menu` "
+            "needs one — tmux refused every terminal type tried: " + " | ".join(refusals))
+
+
 @unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
 class TmuxIntegration(unittest.TestCase):
     def setUp(self) -> None:
         self.addCleanup(self._teardown_socket)
         self._pane_counter = 0
+        self._gate_dir = tempfile.mkdtemp(prefix="charter-integ-gate-")
+        self.addCleanup(shutil.rmtree, self._gate_dir, True)
 
     def _teardown_socket(self) -> None:
         """`kill-server` ends the SERVER but does not remove its own socket FILE —
@@ -114,59 +336,129 @@ class TmuxIntegration(unittest.TestCase):
         _tmux("kill-server")
         (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET).unlink(missing_ok=True)
 
-    def _new_pane(self) -> str:
-        """A fresh session on `SOCKET`, `remain-on-exit` armed, its one pane's id."""
+    def _new_pane(self, dies_by: str = "exit 0") -> tuple[str, str, str]:
+        """A fresh session on `SOCKET`, `remain-on-exit` armed; its name, pane id and GATE.
+
+        The pane runs a program that WAITS for its gate file and then dies by *dies_by* —
+        the caller opens the gate (`_release`) when it wants the death. See `_gate_argv`
+        for why the pane is never driven with `send-keys` instead, which is the shape this
+        module used to use and the reason it failed roughly one CI run in ten.
+        """
         self._pane_counter += 1
         name = f"p{self._pane_counter}"
+        gate = os.path.join(self._gate_dir, f"gate-{name}")
         r = _tmux("new-session", "-d", "-s", name, "-x", "80", "-y", "24",
-                  "-P", "-F", "#{pane_id}")
+                  "-P", "-F", "#{pane_id}", "--", *_gate_argv(gate, dies_by))
         self.assertEqual(r.returncode, 0, r.stderr)
         # Global on this socket's server — cheap to repeat per pane, and every frame
         # wants it regardless (see `commands_frame._PLACEHOLDER_CONF`'s own docstring).
         _tmux("set", "-g", "remain-on-exit", "on")
-        return name, r.stdout.strip()
+        return name, r.stdout.strip(), gate
+
+    @staticmethod
+    def _release(gate: str) -> None:
+        """Open a pane's gate: its program stops waiting and dies the way it was built to."""
+        Path(gate).touch()
+
+    def _require_pane_died_fires(self) -> None:
+        """Skip unless a pane-scoped `pane-died` hook actually FIRES on this machine.
+
+        The two exit-status tests below read a file a hook WROTE. If the hook never runs
+        there is no file, and `open()` raises a `FileNotFoundError` that says nothing
+        about which of the four moving parts (`remain-on-exit`, `set-hook -p`,
+        `set-environment`, `run-shell`) was missing — the shape this module's CI failure
+        actually took. This probes the ONE capability those tests cannot substitute for,
+        against a real pane dying the same way theirs do, and does it with a hook whose
+        action is a CONSTANT path: no `set-environment` value, no `#{pane_dead_status}`,
+        nothing but "did tmux run this at all". A machine that passes this and then fails
+        a test below has a real defect in what the test is about; a machine that fails
+        this could not have run the test in the first place.
+
+        Probed once per process (`_PANE_DIED_FIRES`) — the answer is a property of this
+        tmux and this environment, not of any one test, and each probe costs a pane.
+        """
+        if not _PANE_DIED_FIRES:
+            _, pane, gate = self._new_pane("exit 7")
+            tmp = tempfile.mkdtemp(prefix="charter-integ-probe-")
+            self.addCleanup(shutil.rmtree, tmp, True)
+            marker = os.path.join(tmp, "fired")
+            _tmux("set-hook", "-p", "-t", pane, "pane-died",
+                  f'run-shell "touch {marker}"')
+            self._release(gate)
+            _PANE_DIED_FIRES.append(_await_file(marker))
+        if not _PANE_DIED_FIRES[0]:
+            self.skipTest(
+                "a pane-scoped `pane-died` hook does not fire on this machine, so "
+                "nothing here can carry a harness's exit status out of a dead pane — "
+                "the capability these tests measure is not present to measure")
 
     # -- 0. The hotkey is not a free string ----------------------------------------- #
 
-    def test_a_hostile_hotkey_from_charter_toml_runs_nothing_at_launch(self):
-        """CRITICAL, against a real tmux 3.7c: `[frame] hotkey` reaches
-        `source-file`'s PARSER, and until `instance._HOTKEY_RE` it was type-checked as a
-        `str` and nothing else.
+    def _source_hotkey(self, conf_dir: Path, hotkey: str, name: str
+                       ) -> subprocess.CompletedProcess:
+        """`conf_text`'s own output for *hotkey*, written out and `source-file`'d for
+        real — never a hand-retyped config."""
+        conf = conf_dir / f"{name}.conf"
+        conf.write_text(commands_frame.conf_text(
+            hotkey=hotkey, mouse=False, history_limit=1, session="p1"))
+        return _tmux("source-file", str(conf))
 
-        Three parts, and the middle one is what makes this test able to fail. First the
-        exploit is run for real, unfiltered, and the canary MUST appear — that is the
-        positive control, and without it a fix that broke `conf_text` entirely would
-        look like a pass. Then the same charter.toml goes through `instance.frame_of`,
-        the way `config.FRAME` builds it, and the resolved hotkey must produce no canary
-        at all. Note what the exploit does not need: no keypress, no attached client,
-        nothing but `source-file` returning 0, which it does, silently."""
-        payload = f"/tmp/charter-c1-{os.getpid()}"
-        armed, disarmed = f"{payload}-armed", f"{payload}-disarmed"
-        for path in (armed, disarmed):
-            self.addCleanup(lambda p=path: Path(p).unlink(missing_ok=True))
+    def test_the_hotkey_injection_this_guards_against_is_live_on_this_tmux(self):
+        """The POSITIVE CONTROL for the test below, and the reason it can fail at all:
+        an unfiltered `[frame] hotkey` really does run a command at launch — no keypress,
+        no attached client, nothing but `source-file` accepting the file.
+
+        **Its own capability, and not every tmux has it.** Measured against tmux 3.7c the
+        injected line parses and the canary appears. Measured against tmux 3.4 (Ubuntu
+        24.04, the `ubuntu-latest` runner) tmux's OWN parser refuses the whole file first
+        — `command run-shell: too many arguments (need at most 2)`, `source-file` returns
+        1 — and no canary is ever created. charter's `instance._HOTKEY_RE` is what closes
+        the hole on both, but on a tmux whose parser refuses the exploit outright there is
+        no live exploit here to control against, so this skips and says so rather than
+        asserting that a hostile value is dangerous on a tmux where it is not. Split out
+        of the test below for exactly that reason: the property charter owns must keep
+        running everywhere, and only the control it is a control FOR is version-shaped.
+        """
+        armed = f"/tmp/charter-c1-{os.getpid()}-armed"
+        self.addCleanup(lambda: Path(armed).unlink(missing_ok=True))
         conf_dir = Path(tempfile.mkdtemp(prefix="charter-integ-hotkey-"))
         self.addCleanup(shutil.rmtree, conf_dir, True)
         self._new_pane()
 
-        def _source(hotkey: str, name: str) -> int:
-            conf = conf_dir / f"{name}.conf"
-            conf.write_text(commands_frame.conf_text(
-                hotkey=hotkey, mouse=False, history_limit=1, session="p1"))
-            return _tmux("source-file", str(conf)).returncode
-
-        # 1. The exploit itself, unfiltered — proof this test can fail.
-        self.assertEqual(_source(f"F2\nrun-shell 'touch {armed}'", "armed"), 0,
-                         "`source-file` returns 0 for this; that silence is the defect")
+        r = self._source_hotkey(conf_dir, f"F2\nrun-shell 'touch {armed}'", "armed")
+        if r.returncode != 0:
+            self.skipTest(
+                "this tmux's own parser refuses the injected hotkey before running any "
+                "of it (`source-file` returned "
+                f"{r.returncode}: {(r.stdout + r.stderr).strip()!r}), so the exploit "
+                "this controls for is not reachable here")
         time.sleep(0.5)
         self.assertTrue(os.path.exists(armed),
-                        "the positive control never fired — this test cannot fail as "
-                        "written, so its other half proves nothing")
+                        "`source-file` accepted the hostile hotkey and returned 0, but "
+                        "the injected command never ran — the control proves nothing in "
+                        "that state, and neither does the test it controls for")
 
-        # 2. The same value, arriving the way charter.toml actually delivers it.
+    def test_a_hostile_hotkey_from_charter_toml_runs_nothing_at_launch(self):
+        """CRITICAL: `[frame] hotkey` reaches `source-file`'s PARSER, and until
+        `instance._HOTKEY_RE` it was type-checked as a `str` and nothing else.
+
+        The hostile charter.toml goes through `instance.frame_of`, the way `config.FRAME`
+        builds it, and the resolved hotkey must produce no canary at all. Two assertions,
+        either of which fails if `_HOTKEY_RE` is removed: the resolved value must BE the
+        default, and sourcing it must run nothing. See the test above for the positive
+        control — the proof that an unfiltered value really does execute — which is its
+        own test because not every tmux's parser lets the exploit through.
+        """
+        disarmed = f"/tmp/charter-c1-{os.getpid()}-disarmed"
+        self.addCleanup(lambda: Path(disarmed).unlink(missing_ok=True))
+        conf_dir = Path(tempfile.mkdtemp(prefix="charter-integ-hotkey-"))
+        self.addCleanup(shutil.rmtree, conf_dir, True)
+        self._new_pane()
+
         resolved = instance.frame_of(
             {"frame": {"hotkey": f"F2\nrun-shell 'touch {disarmed}'"}})["hotkey"]
         self.assertEqual(resolved, "F2", "the hostile value must degrade to the default")
-        self.assertEqual(_source(resolved, "disarmed"), 0)
+        self.assertEqual(self._source_hotkey(conf_dir, resolved, "disarmed").returncode, 0)
         time.sleep(0.5)
         self.assertFalse(os.path.exists(disarmed),
                          "a charter.toml hotkey ran a command at launch, with no "
@@ -183,7 +475,7 @@ class TmuxIntegration(unittest.TestCase):
         (the trap), the teardown hook is silently deleted the moment the write hook
         lands — which is precisely the mutation that reintroduced the original hang
         when the two `cmd_launch` calls were swapped."""
-        _, pane_correct = self._new_pane()
+        _, pane_correct, _ = self._new_pane()
         write = commands_frame._pane_died_write_hook_argv(socket=SOCKET, harness_pane=pane_correct)
         teardown = commands_frame._pane_died_teardown_hook_argv(socket=SOCKET, harness_pane=pane_correct)
         self.assertEqual(_run(write).returncode, 0)
@@ -192,7 +484,7 @@ class TmuxIntegration(unittest.TestCase):
         self.assertIn("pane-died[0]", hooks)
         self.assertIn("pane-died[1]", hooks)
 
-        _, pane_wrong = self._new_pane()
+        _, pane_wrong, _ = self._new_pane()
         write2 = commands_frame._pane_died_write_hook_argv(socket=SOCKET, harness_pane=pane_wrong)
         teardown2 = commands_frame._pane_died_teardown_hook_argv(socket=SOCKET, harness_pane=pane_wrong)
         self.assertEqual(_run(teardown2).returncode, 0)
@@ -213,7 +505,8 @@ class TmuxIntegration(unittest.TestCase):
         containing a space, a literal `'`, and a `$(touch ...)` injection attempt all at
         once: the file at that exact path must hold the harness's real exit code, and
         nothing embedded in the path may execute."""
-        session, pane = self._new_pane()
+        self._require_pane_died_fires()
+        session, pane, gate = self._new_pane("exit 42")
         tmp = tempfile.mkdtemp(prefix="charter-integ-inj-")
         self.addCleanup(shutil.rmtree, tmp, True)
         canary = os.path.join(tmp, "canary")
@@ -229,8 +522,8 @@ class TmuxIntegration(unittest.TestCase):
         teardown_cmd = commands_frame._pane_died_teardown_hook_argv(socket=SOCKET, harness_pane=pane)
         self.assertEqual(_run(teardown_cmd).returncode, 0)
 
-        _tmux("send-keys", "-t", pane, "exit 42", "Enter")
-        time.sleep(1)
+        self._release(gate)
+        _await_file(status_path)
 
         self.assertFalse(os.path.exists(canary),
                          "the $(touch ...) inside the plane path must never execute")
@@ -240,14 +533,19 @@ class TmuxIntegration(unittest.TestCase):
     # -- 3. Signal death -------------------------------------------------------------- #
 
     def test_a_signal_death_writes_the_unknown_death_sentinel_not_an_empty_line(self):
-        """Measured against tmux 3.7c: a pane killed by SIGKILL reports `#{pane_dead}`
-        `1` with `#{pane_dead_status}` EMPTY, not a number — `display-message` is
-        checked directly to confirm that is still what THIS tmux does, not merely
-        assumed. The write hook's own `${v:-N}` fallback must turn that empty value into
-        `_UNKNOWN_DEATH_CODE` at the point of writing, so the file it produces is always
-        a parseable integer; `state.exit_code` cannot parse an empty line and would
-        silently read it back as "nothing was ever recorded"."""
-        session, pane = self._new_pane()
+        """Measured against tmux 3.7c and re-measured against tmux 3.4: a pane killed by
+        SIGKILL reports `#{pane_dead}` `1` with `#{pane_dead_status}` EMPTY, not a number
+        — `display-message` is checked directly to confirm that is still what THIS tmux
+        does, not merely assumed. The write hook's own `${v:-N}` fallback must turn that
+        empty value into `_UNKNOWN_DEATH_CODE` at the point of writing, so the file it
+        produces is always a parseable integer; `state.exit_code` cannot parse an empty
+        line and would silently read it back as "nothing was ever recorded".
+
+        The pane's own program signals ITSELF once its gate opens, rather than the test
+        typing the same thing at an interactive shell — see `_gate_argv` for the 30-trial
+        measurement that made the difference between the two shapes."""
+        self._require_pane_died_fires()
+        session, pane, gate = self._new_pane("kill -9 $$")
         tmp = tempfile.mkdtemp(prefix="charter-integ-sig-")
         self.addCleanup(shutil.rmtree, tmp, True)
         status_path = os.path.join(tmp, "exit")
@@ -258,8 +556,8 @@ class TmuxIntegration(unittest.TestCase):
         write_cmd = commands_frame._pane_died_write_hook_argv(socket=SOCKET, harness_pane=pane)
         self.assertEqual(_run(write_cmd).returncode, 0)
 
-        _tmux("send-keys", "-t", pane, "kill -9 $$", "Enter")
-        time.sleep(1)
+        self._release(gate)
+        _await_file(status_path)
 
         dead, _, status = _tmux("display-message", "-p", "-t", pane,
                                 "#{pane_dead}:#{pane_dead_status}").stdout.strip().partition(":")
@@ -616,7 +914,7 @@ class MenuIntegration(PersonaIso, unittest.TestCase):
 
 
 @unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
-class MenuFormatIntegration(unittest.TestCase):
+class MenuFormatIntegration(_NeedsAttachedClient, unittest.TestCase):
     """The CRITICAL finding from the first review round, proved against a REAL,
     RENDERED `display-menu` — not only the argv shape `tests/test_frame_menu.py`'s
     `LabelSafety` checks. `display-menu`'s own docs: "The name and command are formats"
@@ -627,7 +925,8 @@ class MenuFormatIntegration(unittest.TestCase):
 
     A REAL, ATTACHED client is unavoidable here — `display-menu` refuses outright ("no
     current client") without one — which is why every OTHER test in this file avoids
-    attaching one at all. `_attach_pty` is the one place in the suite that does.
+    attaching one at all. `_NeedsAttachedClient._attach_pty` is the one place in the
+    suite that does, and the one place that decides this machine cannot.
     """
 
     def setUp(self) -> None:
@@ -648,45 +947,6 @@ class MenuFormatIntegration(unittest.TestCase):
         self.assertEqual(r.returncode, 0, r.stderr)
         pid = _tmux("display-message", "-p", "-t", fid, "#{pane_pid}").stdout.strip()
         self.addCleanup(_kill_pid, pid)
-
-    def _attach_pty(self, session: str) -> tuple[str, int]:
-        """Forks a real `tmux attach -t session` under a pty — the one way to hand
-        `display-menu` a client it will actually accept for `-c`/`-t` targeting.
-        Registers the fork's own cleanup (SIGKILL, then reap — `_kill_pid` alone only
-        signals; a pty-forked child is THIS process's own, so it is also this process's
-        own zombie to reap, unlike a tmux-spawned pane's process, which reparents away)
-        before returning the attached client's name (`#{client_name}`, read back from
-        tmux itself once the attachment has had time to register) and the pty's own
-        master fd — writing a KEY to the fd (not `tmux send-keys`, confirmed by hand:
-        `send-keys` feeds a PANE's own input queue, which an active menu overlay never
-        reads from) is the only way found to actually select a menu item from here.
-        """
-        pid, fd = pty.fork()
-        if pid == 0:
-            os.execvp("tmux", ["tmux", "-L", SOCKET, "attach", "-t", session])
-
-        def _reap():
-            _kill_pid(str(pid))
-            try:
-                os.waitpid(pid, 0)
-            except OSError:
-                pass
-            try:
-                os.close(fd)
-            except OSError:
-                pass
-        self.addCleanup(_reap)
-
-        deadline = time.monotonic() + 3
-        name = ""
-        while time.monotonic() < deadline:
-            out = _tmux("list-clients", "-t", session, "-F", "#{client_name}")
-            name = out.stdout.strip()
-            if name:
-                break
-            time.sleep(0.1)
-        self.assertTrue(name, "the pty-attached client never registered with tmux")
-        return name, fd
 
     def _drive_menu(self, fd: int, cmd: list[str]) -> None:
         """Bind *cmd* (a real `display-menu` invocation) to a throwaway key and press
@@ -824,7 +1084,7 @@ class MenuFormatIntegration(unittest.TestCase):
 
 
 @unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
-class MenuClientIntegration(unittest.TestCase):
+class MenuClientIntegration(_NeedsAttachedClient, unittest.TestCase):
     """Fix round 2, IMPORTANT-1, proved with two real ptys attached to ONE frame at
     once: the hotkey must open the menu on the PRESSER's own screen, never a
     different attached client's — the defect an earlier version of this mechanism
@@ -948,41 +1208,6 @@ class MenuClientIntegration(unittest.TestCase):
         self.addCleanup(_kill_pid, server_pid)
         pid = _tmux("display-message", "-p", "-t", fid, "#{pane_pid}").stdout.strip()
         self.addCleanup(_kill_pid, pid)
-
-    def _attach_pty(self, session: str, exclude: frozenset = frozenset()) -> tuple[str, int]:
-        """Same shape as `MenuFormatIntegration`'s own helper, extended for a SECOND
-        client on the same session: `list-clients -t session` lists every client
-        attached to it, not only the one just forked, so a second pty here has to
-        pick its OWN name out from among possibly several already there — *exclude*
-        names the ones a caller already knows about."""
-        pid, fd = pty.fork()
-        if pid == 0:
-            os.execvp("tmux", ["tmux", "-L", SOCKET, "attach", "-t", session])
-
-        def _reap():
-            _kill_pid(str(pid))
-            try:
-                os.waitpid(pid, 0)
-            except OSError:
-                pass
-            try:
-                os.close(fd)
-            except OSError:
-                pass
-        self.addCleanup(_reap)
-
-        deadline = time.monotonic() + 3
-        name = ""
-        while time.monotonic() < deadline:
-            out = _tmux("list-clients", "-t", session, "-F", "#{client_name}")
-            names = {n.strip() for n in out.stdout.splitlines() if n.strip()}
-            fresh = names - exclude
-            if fresh:
-                name = next(iter(fresh))
-                break
-            time.sleep(0.1)
-        self.assertTrue(name, "the pty-attached client never registered with tmux")
-        return name, fd
 
     def _install_real_bind(self, fid: str) -> None:
         """`conf_text`'s own bind line, `source-file`'d for real — byte for byte, no

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -35,7 +35,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from charter import commands_frame, hooks, todos
+from charter import commands_frame, hooks, instance, todos
 from charter.frame import menu, notify, state
 
 from tests._isolation import PersonaIso, run_hook
@@ -125,6 +125,52 @@ class TmuxIntegration(unittest.TestCase):
         # wants it regardless (see `commands_frame._PLACEHOLDER_CONF`'s own docstring).
         _tmux("set", "-g", "remain-on-exit", "on")
         return name, r.stdout.strip()
+
+    # -- 0. The hotkey is not a free string ----------------------------------------- #
+
+    def test_a_hostile_hotkey_from_charter_toml_runs_nothing_at_launch(self):
+        """CRITICAL, against a real tmux 3.7c: `[frame] hotkey` reaches
+        `source-file`'s PARSER, and until `instance._HOTKEY_RE` it was type-checked as a
+        `str` and nothing else.
+
+        Three parts, and the middle one is what makes this test able to fail. First the
+        exploit is run for real, unfiltered, and the canary MUST appear — that is the
+        positive control, and without it a fix that broke `conf_text` entirely would
+        look like a pass. Then the same charter.toml goes through `instance.frame_of`,
+        the way `config.FRAME` builds it, and the resolved hotkey must produce no canary
+        at all. Note what the exploit does not need: no keypress, no attached client,
+        nothing but `source-file` returning 0, which it does, silently."""
+        payload = f"/tmp/charter-c1-{os.getpid()}"
+        armed, disarmed = f"{payload}-armed", f"{payload}-disarmed"
+        for path in (armed, disarmed):
+            self.addCleanup(lambda p=path: Path(p).unlink(missing_ok=True))
+        conf_dir = Path(tempfile.mkdtemp(prefix="charter-integ-hotkey-"))
+        self.addCleanup(shutil.rmtree, conf_dir, True)
+        self._new_pane()
+
+        def _source(hotkey: str, name: str) -> int:
+            conf = conf_dir / f"{name}.conf"
+            conf.write_text(commands_frame.conf_text(
+                hotkey=hotkey, mouse=False, history_limit=1, session="p1"))
+            return _tmux("source-file", str(conf)).returncode
+
+        # 1. The exploit itself, unfiltered — proof this test can fail.
+        self.assertEqual(_source(f"F2\nrun-shell 'touch {armed}'", "armed"), 0,
+                         "`source-file` returns 0 for this; that silence is the defect")
+        time.sleep(0.5)
+        self.assertTrue(os.path.exists(armed),
+                        "the positive control never fired — this test cannot fail as "
+                        "written, so its other half proves nothing")
+
+        # 2. The same value, arriving the way charter.toml actually delivers it.
+        resolved = instance.frame_of(
+            {"frame": {"hotkey": f"F2\nrun-shell 'touch {disarmed}'"}})["hotkey"]
+        self.assertEqual(resolved, "F2", "the hostile value must degrade to the default")
+        self.assertEqual(_source(resolved, "disarmed"), 0)
+        time.sleep(0.5)
+        self.assertFalse(os.path.exists(disarmed),
+                         "a charter.toml hotkey ran a command at launch, with no "
+                         "keypress — see instance._HOTKEY_RE")
 
     # -- 1. Append and the order trap ---------------------------------------------- #
 
@@ -493,11 +539,17 @@ class MenuIntegration(PersonaIso, unittest.TestCase):
     inside a live `display-menu -t fid` would (see `menu_argv`'s own docstring for why
     `-t fid` is what supplies that scoping normally).
 
-    Uses `sys.executable -m charter` rather than the bare `charter` text `menu_argv`
-    itself embeds: this developer machine's own `$PATH` may resolve `charter` to an
-    entirely different install than this checkout (confirmed on the machine this test
-    was written on), and `PanelIntegration` above avoids the identical trap the same
-    way, for `charter panel`."""
+    Substitutes `sys.executable` for the `"$CHARTER_PY"` `menu_argv` embeds, rather
+    than tying it to the session — this class fires the action through `run-shell -t
+    fid` directly instead of through a rendered menu, so it is writing the command
+    itself and can simply name the interpreter. (`MenuFormatIntegration` below, which
+    does drive a real rendered menu, sets `CHARTER_PY` on the session instead and
+    leaves `menu_argv`'s own text untouched; `MenuClientIntegration` goes further and
+    proves it with no `charter` on `$PATH` at all.) Either way, never a bare `charter`:
+    this developer machine's own `$PATH` may resolve one to an entirely different
+    install than this checkout (confirmed on the machine this test was written on), and
+    `PanelIntegration` above avoids the identical trap the same way for `charter
+    panel`."""
 
     def setUp(self) -> None:
         super().setUp()
@@ -537,11 +589,11 @@ class MenuIntegration(PersonaIso, unittest.TestCase):
         action_id = menu.build(fid)[0][1]
         self.assertRegex(action_id, r"^a[0-9]+$")
 
-        # The exact template `menu_argv` embeds for this item, `charter` swapped for
-        # `sys.executable -m charter` (see the class docstring) — everything else,
-        # including the absence of any label text, matches byte for byte. `client`
-        # (this test's own no-op stand-in) only affects `-c`, never the per-item
-        # action text this line inspects.
+        # The exact template `menu_argv` embeds for this item, `"$CHARTER_PY"` swapped
+        # for `sys.executable` (see the class docstring) — everything else, including
+        # the absence of any label text, matches byte for byte. `client` (this test's
+        # own no-op stand-in) only affects `-c`, never the per-item action text this
+        # line inspects.
         real_command = menu.menu_argv(fid, SOCKET, client="")[-1]
         self.assertNotIn("pwned", real_command,
                          "sanity: the hostile label must not have leaked into the "
@@ -744,13 +796,16 @@ class MenuFormatIntegration(unittest.TestCase):
         menu.record(fid=fid, entries=[
             (hostile_label, [sys.executable, "-c", f"open({real_canary!r}, 'w').close()"]),
         ])
+        # The item's own action reads `"$CHARTER_PY" -m charter frame-action a0` — no
+        # string substitution needed here any more (an earlier version rewrote a bare
+        # `charter`, which may not be this checkout on `$PATH`). Setting the session's
+        # own `CHARTER_PY` is what production does, so this drives the real mechanism
+        # rather than a rewrite of it: `display-menu -t <session>` scopes the item's
+        # `run-shell` to this session's environment.
+        self.assertEqual(_tmux("set-environment", "-t", fid, "CHARTER_PY",
+                              sys.executable).returncode, 0)
         cmd = menu.menu_argv(fid, SOCKET, client=client)
-        # `charter` (bare, per `menu_argv`'s own text) may not be this checkout on
-        # `$PATH` — same substitution `MenuIntegration` above makes, for the same
-        # reason. The item's own action is the LAST argv element, a single string
-        # (`"run-shell 'charter frame-action a0'"`), not a separate "run-shell" token.
-        cmd[-1] = cmd[-1].replace("charter frame-action",
-                                 f"{sys.executable} -m charter frame-action")
+        self.assertIn("$CHARTER_PY", cmd[-1])
         self._drive_menu(fd, cmd)
 
         self.assertFalse(os.path.exists(format_canary),
@@ -812,40 +867,70 @@ class MenuClientIntegration(unittest.TestCase):
         self.addCleanup(lambda: (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET)
                         .unlink(missing_ok=True))
 
-    def _charter_shim_env(self) -> dict:
-        """A `$PATH` entry standing in for `charter` — see the class docstring for
-        why a string substitution (as `MenuIntegration`/`MenuFormatIntegration`
-        above use) cannot reach the command `cmd_menu` builds internally. `#!` uses
-        `sys.executable` directly (not `/usr/bin/env python3`) so the shim runs
-        under the SAME interpreter this test process does, and `sys.path` is set
-        explicitly inside the shim rather than relied on from the environment: a
-        script executed by its own shebang gets ITS OWN directory as `sys.path[0]`,
-        not this checkout's, so `import charter` would otherwise fail
-        (`ModuleNotFoundError`) — confirmed by hand while building this.
+    def _charter_py_env(self) -> dict:
+        """The environment this class's tmux server starts with: an INTERPRETER shim
+        for `$CHARTER_PY`, and a `$PATH` with no `charter` on it at all.
+
+        Both halves matter, and the second is why this replaced an earlier `$PATH` shim
+        that stood in for a bare `charter` executable. That shim papered over the very
+        requirement this class is now the end-to-end proof of: the production bind ran
+        a bare `charter` off `$PATH`, and the suite supplied one, so nothing ever
+        observed what happens on a machine where `$PATH` has no charter — `run-shell`
+        prints `'charter frame-menu "…"' returned 127` INTO THE HARNESS PANE and drops
+        it into copy-mode, charter drawing in the one rectangle ADR 0018 says it never
+        draws. Scrubbing `$PATH` to a single empty directory means a bare `charter`
+        cannot possibly resolve here, so this class fails if the fix is ever reverted
+        rather than passing on the old shim's charity.
+
+        The shim itself still exists for the reason the old one did, unchanged:
+        `commands_frame.SOCKET` is a hardcoded module constant ("charter", the real
+        production socket) and a subprocess spawned by tmux cannot be told a different
+        one through any argv this module controls. It accepts exactly the `-m charter
+        …` argv the real interpreter would, monkeypatches `SOCKET`, and dispatches to
+        the real `cli.main`. `#!` uses `sys.executable` directly and sets `sys.path`
+        explicitly, because a script executed by its own shebang gets ITS OWN directory
+        as `sys.path[0]`, not this checkout's.
         """
         repo_root = str(Path(__file__).resolve().parent.parent)
         shim_dir = Path(tempfile.mkdtemp(prefix="charter-integ-shim-"))
         self.addCleanup(shutil.rmtree, shim_dir, True)
-        shim = shim_dir / "charter"
+        shim = shim_dir / "charter-py"
         shim.write_text(
             f"#!{sys.executable}\n"
             "import sys\n"
             f"sys.path.insert(0, {repo_root!r})\n"
+            "argv = sys.argv[1:]\n"
+            "assert argv[:2] == ['-m', 'charter'], argv\n"
             "import charter.commands_frame\n"
             f"charter.commands_frame.SOCKET = {SOCKET!r}\n"
             "from charter.cli import main\n"
-            "sys.exit(main(sys.argv[1:]))\n"
+            "sys.exit(main(argv[2:]))\n"
         )
         shim.chmod(0o755)
-        return dict(os.environ, PATH=f"{shim_dir}:{os.environ.get('PATH', '')}")
+        # A `$PATH` holding exactly one thing: tmux. Not an EMPTY directory — this
+        # environment is also what the `_tmux("new-session", …)` call that starts the
+        # server runs under, and it has to be able to find the binary it is starting.
+        # Symlinked into a throwaway directory rather than reusing tmux's own (which on
+        # this machine is a package manager's `bin`, and may well hold a real `charter`
+        # — the exact thing this must not silently supply).
+        bare = Path(tempfile.mkdtemp(prefix="charter-integ-nopath-"))
+        self.addCleanup(shutil.rmtree, bare, True)
+        (bare / "tmux").symlink_to(shutil.which("tmux"))
+        self.assertIsNone(shutil.which("charter", path=str(bare)),
+                          "this class proves a bare `charter` is never needed — its "
+                          "own $PATH must not contain one")
+        self.shim = shim
+        return dict(os.environ, PATH=str(bare))
 
     def _new_session(self, fid: str) -> None:
         """The one `new-session` call that starts this class's fresh server —
-        carries the `charter` shim's `$PATH` (see `_charter_shim_env`). `run-shell`
-        (no explicit `-t`, matching both the bind's own action and every per-item
-        action) falls back to the SERVER's own starting process environment (see
-        `_session_id_env_argv`'s own docstring), so this is the only call in this
-        class that needs the special environment at all.
+        carries the scrubbed `$PATH` (see `_charter_py_env`). `/bin/cat`, absolute,
+        because that `$PATH` has nothing on it. `run-shell` (no explicit `-t`, matching
+        both the bind's own action and every per-item action) falls back to the SERVER's
+        own starting process environment (see `_session_id_env_argv`'s own docstring),
+        so this is the only call in this class that needs the special environment at
+        all — `$CHARTER_PY` itself is tied to the SESSION, the way `cmd_launch` ties
+        it.
 
         Kills both the pane's own process AND the server's own process directly
         (`#{pid}`, tmux's own server-PID format) rather than relying on `setUp`'s
@@ -856,8 +941,8 @@ class MenuClientIntegration(unittest.TestCase):
         docstring already names for a session's PANE process, evidently reachable
         for the SERVER process too under this class's own load. `kill-server`
         stays in `setUp` as a harmless, already-a-no-op-by-then fallback."""
-        r = _tmux("new-session", "-d", "-s", fid, "-x", "80", "-y", "24", "cat",
-                 env=self._charter_shim_env())
+        r = _tmux("new-session", "-d", "-s", fid, "-x", "80", "-y", "24", "/bin/cat",
+                 env=self._charter_py_env())
         self.assertEqual(r.returncode, 0, r.stderr)
         server_pid = _tmux("display-message", "-p", "-t", fid, "#{pid}").stdout.strip()
         self.addCleanup(_kill_pid, server_pid)
@@ -900,10 +985,10 @@ class MenuClientIntegration(unittest.TestCase):
         return name, fd
 
     def _install_real_bind(self, fid: str) -> None:
-        """`conf_text`'s own bind line, `source-file`'d for real — no substitution
-        needed here (see the class docstring): the `charter` shim on `$PATH`
-        already makes the bare `charter` this embeds resolve correctly, against
-        THIS class's own socket."""
+        """`conf_text`'s own bind line, `source-file`'d for real — byte for byte, no
+        substitution of any kind. The bind reads `"$CHARTER_PY" -m charter frame-menu
+        "#{client_name}"`, and `$CHARTER_PY` is tied to this session by the
+        `set-environment` call in the test below, exactly as `cmd_launch` does it."""
         text = commands_frame.conf_text(hotkey="F2", mouse=False, history_limit=1,
                                         session=fid)
         conf = Path(tempfile.mkdtemp(prefix="charter-integ-clientconf-")) / "tmux.conf"
@@ -931,6 +1016,11 @@ class MenuClientIntegration(unittest.TestCase):
         self.assertNotEqual(clientA, clientB)
         self.assertEqual(_run(commands_frame._session_id_env_argv(
             socket=SOCKET, session=fid)).returncode, 0)
+        # `$CHARTER_PY`, carried the same out-of-band way `cmd_launch` carries it —
+        # the shim standing in for `sys.executable` so `commands_frame.SOCKET` lands on
+        # THIS class's own socket rather than the real one (see `_charter_py_env`).
+        self.assertEqual(_tmux("set-environment", "-t", fid, "CHARTER_PY",
+                              str(self.shim)).returncode, 0)
         self._install_real_bind(fid)
 
         # -- A presses: only A's own keystream may select what A's own press opened --

--- a/tests/test_frame_tmuxctl.py
+++ b/tests/test_frame_tmuxctl.py
@@ -58,5 +58,12 @@ class Messages(unittest.TestCase):
         self.assertIn("3.2", msg)
 
 
+class RunArgv(unittest.TestCase):
+    def test_run_rejects_a_string_with_typeerror(self):
+        """The argv guard survives `python -O`, so it raises TypeError, not AssertionError."""
+        with self.assertRaises(TypeError):
+            tmuxctl.run("tmux new-session")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_frame_tmuxctl.py
+++ b/tests/test_frame_tmuxctl.py
@@ -7,6 +7,7 @@ remedy that does not exist costs more than an honest gap".
 
 from __future__ import annotations
 
+import subprocess
 import unittest
 from unittest import mock
 
@@ -34,16 +35,22 @@ class Version(unittest.TestCase):
 
 
 class Floor(unittest.TestCase):
-    def test_the_floor_is_the_version_display_popup_needs(self):
+    def test_the_floor_is_the_version_the_frame_is_checked_against(self):
+        """The NUMBER is unchanged; its justification was wrong. `FLOOR` used to be
+        documented as "the version `display-popup` needs" — `display-popup` appears
+        nowhere in shipped code, in any form, only in two comments. What actually sits
+        near 3.2 is the pane-scoped hook (`set-hook -p`) the exit-code mechanism rests
+        on; `display-menu`, the other named reason, is 3.0. Kept at 3.2 deliberately
+        rather than lowered on an unverified reading of tmux's CHANGES: no tmux older
+        than 3.7c exists on this machine to test against, the cost of the floor being
+        too HIGH is one accurate warning, and the cost of it being too LOW is a frame
+        that starts and then declines to attach."""
         self.assertEqual(tmuxctl.FLOOR, (3, 2))
 
-    def test_a_new_enough_tmux_meets_the_floor(self):
-        with mock.patch.object(tmuxctl, "version", return_value=(3, 7)):
-            self.assertTrue(tmuxctl.meets_floor())
-
-    def test_an_old_tmux_does_not(self):
-        with mock.patch.object(tmuxctl, "version", return_value=(3, 0)):
-            self.assertFalse(tmuxctl.meets_floor())
+    def test_the_resize_hook_floor_stays_above_the_frames_own(self):
+        """Two floors, two meanings — folding them into one would refuse (or warn
+        about) the whole frame over a gap that only costs cosmetic resize drift."""
+        self.assertGreater(tmuxctl.RESIZE_HOOK_FLOOR, tmuxctl.FLOOR)
 
 
 class Messages(unittest.TestCase):
@@ -57,12 +64,95 @@ class Messages(unittest.TestCase):
         self.assertIn("3.0", msg)
         self.assertIn("3.2", msg)
 
+    def test_the_below_floor_message_does_not_claim_the_hotkey_is_disabled(self):
+        """It said "the frame starts with the hotkey disabled". Nothing disables it:
+        `cmd_launch` warns and continues, and `conf_text` still emits the bind. A
+        message describing a mechanism that does not exist is worse than none, because
+        it is the one place an operator looks to find out what they are losing."""
+        msg = tmuxctl.below_floor_message((3, 0))
+        self.assertNotIn("hotkey disabled", msg)
+        self.assertIn("stays bound", msg)
+        self.assertIn("exit code", msg)
+
 
 class RunArgv(unittest.TestCase):
     def test_run_rejects_a_string_with_typeerror(self):
         """The argv guard survives `python -O`, so it raises TypeError, not AssertionError."""
         with self.assertRaises(TypeError):
-            tmuxctl.run("tmux new-session")
+            tmuxctl.run("starting the frame", "tmux new-session")
+
+    def test_interact_rejects_a_string_too(self):
+        """The same rule on the other door out of this module — a guard on one of two
+        entry points is not a guard."""
+        with self.assertRaises(TypeError):
+            tmuxctl.interact("tmux attach -t x")
+
+
+class RunGuardsTheTimeout(unittest.TestCase):
+    """The defect this wrapper exists for: `cmd_launch` issued eleven
+    `subprocess.run(..., timeout=15)` calls with nothing catching
+    `subprocess.TimeoutExpired`, and TEN of them run after `new-session` has already
+    started the harness detached. A wedged tmux server therefore gave the operator a
+    traceback, a filed charter crash report, an orphaned agent session and no reattach
+    line — for a condition that is not a charter bug at all."""
+
+    def test_a_timeout_becomes_a_return_code_rather_than_an_exception(self):
+        with mock.patch("subprocess.run",
+                        side_effect=subprocess.TimeoutExpired(["tmux"], 15)), \
+             mock.patch("charter.util.err") as err:
+            proc = tmuxctl.run("installing the exit-status hook", ["tmux", "-V"])
+        self.assertEqual(proc.returncode, tmuxctl.TIMED_OUT)
+        self.assertNotEqual(proc.returncode, 0, "a timeout must never read as success")
+        err.assert_called_once()
+
+    def test_a_tmux_that_cannot_be_started_becomes_a_return_code_too(self):
+        with mock.patch("subprocess.run", side_effect=OSError("no such binary")), \
+             mock.patch("charter.util.err") as err:
+            proc = tmuxctl.run("starting the frame", ["tmux", "-V"])
+        self.assertEqual(proc.returncode, tmuxctl.COULD_NOT_RUN)
+        err.assert_called_once()
+
+    def test_a_failure_names_the_action_and_tmuxs_own_stderr(self):
+        with mock.patch("subprocess.run", return_value=subprocess.CompletedProcess(
+                ["tmux"], 1, stdout="", stderr="no such session: nope")), \
+             mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            buf = []
+            tmuxctl.run("ending the frame after an early death", ["tmux", "-V"])
+        self.assertTrue(any("ending the frame" in m and "no such session" in m
+                            for m in buf), buf)
+
+    def test_report_false_stays_silent_but_still_reports_the_code(self):
+        """`_live_sessions` asks against a socket no server has ever run on, where a
+        non-zero return is the ORDINARY answer — reporting it would print an error on
+        every first launch on a machine."""
+        with mock.patch("subprocess.run", return_value=subprocess.CompletedProcess(
+                ["tmux"], 1, stdout="", stderr="no server running")), \
+             mock.patch("charter.util.err") as err:
+            proc = tmuxctl.run("listing the frames already running", ["tmux", "-V"],
+                               report=False)
+        self.assertEqual(proc.returncode, 1)
+        err.assert_not_called()
+
+    def test_a_success_reports_nothing(self):
+        with mock.patch("subprocess.run", return_value=subprocess.CompletedProcess(
+                ["tmux"], 0, stdout="%7\n", stderr="")), \
+             mock.patch("charter.util.err") as err:
+            proc = tmuxctl.run("starting the frame", ["tmux", "-V"])
+        self.assertEqual(proc.stdout.strip(), "%7")
+        err.assert_not_called()
+
+    def test_interact_neither_captures_nor_time_boxes(self):
+        """`attach` IS the operator's terminal for as long as the harness runs, and
+        `display-menu` waits for a keypress — capturing either would swallow the
+        operator's own screen, and a timeout on either would end a frame for the crime
+        of being used."""
+        with mock.patch("subprocess.run",
+                        return_value=subprocess.CompletedProcess(["tmux"], 0)) as run:
+            tmuxctl.interact(["tmux", "attach"], env={"A": "b"})
+        _, kwargs = run.call_args
+        self.assertNotIn("timeout", kwargs)
+        self.assertNotIn("capture_output", kwargs)
+        self.assertEqual(kwargs["env"], {"A": "b"})
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_tmuxctl.py
+++ b/tests/test_frame_tmuxctl.py
@@ -1,0 +1,62 @@
+"""Everything that touches the tmux binary, in one module, so the rest is testable.
+
+The messages are asserted because `Deficit` already settled what an absent capability has
+to read like: naming the limit and the command that closes it, never a guess, because "a
+remedy that does not exist costs more than an honest gap".
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter.frame import tmuxctl
+
+
+class Version(unittest.TestCase):
+    def test_a_release_version_parses(self):
+        with mock.patch.object(tmuxctl, "_probe", return_value="tmux 3.7c"):
+            self.assertEqual(tmuxctl.version(), (3, 7))
+
+    def test_a_two_part_version_parses(self):
+        with mock.patch.object(tmuxctl, "_probe", return_value="tmux 3.2"):
+            self.assertEqual(tmuxctl.version(), (3, 2))
+
+    def test_an_absent_binary_is_none_not_zero(self):
+        """None is 'charter has nothing to say', which reads differently from 'version
+        0.0' — the distinction `registry.deficits` makes for an unknown harness."""
+        with mock.patch.object(tmuxctl, "_probe", return_value=None):
+            self.assertIsNone(tmuxctl.version())
+
+    def test_unparseable_output_is_none_rather_than_a_crash(self):
+        with mock.patch.object(tmuxctl, "_probe", return_value="tmux next-3.9"):
+            self.assertIsNone(tmuxctl.version())
+
+
+class Floor(unittest.TestCase):
+    def test_the_floor_is_the_version_display_popup_needs(self):
+        self.assertEqual(tmuxctl.FLOOR, (3, 2))
+
+    def test_a_new_enough_tmux_meets_the_floor(self):
+        with mock.patch.object(tmuxctl, "version", return_value=(3, 7)):
+            self.assertTrue(tmuxctl.meets_floor())
+
+    def test_an_old_tmux_does_not(self):
+        with mock.patch.object(tmuxctl, "version", return_value=(3, 0)):
+            self.assertFalse(tmuxctl.meets_floor())
+
+
+class Messages(unittest.TestCase):
+    def test_the_absent_message_names_the_command_that_fixes_it(self):
+        msg = tmuxctl.absent_message()
+        self.assertIn("tmux", msg)
+        self.assertIn("--no-frame", msg)
+
+    def test_the_below_floor_message_names_both_versions(self):
+        msg = tmuxctl.below_floor_message((3, 0))
+        self.assertIn("3.0", msg)
+        self.assertIn("3.2", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_harness_launch.py
+++ b/tests/test_harness_launch.py
@@ -1,0 +1,39 @@
+"""A harness that charter can run has to say what to type and what to exec.
+
+`registry.KINDS` exists so a harness added to it is covered everywhere the day it is
+registered. That only holds if the launcher reads these two facts off the harness rather
+than keeping its own table — the hardcoded-literal problem the registry was built to end.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import harness
+
+
+class HarnessLaunchIdentity(unittest.TestCase):
+    def test_every_registered_harness_says_what_to_type(self):
+        for h in harness.all():
+            with self.subTest(harness=h.name):
+                self.assertTrue(h.cli_name, f"{h.name} has no cli_name")
+
+    def test_cli_names_are_distinct(self):
+        names = [h.cli_name for h in harness.all()]
+        self.assertEqual(len(names), len(set(names)), f"colliding cli_names: {names}")
+
+    def test_launch_argv_passes_the_operators_arguments_through_verbatim(self):
+        h = harness.get(harness.CLAUDE_CODE)
+        self.assertEqual(h.launch_argv(["--resume", "a;b"]),
+                         ["claude", "--resume", "a;b"])
+
+    def test_launch_argv_returns_a_list_never_a_string(self):
+        """Pinned against tmux 3.7c: separate argv is not shell-interpreted, a joined
+        string is. A harness returning a string would put the injection back."""
+        for h in harness.all():
+            with self.subTest(harness=h.name):
+                self.assertIsInstance(h.launch_argv([]), list)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_news_probeable.py
+++ b/tests/test_news_probeable.py
@@ -135,6 +135,17 @@ class OnlyAListedCommandIsProbeable(unittest.TestCase):
         self.assertTrue(news.probeable("persona lint"))
         self.assertTrue(news.probeable("persona lint --only delegate-when"))
 
+    def test_frame_probe_is_allowed_but_frame_dash_dash_probe_is_not(self):
+        """`charter frame-probe` (this task) is a TOP-LEVEL command specifically because
+        `frame` itself can never be added here: every parser `cli._wire` builds — `frame`
+        included — carries a pass-through `rest` (#317's shape), `--probe` on it or not.
+        Both halves are pinned together so a future edit that lists `("frame",)` instead
+        fails HERE, not only in `TheListIsPinnedToTheParser` below (which would report
+        THAT failure as "frame takes a pass-through argv", true but not why this specific
+        command exists)."""
+        self.assertTrue(news.probeable("frame-probe"))
+        self.assertFalse(news.probeable("frame --probe"))
+
     def test_a_command_that_probes_news_is_still_allowed_here(self):
         """`news --pending` re-enters, and #311's guard is what answers that — a separate
         question, answered later and with its own reason. Folding the two together would


### PR DESCRIPTION
Closes #345.

`charter claude` (also `codex`, `opencode`, `frame -- <cmd>`) runs the harness inside a
tmux-composed frame with charter panels on the edges. It exists because the status line is
Claude Code's surface and the other harnesses have none.

tmux composes the rectangles and owns every part of terminal emulation; charter fills the
edges and never draws or parses the harness's pane. Recorded as **ADR 0018**.

## The decision, measured rather than argued

Two arms were built and benchmarked before either was chosen — one where charter is the app
(Textual + pyte, harness as a widget), one where tmux composes.

| | charter is the app | tmux composes |
| --- | --- | --- |
| end-to-end burst | 1.85 MB/s | **25.2 MB/s** |
| 13 MB build log | ~7 s frozen | 0.51 s |
| VT parse alone | 2.4 MB/s (0.9 with scrollback) | ~37 MB/s |
| screen → pixels | 7.2 ms/frame, 138 fps ceiling | n/a, it is C |

Both arms rendered claude and opencode correctly, so this was a cost decision, not a
feasibility one. Rendering was never the bottleneck; a pure-Python VT emulator is the whole
cost. The maintenance half agreed: the spike's terminal widget was 120 lines and did not
draw a cursor, with mouse, scrollback, bracketed paste, OSC, wide characters and `?2026`
all still owed, on a parser last released 2023-11-12, in a project that ships
`dependencies = []`.

## What ships

- `charter claude|codex|opencode`, `charter frame -- <cmd>`, `charter frame-probe`,
  `--probe` and `--no-frame` on every launcher, `frame-menu`/`frame-action`.
- Top and bottom panels rendering live plane state, repainting from charter's own hooks —
  the frame updates because the agent did something, and costs a `stat` at idle.
- `[frame]` config, `docs/frame.md`, a `doctor` row, a news entry.
- tmux ≥ 3.2 is a runtime requirement of the framed path only. `--no-frame` and any
  non-TTY invocation `exec` the harness directly.

**3624 tests.** Unit modules start no real tmux; `tests/test_frame_tmux_integration.py`
is the only one that does, skips cleanly when tmux is absent, and leaks no processes or
sockets.

## Facts pinned against tmux 3.7c, by rejection

Each of these cost a real bug before it was found:

- separate argv is not shell-interpreted; a joined string is;
- an attached `new-session` returns 0 whatever its command exited with — so exit codes
  travel via `remain-on-exit` and a **pane-scoped** `pane-died` hook;
- a bare `set-hook pane-died` replaces the **whole array**, deleting `[1]` — reordering two
  adjacent lines reintroduces an infinite hang with a green suite;
- tmux reports an **empty** `pane_dead_status` for signal deaths, not a negative one;
- `-f <conf>` is honoured only when the call actually *starts* the server;
- tmux renumbers pane indices on every split, so splits target the harness's `%N`;
- `-t` scopes format state, `-c` selects the client;
- **`display-menu` item names pass through the format engine**, so a label containing
  `#(cmd)` executes it — and `#(id>/tmp/x)` is a legal git branch name. Labels are escaped;
- `window-resized` needs 3.3, or panels drift to 15 of 50 rows on resize.

## Review

Eleven tasks, twenty-three reviews, two fix waves, mutation testing throughout. Findings
that would otherwise have shipped: a frame that built one panel instead of four in silence;
a missing harness binary reporting exit 0; a space in the plane path discarding every exit
code; two infinite hangs; a menu label executing shell from a branch name; a menu drawn on
the wrong operator's terminal; and a `[frame] hotkey` in `charter.toml` running arbitrary
shell at launch with no keypress.

The plan document carries an addendum listing the ten claims it got wrong, corrected against
what building it proved.

## Known follow-ups

Filed separately: the inside-tmux path (charter nests today rather than adding a window),
panel respawn with backoff, pid-based reap, and a missing-binary message for
`charter frame -- <cmd>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
