### PR TITLE
`charter persona remember` no longer commits to a protected branch in silence (#373)

### DIFF
--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -16,7 +16,7 @@ import sys
 import time
 from types import SimpleNamespace
 
-from . import config, contain, gitpolicy, util, workspace, worktree
+from . import config, contain, gitpolicy, planegit, util, workspace, worktree
 from .commands import (_cred_flag, _git, _origin_https, cmd_clone, commit_memory_reactive,
                        commit_push)
 
@@ -707,23 +707,26 @@ def cmd_workspace_autosave(args) -> int:
 
 def cmd_workspace_pushbg(args) -> int:
     """Internal: push HEAD to the control plane via its own forge's CLI (the background
-    half of autosave)."""
-    root = config.ROOT
-    https = _origin_https(root)
-    if not https:
-        return 0
-    cred = _cred_flag(gitpolicy.forge_for(root))
-    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=root).stdout.strip()
-    p = _git([*cred, "push", https, f"HEAD:{branch}"], cwd=root)
-    if p.returncode != 0 and any(s in (p.stderr or "") for s in ("fetch first", "non-fast-forward", "rejected")):
-        _git([*cred, "fetch", https, branch], cwd=root)
-        if _git(["rebase", "FETCH_HEAD"], cwd=root).returncode == 0:
-            p = _git([*cred, "push", https, f"HEAD:{branch}"], cwd=root)
-        else:
-            _git(["rebase", "--abort"], cwd=root)
-            return 0
-    if p.returncode == 0:
-        _git(["update-ref", f"refs/remotes/origin/{branch}", "HEAD"], cwd=root)
+    half of autosave, and of every reactive `persona remember`).
+
+    **This used to be a second implementation of the push, and that was #373.** It had its
+    own rebase-retry, no protected-branch recognition, and ``return 0`` on every failure —
+    so on a plane whose default branch requires a pull request, `charter save` landed the
+    change on `charter/<sha>` (#167) while a reactive memory commit was rejected, kept, and
+    never mentioned again. Eleven commits were stranded on a local `main` in one session,
+    each one destroyed by the next ordinary `git reset --hard origin/main`. Delegating is
+    the fix: `planegit.push_head` is the only pusher, so the policy holds here by
+    construction rather than by keeping two lists of forge signatures in step.
+
+    ``announce=False`` because this runs DETACHED with stdout and stderr on ``/dev/null``
+    (`planegit._spawn_bg_push`). Nothing printed here can reach anybody, which is exactly
+    why `push_head` records the outcome as well as saying it — `charter doctor` is where
+    this process gets to speak.
+
+    Still rc 0 on every outcome: it is spawned from a Stop hook and must never break a
+    turn. What changed is that rc 0 is no longer the only thing it leaves behind.
+    """
+    planegit.push_head(config.ROOT, announce=False)
     return 0
 
 

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -347,6 +347,62 @@ def _plane_default_branch(root: Path) -> str | None:
     return None
 
 
+def _stranded_push(root) -> tuple[str, str] | None:
+    """A ``(finding, action)`` for a memory commit whose push did not reach `origin`, or
+    ``None`` — the surface for `planegit.record_push` (#373).
+
+    The reactive memory push runs detached with ``/dev/null`` for stdout and stderr, so it
+    has no caller to tell when a protected default branch refuses it. It writes down what
+    happened instead, and this is where that gets read: `doctor` runs from SessionStart,
+    which is the surface ADR 0008 already chose for everything else about the plane root.
+
+    **The record is checked, not believed.** A file saying "this did not land" is only true
+    until somebody lands it, and a warning that cannot clear itself is one people learn to
+    scroll past — which is the failure ADR 0008 spent its whole second half on. So the
+    recorded commit is tested against the world: once it is an ancestor of the tracked
+    upstream, the condition is over whatever the file still says. That check is a local ref
+    read, never a fetch, because this runs from a hook that must not reach the network.
+
+    ``unreachable`` is deliberately not reported. A plane with no origin on a forge charter
+    knows has a CONFIGURATION to fix, which `commit_push` already says out loud at the
+    moment it happens; repeating it here every session would put this row permanently in
+    the yellow — the exact cost `check_plane_root` refuses to pay for untracked memory
+    files, and it would buy nothing.
+
+    Never raises: the caller is a preflight check, and `push_record` already degrades a
+    malformed file to ``None`` rather than to an exception.
+    """
+    from . import planegit
+
+    rec = planegit.push_record()
+    if not rec or rec.get("outcome") == planegit.UNREACHABLE:
+        return None
+    head = str(rec.get("head") or "")
+    # `--is-ancestor` exits 0 for yes, 1 for no, and non-zero-not-1 for an unresolvable
+    # ref — a plane with no tracking branch, say. Only a clean 0 is allowed to clear the
+    # notice: "I could not check" must not read as "it landed", which is rule 1 of ADR 0013
+    # in the one place where getting it wrong loses the memory.
+    if head and _git_in(root, "merge-base", "--is-ancestor", head,
+                        "@{upstream}").returncode == 0:
+        return None
+    landed, url, branch = rec.get("landed"), rec.get("url"), rec.get("branch") or "main"
+    if rec.get("outcome") == planegit.BRANCHED and landed:
+        # It IS on the remote — under another name, waiting for a pull request. Naming the
+        # branch matters because the remedy is completely different from the stranded case:
+        # nothing is at risk, something is unfinished.
+        open_it = f"Open it: {url}" if url else "Open a pull request for it."
+        return (f"a memory commit went to '{landed}', not {branch}",
+                f"'{branch}' requires a pull request, so charter pushed {landed} "
+                f"instead. {open_it}")
+    # Nothing reached the remote. The HAZARD is named, not merely the fault, because
+    # `git reset --hard origin/<branch>` is the standard move on noticing a divergence and
+    # it deletes this commit without a trace — the specific way #373's memories were lost.
+    # A reader told only "it is unpushed" runs exactly that command next.
+    return ("a memory commit was committed but never pushed",
+            f"Push it with `charter save` before anything runs `git reset --hard "
+            f"origin/{branch}` in {root}, which would delete it silently.")
+
+
 def check_plane_root() -> Result:
     """Is anyone working in the plane root?
 
@@ -422,8 +478,15 @@ def check_plane_root() -> Result:
         # tracking branch (a plane `git init`-ed by hand), which is not a fault.
         behind = _git_in(root, "rev-list", "--count", "HEAD..@{upstream}")
         behind_n = int(behind.stdout.strip() or 0) if behind.returncode == 0 else 0
+        # And how far it has run AHEAD, which is the other half and the one #373 is about.
+        # A root drifts behind because nobody works in it; it can only get ahead because
+        # something committed here and the push did not land. Read the same way, from an
+        # already-fetched ref, for the same reason.
+        ahead = _git_in(root, "rev-list", "--count", "@{upstream}..HEAD")
+        ahead_n = int(ahead.stdout.strip() or 0) if ahead.returncode == 0 else 0
         upstream = _git_in(root, "rev-parse", "--abbrev-ref", "@{upstream}")
         upstream_ref = upstream.stdout.strip() if upstream.returncode == 0 else ""
+        stranded = _stranded_push(root)
     except (util.ProcTimeout, OSError) as e:
         return Result(name, WARN, detail=f"not checked ({e})",
                       hint=_NOT_CHECKED_HINT)
@@ -439,6 +502,12 @@ def check_plane_root() -> Result:
     if dirty:
         findings.append(f"{len(dirty)} uncommitted file(s)")
         actions.append("Commit control-plane content with `charter save`.")
+    # A FINDING, unlike the drift counts below, because it is not a resting state: it says a
+    # write charter was asked to make did not arrive, and it clears itself the moment the
+    # commit reaches the remote.
+    if stranded:
+        findings.append(stranded[0])
+        actions.append(stranded[1])
     # Said in the DETAIL and never as a finding: a root behind its upstream is the normal
     # resting state of a directory nobody works in, so warning about it would put this row
     # permanently in the yellow — the cost this check already refuses to pay for untracked
@@ -459,6 +528,21 @@ def check_plane_root() -> Result:
     # names — in the check whose whole job is to report state honestly.
     drift = (f", {behind_n} behind {upstream_ref or 'upstream'} at last fetch"
              if behind_n else "")
+    # Stated alongside `behind`, and for the sharper version of the same reason. `clean on
+    # main` over a root three commits AHEAD of its remote is not merely incomplete — it is
+    # the sentence that made `git log <tag>..main` look authoritative while three real
+    # commits sat between them, and turned "nothing to release" into an honest-looking
+    # wrong answer (#373). Unlike `behind`, this is never the resting state of a directory
+    # nobody works in, so it costs no permanent yellow to say.
+    #
+    # The count and nothing more. An earlier draft appended "and unpushed", which is a
+    # different claim and is FALSE in the commonest case that reaches here: after a
+    # protected-branch rejection the commit is on the remote under `charter/<sha>`, so the
+    # root is ahead of `main` and the commit is pushed. Whether anything is at risk is the
+    # finding's job, which knows; the drift clause only knows the two counts. Rule 1 of
+    # ADR 0013, in the row whose whole job is reporting state honestly.
+    if ahead_n:
+        drift += f", {ahead_n} ahead of {upstream_ref or 'upstream'} at last fetch"
     if not findings:
         return Result(name, OK, detail=f"clean on {branch}{drift}")
     # Where the work belongs is said ONCE, after the per-finding actions. Saying it per

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -360,32 +360,35 @@ def _stranded_push(root) -> tuple[str, str] | None:
     until somebody lands it, and a warning that cannot clear itself is one people learn to
     scroll past — which is the failure ADR 0008 spent its whole second half on. So the
     recorded commit is tested against the world: once it is an ancestor of the tracked
-    upstream, the condition is over whatever the file still says. That check is a local ref
-    read, never a fetch, because this runs from a hook that must not reach the network.
+    upstream, the condition is over whatever the file still says. `planegit.is_spent` is
+    that test, asked here rather than spelled out here because the PUSHER asks the same
+    question (it decides whether an open pull request's branch may still be advanced) and
+    two answers to "is this record still live" is how a warning nobody can clear and a
+    branch reused after its pull request merged both arrive. It is a local ref read, never
+    a fetch, because this runs from a hook that must not reach the network — which is why
+    the runner is passed in as `_git_in`, under this check's own timeout budget.
 
-    ``unreachable`` is deliberately not reported. A plane with no origin on a forge charter
-    knows has a CONFIGURATION to fix, which `commit_push` already says out loud at the
-    moment it happens; repeating it here every session would put this row permanently in
-    the yellow — the exact cost `check_plane_root` refuses to pay for untracked memory
-    files, and it would buy nothing.
+    ``unreachable`` is not reported, and as of the #373 review it is not RECORDED either —
+    see `planegit.push_head`. A plane with no origin on a forge charter knows has a
+    CONFIGURATION to fix, which `commit_push` already says out loud at the moment it
+    happens; a guard here would be the second line of defence for something that is now
+    impossible, and the first one failed precisely because it was written as a guard
+    somewhere else instead of as the rule itself.
 
     Never raises: the caller is a preflight check, and `push_record` already degrades a
     malformed file to ``None`` rather than to an exception.
     """
     from . import planegit
 
-    rec = planegit.push_record()
-    if not rec or rec.get("outcome") == planegit.UNREACHABLE:
-        return None
-    head = str(rec.get("head") or "")
-    # `--is-ancestor` exits 0 for yes, 1 for no, and non-zero-not-1 for an unresolvable
-    # ref — a plane with no tracking branch, say. Only a clean 0 is allowed to clear the
-    # notice: "I could not check" must not read as "it landed", which is rule 1 of ADR 0013
-    # in the one place where getting it wrong loses the memory.
-    if head and _git_in(root, "merge-base", "--is-ancestor", head,
-                        "@{upstream}").returncode == 0:
+    rec = planegit.unlanded(lambda a: _git_in(root, *a))
+    if not rec:
         return None
     landed, url, branch = rec.get("landed"), rec.get("url"), rec.get("branch") or "main"
+    # WHY it did not land is in git's own words in the record, and nowhere else — the
+    # background pusher's stderr went to /dev/null. Naming the file is what gives that
+    # field a reader; doctor's own text stays constants (ADR 0009), so nothing a remote
+    # said is interpolated into this line.
+    where = f" What the remote said is in {planegit.push_record_path()}."
     if rec.get("outcome") == planegit.BRANCHED and landed:
         # It IS on the remote — under another name, waiting for a pull request. Naming the
         # branch matters because the remedy is completely different from the stranded case:
@@ -398,9 +401,15 @@ def _stranded_push(root) -> tuple[str, str] | None:
     # `git reset --hard origin/<branch>` is the standard move on noticing a divergence and
     # it deletes this commit without a trace — the specific way #373's memories were lost.
     # A reader told only "it is unpushed" runs exactly that command next.
+    #
+    # Describing it is not preventing it. `hooks._plane_root_branch_reason` refuses a branch
+    # move in the root and could refuse this too — its docstring left `reset` out for want of
+    # evidence, and #373 is the evidence. That is #401, kept separate because it is a new
+    # REFUSAL on the Bash path with its own false-positive cost (`git reset HEAD -- <path>`
+    # is an unstage and must stay runnable), not a fix to this row.
     return ("a memory commit was committed but never pushed",
             f"Push it with `charter save` before anything runs `git reset --hard "
-            f"origin/{branch}` in {root}, which would delete it silently.")
+            f"origin/{branch}` in {root}, which would delete it silently.{where}")
 
 
 def check_plane_root() -> Result:

--- a/charter/planegit.py
+++ b/charter/planegit.py
@@ -179,10 +179,13 @@ class PushResult(NamedTuple):
     detail: str = ""
 
 
-def _push_record_path():
-    """Read from :mod:`charter.config` at CALL time, never bound at import — the test
-    harness re-points the plane with `config.use`, and a path captured at import would
-    write into the developer's real ``.charter/``."""
+def push_record_path():
+    """Where the push record lives — public because `doctor` NAMES it, which is what gives
+    the recorded ``detail`` (git's own words about a push nobody heard) a reader.
+
+    Read from :mod:`charter.config` at CALL time, never bound at import — the test harness
+    re-points the plane with `config.use`, and a path captured at import would write into
+    the developer's real ``.charter/``."""
     return config.STATE_DIR / "plane-push.json"
 
 
@@ -211,10 +214,33 @@ def record_push(res: PushResult, head: str = "") -> PushResult:
     A clean push DELETES the file rather than writing "pushed": the record exists to carry
     a condition that outlives the process, and there is no condition left to carry.
 
+    **ADR 0011 is the ADR that governs whether this file may exist at all**, and it is
+    cited here rather than left for a reader to notice is missing. Its rule is that a record
+    holds only what git cannot know, and that what is written is the PAST tense — never a
+    "current status" field, because a description of how things are can become false while
+    nobody is looking. What is written here is a past observation: *a push of commit
+    ``head`` at time ``at`` came out this way*. There is no reality it can contradict,
+    because the push happened in a process with ``/dev/null`` for a voice and nothing else
+    recorded it. That is the same carve-out ADR 0011 makes for liveness, which is likewise
+    overwritten rather than appended.
+
+    The ADR's other demand is that the present tense be RECONSTRUCTED at read time by
+    joining the record against git, and that is what ``head`` is for: `doctor._stranded_push`
+    joins on it (:func:`is_spent`) and reports nothing once git says the commit reached the
+    upstream. Without that join this would be exactly the marker the ADR forbids.
+
+    Two residual tensions, stated rather than hidden. ``branch`` and ``url`` are derivable
+    — the first from the root's HEAD, the second from ``origin`` plus ``landed`` — and
+    ADR 0011's forbidden list names "which branch a piece is on" outright. They are kept
+    because they are derivable *now* and the record is about *then*: an origin that has
+    since been re-pointed (which is how the `unreachable` overwrite above was found) would
+    re-derive a URL for a push that never went there. Deriving them would make the record
+    agree with a present that is not the one it describes.
+
     Never raises. Every caller is a push, and a push that cannot write a note must still
     have pushed.
     """
-    p = _push_record_path()
+    p = push_record_path()
     try:
         if res.outcome == PUSHED:
             p.unlink(missing_ok=True)
@@ -237,10 +263,80 @@ def push_record() -> dict | None:
     briefing and must never cost it the turn. A defect in this file is charter's own to
     fix, not a reason to take the session down."""
     try:
-        data = json.loads(_push_record_path().read_text())
+        data = json.loads(push_record_path().read_text())
     except (OSError, ValueError):
         return None
     return data if isinstance(data, dict) and data.get("outcome") else None
+
+
+def is_spent(head: str, run) -> bool:
+    """Has the commit a record is ABOUT since reached the tracked upstream?
+
+    The join ADR 0011 demands: a record is a past observation, and the present tense is
+    reconstructed by asking git rather than by believing the file. Once ``head`` is an
+    ancestor of ``@{upstream}`` the condition the record describes is over, whatever the
+    file still says — so `doctor` stops warning and :func:`_land_via_branch` stops reusing
+    the pull-request branch it named.
+
+    ONE definition, two callers, because a "spent" the reporter and the pusher disagreed
+    about is how a warning that cannot clear itself and a branch that is reused after its
+    pull request merged both arrive. *run* takes git's arguments and returns something with
+    a ``returncode``; it is a parameter rather than a call because `doctor` must run this
+    under its SessionStart timeout budget (`doctor._git_in`) and the pusher must not.
+
+    ``--is-ancestor`` exits 0 for yes, 1 for no, and non-zero-not-1 for a ref it cannot
+    resolve — a plane with no tracking branch, say. Only a clean 0 counts: "I could not
+    check" must never read as "it landed", which is rule 1 of ADR 0013 in the one place
+    where getting it wrong loses the memory."""
+    if not head:
+        return False
+    return run(["merge-base", "--is-ancestor", head, "@{upstream}"]).returncode == 0
+
+
+def unlanded(run) -> dict | None:
+    """The recorded push outcome that is STILL true, or ``None``.
+
+    **One decision, three renderings.** `doctor._stranded_push` turns this into a row with
+    a remedy, `statusline._plane_root_alert` into one word that fits beside "dirty", and
+    :func:`_open_pull_request_branch` into "may I still advance that branch". #373 was two
+    implementations of *pushing*; letting three surfaces each decide for themselves whether
+    a record is still worth acting on is the same mistake with a longer fuse — the one that
+    disagrees is always the one nobody was looking at.
+
+    *run* takes git's arguments and returns something with a ``returncode``; see
+    :func:`is_spent` for why the runner is the caller's to choose.
+    """
+    rec = push_record()
+    if not rec:
+        return None
+    return None if is_spent(str(rec.get("head") or ""), run) else rec
+
+
+def _open_pull_request_branch(root) -> str | None:
+    """The ``charter/<sha>`` branch an earlier reactive push is STILL waiting on a pull
+    request for, or ``None`` — the branch :func:`_land_via_branch` should advance instead
+    of minting a new one.
+
+    Before #373 the reactive path pushed nothing, so #167's one-branch-per-rejection shape
+    was a handful of branches from a human typing `charter save`. Routing `persona
+    remember`, `workspace remember`, dispatch backfill, curate and autosave through the
+    same path makes it one abandoned remote branch PER MEMORY, each superseding the last
+    and none of them referenced by anything charter will ever say again. Each new HEAD is a
+    descendant of the one before, so advancing the recorded branch is a fast-forward: one
+    open pull request that accumulates the memory commits, rather than N branches nobody
+    will ever close.
+
+    Two things keep this safe rather than clever. It is only ever offered as a FIRST
+    attempt — the caller pushes it without ``--force``, so git itself refuses anything that
+    is not a fast-forward and the caller falls back to a fresh name; nothing here has to be
+    right about the remote's tip. And a record whose commit has reached the upstream is
+    :func:`is_spent`, so a merged pull request's branch is never resurrected.
+    """
+    rec = unlanded(lambda args: _git(args, cwd=root))
+    if not rec or rec.get("outcome") != BRANCHED:
+        return None
+    landed = rec.get("landed")
+    return landed if landed and isinstance(landed, str) else None
 
 
 def _land_via_branch(root, https: str, cred: list, default_branch: str,
@@ -265,18 +361,35 @@ def _land_via_branch(root, https: str, cred: list, default_branch: str,
     of the remote until the pull request lands, and the caller says so with the command that
     reconciles it.
 
+    **An open pull request is advanced rather than replaced.** The branch this pushed last
+    time is tried FIRST while its record is still live (:func:`_open_pull_request_branch`),
+    without ``--force``, so git refuses anything that is not a fast-forward and a fresh
+    ``charter/<sha>`` is minted instead. That is what keeps the reactive path from leaving
+    one abandoned remote branch per memory — see that function for why this only became a
+    problem once the reactive push existed at all.
+
     ``announce`` is False for the background pusher, whose stdout and stderr are
     ``/dev/null``. It still returns the same `PushResult`, because that is what `doctor`
     reads back — saying it and recording it are two audiences, not two policies.
     """
     sha = _git(["rev-parse", "--short", "HEAD"], cwd=root).stdout.strip() or "change"
-    branch = f"charter/{sha}"
-    p = _git([*cred, "push", https, f"HEAD:refs/heads/{branch}"], cwd=root)
-    if p.returncode != 0:
-        tail = "\n".join((p.stderr or p.stdout or "").splitlines()[-4:])
+    fresh = f"charter/{sha}"
+    reuse = _open_pull_request_branch(root)
+    branch = fresh
+    p = None
+    # A reuse that did not fast-forward is not a failure to report: the fresh name has not
+    # been tried yet, and naming a branch charter chose on the operator's behalf as the
+    # thing that went wrong would send them after a problem they do not have.
+    for candidate in ([reuse] if reuse and reuse != fresh else []) + [fresh]:
+        branch = candidate
+        p = _git([*cred, "push", https, f"HEAD:refs/heads/{candidate}"], cwd=root)
+        if p.returncode == 0:
+            break
+    if p is None or p.returncode != 0:
+        tail = "\n".join((p.stderr or p.stdout or "").splitlines()[-4:]) if p else ""
         if announce:
             util.err(f"'{default_branch}' requires a pull request, and pushing the branch "
-                     f"'{branch}' also failed:")
+                     f"'{fresh}' also failed:")
             for ln in tail.splitlines():
                 util.err("  " + ln)
         return PushResult(STRANDED, default_branch, detail=tail)
@@ -327,7 +440,20 @@ def push_head(root, announce: bool = True) -> PushResult:
         if announce:
             util.warn("origin isn't on a forge charter knows (gitlab.com/github.com/…) — "
                       "committed locally; push manually.")
-        return record_push(PushResult(UNREACHABLE, branch), head)
+        # Returned UNRECORDED, deliberately. `unreachable` is the one outcome
+        # `doctor._stranded_push` never reports — a plane with no origin charter knows has a
+        # CONFIGURATION to fix, not a commit to rescue — so writing it could only ever
+        # DESTROY a real notice, and it did. `cmd_workspace_autosave` reaches
+        # `_spawn_pushbg` through `commit_push(no_push=True)`, which returns before the
+        # `_origin_https` pre-check in `commit_push`, so re-pointing origin at an
+        # unrecognised host and letting the background child run turned
+        #     warn | a memory commit was committed but never pushed, 1 ahead of origin/main
+        # into
+        #     ok   | clean on main, 1 ahead of origin/main
+        # over a commit that existed nowhere but that laptop — measured against a real bare
+        # remote with a real pre-receive hook. A "nothing to report" outcome must never be
+        # able to erase one that had something to report.
+        return PushResult(UNREACHABLE, branch)
 
     from . import gitpolicy
     forge = gitpolicy.forge_for(root)
@@ -337,18 +463,38 @@ def push_head(root, announce: bool = True) -> PushResult:
         return _git([*cred, "push", https, f"HEAD:{branch}"], cwd=root)
 
     p = push()
+    if p.returncode != 0 and _is_protected_rejection(p.stderr or p.stdout or ""):
+        # Asked BEFORE the non-fast-forward retry, not after, and that ordering is load-
+        # bearing rather than tidy. git prints its own `! [remote rejected]` line above a
+        # server-side hook decline, so the word "rejected" in the retry test below matches a
+        # protected branch too — and taking the retry first was not merely a wasted round
+        # trip. Measured against a real bare remote with a real pre-receive hook refusing
+        # refs/heads/main in GitHub's GH006 wording: fetching an origin that is unreachable
+        # fails, which REMOVES FETCH_HEAD, so `rebase FETCH_HEAD` fails, and the outcome was
+        # recorded as `conflict` — #167's pull-request path never reached, no `charter/<sha>`
+        # branch created, the commit genuinely stranded, and charter telling the operator to
+        # resolve a conflict that did not exist.
+        return record_push(_land_via_branch(root, https, cred, branch, announce), head)
     if p.returncode != 0 and any(s in (p.stderr or "") for s in ("fetch first", "non-fast-forward", "rejected")):
         if announce:
             util.info("remote moved — fetching + rebasing, then retrying …")
-        _git([*cred, "fetch", https, branch], cwd=root)
-        if _git(["rebase", "FETCH_HEAD"], cwd=root).returncode != 0:
+        if _git([*cred, "fetch", https, branch], cwd=root).returncode != 0:
+            # A failed fetch leaves NO FETCH_HEAD to rebase onto, so rebasing anyway fails
+            # for a reason that has nothing to do with a conflict. Calling that `conflict`
+            # is the unearned diagnosis ADR 0009 forbids, and it costs more than precision:
+            # it sends the reader to resolve a conflict that does not exist while the real
+            # answer — the push failure below, in git's own words — is discarded.
+            if announce:
+                util.warn("Could not reach origin to fetch, so the retry was skipped.")
+        elif _git(["rebase", "FETCH_HEAD"], cwd=root).returncode != 0:
             _git(["rebase", "--abort"], cwd=root)
             if announce:
                 util.warn("Committed locally, but rebase hit a conflict — resolve manually, then `charter save`.")
             return record_push(PushResult(CONFLICT, branch), head)
-        # The rebase rewrote it, so the commit the record names is a different one now.
-        head = _git(["rev-parse", "HEAD"], cwd=root).stdout.strip()
-        p = push()
+        else:
+            # The rebase rewrote it, so the commit the record names is a different one now.
+            head = _git(["rev-parse", "HEAD"], cwd=root).stdout.strip()
+            p = push()
     if p.returncode == 0:
         _git(["update-ref", f"refs/remotes/origin/{branch}", "HEAD"], cwd=root)  # sync tracking
         if announce:
@@ -359,6 +505,10 @@ def push_head(root, announce: bool = True) -> PushResult:
         # not a failure to report and abandon: without this the change is stranded in the
         # one tree #157 forbids branching, and the operator has to make the same edit again
         # somewhere else and discard this one.
+        #
+        # Not redundant with the identical check above the retry: the FIRST push can fail
+        # plain non-fast-forward, and the SECOND — after a rebase that succeeded — is the
+        # one the protected branch refuses. Same policy, reached from the other side.
         return record_push(_land_via_branch(root, https, cred, branch, announce), head)
     tail = "\n".join((p.stderr or p.stdout or "").splitlines()[-4:])
     if announce:
@@ -444,12 +594,18 @@ def commit_push(root, add_cmd: list, message: str | None,
     if no_push:
         util.info("Skipped push (--no-push).")
         return 0
-    # Asked here as well as inside `push_head`, and only to decide whether spawning is
-    # worth it: a plane with no origin charter recognises has nowhere to push, and firing a
-    # detached child to discover that would leave an `unreachable` record behind for
-    # `doctor` to warn about on a plane whose configuration — not whose commit — is the
-    # thing to fix. The warning is the same one `push_head` gives, said by whichever of
-    # them gets there first.
+    # Asked here as well as inside `push_head`, and now for ONE reason only: on the
+    # background path this is the only voice the operator can hear. `_spawn_bg_push` gives
+    # the child `/dev/null` for stdout and stderr, so `push_head`'s identical warning is
+    # written to be discarded, and a plane whose origin is on no forge charter knows would
+    # say nothing at all about a configuration only a human can fix.
+    #
+    # It is NOT a guard against a spurious `unreachable` record any more. That was the
+    # earlier justification and it was the wrong shape — `cmd_workspace_autosave` reaches
+    # `_spawn_pushbg` through `commit_push(no_push=True)`, which returns above this line, so
+    # the guard was bypassed by a sibling door and a real `branched`/`stranded` notice was
+    # overwritten with "nothing to report". `push_head` no longer records `unreachable` at
+    # all, which is the rule rather than a second place to remember it.
     if not _origin_https(root):
         util.warn("origin isn't on a forge charter knows (gitlab.com/github.com/…) — "
                   "committed locally; push manually.")

--- a/charter/planegit.py
+++ b/charter/planegit.py
@@ -22,9 +22,12 @@ across that seam. With them here, reuse is the cheap path and there is one place
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
+import time
 from pathlib import Path
+from typing import NamedTuple
 
 from . import config, util
 
@@ -151,7 +154,97 @@ def _compare_url(https: str, branch: str) -> str | None:
     return (f"{base}/-/merge_requests/new?merge_request%5Bsource_branch%5D={branch}")
 
 
-def _land_via_branch(root, https: str, cred: list, default_branch: str) -> int:
+#: What a push of the plane root's HEAD did, in one word. Recorded as well as printed —
+#: see :func:`record_push` — so the answer survives a pusher nobody was listening to.
+PUSHED = "pushed"              # it landed on the branch HEAD is on
+BRANCHED = "branched"          # the branch requires a PR → it landed on `charter/<sha>`
+STRANDED = "stranded"          # the branch requires a PR and THAT push failed too
+FAILED = "failed"              # an ordinary push failure, reported rather than diagnosed
+CONFLICT = "conflict"          # the remote moved and the rebase onto it conflicted
+UNREACHABLE = "unreachable"    # no origin on a forge charter knows — nothing to push to
+
+
+class PushResult(NamedTuple):
+    """What :func:`push_head` did, in a shape both a human and `doctor` can read.
+
+    ``branch`` is the branch charter tried to advance (the plane root's HEAD). ``landed``
+    is the remote branch the commit actually reached when that is a *different* one, which
+    is the distinction #373 turns on: "it is on the remote under another name" and "it is
+    on this laptop only" are one exit code apart and worlds apart in consequence.
+    """
+    outcome: str
+    branch: str
+    landed: str | None = None
+    url: str | None = None
+    detail: str = ""
+
+
+def _push_record_path():
+    """Read from :mod:`charter.config` at CALL time, never bound at import — the test
+    harness re-points the plane with `config.use`, and a path captured at import would
+    write into the developer's real ``.charter/``."""
+    return config.STATE_DIR / "plane-push.json"
+
+
+def record_push(res: PushResult, head: str = "") -> PushResult:
+    """Write down what a push of the plane root's HEAD did, and return *res* unchanged.
+
+    **Why a file and not a printed line.** The reactive-memory push is the one path
+    SessionStart tells an agent to use, and it runs DETACHED with stdout and stderr on
+    ``/dev/null`` (`_spawn_bg_push`) so a slow push cannot block the turn. That process has
+    no caller to tell. Before #373 it therefore told nobody: a push rejected by a protected
+    `main` returned 0 into the void, and the memory commit sat on a local branch until the
+    next ``git reset --hard origin/main`` — the standard move on noticing a divergence —
+    deleted it without a trace.
+
+    A record is the honest shape for that. Charter's house rule is to NAME a limit rather
+    than degrade quietly, and the limit here is real: a background push cannot report to a
+    caller that has already returned. So it reports to the next `doctor` instead
+    (`doctor._stranded_push`), which is the surface ADR 0008 already chose for the plane
+    root.
+
+    ``head`` is the commit the outcome is ABOUT, and it is what lets the reader of the
+    record check it against the world instead of trusting it: `doctor` treats a record
+    whose commit has since become an ancestor of the upstream as spent. Without it the
+    file could only be believed, and a stale believed file is the failure ADR 0013 names.
+
+    A clean push DELETES the file rather than writing "pushed": the record exists to carry
+    a condition that outlives the process, and there is no condition left to carry.
+
+    Never raises. Every caller is a push, and a push that cannot write a note must still
+    have pushed.
+    """
+    p = _push_record_path()
+    try:
+        if res.outcome == PUSHED:
+            p.unlink(missing_ok=True)
+            return res
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({
+            "outcome": res.outcome, "branch": res.branch, "landed": res.landed,
+            "url": res.url, "detail": res.detail, "head": head, "at": time.time(),
+        }, indent=2))
+    except OSError:
+        pass
+    return res
+
+
+def push_record() -> dict | None:
+    """The last recorded push outcome, or ``None`` when there is nothing to report.
+
+    ``None`` for a missing file AND for an unreadable or malformed one, deliberately: the
+    only consumer runs from the SessionStart hook, where a hook may cost a session its
+    briefing and must never cost it the turn. A defect in this file is charter's own to
+    fix, not a reason to take the session down."""
+    try:
+        data = json.loads(_push_record_path().read_text())
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) and data.get("outcome") else None
+
+
+def _land_via_branch(root, https: str, cred: list, default_branch: str,
+                     announce: bool = True) -> PushResult:
     """Push the commit that is already on HEAD to a NEW remote branch, and hand back a URL.
 
     The sanctioned path for a control plane whose own repo requires pull requests (#167).
@@ -171,23 +264,109 @@ def _land_via_branch(root, https: str, cred: list, default_branch: str) -> int:
     The cost, stated rather than hidden: local `<default_branch>` is left one commit ahead
     of the remote until the pull request lands, and the caller says so with the command that
     reconciles it.
+
+    ``announce`` is False for the background pusher, whose stdout and stderr are
+    ``/dev/null``. It still returns the same `PushResult`, because that is what `doctor`
+    reads back — saying it and recording it are two audiences, not two policies.
     """
     sha = _git(["rev-parse", "--short", "HEAD"], cwd=root).stdout.strip() or "change"
     branch = f"charter/{sha}"
     p = _git([*cred, "push", https, f"HEAD:refs/heads/{branch}"], cwd=root)
     if p.returncode != 0:
-        util.err(f"'{default_branch}' requires a pull request, and pushing the branch "
-                 f"'{branch}' also failed:")
-        for ln in (p.stderr or p.stdout or "").splitlines()[-4:]:
-            util.err("  " + ln)
-        return 1
-    util.ok(f"'{default_branch}' requires a pull request — pushed {branch} instead.")
+        tail = "\n".join((p.stderr or p.stdout or "").splitlines()[-4:])
+        if announce:
+            util.err(f"'{default_branch}' requires a pull request, and pushing the branch "
+                     f"'{branch}' also failed:")
+            for ln in tail.splitlines():
+                util.err("  " + ln)
+        return PushResult(STRANDED, default_branch, detail=tail)
     url = _compare_url(https, branch)
-    if url:
-        util.info(f"  open it: {url}")
-    util.info(f"  the commit is also on your local {default_branch}, one ahead of the "
-              f"remote. After the PR merges: git -C {root} pull --rebase")
-    return 0
+    if announce:
+        util.ok(f"'{default_branch}' requires a pull request — pushed {branch} instead.")
+        if url:
+            util.info(f"  open it: {url}")
+        util.info(f"  the commit is also on your local {default_branch}, one ahead of the "
+                  f"remote. After the PR merges: git -C {root} pull --rebase")
+    return PushResult(BRANCHED, default_branch, landed=branch, url=url)
+
+
+def push_head(root, announce: bool = True) -> PushResult:
+    """Push the plane root's HEAD to its own branch on origin — **the one pusher**.
+
+    Extracted from `commit_push` for the reason this module exists one layer up: there were
+    two committers, and the copy was the one breaking the rule. #373 was that same fault
+    repeated on the push. `commands_workspace.cmd_workspace_pushbg` — the detached
+    background half of every reactive memory commit — had grown its own push and
+    rebase-retry and stopped there, with no protected-branch recognition and ``return 0``
+    on every failure. So on a plane whose `main` requires a pull request, `charter save`
+    landed the change on `charter/<sha>` (#167) while `charter persona remember` stranded
+    it on local `main` and said nothing:
+
+        charter save            → rejected → _land_via_branch → PR URL printed
+        persona remember (bg)   → rejected → return 0
+
+    With one implementation the protected-branch policy is true on both paths by
+    construction, rather than by two lists of forge signatures somebody keeps in step.
+
+    **Why the branch is never predicted.** Nothing here asks the forge whether `main` is
+    protected before committing, which is the first thing #373 proposes. charter cannot
+    know that without a network call it has no business making from a Stop hook, and
+    guessing it from the branch name is precisely the unearned diagnosis ADR 0009 forbids.
+    The rejection IS the evidence, and it arrives only after the commit exists — so the
+    commit is made, and the *outcome* is what gets reported honestly.
+
+    Always records its outcome (:func:`record_push`), foreground and background alike. The
+    foreground caller also has a human in front of it, so it *says* it too — but a printed
+    line is not a record, and `charter save` on a protected plane leaves a pull request to
+    open whether or not the operator was reading at the time.
+    """
+    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=root).stdout.strip()
+    head = _git(["rev-parse", "HEAD"], cwd=root).stdout.strip()
+    https = _origin_https(root)
+    if not https:
+        if announce:
+            util.warn("origin isn't on a forge charter knows (gitlab.com/github.com/…) — "
+                      "committed locally; push manually.")
+        return record_push(PushResult(UNREACHABLE, branch), head)
+
+    from . import gitpolicy
+    forge = gitpolicy.forge_for(root)
+    cred = _cred_flag(forge)
+
+    def push():
+        return _git([*cred, "push", https, f"HEAD:{branch}"], cwd=root)
+
+    p = push()
+    if p.returncode != 0 and any(s in (p.stderr or "") for s in ("fetch first", "non-fast-forward", "rejected")):
+        if announce:
+            util.info("remote moved — fetching + rebasing, then retrying …")
+        _git([*cred, "fetch", https, branch], cwd=root)
+        if _git(["rebase", "FETCH_HEAD"], cwd=root).returncode != 0:
+            _git(["rebase", "--abort"], cwd=root)
+            if announce:
+                util.warn("Committed locally, but rebase hit a conflict — resolve manually, then `charter save`.")
+            return record_push(PushResult(CONFLICT, branch), head)
+        # The rebase rewrote it, so the commit the record names is a different one now.
+        head = _git(["rev-parse", "HEAD"], cwd=root).stdout.strip()
+        p = push()
+    if p.returncode == 0:
+        _git(["update-ref", f"refs/remotes/origin/{branch}", "HEAD"], cwd=root)  # sync tracking
+        if announce:
+            util.ok(f"Pushed {branch} via {forge.cli} (HTTPS token — no SSH, no 1Password).")
+        return record_push(PushResult(PUSHED, branch), head)
+    if _is_protected_rejection(p.stderr or p.stdout or ""):
+        # The plane's own repo requires a pull request. That is a supported shape (#167),
+        # not a failure to report and abandon: without this the change is stranded in the
+        # one tree #157 forbids branching, and the operator has to make the same edit again
+        # somewhere else and discard this one.
+        return record_push(_land_via_branch(root, https, cred, branch, announce), head)
+    tail = "\n".join((p.stderr or p.stdout or "").splitlines()[-4:])
+    if announce:
+        util.warn(f"Committed, but the {forge.cli} push failed:")
+        for ln in tail.splitlines():
+            util.warn("  " + ln)
+        util.info(f"Check `{forge.cli} auth status`.")
+    return record_push(PushResult(FAILED, branch, detail=tail), head)
 
 
 def commit_push(root, add_cmd: list, message: str | None,
@@ -265,45 +444,27 @@ def commit_push(root, add_cmd: list, message: str | None,
     if no_push:
         util.info("Skipped push (--no-push).")
         return 0
-    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=root).stdout.strip()
-    https = _origin_https(root)
-    if not https:
+    # Asked here as well as inside `push_head`, and only to decide whether spawning is
+    # worth it: a plane with no origin charter recognises has nowhere to push, and firing a
+    # detached child to discover that would leave an `unreachable` record behind for
+    # `doctor` to warn about on a plane whose configuration — not whose commit — is the
+    # thing to fix. The warning is the same one `push_head` gives, said by whichever of
+    # them gets there first.
+    if not _origin_https(root):
         util.warn("origin isn't on a forge charter knows (gitlab.com/github.com/…) — "
                   "committed locally; push manually.")
         return 0
     if background:
         _spawn_bg_push(root)
-        util.info("→ pushing to the control plane in the background.")
+        # Says WHERE the answer will turn up, because this line cannot carry it: the push
+        # happens in a detached child with `/dev/null` for a voice. `charter doctor` reads
+        # what that child recorded (`record_push`). Before #373 this was the last word on a
+        # push that could still be rejected seconds later, unheard — a success line about
+        # something charter had not done yet, which is rule 1 of ADR 0013.
+        util.info("→ pushing to the control plane in the background "
+                  "(`charter doctor` reports the outcome).")
         return 0
-
-    from . import gitpolicy
-    forge = gitpolicy.forge_for(root)
-    cred = _cred_flag(forge)
-
-    def push():
-        return _git([*cred, "push", https, f"HEAD:{branch}"], cwd=root)
-
-    p = push()
-    if p.returncode != 0 and any(s in (p.stderr or "") for s in ("fetch first", "non-fast-forward", "rejected")):
-        util.info("remote moved — fetching + rebasing, then retrying …")
-        _git([*cred, "fetch", https, branch], cwd=root)
-        if _git(["rebase", "FETCH_HEAD"], cwd=root).returncode != 0:
-            _git(["rebase", "--abort"], cwd=root)
-            util.warn("Committed locally, but rebase hit a conflict — resolve manually, then `charter save`.")
-            return 0
-        p = push()
-    if p.returncode == 0:
-        _git(["update-ref", f"refs/remotes/origin/{branch}", "HEAD"], cwd=root)  # sync tracking
-        util.ok(f"Pushed {branch} via {forge.cli} (HTTPS token — no SSH, no 1Password).")
-    elif _is_protected_rejection(p.stderr or p.stdout or ""):
-        # The plane's own repo requires a pull request. That is a supported shape (#167),
-        # not a failure to report and abandon: without this the change is stranded in the
-        # one tree #157 forbids branching, and the operator has to make the same edit again
-        # somewhere else and discard this one.
-        return _land_via_branch(root, https, cred, branch)
-    else:
-        util.warn(f"Committed, but the {forge.cli} push failed:")
-        for ln in (p.stderr or p.stdout or "").splitlines()[-4:]:
-            util.warn("  " + ln)
-        util.info(f"Check `{forge.cli} auth status`.")
-    return 0
+    # rc 1 only when the commit reached NOWHERE — a pull-request branch that also failed.
+    # An ordinary push failure has been reported and stays rc 0, unchanged: `charter save`
+    # having committed successfully is not a failed command.
+    return 1 if push_head(root).outcome == STRANDED else 0

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1482,6 +1482,42 @@ def _head_detached(gitdir: Path) -> bool:
     return bool(txt) and not txt.startswith("ref:")
 
 
+def _unlanded_memory(root: Path) -> str | None:
+    """One coloured phrase for a memory commit whose push did not reach `origin`, or
+    ``None`` — the status line's rendering of `planegit.unlanded` (#373).
+
+    Two shapes, because the remedies are opposite and a reader who is told the wrong one
+    acts on it. ``branched`` means the commit IS on the remote under `charter/<sha>`
+    waiting on a pull request: nothing is at risk, something is unfinished. Anything else
+    means it reached nowhere, and the next `git reset --hard origin/<branch>` destroys it.
+    Only the second is coloured RED — the status line has one register above yellow and
+    spending it on "there is a pull request to open" is how it stops meaning anything.
+
+    Deliberately does NOT name the branch or carry the pull-request URL. This shares one
+    line with `dirty` and `detached HEAD` and truncates from the right; `doctor` and the
+    record file are where the detail lives, and a line that tries to carry a URL loses the
+    words that say what it is about. It is a pointer, not the report.
+
+    Its own subprocess rather than `_run_state`'s cached answer: `ahead` counts commits,
+    and "ahead" is the ordinary state of a plane whose pull request is open. The question
+    here is whether a specific recorded commit is still unlanded, which only
+    `merge-base --is-ancestor` answers. Timed out and swallowed like every other read on
+    this path — the status line's one hard contract is that it never raises.
+    """
+    try:
+        from . import planegit
+        rec = planegit.unlanded(lambda a: subprocess.run(
+            ["git", "-C", str(root), *a], stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL, timeout=3))
+    except Exception:
+        return None
+    if not rec:
+        return None
+    if rec.get("outcome") == planegit.BRANCHED and rec.get("landed"):
+        return f"{_YELLOW}memory awaiting a pull request{_R}"
+    return f"{_RED}memory commit not pushed{_R}"
+
+
 def _plane_root_alert() -> str | None:
     """One line when the **plane root** is being worked in — dirty, detached, or off its
     default branch. ``None`` otherwise, which is the ordinary case.
@@ -1511,6 +1547,20 @@ def _plane_root_alert() -> str | None:
     on screen permanently — furniture, which is the one thing this element must not
     become. The agreement: `doctor` and the status line answer the same question about
     the same tree, and two answers to one question is worse than either alone.
+
+    **A memory commit that did not land is said here too, and that is a timing fix rather
+    than a second opinion (#373).** `doctor` reports it, but `doctor` runs at SessionStart
+    and the hazard it names happens mid-session, in the SAME session that stranded the
+    commit: an agent notices `main` is ahead for reasons it did not intend and reaches for
+    `git reset --hard origin/main`, which deletes the memory without a trace. That agent
+    never saw the SessionStart row. This one renders every turn, on the near side of the
+    hazard. `planegit.unlanded` is the shared decision, so the two surfaces cannot come to
+    different answers about whether there is anything to say — the same discipline
+    ``tracked_dirty`` above exists for.
+
+    It costs no subprocess in the ordinary case: with no record file there is nothing to
+    join against, and the join only runs while something really is unlanded — which is
+    also the only state in which it can clear itself.
     """
     try:
         if not config.HAS_CONTROL_PLANE:
@@ -1559,6 +1609,9 @@ def _plane_root_alert() -> str | None:
         # branch you happened to be on.
         elif default and branch not in ("?", default):
             bits.append(f"{_DIM}on{_R} {branch}{_DIM}, not{_R} {default}")
+        unlanded = _unlanded_memory(root)
+        if unlanded:
+            bits.append(unlanded)
         if not bits:
             return None
 

--- a/docs/news/unreleased-a-memory-push-that-did-not-land.md
+++ b/docs/news/unreleased-a-memory-push-that-did-not-land.md
@@ -1,0 +1,44 @@
+---
+version: unreleased
+headline: A memory commit that never reached the remote now says so, every turn, until it does
+---
+
+On a plane whose default branch requires a pull request, `charter persona remember` wrote the
+memory, committed it to the plane root, printed *"memory recorded"* and exited 0 — while the
+push was rejected in a detached child with `/dev/null` for stdout and stderr. Eleven commits
+were stranded on a local `main` in one session that way, all three agents reporting success.
+The next ordinary `git reset --hard origin/main` deletes them without a trace, and a root
+silently ahead of its remote made `git log <tag>..main` come back empty with three real
+commits sitting between them.
+
+`charter save` had never had this problem: #167 taught it to push `charter/<sha>` and hand back
+a compare URL. The reactive path missed it because `charter workspace _pushbg` was a SECOND
+implementation of the push — its own rebase-retry, no protected-branch recognition, `return 0`
+on every failure. There were two committers once, which is why `planegit` exists; then there
+were two pushers.
+
+Now there is one. `planegit.push_head` is the only pusher, so #167's policy holds on both
+paths by construction rather than by two lists of forge signatures somebody keeps in step.
+
+A detached push has no caller left to report to, so charter **names that limit** instead of
+degrading quietly: the outcome is written to `.charter/plane-push.json`, and two surfaces read
+it. `charter doctor` reports it at SessionStart, with the `reset --hard` hazard named rather
+than only the fault. The status line says it every turn — because the hazard happens
+mid-session, in the same session that stranded the commit, and that agent never saw the
+SessionStart row.
+
+Neither surface believes the file. The recorded commit is joined against git at read time, so
+the notice clears itself the moment the commit reaches the upstream — not when somebody
+remembers to delete a file.
+
+Three things this deliberately does not do. It does not ask the forge whether the branch is
+protected before committing: charter cannot know that without a network call it has no
+business making from a hook, and guessing it from a branch name is the unearned diagnosis
+ADR 0009 forbids. It does not check out a branch in the plane root (#157) — `push
+HEAD:refs/heads/<new>` gets the same benefit with HEAD never moving. And it does not open one
+`charter/<sha>` branch per memory: while its pull request is still open the recorded branch is
+advanced by fast-forward, never force, so a plane on `share = "push"` accumulates commits on
+one branch instead of abandoned branches nobody will close.
+
+Nothing to adopt: upgrading is the whole of it. A plane already carrying a stranded commit is
+told about it on the next `charter doctor`.

--- a/tests/test_reactive_push_is_not_silent.py
+++ b/tests/test_reactive_push_is_not_silent.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import io
 import json
+import re
 import subprocess
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -83,6 +84,16 @@ class PlaneCase(PersonaIso):
         # marker file, which only exists as of the line above. `PersonaIso` restores the
         # real values from the snapshot it took first, so this needs no cleanup of its own.
         config.use(self.tmp)
+        # `$CHARTER_HOME` ESCAPES `PersonaIso`, and this file writes to `config.STATE_DIR`.
+        # `config._migrate_state_dir` returns `$CHARTER_HOME` VERBATIM when it is set, so
+        # `config.use(tmp)` leaves STATE_DIR pointing outside tmp and every `plane-push.json`
+        # here — including the deliberately malformed `{ not json` below — lands in the
+        # developer's real `.charter/`. Unset on this machine and on CI, which is exactly
+        # why it must be pinned rather than trusted: the day somebody sets it to share a
+        # state dir across clones, the suite starts writing into it silently. The same
+        # defence `test_dispatch.py` and `test_workspace_enforcement.py` already carry.
+        config.STATE_DIR = self.tmp / ".charter"
+        self.assertTrue(config.STATE_DIR.is_relative_to(self.tmp))
         self.root = Path(config.ROOT)
         subprocess.run(["git", *_PINS, "init", "-q", "-b", "main", str(self.root)],
                        check=True, capture_output=True)
@@ -290,15 +301,6 @@ class TestDoctorSaysTheCommitDidNotLand(DoctorCase):
         r = doctor.check_plane_root()
         self.assertNotIn("reset --hard", r.hint)
 
-    def test_an_unreachable_origin_is_not_reported_as_a_stranded_commit(self):
-        """A plane with no origin on a forge charter knows has a CONFIGURATION to fix, not
-        a commit to rescue — and `commit_push` already says so at the time. Warning here
-        too would put the row permanently yellow, the exact cost this check refuses to pay
-        for untracked memory files."""
-        head = self.commit_locally()
-        planegit.record_push(planegit.PushResult(planegit.UNREACHABLE, "main"), head=head)
-        self.assertNotIn("reset --hard", doctor.check_plane_root().hint)
-
     def test_unpushed_commits_are_counted_in_the_detail(self):
         """`clean on main` is a statement about the working TREE that reads as one about
         the plane — the complaint `test_doctor_plane_root_behind` records, in the other
@@ -329,6 +331,338 @@ class TestDoctorSaysTheCommitDidNotLand(DoctorCase):
         written = config.STATE_DIR / "plane-push.json"
         self.assertTrue(written.exists())
         self.assertEqual(json.loads(written.read_text())["outcome"], planegit.FAILED)
+
+    def test_the_hint_names_where_the_remotes_own_words_are(self):
+        """The recorded `detail` is git's answer to "why", and the background pusher's
+        stderr went to `/dev/null`, so the file is the only copy. Naming it is what gives
+        that field a reader; `doctor`'s own text stays constants (ADR 0009), so nothing a
+        remote said is interpolated into the row."""
+        head = self.commit_locally()
+        planegit.record_push(planegit.PushResult(planegit.FAILED, "main",
+                                                 detail="remote: boom"), head=head)
+        self.assertIn(str(planegit.push_record_path()), doctor.check_plane_root().hint)
+
+
+class TestAnUnreachableOriginLeavesNoNoticeBehind(DoctorCase):
+    """SUPERSEDES `test_an_unreachable_origin_is_not_reported_as_a_stranded_commit`.
+
+    That test asserted `doctor` IGNORES an `unreachable` record. It passed, and the
+    guarantee it was reaching for was false: the ignoring happened in `doctor` while the
+    WRITING happened in `push_head`, so an `unreachable` record still landed on disk and
+    overwrote a live `branched`/`stranded` one. `cmd_workspace_autosave` reaches the
+    background pusher through `commit_push(no_push=True)`, which returns before
+    `commit_push`'s `_origin_https` pre-check, so re-pointing origin at an unrecognised
+    host was enough to turn
+
+        warn | a memory commit was committed but never pushed, 1 ahead of origin/main
+
+    into
+
+        ok   | clean on main, 1 ahead of origin/main
+
+    over a commit that existed nowhere but that laptop — measured against a real bare
+    remote with a real `pre-receive` hook, not inferred.
+
+    So the rule moved to where it can hold: `push_head` does not RECORD `unreachable` at
+    all. Keeping the old test alongside would have been strictly worse than deleting it —
+    a green assertion about a state production code can no longer produce, guarding the
+    second of the two places whose disagreement was the defect.
+    """
+
+    def _unrecognised_origin(self) -> None:
+        git(self.root, "remote", "set-url", "origin",
+            "https://git.example.invalid/acme/plane.git")
+
+    def test_it_records_nothing_at_all(self):
+        head = self.commit_locally()
+        self._unrecognised_origin()
+        res = planegit.push_head(self.root, announce=False)
+        self.assertEqual(res.outcome, planegit.UNREACHABLE)
+        self.assertIsNone(planegit.push_record(), head)
+
+    def test_it_does_not_overwrite_a_real_notice(self):
+        """The finding itself. A "nothing to report" outcome must never be able to erase
+        one that had something to report."""
+        head = self.commit_locally()
+        planegit.record_push(
+            planegit.PushResult(planegit.BRANCHED, "main", landed="charter/abc1234",
+                                url="https://x/compare/charter/abc1234"), head=head)
+        self._unrecognised_origin()
+        self.pushbg()
+        rec = planegit.push_record() or {}
+        self.assertEqual(rec.get("outcome"), planegit.BRANCHED)
+        self.assertEqual(rec.get("landed"), "charter/abc1234")
+
+    def test_doctor_still_says_the_commit_did_not_land(self):
+        """The end the operator sees, asserted through the whole path rather than on the
+        file: the row must stay WARN, not fall back to `ok | clean on main`."""
+        head = self.commit_locally()
+        planegit.record_push(planegit.PushResult(planegit.FAILED, "main"), head=head)
+        self._unrecognised_origin()
+        self.pushbg()
+        r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("reset --hard", r.hint)
+
+
+class TestAProtectedRejectionIsNotMistakenForAConflict(PlaneCase):
+    """F2. Real git prints its own ``! [remote rejected]`` line above a server-side hook
+    decline, so the word "rejected" in `push_head`'s non-fast-forward test matches a
+    protected branch too — and taking that branch first was not merely a wasted round trip.
+
+    Measured against a real bare remote with a real `pre-receive` hook refusing
+    refs/heads/main in GH006 wording, with an origin git cannot fetch from: the fetch
+    failed, which REMOVED FETCH_HEAD, so `rebase FETCH_HEAD` failed, and charter recorded
+    `conflict`, printed *"remote moved"* and *"rebase hit a conflict"*, created no
+    `charter/<sha>` branch, and left the commit stranded. Every one of those sentences was
+    about something that had not happened — which is #373's own defect, in the code #373
+    added, wearing the retry's clothes.
+
+    So the fixture here carries the ``! [remote rejected]`` line the unit fixture at the
+    top of this file deliberately omits. That omission is what kept this invisible.
+    """
+
+    #: What real git prints. The `! [remote rejected]` line is the whole point.
+    REJECTED = ("remote: error: GH006: Protected branch update failed for refs/heads/main.\n"
+                "remote: error: Required status check \"ci\" is expected.\n"
+                "To https://github.com/acme/plane.git\n"
+                " ! [remote rejected] HEAD -> main (pre-receive hook declined)\n"
+                "error: failed to push some refs to 'https://github.com/acme/plane.git'")
+
+    def fake_git_rejecting_main(self, *, fetch_ok: bool):
+        """git that refuses `HEAD:main` the way a real protected remote does, and whose
+        `fetch` either works or does not. Everything else is real git."""
+        real = planegit._git
+        seen: list[list[str]] = []
+
+        def fake(args, cwd=None, **kw):
+            seen.append(list(args))
+            if "push" in args:
+                if args[-1].endswith(":main"):
+                    return subprocess.CompletedProcess(args, 1, "", self.REJECTED)
+                return subprocess.CompletedProcess(args, 0, "", "")
+            if "fetch" in args and not fetch_ok:
+                return subprocess.CompletedProcess(
+                    args, 128, "", "fatal: unable to access 'https://…': Could not resolve host")
+            return real(args, cwd=cwd, **kw)
+
+        self.enterContext(mock.patch.object(planegit, "_git", fake))
+        self.enterContext(mock.patch.object(commands_workspace, "_git", fake))
+        return seen
+
+    def test_the_pull_request_path_is_reached_even_when_the_fetch_fails(self):
+        seen = self.fake_git_rejecting_main(fetch_ok=False)
+        self.pushbg()
+        self.assertEqual((planegit.push_record() or {}).get("outcome"), planegit.BRANCHED)
+        self.assertTrue(any(a[-1].startswith("HEAD:refs/heads/charter/")
+                            for a in seen if "push" in a), seen)
+
+    def test_no_fetch_or_rebase_is_attempted_at_all(self):
+        """The round trip the author flagged, now closed by the same ordering. A protected
+        branch is recognised from the FIRST push's own words; nothing about the remote
+        moved, so nothing should be fetched or rebased to find that out."""
+        seen = self.fake_git_rejecting_main(fetch_ok=True)
+        self.pushbg()
+        self.assertFalse([a for a in seen if "fetch" in a or "rebase" in a], seen)
+
+    def test_a_failed_fetch_is_never_recorded_as_a_conflict(self):
+        """A fetch that failed leaves no FETCH_HEAD, so rebasing onto it fails for a reason
+        that has nothing to do with a conflict. Reported as the push failure that actually
+        happened — ADR 0009: charter names a cause it recognised, never one it inferred."""
+        real = planegit._git
+
+        def fake(args, cwd=None, **kw):
+            if "push" in args:
+                return subprocess.CompletedProcess(
+                    args, 1, "", "! [rejected] HEAD -> main (fetch first)")
+            if "fetch" in args:
+                return subprocess.CompletedProcess(args, 128, "", "fatal: could not read")
+            return real(args, cwd=cwd, **kw)
+
+        self.enterContext(mock.patch.object(planegit, "_git", fake))
+        self.enterContext(mock.patch.object(commands_workspace, "_git", fake))
+        self.pushbg()
+        self.assertEqual((planegit.push_record() or {}).get("outcome"), planegit.FAILED)
+
+    def test_a_rebase_that_really_conflicts_is_still_a_conflict(self):
+        """The other direction, so the fix above cannot be "stop saying conflict"."""
+        real = planegit._git
+
+        def fake(args, cwd=None, **kw):
+            if "push" in args:
+                return subprocess.CompletedProcess(
+                    args, 1, "", "! [rejected] HEAD -> main (fetch first)")
+            if "fetch" in args:
+                return subprocess.CompletedProcess(args, 0, "", "")
+            if args and args[0] == "rebase" and "--abort" not in args:
+                return subprocess.CompletedProcess(args, 1, "", "CONFLICT (content)")
+            return real(args, cwd=cwd, **kw)
+
+        self.enterContext(mock.patch.object(planegit, "_git", fake))
+        self.enterContext(mock.patch.object(commands_workspace, "_git", fake))
+        self.pushbg()
+        self.assertEqual((planegit.push_record() or {}).get("outcome"), planegit.CONFLICT)
+
+    def test_a_protected_rejection_on_the_RETRY_still_reaches_the_policy(self):
+        """The first push fails plain non-fast-forward; the rebase succeeds; the second
+        push is the one the protected branch refuses. Pins that moving the check earlier
+        did not remove the later one."""
+        real = planegit._git
+        pushes = []
+
+        def fake(args, cwd=None, **kw):
+            if "push" in args:
+                pushes.append(args)
+                if args[-1].endswith(":main"):
+                    return subprocess.CompletedProcess(
+                        args, 1, "",
+                        "! [rejected] HEAD -> main (fetch first)" if len(pushes) == 1
+                        else self.REJECTED)
+                return subprocess.CompletedProcess(args, 0, "", "")
+            if "fetch" in args or (args and args[0] == "rebase"):
+                return subprocess.CompletedProcess(args, 0, "", "")
+            return real(args, cwd=cwd, **kw)
+
+        self.enterContext(mock.patch.object(planegit, "_git", fake))
+        self.enterContext(mock.patch.object(commands_workspace, "_git", fake))
+        self.pushbg()
+        self.assertEqual((planegit.push_record() or {}).get("outcome"), planegit.BRANCHED)
+
+
+class TestOnePullRequestNotOnePerMemory(PlaneCase):
+    """F3. Before #373 the reactive path pushed nothing, so #167's one-branch-per-rejection
+    shape cost a handful of branches from a human typing `charter save`. Routing `persona
+    remember`, `workspace remember`, dispatch backfill, curate and autosave through it makes
+    it one abandoned remote branch PER MEMORY — measured at four branches for four memories
+    against a real bare remote — each superseding the last, none referenced by anything
+    charter will ever say again.
+
+    Each new HEAD is a descendant of the one before, so advancing the recorded branch is a
+    plain fast-forward. Nothing here uses `--force`: git's own refusal is the safety
+    property, and a push that cannot fast-forward falls back to a fresh `charter/<sha>`.
+    """
+
+    def branch_pushes(self, seen) -> list[str]:
+        return [a[-1].split("refs/heads/", 1)[1] for a in seen
+                if "push" in a and a[-1].startswith("HEAD:refs/heads/charter/")]
+
+    def test_a_second_memory_advances_the_same_branch(self):
+        seen = self.fake_git(protected=True)
+        self.pushbg()
+        first = (planegit.push_record() or {}).get("landed")
+        (self.root / "second").write_text("y\n")
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "-qm", "memory: second")
+        self.pushbg()
+        self.assertEqual((planegit.push_record() or {}).get("landed"), first)
+        self.assertEqual(sorted(set(self.branch_pushes(seen))), [first])
+
+    def test_a_branch_that_cannot_fast_forward_falls_back_to_a_fresh_name(self):
+        """git refuses a non-fast-forward push and charter mints a new name rather than
+        forcing. Asserted as an OUTCOME, so nothing here depends on `--force` being absent
+        by inspection."""
+        real = planegit._git
+        planegit.record_push(
+            planegit.PushResult(planegit.BRANCHED, "main", landed="charter/stale00"),
+            head=git(self.root, "rev-parse", "HEAD").stdout.strip())
+
+        def fake(args, cwd=None, **kw):
+            if "push" in args:
+                if args[-1].endswith(":main"):
+                    return subprocess.CompletedProcess(args, 1, "", _GH006)
+                if args[-1].endswith("charter/stale00"):
+                    return subprocess.CompletedProcess(
+                        args, 1, "", "! [rejected] (non-fast-forward)")
+                return subprocess.CompletedProcess(args, 0, "", "")
+            return real(args, cwd=cwd, **kw)
+
+        self.enterContext(mock.patch.object(planegit, "_git", fake))
+        self.enterContext(mock.patch.object(commands_workspace, "_git", fake))
+        self.pushbg()
+        rec = planegit.push_record() or {}
+        self.assertEqual(rec.get("outcome"), planegit.BRANCHED)
+        self.assertNotEqual(rec.get("landed"), "charter/stale00")
+        self.assertTrue(str(rec.get("landed")).startswith("charter/"), rec)
+
+    def test_a_stranded_record_is_never_reused_as_a_branch(self):
+        """Only `branched` names a branch that exists on the remote. `stranded` means the
+        push of that branch FAILED, so reusing the name would advance nothing and would
+        put a name charter never landed into the next record."""
+        seen = self.fake_git(protected=True)
+        planegit.record_push(
+            planegit.PushResult(planegit.STRANDED, "main", landed="charter/neverwas"),
+            head=git(self.root, "rev-parse", "HEAD").stdout.strip())
+        self.pushbg()
+        self.assertNotIn("charter/neverwas", self.branch_pushes(seen))
+
+
+class TestAMergedPullRequestStartsANewBranch(DoctorCase):
+    """The other half of F3's safety: `planegit.is_spent` is what stops a merged pull
+    request's branch being pushed to again, and it is the SAME predicate `doctor` uses to
+    stop warning. Two answers to "is this record still live" is how a branch gets
+    resurrected on one surface while the other has moved on."""
+
+    def test_a_spent_record_stops_naming_a_branch_to_reuse(self):
+        head = self.commit_locally()
+        planegit.record_push(
+            planegit.PushResult(planegit.BRANCHED, "main", landed="charter/merged1"),
+            head=head)
+        self.assertEqual(planegit._open_pull_request_branch(self.root), "charter/merged1")
+        git(self.root, "push", "-q", "origin", "main")      # the pull request merges
+        self.assertIsNone(planegit._open_pull_request_branch(self.root))
+
+    def test_doctor_and_the_pusher_agree_about_spent(self):
+        head = self.commit_locally()
+        planegit.record_push(
+            planegit.PushResult(planegit.BRANCHED, "main", landed="charter/merged2"),
+            head=head)
+        self.assertIn("charter/merged2", doctor.check_plane_root().hint)
+        git(self.root, "push", "-q", "origin", "main")
+        self.assertNotIn("charter/merged2", doctor.check_plane_root().hint)
+        self.assertIsNone(planegit._open_pull_request_branch(self.root))
+
+
+class TestTheStatusLineSaysItOnTheNearSideOfTheHazard(DoctorCase):
+    """F4. `doctor` runs at SessionStart; the hazard it names happens mid-session, in the
+    SAME session that stranded the commit — an agent notices `main` is ahead for reasons it
+    did not intend and reaches for `git reset --hard origin/main`. That agent never saw the
+    SessionStart row. The status line renders every turn."""
+
+    def alert(self) -> str:
+        from charter import statusline
+        return _plain(statusline._plane_root_alert() or "")
+
+    def test_a_clean_plane_says_nothing(self):
+        """A count of zero on every turn is furniture, which is the one thing this element
+        must not become."""
+        self.assertNotIn("memory", self.alert())
+
+    def test_a_commit_that_reached_nowhere_is_named_every_turn(self):
+        head = self.commit_locally()
+        planegit.record_push(planegit.PushResult(planegit.FAILED, "main"), head=head)
+        self.assertIn("memory commit not pushed", self.alert())
+
+    def test_a_commit_waiting_on_a_pull_request_reads_differently(self):
+        """Opposite remedies: nothing is at risk, something is unfinished. A reader told
+        the wrong one acts on it."""
+        head = self.commit_locally()
+        planegit.record_push(
+            planegit.PushResult(planegit.BRANCHED, "main", landed="charter/abc1234"),
+            head=head)
+        said = self.alert()
+        self.assertIn("memory awaiting a pull request", said)
+        self.assertNotIn("not pushed", said)
+
+    def test_it_clears_itself_on_the_same_evidence_doctor_uses(self):
+        head = self.commit_locally()
+        planegit.record_push(planegit.PushResult(planegit.FAILED, "main"), head=head)
+        self.assertIn("memory", self.alert())
+        git(self.root, "push", "-q", "origin", "main")
+        self.assertNotIn("memory", self.alert())
+
+
+def _plain(s: str) -> str:
+    return re.sub(r"\033\[[0-9;]*m", "", s)
 
 
 if __name__ == "__main__":

--- a/tests/test_reactive_push_is_not_silent.py
+++ b/tests/test_reactive_push_is_not_silent.py
@@ -1,0 +1,335 @@
+"""A reactive memory push that cannot land must say so somewhere (#373).
+
+`charter persona remember` on a plane whose `share` is `push` writes the file, commits it
+to the plane root's checked-out branch, prints *"→ pushing to the control plane in the
+background"* and exits 0. The push itself happens in a DETACHED `charter workspace _pushbg`
+with stdout and stderr on ``/dev/null``. When the plane's default branch is protected — as
+charter's own is, by a ruleset with a required status check — that push is rejected and the
+commit is left sitting on local `main`, unpushed, with nothing anywhere saying so.
+
+Three subagents stranded eleven commits that way in one session and all three reported
+"memory recorded". Such a commit then survives only until somebody runs the standard move
+for a diverged branch, `git reset --hard origin/main` — which is exactly what an agent
+reaches for on noticing `main` is ahead for reasons it did not intend.
+
+**The policy already existed and this path never reached it.** #167 decided what charter
+does when the plane's default branch requires a pull request: `planegit._land_via_branch`
+pushes the commit that is already on HEAD to `charter/<sha>` and hands back a compare URL,
+without ever moving the root's HEAD (ADR 0008, and #157's guard). `test_save_pr_gated.py`
+holds that for `charter save`. The reactive path missed it because
+`commands_workspace.cmd_workspace_pushbg` was a SECOND implementation of the push — no
+protected-branch recognition and ``return 0`` on every failure — which is the same
+structural fault `planegit`'s own module docstring says the module was extracted to end,
+one layer down: there were two committers, and then there were two pushers.
+
+    charter save            → rejected → _land_via_branch → PR URL printed
+    persona remember (bg)   → rejected → return 0
+
+So there are two halves to this, failing in opposite directions:
+
+* the background push must reach the same policy (the first two classes below), and
+* its outcome must survive a process that had nobody listening — recorded, and reported by
+  `doctor`, which is the surface ADR 0008 already chose for the plane root (last class).
+
+Deliberately NOT "skip the commit when the branch is protected". charter cannot know a
+branch is protected without asking the remote; `doctor` runs from SessionStart and must not
+reach the network; and ADR 0009 forbids naming a cause charter only inferred. The rejection
+IS the evidence, and it arrives after the commit already exists.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from charter import commands_workspace, config, doctor, planegit
+from tests._isolation import PersonaIso
+
+#: Pinned rather than inherited, for the reason `test_doctor_plane_root_behind` records:
+#: `init.defaultBranch` decides what these fixtures even are, and a machine that sets it and
+#: a CI runner that does not disagree about it. Signing is pinned off so nothing stops to
+#: ask a passphrase of a suite with nobody there to answer.
+_PINS = ["-c", "init.defaultBranch=main", "-c", "commit.gpgsign=false",
+         "-c", "tag.gpgsign=false"]
+
+#: GitHub's protected-branch refusal. Kept character-for-character in step with
+#: `test_save_pr_gated.py`'s fixture, and deliberately WITHOUT the `! [remote rejected]`
+#: line real git also prints: that phrase makes `push_head` take its non-fast-forward
+#: rebase-retry first, and a fake that intercepts only `push` would then run a REAL
+#: `git rebase FETCH_HEAD` against a FETCH_HEAD this fixture never creates. The retry is
+#: harmless in life (the rebase is a no-op and the second push is refused identically) and
+#: pure noise here, so the fixture stays on the shorter form the sibling test established.
+_GH006 = ("remote: error: GH006: Protected branch update failed for refs/heads/main.\n"
+          "remote: error: Required status check \"ci\" is expected.")
+
+
+def git(where, *args):
+    return subprocess.run(["git", *_PINS, "-C", str(where), *args], check=True,
+                          capture_output=True, text=True)
+
+
+class PlaneCase(PersonaIso):
+    """A plane root that is a real git repo with an origin charter recognises."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        # Re-derive rather than hand-setting HAS_CONTROL_PLANE: `config.derive` reads the
+        # marker file, which only exists as of the line above. `PersonaIso` restores the
+        # real values from the snapshot it took first, so this needs no cleanup of its own.
+        config.use(self.tmp)
+        self.root = Path(config.ROOT)
+        subprocess.run(["git", *_PINS, "init", "-q", "-b", "main", str(self.root)],
+                       check=True, capture_output=True)
+        git(self.root, "config", "user.email", "t@e")
+        git(self.root, "config", "user.name", "t")
+        (self.root / "seed").write_text("x\n")
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "-qm", "seed")
+        # Without an origin on a KNOWN forge, the pusher returns before ever pushing and
+        # every assertion below would pass vacuously.
+        git(self.root, "remote", "add", "origin", "https://github.com/acme/plane.git")
+
+    def head_branch(self) -> str:
+        return git(self.root, "symbolic-ref", "--short", "HEAD").stdout.strip()
+
+    def fake_git(self, *, protected: bool, branch_push_ok: bool = True,
+                 failure: str | None = None):
+        """Swap git out for one that answers pushes the way a protected remote does.
+
+        BOTH module-level `_git` bindings are replaced. `commands_workspace` does
+        ``from .commands import _git`` at import time, so patching `planegit._git` alone
+        would leave the pre-fix background pusher running real git against a remote that
+        does not exist — and a test that cannot reach the code it is about is not a test.
+        """
+        real = planegit._git
+        seen: list[list[str]] = []
+
+        def fake(args, cwd=None, **kw):
+            seen.append(list(args))
+            # `push` is not args[0]: the credential flag is prefixed, so the invocation is
+            # `-c credential.helper=… push <url> <refspec>`.
+            if "push" in args:
+                if failure is not None:
+                    return subprocess.CompletedProcess(args, 1, "", failure)
+                if protected and args[-1].endswith(":main"):
+                    return subprocess.CompletedProcess(args, 1, "", _GH006)
+                if not branch_push_ok:
+                    return subprocess.CompletedProcess(args, 1, "", "remote: boom")
+                return subprocess.CompletedProcess(args, 0, "", "")
+            return real(args, cwd=cwd, **kw)
+
+        self.enterContext(mock.patch.object(planegit, "_git", fake))
+        self.enterContext(mock.patch.object(commands_workspace, "_git", fake))
+        return seen
+
+    def pushbg(self):
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = commands_workspace.cmd_workspace_pushbg(None)
+        return rc, out.getvalue() + err.getvalue()
+
+
+class TestTheBackgroundPushObeysTheProtectedBranchPolicy(PlaneCase):
+    def test_it_pushes_the_pull_request_branch_the_way_charter_save_does(self):
+        """#167's policy, on the path SessionStart actually tells an agent to use."""
+        seen = self.fake_git(protected=True)
+        self.pushbg()
+        pushed = [a for a in seen if "push" in a]
+        self.assertTrue(any(p[-1].startswith("HEAD:refs/heads/charter/") for p in pushed),
+                        pushed)
+
+    def test_the_plane_roots_HEAD_never_moves(self):
+        """#157's invariant. The background path has to coexist with the guard, not poke a
+        hole in it — `push HEAD:refs/heads/<new>` needs no checkout and no worktree."""
+        self.fake_git(protected=True)
+        before = self.head_branch()
+        self.pushbg()
+        self.assertEqual(self.head_branch(), before)
+
+    def test_no_checkout_switch_or_branch_is_ever_run_in_the_root(self):
+        seen = self.fake_git(protected=True)
+        self.pushbg()
+        for args in seen:
+            for verb in ("checkout", "switch", "worktree", "branch"):
+                self.assertNotIn(verb, args, args)
+
+    def test_it_records_where_the_commit_actually_landed(self):
+        """A detached child with ``/dev/null`` for a voice has no caller to tell, so the
+        outcome is written down instead of discarded. This is the whole of #373: the commit
+        was fine, and nobody could find out where it went."""
+        self.fake_git(protected=True)
+        self.pushbg()
+        rec = planegit.push_record()
+        self.assertIsNotNone(rec)
+        self.assertEqual(rec["outcome"], planegit.BRANCHED)
+        self.assertTrue(str(rec.get("landed", "")).startswith("charter/"), rec)
+        self.assertIn("github.com/acme/plane/compare/charter/", rec.get("url") or "")
+
+    def test_a_push_that_lands_leaves_no_notice_behind(self):
+        """Otherwise the record outlives the condition and `doctor` warns for ever about a
+        commit that reached the remote an hour ago."""
+        self.fake_git(protected=False)
+        planegit.record_push(planegit.PushResult(planegit.FAILED, "main"), head="deadbeef")
+        self.pushbg()
+        self.assertIsNone(planegit.push_record())
+
+    def test_an_ordinary_failure_is_recorded_and_never_rerouted(self):
+        """ADR 0009: charter may name a cause it RECOGNISED. An auth failure is not a
+        protected branch, and quietly pushing a side branch for one would be inventing a
+        diagnosis — and acting surprisingly on the back of it."""
+        seen = self.fake_git(protected=False, failure="fatal: Authentication failed")
+        self.pushbg()
+        self.assertFalse(any(a[-1].startswith("HEAD:refs/heads/charter/")
+                             for a in seen if "push" in a))
+        self.assertEqual((planegit.push_record() or {}).get("outcome"), planegit.FAILED)
+
+    def test_a_pull_request_branch_that_also_fails_is_recorded_as_stranded(self):
+        """The commit now exists nowhere but this laptop. Recording that as anything softer
+        is the green tick over a push that never happened which `commit_push`'s own
+        docstring already records twice."""
+        self.fake_git(protected=True, branch_push_ok=False)
+        self.pushbg()
+        self.assertEqual((planegit.push_record() or {}).get("outcome"), planegit.STRANDED)
+
+    def test_the_background_push_still_never_breaks_the_turn(self):
+        """It is spawned from a Stop hook. rc 0 regardless is the contract; what changes is
+        that rc 0 is no longer the only thing it leaves behind."""
+        self.fake_git(protected=True, branch_push_ok=False)
+        rc, _ = self.pushbg()
+        self.assertEqual(rc, 0)
+
+    def test_the_background_push_says_nothing_on_stdout_or_stderr(self):
+        """Its streams are ``/dev/null``; anything printed is written to be discarded. The
+        record is the channel, and keeping the announcement off this path is what makes
+        that non-negotiable rather than merely preferred."""
+        self.fake_git(protected=True)
+        _, blob = self.pushbg()
+        self.assertEqual(blob.strip(), "")
+
+
+class TestThereIsOnlyOnePusher(PlaneCase):
+    """The defect was a second implementation, so the fix is asserted as one implementation.
+
+    Both callers reaching `planegit.push_head` is what makes the protected-branch policy
+    true on both paths by construction, rather than by two lists of forge signatures that
+    somebody has to keep in step.
+    """
+
+    def test_the_background_half_goes_through_the_shared_pusher(self):
+        with mock.patch.object(planegit, "push_head") as m:
+            m.return_value = planegit.PushResult(planegit.PUSHED, "main")
+            commands_workspace.cmd_workspace_pushbg(None)
+        self.assertTrue(m.called)
+        self.assertEqual(Path(m.call_args[0][0]), Path(config.ROOT))
+
+    def test_charter_save_goes_through_the_same_one(self):
+        (self.root / "personas").mkdir(exist_ok=True)
+        (self.root / "personas" / "n.md").write_text("x\n")
+        with mock.patch.object(planegit, "push_head") as m:
+            m.return_value = planegit.PushResult(planegit.PUSHED, "main")
+            out, err = io.StringIO(), io.StringIO()
+            with redirect_stdout(out), redirect_stderr(err):
+                planegit.commit_push(self.root, ["add", "-A"], "m")
+        self.assertTrue(m.called)
+
+
+class DoctorCase(PlaneCase):
+    """The plane root with a REAL upstream, so `@{upstream}` resolves as it does live."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        git(self.root, "remote", "remove", "origin")
+        self.bare = self.tmp.parent / f"{self.tmp.name}-remote.git"
+        subprocess.run(["git", *_PINS, "init", "-q", "-b", "main", "--bare", str(self.bare)],
+                       check=True, capture_output=True)
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.bare, ignore_errors=True))
+        git(self.root, "remote", "add", "origin", str(self.bare))
+        git(self.root, "push", "-q", "-u", "origin", "main")
+
+    def commit_locally(self, name="memory.md") -> str:
+        (self.root / name).write_text("a fact\n")
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "-qm", f"memory: {name}")
+        return git(self.root, "rev-parse", "HEAD").stdout.strip()
+
+
+class TestDoctorSaysTheCommitDidNotLand(DoctorCase):
+    def test_a_branched_push_warns_and_hands_over_the_pull_request_url(self):
+        head = self.commit_locally()
+        planegit.record_push(
+            planegit.PushResult(planegit.BRANCHED, "main", landed="charter/abc1234",
+                                url="https://github.com/acme/plane/compare/charter/abc1234?expand=1"),
+            head=head)
+        r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("charter/abc1234", r.detail + r.hint)
+        self.assertIn("compare/charter/abc1234", r.hint)
+
+    def test_a_failed_push_names_the_hazard_that_destroys_the_commit(self):
+        """`git reset --hard origin/main` is the standard move after a divergence and it
+        deletes the memory without a trace. A reader who is not told that will run it."""
+        head = self.commit_locally()
+        planegit.record_push(planegit.PushResult(planegit.FAILED, "main"), head=head)
+        r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("reset --hard", r.hint)
+
+    def test_a_record_whose_commit_reached_the_remote_is_spent(self):
+        """Self-clearing on EVIDENCE rather than on a deletion somebody has to remember:
+        once the recorded commit is an ancestor of the tracked remote ref, the condition is
+        over whatever the file still says."""
+        head = self.commit_locally()
+        git(self.root, "push", "-q", "origin", "main")
+        planegit.record_push(planegit.PushResult(planegit.FAILED, "main"), head=head)
+        r = doctor.check_plane_root()
+        self.assertNotIn("reset --hard", r.hint)
+
+    def test_an_unreachable_origin_is_not_reported_as_a_stranded_commit(self):
+        """A plane with no origin on a forge charter knows has a CONFIGURATION to fix, not
+        a commit to rescue — and `commit_push` already says so at the time. Warning here
+        too would put the row permanently yellow, the exact cost this check refuses to pay
+        for untracked memory files."""
+        head = self.commit_locally()
+        planegit.record_push(planegit.PushResult(planegit.UNREACHABLE, "main"), head=head)
+        self.assertNotIn("reset --hard", doctor.check_plane_root().hint)
+
+    def test_unpushed_commits_are_counted_in_the_detail(self):
+        """`clean on main` is a statement about the working TREE that reads as one about
+        the plane — the complaint `test_doctor_plane_root_behind` records, in the other
+        direction. Three commits sat between a tag and `main` while `git log <tag>..main`
+        came back empty and the honest-looking reading was 'nothing to release'."""
+        self.commit_locally()
+        self.assertIn("1 ahead of", doctor.check_plane_root().detail)
+
+    def test_a_root_in_step_with_its_upstream_says_nothing_extra(self):
+        """A count of zero on every clean preflight would be furniture."""
+        r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertNotIn("ahead of", r.detail)
+
+    def test_a_malformed_record_is_not_a_crash(self):
+        """`check_plane_root` runs from SessionStart, where a hook may cost a session its
+        briefing and must never cost it the turn."""
+        self.commit_locally()
+        p = config.STATE_DIR / "plane-push.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{ not json")
+        self.assertIsInstance(doctor.check_plane_root(), doctor.Result)
+
+    def test_the_record_is_written_under_the_ACTIVE_state_dir(self):
+        """Read from `config` at CALL time. A path bound at import writes into the
+        developer's real `.charter/` and the isolation harness never sees it."""
+        planegit.record_push(planegit.PushResult(planegit.FAILED, "main"), head="abc")
+        written = config.STATE_DIR / "plane-push.json"
+        self.assertTrue(written.exists())
+        self.assertEqual(json.loads(written.read_text())["outcome"], planegit.FAILED)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #373.

Implemented, adversarially reviewed, and re-verified after a findings round — in an ultracode workflow. Each reviewer reproduced the original symptom against the branch point, showed it gone, and mutation-tested every new test to confirm it can actually fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9