### PR TITLE
Release 0.50.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.50.0"
+__version__ = "0.50.1"

--- a/docs/news/0.50.1-relaunch-ignores-cwd.md
+++ b/docs/news/0.50.1-relaunch-ignores-cwd.md
@@ -1,0 +1,29 @@
+---
+version: 0.50.1
+headline: charter re-launching charter can no longer import the directory it was run from
+---
+
+charter spawns itself in seven places — the status line's `gl-refresh` and `_version-check`,
+the frame's panels, a workspace command, the updater. Each built its own argv as
+`[sys.executable, "-m", "charter", ...]`, and `-m` prepends the working directory to
+`sys.path`. So from any directory containing a `charter/` package the child imported *that*
+source tree instead of the installed one: a charter checkout, or a control plane whose root
+happens to be one.
+
+Nothing announced it, and two of the seven sit on the status line's render path. On a charter
+checkout, `gl-refresh` and `_version-check` had been running whatever charter happened to
+live in that directory rather than the charter you installed — for as long as the checkout
+existed.
+
+It surfaced as something else entirely. `charter claude` came up with both panels showing
+**Pane is dead (status 2)**: a panel is spawned with the pane's cwd, so from a checkout it
+imported an older tree that had no `panel` command and argparse exited 2 before charter ran a
+line. The harness pane was fine because `claude` is a real binary — which is exactly why the
+whole thing read as a frame bug and not an import one.
+
+The seven hand-built argv lists are now one helper, `util.self_relaunch_argv`, which adds
+`-P` (3.11+, already charter's floor). The tmux menu template cannot take a flag, so it
+carries `PYTHONSAFEPATH=1` session-scoped instead. A decoy-package test reproduces the
+original failure to prove the shadowing was real, then proves the helper is immune to it.
+
+Nothing to adopt: upgrading is the whole of it.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.50.0",
+            "command": "charter hook sessionstart --plugin-version 0.50.1",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.50.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.50.1",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.50.0",
+            "command": "charter hook pretooluse --plugin-version 0.50.1",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.50.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.50.1",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.50.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.50.1"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.50.0",
+            "command": "charter hook pretooluse-edit --plugin-version 0.50.1",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-bash --plugin-version 0.50.0",
+            "command": "charter hook posttooluse-bash --plugin-version 0.50.1",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.50.0",
+            "command": "charter hook posttooluse --plugin-version 0.50.1",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.50.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.50.1",
             "timeout": 5
           }
         ]
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.50.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.50.1",
             "timeout": 5
           }
         ]
@@ -128,7 +128,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-message --plugin-version 0.50.0",
+            "command": "charter hook posttooluse-message --plugin-version 0.50.1",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.50.0"
+version = "0.50.1"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
A patch release for one bug fix: **#390 / PR #391** (`fa4269f`).

## What is in it

charter re-launched itself as `[sys.executable, "-m", "charter", …]` in seven places. Python's `-m` prepends the cwd to `sys.path`, so spawning from a directory containing a `charter/` package — a charter checkout, or a control plane whose root is one — made the child import that source tree instead of the installed package.

Found in the field: `charter claude` came up with both panels dead, `status 2`, because the panel process imported an older tree with no `panel` command and argparse exited 2. Two of the seven sites (`gl-refresh`, `_version-check`) sit on the status line's render path, so on any charter checkout they had been silently running the wrong charter.

Fixed with one helper adding `-P`, plus `PYTHONSAFEPATH=1` for the tmux menu template that cannot take a flag.

**Patch** is the right level: a bug fix, no new surface, no breaking change.

## The four version carriers move together

| File | |
|---|---|
| `pyproject.toml` | `version` |
| `charter/__init__.py` | `__version__` |
| `.claude-plugin/plugin.json` | `version` |
| `hooks/hooks.json` | all **eleven** `--plugin-version` flags |

Re-grepped for the old version across all four afterwards rather than working from a remembered count — the count grew from nine to eleven since the charter was written. `TestVersionsMoveInLockstep` passes.

## The news entry, deliberately

The fix asks nothing of the reader, so it carries no `check:`/`adopt:` — upgrading is the whole adoption. It still earns an entry, because its job is to **correct a false belief rather than prompt an action**: "the charter your status line runs is the one you installed" was untrue for everyone working inside a charter checkout, indefinitely and silently. Nobody could self-diagnose it — the field symptom presented as a *frame* bug, not an import one, so the entry is the only channel connecting the symptom people saw to the cause. Precedent: `0.47.1` and `0.47.2` are the same shape.

The release guard independently requires an entry for every published version, so this also keeps the tag publishable.

## Asset-freshness gate: not tripped

`tests/test_asset_freshness.py` measures lag in **minors** — `_minor()` discards the patch. `captured.json` stamped `0.50.0` against a `0.50.1` charter computes lag **0**, well inside `MAX_MINOR_LAG = 1`. No regeneration needed. Confirmed by running the gate, not by assuming it.

## Verification

- `python3 -m unittest discover -s tests` → **Ran 3710 tests, OK**
- `charter news --for 0.50.1` → exit 0 (the guard's exact call)
- `TestVersionsMoveInLockstep` + `test_asset_freshness` → 8 tests, OK