### PR TITLE
`charter frame -- <cmd>` reports a missing command instead of going silent (#384)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -73,6 +73,26 @@ the write hook second would wipe out the teardown hook the moment it lands — r
 end to end by swapping the two `cmd_launch` calls: the session hung exactly the way it
 did before either hook existed. See `_pane_died_teardown_hook_argv`'s own docstring.
 
+**A command that dies before the frame is drawn is reported AFTER the fact, never
+refused before it (#384).** The eager `#{pane_dead}` check above is exactly what makes
+that death total: it catches the dead pane, runs `kill-session`, and because `code is
+not None` from that moment the entire attach branch — panels, `select-pane`, `attach` —
+is skipped, so there is no pane, no attach, and nothing drawn. Measured under a pty
+against a real tmux 3.7c: **zero bytes**, both for `charter frame -- nosuchthing` and
+for `charter frame -- sh -c 'echo boom >&2; exit 9'` — a far wider class than a missing
+binary. A `shutil.which(argv[0])` pre-check would not have covered that class and would
+have cost something real, because what `charter frame --` accepts is TMUX's rule, not
+charter's: verified against 3.7c that a SINGLE argument is handed to a shell (so
+`charter frame -- 'ulimit -n; exit 3'` is a whole command line — builtins, `;`,
+redirection) while TWO OR MORE are `execvp`'d directly. `which` over the first form asks
+the wrong question of text that is not even one word; over the second it is a prediction
+where a real answer arrives for free a few milliseconds later (a binary that resolves
+can still exit 127 for its own reasons, or carry a broken shebang). So nothing is
+refused, and `early_death_message` builds the report out of what tmux actually did —
+quoting the pane (`_pane_last_words`, read BEFORE `kill-session` destroys it) when the
+shell already said what was wrong, and answering for itself when a failed `execvp` left
+the pane empty and a bare exit 1.
+
 **Every tmux command here goes through `frame/tmuxctl.py`, and the timeout is the
 reason.** `cmd_launch` used to issue eleven `subprocess.run(…, timeout=15)` calls of its
 own with nothing catching `subprocess.TimeoutExpired`. Ten of them run AFTER
@@ -148,6 +168,24 @@ _CHARTER_PY_ENV = tmuxctl.CHARTER_PY_ENV
 #: `cmd_launch` on to `attach` a session with nothing left to end it, recreating the
 #: exact hang the eager check exists to close, just from a signal instead of a race.
 _UNKNOWN_DEATH_CODE = 1
+
+
+#: tmux's own trailer, drawn INTO a dead pane by `remain-on-exit` and therefore the last
+#: line of every capture `_pane_last_words` ever takes (measured against tmux 3.7c: `Pane
+#: is dead (status 127, Sun Aug 23 18:15:16 2026)`). Stripped, because repeating it would
+#: be charter answering in tmux's words immediately after answering in its own — and
+#: because the timestamp makes the line different on every run, which is exactly the kind
+#: of noise an operator learns to skip past. Safe by construction rather than by tmux's
+#: wording holding still: a trailer that stopped matching this is repeated back, which is
+#: merely untidy, never silent.
+_PANE_IS_DEAD = re.compile(r"^Pane is dead\b")
+
+#: How many of a dead pane's own lines charter repeats back. A TAIL, not a head:
+#: `capture-pane -S -` returns the pane's whole history (up to `[frame] history-limit`,
+#: 50 000 by default) and the reason a thing died is at the end of what it printed. Ten
+#: covers a shell's one-line `command not found` and a short traceback, and keeps a
+#: harness that managed a screenful on its way out from burying charter's own line.
+_PANE_LINES_SHOWN = 10
 
 
 def bypass(argv: list[str]) -> int:
@@ -606,6 +644,109 @@ def _query_pane_dead_status(socket: str, harness_pane: str) -> int | None:
     return _UNKNOWN_DEATH_CODE
 
 
+def _pane_last_words(socket: str, harness_pane: str) -> list[str]:
+    """Everything a dead pane still holds, tmux's own trailer stripped off.
+
+    **`-S -` is why this is not a bare `capture-pane -p`, and it was measured rather than
+    reasoned.** `remain-on-exit` appends its own `Pane is dead (…)` line at the bottom,
+    which scrolls the visible screen down by one — so the DEFAULT (visible-screen-only)
+    capture of a command that printed exactly one line comes back with that line already
+    pushed into history and blanks where it used to be. Verified against tmux 3.7c with
+    a missing command: `capture-pane -p` returned tmux's trailer and nothing else, while
+    `capture-pane -p -S -` returned `zsh:1: command not found: …` as well. The single
+    line that matters here is precisely the one the default form loses.
+
+    `report=False`, for the same shape of reason `_query_pane_dead_status` gives: this
+    runs only when `cmd_launch` is already reporting a real failure, and a second,
+    louder line about the DIAGNOSTIC having failed would bury the failure it was sent to
+    explain. An empty answer needs no special casing — `early_death_message` has a
+    complete message either way, which is the property that keeps a failed capture from
+    putting the launch back to the zero bytes #384 is about.
+    """
+    out = tmuxctl.run("reading what the harness printed before it died",
+                      ["tmux", "-L", socket, "capture-pane", "-p", "-S", "-",
+                       "-t", harness_pane],
+                      timeout=5, report=False)
+    if out.returncode != 0:
+        return []
+    lines = [ln.rstrip() for ln in out.stdout.splitlines()]
+    lines = [ln for ln in lines if ln.strip() and not _PANE_IS_DEAD.match(ln)]
+    return lines[-_PANE_LINES_SHOWN:]
+
+
+def _could_not_have_run(word: str) -> str | None:
+    """Why *word* cannot have been a program at all, or ``None`` when it could have.
+
+    Three states, not two, because they take three different remedies and because tmux
+    collapses the last two into one indistinguishable answer (see
+    `early_death_message`): resolvable on `$PATH` — nothing to say, something ran and the
+    exit code is its own; a path that EXISTS but is not executable — `chmod +x`, or name
+    the interpreter; and neither — a typo, or something never installed.
+
+    **Asked only AFTER a launch has already failed, never before one.** The same call
+    used as a pre-check would decide what `charter frame --` ACCEPTS, and it is not
+    entitled to: `shutil.which` answers a question about `execvp`, while tmux hands a
+    lone argument to a shell (see `early_death_message`). Used here it decides only how
+    an error that has already happened is worded, which narrows nothing.
+    """
+    if shutil.which(word):
+        return None
+    if os.path.exists(word):
+        return (f"`{word}` is a file that exists but is not executable — `chmod +x` it, "
+                f"or put its interpreter first")
+    return (f"`{word}` is neither on $PATH nor a path that exists, and with two or more "
+            f"words there is no shell in the way to resolve it — so nothing ran")
+
+
+def early_death_message(argv: list[str], code: int, last_words: list[str]) -> str:
+    """What an operator is told when their command died before the frame was ever drawn.
+
+    **The design call #384 left open, and the argument for taking it this way.** `charter
+    <harness>` can refuse a missing binary before tmux (see `cmd_launch`'s `if h and not
+    shutil.which(h.binary)`), because charter chose that name itself. `charter frame --
+    <cmd>` cannot be closed the same way without changing what it ACCEPTS, and what it
+    accepts is tmux's rule, not charter's — verified against tmux 3.7c:
+
+    * ONE argument is handed to a shell. `charter frame -- 'ulimit -n; exit 3'` is a
+      whole command line: builtins, `;`, pipelines, redirection. `shutil.which` over that
+      argument is not a stricter check, it is a check of the wrong thing — the text is
+      not even one word.
+    * TWO OR MORE arguments are `execvp`'d directly, with no shell anywhere.
+
+    So nothing is refused up front. The failure is reported afterwards, out of what tmux
+    actually did — which costs one `capture-pane` on a path that has already failed, and
+    is an ANSWER where a pre-check could only ever have been a prediction (a binary that
+    resolves can still exit 127 for its own reasons, or have a broken shebang).
+
+    The two forms leave two different residues, which is why this message has two shapes:
+
+    * one argument, missing command — the shell runs, prints its own `command not found`,
+      exits **127**. Accurate words already exist; they are just in a pane nobody ever
+      attached to, so charter repeats them back rather than inventing worse ones.
+    * two or more, missing command — `execvp` fails inside tmux's own child, which exits
+      **1** with the pane completely EMPTY. There is nothing to repeat, and a bare 1 is
+      indistinguishable from a program that ran and failed. Only there does charter
+      answer the resolution question itself (`_could_not_have_run`), and only because
+      with no shell involved the inference is sound: a word that resolves to nothing
+      provably could not have run.
+
+    Charter fills SILENCE and does not argue with a pane that already spoke — hence the
+    early return. A program that printed and then failed plainly did run, so a `$PATH`
+    note layered on top of its own words would be wrong as often as not.
+    """
+    lines = [f"charter frame: `{' '.join(argv)}` exited {code} before the frame was "
+             f"drawn — you were never attached, so nothing it printed was ever on screen."]
+    if last_words:
+        lines.append("  the pane still had this in it:")
+        lines.extend(f"    {ln}" for ln in last_words)
+        return "\n".join(lines)
+    lines.append("  the pane was empty — it printed nothing at all.")
+    note = _could_not_have_run(argv[0]) if len(argv) > 1 else None
+    if note:
+        lines.append(f"  {note}")
+    return "\n".join(lines)
+
+
 def cmd_launch(args) -> int:
     """One launcher, shared by every registered harness and by `charter frame --`."""
     if getattr(args, "probe", False):
@@ -652,7 +793,11 @@ def cmd_launch(args) -> int:
     # verbatim word, and it is allowed to be a shell builtin, a relative path, or
     # anything else tmux's own resolution accepts — a `which` check over THAT would
     # narrow what the escape hatch accepts, which is a design change and not this fix.
-    # So the escape hatch keeps its current behaviour exactly, unchanged.
+    #
+    # The escape hatch's ACCEPTANCE is still exactly that: nothing is refused for it, and
+    # #384 deliberately did not change that either (see the module docstring, and
+    # `early_death_message`'s own). Its SILENCE is what changed — the same death is now
+    # legible from the other end, once tmux has already answered.
     if h and not shutil.which(h.binary):
         return bypass(argv)
 
@@ -843,6 +988,19 @@ def cmd_launch(args) -> int:
     code = _query_pane_dead_status(SOCKET, harness_pane)
     if code is not None:
         state.record_exit(fid, code)
+        if code != 0:
+            # The one path on which NOTHING is ever drawn (#384): no panels, no
+            # `select-pane`, no `attach` — the whole `if code is None:` block below is
+            # skipped from here on — so this is the only chance the operator has of
+            # learning anything at all. Read the pane BEFORE `kill-session` destroys it;
+            # afterwards there is nothing left to read.
+            #
+            # Only for a FAILURE. A command that finished cleanly before the frame came
+            # up (`charter frame -- true`) reaches this same branch with 0, and whatever
+            # it wrote was its stdout — charter repeating that onto stderr would be
+            # inventing output on the wrong stream. Its exit code is the whole message.
+            util.err(early_death_message(argv, code,
+                                         _pane_last_words(SOCKET, harness_pane)))
         tmuxctl.run("ending the frame after an early death",
                     ["tmux", "-L", SOCKET, "kill-session", "-t", fid], env=env)
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -82,6 +82,50 @@ the harness's real status and exits with that. `--no-frame` and the automatic by
 stdout is not a terminal both skip the frame entirely and `exec` straight into the harness,
 so a pipe (`charter claude -p … | jq`) carries the real exit code with no help needed.
 
+## What `charter frame -- <cmd>` accepts
+
+The escape hatch runs whatever **tmux** runs, and charter refuses nothing up front. That
+rule is tmux's rather than charter's, and it has one edge worth knowing (measured against
+tmux 3.7c):
+
+    charter frame -- 'ulimit -n; exit 3'    # ONE argument  → handed to a shell
+    charter frame -- ./build.sh --release   # TWO OR MORE   → exec'd directly, no shell
+
+So a single argument can be a whole command line — builtins, `;`, pipelines, redirection —
+while two or more are looked up as a program and its arguments, with nothing in between to
+expand or resolve them.
+
+Charter deliberately does **not** check the command against `$PATH` before starting it.
+Such a check answers the wrong question for the first form (that text is not even one
+word), and for the second it is a guess where a real answer arrives milliseconds later: a
+command that resolves can still exit 127 on its own, or carry a broken shebang.
+
+## When the command dies before the frame is drawn
+
+This is the one case where you were never attached to anything, so without a report there
+is nothing at all to see — and until 0.50 there wasn't. `charter frame -- nosuchthing`
+returned 127 having printed **zero bytes**; so did anything else that died in the opening
+milliseconds, a harness crashing on a bad config included. Charter now says what happened,
+after the fact, out of what tmux actually did:
+
+    ✗ charter frame: `nosuchthing` exited 127 before the frame was drawn — you were never
+      attached, so nothing it printed was ever on screen.
+      the pane still had this in it:
+        zsh:1: command not found: nosuchthing
+
+The dead pane's own last words are quoted back when there are any — that second line is
+your shell's, whichever shell tmux starts on this machine, and it is more accurate than
+anything charter could write in its place. When there are none — a failed direct exec
+leaves the pane completely empty and a bare exit 1 — charter answers for itself instead,
+telling apart the three states that need three different remedies: on `$PATH`, a file that
+exists but is not executable, or neither.
+
+A command that finishes *successfully* before the frame comes up (`charter frame -- true`)
+is not reported, and its output is not reprinted: that was its stdout, and charter will not
+invent it on stderr. If you want a short command's output, `--no-frame` — or a pipe, which
+bypasses the frame on its own — is the right tool; the frame is for something you sit in
+front of.
+
 ## When the terminal is too small
 
 Below `[frame]`'s `min-cols`/`min-rows`, the side panels (`left`/`right`) are the first to

--- a/docs/news/unreleased-a-frame-that-dies-instantly-says-so.md
+++ b/docs/news/unreleased-a-frame-that-dies-instantly-says-so.md
@@ -1,0 +1,43 @@
+---
+version: unreleased
+headline: A framed command that dies instantly now says so, instead of nothing at all
+---
+
+`charter frame -- nosuchthing` used to return 127 having printed **zero bytes**. Not a
+short message, not tmux's own — nothing. The same was true of anything else that died in
+the frame's opening milliseconds: a harness crashing on a bad config, a script with a
+broken shebang, `charter frame -- sh -c 'echo boom >&2; exit 9'`. All of it, silent.
+
+The silence was structural rather than a missing `print`. charter asks tmux directly
+whether the harness pane died the moment its exit-code hooks are installed — a check that
+exists to stop `attach` blocking forever on a session nothing is left to end. When it says
+yes, charter records the code, runs `kill-session`, and skips the whole attach branch:
+panels, focus, `attach`. So on exactly the path where something went wrong, there was no
+pane to see it in and no attach to see it through.
+
+Now:
+
+    ✗ charter frame: `nosuchthing` exited 127 before the frame was drawn — you were never
+      attached, so nothing it printed was ever on screen.
+      the pane still had this in it:
+        zsh:1: command not found: nosuchthing
+
+**Nothing was narrowed to get there.** The obvious fix — check the command against `$PATH`
+before starting it — would have changed what `charter frame --` *accepts*, and what it
+accepts is tmux's rule, not charter's: one argument is handed to a shell, two or more are
+exec'd directly. `charter frame -- 'ulimit -n; exit 3'` is a whole command line, builtins
+and semicolons and all, and a `which`-style check over that text is asking the wrong
+question of something that is not even one word. For the two-or-more form such a check
+would only be a prediction, when the real answer arrives milliseconds later — a command
+that resolves can still exit 127 on its own account.
+
+So charter refuses nothing and reports afterwards, out of what tmux actually did. The dead
+pane's own last words are read back before the session is torn down, because your shell's
+`command not found` is more accurate than anything charter would write in its place. When
+there are no words — a failed direct exec leaves the pane completely empty and a bare exit
+1 — charter answers for itself, and tells apart the three states that need three different
+remedies: on `$PATH`, a file that exists but is not executable, or neither.
+
+A command that finishes *successfully* before the frame comes up is still silent, on
+purpose: whatever it wrote was its stdout, and charter is not going to reprint it onto
+stderr. `docs/frame.md` has the whole contract.

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -650,14 +650,17 @@ class _FakeTmux:
 
     def __init__(self, *, pane_id="%7", exit_code=None, race_death_status=None,
                 still_live=False, pre_existing_sessions=frozenset(),
-                panel_pane_ids=None,
+                panel_pane_ids=None, pane_capture="",
                 session_rc=0, source_rc=0, env_set_rc=0, write_hook_rc=0,
                 teardown_hook_rc=0, panel_rc=0, select_rc=0, attach_rc=0, dm_rc=0,
-                kill_rc=0, arm_rc=0, resize_hook_rc=0,
+                kill_rc=0, arm_rc=0, resize_hook_rc=0, capture_rc=0,
                 resize_hook_stderr="bad resize hook target"):
         self.pane_id = pane_id
         self.exit_code = exit_code
         self.race_death_status = race_death_status
+        # What `capture-pane` reports the dead pane still had in it — the ONLY place a
+        # command that died before `attach` ever got the chance to say anything (#384).
+        self.pane_capture = pane_capture
         self.still_live = still_live
         self.pre_existing_sessions = pre_existing_sessions
         # slot -> pane id `split-window` reports for it. Empty by default (see
@@ -676,6 +679,7 @@ class _FakeTmux:
         self.kill_rc = kill_rc
         self.arm_rc = arm_rc
         self.resize_hook_rc = resize_hook_rc
+        self.capture_rc = capture_rc
         # Distinct from every other stderr string in this fake — a test needs to
         # control it independently to exercise the "invalid option" degrade (fix
         # round 3, item 2) separately from an ordinary resize-hook failure.
@@ -737,6 +741,10 @@ class _FakeTmux:
         if "display-message" in cmd:
             out = f"1:{self.race_death_status}" if self.race_death_status is not None else "0:"
             return subprocess.CompletedProcess(cmd, self.dm_rc, stdout=out, stderr="")
+        if "capture-pane" in cmd:
+            return subprocess.CompletedProcess(cmd, self.capture_rc,
+                                               stdout=self.pane_capture if self.capture_rc == 0 else "",
+                                               stderr="" if self.capture_rc == 0 else "no such pane")
         if "kill-session" in cmd:
             self.kill_session_called = True
             return subprocess.CompletedProcess(cmd, self.kill_rc, stdout="",
@@ -1450,6 +1458,221 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertIn("frame_dir_create", order)
         self.assertLess(order.index("reap"), order.index("frame_dir_create"),
                         f"reap must run before this frame's own directory is created: {order}")
+
+
+class EarlyDeathIsLegible(PersonaIso, unittest.TestCase):
+    """#384: a command that dies before the frame is drawn must not die in silence.
+
+    The exact shape of that silence, measured under a pty against a real tmux 3.7c:
+    `new-session` starts the command, it dies instantly, the eager
+    `_query_pane_dead_status` catches the dead pane, `kill-session` runs, and because
+    `code is not None` from that moment the ENTIRE `if code is None:` block — panels,
+    `select-pane`, `attach` — is skipped. There is no pane and no attach, so **zero
+    bytes** reach the operator and the launch returns a number with no explanation.
+
+    `MissingHarnessBinary` above closes this for a REGISTERED harness by refusing before
+    tmux is ever reached — charter chose that binary's name, so `shutil.which` is asking
+    about charter's own claim. The escape hatch cannot be closed that way, and that is
+    the design call #384 left open: `charter frame -- <cmd>` runs whatever TMUX runs, and
+    tmux's own rule (verified against 3.7c) is that ONE argument goes to a shell — so
+    `charter frame -- 'ulimit -n; exit 3'` is a whole shell command line, builtin and
+    all — while TWO OR MORE are `execvp`'d directly. A `shutil.which(argv[0])` pre-check
+    answers neither question: it would refuse the shell form outright, and for the
+    `execvp` form it would still be a prediction where an answer is available for free a
+    few milliseconds later. So nothing is refused up front; the failure is reported
+    afterwards, out of what tmux actually did.
+
+    Charter has to say two different things because tmux leaves two different residues
+    (both measured against 3.7c, both pinned by
+    `tests/test_frame_tmux_integration.py::EarlyDeathIntegration`):
+
+    * ONE argument, missing command — the shell runs, prints `command not found`, exits
+      **127**. The accurate words already exist; they are just in a pane nobody ever
+      attached to. Charter repeats them back.
+    * TWO OR MORE arguments, missing command — `execvp` fails inside tmux's own child,
+      which exits **1** with the pane completely EMPTY. Nothing to repeat, and a bare 1
+      is indistinguishable from a program that ran and failed. Only there does charter
+      answer the resolution question itself.
+    """
+
+    def test_a_command_that_dies_before_the_frame_is_drawn_says_so(self):
+        """The headline defect. Nothing on `$PATH` resolves for the duration — the
+        strongest form of the question and the one that pins the CONTRACT at the same
+        time: the launch must still reach `new-session` (refusing here would narrow what
+        the escape hatch accepts) and must still come back with charter's own account of
+        what happened.
+
+        Asserts charter's OWN framing — the phrase and the exit code — rather than the
+        command's name, which also appears in the pane text
+        `test_the_dead_panes_own_last_words_are_repeated_back` covers. Deleting only the
+        `capture-pane` call leaves this test green and that one red, and vice versa;
+        asserting on the name alone would have collapsed the two into one."""
+        fake = _FakeTmux(race_death_status=127,
+                         pane_capture="zsh:1: command not found: nosuchthing-xyz\n")
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake, harness="", rest=["--", "nosuchthing-xyz"],
+                         which=lambda name, *a, **k: None)
+        self.assertEqual(rc, 127)
+        self.assertTrue(any("new-session" in c for c in fake.calls),
+                        "the escape hatch must still run a command that is not on $PATH")
+        self.assertTrue(any("charter frame:" in m and "127" in m for m in buf),
+                        f"the operator was told nothing about a dead frame: {buf}")
+
+    def test_the_dead_panes_own_last_words_are_repeated_back(self):
+        """The half charter cannot write itself. A lone `nosuchthing-xyz` reaches a
+        SHELL (tmux's one-argument rule), and the shell's own `command not found` names
+        the word, the interpreter and the line — all of it accurate, all of it in a pane
+        that is about to be killed without ever having been drawn. Reading it back out
+        before `kill-session` is what turns tmux's silence into a report."""
+        fake = _FakeTmux(race_death_status=127,
+                         pane_capture="zsh:1: command not found: nosuchthing-xyz\n")
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            _launch(fake, harness="", rest=["--", "nosuchthing-xyz"])
+        self.assertTrue(any("command not found: nosuchthing-xyz" in m for m in buf),
+                        f"the pane's own last words never reached the operator: {buf}")
+
+    def test_the_pane_is_read_before_the_session_is_killed(self):
+        """Ordering, and load-bearing rather than incidental — `kill-session` destroys
+        the pane, so a capture issued after it can only ever come back empty. Pinned by
+        comparing indices, the same way
+        `test_the_write_hook_is_installed_before_the_teardown_hook` pins the other
+        ordering this launcher depends on.
+
+        `"set-hook" not in c` is not decoration: `_pane_died_teardown_hook_argv`'s ACTION
+        is the literal string `kill-session`, so an unfiltered search finds the hook
+        INSTALL — issued long before either the capture or the real teardown — and this
+        test failed against a correct implementation until it stopped matching that."""
+        fake = _FakeTmux(race_death_status=127, pane_capture="boom\n")
+        with mock.patch("charter.util.err"):
+            _launch(fake, harness="", rest=["--", "nosuchthing-xyz"])
+        capture_idx = next(i for i, c in enumerate(fake.calls) if "capture-pane" in c)
+        kill_idx = next(i for i, c in enumerate(fake.calls)
+                        if "kill-session" in c and "set-hook" not in c)
+        self.assertLess(capture_idx, kill_idx,
+                        "the pane must be read BEFORE it is destroyed, or there is "
+                        "nothing left to read")
+
+    def test_a_clean_early_exit_is_not_reported_as_a_failure(self):
+        """`charter frame -- true` finishes before the frame is drawn too, and reaches
+        this exact path with status 0. Nothing is wrong, so nothing is said — and the
+        pane is not even read: whatever a SUCCESSFUL command wrote was its stdout, and
+        charter repeating it onto stderr would be inventing output on the wrong stream.
+        The exit code is the whole message."""
+        fake = _FakeTmux(race_death_status=0, pane_capture="hi\n")
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake, harness="", rest=["--", "true"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(buf, [], f"a clean early exit must say nothing: {buf}")
+        self.assertFalse(any("capture-pane" in c for c in fake.calls),
+                         "a successful command's own output is not charter's to reprint")
+
+    def test_a_launch_that_reaches_attach_never_reads_the_pane(self):
+        """The ordinary path: the operator WAS attached and watched the harness live and
+        die on their own screen. Reading the pane back there and printing it would
+        replay the entire session onto stderr after the fact. The report belongs to the
+        one path where nothing was ever shown."""
+        fake = _FakeTmux(exit_code=3, pane_capture="a whole session\n")
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake)
+        self.assertEqual(rc, 3)
+        self.assertFalse(any("capture-pane" in c for c in fake.calls),
+                         "a frame the operator actually saw must not be replayed at them")
+        self.assertEqual(buf, [])
+
+    def test_tmuxs_own_dead_pane_trailer_is_not_repeated_back(self):
+        """`remain-on-exit` draws `Pane is dead (status 127, <date>)` INTO the pane —
+        measured against tmux 3.7c, and it is the last line every capture of a dead pane
+        comes back with. Echoing it would be charter reporting in tmux's words, at
+        length, immediately after saying the same thing in its own; and the timestamp
+        makes the line different on every single run. Filtered out — and the filter is
+        safe by construction rather than by tmux's wording never changing: a trailer that
+        stopped matching would be repeated back, which is merely noisy, never silent."""
+        fake = _FakeTmux(
+            race_death_status=127,
+            pane_capture="zsh:1: command not found: nope\n\n"
+                         "Pane is dead (status 127, Sun Aug 23 18:15:16 2026)\n")
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            _launch(fake, harness="", rest=["--", "nope"])
+        self.assertTrue(any("command not found: nope" in m for m in buf), buf)
+        self.assertFalse(any("Pane is dead" in m for m in buf),
+                         f"tmux's own trailer was repeated back at the operator: {buf}")
+
+    def test_a_capture_that_fails_still_leaves_charters_own_account(self):
+        """The capture is additive, never the report itself. A `capture-pane` that fails
+        outright (the pane raced away, a wedged server) must not take the message down
+        with it — that would put the launch straight back to the zero bytes #384 is
+        about. Nor is the failed capture itself reported: the operator is already being
+        told about a real failure, and a second line about the diagnostic charter tried
+        to run buries it."""
+        fake = _FakeTmux(race_death_status=127, capture_rc=1)
+        errored, warned = [], []
+        with mock.patch("charter.util.err", side_effect=lambda m: errored.append(m)), \
+             mock.patch("charter.util.warn", side_effect=lambda m: warned.append(m)):
+            rc = _launch(fake, harness="", rest=["--", "nosuchthing-xyz"])
+        self.assertEqual(rc, 127)
+        self.assertEqual(len(errored), 1,
+                         f"exactly one account of the failure, not two: {errored}")
+        self.assertIn("127", errored[0])
+        self.assertEqual(warned, [])
+
+    def test_a_multi_word_command_that_printed_nothing_is_diagnosed_against_the_path(self):
+        """The case tmux leaves charter nothing to work with. Measured against 3.7c: two
+        or more arguments are `execvp`'d directly, and a failed `execvp` exits tmux's own
+        child with **1** and an EMPTY pane — no shell was ever involved, so nothing said
+        `command not found`. A bare 1 is indistinguishable from a program that ran and
+        failed, so this is the one place charter answers the resolution question itself.
+
+        Sound, not a guess: with no shell in the way, a word that resolves to nothing
+        provably could not have run."""
+        with mock.patch("charter.commands_frame.shutil.which", return_value=None):
+            msg = commands_frame.early_death_message(["nosuchthing-xyz", "--flag"], 1, [])
+        self.assertIn("nosuchthing-xyz", msg)
+        self.assertIn("$PATH", msg)
+
+    def test_a_lone_word_is_never_diagnosed_against_the_path(self):
+        """The contract, stated as a message rather than as a refusal — and the test
+        that fails if anyone "simplifies" the diagnosis into a blanket check of
+        `argv[0]`. tmux hands a SINGLE argument to a shell, so that argument is a shell
+        command line: `ulimit` is a builtin no `$PATH` will ever hold, and the text here
+        is not even one word. `shutil.which` has nothing to say about it, so charter
+        does not pretend otherwise — the shell already spoke, and
+        `test_the_dead_panes_own_last_words_are_repeated_back` is how that reaches the
+        operator."""
+        with mock.patch("charter.commands_frame.shutil.which", return_value=None):
+            msg = commands_frame.early_death_message(["ulimit -n; exit 3"], 3, [])
+        self.assertNotIn("$PATH", msg)
+        self.assertIn("3", msg)
+
+    def test_a_pane_that_spoke_for_itself_is_never_second_guessed(self):
+        """The second half of the same rule: charter fills SILENCE, it does not argue
+        with a pane that already said what went wrong. A command whose own words came
+        back gets those words and no `$PATH` speculation layered on top — which would be
+        wrong as often as not, since a program that printed and then failed plainly did
+        run."""
+        with mock.patch("charter.commands_frame.shutil.which", return_value=None):
+            msg = commands_frame.early_death_message(
+                ["nosuchthing-xyz", "--flag"], 1, ["config: no such profile 'x'"])
+        self.assertIn("config: no such profile 'x'", msg)
+        self.assertNotIn("$PATH", msg)
+
+    def test_an_existing_but_unexecutable_path_is_told_apart_from_a_missing_one(self):
+        """Three states, not two — "resolvable on `$PATH`", "a path that exists", and
+        "neither" — because they need three different remedies and `execvp` fails
+        identically for the last two (exit 1, empty pane). Telling an operator to check
+        their `$PATH` for a script sitting right there, missing only `chmod +x`, sends
+        them looking in the wrong place."""
+        script = self.tmp / "not-executable.sh"
+        script.write_text("#!/bin/sh\necho hi\n")  # deliberately never chmod +x'd
+        with mock.patch("charter.commands_frame.shutil.which", return_value=None):
+            msg = commands_frame.early_death_message([str(script), "--flag"], 1, [])
+        self.assertIn("not executable", msg)
+        self.assertNotIn("$PATH", msg,
+                         "a file that is right there is not a $PATH problem")
 
 
 class BypassRouting(unittest.TestCase):

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -273,6 +273,24 @@ def _await_client(session: str, exclude: frozenset, pid: int) -> str:
     return ""
 
 
+def _await_dead(pane: str, timeout: float = 5.0) -> int | None:
+    """Poll the launcher's OWN `_query_pane_dead_status` until *pane* is gone.
+
+    Polled rather than slept for the same reason `_await_file` is: how long tmux takes to
+    reap a child and mark its pane dead is a property of the machine, and a fixed sleep
+    turns a loaded one into a failure instead of a slow pass. `None` back means the pane
+    was still alive when time ran out — which the caller asserts on, since every command
+    handed to this module's own helper is built to die at once.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        code = commands_frame._query_pane_dead_status(SOCKET, pane)
+        if code is not None:
+            return code
+        time.sleep(0.1)
+    return None
+
+
 class _NeedsAttachedClient:
     """`_attach_pty` for the two classes that need a REAL, ATTACHED client, and the
     capability probe that decides whether this machine can give them one.
@@ -1803,6 +1821,146 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         for slot, pane in panes.items():
             self.assertEqual(self._alive(pane), "0",
                              f"the {slot!r} panel died sometime after repainting")
+
+
+@unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
+class EarlyDeathIntegration(unittest.TestCase):
+    """#384: what a command that dies before the frame is drawn actually leaves behind.
+
+    `commands_frame.early_death_message`'s whole design rests on facts about TMUX, not
+    about charter — which of `sh -c` and `execvp` runs a given `charter frame -- <cmd>`,
+    and what each leaves in the pane when the command is not there. Those were measured
+    by hand against tmux 3.7c while deciding not to add a `shutil.which()` pre-check;
+    this class is that hand-measurement turned into something that reruns.
+
+    **The acceptance contract is the first two tests, and they are the reason the
+    pre-check was refused.** tmux's own rule: ONE argument is handed to a shell, TWO OR
+    MORE are `execvp`'d directly. So `charter frame -- 'exit 7'` is a shell command line
+    — `shutil.which` over that text would be asking the wrong question of the wrong
+    string — while `charter frame -- exit 7` is a direct exec of a program called `exit`
+    that does not exist. Neither test names a version; both read what this tmux does.
+
+    Assertions are deliberately about the exit code and about what reaches the MESSAGE,
+    never about a shell's exact wording (`sh`, `bash`, `dash` and `zsh` all phrase
+    "command not found" differently, and tmux's `default-shell` is whatever the machine
+    says) and never about a tmux version string.
+    """
+
+    #: A word no `$PATH` will resolve and no file is named — the same shape
+    #: `tests/test_frame_launcher.py` uses, spelled long enough that a machine that
+    #: somehow HAS it would be telling us something worth knowing.
+    MISSING = "charter-definitely-not-a-real-binary-xyz"
+
+    def setUp(self) -> None:
+        self.addCleanup(self._teardown_socket)
+        self._conf_dir = Path(tempfile.mkdtemp(prefix="charter-integ-death-"))
+        self.addCleanup(shutil.rmtree, self._conf_dir, True)
+        self._n = 0
+
+    def _teardown_socket(self) -> None:
+        """Kill this class's own server, THEN unlink its socket file — see
+        `PanelIntegration._teardown_socket` for the full reasoning, identical here.
+        Load-bearing rather than tidy for THIS class specifically: its sessions arm
+        `remain-on-exit`, so a dead pane's session does not end on its own and tmux's
+        `exit-empty` default never gets the chance to retire the server."""
+        _tmux("kill-server")
+        (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET).unlink(missing_ok=True)
+
+    def _die(self, *harness_argv: str) -> tuple[str, int | None]:
+        """Run *harness_argv* the way `cmd_launch` runs it, and wait for it to die.
+
+        Built from `layout.session_argv` and `commands_frame._PLACEHOLDER_CONF` rather
+        than a hand-retyped `new-session`, so this measures the exact bytes the launcher
+        sends — including `--`, which is what stops tmux reading a leading `-` in an
+        operator's own command as one of its own flags.
+
+        `remain-on-exit` is armed BOTH ways for the same reason `cmd_launch` arms it both
+        ways: the placeholder's `-f` is honoured only by the call that STARTS the server,
+        so the second and later sessions in one test would otherwise let their pane
+        vanish the instant it died — and a pane that is gone answers nothing, which would
+        make every assertion below vacuous rather than red.
+        """
+        self._n += 1
+        name = f"d{self._n}"
+        conf = self._conf_dir / f"{name}.conf"
+        conf.write_text(commands_frame._PLACEHOLDER_CONF)
+        _tmux("set", "-g", "remain-on-exit", "on")  # no-op (and an error) before the
+                                                    # first session; `-f` covers that one
+        r = _run(layout.session_argv(session=name, conf=str(conf), socket=SOCKET,
+                                     cols=80, rows=24, harness_argv=list(harness_argv)))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        pane = r.stdout.strip()
+        self.assertTrue(pane, "tmux reported no pane id for the new session")
+        return pane, _await_dead(pane)
+
+    def test_a_lone_argument_reaches_a_shell_not_execvp(self):
+        """Half of the contract `charter frame --` is not allowed to narrow. `exit 7` is
+        not a program on any machine — it is shell syntax, and it comes back as 7 only if
+        tmux ran it through a shell. A `shutil.which(argv[0])` pre-check would refuse
+        this text outright (it is not even one word), which is why #384's fix reports
+        after the fact instead of predicting beforehand."""
+        pane, code = self._die("exit 7")
+        self.assertEqual(code, 7,
+                         "a single argument must reach a shell — `charter frame -- "
+                         "'ulimit -n; exit 3'` and every other one-liner depend on it")
+
+    def test_two_or_more_arguments_are_exec_d_directly_with_no_shell(self):
+        """The other half, and what makes charter's own `$PATH` note SOUND rather than a
+        guess: split into two arguments, the same text is `execvp`'d, so `exit` is looked
+        up as a program, is not found, and cannot possibly have run. A word that resolves
+        to nothing in THIS form provably never executed — which is the one condition
+        under which `_could_not_have_run` is allowed to speak."""
+        pane, code = self._die("exit", "7")
+        self.assertIsNotNone(code, "the pane should have died at once")
+        self.assertNotEqual(code, 7,
+                            "`exit 7` must NOT be interpreted by a shell once it is two "
+                            "arguments — charter's own diagnosis depends on the split")
+        self.assertNotEqual(code, 0)
+
+    def test_a_missing_commands_own_words_survive_into_the_report(self):
+        """The fix's load-bearing measurement: the shell's `command not found` is still
+        readable in the dead pane, so charter never has to invent a worse sentence.
+
+        This is also what fails if `-S -` is ever dropped from `_pane_last_words`.
+        Measured against tmux 3.7c: `remain-on-exit` appends its own `Pane is dead (…)`
+        line, which scrolls the visible screen by one — so a plain `capture-pane -p` of a
+        command that printed exactly ONE line comes back with blanks where that line was.
+        The whole message lives in the line the default form loses.
+
+        No shell's exact phrasing is asserted (`sh`, `dash`, `bash` and `zsh` all differ,
+        and tmux uses the machine's own `default-shell`) — only that the missing word
+        itself comes back, which every one of them names."""
+        pane, code = self._die(self.MISSING)
+        self.assertIsNotNone(code, "the pane should have died at once")
+        self.assertNotEqual(code, 0)
+        words = commands_frame._pane_last_words(SOCKET, pane)
+        self.assertTrue(any(self.MISSING in ln for ln in words),
+                        f"the shell said what was wrong and charter could not read it "
+                        f"back: {words!r}")
+        self.assertFalse(any("Pane is dead" in ln for ln in words),
+                         f"tmux's own trailer must not be quoted back: {words!r}")
+        msg = commands_frame.early_death_message([self.MISSING], code, words)
+        self.assertIn(self.MISSING, msg)
+
+    def test_the_operator_is_named_the_command_whichever_residue_tmux_left(self):
+        """End to end for the form that leaves charter nothing to quote. Measured
+        against tmux 3.7c: a failed `execvp` exits tmux's own child with 1 and an
+        entirely EMPTY pane — no shell ran, so nothing said `command not found`, and a
+        bare 1 is indistinguishable from a program that ran and failed.
+
+        Asserted on the MESSAGE rather than on the pane being empty, deliberately. Which
+        residue a given tmux leaves is that tmux's business, and charter is correct
+        either way — it quotes the pane when there is one and answers for itself when
+        there is not. What must never differ is that the operator is told which command
+        died, which is the whole of #384. The branch-specific wording is pinned where it
+        can be pinned exactly, in `tests/test_frame_launcher.py::EarlyDeathIsLegible`."""
+        pane, code = self._die(self.MISSING, "--flag")
+        self.assertIsNotNone(code, "the pane should have died at once")
+        self.assertNotEqual(code, 0)
+        words = commands_frame._pane_last_words(SOCKET, pane)
+        msg = commands_frame.early_death_message([self.MISSING, "--flag"], code, words)
+        self.assertIn(self.MISSING, msg)
+        self.assertIn(str(code), msg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #384.

Implemented and adversarially reviewed in an ultracode workflow: the reviewer reproduced the original symptom against the branch point, showed it gone on HEAD, and mutation-tested every new test to confirm it can actually fail. Verdict: approved, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9