### PR TITLE
Frame content parity: one gather, many slot renderers (#385)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -717,15 +717,16 @@ def cmd_launch(args) -> int:
     frame = config.FRAME
     slots = layout.visible_slots(frame["slots"], cols, rows, frame["min_cols"], frame["min_rows"])
 
-    # `[frame] slots` accepts `left`/`right` (`instance.FRAME_SLOTS`, sized by
-    # `layout.SLOT_SIZE`) even though `frame.slots.SLOTS` — the RENDERER registry —
-    # does not implement either one yet. Left unfiltered, `panel_argvs` below would
-    # still split a real pane for it; `panel.run` correctly refuses or exits 2 (Task
-    # 7's own "no empty pane" rule), but with `remain-on-exit on` keeping that pane
-    # alive, the operator is left with a permanently dead, wrapped-error 22-column
-    # pane and no explanation at the point the frame actually came up. Skipping an
-    # unimplemented slot here instead means the harness pane simply keeps that space —
-    # the same degrade `visible_slots` itself already makes under a tight terminal.
+    # `[frame] slots` can accept a slot (`instance.FRAME_SLOTS`, sized by
+    # `layout.SLOT_SIZE`) that `frame.slots.SLOTS` — the RENDERER registry — has no
+    # renderer for (as `left`/`right` were until Task 3 (#385) gave them one). Left
+    # unfiltered, `panel_argvs` below would still split a real pane for it;
+    # `panel.run` correctly refuses or exits 2 (Task 7's own "no empty pane" rule),
+    # but with `remain-on-exit on` keeping that pane alive, the operator is left with
+    # a permanently dead, wrapped-error 22-column pane and no explanation at the
+    # point the frame actually came up. Skipping an unimplemented slot here instead
+    # means the harness pane simply keeps that space — the same degrade
+    # `visible_slots` itself already makes under a tight terminal.
     #
     # Silently, and that is the deliberate half: which slots have a renderer is a
     # property of THIS BUILD, not of this launch, so a warning here repeats an

--- a/charter/frame/gather.py
+++ b/charter/frame/gather.py
@@ -1,0 +1,266 @@
+"""One scan of the plane's repo state, cached under the frame's own directory.
+
+``statusline.render`` performs an expensive gather before it lays anything out:
+``_repo_trees``, ``_repo_states`` (one ``git status --porcelain --branch`` per
+repo), ``_branch`` per tree, and ``glstate.read_for``. The frame has up to four
+panels (``top``/``left``/``right``/``bottom``); if each gathered independently
+that would be four identical git sweeps per repaint, which destroys the property
+the frame was built for — see ``charter/frame/panel.py``'s own docstring: a panel
+repaints only on a ``state.version`` bump, so watching a frame must cost a
+``stat`` at idle, never a sweep.
+
+So the gather happens ONCE here and is cached as plain JSON under the frame's own
+directory (``charter/frame/state.py``'s ``frame_dir``) — never as ``tui.Node``\\ s
+or ANSI. Composition (ranking, capping, columns) is a later task's job: "share the
+gather, not the composition" (docs/superpowers/plans/2026-08-23-frame-parity.md).
+:func:`scan` is the expensive part; :func:`save`/:func:`read` are the cache's
+write/read pair; :func:`refresh` is the two composed, for the hook that will call
+this on every plane-state bump (Task 2).
+
+Every helper that actually gathers something is reused from ``statusline.py`` —
+the SAME ``_repo_trees``, ``_repo_states``, ``_branch``, ``_detail_worktrees``,
+``_current`` the status line calls, including the SAME ``_STATE_TTL``-cached
+``repostate.json`` underneath ``_repo_states``. A fix to a repo row's git-status
+logic lands here automatically; nothing about a repo's dirty/ahead/behind state is
+re-derived. ``charter/statusline.py``'s render path is not modified — this module
+only calls it.
+
+**Never raises.** Every field gathered below is wrapped individually, so one bad
+repo (a ``.git`` gone missing between ``_repo_trees`` and ``_branch``, say)
+degrades that repo's row rather than the whole scan, and the whole function falls
+back to an empty structure rather than propagate. Task 2 will call this from
+inside charter's hooks, where "a hook may cost a session its briefing, never its
+turn" (``charter/frame/notify.py``) applies with the same force here.
+
+**No per-session payload.** The status line receives Claude Code's JSON payload
+(session id, the session's cwd) on stdin every render; a frame panel has no such
+thing. :func:`scan` asks ``workspace.resolve()``/``_current({"cwd": ...})`` with
+the *process's own* cwd instead — the same precedence ``frame/slots.py``'s
+``_top`` already reads. A frame panel and the ambient ``charter statusline
+--watch`` are the same kind of caller as far as this is concerned.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from .. import config
+from . import state
+
+#: Filename under a frame's own directory (``state.frame_dir``) that holds the
+#: cached scan. Private to this module — nothing outside ``gather.py`` needs the
+#: name; a caller asks :func:`save`/:func:`read` instead of the path.
+_CACHE_NAME = "gather.json"
+
+
+def _cache_file(fid: str, *, create: bool) -> Path | None:
+    """The cache file's path for *fid*, or ``None`` when ``state.frame_dir``
+    refuses it (a hostile id) or — with ``create=False`` — its directory has never
+    been made.
+
+    ``create`` is forwarded to :func:`state.frame_dir` unchanged, for the same
+    reason that module keeps reads and writes on separate paths: a READ
+    (:func:`read`) must never create the directory it is only trying to look at
+    (the same rule ``state.version`` documents — a panel's poll must not
+    resurrect a directory ``reap()`` just removed), while a WRITE (:func:`save`)
+    is exactly the case allowed to mint one.
+    """
+    d = state.frame_dir(fid, create=create)
+    return None if d is None else d / _CACHE_NAME
+
+
+def _empty(workspace: str | None) -> dict:
+    """The structure :func:`scan` (and :func:`read`, on total failure) falls back
+    to — still a plain, JSON-serialisable dict, so a renderer never needs a
+    ``None``-check before indexing into it."""
+    return {
+        "gathered_at": time.time(),
+        "workspace": workspace or "",
+        "current_repo": None,
+        "repos": [],
+        "worktrees": [],
+    }
+
+
+def _entry(d: Path, branch: str, states: dict, gl: dict, cur_repo: str | None) -> dict:
+    """One tree's row — repo or worktree alike, the same facts
+    ``statusline._tree_cells`` draws from, minus everything that is layout
+    (colour, truncation, tree glyphs, presence text). A narrow-pane renderer
+    reads this directly; it never re-derives dirty/ahead/behind/ci/change from
+    ``states``/``gl`` itself, which is the whole point of gathering once.
+    """
+    st = states.get(d) or {}
+    info = gl.get(d) or {}
+    return {
+        "name": d.name,
+        "branch": branch,
+        "dirty": bool(st.get("dirty")),
+        "tracked_dirty": bool(st.get("tracked_dirty")),
+        "ahead": int(st.get("ahead") or 0),
+        "behind": int(st.get("behind") or 0),
+        "ci": info.get("ci"),
+        "change": info.get("change"),
+        "sigil": info.get("sigil") or "",
+        "current": d.name == cur_repo,
+    }
+
+
+def scan(workspace: str | None = None, cwd: str | None = None) -> dict:
+    """Perform the gather ``statusline.render`` performs before layout, and
+    return it as a plain dict — no ``tui.Node``, no ANSI, no truncation, safe to
+    ``json.dumps`` as-is.
+
+    *workspace* defaults to ``workspace.resolve()`` (no session payload — see the
+    module docstring). *cwd* defaults to ``os.getcwd()`` and is used only to
+    decide which repo (or worktree) is ``"current"``, matching ``_repo_rows``'
+    own rule verbatim.
+
+    Best-effort at every step, individually wrapped, so one failing piece
+    degrades gracefully rather than losing everything gathered so far; the
+    return is still a well-formed structure even if every single step failed.
+    """
+    from .. import glstate
+    from .. import statusline as sl
+    from .. import workspace as ws_mod
+
+    try:
+        resolved_cwd = cwd if cwd is not None else os.getcwd()
+    except OSError:
+        resolved_cwd = None
+
+    try:
+        active = workspace or ws_mod.resolve(cwd=resolved_cwd)
+    except Exception:
+        active = workspace or config.DEFAULT_WORKSPACE_FALLBACK
+
+    try:
+        cur = sl._current({"cwd": resolved_cwd}) if resolved_cwd else None
+    except Exception:
+        cur = None
+
+    try:
+        dirs = sl._repo_trees(active)
+    except Exception:
+        dirs = []
+
+    try:
+        detail_wts = sl._detail_worktrees(active, dirs)
+    except Exception:
+        detail_wts = []
+
+    scan_dirs = [*dirs, *detail_wts]
+
+    try:
+        states = sl._repo_states(scan_dirs)
+    except Exception:
+        states = {}
+
+    branches: dict = {}
+    for d in scan_dirs:
+        try:
+            branches[d] = sl._branch(d)
+        except Exception:
+            branches[d] = "?"
+
+    try:
+        gl = glstate.read_for(scan_dirs, branches)
+    except Exception:
+        gl = {}
+
+    # Same background refresh the status line kicks off on every render (see
+    # `render`'s own call to it). Deliberately kept: a frame that never runs
+    # alongside a rendered status line — the ordinary case once a session lives
+    # inside `charter claude` — would otherwise never keep CI/MR state warm at
+    # all, and `glstate.read_for` only ever serves what was last fetched. Cheap
+    # when there is nothing to do: gated by `glstate`'s own `SPAWN_COOLDOWN` and
+    # an on-disk lock, so four panels (or a burst of hook-driven refreshes)
+    # calling this pay for one stat each, not one spawn each.
+    try:
+        glstate.maybe_spawn(scan_dirs, active)
+    except Exception:
+        pass
+
+    # Verbatim copy of `_repo_rows`' own rule: the workspace half of `cur` may
+    # name the active workspace, or (see `_current`'s docstring) the shared root
+    # tree that counts as current in every workspace alike.
+    cur_repo = cur[1] if (cur and (cur[0] is None or cur[0] == active)) else None
+
+    try:
+        repos = [_entry(d, branches.get(d, "?"), states, gl, cur_repo) for d in dirs]
+        repo_for_wt = dirs[0].name if dirs else None
+        worktrees = []
+        for w in detail_wts:
+            entry = _entry(w, branches.get(w, "?"), states, gl, cur_repo)
+            entry["repo"] = repo_for_wt
+            worktrees.append(entry)
+    except Exception:
+        repos, worktrees = [], []
+
+    return {
+        "gathered_at": time.time(),
+        "workspace": active,
+        "current_repo": cur_repo,
+        "repos": repos,
+        "worktrees": worktrees,
+    }
+
+
+def save(fid: str, data: dict) -> None:
+    """Write *data* (from :func:`scan`) as JSON under *fid*'s frame directory.
+
+    Atomic — a temp file plus ``os.replace``, the same shape ``state.bump`` uses
+    and for the same reason: a reader must never observe a half-written cache.
+    Never raises: this runs from a hook (Task 2), where a failure here must
+    degrade to "the cache did not update" rather than cost the session its turn.
+    """
+    f = _cache_file(fid, create=True)
+    if f is None:
+        return
+    tmp = f.with_name(f.name + ".tmp")
+    try:
+        tmp.write_text(json.dumps(data))
+        os.replace(tmp, f)
+    except OSError:
+        return
+
+
+def read(fid: str, *, workspace: str | None = None, cwd: str | None = None) -> dict:
+    """The cached scan for *fid*, or a fresh one when there is nothing cached to
+    read.
+
+    Degrades rather than raises at every stage a cache can go wrong: a hostile or
+    never-bumped *fid* (no directory at all — the ordinary cold-start case, not
+    an error), a directory with no cache file yet, and a cache file that is not
+    valid JSON (``json.JSONDecodeError``, a ``ValueError`` subclass) all fall
+    through to a fresh :func:`scan` — the same one a caller would otherwise have
+    no data to draw from. This never returns ``None``.
+    """
+    f = _cache_file(fid, create=False)
+    if f is not None:
+        try:
+            return json.loads(f.read_text())
+        except (OSError, ValueError):
+            pass
+    try:
+        return scan(workspace=workspace, cwd=cwd)
+    except Exception:
+        return _empty(workspace)
+
+
+def refresh(fid: str, *, workspace: str | None = None, cwd: str | None = None) -> dict:
+    """:func:`scan` then :func:`save` — what the bumping hook (Task 2) calls.
+
+    Returns the freshly-gathered data, so a caller that wants it immediately does
+    not have to pay for a second :func:`read` right after writing it. Never
+    raises: `scan` and `save` each already promise that individually, so this
+    only has to not undo it by calling them any other way.
+    """
+    try:
+        data = scan(workspace=workspace, cwd=cwd)
+    except Exception:
+        data = _empty(workspace)
+    save(fid, data)
+    return data

--- a/charter/frame/gather.py
+++ b/charter/frame/gather.py
@@ -227,23 +227,51 @@ def save(fid: str, data: dict) -> None:
         return
 
 
+def _shaped_like_a_scan(data) -> bool:
+    """True when *data* is at least the shape a renderer can index into without
+    its own ``None``/type check — a ``dict`` carrying ``repos``/``worktrees`` as
+    lists.
+
+    Mirrors ``glstate.read_for``'s own defensive-read pattern (``glstate.py``'s
+    docstring: "an entry written by an OLDER charter... is read with a fallback
+    so a stale on-disk cache still renders... rather than raising a KeyError").
+    A cache file surviving a redeploy is the ordinary case here too, and
+    ``json.loads`` succeeding proves only that the bytes were valid JSON — ``42``,
+    ``"a string"``, ``[1, 2, 3]``, and ``{"foo": "bar"}`` all parse cleanly and
+    are all useless to :func:`read`'s caller. This is deliberately loose beyond
+    that: it does not require every field :func:`_entry` writes, so a *future*
+    ``scan()`` adding a new field does not make today's otherwise-good cache
+    file look corrupt.
+    """
+    return (isinstance(data, dict)
+            and isinstance(data.get("repos"), list)
+            and isinstance(data.get("worktrees"), list))
+
+
 def read(fid: str, *, workspace: str | None = None, cwd: str | None = None) -> dict:
-    """The cached scan for *fid*, or a fresh one when there is nothing cached to
+    """The cached scan for *fid*, or a fresh one when there is nothing valid to
     read.
 
     Degrades rather than raises at every stage a cache can go wrong: a hostile or
     never-bumped *fid* (no directory at all — the ordinary cold-start case, not
-    an error), a directory with no cache file yet, and a cache file that is not
-    valid JSON (``json.JSONDecodeError``, a ``ValueError`` subclass) all fall
-    through to a fresh :func:`scan` — the same one a caller would otherwise have
-    no data to draw from. This never returns ``None``.
+    an error), a directory with no cache file yet, a cache file that is not valid
+    JSON (``json.JSONDecodeError``, a ``ValueError`` subclass), and — because
+    ``json.loads`` succeeding says nothing about what it produced — a cache file
+    that parses to something not :func:`_shaped_like_a_scan` (a bare int/str/
+    list, a dict missing ``repos``/``worktrees``, or the wrong types for them)
+    all fall through to a fresh :func:`scan`, the same one a caller would
+    otherwise have no data to draw from. This never returns anything but a dict
+    carrying ``repos``/``worktrees`` as lists — never the raw, untrusted value a
+    corrupt or stale cache file happened to contain.
     """
     f = _cache_file(fid, create=False)
     if f is not None:
         try:
-            return json.loads(f.read_text())
+            data = json.loads(f.read_text())
         except (OSError, ValueError):
-            pass
+            data = None
+        if _shaped_like_a_scan(data):
+            return data
     try:
         return scan(workspace=workspace, cwd=cwd)
     except Exception:

--- a/charter/frame/gather.py
+++ b/charter/frame/gather.py
@@ -25,6 +25,17 @@ logic lands here automatically; nothing about a repo's dirty/ahead/behind state 
 re-derived. ``charter/statusline.py``'s render path is not modified — this module
 only calls it.
 
+**Every repo entry also carries its own ``worktree_count``** (fix round 1,
+finding 2, #385) — ``worktree.dirs_for(active, d.name)``, the SAME filesystem-only
+(no subprocess) call ``statusline._repo_rows`` already makes PER REPO on every
+render for its ``⑂N`` badge, gathered here once instead. Task 3 shipped without
+this and reported the gap rather than adding a live call to its own renderer: a
+multi-repo workspace's cache carried repo rows with no piece information at all,
+because ``_detail_worktrees`` (below) only ever builds full piece ROWS for the
+single-repo case, and nothing folded the plain per-repo COUNT in for every other
+shape. Now every ``repos[i]["worktree_count"]`` is real regardless of repo count;
+only the full per-piece detail rows (``worktrees``, below) stay single-repo-only.
+
 **Never raises.** Every field gathered below is wrapped individually, so one bad
 repo (a ``.git`` gone missing between ``_repo_trees`` and ``_branch``, say)
 degrades that repo's row rather than the whole scan, and the whole function falls
@@ -85,12 +96,17 @@ def _empty(workspace: str | None) -> dict:
     }
 
 
-def _entry(d: Path, branch: str, states: dict, gl: dict, cur_repo: str | None) -> dict:
+def _entry(d: Path, branch: str, states: dict, gl: dict, cur_repo: str | None,
+          worktree_count: int = 0) -> dict:
     """One tree's row — repo or worktree alike, the same facts
     ``statusline._tree_cells`` draws from, minus everything that is layout
     (colour, truncation, tree glyphs, presence text). A narrow-pane renderer
     reads this directly; it never re-derives dirty/ahead/behind/ci/change from
     ``states``/``gl`` itself, which is the whole point of gathering once.
+
+    *worktree_count* defaults to 0 (right for a worktree/piece entry — a piece
+    does not itself have pieces); :func:`scan` passes the real count only for
+    a REPO entry. See ``worktree_count``'s own note on :func:`scan`.
     """
     st = states.get(d) or {}
     info = gl.get(d) or {}
@@ -105,6 +121,7 @@ def _entry(d: Path, branch: str, states: dict, gl: dict, cur_repo: str | None) -
         "change": info.get("change"),
         "sigil": info.get("sigil") or "",
         "current": d.name == cur_repo,
+        "worktree_count": int(worktree_count),
     }
 
 
@@ -188,8 +205,31 @@ def scan(workspace: str | None = None, cwd: str | None = None) -> dict:
     # tree that counts as current in every workspace alike.
     cur_repo = cur[1] if (cur and (cur[0] is None or cur[0] == active)) else None
 
+    # Fix round 1, finding 2 (#385): `_repo_rows` gets its `⑂N` badge from a
+    # fresh, always-live `worktree.dirs_for(active, d.name)` call PER REPO, on
+    # every render, independent of `detail_wts` above (which only ever holds
+    # rows for the single-repo case — `_detail_worktrees`' own rule). That
+    # per-repo count was never folded into this scan, so a multi-repo
+    # workspace's cache carried no piece information at all — the exact gap
+    # Task 3 found and reported rather than working around with a live call of
+    # its own. `worktree.dirs_for` is filesystem-only (no subprocess, no
+    # network — see its own docstring), so gathering it here costs the same
+    # `iterdir`+`stat` sweep `_repo_rows` already pays, once, rather than once
+    # per panel that wants it.
+    wt_counts: dict = {}
     try:
-        repos = [_entry(d, branches.get(d, "?"), states, gl, cur_repo) for d in dirs]
+        from .. import worktree as wt_mod
+        for d in dirs:
+            try:
+                wt_counts[d] = len(wt_mod.dirs_for(active, d.name))
+            except Exception:
+                wt_counts[d] = 0
+    except Exception:
+        pass
+
+    try:
+        repos = [_entry(d, branches.get(d, "?"), states, gl, cur_repo,
+                        worktree_count=wt_counts.get(d, 0)) for d in dirs]
         repo_for_wt = dirs[0].name if dirs else None
         worktrees = []
         for w in detail_wts:

--- a/charter/frame/notify.py
+++ b/charter/frame/notify.py
@@ -3,6 +3,31 @@
 Called from `charter/hooks.py`, where the posture is absolute (see that module's own
 docstring, and `contain.py`'s): a hook may cost a session its briefing, never its turn.
 
+**Bumping the version and refreshing the gather cache share the one debounce below,
+deliberately, not two.** `gather.refresh` is the expensive half (a cold `scan()` costs
+~35ms and three git invocations; `state.bump` costs one `os.replace` of a few bytes) but
+they exist for the same reason: "the plane changed enough that a panel should redraw
+with new facts." A panel only ever looks at the cache *because* the version it polls
+moved (`panel.py`'s own contract) — a separate, longer-lived debounce for the cache would
+mean the version bumps on every debounce-eligible call while the cache trails behind on
+its own slower clock, and a panel would repaint on a version bump into a cache that is
+`stat`-fresh but factually stale, exactly the gap this task exists to close. One shared
+gate means a panel that just saw the version move always finds a cache gathered at the
+same moment, not an older one.
+
+Refresh happens BEFORE the bump, not after, for the same reason: a panel's poll loop
+(`panel.TICK`) reads `state.version` first and the cache second, so if the version were
+bumped first there would be a window — however small — where a poller sees the new
+version and still reads the stale cache. Refreshing first closes that window instead of
+leaving it to be usually-too-small-to-matter.
+
+The scan's own expense is bounded twice over, not once: this debounce caps it at once
+per 250ms, and inside that, `statusline._repo_states`' 5-second TTL caps the actual `git
+status` subprocesses far below even that — so in a burst of tool calls closer together
+than 250ms apart, only one in the burst pays anything beyond the cheap
+`now - _last["at"] < DEBOUNCE` check, and even that one is usually paying for cache-hit
+work (~0.3ms), not a cold sweep.
+
 **Every `posttooluse*` handler calls this, not just the bare-named `posttooluse`.**
 `hooks/hooks.json` scopes `posttooluse` itself to `Write|Edit|MultiEdit` — Bash, Skill,
 Task/Agent and SendMessage each route to their own handler (`posttooluse-bash`,
@@ -50,14 +75,25 @@ _last = {"at": 0.0}
 
 
 def plane_changed() -> None:
-    """Bump the frame this process is running inside, if any. Never raises.
+    """Bump the frame this process is running inside, if any, and refresh its
+    gather cache so panels stay pure readers. Never raises.
 
     A no-op outside a frame (`$CHARTER_SESSION_ID` unset — the common case, most
-    sessions run with no frame at all) and a no-op inside the debounce window. The
-    `except Exception` is not defensive boilerplate: `state.bump` already swallows its
-    own `OSError`s, but this also guards `os.environ.get`/`time.monotonic` and any
-    future change to either — the one rule this module exists to keep is that NOTHING
-    reaching it from a hook ever turns into a raised exception.
+    sessions run with no frame at all) and a no-op inside the debounce window. Both
+    checks happen before `gather` is even imported, so the common "no frame" path never
+    touches the gather module at all, let alone gathers anything.
+
+    The `gather.refresh` call is wrapped in its OWN `try/except`, separate from the
+    outer one: `state.bump` must still run — and the version must still move — even if
+    the refresh fails (a corrupt cache directory, a `TypeError` in some future field),
+    because bumping the version is this function's original, load-bearing promise and a
+    test (`test_a_change_bumps_the_running_frame`) already pins it. Losing a cache
+    refresh degrades a panel to what it already shows; losing the bump would make a
+    panel go stale forever. The outer `except Exception` is not defensive boilerplate
+    even so: `state.bump` and `gather.refresh` already swallow their own errors, but
+    this also guards `os.environ.get`/`time.monotonic`/the `gather` import itself and
+    any future change to any of them — the one rule this module exists to keep is that
+    NOTHING reaching it from a hook ever turns into a raised exception.
     """
     try:
         fid = os.environ.get("CHARTER_SESSION_ID")
@@ -67,6 +103,11 @@ def plane_changed() -> None:
         if now - _last["at"] < DEBOUNCE:
             return
         _last["at"] = now
+        try:
+            from . import gather
+            gather.refresh(fid)
+        except Exception:
+            pass
         state.bump(fid)
     except Exception:
         return

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -55,6 +55,182 @@ def _top(fid: str) -> str:
     return tui.truncate(f"{left}  {right}", _width())
 
 
+class _RowKey:
+    """A directory-shaped key for one cache row: `_pick_rows` wants something with
+    a `.name` it can compare against `cur_repo` and use as a `states`/`gl` dict
+    key (ordinarily a `Path`) — this is that, minus the filesystem, since nothing
+    in :func:`_left` touches one. Identity-hashed on purpose (no `__eq__`
+    override): two repos can share a name only if the cache itself is
+    inconsistent, and identity keeps every row distinct even then, the same
+    guarantee a real `Path` object would not actually make either (two `Path`s
+    for the same string compare equal)."""
+
+    __slots__ = ("name",)
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+def _needs_attention(r: dict) -> bool:
+    """True when a repo/piece row has something on it worth a look — the same
+    four facts `_repo_rows`' own "…(+N more)" line checks before it dares say
+    "all clean": dirty, unpushed/behind, a failing or running pipeline, an open
+    change. Shared by :func:`_left`'s own overflow line so the two claims (which
+    repos are hidden, and whether that is safe to say) cannot drift apart."""
+    return bool(r.get("dirty") or r.get("ahead") or r.get("behind")
+               or r.get("ci") in ("failed", "running") or r.get("change"))
+
+
+def _repo_line(r: dict, color: str) -> str:
+    """One repo, one line: name (bold+underline if it is where you are standing,
+    coloured by the same per-position palette `_repo_rows` cycles), branch with
+    its dirty/ahead/behind markers, then CI and an open change if there is room.
+
+    `_markers` and `_CI_MARK` are `statusline.py`'s own — called, not
+    reimplemented, so a fix to what a marker or a CI glyph means lands here the
+    moment it lands in the wide table. Only the CI *glyph* is kept, not
+    `_ci_part`'s trailing label (`"✓ passed"`): a narrow pane spends its columns
+    on the branch and the markers first, and the label would just be the first
+    thing `tui.truncate` throws away.
+    """
+    from .. import statusline as sl
+    emph = f"{sl._BOLD}{sl._UNDER}" if r.get("current") else ""
+    name = f"{emph}{color}{r['name']}{sl._R}"
+    _plain, marks, _dirty = sl._markers(r)
+    branch = f"{sl._DIM}{r.get('branch') or '?'}{sl._R}{marks}"
+    line = f"{name} {branch}"
+    ci = r.get("ci")
+    if ci:
+        c, glyph, _label = sl._CI_MARK.get(ci, (sl._DIM, "?", ci))
+        line += f" {c}{glyph}{sl._R}"
+    change = r.get("change")
+    if change:
+        sigil = r.get("sigil") or "!"
+        line += f" {sl._GREEN}{sigil}{change}{sl._R}"
+    return line
+
+
+def _piece_line(p: dict) -> str:
+    """One piece (worktree), indented under its repo — same cells as
+    :func:`_repo_line` minus the palette colour and the bold/underline emphasis,
+    which belong to a REPO's row, not one of its pieces."""
+    from .. import statusline as sl
+    _plain, marks, _dirty = sl._markers(p)
+    branch = f"{sl._DIM}{p.get('branch') or '?'}{sl._R}{marks}"
+    return f"{sl._DIM}{sl._TREE_WT}{sl._R}{p['name']} {branch}"
+
+
+def _left(fid: str) -> str:
+    """Repo rows, narrow: the same per-tree facts `_tree_cells` draws in the wide
+    status-line table (name, branch, dirty/ahead/behind markers, CI, open
+    change), recomposed for a 22-column pane rather than reusing the `tui.Node`s
+    built for the wide one — `_NAME_W` (32) and `_BRANCH_W` (34) alone already
+    exceed this whole pane's width, which is exactly why "share the gather, not
+    the composition" is this plan's own rule.
+
+    Reads ONLY `gather.read(fid)` — the cache Task 1 built and Task 2 keeps
+    refreshed — never a repo directory listing, a `git status`, or a
+    `glstate.read_for` of its own; every field a row needs (`name`, `branch`,
+    `dirty`, `tracked_dirty`, `ahead`, `behind`, `ci`, `change`, `sigil`,
+    `current`) is already sitting in that one gather. `_pick_rows` is called
+    rather than reinvented for the same reason: it already carries the lesson
+    `statusline.py` paid for in production (an unranked slice of 18 clones
+    showed thirteen clean repos on `main` and hid the one dirty repo you were
+    actually standing in) — `_pick_rows` wants directory-shaped keys (`.name`,
+    hashable), so each cache row is wrapped in a bare `_RowKey` rather than a
+    `Path`: nothing here touches a filesystem, and a `Path` would imply one
+    exists to touch (and, unlike a `Path`, two `_RowKey`s never compare equal
+    just because their names happen to match — see its own docstring).
+
+    `left` is a full-height pane with rows to fill, unlike `top`/`bottom`'s fixed
+    single row — but nothing in this module measures how many it actually has
+    (`_width` measures COLUMNS; there is no equivalent asked for here). The
+    budget handed to `_pick_rows` is `_MAX_REPO_LINES`, the same cap the wide
+    table itself uses, reused rather than invented fresh; `panel.py`'s own
+    height clamp (`_rows()` there — see its "Height is this module's job"
+    section) is what actually protects a short pane from an overflow.
+
+    Piece rows come from `data["worktrees"]`, which `gather.scan` populates
+    ONLY when the workspace resolves to exactly one repo — it mirrors
+    `statusline._detail_worktrees`'s own single-repo rule verbatim (see that
+    function's docstring: spending rows on piece detail is only a good trade
+    when there is exactly one repo to spend them on). A MULTI-repo workspace's
+    per-repo worktree COUNT — the `⑂N` badge and one-line piece-name summary
+    `_repo_rows` draws via a fresh, always-live `worktree.dirs_for(active,
+    d.name)` call of its own — was never part of Task 1's cache at all, and
+    nothing here re-derives it with a live call of its own to patch that over:
+    see this task's report.
+    """
+    from .. import statusline as sl
+    from . import gather
+
+    data = gather.read(fid)
+    repos = data.get("repos") or []
+    w = _width()
+    if not repos:
+        return tui.truncate(f"{sl._DIM}no repos{sl._R}", w)
+
+    color_by_name = {r["name"]: sl._PALETTE[i % len(sl._PALETTE)]
+                     for i, r in enumerate(repos)}
+    keys = [_RowKey(r["name"]) for r in repos]
+    by_key = dict(zip(keys, repos))
+    cur_repo = data.get("current_repo")
+
+    budget = sl._MAX_REPO_LINES
+    capped = len(keys) > budget
+    show = sl._pick_rows(keys, (budget - 1) if capped else budget,
+                         cur_repo, by_key, by_key) if capped else keys
+
+    lines = [tui.truncate(_repo_line(by_key[k], color_by_name[by_key[k]["name"]]), w)
+             for k in show]
+
+    if capped:
+        shown = set(show)
+        hidden = [k for k in keys if k not in shown]
+        quiet = not any(_needs_attention(by_key[k]) for k in hidden)
+        note = ", clean" if quiet else ""
+        lines.append(tui.truncate(f"{sl._DIM}…(+{len(hidden)} more{note}){sl._R}", w))
+
+    for p in (data.get("worktrees") or []):
+        lines.append(tui.truncate(_piece_line(p), w))
+
+    return "\n".join(lines)
+
+
+def _right(fid: str) -> str:
+    """Persona chips — memory badges, in-flight badges and vault dots included,
+    because `statusline._persona_chips` already builds one chip as all four
+    combined (`◆ name` + vault dot + memory badge + health mark + in-flight
+    badge) and this calls it rather than reassembling the same facts out of
+    `_mem_badge`/`_inflight_badge`/`_inflight_by_persona`/`_vault_dot`/
+    `_mem_count` itself. A fix to any one of those five lands here the moment it
+    lands in the status line's right column — nothing in this module could drift
+    from it, because nothing in this module repeats what it does.
+
+    No per-turn session id to hand it: unlike `statusline.render`, a frame panel
+    never receives Claude Code's JSON payload on stdin (see `gather.py`'s own
+    module docstring for the identical point about the gather side).
+    `_persona_chips()`'s own default (`session=None`) is exactly right here —
+    its ephemeral-memory count falls back through `charter.session.current`,
+    which reads `$CHARTER_SESSION_ID`/`$CLAUDE_CODE_SESSION_ID` out of the
+    environment a launched panel process inherits whole from the harness (the
+    same env var `notify.plane_changed` already depends on being set there).
+
+    No guard of its own around the call: `_persona_chips` already swallows
+    every failure internally and answers `[]` (its own docstring's "never
+    breaks the status line"), and `render`'s caller-side `try/except` covers
+    whatever gets past that — the same trust `_top`/`_bottom` already place in
+    it rather than each re-wrapping their own calls into `statusline.py`.
+    """
+    from .. import statusline as sl
+
+    w = _width()
+    chips = sl._persona_chips()
+    if not chips:
+        return tui.truncate(f"{sl._DIM}no personas{sl._R}", w)
+    return "\n".join(tui.truncate(c, w) for c in chips)
+
+
 def _bottom(fid: str) -> str:
     """What still wants attention, and how to act on it.
 
@@ -82,19 +258,23 @@ def _bottom(fid: str) -> str:
 
 #: Every slot charter can draw. `panel.run` refuses a name that is not in here rather
 #: than painting an empty pane, because an empty pane reads as a broken frame.
-SLOTS = {"top": _top, "bottom": _bottom}
+SLOTS = {"top": _top, "bottom": _bottom, "left": _left, "right": _right}
 
 
 def unimplemented(configured) -> list[str]:
     """Which of *configured* charter sizes and accepts but has no renderer for.
 
-    `left`/`right` today: `instance.FRAME_SLOTS` accepts both and `layout.SLOT_SIZE`
-    sizes both, while :data:`SLOTS` implements neither. Three callers need exactly this
-    list and must agree — `commands_frame.cmd_launch` (to skip splitting a pane that
-    would be permanently dead under `remain-on-exit on`), `commands_frame.frame_ready`
-    (`--probe`) and `doctor.check_frame` (both to SAY so, which is the only place it is
-    said at all now) — so the question is answered here, next to the registry that
-    answers it, rather than three times over.
+    Answers empty as of Task 3: `left`/`right` landed beside `top`/`bottom` in
+    :data:`SLOTS`, so every slot `instance.FRAME_SLOTS` accepts and
+    `layout.SLOT_SIZE` sizes now has a renderer. Kept rather than deleted —
+    the next slot this frame grows will pass through here on day one exactly
+    the way `left`/`right` did until this task, and three callers need exactly
+    this list and must agree — `commands_frame.cmd_launch` (to skip splitting a
+    pane that would be permanently dead under `remain-on-exit on`),
+    `commands_frame.frame_ready` (`--probe`) and `doctor.check_frame` (both to
+    SAY so, which is the only place it is said at all now) — so the question
+    stays answered here, next to the registry that answers it, rather than
+    three times over.
     """
     return sorted({s for s in configured if s not in SLOTS})
 

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -81,43 +81,124 @@ def _needs_attention(r: dict) -> bool:
                or r.get("ci") in ("failed", "running") or r.get("change"))
 
 
-def _repo_line(r: dict, color: str) -> str:
-    """One repo, one line: name (bold+underline if it is where you are standing,
-    coloured by the same per-position palette `_repo_rows` cycles), branch with
-    its dirty/ahead/behind markers, then CI and an open change if there is room.
+def _row(lead: str, name_markup: str, r: dict, width: int, badge_n: int = 0) -> str:
+    """One row — *lead* glyphs, a name, then branch+markers, CI, an open
+    change, and (last, lowest priority) a `⑂N` piece-count badge — each field
+    sized against its OWN budget rather than the assembled line trimmed once
+    from the right at the end.
+
+    **Fix round 1, finding 1.** The first version of this function built the
+    whole line (`f"{name} {branch}{marks} {ci} {change}"`) and let a single
+    `tui.truncate` at the call site cut whatever didn't fit off the end. On
+    this project's own branches — `worktree-recall-since`,
+    `browser-session-scope`, `global-shim-refresh`: 21-28 characters is the
+    NORM here, not an edge case — `name + " " + branch` alone already fills a
+    22-column pane, so the cut always landed on the markers, the CI glyph and
+    the change sigil. A dirty, CI-failing, unpushed repo rendered as
+    `"charter worktree-reca…"` — a FALSE CLEAN reading, worse than not having
+    the panel at all for a panel that exists to surface exactly that.
+
+    `statusline._branch_cell_for` already keeps the right rule for the wide
+    table (`_BRANCH_W - width(marks)`, so the branch shrinks and the markers
+    never do) — this generalises it to a whole LINE's budget rather than one
+    fixed-width cell, and extends the same "shrink the least important field
+    first" idea to CI and an open change: they are appended whole or not at
+    all (never character-truncated — half a glyph reads as broken, an absent
+    one reads honestly as "no room to say"), in priority order behind the
+    markers, and the branch — read last on this line, and the one field
+    genuinely fine to abbreviate — is what actually gives up its columns.
 
     `_markers` and `_CI_MARK` are `statusline.py`'s own — called, not
-    reimplemented, so a fix to what a marker or a CI glyph means lands here the
-    moment it lands in the wide table. Only the CI *glyph* is kept, not
-    `_ci_part`'s trailing label (`"✓ passed"`): a narrow pane spends its columns
-    on the branch and the markers first, and the label would just be the first
-    thing `tui.truncate` throws away.
+    reimplemented, so a fix to what a marker or a CI glyph means lands here
+    the moment it lands in the wide table.
     """
     from .. import statusline as sl
-    emph = f"{sl._BOLD}{sl._UNDER}" if r.get("current") else ""
-    name = f"{emph}{color}{r['name']}{sl._R}"
+
     _plain, marks, _dirty = sl._markers(r)
-    branch = f"{sl._DIM}{r.get('branch') or '?'}{sl._R}{marks}"
-    line = f"{name} {branch}"
+    marks_w = tui.width(marks)
+
     ci = r.get("ci")
+    ci_text = ""
     if ci:
         c, glyph, _label = sl._CI_MARK.get(ci, (sl._DIM, "?", ci))
-        line += f" {c}{glyph}{sl._R}"
+        ci_text = f" {c}{glyph}{sl._R}"
+    ci_w = tui.width(ci_text)
+
     change = r.get("change")
+    change_text = ""
     if change:
         sigil = r.get("sigil") or "!"
-        line += f" {sl._GREEN}{sigil}{change}{sl._R}"
-    return line
+        change_text = f" {sl._GREEN}{sigil}{change}{sl._R}"
+    change_w = tui.width(change_text)
+
+    badge_text = f" {sl._DIM}⑂{badge_n}{sl._R}" if badge_n else ""
+    badge_w = tui.width(badge_text)
+
+    branch = r.get("branch") or "?"
+    lead_w = tui.width(lead)
+
+    budget = max(0, width - lead_w)
+    name_w = min(tui.width(name_markup), max(1, budget // 2))
+    name_shown = tui.truncate(name_markup, name_w)
+    budget -= tui.width(name_shown)
+
+    sep = " " if budget > 0 else ""
+    budget -= tui.width(sep)
+
+    # What's left for the branch, once the markers glued to it are reserved.
+    remaining = budget - marks_w
+    # CI, an open change, and the piece badge are included only while there is
+    # still at least 1 column left over for the branch itself after they are —
+    # dropped whole, priority order, rather than let any of them crowd the
+    # branch out entirely.
+    show_ci = bool(ci_text) and (remaining - ci_w) >= 1
+    tail_w = ci_w if show_ci else 0
+    show_change = bool(change_text) and (remaining - tail_w - change_w) >= 1
+    if show_change:
+        tail_w += change_w
+    show_badge = bool(badge_text) and (remaining - tail_w - badge_w) >= 1
+    if show_badge:
+        tail_w += badge_w
+
+    branch_w = max(1, remaining - tail_w)
+    branch_shown = tui.truncate(f"{sl._DIM}{branch}{sl._R}", branch_w)
+
+    line = f"{lead}{name_shown}{sep}{branch_shown}{marks}"
+    if show_ci:
+        line += ci_text
+    if show_change:
+        line += change_text
+    if show_badge:
+        line += badge_text
+    # Safety net, not the fix: correct budgeting above should already leave
+    # this a no-op (`tui.truncate`'s own fast path returns unchanged input
+    # unmodified) — kept only so a rounding slip degrades to a trimmed line
+    # rather than an over-width one, the same belt-and-braces `panel.py`
+    # already keeps around its own measurements.
+    return tui.truncate(line, width)
 
 
-def _piece_line(p: dict) -> str:
-    """One piece (worktree), indented under its repo — same cells as
-    :func:`_repo_line` minus the palette colour and the bold/underline emphasis,
-    which belong to a REPO's row, not one of its pieces."""
+def _repo_line(r: dict, color: str, width: int, badge_n: int = 0) -> str:
+    """One repo, one line: name (bold+underline if it is where you are
+    standing, coloured by the same per-position palette `_repo_rows` cycles),
+    then :func:`_row`'s shared branch/markers/CI/change/badge composition.
+
+    *badge_n* is the repo's `⑂N` — the pieces NOT already shown as their own
+    rows below it (see :func:`_left`'s own docstring: `0` when every piece
+    already has a row, or when the repo has none)."""
     from .. import statusline as sl
-    _plain, marks, _dirty = sl._markers(p)
-    branch = f"{sl._DIM}{p.get('branch') or '?'}{sl._R}{marks}"
-    return f"{sl._DIM}{sl._TREE_WT}{sl._R}{p['name']} {branch}"
+    emph = f"{sl._BOLD}{sl._UNDER}" if r.get("current") else ""
+    name_markup = f"{emph}{color}{r['name']}{sl._R}"
+    return _row("", name_markup, r, width, badge_n=badge_n)
+
+
+def _piece_line(p: dict, width: int) -> str:
+    """One piece (worktree), indented under its repo — same composition as
+    :func:`_repo_line` minus the palette colour and the bold/underline
+    emphasis, which belong to a REPO's row, not one of its pieces."""
+    from .. import statusline as sl
+    lead = f"{sl._DIM}{sl._TREE_WT}{sl._R}"
+    return _row(lead, p["name"], p, width)
 
 
 def _left(fid: str) -> str:
@@ -132,15 +213,16 @@ def _left(fid: str) -> str:
     refreshed — never a repo directory listing, a `git status`, or a
     `glstate.read_for` of its own; every field a row needs (`name`, `branch`,
     `dirty`, `tracked_dirty`, `ahead`, `behind`, `ci`, `change`, `sigil`,
-    `current`) is already sitting in that one gather. `_pick_rows` is called
-    rather than reinvented for the same reason: it already carries the lesson
-    `statusline.py` paid for in production (an unranked slice of 18 clones
-    showed thirteen clean repos on `main` and hid the one dirty repo you were
-    actually standing in) — `_pick_rows` wants directory-shaped keys (`.name`,
-    hashable), so each cache row is wrapped in a bare `_RowKey` rather than a
-    `Path`: nothing here touches a filesystem, and a `Path` would imply one
-    exists to touch (and, unlike a `Path`, two `_RowKey`s never compare equal
-    just because their names happen to match — see its own docstring).
+    `current`, `worktree_count`) is already sitting in that one gather.
+    `_pick_rows` is called rather than reinvented for the same reason: it
+    already carries the lesson `statusline.py` paid for in production (an
+    unranked slice of 18 clones showed thirteen clean repos on `main` and hid
+    the one dirty repo you were actually standing in) — `_pick_rows` wants
+    directory-shaped keys (`.name`, hashable), so each cache row is wrapped in
+    a bare `_RowKey` rather than a `Path`: nothing here touches a filesystem,
+    and a `Path` would imply one exists to touch (and, unlike a `Path`, two
+    `_RowKey`s never compare equal just because their names happen to match —
+    see its own docstring).
 
     `left` is a full-height pane with rows to fill, unlike `top`/`bottom`'s fixed
     single row — but nothing in this module measures how many it actually has
@@ -154,12 +236,14 @@ def _left(fid: str) -> str:
     ONLY when the workspace resolves to exactly one repo — it mirrors
     `statusline._detail_worktrees`'s own single-repo rule verbatim (see that
     function's docstring: spending rows on piece detail is only a good trade
-    when there is exactly one repo to spend them on). A MULTI-repo workspace's
-    per-repo worktree COUNT — the `⑂N` badge and one-line piece-name summary
-    `_repo_rows` draws via a fresh, always-live `worktree.dirs_for(active,
-    d.name)` call of its own — was never part of Task 1's cache at all, and
-    nothing here re-derives it with a live call of its own to patch that over:
-    see this task's report.
+    when there is exactly one repo to spend them on). Every OTHER repo's
+    pieces — the ones never turned into rows of their own — still get a `⑂N`
+    badge on their repo's own line, from `worktree_count` (fix round 1,
+    finding 2, #385: this used to be missing from the cache entirely for a
+    multi-repo workspace; `gather.py`'s own module docstring records the
+    fix). `_repo_line` is handed `0` whenever every one of a repo's pieces
+    already has its own row — the badge means "there is more you cannot see
+    here," not "this repo has pieces."
     """
     from .. import statusline as sl
     from . import gather
@@ -176,23 +260,39 @@ def _left(fid: str) -> str:
     by_key = dict(zip(keys, repos))
     cur_repo = data.get("current_repo")
 
+    # How many of a repo's pieces already have their own row below it
+    # (`data["worktrees"]`, single-repo-only — see the docstring above), so
+    # the badge can say "there is more" rather than double-count what is
+    # already on screen.
+    shown_pieces: dict = {}
+    for p in (data.get("worktrees") or []):
+        shown_pieces[p.get("repo")] = shown_pieces.get(p.get("repo"), 0) + 1
+
+    def _badge_for(r: dict) -> int:
+        total = r.get("worktree_count") or 0
+        return total if shown_pieces.get(r["name"], 0) < total else 0
+
     budget = sl._MAX_REPO_LINES
     capped = len(keys) > budget
     show = sl._pick_rows(keys, (budget - 1) if capped else budget,
                          cur_repo, by_key, by_key) if capped else keys
 
-    lines = [tui.truncate(_repo_line(by_key[k], color_by_name[by_key[k]["name"]]), w)
+    lines = [_repo_line(by_key[k], color_by_name[by_key[k]["name"]], w,
+                        badge_n=_badge_for(by_key[k]))
              for k in show]
 
     if capped:
         shown = set(show)
         hidden = [k for k in keys if k not in shown]
         quiet = not any(_needs_attention(by_key[k]) for k in hidden)
-        note = ", clean" if quiet else ""
+        # Same wording as `_repo_rows`' own overflow line (`statusline.py`) —
+        # this used to say bare ", clean", a needless divergence between the
+        # two surfaces for the exact same claim.
+        note = ", all clean" if quiet else ""
         lines.append(tui.truncate(f"{sl._DIM}…(+{len(hidden)} more{note}){sl._R}", w))
 
     for p in (data.get("worktrees") or []):
-        lines.append(tui.truncate(_piece_line(p), w))
+        lines.append(_piece_line(p, w))
 
     return "\n".join(lines)
 

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -44,7 +44,41 @@ def _width() -> int:
 
 
 def _top(fid: str) -> str:
-    """Identity: where you are, pinned or not, and who you are being."""
+    """Identity: where you are, pinned or not, and who you are being.
+
+    **Task 4 investigation (#385) — the context/cache gauge cannot run here, and this
+    deliberately does not call it.** The plan's slot table lists "context/session when
+    available" for `top`, naming `statusline._session_strip(payload, sid)` and
+    `statusline._context_gauge(payload)` as the wide layout's source for it. Read end to
+    end before writing anything here, per the task brief's own instruction:
+
+    `_context_gauge(payload)` is gated on `payload.get("context_window")` at every single
+    branch — `ctx NN%` needs `cw["used_percentage"]`, `cache NN%` needs
+    `cw["current_usage"]`'s two token counts, and even the REBUILD/cold-streak history
+    (`_record_turn`, `_rebuilds`, `_cache_hint`) only runs *nested inside* the
+    `if read or write:` block those same live numbers gate — so there is no path through
+    this function that produces anything without a payload carrying real numbers THIS
+    turn. And there is exactly one source for that payload: `statusline.main` does
+    `payload = json.load(sys.stdin)` — Claude Code's per-turn JSON, sent only to the
+    process it invokes as the configured `statusLine` command. A frame panel is started
+    once, as a long-lived tmux pane command (`panel.run`, polling `state.version`), never
+    re-invoked per turn and never handed that stdin — `gather.py`'s own module docstring
+    already establishes this identically for the gather side ("No per-session payload").
+
+    So `_context_gauge({})`/`_context_gauge(None)` is not a degraded case here, it is
+    the ONLY case, forever, no matter what the session has done — calling it would add a
+    line of code whose return value this docstring can already prove is always `[]`.
+    Composing `_session_strip(payload, sid)` instead would not help: it is exactly
+    `[*_context_gauge(payload), *_session_news(sid)]`, so with the gauge half structurally
+    dead the call would only ever surface `_session_news`'s half — which is `bottom`'s
+    own, explicit assignment (see `_bottom`'s docstring), not `top`'s. Calling it here
+    too would either duplicate `bottom` byte-for-byte or (worse, since a panel's `sid` may
+    differ in nothing from `bottom`'s) read as two different panes agreeing by
+    coincidence. Per the task brief: "a gauge that silently reads zero is worse than no
+    gauge" — so this is left out, not stubbed in, until #386 (which owns the suppression
+    and recording question this finding feeds) decides a panel should have its own
+    persisted usage snapshot to read. Pinned by `tests.test_frame_slots.TopRenderer`.
+    """
     from .. import __version__, statusline, workspace
     ws = workspace.resolve()
     src = workspace.source()
@@ -331,29 +365,109 @@ def _right(fid: str) -> str:
     return "\n".join(tui.truncate(c, w) for c in chips)
 
 
+def _fit_fields(priority: list[tuple[str, str]], width: int) -> set[str]:
+    """Which names among *priority* — an ordered list of ``(name, text)`` pairs, highest
+    priority first — fit *width* once joined with `` · ``, decided one at a time in that
+    order: each field's FULL text counted against what is left, included whole or
+    dropped whole, never character-sliced. The first non-empty field is always kept even
+    when it alone is over budget (so a row this feeds is never blank on its own account —
+    a trailing `tui.truncate` at the call site is what actually protects the pane in that
+    case, the same "safety net, not the fix" role it plays in :func:`_row`).
+
+    Factored out of :func:`_bottom` so this priority-and-width logic is testable against
+    exactly the fields a test wants, in isolation — `_bottom` also always carries a todo
+    count and a hotkey hint that would otherwise compete for the same narrow budgets an
+    adversarial test needs to construct.
+    """
+    sep_w = tui.width(" · ")
+    budget = width
+    keep: set[str] = set()
+    for name, text in priority:
+        if not text:
+            continue
+        need = tui.width(text) + (sep_w if keep else 0)
+        if need > budget and keep:
+            continue          # doesn't fit and something already does — drop it whole
+        keep.add(name)
+        budget -= need
+    return keep
+
+
 def _bottom(fid: str) -> str:
     """What still wants attention, and how to act on it.
 
-    Only the first alert, deliberately: bottom is a fixed single-row pane, and
-    `_alerts()` already returns its entries in priority order, so this picks which one
-    survives rather than leaving it to whichever one happens to fit before
-    `tui.truncate`'s ellipsis — the same truncation-order reasoning `statusline.py`
-    names inline wherever a row has to choose what to drop.
+    Only the first alert, deliberately: `_alerts()` already returns its entries in
+    priority order, so this picks which one survives rather than leaving it to whichever
+    happens to fit before an ellipsis — the same truncation-order reasoning
+    `statusline.py` names inline wherever a row has to choose what to drop.
+
+    **Task 4 (#385) adds `statusline._session_news(sid)`** — this session's own
+    denied/recorded/dispatched counters, deliberately silent unless something actually
+    happened (see `_session_news`'s own docstring). Unlike the context/cache gauge (see
+    `_top`'s docstring for why THAT stays out), `_session_news` needs no per-turn Claude
+    Code payload at all — `inflight.live()` reads a shared on-disk tracker and
+    `trace.read(sid)` reads the session's own trace log, both real independent of any
+    stdin JSON. It only needs a session id, which — like `_right`'s persona chips — a
+    panel has none passed to it; `session.current()` reads the same
+    `$CHARTER_SESSION_ID`/`$CLAUDE_CODE_SESSION_ID` a launched panel inherits whole from
+    the harness (`_right`'s docstring makes the identical point for `_persona_chips`).
+
+    **Four candidate fields now, not three, each shown WHOLE or dropped WHOLE — never
+    one assembled string cut once from the right.** `bottom` is one fixed row
+    (`layout.SLOT_SIZE["bottom"] == 1`) but its WIDTH is the frame's own, not a narrow
+    side panel's, so ordinarily every field fits comfortably and this never has to choose.
+    But `layout.py`'s own module docstring records a REAL tmux 3.7c resize that
+    transiently starves a fixed-size pane before the corrective hook snaps it back — not
+    hypothetical, reachable by an ordinary window resize at any moment (Task 3's fix
+    round 2 pinned the identical shape for `left`). A naive single `tui.truncate` over the
+    joined line would risk Task 3's own Critical on perfectly ordinary data: an alert
+    exists specifically to carry the command that fixes it, and slicing into that command
+    mid-word reads as "no problem here" — the exact false-clean failure this plan's
+    Global Constraints call out by name.
+
+    Priority order, highest first: the one alert (`_alerts()`'s own top pick — an
+    actionable control-plane problem, carrying its own fix); `_session_news` (this
+    session's own activity — silent unless it already has something to say, so its mere
+    presence is the signal); the todo count (persistent state, not urgent); the
+    configured hotkey hint (the one thing always rediscoverable another way, so it is
+    first to give up its columns). Once decided, the survivors are RE-JOINED in the
+    original reading order (todo, alert, news, hotkey) — priority governs only who is
+    dropped when the pane is starved, not how a healthy pane reads.
 
     The hotkey is READ, not spelled out: `[frame] hotkey` is configurable, and this row
-    hardcoded `F2 menu` — so a plane on `hotkey = "F1"` had its own panel telling every
-    operator the wrong key, on every repaint, forever. `config.FRAME` is the resolved
-    value `commands_frame.conf_text` binds, so there is one source for what the panel
-    says and what the frame actually does.
+    used to hardcode `F2 menu` — so a plane on `hotkey = "F1"` had its own panel telling
+    every operator the wrong key, on every repaint, forever. `config.FRAME` is the
+    resolved value `commands_frame.conf_text` binds, so there is one source for what the
+    panel says and what the frame actually does.
     """
-    from .. import config, statusline, workspace
+    from .. import config, session as _session, statusline as sl, workspace
     ws = workspace.resolve()
-    todos = statusline._todo_count(ws)
-    alerts = statusline._alerts(ws)
-    parts = [f"{todos} todo" + ("s" if todos != 1 else "")]
-    parts.extend(alerts[:1])
-    parts.append(f"{config.FRAME['hotkey']} menu")
-    return tui.truncate(" · ".join(p for p in parts if p), _width())
+    todos = sl._todo_count(ws)
+    alerts = sl._alerts(ws)
+    news = sl._session_news(_session.current())
+    w = _width()
+
+    # Unconditional, unlike `news` below — this predates Task 4 and stays exactly as it
+    # was (`0 todo` included) rather than adopting `_session_news`'s "silent unless
+    # something happened" discipline on the side; changing an existing field's own
+    # presence rule is not this task's job.
+    todo_text = f"{todos} todo" + ("s" if todos != 1 else "")
+    alert_text = alerts[0] if alerts else ""
+    news_text = f"{sl._DIM} · {sl._R}".join(news) if news else ""
+    hotkey_text = f"{config.FRAME['hotkey']} menu"
+
+    # Decide who survives, highest priority first (see this function's own docstring
+    # above for why); `_fit_fields` does the actual budgeting so it can be tested in
+    # isolation.
+    keep = _fit_fields(
+        [("alert", alert_text), ("news", news_text),
+         ("todo", todo_text), ("hotkey", hotkey_text)], w)
+
+    # Re-assembled in the original reading order, not priority order — priority decided
+    # only who was cut.
+    fields = {"alert": alert_text, "news": news_text, "todo": todo_text, "hotkey": hotkey_text}
+    parts = [fields[n] for n in ("todo", "alert", "news", "hotkey") if n in keep]
+    return tui.truncate(" · ".join(parts), w)
 
 
 #: Every slot charter can draw. `panel.run` refuses a name that is not in here rather

--- a/docs/superpowers/plans/2026-08-23-frame-parity.md
+++ b/docs/superpowers/plans/2026-08-23-frame-parity.md
@@ -1,0 +1,49 @@
+# Frame content parity — implementation plan (#385)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** the frame shows what the status line shows, by composing the renderers that already exist rather than reimplementing them.
+
+**Architecture:** one gather, many slot renderers. `charter/frame/gather.py` owns the expensive, correctness-critical part (repo states, branches, gl state) and writes a cache; panels are pure readers; the hook that already bumps the version refreshes the cache, because a bump is exactly "plane state changed".
+
+**Spec:** issue #385, plus the design settled by grilling and recorded in this plan's Global Constraints.
+
+## Global Constraints
+
+- `dependencies = []`. stdlib `unittest`, never pytest.
+- **Share the gather, not the composition.** `_repo_rows` returns `tui.Node`s laid out for a wide boxed frame; a 22-column pane needs its own composition. Reuse `states`/`branches`/`gl`; write narrow renderers.
+- **Panels are pure readers.** `_run_state` shells out to `git status --porcelain --branch` per repo; four panels each gathering means four identical sweeps per repaint. Panels read a cache; the bumping hook writes it. The frame must still cost a `stat` at idle.
+- **`render()` never raises** — a panel that dies leaves a hole in the frame.
+- **Panels measure their own tty**, never `$COLUMNS`. `tui.term_width()` reads the env first, which is right for the status line and wrong in a pane.
+- **`tui.width` counts display cells, not characters** — a wide glyph that fits by `len()` still wraps a pane and pushes the frame apart.
+- **Do not modify `charter/statusline.py`'s render path.** The status line keeps working exactly as it does; this plan only *calls* its helpers.
+- Only `tests/test_frame_tmux_integration.py` may start a real tmux, and it must **probe capability, not presence** — CI is Ubuntu with tmux 3.4 and `TERM=dumb`.
+- Every test verified by mutation: apply it, confirm red, restore, confirm green. Clear `__pycache__` between runs. A test asserting on anything the test process did not itself set is not trusted until mutated — this branch's predecessor shipped three vacuous tests, two from ambient environment.
+
+## Slot assignment
+
+Follows the zones `statusline.py` already argues for, so the frame does not invent a second information architecture:
+
+| slot | content |
+| --- | --- |
+| `top` | identity: workspace, pin, persona, version, context/session when available |
+| `left` | repo rows, piece summaries |
+| `right` | persona chips, memory badges, in-flight badges, vault dots |
+| `bottom` | alerts, news, todo count, hotkey hint |
+
+## Tasks
+
+### Task 1 — `charter/frame/gather.py`: one scan, cached
+Extract the gather `statusline.render` performs (`_repo_trees`, `_repo_states`, `_branch`, `glstate.read_for`) into a module that returns a plain data structure and can write/read it as JSON under the frame's directory. Pure of layout. Tests: the cache round-trips; a corrupt cache degrades to a fresh gather rather than raising; a missing cache is not an error.
+
+### Task 2 — the bumping hook refreshes the cache
+`notify.plane_changed()` already fires from seven hook sites, debounced. It writes the version; make it also refresh the gather cache for the running frame. Must remain never-raising and must not add measurable cost to `posttooluse-bash`. Tests: a bump refreshes; a failure to gather does not raise; the debounce still holds.
+
+### Task 3 — `left` and `right` renderers
+Add them to `slots.SLOTS`, composed narrow from the cache. `unimplemented()` shrinks accordingly. Tests: each renders inside its pane width measured in display cells; each degrades to a readable line when the cache is empty; a CJK-heavy workspace name still fits.
+
+### Task 4 — enrich `top` and `bottom`
+Compose the remaining helpers into the two existing slots. Tests: content appears; each still fits one row; `render` still never raises.
+
+### Task 5 — real-tmux integration
+A four-edge frame comes up with all four panels alive and showing real content, and repaints after a `state.bump`. Capability-probed, skip-if-absent, leaks nothing.

--- a/tests/test_frame_doctor.py
+++ b/tests/test_frame_doctor.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 import unittest
 from unittest import mock
 
-from charter import doctor
+from charter import config, doctor
+from charter.frame import slots
 
 
 class FrameRow(unittest.TestCase):
@@ -56,12 +57,20 @@ class FrameRow(unittest.TestCase):
 
     def test_a_slot_with_no_renderer_is_a_ceiling_this_row_names(self):
         """The second standing condition that moved off the launch path (see
-        `commands_frame.frame_ready`): `[frame] slots` accepts `left`/`right`, charter
-        sizes them, and nothing draws in them. It used to be a `util.warn` printed
-        microseconds before tmux switched the terminal to the alternate screen."""
+        `commands_frame.frame_ready`): `[frame] slots` accepts a slot charter sizes
+        but has no renderer for, and nothing draws in it. It used to be a
+        `util.warn` printed microseconds before tmux switched the terminal to the
+        alternate screen.
+
+        `left`/`right` shipped renderers in Task 3 (#385), so the registry — not a
+        hardcoded pair — is patched to simulate the one still-standing case: a slot
+        `config.FRAME["slots"]` accepts with nothing in `frame.slots.SLOTS` to draw
+        it, the same gap `left`/`right` used to be until this task closed it."""
         from charter import config
         with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
-             mock.patch.dict(config.FRAME, {"slots": ["top", "right"]}):
+             mock.patch.dict(config.FRAME, {"slots": ["top", "right"]}), \
+             mock.patch.dict(slots.SLOTS):
+            del slots.SLOTS["right"]
             r = doctor.check_frame()
         self.assertEqual(r.status, doctor.WARN)
         self.assertIn("right", r.hint)

--- a/tests/test_frame_gather.py
+++ b/tests/test_frame_gather.py
@@ -93,6 +93,62 @@ class ScanReusesStatuslineHelpers(ClonedRepoIso, unittest.TestCase):
         self.assertIsNone(data["current_repo"])
 
 
+class WorktreeCountPerRepo(ClonedRepoIso, unittest.TestCase):
+    """Fix round 1, finding 2 (#385): `_repo_rows` gets its `⑂N` badge from a
+    live `worktree.dirs_for(active, d.name)` call PER REPO, independent of
+    `_detail_worktrees` (single-repo-only). That per-repo count was never
+    folded into `scan()`, so `repos[i]["worktree_count"]` did not exist at all
+    — a multi-repo workspace's cache carried no piece information whatsoever.
+    These pin the field is now REAL, not merely present, in exactly the shape
+    (2+ repos) the gap was reported against."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.repo2 = config.WORKSPACES_DIR / config.DEFAULT_WORKSPACE / "second"
+        _init_repo(self.repo2)
+
+    def _add_piece(self, repo: Path, piece: str) -> Path:
+        """A worktree DIRECTORY at the path charter's own registry uses —
+        `worktree.dirs_for` is filesystem-only (`base.iterdir()`, no
+        subprocess — see its own docstring), and with two repos
+        `_detail_worktrees` never selects either for full detail rows (its own
+        single-repo rule), so nothing in `scan()` ever reads THIS directory as
+        a tree of its own; a bare directory is the honest fixture for a count
+        that only cares that it exists."""
+        from charter import worktree
+        p = worktree.path_for(config.DEFAULT_WORKSPACE, repo.name, piece)
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    def test_a_repo_with_no_pieces_counts_zero(self):
+        data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.tmp))
+        by_name = {r["name"]: r for r in data["repos"]}
+        self.assertEqual(by_name["demo"]["worktree_count"], 0)
+        self.assertEqual(by_name["second"]["worktree_count"], 0)
+
+    def test_a_multi_repo_workspaces_piece_count_is_real_per_repo(self):
+        """The exact gap: with TWO repos, `detail_wts`/`data["worktrees"]` is
+        always `[]` (`_detail_worktrees`'s single-repo rule) — before this fix
+        round, that meant `demo`'s two real pieces were invisible to `left`
+        entirely, not merely uncounted."""
+        self._add_piece(self.repo, "piece-a")
+        self._add_piece(self.repo, "piece-b")
+        data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.tmp))
+        by_name = {r["name"]: r for r in data["repos"]}
+        self.assertEqual(by_name["demo"]["worktree_count"], 2)
+        self.assertEqual(by_name["second"]["worktree_count"], 0)
+        # The gap this pins: `detail_wts` truly is empty here, so the count is
+        # the ONLY place this fact survives into the cache at all.
+        self.assertEqual(data["worktrees"], [])
+
+    def test_a_broken_worktree_lookup_does_not_raise_and_zeroes_the_count(self):
+        with mock.patch("charter.worktree.dirs_for", side_effect=RuntimeError("boom")):
+            data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.tmp))
+        by_name = {r["name"]: r for r in data["repos"]}
+        self.assertEqual(by_name["demo"]["worktree_count"], 0)
+        self.assertEqual(by_name["second"]["worktree_count"], 0)
+
+
 class DivergedRepoIso(ClonedRepoIso):
     """`ClonedRepoIso`'s repo, but with real ahead/behind AND an upstream to
     diverge from — the `tests/test_worktree.py` `_add_upstream` pattern (a bare

--- a/tests/test_frame_gather.py
+++ b/tests/test_frame_gather.py
@@ -1,0 +1,185 @@
+"""One scan of the plane's repo state, cached under the frame's own directory.
+
+``gather.scan()`` is ``statusline.render``'s pre-layout gather (``_repo_trees``,
+``_repo_states``, ``_branch``, ``_current``, ``glstate.read_for``), reused rather
+than reimplemented so a fix to a repo row's git-status logic lands in both
+surfaces at once. ``save``/``read`` are the cache's write/read pair a hook (Task
+2) and a panel (Tasks 3/4) will use; ``refresh`` is the two composed.
+
+Real git fixtures for the data-correctness tests (the
+``tests/test_statusline_worktree_rows.py`` pattern) — a mocked git would prove
+nothing about whether ``scan()`` actually reads what ``_repo_states``/``_branch``
+read. The cache-behaviour tests (round-trip, corrupt, missing) mock ``scan()``
+itself instead, so they pin the CACHING contract independent of whatever git
+happens to be installed, and independent of the data-correctness tests above.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import config
+from charter.frame import gather, state
+
+from tests._isolation import PersonaIso
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+
+def _init_repo(path: Path, branch: str = "main") -> Path:
+    """A real git repo with one commit — the same fixture shape
+    ``tests/test_statusline_worktree_rows.py`` uses, so a repo ``scan()`` reads
+    and a repo ``statusline.render()`` reads are built identically."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", branch, str(path)],
+                   check=True, capture_output=True)
+    _git(path, "config", "user.email", "t@example.com")
+    _git(path, "config", "user.name", "t")
+    _git(path, "config", "gc.auto", "0")
+    _git(path, "config", "maintenance.auto", "false")
+    (path / "README.md").write_text("hello\n")
+    _git(path, "add", "README.md")
+    _git(path, "-c", "commit.gpgsign=false", "commit", "-qm", "init")
+    return path
+
+
+class ClonedRepoIso(PersonaIso):
+    """A plane with one repo cloned into the active workspace, real git in it."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.HAS_CONTROL_PLANE = True
+        self.repo = config.WORKSPACES_DIR / config.DEFAULT_WORKSPACE / "demo"
+        _init_repo(self.repo)
+
+
+class ScanReusesStatuslineHelpers(ClonedRepoIso, unittest.TestCase):
+    """Pins that `scan()`'s fields are the REAL values `_repo_states`/`_branch`
+    read, not placeholders. A field that always reported the same thing whatever
+    the repo's actual state is exactly the "vacuous test" failure mode named in
+    this task's brief — except here it would be a vacuous *production field*, and
+    these tests exist to make that impossible to ship unnoticed."""
+
+    def test_lists_the_workspace_clone_with_its_real_branch(self):
+        data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.tmp))
+        self.assertEqual([r["name"] for r in data["repos"]], ["demo"])
+        self.assertEqual(data["repos"][0]["branch"], "main")
+
+    def test_a_clean_repo_is_not_dirty(self):
+        data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.tmp))
+        self.assertFalse(data["repos"][0]["dirty"])
+
+    def test_an_untracked_file_marks_the_repo_dirty(self):
+        (self.repo / "scratch.txt").write_text("x\n")
+        data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.tmp))
+        self.assertTrue(data["repos"][0]["dirty"])
+
+    def test_standing_inside_the_repo_marks_it_current(self):
+        data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.repo))
+        self.assertTrue(data["repos"][0]["current"])
+        self.assertEqual(data["current_repo"], "demo")
+
+    def test_standing_at_the_plane_root_does_not_mark_it_current(self):
+        data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.tmp))
+        self.assertFalse(data["repos"][0]["current"])
+        self.assertIsNone(data["current_repo"])
+
+
+class ScanWithNoRepos(PersonaIso, unittest.TestCase):
+    def test_an_empty_workspace_scans_to_an_empty_repo_list_without_raising(self):
+        data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.tmp))
+        self.assertEqual(data["repos"], [])
+        self.assertEqual(data["worktrees"], [])
+
+
+class ScanNeverRaises(PersonaIso, unittest.TestCase):
+    """Every step in `scan()` is wrapped individually — Task 2 calls this from a
+    hook, where "a hook may cost a session its briefing, never its turn"."""
+
+    def test_a_broken_workspace_resolve_does_not_raise(self):
+        with mock.patch("charter.workspace.resolve", side_effect=RuntimeError("boom")):
+            data = gather.scan(cwd=str(self.tmp))  # must not raise
+        self.assertEqual(data["repos"], [])
+
+    def test_a_broken_repo_trees_lookup_does_not_raise(self):
+        with mock.patch("charter.statusline._repo_trees", side_effect=RuntimeError("boom")):
+            data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.tmp))
+        self.assertEqual(data["repos"], [])
+
+    def test_a_broken_glstate_read_does_not_raise(self):
+        with mock.patch("charter.glstate.read_for", side_effect=RuntimeError("boom")):
+            data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.tmp))
+        self.assertEqual(data["workspace"], config.DEFAULT_WORKSPACE)
+
+
+class RoundTrip(PersonaIso, unittest.TestCase):
+    def test_a_saved_scan_comes_back_unchanged_without_gathering_again(self):
+        """The strong form of "round-trips": not merely that `read()` returns
+        equal data, but that it comes from the FILE — `scan()` is mocked to
+        raise, so a `read()` that silently re-gathered instead of trusting a
+        valid cache would fail this test, not just return a different value."""
+        data = {"gathered_at": 1.0, "workspace": "w", "current_repo": "demo",
+                "repos": [{"name": "demo", "branch": "main", "dirty": False,
+                           "tracked_dirty": False, "ahead": 0, "behind": 1,
+                           "ci": "success", "change": 3, "sigil": "!",
+                           "current": True}],
+                "worktrees": []}
+        gather.save("f-1", data)
+        with mock.patch.object(gather, "scan",
+                               side_effect=AssertionError("must not gather again")):
+            got = gather.read("f-1")
+        self.assertEqual(got, data)
+
+
+class CorruptCache(PersonaIso, unittest.TestCase):
+    def test_a_corrupt_cache_degrades_to_a_fresh_gather(self):
+        d = state.frame_dir("f-1", create=True)
+        (d / "gather.json").write_text("{not valid json")
+        sentinel = {"gathered_at": 0.0, "workspace": "sentinel", "current_repo": None,
+                    "repos": [], "worktrees": []}
+        with mock.patch.object(gather, "scan", return_value=sentinel) as scan_mock:
+            got = gather.read("f-1")
+        scan_mock.assert_called_once()
+        self.assertEqual(got, sentinel)
+
+
+class MissingCache(PersonaIso, unittest.TestCase):
+    def test_a_never_bumped_frame_is_not_an_error(self):
+        sentinel = {"gathered_at": 0.0, "workspace": "sentinel", "current_repo": None,
+                    "repos": [], "worktrees": []}
+        self.assertFalse(state.frame_dir("never-bumped").exists())
+        with mock.patch.object(gather, "scan", return_value=sentinel) as scan_mock:
+            got = gather.read("never-bumped")
+        scan_mock.assert_called_once()
+        self.assertEqual(got, sentinel)
+
+    def test_a_hostile_fid_does_not_raise(self):
+        gather.read("../../escaped")  # must not raise
+        self.assertFalse(state._root().exists())
+
+
+class SaveIsHardened(PersonaIso, unittest.TestCase):
+    def test_saving_against_a_hostile_fid_does_not_raise_or_create(self):
+        gather.save("../../escaped", {"repos": []})  # must not raise
+        self.assertFalse(state._root().exists())
+
+
+class RefreshComposesScanAndSave(ClonedRepoIso, unittest.TestCase):
+    def test_refresh_writes_a_cache_read_can_then_find_without_gathering_again(self):
+        data = gather.refresh("f-1", workspace=config.DEFAULT_WORKSPACE, cwd=str(self.repo))
+        self.assertEqual(data["repos"][0]["name"], "demo")
+        cache_file = state.frame_dir("f-1") / "gather.json"
+        self.assertTrue(cache_file.exists())
+        with mock.patch.object(gather, "scan",
+                               side_effect=AssertionError("must not gather again")):
+            self.assertEqual(gather.read("f-1"), data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_gather.py
+++ b/tests/test_frame_gather.py
@@ -16,7 +16,9 @@ happens to be installed, and independent of the data-correctness tests above.
 
 from __future__ import annotations
 
+import json
 import subprocess
+import time
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -91,6 +93,102 @@ class ScanReusesStatuslineHelpers(ClonedRepoIso, unittest.TestCase):
         self.assertIsNone(data["current_repo"])
 
 
+class DivergedRepoIso(ClonedRepoIso):
+    """`ClonedRepoIso`'s repo, but with real ahead/behind AND an upstream to
+    diverge from — the `tests/test_worktree.py` `_add_upstream` pattern (a bare
+    repo standing in for a remote, no network needed), extended with a second
+    clone that pushes a commit of its own so `self.repo`'s ``fetch`` sees a
+    remote-tracking ref it has not merged. Real divergence from ``git status
+    --porcelain --branch``, never an asserted number — `_entry()`'s `ahead`/
+    `behind` fields are pinned by nothing (fix round 1, finding 2) precisely
+    because `RoundTrip`'s hand-built fixture never exercises the git-reading
+    code that fills them in.
+
+    Ahead and behind are made UNEQUAL (2 and 1) on purpose: the coordinator's
+    own mutation probe swapped the `ahead`/`behind` key lookups in `_entry()`
+    and the suite stayed green — which an equal-valued fixture (1 and 1) would
+    have hidden even with a correct test, since swapping two equal numbers is
+    invisible to `assertEqual`."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        origin = self.tmp / "origin.git"
+        subprocess.run(["git", "init", "-q", "--bare", "-b", "main", str(origin)],
+                       check=True, capture_output=True)
+        _git(self.repo, "remote", "add", "origin", str(origin))
+        _git(self.repo, "push", "-q", "-u", "origin", "main")
+
+        # behind: someone else pushes to `origin`; `self.repo` fetches (updates
+        # the remote-tracking ref) but never merges it into its own `main`.
+        other = self.tmp / "other-clone"
+        subprocess.run(["git", "clone", "-q", str(origin), str(other)],
+                       check=True, capture_output=True)
+        _git(other, "config", "user.email", "o@example.com")
+        _git(other, "config", "user.name", "o")
+        (other / "REMOTE.md").write_text("from elsewhere\n")
+        _git(other, "add", "REMOTE.md")
+        _git(other, "-c", "commit.gpgsign=false", "commit", "-qm", "remote change")
+        _git(other, "push", "-q", "origin", "main")
+        _git(self.repo, "fetch", "-q", "origin")
+
+        # ahead: two commits of `self.repo`'s own, never pushed — 2 vs. `behind`'s
+        # 1, deliberately unequal (see the class docstring).
+        (self.repo / "LOCAL.md").write_text("local change\n")
+        _git(self.repo, "add", "LOCAL.md")
+        _git(self.repo, "-c", "commit.gpgsign=false", "commit", "-qm", "local change")
+        (self.repo / "LOCAL.md").write_text("local change 2\n")
+        _git(self.repo, "add", "LOCAL.md")
+        _git(self.repo, "-c", "commit.gpgsign=false", "commit", "-qm", "local change 2")
+
+
+class EntryFieldsAreReal(DivergedRepoIso, unittest.TestCase):
+    """Fix round 1, finding 2: `tracked_dirty`, `ahead`, `behind`, `ci`, `change`
+    and `sigil` were built by `_entry()` but exercised only through
+    `RoundTrip`'s hand-built fixture, which proves `save`/`read` round-trip JSON
+    and proves nothing about `_entry()`'s own construction — confirmed by
+    mutation (swapping the `ahead`/`behind` lookups, or hardcoding `"ci": None`,
+    both left the suite green). Each test below uses a fixture with a
+    non-default value for the field it checks, so a swapped key or a dropped
+    lookup has somewhere to be caught."""
+
+    def test_ahead_and_behind_reflect_real_divergence(self):
+        data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.repo))
+        entry = data["repos"][0]
+        self.assertEqual(entry["ahead"], 2)
+        self.assertEqual(entry["behind"], 1)
+
+    def test_an_untracked_only_change_is_dirty_but_not_tracked_dirty(self):
+        (self.repo / "scratch.txt").write_text("x\n")
+        data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.repo))
+        entry = data["repos"][0]
+        self.assertTrue(entry["dirty"])
+        self.assertFalse(entry["tracked_dirty"])
+
+    def test_a_tracked_edit_marks_both_dirty_and_tracked_dirty(self):
+        (self.repo / "LOCAL.md").write_text("edited\n")
+        data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.repo))
+        entry = data["repos"][0]
+        self.assertTrue(entry["dirty"])
+        self.assertTrue(entry["tracked_dirty"])
+
+    def test_ci_change_and_sigil_come_from_glstate(self):
+        """`glstate.read_for` only matches a cache entry whose recorded branch
+        equals the tree's CURRENT branch (`glstate.py`'s own staleness rule) —
+        seeded under ``"main"`` to match `self.repo`'s real branch, not a
+        made-up one, so this proves the wiring rather than a coincidence."""
+        cache_file = config.STATE_DIR / "cache" / "glstate.json"
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(json.dumps({
+            str(self.repo): {"branch": "main", "ts": time.time(),
+                              "change": 7, "ci": "failed", "sigil": "!"},
+        }))
+        data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.repo))
+        entry = data["repos"][0]
+        self.assertEqual(entry["ci"], "failed")
+        self.assertEqual(entry["change"], 7)
+        self.assertEqual(entry["sigil"], "!")
+
+
 class ScanWithNoRepos(PersonaIso, unittest.TestCase):
     def test_an_empty_workspace_scans_to_an_empty_repo_list_without_raising(self):
         data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.tmp))
@@ -141,6 +239,37 @@ class CorruptCache(PersonaIso, unittest.TestCase):
     def test_a_corrupt_cache_degrades_to_a_fresh_gather(self):
         d = state.frame_dir("f-1", create=True)
         (d / "gather.json").write_text("{not valid json")
+        sentinel = {"gathered_at": 0.0, "workspace": "sentinel", "current_repo": None,
+                    "repos": [], "worktrees": []}
+        with mock.patch.object(gather, "scan", return_value=sentinel) as scan_mock:
+            got = gather.read("f-1")
+        scan_mock.assert_called_once()
+        self.assertEqual(got, sentinel)
+
+
+class WrongShapedCache(PersonaIso, unittest.TestCase):
+    """Fix round 1, finding 1: `json.loads` succeeding proves only that the
+    bytes were valid JSON, not that they are a scan. `42`, a bare string, a
+    list, and a dict missing `repos`/`worktrees` all parse cleanly — and each
+    used to come back from `read()` VERBATIM, so a renderer indexing
+    `data["repos"]` on the `42` case got `TypeError: 'int' object is not
+    subscriptable` instead of the degrade this module exists to provide."""
+
+    def test_a_bare_int_falls_through_to_a_fresh_gather(self):
+        self._assert_falls_through("42")
+
+    def test_a_bare_string_falls_through_to_a_fresh_gather(self):
+        self._assert_falls_through('"a string"')
+
+    def test_a_bare_list_falls_through_to_a_fresh_gather(self):
+        self._assert_falls_through("[1, 2, 3]")
+
+    def test_a_dict_missing_repos_and_worktrees_falls_through_to_a_fresh_gather(self):
+        self._assert_falls_through('{"foo": "bar"}')
+
+    def _assert_falls_through(self, raw_json: str) -> None:
+        d = state.frame_dir("f-1", create=True)
+        (d / "gather.json").write_text(raw_json)
         sentinel = {"gathered_at": 0.0, "workspace": "sentinel", "current_repo": None,
                     "repos": [], "worktrees": []}
         with mock.patch.object(gather, "scan", return_value=sentinel) as scan_mock:

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -39,7 +39,7 @@ from unittest import mock
 
 from tests._isolation import PersonaIso
 from charter import commands_frame, config
-from charter.frame import menu, state
+from charter.frame import menu, slots, state
 
 
 def _harness_binary_installed(resolver=None):
@@ -457,13 +457,21 @@ class Probe(unittest.TestCase):
 
     def test_a_slot_with_no_renderer_is_named_by_probe(self):
         """The second standing ceiling that moved off the launch path: `[frame] slots`
-        accepts `left`/`right` and `layout.SLOT_SIZE` sizes them, but `frame.slots.SLOTS`
-        implements neither, so the harness pane silently keeps that space. Read from
-        `config.FRAME` with nothing started — the probe's own read-only promise."""
+        accepts a slot charter sizes but `frame.slots.SLOTS` has no renderer for, so
+        the harness pane silently keeps that space. Read from `config.FRAME` with
+        nothing started — the probe's own read-only promise.
+
+        `left`/`right` shipped renderers in Task 3 (#385) — both are removed from the
+        registry here (restored after, via `mock.patch.dict`) to simulate the one
+        still-standing case the same way, rather than asserting against a pair that
+        no longer names it."""
         with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
              mock.patch.dict(config.FRAME, {"slots": ["top", "left", "right"]}), \
+             mock.patch.dict(slots.SLOTS), \
              mock.patch("charter.commands_frame.subprocess.run") as run, \
              mock.patch("builtins.print") as p:
+            del slots.SLOTS["left"]
+            del slots.SLOTS["right"]
             rc = commands_frame.cmd_probe()
         self.assertEqual(rc, 0, "an unimplemented slot is a ceiling, not a failure")
         run.assert_not_called()
@@ -1367,17 +1375,23 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertNotIn("LINES", fake.new_session_env)
 
     def test_a_configured_slot_with_no_renderer_is_skipped_not_spawned_dead(self):
-        """`[frame] slots` accepts `left`/`right` (`instance.FRAME_SLOTS`, sized by
-        `layout.SLOT_SIZE`) even though `frame.slots.SLOTS` — the renderer registry —
-        has no renderer for either yet. Spawning a real pane for one anyway would leave
-        the operator a permanently dead, wrapped-error pane under `remain-on-exit on`
-        (`panel.run` correctly refuses it, exit 2, but nothing then explains why at the
-        point the frame actually comes up). This pins that no such pane is even
-        attempted, one warning names it, and the implemented slots still draw."""
+        """`[frame] slots` accepts a slot (`instance.FRAME_SLOTS`, sized by
+        `layout.SLOT_SIZE`) that `frame.slots.SLOTS` — the renderer registry — has no
+        renderer for. Spawning a real pane for one anyway would leave the operator a
+        permanently dead, wrapped-error pane under `remain-on-exit on` (`panel.run`
+        correctly refuses it, exit 2, but nothing then explains why at the point the
+        frame actually comes up). This pins that no such pane is even attempted, one
+        warning names it, and the implemented slots still draw.
+
+        `left` shipped a renderer in Task 3 (#385) — removed from the registry here
+        (restored after, via `mock.patch.dict`) to keep simulating the one
+        still-standing case, rather than asserting against a slot that now draws."""
         fake = _FakeTmux(exit_code=0)
         buf = []
         with mock.patch.dict(config.FRAME, {"slots": ["top", "bottom", "left"]}), \
+             mock.patch.dict(slots.SLOTS), \
              mock.patch("charter.util.warn", side_effect=lambda m: buf.append(m)):
+            del slots.SLOTS["left"]
             rc = _launch(fake)
         self.assertEqual(rc, 0)
         self.assertFalse(any("panel" in c and "left" in c for c in fake.calls),

--- a/tests/test_frame_liveness.py
+++ b/tests/test_frame_liveness.py
@@ -12,7 +12,7 @@ import unittest
 from unittest import mock
 
 from charter import hooks
-from charter.frame import notify, state
+from charter.frame import gather, notify, state
 
 from tests._isolation import PersonaIso, run_hook
 
@@ -37,24 +37,74 @@ class Notify(PersonaIso, unittest.TestCase):
         """Not just "does not raise" — `state.bump` is itself hardened against a bad id
         (`contain.segment_ok` rejects a non-str/`None` name harmlessly), so a version of
         this guard that forwarded a missing id to `state.bump` anyway would still not
-        raise. Spying on `state.bump` catches that the guard-removed version wouldn't:
-        it proves nothing was even attempted, not merely that nothing blew up.
+        raise. Spying on `state.bump`/`gather.refresh` catches that the guard-removed
+        version wouldn't: it proves nothing was even attempted, not merely that nothing
+        blew up — the property this task's brief calls "must cost nothing outside a
+        frame," checked before any gather work, not just before the bump.
 
         `_last["at"]` is reset here too, same as the other cases — otherwise the
         debounce window left over from a test that ran moments earlier (`_last["at"]`
         being very recent) would return early and mask a missing/broken `fid` guard
         just as effectively as a correct one, and this test would pass either way."""
         with mock.patch.dict(os.environ, {}, clear=True), \
-             mock.patch.object(state, "bump") as bump:
+             mock.patch.object(state, "bump") as bump, \
+             mock.patch.object(gather, "refresh") as refresh:
             notify._last["at"] = 0.0
             notify.plane_changed()   # must not raise
             bump.assert_not_called()
+            refresh.assert_not_called()
 
     def test_a_broken_state_directory_never_reaches_the_hook(self):
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}), \
              mock.patch.object(state, "bump", side_effect=OSError("read-only")):
             notify._last["at"] = 0.0
             notify.plane_changed()   # must not raise
+
+    def test_a_bump_refreshes_the_gather_cache(self):
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}), \
+             mock.patch.object(gather, "refresh") as refresh:
+            notify._last["at"] = 0.0
+            notify.plane_changed()
+            refresh.assert_called_once_with("f-1")
+
+    def test_a_second_call_inside_the_debounce_window_skips_the_refresh_too(self):
+        """The cache refresh rides the SAME debounce as the version bump (see the
+        module docstring on why one gate rather than two) — a second call within the
+        250ms window must not gather again, exactly like it must not bump again."""
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}), \
+             mock.patch.object(gather, "refresh") as refresh:
+            notify._last["at"] = 0.0
+            notify.plane_changed()
+            notify.plane_changed()
+            refresh.assert_called_once()
+
+    def test_a_failure_to_gather_does_not_raise_and_the_bump_still_happens(self):
+        """The property this task's brief puts first: a `gather.refresh` that somehow
+        raises must not escape `plane_changed()` — proven here with a real
+        `RuntimeError`, not by trusting `gather`'s own advertised politeness. And
+        because the version bump is this function's original, load-bearing promise
+        (pinned separately by `test_a_change_bumps_the_running_frame`), a broken
+        refresh must not take the bump down with it: the version still has to move."""
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}), \
+             mock.patch.object(gather, "refresh", side_effect=RuntimeError("boom")):
+            before = state.version("f-1")
+            notify._last["at"] = 0.0
+            notify.plane_changed()   # must not raise
+            self.assertNotEqual(before, state.version("f-1"))
+
+    def test_the_cache_refreshes_before_the_version_bumps(self):
+        """So a panel that polls `state.version` and then reads the cache never finds
+        the version already moved but the cache still stale — see the module
+        docstring's "refresh happens BEFORE the bump" note."""
+        order = []
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}), \
+             mock.patch.object(gather, "refresh",
+                                side_effect=lambda fid: order.append("refresh")), \
+             mock.patch.object(state, "bump",
+                                side_effect=lambda fid: order.append("bump")):
+            notify._last["at"] = 0.0
+            notify.plane_changed()
+        self.assertEqual(order, ["refresh", "bump"])
 
 
 #: Every hook family the spec names as a liveness trigger, and what each one buys.

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -331,6 +331,19 @@ class LeftRenderer(PersonaIso, unittest.TestCase):
         self.assertIn("!12", out, "the open change must survive")
 
     def test_a_cjk_heavy_repo_name_still_fits_a_narrow_pane(self):
+        """Fix round 2, finding 1: pins the width invariant end-to-end through
+        `_left`/`_repo_line` for a real CJK repo name — it does NOT by itself
+        pin that `_row`'s name truncation is cell-aware rather than
+        char-aware. A repo's `name_markup` carries an ANSI colour prefix
+        (`_PALETTE`), and naive `name_markup[:name_w]` character-slicing
+        spends several of the budgeted characters on the escape bytes rather
+        than the CJK text — which happens to *under*-consume the intended
+        cell budget for this fixture, so this test stays green under that
+        mutation (verified: reverting `_row`'s `tui.truncate(name_markup,
+        name_w)` to `name_markup[:name_w]` does not red this test, with or
+        without the trailing safety-net truncate). `_piece_line`'s CJK test
+        below is the one that actually pins cell-awareness — a piece name
+        carries no ANSI prefix to accidentally absorb the mistake."""
         cjk = "測" * 30  # 30 characters, 60 display cells
         _seed("f-1", repos=[_row(cjk)])
         with mock.patch("os.get_terminal_size", return_value=os.terminal_size((20, 24))), \
@@ -338,6 +351,61 @@ class LeftRenderer(PersonaIso, unittest.TestCase):
             out = slots.render("left", "f-1")
         for line in out.splitlines():
             self.assertLessEqual(tui.width(line), 20)
+
+    def test_a_cjk_heavy_piece_name_does_not_crowd_out_its_branch_or_markers(self):
+        """Fix round 2, finding 1: the genuinely fragile field. A piece's name
+        (`_piece_line`, `p["name"]`) carries no ANSI prefix, so nothing
+        absorbs a char-vs-cell counting mistake the way the repo-name test
+        above happens to. With `tui.truncate` doing the real truncation, the
+        branch and its markers survive alongside a correctly-shrunk CJK name
+        (`'╰─ 測測測… main* ✗'`); under naive `name_markup[:name_w]` slicing
+        the name alone consumes 2x its intended cell budget (each CJK
+        character sliced in COUNT costs 2 cells), so the branch, the dirty
+        marker and the CI glyph are all pushed out entirely by the trailing
+        safety-net truncate — the SAME false-clean failure mode fix round 1
+        closed for the branch field, reopened here through the name field."""
+        cjk = "測" * 30  # 30 characters, 60 display cells
+        _seed("f-1", repos=[_row("demo", worktree_count=1)],
+             worktrees=[_row(cjk, repo="demo", branch="main",
+                             dirty=True, ci="failed")])
+        with mock.patch("os.get_terminal_size", return_value=os.terminal_size((20, 24))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            out = slots.render("left", "f-1")
+        for line in out.splitlines():
+            with self.subTest(line=line):
+                self.assertLessEqual(tui.width(line), 20)
+        piece_line = tui.strip_ansi(out.splitlines()[-1])
+        self.assertIn("main", piece_line, "the branch must survive")
+        self.assertIn("*", piece_line, "the dirty marker must survive")
+        self.assertIn("✗", piece_line, "the CI glyph must survive")
+
+    def test_a_starved_pane_drops_lowest_priority_fields_first(self):
+        """Fix round 2, finding 2: reachable in production despite the
+        22-column DEFAULT — `layout.py`'s own module docstring measures real
+        tmux 3.7c redistributing every pane proportionally on a resize, `-l
+        size` notwithstanding ("growing a 120x30 frame to 200x50 stretched two
+        one-row panels to 8 and 7 rows" before a corrective `window-resized`
+        hook snapped them back): an ORDINARY window resize, not a future
+        configurability feature. `_width()` measures the real pane rather
+        than trusting `layout.SLOT_SIZE` for exactly this reason.
+
+        Pins `_row`'s priority order (CI drops before the dirty marker, which
+        `_left`'s own overflow-quiet logic and `_tree_cells`' wide-table
+        counterpart both treat as the higher-priority fact) rather than
+        merely the total width bound `test_never_exceeds_the_pane_width_...`
+        above already covers."""
+        _seed("f-1", repos=[_row("ab", branch="main", dirty=True, ci="failed")])
+        # (width, marker expected, CI glyph expected) — matches this fixture
+        # measured directly: 'ab main* ✗' / 'ab m…* ✗' / 'ab m…*' / 'ab …'.
+        cases = [(10, True, True), (8, True, True), (6, True, False), (4, False, False)]
+        for width, want_marker, want_ci in cases:
+            with mock.patch("os.get_terminal_size", return_value=os.terminal_size((width, 24))), \
+                 mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+                line = tui.strip_ansi(slots.render("left", "f-1").splitlines()[0])
+            with self.subTest(width=width):
+                self.assertLessEqual(tui.width(line), width)
+                self.assertEqual("*" in line, want_marker)
+                self.assertEqual("✗" in line, want_ci)
 
     def test_a_failing_gather_read_yields_a_line_rather_than_an_exception(self):
         """A panel that raises leaves a hole in the frame — `slots.render`'s own

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -26,14 +26,15 @@ from tests._isolation import PersonaIso
 
 
 def _row(name, *, branch="main", dirty=False, tracked_dirty=False, ahead=0, behind=0,
-        ci=None, change=None, sigil="", current=False, repo=None) -> dict:
+        ci=None, change=None, sigil="", current=False, repo=None,
+        worktree_count=0) -> dict:
     """A `gather`-cache-shaped row — the exact fields `gather._entry` writes, built
     directly rather than through a real `git`/`gather.scan`: these tests pin `left`'s
     own COMPOSITION (what it does with a row already in the cache), which
     `tests/test_frame_gather.py` already covers the gather side of independently."""
     d = {"name": name, "branch": branch, "dirty": dirty, "tracked_dirty": tracked_dirty,
         "ahead": ahead, "behind": behind, "ci": ci, "change": change, "sigil": sigil,
-        "current": current}
+        "current": current, "worktree_count": worktree_count}
     if repo is not None:
         d["repo"] = repo
     return d
@@ -223,6 +224,27 @@ class LeftRenderer(PersonaIso, unittest.TestCase):
              worktrees=[_row("piece-one", repo="demo")])
         self.assertIn("piece-one", tui.strip_ansi(slots.render("left", "f-1")))
 
+    def test_a_multi_repo_workspaces_piece_count_shows_as_a_badge(self):
+        """Fix round 1, finding 2: `worktree_count` did not exist in the cache at
+        all for a multi-repo workspace before this round — `data["worktrees"]`
+        is `[]` here (as it always is with two repos; `gather._detail_worktrees`'
+        own single-repo rule), so the badge is the ONLY way either repo's pieces
+        are visible at all."""
+        _seed("f-1", repos=[_row("demo", worktree_count=3),
+                            _row("second", worktree_count=0)],
+             worktrees=[])
+        out = tui.strip_ansi(slots.render("left", "f-1"))
+        self.assertIn("⑂3", out)
+
+    def test_a_repo_whose_pieces_are_all_shown_as_rows_carries_no_badge(self):
+        """The single-repo case: every piece already has its own row
+        (`data["worktrees"]`), so the badge — "there is more you cannot see" —
+        would be actively misleading if it appeared anyway."""
+        _seed("f-1", repos=[_row("demo", worktree_count=1)],
+             worktrees=[_row("piece-one", repo="demo")])
+        out = tui.strip_ansi(slots.render("left", "f-1"))
+        self.assertNotIn("⑂", out)
+
     def test_picks_the_dirty_repo_over_clean_ones_when_over_budget(self):
         """`_pick_rows` is CALLED here, not reinvented — the same ranking
         `statusline.py`'s own regression (an unranked slice of 18 clones showed
@@ -235,6 +257,16 @@ class LeftRenderer(PersonaIso, unittest.TestCase):
         self.assertIn("zzz-dirty-one-past-the-cap",
                       tui.strip_ansi(slots.render("left", "f-1")))
 
+    def test_the_overflow_note_matches_the_wide_tables_own_wording(self):
+        """Fix round 1, finding 3: this line used to say `", clean"` where
+        `_repo_rows`' own overflow line (`statusline.py`) says `", all clean"` —
+        the same claim, worded two different ways on the two surfaces."""
+        clean = [_row(f"clean-{i}") for i in range(statusline._MAX_REPO_LINES + 1)]
+        _seed("f-1", repos=clean)
+        out = tui.strip_ansi(slots.render("left", "f-1"))
+        self.assertIn(", all clean)", out)
+        self.assertNotIn("more, clean)", out)
+
     def test_never_exceeds_the_pane_width(self):
         _seed("f-1", repos=[_row("a-repo-with-quite-a-long-descriptive-name",
                                 change=999999, ci="failed", ahead=12, behind=34)])
@@ -244,6 +276,59 @@ class LeftRenderer(PersonaIso, unittest.TestCase):
         for line in out.splitlines():
             with self.subTest(line=line):
                 self.assertLessEqual(tui.width(line), 22)
+
+    def test_never_exceeds_the_pane_width_even_when_narrower_than_the_markers(self):
+        """`_row`'s own per-field budgeting can still ask for more than a truly
+        tiny pane has (each field's floor is `max(1, ...)`, and those floors can
+        sum past `width` once the pane is narrower than the markers themselves)
+        — `_row`'s trailing `tui.truncate(line, width)` is the backstop for
+        exactly that. Confirmed load-bearing by mutation: dropping it lets a
+        5-repo-state line overflow a 3-column pane to 8 display cells."""
+        _seed("f-1", repos=[_row("abcdef", dirty=True, ahead=3, behind=2,
+                                ci="failed", change=5, sigil="!")])
+        with mock.patch("os.get_terminal_size", return_value=os.terminal_size((3, 24))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            out = slots.render("left", "f-1")
+        for line in out.splitlines():
+            with self.subTest(line=line):
+                self.assertLessEqual(tui.width(line), 3)
+
+    def test_a_realistic_long_branch_does_not_crowd_out_the_dirty_marker_or_ci_glyph(self):
+        """Fix round 1, finding 1: a single `tui.truncate` over the whole assembled
+        line cut from the right, and this project's own branches
+        (`worktree-recall-since`, `browser-session-scope`, `global-shim-refresh`:
+        21-28 characters, the norm here) are long enough that `name + " " +
+        branch` alone fills a 22-column pane before the dirty marker, the CI
+        glyph or an open change is ever reached — a FALSE CLEAN reading on a
+        dirty, CI-failing, unpushed repo. `test_a_dirty_repo_shows_the_dirty_marker`
+        and `test_a_failing_ci_status_shows_its_glyph` above use `branch="main"`
+        (no truncation pressure) and would not have caught this; this fixture
+        matches the reviewer's own repro exactly."""
+        _seed("f-1", repos=[_row("charter", branch="worktree-recall-since",
+                                dirty=True, ahead=1, ci="failed")])
+        with mock.patch("os.get_terminal_size", return_value=os.terminal_size((22, 24))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            out = tui.strip_ansi(slots.render("left", "f-1"))
+        self.assertIn("*", out, "the dirty marker must survive truncation")
+        self.assertIn("✗", out, "the CI glyph must survive truncation")
+
+    def test_a_long_branch_with_a_change_still_surfaces_marker_ci_and_change(self):
+        """The three-field version of the test above, at the ACTUAL production
+        pane width (`layout.SLOT_SIZE["left"] == 22`) — pins that reserving room
+        for CI does not itself starve a trailing open change (`_row`'s priority
+        order includes it last), the case a narrower, artificial width would
+        have to invent rather than measure."""
+        _seed("f-1", repos=[_row("charter", branch="worktree-recall-since",
+                                dirty=True, ahead=1, ci="failed",
+                                change=12, sigil="!")])
+        with mock.patch("os.get_terminal_size", return_value=os.terminal_size((22, 24))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            line = slots.render("left", "f-1").splitlines()[0]
+        out = tui.strip_ansi(line)
+        self.assertLessEqual(tui.width(line), 22)
+        self.assertIn("*", out, "the dirty marker must survive")
+        self.assertIn("✗", out, "the CI glyph must survive")
+        self.assertIn("!12", out, "the open change must survive")
 
     def test_a_cjk_heavy_repo_name_still_fits_a_narrow_pane(self):
         cjk = "測" * 30  # 30 characters, 60 display cells

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -19,10 +19,32 @@ import sys
 import unittest
 from unittest import mock
 
-from charter import config, tui
-from charter.frame import slots
+from charter import config, statusline, tui
+from charter.frame import gather, slots
 
 from tests._isolation import PersonaIso
+
+
+def _row(name, *, branch="main", dirty=False, tracked_dirty=False, ahead=0, behind=0,
+        ci=None, change=None, sigil="", current=False, repo=None) -> dict:
+    """A `gather`-cache-shaped row — the exact fields `gather._entry` writes, built
+    directly rather than through a real `git`/`gather.scan`: these tests pin `left`'s
+    own COMPOSITION (what it does with a row already in the cache), which
+    `tests/test_frame_gather.py` already covers the gather side of independently."""
+    d = {"name": name, "branch": branch, "dirty": dirty, "tracked_dirty": tracked_dirty,
+        "ahead": ahead, "behind": behind, "ci": ci, "change": change, "sigil": sigil,
+        "current": current}
+    if repo is not None:
+        d["repo"] = repo
+    return d
+
+
+def _seed(fid: str, **overrides) -> dict:
+    data = {"gathered_at": 0.0, "workspace": "w", "current_repo": None,
+           "repos": [], "worktrees": []}
+    data.update(overrides)
+    gather.save(fid, data)
+    return data
 
 
 class Render(PersonaIso, unittest.TestCase):
@@ -83,18 +105,22 @@ class Unimplemented(unittest.TestCase):
     splitting a pane that would be permanently dead under `remain-on-exit on`),
     `frame_ready` (`--probe`) and `doctor.check_frame`."""
 
-    def test_the_two_sized_but_unrendered_slots_are_named(self):
-        self.assertEqual(slots.unimplemented(["top", "left", "bottom", "right"]),
-                         ["left", "right"])
+    def test_all_four_slots_now_have_a_renderer(self):
+        """Task 3 landed `left`/`right` beside `top`/`bottom`: every slot
+        `instance.FRAME_SLOTS` accepts now has a renderer, so a fully-configured
+        frame names nothing missing."""
+        self.assertEqual(slots.unimplemented(["top", "left", "bottom", "right"]), [])
 
     def test_an_all_implemented_configuration_names_nothing(self):
         self.assertEqual(slots.unimplemented(["top", "bottom"]), [])
 
     def test_the_answer_comes_from_the_registry_not_a_hardcoded_pair(self):
-        """`left`/`right` are today's answer, not the rule. A renderer landing for one
-        of them must take it off this list without anybody remembering to edit a
-        literal — so the registry is patched and the answer must follow."""
-        with mock.patch.dict(slots.SLOTS, {"left": lambda fid: "drawn"}):
+        """`left`/`right` having renderers today is not the rule this function follows
+        — the registry is. Proved here from the other direction now that both are
+        implemented: temporarily REMOVE one from the registry and the answer must
+        follow, exactly as it would the day a real slot's renderer regresses."""
+        with mock.patch.dict(slots.SLOTS):
+            del slots.SLOTS["right"]
             self.assertEqual(slots.unimplemented(["top", "left", "right"]), ["right"])
 
 
@@ -159,6 +185,134 @@ class WideGlyphs(PersonaIso, unittest.TestCase):
                          return_value=os.terminal_size((20, 3))):
             line = slots.render("top", "f-1")
         self.assertLessEqual(tui.width(line), 20)
+
+
+class LeftRenderer(PersonaIso, unittest.TestCase):
+    """`left`: repo rows composed narrow straight from `gather`'s cache — never a
+    `git` call, never `glstate`, never `_repo_rows`' `tui.Node`s (built for a wide
+    boxed frame; `_NAME_W`=32 alone exceeds this whole pane)."""
+
+    def test_lists_a_repo_from_the_cache(self):
+        _seed("f-1", repos=[_row("demo")])
+        self.assertIn("demo", slots.render("left", "f-1"))
+
+    def test_degrades_to_a_readable_line_with_an_empty_cache(self):
+        _seed("f-1")
+        out = slots.render("left", "f-1")
+        self.assertTrue(out.strip())
+        self.assertIn("no repos", tui.strip_ansi(out))
+
+    def test_a_dirty_repo_shows_the_dirty_marker(self):
+        _seed("f-1", repos=[_row("demo", dirty=True)])
+        self.assertIn("*", tui.strip_ansi(slots.render("left", "f-1")))
+
+    def test_a_clean_repo_shows_no_dirty_marker(self):
+        _seed("f-1", repos=[_row("demo", dirty=False)])
+        self.assertNotIn("*", tui.strip_ansi(slots.render("left", "f-1")))
+
+    def test_an_open_change_shows_its_sigil_and_number(self):
+        _seed("f-1", repos=[_row("demo", change=42, sigil="!")])
+        self.assertIn("!42", tui.strip_ansi(slots.render("left", "f-1")))
+
+    def test_a_failing_ci_status_shows_its_glyph(self):
+        _seed("f-1", repos=[_row("demo", ci="failed")])
+        self.assertIn("✗", tui.strip_ansi(slots.render("left", "f-1")))
+
+    def test_a_piece_from_the_worktrees_cache_field_is_shown(self):
+        _seed("f-1", repos=[_row("demo")],
+             worktrees=[_row("piece-one", repo="demo")])
+        self.assertIn("piece-one", tui.strip_ansi(slots.render("left", "f-1")))
+
+    def test_picks_the_dirty_repo_over_clean_ones_when_over_budget(self):
+        """`_pick_rows` is CALLED here, not reinvented — the same ranking
+        `statusline.py`'s own regression (an unranked slice of 18 clones showed
+        thirteen clean repos and hid the one dirty one) was filed against. A plain
+        `dirs[:budget]` slice would keep `clean-0..clean-N` (they sort first) and
+        drop `zzz-dirty` off the end."""
+        clean = [_row(f"clean-{i}") for i in range(statusline._MAX_REPO_LINES)]
+        dirty = _row("zzz-dirty-one-past-the-cap", dirty=True)
+        _seed("f-1", repos=clean + [dirty])
+        self.assertIn("zzz-dirty-one-past-the-cap",
+                      tui.strip_ansi(slots.render("left", "f-1")))
+
+    def test_never_exceeds_the_pane_width(self):
+        _seed("f-1", repos=[_row("a-repo-with-quite-a-long-descriptive-name",
+                                change=999999, ci="failed", ahead=12, behind=34)])
+        with mock.patch("os.get_terminal_size", return_value=os.terminal_size((22, 24))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            out = slots.render("left", "f-1")
+        for line in out.splitlines():
+            with self.subTest(line=line):
+                self.assertLessEqual(tui.width(line), 22)
+
+    def test_a_cjk_heavy_repo_name_still_fits_a_narrow_pane(self):
+        cjk = "測" * 30  # 30 characters, 60 display cells
+        _seed("f-1", repos=[_row(cjk)])
+        with mock.patch("os.get_terminal_size", return_value=os.terminal_size((20, 24))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            out = slots.render("left", "f-1")
+        for line in out.splitlines():
+            self.assertLessEqual(tui.width(line), 20)
+
+    def test_a_failing_gather_read_yields_a_line_rather_than_an_exception(self):
+        """A panel that raises leaves a hole in the frame — `slots.render`'s own
+        promise, pinned here against a renderer that actually reaches into a real
+        dependency (`gather.read`) rather than the generic lambda `Render`'s own
+        `test_a_failing_renderer...` uses."""
+        with mock.patch.object(gather, "read", side_effect=RuntimeError("boom")):
+            self.assertIn("charter", slots.render("left", "f-1"))
+
+
+class RightRenderer(PersonaIso, unittest.TestCase):
+    """`right`: `statusline._persona_chips` called, not reassembled — each chip
+    already carries its own memory badge, in-flight badge and vault dot."""
+
+    def test_lists_a_persona_chip(self):
+        self.make_persona("alice")
+        self.assertIn("alice", tui.strip_ansi(slots.render("right", "f-1")))
+
+    def test_degrades_to_a_readable_line_with_no_personas(self):
+        out = slots.render("right", "f-1")
+        self.assertTrue(out.strip())
+        self.assertIn("no personas", tui.strip_ansi(out))
+
+    def test_calls_persona_chips_rather_than_reassembling_it(self):
+        """A fix to a chip (its vault dot, its memory badge, its in-flight badge)
+        must land here the moment it lands in the status line — pinned by handing
+        `_persona_chips` a value nothing in `_right` could have produced on its
+        own, and requiring it survive to the pane byte-for-byte."""
+        with mock.patch("charter.statusline._persona_chips",
+                        return_value=["SENTINEL-CHIP-0xF00D"]):
+            out = slots.render("right", "f-1")
+        self.assertIn("SENTINEL-CHIP-0xF00D", out)
+
+    def test_never_exceeds_the_pane_width(self):
+        self.make_persona("a-persona-with-quite-a-long-descriptive-name")
+        with mock.patch("os.get_terminal_size", return_value=os.terminal_size((22, 24))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            out = slots.render("right", "f-1")
+        for line in out.splitlines():
+            with self.subTest(line=line):
+                self.assertLessEqual(tui.width(line), 22)
+
+    def test_a_cjk_heavy_persona_name_still_fits_a_narrow_pane(self):
+        cjk = "測" * 30  # 30 characters, 60 display cells
+        self.make_persona(cjk)
+        with mock.patch("os.get_terminal_size", return_value=os.terminal_size((20, 24))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            out = slots.render("right", "f-1")
+        for line in out.splitlines():
+            self.assertLessEqual(tui.width(line), 20)
+
+    def test_a_failing_persona_chips_call_yields_a_line_rather_than_an_exception(self):
+        """`_right` carries no guard of its own around the call (`_persona_chips`
+        already swallows its own failures) — this pins `render`'s own outer
+        `try/except` as the thing that actually catches whatever gets past that,
+        the same generic promise `Render.test_a_failing_renderer_yields_a_line...`
+        pins for an arbitrary slot, exercised here through a real dependency."""
+        with mock.patch("charter.statusline._persona_chips",
+                        side_effect=RuntimeError("boom")):
+            self.assertIn("charter", slots.render("right", "f-1"))
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -188,6 +188,184 @@ class WideGlyphs(PersonaIso, unittest.TestCase):
         self.assertLessEqual(tui.width(line), 20)
 
 
+class TopRenderer(PersonaIso, unittest.TestCase):
+    """Task 4 (#385) investigated `top`'s "context/session when available" bullet —
+    `statusline._session_strip`/`_context_gauge` — and found neither can produce
+    anything from a panel process: both are gated at every branch on Claude Code's
+    per-turn stdin payload, which only `statusline.main` ever receives, never a
+    long-lived tmux pane command. See `slots._top`'s own docstring for the full
+    argument. These tests pin that finding as a regression rather than a one-time
+    observation: a future edit that wires either call back into `_top` "because it
+    compiles" must turn one of these red, since the call would return `[]` forever and
+    add nothing but a docstring gone stale."""
+
+    def test_the_context_gauge_is_never_called_by_top(self):
+        with mock.patch("charter.statusline._context_gauge") as gauge:
+            slots.render("top", "f-1")
+        gauge.assert_not_called()
+
+    def test_the_session_strip_is_never_called_by_top(self):
+        with mock.patch("charter.statusline._session_strip") as strip:
+            slots.render("top", "f-1")
+        strip.assert_not_called()
+
+    def test_context_gauge_confirmed_empty_with_no_payload_the_premise_top_relies_on(self):
+        """The load-bearing fact behind leaving the gauge out: with no live per-turn
+        payload — exactly what a panel process always has — `_context_gauge` produces
+        nothing, not a misleading zero. `tests/test_statusline_gauge.py` already pins
+        this generically (`test_silent_before_first_api_call`); repeated here because
+        it is the premise `_top`'s design decision rests on."""
+        self.assertEqual(statusline._context_gauge(None), [])
+        self.assertEqual(statusline._context_gauge({}), [])
+
+
+class BottomRenderer(PersonaIso, unittest.TestCase):
+    """`bottom` composes a fourth field now — `statusline._session_news` — alongside
+    the todo count, the top alert, and the hotkey hint already there. See
+    `slots._bottom`'s own docstring for the priority-drop design and why a single
+    trailing `tui.truncate` over the whole joined line is not enough by itself."""
+
+    def test_session_news_appears_alongside_the_alerts(self):
+        with mock.patch("charter.statusline._session_news", return_value=["⛊ 1 denied"]), \
+             mock.patch("charter.statusline._alerts", return_value=["⚠ something"]):
+            out = tui.strip_ansi(slots.render("bottom", "f-1"))
+        self.assertIn("⛊ 1 denied", out)
+        self.assertIn("⚠ something", out)
+
+    def test_session_news_uses_this_panels_own_session_id(self):
+        """A panel has no per-turn payload to hand `_session_news` a session id — the
+        identical point `_top`'s docstring makes about the gauge. `session.current()`
+        supplies it, the same fallback `_right` already trusts for `_persona_chips`.
+        Pinned with a sentinel id nothing in `_bottom` could have produced on its own,
+        and requiring it actually reach the call."""
+        with mock.patch("charter.session.current", return_value="SID-SENTINEL-0xF00D"), \
+             mock.patch("charter.statusline._session_news", return_value=[]) as news:
+            slots.render("bottom", "f-1")
+        news.assert_called_once_with("SID-SENTINEL-0xF00D")
+
+    def test_never_exceeds_the_pane_width(self):
+        with mock.patch("charter.statusline._session_news",
+                        return_value=["⛊ 1 denied", "⚡ 2"]), \
+             mock.patch("charter.statusline._alerts",
+                        return_value=["⚠ reinit: charter ws reinit needed right now"]), \
+             mock.patch("charter.statusline._todo_count", return_value=7), \
+             mock.patch("os.get_terminal_size", return_value=os.terminal_size((22, 3))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            out = slots.render("bottom", "f-1")
+        for line in out.splitlines():
+            self.assertLessEqual(tui.width(line), 22)
+
+    def test_a_starved_pane_drops_the_hotkey_and_todo_before_the_alert_or_news(self):
+        """Sweeps a few widths against the same four fields, matching
+        `LeftRenderer.test_a_starved_pane_drops_lowest_priority_fields_first`'s style:
+        the alert survives everywhere it is asked to, and the hotkey — the one thing
+        always rediscoverable another way — is first to give up its columns."""
+        with mock.patch("charter.statusline._alerts", return_value=["AAAAA"]), \
+             mock.patch("charter.statusline._session_news", return_value=["NNNNN"]), \
+             mock.patch("charter.statusline._todo_count", return_value=3), \
+             mock.patch.dict(config.FRAME, {"hotkey": "F2"}):
+            for w, want_alert, want_news, want_todo, want_hotkey in (
+                (80, True, True, True, True),
+                (10, True, False, False, False),
+                (20, True, True, False, False),
+            ):
+                with mock.patch("os.get_terminal_size",
+                                return_value=os.terminal_size((w, 3))), \
+                     mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+                    out = tui.strip_ansi(slots.render("bottom", "f-1"))
+                with self.subTest(width=w):
+                    self.assertLessEqual(tui.width(out), w)
+                    self.assertEqual("AAAAA" in out, want_alert)
+                    self.assertEqual("NNNNN" in out, want_news)
+                    self.assertEqual("3 todos" in out, want_todo)
+                    self.assertEqual("F2 menu" in out, want_hotkey)
+
+    def test_a_failing_session_news_call_yields_a_line_rather_than_an_exception(self):
+        with mock.patch("charter.statusline._session_news",
+                        side_effect=RuntimeError("boom")):
+            self.assertIn("charter", slots.render("bottom", "f-1"))
+
+    def test_empty_fields_leave_no_stray_separator(self):
+        """No alerts, no session news — `_fit_fields` must SKIP an empty field rather
+        than keep it and let ` · `.join emit a blank slot between separators
+        (`"5 todos ·  · F2 menu"`, say). Asserts the exact string rather than just
+        `in`/`not in`, so a stray separator cannot hide inside a substring match."""
+        with mock.patch("charter.statusline._alerts", return_value=[]), \
+             mock.patch("charter.statusline._session_news", return_value=[]), \
+             mock.patch("charter.statusline._todo_count", return_value=5), \
+             mock.patch.dict(config.FRAME, {"hotkey": "F2"}):
+            out = tui.strip_ansi(slots.render("bottom", "f-1"))
+        self.assertEqual(out, "5 todos · F2 menu")
+
+    def test_the_todo_count_still_shows_at_zero_unlike_the_new_news_field(self):
+        """`todo` predates Task 4 and keeps its own, different presence rule: `_bottom`
+        showed `0 todo` even at zero before this task touched the function, unlike
+        `_session_news`'s "silent unless something happened" discipline — Task 4 must
+        not quietly fold the two together. Caught for real during this task: an earlier
+        draft gated `todo_text` on `if todos`, which passed every test in this file (all
+        of them mock a non-zero todo count) and only broke three tests in OTHER files
+        (`test_frame_panel.py`, `test_frame_tmux_integration.py`) that render `bottom`
+        against a real, empty environment where the todo count is genuinely 0."""
+        with mock.patch("charter.statusline._todo_count", return_value=0):
+            out = tui.strip_ansi(slots.render("bottom", "f-1"))
+        self.assertIn("0 todo", out)
+
+    def test_a_failing_session_current_call_yields_a_line_rather_than_an_exception(self):
+        with mock.patch("charter.session.current", side_effect=RuntimeError("boom")):
+            self.assertIn("charter", slots.render("bottom", "f-1"))
+
+    def test_never_exceeds_the_pane_width_even_narrower_than_a_single_field(self):
+        """`_fit_fields` always force-keeps the first non-empty field so the row is
+        never blank on its own account (mirrors `_row`'s `max(1, ...)` branch floor) —
+        which means the trailing `tui.truncate` at the call site, not the budgeting
+        loop, is what actually protects a pane narrower than that one field. Mirrors
+        `LeftRenderer.test_never_exceeds_the_pane_width_even_when_narrower_than_the_markers`."""
+        with mock.patch("charter.statusline._alerts",
+                        return_value=["a very long alert that will not fit at all"]), \
+             mock.patch("charter.statusline._session_news", return_value=[]), \
+             mock.patch("charter.statusline._todo_count", return_value=0), \
+             mock.patch("os.get_terminal_size", return_value=os.terminal_size((3, 3))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            out = slots.render("bottom", "f-1")
+        self.assertLessEqual(tui.width(out), 3)
+
+
+class FitFields(unittest.TestCase):
+    """`slots._fit_fields` in isolation, free of `_bottom`'s other, always-present
+    fields (todo, hotkey) — so a test can construct the exact width pressure it wants
+    without those competing for the same budget."""
+
+    def test_the_first_field_is_kept_even_when_it_alone_exceeds_the_width(self):
+        self.assertEqual(slots._fit_fields([("a", "AAAAAAAAAA")], 3), {"a"})
+
+    def test_a_later_field_is_dropped_whole_once_the_budget_runs_out(self):
+        self.assertEqual(
+            slots._fit_fields([("a", "AAA"), ("b", "BBBBBBBBBB")], 6), {"a"})
+
+    def test_measures_in_display_cells_not_characters(self):
+        """`"測"` is one character but TWO display cells. Sized so a `len()`-based
+        mistake (which would compute 1, leaving 4 of the 5-wide budget spare after
+        `"A"`) says there is room for it, while the real width-based measurement
+        (2, against a `budget - sep` of only... the arithmetic is spelled out in the
+        comment below) correctly says there is not. Unlike `_row`, nothing here ever
+        slices a field's TEXT, so a trailing safety-net truncate can never paper over
+        this mistake the way it did for the predecessor's CJK repo-name test — this
+        asserts on `_fit_fields`'s own return value, before any string is even
+        assembled.
+
+        budget=5: `"A"` costs 1 -> 4 left. `"測"` needs `width("測")=2 + sep(3) = 5`
+        against that `4` -> doesn't fit, correctly dropped. A `len()`-based version
+        would compute `len("測")=1 + 3 = 4`, which DOES fit against `4` -> wrongly
+        kept.
+        """
+        self.assertEqual(slots._fit_fields([("alert", "A"), ("news", "測")], 5),
+                         {"alert"})
+        # One column more and the real (width-based) arithmetic agrees it fits too —
+        # confirms this is a boundary case, not `_fit_fields` refusing CJK outright.
+        self.assertEqual(slots._fit_fields([("alert", "A"), ("news", "測")], 6),
+                         {"alert", "news"})
+
+
 class LeftRenderer(PersonaIso, unittest.TestCase):
     """`left`: repo rows composed narrow straight from `gather`'s cache — never a
     `git` call, never `glstate`, never `_repo_rows`' `tui.Node`s (built for a wide

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -687,13 +687,31 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.addCleanup(_tmux, "kill-server")
-        self.addCleanup(lambda: (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET)
-                        .unlink(missing_ok=True))
+        # kill-server THEN unlink, never two separately-registered `addCleanup`
+        # calls in that order — `addCleanup` runs LIFO, so `addCleanup(kill-server)`
+        # followed by `addCleanup(unlink)` actually runs unlink FIRST — see
+        # `_teardown_socket`'s own docstring below for why that is backwards and
+        # when it stops being harmless.
+        self.addCleanup(self._teardown_socket)
         (self.tmp / "charter.toml").write_text("")
         self.env = dict(os.environ, CHARTER_ROOT=str(self.tmp), CHARTER_WORKSPACE="demo")
         self.env.pop("CHARTER_HOME", None)  # let it derive under CHARTER_ROOT, like this
                                             # process's own PersonaIso-isolated config
+
+    def _teardown_socket(self) -> None:
+        """Kill this class's own tmux server, THEN unlink its socket file — see
+        `TmuxIntegration._teardown_socket` for why the file survives `kill-server`
+        on its own. Order matters here specifically, not just tidily: two separate
+        `addCleanup` calls (`kill-server`, then `unlink`) run LIFO — unlink FIRST,
+        kill-server SECOND — which reconnects to nothing once the socket's own
+        directory entry is already gone. Harmless for THIS class today (its
+        sessions never arm `remain-on-exit`, so `_kill_pid` on each pane's own
+        process already ends the session, then the server, on tmux's own
+        `exit-empty` default before `kill-server` is ever asked to do anything) —
+        fixed anyway so this class cannot silently start leaking the day it, or a
+        test added to it, ever does."""
+        _tmux("kill-server")
+        (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET).unlink(missing_ok=True)
 
     def _spawn_panel(self, session: str, fid: str) -> None:
         """One `charter panel bottom --session <fid>` pane, in a fresh session named
@@ -851,12 +869,19 @@ class MenuIntegration(PersonaIso, unittest.TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.addCleanup(_tmux, "kill-server")
-        self.addCleanup(lambda: (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET)
-                        .unlink(missing_ok=True))
+        # kill-server THEN unlink — see `PanelIntegration._teardown_socket`'s own
+        # docstring for why two separately-registered `addCleanup` calls in that
+        # order run backwards (`addCleanup` is LIFO).
+        self.addCleanup(self._teardown_socket)
         (self.tmp / "charter.toml").write_text("")
         self.env = dict(os.environ, CHARTER_ROOT=str(self.tmp), CHARTER_WORKSPACE="demo")
         self.env.pop("CHARTER_HOME", None)
+
+    def _teardown_socket(self) -> None:
+        """Kill this class's own tmux server, THEN unlink its socket file — see
+        `PanelIntegration._teardown_socket` for the full reasoning, identical here."""
+        _tmux("kill-server")
+        (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET).unlink(missing_ok=True)
 
     def test_a_hostile_label_never_reaches_what_the_resolved_action_runs(self):
         fid = state.frame_id("menu-integ", os.getpid())
@@ -930,9 +955,16 @@ class MenuFormatIntegration(_NeedsAttachedClient, unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self.addCleanup(_tmux, "kill-server")
-        self.addCleanup(lambda: (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET)
-                        .unlink(missing_ok=True))
+        # kill-server THEN unlink — see `PanelIntegration._teardown_socket`'s own
+        # docstring for why two separately-registered `addCleanup` calls in that
+        # order run backwards (`addCleanup` is LIFO).
+        self.addCleanup(self._teardown_socket)
+
+    def _teardown_socket(self) -> None:
+        """Kill this class's own tmux server, THEN unlink its socket file — see
+        `PanelIntegration._teardown_socket` for the full reasoning, identical here."""
+        _tmux("kill-server")
+        (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET).unlink(missing_ok=True)
 
     def _new_session(self, fid: str) -> None:
         """A fresh `cat`-backed session named *fid*, with its pane's OWN pid registered
@@ -1123,9 +1155,35 @@ class MenuClientIntegration(_NeedsAttachedClient, unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self.addCleanup(_tmux, "kill-server")
-        self.addCleanup(lambda: (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET)
-                        .unlink(missing_ok=True))
+        # kill-server THEN unlink — see `_teardown_socket`'s own docstring below:
+        # THIS class, unlike its siblings above, is not merely defending against a
+        # hypothetical here.
+        self.addCleanup(self._teardown_socket)
+
+    def _teardown_socket(self) -> None:
+        """Kill this class's own tmux server, THEN unlink its socket file.
+
+        Two separately-registered `addCleanup` calls (`kill-server`, then `unlink`)
+        run LIFO — unlink FIRST, kill-server SECOND — and a `kill-server` issued
+        after the socket's own directory entry is already gone cannot reconnect to
+        the still-live server at all (see `FourEdgeIntegration.setUp`'s own
+        docstring for the measured leak this produces). That reversed order is
+        harmless for `PanelIntegration`/`MenuIntegration`/`MenuFormatIntegration`
+        above only because none of THEIR sessions arm `remain-on-exit`. **This
+        class is the one exception, and arms it globally, not incidentally**:
+        `_install_real_bind` below sources `commands_frame.conf_text(...)` for
+        real, which emits `set -g remain-on-exit on` (`commands_frame.py`) —
+        server-wide, not scoped to one session. It survives today with the two-call
+        ordering bug anyway (confirmed by removing only `_new_session`'s own
+        `addCleanup(_kill_pid, server_pid)`, which alone still leaves a PPID-1
+        orphan) because `_new_session` ALSO SIGKILLs the server's own process
+        directly by pid — a second, independent teardown path that has nothing to
+        do with `kill-server` succeeding or failing. This fix removes the
+        dependency on that second path rather than continuing to rely on it being
+        present on every test added to this class in the future.
+        """
+        _tmux("kill-server")
+        (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET).unlink(missing_ok=True)
 
     def _charter_py_env(self) -> dict:
         """The environment this class's tmux server starts with: an INTERPRETER shim
@@ -1354,6 +1412,18 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
     a panel showing "no repos" would be ALIVE and would tell you nothing about
     whether any of that chain actually works (see this module's own task brief).
 
+    **Fix round 1 closed three links this proof left unproven, all the same shape
+    (green even with the actual mechanism disabled):** a real, uncommitted file in
+    the fixture repo (mutation testing found `left`'s row shows a clean repo as
+    clean whether or not `gather.scan`'s own `_repo_states` sweep — the real `git
+    status --porcelain --branch` half — ever ran at all, since name/branch alone
+    come from `_repo_trees`/`_branch`, neither of which touches it); a direct read
+    of the cache FILE (`gather._cache_file`), not only the pane's own text, both
+    right after priming and right after the real hook fires (mutation testing
+    found `gather.save` could be neutered outright and every content assertion
+    still passed, because `gather.read`'s own missing-cache fallback recomputes a
+    live scan whenever there is nothing to read).
+
     The repaint proof mutates the repo's BRANCH, not its dirty bit, deliberately:
     `gather.py`'s `_branch` reads `.git/HEAD` straight, with no cache of its own,
     while dirty/ahead/behind ride `statusline._repo_states`' 5-second TTL
@@ -1361,39 +1431,50 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
     two gathers taken seconds apart — a dirty-bit mutation immediately after the
     frame's first (TTL-warming) gather would be flaky against the very caching
     behaviour this plan depends on, for a reason that has nothing to do with
-    whether the repaint actually worked. A branch switch has no such cache to race.
+    whether the repaint actually worked. A branch switch has no such cache to race
+    — which is exactly why the ALIVE test above needs its OWN, separate dirty file
+    (created before the frame ever launches, so no TTL race is possible) to prove
+    the `_repo_states` half at all.
+
+    **Capability, not presence — this module's own opening promise, checked for
+    this class specifically.** Every tmux primitive `_spawn_frame`/the tests above
+    use — `new-session -x/-y -P -F`, `split-window -t <pane-id> -l N`,
+    `select-pane`, `#{pane_dead}`/`#{pane_active}`/`#{pane_pid}`,
+    `capture-pane -p`, `set -g remain-on-exit` — predates charter's own declared
+    floor (`tmuxctl.FLOOR`, tmux 3.2), which CI's tmux 3.4 already clears; none of
+    it is gated behind a version this class would need to probe. Unlike
+    `MenuFormatIntegration`/`MenuClientIntegration` above, nothing here attaches a
+    real client (`display-menu`'s "no current client" refusal, and `TERM=dumb`'s
+    inability to give it one, are why those two classes need
+    `_NeedsAttachedClient` at all) — `capture-pane`/`display-message` read a
+    pane's state and content directly, needing no client attached to it, so
+    `TERM=dumb`'s specific failure mode (a pty-attached CLIENT that cannot
+    register) never applies to this class. Confirmed directly, not merely
+    inferred: this whole module, `FourEdgeIntegration` included, passes 17/17
+    under `TERM=dumb` with nothing skipped. `_HAS_TMUX` (presence) is therefore
+    the right and only gate for this class — no narrower capability probe is
+    missing here the way one was for the classes this module's own opening
+    docstring describes.
     """
 
     def setUp(self) -> None:
         super().setUp()
-        # ONE combined cleanup, kill-server THEN unlink — never two separate
-        # `addCleanup` calls in that order, which is what `PanelIntegration`/
-        # `MenuIntegration`/`MenuFormatIntegration`/`MenuClientIntegration` above
-        # each do. `addCleanup` runs LIFO (confirmed by hand: two cleanups
-        # registered `kill-server` then `unlink` run `unlink` FIRST, `kill-server`
-        # SECOND — backwards), which is harmless for every one of those classes
-        # because none of them arms `remain-on-exit`: their sessions hold exactly
-        # one long-lived pane process, `_kill_pid` SIGKILLs it directly, and with
-        # `remain-on-exit` at tmux's own default (off) that ends the pane, which
-        # ends the session, which ends the server on its own (`exit-empty`'s
-        # default) — `kill-server` there is only ever a no-op confirming a death
-        # that already happened. This class is different: `_spawn_frame` writes
-        # `commands_frame._PLACEHOLDER_CONF` (`remain-on-exit on`) into its `-f`
-        # config, the same placeholder `cmd_launch` itself loads, specifically so a
-        # panel that crashes leaves an inspectable pane rather than vanishing. With
-        # `remain-on-exit` ON, killing every pane's own process (`_kill_pid`, in
-        # `_spawn_frame`) does NOT end the session — only an explicit
-        # `kill-session`/`kill-server` does. Reversed order was measured to leak: a
-        # `kill-server` call issued AFTER the socket's own directory entry is
-        # already unlinked cannot reconnect to the still-running server at all (a
-        # UNIX socket path removed from the filesystem cannot be dialled again,
-        # even though the process holding the listening end is still very much
-        # alive), so the server — with its `sleep 600` harness pane and four dead
-        # `charter panel` panes, `remain-on-exit` keeping all of them around —
-        # never exits and outlives the test process. `TmuxIntegration.
-        # _teardown_socket` above already gets this order right, in one function;
-        # this repeats that shape rather than the two-call one every other class
-        # in this file happens to get away with.
+        # ONE combined cleanup, kill-server THEN unlink — never two separately
+        # registered `addCleanup` calls in that order (`addCleanup` runs LIFO, so
+        # that shape runs unlink FIRST, kill-server SECOND — backwards). Every
+        # class in this module now uses this same combined shape (see
+        # `MenuClientIntegration._teardown_socket` for the measured leak the
+        # reversed order produces once a session's `remain-on-exit` is armed,
+        # which is this class's own situation too: `_spawn_frame` writes
+        # `commands_frame._PLACEHOLDER_CONF` — `set -g remain-on-exit on` — into
+        # its `-f` config, the same placeholder `cmd_launch` itself loads, so a
+        # crashed panel leaves an inspectable pane rather than vanishing. With it
+        # on, killing every pane's own process (`_kill_pid`, in `_spawn_frame`)
+        # does NOT end the session; only an explicit `kill-session`/`kill-server`
+        # does, and unlike `MenuClientIntegration` this class has no second,
+        # independent teardown path (a directly-SIGKILLed server pid) to fall
+        # back on if the ordering is wrong — getting it right here is the only
+        # thing standing between a `sleep 600` harness pane and an orphan).
         self.addCleanup(self._teardown_socket)
         (self.tmp / "charter.toml").write_text("")
         self.env = dict(os.environ, CHARTER_ROOT=str(self.tmp), CHARTER_WORKSPACE="demo")
@@ -1401,6 +1482,8 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
                                             # this process's own PersonaIso-isolated config
 
     def _teardown_socket(self) -> None:
+        """Kill this class's own tmux server, THEN unlink its socket file — see
+        `setUp`'s own comment for why the order is load-bearing here specifically."""
         _tmux("kill-server")
         (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET).unlink(missing_ok=True)
 
@@ -1430,6 +1513,32 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
 
     def _alive(self, pane: str) -> str:
         return _tmux("display-message", "-p", "-t", pane, "#{pane_dead}").stdout.strip()
+
+    def _wait_for(self, pane: str, needle: str, timeout: float = 5.0) -> str:
+        """Poll `capture-pane` for *pane* until *needle* appears or *timeout*
+        elapses, returning whatever was last captured either way.
+
+        Fix round 1: a fixed `time.sleep(1.5)` used to stand where this is called
+        from — a guess about how long a cold `charter` import plus a full
+        `gather.scan` (subprocess git calls included) takes on THIS machine,
+        wrong in both directions: measured content landing in ~0.08s on a normal
+        run (so the sleep was mostly wasted time, four such waits per test in the
+        heaviest class in this module), and a hard, unrecoverable failure on any
+        runner slow enough to still be starting up at 1.5s — exactly the
+        "polling makes a slow machine slow rather than wrong" property
+        `_await_file` above already established for this file's other classes,
+        applied here to a first paint rather than a repaint. Content, not mere
+        pane existence: a pane can be alive and blank (or alive and still on its
+        LAST paint) well before it has the real content a caller wants to assert
+        on, so this waits for the actual needle, not a fixed delay standing in
+        for "probably done by now".
+        """
+        deadline = time.monotonic() + timeout
+        content = self._capture(pane)
+        while time.monotonic() < deadline and needle not in content:
+            time.sleep(0.1)
+            content = self._capture(pane)
+        return content
 
     def _spawn_frame(self, fid: str) -> tuple[str, dict[str, str]]:
         """Launch a real four-slot frame: `layout.session_argv` for the harness pane,
@@ -1487,11 +1596,25 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         real content a broken renderer (or an empty, never-gathered cache) could
         not have produced, and the harness pane — not the last panel
         `split-window` happened to draw — holds keyboard focus once the launch
-        finishes."""
+        finishes.
+
+        **Fix round 1: the repo is made DIRTY before the frame ever launches, not
+        left pristine.** `_init_repo`'s own repo has nothing uncommitted, so
+        without this, `left`'s row shows no marker regardless of whether
+        `gather.scan`'s `_repo_states` half (a real `git status --porcelain
+        --branch` subprocess) ran at all — a mutation that replaced that whole
+        sweep with `{}` left every assertion in this test green, because
+        everything asserted before this fix (repo name, branch) comes from
+        `_repo_trees`/`_branch` alone, neither of which touches `_repo_states`.
+        The `*` dirty marker asserted below is the one thing in this test that
+        can only come from that sweep actually running and actually landing in
+        the cache `left` reads back.
+        """
         repo_name = f"cnry{os.getpid() % 10000}"
         branch = f"br{os.getpid() % 10000}a"
         repo = config.WORKSPACES_DIR / "demo" / repo_name
         _init_repo(repo, branch)
+        (repo / "scratch.txt").write_text("uncommitted\n")
         todos.add("demo", "a todo the bottom panel should count")
         persona_name = self.make_persona(f"p{os.getpid() % 100}")
 
@@ -1499,7 +1622,17 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         harness_pane, panes = self._spawn_frame(fid)
         self.assertEqual(set(panes), {"top", "bottom", "left", "right"})
 
-        time.sleep(1.5)
+        # Poll for real content (`_wait_for`'s own docstring — fix round 1:
+        # replaces a fixed `time.sleep(1.5)` that guessed at how long four cold
+        # `charter` imports plus four `gather.scan` git sweeps take). This also
+        # does the flat sleep's OTHER job — giving a genuine startup crash time
+        # to register — for free: a dead pane never satisfies its needle, so
+        # `_wait_for` spends its own timeout before falling through to the alive
+        # check below, same as a deliberate wait would have.
+        top = self._wait_for(panes["top"], "demo")
+        left = self._wait_for(panes["left"], repo_name)
+        right = self._wait_for(panes["right"], persona_name)
+        bottom = self._wait_for(panes["bottom"], "1 todo")
 
         for slot, pane in panes.items():
             self.assertEqual(self._alive(pane), "0",
@@ -1508,18 +1641,19 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
                              f"green-suite gap `PanelIntegration`'s own docstring "
                              f"names, now for all four slots at once)")
 
-        top = self._capture(panes["top"])
         self.assertIn("demo", top, f"top never showed the real workspace name:\n{top!r}")
 
-        left = self._capture(panes["left"])
         self.assertIn(repo_name, left, f"left never showed the real repo:\n{left!r}")
         self.assertIn(branch, left, f"left never showed the real branch:\n{left!r}")
+        self.assertIn("*", left,
+                      f"left never showed the dirty marker for a real uncommitted "
+                      f"file — either gather.scan's own git-status sweep never "
+                      f"ran, or nothing carried its result into the cached "
+                      f"row:\n{left!r}")
 
-        right = self._capture(panes["right"])
         self.assertIn(persona_name, right,
                       f"right never showed the real persona:\n{right!r}")
 
-        bottom = self._capture(panes["bottom"])
         self.assertIn("1 todo", bottom,
                       f"bottom never showed the real todo count:\n{bottom!r}")
 
@@ -1580,9 +1714,23 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         # session's own environment the way every panel below does.
         gather.refresh(fid, workspace="demo")
 
-        time.sleep(1.5)
-        left_before = self._capture(panes["left"])
-        bottom_before = self._capture(panes["bottom"])
+        # Fix round 1: prove the CACHE FILE itself exists and holds *branch_a* —
+        # not only that `left` shows the right text, which `gather.read`'s own
+        # missing-cache fallback (a fresh, live scan) can produce with `gather.
+        # save` neutered outright and no cache ever written at all. This is the
+        # direct check that `gather.refresh` did the WRITE half of its job, not
+        # only the read a panel happens to see regardless.
+        cache = gather._cache_file(fid, create=False)
+        self.assertTrue(cache is not None and cache.exists(),
+                        "gather.refresh's own save() never produced a cache file "
+                        "for this frame — priming succeeded at reading but not "
+                        "at writing")
+        self.assertIn(branch_a, cache.read_text(),
+                      f"the primed cache file exists but does not hold the "
+                      f"starting branch:\n{cache.read_text()!r}")
+
+        left_before = self._wait_for(panes["left"], branch_a)
+        bottom_before = self._wait_for(panes["bottom"], "1 todo")
         self.assertIn(branch_a, left_before,
                       f"left never showed the starting branch:\n{left_before!r}")
         self.assertIn("1 todo", bottom_before,
@@ -1620,18 +1768,12 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
             })
         self.assertIsNone(out, "posttooluse should emit nothing for a plain Read")
 
-        def _wait_for_change(pane: str, before: str) -> str:
-            deadline = time.monotonic() + 3
-            after = before
-            while time.monotonic() < deadline:
-                after = self._capture(pane)
-                if after != before:
-                    return after
-                time.sleep(0.2)
-            return after
-
-        left_after = _wait_for_change(panes["left"], left_before)
-        bottom_after = _wait_for_change(panes["bottom"], bottom_before)
+        # `self._wait_for` — the SAME poll `_wait_for` already uses for the FIRST
+        # paint (fix round 1) — waits for the specific new fact each panel is
+        # expected to show, rather than a fixed sleep or an undifferentiated
+        # "content changed" check.
+        left_after = self._wait_for(panes["left"], branch_b)
+        bottom_after = self._wait_for(panes["bottom"], "2 todos")
 
         self.assertNotEqual(left_after, left_before,
                             f"left never repainted after a real hooks.posttooluse() "
@@ -1641,6 +1783,16 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         self.assertNotIn(branch_a, left_after,
                          f"left kept showing the OLD branch after the switch — a "
                          f"stale cache surviving its own refresh:\n{left_after!r}")
+
+        # Fix round 1: the cache FILE on disk, not only the pane's own capture,
+        # now holds the new branch — proving the hook's `gather.refresh` call did
+        # the WRITE `notify.plane_changed` is supposed to perform, the same
+        # direct check made against `branch_a` above, repeated here against the
+        # value only a SECOND, successful refresh could have produced.
+        self.assertIn(branch_b, cache.read_text(),
+                      f"left repainted (or the panel's own live fallback masked "
+                      f"a broken refresh) but the cache file itself was never "
+                      f"updated with the new branch:\n{cache.read_text()!r}")
 
         self.assertNotEqual(bottom_after, bottom_before,
                             f"bottom never repainted after the same real hook call; "

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -53,8 +53,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from charter import commands_frame, hooks, instance, todos
-from charter.frame import menu, notify, state
+from charter import commands_frame, config, hooks, instance, todos
+from charter.frame import gather, layout, menu, notify, state
 
 from tests._isolation import PersonaIso, run_hook
 
@@ -1286,6 +1286,371 @@ class MenuClientIntegration(_NeedsAttachedClient, unittest.TestCase):
             time.sleep(0.2)
         self.assertTrue(os.path.exists(canary_b),
                         "B's own hotkey press must open B's own, selectable menu")
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+
+def _init_repo(path: Path, branch: str) -> Path:
+    """A real git repo with one commit, on *branch* — the same fixture shape
+    `tests/test_frame_gather.py`'s own `_init_repo` uses, duplicated here (rather
+    than imported across test modules) so this module stays as self-contained as
+    every other fixture in it already is. `FourEdgeIntegration` below is the only
+    caller: it needs a repo a real `charter panel left --session <fid>` subprocess
+    can gather for itself, through `gather.scan`, exactly the way an operator's own
+    clone would be gathered."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", branch, str(path)],
+                   check=True, capture_output=True)
+    _git(path, "config", "user.email", "t@example.com")
+    _git(path, "config", "user.name", "t")
+    _git(path, "config", "gc.auto", "0")
+    _git(path, "config", "maintenance.auto", "false")
+    (path / "README.md").write_text("hello\n")
+    _git(path, "add", "README.md")
+    _git(path, "-c", "commit.gpgsign=false", "commit", "-qm", "init")
+    return path
+
+
+@unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
+class FourEdgeIntegration(PersonaIso, unittest.TestCase):
+    """Task 5 (#385), the closing proof for this whole plan: a frame configured with
+    ALL FOUR slots comes up with all four panes alive and drawing REAL content, and
+    repaints after a real `state.bump`. Tasks 1-4 were each unit-tested — a mocked
+    `scan()`, an in-process cache read, a renderer called directly against a fixed
+    `width`. Nothing before this class has ever run `gather.scan`,
+    `notify.plane_changed`, `slots.render` and a real tmux pane together, in the
+    same process tree, against a real git repo — this is the one place the whole
+    composition (gather -> cache -> hook -> panel -> renderer -> a pane an operator
+    can actually read) is proven at once.
+
+    `PanelIntegration` above already proves ONE panel end to end (`bottom`, driven
+    by a direct `charter panel bottom --session <fid>` new-session). This class
+    proves the COMPOSITION `layout.panel_argvs` exists for instead: four real
+    splits off the SAME harness pane id, in the same launch — the exact multi-split
+    scenario `layout.py`'s own module docstring names as the index-churn hazard
+    pane ids were built to close (tmux renumbers pane INDICES on every split;
+    `PanelIntegration` only ever creates one pane total, so it can never exercise a
+    second or third split landing on the wrong rectangle). `_spawn_frame` below
+    calls `layout.session_argv` then `layout.panel_argvs` — the same two real,
+    production argv-building functions `commands_frame.cmd_launch` calls, run here
+    without the parts of `cmd_launch` this task is not about (the hotkey menu, the
+    exit-code hooks) — those are already proven end to end by `TmuxIntegration`/
+    `MenuIntegration`/`MenuFormatIntegration`/`MenuClientIntegration` above, and
+    duplicating them here would only be a second, weaker copy.
+
+    **Only `left` is asserted through content that could only have come from the
+    cache Tasks 1/2 built.** `top` (workspace/persona/version), `right` (persona
+    chips) and `bottom` (todo count/alerts) all read live at render time —
+    `slots.py`'s own docstrings for `_top`/`_right`/`_bottom` each say so — real
+    subprocess, real data, but none of it through `gather.py`'s cache. `left` is
+    the one slot `slots._left` reads EXCLUSIVELY from `gather.read(fid)` (see that
+    function's own docstring: "never a repo directory listing, a `git status`, or a
+    `glstate.read_for` of its own"), so a real repo's real branch name showing up
+    in a captured `left` pane is the one assertion in this whole file that proves
+    the actual thing this plan is for: a real `git` sweep, gathered ONCE, cached to
+    disk by a hook, and read back by a panel process that never itself calls git —
+    a panel showing "no repos" would be ALIVE and would tell you nothing about
+    whether any of that chain actually works (see this module's own task brief).
+
+    The repaint proof mutates the repo's BRANCH, not its dirty bit, deliberately:
+    `gather.py`'s `_branch` reads `.git/HEAD` straight, with no cache of its own,
+    while dirty/ahead/behind ride `statusline._repo_states`' 5-second TTL
+    (`_STATE_TTL`), keyed by directory path and blind to a file appearing between
+    two gathers taken seconds apart — a dirty-bit mutation immediately after the
+    frame's first (TTL-warming) gather would be flaky against the very caching
+    behaviour this plan depends on, for a reason that has nothing to do with
+    whether the repaint actually worked. A branch switch has no such cache to race.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # ONE combined cleanup, kill-server THEN unlink — never two separate
+        # `addCleanup` calls in that order, which is what `PanelIntegration`/
+        # `MenuIntegration`/`MenuFormatIntegration`/`MenuClientIntegration` above
+        # each do. `addCleanup` runs LIFO (confirmed by hand: two cleanups
+        # registered `kill-server` then `unlink` run `unlink` FIRST, `kill-server`
+        # SECOND — backwards), which is harmless for every one of those classes
+        # because none of them arms `remain-on-exit`: their sessions hold exactly
+        # one long-lived pane process, `_kill_pid` SIGKILLs it directly, and with
+        # `remain-on-exit` at tmux's own default (off) that ends the pane, which
+        # ends the session, which ends the server on its own (`exit-empty`'s
+        # default) — `kill-server` there is only ever a no-op confirming a death
+        # that already happened. This class is different: `_spawn_frame` writes
+        # `commands_frame._PLACEHOLDER_CONF` (`remain-on-exit on`) into its `-f`
+        # config, the same placeholder `cmd_launch` itself loads, specifically so a
+        # panel that crashes leaves an inspectable pane rather than vanishing. With
+        # `remain-on-exit` ON, killing every pane's own process (`_kill_pid`, in
+        # `_spawn_frame`) does NOT end the session — only an explicit
+        # `kill-session`/`kill-server` does. Reversed order was measured to leak: a
+        # `kill-server` call issued AFTER the socket's own directory entry is
+        # already unlinked cannot reconnect to the still-running server at all (a
+        # UNIX socket path removed from the filesystem cannot be dialled again,
+        # even though the process holding the listening end is still very much
+        # alive), so the server — with its `sleep 600` harness pane and four dead
+        # `charter panel` panes, `remain-on-exit` keeping all of them around —
+        # never exits and outlives the test process. `TmuxIntegration.
+        # _teardown_socket` above already gets this order right, in one function;
+        # this repeats that shape rather than the two-call one every other class
+        # in this file happens to get away with.
+        self.addCleanup(self._teardown_socket)
+        (self.tmp / "charter.toml").write_text("")
+        self.env = dict(os.environ, CHARTER_ROOT=str(self.tmp), CHARTER_WORKSPACE="demo")
+        self.env.pop("CHARTER_HOME", None)  # derive STATE_DIR under CHARTER_ROOT, like
+                                            # this process's own PersonaIso-isolated config
+
+    def _teardown_socket(self) -> None:
+        _tmux("kill-server")
+        (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET).unlink(missing_ok=True)
+
+    def _run_env(self, cmd: list[str]) -> subprocess.CompletedProcess:
+        """Run a full tmux argv — already built by `layout.py`'s own functions, never
+        hand-retyped — under this class's own throwaway plane. Mirrors
+        `commands_frame.cmd_launch`'s own behaviour exactly: it passes `env=env` to
+        EVERY tmux call it makes on a launch, not only the first (`new-session`
+        alone is not enough — a split's own local tmux-CLIENT invocation does not
+        need `$CHARTER_ROOT` itself, since a spawned pane's environment comes from
+        the SESSION's tracked environment set at `new-session` time, not from
+        whatever invoked the later `split-window` — but this matches production
+        rather than relying on that distinction holding forever). `cwd` is pinned
+        to the checkout root for the same reason `PanelIntegration._spawn_panel`
+        pins it: `python3 -m charter` needs `charter` importable off the CURRENT
+        DIRECTORY when the package is not installed, and nothing here should depend
+        on wherever `unittest discover` happens to have been invoked from.
+        """
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=10,
+                              env=self.env, cwd=str(_REPO_ROOT))
+
+    def _pane_pid(self, pane: str) -> str:
+        return _tmux("display-message", "-p", "-t", pane, "#{pane_pid}").stdout.strip()
+
+    def _capture(self, pane: str) -> str:
+        return _tmux("capture-pane", "-p", "-t", pane).stdout
+
+    def _alive(self, pane: str) -> str:
+        return _tmux("display-message", "-p", "-t", pane, "#{pane_dead}").stdout.strip()
+
+    def _spawn_frame(self, fid: str) -> tuple[str, dict[str, str]]:
+        """Launch a real four-slot frame: `layout.session_argv` for the harness pane,
+        then `layout.panel_argvs` for all four splits off its id — the same two
+        calls `cmd_launch` makes. Returns the harness pane id and a `slot -> pane
+        id` map; every pane's own pid (`#{pane_pid}`, captured immediately — never
+        the session or pane id, which name tmux objects, not the OS process
+        underneath) is registered for `_kill_pid` cleanup as it is created, exactly
+        the way `PanelIntegration`/`MenuIntegration` above already have to (see
+        `_kill_pid`'s own docstring for why `kill-server` alone leaves orphans).
+        """
+        conf_dir = Path(tempfile.mkdtemp(prefix="charter-integ-4edge-"))
+        self.addCleanup(shutil.rmtree, conf_dir, True)
+        conf_path = conf_dir / "tmux.conf"
+        # The same placeholder `cmd_launch` writes ahead of its own `new-session`
+        # call — `commands_frame._PLACEHOLDER_CONF` arms `remain-on-exit` from the
+        # very first moment, so a panel that crashes at startup leaves a pane this
+        # test can still inspect rather than one that simply vanishes.
+        conf_path.write_text(commands_frame._PLACEHOLDER_CONF)
+
+        session_cmd = layout.session_argv(session=fid, conf=str(conf_path), socket=SOCKET,
+                                          cols=120, rows=40, harness_argv=["sleep", "600"])
+        r = self._run_env(session_cmd)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness_pane = r.stdout.strip()
+        self.assertTrue(harness_pane, "tmux did not report the harness pane's id")
+        self.addCleanup(_kill_pid, self._pane_pid(harness_pane))
+
+        slots = ["top", "bottom", "left", "right"]
+        panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=SOCKET,
+                                        charter_argv=[sys.executable, "-m", "charter"],
+                                        harness_pane=harness_pane)
+        panes: dict[str, str] = {}
+        for slot, cmd in zip(slots, panel_cmds):
+            p = self._run_env(cmd)
+            self.assertEqual(p.returncode, 0, f"splitting {slot!r}: {p.stderr}")
+            pane_id = p.stdout.strip()
+            self.assertTrue(pane_id, f"tmux did not report {slot!r}'s pane id")
+            panes[slot] = pane_id
+            self.addCleanup(_kill_pid, self._pane_pid(pane_id))
+
+        # The same refocus `cmd_launch` performs once every panel is drawn (its own
+        # comment: `split-window` makes the newly created pane active by default,
+        # so after four splits the LAST panel drawn — never the harness — has
+        # focus unless something puts it back). A literal `select-pane`, not one of
+        # the argv-building functions above: it targets a tmux-ASSIGNED pane id,
+        # carrying nothing an operator or a config file ever supplied, so there is
+        # no injection surface here for a helper to guard against.
+        self._run_env(["tmux", "-L", SOCKET, "select-pane", "-t", harness_pane])
+        return harness_pane, panes
+
+    def test_all_four_panels_come_up_alive_with_real_content_and_the_harness_keeps_focus(self):
+        """Launch composition, proven end to end: a frame with `top`/`left`/`right`/
+        `bottom` all configured comes up with all four panes alive, each showing
+        real content a broken renderer (or an empty, never-gathered cache) could
+        not have produced, and the harness pane — not the last panel
+        `split-window` happened to draw — holds keyboard focus once the launch
+        finishes."""
+        repo_name = f"cnry{os.getpid() % 10000}"
+        branch = f"br{os.getpid() % 10000}a"
+        repo = config.WORKSPACES_DIR / "demo" / repo_name
+        _init_repo(repo, branch)
+        todos.add("demo", "a todo the bottom panel should count")
+        persona_name = self.make_persona(f"p{os.getpid() % 100}")
+
+        fid = state.frame_id("four-edge-alive", os.getpid())
+        harness_pane, panes = self._spawn_frame(fid)
+        self.assertEqual(set(panes), {"top", "bottom", "left", "right"})
+
+        time.sleep(1.5)
+
+        for slot, pane in panes.items():
+            self.assertEqual(self._alive(pane), "0",
+                             f"the {slot!r} panel died at startup — a hole in the "
+                             f"frame, not a degraded row (the launcher-days-of-a-"
+                             f"green-suite gap `PanelIntegration`'s own docstring "
+                             f"names, now for all four slots at once)")
+
+        top = self._capture(panes["top"])
+        self.assertIn("demo", top, f"top never showed the real workspace name:\n{top!r}")
+
+        left = self._capture(panes["left"])
+        self.assertIn(repo_name, left, f"left never showed the real repo:\n{left!r}")
+        self.assertIn(branch, left, f"left never showed the real branch:\n{left!r}")
+
+        right = self._capture(panes["right"])
+        self.assertIn(persona_name, right,
+                      f"right never showed the real persona:\n{right!r}")
+
+        bottom = self._capture(panes["bottom"])
+        self.assertIn("1 todo", bottom,
+                      f"bottom never showed the real todo count:\n{bottom!r}")
+
+        focus = _tmux("display-message", "-p", "-t", harness_pane,
+                      "#{pane_active}").stdout.strip()
+        self.assertEqual(focus, "1",
+                         "the harness pane lost focus to the last panel drawn — an "
+                         "operator's harness must be able to receive a keystroke "
+                         "the instant the frame comes up")
+
+    def test_a_state_bump_through_the_real_hook_repaints_left_and_bottom_with_new_facts(self):
+        """Closes the gap `PanelIntegration`'s own hook test
+        (`test_a_real_hook_call_repaints_a_live_panel_without_a_direct_state_bump`)
+        leaves open for THIS plan: that test drives `hooks.posttooluse` against
+        `bottom` alone, which never touches `gather.py` at all. This drives the
+        SAME real hook — never a direct `state.bump` or `gather.refresh` call — and
+        watches `left` repaint with a NEW branch name that only exists because
+        `notify.plane_changed` ran `gather.refresh` BEFORE `state.bump` (Task 2's
+        own contract, and its own docstring's reason: refresh-then-bump closes the
+        window where a poller sees the new version and still reads the stale
+        cache). A version bump into a stale or never-refreshed cache would leave
+        `left` showing the OLD branch forever — this is the one test in the file
+        that would catch that. `bottom` is watched in the same pass, from the SAME
+        single hook call, to pin that one refresh/bump serves every slot that asks,
+        not only the one `PanelIntegration` already covers.
+
+        **The cache is warmed with one direct `gather.refresh` call before any
+        assertion runs — this is load-bearing, not incidental.** Caught by
+        mutation: with no cache file on disk yet, `gather.read`'s OWN fallback
+        (`_left` calls it, this file's `left` panel does not) recomputes a FRESH
+        scan on every call regardless of whether the cache was ever written — so
+        with `notify.plane_changed`'s `gather.refresh` call deleted outright (a
+        real mutation tried while writing this test), `left` still showed the new
+        branch every time, because it was never reading a cache at all, only ever
+        falling through to a live scan. That passed for the wrong reason and would
+        have shipped a vacuous proof of Task 2's whole contract. Priming the cache
+        first (real production `gather.refresh`, called directly — the same
+        function `notify.plane_changed` is supposed to call) means the SECOND
+        gather event below can only show the new branch by successfully
+        OVERWRITING an already-valid cache file — the one behaviour that
+        distinguishes "the hook refreshed the cache" from "the panel quietly
+        recovered on its own."
+        """
+        repo_name = f"cnry{os.getpid() % 10000}"
+        branch_a = f"br{os.getpid() % 10000}a"
+        branch_b = f"br{os.getpid() % 10000}b"
+        repo = config.WORKSPACES_DIR / "demo" / repo_name
+        _init_repo(repo, branch_a)
+        todos.add("demo", "the first todo")
+
+        fid = state.frame_id("four-edge-repaint", os.getpid())
+        _harness_pane, panes = self._spawn_frame(fid)
+
+        # Prime the cache for real, mirroring an already-fired prior hook (see the
+        # docstring above for why this is load-bearing) — `workspace="demo"`
+        # explicit rather than relying on `$CHARTER_WORKSPACE`, since this call
+        # runs IN this test process, not a subprocess that inherited the tmux
+        # session's own environment the way every panel below does.
+        gather.refresh(fid, workspace="demo")
+
+        time.sleep(1.5)
+        left_before = self._capture(panes["left"])
+        bottom_before = self._capture(panes["bottom"])
+        self.assertIn(branch_a, left_before,
+                      f"left never showed the starting branch:\n{left_before!r}")
+        self.assertIn("1 todo", bottom_before,
+                      f"bottom never showed the starting todo count:\n{bottom_before!r}")
+
+        # The mutation: a real branch switch (see the class docstring for why this,
+        # not a dirty-bit change, is what a repaint proof here mutates) and a
+        # second todo — both real plane-state changes, the kind `notify.
+        # plane_changed` exists to notice.
+        _git(repo, "checkout", "-q", "-b", branch_b)
+        todos.add("demo", "the second todo")
+
+        # Reset the debounce (see `PanelIntegration`'s own identical line): a
+        # window left over from another test in this same process must not mask a
+        # broken hook wiring by silently no-op'ing this call.
+        notify._last["at"] = 0.0
+        # `CHARTER_WORKSPACE`, not only `CHARTER_SESSION_ID`: this hook call runs
+        # IN-PROCESS (`run_hook`, not a subprocess), so `gather.refresh` inside it
+        # resolves the active workspace through THIS process's real `os.environ` —
+        # unlike every panel subprocess in this class, which inherits `demo` from
+        # the tmux SESSION environment `_spawn_frame` set at `new-session` time
+        # (via `self.env`). Without this, `workspace.resolve()` falls through to
+        # this throwaway plane's own `DEFAULT_WORKSPACE` instead (this process's
+        # cwd is the checkout root, not inside `demo`'s own tree, so the cwd rung
+        # cannot rescue it either) — `gather.refresh` would then cache a scan of
+        # the WRONG, repo-less workspace, and `left` would repaint to "no repos"
+        # rather than the new branch, for a reason that has nothing to do with
+        # whether the refresh/bump wiring itself works.
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": fid,
+                                          "CHARTER_WORKSPACE": "demo"}):
+            out = run_hook(hooks.posttooluse, {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "/nonexistent"},
+                "session_id": "four-edge-hook-session",
+            })
+        self.assertIsNone(out, "posttooluse should emit nothing for a plain Read")
+
+        def _wait_for_change(pane: str, before: str) -> str:
+            deadline = time.monotonic() + 3
+            after = before
+            while time.monotonic() < deadline:
+                after = self._capture(pane)
+                if after != before:
+                    return after
+                time.sleep(0.2)
+            return after
+
+        left_after = _wait_for_change(panes["left"], left_before)
+        bottom_after = _wait_for_change(panes["bottom"], bottom_before)
+
+        self.assertNotEqual(left_after, left_before,
+                            f"left never repainted after a real hooks.posttooluse() "
+                            f"call; still showing:\n{left_before!r}")
+        self.assertIn(branch_b, left_after,
+                      f"left repainted but not with the NEW branch:\n{left_after!r}")
+        self.assertNotIn(branch_a, left_after,
+                         f"left kept showing the OLD branch after the switch — a "
+                         f"stale cache surviving its own refresh:\n{left_after!r}")
+
+        self.assertNotEqual(bottom_after, bottom_before,
+                            f"bottom never repainted after the same real hook call; "
+                            f"still showing:\n{bottom_before!r}")
+        self.assertIn("2 todos", bottom_after,
+                      f"bottom repainted but not with the NEW todo count:\n{bottom_after!r}")
+
+        for slot, pane in panes.items():
+            self.assertEqual(self._alive(pane), "0",
+                             f"the {slot!r} panel died sometime after repainting")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #385. First of three for frame v2 (#386 suppression, #387 density/animation).

The frame shipped in #380 showing a small fraction of what the status line shows — nine
renderers existed in `statusline.py` and the frame called none of them. This closes that
gap by **composing** those renderers rather than reimplementing them, so a fix to a repo
row or a persona chip lands in both surfaces at once.

## One gather, many renderers

`_run_state` shells out to `git status --porcelain --branch` per repo. With four panels,
gathering per-panel would mean four identical sweeps per repaint and would destroy the
property the frame was built for: it costs a `stat` when nothing is happening.

So `charter/frame/gather.py` performs the scan once and caches it as plain JSON, and
**the hook that already bumps the frame's version refreshes it** — a bump means "plane
state changed", which is exactly when a rescan is worth doing. Panels are pure readers.

Measured: 25.8 ms cold with 3 git invocations on a 3-repo workspace, 0.61 ms warm behind
the 5-second TTL `statusline._repo_states` already maintains, 0.30 µs with no frame
(`plane_changed` returns before importing anything). The refresh runs before the bump in
its own `try/except`, so a failed gather can never cost the version bump — a panel that
never learns the plane changed is worse than one reading a slightly stale cache.

## Slots

Zones follow what `statusline.py` already argues for, so the frame does not invent a
second information architecture: repos and pieces on `left`, personas/memory/in-flight/
vaults on `right`, identity on `top`, alerts and session news on `bottom`.

`left`/`right` were already accepted by config and sized by the layout; only the renderers
were missing.

**Narrow composition, not reuse of the wide layout.** A 22-column pane needs its own
composition — and the first draft proved why: it assembled `name + branch + markers` then
truncated once from the right, so on this repo's own ordinary branch names
(`worktree-recall-since`, 21 chars) the dirty flag and CI glyph were silently discarded.
A dirty, CI-failing, unpushed repo rendered as clean. Fields are now budgeted
individually, reserving room for the markers the way `statusline._branch_cell_for` does.

## What is deliberately not here

`_context_gauge` and `_session_strip` take the Claude Code status-line payload, which
reaches `statusline.main`'s stdin and never a panel process. The token history they read
is written by `_record_turn` on the status line's own render path, so its freshness
depends on an untracked assumption — that a `statusLine` command is configured and firing.
Reading it from a panel would mean silently trusting staleness semantics nobody designed,
so `top` gains no gauge and regression tests pin that neither function is called. #386
owns that decision.

## Tests

3697, +72 over `main`. `FourEdgeIntegration` proves the composition end to end against a
real tmux: four panels alive with real content, harness focused, repainting through the
real `hooks.posttooluse`.

Every test verified by mutation. Four distinct flavours of test-that-cannot-fail were
caught and fixed on this branch and its predecessor: an ambient environment variable
already set in the test process; a fix invalidating its own test in the same commit; an
ANSI colour prefix absorbing a char-vs-cell mutation; and a missing-cache fallback masking
a deleted call. The last one mattered most — neutering `gather.save` left the four-edge
test green, meaning the branch's central claim (panels are pure readers) was not covered
by the one test written to prove it. It is now.

Integration tests probe capability rather than presence — CI is Ubuntu with tmux 3.4 and
`TERM=dumb`, development is macOS with 3.7c and a real terminal.

Also fixed along the way: an `addCleanup` LIFO ordering bug that unlinked the socket
before `kill-server`, leaking tmux servers, in four test classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
