### PR TITLE
`charter trace --summary` no longer counts charter's own test suite (#372)

### DIFF
--- a/charter/trace.py
+++ b/charter/trace.py
@@ -6,6 +6,27 @@ This is **not** OpenTelemetry — no collector, no network, no deps. It's a stdl
 JSONL record under gitignored ``.charter/persona-state/trace/<session>.jsonl`` so you can
 answer "what did the agent/personas just do?" and feed the eval loop. Capture is
 best-effort and never raises — observability must never break the thing it observes.
+
+**Nothing here filters, and nothing here is marked "not really yours."** Every row in
+``<session>.jsonl`` is a fact about that session, and ``charter trace --summary`` counts
+rows without exception. That is a decision, and #372 is the case that forced it: the summary
+once reported 581 guard denials of which 556 were recorded while charter's own test suite
+ran — a suite run resolves its plane by walking up for ``charter.toml``, so a checkout
+sitting inside somebody's plane writes into THAT plane, under the ambient
+``$CHARTER_SESSION_ID``. Two fixes were available at the reader and both were refused:
+
+* Dropping the suite's rows from the count would make "quiet because nothing happened" and
+  "quiet because we filtered" print identically. A trace that can be silent for two
+  different reasons is worse than a loud one.
+* Marking rows instead — *"556 of these were the test suite"* — reads honestly, but the mark
+  has to come from something the runtime can see, an env var or a config key. That is an
+  override the observed agent could set on its own denials, and
+  ``hooks._OVERRIDE_NOTE`` spends a paragraph refusing exactly that trade for the guards
+  themselves. The record of a guard does not get a weaker rule than the guard.
+
+So the boundary is the WRITER: a test pins its own root and never reaches the operator's
+plane (#227, and ``tests/test_the_suite_writes_no_trace_into_the_operators_plane.py``, which
+holds the invariant). Rows that exist happened; a count of them is the truth.
 """
 
 from __future__ import annotations

--- a/tests/test_inflight_dispatch.py
+++ b/tests/test_inflight_dispatch.py
@@ -204,17 +204,19 @@ class DispatchNudge(unittest.TestCase):
     def setUp(self) -> None:
         self._td = TemporaryDirectory()
         root = Path(self._td.name)
-        self._state, self._root = config.STATE_DIR, config.ROOT
-        self._personas = config.PERSONAS_DIR
-        config.STATE_DIR = root / ".charter"
-        config.ROOT = root
-        config.PERSONAS_DIR = root / "personas"
+        # `config.use`, not three named attributes. The nudge these cases drive calls
+        # `_trace("dispatch-ask", data.get("session_id"))`, and `_run`'s payload carries no
+        # session id — so the row fell through to the ambient `$CHARTER_SESSION_ID` and
+        # landed in the OPERATOR's live trace bucket, which is what `charter trace
+        # --summary` counts (#372). `PERSONA_STATE_DIR` was the attribute this list missed;
+        # `config.DERIVED` exists so a fixture cannot miss one.
+        #
+        # `charter.toml` first, because `use` re-derives HAS_CONTROL_PLANE and the
+        # hand-rolled patch left the real plane's `True` standing.
+        (root / "charter.toml").write_text("schema = 1\n")
+        self._orig = config.use(root)
         self.addCleanup(self._td.cleanup)
-
-        def _restore():
-            config.STATE_DIR, config.ROOT = self._state, self._root
-            config.PERSONAS_DIR = self._personas
-        self.addCleanup(_restore)
+        self.addCleanup(lambda: config.restore(self._orig))
 
         self._persona("coder", "dispatch-isolation: worktree\n")
         self._persona("explorer", "")

--- a/tests/test_the_suite_writes_no_trace_into_the_operators_plane.py
+++ b/tests/test_the_suite_writes_no_trace_into_the_operators_plane.py
@@ -1,0 +1,136 @@
+"""A test run must leave no row in the operator's trace (#372).
+
+`charter trace --summary` reported 581 guard denials for one session, 556 of which were
+recorded while charter's own test suite ran. A suite run resolves its plane the way every
+command does — walk up for `charter.toml`, then hop outward through `workspaces/` — so a
+charter checkout that lives inside somebody's plane resolves to THAT plane. Any test that
+reaches a real handler without redirecting `config` therefore appends to the developer's
+own `.charter/persona-state/trace/`, under the ambient `$CHARTER_SESSION_ID`: the live
+session bucket the summary reads.
+
+**The boundary is the writer, and it stays there.** #227 put it there — it pinned
+`$CHARTER_ROOT` for the hook subprocesses and moved `test_plugin` onto `config.use` — and
+that is what killed the denials. The two alternatives were considered and refused:
+
+* *Filter the summary.* A count that drops rows makes "quiet because nothing happened" and
+  "quiet because we filtered" print the same thing, which is the one confusion an
+  observability tool may not create.
+* *Mark the rows and say "556 of these were the test suite".* Honest to read, but the mark
+  has to come from something the runtime can see — an env var or a config key — and that is
+  an override the agent under observation could set on its own denials.
+  `hooks._OVERRIDE_NOTE` refuses exactly that trade for the guards; the record of the guards
+  does not get a weaker rule than the guards.
+
+So nothing is filtered and nothing is marked, and the invariant that makes that safe is
+asserted here: no fixture may write into the plane the suite resolved to.
+
+Both defects below have the same shape — a fixture that hand-picks the `config` attributes
+it redirects and misses `PERSONA_STATE_DIR`, which is the attribute the trace writes
+through. `config.DERIVED` exists so that a fixture cannot miss one (its own docstring names
+the vault registry a hand-picked list already orphaned), so the fix is to redirect through
+`config.use` rather than to lengthen the list by one.
+
+They were found by running the suite with `$CHARTER_ROOT` pinned to an empty plane and
+listing what appeared under its `persona-state/`. That is also how a third would be found;
+this module only pins the two that exist.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from charter import config, trace
+# The MODULES, never the classes: `from … import TestSessionLock` would bind a TestCase
+# subclass in this module's namespace, and `TestLoader` collects by namespace — the
+# borrowed fixtures would then run a second time in every suite run, under this file's name.
+from tests import test_inflight_dispatch, test_workspace_lock
+
+
+class _AFixtureThatForgetsPersonaStateDir(unittest.TestCase):
+    """The positive control: a fixture with the exact defect, kept so the probe below is
+    known to SEE a leak rather than merely to report none.
+
+    Its probe method is deliberately not named ``test_*``. Discovery collects this class
+    (a leading underscore does not hide it from `TestLoader`) and would otherwise run the
+    leak for real, into the developer's plane, every suite run.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="charter-372-control-"))
+        self._orig = config.STATE_DIR
+        config.STATE_DIR = self.tmp / ".charter"      # ...and PERSONA_STATE_DIR is missed
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.addCleanup(lambda: setattr(config, "STATE_DIR", self._orig))
+
+    def runProbe(self) -> None:
+        trace.record("probe", session="control")
+
+
+class TraceLeakProbe(unittest.TestCase):
+    def files_left_in_the_operators_plane(self, case_class, method: str) -> list[str]:
+        """Run one real test method with the ambient plane pointed at a sentinel, and
+        return the trace files the run left behind there.
+
+        The sentinel is a throwaway plane, never the real one: a RED run of this module
+        must not commit the very act it exists to forbid. It is a plane rather than a bare
+        directory (`charter.toml` present) so `HAS_CONTROL_PLANE` is what it would be on a
+        developer's machine — the guards and nudges these fixtures drive are gated on it,
+        and a fixture that stopped reaching its handler would report "no leak" for the
+        wrong reason.
+        """
+        sentinel = Path(tempfile.mkdtemp(prefix="charter-372-sentinel-"))
+        (sentinel / "charter.toml").write_text("schema = 1\n")
+        outer = config.use(sentinel)
+        try:
+            result = unittest.TestResult()
+            case_class(method).run(result)
+            self.assertTrue(
+                result.wasSuccessful(),
+                f"{case_class.__name__}.{method} did not pass, so it proves nothing about "
+                f"leaking: {result.errors or result.failures}")
+            d = sentinel / ".charter" / "persona-state" / "trace"
+            return sorted(p.name for p in d.glob("*.jsonl")) if d.is_dir() else []
+        finally:
+            config.restore(outer)
+            shutil.rmtree(sentinel, ignore_errors=True)
+
+
+class TestTheProbeCanSeeALeak(TraceLeakProbe):
+    """Without this, every assertion below would pass just as well if the probe were blind."""
+
+    def test_a_fixture_that_misses_persona_state_dir_is_caught(self):
+        self.assertEqual(
+            ["control.jsonl"],
+            self.files_left_in_the_operators_plane(
+                _AFixtureThatForgetsPersonaStateDir, "runProbe"))
+
+
+class TestNoFixtureWritesIntoTheOperatorsTrace(TraceLeakProbe):
+    def test_the_workspace_lock_fixture_writes_nowhere_real(self):
+        """`workspace.set_active` records `workspace-use`. This fixture redirected five
+        attributes and not `PERSONA_STATE_DIR`, so twenty rows a run landed in the
+        developer's plane — under `sess-lock-test` and `fresh-sess`, buckets that are still
+        sitting in real `.charter/persona-state/trace/` directories."""
+        self.assertEqual(
+            [],
+            self.files_left_in_the_operators_plane(
+                test_workspace_lock.TestSessionLock,
+                "test_first_confirm_locks_the_session"))
+
+    def test_the_dispatch_nudge_fixture_writes_nowhere_real(self):
+        """The worst of the two, because it has no session id of its own: the payload
+        carries none, so `_trace("dispatch-ask", ...)` falls through to the ambient
+        `$CHARTER_SESSION_ID` and the row lands in the operator's LIVE session — exactly
+        where `charter trace --summary` counts it."""
+        self.assertEqual(
+            [],
+            self.files_left_in_the_operators_plane(
+                test_inflight_dispatch.DispatchNudge,
+                "test_overlapping_code_writer_is_nudged"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workspace_lock.py
+++ b/tests/test_workspace_lock.py
@@ -2,9 +2,9 @@
 switched mid-session (unless forced), and SessionStart nudges the agent to confirm one.
 
 The lock is keyed by the Claude session id and stored at ``.charter/sessions/<sid>.lock``.
-These paths are import-time-derived from ``STATE_DIR``, so the test repoints
-``STATE_DIR``/``SESSIONS_DIR``/``TERMINALS_DIR``/``WORKSPACES_DIR`` at a tmp dir and pins
-``$CLAUDE_CODE_SESSION_ID`` so ``set_active`` sees a stable session.
+These paths are derived from ``STATE_DIR``, so the fixture repoints the whole plane at a tmp
+dir through ``config.use`` and pins ``$CLAUDE_CODE_SESSION_ID`` so ``set_active`` sees a
+stable session.
 """
 
 from __future__ import annotations
@@ -28,13 +28,19 @@ class WorkspaceLockBase(unittest.TestCase):
 
     def setUp(self) -> None:
         self.tmp = Path(tempfile.mkdtemp(prefix="edm-wslock-"))
-        self._orig = {k: getattr(config, k)
-                      for k in ("ROOT", "STATE_DIR", "SESSIONS_DIR", "TERMINALS_DIR", "WORKSPACES_DIR")}
-        config.ROOT = self.tmp
-        config.STATE_DIR = self.tmp / ".charter"
-        config.SESSIONS_DIR = config.STATE_DIR / "sessions"
-        config.TERMINALS_DIR = config.STATE_DIR / "terminals"
-        config.WORKSPACES_DIR = self.tmp / "workspaces"
+        # `config.use`, not a hand-picked list. This fixture named five attributes and
+        # `set_active` writes through a sixth — `PERSONA_STATE_DIR`, where the trace lives —
+        # so every case below appended `workspace-use`/`workspace-refused` rows to the
+        # DEVELOPER's own plane, twenty a run, in the session bucket `charter trace
+        # --summary` counts (#372). `config.DERIVED` is the single definition of what
+        # follows from a root precisely so a fixture cannot miss one; #227 moved
+        # `test_plugin` onto the same seam after the same failure.
+        #
+        # `charter.toml` first: `use` re-derives HAS_CONTROL_PLANE, and these cases drive
+        # handlers that are gated on it. The hand-rolled patch left the real plane's value
+        # standing, so dropping the marker would silently change what is under test.
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        self._orig = config.use(self.tmp)
         config.WORKSPACES_DIR.mkdir(parents=True, exist_ok=True)
 
         self._orig_env = {k: os.environ.get(k) for k in ("CLAUDE_CODE_SESSION_ID", "CHARTER_WORKSPACE")}
@@ -43,8 +49,7 @@ class WorkspaceLockBase(unittest.TestCase):
         self.addCleanup(self._restore)
 
     def _restore(self) -> None:
-        for k, v in self._orig.items():
-            setattr(config, k, v)
+        config.restore(self._orig)
         for k, v in self._orig_env.items():
             if v is None:
                 os.environ.pop(k, None)


### PR DESCRIPTION
Closes #372.

Implemented and adversarially reviewed in an ultracode workflow: the reviewer reproduced the original symptom against the branch point, showed it gone on HEAD, and mutation-tested every new test to confirm it can actually fail. Verdict: approved, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9