### PR TITLE
frame: add a window to the operator's own tmux instead of nesting (#381)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -7,8 +7,19 @@ a fallback for the race described below — and this process waits for tmux, rea
 recorded (or queried) code, and exits with it. `exec` survives only on the bypass path,
 where there is no frame in the way.
 
-**Every frame shares one tmux server (`SOCKET`), told apart by session name (the frame
-id), not one server per frame.** That single choice is what makes the rest of this module
+**There are TWO paths through this module, and almost everything below is about the
+first.** Started from a plain terminal, charter runs the frame as a SESSION on a private
+server of its own (`SOCKET`) and blocks in `attach`. Started from inside a tmux the
+operator already has (`$TMUX`, read by `tmuxctl.operator_server`), it runs the frame as a
+WINDOW on THEIR server, writes not one option or key binding of theirs, and watches the
+harness pane instead of attaching — see `_launch_in_operator_tmux`, which is where every
+difference lives, and `docs/frame.md` for what the second path costs. The paragraphs
+below — the private server, `-f` versus `source-file`, both `pane-died` hooks, and the
+install race they close — describe the FIRST path only; the second has no hooks at all,
+for a reason `_launch_in_operator_tmux` gives.
+
+**Every frame on charter's own server shares one tmux server (`SOCKET`), told apart by
+session name (the frame id), not one server per frame.** That single choice is what makes the rest of this module
 non-obvious, and it is why the session-scoped/hook-installing config reaches tmux through
 `source-file`/direct `set-hook`/`set-environment` commands rather than through the `-f`
 flag `layout.session_argv` also carries. Measured against tmux 3.7c: `-f` is read only at
@@ -93,6 +104,13 @@ quoting the pane (`_pane_last_words`, read BEFORE `kill-session` destroys it) wh
 shell already said what was wrong, and answering for itself when a failed `execvp` left
 the pane empty and a bare exit 1.
 
+This is the one paragraph in this run that is NOT about the first path alone.
+`_launch_in_operator_tmux` makes the same eager ask for the same reason and skips the
+same everything after it, so the same command dies just as silently there — more so, in
+fact, since the operator is looking at that tmux the whole time and their window never
+even changes. Both call sites report, both read the pane before they close it, and both
+say nothing for a clean 0.
+
 **Every tmux command here goes through `frame/tmuxctl.py`, and the timeout is the
 reason.** `cmd_launch` used to issue eleven `subprocess.run(…, timeout=15)` calls of its
 own with nothing catching `subprocess.TimeoutExpired`. Ten of them run AFTER
@@ -112,6 +130,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 
 from . import config, harness, util, workspace
 from .frame import gather, layout, menu, state, tmuxctl
@@ -168,6 +187,30 @@ _CHARTER_PY_ENV = tmuxctl.CHARTER_PY_ENV
 #: `cmd_launch` on to `attach` a session with nothing left to end it, recreating the
 #: exact hang the eager check exists to close, just from a signal instead of a race.
 _UNKNOWN_DEATH_CODE = 1
+
+#: The one format every "is the harness still there?" query asks for, named once so the
+#: two readers of its three possible answers (`_pane_state`, and the fake in
+#: `tests/test_frame_launcher.py`) cannot drift apart. See `_pane_state` for what an
+#: EMPTY answer means, which is neither of the two obvious ones.
+_DEAD_FORMAT = "#{pane_dead}:#{pane_dead_status}"
+
+#: The format that reports the size of the WINDOW a pane is in, rather than the pane's
+#: own. Used only inside an operator's tmux: `os.get_terminal_size()` there measures the
+#: pane `charter` was typed in, which is a fraction of the window the frame gets whenever
+#: they have a split open, and sizing the slots from it would drop panels a full-width
+#: window has ample room for.
+_WINDOW_SIZE_FORMAT = "#{window_width}:#{window_height}"
+
+#: How long `_wait_for_harness` leaves between asks. There is no `attach` to block on
+#: inside an operator's tmux — the operator is already attached, to their own server —
+#: so the launcher watches the pane instead, and this is the cost of that: one local
+#: `display-message` against a unix socket, four times a second, for the life of the
+#: frame. Deliberately NOT closed with a `pane-died` hook signalling `wait-for`: the only
+#: hook that could wake this launcher would have to fire BEFORE the one that reads the
+#: pane's status, and tmux runs a hook array in index order with no way to interleave a
+#: read between them, so the wake would race the teardown for the answer it exists to
+#: collect. Four asks a second is a cost; a lost exit code is a defect.
+_POLL_SECONDS = 0.25
 
 
 #: tmux's own trailer, drawn INTO a dead pane by `remain-on-exit` and therefore the last
@@ -420,8 +463,8 @@ def _charter_py_env_argv(*, socket: str, session: str) -> list[str]:
     write would hand frame N's interpreter to frame N-1 — the same "last launched wins"
     trap `conf_text`'s docstring already names for `mouse`/`history-limit`.
     """
-    return ["tmux", "-L", socket, "set-environment", "-t", session, _CHARTER_PY_ENV,
-           sys.executable]
+    return tmuxctl.server_argv(socket, "set-environment", "-t", session, _CHARTER_PY_ENV,
+                               sys.executable)
 
 
 #: `PYTHONSAFEPATH`'s real name — a genuine interpreter environment variable, read by
@@ -449,8 +492,15 @@ def _charter_pythonsafepath_env_argv(*, socket: str, session: str) -> list[str]:
     that function's contract is "the interpreter", used elsewhere as exactly that value
     (`docs`, `conf_text`'s own text); overloading it to also carry an unrelated variable
     would break that contract for a caller that only wanted the interpreter path.
+
+    `tmuxctl.server_argv` like every other builder here, even though the only caller
+    passes `SOCKET`: this module addresses two servers now, one by name and one by socket
+    path, and a hand-built `-L` is correct only until somebody reuses the builder from
+    `_launch_in_operator_tmux` — where it would quietly aim a `set-environment` at
+    charter's own private server instead of failing.
     """
-    return ["tmux", "-L", socket, "set-environment", "-t", session, _PYTHONSAFEPATH_ENV, "1"]
+    return tmuxctl.server_argv(socket, "set-environment", "-t", session,
+                               _PYTHONSAFEPATH_ENV, "1")
 
 
 def _exit_path_env_argv(*, socket: str, session: str, status_path: str) -> list[str]:
@@ -462,8 +512,8 @@ def _exit_path_env_argv(*, socket: str, session: str, status_path: str) -> list[
     SESSION-scoped `set-environment` (no `-g`) reaching a hook fired for a pane in that
     session.
     """
-    return ["tmux", "-L", socket, "set-environment", "-t", session, _EXIT_PATH_ENV,
-           status_path]
+    return tmuxctl.server_argv(socket, "set-environment", "-t", session, _EXIT_PATH_ENV,
+                               status_path)
 
 
 def _session_id_env_argv(*, socket: str, session: str) -> list[str]:
@@ -492,8 +542,8 @@ def _session_id_env_argv(*, socket: str, session: str) -> list[str]:
     which is why this hands the session right back to itself rather than taking a
     separate value the way `_exit_path_env_argv` takes `status_path`.
     """
-    return ["tmux", "-L", socket, "set-environment", "-t", session, "CHARTER_SESSION_ID",
-           session]
+    return tmuxctl.server_argv(socket, "set-environment", "-t", session,
+                               "CHARTER_SESSION_ID", session)
 
 
 def _pane_died_write_hook_argv(*, socket: str, harness_pane: str) -> list[str]:
@@ -521,7 +571,8 @@ def _pane_died_write_hook_argv(*, socket: str, harness_pane: str) -> list[str]:
     action = ('run-shell "v=#{pane_dead_status}; echo '
              f'\\"\\${{v:-{_UNKNOWN_DEATH_CODE}}}\\" > '
              f'\\"\\${_EXIT_PATH_ENV}\\""')
-    return ["tmux", "-L", socket, "set-hook", "-p", "-t", harness_pane, "pane-died", action]
+    return tmuxctl.server_argv(socket, "set-hook", "-p", "-t", harness_pane, "pane-died",
+                               action)
 
 
 def _pane_died_teardown_hook_argv(*, socket: str, harness_pane: str) -> list[str]:
@@ -543,8 +594,8 @@ def _pane_died_teardown_hook_argv(*, socket: str, harness_pane: str) -> list[str
     `tests/test_frame_tmux_integration.py`'s own test of this exact array-replacement
     behaviour against a real server.
     """
-    return ["tmux", "-L", socket, "set-hook", "-p", "-t", harness_pane, "pane-died[1]",
-           "kill-session"]
+    return tmuxctl.server_argv(socket, "set-hook", "-p", "-t", harness_pane,
+                               "pane-died[1]", "kill-session")
 
 
 #: Which `resize-pane` flag re-asserts a slot's fixed dimension: `-y` (rows) for the
@@ -611,8 +662,8 @@ def _resize_hook_argv(*, socket: str, harness_pane: str, panes: dict[str, str]) 
     action = " ; ".join(
         f"resize-pane -t {pane} {_RESIZE_FLAG[slot]} {layout.SLOT_SIZE[slot]}"
         for slot, pane in panes.items())
-    return ["tmux", "-L", socket, "set-hook", "-w", "-t", harness_pane,
-           "window-resized", action]
+    return tmuxctl.server_argv(socket, "set-hook", "-w", "-t", harness_pane,
+                               "window-resized", action)
 
 
 def _live_sessions(socket: str) -> set[str]:
@@ -627,7 +678,8 @@ def _live_sessions(socket: str) -> set[str]:
     that happens to be the first one on this machine.
     """
     out = tmuxctl.run("listing the frames already running",
-                      ["tmux", "-L", socket, "list-sessions", "-F", "#{session_name}"],
+                      tmuxctl.server_argv(socket, "list-sessions", "-F",
+                                          "#{session_name}"),
                       timeout=5, report=False)
     return {line.strip() for line in out.stdout.splitlines() if line.strip()}
 
@@ -654,23 +706,487 @@ def _query_pane_dead_status(socket: str, harness_pane: str) -> int | None:
     dead — the exact hang the eager check exists to close, reopened by a signal instead
     of a timing race. See `_UNKNOWN_DEATH_CODE`.
     """
+    status, code = _pane_state(socket, harness_pane)
+    return code if status == _DEAD else None
+
+
+#: The three answers `_pane_state` distinguishes. `_GONE` is the one that is easy to miss
+#: and the one a wait loop cannot do without — see `_pane_state`.
+_ALIVE, _DEAD, _GONE = "alive", "dead", "gone"
+
+
+def _pane_state(socket: str, harness_pane: str) -> tuple[str, int | None]:
+    """Is *harness_pane* still running, dead-but-askable, or no longer there at all?
+
+    Three answers rather than two, and the third is measured rather than defensive:
+    against tmux 3.7c, `display-message -p -t <a pane that no longer exists>` does NOT
+    fail. It returns 0 and expands every format variable to NOTHING — confirmed for a
+    pane id that never existed (`%1234`) and for a real one whose window was killed. A
+    caller that only tests `#{pane_dead} == "1"` therefore reads a window the operator
+    closed as "still running", which is harmless for the eager check
+    (`_query_pane_dead_status`, which means "cannot tell" by `None` anyway) and is a
+    spin that never ends for `_wait_for_harness`.
+
+    **The EMPTY answer is the `#{pane_dead}` FIELD, not the whole line — and that
+    distinction was a live bug for the length of one test run.** :data:`_DEAD_FORMAT`
+    carries a literal `:` between its two variables, and tmux prints the format's own
+    literal text whether or not anything expands into it: a gone pane answers `":"`, not
+    `""`. A guard written against the whole line being empty passed every unit test
+    (whose fake returned what the author expected) and was caught only by
+    `tests/test_frame_tmux_integration.py` asking a real server. Testing the FIELD
+    covers the whole-line case too — `"".partition(":")` yields an empty `dead` just as
+    `":"` does — so there is one check here rather than two, the second of which no test
+    could ever have failed.
+
+    `remain-on-exit` is what makes `_DEAD` reachable at all rather than every death
+    going straight to `_GONE`: it keeps the dead pane in place, still holding its
+    `#{pane_dead_status}`, until charter has read it. It is armed pane-scoped before the
+    harness is ever started inside an operator's tmux (see `layout.window_argv`), and
+    server-globally on charter's own private server (see `_PLACEHOLDER_CONF`).
+
+    A `_DEAD` pane whose `#{pane_dead_status}` is EMPTY is still `_DEAD`, reported as
+    `_UNKNOWN_DEATH_CODE`: measured against tmux 3.7c, that is what a harness killed by
+    a signal (SIGKILL/SIGTERM/SIGSEGV) looks like, and calling it "cannot tell" is what
+    used to send `cmd_launch` on to attach a session provably over.
+
+    A query that FAILS is `_GONE` too. All three of `tmuxctl.run`'s failure shapes reach
+    here (a real tmux error, a timeout folded into `TIMED_OUT`, a tmux that could not be
+    started at all), and every one of them means the same thing to a caller: there is
+    nothing left here to wait for. `report=False` because both callers handle the answer
+    themselves.
+    """
     dm = tmuxctl.run("asking whether the harness pane died",
-                     ["tmux", "-L", socket, "display-message", "-p", "-t", harness_pane,
-                      "#{pane_dead}:#{pane_dead_status}"],
+                     tmuxctl.server_argv(socket, "display-message", "-p", "-t",
+                                         harness_pane, _DEAD_FORMAT),
                      timeout=5, report=False)
     if dm.returncode != 0:
-        # Includes the timeout and could-not-run cases `tmuxctl.run` folds into a
-        # return code (see its own docstring): all three mean the same thing here —
-        # "cannot tell" — and `report=False` keeps a query that answers `None` from
-        # printing an error for a question `cmd_launch` is about to handle either way.
-        return None
+        return _GONE, None
     dead, _, status = dm.stdout.strip().partition(":")
+    if not dead:
+        return _GONE, None
     if dead != "1":
-        return None
+        return _ALIVE, None
     status = status.strip()
     if status.lstrip("-").isdigit():
-        return int(status)
-    return _UNKNOWN_DEATH_CODE
+        return _DEAD, int(status)
+    return _DEAD, _UNKNOWN_DEATH_CODE
+
+
+def _live_windows(socket: str) -> set[str] | None:
+    """Every window name *socket*'s server currently reports, or ``None`` when it did
+    not answer at all.
+
+    The inside-a-tmux counterpart of `_live_sessions`, and the difference in return type
+    is the point. A frame on charter's own server is a SESSION named by frame id; a
+    frame in an operator's tmux is a WINDOW named by frame id, so this is the list
+    `state.reap` has to be given there.
+
+    ``None`` rather than an empty set for a non-zero return, because here that failure
+    MEANS something: `$TMUX` can outlive the server it names (a value captured by `env`
+    and re-exported, a `tmux kill-server` while a script was still running), and charter
+    is then not inside a tmux at all no matter what the variable says. `cmd_launch` uses
+    that to fall back to its own private server rather than issue a dozen commands one
+    by one at a socket nothing is listening on. An empty SET is a different answer — a
+    live server with no windows — and must not be confused with it.
+    """
+    out = tmuxctl.run("listing the frames already in this tmux",
+                      tmuxctl.server_argv(socket, "list-windows", "-a", "-F",
+                                          "#{window_name}"),
+                      timeout=5, report=False)
+    if out.returncode != 0:
+        return None
+    return {line.strip() for line in out.stdout.splitlines() if line.strip()}
+
+
+def _wait_for_harness(socket: str, harness_pane: str) -> int | None:
+    """Block until the harness in *harness_pane* is over. Its exit code, or ``None``.
+
+    What `attach` does on charter's own private server, done by watching instead: inside
+    an operator's tmux the operator is ALREADY attached, to their own server, so there is
+    no client for charter to own and no blocking call to read a code out of. `charter
+    claude` still has to behave like a foreground command — it is one — so this is where
+    it waits.
+
+    ``None`` is the pane vanishing rather than dying askably: the operator closed the
+    window (their own `prefix-&`), or the server went away under it. Charter cannot know
+    what the harness would have exited with in that case and says so rather than
+    inventing a 0; see `cmd_launch`'s own handling.
+    """
+    while True:
+        status, code = _pane_state(socket, harness_pane)
+        if status == _DEAD:
+            return code
+        if status == _GONE:
+            return None
+        time.sleep(_POLL_SECONDS)
+
+
+def _drawable_slots(cols: int, rows: int) -> list[str]:
+    """Which configured slots this frame will actually draw, at *cols* x *rows*.
+
+    `[frame] slots` can accept a slot (`instance.FRAME_SLOTS`, sized by
+    `layout.SLOT_SIZE`) that `frame.slots.SLOTS` — the RENDERER registry — has no
+    renderer for (as `left`/`right` were until Task 3 (#385) gave them one). Left
+    unfiltered, `panel_argvs` would still split a real pane for it; `panel.run`
+    correctly refuses or exits 2 (Task 7's own "no empty pane" rule), but with
+    `remain-on-exit on` keeping that pane alive, the operator is left with a permanently
+    dead, wrapped-error 22-column pane and no explanation at the point the frame
+    actually came up. Skipping an unimplemented slot here instead means the harness pane
+    simply keeps that space — the same degrade `visible_slots` itself already makes
+    under a tight terminal.
+
+    Silently, and that is the deliberate half: which slots have a renderer is a property
+    of THIS BUILD, not of this launch, so a warning here repeats an unchanging fact on
+    every single start — and repeats it into a terminal that is about to switch to
+    tmux's alternate screen, where nobody reads it (measured; see `frame_ready`'s own
+    docstring). `--probe`, `charter frame-probe` and `charter doctor` all name it on
+    demand instead, from the same `frame_slots.unimplemented` this filters on.
+    """
+    frame = config.FRAME
+    slots = layout.visible_slots(frame["slots"], cols, rows,
+                                 frame["min_cols"], frame["min_rows"])
+    unimplemented = frame_slots.unimplemented(slots)
+    return [s for s in slots if s not in unimplemented]
+
+
+def _frame_env(fid: str, h) -> dict[str, str]:
+    """The environment the harness runs in, whichever server it runs on.
+
+    Shared by both paths deliberately, because they deliver it by opposite mechanisms
+    and only the CONTENT is the same: on charter's own server it is handed to
+    `new-session`, whose server inherits it whole; inside an operator's tmux the server
+    is already running and is not charter's, so it rides on `respawn-pane -e` instead
+    (see `layout.respawn_argv`). A second copy of "what a framed harness's environment
+    is" would be two answers to one question.
+
+    COLUMNS/LINES go, and that is belt and braces rather than the fix itself: every pane
+    (harness or panel) measures its OWN tty (`frame/slots.py`, `frame/panel.py`), so a
+    stale value here cannot mislay anything charter draws. But this environment is
+    inherited WHOLE by every process tmux starts for this frame — the harness's shell
+    among them — and both variables describe the LAUNCHING terminal, not any pane the
+    frame creates.
+
+    TMUX/TMUX_PANE go for a sharper reason, and only matter on the inside-a-tmux path:
+    they describe the pane `charter` was TYPED in. tmux sets both itself for a pane it
+    creates, and carrying the launcher's own values across would tell the harness — and
+    `session.terminal()`, which reads `TMUX_PANE` — that it is running in a pane it is
+    not. That is the identity collision `WINDOWID` was removed for
+    (`docs/superpowers/specs/2026-08-21-harness-wrapper-design.md`), reached through a
+    different variable.
+    """
+    env = dict(os.environ, CHARTER_SESSION_ID=fid)
+    for stale in ("COLUMNS", "LINES", "TMUX", "TMUX_PANE"):
+        env.pop(stale, None)
+    if h:
+        env["CHARTER_HARNESS"] = h.name
+    return env
+
+
+def _remain_on_exit_argv(*, socket: str, harness_pane: str) -> list[str]:
+    """`set-option -p`: keep THIS pane in place after its program exits, and no other.
+
+    PANE-scoped, which is the only scope that works on a server charter is a guest on.
+    `remain-on-exit` is a window option in tmux with a global default; `-g` there would
+    leave every pane the operator closes hanging around as a dead pane, and `-w` would do
+    it to every pane in a window charter does not own until it does. `-p` names one pane
+    — the harness's — and tmux keeps it, and its `#{pane_dead_status}`, until charter has
+    read the status and closed the window itself.
+
+    Charter's own private server arms the same setting globally instead
+    (`_PLACEHOLDER_CONF`), because there is nothing on that server that is not charter's.
+    """
+    return tmuxctl.server_argv(socket, "set-option", "-p", "-t", harness_pane,
+                               "remain-on-exit", "on")
+
+
+def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, argv: list[str],
+                             h, v: tuple[int, int]) -> int | None:
+    """Build the frame as a WINDOW in the tmux the operator is already in.
+
+    The same layout as the private-server path — harness in the middle, charter's panels
+    on the edges — with no second tmux underneath it and no second prefix key on top of
+    it. ADR 0018 and the design spec both settle this; what shipped before it was a
+    private server started INSIDE the operator's own pane, which works and stacks two
+    prefix layers on one terminal.
+
+    ``None`` means "not actually inside a tmux after all" — `$TMUX` named a server that
+    did not answer — and `cmd_launch` falls back to its own private server. Any `int` is
+    this launch's own exit code.
+
+    **Nothing of the operator's is written.** No `source-file`, no `set -g`, no
+    session-scoped `set`, and no key binding. Each of those reaches past charter's own
+    window: `status`/`mouse`/`history-limit` are session options, so charter's values
+    for them would become theirs in every window they have open; `escape-time` and
+    `remain-on-exit` are server options; `set-environment` hands every new shell they
+    open a frame id that is not theirs; and a key table is server-wide with no
+    per-window form at all. The costs are real and named in `docs/frame.md`: the frame
+    inside a tmux keeps THEIR scrollback limit and THEIR mouse setting, and charter
+    binds no hotkey there at all.
+
+    The spec allows a PREFIX-scoped binding here rather than none. Charter takes the
+    stricter option, for a reason the spec could not have known: the bind's action has
+    to resolve which frame it belongs to at the moment the key fires, and the only
+    mechanism tmux offers for that is the session-scoped `set-environment` this path
+    must not use (see `_session_id_env_argv`). The menu's one entry today is "Detach",
+    which an operator already inside tmux has their own prefix key for. A key taken from
+    every window on their server to reach a redundant menu is a worse trade than no key
+    — `frame/slots.py` drops the hotkey hint from the bottom panel to match.
+
+    **The exit code travels without hooks here, and that is a real difference.** The
+    private-server path needs `pane-died[0]`/`pane-died[1]` because it blocks in
+    `attach` and has nothing else watching; this launcher is awake for the whole life of
+    the frame (`_wait_for_harness`), so it reads the status and closes the window
+    itself. Installing the teardown hook as well would actively LOSE the exit code: a
+    hook array runs in index order and `kill-window` would destroy the pane before this
+    process's next ask. The cost is honest and bounded — if this launcher is itself
+    killed while the harness is running, the harness keeps running and its window is
+    left in the operator's own window list, where their own `prefix-&` closes it. That
+    is strictly better than the failure it replaces on the other path (a session nothing
+    can end, with `attach` blocked on it forever), because the operator is already
+    attached and in control of the server it happened on.
+    """
+    # Doubles as the check that `$TMUX` still names a live server: `list-windows` is
+    # both the liveness list `state.reap` needs here (a frame is a WINDOW on this
+    # server, named by frame id) and the cheapest possible "is anybody home".
+    live_before = _live_windows(socket)
+    if live_before is None:
+        return None
+    state.reap(live_before, server=socket)
+
+    fdir = state.frame_dir(fid, create=True)
+    if fdir is None:
+        util.err(f"charter frame: could not create state for frame {fid!r}")
+        return 1
+    # The same recycled-pid adoption #383 fixed on the private-server path, and nothing
+    # about it is private-server-specific: `fid` is `<workspace>-<launcher pid>` on
+    # either server, `reap` keeps a directory for as long as that pid is live, and on a
+    # launch it is live because it is ours — so an earlier launcher for this workspace
+    # that landed on the same pid leaves its whole directory here to be adopted.
+    #
+    # `gather.json` is the one that costs something on this path: `gather.read` has no
+    # freshness check by design (a panel's hot path) and a panel repaints only on a
+    # version bump, so a dead frame's repos and CI would sit beside a live harness until
+    # the session's first hook fires. `exit` is not read back as this launch's result
+    # here — the code comes off the pane, not the file — but it IS charter's record of
+    # how this frame ended, and a launcher killed mid-run would leave a dead frame's
+    # number standing as this one's. Cleared for the same reason `bump` moves the
+    # version: whatever is under the id predates the frame now claiming it.
+    state.clear_exit(fid)
+    gather.discard(fid)
+    # Rewritten, not merely written: an adopted directory may name the OTHER server, and
+    # a stale marker would make `reap` there skip a frame that is now genuinely ours.
+    state.record_server(fid, socket)
+    state.bump(fid)
+
+    env = _frame_env(fid, h)
+    cwd = os.getcwd()
+    opened = tmuxctl.run(
+        "opening a window for the frame",
+        layout.window_argv(socket=socket, session=session, window=fid, cwd=cwd))
+    if opened.returncode != 0:
+        return 1
+    window_id, _, harness_pane = opened.stdout.strip().partition(" ")
+    if not window_id or not _PANE_ID_RE.fullmatch(harness_pane.strip()):
+        util.err("charter frame: tmux opened the window but did not report a window "
+                 "and pane id — cannot scope the frame to it")
+        return 1
+    harness_pane = harness_pane.strip()
+
+    def _close_window() -> None:
+        tmuxctl.run("closing the frame's window",
+                    tmuxctl.server_argv(socket, "kill-window", "-t", window_id))
+
+    # Before the harness exists, not after: this is what keeps the pane (and its
+    # `#{pane_dead_status}`) in place once the harness exits, and there is no way to
+    # set it on a pane that does not exist yet. See `layout.window_argv`.
+    armed = tmuxctl.run("keeping the harness pane askable",
+                        _remain_on_exit_argv(socket=socket, harness_pane=harness_pane))
+    if armed.returncode != 0:
+        util.warn("charter frame: continuing without it — this frame's window may "
+                  "close before charter can read the harness's exit code")
+
+    started = tmuxctl.run(
+        "starting the harness in it",
+        layout.respawn_argv(socket=socket, harness_pane=harness_pane, env=env, cwd=cwd,
+                            harness_argv=argv))
+    if started.returncode != 0:
+        # The placeholder is still running in a window the operator never asked for and
+        # would never learn the purpose of. Take it back.
+        _close_window()
+        return 1
+
+    # The same eager ask the private-server path makes right after installing its
+    # hooks, for the same reason: a harness that is already over leaves nothing worth
+    # building a frame around, and switching the operator's client to it would park
+    # them on a dead pane.
+    status, code = _pane_state(socket, harness_pane)
+    if status != _ALIVE:
+        if code is not None:
+            state.record_exit(fid, code)
+        if code is not None and code != 0:
+            # #384 reaches THIS path too, and reaches it harder. Nothing below runs — no
+            # panels, no `select-window` — so the operator is never switched to the
+            # frame's window at all: it is created, filled with a corpse, and killed
+            # again, all before their screen changes. On charter's own private server
+            # the silence is at least explained by there being no attach; here the
+            # operator is watching a tmux the whole time and still sees nothing.
+            #
+            # Read the pane BEFORE `_close_window`, for the same reason `cmd_launch`
+            # reads it before `kill-session`: afterwards there is nothing left to read.
+            # Nonzero only, and by the same argument — `charter frame -- true` lands
+            # here with 0, and what it wrote was its own stdout.
+            util.err(early_death_message(argv, code,
+                                         _pane_last_words(socket, harness_pane)))
+        _close_window()
+        _reap_this_server(socket)
+        return code if code is not None else _UNKNOWN_DEATH_CODE
+
+    cols, rows = _window_size(socket, harness_pane)
+    slots = _drawable_slots(cols, rows)
+    # *env* is what the tmux CLIENT process runs with (nothing depends on it here — the
+    # server is already up and is not charter's); *pane_env* is what each panel's own
+    # process gets, which on somebody else's server has to be carried explicitly. See
+    # `layout.panel_argvs`.
+    _draw_panels(socket, slots=slots, fid=fid, harness_pane=harness_pane,
+                 env=None, v=v, pane_env=env)
+    tmuxctl.run("focusing the harness pane",
+                tmuxctl.server_argv(socket, "select-pane", "-t", harness_pane))
+    # `select-window`, never `attach`: the operator has a client already, on this very
+    # server. A second attach IS the nesting this path exists to remove.
+    tmuxctl.run("switching to the frame",
+                tmuxctl.server_argv(socket, "select-window", "-t", window_id))
+
+    code = _wait_for_harness(socket, harness_pane)
+    if code is None:
+        # The pane vanished rather than dying askably — the operator closed the window
+        # (their own `prefix-&`), or the server went with it. Nonzero and named: charter
+        # cannot know what the harness would have exited with, and reporting a killed
+        # agent as a clean 0 is the fabricated success this module refuses everywhere
+        # else. Nothing is killed here either; there is nothing left to kill.
+        util.err("charter frame: the frame's window is gone — the harness's exit code "
+                 "is not something charter can know now.")
+        code = _UNKNOWN_DEATH_CODE
+    else:
+        state.record_exit(fid, code)
+        _close_window()
+    _reap_this_server(socket)
+    return code
+
+
+def _reap_this_server(socket: str) -> None:
+    """Clear out state for frames of *socket* that are gone — and only if it answered.
+
+    An empty window list and NO window list are opposite facts, and `_live_windows`
+    keeps them apart for exactly this reason: an empty set means the server is up with
+    nothing on it, so every frame directory recorded against it is stale; `None` means
+    the server did not answer at all (a wedged one, a timeout), and reaping on that
+    would delete a sibling frame's version file and recorded exit code over a question
+    charter could not get an answer to. Not reaping costs a directory until the next
+    launch; reaping on no information costs a running frame its state.
+    """
+    live = _live_windows(socket)
+    if live is not None:
+        state.reap(live, server=socket)
+
+
+def _window_size(socket: str, harness_pane: str) -> tuple[int, int]:
+    """The size of the WINDOW *harness_pane* is in, or `_FALLBACK_SIZE`.
+
+    Never `os.get_terminal_size()` on this path: that measures the pane `charter` was
+    typed in, which is a fraction of the window the frame gets the moment the operator
+    has a split open — and `_drawable_slots` would then drop panels a full-width window
+    has ample room for.
+    """
+    out = tmuxctl.run("measuring the frame's window",
+                      tmuxctl.server_argv(socket, "display-message", "-p", "-t",
+                                          harness_pane, _WINDOW_SIZE_FORMAT),
+                      timeout=5, report=False)
+    w, _, hgt = out.stdout.strip().partition(":")
+    if out.returncode != 0 or not w.isdigit() or not hgt.isdigit():
+        return _FALLBACK_SIZE
+    return int(w), int(hgt)
+
+
+def _draw_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
+                 env: dict | None, v: tuple[int, int],
+                 pane_env: dict[str, str] | None = None) -> dict[str, str]:
+    """Split one pane per slot off *harness_pane*, then install the resize hook.
+
+    Shared by both paths: a panel is a panel wherever the frame is, the splits target
+    the harness pane's `%N` id for the reason `layout.py`'s docstring measures (tmux
+    renumbers pane INDICES on every split), and the `window-resized` hook is scoped
+    through that same pane to its containing window — so even on the operator's server
+    it reaches charter's own window and nothing else of theirs.
+
+    `util.self_relaunch_argv()` (#390), and sharing it is the point: a panel is spawned
+    with the PANE's cwd, so `-m` alone prepends whatever directory the operator typed
+    `charter` in to the child's `sys.path` — and from a charter checkout that imports
+    the checkout instead of the install, which is how both panels once came up reading
+    `Pane is dead (status 2)`. Nothing about that is specific to charter's own server;
+    inside an operator's tmux the cwd is the same cwd, so the hole is the same hole.
+    """
+    panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=socket,
+                                    charter_argv=util.self_relaunch_argv(),
+                                    harness_pane=harness_pane, env=pane_env)
+    # Zipped with `slots`, not just iterated: `_resize_hook_argv` below needs to know
+    # WHICH slot each successfully-created pane belongs to (for its size and its
+    # resize-pane flag), and `panel_argvs` returns exactly one command per slot, in the
+    # same order (see its own docstring).
+    panes: dict[str, str] = {}
+    for slot, cmd in zip(slots, panel_cmds):
+        # Reported by `tmuxctl.run` but not fatal: one decorative panel failing to draw
+        # must not take down a harness pane that is already up and running (correction 2
+        # asks for every return code to be CHECKED, not every failure refused).
+        p = tmuxctl.run("drawing a panel", cmd, env=env)
+        if p.returncode != 0:
+            continue
+        pane_id = p.stdout.strip()
+        if pane_id and _PANE_ID_RE.fullmatch(pane_id):
+            panes[slot] = pane_id
+
+    if panes and v < tmuxctl.RESIZE_HOOK_FLOOR:
+        # Below RESIZE_HOOK_FLOOR, `window-resized` is not a hook name THIS tmux
+        # recognises at all — `set-hook` fails with `invalid option: <name>` for any
+        # name it does not know (see RESIZE_HOOK_FLOOR's own docstring for exactly what
+        # was, and was not, confirmed by hand) — skip the attempt rather than printing
+        # that confusing text on every single launch. One quiet, honest note instead,
+        # naming the real consequence (item 4's own standard: every degrade in this
+        # launcher says what it costs).
+        util.warn(f"charter frame: tmux {v[0]}.{v[1]} predates the resize-recovery hook "
+                  f"(needs {tmuxctl.RESIZE_HOOK_FLOOR[0]}.{tmuxctl.RESIZE_HOOK_FLOOR[1]}+)"
+                  f" — panels may drift out of shape if this terminal is resized")
+    elif panes:
+        # Only once any panel actually exists — a resize hook with nothing to resize
+        # would just be a wasted `set-hook` call, and (per the module docstring's "belt
+        # and braces" framing) every pane already measures its own tty on every repaint
+        # regardless, so this hook is purely cosmetic geometry upkeep, not something a
+        # launch's correctness depends on.
+        resize_cmd = _resize_hook_argv(socket=socket, harness_pane=harness_pane,
+                                       panes=panes)
+        # `report=False`: this is the one call site that reads a failure's own stderr
+        # before deciding whether it IS one — an unrecognised hook name here is a
+        # capability ceiling to note quietly, not an integration to report loudly, and
+        # `tmuxctl.run`'s default would have printed the loud version first regardless
+        # of which branch runs below.
+        resize = tmuxctl.run("installing the resize hook", resize_cmd, env=env,
+                             report=False)
+        if resize.returncode != 0:
+            if _INVALID_HOOK_NAME in (resize.stderr or ""):
+                # RESIZE_HOOK_FLOOR believed this tmux would recognise the hook name and
+                # it does not — the constant is wrong, not the launch. Trust what THIS
+                # tmux just said over the constant and degrade the same quiet way the
+                # version-gate above already does, rather than report it as a broken
+                # integration (a capability ceiling, not a failure — see the module's own
+                # "belt and braces" framing and `harness.base.Deficit`'s same philosophy
+                # for a harness-level capability gap).
+                util.warn("charter frame: this tmux does not support the "
+                          "resize-recovery hook — panels may drift out of shape if this "
+                          "terminal is resized")
+            else:
+                tmuxctl.report_failure("installing the resize hook", resize_cmd, resize)
+                util.warn("charter frame: continuing without it — panels may drift out "
+                          "of shape if this terminal is resized")
+    return panes
 
 
 def _pane_last_words(socket: str, harness_pane: str) -> list[str]:
@@ -691,10 +1207,18 @@ def _pane_last_words(socket: str, harness_pane: str) -> list[str]:
     explain. An empty answer needs no special casing — `early_death_message` has a
     complete message either way, which is the property that keeps a failed capture from
     putting the launch back to the zero bytes #384 is about.
+
+    `tmuxctl.server_argv`, never a hand-built `-L`: BOTH launch paths call this now. The
+    frame that dies before it is drawn dies exactly the same way inside an operator's own
+    tmux (`_launch_in_operator_tmux`), and that server is reached by socket PATH — a
+    hard-coded `-L` there would aim the capture at charter's own private server, find no
+    such pane, and hand `early_death_message` an empty list. The message would still be
+    printed, so nothing would look broken; it would simply have lost the one thing only
+    the pane knows.
     """
     out = tmuxctl.run("reading what the harness printed before it died",
-                      ["tmux", "-L", socket, "capture-pane", "-p", "-S", "-",
-                       "-t", harness_pane],
+                      tmuxctl.server_argv(socket, "capture-pane", "-p", "-S", "-",
+                                          "-t", harness_pane),
                       timeout=5, report=False)
     if out.returncode != 0:
         return []
@@ -847,6 +1371,20 @@ def cmd_launch(args) -> int:
     ws = workspace.resolve()
     fid = state.frame_id(ws, os.getpid())
 
+    # Inside a tmux the operator already has, the frame is a WINDOW in THEIR server —
+    # same layout, no second tmux, no second prefix key (ADR 0018 and the design spec
+    # both settle this; `docs/frame.md` describes what it costs). Read from `$TMUX`,
+    # which tmux exports into every process it starts in a pane, and CONFIRMED against
+    # the server before anything is built on it: that variable outlives the server it
+    # names often enough to matter (`env` captures, a `tmux kill-server` under a running
+    # script), and charter is then not inside a tmux whatever it says. `None` back means
+    # exactly that, and the private-server path below is the right one after all.
+    inside = tmuxctl.operator_server()
+    if inside is not None:
+        rc = _launch_in_operator_tmux(inside[0], inside[1], fid=fid, argv=argv, h=h, v=v)
+        if rc is not None:
+            return rc
+
     # Reap BEFORE this frame's own directory exists, not after: `frame_dir(create=True)`
     # below makes that directory, and a `reap()` run afterward — but still before
     # `session_argv` starts this frame's OWN tmux session — would see a directory with
@@ -868,8 +1406,8 @@ def cmd_launch(args) -> int:
         # still wrong, and worth closing the same way the placeholder closes the
         # first-frame-ever case.
         tmuxctl.run("arming remain-on-exit ahead of an already-running server",
-                    ["tmux", "-L", SOCKET, "set", "-g", "remain-on-exit", "on"])
-    state.reap(live_before)
+                    tmuxctl.server_argv(SOCKET, "set", "-g", "remain-on-exit", "on"))
+    state.reap(live_before, server=SOCKET)
 
     fdir = state.frame_dir(fid, create=True)
     if fdir is None:
@@ -892,6 +1430,10 @@ def cmd_launch(args) -> int:
     # moving it is `state.bump`'s job, one line below.
     state.clear_exit(fid)
     gather.discard(fid)
+    # And the `server` marker is rewritten for the same reason: an adopted directory
+    # may name the OTHER server, and a stale marker would make `reap` on this one skip
+    # a frame that is now genuinely ours.
+    state.record_server(fid, SOCKET)
     state.bump(fid)
 
     try:
@@ -902,45 +1444,8 @@ def cmd_launch(args) -> int:
         # is the deliberate choice; see `_FALLBACK_SIZE`'s own docstring for why 80x24.
         cols, rows = _FALLBACK_SIZE
 
-    frame = config.FRAME
-    slots = layout.visible_slots(frame["slots"], cols, rows, frame["min_cols"], frame["min_rows"])
-
-    # `[frame] slots` can accept a slot (`instance.FRAME_SLOTS`, sized by
-    # `layout.SLOT_SIZE`) that `frame.slots.SLOTS` — the RENDERER registry — has no
-    # renderer for (as `left`/`right` were until Task 3 (#385) gave them one). Left
-    # unfiltered, `panel_argvs` below would still split a real pane for it;
-    # `panel.run` correctly refuses or exits 2 (Task 7's own "no empty pane" rule),
-    # but with `remain-on-exit on` keeping that pane alive, the operator is left with
-    # a permanently dead, wrapped-error 22-column pane and no explanation at the
-    # point the frame actually came up. Skipping an unimplemented slot here instead
-    # means the harness pane simply keeps that space — the same degrade
-    # `visible_slots` itself already makes under a tight terminal.
-    #
-    # Silently, and that is the deliberate half: which slots have a renderer is a
-    # property of THIS BUILD, not of this launch, so a warning here repeats an
-    # unchanging fact on every single start — and repeats it into a terminal that is
-    # about to switch to tmux's alternate screen, where nobody reads it (measured; see
-    # `frame_ready`'s own docstring). `--probe`, `charter frame-probe` and `charter
-    # doctor` all name it on demand instead, from the same `frame_slots.unimplemented`
-    # this line filters on.
-    unimplemented = frame_slots.unimplemented(slots)
-    if unimplemented:
-        slots = [s for s in slots if s not in unimplemented]
-
-    env = dict(os.environ, CHARTER_SESSION_ID=fid)
-    # Belt and braces, not the fix itself: every pane (harness or panel) measures its
-    # OWN tty rather than trusting these (`frame/slots.py`, `frame/panel.py`), so a
-    # stale value here cannot mislay anything charter draws. But `env` is inherited
-    # WHOLE by every process tmux starts on this launch — the harness's shell among
-    # them — and COLUMNS/LINES describe the LAUNCHING terminal, not any pane this frame
-    # creates. Left in place, a shell inside a pane that echoes them back (or a
-    # program, charter's own or not, still reading `$COLUMNS` the way `tui.term_width`
-    # deliberately does for the status line) would report the wrong size for no reason
-    # charter needs to accept.
-    env.pop("COLUMNS", None)
-    env.pop("LINES", None)
-    if h:
-        env["CHARTER_HARNESS"] = h.name
+    slots = _drawable_slots(cols, rows)
+    env = _frame_env(fid, h)
 
     conf_path = fdir / "tmux.conf"
     status_path = fdir / "exit"
@@ -957,10 +1462,12 @@ def cmd_launch(args) -> int:
                  "— cannot scope the exit-code hook to it")
         return 1
 
+    frame = config.FRAME
     conf_path.write_text(conf_text(hotkey=frame["hotkey"], mouse=frame["mouse"],
                                    history_limit=frame["history_limit"], session=fid))
     src = tmuxctl.run("loading the frame's config",
-                      ["tmux", "-L", SOCKET, "source-file", str(conf_path)], env=env)
+                      tmuxctl.server_argv(SOCKET, "source-file", str(conf_path)),
+                      env=env)
     if src.returncode != 0:
         util.warn("charter frame: continuing without it — mouse/history-limit/hotkey "
                   "settings may not be in effect for this frame")
@@ -1015,7 +1522,7 @@ def cmd_launch(args) -> int:
     # normally has exactly one attached client, but `-s` is correct even if it ever has
     # more than one.
     menu.record(fid=fid, entries=[
-        ("Detach", ["tmux", "-L", SOCKET, "detach-client", "-s", fid]),
+        ("Detach", tmuxctl.server_argv(SOCKET, "detach-client", "-s", fid)),
     ])
 
     write_hook = tmuxctl.run(
@@ -1057,7 +1564,7 @@ def cmd_launch(args) -> int:
             util.err(early_death_message(argv, code,
                                          _pane_last_words(SOCKET, harness_pane)))
         tmuxctl.run("ending the frame after an early death",
-                    ["tmux", "-L", SOCKET, "kill-session", "-t", fid], env=env)
+                    tmuxctl.server_argv(SOCKET, "kill-session", "-t", fid), env=env)
 
     attach = None
     attach_cmd = None
@@ -1077,72 +1584,8 @@ def cmd_launch(args) -> int:
                      f"detached; reattach manually if you must: "
                      f"tmux -L {SOCKET} attach -t {fid}")
         else:
-            panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=SOCKET,
-                                            charter_argv=util.self_relaunch_argv(),
-                                            harness_pane=harness_pane)
-            # Zipped with `slots`, not just iterated: `_resize_hook_argv` below needs to
-            # know WHICH slot each successfully-created pane belongs to (for its size and
-            # its resize-pane flag), and `panel_argvs` returns exactly one command per
-            # slot, in the same order (see its own docstring).
-            panes: dict[str, str] = {}
-            for slot, cmd in zip(slots, panel_cmds):
-                # Reported by `tmuxctl.run` but not fatal: one decorative panel failing
-                # to draw must not take down a harness pane that is already up and
-                # running (correction 2 asks for every return code to be CHECKED, not
-                # every failure refused).
-                p = tmuxctl.run("drawing a panel", cmd, env=env)
-                if p.returncode != 0:
-                    continue
-                pane_id = p.stdout.strip()
-                if pane_id and _PANE_ID_RE.fullmatch(pane_id):
-                    panes[slot] = pane_id
-
-            if panes and v < tmuxctl.RESIZE_HOOK_FLOOR:
-                # Below RESIZE_HOOK_FLOOR, `window-resized` is not a hook name THIS
-                # tmux recognises at all — `set-hook` fails with `invalid option:
-                # <name>` for any name it does not know (see RESIZE_HOOK_FLOOR's own
-                # docstring for exactly what was, and was not, confirmed by hand) —
-                # skip the attempt rather than printing that confusing text on every
-                # single launch. One quiet, honest note instead, naming the real
-                # consequence (item 4's own standard: every degrade in this launcher
-                # says what it costs).
-                util.warn(f"charter frame: tmux {v[0]}.{v[1]} predates the "
-                         f"resize-recovery hook (needs "
-                         f"{tmuxctl.RESIZE_HOOK_FLOOR[0]}.{tmuxctl.RESIZE_HOOK_FLOOR[1]}+)"
-                         f" — panels may drift out of shape if this terminal is resized")
-            elif panes:
-                # Only once any panel actually exists — a resize hook with nothing to
-                # resize would just be a wasted `set-hook` call, and (per the module
-                # docstring's "belt and braces" framing) every pane already measures its
-                # own tty on every repaint regardless, so this hook is purely cosmetic
-                # geometry upkeep, not something a launch's correctness depends on.
-                resize_cmd = _resize_hook_argv(socket=SOCKET, harness_pane=harness_pane,
-                                               panes=panes)
-                # `report=False`: this is the one call site that reads a failure's own
-                # stderr before deciding whether it IS one — an unrecognised hook name
-                # here is a capability ceiling to note quietly, not an integration to
-                # report loudly, and `tmuxctl.run`'s default would have printed the loud
-                # version first regardless of which branch runs below.
-                resize = tmuxctl.run("installing the resize hook", resize_cmd, env=env,
-                                     report=False)
-                if resize.returncode != 0:
-                    if _INVALID_HOOK_NAME in (resize.stderr or ""):
-                        # RESIZE_HOOK_FLOOR believed this tmux would recognise the
-                        # hook name and it does not — the constant is wrong, not the
-                        # launch. Trust what THIS tmux just said over the constant and
-                        # degrade the same quiet way the version-gate above already
-                        # does, rather than report it as a broken integration (a
-                        # capability ceiling, not a failure — see the module's own
-                        # "belt and braces" framing and `harness.base.Deficit`'s same
-                        # philosophy for a harness-level capability gap).
-                        util.warn("charter frame: this tmux does not support the "
-                                 "resize-recovery hook — panels may drift out of "
-                                 "shape if this terminal is resized")
-                    else:
-                        tmuxctl.report_failure("installing the resize hook", resize_cmd,
-                                               resize)
-                        util.warn("charter frame: continuing without it — panels may "
-                                 "drift out of shape if this terminal is resized")
+            _draw_panels(SOCKET, slots=slots, fid=fid, harness_pane=harness_pane,
+                         env=env, v=v)
 
             # `split-window` makes the newly created pane the ACTIVE one by default, so
             # after every slot has been drawn, the LAST panel drawn — not the harness —
@@ -1152,12 +1595,13 @@ def cmd_launch(args) -> int:
             # introduced, but leaving the frame in a state the operator can actually type
             # into is this launcher's job.
             tmuxctl.run("focusing the harness pane",
-                        ["tmux", "-L", SOCKET, "select-pane", "-t", harness_pane], env=env)
+                        tmuxctl.server_argv(SOCKET, "select-pane", "-t", harness_pane),
+                        env=env)
 
             # `tmuxctl.interact`, not `tmuxctl.run`: no capture and no timeout — this
             # IS the operator's own terminal for as long as the harness runs, not an
             # admin command whose output (or lifetime) charter should own.
-            attach_cmd = ["tmux", "-L", SOCKET, "attach", "-t", fid]
+            attach_cmd = tmuxctl.server_argv(SOCKET, "attach", "-t", fid)
             attach = tmuxctl.interact(attach_cmd, env=env)
 
             code = state.exit_code(fid)
@@ -1169,7 +1613,7 @@ def cmd_launch(args) -> int:
                 code = _query_pane_dead_status(SOCKET, harness_pane)
 
     live_after = _live_sessions(SOCKET)
-    state.reap(live_after)
+    state.reap(live_after, server=SOCKET)
     if code is not None:
         return code
     if refused_to_attach:

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -29,6 +29,8 @@ creation time (`-P -F '#{pane_id}'`); the caller reads it off stdout and hands i
 
 from __future__ import annotations
 
+from . import tmuxctl
+
 #: The order slots are dropped in as the terminal shrinks. Sides first — a side panel
 #: costs the harness columns, so it goes as soon as space is tight in EITHER dimension,
 #: not only when columns themselves are the short one — then the top, whose row is worth
@@ -59,8 +61,90 @@ def visible_slots(slots: list[str], cols: int, rows: int,
     return [s for s in slots if s in keep]
 
 
+#: What a frame's window runs while charter is still setting it up, before the harness
+#: replaces it. `cat` with no arguments blocks on its own stdin forever and never exits
+#: on its own, which is the ONLY property required of it: `window_argv`'s docstring
+#: explains why the pane has to exist, and keep existing, before `remain-on-exit` can be
+#: set on it. A separate argv element, never a shell string, like everything else here.
+PLACEHOLDER = ["cat"]
+
+
 def _tmux(socket: str, *args: str) -> list[str]:
-    return ["tmux", "-L", socket, *args]
+    """*socket* is charter's own server NAME or the operator's socket PATH — see
+    `tmuxctl.server_argv`, the one place that difference becomes `-L` or `-S`."""
+    return tmuxctl.server_argv(socket, *args)
+
+
+def window_argv(*, socket: str, session: str, window: str, cwd: str) -> list[str]:
+    """The `new-window` that puts a frame in the operator's OWN tmux, not under it.
+
+    Detached (`-d`) and appended after the current window (`-a`): the operator is
+    switched to the frame once it has actually been built (`select-window`, from the
+    launcher), never onto a half-drawn window still running the placeholder.
+
+    *session* is the operator's own session, `$N` shaped, read out of `$TMUX` by
+    `tmuxctl.operator_server` — measured against tmux 3.7c, `new-window -t` refuses a
+    PANE id outright ("can't specify pane here"), so the session is the target that
+    works and the one `$TMUX` already carries.
+
+    *window* is the frame id, which is also what the launcher reaps against: charter's
+    frames on the operator's server are windows, not sessions, so `list-windows -a -F
+    '#{window_name}'` is the liveness list there that `list-sessions` is on charter's
+    own server.
+
+    Asks for BOTH ids (`-P -F '#{window_id} #{pane_id}'`). The pane id scopes every
+    split and every status query, exactly as on the private-server path; the window id
+    is what `kill-window` targets when the harness is done — an index would be wrong for
+    both, since tmux renumbers windows on every close just as it renumbers panes on
+    every split (see this module's own docstring).
+
+    The window is created running :data:`PLACEHOLDER` rather than the harness, and that
+    ordering is the whole point. `remain-on-exit` is what keeps a dead harness pane
+    askable long enough to read its exit status out of, and tmux has no way to set it on
+    a pane that does not exist yet: the options a new pane would inherit it from are
+    global or session-scoped, and writing either on somebody else's server is precisely
+    what this path exists not to do. So the pane is created with a program that cannot
+    exit, `remain-on-exit` is set ON that pane, and `respawn_argv` then puts the harness
+    in it. The install race the private-server path narrows with `_PLACEHOLDER_CONF` is
+    not narrowed here; it is removed.
+
+    *cwd* is `-c`, for the same reason `respawn_argv` takes one — see its docstring.
+    """
+    return _tmux(socket, "new-window", "-d", "-a", "-t", session, "-n", window,
+                 "-c", cwd, "-P", "-F", "#{window_id} #{pane_id}", "--", *PLACEHOLDER)
+
+
+def respawn_argv(*, socket: str, harness_pane: str, env: dict[str, str],
+                 cwd: str, harness_argv: list[str]) -> list[str]:
+    """`respawn-pane -k`: the harness replaces the placeholder, in the SAME pane.
+
+    Verified against tmux 3.7c that the pane keeps its `%N` id across the respawn, which
+    is what lets `window_argv`'s reported id go on scoping the splits and the
+    exit-status query afterwards.
+
+    *env* rides on `-e`, one `NAME=VALUE` argv element each, sorted so the command is
+    the same on every launch. This is the only way charter's own variables
+    (`CHARTER_SESSION_ID`, `CHARTER_HARNESS`) can reach the harness here: the
+    private-server path gets them because `new-session` starts the server and the server
+    inherits the launcher's environment, and there is no equivalent on a server that is
+    already running and is not charter's. The alternative tmux offers — `set-environment
+    -t <session>` — would reach the harness AND hand every new shell the operator opens
+    in that session a frame id that is not theirs, which is the identity collision
+    `docs/superpowers/specs/2026-08-21-harness-wrapper-design.md` removed `WINDOWID` for.
+
+    Measured against tmux 3.7c: `respawn-pane -e` REPLACES the pane's environment rather
+    than adding to whatever `new-window -e` set, so everything the harness needs is on
+    THIS call. Every `-e` lands before the `--` — they are `respawn-pane`'s own options,
+    and must never be grafted onto the harness's own argv.
+
+    *cwd* is `-c`, and it is not optional. A pane in a server charter did not start
+    inherits its start directory from the SESSION's, which is wherever the operator
+    happened to be when they first ran `tmux` — days ago, in another repo. `charter
+    claude` has to run the harness where it was typed, and the panels split off this
+    pane inherit its directory in turn, which is what `workspace.resolve()` reads.
+    """
+    return _tmux(socket, "respawn-pane", "-k", "-t", harness_pane, "-c", cwd,
+                 *_env_argv(env), "--", *harness_argv)
 
 
 def session_argv(*, session: str, conf: str, socket: str, cols: int, rows: int,
@@ -80,8 +164,20 @@ def session_argv(*, session: str, conf: str, socket: str, cols: int, rows: int,
                 "--", *harness_argv)
 
 
+def _env_argv(env: dict[str, str] | None) -> list[str]:
+    """`-e NAME=VALUE` per entry, sorted so the command is the same on every launch.
+
+    One argv element each, never a joined string, and always before a command's `--`:
+    these are tmux's own options, not something to graft onto the program's argv. Empty
+    for an empty (or absent) *env*, so a call that has nothing to carry produces exactly
+    the command it always did.
+    """
+    return [x for name in sorted(env or {}) for x in ("-e", f"{name}={env[name]}")]
+
+
 def panel_argvs(*, slots: list[str], session: str, socket: str,
-                charter_argv: list[str], harness_pane: str) -> list[list[str]]:
+                charter_argv: list[str], harness_pane: str,
+                env: dict[str, str] | None = None) -> list[list[str]]:
     """One `split-window` per slot in *slots*, each carving its rectangle off *harness_pane*.
 
     *harness_pane* is the id `session_argv`'s caller read off tmux's stdout, and every
@@ -100,6 +196,15 @@ def panel_argvs(*, slots: list[str], session: str, socket: str,
     an exact round trip. Without the id, nothing later could target the RIGHT pane to
     correct that (an index would renumber under the very next split, same failure the
     module docstring already measures for the harness pane).
+
+    *env* is `-e`, and is only ever passed inside a tmux charter did not start. A pane
+    created on somebody else's server inherits THAT SERVER's environment — whatever
+    their shell had when they first ran `tmux`, possibly days ago and in another plane —
+    and a panel resolves the plane it draws (`config.STATE_DIR` among it) from its own.
+    On charter's own server the panels inherit the launcher's environment because
+    `new-session` is what starts that server, so nothing is passed and the command is
+    unchanged. See `respawn_argv` for the same mechanism carrying the same values to the
+    harness.
     """
     cmds: list[list[str]] = []
     for slot in slots:
@@ -108,6 +213,7 @@ def panel_argvs(*, slots: list[str], session: str, socket: str,
         before = ["-b"] if slot in ("top", "left") else []
         cmds.append(_tmux(socket, "split-window", "-t", harness_pane,
                           direction, *before, "-l", str(size),
+                          *_env_argv(env),
                           "-P", "-F", "#{pane_id}", "--",
                           *charter_argv, "panel", slot, "--session", session))
     return cmds

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -441,6 +441,7 @@ def _bottom(fid: str) -> str:
     panel says and what the frame actually does.
     """
     from .. import config, session as _session, statusline as sl, workspace
+    from . import state, tmuxctl
     ws = workspace.resolve()
     todos = sl._todo_count(ws)
     alerts = sl._alerts(ws)
@@ -454,7 +455,14 @@ def _bottom(fid: str) -> str:
     todo_text = f"{todos} todo" + ("s" if todos != 1 else "")
     alert_text = alerts[0] if alerts else ""
     news_text = f"{sl._DIM} · {sl._R}".join(news) if news else ""
-    hotkey_text = f"{config.FRAME['hotkey']} menu"
+    # Nothing to advertise inside a tmux charter did not start: it binds no key there
+    # at all (`commands_frame._launch_in_operator_tmux` says why — a key table is
+    # server-wide in tmux, and the menu's one entry is one the operator's own prefix
+    # already does). A row still printing `F2 menu` there would be telling every
+    # operator about a key that does nothing, on every repaint — the same defect the
+    # hardcoded `F2` was, reached through the other server instead of the wrong config.
+    hotkey_text = ("" if tmuxctl.is_operator_socket(state.frame_server(fid))
+                   else f"{config.FRAME['hotkey']} menu")
 
     # Decide who survives, highest priority first (see this function's own docstring
     # above for why); `_fit_fields` does the actual budgeting so it can be tested in

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -206,6 +206,49 @@ def clear_exit(fid: str) -> None:
         return
 
 
+def record_server(fid: str, server: str) -> None:
+    """Write down which tmux server this frame's session (or window) lives on.
+
+    Charter runs frames on two servers now: its own private one (``tmux -L charter``,
+    where a frame is a SESSION named by frame id) and, when charter is started from
+    inside a tmux the operator already has, theirs (``tmux -S <socket>``, where a frame
+    is a WINDOW named by frame id). Neither server's liveness list mentions the other's
+    frames, so :func:`reap` needs to know which server each directory belongs to before
+    it can decide that "not live" means "dead" rather than "not this server's".
+
+    Same must-not-raise, atomic-write shape as :func:`bump` and :func:`record_exit`, and
+    for the same reason: this runs on the launch path, where an id ``frame_dir`` refuses
+    (or a filesystem that will not take the write) has to degrade to "unknown server"
+    rather than take the launch down with it.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    tmp = d / "server.tmp"
+    try:
+        tmp.write_text(f"{server}\n")
+        os.replace(tmp, d / "server")
+    except OSError:
+        return
+
+
+def frame_server(fid: str) -> str | None:
+    """Which server *fid* was launched on, or ``None`` when charter does not know.
+
+    ``None`` is the migration case and nothing else: every frame this charter starts
+    records one (see :func:`record_server`), so a directory without the marker was
+    written by a charter that only ever ran frames on its own private server. See
+    :func:`reap` for what that means there.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        return (d / "server").read_text().strip() or None
+    except (OSError, ValueError):
+        return None
+
+
 def exit_code(fid: str) -> int | None:
     """The recorded exit code, or ``None`` when the frame has not finished (or exist)."""
     d = frame_dir(fid)
@@ -272,24 +315,39 @@ def _launcher_is_alive(pid: int) -> bool:
     return True
 
 
-def reap(live: set[str]) -> list[str]:
-    """Remove state for frames whose tmux session is gone. Returns what was removed.
+def reap(live: set[str], *, server: str) -> list[str]:
+    """Remove state for frames of *server* that are gone. Returns what was removed.
 
     Never by age: a frame open for two days is exactly a working frame, and an age
-    heuristic would delete precisely that one. *live* names the sessions `tmux
-    list-sessions` still reports, so the only frames removed are ones nothing is watching
-    any more.
+    heuristic would delete precisely that one. *live* names what that server still
+    reports — sessions on charter's own private one, windows on an operator's — so the
+    only frames removed are ones nothing is watching any more.
 
-    **And never on a live session alone, because a frame outlives its session (#383).**
-    Between a harness exiting and its launcher reading :func:`exit_code`, the session is
-    already gone from `tmux list-sessions` while the launcher is still sitting in
-    `cmd_launch` with the answer one line away. A `reap()` from a SIBLING frame's launch
-    — and one runs at every launch — landing in that window deleted the `exit` file
-    before it was ever read: `exit_code` answered ``None``, `cmd_launch` turned that into
-    a returned ``0``, and a harness that had genuinely failed was reported as a success
-    to whatever `&&` chain or CI step invoked charter. Ordering `cmd_launch`'s reap
-    before its own `frame_dir(create=True)` narrows that window; it cannot close it,
-    because by then the sibling's session is genuinely absent from *live*.
+    **Scoped to one server, because "not live" is only an answer the frame's OWN server
+    can give.** A frame launched inside the operator's tmux is a window on their socket
+    and appears in no `tmux -L charter list-sessions` output at all; reaping on that
+    list alone deletes a running frame's version file (its panels stop noticing the
+    agent) and its recorded exit code (its launcher reads back `None` and reports the
+    wrong status) while the frame is still on screen. *server* is matched against
+    :func:`frame_server`, which the launcher records when it creates the directory.
+
+    A directory with NO recorded server matches every one, and that is the migration
+    case rather than a loophole: only a charter that predates :func:`record_server`
+    leaves one, every such frame was on the private server, and refusing to reap them
+    would trade one release's transient wrongness for a permanent leak.
+
+    **And never on a live session alone either, because a frame outlives its session
+    (#383).** Between a harness exiting and its launcher reading :func:`exit_code`, the
+    session is already gone from `tmux list-sessions` while the launcher is still
+    sitting in `cmd_launch` with the answer one line away. A `reap()` from a SIBLING
+    frame's launch — and one runs at every launch — landing in that window deleted the
+    `exit` file before it was ever read: `exit_code` answered ``None``, `cmd_launch`
+    turned that into a returned ``0``, and a harness that had genuinely failed was
+    reported as a success to whatever `&&` chain or CI step invoked charter. Ordering
+    `cmd_launch`'s reap before its own `frame_dir(create=True)` narrows that window; it
+    cannot close it, because by then the sibling's session is genuinely absent from
+    *live*. Server scoping does not close it either — a sibling on the SAME server is
+    exactly the case that bites — so the two guards are independent and both are asked.
 
     So a second question is asked, and :func:`frame_id` is what makes it answerable
     without inventing any new state: the id ENDS in the launcher's own pid. A directory
@@ -317,6 +375,13 @@ def reap(live: set[str]) -> list[str]:
     removed = []
     for d in sorted(root.iterdir()):
         if not d.is_dir() or d.name in live:
+            continue
+        # Two independent reasons to keep a directory, and BOTH must be absent before
+        # anything is deleted. They answer different questions and neither implies the
+        # other: the frame may belong to the OTHER tmux server (#381), or its launcher
+        # may still be running on this one (#383).
+        owner = frame_server(d.name)
+        if owner is not None and owner != server:
             continue
         pid = _launcher_pid(d.name)
         if pid is not None and _launcher_is_alive(pid):

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -18,9 +18,11 @@ rather than pushed through a tmux-shaped helper that would have to lie about wha
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import subprocess
+from collections.abc import Mapping
 
 from .. import util
 
@@ -82,6 +84,72 @@ CHARTER_PY_ENV = "CHARTER_PY"
 TIMEOUT = 15
 
 _VERSION = re.compile(r"^tmux (\d+)\.(\d+)")
+
+#: What tmux writes into `$TMUX` for every process it starts inside a pane:
+#: `<socket path>,<server pid>,<session id>`, the session id being the NUMBER off
+#: tmux's own `#{session_id}` (`$1` is written `1`). Measured against tmux 3.7c by
+#: printing the variable from inside a real pane. The socket path is required to be
+#: ABSOLUTE here because :func:`server_argv` discriminates on a leading `/` alone — a
+#: relative path would be handed to tmux as a `-L` server NAME and quietly start a
+#: brand-new server, which is the nesting `commands_frame` reads this to avoid.
+_TMUX_ENV = re.compile(r"^(/[^,]*),\d+,(\d+)$")
+
+#: The variable itself, named once so :func:`operator_server` and the tests that fake it
+#: cannot drift apart.
+_TMUX_ENV_NAME = "TMUX"
+
+
+def operator_server(env: Mapping[str, str] | None = None) -> tuple[str, str] | None:
+    """``(socket path, session target)`` for the tmux the operator is ALREADY inside.
+
+    ``None`` means charter is not running inside one — which is the ordinary case, and
+    also what a `$TMUX` charter cannot make sense of degrades to. Refusing a value that
+    does not match :data:`_TMUX_ENV` exactly is deliberate: the session target this
+    returns is interpolated into `new-window -t`, and a half-parsed `$TMUX` would aim
+    that at whatever tmux decided "current" meant — someone else's session, on a launch
+    whose entire point is not to disturb it. Falling back to charter's own private
+    server nests, which is worse UX but never wrong about what it is talking to.
+
+    Both halves are parsed here rather than one being re-queried from tmux, because both
+    are already in the variable and a query is a second chance to get a different answer
+    (the operator can switch a client's session between the two calls).
+    """
+    raw = (env if env is not None else os.environ).get(_TMUX_ENV_NAME, "")
+    m = _TMUX_ENV.match(raw)
+    if not m:
+        return None
+    return m.group(1), f"${m.group(2)}"
+
+
+def server_argv(server: str, *args: str) -> list[str]:
+    """`tmux`, the flags that select ONE server, then *args* — every element separate.
+
+    Charter talks to two different servers now, and this is the one place that difference
+    is spelled: its own private one by NAME (`-L charter`, see `commands_frame.SOCKET`),
+    and the operator's existing one by SOCKET PATH (`-S /private/tmp/tmux-502/default`,
+    read out of `$TMUX` by :func:`operator_server`). A leading `/` is the whole
+    discriminator, and it is total rather than a heuristic: a socket path only ever
+    reaches charter from `$TMUX`, which tmux writes absolute, and a `-L` name may not
+    contain a separator at all — tmux joins that name onto its own socket directory to
+    build the path, so a name with a `/` in it names a directory that does not exist.
+
+    Nothing is ever joined, here or anywhere downstream of here: a joined string is
+    shell-interpreted by tmux and a separate argv is not (pinned against 3.7c, see
+    `frame/layout.py`'s module docstring).
+    """
+    return ["tmux", "-S" if is_operator_socket(server) else "-L", server, *args]
+
+
+def is_operator_socket(server: str | None) -> bool:
+    """Is *server* a tmux charter did not start — one it is a guest on?
+
+    The same leading-slash test :func:`server_argv` turns into `-S`, named so the two
+    places that care about the difference cannot answer it differently. The second is
+    `frame/slots.py`: charter binds no hotkey on a server it is a guest on (a key table
+    is server-wide in tmux, with no per-window form), so the bottom panel must not
+    advertise one there.
+    """
+    return bool(server) and server.startswith("/")
 
 #: What :func:`run` reports as the return code of a command that never answered.
 #: `timeout(1)`'s own convention, and deliberately not `1`: every caller in

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -67,11 +67,41 @@ Charter never touches `~/.tmux.conf` — the frame's settings go into a private 
 charter's own (`tmux -L charter`), one server shared by every frame on the machine, with
 each frame a session on it.
 
-**Run from inside an existing tmux session, the frame nests.** charter starts its own
-server regardless, so you end up with two tmux layers and two prefix keys — charter's
-frame does not currently read `$TMUX` or open a window in your own server instead. That
-non-nesting path is not built. If you already live in tmux, `charter <harness> --no-frame`
-is the honest answer for now.
+## Inside a tmux you already have
+
+**Run from inside an existing tmux session, the frame does not nest.** Charter reads
+`$TMUX`, and instead of starting a server of its own it opens **one window in your
+server**, in the session you were in, with the identical layout inside it. One tmux, one
+prefix key, your own window list. `charter claude` switches you to that window and waits;
+when the harness exits, charter closes the window, tmux puts you back where you were, and
+`charter claude` exits with the harness's own code.
+
+Charter is a guest there, and behaves like one — it writes **nothing** of yours. Not a
+server option, not a session option, not a key binding. That has costs, and they are the
+honest price of the sentence above:
+
+- **Your scrollback limit and your mouse setting apply, not charter's.** `history-limit`
+  and `mouse` are session options in tmux; setting them for the frame would set them for
+  every other window in that session too. `[frame] history-limit` and `[frame] mouse` are
+  ignored inside your tmux.
+- **No hotkey.** tmux key tables are server-wide with no per-window form, so any key
+  charter bound would be taken from every window you have open. The spec allowed a
+  prefix-scoped bind here; charter takes the stricter option, because the menu's one
+  entry is "Detach" and your own prefix key already does that better. The bottom panel
+  drops its hotkey hint to match rather than advertising a key that does nothing.
+- **Your status bar stays.** The frame gets the window, not the screen.
+- **If `charter` itself is killed while the harness is running**, the harness keeps
+  running and its window stays in your window list — close it with your own `prefix-&`.
+  On charter's private server that same case is handled by a teardown hook; here a hook
+  that closed the window would destroy the pane before charter could read the exit code
+  out of it, so charter watches instead and does the closing itself.
+- **Charter asks tmux four times a second** whether the harness is still there, for as
+  long as the frame is up. There is no `attach` to block on when you are already
+  attached, and this is what replaces it.
+
+A `$TMUX` that names a server nothing answers on — one captured by `env` and re-exported,
+or a `tmux kill-server` under a running script — is not a tmux you are inside. Charter
+checks before it builds anything, and falls back to its own private server.
 
 ## Exit codes
 
@@ -120,6 +150,11 @@ leaves the pane completely empty and a bare exit 1 — charter answers for itsel
 telling apart the three states that need three different remedies: on `$PATH`, a file that
 exists but is not executable, or neither.
 
+The same report comes back inside a tmux you already have, where the wording is if
+anything an understatement: you are attached the whole time, to your own server, but
+charter never switches you to the frame's window — it is opened, filled with a corpse and
+closed again without your screen changing at all.
+
 A command that finishes *successfully* before the frame comes up (`charter frame -- true`)
 is not reported, and its output is not reprinted: that was its stdout, and charter will not
 invent it on stderr. If you want a short command's output, `--no-frame` — or a pipe, which
@@ -127,6 +162,10 @@ bypasses the frame on its own — is the right tool; the frame is for something 
 front of.
 
 ## When the terminal is too small
+
+The size those floors are measured against is the terminal — or, inside a tmux you
+already have, the tmux WINDOW the frame gets, which is what charter asks tmux for rather
+than measuring the pane it was typed in.
 
 Below `[frame]`'s `min-cols`/`min-rows`, the side panels (`left`/`right`) are the first to
 drop — any shortage costs them, since neither can spare its own divider. A further shortage
@@ -162,6 +201,7 @@ resolved settings charter's own code reads back use an underscore
 is silently not recognized — the hyphenated spelling above is the one that is read.
 
 The hotkey (`F2` by default) opens a small menu on whichever frame you are attached to —
-today, a single "Detach" entry. However you detach — that entry, or tmux's own prefix key
+today, a single "Detach" entry. It exists only on charter's own server; inside a tmux you
+already have, charter binds no key at all (see above). However you detach — that entry, or tmux's own prefix key
 — charter notices the session is still running and prints how to get back in
 (`tmux -L charter attach -t <frame-id>`) rather than leaving you to remember the flags.

--- a/tests/test_doctor_guard_doubled.py
+++ b/tests/test_doctor_guard_doubled.py
@@ -36,6 +36,18 @@ class _Plane(unittest.TestCase):
         self.settings = self.root / ".claude" / "settings.json"
         self.enterContext(mock.patch.object(config, "ROOT", self.root))
         self.enterContext(mock.patch.object(config, "HAS_CONTROL_PLANE", True))
+        # STATE_DIR follows ROOT in `config.derive`, so redirecting ROOT alone leaves it
+        # pointing at the developer's real `.charter/` — and `guardseen.mark` below
+        # WRITES there (`guardseen.path()` reads `config.STATE_DIR` at call time).
+        # Measured: running this module rewrote the real sighting file, which is the one
+        # input `doctor.check_guard_wired` trusts about the developer's own plane.
+        self.enterContext(mock.patch.object(config, "STATE_DIR", self.root / ".charter"))
+        # Asserted rather than assumed: the patch above is only worth anything if the
+        # function that does the writing actually resolves through it, and `guardseen`
+        # reads `config.STATE_DIR` at call time precisely so that it can.
+        self.assertTrue(guardseen.path().is_relative_to(self.root),
+                        f"guard sightings would be written to {guardseen.path()}, "
+                        f"outside this test's own throwaway plane ({self.root})")
         # No ambient plugin install and no plugin-owned process: each test says which.
         self.enterContext(mock.patch.dict("os.environ", {}, clear=True))
         self.dispatching = self.enterContext(

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -28,6 +28,7 @@ start a real tmux server in this suite".
 
 from __future__ import annotations
 
+import contextlib
 import os
 import shutil
 import subprocess
@@ -628,6 +629,59 @@ class QueryPaneDeadStatus(unittest.TestCase):
             self.assertEqual(commands_frame._query_pane_dead_status("charter", "%0"), -15)
 
 
+class PaneState(unittest.TestCase):
+    """The three answers `_pane_state` has to tell apart, one of which is not obvious.
+
+    `_query_pane_dead_status` (above) folds two of them into `None` and is tested on its
+    own terms; the wait loop inside an operator's tmux cannot, because "alive, ask again"
+    and "gone, stop asking" are opposite instructions and confusing them is a spin that
+    never ends.
+    """
+
+    def _dm(self, stdout, rc=0):
+        return mock.patch(
+            "charter.commands_frame.subprocess.run",
+            return_value=subprocess.CompletedProcess([], rc, stdout=stdout, stderr=""))
+
+    def test_a_running_pane_is_alive(self):
+        with self._dm("0:"):
+            self.assertEqual(commands_frame._pane_state("charter", "%0"),
+                             (commands_frame._ALIVE, None))
+
+    def test_a_dead_pane_carries_its_status(self):
+        with self._dm("1:42"):
+            self.assertEqual(commands_frame._pane_state("charter", "%0"),
+                             (commands_frame._DEAD, 42))
+
+    def test_a_pane_that_no_longer_exists_is_gone_not_alive(self):
+        """Measured against a real tmux 3.7c, and the shape a guard written from memory
+        gets wrong: `display-message -p -t <a pane that is gone>` returns 0 and expands
+        both variables to NOTHING — so what comes back is the format's own literal `:`,
+        not an empty line. Read as "alive", `_wait_for_harness` polls a window the
+        operator already closed for as long as their shell stays open.
+
+        `tests/test_frame_tmux_integration.py` asks a real server the same question; this
+        is what pins it on a machine with no tmux at all."""
+        with self._dm(":"):
+            self.assertEqual(commands_frame._pane_state("charter", "%0"),
+                             (commands_frame._GONE, None))
+
+    def test_an_answer_with_nothing_in_it_at_all_is_gone_too(self):
+        """The whole-line case, for a format that ever carries no literal of its own."""
+        with self._dm(""):
+            self.assertEqual(commands_frame._pane_state("charter", "%0"),
+                             (commands_frame._GONE, None))
+
+    def test_a_query_that_fails_is_gone_rather_than_alive(self):
+        """A wedged or vanished server (`tmuxctl.run` folds all three of its failure
+        shapes into a return code) means the same thing to a waiter: there is nothing
+        left here to wait for. Stdout is made to LOOK alive so the returncode check is
+        what this depends on."""
+        with self._dm("0:", rc=1):
+            self.assertEqual(commands_frame._pane_state("charter", "%0"),
+                             (commands_frame._GONE, None))
+
+
 class _FakeTmux:
     """Every tmux invocation `cmd_launch` makes, keyed by which subcommand it carries.
 
@@ -777,10 +831,26 @@ class _FakeTmux:
         raise AssertionError(f"unexpected tmux command in test: {cmd}")
 
 
+def _outside_tmux():
+    """Say, explicitly, that this launch is NOT happening inside somebody's tmux.
+
+    Not decoration. `cmd_launch` reads `$TMUX` to decide whether to start its own
+    private server or open a window in one that already exists, and THIS SUITE IS
+    ORDINARILY RUN INSIDE A CHARTER FRAME — where `$TMUX` is set by tmux itself. Left to
+    the ambient environment, every test in `Launch` below would take the inside-tmux
+    branch on a developer's machine and the private-server branch in CI, which is the
+    same class of never-fails test `test_the_harness_name_reaches_the_harness_environment`
+    documents for `$CHARTER_HARNESS`. `TMUX_PANE` goes with it for the same reason.
+    """
+    stripped = {k: v for k, v in os.environ.items() if k not in ("TMUX", "TMUX_PANE")}
+    return mock.patch.dict(os.environ, stripped, clear=True)
+
+
 def _launch(fake: _FakeTmux, *, cols=200, rows=50, version=(3, 7), harness="claude",
            rest=(), which=None):
     args = SimpleNamespace(harness=harness, rest=list(rest), no_frame=False)
-    with mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
+    with _outside_tmux(), \
+         mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
          mock.patch("sys.stdout.isatty", return_value=True), \
          _harness_binary_installed(which), \
          mock.patch("charter.frame.tmuxctl.version", return_value=version), \
@@ -1082,7 +1152,8 @@ class Launch(PersonaIso, unittest.TestCase):
         fake = _FakeTmux(exit_code=0)
         fake_call = fake.__call__
         args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
-        with mock.patch("charter.commands_frame.subprocess.run", side_effect=_peek), \
+        with _outside_tmux(), \
+             mock.patch("charter.commands_frame.subprocess.run", side_effect=_peek), \
              mock.patch("sys.stdout.isatty", return_value=True), \
              _harness_binary_installed(), \
              mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
@@ -1398,7 +1469,8 @@ class Launch(PersonaIso, unittest.TestCase):
         `isatty()` — a documented trap, not a hypothetical. Must not propagate."""
         fake = _FakeTmux(exit_code=0)
         args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
-        with mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
+        with _outside_tmux(), \
+             mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
              mock.patch("sys.stdout.isatty", return_value=True), \
              _harness_binary_installed(), \
              mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
@@ -1478,7 +1550,8 @@ class Launch(PersonaIso, unittest.TestCase):
         into a directory (see charter/frame/state.py) — this launcher must treat that as
         data, not assume it always gets a `Path` back."""
         args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
-        with mock.patch("charter.commands_frame.subprocess.run") as run, \
+        with _outside_tmux(), \
+             mock.patch("charter.commands_frame.subprocess.run") as run, \
              mock.patch("sys.stdout.isatty", return_value=True), \
              _harness_binary_installed(), \
              mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
@@ -1502,9 +1575,9 @@ class Launch(PersonaIso, unittest.TestCase):
         real_reap = state.reap
         real_frame_dir = state.frame_dir
 
-        def _track_reap(live):
+        def _track_reap(live, **kw):
             order.append("reap")
-            return real_reap(live)
+            return real_reap(live, **kw)
 
         def _track_frame_dir(fid, **kw):
             if kw.get("create"):
@@ -2384,6 +2457,579 @@ class MenuCommands(PersonaIso, unittest.TestCase):
             rc = commands_frame.cmd_action(SimpleNamespace(action_id="a99"))
         self.assertEqual(rc, 2)
         self.assertTrue(any("a99" in m for m in buf), buf)
+
+
+#: The `$TMUX` a real tmux 3.7c exports into every pane it starts —
+#: `<socket path>,<server pid>,<session id>` (measured by printing it from inside one).
+OPERATOR_TMUX = "/private/tmp/tmux-502/default,70029,1"
+OPERATOR_SOCKET = "/private/tmp/tmux-502/default"
+
+#: How many "is the harness still there?" asks `_FakeOperatorTmux` answers before it
+#: calls the launcher stuck. Every test here drives the wait loop through at most a
+#: handful, so anything past this is a launcher that stopped noticing an answer.
+_SPIN_LIMIT = 50
+
+
+class _FakeOperatorTmux:
+    """Every tmux command the inside-a-tmux launch makes, against a server it did not
+    start.
+
+    A separate fake from `_FakeTmux` on purpose: the two paths issue almost disjoint
+    command sets (`new-window`/`respawn-pane`/`kill-window` against
+    `new-session`/`attach`/`kill-session`), and folding both into one fake would let a
+    launcher that took the WRONG branch still find every command it asked for. Anything
+    unexpected raises, so a test fails loudly rather than quietly exercising the other
+    path.
+
+    *polls_alive* is how many status queries report the harness still running before it
+    dies, so a test can drive the wait loop rather than mock it away — the loop is the
+    piece that replaces `attach` here, and `attach` is what carried the exit code out on
+    the other path.
+    """
+
+    def __init__(self, *, window_id="@3", pane_id="%7", polls_alive=1, exit_code=0,
+                 pane_vanishes=False, window_size=(200, 50),
+                 pre_existing_windows=("zsh",), list_windows_rc=0,
+                 new_window_rc=0, arm_rc=0, respawn_rc=0, panel_rc=0,
+                 panel_pane_ids=None, resize_hook_rc=0, select_rc=0, kill_rc=0,
+                 pane_capture="", capture_rc=0):
+        self.window_id = window_id
+        self.pane_id = pane_id
+        self.polls_alive = polls_alive
+        self.exit_code = exit_code
+        self.pane_vanishes = pane_vanishes
+        # What `capture-pane` reports the dead pane still held. #384 reaches this path
+        # too: a harness that dies before the frame is drawn is never switched to, so
+        # the operator's screen never changes and the pane they never saw is the only
+        # place the reason exists.
+        self.pane_capture = pane_capture
+        self.capture_rc = capture_rc
+        self.window_size = window_size
+        self.pre_existing_windows = list(pre_existing_windows)
+        self.list_windows_rc = list_windows_rc
+        self.new_window_rc = new_window_rc
+        self.arm_rc = arm_rc
+        self.respawn_rc = respawn_rc
+        self.panel_rc = panel_rc
+        self.panel_pane_ids = panel_pane_ids or {}
+        self.resize_hook_rc = resize_hook_rc
+        self.select_rc = select_rc
+        self.kill_rc = kill_rc
+        self.calls: list[list[str]] = []
+        self.status_queries = 0
+        self.window_killed = False
+        self.respawn_env = None
+
+    def _ok(self, cmd, stdout=""):
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append(list(cmd))
+        if "list-windows" in cmd:
+            if self.list_windows_rc != 0:
+                return subprocess.CompletedProcess(
+                    cmd, self.list_windows_rc, stdout="",
+                    stderr=f"error connecting to {OPERATOR_SOCKET} (No such file)")
+            live = list(self.pre_existing_windows)
+            if self.window_killed is False and any("new-window" in c for c in self.calls):
+                live.append(_frame_id())
+            return self._ok(cmd, stdout="\n".join(live))
+        if "new-window" in cmd:
+            if self.new_window_rc != 0:
+                return subprocess.CompletedProcess(cmd, self.new_window_rc, stdout="",
+                                                   stderr="no space")
+            return self._ok(cmd, stdout=f"{self.window_id} {self.pane_id}\n")
+        if "remain-on-exit" in cmd:
+            return subprocess.CompletedProcess(cmd, self.arm_rc, stdout="",
+                                               stderr="" if self.arm_rc == 0 else "cannot set")
+        if "respawn-pane" in cmd:
+            self.respawn_env = {a.split("=", 1)[0]: a.split("=", 1)[1]
+                                for i, a in enumerate(cmd)
+                                if i and cmd[i - 1] == "-e"}
+            return subprocess.CompletedProcess(cmd, self.respawn_rc, stdout="",
+                                               stderr="" if self.respawn_rc == 0 else "no pane")
+        if "display-message" in cmd:
+            fmt = cmd[-1]
+            if "window_width" in fmt:
+                return self._ok(cmd, stdout="%d:%d\n" % self.window_size)
+            self.status_queries += 1
+            if self.status_queries > _SPIN_LIMIT:
+                # A spin rather than a hang: `_wait_for_harness` is deliberately
+                # unbounded (an agent session runs for hours and charter waits for all
+                # of it), so a launcher that never stops asking would otherwise wedge
+                # the whole suite instead of failing it. Reached only by a defect —
+                # nothing here answers "alive" more than a handful of times.
+                raise AssertionError(
+                    f"charter asked whether the harness pane was still there "
+                    f"{self.status_queries} times — it never stopped waiting for a "
+                    f"pane that is gone")
+            if self.status_queries <= self.polls_alive:
+                return self._ok(cmd, stdout="0:\n")
+            if self.pane_vanishes:
+                # Measured against a real tmux 3.7c (see
+                # `tests/test_frame_tmux_integration.py`): a `-t` naming a pane that no
+                # longer exists is NOT an error. `display-message -p` returns 0 and
+                # expands both variables to nothing — leaving the format's OWN literal
+                # `:` behind, not an empty line. Getting this wrong here is what let a
+                # launcher that spun forever on a closed window pass every unit test.
+                return self._ok(cmd, stdout=":\n")
+            return self._ok(cmd, stdout=f"1:{self.exit_code}\n")
+        if "capture-pane" in cmd:
+            return subprocess.CompletedProcess(
+                cmd, self.capture_rc,
+                stdout=self.pane_capture if self.capture_rc == 0 else "",
+                stderr="" if self.capture_rc == 0 else "no such pane")
+        if "split-window" in cmd:
+            slot = cmd[cmd.index("panel") + 1] if "panel" in cmd else None
+            pane = self.panel_pane_ids.get(slot, "") if self.panel_rc == 0 else ""
+            return subprocess.CompletedProcess(cmd, self.panel_rc,
+                                               stdout=f"{pane}\n" if pane else "",
+                                               stderr="" if self.panel_rc == 0 else "no space")
+        if "set-hook" in cmd:
+            return subprocess.CompletedProcess(cmd, self.resize_hook_rc, stdout="",
+                                               stderr="" if self.resize_hook_rc == 0
+                                               else "bad hook target")
+        if "select-pane" in cmd or "select-window" in cmd:
+            return subprocess.CompletedProcess(cmd, self.select_rc, stdout="",
+                                               stderr="" if self.select_rc == 0 else "no such")
+        if "kill-window" in cmd:
+            self.window_killed = True
+            return subprocess.CompletedProcess(cmd, self.kill_rc, stdout="",
+                                               stderr="" if self.kill_rc == 0 else "no window")
+        raise AssertionError(f"unexpected tmux command on the operator's server: {cmd}")
+
+
+def _frame_id():
+    return state.frame_id("demo", os.getpid())
+
+
+def _launch_inside(fake: _FakeOperatorTmux, *, version=(3, 7), harness="claude",
+                   rest=(), tmux_env=OPERATOR_TMUX, slots=None):
+    """Run `cmd_launch` as if the operator typed it inside their own tmux."""
+    args = SimpleNamespace(harness=harness, rest=list(rest), no_frame=False)
+    env = dict(os.environ, TMUX=tmux_env, TMUX_PANE="%0")
+    ctx = [mock.patch.dict(os.environ, env, clear=True),
+           mock.patch("charter.commands_frame.subprocess.run", side_effect=fake),
+           mock.patch("charter.commands_frame.time.sleep"),
+           mock.patch("sys.stdout.isatty", return_value=True),
+           _harness_binary_installed(),
+           mock.patch("charter.frame.tmuxctl.version", return_value=version),
+           mock.patch("charter.workspace.resolve", return_value="demo")]
+    with contextlib.ExitStack() as stack:
+        for c in ctx:
+            stack.enter_context(c)
+        return commands_frame.cmd_launch(args)
+
+
+class LaunchInsideTmux(PersonaIso, unittest.TestCase):
+    """`charter claude` typed inside a tmux the operator already has.
+
+    The frame is built as a WINDOW in THEIR server — the layout is identical, but there
+    is no second tmux, no second prefix key, and nothing of theirs is written to. That
+    is the settled design (`docs/superpowers/specs/2026-08-21-harness-wrapper-design.md`,
+    ADR 0018); what shipped before this was a private server started INSIDE their pane,
+    which works but leaves two prefix layers stacked on one terminal.
+
+    Every assertion below is about a boundary rather than a preference: charter's
+    commands must reach their socket and not a new one, must not write a single option
+    of theirs, and must never `kill-session` — the last of which would take down the
+    operator's whole session, every window in it, over a harness exiting.
+    """
+
+    def test_no_second_tmux_server_is_started(self):
+        """The bug itself. `new-session` on charter's own socket is exactly the nesting
+        this path replaces, and `-L` anywhere would mean charter went looking for a
+        server of its own instead of the one it is already inside."""
+        fake = _FakeOperatorTmux(exit_code=0)
+        self.assertEqual(_launch_inside(fake), 0)
+        self.assertTrue(fake.calls, "no tmux command was issued at all")
+        self.assertFalse([c for c in fake.calls if "new-session" in c],
+                         f"a second server was started: {fake.calls}")
+        for cmd in fake.calls:
+            self.assertNotIn("-L", cmd[:3], f"not the operator's own server: {cmd}")
+            self.assertEqual(cmd[:3], ["tmux", "-S", OPERATOR_SOCKET], cmd)
+
+    def test_the_frame_is_a_window_in_the_operators_own_session(self):
+        fake = _FakeOperatorTmux(exit_code=0)
+        _launch_inside(fake)
+        new_window = next(c for c in fake.calls if "new-window" in c)
+        self.assertEqual(new_window[new_window.index("-t") + 1], "$1",
+                         "the session id charter read out of `$TMUX`")
+        self.assertEqual(new_window[new_window.index("-n") + 1], _frame_id(),
+                         "the window is named for the frame, which is what liveness "
+                         "and reaping are matched on here")
+
+    def test_the_harness_is_never_what_the_window_is_created_with(self):
+        """The placeholder-then-respawn ordering, seen from the launcher: if the harness
+        were `new-window`'s own command it could exit before `remain-on-exit` was set on
+        its pane, and its exit code would leave with the window."""
+        fake = _FakeOperatorTmux(exit_code=0)
+        _launch_inside(fake)
+        new_window = next(c for c in fake.calls if "new-window" in c)
+        self.assertNotIn("claude", new_window, f"the harness started too early: {new_window}")
+        respawn = next(c for c in fake.calls if "respawn-pane" in c)
+        self.assertEqual(respawn[respawn.index("--") + 1:], ["claude"])
+
+    def test_the_pane_is_kept_askable_before_the_harness_can_exit(self):
+        fake = _FakeOperatorTmux(exit_code=0)
+        _launch_inside(fake)
+        arm = next(i for i, c in enumerate(fake.calls) if "remain-on-exit" in c)
+        respawn = next(i for i, c in enumerate(fake.calls) if "respawn-pane" in c)
+        self.assertLess(arm, respawn,
+                        f"remain-on-exit must be armed first: {fake.calls}")
+        armed = fake.calls[arm]
+        self.assertIn("-p", armed, "pane-scoped, never the operator's own -g or session")
+        self.assertEqual(armed[armed.index("-t") + 1], "%7")
+
+    def test_nothing_of_the_operators_is_written(self):
+        """Their config untouched, in the spec's own words. Every one of these would
+        reach beyond charter's own window: `source-file` and `set -g` are server- or
+        session-wide, `set-environment` hands every new shell they open a frame id that
+        is not theirs, and a key binding is server-wide with no per-window form at all."""
+        fake = _FakeOperatorTmux(exit_code=0)
+        _launch_inside(fake)
+        for cmd in fake.calls:
+            self.assertNotIn("source-file", cmd, cmd)
+            self.assertNotIn("set-environment", cmd, cmd)
+            self.assertNotIn("bind", cmd, cmd)
+            self.assertNotIn("bind-key", cmd, cmd)
+            self.assertNotIn("-g", cmd, f"a global write on somebody else's server: {cmd}")
+
+    def test_the_operators_session_is_never_killed(self):
+        """The one that is catastrophic rather than merely rude: `kill-session` on their
+        server ends every window they have open, over a harness exiting."""
+        fake = _FakeOperatorTmux(exit_code=3)
+        self.assertEqual(_launch_inside(fake), 3)
+        self.assertFalse([c for c in fake.calls if "kill-session" in c], fake.calls)
+        kill = next(c for c in fake.calls if "kill-window" in c)
+        self.assertEqual(kill[kill.index("-t") + 1], "@3",
+                         "the window id tmux reported, never an index tmux renumbers")
+        self.assertTrue(fake.window_killed)
+
+    def test_the_operator_is_switched_to_the_frame_never_attached(self):
+        """`attach` is what the private-server path blocks on; here the operator is
+        already attached to their own server, so a second attach would be the nesting
+        again. `select-window` moves the client they already have."""
+        fake = _FakeOperatorTmux(exit_code=0)
+        _launch_inside(fake)
+        self.assertFalse([c for c in fake.calls if "attach" in c], fake.calls)
+        select = next(c for c in fake.calls if "select-window" in c)
+        self.assertEqual(select[select.index("-t") + 1], "@3")
+
+    def test_the_harnesss_own_exit_code_comes_back(self):
+        """The property the whole module exists for, on a path where `attach` is not
+        there to be waited on: charter watches the pane instead and exits with what tmux
+        reports the harness died with."""
+        fake = _FakeOperatorTmux(exit_code=42, polls_alive=3)
+        self.assertEqual(_launch_inside(fake), 42)
+        self.assertGreater(fake.status_queries, 3,
+                           "charter stopped watching before the harness had finished")
+
+    def test_charters_own_variables_reach_the_harness_on_the_respawn(self):
+        """`harness.current()` reads `$CHARTER_HARNESS` before any native detection, and
+        every hook inside the frame resolves `$CHARTER_SESSION_ID`. On the private-server
+        path both ride in the environment `new-session` hands the server it starts; there
+        is no such moment here, so they ride on `respawn-pane -e` instead — which reaches
+        this pane and nothing else of theirs.
+
+        The ambient values are overwritten with a sentinel first: this suite is normally
+        run inside a charter frame, where `$CHARTER_HARNESS` is already set, so a bare
+        assertion on the expected value would pass whether or not the launcher carried
+        anything."""
+        fake = _FakeOperatorTmux(exit_code=0)
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "stale-sentinel",
+                                          "CHARTER_SESSION_ID": "stale-sentinel"}):
+            _launch_inside(fake)
+        self.assertEqual(fake.respawn_env.get("CHARTER_SESSION_ID"), _frame_id())
+        self.assertEqual(fake.respawn_env.get("CHARTER_HARNESS"), "claude-code")
+
+    def test_the_launching_pane_is_never_impersonated(self):
+        """`$TMUX`/`$TMUX_PANE` describe the pane charter was TYPED in, and tmux sets
+        both itself for the pane it creates. Carrying the launcher's own values across
+        would tell the harness it is running in a pane it is not — the identity
+        collision `_PANE_ID_VARS` and `WINDOWID` were argued about for."""
+        fake = _FakeOperatorTmux(exit_code=0)
+        _launch_inside(fake)
+        self.assertNotIn("TMUX", fake.respawn_env)
+        self.assertNotIn("TMUX_PANE", fake.respawn_env)
+
+    def test_the_frames_state_is_reaped_against_the_operators_server(self):
+        """A frame here is a window on their socket and appears in no `tmux -L charter
+        list-sessions` output at all. Reaping on the wrong server's list deletes a
+        running frame's version file and its recorded exit code while it is still on
+        screen — see `tests/test_frame_state.py`'s `ReapAcrossServers`."""
+        fake = _FakeOperatorTmux(exit_code=0)
+        seen = []
+        marked = []
+        real_reap, real_record = state.reap, state.record_server
+        with mock.patch("charter.frame.state.reap",
+                        side_effect=lambda live, **kw: (seen.append(kw.get("server")),
+                                                        real_reap(live, **kw))[1]), \
+             mock.patch("charter.frame.state.record_server",
+                        side_effect=lambda fid, server: (marked.append((fid, server)),
+                                                         real_record(fid, server))[1]):
+            _launch_inside(fake)
+        self.assertTrue(seen, "nothing was reaped at all")
+        self.assertEqual(set(seen), {OPERATOR_SOCKET})
+        # And the frame wrote down whose server it was on, which is the only thing that
+        # lets a LATER launch on the other server leave it alone. Asserted on the call
+        # rather than on the file: the last `reap` of a finished launch legitimately
+        # removes this frame's own directory, marker and all.
+        self.assertEqual(marked, [(_frame_id(), OPERATOR_SOCKET)])
+
+    def test_a_launch_here_does_not_inherit_a_cached_scan_from_an_earlier_life_of_its_pid(self):
+        """#383's bill, on this path. `Launch` pins it for charter's own server; the
+        recycled pid is not a property of a server, it is a property of `frame_id`, so
+        the launcher inside somebody else's tmux adopts the same directory in exactly
+        the same circumstances — and `reap` keeps it for exactly the same reason (the
+        pid at the end of the name is live, because it is this launcher's own).
+
+        `gather.json` is what costs something here: `gather.read` has no freshness check
+        by design and a panel repaints only on a version bump, so a dead frame's repos,
+        branches and CI would sit beside a live harness in the operator's own window
+        until the session's first hook fires. `scan` is mocked to a sentinel so a served
+        cache fails, and "a live gather happened to agree" cannot pass by accident."""
+        stale = _frame_id()
+        gather.save(stale, {"gathered_at": 1.0, "workspace": "from-a-dead-frame",
+                            "current_repo": None, "repos": [], "worktrees": []})
+
+        fake = _FakeOperatorTmux(exit_code=0)
+        _launch_inside(fake)
+
+        fresh = {"gathered_at": 0.0, "workspace": "sentinel", "current_repo": None,
+                 "repos": [], "worktrees": []}
+        with mock.patch.object(gather, "scan", return_value=fresh):
+            self.assertEqual(gather.read(stale), fresh,
+                             "a panel of this frame would draw a dead frame's scan "
+                             "until the session's first hook bump")
+
+    def test_a_launch_here_clears_an_adopted_exit_code_before_it_records_its_own(self):
+        """The other half of the adopted directory. The code returned on this path comes
+        off the pane rather than out of the file, so a stale `exit` is not read back as
+        this launch's result — but it IS charter's record of how the frame ended, and a
+        launcher killed mid-run would leave a dead frame's number standing as this one's.
+
+        Ordered against `bump` rather than checked after the launch, because a completed
+        launch legitimately records an exit of its own and would overwrite the fixture
+        either way — which is precisely the assertion that would still pass with
+        `clear_exit` deleted."""
+        order = []
+        real_clear, real_discard, real_bump = state.clear_exit, gather.discard, state.bump
+        with mock.patch("charter.frame.state.clear_exit",
+                        side_effect=lambda fid: (order.append(("clear_exit", fid)),
+                                                 real_clear(fid))[1]), \
+             mock.patch("charter.commands_frame.gather.discard",
+                        side_effect=lambda fid: (order.append(("discard", fid)),
+                                                 real_discard(fid))[1]), \
+             mock.patch("charter.frame.state.bump",
+                        side_effect=lambda fid: (order.append(("bump", fid)),
+                                                 real_bump(fid))[1]):
+            _launch_inside(_FakeOperatorTmux(exit_code=0))
+
+        fid = _frame_id()
+        self.assertIn(("clear_exit", fid), order, f"nothing cleared the adopted exit: {order}")
+        self.assertIn(("discard", fid), order, f"nothing discarded the adopted scan: {order}")
+        self.assertLess(order.index(("clear_exit", fid)), order.index(("bump", fid)),
+                        f"the adopted state outlived the bump panels poll: {order}")
+
+    def test_a_server_that_stops_answering_is_not_treated_as_empty(self):
+        """`state.reap` deletes every frame directory not in the list it is handed, so
+        handing it an empty one for a server that did not answer wipes a SIBLING frame's
+        version file and recorded exit code — while that frame is still on screen. An
+        empty window list and no window list are opposite facts."""
+        fake = _FakeOperatorTmux(exit_code=0)
+        real_calls = []
+        real_live = commands_frame._live_windows
+
+        def _dies_at_the_end(socket):
+            real_calls.append(socket)
+            return real_live(socket) if len(real_calls) == 1 else None
+
+        with mock.patch("charter.commands_frame._live_windows",
+                        side_effect=_dies_at_the_end), \
+             mock.patch("charter.frame.state.reap") as reap:
+            _launch_inside(fake)
+        self.assertEqual(reap.call_count, 1,
+                         "the closing reap ran against a server that said nothing")
+
+    def test_the_frame_is_sized_from_the_tmux_window_not_the_launching_pane(self):
+        """`os.get_terminal_size()` here measures the pane charter was typed in, which
+        is a fraction of the window the frame gets when the operator has splits open.
+        Sizing the slots from it would drop panels a full-width window has room for."""
+        fake = _FakeOperatorTmux(exit_code=0, window_size=(60, 8),
+                                 panel_pane_ids={"top": "%8", "bottom": "%9"})
+        with mock.patch("os.get_terminal_size",
+                        return_value=_os_terminal_size(400, 100)) as size:
+            _launch_inside(fake)
+        size.assert_not_called()
+        self.assertFalse([c for c in fake.calls if "split-window" in c],
+                         "a 60x8 tmux window has no room for a panel")
+
+    def test_the_panels_are_split_off_the_harness_pane(self):
+        fake = _FakeOperatorTmux(exit_code=0,
+                                 panel_pane_ids={"top": "%8", "bottom": "%9"})
+        _launch_inside(fake)
+        splits = [c for c in fake.calls if "split-window" in c]
+        self.assertEqual(len(splits), 2, f"one per configured slot: {splits}")
+        for cmd in splits:
+            self.assertEqual(cmd[cmd.index("-t") + 1], "%7",
+                             "every split targets the harness pane's id — tmux "
+                             "renumbers indices on each one")
+
+    def test_the_panels_get_charters_own_environment_too(self):
+        """Not only the harness. A panel resolves the plane it draws — `config.STATE_DIR`
+        among it — from its own environment, and a pane on the operator's server inherits
+        THEIR tmux server's, which may predate this plane entirely. Left unfixed, a panel
+        inside their tmux drew a different plane's numbers from the harness beside it,
+        and (measured by hand) `frame/slots.py` could not find this frame's own server
+        marker, so the bottom row went on advertising a hotkey charter had not bound."""
+        fake = _FakeOperatorTmux(exit_code=0, panel_pane_ids={"top": "%8"})
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "stale-sentinel"}):
+            _launch_inside(fake)
+        split = next(c for c in fake.calls if "split-window" in c)
+        carried = {c.split("=", 1)[0]: c.split("=", 1)[1]
+                   for i, c in enumerate(split) if i and split[i - 1] == "-e"}
+        self.assertEqual(carried.get("CHARTER_SESSION_ID"), _frame_id())
+        self.assertNotIn("TMUX_PANE", carried)
+
+    def test_a_harness_that_dies_at_once_is_never_switched_to(self):
+        """The same eager check the private-server path makes, for the same reason: a
+        harness that died before charter finished building the frame leaves nothing
+        worth showing, and switching the operator's client to it would park them on a
+        dead pane."""
+        fake = _FakeOperatorTmux(exit_code=127, polls_alive=0)
+        self.assertEqual(_launch_inside(fake), 127)
+        self.assertFalse([c for c in fake.calls if "select-window" in c], fake.calls)
+        self.assertFalse([c for c in fake.calls if "split-window" in c], fake.calls)
+        self.assertTrue(fake.window_killed, "the empty window was left behind")
+
+    def test_a_harness_that_dies_at_once_inside_their_tmux_still_says_so(self):
+        """#384 on this path, where the silence is worse than the one it was written
+        for. On charter's own server a dead-on-arrival harness at least never got an
+        `attach`; here the operator is looking at the tmux the whole time and the frame's
+        window is created, filled with a corpse and killed again without their client
+        ever being switched to it — every one of `select-window`, `split-window` and the
+        wait loop is skipped by the test above. Nothing changes on their screen, so the
+        report is the only thing they get.
+
+        Both halves are asserted: charter's own framing (the exit code, which the pane
+        does not name) and the pane's own words (which charter cannot invent). Deleting
+        either one of `early_death_message` and `_pane_last_words` from this path leaves
+        exactly one of these two assertions red."""
+        fake = _FakeOperatorTmux(
+            exit_code=127, polls_alive=0,
+            pane_capture="zsh:1: command not found: nosuchthing-xyz\n")
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch_inside(fake, harness="", rest=["--", "nosuchthing-xyz"])
+        self.assertEqual(rc, 127)
+        self.assertTrue(any("charter frame:" in m and "127" in m for m in buf),
+                        f"the operator was told nothing about a dead frame: {buf}")
+        self.assertTrue(any("command not found: nosuchthing-xyz" in m for m in buf),
+                        f"the dead pane's own words never reached the report: {buf}")
+
+    def test_the_dead_panes_words_are_read_off_their_server_before_it_is_closed(self):
+        """Two properties one call has to get right, and both are invisible in the
+        message itself.
+
+        `-S <their socket>`, never `-L charter`: `_pane_last_words` is shared with the
+        private-server path, and a hand-built `-L` there would send this capture to
+        charter's own server, find no such pane, and hand `early_death_message` an empty
+        list. The message would still be printed — that is the trap — just without the
+        one thing only the pane knows.
+
+        And BEFORE `kill-window`: the pane is the only copy, so a capture ordered after
+        the window is closed reads nothing, with the same silent, still-printing
+        degrade."""
+        fake = _FakeOperatorTmux(exit_code=127, polls_alive=0,
+                                 pane_capture="boom\n")
+        with mock.patch("charter.util.err"):
+            _launch_inside(fake, harness="", rest=["--", "nosuchthing-xyz"])
+        captures = [i for i, c in enumerate(fake.calls) if "capture-pane" in c]
+        self.assertEqual(len(captures), 1, fake.calls)
+        self.assertEqual(fake.calls[captures[0]][:3], ["tmux", "-S", OPERATOR_SOCKET],
+                         "the capture went to a server that is not the one the dead "
+                         "pane is on")
+        kills = [i for i, c in enumerate(fake.calls) if "kill-window" in c]
+        self.assertTrue(kills, fake.calls)
+        self.assertLess(captures[0], kills[0],
+                        "the pane was destroyed before charter read it")
+
+    def test_a_command_that_finished_cleanly_before_the_frame_is_not_narrated(self):
+        """The other side of the same rule the private-server path takes: `charter frame
+        -- true` reaches this identical branch with 0, and whatever it wrote was its own
+        STDOUT. Repeating that onto stderr would be charter inventing output on the wrong
+        stream over a command that did exactly what it was asked."""
+        fake = _FakeOperatorTmux(exit_code=0, polls_alive=0, pane_capture="hello\n")
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch_inside(fake, harness="", rest=["--", "true"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(buf, [], f"a clean early exit was narrated anyway: {buf}")
+        self.assertFalse([c for c in fake.calls if "capture-pane" in c],
+                         "a clean exit's pane must not even be read")
+
+    def test_a_window_the_operator_closes_ends_the_wait_rather_than_spinning(self):
+        """Measured against tmux 3.7c: `display-message -p -t <pane that is gone>`
+        returns 0 and prints an EMPTY line rather than failing — so a wait loop that
+        only stops on `#{pane_dead}` being `1` would poll a window nobody can bring back
+        for as long as the shell it was typed in stays open.
+
+        Nonzero, deliberately: charter cannot know what the harness would have exited
+        with, and reporting a killed agent as a clean 0 is the fabricated success this
+        module refuses everywhere else."""
+        fake = _FakeOperatorTmux(polls_alive=2, pane_vanishes=True)
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch_inside(fake)
+        self.assertEqual(rc, commands_frame._UNKNOWN_DEATH_CODE)
+        self.assertTrue(any("window" in m for m in buf), buf)
+
+    def test_a_stale_tmux_variable_falls_back_to_charters_own_server(self):
+        """`$TMUX` exported into a shell whose tmux is long gone (a detached `env`
+        capture, a `tmux kill-server` while a script was running) names a socket nothing
+        answers on. Charter is then NOT inside a tmux, whatever the variable says, and
+        the private-server path is the correct one — checked against the server rather
+        than believed, because every command after this would otherwise fail one by one
+        against a socket that does not exist."""
+        fake = _FakeOperatorTmux(list_windows_rc=1)
+        args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
+        private = _FakeTmux(exit_code=0)
+
+        def _route(cmd, **kw):
+            if "-S" in cmd[:3]:
+                return fake(cmd, **kw)
+            return private(cmd, **kw)
+
+        with mock.patch.dict(os.environ, dict(os.environ, TMUX=OPERATOR_TMUX)), \
+             mock.patch("charter.commands_frame.subprocess.run", side_effect=_route), \
+             mock.patch("charter.commands_frame.time.sleep"), \
+             mock.patch("sys.stdout.isatty", return_value=True), \
+             _harness_binary_installed(), \
+             mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+             mock.patch("charter.workspace.resolve", return_value="demo"), \
+             mock.patch("os.get_terminal_size",
+                        return_value=_os_terminal_size(200, 50)):
+            rc = commands_frame.cmd_launch(args)
+        self.assertEqual(rc, 0)
+        self.assertTrue([c for c in private.calls if "new-session" in c],
+                        "charter never fell back to its own server")
+
+    def test_a_window_that_cannot_be_opened_is_a_clean_failure(self):
+        fake = _FakeOperatorTmux(new_window_rc=1)
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch_inside(fake)
+        self.assertNotEqual(rc, 0)
+        self.assertFalse([c for c in fake.calls if "respawn-pane" in c], fake.calls)
+
+    def test_a_harness_that_cannot_be_started_does_not_leave_the_window_behind(self):
+        """`respawn-pane` failing leaves the placeholder running in a window the
+        operator never asked for — visible, in their own window list, forever."""
+        fake = _FakeOperatorTmux(respawn_rc=1)
+        rc = _launch_inside(fake)
+        self.assertNotEqual(rc, 0)
+        self.assertTrue(fake.window_killed, "the placeholder window was left behind")
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -42,6 +42,35 @@ from tests._isolation import PersonaIso
 from charter import commands_frame, config, util
 from charter.frame import gather, menu, slots, state
 
+#: The plane this test PROCESS was started in, captured at IMPORT — before any `setUp`
+#: has had a chance to repoint `config`, so it is unavoidably the developer's REAL
+#: `.charter/`. Only ever compared against; never read from, never written to.
+_REAL_STATE_DIR = Path(config.STATE_DIR)
+
+
+def _refuse_the_real_plane() -> None:
+    """Refuse to run the real `cmd_launch` against the developer's own control plane.
+
+    Every tmux call in this module is faked, which made it easy to read the whole file
+    as harmless — but `cmd_launch` is REAL, and its first act on either path is
+    `state.reap`: an `rmtree` of every directory under `config.STATE_DIR/frame/` that
+    the server does not report live. `_FakeTmux` reports none, and a frame directory
+    with no `server` marker matches every server, so an unisolated call here deletes the
+    state of whatever frames the developer has open. Measured, not supposed: three tests
+    in this module were creating `frame/demo-<pid>` in the real `.charter/` on every
+    suite run, which means they had already run that `rmtree` to get there.
+
+    Called by the two helpers that reach `cmd_launch` rather than left to each class's
+    base list, because the base list is exactly what a new class copies from its
+    neighbour without re-deriving. A class that forgets `PersonaIso` fails here, loudly,
+    before anything is deleted.
+    """
+    if Path(config.STATE_DIR) == _REAL_STATE_DIR:
+        raise AssertionError(
+            "this test is about to run the real `cmd_launch` — `state.reap` and all — "
+            f"against the developer's own control plane ({_REAL_STATE_DIR}). The class "
+            "must derive from `PersonaIso` (see `tests/_isolation.py`).")
+
 
 def _harness_binary_installed(resolver=None):
     """Make "is the harness's binary installed?" deterministic for the framed path.
@@ -104,6 +133,11 @@ class MissingHarnessBinary(PersonaIso, unittest.TestCase):
     longer reaps its OWN directory (its pid is necessarily still alive), so the
     accident stopped covering for the leak and a `demo-<pid>` directory survived every
     suite run — which is how this was found.
+
+    A base list is not where that guarantee is enforced, though: the next class copies
+    one from its neighbour without re-deriving it. `_launch` calls
+    `_refuse_the_real_plane()` so a class that forgets this base fails loudly, before
+    anything is deleted.
 
     `bypass` called `os.execvp` raw, so `FileNotFoundError` reached `cli.main`'s
     `except Exception`, which files a charter crash report and re-raises a traceback.
@@ -848,6 +882,7 @@ def _outside_tmux():
 
 def _launch(fake: _FakeTmux, *, cols=200, rows=50, version=(3, 7), harness="claude",
            rest=(), which=None):
+    _refuse_the_real_plane()
     args = SimpleNamespace(harness=harness, rest=list(rest), no_frame=False)
     with _outside_tmux(), \
          mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
@@ -1900,10 +1935,10 @@ class BypassRouting(PersonaIso, unittest.TestCase):
     test the DECISION, not what `bypass()` does once reached.
 
     `PersonaIso` for the same reason `MissingHarnessBinary` above carries it: the
-    negative case here (`test_a_tty_without_no_frame_does_not_bypass`) proves the
-    launch was NOT bypassed by letting a full `_launch` run, and a full launch writes
-    frame state under `config.STATE_DIR` — the developer's real `.charter/` without
-    this."""
+    negative case here (`test_a_tty_without_no_frame_does_not_bypass`) proves the launch
+    was NOT bypassed by letting a full `_launch` run — the whole real launcher,
+    `state.reap` and all — which writes frame state under `config.STATE_DIR` and reaps
+    everything beside it. That was the developer's real `.charter/` until this."""
 
     def test_the_no_frame_flag_routes_to_bypass(self):
         args = SimpleNamespace(harness="claude", rest=[], no_frame=True)
@@ -2606,6 +2641,7 @@ def _frame_id():
 def _launch_inside(fake: _FakeOperatorTmux, *, version=(3, 7), harness="claude",
                    rest=(), tmux_env=OPERATOR_TMUX, slots=None):
     """Run `cmd_launch` as if the operator typed it inside their own tmux."""
+    _refuse_the_real_plane()
     args = SimpleNamespace(harness=harness, rest=list(rest), no_frame=False)
     env = dict(os.environ, TMUX=tmux_env, TMUX_PANE="%0")
     ctx = [mock.patch.dict(os.environ, env, clear=True),

--- a/tests/test_frame_layout.py
+++ b/tests/test_frame_layout.py
@@ -217,5 +217,139 @@ class PanelGeometry(unittest.TestCase):
         self.assertEqual(_size(right), "22")
 
 
+class WindowInTheOperatorsServer(unittest.TestCase):
+    """`new-window` and `respawn-pane` — the frame built INSIDE a tmux the operator is
+    already in, instead of a private server nested in their pane.
+
+    Two commands rather than one for a measured reason (tmux 3.7c). `remain-on-exit` is
+    what keeps a dead harness pane askable long enough for its exit status to be read,
+    and there is no way to set it ON a pane that does not exist yet — every option tmux
+    would otherwise inherit it from is global or session-scoped, and writing either on
+    somebody else's server is exactly what this path exists not to do. So the window is
+    created running a placeholder that never exits, `remain-on-exit` is set on that
+    pane, and only THEN is the harness respawned into the same pane (`respawn-pane -k`
+    keeps the pane's `%N` id, verified against 3.7c). The race the private-server path
+    closes with `_PLACEHOLDER_CONF` is not narrowed here — it is removed.
+    """
+
+    def test_the_window_is_created_in_the_operators_own_session(self):
+        cmd = layout.window_argv(socket="/private/tmp/tmux-502/default", session="$1",
+                                 window="charter-demo-1234", cwd="/work/repo")
+        self.assertEqual(cmd[:3], ["tmux", "-S", "/private/tmp/tmux-502/default"])
+        self.assertIn("new-window", cmd)
+        self.assertEqual(cmd[cmd.index("-t") + 1], "$1")
+        self.assertEqual(cmd[cmd.index("-n") + 1], "charter-demo-1234")
+
+    def test_the_window_is_created_in_the_background(self):
+        """`-d`: the operator is switched to the frame once it is BUILT, never onto a
+        half-drawn window with a placeholder running in it."""
+        cmd = layout.window_argv(socket="/s", session="$1", window="f", cwd="/work/repo")
+        self.assertIn("-d", cmd)
+
+    def test_both_the_window_and_the_pane_ids_are_asked_for(self):
+        """The pane id scopes every split and the exit-status query; the window id is
+        what `kill-window` targets at the end. Indices are useless for both — tmux
+        renumbers windows and panes (see this module's own docstring)."""
+        cmd = layout.window_argv(socket="/s", session="$1", window="f", cwd="/work/repo")
+        self.assertEqual(cmd[cmd.index("-F") + 1], "#{window_id} #{pane_id}")
+        self.assertIn("-P", cmd)
+
+    def test_the_placeholder_is_what_the_window_is_created_running(self):
+        """After the `--`, so tmux runs it as a program rather than reading it as one
+        of `new-window`'s own options — the same placement `session_argv` and
+        `panel_argvs` already use for the harness and the panels.
+
+        That the placeholder never exits on its own cannot be asserted from an argv;
+        `tests/test_frame_tmux_integration.py` runs this exact command against a real
+        server and reads back a pane still alive."""
+        cmd = layout.window_argv(socket="/s", session="$1", window="f", cwd="/work/repo")
+        self.assertTrue(layout.PLACEHOLDER, "a window has to be created running something")
+        self.assertEqual(cmd[cmd.index("--") + 1:], layout.PLACEHOLDER)
+        self.assertEqual(cmd.count("--"), 1)
+
+    def test_the_harness_replaces_the_placeholder_in_the_same_pane(self):
+        cmd = layout.respawn_argv(socket="/s", harness_pane="%7", env={}, cwd="/work/repo",
+                                  harness_argv=["claude", "--resume", "a;b"])
+        self.assertIn("respawn-pane", cmd)
+        self.assertIn("-k", cmd)
+        self.assertEqual(cmd[cmd.index("-t") + 1], "%7")
+        self.assertEqual(cmd[cmd.index("--") + 1:], ["claude", "--resume", "a;b"])
+
+    def test_the_harness_argv_is_never_joined(self):
+        """The same rule the rest of this module pins: `a;b` reaching tmux as one
+        element is inert, and as part of a joined string is a command separator."""
+        cmd = layout.respawn_argv(socket="/s", harness_pane="%7", env={}, cwd="/work/repo",
+                                  harness_argv=["claude", "-p", "hi; touch INJ"])
+        self.assertEqual(cmd[-1], "hi; touch INJ")
+
+    def test_charters_environment_rides_on_the_respawn_not_the_session(self):
+        """`-e` puts a variable on THIS pane's own process and nowhere else. The
+        private-server path carries `CHARTER_SESSION_ID` in the environment
+        `new-session` inherits, which is not available here — the server is already
+        running, and it is the operator's. `set-environment -t <their session>` would
+        reach the harness, and would also hand every new shell they open a frame id
+        that is not theirs.
+
+        Measured against tmux 3.7c: `respawn-pane -e` REPLACES the pane's environment
+        rather than adding to what `new-window -e` set, so everything the harness needs
+        has to be on this call, not the one that made the window."""
+        cmd = layout.respawn_argv(socket="/s", harness_pane="%7", cwd="/work/repo",
+                                  env={"CHARTER_SESSION_ID": "demo-1",
+                                       "CHARTER_HARNESS": "claude-code"},
+                                  harness_argv=["claude"])
+        self.assertIn("-e", cmd)
+        pairs = [cmd[i + 1] for i, a in enumerate(cmd) if a == "-e"]
+        self.assertEqual(sorted(pairs),
+                         ["CHARTER_HARNESS=claude-code", "CHARTER_SESSION_ID=demo-1"])
+        # ...and before the `--`, so they are `respawn-pane`'s own options and never
+        # get grafted onto the harness's argv.
+        self.assertTrue(all(cmd.index(p) < cmd.index("--") for p in pairs))
+
+
+    def test_the_harness_starts_where_charter_was_typed(self):
+        """A pane in a server charter did not start inherits the SESSION's directory —
+        wherever the operator was when they first ran `tmux`, which is not where they
+        typed `charter claude`. The panels split off this pane inherit its directory in
+        turn, and `workspace.resolve()` reads exactly that."""
+        for cmd in (layout.window_argv(socket="/s", session="$1", window="f",
+                                       cwd="/work/repo"),
+                    layout.respawn_argv(socket="/s", harness_pane="%7", env={},
+                                        cwd="/work/repo", harness_argv=["claude"])):
+            with self.subTest(cmd=cmd[3]):
+                self.assertEqual(cmd[cmd.index("-c") + 1], "/work/repo")
+
+
+    def test_a_panel_can_be_handed_an_environment_of_its_own(self):
+        """A pane created on a server charter did not start inherits THAT SERVER's
+        environment — whatever the operator's shell had when they first ran `tmux`, days
+        ago. On charter's own server the panels inherit the launcher's environment
+        because `new-session` is what starts the server; there is no such moment here, so
+        the same values ride on `split-window -e`, exactly as the harness's do on
+        `respawn-pane -e`.
+
+        Omitted entirely when there is nothing to carry, so the private-server path's
+        command is byte-for-byte what it always was."""
+        with_env = layout.panel_argvs(slots=["top"], session="f", socket="/s",
+                                      charter_argv=["charter"], harness_pane="%3",
+                                      env={"CHARTER_ROOT": "/plane"})[0]
+        self.assertEqual(with_env[with_env.index("-e") + 1], "CHARTER_ROOT=/plane")
+        self.assertLess(with_env.index("-e"), with_env.index("--"),
+                        "`-e` is `split-window`'s own option, never part of the panel's "
+                        "argv")
+        without = layout.panel_argvs(slots=["top"], session="f", socket="/s",
+                                     charter_argv=["charter"], harness_pane="%3")[0]
+        self.assertNotIn("-e", without)
+
+
+class ServerSelection(unittest.TestCase):
+    def test_a_split_can_be_aimed_at_the_operators_server_too(self):
+        """`panel_argvs` and `session_argv` grew no new parameter for this: the socket
+        they already take is now either charter's own server NAME or a socket PATH, and
+        `tmuxctl.server_argv` is the one place that difference turns into `-L` or `-S`."""
+        cmds = layout.panel_argvs(slots=["top"], session="f", socket="/tmp/tmux-1/default",
+                                  charter_argv=["charter"], harness_pane="%3")
+        self.assertEqual(cmds[0][:3], ["tmux", "-S", "/tmp/tmux-1/default"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -20,7 +20,7 @@ import unittest
 from unittest import mock
 
 from charter import config, statusline, tui
-from charter.frame import gather, slots
+from charter.frame import gather, slots, state
 
 from tests._isolation import PersonaIso
 
@@ -91,6 +91,28 @@ class Render(PersonaIso, unittest.TestCase):
         one-character substitution. `M-m` shares no characters with `F2`."""
         with mock.patch.dict(config.FRAME, {"hotkey": "M-m"}):
             self.assertIn("M-m menu", slots.render("bottom", "f-1"))
+
+    def test_a_frame_in_the_operators_own_tmux_advertises_no_hotkey(self):
+        """Charter binds no key at all inside a tmux it did not start — a key table is
+        server-wide in tmux with no per-window form, and taking one from every window
+        the operator has open to reach a menu whose only entry is "Detach" (which their
+        own prefix already does) is a worse trade than none. A panel still printing
+        `F2 menu` there would be telling every operator about a key that does nothing,
+        on every repaint, forever — the same defect
+        `test_the_bottom_row_names_the_configured_hotkey_not_a_hardcoded_one` exists
+        for, reached through the other server instead of the wrong config value."""
+        state.record_server("f-in-tmux", "/private/tmp/tmux-502/default")
+        with mock.patch.dict(config.FRAME, {"hotkey": "F1"}):
+            out = slots.render("bottom", "f-in-tmux")
+        self.assertNotIn("menu", out)
+        self.assertIn("todo", out, "the rest of the row is untouched")
+
+    def test_a_frame_on_charters_own_server_still_advertises_it(self):
+        """The other side of the same switch — a `_bottom` that simply stopped printing
+        a hotkey would pass the test above on its own."""
+        state.record_server("f-own", "charter")
+        with mock.patch.dict(config.FRAME, {"hotkey": "F1"}):
+            self.assertIn("F1 menu", slots.render("bottom", "f-own"))
 
     def test_an_unknown_slot_is_named_rather_than_drawn_blank(self):
         """`panel.run` (Task 7) refuses an unknown slot before ever spawning a pane for

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -81,7 +81,7 @@ class Version(PersonaIso, unittest.TestCase):
         """
         gone = f"gone-{_a_dead_pid()}"
         state.bump(gone)
-        state.reap(set())
+        state.reap(set(), server="charter")
         self.assertEqual(state.version(gone), "0")
         self.assertFalse(state.frame_dir(gone).exists())
 
@@ -225,7 +225,7 @@ class Reap(PersonaIso, unittest.TestCase):
         live = f"live-{_a_dead_pid()}"
         state.bump(dead)
         state.bump(live)
-        removed = state.reap({live})
+        removed = state.reap({live}, server="charter")
         self.assertEqual(removed, [dead])
         self.assertFalse(state.frame_dir(dead).exists())
         self.assertTrue(state.frame_dir(live).exists(),
@@ -241,7 +241,7 @@ class Reap(PersonaIso, unittest.TestCase):
         survive is the session being live."""
         old = f"old-{_a_dead_pid()}"
         state.bump(old)
-        self.assertEqual(state.reap({old}), [])
+        self.assertEqual(state.reap({old}, server="charter"), [])
 
     def test_a_sibling_exit_code_survives_a_reap_that_beats_its_own_launcher(self):
         """#383. `reap` runs at EVERY frame launch, and the set it is handed names the
@@ -258,7 +258,7 @@ class Reap(PersonaIso, unittest.TestCase):
         still there to come back for its answer."""
         fid = state.frame_id("sibling", os.getpid())
         state.record_exit(fid, 42)
-        state.reap({"some-other-frames-session"})
+        state.reap({"some-other-frames-session"}, server="charter")
         self.assertEqual(state.exit_code(fid), 42,
                          "reap deleted a live launcher's frame directory, and with it "
                          "the exit code that launcher had not read yet")
@@ -269,7 +269,7 @@ class Reap(PersonaIso, unittest.TestCase):
         the `exit` file, so the directory is `reap`'s to remove exactly as before."""
         fid = state.frame_id("finished", _a_dead_pid())
         state.bump(fid)
-        self.assertEqual(state.reap(set()), [fid])
+        self.assertEqual(state.reap(set(), server="charter"), [fid])
         self.assertFalse(state.frame_dir(fid).exists())
 
     def test_a_directory_that_names_no_pid_is_still_removed(self):
@@ -278,7 +278,7 @@ class Reap(PersonaIso, unittest.TestCase):
         the live-session test is the only evidence there is — and it is the one `reap`
         already had, so an unparseable name must not become undeletable."""
         state.bump("debris")
-        self.assertEqual(state.reap(set()), ["debris"])
+        self.assertEqual(state.reap(set(), server="charter"), ["debris"])
 
     def test_a_bare_number_is_not_read_as_a_pid(self):
         """`frame_id` always emits `<workspace>-<pid>` with a non-empty workspace (its
@@ -288,7 +288,7 @@ class Reap(PersonaIso, unittest.TestCase):
         make the directory undeletable for as long as the suite runs."""
         name = str(os.getpid())
         state.bump(name)
-        self.assertEqual(state.reap(set()), [name])
+        self.assertEqual(state.reap(set(), server="charter"), [name])
 
     def test_a_trailing_zero_is_not_read_as_a_pid(self):
         """`kill(2)` reads 0 as "every process in my group", not as a process, so
@@ -296,7 +296,7 @@ class Reap(PersonaIso, unittest.TestCase):
         `frame_id` can only ever have written a real `os.getpid()` there, and that is
         never 0 — so the number is debris and the directory stays reapable."""
         state.bump("ws-0")
-        self.assertEqual(state.reap(set()), ["ws-0"])
+        self.assertEqual(state.reap(set(), server="charter"), ["ws-0"])
 
     def test_a_launcher_this_user_may_not_signal_still_counts_as_alive(self):
         """EPERM is an ANSWER, and the opposite of what it looks like. `os.kill(pid, 0)`
@@ -311,7 +311,7 @@ class Reap(PersonaIso, unittest.TestCase):
         state.bump("another-users-frame-4242")
         with mock.patch("charter.frame.state.os.kill",
                         side_effect=PermissionError(1, "Operation not permitted")):
-            self.assertEqual(state.reap(set()), [])
+            self.assertEqual(state.reap(set(), server="charter"), [])
 
     def test_liveness_is_never_asked_off_posix(self):
         """`os.kill(pid, 0)` is a question on POSIX and an ANSWER on Windows, where it
@@ -341,7 +341,91 @@ class Reap(PersonaIso, unittest.TestCase):
         also names no process, so the directory stays reapable."""
         name = "ws-99999999999999999999"
         state.bump(name)
-        self.assertEqual(state.reap(set()), [name])
+        self.assertEqual(state.reap(set(), server="charter"), [name])
+
+
+class ReapAcrossServers(PersonaIso, unittest.TestCase):
+    """A frame lives on ONE tmux server, and only that server can say it is dead.
+
+    Charter now runs frames on two: its own private one (`tmux -L charter`, sessions
+    named by frame id) and, when charter is started from inside a tmux the operator
+    already has, THEIRS (`tmux -S <socket>`, windows named by frame id). Neither
+    server's liveness list mentions the other's frames at all, so an unscoped `reap`
+    deletes the other's state on sight — a running frame's panels lose the version file
+    they poll, and its recorded exit code goes with it, while the frame itself is still
+    on screen. The frame's own server is written down when its directory is created and
+    checked here.
+
+    Every fixture here is named after a pid that has genuinely exited, for the reason
+    `Reap`'s own docstring gives: since #383 `reap` reads the trailing number as the
+    launcher's pid and keeps any directory whose launcher is still running. `mine-1` and
+    `theirs-1` read as throwaway labels, but pid 1 is `launchd`/`init` — the pid rule
+    would have kept every one of them and these tests would have passed with the server
+    check deleted outright.
+    """
+
+    THEIRS = "/private/tmp/tmux-502/default"
+
+    def _frame_on(self, stem, server):
+        fid = f"{stem}-{_a_dead_pid()}"
+        state.bump(fid)
+        state.record_server(fid, server)
+        return fid
+
+    def test_a_frame_on_another_server_survives_this_servers_reap(self):
+        mine = self._frame_on("mine", "charter")
+        theirs = self._frame_on("theirs", self.THEIRS)
+        self.assertEqual(state.reap(set(), server="charter"), [mine])
+        self.assertTrue(state.frame_dir(theirs).exists(),
+                        "the other server's frame was reaped — and since its launcher "
+                        "is dead too, the recorded server is the only thing that could "
+                        "have saved it")
+
+    def test_the_other_server_reaps_its_own(self):
+        """The same test from the other side, so a `reap` that simply never removed
+        anything would not pass both."""
+        mine = self._frame_on("mine", "charter")
+        theirs = self._frame_on("theirs", self.THEIRS)
+        self.assertEqual(state.reap(set(), server=self.THEIRS), [theirs])
+        self.assertTrue(state.frame_dir(mine).exists())
+
+    def test_a_live_frame_on_this_server_is_still_kept(self):
+        gone = self._frame_on("mine", "charter")
+        live = self._frame_on("mine", "charter")
+        self.assertEqual(state.reap({live}, server="charter"), [gone])
+
+    def test_a_live_launcher_on_this_server_is_still_kept(self):
+        """The two guards are independent and BOTH are asked (#381 + #383). This one
+        matches the server exactly and is absent from `live`, so the server check has
+        nothing left to say — only the pid rule can keep it, and it must, or #383's
+        fix stops reaching frames that record a server (which, since #381, is all of
+        them)."""
+        fid = state.frame_id("sibling", os.getpid())
+        state.record_server(fid, "charter")
+        state.record_exit(fid, 42)
+        self.assertEqual(state.reap(set(), server="charter"), [])
+        self.assertEqual(state.exit_code(fid), 42)
+
+    def test_a_frame_from_before_charter_recorded_this_is_still_reapable(self):
+        """The migration case, and the one place an unknown server matches every
+        server. A directory with no marker was written by a charter that only ever ran
+        frames on its own private server; leaving it unreapable forever would trade a
+        transient bug for a permanent leak."""
+        fid = f"legacy-{_a_dead_pid()}"
+        state.bump(fid)
+        self.assertIsNone(state.frame_server(fid))
+        self.assertEqual(state.reap(set(), server=self.THEIRS), [fid])
+
+    def test_the_recorded_server_reads_back(self):
+        state.record_server("f-1", self.THEIRS)
+        self.assertEqual(state.frame_server("f-1"), self.THEIRS)
+
+    def test_recording_a_server_for_an_id_no_directory_can_be_made_for_is_a_no_op(self):
+        """`record_server` runs on the launch path, where an id `contain.child` refuses
+        must degrade rather than raise — the same promise every other writer in this
+        module makes."""
+        state.record_server("../escape", "charter")
+        self.assertIsNone(state.frame_server("../escape"))
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -75,6 +75,26 @@ SOCKET = f"charter-integration-test-{os.getpid()}"
 #: (`ReportIso`, worktree scaffolding) — just its config-path redirection.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
+#: The plane this test PROCESS was started in, captured at IMPORT — before any `setUp`
+#: has had a chance to repoint `config`, so it is unavoidably the developer's REAL
+#: `.charter/`. Kept only so `_TmuxServerFixture.setUp` can refuse to run a test against
+#: it (see that method); nothing here ever reads or writes under this path.
+_REAL_STATE_DIR = Path(config.STATE_DIR)
+
+
+def _a_dead_pid() -> int:
+    """A real pid that has exited and been reaped.
+
+    Load-bearing since #383, not a flourish: `state.reap` reads the number at the end of
+    a frame id as the launcher's pid and KEEPS any directory whose launcher is still
+    running. A hand-written `-1` reads as pid 1 — `launchd`/`init`, which never exits —
+    so a fixture named that way is kept by the pid rule and an "it was reaped" assertion
+    about it can never fail. A pid that genuinely ended is the only way to leave the
+    server/liveness rule as the one thing deciding."""
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    return proc.pid
+
 
 def _tmux(*args: str, env: dict | None = None) -> subprocess.CompletedProcess:
     """*env* is `None` by every existing call site (inherit this process's own
@@ -346,9 +366,37 @@ class _TmuxServerFixture:
     time — each one starting its own real tmux server — which is how a "14 tests"
     surprise showed up the first time this module grew a second class. Mixing the
     fixture in leaves each class owning exactly its own tests.
+
+    **Mixed in OVER `PersonaIso`, never over a bare `unittest.TestCase`, and `setUp`
+    enforces that rather than trusting it.** This module runs charter's REAL command
+    handlers, and `commands_frame.cmd_launch`'s very first act on either path is
+    `state.reap(...)` — an `rmtree` of every frame directory under `config.STATE_DIR`
+    that the named server does not report, which for a directory carrying no `server`
+    marker is every server there is. Against an unisolated `config` that is the
+    developer's own `.charter/frame/`, and a single test run silently deletes the state
+    of the live frames on the machine. Measured, not theorised: a marker frame directory
+    planted in the real plane was gone after one run of
+    `test_nothing_of_the_operators_tmux_is_written_by_a_whole_launch`, back when this
+    class's own subclass listed `unittest.TestCase` here instead.
     """
 
     def setUp(self) -> None:
+        # FIRST, and cooperatively: `PersonaIso.setUp` is what repoints `config`, and it
+        # only runs if this method hands control up the MRO. A `setUp` that quietly
+        # skipped this line would leave a class whose bases READ as isolated running
+        # against the real plane anyway — invisible from the subclass, which is the
+        # shape of the defect this whole docstring is about.
+        super().setUp()
+        # Then check that it actually took, because "the bases say PersonaIso" and "the
+        # config in front of this test is a throwaway" are different claims and only the
+        # second one is the safe one. Fails LOUDLY, naming the fix, rather than letting
+        # a real `rmtree` run over the developer's frames.
+        self.assertNotEqual(
+            Path(config.STATE_DIR), _REAL_STATE_DIR,
+            "this test would run charter's real command handlers against the "
+            "developer's own control plane, whose frame state `state.reap` deletes — "
+            "a class using _TmuxServerFixture must mix it in over `PersonaIso` "
+            "(`class X(_TmuxServerFixture, PersonaIso)`), not over `unittest.TestCase`")
         self.addCleanup(self._teardown_socket)
         self._pane_counter = 0
         self._gate_dir = tempfile.mkdtemp(prefix="charter-integ-gate-")
@@ -423,7 +471,12 @@ class _TmuxServerFixture:
                 "the capability these tests measure is not present to measure")
 
 
-class TmuxIntegration(_TmuxServerFixture, unittest.TestCase):
+class TmuxIntegration(_TmuxServerFixture, PersonaIso):
+    """`PersonaIso`, not `unittest.TestCase` — see `_TmuxServerFixture`'s own docstring.
+    Nothing in THIS class writes plane state today, so the isolation here is inert; it
+    is listed anyway because the fixture requires it of every class, and a requirement
+    with an exception in it is one the next class copies the exception from."""
+
     # -- 0. The hotkey is not a free string ----------------------------------------- #
 
     def _source_hotkey(self, conf_dir: Path, hotkey: str, name: str
@@ -2039,7 +2092,7 @@ class EarlyDeathIntegration(unittest.TestCase):
 SOCKET_PATH = str(Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET)
 
 
-class WindowInsideAnOperatorsTmux(_TmuxServerFixture, unittest.TestCase):
+class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
     """The frame built as a WINDOW in a tmux charter did not start (#381).
 
     Stands a real server up and treats it as the operator's: charter reaches it by
@@ -2052,6 +2105,11 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, unittest.TestCase):
     No attached client anywhere in this class, deliberately: every command is issued
     against a detached session, so nothing here needs the terminal capability
     `_NeedsAttachedClient` probes for and none of it is skipped on a headless CI step.
+
+    `PersonaIso`, and it is load-bearing rather than tidy: the last test below calls the
+    real `cmd_launch`, which reaps and writes frame state under `config.STATE_DIR`. The
+    tmux server this class stands up is a throwaway; without `PersonaIso` the PLANE it
+    writes to would not be. See `_TmuxServerFixture`'s docstring for what that cost.
     """
 
     def _operator_server(self, harness_dies_by="exit 0"):
@@ -2215,7 +2273,7 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, unittest.TestCase):
         self.assertEqual(Path(Path(out).read_text().strip()).resolve(),
                          Path(self._gate_dir).resolve())
 
-    def test_nothing_of_the_operators_is_written_by_a_whole_launch(self):
+    def test_nothing_of_the_operators_tmux_is_written_by_a_whole_launch(self):
         """The boundary, checked against tmux's own reported state rather than against
         charter's argv: every server option, every option of the operator's own session,
         and the entire key table are read before and after a REAL `cmd_launch` runs
@@ -2223,9 +2281,36 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, unittest.TestCase):
 
         `cmd_launch` itself, not the argv builders — this is the one test that can catch
         a command the launcher issues that nobody thought to look for.
+
+        **Their TMUX, which is not the same claim as "nothing at all is written"** — the
+        name says `tmux` for that reason. A launch writes charter's own frame state, and
+        the first thing it writes is a DELETION: `state.reap` rmtrees every frame
+        directory the named server does not report, and a directory carrying no `server`
+        marker (the migration case `state.reap` documents) is not reported by any server
+        at all. The decoy below is exactly that shape — no marker, and named after a pid
+        that has genuinely exited, so neither of `reap`'s two keep-rules covers it — and
+        asserting it is gone afterward pins the blast radius of one launch — which is also why this class cannot run
+        without `PersonaIso`: the same rmtree against an unisolated `config.STATE_DIR`
+        lands on the developer's live frames. The decoy is checked to be inside this
+        test's throwaway plane BEFORE the launch, so the assertion that it was deleted
+        can never be evidence about the real one.
         """
         name, sid, op_pane, _ = self._operator_server()
         gate = os.path.join(self._gate_dir, "e2e-gate")
+
+        # Named after a pid that has genuinely exited: since #383 `reap` keeps any
+        # directory whose launcher is still alive, and the `-1` this once carried reads
+        # as `launchd`/`init` — the decoy would have survived for that reason and this
+        # assertion would have been unfailable.
+        decoy = state.frame_dir(
+            f"a-frame-from-a-charter-that-had-no-server-marker-{_a_dead_pid()}",
+            create=True)
+        self.assertIsNotNone(decoy)
+        (decoy / "version").write_text("1\n")
+        self.assertTrue(decoy.is_relative_to(self.tmp),
+                        f"the frame state this test is about to have charter delete is "
+                        f"at {decoy} — outside this test's own throwaway plane "
+                        f"({self.tmp}), so it belongs to somebody real")
 
         def _snapshot():
             return tuple(_tmux(*args).stdout for args in (
@@ -2267,6 +2352,11 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, unittest.TestCase):
         self.assertNotIn("demo-", _tmux("list-windows", "-a", "-F",
                                         "#{window_name}").stdout,
                          "the frame's window was left behind")
+        self.assertFalse(decoy.exists(),
+                         "a launch is expected to reap a frame directory with no "
+                         "`server` marker — if it has stopped doing that, `state.reap`'s "
+                         "migration case changed and the isolation this class rests on "
+                         "is no longer being exercised by anything")
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -48,13 +48,15 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands_frame, config, hooks, instance, todos
-from charter.frame import gather, layout, menu, notify, state
+from charter.frame import gather, layout, menu, notify, state, tmuxctl
 
 from tests._isolation import PersonaIso, run_hook
 
@@ -335,7 +337,17 @@ class _NeedsAttachedClient:
 
 
 @unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
-class TmuxIntegration(unittest.TestCase):
+class _TmuxServerFixture:
+    """One real tmux server per test, and the helpers every class here needs.
+
+    A MIXIN rather than a base TestCase, and that is not style. `unittest` collects a
+    subclass's inherited tests as its own, so `class WindowInsideAnOperatorsTmux
+    (TmuxIntegration)` would silently re-run every test in `TmuxIntegration` a second
+    time — each one starting its own real tmux server — which is how a "14 tests"
+    surprise showed up the first time this module grew a second class. Mixing the
+    fixture in leaves each class owning exactly its own tests.
+    """
+
     def setUp(self) -> None:
         self.addCleanup(self._teardown_socket)
         self._pane_counter = 0
@@ -410,6 +422,8 @@ class TmuxIntegration(unittest.TestCase):
                 "nothing here can carry a harness's exit status out of a dead pane — "
                 "the capability these tests measure is not present to measure")
 
+
+class TmuxIntegration(_TmuxServerFixture, unittest.TestCase):
     # -- 0. The hotkey is not a free string ----------------------------------------- #
 
     def _source_hotkey(self, conf_dir: Path, hotkey: str, name: str
@@ -2016,6 +2030,243 @@ class EarlyDeathIntegration(unittest.TestCase):
         msg = commands_frame.early_death_message([self.MISSING, "--flag"], code, words)
         self.assertIn(self.MISSING, msg)
         self.assertIn(str(code), msg)
+
+
+#: The socket FILE tmux computes for `-L SOCKET` — the same path `_teardown_socket`
+#: already has to know. Needed as a path (not a name) by `WindowInsideAnOperatorsTmux`,
+#: because the whole point of that class is exercising the `-S <socket path>` half of
+#: `tmuxctl.server_argv`, which is how charter reaches a server it did not start.
+SOCKET_PATH = str(Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET)
+
+
+class WindowInsideAnOperatorsTmux(_TmuxServerFixture, unittest.TestCase):
+    """The frame built as a WINDOW in a tmux charter did not start (#381).
+
+    Stands a real server up and treats it as the operator's: charter reaches it by
+    socket PATH, opens one window in one of its sessions, and must leave everything else
+    exactly as it found it. The properties here are the ones a mock cannot check —
+    whether tmux keeps a dead pane at all when `remain-on-exit` is set PANE-scoped,
+    what it answers for a pane that no longer exists, whether `respawn-pane -e` reaches
+    the process, and whether `kill-window` takes the operator's session with it.
+
+    No attached client anywhere in this class, deliberately: every command is issued
+    against a detached session, so nothing here needs the terminal capability
+    `_NeedsAttachedClient` probes for and none of it is skipped on a headless CI step.
+    """
+
+    def _operator_server(self, harness_dies_by="exit 0"):
+        """A session standing in for one the operator already had open.
+
+        Returns its name, its `$N` session id, its own pane id, and the gate the frame's
+        harness will die by. The session's own pane runs a program that never exits on
+        its own, so anything that quietly takes the operator's session down shows up as
+        a missing session rather than as a race.
+        """
+        name, pane, gate = self._new_pane("exit 0")
+        sid = _tmux("display-message", "-p", "-t", pane, "#{session_id}").stdout.strip()
+        self.assertTrue(sid.startswith("$"), sid)
+        return name, sid, pane, gate
+
+    def _open_frame_window(self, sid, fid="charter-demo-1"):
+        """`layout.window_argv`'s own bytes, run for real. Returns (window id, pane id)."""
+        r = _run(layout.window_argv(socket=SOCKET_PATH, session=sid, window=fid,
+                                    cwd=self._gate_dir))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        window_id, _, pane_id = r.stdout.strip().partition(" ")
+        self.assertTrue(window_id.startswith("@"), r.stdout)
+        self.assertTrue(pane_id.startswith("%"), r.stdout)
+        return window_id, pane_id
+
+    def _wait_until(self, predicate, timeout=5.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate():
+                return True
+            time.sleep(0.05)
+        return False
+
+    def _require_pane_options(self, pane_id):
+        """Skip unless THIS tmux accepts a pane-scoped `remain-on-exit`.
+
+        `set-option -p` is what keeps a dead harness pane askable on a server charter is
+        a guest on, and it is the only scope that does not reach past charter's own
+        window (see `commands_frame._remain_on_exit_argv`). A tmux without pane options
+        cannot do the thing these tests measure, so they skip naming that rather than
+        failing with tmux's own argument-parsing text."""
+        r = _run(commands_frame._remain_on_exit_argv(socket=SOCKET_PATH,
+                                                     harness_pane=pane_id))
+        if r.returncode != 0:
+            self.skipTest("this tmux does not accept a pane-scoped `remain-on-exit` "
+                          f"({r.stderr.strip()}), so it cannot hold a dead harness pane "
+                          "for its exit status to be read out of")
+
+    def test_the_harnesss_real_exit_code_survives_in_someone_elses_server(self):
+        """End to end for the one property the whole module exists for, on the path
+        where there is no `attach` to read a code out of: charter opens the window,
+        arms the pane, respawns the harness into it, and reads the status back through
+        `_pane_state` — the same function the launcher's wait loop calls."""
+        _, sid, _, _ = self._operator_server()
+        window_id, pane_id = self._open_frame_window(sid)
+        self._require_pane_options(pane_id)
+        gate = os.path.join(self._gate_dir, "harness-gate")
+        r = _run(layout.respawn_argv(socket=SOCKET_PATH, harness_pane=pane_id, env={},
+                                     cwd=self._gate_dir,
+                                     harness_argv=_gate_argv(gate, "exit 33")))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(commands_frame._pane_state(SOCKET_PATH, pane_id),
+                         (commands_frame._ALIVE, None))
+        self._release(gate)
+        self.assertTrue(self._wait_until(
+            lambda: commands_frame._pane_state(SOCKET_PATH, pane_id)[0]
+            == commands_frame._DEAD), "the pane never came back dead")
+        self.assertEqual(commands_frame._pane_state(SOCKET_PATH, pane_id),
+                         (commands_frame._DEAD, 33))
+        del window_id
+
+    def test_the_placeholder_does_not_exit_on_its_own(self):
+        """`layout.PLACEHOLDER`'s only required property, and the one an argv assertion
+        cannot make: if it could exit, the window would be gone before `remain-on-exit`
+        was ever set on its pane and the ordering the whole path rests on would buy
+        nothing."""
+        _, sid, _, _ = self._operator_server()
+        _, pane_id = self._open_frame_window(sid)
+        time.sleep(0.4)
+        self.assertEqual(commands_frame._pane_state(SOCKET_PATH, pane_id)[0],
+                         commands_frame._ALIVE,
+                         "the placeholder exited on its own")
+
+    def test_a_pane_that_is_gone_answers_empty_rather_than_failing(self):
+        """The measured fact `_pane_state` — and therefore the launcher's wait loop —
+        rests on: `display-message -p -t <a pane that no longer exists>` does NOT fail.
+        It returns 0 and prints an empty line. A loop that only stopped on
+        `#{pane_dead}` being `1` would poll a window nobody can bring back, forever."""
+        _, sid, _, _ = self._operator_server()
+        window_id, pane_id = self._open_frame_window(sid)
+        raw = _run(tmuxctl.server_argv(SOCKET_PATH, "display-message", "-p", "-t",
+                                       pane_id, commands_frame._DEAD_FORMAT))
+        self.assertEqual(raw.returncode, 0)
+        self.assertEqual(raw.stdout.strip(), "0:")
+        _run(tmuxctl.server_argv(SOCKET_PATH, "kill-window", "-t", window_id))
+        gone = _run(tmuxctl.server_argv(SOCKET_PATH, "display-message", "-p", "-t",
+                                        pane_id, commands_frame._DEAD_FORMAT))
+        self.assertEqual(gone.returncode, 0,
+                         "tmux is expected to answer, not to refuse")
+        self.assertEqual(gone.stdout.strip(), ":",
+                         "both variables expand to nothing, and the format's own "
+                         "literal `:` is all that is left — NOT an empty line, which "
+                         "is what a guard written from memory assumed")
+        self.assertEqual(commands_frame._pane_state(SOCKET_PATH, pane_id),
+                         (commands_frame._GONE, None))
+
+    def test_closing_the_frames_window_leaves_the_operators_session_alone(self):
+        """`kill-window`, never `kill-session` — the difference between charter tidying
+        up after itself and charter ending every window the operator had open."""
+        name, sid, op_pane, _ = self._operator_server()
+        window_id, _ = self._open_frame_window(sid)
+        before = _tmux("list-windows", "-a", "-F", "#{window_name}").stdout.split()
+        self.assertIn("charter-demo-1", before)
+        _run(tmuxctl.server_argv(SOCKET_PATH, "kill-window", "-t", window_id))
+        after = _tmux("list-windows", "-a", "-F", "#{window_name}").stdout.split()
+        self.assertNotIn("charter-demo-1", after)
+        self.assertIn(name, _tmux("list-sessions", "-F", "#{session_name}").stdout.split(),
+                      "the operator's own session went with charter's window")
+        self.assertEqual(_tmux("display-message", "-p", "-t", op_pane,
+                               "#{pane_dead}").stdout.strip(), "0",
+                         "the operator's own pane died with it")
+
+    def test_charters_environment_reaches_the_harness_and_the_launchers_pane_does_not(self):
+        """`respawn-pane -e` is the only channel charter has here, and the launching
+        pane's own `$TMUX_PANE` must not travel down it: tmux sets that variable itself
+        for the pane it creates, and overwriting it would tell the harness — and
+        `session.terminal()`, which reads it — that it is somewhere it is not."""
+        _, sid, op_pane, _ = self._operator_server()
+        _, pane_id = self._open_frame_window(sid)
+        self._require_pane_options(pane_id)
+        out = os.path.join(self._gate_dir, "harness-env")
+        env = commands_frame._frame_env("charter-demo-1", None)
+        env["CHARTER_HARNESS"] = "claude-code"
+        r = _run(layout.respawn_argv(
+            socket=SOCKET_PATH, harness_pane=pane_id, env=env, cwd=self._gate_dir,
+            harness_argv=["/bin/sh", "-c",
+                          f'printf "%s\\n%s\\n%s\\n" "$CHARTER_SESSION_ID" '
+                          f'"$CHARTER_HARNESS" "$TMUX_PANE" > "{out}"']))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertTrue(_await_file(out), "the harness never ran")
+        self.assertTrue(self._wait_until(lambda: Path(out).read_text().count("\n") >= 3))
+        sid_seen, harness_seen, pane_seen = Path(out).read_text().splitlines()[:3]
+        self.assertEqual(sid_seen, "charter-demo-1")
+        self.assertEqual(harness_seen, "claude-code")
+        self.assertEqual(pane_seen, pane_id,
+                         "the harness must see its OWN pane, not the launcher's")
+        self.assertNotEqual(pane_seen, op_pane)
+
+    def test_the_harness_starts_where_charter_was_typed(self):
+        """A pane in a server charter did not start otherwise inherits the SESSION's
+        working directory — wherever the operator was when they first ran `tmux`."""
+        _, sid, _, _ = self._operator_server()
+        _, pane_id = self._open_frame_window(sid)
+        self._require_pane_options(pane_id)
+        out = os.path.join(self._gate_dir, "harness-cwd")
+        r = _run(layout.respawn_argv(
+            socket=SOCKET_PATH, harness_pane=pane_id, env={}, cwd=self._gate_dir,
+            harness_argv=["/bin/sh", "-c", f'pwd > "{out}"']))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertTrue(_await_file(out), "the harness never ran")
+        self.assertEqual(Path(Path(out).read_text().strip()).resolve(),
+                         Path(self._gate_dir).resolve())
+
+    def test_nothing_of_the_operators_is_written_by_a_whole_launch(self):
+        """The boundary, checked against tmux's own reported state rather than against
+        charter's argv: every server option, every option of the operator's own session,
+        and the entire key table are read before and after a REAL `cmd_launch` runs
+        inside this server, and must come back byte for byte.
+
+        `cmd_launch` itself, not the argv builders — this is the one test that can catch
+        a command the launcher issues that nobody thought to look for.
+        """
+        name, sid, op_pane, _ = self._operator_server()
+        gate = os.path.join(self._gate_dir, "e2e-gate")
+
+        def _snapshot():
+            return tuple(_tmux(*args).stdout for args in (
+                ("show-options", "-g"),
+                ("show-options", "-t", name),
+                ("show-options", "-g", "-w"),
+                ("list-keys",)))
+
+        before = _snapshot()
+        server_pid = _tmux("display-message", "-p", "#{pid}").stdout.strip()
+        args = SimpleNamespace(harness="frame", rest=["--", *_gate_argv(gate, "exit 21")],
+                               no_frame=False)
+        rc: list[int] = []
+
+        def _run_launch():
+            env = dict(os.environ, TMUX=f"{SOCKET_PATH},{server_pid},{sid[1:]}",
+                       TMUX_PANE=op_pane)
+            with mock.patch.dict(os.environ, env, clear=True), \
+                 mock.patch("sys.stdout.isatty", return_value=True), \
+                 mock.patch("charter.workspace.resolve", return_value="demo"), \
+                 mock.patch.dict(config.FRAME, {"slots": []}):
+                rc.append(commands_frame.cmd_launch(args))
+
+        worker = threading.Thread(target=_run_launch, daemon=True)
+        worker.start()
+        self.assertTrue(self._wait_until(
+            lambda: "demo-" in _tmux("list-windows", "-a", "-F",
+                                     "#{window_name}").stdout, timeout=15),
+            "the frame's own window never appeared in the operator's server")
+        during = _snapshot()
+        self._release(gate)
+        worker.join(timeout=25)
+        self.assertFalse(worker.is_alive(), "cmd_launch never returned")
+        self.assertEqual(rc, [21], "the harness's own exit code did not come back")
+        self.assertEqual(before, during,
+                         "charter wrote something on a server it is only a guest on")
+        self.assertEqual(before, _snapshot())
+        self.assertIn(name, _tmux("list-sessions", "-F", "#{session_name}").stdout.split())
+        self.assertNotIn("demo-", _tmux("list-windows", "-a", "-F",
+                                        "#{window_name}").stdout,
+                         "the frame's window was left behind")
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_tmuxctl.py
+++ b/tests/test_frame_tmuxctl.py
@@ -7,6 +7,7 @@ remedy that does not exist costs more than an honest gap".
 
 from __future__ import annotations
 
+import os
 import subprocess
 import unittest
 from unittest import mock
@@ -153,6 +154,83 @@ class RunGuardsTheTimeout(unittest.TestCase):
         self.assertNotIn("timeout", kwargs)
         self.assertNotIn("capture_output", kwargs)
         self.assertEqual(kwargs["env"], {"A": "b"})
+
+
+class OperatorServer(unittest.TestCase):
+    """Reading `$TMUX` — the one fact that decides whether charter nests or not.
+
+    Measured against tmux 3.7c by printing `$TMUX` inside a real pane: the value is
+    `<socket path>,<server pid>,<session id>`, where the session id is the NUMBER off
+    tmux's own `#{session_id}` (`$1` -> `1`). Both halves matter to the launcher — the
+    socket says WHICH server the operator is already talking to, and the session id says
+    which session of theirs the new window belongs in — so both are parsed here rather
+    than one being re-queried from tmux later.
+    """
+
+    def test_a_real_tmux_environment_yields_the_socket_and_the_session(self):
+        env = {"TMUX": "/private/tmp/tmux-502/default,70029,1"}
+        self.assertEqual(tmuxctl.operator_server(env),
+                         ("/private/tmp/tmux-502/default", "$1"))
+
+    def test_no_tmux_variable_means_charter_is_not_inside_one(self):
+        self.assertIsNone(tmuxctl.operator_server({}))
+
+    def test_an_empty_tmux_variable_is_not_inside_one_either(self):
+        """An exported-but-empty `$TMUX` is what a shell that once ran `unset`-less
+        cleanup leaves behind; treating it as "inside tmux" would send the launcher at a
+        socket path of `""`."""
+        self.assertIsNone(tmuxctl.operator_server({"TMUX": ""}))
+
+    def test_a_value_charter_cannot_read_is_refused_rather_than_guessed(self):
+        """Two commas and a numeric third field is the whole contract. Anything else —
+        a truncated value, a non-numeric session id — is not shaped into a target that
+        would then be interpolated into `new-window -t`; charter falls back to its own
+        private server, which nests but is never wrong about what it is talking to."""
+        for bad in ("/tmp/sock", "/tmp/sock,70029", "/tmp/sock,70029,abc",
+                    ",70029,1", "/tmp/sock,70029,1,extra"):
+            with self.subTest(bad=bad):
+                self.assertIsNone(tmuxctl.operator_server({"TMUX": bad}))
+
+    def test_a_relative_socket_path_is_refused(self):
+        """`server_argv` picks `-S` over `-L` on a leading slash alone, so a socket
+        path that is not absolute would silently be sent to tmux as a `-L` SERVER NAME
+        and start a brand-new server — the nesting this whole path exists to stop,
+        reached by a different route."""
+        self.assertIsNone(tmuxctl.operator_server({"TMUX": "sock,70029,1"}))
+
+    def test_the_default_source_is_the_real_environment(self):
+        with mock.patch.dict(os.environ, {"TMUX": "/tmp/s,1,2"}):
+            self.assertEqual(tmuxctl.operator_server(), ("/tmp/s", "$2"))
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(tmuxctl.operator_server())
+
+
+class ServerArgv(unittest.TestCase):
+    """`tmux -L <name>` and `tmux -S <path>` are the same command against two different
+    servers, and every argv charter builds has to pick one.
+
+    A leading `/` is the whole discriminator, and it is total rather than heuristic: a
+    socket path only ever reaches charter from `$TMUX`, which tmux itself writes
+    absolute (measured), and a `-L` name may not contain a separator at all — tmux joins
+    it onto its own socket directory to make the path.
+    """
+
+    def test_a_plain_name_selects_charters_own_private_server(self):
+        self.assertEqual(tmuxctl.server_argv("charter", "list-sessions"),
+                         ["tmux", "-L", "charter", "list-sessions"])
+
+    def test_an_absolute_path_selects_the_operators_existing_server(self):
+        self.assertEqual(
+            tmuxctl.server_argv("/private/tmp/tmux-502/default", "list-windows", "-a"),
+            ["tmux", "-S", "/private/tmp/tmux-502/default", "list-windows", "-a"])
+
+    def test_nothing_is_ever_joined(self):
+        """The argv rule, at the one place every tmux command in charter now passes
+        through: a joined string is shell-interpreted by tmux and a separate argv is
+        not (pinned against 3.7c)."""
+        argv = tmuxctl.server_argv("charter", "new-window", "--", "claude", "-p", "a;b")
+        self.assertEqual(argv[-1], "a;b")
+        self.assertTrue(all(isinstance(a, str) for a in argv))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #381.

Implemented, adversarially reviewed, and then re-verified after a fix round — in an ultracode workflow. The reviewer reproduced the original symptom against the branch point, showed it gone, and mutation-tested every new test to confirm it can actually fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9