### PR TITLE
Re-launch charter with -P so it never imports the cwd's charter (#390)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -337,8 +337,8 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
     environment goes through, and the two do not behave alike.
 
     **`"$CHARTER_PY" -m charter`, never a bare `charter`.** The panels already launch
-    charter as `[sys.executable, "-m", "charter"]` (see `cmd_launch`'s `panel_argvs`
-    call) precisely because the `charter` an operator's `$PATH` resolves may be a
+    charter via `util.self_relaunch_argv()` (see `cmd_launch`'s `panel_argvs` call)
+    precisely because the `charter` an operator's `$PATH` resolves may be a
     different install, or no install at all — a `uv tool` shim not on the tmux server's
     own PATH, a checkout run as `python -m charter`. This line had kept the bare name,
     and the failure lands in the worst possible place: `run-shell` reports a non-zero
@@ -384,6 +384,35 @@ def _charter_py_env_argv(*, socket: str, session: str) -> list[str]:
     """
     return ["tmux", "-L", socket, "set-environment", "-t", session, _CHARTER_PY_ENV,
            sys.executable]
+
+
+#: `PYTHONSAFEPATH`'s real name — a genuine interpreter environment variable, read by
+#: `python` itself at startup, not a charter-invented one. Carried alongside
+#: `CHARTER_PY_ENV`, never folded into it: see `_charter_pythonsafepath_env_argv`.
+_PYTHONSAFEPATH_ENV = "PYTHONSAFEPATH"
+
+
+def _charter_pythonsafepath_env_argv(*, socket: str, session: str) -> list[str]:
+    """`set-environment`: closes the same hole `util.self_relaunch_argv`'s `-P` closes
+    for every OTHER self-relaunch site (#390), for the one shape that cannot take a flag.
+
+    `"$CHARTER_PY" -m charter ...` — the hotkey bind (`conf_text`) and every menu item's
+    own action (`frame.menu.menu_argv`) — is a shell TEMPLATE shared by every session on
+    `SOCKET`, built once and never per-invocation; there is nowhere in it to splice a
+    `-P` without re-embedding per-machine text, the exact construction `conf_text`'s own
+    docstring already bans for `status_path`. `PYTHONSAFEPATH=1` is `-P`'s own
+    environment-variable form — carried the identical session-scoped way
+    `_charter_py_env_argv` carries `$CHARTER_PY` itself, so it reaches the same shell
+    that call already proves reaches: without this, a pane whose cwd happens to be a
+    charter checkout would have the hotkey menu import THAT tree the moment it opens,
+    same failure shape as the panel argv, just one layer further from the operator.
+
+    A separate `set-environment` call rather than folded into `_charter_py_env_argv`'s:
+    that function's contract is "the interpreter", used elsewhere as exactly that value
+    (`docs`, `conf_text`'s own text); overloading it to also carry an unrelated variable
+    would break that contract for a caller that only wanted the interpreter path.
+    """
+    return ["tmux", "-L", socket, "set-environment", "-t", session, _PYTHONSAFEPATH_ENV, "1"]
 
 
 def _exit_path_env_argv(*, socket: str, session: str, status_path: str) -> list[str]:
@@ -807,6 +836,18 @@ def cmd_launch(args) -> int:
         util.warn("charter frame: continuing without it — the hotkey menu may not open "
                   "on this frame")
 
+    # #390: the same "-m prepends the cwd to sys.path" hole `util.self_relaunch_argv`'s
+    # `-P` closes for the panel argv below, closed here as `PYTHONSAFEPATH=1` because
+    # the hotkey/menu template above has no room for a per-invocation flag — see
+    # `_charter_pythonsafepath_env_argv`'s own docstring.
+    safepath_set = tmuxctl.run("carrying PYTHONSAFEPATH to the hotkey menu",
+                               _charter_pythonsafepath_env_argv(socket=SOCKET, session=fid),
+                               env=env)
+    if safepath_set.returncode != 0:
+        util.warn("charter frame: continuing without it — the hotkey menu may import "
+                  "the wrong charter if this pane's directory has its own `charter/` "
+                  "package")
+
     # The menu itself: what the hotkey actually opens. A single "Detach" entry — the
     # spec's own words, "Detach is allowed and prints how to reattach" — proves the
     # mechanism end to end (bind → menu → opaque id → real command) without inventing a
@@ -865,7 +906,7 @@ def cmd_launch(args) -> int:
                      f"tmux -L {SOCKET} attach -t {fid}")
         else:
             panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=SOCKET,
-                                            charter_argv=[sys.executable, "-m", "charter"],
+                                            charter_argv=util.self_relaunch_argv(),
                                             harness_pane=harness_pane)
             # Zipped with `slots`, not just iterated: `_resize_hook_argv` below needs to
             # know WHICH slot each successfully-created pane belongs to (for its size and

--- a/charter/commands_update.py
+++ b/charter/commands_update.py
@@ -52,6 +52,12 @@ def installer_for(executable: Path) -> tuple[str, list[str] | None]:
     else's environment. Ambiguity resolves to *named, not run* — the same restraint charter
     keeps for a host's plugin command, for the same reason: a wrong guess here mutates the
     reader's machine.
+
+    Not one of #390's self-relaunch sites, checked directly: *executable* here is
+    STRING-MATCHED against `_MARKERS` to identify which tool owns the install
+    (`uv`/`pipx`/unknown) — it is never handed to `-m` or otherwise used to import
+    `charter`, so `-m`'s cwd-prepend hole (`util.self_relaunch_argv`'s own docstring)
+    does not apply to this function at all.
     """
     p = str(executable)
     for name, markers in _MARKERS:

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -649,6 +649,22 @@ def _ws_meta_paths(name: str) -> list[str]:
                       wd / "todos") if p.exists()]
 
 
+def _spawn_pushbg(root) -> None:
+    """Fire a detached background push of the workspace's just-committed metadata
+    (best-effort) so a slow push never blocks the turn — the same mechanism, for the
+    same reason, as `planegit._spawn_bg_push` (`discover`'s own background push of
+    HEAD). `util.self_relaunch_argv` (#390) is what keeps the child from importing
+    whatever `charter/` package happens to sit under *root* instead of the installed
+    package — this always runs with cwd set to the control plane root, which for
+    anyone developing charter itself IS a checkout with its own `charter/` package."""
+    try:
+        subprocess.Popen(util.self_relaunch_argv("workspace", "_pushbg"),
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                         stdin=subprocess.DEVNULL, start_new_session=True, cwd=str(root))
+    except Exception:
+        pass
+
+
 def cmd_workspace_autosave(args) -> int:
     """Internal (Stop hook): debounced, secret-scanned auto-save of the active workspace's
     manifest + memory — a reactive, agent-triggered commit, so it honours the control
@@ -683,9 +699,7 @@ def cmd_workspace_autosave(args) -> int:
         marker.write_text(str(time.time()))
         if share == "push":
             # detached background push — the turn returns immediately
-            subprocess.Popen([sys.executable, "-m", "charter", "workspace", "_pushbg"],
-                             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                             stdin=subprocess.DEVNULL, start_new_session=True, cwd=str(config.ROOT))
+            _spawn_pushbg(config.ROOT)
     except Exception:
         pass
     return 0

--- a/charter/glstate.py
+++ b/charter/glstate.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sys
 import time
 import urllib.parse
 from pathlib import Path
@@ -222,8 +221,11 @@ def maybe_spawn(dirs, workspace: str | None = None) -> None:
     # Target the installed package via `-m`, not a path inside the control plane —
     # a control plane has no `bin/edm` (that script lived in the old monorepo the
     # engine was extracted from); `-m charter` resolves through the same
-    # interpreter/venv that is already running this process.
-    cmd = [sys.executable, "-m", "charter", "gl-refresh"]
+    # interpreter/venv that is already running this process. `-P` (util.self_relaunch_argv,
+    # #390) is what keeps that resolution honest: this runs on the status line's own
+    # render path, so a project directory that happens to have its own `charter/` package
+    # (any charter checkout) would otherwise get shadowed on every single render.
+    cmd = util.self_relaunch_argv("gl-refresh")
     if workspace:
         cmd += ["--workspace", workspace]
     try:

--- a/charter/planegit.py
+++ b/charter/planegit.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-import sys
 from pathlib import Path
 
 from . import config, util
@@ -80,11 +79,12 @@ def _origin_https(root) -> str | None:
 # --------------------------------------------------------------------------- #
 def _spawn_bg_push(root) -> None:
     """Fire a detached background push of HEAD (best-effort) so a slow push never blocks
-    the turn — the same mechanism the workspace Stop-hook auto-save uses."""
-    import subprocess
-    import sys
+    the turn — the same mechanism the workspace Stop-hook auto-save uses
+    (`commands_workspace._spawn_pushbg`). `util.self_relaunch_argv` (#390) is what keeps
+    the child from importing whatever `charter/` package happens to sit under *root*
+    instead of the installed one."""
     try:
-        subprocess.Popen([sys.executable, "-m", "charter", "workspace", "_pushbg"],
+        subprocess.Popen(util.self_relaunch_argv("workspace", "_pushbg"),
                          stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
                          stdin=subprocess.DEVNULL, start_new_session=True, cwd=str(root))
     except Exception:

--- a/charter/update.py
+++ b/charter/update.py
@@ -14,11 +14,10 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sys
 import time
 from pathlib import Path
 
-from . import config
+from . import config, util
 
 #: PyPI distribution name. The *command* is `charter`; the *package* is `charter-cp`
 #: (PyPI would not allow `charter`), so the metadata lives under the latter.
@@ -181,8 +180,12 @@ def maybe_spawn() -> None:
     try:
         lock.parent.mkdir(parents=True, exist_ok=True)
         lock.touch()          # touch FIRST: a spawn storm is worse than a missed check
+        # -P (util.self_relaunch_argv, #390): this ALSO runs on the status line's own
+        # render path (see the module docstring's mirror of glstate) — without it, a
+        # project directory with its own `charter/` package would shadow the installed
+        # one on every render, exactly as quietly as glstate's own gl-refresh did.
         subprocess.Popen(
-            [sys.executable, "-m", "charter", "_version-check"],
+            util.self_relaunch_argv("_version-check"),
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL, start_new_session=True, env=os.environ.copy(),
         )

--- a/charter/util.py
+++ b/charter/util.py
@@ -271,6 +271,34 @@ def branch_of(tree: Path) -> str:
     return txt[:7] if txt else "?"            # detached HEAD → short sha
 
 
+def self_relaunch_argv(*args: str) -> list[str]:
+    """The argv that re-launches charter as *this interpreter's own install* — never
+    whatever ``charter/`` package happens to sit under the child's cwd (#390).
+
+    ``python -m charter`` prepends the CURRENT WORKING DIRECTORY to ``sys.path`` before
+    it even looks for the module to run — ``-m``'s own documented behaviour, not a bug in
+    it. Every charter self-relaunch site sets its child's cwd to something outside
+    charter's own control (a project directory, a workspace root, wherever an operator's
+    pane happened to start), and when THAT directory contains its own ``charter/``
+    package — a charter checkout dogfooding itself, the common case for anyone
+    developing charter — the child imports that tree instead of the installed one. On a
+    tree that predates a command the installed one has, the failure lands as an
+    argparse ``invalid choice`` and exit 2, which is how this shipped: ``charter claude``
+    came up with both panels dead, and the harness pane survived only because ``claude``
+    is a real binary rather than another self-relaunch.
+
+    ``-P`` (3.11+; ``pyproject.toml`` already requires it) is ``-m``'s own switch for
+    "don't do that". One helper, not a `[sys.executable, "-m", "charter", ...]` hand-built
+    at every call site — the same shape as the frame's own "never join argv" rule: correct
+    by construction rather than remembered at five (now seven) separate places. A shell
+    TEMPLATE that embeds ``"$CHARTER_PY" -m charter`` (the tmux hotkey bind and its menu
+    items — see ``commands_frame.py``'s own module docstring) cannot use this helper
+    directly; those carry ``PYTHONSAFEPATH=1`` instead, the environment-variable form of
+    the same switch, alongside ``$CHARTER_PY`` itself.
+    """
+    return [sys.executable, "-P", "-m", "charter", *args]
+
+
 def detach_self(args: list[str]) -> bool:
     """Re-run ``charter <args>`` in a process that outlives this one. True if it started.
 
@@ -285,7 +313,7 @@ def detach_self(args: list[str]) -> bool:
     """
     try:
         subprocess.Popen(
-            [sys.executable, "-m", "charter", *args],
+            self_relaunch_argv(*args),
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL, start_new_session=True, env=os.environ.copy(),
         )

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -38,7 +38,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from tests._isolation import PersonaIso
-from charter import commands_frame, config
+from charter import commands_frame, config, util
 from charter.frame import menu, slots, state
 
 
@@ -871,6 +871,46 @@ class Launch(PersonaIso, unittest.TestCase):
                          "charter installs, so a `-g` write would hand frame N's "
                          "interpreter to frame N-1")
         self.assertEqual(cmd[-1], sys.executable)
+
+    def test_pythonsafepath_is_carried_to_the_hotkey_menu_too(self):
+        """#390: `"$CHARTER_PY" -m charter ...` (the bind `Conf` pins, and every menu
+        item's own action — `frame.menu.menu_argv`) is a shell TEMPLATE shared by every
+        session on `SOCKET`, so there is nowhere in it to put a per-invocation `-P` the
+        way the panel argv gets one (see `test_panels_are_launched_via_self_relaunch_argv`
+        below) without re-embedding per-machine text `conf_text`'s own docstring already
+        bans. `PYTHONSAFEPATH=1`, carried the same session-scoped way as `CHARTER_PY`
+        itself, is `-P`'s equivalent for exactly this case: an interpreter env var every
+        `"$CHARTER_PY" -m charter` the hotkey or a menu item runs inherits, immune to
+        whatever `charter/` package happens to sit under the pane's own cwd."""
+        fake = _FakeTmux(exit_code=0)
+        _launch(fake)
+        safepath_calls = [c for c in fake.calls
+                          if "set-environment" in c and "PYTHONSAFEPATH" in c]
+        self.assertEqual(len(safepath_calls), 1,
+                         f"PYTHONSAFEPATH must be carried exactly once: {fake.calls}")
+        cmd = safepath_calls[0]
+        self.assertEqual(cmd[cmd.index("-t") + 1], fake.fid,
+                         "session-scoped, same reasoning as CHARTER_PY: two planes on "
+                         "one laptop can be two different charter installs")
+        self.assertEqual(cmd[-1], "1")
+
+    def test_panels_are_launched_via_self_relaunch_argv(self):
+        """#390's visible failure: the panel argv (`layout.panel_argvs`'s `charter_argv`)
+        used to be a hand-built `[sys.executable, "-m", "charter"]` with no `-P`. Spawned
+        with the pane's cwd set to wherever the operator launched from, a charter checkout
+        cwd made the child import THAT tree instead of the installed one — on a tree
+        without a `panel` command, argparse exits 2 before charter ever runs, and both
+        panels came up dead. `tests/test_self_relaunch_shadowing.py` proves the mechanism
+        against a real decoy package; this pins that the production call site actually
+        uses it."""
+        fake = _FakeTmux(exit_code=0)
+        _launch(fake)
+        panel_calls = [c for c in fake.calls if "split-window" in c]
+        self.assertTrue(panel_calls, "no panel was drawn — this test would be vacuous")
+        for c in panel_calls:
+            dd = c.index("--")
+            self.assertEqual(c[dd + 1:dd + 5], util.self_relaunch_argv(),
+                             f"panel argv was not built via self_relaunch_argv: {c}")
 
     def test_the_harness_name_reaches_the_harness_environment(self):
         """`harness.current()` reads `$CHARTER_HARNESS` FIRST, before any native

--- a/tests/test_glstate.py
+++ b/tests/test_glstate.py
@@ -40,7 +40,9 @@ class MaybeSpawnCommandTests(PersonaIso):
         cmd = captured["cmd"]
         self.assertEqual(cmd[0], sys.executable)
         # -m charter, not a script path inside the control plane (no bin/edm here).
-        self.assertEqual(cmd[1:4], ["-m", "charter", "gl-refresh"])
+        # -P (#390): without it, spawned with this render path's own cwd, `-m` would
+        # import a `charter/` package sitting under that cwd instead of the installed one.
+        self.assertEqual(cmd[1:5], ["-P", "-m", "charter", "gl-refresh"])
         joined = " ".join(str(c) for c in cmd)
         self.assertNotIn("bin/edm", joined)
         self.assertNotIn(str(glstate.config.ROOT), joined)

--- a/tests/test_hooks_need_no_async.py
+++ b/tests/test_hooks_need_no_async.py
@@ -60,7 +60,9 @@ class Detaching(unittest.TestCase):
         with mock.patch.object(util.subprocess, "Popen") as popen:
             self.assertTrue(util.detach_self(["persona", "_gc"]))
         argv = popen.call_args.args[0]
-        self.assertEqual(argv[1:], ["-m", "charter", "persona", "_gc"])
+        # -P (#390): `-m` prepends the cwd to sys.path, so a hook run from a charter
+        # checkout would otherwise respawn that tree instead of the installed package.
+        self.assertEqual(argv[1:], ["-P", "-m", "charter", "persona", "_gc"])
         self.assertNotIn("--detach", argv)
 
     def test_the_child_outlives_the_hook(self):

--- a/tests/test_self_relaunch_argv.py
+++ b/tests/test_self_relaunch_argv.py
@@ -1,0 +1,124 @@
+"""Every self-relaunch site builds its child argv through `util.self_relaunch_argv`,
+never a hand-built `[sys.executable, "-m", "charter", ...]` list of its own — #390.
+
+`python -m charter` prepends the current working directory to `sys.path` before it even
+looks for the `charter` package to import (`-m`'s own documented behaviour). Every site
+below sets its child's `cwd` to something outside charter's own control — a project
+directory, a workspace root, wherever an operator's pane happened to start — and when
+THAT directory contains its own `charter/` package (a charter checkout dogfooding
+itself, the common case for anyone developing charter), the child imports that tree
+instead of the installed one. `-P` (3.11+, `pyproject.toml` already requires it) is
+`-m`'s own switch for "don't do that".
+
+`tests/test_self_relaunch_shadowing.py` proves the mechanism end to end against a real
+decoy package that genuinely shadows. This module is the fast half: one test per site,
+asserting the argv it hands to `Popen`/`split-window` carries `-P` — a passing
+end-to-end test on ONE site does not prove the other sites were changed, so each is
+pinned separately here.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import glstate, planegit, update, util
+from charter import commands_workspace as cw
+
+from tests._isolation import PersonaIso
+
+
+class SelfRelaunchArgvShape(unittest.TestCase):
+    """The helper itself: charter/util.py."""
+
+    def test_bare_call_is_the_interpreter_plus_dash_p_plus_the_module(self):
+        self.assertEqual(util.self_relaunch_argv(),
+                         [sys.executable, "-P", "-m", "charter"])
+
+    def test_extra_args_are_appended_after_the_module(self):
+        self.assertEqual(
+            util.self_relaunch_argv("workspace", "_pushbg"),
+            [sys.executable, "-P", "-m", "charter", "workspace", "_pushbg"],
+        )
+
+
+class DetachSelfUsesIt(unittest.TestCase):
+    """charter/util.py:288 — `detach_self`, a session-start hook's own background
+    refresh (`gl-refresh`, `persona _gc`)."""
+
+    def test_argv_carries_dash_p(self):
+        with mock.patch.object(util.subprocess, "Popen") as popen:
+            self.assertTrue(util.detach_self(["gl-refresh"]))
+        argv = popen.call_args.args[0]
+        self.assertEqual(argv, util.self_relaunch_argv("gl-refresh"))
+
+
+class GlstateMaybeSpawnUsesIt(PersonaIso):
+    """charter/glstate.py:226 — `gl-refresh`, spawned from the status line's own render
+    path. The quiet one: on any charter checkout this ran the wrong charter on every
+    render, indefinitely, until fixed."""
+
+    def test_argv_carries_dash_p(self):
+        d = self.tmp / "somerepo"
+        d.mkdir(parents=True, exist_ok=True)
+        captured = {}
+
+        def fake_popen(cmd, **kw):
+            captured["cmd"] = cmd
+            return mock.MagicMock()
+
+        with mock.patch.object(glstate.subprocess, "Popen", side_effect=fake_popen):
+            glstate.maybe_spawn([d])
+
+        self.assertIn("cmd", captured, "Popen was never called — nothing was stale?")
+        self.assertEqual(captured["cmd"], util.self_relaunch_argv("gl-refresh"))
+
+
+class UpdateMaybeSpawnUsesIt(PersonaIso):
+    """charter/update.py:185 — `_version-check`, ALSO spawned from the status line's own
+    render path. Not one of the five sites #390 originally named; found by grepping the
+    tree for every `sys.executable`."""
+
+    def test_argv_carries_dash_p(self):
+        captured = {}
+
+        def fake_popen(cmd, **kw):
+            captured["cmd"] = cmd
+            return mock.MagicMock()
+
+        with mock.patch.object(update.subprocess, "Popen", side_effect=fake_popen):
+            update.maybe_spawn()
+
+        self.assertIn("cmd", captured, "Popen was never called — was the cache fresh?")
+        self.assertEqual(captured["cmd"], util.self_relaunch_argv("_version-check"))
+
+
+class WorkspaceAutosavePushUsesIt(unittest.TestCase):
+    """charter/commands_workspace.py:686 — `workspace _pushbg`, the Stop-hook autosave's
+    background push under the `push` sharing posture."""
+
+    def test_argv_carries_dash_p(self):
+        with mock.patch.object(cw.subprocess, "Popen") as popen:
+            cw._spawn_pushbg(Path("/some/control/plane"))
+        argv = popen.call_args.args[0]
+        self.assertEqual(argv, util.self_relaunch_argv("workspace", "_pushbg"))
+        self.assertEqual(popen.call_args.kwargs.get("cwd"), "/some/control/plane")
+
+
+class DiscoverPushUsesIt(unittest.TestCase):
+    """charter/planegit.py:87 — `workspace _pushbg`, `discover`'s own background push of
+    HEAD, the sibling of the autosave push above."""
+
+    def test_argv_carries_dash_p(self):
+        with mock.patch.object(planegit.subprocess, "Popen") as popen:
+            planegit._spawn_bg_push(Path("/some/control/plane"))
+        argv = popen.call_args.args[0]
+        self.assertEqual(argv, util.self_relaunch_argv("workspace", "_pushbg"))
+        self.assertEqual(popen.call_args.kwargs.get("cwd"), "/some/control/plane")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_self_relaunch_shadowing.py
+++ b/tests/test_self_relaunch_shadowing.py
@@ -1,0 +1,161 @@
+"""#390: `python -m charter` prepends the CURRENT WORKING DIRECTORY to `sys.path`
+before it even looks for the `charter` package — undocumented nowhere, but `-m`'s own
+well-documented behaviour. Charter re-launches itself as
+`[sys.executable, "-m", "charter", ...]` from seven places (five reported, two more
+found by grepping the tree for every `sys.executable` — see
+`tests/test_self_relaunch_argv.py`'s own module docstring for the full list), each
+setting the child's cwd to something a caller controls: a project directory, a workspace
+root, wherever an operator's pane happened to start. On any of those that happens to
+contain its own `charter/` package — a charter checkout dogfooding itself, the common
+case for anyone developing charter — the child imports THAT tree instead of the
+installed one.
+
+This is the slow half, real subprocesses against a real decoy `charter/` package that
+genuinely shadows (`TheDecoyGenuinelyShadows` proves it directly, not by assumption).
+`tests/test_self_relaunch_argv.py` is the fast half: it pins that every production call
+site actually builds an argv carrying `-P` (3.11+, `pyproject.toml` already requires
+it), using mocks — a passing test here on ONE call site does not, by itself, prove the
+other six were fixed.
+
+`PYTHONPATH`, not a real installed distribution, stands in below for "the real package,
+findable without depending on cwd": this dev checkout has no separate `uv tool`/`pipx`
+install of its own to test against — confirmed by hand, `python3 -m charter` run from an
+unrelated directory with no `PYTHONPATH` set raises `ModuleNotFoundError` (this
+sandbox's own test suite only imports `charter` at all because IT, too, is
+conventionally run with the repo root as cwd). `-P`/`PYTHONSAFEPATH` strip only the
+cwd/script-dir entry `-m`/`-c` auto-prepend, never a `PYTHONPATH` entry or a real
+site-packages one — indistinguishable from `-P`'s own point of view, so this is a
+faithful stand-in for a real install rather than a shortcut around the mechanism being
+tested (verified by hand: `PYTHONPATH=<repo> python3 -m charter --version` run from a
+decoy cwd prints the decoy; the same command with `-P` added prints the repo's own
+installed version).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+import charter
+from charter import util
+from charter.frame import layout
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALLED_VERSION = charter.__version__
+DECOY_VERSION = "0.0.0-decoy"
+
+#: Just enough argparse to answer `--version` and to refuse `panel` — an old charter
+#: build with no `panel` command is exactly what #390's field report was.
+_DECOY_MAIN = '''\
+import argparse
+from . import __version__
+p = argparse.ArgumentParser(prog="charter")
+p.add_argument("--version", action="version", version=f"charter {__version__}")
+sub = p.add_subparsers(dest="command")
+sub.add_parser("doctor")
+p.parse_args()
+'''
+
+
+class WithADecoyCwd(unittest.TestCase):
+    """A temp dir whose own `charter/` package is a different, fake version — "a
+    directory containing a charter/ package", #390's own words."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="charter-decoy-"))
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        pkg = self.tmp / "charter"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text(f'__version__ = "{DECOY_VERSION}"\n')
+        (pkg / "__main__.py").write_text(_DECOY_MAIN)
+
+        self.env = dict(os.environ)
+        # Stands in for a real install — see the module docstring for why this is a
+        # faithful substitute for `-P`'s own purposes, not a shortcut around them.
+        self.env["PYTHONPATH"] = str(REPO_ROOT)
+        # Never let a spawned child touch this machine's real ~/.charter.
+        self.env["CHARTER_HOME"] = str(self.tmp / ".charter-home")
+
+
+class TheDecoyGenuinelyShadows(WithADecoyCwd):
+    """Without this class, every test below would be trivially satisfiable by a decoy
+    that fails to shadow. This project has already caught four distinct flavours of
+    test that cannot fail — a decoy like that would be a fifth."""
+
+    def test_bare_dash_m_imports_the_decoy_not_the_real_package(self):
+        p = subprocess.run([sys.executable, "-m", "charter", "--version"],
+                           cwd=self.tmp, env=self.env,
+                           capture_output=True, text=True, timeout=15)
+        self.assertEqual(p.returncode, 0, p.stderr)
+        self.assertEqual(p.stdout.strip(), f"charter {DECOY_VERSION}")
+
+    def test_bare_dash_m_reproduces_the_reported_panel_failure(self):
+        """The exact field report: both panels dead, status 2 —
+        ``charter: error: argument command: invalid choice: 'panel'`` — because the
+        checkout's own tree, with no ``panel`` command, shadowed the installed one that
+        has it."""
+        p = subprocess.run([sys.executable, "-m", "charter", "panel", "top",
+                            "--session", "f-1"],
+                           cwd=self.tmp, env=self.env,
+                           capture_output=True, text=True, timeout=15)
+        self.assertEqual(p.returncode, 2)
+        self.assertIn("invalid choice: 'panel'", p.stderr)
+
+
+class SelfRelaunchArgvIsImmuneToTheDecoy(WithADecoyCwd):
+    """The mechanism `util.self_relaunch_argv` — every call site's shared helper —
+    actually buys."""
+
+    def test_reports_the_installed_version_not_the_decoys(self):
+        argv = util.self_relaunch_argv("--version")
+        p = subprocess.run(argv, cwd=self.tmp, env=self.env,
+                           capture_output=True, text=True, timeout=15)
+        self.assertEqual(p.returncode, 0, p.stderr)
+        self.assertEqual(p.stdout.strip(), f"charter {INSTALLED_VERSION}",
+                         f"imported the decoy despite -P: stdout={p.stdout!r} "
+                         f"stderr={p.stderr!r}")
+
+
+class APanelSpawnedTheWayCmdLaunchSpawnsIt(WithADecoyCwd):
+    """#390's own reported symptom, proved against the REAL production call site:
+    `commands_frame.cmd_launch` builds the panel argv via
+    ``layout.panel_argvs(..., charter_argv=util.self_relaunch_argv())``
+    (charter/commands_frame.py:868). tmux itself is never started here — `panel_argvs`
+    is pure (see its own docstring), so the argv it builds is extracted and run directly
+    as the subprocess a real tmux pane would otherwise run."""
+
+    def _panel_argv(self) -> list[str]:
+        [cmd] = layout.panel_argvs(slots=["top"], session="f-1", socket="testsock",
+                                   charter_argv=util.self_relaunch_argv(),
+                                   harness_pane="%0")
+        dashdash = cmd.index("--")
+        return cmd[dashdash + 1:]
+
+    def test_runs_rather_than_exiting_2(self):
+        with subprocess.Popen(self._panel_argv(), cwd=self.tmp, env=self.env,
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                              text=True) as proc:
+            try:
+                time.sleep(0.6)
+                rc = proc.poll()
+                if rc is not None:
+                    out, err = proc.communicate()
+                    self.fail(f"panel exited early (rc={rc}) instead of running — the "
+                             f"#390 symptom itself:\nstdout={out!r}\nstderr={err!r}")
+            finally:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #390. Found in the field: `charter claude` came up with both panels showing
`Pane is dead (status 2)`.

## The bug

charter re-launched itself as `[sys.executable, "-m", "charter", …]`. Python's `-m`
prepends the cwd to `sys.path`, so spawning from a directory containing a `charter/`
package — a charter checkout, or a control plane whose root is one — made the child import
**that source tree** instead of the installed package.

```
(cd /tmp && python3 -m charter --version)                      charter 0.50.0   # installed
(cd ~/IdeaProjects/charter && python3 -m charter --version)    charter 0.49.0   # the cwd's tree
(cd ~/IdeaProjects/charter && python3 -P -m charter --version) charter 0.50.0
```

The panel process is spawned with the pane's cwd set to wherever the operator launched
from. From a charter checkout it imported an older tree with no `panel` command, and
argparse exited 2 before charter ran a line:

    charter: error: argument command: invalid choice: 'panel'

The harness pane was unaffected — `claude` is a real binary, not subject to Python's path
rules — so only the panels died, which is why it read as a frame bug for a long time.

## Wider than the frame

Seven Python self-relaunch sites were affected, not the one that was visible:

- `commands_frame.py` — panel argv (the visible failure) and `CHARTER_PY`
- `glstate.py` — `charter gl-refresh`, **spawned from the status line's render path**
- `update.py` — `charter _version-check`, also on the render path
- `util.py` — `detach_self`
- `commands_workspace.py` and `planegit.py` — `workspace _pushbg`

The two on the status line's render path are the quiet ones: on any charter checkout they
have been running whatever charter happened to sit in that directory, indefinitely and
invisibly, because nothing about them is loud when they go wrong.

`commands_update.py`'s `installer_for(sys.executable)` was checked and is **not** affected —
it string-matches the path and never hands it to `-m`. Documented in place.

## Fix

One helper — `util.self_relaunch_argv(*args)` → `[sys.executable, "-P", "-m", "charter", *args]`
— used by all seven, rather than five (now seven) hand-built argv lists. `-P` is 3.11+ and
`pyproject.toml` already requires `>=3.11`. The eighth site, the tmux hotkey/menu shell
template, cannot take a per-invocation flag, so it carries `PYTHONSAFEPATH=1`
session-scoped alongside `$CHARTER_PY`.

This is the same shape as the frame's own "never join argv" rule: make the mechanism
correct by construction rather than remembering it at seven call sites.

## Tests

3710, up from 3697. `test_self_relaunch_shadowing.py` builds a real decoy `charter/`
package, proves it genuinely shadows by reproducing the exact reported
`invalid choice: 'panel'` failure, then proves the helper and a panel spawned the way
`cmd_launch` spawns it are immune. `test_self_relaunch_argv.py` pins the argv and env each
of the seven sites builds, so no site can be left un-migrated.

Verified end to end against the reported symptom: a frame launched from a charter checkout
now comes up with all panes alive and panels rendering real state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
