### PR TITLE
frame: a dying panel says why, and respawns with backoff (#382)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -676,7 +676,7 @@ def _add_frame_parsers(sub) -> None:
     # naming `frame-probe` silently launching a harness instead of reading tmux's own
     # version (see `commands_frame.cmd_probe`'s own docstring).
     _core_commands = set(sub.choices) | {"frame", "panel", "frame-menu", "frame-action",
-                                         "frame-probe"}
+                                         "frame-probe", "frame-respawn"}
 
     # Which harness (by `.name`, never `.cli_name` — that's the dict key below) has
     # already claimed each word, so a SECOND harness wanting it is told who got there
@@ -747,6 +747,17 @@ def _add_frame_parsers(sub) -> None:
     act = sub.add_parser("frame-action")
     act.add_argument("action_id")
     act.set_defaults(func=commands_frame.cmd_action)
+
+    # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the
+    # two above. Fired by a PANEL pane's own `pane-died` hook (#382,
+    # `commands_frame._panel_died_hook_argv`) — never typed by an operator, and never by
+    # the harness pane's hooks, which carry the exit code instead. The frame it belongs
+    # to is resolved from `$CHARTER_SESSION_ID` at the moment the hook fires, exactly
+    # like `frame-menu`; only the slot and the pane to revive travel on the argv.
+    rs = sub.add_parser("frame-respawn")
+    rs.add_argument("slot")
+    rs.add_argument("--pane", dest="pane", required=True)
+    rs.set_defaults(func=commands_frame.cmd_respawn)
 
     # A TOP-LEVEL sibling of `frame` for a DIFFERENT reason than `frame-menu`/
     # `frame-action` above: those two exist because `_split_frame_argv` eats everything

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -418,7 +418,8 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str) -> 
     environment goes through, and the two do not behave alike.
 
     **`"$CHARTER_PY" -m charter`, never a bare `charter`.** The panels already launch
-    charter via `util.self_relaunch_argv()` (see `cmd_launch`'s `panel_argvs` call)
+    charter via `util.self_relaunch_argv()` (inside `layout.panel_command`, which owns
+    that half of the panel argv for both the launcher and `cmd_respawn`)
     precisely because the `charter` an operator's `$PATH` resolves may be a
     different install, or no install at all — a `uv tool` shim not on the tmux server's
     own PATH, a checkout run as `python -m charter`. This line had kept the bare name,
@@ -1187,7 +1188,6 @@ def _draw_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     inside an operator's tmux the cwd is the same cwd, so the hole is the same hole.
     """
     panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=socket,
-                                    charter_argv=util.self_relaunch_argv(),
                                     harness_pane=harness_pane, env=pane_env)
     # Zipped with `slots`, not just iterated: `_resize_hook_argv` below needs to know
     # WHICH slot each successfully-created pane belongs to (for its size and its
@@ -1840,8 +1840,7 @@ def cmd_respawn(args) -> int:
     tmuxctl.run(
         f"bringing the {args.slot} panel back",
         ["tmux", "-L", SOCKET, "respawn-pane", "-t", args.pane, "--",
-         *layout.panel_command(slot=args.slot, session=fid,
-                               charter_argv=[sys.executable, "-m", "charter"])])
+         *layout.panel_command(slot=args.slot, session=fid)])
     return 0
 
 

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -598,6 +598,67 @@ def _pane_died_teardown_hook_argv(*, socket: str, harness_pane: str) -> list[str
                                "pane-died[1]", "kill-session")
 
 
+#: How many times one slot's panel may be brought back before charter stops trying, per
+#: frame. The spec's own number ("a dead panel stays visible with its error, respawns
+#: with backoff, and gives up after 3 attempts"). The cap is the entire reason a count
+#: exists on disk at all: verified against tmux 3.7c that a pane's `pane-died` hook
+#: SURVIVES the `respawn-pane` it triggers, so a panel that dies instantly on every
+#: start would otherwise respawn forever with nothing anywhere counting.
+_RESPAWN_ATTEMPTS = 3
+
+#: What each attempt waits before bringing the pane back, indexed by attempt number.
+#: Backoff rather than three immediate retries because a panel that fails AT STARTUP
+#: fails in milliseconds: fired back to back, all three attempts land inside the same
+#: broken condition and the whole budget is spent before anything transient (a
+#: filesystem hiccup, a plane mid-upgrade replacing charter's own files) could clear.
+#: The sleep happens in a `run-shell -b` child, never in tmux's own command queue — see
+#: `_panel_died_hook_argv` for why the `-b` is load-bearing and not tidiness.
+_RESPAWN_BACKOFF = (1.0, 2.0, 4.0)
+
+
+def _panel_died_hook_argv(*, socket: str, panel_pane: str, slot: str) -> list[str]:
+    """`pane-died`, scoped to ONE PANEL pane: bring that panel back.
+
+    **Not the harness pane's hook array, and this is the property to keep.** The two
+    exit-code hooks (`_pane_died_write_hook_argv`, `_pane_died_teardown_hook_argv`) live
+    in the HARNESS pane's own `pane-died` array, where an unindexed `set-hook` replaces
+    the whole array — the trap their install order exists to work around. This hook is
+    `-p -t <panel pane>`: a different pane, a different option array. Verified against
+    tmux 3.7c that installing it leaves the harness pane's `pane-died[0]`/`[1]` read back
+    byte-identical, and that a panel dying fires only this hook and not the harness
+    pane's `kill-session`. It is unindexed because nothing else installs a hook on a
+    panel pane at all — there is no `[1]` here to delete.
+
+    **`run-shell -b`, backgrounded, and both halves of that matter.** Un-backgrounded,
+    tmux prints a non-zero command's own `'…' returned N` INTO THE HARNESS PANE and
+    drops it into copy-mode — charter drawing in the one rectangle ADR 0018 says it
+    never draws, which `conf_text`'s docstring records happening for real. Measured with
+    `-b` against 3.7c: a command that both writes to stdout and exits non-zero produced
+    nothing in the harness pane and left it out of copy-mode. The second half is timing:
+    the command deliberately SLEEPS for its backoff, and a blocking `run-shell` in a
+    hook stalls tmux's command queue for that whole time.
+
+    **Single-quoted, so tmux does not eat the `$`.** `_pane_died_write_hook_argv`'s
+    docstring measures the opposite case — an unescaped `$` inside a tmux DOUBLE-quoted
+    argument is consumed by tmux's own parsing before any shell sees it. Single quotes
+    are what `conf_text`'s hotkey bind already uses for the identical job, and the exact
+    action string this function builds was run end to end against tmux 3.7c: the hook
+    fires, `/bin/sh` expands `$CHARTER_PY` itself, and the argv arrives intact with
+    `$CHARTER_SESSION_ID` present in the spawned shell's environment.
+
+    Only two values are interpolated and both are safe BY CONSTRUCTION, not by
+    good behaviour: *panel_pane* is tmux's own `%<digits>`, already checked against
+    `_PANE_ID_RE` by `cmd_launch` before it is kept, and *slot* is a key of
+    `frame_slots.SLOTS` — `cmd_launch` filters everything else out (`unimplemented`)
+    before a pane is ever split for it. Nothing operator- or plane-derived reaches this
+    text, which is the same rule the module docstring's "constant string" section sets
+    for `status_path`.
+    """
+    action = (f"run-shell -b '\"${_CHARTER_PY_ENV}\" -m charter frame-respawn "
+              f"{slot} --pane {panel_pane}'")
+    return ["tmux", "-L", socket, "set-hook", "-p", "-t", panel_pane, "pane-died", action]
+
+
 #: Which `resize-pane` flag re-asserts a slot's fixed dimension: `-y` (rows) for the
 #: horizontal strips, `-x` (columns) for the side columns — the same axis `layout.py`'s
 #: own `-v`/`-h` split direction already encodes for the same slots, read here rather
@@ -1422,18 +1483,23 @@ def cmd_launch(args) -> int:
     # is, because it is ours. Everything recorded under this id therefore predates this
     # frame, and a launch beginning is the one moment that can be certain of it.
     #
-    # Two files, because two readers inherit: `state.exit_code(fid)` below would read a
-    # dead frame's `exit` back as this launch's own return value, and `gather.read(fid)`
+    # Three things, because three readers inherit. `state.exit_code(fid)` below would
+    # read a dead frame's `exit` back as this launch's own return value. `gather.read(fid)`
     # (no freshness check, by design — it is a panel's hot path) would serve a dead
-    # frame's scan to every panel until the session's first hook bump. `version` is
-    # deliberately left: it is a counter panels compare against their last reading, and
-    # moving it is `state.bump`'s job, one line below.
+    # frame's scan to every panel until the session's first hook bump. And
+    # `state.respawn_attempt` never resets (#382), so the dead frame's respawn counts —
+    # at least one per slot, since every panel's `pane-died` hook fired during ITS
+    # teardown, and possibly already at `_RESPAWN_ATTEMPTS` — would be charged to this
+    # frame's panels, which would then die once and stay dead. `version` is deliberately
+    # left: it is a counter panels compare against their last reading, and moving it is
+    # `state.bump`'s job, one line below.
     state.clear_exit(fid)
     gather.discard(fid)
     # And the `server` marker is rewritten for the same reason: an adopted directory
     # may name the OTHER server, and a stale marker would make `reap` on this one skip
     # a frame that is now genuinely ours.
     state.record_server(fid, SOCKET)
+    state.clear_respawn(fid)
     state.bump(fid)
 
     try:
@@ -1584,8 +1650,31 @@ def cmd_launch(args) -> int:
                      f"detached; reattach manually if you must: "
                      f"tmux -L {SOCKET} attach -t {fid}")
         else:
-            _draw_panels(SOCKET, slots=slots, fid=fid, harness_pane=harness_pane,
-                         env=env, v=v)
+            panes = _draw_panels(SOCKET, slots=slots, fid=fid, harness_pane=harness_pane,
+                                 env=env, v=v)
+            for slot, pane_id in panes.items():
+                # This panel's OWN `pane-died` hook, so a panel whose process dies
+                # outright is brought back instead of leaving a hole for the frame's
+                # whole life (#382). Scoped to this pane — never the harness pane, whose
+                # `pane-died` array carries the exit code and must not gain a third
+                # writer (see `_panel_died_hook_argv`). Reported but never fatal, like
+                # every other decorative tmux command here: a panel that cannot be armed
+                # for respawn is still a panel that came up.
+                #
+                # Private-server-only, deliberately, and not folded into `_draw_panels`
+                # itself: `cmd_respawn` (the hook's own action) and
+                # `_panel_died_hook_argv` both assume `SOCKET`, charter's own server
+                # NAME — `-L`, never `-S` — which is correct here and wrong on the
+                # operator's own tmux, where the frame's server is a socket PATH read
+                # from `$TMUX`. Arming a panel there today would install a hook whose
+                # action targets the wrong tmux server entirely. Extending #382 across
+                # that boundary is real work — resolving `cmd_respawn`'s target from
+                # `state.frame_server(fid)` and its liveness check from windows rather
+                # than sessions — not something to invent as a side effect of this
+                # rebase.
+                tmuxctl.run(f"arming the {slot} panel for respawn",
+                           _panel_died_hook_argv(socket=SOCKET, panel_pane=pane_id,
+                                                 slot=slot), env=env)
 
             # `split-window` makes the newly created pane the ACTIVE one by default, so
             # after every slot has been drawn, the LAST panel drawn — not the harness —
@@ -1689,6 +1778,71 @@ def cmd_menu(args) -> int:
     # no-capture, no-timeout side of `tmuxctl` — time-boxing it would close a menu for
     # the crime of being read slowly.
     return tmuxctl.interact(menu.menu_argv(fid, SOCKET, client=args.client)).returncode
+
+
+def cmd_respawn(args) -> int:
+    """`charter frame-respawn <slot> --pane %N` — bring one dead panel back, or stop.
+
+    Fired only by a panel pane's own `pane-died` hook (`_panel_died_hook_argv`), never
+    typed. It exists as a charter command because the two things standing between "a
+    panel died" and "respawn it forever" — a count, and a wait — are both things tmux
+    itself cannot do.
+
+    **Which failures reach here at all.** `frame/panel.py` now holds its pane open for
+    every failure charter's own Python can see, painting the reason into the pane rather
+    than exiting into tmux's `Pane is dead (status N)` message (#382's first half). So a
+    panel that reaches this hook is one whose PROCESS is gone — the interpreter failing
+    to start, a SIGKILL, an OOM — which is the only kind restarting could ever help.
+
+    **Always 0.** This is a `run-shell -b` child; nothing reads its status, and a
+    non-zero exit is exactly what makes tmux print into the harness pane on the
+    un-backgrounded path (see `_panel_died_hook_argv`). Every refusal below is a quiet
+    no-op for the same reason: there is no screen left to report it on that is not the
+    agent's own.
+
+    Refusals, in the order they are checked:
+
+    * no `$CHARTER_SESSION_ID` — not fired by a frame at all, so there is no frame to
+      resolve or count against (`cmd_menu` treats the same gap the same way);
+    * a *slot* with no renderer — bringing it back would recreate exactly the
+      permanently-dead pane `cmd_launch`'s `unimplemented` filter exists to prevent;
+    * a *pane* that is not tmux's own `%<digits>` — the value arrived through text tmux
+      re-parsed, so it gets the same treatment `_PANE_ID_RE` already gives the resize
+      hook's target;
+    * a count `state.respawn_attempt` could not record (`None`) — treating that as
+      "attempt 1" would respawn forever, the one outcome the cap exists to prevent;
+    * the cap itself, `_RESPAWN_ATTEMPTS`. Giving up is not a failure here: the pane
+      stays dead with tmux's own message in it, which is the spec's own "a dead panel
+      stays visible with its error".
+
+    **The liveness check is AFTER the backoff, deliberately.** Every panel pane dies
+    when the frame is torn down, so every panel's hook fires on the way out — the
+    ordinary end of every frame, not an edge case. Asking before the sleep would race
+    `kill-session`; asking after it means the teardown has had the whole backoff to
+    finish, and a respawn into a session that no longer exists (one failure report per
+    panel, for nothing being wrong) is avoided rather than reported.
+    """
+    fid = os.environ.get("CHARTER_SESSION_ID", "")
+    if not fid or args.slot not in frame_slots.SLOTS:
+        return 0
+    if not _PANE_ID_RE.fullmatch(args.pane or ""):
+        return 0
+    attempt = state.respawn_attempt(fid, args.slot)
+    if attempt is None or attempt > _RESPAWN_ATTEMPTS:
+        return 0
+    # `min(...)`: the two constants are the same length today and `attempt` is already
+    # capped above, so this changes nothing now — it is here so raising
+    # `_RESPAWN_ATTEMPTS` alone degrades to "wait the longest backoff again" instead of
+    # an IndexError inside a tmux hook, where nothing would print it.
+    time.sleep(_RESPAWN_BACKOFF[min(attempt, len(_RESPAWN_BACKOFF)) - 1])
+    if fid not in _live_sessions(SOCKET):
+        return 0
+    tmuxctl.run(
+        f"bringing the {args.slot} panel back",
+        ["tmux", "-L", SOCKET, "respawn-pane", "-t", args.pane, "--",
+         *layout.panel_command(slot=args.slot, session=fid,
+                               charter_argv=[sys.executable, "-m", "charter"])])
+    return 0
 
 
 def cmd_action(args) -> int:

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -175,6 +175,20 @@ def _env_argv(env: dict[str, str] | None) -> list[str]:
     return [x for name in sorted(env or {}) for x in ("-e", f"{name}={env[name]}")]
 
 
+def panel_command(*, slot: str, session: str, charter_argv: list[str]) -> list[str]:
+    """The command one panel pane runs — the part after `split-window`'s own `--`.
+
+    Split out of :func:`panel_argvs` because a panel is started TWICE by two different
+    modules: once by the launcher's `split-window`, and again by
+    `commands_frame.cmd_respawn`'s `respawn-pane` after the pane's `pane-died` hook
+    fires (#382). Two hand-written copies of this argv is exactly the drift that ends
+    with a respawned panel running a slightly different command from the one the
+    launcher spawned — a stale flag, a missing `--session` — and failing in a way that
+    only ever reproduces after something has already died once.
+    """
+    return [*charter_argv, "panel", slot, "--session", session]
+
+
 def panel_argvs(*, slots: list[str], session: str, socket: str,
                 charter_argv: list[str], harness_pane: str,
                 env: dict[str, str] | None = None) -> list[list[str]]:
@@ -215,5 +229,6 @@ def panel_argvs(*, slots: list[str], session: str, socket: str,
                           direction, *before, "-l", str(size),
                           *_env_argv(env),
                           "-P", "-F", "#{pane_id}", "--",
-                          *charter_argv, "panel", slot, "--session", session))
+                          *panel_command(slot=slot, session=session,
+                                         charter_argv=charter_argv)))
     return cmds

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -4,6 +4,15 @@ Pure on purpose. Everything that decides *what the frame looks like* lives here 
 returns plain lists of strings, so the whole shape is under test on a machine with no
 tmux, and so the argv rule below is enforced mechanically instead of by review.
 
+The one thing this module reads from outside its own arguments is the running
+interpreter's path, via `util.self_relaunch_argv()` in `panel_command` — no process is
+started, nothing is measured, and the result is as deterministic as any other string
+here. It is read HERE rather than passed in because the two callers that start a panel
+otherwise each hand in their own copy of that argv, and one of them promptly got it
+wrong (#390's `-P`, missing from the respawn path — see `panel_command`'s own
+docstring). Same reasoning as the never-join-argv rule below: the property is worth more
+enforced by construction than remembered at every call site.
+
 **Nothing here ever joins argv.** Pinned against tmux 3.7c: `new-session … printf
 'hello;touch INJ'` passed as separate arguments creates no file, and the same text as one
 string creates it. Workspace, repo, branch and persona names all reach a frame from
@@ -30,6 +39,7 @@ creation time (`-P -F '#{pane_id}'`); the caller reads it off stdout and hands i
 from __future__ import annotations
 
 from . import tmuxctl
+from .. import util
 
 #: The order slots are dropped in as the terminal shrinks. Sides first — a side panel
 #: costs the harness columns, so it goes as soon as space is tight in EITHER dimension,
@@ -175,7 +185,7 @@ def _env_argv(env: dict[str, str] | None) -> list[str]:
     return [x for name in sorted(env or {}) for x in ("-e", f"{name}={env[name]}")]
 
 
-def panel_command(*, slot: str, session: str, charter_argv: list[str]) -> list[str]:
+def panel_command(*, slot: str, session: str) -> list[str]:
     """The command one panel pane runs — the part after `split-window`'s own `--`.
 
     Split out of :func:`panel_argvs` because a panel is started TWICE by two different
@@ -185,12 +195,25 @@ def panel_command(*, slot: str, session: str, charter_argv: list[str]) -> list[s
     with a respawned panel running a slightly different command from the one the
     launcher spawned — a stale flag, a missing `--session` — and failing in a way that
     only ever reproduces after something has already died once.
+
+    **The interpreter half is built here too, not passed in.** This function used to
+    take a *charter_argv* and both callers handed it one, which left the ONE part of
+    the argv that actually differs between them outside the shared helper — and it
+    promptly drifted: the launcher moved to `util.self_relaunch_argv()` for #390's `-P`
+    while `cmd_respawn`, written against the same seam a release earlier, kept a
+    hand-built `[sys.executable, "-m", "charter"]`. That is #390's own failure with a
+    delay fuse on it: `respawn-pane` starts the new process in the PANE's cwd, which for
+    anyone dogfooding charter is a charter checkout, so the respawned panel would import
+    that tree rather than the installed one and die again — this time for a reason
+    nothing in the frame could show. Owning the whole argv here is what makes the
+    extraction actually deliver the no-drift property it was created for: there is no
+    longer a parameter for a caller to get wrong.
     """
-    return [*charter_argv, "panel", slot, "--session", session]
+    return [*util.self_relaunch_argv(), "panel", slot, "--session", session]
 
 
 def panel_argvs(*, slots: list[str], session: str, socket: str,
-                charter_argv: list[str], harness_pane: str,
+                harness_pane: str,
                 env: dict[str, str] | None = None) -> list[list[str]]:
     """One `split-window` per slot in *slots*, each carving its rectangle off *harness_pane*.
 
@@ -229,6 +252,5 @@ def panel_argvs(*, slots: list[str], session: str, socket: str,
                           direction, *before, "-l", str(size),
                           *_env_argv(env),
                           "-P", "-F", "#{pane_id}", "--",
-                          *panel_command(slot=slot, session=session,
-                                         charter_argv=charter_argv)))
+                          *panel_command(slot=slot, session=session)))
     return cmds

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -40,6 +40,38 @@ happens to bump the version next — on an idle agent, that could be a long wait
 pane looks broken for all of it. The handler only sets a flag; a signal handler runs
 between bytecodes on the main thread, wherever the run loop happens to be, so it must not
 itself call anything that could block or recurse.
+
+**A panel that fails does not exit — it paints why and holds the pane open.** This is
+the half `slots.render`'s never-raise promise cannot reach from where it sits: it
+guards what a RENDERER raises, and a panel that dies on the way to it (an unknown slot,
+a crash in this module's own poll, a `tui` helper blowing up) bypasses that guarantee
+entirely, leaving the operator a hole in the frame with nothing in it to read. Writing
+the reason to stderr does not fix that, and the measurement is why (real tmux 3.7c,
+`remain-on-exit on`): tmux writes its own `Pane is dead (status N, <date>)` message by
+moving to the pane's LAST row and issuing a linefeed first, which scrolls the pane up by
+exactly one line — in a six-row pane the first of three stderr lines is lost and the
+rest survive, but `top` and `bottom` are ONE row (`layout.SLOT_SIZE`), so that one
+scrolled line is the whole pane and `Pane is dead (status 2)` is provably all that is
+left. It cost a real debugging session, whose only way through was running the panel's
+argv by hand outside tmux. A pane whose process is still ALIVE keeps what it painted
+(measured the same way), so `_hold` paints the reason and then simply does not return.
+
+A panel that is held is also a panel tmux never sees die, so the respawn hook
+`commands_frame._panel_died_hook_argv` installs never fires for it — deliberately: the
+two mechanisms divide at exactly the line between a failure charter's own Python can
+see (painted here, once, and left readable) and one it cannot (the interpreter itself
+failing to start, a SIGKILL), which is the only kind respawning could ever help.
+
+**Holding rather than exiting into that hook is a decision, so here is the argument.**
+Exiting would let a crashed panel be retried three times, which sounds strictly better
+until you ask what can actually reach the handler: `slots.render` catches everything a
+renderer raises, `state.version` catches everything a read raises, and `_rows` catches
+its own `OSError` — so what is left is a genuine bug in charter, or a pane whose fd has
+gone away. Neither is transient, so all a retry buys is three more identical crashes,
+and the cost is certain: three deaths, and then tmux's own message scrolling the reason
+out of a one-row pane — the exact failure this whole section exists to end. The pane
+that HAS gone away needs no special case either; `_hold`'s own write raises in turn, the
+process dies for real, and the respawn hook takes it from there.
 """
 
 from __future__ import annotations
@@ -49,6 +81,7 @@ import signal
 import sys
 import time
 
+from .. import tui
 from . import slots, state
 
 #: How often the version file is checked when nothing else has woken this panel. A
@@ -78,6 +111,20 @@ def _rows() -> int:
         return _DEFAULT_ROWS
 
 
+def _write(text: str) -> None:
+    """Clear the pane and put *text* in it, clamped to this pane's real row count.
+
+    The one place anything reaches the pane's screen, shared by the ordinary paint and
+    by the failure paint below — so a panel saying why it stopped goes through exactly
+    the same clear-then-write discipline as a panel doing its job, rather than a second
+    hand-rolled write that could leave half of tmux's own dead-pane text on screen
+    beside it.
+    """
+    lines = text.split("\n")[:_rows()]
+    sys.stdout.write("\x1b[H\x1b[2J" + "\n".join(lines))
+    sys.stdout.flush()
+
+
 def _paint(slot: str, fid: str) -> None:
     """Clear the pane and draw *slot* whole, clamped to this pane's real row count.
 
@@ -86,9 +133,40 @@ def _paint(slot: str, fid: str) -> None:
     contract (one string) carries no notion of height at all — see the module
     docstring's "Height is this module's job" section.
     """
-    lines = slots.render(slot, fid).split("\n")[:_rows()]
-    sys.stdout.write("\x1b[H\x1b[2J" + "\n".join(lines))
-    sys.stdout.flush()
+    _write(slots.render(slot, fid))
+
+
+def _hold(reason: str, *, once: bool, rc: int) -> int:
+    """Paint *reason* into the pane and then stay alive, so it can still be read.
+
+    The whole of this module's answer to a panel that cannot run: **returning is the
+    bug**. A panel process that exits hands its pane to `remain-on-exit`, and tmux then
+    scrolls the pane by exactly one line to write `Pane is dead (status N, <date>)` over
+    it — which in the one-row `top`/`bottom` panes is the entire pane (measured against
+    real tmux 3.7c; see the module docstring). So the reason is painted and the process
+    simply does not leave, which is the only state in which a pane keeps what was
+    written to it.
+
+    Reaches no renderer on purpose — the failure being reported may BE a failure of
+    that path, and a message about a broken renderer must not need the renderer to
+    work. It does still measure through `slots._width`, which is deliberate and not an
+    exception to that: measuring is one `os.get_terminal_size` call with its own
+    `OSError` fallback, it is the module docstring's stated reason for not owning width
+    here at all, and an unclamped line wraps in a 22-column `left` pane and scrolls
+    itself out of the pane it was written to be readable in.
+
+    *rc* is what `run` returns when it cannot hold — `once=True`, which only tests pass
+    (`charter panel` itself never does). The distinction matters for exactly one reader:
+    a test can still assert a panel REFUSED a bad slot, without the production path
+    having to exit to say so.
+    """
+    _write(tui.truncate(f" charter: {reason}", slots._width()))
+    while not once:
+        # Not `signal.pause()`: SIGWINCH is armed for the ordinary loop and would wake
+        # this one on every resize into a tight spin. A tick is the same idle cost the
+        # live loop already pays (see `TICK`), and there is nothing here to recompute.
+        time.sleep(TICK)
+    return rc
 
 
 def _install_sigwinch(resized: dict) -> object:
@@ -139,21 +217,15 @@ def _tick(resized: dict, seen: str, slot: str, fid: str) -> str:
     return seen
 
 
-def run(slot: str, fid: str, *, once: bool = False) -> int:
-    """Run one panel: refuse an unknown slot, then paint on every version bump or
-    resize until killed (`once=True` — never passed by `charter panel` itself, only by
-    tests — paints exactly once and returns).
+def _watch(slot: str, fid: str, *, once: bool) -> int:
+    """The live loop: paint on every version bump or resize until killed.
 
-    Refuses rather than drawing an empty pane for a *slot* not in `slots.SLOTS`: an
-    empty pane reads as a broken frame, and `layout.panel_argvs` can in principle be
-    handed a slot name `slots.py` does not (yet) implement a renderer for (`left`/
-    `right` today — see `layout.SLOT_SIZE`).
+    Split out of `run` so the SIGWINCH handler it arms is restored by its own `finally`
+    before `run`'s failure path can hold the pane open — a handler left installed for
+    the rest of a held process's life would keep waking a loop that has nothing left to
+    repaint, and `RunOnceLoop.test_once_true_restores_the_previous_sigwinch_handler`
+    already pins that this module leaks no handler past its own work.
     """
-    if slot not in slots.SLOTS:
-        print(f"charter panel: unknown slot {slot!r} "
-              f"(known: {', '.join(sorted(slots.SLOTS))})", file=sys.stderr)
-        return 2
-
     resized = {"flag": True}  # the first pass always paints, resized or not
     old_handler = _install_sigwinch(resized)
     try:
@@ -165,3 +237,40 @@ def run(slot: str, fid: str, *, once: bool = False) -> int:
             time.sleep(TICK)
     finally:
         signal.signal(signal.SIGWINCH, old_handler)
+
+
+def run(slot: str, fid: str, *, once: bool = False) -> int:
+    """Run one panel: refuse an unknown slot, then paint on every version bump or
+    resize until killed (`once=True` — never passed by `charter panel` itself, only by
+    tests — paints exactly once and returns).
+
+    Refuses rather than drawing an empty pane for a *slot* not in `slots.SLOTS`: an
+    empty pane reads as a broken frame, and `layout.panel_argvs` can in principle be
+    handed a slot name `slots.py` does not (yet) implement a renderer for (`left`/
+    `right` today — see `layout.SLOT_SIZE`).
+
+    **Neither refusal nor a crash exits.** Both end in `_hold`, which paints the reason
+    into the pane and stays there, because a panel process that returns hands its pane
+    to tmux's own `Pane is dead (status N)` message — which scrolls a one-row `top`/
+    `bottom` pane clean (measured; see the module docstring). The stderr line is kept
+    beside the paint rather than replaced by it: it is the only trace left when this is
+    run by hand for debugging with stdout redirected (`charter panel top --session x >
+    /tmp/log`), the case `_DEFAULT_ROWS` already exists for, and inside a real pane the
+    paint's own `\\x1b[2J` wipes it a moment later anyway.
+
+    `except Exception`, matching `slots.render`'s own guard and for the same reason —
+    `KeyboardInterrupt` and `SystemExit` are how this process is MEANT to end, and
+    swallowing either would hold a pane open against the operator killing it.
+    """
+    if slot not in slots.SLOTS:
+        reason = (f"unknown slot {slot!r} "
+                  f"(known: {', '.join(sorted(slots.SLOTS))})")
+        print(f"charter panel: {reason}", file=sys.stderr)
+        return _hold(reason, once=once, rc=2)
+
+    try:
+        return _watch(slot, fid, once=once)
+    except Exception as e:
+        reason = f"{slot} panel stopped ({type(e).__name__}: {e})"
+        print(f"charter panel: {reason}", file=sys.stderr)
+        return _hold(reason, once=once, rc=1)

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -260,6 +260,114 @@ def exit_code(fid: str) -> int | None:
         return None
 
 
+#: The subdirectory :func:`respawn_attempt` counts in, named once so
+#: :func:`clear_respawn` cannot drift away from it — the two are only correct together.
+_RESPAWN_DIR = "respawn"
+
+
+def respawn_attempt(fid: str, slot: str) -> int | None:
+    """Claim the next respawn attempt for *slot* in *fid*, or ``None`` when it cannot.
+
+    Read-increment-write of a single integer, one file per slot. tmux has no way to
+    count anything, and a panel pane's `pane-died` hook SURVIVES the respawn it triggers
+    (verified against real tmux 3.7c — `show-hooks -p` reads the hook back unchanged
+    afterwards), so without a count on disk a panel that dies instantly on every start
+    respawns in a hot loop forever. This is the only thing bounding it; see
+    `commands_frame._RESPAWN_ATTEMPTS`.
+
+    **Never reset, and not by oversight.** A successful respawn does not zero the count,
+    so the budget is three deaths across the whole life of one frame rather than three
+    in a row. The alternative needs a definition of "the panel came back up and stayed
+    up" that nothing here can observe — tmux only reports that a process was started,
+    not that it kept running — and guessing at one is how a panel that dies every
+    ninety seconds gets respawned forever while still looking healthy at each individual
+    check. What keeps that budget attached to a FRAME rather than to a reused id is
+    :func:`clear_respawn`, which a launch calls as it claims the id.
+
+    ``None`` — never ``0``, never a silent restart of the count — for every way this can
+    fail to record: an *fid* or *slot* :func:`contain.child` refuses, a directory that
+    cannot be made, a write that cannot complete. The caller reads it as "give up",
+    which is the safe direction: the failure mode of counting wrong here is an unbounded
+    respawn loop, and a dead pane still shows tmux's own `Pane is dead (status N)`.
+
+    **``create=False``, deliberately, even though this writes.** A frame that still
+    exists always has its directory (`cmd_launch` creates and `bump`s it before any pane
+    is split), so refusing to count for a frame whose state is already gone costs a live
+    frame nothing. What `create=True` would buy is the power to REMAKE a directory
+    :func:`reap` has removed — one orphan per frame, surviving until some later launch
+    reaps it, which is exactly the resurrect-what-reap-just-deleted hazard this module's
+    own docstring records for `version()`. Every panel pane dies when its frame is torn
+    down, so every panel's `pane-died` hook fires on the way out and lands here; since
+    #383 :func:`reap` keeps a directory while the launcher pid in its name is live, so on
+    that path the directory is usually still present and a count is spent on a frame that
+    is already over. Harmless, and deliberately not special-cased: `cmd_respawn` re-asks
+    whether the session exists after its backoff, and the directory goes when the next
+    launch reaps it or clears it.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    root = d / _RESPAWN_DIR
+    try:
+        root.mkdir(exist_ok=True)
+    except OSError:
+        return None
+    # One file per slot under a directory of their own, rather than a `respawn-<slot>`
+    # sibling of `version`/`exit` in the frame directory itself. The prefix version put
+    # the slot in the SECOND path component, where every separator-carrying name lands
+    # under a `respawn-<x>` directory that never exists — so the write failed and this
+    # function answered `None` whether `contain.child` was here or not, making the
+    # guard unobservable and, by the only test that could have pinned it, dead. With
+    # the slot as the first component under a directory that DOES exist, a name like
+    # `../y` would really be written outside this frame's own directory, and refusing
+    # it is a behaviour a test can tell apart from a failed write.
+    f = contain.child(root, slot)
+    if f is None:
+        return None
+    try:
+        previous = int(f.read_text().strip())
+    except (OSError, ValueError):
+        # No file yet is the ordinary case (the first death of this frame's own panel);
+        # unparseable content is treated identically rather than specially, exactly as
+        # `version` and `exit_code` above treat theirs — this is a counter, not a
+        # record anything else has to agree with.
+        previous = 0
+    n = previous + 1
+    try:
+        f.write_text(f"{n}\n")
+    except OSError:
+        return None
+    return n
+
+
+def clear_respawn(fid: str) -> None:
+    """Forget every respawn count under *fid*, because a NEW frame is claiming the id.
+
+    The third line on :func:`clear_exit`'s bill, and the same recycled pid underneath it
+    (#383). A frame id is ``<workspace>-<launcher pid>``; since #383 :func:`reap` keeps a
+    directory for as long as the pid in its name is live, and on a launch that pid is
+    live BECAUSE IT IS THE LAUNCHER'S OWN — so a launcher landing on a pid an earlier
+    launcher for the SAME workspace already used adopts that earlier frame's whole
+    directory, its ``respawn/`` counts included.
+
+    Inheriting those is not litter, it is a budget already spent. :func:`respawn_attempt`
+    never resets, and every panel's `pane-died` hook fires during the previous frame's
+    teardown, so an adopted count is at least one per slot and may already sit at
+    `commands_frame._RESPAWN_ATTEMPTS`. The new frame's panels would then die once and
+    stay dead without ever being brought back — the precise outcome the count exists to
+    ration, handed out for a pid number rather than for anything that happened. Clearing
+    as the id is claimed keeps "three deaths" a property of a frame, not of a name.
+
+    Never raises, and never creates: ``rmtree(ignore_errors=True)`` is the same tool
+    :func:`reap` uses for the same must-not-fail reason, and the ordinary first launch
+    for a workspace has no directory here at all — it must not mint one just to empty it.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return
+    shutil.rmtree(d / _RESPAWN_DIR, ignore_errors=True)
+
+
 def _launcher_pid(name: str) -> int | None:
     """The launcher pid :func:`frame_id` put at the end of *name*, or ``None``.
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -63,6 +63,22 @@ changed.
 shell's environment whole, so trusting `$COLUMNS` there would lay a panel out at the outer
 terminal's width and wrap inside its own much narrower one.
 
+**A panel that fails says so in its own pane.** Anything charter's own code can see — an
+unknown slot, a renderer that raises, a crash in the panel's poll — is painted into the
+pane as one line, and the panel then stays alive holding it there rather than exiting. That
+last part is the point: a panel process that exits hands its pane to tmux, which writes
+`Pane is dead (status N)` over it after scrolling the pane up one line, and `top` and
+`bottom` are one line tall, so exiting is what made the reason unreadable.
+
+**A panel whose process is gone is respawned, three times.** Deaths charter's own code
+cannot see — the interpreter failing to start, a kill, an out-of-memory — fire that panel's
+own `pane-died` hook, and charter brings the pane back after a growing pause (1s, 2s, 4s).
+After the third attempt it stops and leaves the pane dead with tmux's own message visible.
+The count is per slot, per frame, and is not reset by a respawn that appears to work: three
+deaths in one frame's life is a broken panel, not a streak to start over. A panel has never
+been able to take the agent down with it; the hook is scoped to the panel's own pane, so it
+cannot reach the harness pane's hooks, which are what carry the agent's exit code.
+
 Charter never touches `~/.tmux.conf` — the frame's settings go into a private server of
 charter's own (`tmux -L charter`), one server shared by every frame on the machine, with
 each frame a session on it.

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -74,6 +74,11 @@ last part is the point: a panel process that exits hands its pane to tmux, which
 cannot see — the interpreter failing to start, a kill, an out-of-memory — fire that panel's
 own `pane-died` hook, and charter brings the pane back after a growing pause (1s, 2s, 4s).
 After the third attempt it stops and leaves the pane dead with tmux's own message visible.
+That message really is all there is for this half, and not because charter throws anything
+away: an interpreter that cannot start never runs a line, so nothing is written into the
+pane to preserve (measured — a pane whose command is a nonexistent python shows
+`Pane is dead (status 1)` and an empty scrollback behind it). Restarting is the only thing
+that can help a failure like that, which is why it is the half that gets a retry.
 The count is per slot, per frame, and is not reset by a respawn that appears to work: three
 deaths in one frame's life is a broken panel, not a streak to start over. A panel has never
 been able to take the agent down with it; the hook is scoped to the panel's own pane, so it

--- a/docs/news/unreleased-a-dead-panel-says-why.md
+++ b/docs/news/unreleased-a-dead-panel-says-why.md
@@ -1,0 +1,26 @@
+---
+version: unreleased
+headline: A panel that dies now says why, and comes back
+---
+
+A charter panel that failed to start showed you one line, and it was tmux's, not charter's:
+`Pane is dead (status 2)`. Nothing else. The panel's own stderr did reach the pane — and
+was then scrolled straight out of it, because tmux writes that message by pushing the pane
+up exactly one line first, and `top` and `bottom` are one line tall. Diagnosing it meant
+copying the panel's argv out of the frame and running it by hand.
+
+Two changes, one for each half of a dead panel.
+
+**A panel that can see its own failure no longer exits.** It paints the reason into its own
+pane and stays there, so the pane keeps it: `charter: unknown slot 'sideways' (known:
+bottom, left, right, top)`, or `charter: bottom panel stopped (ValueError: ...)`, clamped to
+the pane's real width. This is the promise `slots.render` already made for a renderer that
+raises — a panel never leaves a hole in the frame — extended to every failure that happens
+on the way to it, which is the half it could never cover from where it sat.
+
+**A panel whose process is gone is brought back.** Each panel pane now carries its own
+`pane-died` hook, and a death respawns it after a growing pause — three attempts, then
+charter stops and leaves the dead pane and its message exactly where you can read them. The
+hook is scoped to the panel's own pane, so nothing about it touches the harness pane, whose
+own `pane-died` hooks carry your agent's real exit code. A panel still cannot take the agent
+down with it; now it also cannot stay dead for the frame's whole life.

--- a/docs/news/unreleased-a-dead-panel-says-why.md
+++ b/docs/news/unreleased-a-dead-panel-says-why.md
@@ -24,3 +24,10 @@ charter stops and leaves the dead pane and its message exactly where you can rea
 hook is scoped to the panel's own pane, so nothing about it touches the harness pane, whose
 own `pane-died` hooks carry your agent's real exit code. A panel still cannot take the agent
 down with it; now it also cannot stay dead for the frame's whole life.
+
+The respawn runs the launcher's own panel argv, built in one place for both — including the
+`-P` that 0.50.1 added so charter never imports the `charter/` package sitting in the
+directory a pane happens to have started in. That matters more here than anywhere: a respawn
+starts in the dead pane's own directory, which for anyone working on charter is a charter
+checkout, and a panel that came back importing the wrong tree would die again with nothing
+left to say why.

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -569,8 +569,14 @@ class Respawn(PersonaIso, unittest.TestCase):
         cmd = fake.respawns[0]
         self.assertEqual(cmd[cmd.index("-t") + 1], "%11")
         self.assertEqual(cmd[cmd.index("--") + 1:],
-                         layout.panel_command(slot="bottom", session="f-1",
-                                              charter_argv=[sys.executable, "-m", "charter"]))
+                         layout.panel_command(slot="bottom", session="f-1"))
+        # Not only "the same as the launcher's": #390's own shape, spelled out, so this
+        # cannot pass by both sides losing `-P` together. `respawn-pane` starts the new
+        # process in the PANE's cwd, which for a dogfooding operator IS a charter
+        # checkout — a respawn without `-P` is #390 again, on the one path where the
+        # panel has already failed once and there is nothing left to show why.
+        self.assertEqual(cmd[cmd.index("--") + 1:][:4],
+                         [sys.executable, "-P", "-m", "charter"])
 
     def test_it_gives_up_after_three_attempts_and_leaves_the_pane_dead(self):
         """The cap the spec names. Without it, a panel that dies instantly on every
@@ -1278,7 +1284,7 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertEqual(cmd[-1], "1")
 
     def test_panels_are_launched_via_self_relaunch_argv(self):
-        """#390's visible failure: the panel argv (`layout.panel_argvs`'s `charter_argv`)
+        """#390's visible failure: the panel argv (built inside `layout.panel_command`)
         used to be a hand-built `[sys.executable, "-m", "charter"]` with no `-P`. Spawned
         with the pane's cwd set to wherever the operator launched from, a charter checkout
         cwd made the child import THAT tree instead of the installed one — on a tree

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -40,7 +40,7 @@ from unittest import mock
 
 from tests._isolation import PersonaIso
 from charter import commands_frame, config, util
-from charter.frame import gather, menu, slots, state
+from charter.frame import gather, layout, menu, slots, state, tmuxctl
 
 #: The plane this test PROCESS was started in, captured at IMPORT — before any `setUp`
 #: has had a chance to repoint `config`, so it is unavoidably the developer's REAL
@@ -427,6 +427,253 @@ class PaneDiedHooks(unittest.TestCase):
                               "CHARTER_SESSION_ID", "demo-1"])
 
 
+class PanelRespawnHook(unittest.TestCase):
+    """`pane-died`, scoped to a PANEL pane — the other half of #382.
+
+    `remain-on-exit` keeps a dead panel visible with its error, which is the half that
+    already worked. This is the half that was specced and never built: a panel that dies
+    stays dead for the frame's whole life. `charter/frame/panel.py` now holds its pane
+    open for every failure charter's own Python can SEE, so what is left for this hook
+    is exactly the kind it cannot — the interpreter failing to start, a SIGKILL, an OOM.
+
+    Every property below was verified by hand against a real tmux 3.7c before being
+    written down here, because none of it can be from inside this suite (see the module
+    docstring's "never start a real tmux server" rule):
+
+    * a pane-scoped `pane-died` hook on a PANEL pane fires when that panel's process
+      dies, and does NOT fire the harness pane's own hooks;
+    * installing it leaves the harness pane's `pane-died[0]`/`[1]` array byte-identical
+      (`show-hooks -p` before and after) — pane options are per pane, so the array
+      replacement `_pane_died_teardown_hook_argv`'s docstring measures cannot reach
+      across panes;
+    * `run-shell -b` (backgrounded, unlike `conf_text`'s hotkey bind) prints NOTHING
+      into the harness pane and does not drop it into copy-mode even when the command
+      it runs exits non-zero — the exact failure `conf_text`'s docstring records for
+      the un-backgrounded form;
+    * the single-quoted inner command reaches `/bin/sh` with `$CHARTER_PY` unexpanded by
+      tmux, so the SHELL expands it, and `$CHARTER_SESSION_ID` is in that shell's
+      environment (`set-environment -t <session>`, already issued by `cmd_launch`);
+    * the hook SURVIVES the `respawn-pane` it triggers, which is why an attempt count on
+      disk is the only thing bounding the loop.
+    """
+
+    def test_it_is_scoped_to_the_panel_pane_never_the_harness_pane(self):
+        """`-p -t <panel pane>`: an unscoped (or session-scoped) `pane-died` hook fires
+        for ANY pane, so it would respawn a panel every time the HARNESS died — and,
+        worse, would be a second writer of the same option array the exit-code hooks
+        live in."""
+        cmd = commands_frame._panel_died_hook_argv(socket="charter", panel_pane="%11",
+                                                   slot="top")
+        self.assertIn("-p", cmd)
+        self.assertEqual(cmd[cmd.index("-t") + 1], "%11")
+        self.assertEqual(cmd[cmd.index("set-hook") + 1], "-p")
+
+    def test_the_action_names_the_slot_and_the_pane_it_must_bring_back(self):
+        action = commands_frame._panel_died_hook_argv(socket="charter", panel_pane="%11",
+                                                      slot="bottom")[-1]
+        self.assertIn("frame-respawn", action)
+        self.assertIn("bottom", action)
+        self.assertIn("%11", action)
+
+    def test_the_action_never_names_a_bare_charter_off_the_path(self):
+        """The same trap `conf_text`'s own docstring measures for the hotkey bind: a
+        bare `charter` resolves against the tmux SERVER's `$PATH`, which need not have
+        charter on it at all. The interpreter is carried out of band in
+        `$CHARTER_PY` (`_charter_py_env_argv`) and expanded by the shell this action
+        spawns — single-quoted, so tmux's own parsing leaves the `$` alone (verified
+        against 3.7c: `show-hooks` reads the action back with the dollar escaped and
+        the spawned shell receives the expanded path)."""
+        action = commands_frame._panel_died_hook_argv(socket="charter", panel_pane="%11",
+                                                      slot="top")[-1]
+        self.assertIn(f'"${tmuxctl.CHARTER_PY_ENV}" -m charter', action)
+
+    def test_the_action_is_backgrounded_so_it_cannot_draw_in_the_harness_pane(self):
+        """`run-shell -b`, not a bare `run-shell`. Un-backgrounded, tmux prints a
+        non-zero command's own `'…' returned N` into the HARNESS pane and drops it into
+        copy-mode — charter drawing in the one rectangle ADR 0018 says it never draws
+        (`conf_text`'s docstring records that happening for real). Backgrounded, the
+        same failing command produced no output there at all (measured against 3.7c).
+        This also matters because the command deliberately SLEEPS for its backoff: a
+        blocking `run-shell` would stall tmux's command queue for seconds."""
+        action = commands_frame._panel_died_hook_argv(socket="charter", panel_pane="%11",
+                                                      slot="top")[-1]
+        self.assertTrue(action.startswith("run-shell -b "), action)
+
+    def test_it_is_a_clean_argv_list_naming_charters_own_socket(self):
+        cmd = commands_frame._panel_died_hook_argv(socket="charter", panel_pane="%11",
+                                                   slot="top")
+        self.assertTrue(all(isinstance(a, str) for a in cmd))
+        self.assertEqual(cmd[:4], ["tmux", "-L", "charter", "set-hook"])
+
+
+class _RespawnTmux:
+    """A tmux that answers only what `cmd_respawn` asks: is the session still live, and
+    did the pane come back."""
+
+    def __init__(self, *, live=("f-1",), respawn_rc=0):
+        self.live = list(live)
+        self.respawn_rc = respawn_rc
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append(list(cmd))
+        if "list-sessions" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, stdout="\n".join(self.live),
+                                               stderr="")
+        if "respawn-pane" in cmd:
+            return subprocess.CompletedProcess(cmd, self.respawn_rc, stdout="",
+                                               stderr="" if self.respawn_rc == 0
+                                               else "no such pane")
+        raise AssertionError(f"unexpected tmux command in test: {cmd}")
+
+    @property
+    def respawns(self):
+        return [c for c in self.calls if "respawn-pane" in c]
+
+
+def _respawn(fake, *, slot="bottom", pane="%11", fid="f-1", slept=None):
+    args = SimpleNamespace(slot=slot, pane=pane)
+    env = {"CHARTER_SESSION_ID": fid} if fid is not None else {}
+    with mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
+         mock.patch.dict(os.environ, env, clear=True), \
+         mock.patch("charter.commands_frame.time.sleep",
+                    side_effect=(slept.append if slept is not None else lambda _d: None)):
+        return commands_frame.cmd_respawn(args)
+
+
+class Respawn(PersonaIso, unittest.TestCase):
+    """`charter frame-respawn` — what the panel pane's `pane-died` hook actually runs.
+
+    The spec's own sentence, in full: "A dead panel stays visible with its error,
+    respawns with backoff, and gives up after 3 attempts. A panel must never be able to
+    take the agent down with it." The first clause and the last already held; these are
+    the middle two.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # A live frame always has its own state directory: `cmd_launch` creates and
+        # bumps it before the first pane is split. `state.respawn_attempt` deliberately
+        # does not create one (it would resurrect a directory `reap` just deleted at
+        # teardown), so a test standing in for a running frame has to stand it up.
+        state.bump("f-1")
+
+    def test_the_first_death_brings_the_panel_back_with_its_own_argv(self):
+        """Not an approximation of the panel's command — the SAME list
+        `layout.panel_command` gave `panel_argvs` at launch, so a respawned panel cannot
+        drift from the one the launcher spawned."""
+        fake = _RespawnTmux()
+        rc = _respawn(fake)
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(fake.respawns), 1, fake.calls)
+        cmd = fake.respawns[0]
+        self.assertEqual(cmd[cmd.index("-t") + 1], "%11")
+        self.assertEqual(cmd[cmd.index("--") + 1:],
+                         layout.panel_command(slot="bottom", session="f-1",
+                                              charter_argv=[sys.executable, "-m", "charter"]))
+
+    def test_it_gives_up_after_three_attempts_and_leaves_the_pane_dead(self):
+        """The cap the spec names. Without it, a panel that dies instantly on every
+        start respawns forever — the hook survives each respawn (measured against tmux
+        3.7c), so nothing else would ever stop it. The fourth death must leave the pane
+        exactly as tmux left it: dead, with its own `Pane is dead (status N)` still
+        readable, which is the outcome the spec asks for rather than a failure."""
+        fake = _RespawnTmux()
+        for _ in range(commands_frame._RESPAWN_ATTEMPTS):
+            _respawn(fake)
+        self.assertEqual(len(fake.respawns), commands_frame._RESPAWN_ATTEMPTS)
+        _respawn(fake)
+        self.assertEqual(len(fake.respawns), commands_frame._RESPAWN_ATTEMPTS,
+                         "a fourth death was respawned — the cap is not holding")
+
+    def test_each_attempt_waits_longer_than_the_one_before(self):
+        """"With backoff", and the reason is a real one rather than politeness: a panel
+        that fails at startup fails in milliseconds, so three back-to-back respawns
+        would all land inside the same broken condition and burn the whole budget before
+        anything transient (a filesystem hiccup, a plane mid-upgrade) could clear."""
+        slept = []
+        fake = _RespawnTmux()
+        for _ in range(commands_frame._RESPAWN_ATTEMPTS):
+            _respawn(fake, slept=slept)
+        self.assertEqual(len(slept), commands_frame._RESPAWN_ATTEMPTS)
+        self.assertEqual(slept, sorted(slept))
+        self.assertLess(slept[0], slept[-1], slept)
+
+    def test_a_frame_whose_session_has_already_ended_is_not_respawned(self):
+        """Every panel pane dies when the frame is torn down, so every panel's hook
+        fires on the way out — the ORDINARY case, not an edge one. Respawning into a
+        session that no longer exists would fail once per panel and report each failure
+        as if something had gone wrong. Checked AFTER the backoff sleep, not before:
+        that is the window in which the teardown actually completes."""
+        fake = _RespawnTmux(live=())
+        rc = _respawn(fake)
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.respawns, [], "a finished frame's panel was respawned")
+
+    def test_a_slot_with_no_renderer_is_refused_rather_than_respawned(self):
+        """Same rule `cmd_launch` already applies when it declines to split a pane for
+        an unimplemented slot: bringing one back would recreate exactly the permanently
+        dead pane that filter exists to prevent."""
+        fake = _RespawnTmux()
+        rc = _respawn(fake, slot="sideways")
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.respawns, [])
+
+    def test_a_pane_id_of_the_wrong_shape_is_never_used_as_a_target(self):
+        """The value arrives via a tmux hook action, which is text tmux re-parsed — the
+        same reason `_PANE_ID_RE` guards `_resize_hook_argv`. A target that is not
+        `%<digits>` is treated as no target at all."""
+        fake = _RespawnTmux()
+        rc = _respawn(fake, pane="-t;kill-server")
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.respawns, [])
+
+    def test_no_frame_id_in_the_environment_is_a_quiet_no_op(self):
+        """`$CHARTER_SESSION_ID` is how every `run-shell`-spawned charter command
+        resolves its own frame (`cmd_menu` does the same). Arriving without one means
+        this was not fired by a frame at all; there is nothing to respawn and nowhere to
+        report it."""
+        fake = _RespawnTmux()
+        rc = _respawn(fake, fid=None)
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.respawns, [])
+
+    def test_a_panel_of_an_already_reaped_frame_is_not_respawned(self):
+        """The frame is over and its state is gone — `state.respawn_attempt` refuses to
+        count for a directory `reap` removed, and refusing to count is refusing to
+        respawn. Belt to the liveness check's braces: that check happens after the
+        backoff, so a `reap` that lands in between still has to leave a panel unrespawned
+        rather than counted from zero.
+
+        The pid at the end of the id is load-bearing since #383: `reap` keeps a directory
+        while the launcher named in it is still running, and this class's own `f-1`
+        fixture ends in pid 1 — `launchd`/`init`, which never exits — so `reap(set())`
+        would rightly keep it and the test would prove the opposite of its name. A pid
+        that has genuinely exited is a fact about this machine rather than a guess about
+        it (the same reason `test_frame_state._a_dead_pid` exists)."""
+        dead = subprocess.Popen([sys.executable, "-c", "pass"])
+        dead.wait()
+        fid = f"f-{dead.pid}"
+        state.bump(fid)
+        fake = _RespawnTmux(live=(fid,))
+        state.reap(set(), server=commands_frame.SOCKET)
+        self.assertFalse(state.frame_dir(fid).exists(), "the fixture was not reaped")
+
+        rc = _respawn(fake, fid=fid)
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.respawns, [])
+
+    def test_a_count_that_cannot_be_recorded_gives_up_rather_than_looping(self):
+        """`state.respawn_attempt` answers `None` when it cannot record the attempt at
+        all. Treating that as "attempt 1" would respawn forever — the one outcome the
+        cap exists to prevent — so it degrades the same way exceeding the cap does."""
+        fake = _RespawnTmux()
+        with mock.patch("charter.frame.state.respawn_attempt", return_value=None):
+            rc = _respawn(fake)
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.respawns, [])
+
+
 class MissingTmux(unittest.TestCase):
     def test_an_absent_tmux_names_the_remedy_and_does_not_start_a_frame(self):
         """Adapted from the task brief's own draft, which mocked `tmuxctl.available()`.
@@ -757,6 +1004,7 @@ class _FakeTmux:
                 session_rc=0, source_rc=0, env_set_rc=0, write_hook_rc=0,
                 teardown_hook_rc=0, panel_rc=0, select_rc=0, attach_rc=0, dm_rc=0,
                 kill_rc=0, arm_rc=0, resize_hook_rc=0, capture_rc=0,
+                respawn_hook_rc=0,
                 resize_hook_stderr="bad resize hook target"):
         self.pane_id = pane_id
         self.exit_code = exit_code
@@ -783,6 +1031,7 @@ class _FakeTmux:
         self.arm_rc = arm_rc
         self.resize_hook_rc = resize_hook_rc
         self.capture_rc = capture_rc
+        self.respawn_hook_rc = respawn_hook_rc
         # Distinct from every other stderr string in this fake — a test needs to
         # control it independently to exercise the "invalid option" degrade (fix
         # round 3, item 2) separately from an ordinary resize-hook failure.
@@ -816,6 +1065,12 @@ class _FakeTmux:
             return subprocess.CompletedProcess(cmd, self.env_set_rc, stdout="",
                                                stderr="" if self.env_set_rc == 0 else "bad session")
         if "set-hook" in cmd:
+            if any("frame-respawn" in a for a in cmd):
+                # A PANEL pane's own respawn hook (#382) — a different pane's option
+                # array from the harness pane's two exit-code hooks, and given its own
+                # knob here so a test can fail it without touching those.
+                return subprocess.CompletedProcess(cmd, self.respawn_hook_rc, stdout="",
+                                                   stderr="" if self.respawn_hook_rc == 0 else "bad panel target")
             if "pane-died[1]" in cmd:
                 return subprocess.CompletedProcess(cmd, self.teardown_hook_rc, stdout="",
                                                    stderr="" if self.teardown_hook_rc == 0 else "bad teardown target")
@@ -1344,6 +1599,71 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertTrue(any("attach" in c for c in fake.calls),
                         "a decorative panel failing must not cancel the attach")
 
+    def test_every_drawn_panel_is_armed_for_its_own_respawn(self):
+        """#382's second half at the launcher: a panel that dies must be brought back,
+        and nothing can bring it back unless a hook was installed on ITS pane while it
+        was alive. One hook per drawn panel, each targeting the pane tmux actually
+        reported for that slot and naming that slot."""
+        fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11", "bottom": "%12"})
+        rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        hooks = [c for c in fake.calls
+                 if "set-hook" in c and any("frame-respawn" in a for a in c)]
+        self.assertEqual(len(hooks), 2, fake.calls)
+        by_pane = {c[c.index("-t") + 1]: c[-1] for c in hooks}
+        self.assertIn("top", by_pane["%11"])
+        self.assertIn("bottom", by_pane["%12"])
+
+    def test_a_panel_whose_pane_id_was_never_learned_is_not_armed(self):
+        """Same guard the resize hook already has, for the same reason: without a valid
+        `%<digits>` there is no target, and a hook installed against a guessed one would
+        either fail outright or arm the wrong pane. `top` reports a value of the wrong
+        shape and `bottom` a real one — only `bottom` may be armed."""
+        fake = _FakeTmux(exit_code=0,
+                         panel_pane_ids={"top": "not-a-pane-id", "bottom": "%12"})
+        rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        hooks = [c for c in fake.calls
+                 if "set-hook" in c and any("frame-respawn" in a for a in c)]
+        self.assertEqual([c[c.index("-t") + 1] for c in hooks], ["%12"])
+
+    def test_arming_the_panels_never_touches_the_harness_panes_own_hooks(self):
+        """The regression this issue explicitly forbids. The harness pane's `pane-died`
+        array holds the exit-code write hook at `[0]` and `kill-session` at `[1]`, and
+        an unindexed `set-hook pane-died` REPLACES a whole array — so a third
+        `pane-died` writer is exactly the shape that deletes teardown and brings back
+        the hang. It is safe only because it targets a DIFFERENT PANE, which is a
+        property of the argv and therefore testable here: no respawn hook may name the
+        harness pane, and the harness pane's own two hooks must still be exactly two,
+        write before teardown. (Verified against real tmux 3.7c as well: `show-hooks -p`
+        on the harness pane reads back identically before and after a panel pane is
+        armed, and a panel dying does not fire `kill-session`.)"""
+        fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11", "bottom": "%12"})
+        _launch(fake)
+        harness_hooks = [c for c in fake.calls
+                         if "set-hook" in c and "pane-died" in " ".join(c)
+                         and c[c.index("-t") + 1] == fake.pane_id]
+        self.assertEqual(len(harness_hooks), 2,
+                         f"the harness pane's hook array gained a writer: {harness_hooks}")
+        self.assertNotIn("pane-died[1]", harness_hooks[0])
+        self.assertIn("pane-died[1]", harness_hooks[1])
+        for c in fake.calls:
+            if any("frame-respawn" in a for a in c):
+                self.assertNotEqual(c[c.index("-t") + 1], fake.pane_id,
+                                    "a respawn hook was installed on the harness pane")
+
+    def test_a_failed_respawn_arming_is_reported_but_not_fatal(self):
+        """Same treatment every other decorative tmux command in this launcher gets: a
+        panel that cannot be armed for respawn is still a panel that came up, and the
+        harness pane is already running."""
+        fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11"}, respawn_hook_rc=1)
+        buf = []
+        with mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        self.assertTrue(any("respawn" in m for m in buf), buf)
+        self.assertTrue(any("attach" in c for c in fake.calls))
+
     def test_a_resize_hook_is_installed_reasserting_every_drawn_panels_size(self):
         """Cross-task fix round, item 3: tmux's own layout engine redistributes EVERY
         pane proportionally on any resize, `-l size` notwithstanding — verified by hand
@@ -1710,6 +2030,31 @@ class Launch(PersonaIso, unittest.TestCase):
             self.assertEqual(gather.read(fake.fid), fresh,
                              "a panel of this frame would draw a dead frame's scan "
                              "until the session's first hook bump")
+
+    def test_a_launch_does_not_inherit_a_spent_respawn_budget_from_its_pid(self):
+        """The third thing the recycled directory carries (#382 meeting #383), and the
+        one whose inheritance is not merely stale but already exhausted.
+
+        `state.respawn_attempt` never resets — three deaths across a frame's whole life,
+        deliberately — and every panel's `pane-died` hook fires during its own frame's
+        TEARDOWN, so a directory left behind by a finished frame always has counts in it
+        and may well be at `_RESPAWN_ATTEMPTS` already. Adopted by a new frame, those
+        counts are charged to panels that have not died once: the first real death of
+        this frame's `top` panel would be refused as attempt 4, and a panel that charter
+        promises to bring back would simply stay dead, with nothing anywhere saying it
+        was another frame's budget that ran out."""
+        stale = state.frame_id("demo", os.getpid())   # the id `_launch` is about to mint
+        state.bump(stale)
+        for _ in range(commands_frame._RESPAWN_ATTEMPTS + 1):
+            state.respawn_attempt(stale, "top")
+
+        fake = _FakeTmux(still_live=True)
+        _launch(fake)
+
+        self.assertEqual(fake.fid, stale, "the fixture stopped colliding — proves nothing")
+        self.assertEqual(state.respawn_attempt(fake.fid, "top"), 1,
+                         "this frame's first panel death was charged to a dead frame's "
+                         "budget and would never be respawned")
 
 
 class EarlyDeathIsLegible(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_layout.py
+++ b/tests/test_frame_layout.py
@@ -13,8 +13,10 @@ build the splits — see `charter/frame/layout.py`'s module docstring for the me
 
 from __future__ import annotations
 
+import sys
 import unittest
 
+from charter import util
 from charter.frame import layout
 
 
@@ -22,8 +24,7 @@ SESSION = dict(session="charter-demo-1234", conf="/tmp/f/tmux.conf",
                socket="charter", cols=200, rows=50,
                harness_argv=["claude", "--resume", "a;b"])
 
-PANELS = dict(session="charter-demo-1234", socket="charter",
-              charter_argv=["charter"], harness_pane="%0")
+PANELS = dict(session="charter-demo-1234", socket="charter", harness_pane="%0")
 
 
 def _direction(cmd: list[str]) -> str:
@@ -166,12 +167,10 @@ class PanelCommand(unittest.TestCase):
     """
 
     def test_the_split_runs_exactly_what_a_respawn_would_run(self):
-        charter_argv = ["/usr/bin/python3", "-m", "charter"]
         split = layout.panel_argvs(slots=["bottom"], session="f-1", socket="charter",
-                                   charter_argv=charter_argv, harness_pane="%0")[0]
+                                   harness_pane="%0")[0]
         self.assertEqual(split[split.index("--") + 1:],
-                         layout.panel_command(slot="bottom", session="f-1",
-                                              charter_argv=charter_argv))
+                         layout.panel_command(slot="bottom", session="f-1"))
 
     def test_it_carries_the_slot_and_the_session_the_cli_requires(self):
         """`cli.build_parser`'s `panel` parser takes `<slot> --session <fid>` and makes
@@ -179,8 +178,23 @@ class PanelCommand(unittest.TestCase):
         which is the hole #382's first half exists to make legible rather than to
         create a second source of."""
         self.assertEqual(
-            layout.panel_command(slot="top", session="f-9", charter_argv=["c"]),
-            ["c", "panel", "top", "--session", "f-9"])
+            layout.panel_command(slot="top", session="f-9"),
+            [*util.self_relaunch_argv(), "panel", "top", "--session", "f-9"])
+
+    def test_the_interpreter_half_is_the_shared_helpers_and_carries_dash_p(self):
+        """#390, and the reason this function stopped taking a *charter_argv* at all.
+
+        A `charter_argv` PARAMETER is what let the launcher and `cmd_respawn` disagree:
+        the launcher moved to `util.self_relaunch_argv()` and the respawn kept a
+        hand-built `[sys.executable, "-m", "charter"]`, so a respawned panel would have
+        imported whatever `charter/` package sat in the pane's own cwd — a charter
+        checkout, for anyone dogfooding. Asserted against the LITERAL prefix as well as
+        against the helper, so a helper that itself lost `-P` cannot make this test
+        agree with a broken production path (the helper's own shape is pinned in
+        `tests/test_self_relaunch_argv.py`, but a test that only compares two things
+        that move together proves neither)."""
+        cmd = layout.panel_command(slot="bottom", session="f-1")
+        self.assertEqual(cmd[:4], [sys.executable, "-P", "-m", "charter"])
 
 
 class PanelGeometry(unittest.TestCase):
@@ -358,14 +372,14 @@ class WindowInTheOperatorsServer(unittest.TestCase):
         Omitted entirely when there is nothing to carry, so the private-server path's
         command is byte-for-byte what it always was."""
         with_env = layout.panel_argvs(slots=["top"], session="f", socket="/s",
-                                      charter_argv=["charter"], harness_pane="%3",
+                                      harness_pane="%3",
                                       env={"CHARTER_ROOT": "/plane"})[0]
         self.assertEqual(with_env[with_env.index("-e") + 1], "CHARTER_ROOT=/plane")
         self.assertLess(with_env.index("-e"), with_env.index("--"),
                         "`-e` is `split-window`'s own option, never part of the panel's "
                         "argv")
         without = layout.panel_argvs(slots=["top"], session="f", socket="/s",
-                                     charter_argv=["charter"], harness_pane="%3")[0]
+                                     harness_pane="%3")[0]
         self.assertNotIn("-e", without)
 
 
@@ -375,7 +389,7 @@ class ServerSelection(unittest.TestCase):
         they already take is now either charter's own server NAME or a socket PATH, and
         `tmuxctl.server_argv` is the one place that difference turns into `-L` or `-S`."""
         cmds = layout.panel_argvs(slots=["top"], session="f", socket="/tmp/tmux-1/default",
-                                  charter_argv=["charter"], harness_pane="%3")
+                                  harness_pane="%3")
         self.assertEqual(cmds[0][:3], ["tmux", "-S", "/tmp/tmux-1/default"])
 
 

--- a/tests/test_frame_layout.py
+++ b/tests/test_frame_layout.py
@@ -155,6 +155,34 @@ class PanelArgvs(unittest.TestCase):
         self.assertEqual(targets, {"%0"})
 
 
+class PanelCommand(unittest.TestCase):
+    """One definition of what a panel pane runs, because two modules start one.
+
+    The launcher splits a pane for it; `commands_frame.cmd_respawn` brings the same
+    panel back with `respawn-pane` after its `pane-died` hook fires (#382). Two
+    hand-written copies of this argv drift, and the drift only ever shows up after
+    something has already died once — which is the worst possible moment to discover
+    the respawned panel is running a slightly different command.
+    """
+
+    def test_the_split_runs_exactly_what_a_respawn_would_run(self):
+        charter_argv = ["/usr/bin/python3", "-m", "charter"]
+        split = layout.panel_argvs(slots=["bottom"], session="f-1", socket="charter",
+                                   charter_argv=charter_argv, harness_pane="%0")[0]
+        self.assertEqual(split[split.index("--") + 1:],
+                         layout.panel_command(slot="bottom", session="f-1",
+                                              charter_argv=charter_argv))
+
+    def test_it_carries_the_slot_and_the_session_the_cli_requires(self):
+        """`cli.build_parser`'s `panel` parser takes `<slot> --session <fid>` and makes
+        `--session` required — a command missing either is a pane that fails at startup,
+        which is the hole #382's first half exists to make legible rather than to
+        create a second source of."""
+        self.assertEqual(
+            layout.panel_command(slot="top", session="f-9", charter_argv=["c"]),
+            ["c", "panel", "top", "--session", "f-9"])
+
+
 class PanelGeometry(unittest.TestCase):
     """Pins the one property nothing else in this file checks: each slot's actual shape.
 

--- a/tests/test_frame_panel.py
+++ b/tests/test_frame_panel.py
@@ -20,7 +20,7 @@ import os
 import signal
 import sys
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from unittest import mock
 
 from charter import tui
@@ -43,6 +43,92 @@ class Draw(PersonaIso, unittest.TestCase):
     def test_an_unknown_slot_is_refused_rather_than_drawn_blank(self):
         rc = panel.run("sideways", "f-1", once=True)
         self.assertNotEqual(rc, 0)
+
+
+class FailureIsVisibleInThePane(PersonaIso, unittest.TestCase):
+    """A panel that cannot do its job must PAINT the reason and stay alive, because a
+    panel that exits leaves nothing an operator can read.
+
+    Measured against real tmux 3.7c, which is the whole reason this class exists.
+    `remain-on-exit on` keeps a dead pane, and tmux then writes `Pane is dead (status
+    N, <date>)` into it — but it writes that message by moving the cursor to the LAST
+    row and issuing a linefeed first, which scrolls the pane up by exactly one line. In
+    a six-row pane that costs the first of three stderr lines (`L1` gone, `L2`/`L3`
+    still readable); in the ONE-ROW panes charter actually uses for `top` and `bottom`
+    (`layout.SLOT_SIZE`) that one scrolled line is the entire pane, so a panel's stderr
+    is provably unreadable there and `Pane is dead (status 2)` is all that is left. A
+    pane whose process is still ALIVE keeps whatever it painted (measured the same way).
+
+    So the fix is not "write the error somewhere better" — it is "do not exit". This is
+    `slots.render`'s never-raise promise (`charter/frame/slots.py`) extended to the
+    failures that happen BEFORE any renderer is reached, which is the exact gap it
+    cannot cover from where it sits.
+    """
+
+    def test_an_unknown_slot_paints_the_reason_into_the_pane(self):
+        """`Draw.test_an_unknown_slot_is_refused_rather_than_drawn_blank` above already
+        pins the refusal; it passes just as well when the only trace is a stderr line
+        tmux is about to scroll away. This pins the half that survives: the reason is on
+        the pane's own SCREEN — stdout, the same file descriptor `_paint` writes to —
+        naming the slot that was refused."""
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = panel.run("sideways", "f-1", once=True)
+        self.assertNotEqual(rc, 0)
+        self.assertIn("sideways", out.getvalue(),
+                      f"the refusal never reached the pane's own screen: {out.getvalue()!r}")
+
+    def test_a_crash_before_render_is_painted_rather_than_ending_the_pane(self):
+        """`slots.render` catches whatever a RENDERER raises, so the hole it guards is
+        the one it cannot see from inside itself: anything raising on the way to it.
+        Stood up here by making `render` itself raise — the one mock that reproduces
+        every such failure at once (a `tui` helper blowing up, a `state` read this
+        module calls directly, an fd that has gone away) without pretending to know
+        which of them it will be."""
+        out, err = io.StringIO(), io.StringIO()
+        with mock.patch("charter.frame.panel.slots.render",
+                        side_effect=RuntimeError("boom")):
+            with redirect_stdout(out), redirect_stderr(err):
+                rc = panel.run("bottom", "f-1", once=True)
+        self.assertNotEqual(rc, 0)
+        self.assertIn("RuntimeError", out.getvalue(),
+                      f"the crash never reached the pane's own screen: {out.getvalue()!r}")
+
+    def test_a_failed_panel_holds_the_pane_open_instead_of_exiting(self):
+        """The half the painted text depends on. Painting the reason and then RETURNING
+        is worth nothing: the process exits, tmux writes `Pane is dead (...)` over the
+        one row this panel owns, and the reason is gone. `once=True` — the only way
+        every other test in this file can call `run` at all — is exactly the mode that
+        cannot show this, so this one runs the real loop and interrupts it from inside
+        `time.sleep`. `KeyboardInterrupt` deliberately, not a plain exception: it is a
+        `BaseException`, so it proves the hold is not merely being swallowed by the
+        same `except Exception` that put us here."""
+        slept = []
+
+        def _interrupt(delay):
+            slept.append(delay)
+            raise KeyboardInterrupt
+
+        with mock.patch("charter.frame.panel.time.sleep", side_effect=_interrupt):
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                with self.assertRaises(KeyboardInterrupt):
+                    panel.run("sideways", "f-1")
+        self.assertTrue(slept, "a refused panel exited instead of holding its pane open")
+
+    def test_the_painted_reason_is_clamped_to_the_panes_own_width(self):
+        """The failure paint shares nothing with `slots.render` — deliberately, so a
+        failure INSIDE the render path cannot take the message about it down too — which
+        means it also does not inherit `render`'s own truncation. A message wider than a
+        22-column `left` pane would wrap and scroll itself out of a pane it was written
+        to be readable in."""
+        out = io.StringIO()
+        with mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+             mock.patch("os.get_terminal_size", return_value=os.terminal_size((24, 1))):
+            with redirect_stdout(out), redirect_stderr(io.StringIO()):
+                panel.run("a-very-long-slot-name-indeed", "f-1", once=True)
+        painted = out.getvalue().split("\x1b[2J", 1)[1]
+        for line in painted.split("\n"):
+            self.assertLessEqual(tui.width(line), 24, painted)
 
 
 class Height(unittest.TestCase):

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -206,6 +206,148 @@ class ClearExit(PersonaIso, unittest.TestCase):
             state.clear_exit("f-1")  # must not raise
 
 
+class RespawnAttempts(PersonaIso, unittest.TestCase):
+    """The counter that stops a broken panel respawning forever.
+
+    A panel pane's `pane-died` hook survives the respawn it triggers (verified against
+    real tmux 3.7c: `show-hooks -p` reads the hook back unchanged after `respawn-pane`),
+    so a panel that dies instantly on every start would respawn in a hot loop with
+    nothing anywhere counting. tmux cannot count; this is where the count lives.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # `respawn_attempt` never creates a frame's directory (see its own docstring),
+        # so these tests stand up the state a live frame always already has: `cmd_launch`
+        # creates and bumps it before a single pane is split.
+        for fid in ("f-1", "f-2"):
+            state.bump(fid)
+
+    def test_the_first_attempt_is_one_and_each_call_claims_the_next(self):
+        self.assertEqual(state.respawn_attempt("f-1", "top"), 1)
+        self.assertEqual(state.respawn_attempt("f-1", "top"), 2)
+        self.assertEqual(state.respawn_attempt("f-1", "top"), 3)
+
+    def test_each_slot_counts_on_its_own(self):
+        """One broken panel must not spend another's attempts — a `left` renderer that
+        crashes on every start would otherwise use up `bottom`'s budget and stop a
+        perfectly healthy panel being brought back after an unrelated death."""
+        state.respawn_attempt("f-1", "top")
+        state.respawn_attempt("f-1", "top")
+        self.assertEqual(state.respawn_attempt("f-1", "bottom"), 1)
+
+    def test_each_frame_counts_on_its_own(self):
+        state.respawn_attempt("f-1", "top")
+        self.assertEqual(state.respawn_attempt("f-2", "top"), 1)
+
+    def test_a_frame_already_reaped_cannot_count_and_is_not_recreated(self):
+        """Counting must not resurrect a directory `reap` has deleted — the hazard this
+        module's own docstring records for `version()`, reached here through a write
+        path instead of a read.
+
+        Reached from a real frame's teardown, though less often since #383: the panels
+        all die when the session is killed, so every panel's `pane-died` hook fires on
+        the way out, and `reap` now KEEPS a directory whose launcher pid is still live —
+        which the launcher's own closing `reap()` always is. So the directory usually
+        survives that moment and is taken by a later launch instead; this is the case
+        after that, where the count arrives at a name nothing owns any more. `f-gone`
+        carries no pid at all (`_launcher_pid` needs `<name>-<digits>`), so `reap`
+        removes it exactly as it did before #383."""
+        state.bump("f-gone")
+        state.reap(set(), server="charter")
+        self.assertIsNone(state.respawn_attempt("f-gone", "top"))
+        self.assertFalse(state.frame_dir("f-gone").exists(),
+                         "counting a respawn recreated a frame directory reap removed")
+
+    def test_a_frame_id_the_directory_layer_refuses_cannot_count(self):
+        """`None`, never a number — and the caller reads that as "give up", not as
+        "attempt zero". A count that cannot be recorded is exactly the state in which
+        respawning is unbounded, so the safe degrade is to stop, leaving the dead pane
+        and its own message visible."""
+        self.assertIsNone(state.respawn_attempt("../../etc", "top"))
+
+    def test_a_slot_name_with_a_separator_is_refused_rather_than_joined(self):
+        """The slot is part of a FILE name. `commands_frame.cmd_respawn` already refuses
+        a slot with no renderer before reaching here, but this module's own rule is that
+        a name handed to it is resolved through `contain.child` rather than trusted by
+        whoever called it (see `frame_dir`'s own docstring).
+
+        `../y`, not the obvious `../../../etc/passwd`, and the difference IS the test.
+        The obvious one lands under directories that do not exist, so a version with no
+        containment check at all still answers `None` — from the failed write, not from
+        any refusal — and the test passes green over a deleted guard (confirmed by
+        mutation twice: the first shape of both this test and the code under it was
+        green with `contain.child` replaced by a bare join). `../y` climbs exactly one
+        level, out of the per-slot directory and back into the frame's own, where the
+        write really would succeed — so only a refusal can produce `None`, and the file
+        it would have left behind is checked for directly.
+        """
+        d = state.frame_dir("f-1", create=True)
+        self.assertIsNone(state.respawn_attempt("f-1", "../y"))
+        self.assertFalse((d / "y").exists(),
+                         "the slot name was joined onto the path instead of refused")
+        self.assertIsNone(state.respawn_attempt("f-1", "../../../etc/passwd"))
+
+    def test_a_write_that_fails_cannot_count_rather_than_raising(self):
+        """Same must-not-raise promise as `bump`: this runs from a tmux hook."""
+        state.respawn_attempt("f-1", "top")
+        with mock.patch("pathlib.Path.write_text", side_effect=OSError("full")):
+            self.assertIsNone(state.respawn_attempt("f-1", "top"))
+
+
+class ClearRespawn(PersonaIso, unittest.TestCase):
+    """The other half of `clear_exit`'s bill, for the counter rather than the exit code.
+
+    Same cause: since #383 `reap` keeps a directory while the pid in its name is live,
+    so a launcher landing on a recycled pid for the SAME workspace mints the same id and
+    adopts the previous frame's whole directory. `respawn_attempt` never resets, so an
+    adopted count is a budget already spent on deaths that happened to another frame.
+    """
+
+    def test_the_next_attempt_starts_from_one_again(self):
+        state.bump("f-1")
+        state.respawn_attempt("f-1", "top")
+        state.respawn_attempt("f-1", "top")
+        state.clear_respawn("f-1")
+        self.assertEqual(state.respawn_attempt("f-1", "top"), 1)
+
+    def test_every_slot_is_cleared_not_only_the_one_that_died(self):
+        """A frame's panels each keep their own file, and all of them are the previous
+        frame's. Clearing one slot would leave the rest of the new frame's panels with a
+        budget spent by a frame they were never part of."""
+        state.bump("f-1")
+        for slot in ("top", "bottom", "left"):
+            state.respawn_attempt("f-1", slot)
+        state.clear_respawn("f-1")
+        for slot in ("top", "bottom", "left"):
+            self.assertEqual(state.respawn_attempt("f-1", slot), 1, slot)
+
+    def test_only_this_frames_counts_go(self):
+        state.bump("f-1")
+        state.bump("f-2")
+        state.respawn_attempt("f-2", "top")
+        state.clear_respawn("f-1")
+        self.assertEqual(state.respawn_attempt("f-2", "top"), 2)
+
+    def test_the_version_a_panel_polls_is_left_alone(self):
+        """Same rule `clear_exit` follows: moving the counter panels compare against is
+        `bump`'s business, and `cmd_launch` calls it one line later anyway."""
+        state.bump("f-1")
+        before = state.version("f-1")
+        state.clear_respawn("f-1")
+        self.assertEqual(state.version("f-1"), before)
+
+    def test_clearing_a_frame_that_never_counted_creates_nothing(self):
+        """The ordinary first launch for a workspace has no directory here at all, and
+        a launch must not mint one just to empty it."""
+        state.clear_respawn("never-existed")
+        self.assertFalse(state.frame_dir("never-existed").exists())
+
+    def test_clearing_a_hostile_fid_does_not_raise(self):
+        state.clear_respawn("../../escaped")  # must not raise
+        self.assertFalse(state._root().exists())
+
+
 class Reap(PersonaIso, unittest.TestCase):
     """Every fixture in here is named after a pid that has genuinely exited, the KEPT
     ones as deliberately as the removed ones.

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -1023,28 +1023,68 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
         reason string is printed to stderr by a process that then exits 2, in a pane of
         the identical size, on the same tmux:
 
-        * the VISIBLE screen holds tmux's own `Pane is dead (status 2, ...)` and NOT the
-          reason — the operator's whole view, the `Pane is dead (status 2)` of the field
-          report. The wording half of that is probed rather than assumed: it is
-          `remain-on-exit-format`, an option, and this socket's server loads whatever
-          `~/.tmux.conf` the machine has. The half that matters — the reason is NOT
-          there — is asserted unconditionally;
+        * the VISIBLE screen does NOT hold the reason — the operator's whole view, the
+          `Pane is dead (status 2)` of the field report;
         * the reason IS in the pane's history one line up. That second assertion is what
           makes this a measurement rather than a guess: it rules out the other
           explanation for an empty screen — that a panel's stderr never reaches its pane
           at all, which is what the issue originally reported and which would call for a
-          completely different fix. It reaches the pane; tmux scrolls it away by moving
-          to the last row and issuing a linefeed before writing its own message.
+          completely different fix. It reaches the pane, and the pane cannot hold it.
+
+        **Neither tmux's dead-pane MESSAGE nor the exit status tmux records is asserted
+        here, and that is a measurement rather than a concession.** An earlier version
+        of this test asserted `Pane is dead` was on the visible screen, guarded by a
+        probe of `remain-on-exit-format` — which is an option, and says only what tmux
+        WOULD write. It went green on tmux 3.7c and on three of the four `ubuntu-latest`
+        jobs, and failed the fourth with `capture-pane` reporting a single blank line
+        for a pane tmux had already answered `#{pane_dead}` `1` for. Asserting
+        `#{pane_dead_status}` instead — the structural half of the same sentence — would
+        have failed the same job for the same reason.
+
+        Re-measured against tmux 3.4 in an Ubuntu 24.04 container, running this exact
+        fixture. On an idle box it behaves exactly like 3.7c: `#{pane_dead_status}` `2`,
+        the message in the pane, every time. Pinned to ONE cpu against four spin loops —
+        a busy shared runner — 11 of 120 deaths, and 5 of a further 60, ended
+        `#{pane_dead}` `1` with an EMPTY status and NOTHING written into the pane. And
+        permanently, not briefly: polling the status for a further 8 seconds never
+        filled it in. It is the same shape `_gate_argv`'s own docstring already records
+        for 3.4 — dead pane, empty status, `pane-died` never fires — from tmux 3.4's
+        `server_destroy_pane` not having the child's status when the pane's fd closes.
+        tmux 3.7c writes both, every time.
+
+        So on the two tmuxes this suite must pass on, the fd closing (`#{pane_dead}`) is
+        the only thing tmux reports about a death that can be relied on, and everything
+        else below is read from the pane's own CONTENT. Nothing is widened to accept two
+        outcomes: the version-dependent facts are not asserted weakly, they are not
+        asserted at all, because they are not what this test measures. (It is also why
+        `TmuxIntegration`'s exit-status tests wait on the FILE a `pane-died` hook wrote
+        rather than on `#{pane_dead}` — that file cannot appear until tmux has the
+        child's status, so it is a synchronisation point where `#{pane_dead}` is not.)
+        The three assertions this test does keep were then run 60 times under that same
+        one-cpu load: 3 runs landed in the window above, and none of the three
+        assertions moved.
 
         **One row is the fixture's load-bearing half, and for a sharper reason than
-        "small".** That linefeed scrolls the pane by exactly ONE line, so what is lost is
-        whatever sits on the pane's TOP row — a six-row pane loses its first line and
-        keeps the other five. A one-row pane's only row IS its top row, so a reason
-        written there cannot survive whatever else it says or however little of it there
-        is. That is why `top` and `bottom` (`layout.SLOT_SIZE`: 1) were the panels that
-        left an operator with nothing, and it is the property the mutation check for this
-        test flips: at six rows, with one filler line printed ahead of the reason, the
-        reason lands off the top row, survives the scroll, and this assertion goes red.
+        "small".** Measured against tmux 3.7c with the process still ALIVE and no death
+        to write a message about yet: this 74-column reason, `print`ed to a 40-column
+        ONE-row pane, leaves the visible screen ALREADY blank — the wrap and the print's
+        own trailing newline each scroll the pane's only row into history. So at the
+        size `top` and `bottom` actually are (`layout.SLOT_SIZE`: 1) the operator's
+        nothing does not wait for the death, and does not depend on which tmux is
+        running: the dead-pane message, where a tmux writes one, lands on a row that was
+        already empty. It is also why `panel._write` — the one path `_hold` paints
+        through — ends its write with NO trailing newline: at this geometry a newline is
+        indistinguishable from never having painted.
+
+        Bigger panes are where tmux's own behaviour starts to matter, which is exactly
+        why this fixture does not use one, and the mutation check for this assertion is
+        that boundary: at `-y 6` with one filler line printed AHEAD of the reason, the
+        reason's first wrapped line — the one carrying the slot name — survives on the
+        visible screen and this assertion goes red. (`-y 6` alone does NOT flip it on
+        3.7c: measured, tmux's one-line scroll evicts precisely that first wrapped line
+        and leaves the second, so the assertion still passes for a reason that has
+        nothing to do with what it claims. The filler line is what moves the slot name
+        clear of that scroll.)
         """
         gate_dir = tempfile.mkdtemp(prefix="charter-integ-gate-")
         self.addCleanup(shutil.rmtree, gate_dir, True)
@@ -1066,20 +1106,9 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
                          "the control process never died — nothing is being measured")
 
         visible = self._capture("panel-oldshape")
-        # Probed, not assumed — this module's own rule. What tmux writes over a dead
-        # pane is `remain-on-exit-format`, an OPTION, and unlike every other session in
-        # this file's classes these tests run on a server that loaded whatever
-        # `~/.tmux.conf` the machine has (charter's own frames pass `-f`; a shared
-        # socket cannot). A runner that has customised it is not a charter failure, so
-        # the field report's own wording is checked only where tmux still produces it.
-        # The two assertions that follow are the measurement and are never skipped.
-        fmt = _tmux("show-options", "-gv", "remain-on-exit-format").stdout
-        if "Pane is dead" in fmt:
-            self.assertIn("Pane is dead", visible,
-                          f"tmux did not write its own message: {visible!r}")
         self.assertNotIn(self._BAD_SLOT, visible,
                          "the reason survived on the visible screen of a ONE-row pane — "
-                         "tmux no longer evicts the top row to write its own message, "
+                         "a pane that small no longer loses a newline-terminated write, "
                          "so `panel._hold` is solving a problem that no longer exists: "
                          f"{visible!r}")
         with_history = self._capture("panel-oldshape", "-S", "-3")

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -582,6 +582,80 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
                          "behaviour is the entire reason cmd_launch's install order is "
                          "load-bearing")
 
+    def test_arming_a_panel_pane_leaves_the_harness_panes_hook_array_alone(self):
+        """#382's own warning, checked against a real server rather than argued.
+
+        A panel pane now gets its OWN `pane-died` hook (`_panel_died_hook_argv`), and
+        `pane-died` is the same event whose array the harness pane uses for the exit
+        code — where an unindexed `set-hook` REPLACES THE WHOLE ARRAY, as the test above
+        measures. A third writer of that array would delete `[1]` and bring back the
+        hang. It is safe only because pane options are PER PANE, which is exactly the
+        thing to verify here: the harness pane's array is read back before and after the
+        panel pane is armed and must be byte-identical, and the panel's own array must
+        hold only its own hook."""
+        _, harness_pane, _ = self._new_pane()
+        _run(commands_frame._pane_died_write_hook_argv(socket=SOCKET,
+                                                       harness_pane=harness_pane))
+        _run(commands_frame._pane_died_teardown_hook_argv(socket=SOCKET,
+                                                          harness_pane=harness_pane))
+        before = _tmux("show-hooks", "-p", "-t", harness_pane).stdout
+
+        panel_pane = _tmux("split-window", "-t", harness_pane, "-v", "-l", "1",
+                           "-P", "-F", "#{pane_id}", "--",
+                           *_gate_argv(os.path.join(self._gate_dir, "never"), "exit 0")
+                           ).stdout.strip()
+        self.assertTrue(panel_pane.startswith("%"), panel_pane)
+        armed = _run(commands_frame._panel_died_hook_argv(
+            socket=SOCKET, panel_pane=panel_pane, slot="bottom"))
+        self.assertEqual(armed.returncode, 0, armed.stderr)
+
+        after = _tmux("show-hooks", "-p", "-t", harness_pane).stdout
+        self.assertEqual(before, after,
+                         "arming a PANEL pane for respawn changed the HARNESS pane's "
+                         "own pane-died array — the exit code and the teardown both "
+                         "live there")
+        self.assertIn("pane-died[0]", after)
+        self.assertIn("pane-died[1]", after)
+        panel_hooks = _tmux("show-hooks", "-p", "-t", panel_pane).stdout
+        self.assertIn("frame-respawn", panel_hooks)
+        self.assertNotIn("kill-session", panel_hooks,
+                         "a panel's own hook must never be able to end the frame")
+
+    def test_a_dead_panels_hook_runs_charter_with_the_slot_and_pane_it_must_revive(self):
+        """The whole respawn mechanism end to end, minus the respawn itself: does the
+        action string `_panel_died_hook_argv` builds actually FIRE, reach a shell, and
+        deliver the right argv?
+
+        Four separate things have to hold at once and none of them can be checked by
+        reading the string: tmux must not eat the `$` before the shell sees it (the
+        failure `_pane_died_write_hook_argv`'s docstring measures for double quotes),
+        `$CHARTER_PY` must be resolvable from a `run-shell` spawned by a PANE-scoped
+        hook, `run-shell -b` must still run the command at all, and the slot and pane id
+        must arrive as separate argv words. `$CHARTER_PY` is pointed at a script that
+        records its own argv, so what is asserted is what charter would really have been
+        invoked with."""
+        self._require_pane_died_fires()
+        session, pane, gate = self._new_pane("exit 3")
+        tmp = tempfile.mkdtemp(prefix="charter-integ-respawn-")
+        self.addCleanup(shutil.rmtree, tmp, True)
+        marker = os.path.join(tmp, "argv")
+        fake_py = os.path.join(tmp, "fake-charter-py")
+        Path(fake_py).write_text(
+            f'#!/bin/sh\nprintf "%s" "$*" > {marker}\n')
+        os.chmod(fake_py, 0o755)
+        self.assertEqual(
+            _run(commands_frame._charter_py_env_argv(socket=SOCKET, session=session)
+                 [:-1] + [fake_py]).returncode, 0)
+        self.assertEqual(
+            _run(commands_frame._panel_died_hook_argv(socket=SOCKET, panel_pane=pane,
+                                                      slot="top")).returncode, 0)
+        self._release(gate)
+        self.assertTrue(_await_file(marker),
+                        "the panel's own pane-died hook never reached a shell — "
+                        f"hooks: {_tmux('show-hooks', '-p', '-t', pane).stdout!r}")
+        self.assertEqual(Path(marker).read_text().split(),
+                         ["-m", "charter", "frame-respawn", "top", "--pane", pane])
+
     # -- 2. Path delivery and injection ---------------------------------------------- #
 
     def test_the_exit_status_path_round_trips_a_hostile_plane_path(self):

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -96,6 +96,30 @@ def _a_dead_pid() -> int:
     return proc.pid
 
 
+def _importable_env(env: dict) -> dict:
+    """*env* with this checkout on `$PYTHONPATH`, so a panel spawned with `-P` can still
+    import it.
+
+    Every panel argv in this module now comes from `layout.panel_command`, which builds
+    its interpreter half with `util.self_relaunch_argv()` — `[sys.executable, "-P", "-m",
+    "charter", ...]`. `-P` is the whole point (#390: without it a panel spawned into a
+    cwd that happens to hold a `charter/` package imports THAT tree), and it is also
+    exactly what stops `cwd=_REPO_ROOT` from making `charter` importable the way these
+    classes used to rely on. `$PYTHONPATH` is the substitute `tests/
+    test_self_relaunch_shadowing.py` already established and measured for this: `-P`
+    strips only the cwd/script-dir entry `-m` auto-prepends, never a `PYTHONPATH` entry
+    or a real site-packages one, so a checkout reached this way stands in for a real
+    install without weakening the flag being tested.
+
+    Prepended rather than assigned: a runner that already exports `$PYTHONPATH` keeps it,
+    and this checkout still wins over anything else on it — a panel under test must be
+    THIS tree's panel.
+    """
+    existing = env.get("PYTHONPATH", "")
+    return dict(env, PYTHONPATH=(f"{_REPO_ROOT}{os.pathsep}{existing}" if existing
+                                 else str(_REPO_ROOT)))
+
+
 def _tmux(*args: str, env: dict | None = None) -> subprocess.CompletedProcess:
     """*env* is `None` by every existing call site (inherit this process's own
     environment, unchanged) — `PanelIntegration` is the one caller that needs a
@@ -856,6 +880,7 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
         self.env = dict(os.environ, CHARTER_ROOT=str(self.tmp), CHARTER_WORKSPACE="demo")
         self.env.pop("CHARTER_HOME", None)  # let it derive under CHARTER_ROOT, like this
                                             # process's own PersonaIso-isolated config
+        self.env = _importable_env(self.env)  # the panel argv carries -P — see the helper
 
     def _teardown_socket(self) -> None:
         """Kill this class's own tmux server, THEN unlink its socket file — see
@@ -863,29 +888,205 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
         on its own. Order matters here specifically, not just tidily: two separate
         `addCleanup` calls (`kill-server`, then `unlink`) run LIFO — unlink FIRST,
         kill-server SECOND — which reconnects to nothing once the socket's own
-        directory entry is already gone. Harmless for THIS class today (its
-        sessions never arm `remain-on-exit`, so `_kill_pid` on each pane's own
-        process already ends the session, then the server, on tmux's own
-        `exit-empty` default before `kill-server` is ever asked to do anything) —
-        fixed anyway so this class cannot silently start leaking the day it, or a
-        test added to it, ever does."""
+        directory entry is already gone. It was harmless when this class was
+        written (no session of its own armed `remain-on-exit`, so `_kill_pid` on
+        each pane's own process already ended the session, then the server, on
+        tmux's own `exit-empty` default before `kill-server` was ever asked to do
+        anything) and was fixed anyway, so this class could not silently start
+        leaking the day a test added to it armed one. That day has arrived: the two
+        failure tests below arm `remain-on-exit` for their own window, exactly as a
+        real frame has it armed, and with it on a killed pane leaves the session
+        standing — only this `kill-server`, running FIRST, takes it down."""
         _tmux("kill-server")
         (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET).unlink(missing_ok=True)
 
-    def _spawn_panel(self, session: str, fid: str) -> None:
-        """One `charter panel bottom --session <fid>` pane, in a fresh session named
+    def _spawn_panel(self, session: str, fid: str, *,
+                     slot: str = "bottom", rows: int = 5) -> None:
+        """One `charter panel <slot> --session <fid>` pane, in a fresh session named
         *session* on this class's socket. Registers `_kill_pid` as a cleanup — see its
         own docstring for why `kill-server` alone leaves this process orphaned — using
         the pane's OWN pid (`#{pane_pid}`), captured immediately, rather than the
         session or pane id: those name tmux objects, not the OS process underneath
         them, and killing the process is the actual guarantee this method exists to
-        give every caller."""
-        argv = [sys.executable, "-m", "charter", "panel", "bottom", "--session", fid]
-        r = _tmux("new-session", "-d", "-s", session, "-x", "40", "-y", "5",
+        give every caller.
+
+        The argv comes from `layout.panel_command` — the launcher's own — rather than
+        being retyped here. Retyped, it drifted once already and in the direction that
+        matters: it kept a bare `[sys.executable, "-m", "charter"]` after production had
+        moved to `util.self_relaunch_argv()`, which is exactly the difference #390 is
+        about, so this class was spawning a shape production no longer spawns.
+
+        *rows* defaults to the five this class's original three tests use; the failure
+        tests below pass `1`, because ONE row is the size `layout.SLOT_SIZE` gives `top`
+        and `bottom` and the only size at which tmux's own dead-pane message costs the
+        whole pane rather than one line of it."""
+        argv = layout.panel_command(slot=slot, session=fid)
+        r = _tmux("new-session", "-d", "-s", session, "-x", "40", "-y", str(rows),
                   "-c", str(_REPO_ROOT), "--", *argv, env=self.env)
         self.assertEqual(r.returncode, 0, r.stderr)
         pid = _tmux("display-message", "-p", "-t", session, "#{pane_pid}").stdout.strip()
         self.addCleanup(_kill_pid, pid)
+
+    # -- A panel that cannot start, and what the operator is left looking at ---------- #
+
+    #: The slot no renderer exists for, so `panel.run` refuses it before reaching any
+    #: state at all — the cheapest genuine startup failure charter's own Python can see,
+    #: and one of the two the issue names.
+    _BAD_SLOT = "nosuchslot"
+
+    #: What that refusal writes to stderr, byte for byte (`frame/panel.py`'s `run`).
+    #: Shared by the two tests below so the control below fails for the same REASON, and
+    #: differs only in what the process does after printing it.
+    _BAD_SLOT_STDERR = (f"charter panel: unknown slot '{_BAD_SLOT}' "
+                        f"(known: bottom, left, right, top)")
+
+    #: A pane program that waits for a gate file, prints *stderr text* and exits 2 — the
+    #: pre-#382 panel, reduced to the only two things about it that mattered. The gate
+    #: is what makes `remain-on-exit` arm-able in time: `set -w` cannot be issued before
+    #: the session exists, and without the gate the process would already be gone.
+    _DYING_PROGRAM = ("import os, sys, time\n"
+                      "while not os.path.exists(sys.argv[1]): time.sleep(0.02)\n"
+                      "print(sys.argv[2], file=sys.stderr)\n"
+                      "sys.exit(2)\n")
+
+    def _capture(self, target: str, *history: str) -> str:
+        """What `capture-pane` reports for *target* — the VISIBLE screen by default,
+        which is the whole point: it is what an operator sees without knowing to scroll
+        a one-row pane's history. Pass `"-S", "-3"` to look into that history instead."""
+        return _tmux("capture-pane", "-p", *history, "-t", target).stdout
+
+    def _dead(self, target: str) -> str:
+        return _tmux("display-message", "-p", "-t", target, "#{pane_dead}").stdout.strip()
+
+    def _remain_on_exit(self, session: str) -> None:
+        """Arm `remain-on-exit` for *session*'s own window, the way a real frame has it
+        armed from its very first moment (`commands_frame._PLACEHOLDER_CONF`).
+
+        Window-scoped (`set -w -t`), not `set -g`: this class runs several sessions on
+        one socket in sequence, and a global option would outlive the test that set it
+        and change how every LATER test's pane behaves when its process ends — the exact
+        cross-test leak the module docstring gives each test its own session to avoid."""
+        r = _tmux("set", "-w", "-t", session, "remain-on-exit", "on")
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def _wait_for(self, target: str, needle: str, timeout: float = 8.0) -> str:
+        """Poll `capture-pane` until *needle* is on the visible screen, returning the
+        last capture either way — the same "poll for content, never sleep a guess"
+        shape `_await_file` uses, so a slow runner is slow rather than wrong."""
+        deadline = time.monotonic() + timeout
+        seen = self._capture(target)
+        while time.monotonic() < deadline and needle not in seen:
+            time.sleep(0.1)
+            seen = self._capture(target)
+        return seen
+
+    def test_a_panel_that_cannot_start_paints_the_reason_into_a_one_row_pane(self):
+        """#382's FIRST half, against a real tmux at the real size — the half that cost
+        a debugging session, and the half nothing until now actually observed.
+
+        Every other test of `_hold` in this suite calls `panel.run(..., once=True)`
+        in-process and reads the return value, which proves the refusal happens and
+        proves nothing at all about what an operator sees: the failure being fixed is
+        specifically that the reason DID reach the pane and was then scrolled out of it
+        by tmux's own dead-pane message. So this spawns the real `charter panel` argv
+        into a real ONE-ROW pane (`layout.SLOT_SIZE["bottom"]`) with `remain-on-exit`
+        armed exactly as a real frame arms it, and asserts on `capture-pane` — what is
+        on the screen — not on a return code.
+
+        Two assertions, and both are load-bearing. The reason must be READABLE, and the
+        pane must still be ALIVE (`#{pane_dead}` `0`): a panel that painted the reason
+        and then exited would satisfy the first for a few milliseconds and lose it to
+        `Pane is dead (status 2)` immediately after, which is precisely the pre-#382
+        behaviour. The companion test below is the control for the second half of that
+        sentence — it measures what this pane WOULD have shown had `_hold` returned.
+        """
+        fid = state.frame_id("panel-integ-badslot", os.getpid())
+        self._spawn_panel("panel-badslot", fid, slot=self._BAD_SLOT, rows=1)
+        self._remain_on_exit("panel-badslot")
+
+        needle = f"unknown slot '{self._BAD_SLOT}'"
+        seen = self._wait_for("panel-badslot", needle)
+        self.assertIn(needle, seen,
+                      "a panel that cannot start left nothing readable in its own "
+                      f"one-row pane — all the operator has is: {seen!r}")
+        self.assertEqual(self._dead("panel-badslot"), "0",
+                         "the panel painted its reason and then EXITED — tmux is about "
+                         "to write `Pane is dead (status 2)` over the only row this "
+                         "pane has, which is the whole failure #382 is about")
+
+    def test_the_same_reason_on_stderr_alone_is_scrolled_out_of_a_one_row_pane(self):
+        """The control, and the measurement `_hold` exists because of.
+
+        Without this, the test above proves only "text can appear in a pane" — it does
+        not establish that the OLD shape (print the reason, exit) genuinely fails, so a
+        reader has no way to tell whether `_hold` bought anything. Here the identical
+        reason string is printed to stderr by a process that then exits 2, in a pane of
+        the identical size, on the same tmux:
+
+        * the VISIBLE screen holds tmux's own `Pane is dead (status 2, ...)` and NOT the
+          reason — the operator's whole view, the `Pane is dead (status 2)` of the field
+          report. The wording half of that is probed rather than assumed: it is
+          `remain-on-exit-format`, an option, and this socket's server loads whatever
+          `~/.tmux.conf` the machine has. The half that matters — the reason is NOT
+          there — is asserted unconditionally;
+        * the reason IS in the pane's history one line up. That second assertion is what
+          makes this a measurement rather than a guess: it rules out the other
+          explanation for an empty screen — that a panel's stderr never reaches its pane
+          at all, which is what the issue originally reported and which would call for a
+          completely different fix. It reaches the pane; tmux scrolls it away by moving
+          to the last row and issuing a linefeed before writing its own message.
+
+        **One row is the fixture's load-bearing half, and for a sharper reason than
+        "small".** That linefeed scrolls the pane by exactly ONE line, so what is lost is
+        whatever sits on the pane's TOP row — a six-row pane loses its first line and
+        keeps the other five. A one-row pane's only row IS its top row, so a reason
+        written there cannot survive whatever else it says or however little of it there
+        is. That is why `top` and `bottom` (`layout.SLOT_SIZE`: 1) were the panels that
+        left an operator with nothing, and it is the property the mutation check for this
+        test flips: at six rows, with one filler line printed ahead of the reason, the
+        reason lands off the top row, survives the scroll, and this assertion goes red.
+        """
+        gate_dir = tempfile.mkdtemp(prefix="charter-integ-gate-")
+        self.addCleanup(shutil.rmtree, gate_dir, True)
+        gate = os.path.join(gate_dir, "die")
+
+        r = _tmux("new-session", "-d", "-s", "panel-oldshape", "-x", "40", "-y", "1",
+                  "--", sys.executable, "-c", self._DYING_PROGRAM, gate,
+                  self._BAD_SLOT_STDERR, env=self.env)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.addCleanup(_kill_pid, _tmux("display-message", "-p", "-t",
+                                         "panel-oldshape", "#{pane_pid}").stdout.strip())
+        self._remain_on_exit("panel-oldshape")
+        Path(gate).write_text("x")
+
+        deadline = time.monotonic() + 8
+        while time.monotonic() < deadline and self._dead("panel-oldshape") != "1":
+            time.sleep(0.1)
+        self.assertEqual(self._dead("panel-oldshape"), "1",
+                         "the control process never died — nothing is being measured")
+
+        visible = self._capture("panel-oldshape")
+        # Probed, not assumed — this module's own rule. What tmux writes over a dead
+        # pane is `remain-on-exit-format`, an OPTION, and unlike every other session in
+        # this file's classes these tests run on a server that loaded whatever
+        # `~/.tmux.conf` the machine has (charter's own frames pass `-f`; a shared
+        # socket cannot). A runner that has customised it is not a charter failure, so
+        # the field report's own wording is checked only where tmux still produces it.
+        # The two assertions that follow are the measurement and are never skipped.
+        fmt = _tmux("show-options", "-gv", "remain-on-exit-format").stdout
+        if "Pane is dead" in fmt:
+            self.assertIn("Pane is dead", visible,
+                          f"tmux did not write its own message: {visible!r}")
+        self.assertNotIn(self._BAD_SLOT, visible,
+                         "the reason survived on the visible screen of a ONE-row pane — "
+                         "tmux no longer evicts the top row to write its own message, "
+                         "so `panel._hold` is solving a problem that no longer exists: "
+                         f"{visible!r}")
+        with_history = self._capture("panel-oldshape", "-S", "-3")
+        self.assertIn(self._BAD_SLOT, with_history,
+                      "the reason never reached the pane AT ALL — that is a different "
+                      "failure from the one #382 fixes, and `_hold` would not cure it: "
+                      f"{with_history!r}")
 
     def test_a_bottom_panel_draws_and_repaints_on_a_real_state_bump(self):
         """Minimal shape: a real pane running `charter panel bottom --session <fid>`
@@ -1694,6 +1895,7 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         self.env = dict(os.environ, CHARTER_ROOT=str(self.tmp), CHARTER_WORKSPACE="demo")
         self.env.pop("CHARTER_HOME", None)  # derive STATE_DIR under CHARTER_ROOT, like
                                             # this process's own PersonaIso-isolated config
+        self.env = _importable_env(self.env)  # the panel argv carries -P — see the helper
 
     def _teardown_socket(self) -> None:
         """Kill this class's own tmux server, THEN unlink its socket file — see
@@ -1783,7 +1985,6 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
 
         slots = ["top", "bottom", "left", "right"]
         panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=SOCKET,
-                                        charter_argv=[sys.executable, "-m", "charter"],
                                         harness_pane=harness_pane)
         panes: dict[str, str] = {}
         for slot, cmd in zip(slots, panel_cmds):

--- a/tests/test_self_relaunch_argv.py
+++ b/tests/test_self_relaunch_argv.py
@@ -15,20 +15,67 @@ decoy package that genuinely shadows. This module is the fast half: one test per
 asserting the argv it hands to `Popen`/`split-window` carries `-P` — a passing
 end-to-end test on ONE site does not prove the other sites were changed, so each is
 pinned separately here.
+
+**And one test that is not per-site at all.** `NoHandBuiltSelfRelaunchArgvAnywhere`
+below reads the package's own source and fails on ANY hand-built `-m charter` argv,
+wherever it appears. The per-site tests cannot do that job, and the gap is not
+hypothetical: `commands_frame.cmd_respawn` — written on a branch cut before this module
+existed — landed a brand-new `[sys.executable, "-m", "charter"]` site with a clean merge,
+and every test here stayed green because a NEW site is invisible to a list of OLD ones.
+A respawn is spawned into the dead pane's OWN cwd, which for anyone dogfooding charter is
+a charter checkout, so that site was #390 exactly, on the one path where the panel has
+already failed once and there is nothing left to say why.
 """
 
 from __future__ import annotations
 
+import ast
 import subprocess
 import sys
 import unittest
 from pathlib import Path
 from unittest import mock
 
+import charter
 from charter import glstate, planegit, update, util
 from charter import commands_workspace as cw
 
 from tests._isolation import PersonaIso
+
+#: The package directory this test process actually imported, not a path guessed from
+#: `__file__`'s neighbours — whatever `charter` means to the rest of the suite is what
+#: gets read here.
+_PKG = Path(charter.__file__).resolve().parent
+
+#: The one function allowed to contain the argv every other site must call it for.
+_HELPER = "self_relaunch_argv"
+
+
+def _hand_built_relaunch_argvs() -> list[tuple[str, int, str]]:
+    """Every list/tuple literal in the package that spells out `-m charter` itself.
+
+    An AST walk rather than a text grep, and that is not fastidiousness: a grep is
+    defeated by a line break between `"-m",` and `"charter"`, by a different quote
+    style, and by any of it appearing in a docstring — this module's own docstring
+    would match its own grep. The AST sees the literal `-m` followed by `charter`
+    among a sequence's string constants however it is spelled or wrapped, and sees
+    nothing at all in prose.
+
+    Returns `(file, line, source)` triples so a failure names the site rather than
+    merely asserting one exists.
+    """
+    found = []
+    for path in sorted(_PKG.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.List, ast.Tuple)):
+                continue
+            words = [e.value for e in node.elts
+                     if isinstance(e, ast.Constant) and isinstance(e.value, str)]
+            if any(a == "-m" and b == "charter" for a, b in zip(words, words[1:])):
+                found.append((str(path.relative_to(_PKG.parent)), node.lineno,
+                              ast.unparse(node)))
+    return found
 
 
 class SelfRelaunchArgvShape(unittest.TestCase):
@@ -118,6 +165,54 @@ class DiscoverPushUsesIt(unittest.TestCase):
         argv = popen.call_args.args[0]
         self.assertEqual(argv, util.self_relaunch_argv("workspace", "_pushbg"))
         self.assertEqual(popen.call_args.kwargs.get("cwd"), "/some/control/plane")
+
+
+class NoHandBuiltSelfRelaunchArgvAnywhere(unittest.TestCase):
+    """The whole-tree rule, so a site nobody has thought of yet is still covered.
+
+    Every class above names a call site that exists today. That is the one thing such a
+    test cannot do for a site added tomorrow, and tomorrow arrived: `cmd_respawn` shipped
+    a fresh `[sys.executable, "-m", "charter"]` on a branch cut before `-P` landed, merged
+    cleanly (different lines), and left this module fully green while re-opening #390 on
+    the respawn path. This test reads the source instead of the call sites, so the NEXT
+    one fails on the way in.
+    """
+
+    def test_the_detector_finds_the_helpers_own_literal(self):
+        """First, that the detector is not vacuous.
+
+        A scanner that parsed nothing — a wrong package path, a `rglob` that matched no
+        files, an AST shape that never fires — would make the test below pass forever
+        while checking nothing, which is this project's most-caught flavour of broken
+        test. `util.self_relaunch_argv` contains the one literal of exactly the shape
+        being hunted, so finding it proves the hunt works on the real thing rather than
+        on a fixture built to be found.
+        """
+        sites = _hand_built_relaunch_argvs()
+        helper = [s for s in sites if s[0] == "charter/util.py"]
+        self.assertEqual(len(helper), 1,
+                         f"the detector did not find `util.{_HELPER}`'s own argv "
+                         f"literal — it is not detecting anything: {sites}")
+        self.assertIn("-P", helper[0][2],
+                      f"the helper itself lost `-P`: {helper[0][2]}")
+
+    def test_no_other_module_builds_one_itself(self):
+        """Then, the rule: `charter/util.py` is the only file allowed to spell it out.
+
+        Not "every file except this one call site" — any file. A new self-relaunch is
+        one `util.self_relaunch_argv(...)` call, and there is no case where writing the
+        list out by hand is the right answer: the `-P` it must carry is the same `-P`
+        everywhere, and a shell TEMPLATE that cannot take a flag carries
+        `PYTHONSAFEPATH=1` instead (see `commands_frame._charter_pythonsafepath_env_argv`)
+        rather than a hand-built argv.
+        """
+        offenders = [s for s in _hand_built_relaunch_argvs() if s[0] != "charter/util.py"]
+        self.assertEqual(
+            offenders, [],
+            "hand-built `-m charter` argv outside `util.self_relaunch_argv` — call the "
+            "helper instead, so this site cannot import whatever `charter/` package "
+            "happens to sit in its child's cwd (#390):\n" +
+            "\n".join(f"  {f}:{line}  {src}" for f, line, src in offenders))
 
 
 if __name__ == "__main__":

--- a/tests/test_self_relaunch_shadowing.py
+++ b/tests/test_self_relaunch_shadowing.py
@@ -124,15 +124,21 @@ class SelfRelaunchArgvIsImmuneToTheDecoy(WithADecoyCwd):
 
 class APanelSpawnedTheWayCmdLaunchSpawnsIt(WithADecoyCwd):
     """#390's own reported symptom, proved against the REAL production call site:
-    `commands_frame.cmd_launch` builds the panel argv via
-    ``layout.panel_argvs(..., charter_argv=util.self_relaunch_argv())``
-    (charter/commands_frame.py:868). tmux itself is never started here — `panel_argvs`
-    is pure (see its own docstring), so the argv it builds is extracted and run directly
-    as the subprocess a real tmux pane would otherwise run."""
+    `commands_frame.cmd_launch` builds the panel argv via `layout.panel_argvs`, whose
+    `panel_command` calls `util.self_relaunch_argv()` itself. tmux itself is never
+    started here — `panel_argvs` is pure (see its own docstring), so the argv it builds
+    is extracted and run directly as the subprocess a real tmux pane would otherwise
+    run.
+
+    Nothing is passed in: the interpreter half used to be a `charter_argv` argument this
+    test handed the helper's own output to, which meant this test proved the helper was
+    immune and said nothing about what production passed. `panel_command` now owns that
+    half for the launcher and for `cmd_respawn` alike, so the argv below is production's
+    with nothing supplied by the test — which is also what makes `RespawnRunsTheSameArgv`
+    below cover the respawn path for free."""
 
     def _panel_argv(self) -> list[str]:
         [cmd] = layout.panel_argvs(slots=["top"], session="f-1", socket="testsock",
-                                   charter_argv=util.self_relaunch_argv(),
                                    harness_pane="%0")
         dashdash = cmd.index("--")
         return cmd[dashdash + 1:]
@@ -148,6 +154,39 @@ class APanelSpawnedTheWayCmdLaunchSpawnsIt(WithADecoyCwd):
                     out, err = proc.communicate()
                     self.fail(f"panel exited early (rc={rc}) instead of running — the "
                              f"#390 symptom itself:\nstdout={out!r}\nstderr={err!r}")
+            finally:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=5)
+
+
+class RespawnRunsTheSameArgvAgainstTheDecoy(WithADecoyCwd):
+    """The respawn path, against the same decoy — the site that actually regressed.
+
+    `commands_frame.cmd_respawn` runs `respawn-pane -t %N -- <layout.panel_command(...)>`,
+    and `respawn-pane` starts that command in THE PANE'S OWN cwd. For anyone dogfooding
+    charter that is a charter checkout, so a respawn argv without `-P` is #390 verbatim,
+    on the one path where the panel has already died once and tmux's own
+    `Pane is dead (status 2)` is all the operator gets. Same decoy, same measurement as
+    the launcher's argv above; what differs is only which production function built it.
+    """
+
+    def test_the_respawn_command_runs_rather_than_exiting_2(self):
+        argv = layout.panel_command(slot="top", session="f-1")
+        with subprocess.Popen(argv, cwd=self.tmp, env=self.env,
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                              text=True) as proc:
+            try:
+                time.sleep(0.6)
+                rc = proc.poll()
+                if rc is not None:
+                    out, err = proc.communicate()
+                    self.fail(f"the respawn argv exited early (rc={rc}) instead of "
+                              f"running — #390 on the respawn path:\n"
+                              f"stdout={out!r}\nstderr={err!r}")
             finally:
                 proc.terminate()
                 try:


### PR DESCRIPTION
Closes #382.

Implemented, adversarially reviewed, and then re-verified after a fix round — in an ultracode workflow. The reviewer reproduced the original symptom against the branch point, showed it gone, and mutation-tested every new test to confirm it can actually fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9