### PR TITLE
frame: reap keeps a frame whose launcher is still alive (#383)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -114,7 +114,7 @@ import subprocess
 import sys
 
 from . import config, harness, util, workspace
-from .frame import layout, menu, state, tmuxctl
+from .frame import gather, layout, menu, state, tmuxctl
 # Aliased: `cmd_launch` already has a local variable named `slots` (the VISIBLE slot
 # list `layout.visible_slots` returns) — importing the renderer registry under its own
 # name would be shadowed by that local the moment it's assigned, and a `slots.SLOTS`
@@ -881,9 +881,17 @@ def cmd_launch(args) -> int:
     # The pid this launch was handed may have belonged to an earlier launcher for the
     # same workspace, which mints the SAME `fid` — and since #383 `reap` keeps that
     # earlier directory for as long as the pid in its name is live, which right now it
-    # is, because it is ours. Any `exit` recorded under this id therefore predates this
-    # frame, and `state.exit_code(fid)` below would read it back as this launch's own.
+    # is, because it is ours. Everything recorded under this id therefore predates this
+    # frame, and a launch beginning is the one moment that can be certain of it.
+    #
+    # Two files, because two readers inherit: `state.exit_code(fid)` below would read a
+    # dead frame's `exit` back as this launch's own return value, and `gather.read(fid)`
+    # (no freshness check, by design — it is a panel's hot path) would serve a dead
+    # frame's scan to every panel until the session's first hook bump. `version` is
+    # deliberately left: it is a counter panels compare against their last reading, and
+    # moving it is `state.bump`'s job, one line below.
     state.clear_exit(fid)
+    gather.discard(fid)
     state.bump(fid)
 
     try:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -878,6 +878,12 @@ def cmd_launch(args) -> int:
         # ENAMETOOLONG) must not be treated as a Path here just because it usually is one.
         util.err(f"charter frame: could not create state for frame {fid!r}")
         return 1
+    # The pid this launch was handed may have belonged to an earlier launcher for the
+    # same workspace, which mints the SAME `fid` — and since #383 `reap` keeps that
+    # earlier directory for as long as the pid in its name is live, which right now it
+    # is, because it is ours. Any `exit` recorded under this id therefore predates this
+    # frame, and `state.exit_code(fid)` below would read it back as this launch's own.
+    state.clear_exit(fid)
     state.bump(fid)
 
     try:

--- a/charter/frame/gather.py
+++ b/charter/frame/gather.py
@@ -318,6 +318,43 @@ def read(fid: str, *, workspace: str | None = None, cwd: str | None = None) -> d
         return _empty(workspace)
 
 
+def discard(fid: str) -> None:
+    """Forget the cached scan under *fid*, because a NEW frame is claiming the id.
+
+    The gather half of ``state.clear_exit``'s bill, and the same recycled pid
+    underneath it (#383). A frame id is ``<workspace>-<launcher pid>``; since #383
+    ``state.reap`` keeps a directory for as long as the pid in its name is live, and
+    on a launch that pid is live because it is the launcher's own — so a launcher
+    landing on a pid an earlier launcher for the same workspace already used adopts
+    that earlier frame's whole directory, ``gather.json`` included.
+
+    :func:`read` has no freshness check and needs none — it is the hot path a panel
+    polls, and the cache is kept current by ``notify.plane_changed`` — so it hands
+    back whatever parses. Nothing corrects it either: a panel repaints only on a
+    ``state.version`` bump, so the dead frame's repos, branches and CI would sit on
+    screen until the session's first hook fires, which may be minutes of the operator
+    reading a scan from another day. Before #383 this could not happen, because
+    ``reap`` had deleted the directory and :func:`read` fell through to a live
+    :func:`scan`; deleting the file here puts a launch back on exactly that path
+    rather than inventing a TTL, which would be the age heuristic ``reap``'s own
+    docstring refuses.
+
+    Never raises, and never creates — ``create=False``, the same rule :func:`read`
+    follows, because the ordinary first launch for a workspace has no directory here
+    at all and a launch must not mint one just to delete a file inside it.
+    """
+    f = _cache_file(fid, create=False)
+    if f is None:
+        return
+    try:
+        f.unlink(missing_ok=True)
+    except OSError:
+        # Same must-not-raise promise the rest of this module makes: a launch is not
+        # worth failing over a file that could not be deleted. The cost of losing here
+        # is a stale panel until the first bump, not a lost launch.
+        return
+
+
 def refresh(fid: str, *, workspace: str | None = None, cwd: str | None = None) -> dict:
     """:func:`scan` then :func:`save` — what the bumping hook (Task 2) calls.
 

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -176,6 +176,36 @@ def record_exit(fid: str, code: int) -> None:
         return
 
 
+def clear_exit(fid: str) -> None:
+    """Forget any exit code recorded under *fid*, because a new frame is claiming the id.
+
+    The bill for #383's rule, and the reason it is only a bill and not a defect. A frame
+    id is ``<workspace>-<launcher pid>`` and pids are recycled — Linux wraps at
+    ``kernel.pid_max``, 32768 by default — so a launcher for the same workspace really
+    does land on a pid an earlier launcher already used. Since :func:`reap` keeps a
+    directory for as long as the pid in its name is live, and on a launch that pid is
+    live BECAUSE IT IS THE LAUNCHER'S OWN, the earlier frame's directory survives to be
+    adopted by the new one, ``exit`` file included. `cmd_launch` then reads that stale
+    code back as its own and returns it: a harness running perfectly well, detached, is
+    reported as having failed with a dead frame's number.
+
+    A launch beginning is the one moment that can be certain about this — whatever is
+    recorded under the id was recorded before this frame existed. Only ``exit`` is
+    removed: ``version`` is a counter panels poll, and moving it is :func:`bump`'s job.
+    Never raises, and never creates, for the same reasons as everything else here.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return
+    try:
+        (d / "exit").unlink(missing_ok=True)
+    except OSError:
+        # Same must-not-raise promise the rest of this module makes: a launch is not
+        # worth failing over a file that could not be deleted, and the stale-code
+        # reading below is the caller's own to notice.
+        return
+
+
 def exit_code(fid: str) -> int | None:
     """The recorded exit code, or ``None`` when the frame has not finished (or exist)."""
     d = frame_dir(fid)
@@ -187,6 +217,61 @@ def exit_code(fid: str) -> int | None:
         return None
 
 
+def _launcher_pid(name: str) -> int | None:
+    """The launcher pid :func:`frame_id` put at the end of *name*, or ``None``.
+
+    The inverse of :func:`frame_id`'s last line and nothing more — a reader, not a
+    parser of arbitrary text. ``None`` means "this name carries no pid", which is a real
+    answer and not a failure: the frame root can hold debris, a hand-made directory, or a
+    name minted by an older charter, and none of those may become undeletable just
+    because nothing can be read out of them.
+
+    Requires the separator, so a bare ``12345`` reads as ``None`` rather than as a pid —
+    :func:`frame_id` always emits ``<workspace>-<pid>`` with a non-empty workspace (its
+    ``or "frame"`` fallback guarantees it), so a name without one did not come from here
+    and its digits are not a claim about any process. ``rpartition`` rather than
+    ``split``, because a workspace may contain ``-`` itself (``harness-wrapper-4242``).
+    """
+    head, sep, tail = name.rpartition("-")
+    if not sep or not head or not tail.isdigit():
+        return None
+    pid = int(tail)
+    # `0` is "every process in my group" to `kill(2)`, not a process — and `frame_id`
+    # can only ever have written a real `os.getpid()` here, which is never 0 or negative.
+    return pid if pid > 0 else None
+
+
+def _launcher_is_alive(pid: int) -> bool:
+    """Is the process *pid* names still running? Asks; never signals anything.
+
+    ``os.kill(pid, 0)`` is a QUESTION on POSIX and an ANSWER on Windows, where it maps to
+    ``TerminateProcess`` and would kill whatever the name happened to hold (the same trap
+    ``news._outer_probe`` documents). Off POSIX the pid is taken at its word — a frame
+    directory that outlives its launcher there costs a few hundred bytes, where getting
+    it wrong costs somebody else's process. Belt and braces in practice: :func:`reap` is
+    only ever called from `commands_frame.cmd_launch`, which has already refused if there
+    is no tmux, and there is no tmux off POSIX.
+
+    ``PermissionError`` (EPERM) is an ANSWER too, and the opposite of what it looks like:
+    the process exists, it simply is not ours to signal. Reading it as "gone" would make
+    every frame launched by another user reapable while it was still running.
+    """
+    if os.name != "posix":
+        return True
+    try:
+        os.kill(pid, 0)   # signal 0 asks whether it exists; it sends nothing
+    except ProcessLookupError:
+        return False
+    except OverflowError:
+        # A number too large for a `pid_t` — `int()` accepted it happily and `os.kill`
+        # would raise straight out of a launch. NOT an `OSError`, so it needs naming
+        # separately. It cannot name a live process, so the directory stays reapable.
+        return False
+    except OSError:
+        return True       # alive, and not ours to signal
+    return True
+
+
 def reap(live: set[str]) -> list[str]:
     """Remove state for frames whose tmux session is gone. Returns what was removed.
 
@@ -194,13 +279,48 @@ def reap(live: set[str]) -> list[str]:
     heuristic would delete precisely that one. *live* names the sessions `tmux
     list-sessions` still reports, so the only frames removed are ones nothing is watching
     any more.
+
+    **And never on a live session alone, because a frame outlives its session (#383).**
+    Between a harness exiting and its launcher reading :func:`exit_code`, the session is
+    already gone from `tmux list-sessions` while the launcher is still sitting in
+    `cmd_launch` with the answer one line away. A `reap()` from a SIBLING frame's launch
+    — and one runs at every launch — landing in that window deleted the `exit` file
+    before it was ever read: `exit_code` answered ``None``, `cmd_launch` turned that into
+    a returned ``0``, and a harness that had genuinely failed was reported as a success
+    to whatever `&&` chain or CI step invoked charter. Ordering `cmd_launch`'s reap
+    before its own `frame_dir(create=True)` narrows that window; it cannot close it,
+    because by then the sibling's session is genuinely absent from *live*.
+
+    So a second question is asked, and :func:`frame_id` is what makes it answerable
+    without inventing any new state: the id ENDS in the launcher's own pid. A directory
+    whose launcher is still a live process is one somebody may still come back to, and
+    is left alone — no age, no timestamps, no extra file, nothing to keep in sync.
+
+    Both ways of being wrong point the same way, deliberately. A pid the OS has recycled
+    onto an unrelated process reads as "alive" and costs one directory's cleanup, deferred
+    until that process ends and some later launch reaps it — bounded, silent, and measured
+    in bytes. Reading a live launcher as dead costs a real exit code, which is the defect
+    above. A launcher also no longer reaps its OWN directory on the way out (its pid is,
+    necessarily, still alive); the next launch takes it, which is what already happens for
+    every frame that ended while nothing else was starting.
+
+    Recycling has one sharper form that is NOT paid for in bytes, and it is paid for in
+    :func:`clear_exit` rather than here: a pid recycled onto a launcher for the SAME
+    workspace mints the same id, so the kept directory is not merely litter, it is the id
+    the new frame is about to adopt — stale ``exit`` file included. Deciding that here
+    would mean guessing which of two frames a directory belongs to; the launcher knows,
+    because it is the one claiming the id, so it clears the file as it starts.
     """
     root = _root()
     if not root.is_dir():
         return []
     removed = []
     for d in sorted(root.iterdir()):
-        if d.is_dir() and d.name not in live:
-            shutil.rmtree(d, ignore_errors=True)
-            removed.append(d.name)
+        if not d.is_dir() or d.name in live:
+            continue
+        pid = _launcher_pid(d.name)
+        if pid is not None and _launcher_is_alive(pid):
+            continue
+        shutil.rmtree(d, ignore_errors=True)
+        removed.append(d.name)
     return removed

--- a/tests/test_frame_gather.py
+++ b/tests/test_frame_gather.py
@@ -355,6 +355,64 @@ class SaveIsHardened(PersonaIso, unittest.TestCase):
         self.assertFalse(state._root().exists())
 
 
+class Discard(PersonaIso, unittest.TestCase):
+    """A new frame adopting a recycled pid inherits the directory of the frame that
+    held that pid before it — #383's `state.reap` keeps a directory while its pid is
+    live, and on a launch that pid is the launcher's own. `state.clear_exit` stops the
+    dead frame's exit code coming with it; `discard` stops its cached SCAN coming with
+    it, which `read` would otherwise serve to every panel (no freshness check, by
+    design) until the session's first hook bump."""
+
+    _SENTINEL = {"gathered_at": 0.0, "workspace": "sentinel", "current_repo": None,
+                 "repos": [], "worktrees": []}
+
+    def test_a_saved_scan_is_gone_afterwards(self):
+        gather.save("f-1", {"gathered_at": 1.0, "workspace": "from-a-dead-frame",
+                            "current_repo": None, "repos": [], "worktrees": []})
+        gather.discard("f-1")
+        with mock.patch.object(gather, "scan", return_value=self._SENTINEL) as scan_mock:
+            got = gather.read("f-1")
+        scan_mock.assert_called_once()
+        self.assertEqual(got, self._SENTINEL,
+                         "a dead frame's cached scan was served to the frame that "
+                         "adopted its id")
+
+    def test_the_version_a_panel_polls_is_left_alone(self):
+        """`version` is a monotonic counter panels compare against their last reading;
+        moving it — or removing it — is `state.bump`'s business, not this function's.
+        Same division `state.clear_exit` makes."""
+        state.bump("f-1")
+        before = state.version("f-1")
+        gather.discard("f-1")
+        self.assertEqual(state.version("f-1"), before)
+
+    def test_the_recorded_exit_code_is_left_alone(self):
+        """The other file under the same directory has its own owner (`clear_exit`),
+        called from the same two lines of `cmd_launch`. Neither may reach across."""
+        state.record_exit("f-1", 42)
+        gather.discard("f-1")
+        self.assertEqual(state.exit_code("f-1"), 42)
+
+    def test_discarding_a_frame_that_has_no_cache_creates_nothing(self):
+        """It runs on the launch path against an id that usually has no directory at
+        all — the ordinary first launch for a workspace. A launch must not mint one
+        just to delete a file inside it, the same rule `read` follows."""
+        gather.discard("never-existed")
+        self.assertFalse(state.frame_dir("never-existed").exists())
+
+    def test_discarding_a_hostile_fid_does_not_raise_or_create(self):
+        gather.discard("../../escaped")  # must not raise
+        self.assertFalse(state._root().exists())
+
+    def test_discarding_survives_a_failing_unlink(self):
+        """Nothing in this module raises: a launch is not worth failing over a file
+        that could not be deleted."""
+        gather.save("f-1", self._SENTINEL)
+        with mock.patch("charter.frame.gather.Path.unlink",
+                        side_effect=OSError("read-only")):
+            gather.discard("f-1")  # must not raise
+
+
 class RefreshComposesScanAndSave(ClonedRepoIso, unittest.TestCase):
     def test_refresh_writes_a_cache_read_can_then_find_without_gathering_again(self):
         data = gather.refresh("f-1", workspace=config.DEFAULT_WORKSPACE, cwd=str(self.repo))

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -39,7 +39,7 @@ from unittest import mock
 
 from tests._isolation import PersonaIso
 from charter import commands_frame, config, util
-from charter.frame import menu, slots, state
+from charter.frame import gather, menu, slots, state
 
 
 def _harness_binary_installed(resolver=None):
@@ -85,9 +85,24 @@ class Bypass(unittest.TestCase):
         ex.assert_called_once_with("claude", ["claude", "-p", "hi"])
 
 
-class MissingHarnessBinary(unittest.TestCase):
+class MissingHarnessBinary(PersonaIso, unittest.TestCase):
     """`charter claude` before `claude` is installed — the most likely FIRST-RUN state
     of this whole feature.
+
+    `PersonaIso` because one test below (`test_an_installed_harness_is_not_short_circuited`)
+    runs a FULL `_launch`, and `cmd_launch` reads `config.STATE_DIR` — the developer's
+    own `.charter/` without it. Writing there was the smaller half: `cmd_launch` also
+    calls `state.reap(live_before)`, and `_FakeTmux` answers the pre-`new-session`
+    `list-sessions` with an EMPTY set, so every framed test here ran `reap(set())`
+    against the real plane and deleted the operator's own frame directories — the
+    unread-`exit`-file state #383 exists to protect, on a machine that has live frames
+    on it. Verified by watching a real `.charter/frame/` across a suite run.
+
+    It stayed invisible because the litter cleaned itself up: `cmd_launch`'s closing
+    `reap()` took this launch's own directory back out again. Since #383 a launcher no
+    longer reaps its OWN directory (its pid is necessarily still alive), so the
+    accident stopped covering for the leak and a `demo-<pid>` directory survived every
+    suite run — which is how this was found.
 
     `bypass` called `os.execvp` raw, so `FileNotFoundError` reached `cli.main`'s
     `except Exception`, which files a charter crash report and re-raises a traceback.
@@ -1113,6 +1128,12 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertTrue(any("detach" in m.lower() and fake.fid in m for m in buf),
                         f"no reattach message was printed: {buf}")
         # The frame's own directory must not be reaped while the session is still live.
+        # Weak evidence for the live-session rule specifically, and deliberately not
+        # dressed up as more: since #383 this directory is kept by EITHER rule, because
+        # `fid` ends in the launcher's pid and the launcher is this test process. That
+        # is inherent — a launch's own id always names a live pid — so `Reap`'s fixtures
+        # in tests/test_frame_state.py are where the live-session rule is pinned alone,
+        # deliberately named after dead pids so nothing else can keep them.
         self.assertTrue(state.frame_dir(fake.fid).exists())
 
     def test_refuses_to_attach_when_the_teardown_hook_fails_to_install(self):
@@ -1552,6 +1573,36 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertTrue(any("detach" in m.lower() for m in buf),
                         f"no reattach message — the stale code suppressed it: {buf}")
 
+    def test_a_launch_does_not_inherit_a_cached_scan_from_an_earlier_life_of_its_pid(self):
+        """The second file the recycled directory carries, and the second reader that
+        inherits it. `exit` is read once, by this launcher; `gather.json` is read by
+        every PANEL, on every repaint, and `gather.read` has no freshness check by
+        design — it is a panel's hot path, kept current by `notify.plane_changed`.
+
+        So a launch adopting a dead frame's directory draws that frame's repos,
+        branches and CI, and nothing corrects it: a panel repaints only on a
+        `state.version` bump, so a scan from another day sits on screen until the
+        session's first hook fires. Before #383 this was unreachable — `reap` had
+        deleted the directory and `read` fell through to a live `scan` — and clearing
+        the file on the launch path is what puts it back on exactly that path.
+
+        `scan` is mocked to a sentinel, so this fails if the stale cache is served AND
+        distinguishes that from "a live gather happened to agree"."""
+        stale = state.frame_id("demo", os.getpid())   # the id `_launch` is about to mint
+        gather.save(stale, {"gathered_at": 1.0, "workspace": "from-a-dead-frame",
+                            "current_repo": None, "repos": [], "worktrees": []})
+
+        fake = _FakeTmux(still_live=True)
+        _launch(fake)
+
+        self.assertEqual(fake.fid, stale, "the fixture stopped colliding — proves nothing")
+        fresh = {"gathered_at": 0.0, "workspace": "sentinel", "current_repo": None,
+                 "repos": [], "worktrees": []}
+        with mock.patch.object(gather, "scan", return_value=fresh):
+            self.assertEqual(gather.read(fake.fid), fresh,
+                             "a panel of this frame would draw a dead frame's scan "
+                             "until the session's first hook bump")
+
 
 class EarlyDeathIsLegible(PersonaIso, unittest.TestCase):
     """#384: a command that dies before the frame is drawn must not die in silence.
@@ -1768,12 +1819,18 @@ class EarlyDeathIsLegible(PersonaIso, unittest.TestCase):
                          "a file that is right there is not a $PATH problem")
 
 
-class BypassRouting(unittest.TestCase):
+class BypassRouting(PersonaIso, unittest.TestCase):
     """`Bypass.test_a_pipe_gets_no_frame` pins `bypass()`'s OWN argv shape but never
     calls `cmd_launch` at all — it cannot catch a `cmd_launch` that stopped routing to
     `bypass()` in the first place (confirmed: deleting the routing check, or replacing
     it with `if False:`, left the full suite green before this class existed). These
-    test the DECISION, not what `bypass()` does once reached."""
+    test the DECISION, not what `bypass()` does once reached.
+
+    `PersonaIso` for the same reason `MissingHarnessBinary` above carries it: the
+    negative case here (`test_a_tty_without_no_frame_does_not_bypass`) proves the
+    launch was NOT bypassed by letting a full `_launch` run, and a full launch writes
+    frame state under `config.STATE_DIR` — the developer's real `.charter/` without
+    this."""
 
     def test_the_no_frame_flag_routes_to_bypass(self):
         args = SimpleNamespace(harness="claude", rest=[], no_frame=True)

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1499,6 +1499,59 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertLess(order.index("reap"), order.index("frame_dir_create"),
                         f"reap must run before this frame's own directory is created: {order}")
 
+    def test_a_launch_does_not_eat_a_sibling_frames_unread_exit_code(self):
+        """#383, at the altitude where it costs something. Ordering the reap first (the
+        test above) NARROWS the window in which a sibling's `exit` file can be deleted
+        out from under its own launcher; it cannot close it, because the sibling's tmux
+        session is genuinely gone by then and so is genuinely absent from `live`. What
+        closes it is that the sibling's LAUNCHER is still running, and the frame id says
+        so: `frame_id` puts that launcher's pid at the end of the name.
+
+        The stand-in is a real child process, deliberately not this test process: this
+        launch's own frame id is `frame_id("demo", os.getpid())`, so borrowing our pid
+        would test the launcher not reaping ITSELF — a different property, and one that
+        would still pass with the sibling case broken. The child sleeps far longer than
+        the launch and is killed on cleanup."""
+        child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(300)"])
+        self.addCleanup(child.wait)
+        self.addCleanup(child.kill)
+        sibling = state.frame_id("other-workspace", child.pid)
+        state.record_exit(sibling, 42)
+
+        _launch(_FakeTmux(exit_code=0))
+
+        self.assertEqual(state.exit_code(sibling), 42,
+                         "a launch reaped a sibling frame whose launcher was still "
+                         "alive — that launcher now returns a fabricated 0 for a "
+                         "harness that exited 42")
+
+    def test_a_launch_does_not_inherit_an_exit_code_from_an_earlier_life_of_its_pid(self):
+        """The bill for #383's fix, paid here rather than left to be discovered. A frame
+        id is `<workspace>-<launcher pid>` and pids are recycled — Linux wraps at
+        `kernel.pid_max`, 32768 by default — so a launcher for the same workspace really
+        does land on a pid an earlier launcher already used. `reap` now keeps a directory
+        for as long as the pid in its name is live, and on THIS launch that pid is live
+        because it is ours: the earlier frame's directory, `exit` file and all, is still
+        there when this launch adopts the same id.
+
+        Read back, that stale code becomes this launch's own return value. Asserted on
+        the DETACH path, where nothing new is ever recorded and the stale file is
+        therefore the only thing `state.exit_code` can find — a harness running perfectly
+        well, detached, would be reported as having failed with a dead frame's number and
+        the reattach line would never print."""
+        stale = state.frame_id("demo", os.getpid())   # the id `_launch` is about to mint
+        state.record_exit(stale, 99)
+
+        fake = _FakeTmux(still_live=True)
+        buf = []
+        with mock.patch("charter.util.info", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake)
+
+        self.assertEqual(fake.fid, stale, "the fixture stopped colliding — proves nothing")
+        self.assertEqual(rc, 0, "a previous frame's exit code was returned as this one's")
+        self.assertTrue(any("detach" in m.lower() for m in buf),
+                        f"no reattach message — the stale code suppressed it: {buf}")
+
 
 class EarlyDeathIsLegible(PersonaIso, unittest.TestCase):
     """#384: a command that dies before the frame is drawn must not die in silence.

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -7,11 +7,24 @@ the other's activity.
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 import unittest
 from unittest import mock
 
 from tests._isolation import PersonaIso
 from charter.frame import state
+
+
+def _a_dead_pid() -> int:
+    """A real pid that has exited and been reaped. Preferred over a large made-up
+    number, which is a guess about the machine rather than a fact about it — and since
+    #383 the number at the end of a frame id is asked about rather than ignored, a made-up
+    one could name somebody else's live process and quietly change what a test proves."""
+    p = subprocess.Popen([sys.executable, "-c", "pass"])
+    p.wait()
+    return p.pid
 
 
 class FrameId(unittest.TestCase):
@@ -59,11 +72,18 @@ class Version(PersonaIso, unittest.TestCase):
 
     def test_reap_then_version_does_not_resurrect_the_directory(self):
         """If `version()` ever called `bump()` on a miss, this would fight `reap()`
-        forever: reap deletes, the next poll recreates, reap deletes again."""
-        state.bump("gone-1")
+        forever: reap deletes, the next poll recreates, reap deletes again.
+
+        The pid in the name is load-bearing since #383 — `reap` refuses to remove a
+        directory whose launcher is still running, so the frame this test needs reaped
+        has to be named after a pid that is genuinely over. `gone-1` used to read as a
+        throwaway label; pid 1 is `launchd`/`init`, and reap would now (rightly) keep it.
+        """
+        gone = f"gone-{_a_dead_pid()}"
+        state.bump(gone)
         state.reap(set())
-        self.assertEqual(state.version("gone-1"), "0")
-        self.assertFalse(state.frame_dir("gone-1").exists())
+        self.assertEqual(state.version(gone), "0")
+        self.assertFalse(state.frame_dir(gone).exists())
 
 
 class FrameDirContainment(PersonaIso, unittest.TestCase):
@@ -147,19 +167,162 @@ class ExitCode(PersonaIso, unittest.TestCase):
         self.assertEqual(state.exit_code("f-1"), 42)
 
 
+class ClearExit(PersonaIso, unittest.TestCase):
+    """A new frame adopting a recycled pid inherits the directory of the frame that had
+    that pid before it (#383 keeps a directory while its pid is live, and on a launch
+    that pid is the launcher's own). `clear_exit` is what stops it inheriting the dead
+    frame's exit code along with the directory."""
+
+    def test_a_recorded_code_is_gone_afterwards(self):
+        state.record_exit("f-1", 99)
+        state.clear_exit("f-1")
+        self.assertIsNone(state.exit_code("f-1"))
+
+    def test_the_version_a_panel_polls_is_left_alone(self):
+        """Only `exit` is stale on a relaunch. `version` is a monotonic counter panels
+        compare against their last reading, and moving it backwards — or removing it —
+        is `bump`'s business, not this function's."""
+        state.bump("f-1")
+        before = state.version("f-1")
+        state.clear_exit("f-1")
+        self.assertEqual(state.version("f-1"), before)
+
+    def test_clearing_a_frame_that_was_never_recorded_creates_nothing(self):
+        """It runs on the launch path against an id that usually has no directory at
+        all — the ordinary first launch for a workspace. A read must not mint one, the
+        same rule `version()` follows."""
+        state.clear_exit("never-existed")
+        self.assertFalse(state.frame_dir("never-existed").exists())
+
+    def test_clearing_a_hostile_fid_does_not_raise(self):
+        state.clear_exit("../../escaped")  # must not raise
+        self.assertFalse(state._root().exists())
+
+    def test_clearing_survives_a_failing_unlink(self):
+        """Nothing in this module raises: a launch is not worth failing over a file
+        that could not be deleted."""
+        state.record_exit("f-1", 99)
+        with mock.patch("charter.frame.state.Path.unlink", side_effect=OSError("read-only")):
+            state.clear_exit("f-1")  # must not raise
+
+
 class Reap(PersonaIso, unittest.TestCase):
     def test_a_directory_whose_session_is_gone_is_removed(self):
-        state.bump("dead-1")
+        # `dead-1` up to #383: the trailing number was decoration, and pid 1 is
+        # `launchd`/`init`, so reap would now refuse to remove it. A frame that is
+        # genuinely finished has to be named after a pid that is genuinely finished.
+        dead = f"dead-{_a_dead_pid()}"
+        state.bump(dead)
         state.bump("live-1")
         removed = state.reap({"live-1"})
-        self.assertEqual(removed, ["dead-1"])
-        self.assertFalse(state.frame_dir("dead-1").exists())
+        self.assertEqual(removed, [dead])
+        self.assertFalse(state.frame_dir(dead).exists())
         self.assertTrue(state.frame_dir("live-1").exists())
 
     def test_a_live_frame_is_never_reaped_by_age(self):
         """A long-lived frame is exactly what an age heuristic would eat."""
         state.bump("old-1")
         self.assertEqual(state.reap({"old-1"}), [])
+
+    def test_a_sibling_exit_code_survives_a_reap_that_beats_its_own_launcher(self):
+        """#383. `reap` runs at EVERY frame launch, and the set it is handed names the
+        tmux sessions live at that instant. A sibling frame whose session has just ended
+        is therefore absent from it while its own launcher is still inside `cmd_launch`,
+        one line short of reading the `exit` file it just recorded. Removing the
+        directory there does not merely lose bookkeeping: `exit_code` answers `None`,
+        `cmd_launch` turns that into a returned 0, and a harness that actually failed is
+        reported as a success to whatever `&&` chain or CI step called charter.
+
+        This test process's own pid stands in for that launcher. It is not a charter
+        launcher, which is the point — `reap` cannot tell the difference and must not
+        try: all it may ask is whether the process named at the end of the directory is
+        still there to come back for its answer."""
+        fid = state.frame_id("sibling", os.getpid())
+        state.record_exit(fid, 42)
+        state.reap({"some-other-frames-session"})
+        self.assertEqual(state.exit_code(fid), 42,
+                         "reap deleted a live launcher's frame directory, and with it "
+                         "the exit code that launcher had not read yet")
+
+    def test_a_frame_whose_launcher_has_exited_is_still_removed(self):
+        """The other half of #383, and the one that keeps the fix from being a no-op
+        dressed as a fix: once the pid in the name is gone there is nobody left to read
+        the `exit` file, so the directory is `reap`'s to remove exactly as before."""
+        fid = state.frame_id("finished", _a_dead_pid())
+        state.bump(fid)
+        self.assertEqual(state.reap(set()), [fid])
+        self.assertFalse(state.frame_dir(fid).exists())
+
+    def test_a_directory_that_names_no_pid_is_still_removed(self):
+        """Not everything under the frame root was minted by `frame_id`: debris, a
+        hand-made directory, a name from an older charter. With no pid to ask about,
+        the live-session test is the only evidence there is — and it is the one `reap`
+        already had, so an unparseable name must not become undeletable."""
+        state.bump("debris")
+        self.assertEqual(state.reap(set()), ["debris"])
+
+    def test_a_bare_number_is_not_read_as_a_pid(self):
+        """`frame_id` always emits `<workspace>-<pid>` with a non-empty workspace (its
+        `or "frame"` fallback guarantees one), so a directory that is nothing but digits
+        did not come from it and those digits are not a claim about any process. Named
+        after THIS process's pid — as live as a pid gets — so reading it as one would
+        make the directory undeletable for as long as the suite runs."""
+        name = str(os.getpid())
+        state.bump(name)
+        self.assertEqual(state.reap(set()), [name])
+
+    def test_a_trailing_zero_is_not_read_as_a_pid(self):
+        """`kill(2)` reads 0 as "every process in my group", not as a process, so
+        `os.kill(0, 0)` SUCCEEDS and a frame named `ws-0` would look alive forever.
+        `frame_id` can only ever have written a real `os.getpid()` there, and that is
+        never 0 — so the number is debris and the directory stays reapable."""
+        state.bump("ws-0")
+        self.assertEqual(state.reap(set()), ["ws-0"])
+
+    def test_a_launcher_this_user_may_not_signal_still_counts_as_alive(self):
+        """EPERM is an ANSWER, and the opposite of what it looks like. `os.kill(pid, 0)`
+        raises `PermissionError` for a process that exists and belongs to somebody else —
+        another operator's frame on a shared machine, or one launched under `sudo`.
+        Read as "gone", it would make every such frame reapable while its harness was
+        still running, which is #383 again with a different cast.
+
+        Forced rather than found: pid 1 answers this way for an unprivileged run and
+        answers plain success for a root CI container, so asking the real machine would
+        pin the branch on a laptop and quietly stop pinning it in CI."""
+        state.bump("another-users-frame-4242")
+        with mock.patch("charter.frame.state.os.kill",
+                        side_effect=PermissionError(1, "Operation not permitted")):
+            self.assertEqual(state.reap(set()), [])
+
+    def test_liveness_is_never_asked_off_posix(self):
+        """`os.kill(pid, 0)` is a question on POSIX and an ANSWER on Windows, where it
+        maps to `TerminateProcess` — asking it there would kill whatever process the
+        number in a directory name happened to land on. `news._outer_probe` documents
+        the same trap and this file's own suite pins it there; this pins it here, where
+        the number comes off a filesystem name rather than an environment variable.
+
+        Asserted on the helper rather than through `reap`, and not for tidiness:
+        `mock.patch` of `os.name` is global for its duration, and `_root()` builds a
+        `Path` — under a patched `os.name` pathlib refuses to instantiate at all
+        ("cannot instantiate 'WindowsPath' on your system"), so a test driving the whole
+        of `reap` would fail on the wrong line and prove nothing about `os.kill`. The
+        pid handed over is real and live (ours), so a helper that asked anyway would get
+        a truthful "alive" back — the assertion has to be that the question was never
+        PUT, not that the answer came out a particular way."""
+        with mock.patch("charter.frame.state.os.name", "nt"), \
+             mock.patch("charter.frame.state.os.kill") as kill:
+            self.assertTrue(state._launcher_is_alive(os.getpid()))
+        kill.assert_not_called()
+
+    def test_a_number_too_large_to_be_a_pid_neither_raises_nor_survives(self):
+        """`reap` runs on the launch path, where this module's own docstring promises
+        nothing raises. A trailing number beyond what a `pid_t` can hold parses as an
+        int perfectly well and then makes `os.kill` raise `OverflowError` — which is
+        NOT an `OSError`, so guarding only that would let it escape into a launch. It
+        also names no process, so the directory stays reapable."""
+        name = "ws-99999999999999999999"
+        state.bump(name)
+        self.assertEqual(state.reap(set()), [name])
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -207,22 +207,41 @@ class ClearExit(PersonaIso, unittest.TestCase):
 
 
 class Reap(PersonaIso, unittest.TestCase):
+    """Every fixture in here is named after a pid that has genuinely exited, the KEPT
+    ones as deliberately as the removed ones.
+
+    Up to #383 the trailing number in these names was decoration (`dead-1`, `live-1`,
+    `old-1`); `reap` now reads it as the launcher's pid, and **pid 1 is `launchd`/`init`,
+    which never exits**. On the remove side that is loud — a fixture reap refuses to
+    remove fails its own assertion. On the KEEP side it is silent and worse: `live-1`
+    and `old-1` were kept by the pid rule, the `live` argument stopped deciding anything,
+    and both tests passed with the live-session check deleted outright. `_a_dead_pid()`
+    on both sides puts membership in `live` back to being the only thing that can keep
+    a directory here.
+    """
+
     def test_a_directory_whose_session_is_gone_is_removed(self):
-        # `dead-1` up to #383: the trailing number was decoration, and pid 1 is
-        # `launchd`/`init`, so reap would now refuse to remove it. A frame that is
-        # genuinely finished has to be named after a pid that is genuinely finished.
         dead = f"dead-{_a_dead_pid()}"
+        live = f"live-{_a_dead_pid()}"
         state.bump(dead)
-        state.bump("live-1")
-        removed = state.reap({"live-1"})
+        state.bump(live)
+        removed = state.reap({live})
         self.assertEqual(removed, [dead])
         self.assertFalse(state.frame_dir(dead).exists())
-        self.assertTrue(state.frame_dir("live-1").exists())
+        self.assertTrue(state.frame_dir(live).exists(),
+                        "the live session's directory was reaped — and since its "
+                        "launcher is dead, `live` is the only thing that could have "
+                        "saved it")
 
     def test_a_live_frame_is_never_reaped_by_age(self):
-        """A long-lived frame is exactly what an age heuristic would eat."""
-        state.bump("old-1")
-        self.assertEqual(state.reap({"old-1"}), [])
+        """A long-lived frame is exactly what an age heuristic would eat.
+
+        The pid is a dead one on purpose (see the class docstring): this is the test
+        that pins "reap never deletes by age", so the only reason its fixture may
+        survive is the session being live."""
+        old = f"old-{_a_dead_pid()}"
+        state.bump(old)
+        self.assertEqual(state.reap({old}), [])
 
     def test_a_sibling_exit_code_survives_a_reap_that_beats_its_own_launcher(self):
         """#383. `reap` runs at EVERY frame launch, and the set it is handed names the

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -957,7 +957,7 @@ class MenuIntegration(PersonaIso, unittest.TestCase):
 
 
 @unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
-class MenuFormatIntegration(_NeedsAttachedClient, unittest.TestCase):
+class MenuFormatIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase):
     """The CRITICAL finding from the first review round, proved against a REAL,
     RENDERED `display-menu` — not only the argv shape `tests/test_frame_menu.py`'s
     `LabelSafety` checks. `display-menu`'s own docs: "The name and command are formats"
@@ -970,13 +970,38 @@ class MenuFormatIntegration(_NeedsAttachedClient, unittest.TestCase):
     current client") without one — which is why every OTHER test in this file avoids
     attaching one at all. `_NeedsAttachedClient._attach_pty` is the one place in the
     suite that does, and the one place that decides this machine cannot.
+
+    **A THROWAWAY plane, `PanelIntegration`'s shape exactly, and it was not one until
+    now.** Every test here calls `menu.record`, which goes `menu._table(fid,
+    create=True)` -> `state.frame_dir(fid, create=True)` -> `config.STATE_DIR` — so
+    without `PersonaIso` this class MINTED `menu-fmt-integ*-<pid>` directories in the
+    developer's REAL `.charter/frame/` and left them there, three per run, measured by
+    listing that directory before and after. Nothing reaps them either: since #383 a
+    directory whose name ends in a live pid is kept, and while the suite is running that
+    pid is the suite's own.
+
+    `PersonaIso` alone only covers what a Python IMPORT of `charter` reads in THIS
+    process, and one test below (`test_an_escaped_label_still_lets_the_real_action_run_
+    when_selected`) fires a REAL `charter frame-action` SUBPROCESS that has to find the
+    very table `menu.record` just wrote. `$CHARTER_ROOT` carries the same throwaway plane
+    across that boundary — passed to the `new-session` that STARTS this class's server,
+    because a `run-shell` with no `-t` inherits the SERVER's own starting process
+    environment (`commands_frame._session_id_env_argv`'s own docstring measures this) —
+    and `charter.toml` has to exist at that path or `root.find_root` refuses it outright.
     """
 
     def setUp(self) -> None:
+        super().setUp()
         # kill-server THEN unlink — see `PanelIntegration._teardown_socket`'s own
         # docstring for why two separately-registered `addCleanup` calls in that
-        # order run backwards (`addCleanup` is LIFO).
+        # order run backwards (`addCleanup` is LIFO). Registered AFTER
+        # `PersonaIso.setUp`'s own plane cleanup, so LIFO runs it FIRST: the tmux
+        # server dies while the plane it was pointed at still exists.
         self.addCleanup(self._teardown_socket)
+        (self.tmp / "charter.toml").write_text("")
+        self.env = dict(os.environ, CHARTER_ROOT=str(self.tmp), CHARTER_WORKSPACE="demo")
+        self.env.pop("CHARTER_HOME", None)  # let it derive under CHARTER_ROOT, like this
+                                            # process's own PersonaIso-isolated config
 
     def _teardown_socket(self) -> None:
         """Kill this class's own tmux server, THEN unlink its socket file — see
@@ -992,8 +1017,14 @@ class MenuFormatIntegration(_NeedsAttachedClient, unittest.TestCase):
         around it the same way, and this class needs the identical fix (confirmed by
         hand: without this, three "cat" processes were still alive under `pgrep -f
         'tmux -L charter-integration-test'` after this class's own tests finished and
-        `kill-server` had already run)."""
-        r = _tmux("new-session", "-d", "-s", fid, "-x", "80", "-y", "24", "cat")
+        `kill-server` had already run).
+
+        The one call in this class that carries `self.env`: it is the call that STARTS
+        the server, and a `run-shell` with no `-t` reads the server's own starting
+        environment, which is how the `charter frame-action` subprocess a menu selection
+        spawns lands on this test's throwaway plane rather than the developer's."""
+        r = _tmux("new-session", "-d", "-s", fid, "-x", "80", "-y", "24", "cat",
+                  env=self.env)
         self.assertEqual(r.returncode, 0, r.stderr)
         pid = _tmux("display-message", "-p", "-t", fid, "#{pane_pid}").stdout.strip()
         self.addCleanup(_kill_pid, pid)
@@ -1134,7 +1165,7 @@ class MenuFormatIntegration(_NeedsAttachedClient, unittest.TestCase):
 
 
 @unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
-class MenuClientIntegration(_NeedsAttachedClient, unittest.TestCase):
+class MenuClientIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase):
     """Fix round 2, IMPORTANT-1, proved with two real ptys attached to ONE frame at
     once: the hotkey must open the menu on the PRESSER's own screen, never a
     different attached client's — the defect an earlier version of this mechanism
@@ -1170,13 +1201,28 @@ class MenuClientIntegration(_NeedsAttachedClient, unittest.TestCase):
        already documents for label rendering, evidently not limited to format
        expansion. The REAL bind is not a nicety here; it is the only path observed
        to work at all.
+
+    A THROWAWAY plane, for the same reason and by the same mechanism as
+    `MenuFormatIntegration` above: `menu.record` reaches `config.STATE_DIR`, so without
+    `PersonaIso` this class minted a `menu-client-integ-<pid>` directory in the
+    developer's REAL `.charter/frame/` on every run. This class already builds its own
+    environment for the `new-session` that starts its server (`_charter_py_env`, for the
+    scrubbed `$PATH`), so `$CHARTER_ROOT` is carried there rather than in a second one —
+    and it has to reach the server's STARTING environment specifically, because that is
+    what the real bind's own `run-shell` inherits.
     """
 
     def setUp(self) -> None:
+        super().setUp()
         # kill-server THEN unlink — see `_teardown_socket`'s own docstring below:
         # THIS class, unlike its siblings above, is not merely defending against a
-        # hypothetical here.
+        # hypothetical here. Registered AFTER `PersonaIso.setUp`'s own plane cleanup,
+        # so LIFO runs it FIRST — the server dies while the plane it reads still exists.
         self.addCleanup(self._teardown_socket)
+        # `$CHARTER_ROOT` is refused outright without this marker (`root.find_root`
+        # raises rather than falling back), which would leave the real bind's own
+        # `charter frame-menu` subprocess failing instead of reading this test's plane.
+        (self.tmp / "charter.toml").write_text("")
 
     def _teardown_socket(self) -> None:
         """Kill this class's own tmux server, THEN unlink its socket file.
@@ -1256,7 +1302,16 @@ class MenuClientIntegration(_NeedsAttachedClient, unittest.TestCase):
                           "this class proves a bare `charter` is never needed — its "
                           "own $PATH must not contain one")
         self.shim = shim
-        return dict(os.environ, PATH=str(bare))
+        # `$CHARTER_ROOT` rides along here rather than in a second environment: this is
+        # the env the server STARTS under, and the real bind's `run-shell` (no `-t`)
+        # inherits exactly that. `$CHARTER_HOME` is dropped so `STATE_DIR` derives under
+        # the throwaway root the way this process's own PersonaIso-isolated config does —
+        # left in place it would win outright (`config._migrate_state_dir` returns it
+        # verbatim) and put the shim right back on the developer's real plane.
+        env = dict(os.environ, PATH=str(bare), CHARTER_ROOT=str(self.tmp),
+                   CHARTER_WORKSPACE="demo")
+        env.pop("CHARTER_HOME", None)
+        return env
 
     def _new_session(self, fid: str) -> None:
         """The one `new-session` call that starts this class's fresh server —


### PR DESCRIPTION
Closes #383.

Implemented, adversarially reviewed, and then re-verified after a fix round — in an ultracode workflow. The reviewer reproduced the original symptom against the branch point, showed it gone, and mutation-tested every new test to confirm it can actually fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9