### PR TITLE
an approval records what earned it (#375)

### DIFF
--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -206,6 +206,15 @@ def _ask_mark_take(sid, tuid) -> str | None:
     call of every tool a nudge can be raised on, and a directory scan there grows with the
     number of markers in the sessions dir, while a fixed pair of `stat()`s on a path that
     is almost always absent does not.
+
+    **It answers with ONE kind, and that is only correct while one `tool_use_id` can carry
+    at most one pending ask.** Two markers on the same id would resolve to whichever kind
+    stands first in :data:`_ASK_KINDS` and leave the other to age out under `_prune` —
+    counted as an ask, never as an approval, which is the reading that deleted a guard in
+    #371. Nothing here enforces that; the matchers in ``hooks/hooks.json`` do, by giving
+    the two nudges disjoint tool families (``Task|Agent`` and ``Write|Edit|MultiEdit``), and
+    `test_ask_approval_names_its_nudge.py` holds them to it — so a third nudge sharing a
+    family with an existing one fails a test rather than silently losing a count.
     """
     for kind in _ASK_KINDS:
         f = _ask_mark(sid, tuid, kind)

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -113,11 +113,27 @@ def _unattended(data: dict) -> bool:
     return (data or {}).get("permission_mode") == UNATTENDED_MODE
 
 
-def _ask(event: str, reason: str, data: dict | None = None) -> bool:
+#: Every nudge charter can raise, named by the ask event its site records — and therefore
+#: by the approval event that nudge earns (``<kind>-approved``). This is the list
+#: :func:`_ask_mark_take` looks in, so a nudge missing from it leaves a marker nothing ever
+#: takes: its asks are counted, its approvals never are, and the ratio reads as "nobody
+#: ever approves this" — which is the shape of the conclusion #371 acted on, reached
+#: falsely. Nothing in the type system can hold that, so
+#: `test_ask_approval_names_its_nudge.py` ties this tuple to the actual `_ask` call sites.
+_ASK_KINDS = ("routing-ask", "dispatch-ask")
+
+
+def _ask(event: str, reason: str, kind: str, data: dict | None = None) -> bool:
     """Surface a nudge and let the developer decide (not a hard block).
 
+    *kind* is the ask event this call site records — one of :data:`_ASK_KINDS`. It is what
+    makes the approval attributable: the marker is named with it, so :func:`_ask_approved`
+    can record ``<kind>-approved`` without `PostToolUse` — which knows a tool family and
+    never which guard asked — having to be told anything. Required rather than defaulted,
+    so a third nudge cannot arrive uncountable by omission (#375).
+
     Pass ``data`` (the hook payload) to make the outcome countable: it leaves a marker
-    keyed by this call's ``tool_use_id``, which :func:`posttooluse_bash` clears if the tool
+    keyed by this call's ``tool_use_id``, which :func:`_ask_approved` clears if the tool
     actually runs. Without it an ask is unmeasurable — which is how 231 clone-commit
     prompts accumulated with no evidence for or against keeping the guard (#290).
 
@@ -140,7 +156,7 @@ def _ask(event: str, reason: str, data: dict | None = None) -> bool:
         _trace("ask-unattended", data.get("session_id"), reason=reason[:70])
         return False
     if data is not None:
-        _ask_mark_set(data.get("session_id"), data.get("tool_use_id"))
+        _ask_mark_set(data.get("session_id"), data.get("tool_use_id"), kind)
     _emit({"hookSpecificOutput": {
         "hookEventName": event,
         "permissionDecision": "ask",
@@ -149,17 +165,29 @@ def _ask(event: str, reason: str, data: dict | None = None) -> bool:
     return True
 
 
-def _ask_mark(sid, tuid):
+def _ask_mark(sid, tuid, kind):
     """One file per PENDING ask. Same shape as `_route_mark` — a marker in the sessions
-    dir, named by ids only. No prompt text, no command, nothing but the correlation key."""
-    if not sid or not tuid:
+    dir, named by ids only. No prompt text, no command, nothing but the correlation key
+    and which nudge raised it.
+
+    **The kind is in the NAME, and the file stays empty** (#375). It has to travel somehow:
+    a `PostToolUse` payload says which tool family ran and never which guard asked, so
+    before this every approval landed in one undifferentiated `ask-approved` and "is THIS
+    nudge earning its interruptions" — the only form the question is ever asked in — had no
+    answer. The name keeps the property this marker was designed for, where contents would
+    not: a kind is a fixed string chosen in code (:data:`_ASK_KINDS`), never a value out of
+    the payload, so nothing about the work can reach the filesystem through it. It also
+    keeps creation atomic — the `touch` IS the record, with no second write to be torn
+    across — and keeps the read side a `stat()`.
+    """
+    if not sid or not tuid or not kind:
         return None
     safe = lambda v: re.sub(r"[^A-Za-z0-9._-]", "", str(v))  # noqa: E731 — becomes a filename
-    return config.SESSIONS_DIR / f"{safe(sid)}.{safe(tuid)}.ask-pending"
+    return config.SESSIONS_DIR / f"{safe(sid)}.{safe(tuid)}.{safe(kind)}.ask-pending"
 
 
-def _ask_mark_set(sid, tuid) -> None:
-    f = _ask_mark(sid, tuid)
+def _ask_mark_set(sid, tuid, kind) -> None:
+    f = _ask_mark(sid, tuid, kind)
     if f is None:
         return
     try:
@@ -169,17 +197,26 @@ def _ask_mark_set(sid, tuid) -> None:
         pass
 
 
-def _ask_mark_take(sid, tuid) -> bool:
-    """True exactly once per pending ask — the unlink IS the idempotency, so a replayed
-    PostToolUse cannot inflate the approval count."""
-    f = _ask_mark(sid, tuid)
-    if f is None or not f.exists():
-        return False
-    try:
-        f.unlink()
-        return True
-    except OSError:
-        return False
+def _ask_mark_take(sid, tuid) -> str | None:
+    """The kind of the pending ask, exactly once — the unlink IS the idempotency, so a
+    replayed PostToolUse cannot inflate the approval count. ``None`` when none is pending.
+
+    One `stat()` per registered nudge (two today) rather than one overall, because the
+    caller knows the ids and not the kind. Deliberately not a `glob`: this runs on every
+    call of every tool a nudge can be raised on, and a directory scan there grows with the
+    number of markers in the sessions dir, while a fixed pair of `stat()`s on a path that
+    is almost always absent does not.
+    """
+    for kind in _ASK_KINDS:
+        f = _ask_mark(sid, tuid, kind)
+        if f is None or not f.exists():
+            continue
+        try:
+            f.unlink()
+            return kind
+        except OSError:
+            return None
+    return None
 
 
 def _ask_approved(data: dict) -> None:
@@ -196,18 +233,30 @@ def _ask_approved(data: dict) -> None:
     and the two nudges that remain raise on ``Task|Agent`` and on ``Write|Edit|MultiEdit``
     — so every approval either of them ever received was already uncountable, and the
     deletion would have pinned the numerator at zero for good. Two code paths answering
-    "was this nudge approved?" is how that stayed invisible; there is now one.
+    "was this nudge approved?" is how that stayed invisible; there is now one. The kind
+    travels in the marker's NAME for that same reason: a per-family approval event would
+    put the question back into three places, one per handler.
 
-    **Kept to a stat() on the common path.** Every caller is registered against every call
-    of its tool, so the overwhelming majority of invocations must find no marker and return
-    having written nothing — no trace line, no read of the trace, no import beyond what is
-    already loaded.
+    **Recorded as ``<kind>-approved``, never as a bare ``ask-approved``** (#375). The ask
+    half already names its guard — `routing-ask` and `dispatch-ask` are separate events on
+    purpose, so a judgement about one is never made from rows belonging to another — and an
+    approval counter shared between them gives back exactly what that separation bought.
+    Pairing by NAME rather than by a field is what makes it readable: `charter trace
+    --summary` aggregates event names and nothing else, so `routing-ask=5,
+    routing-ask-approved=3` is a ratio on the line that already exists, where a `reason`
+    field would not appear in the summary at all.
+
+    **Kept to a stat() on the common path** — now one per registered nudge. Every caller is
+    registered against every call of its tool, so the overwhelming majority of invocations
+    must find no marker and return having written nothing: no trace line, no read of the
+    trace, no read of any marker, no import beyond what is already loaded.
     """
     try:
         sid, tuid = data.get("session_id"), data.get("tool_use_id")
-        if not _ask_mark_take(sid, tuid):
+        kind = _ask_mark_take(sid, tuid)
+        if kind is None:
             return
-        _trace("ask-approved", sid)
+        _trace(f"{kind}-approved", sid)
     except Exception:
         return  # bookkeeping must never break a turn
 
@@ -2195,11 +2244,14 @@ def pretooluse_dispatch() -> int:
                 f"`{agent}` writes code and {peers} "
                 f"{'is' if len(others) == 1 else 'are'} already running. They share one "
                 f"working tree, so parallel edits interleave silently. Dispatch this one "
-                f"with `isolation: worktree`, or let the other finish first.", data):
+                f"with `isolation: worktree`, or let the other finish first.",
+                "dispatch-ask", data):
             # The ask half of the tally. Passing `data` above already leaves the marker
-            # `posttooluse_bash` turns into an `ask-approved`, so without this row those
-            # approvals counted against a denominator nothing ever incremented — the exact
-            # shape #290 was filed to remove, left behind at the third of three sites.
+            # `_ask_approved` turns into a `dispatch-ask-approved` — named for this nudge
+            # since #375, so the ratio is this guard's and not a pool shared with the
+            # routing one — so without this row those approvals counted against a
+            # denominator nothing ever incremented, the exact shape #290 was filed to
+            # remove, left behind at the third of three sites.
             #
             # Its own event name, not `ask`: every historical `ask` row means the
             # clone-commit guard, and folding this in would corrupt the series a judgement
@@ -2608,7 +2660,8 @@ def pretooluse_edit() -> int:
     if _ask("PreToolUse",
             f"the roster was shown this turn and nothing was dispatched — you are editing "
             f"as the acting persona. Available: {who}. charter is not saying this is "
-            f"theirs; approve to carry on, or dispatch instead. (`routing: require`)", data):
+            f"theirs; approve to carry on, or dispatch instead. (`routing: require`)",
+            "routing-ask", data):
         _trace("routing-ask", data.get("session_id"))
     return 0
 

--- a/docs/news/unreleased-an-approval-names-its-nudge.md
+++ b/docs/news/unreleased-an-approval-names-its-nudge.md
@@ -1,0 +1,33 @@
+---
+version: unreleased
+headline: An approval names the nudge that earned it
+---
+
+`charter trace --summary` can now tell you which guard an approval belongs to. It could not
+before: charter raises two nudges — `routing-ask`, when a `routing: require` persona edits
+after the roster fired, and `dispatch-ask`, when a code-writing peer is already in flight —
+and every approval of either landed in one shared `ask-approved` row.
+
+That made the only question ever asked of a nudge unanswerable. #371 deleted the
+clone-commit guard on the strength of *its own* 471 asks and 97-of-98 approvals; a counter
+shared between two guards cannot produce that number for either of them. An approval is now
+recorded as `<kind>-approved`, so the pair reads as a ratio on the line that already exists:
+
+```
+by event: routing-ask=5, routing-ask-approved=3, dispatch-ask=2, dispatch-ask-approved=2
+```
+
+**Named rather than given a `reason` field**, because `--summary` aggregates event names and
+nothing else — a field would have satisfied the description of the problem and never reached
+the place the question is asked. The kind travels in the pending marker's filename, which
+keeps the property that marker was designed for: a kind is a fixed string chosen in code, so
+nothing about your work reaches the filesystem through it, and the read side stays a
+`stat()` on the hot path.
+
+**Rows already in your store keep their old name.** `ask-approved` is frozen at whatever it
+reached and the two new counters start at zero, so for a while `--summary` will show a long
+`routing-ask` count beside a short `routing-ask-approved` one. That gap is the changeover,
+not a nudge nobody approves — which is worth saying, since misreading a ratio in exactly
+that direction is what this entry exists to prevent. Old rows stay `ask-approved` rather
+than being rewritten: a trace store is a record of what charter observed, and the approvals
+in it genuinely were not attributable when they were written.

--- a/tests/test_ask_approval_names_its_nudge.py
+++ b/tests/test_ask_approval_names_its_nudge.py
@@ -1,0 +1,214 @@
+"""An approval names the nudge that earned it (#375).
+
+`ask-approved` carried a session id and nothing else. Charter raises two nudges today —
+`routing-ask` (`pretooluse_edit`, on `Write|Edit|MultiEdit`) and `dispatch-ask`
+(`pretooluse_dispatch`, on `Task|Agent`) — and every approval of either landed in that one
+undifferentiated counter. So "asked N, approved M" was answerable in aggregate and not per
+guard, which is the only form the question has ever been asked in: #371 deleted the
+clone-commit nudge on the strength of *its own* 471/97, and a mixed counter cannot produce
+that number for any of the nudges that are left.
+
+**Why the name and not a field.** The ask half already names its guard — `routing-ask` and
+`dispatch-ask` are separate events on purpose, so that a judgement about one is never made
+from rows belonging to another. The approval half now follows the same convention:
+`<kind>-approved`. That makes `charter trace --summary`'s existing `by event` line answer
+the question with no change to the reader at all — `routing-ask=5, routing-ask-approved=3`
+reads as a ratio — where a field would have needed the reader taught to group by it.
+
+**Why the marker filename carries the kind.** `_ask_mark`'s contents are deliberately
+empty, and there is no other channel between the two halves: `PostToolUse` knows a tool
+family, never which guard asked. A kind is a fixed name chosen in code, not a value from
+the payload — no prompt text, no command, nothing about the work — which is exactly what
+makes it safe to put in a NAME that is already read. The approval half therefore stays one
+code path (`_ask_approved`) rather than one per PostToolUse family, which is the property
+#371 showed matters: when two code paths answered "was this nudge approved?", one of them
+was wrong for months without anybody being able to see it.
+
+The structural half below is the part that keeps this true. A nudge whose kind is not in
+`_ASK_KINDS` writes a marker nothing ever takes, so its approvals would be silently
+uncountable — the precise defect #290 was filed to remove, arriving by a new door.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import unittest
+from collections import Counter
+from unittest import mock
+
+from charter import config, hooks, trace
+from tests import test_dispatch_ask_is_counted as _sites
+from tests._isolation import PersonaIso, run_hook
+
+SESSION = "s-375"
+WORK = "refactor the release tagging flow, maybe something cleaner"
+
+
+def _decision(r):
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+
+
+class TwoNudgesInOnePlane(PersonaIso):
+    """Both surviving nudges, live in ONE session — the condition #375 names as the one
+    under which the aggregate counter is actually wrong. Each fixture asserts the nudge
+    really fired before anything is counted: both fire only under a specific arrangement
+    (a code-writing peer in flight; a roster shown and not followed), so a fixture that
+    stops reaching `_ask` must fail loudly rather than report zero approvals of zero asks.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "default"}))
+        self.make_persona("steward", routing="require",
+                          **{"delegate-when": "steward work", "vault": "none"})
+        self.make_persona("coder", **{"dispatch-isolation": "worktree",
+                                      "delegate-when": "code work", "vault": "none"})
+
+    # -- the overlapping-dispatch nudge: Task in, Task out --------------------- #
+    def _dispatch(self, tuid: str) -> tuple[dict, dict | None]:
+        payload = {"tool_name": "Task", "tool_input": {"subagent_type": "coder"},
+                   "session_id": SESSION, "tool_use_id": tuid}
+        return payload, run_hook(hooks.pretooluse_dispatch, payload)
+
+    def dispatch_nudge(self) -> dict:
+        self._dispatch("tu_first")                      # puts `coder` in flight
+        payload, r = self._dispatch("tu_overlap")
+        self.assertEqual("ask", _decision(r),
+                         "fixture never reached the dispatch nudge — the count proves nothing")
+        return payload
+
+    def approve_dispatch(self, payload: dict) -> None:
+        run_hook(hooks.posttooluse_dispatch, {**payload, "tool_response": ""})
+
+    # -- the routing nudge: roster shown, nothing dispatched, then an edit ------ #
+    def routing_nudge(self) -> dict:
+        payload = {"session_id": SESSION, "tool_name": "Edit", "tool_use_id": "tu_edit",
+                   "tool_input": {"file_path": "/tmp/x.py"}}
+        with mock.patch.dict(os.environ, {"CHARTER_PERSONA": "steward"}):
+            run_hook(hooks.userpromptsubmit, {"session_id": SESSION, "prompt": WORK})
+            r = run_hook(hooks.pretooluse_edit, payload)
+        self.assertEqual("ask", _decision(r),
+                         "fixture never reached the routing nudge — the count proves nothing")
+        return payload
+
+    def approve_edit(self, payload: dict) -> None:
+        run_hook(hooks.posttooluse, payload)
+
+    def asks(self) -> dict[str, int]:
+        """Every ask-shaped row this session recorded, counted — the `by event` line of
+        `charter trace --summary`, restricted to the family under test."""
+        c = Counter(e["event"] for e in trace.read(SESSION))
+        return {k: v for k, v in c.items() if "ask" in k}
+
+
+class TestAnApprovalNamesTheNudgeThatEarnedIt(TwoNudgesInOnePlane):
+    def test_the_dispatch_nudge_s_approval_is_named_for_it(self):
+        self.approve_dispatch(self.dispatch_nudge())
+        self.assertEqual({"dispatch-ask": 1, "dispatch-ask-approved": 1}, self.asks())
+
+    def test_the_routing_nudge_s_approval_is_named_for_it(self):
+        self.approve_edit(self.routing_nudge())
+        self.assertEqual({"routing-ask": 1, "routing-ask-approved": 1}, self.asks())
+
+    def test_two_nudges_in_one_session_are_told_apart(self):
+        """The whole issue: one approved, one not, and the record says WHICH.
+
+        Against the old aggregate row this reads `ask-approved=1` beside `routing-ask=1`
+        and `dispatch-ask=1` — a 50% approval rate that belongs to neither guard.
+        """
+        self.approve_edit(self.routing_nudge())   # approved: the tool ran
+        self.dispatch_nudge()                     # declined: no PostToolUse ever arrives
+        self.assertEqual({"routing-ask": 1, "routing-ask-approved": 1, "dispatch-ask": 1},
+                         self.asks())
+
+    def test_no_undifferentiated_approval_row_is_written(self):
+        """Stated separately from the counts above, because the failure it guards is a
+        SECOND row rather than a missing one: an approval recorded under both names would
+        satisfy every assertion here except this one, and would double every tally."""
+        self.approve_dispatch(self.dispatch_nudge())
+        self.assertEqual(0, self.asks().get("ask-approved", 0),
+                         "a bare `ask-approved` cannot be attributed to any guard (#375)")
+
+
+class TestTheMarkerIsWhatCarriesTheKind(TwoNudgesInOnePlane):
+    """The mechanism, asserted on its own so a failure is diagnosed where it happened."""
+
+    def test_the_pending_marker_names_the_nudge(self):
+        self.dispatch_nudge()
+        names = [p.name for p in config.SESSIONS_DIR.glob("*.ask-pending")]
+        self.assertEqual(1, len(names), f"expected one pending ask, got {names}")
+        self.assertIn("dispatch-ask", names[0])
+
+    def test_taking_it_reports_which_nudge_it_was(self):
+        hooks._ask_mark_set("s-mark", "tu_1", "routing-ask")
+        self.assertEqual("routing-ask", hooks._ask_mark_take("s-mark", "tu_1"))
+        self.assertIsNone(hooks._ask_mark_take("s-mark", "tu_1"),
+                          "the unlink IS the idempotency — a replay must report nothing")
+
+    def test_a_marker_of_one_kind_is_not_taken_as_another(self):
+        hooks._ask_mark_set("s-mark", "tu_1", "routing-ask")
+        self.assertTrue(hooks._ask_mark("s-mark", "tu_1", "routing-ask").exists())
+        self.assertFalse(hooks._ask_mark("s-mark", "tu_1", "dispatch-ask").exists())
+
+
+class TestANewNudgeCannotBecomeUncountable(unittest.TestCase):
+    """`_ASK_KINDS` is what `_ask_mark_take` looks for, and it is the one place a third
+    nudge can be forgotten. A kind that is not in it produces a marker nothing ever takes:
+    the ask is counted, the approval never is, and the ratio reads as "nobody ever approves
+    this" — which is the conclusion #371 acted on, arrived at falsely.
+
+    Reuses the AST scan `test_dispatch_ask_is_counted` already holds rather than growing a
+    second one, so both structural rules see exactly the same set of call sites.
+    """
+
+    SITES = _sites.TestEveryAskSiteRecordsAnAsk
+
+    @classmethod
+    def _sites_that_ask(cls) -> dict[str, ast.FunctionDef]:
+        found = cls.SITES._functions_that_ask()
+        assert found, "precondition: the scan found no `_ask` call site at all"
+        return found
+
+    @staticmethod
+    def _kinds_passed(fn: ast.FunctionDef) -> list[str | None]:
+        """The `kind` every `_ask(...)` call in *fn* passes — ``None`` for a non-literal,
+        which is itself a failure: a kind computed at runtime cannot be checked here."""
+        out: list[str | None] = []
+        for call in ast.walk(fn):
+            if not (isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+                    and call.func.id == "_ask"):
+                continue
+            kw = {k.arg: k.value for k in call.keywords}
+            node = kw.get("kind") or (call.args[2] if len(call.args) > 2 else None)
+            out.append(node.value if isinstance(node, ast.Constant) else None)
+        return out
+
+    def test_every_ask_site_passes_a_registered_kind(self):
+        for name, fn in sorted(self._sites_that_ask().items()):
+            with self.subTest(handler=name):
+                kinds = self._kinds_passed(fn)
+                self.assertTrue(kinds, f"{name} calls _ask without a kind")
+                for kind in kinds:
+                    self.assertIn(kind, hooks._ASK_KINDS,
+                                  f"{name} raises a nudge `_ask_mark_take` never looks "
+                                  f"for, so its approvals are uncountable")
+
+    def test_the_kind_is_the_event_the_site_records(self):
+        """`<kind>` and `<kind>-approved` have to pair by NAME in the summary — which they
+        only do if the kind is the same string the site traces for the ask itself."""
+        for name, fn in sorted(self._sites_that_ask().items()):
+            with self.subTest(handler=name):
+                self.assertEqual(set(self._kinds_passed(fn)),
+                                 set(self.SITES._ask_shaped_events(fn)),
+                                 f"{name}'s ask row and its approval row would not pair")
+
+    def test_the_registry_holds_nothing_no_site_raises(self):
+        """A stale kind costs a `stat()` on every tool call for a nudge that cannot fire,
+        and reads as a nudge that exists."""
+        used = {k for fn in self._sites_that_ask().values() for k in self._kinds_passed(fn)}
+        self.assertEqual(set(hooks._ASK_KINDS), used)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ask_approval_names_its_nudge.py
+++ b/tests/test_ask_approval_names_its_nudge.py
@@ -32,6 +32,7 @@ uncountable — the precise defect #290 was filed to remove, arriving by a new d
 from __future__ import annotations
 
 import ast
+import itertools
 import os
 import unittest
 from collections import Counter
@@ -40,6 +41,7 @@ from unittest import mock
 from charter import config, hooks, trace
 from tests import test_dispatch_ask_is_counted as _sites
 from tests._isolation import PersonaIso, run_hook
+from tests.test_plugin import _hooks_json as _manifest
 
 SESSION = "s-375"
 WORK = "refactor the release tagging flow, maybe something cleaner"
@@ -101,6 +103,19 @@ class TwoNudgesInOnePlane(PersonaIso):
         c = Counter(e["event"] for e in trace.read(SESSION))
         return {k: v for k, v in c.items() if "ask" in k}
 
+    def approvals(self) -> list[str]:
+        """Every approval row, found by SHAPE and read out of the WHOLE trace.
+
+        Deliberately not `asks()`: that filters on ``"ask" in k``, which is right for the
+        ratio line and wrong for "did charter invent an approval". An approval whose kind
+        went wrong need not contain "ask" at all — `None-approved` is what `_ask_approved`
+        writes if its ``if kind is None: return`` is dropped — so the filter that makes the
+        ratio readable is also a filter that hides the failure. Named kinds are asserted
+        against `asks()`; the existence of a row nobody can attribute is asserted here.
+        """
+        return sorted(e["event"] for e in trace.read(SESSION)
+                      if e["event"].endswith("-approved"))
+
 
 class TestAnApprovalNamesTheNudgeThatEarnedIt(TwoNudgesInOnePlane):
     def test_the_dispatch_nudge_s_approval_is_named_for_it(self):
@@ -122,13 +137,21 @@ class TestAnApprovalNamesTheNudgeThatEarnedIt(TwoNudgesInOnePlane):
         self.assertEqual({"routing-ask": 1, "routing-ask-approved": 1, "dispatch-ask": 1},
                          self.asks())
 
-    def test_no_undifferentiated_approval_row_is_written(self):
+    def test_every_approval_row_written_names_a_nudge(self):
         """Stated separately from the counts above, because the failure it guards is a
         SECOND row rather than a missing one: an approval recorded under both names would
-        satisfy every assertion here except this one, and would double every tally."""
+        satisfy every assertion here except this one, and would double every tally.
+
+        Asserted as the whole list of `-approved` rows rather than as
+        ``asks().get("ask-approved", 0) == 0``. That literal names one string of the many
+        that cannot be attributed to a guard, and it is a string no code path can produce
+        any more — so it holds only against a mutation that reintroduces that exact spelling
+        and lets every other unattributable row through, `None-approved` included.
+        """
         self.approve_dispatch(self.dispatch_nudge())
-        self.assertEqual(0, self.asks().get("ask-approved", 0),
-                         "a bare `ask-approved` cannot be attributed to any guard (#375)")
+        self.assertEqual(["dispatch-ask-approved"], self.approvals(),
+                         "an approval row was written that no guard can be credited with "
+                         "or debited for (#375)")
 
 
 class TestTheMarkerIsWhatCarriesTheKind(TwoNudgesInOnePlane):
@@ -208,6 +231,58 @@ class TestANewNudgeCannotBecomeUncountable(unittest.TestCase):
         and reads as a nudge that exists."""
         used = {k for fn in self._sites_that_ask().values() for k in self._kinds_passed(fn)}
         self.assertEqual(set(hooks._ASK_KINDS), used)
+
+
+class TestOneToolUseIdCarriesAtMostOnePendingAsk(unittest.TestCase):
+    """`_ask_mark_take` answers with ONE kind, so two markers on one `tool_use_id` would
+    resolve to whichever kind stands first in `_ASK_KINDS` and leave the other to age out
+    — counted as an ask and never as an approval, which is precisely the shape #371 read a
+    guard's deletion off.
+
+    That cannot happen today, and the reason is not in `hooks.py`: the two nudges are raised
+    from PreToolUse handlers whose SHIPPED matchers name disjoint tool families, so no
+    single tool call reaches both. This asserts that, rather than the docstring asserting it
+    — the assumption lives in `hooks/hooks.json`, which nothing else here reads, and a third
+    nudge added on `Write|Edit|MultiEdit` would satisfy every other test in this file while
+    silently making one of the two counts wrong.
+
+    Reads the manifest through `test_plugin`'s reader rather than a second one, so both
+    files see the same shipped file.
+    """
+
+    @staticmethod
+    def _matcher_of(handler: str) -> str:
+        """The tool matcher `hooks.json` ships for ``charter hook <handler>``."""
+        found = [entry.get("matcher") for entries in _manifest().values()
+                 for entry in entries for hook in entry["hooks"]
+                 if f"charter hook {handler} " in hook["command"] + " "]
+        assert len(found) == 1, f"{handler}: expected one manifest entry, got {found}"
+        return found[0] or ""
+
+    @classmethod
+    def _families(cls) -> dict[str, set[str]]:
+        """Tool name -> the nudge-raising handlers registered for it."""
+        names = {n for n in TestANewNudgeCannotBecomeUncountable._sites_that_ask()}
+        # `_HANDLERS` maps the manifest's hyphenated name onto the function.
+        by_fn = {fn.__name__: name for name, fn in hooks._HANDLERS.items()}
+        return {n: set(cls._matcher_of(by_fn[n]).split("|")) for n in sorted(names)}
+
+    def test_the_scan_found_the_real_handlers_in_the_shipped_manifest(self):
+        """Precondition: a matcher lookup that silently found nothing would make the
+        disjointness below vacuously true."""
+        fams = self._families()
+        self.assertEqual({"pretooluse_dispatch", "pretooluse_edit"}, set(fams))
+        for name, tools in fams.items():
+            self.assertTrue(tools and all(tools), f"{name} has no shipped matcher: {tools}")
+
+    def test_no_two_nudges_can_be_raised_on_the_same_tool(self):
+        fams = self._families()
+        for a, b in itertools.combinations(sorted(fams), 2):
+            with self.subTest(pair=(a, b)):
+                self.assertEqual(set(), fams[a] & fams[b],
+                                 f"{a} and {b} can both raise on the same tool call, so one "
+                                 f"tool_use_id can carry two pending asks — `_ask_mark_take` "
+                                 f"answers with one kind and the other is never counted")
 
 
 if __name__ == "__main__":

--- a/tests/test_ask_outcome_is_recorded.py
+++ b/tests/test_ask_outcome_is_recorded.py
@@ -25,6 +25,12 @@ handlers, and the cases below assert it on each tool family. The fixtures are re
 real committed frontmatter, and each one asserts the ask actually fired before asserting
 anything about the count — a fixture that stops reaching `_ask` must fail loudly rather than
 report zero approvals of zero asks.
+
+**The approval event is named for its nudge** (#375): `dispatch-ask-approved`, not a bare
+`ask-approved`. Every assertion below therefore names the kind the fixture actually raises.
+That matters more than a rename usually would — the negative cases here (`assertNotIn`,
+`count`) would go vacuously green against the string `ask-approved`, which no code path can
+produce any more, so a test asserting the old name would still pass while testing nothing.
 """
 
 import unittest
@@ -39,6 +45,9 @@ class AskOutcomeCase(InAControlPlane):
 
     SID = "s"
     TUID = "tu_1"
+    #: What this fixture's nudge is called, and so what its approval is called (#375).
+    KIND = "dispatch-ask"
+    APPROVED = "dispatch-ask-approved"
 
     def setUp(self) -> None:
         super().setUp()
@@ -68,12 +77,21 @@ class AskOutcomeCase(InAControlPlane):
 class TestAnApprovedAskIsRecorded(AskOutcomeCase):
     def test_the_tool_running_marks_it_approved(self):
         self.approve(self.ask())
-        self.assertIn("ask-approved", self.events())
+        self.assertIn(self.APPROVED, self.events())
 
     def test_the_ask_itself_is_still_traced(self):
         """Both halves, or the ratio has no denominator."""
         self.ask()
-        self.assertIn("dispatch-ask", self.events())
+        self.assertIn(self.KIND, self.events())
+
+    def test_the_two_halves_pair_by_name(self):
+        """Why the approval is named for its nudge (#375): `charter trace --summary`
+        aggregates event NAMES, so `dispatch-ask` beside `dispatch-ask-approved` is a
+        ratio on the line that already exists. A shared counter could not be attributed
+        to either guard, and a `reason` field would not reach the summary at all."""
+        self.approve(self.ask())
+        self.assertEqual([self.KIND, self.APPROVED],
+                         [e for e in self.events() if "ask" in e])
 
     def test_the_marker_is_consumed(self):
         p = self.ask()
@@ -86,12 +104,12 @@ class TestAnUnansweredAskIsNotRecordedAsApproved(AskOutcomeCase):
     def test_no_post_tool_use_means_no_approval(self):
         """A declined ask blocks the tool, so PostToolUse never fires for it."""
         self.ask()
-        self.assertNotIn("ask-approved", self.events())
+        self.assertNotIn(self.APPROVED, self.events())
 
     def test_a_different_tool_call_does_not_resolve_it(self):
         p = self.ask()
         self.approve({**p, "tool_use_id": "tu_other"})
-        self.assertNotIn("ask-approved", self.events())
+        self.assertNotIn(self.APPROVED, self.events())
 
 
 class TestItIsCheapAndSafeOnTheHotPath(AskOutcomeCase):
@@ -100,14 +118,14 @@ class TestItIsCheapAndSafeOnTheHotPath(AskOutcomeCase):
         return. It must never invent a row."""
         self.approve({"tool_name": "Task", "tool_input": {"subagent_type": "coder"},
                       "session_id": self.SID, "tool_use_id": "tu_never_asked"})
-        self.assertNotIn("ask-approved", self.events())
+        self.assertNotIn(self.APPROVED, self.events())
 
     def test_it_resolves_only_once(self):
         """The unlink IS the idempotency — a replayed PostToolUse cannot inflate the count."""
         p = self.ask()
         self.approve(p)
         self.approve(p)
-        self.assertEqual(1, self.events().count("ask-approved"))
+        self.assertEqual(1, self.events().count(self.APPROVED))
 
 
 class TestEveryToolFamilyThatCanAskCanAlsoRecordTheApproval(InAControlPlane):
@@ -117,27 +135,36 @@ class TestEveryToolFamilyThatCanAskCanAlsoRecordTheApproval(InAControlPlane):
     Asserted directly on the marker rather than through a nudge fixture, because the claim
     is about the HANDLER — that each PostToolUse family consumes a pending ask — and a
     per-family nudge fixture would make three different preconditions carry one assertion.
+
+    Each row carries the KIND its pending marker was left under, and the handler is checked
+    against `<kind>-approved` (#375). The kinds differ per row on purpose: a handler must
+    take whatever nudge is pending on its tool_use_id, not one kind it is hardcoded for.
+    `posttooluse_bash` gets `routing-ask` precisely because no nudge raises on **Bash**
+    today — the handler still has to work the day one does, which is the property whose
+    absence #371 exposed.
     """
 
-    HANDLERS = (("posttooluse_bash", {"tool_name": "Bash"}),
-                ("posttooluse", {"tool_name": "Edit", "tool_input": {"file_path": "/x/y.py"}}),
-                ("posttooluse_dispatch", {"tool_name": "Task",
-                                          "tool_input": {"subagent_type": "coder"},
-                                          "tool_response": ""}))
+    HANDLERS = (("posttooluse_bash", "routing-ask", {"tool_name": "Bash"}),
+                ("posttooluse", "routing-ask",
+                 {"tool_name": "Edit", "tool_input": {"file_path": "/x/y.py"}}),
+                ("posttooluse_dispatch", "dispatch-ask",
+                 {"tool_name": "Task", "tool_input": {"subagent_type": "coder"},
+                  "tool_response": ""}))
 
     def test_each_one_consumes_a_pending_ask_and_records_it(self):
-        for name, payload in self.HANDLERS:
+        for name, kind, payload in self.HANDLERS:
             with self.subTest(handler=name):
                 sid, tuid = f"s-{name}", "tu_1"
-                hooks._ask_mark_set(sid, tuid)
-                self.assertTrue(hooks._ask_mark(sid, tuid).exists(),
+                hooks._ask_mark_set(sid, tuid, kind)
+                self.assertTrue(hooks._ask_mark(sid, tuid, kind).exists(),
                                 "precondition: an ask is pending")
                 run_hook(getattr(hooks, name), {**payload, "session_id": sid,
                                                 "tool_use_id": tuid})
-                self.assertFalse(hooks._ask_mark(sid, tuid).exists(),
+                self.assertFalse(hooks._ask_mark(sid, tuid, kind).exists(),
                                  f"{name} left the marker behind")
-                self.assertIn("ask-approved", [e["event"] for e in trace.read(sid)],
-                              f"{name} consumed the marker without recording the approval")
+                self.assertIn(f"{kind}-approved", [e["event"] for e in trace.read(sid)],
+                              f"{name} consumed the marker without recording the approval "
+                              f"under the name of the nudge that earned it")
 
 
 if __name__ == "__main__":

--- a/tests/test_ask_outcome_is_recorded.py
+++ b/tests/test_ask_outcome_is_recorded.py
@@ -31,6 +31,16 @@ report zero approvals of zero asks.
 That matters more than a rename usually would — the negative cases here (`assertNotIn`,
 `count`) would go vacuously green against the string `ask-approved`, which no code path can
 produce any more, so a test asserting the old name would still pass while testing nothing.
+
+**And the negative cases are asserted on the approval SHAPE, not on one approval's name.**
+Naming a single kind is the *other* half of the same trap, and it is the half #375 opened
+rather than closed: while `ask-approved` was the only approval there was, `assertNotIn("ask
+-approved", …)` said "no approval row was invented"; once approvals have one name per nudge,
+`assertNotIn("dispatch-ask-approved", …)` says only "no *dispatch* approval was invented",
+and a row invented under any other name — `routing-ask-approved`, or the `None-approved` a
+dropped ``if kind is None`` guard produces — walks straight past it. The universal claim is
+what these cases are for ("It must never invent a row"), so they read every `-approved` row
+in the session and assert the whole list. `_approvals` below is that reading.
 """
 
 import unittest
@@ -70,6 +80,18 @@ class AskOutcomeCase(InAControlPlane):
     def events(self, sid=None):
         return [e["event"] for e in trace.read(sid or self.SID)]
 
+    def approvals(self, sid=None):
+        """Every approval row in the session, found by SHAPE rather than by name.
+
+        The claim the negative cases carry is universal — charter must not invent an
+        approval — and after #375 no single name can express it. `_ASK_KINDS` is two
+        strings today and a suffix match covers a third the day it arrives, including the
+        kinds that are not supposed to exist: `None-approved` is what `_ask_approved`
+        writes if its ``if kind is None: return`` is ever dropped, and it contains neither
+        "dispatch" nor even "ask".
+        """
+        return [e for e in self.events(sid) if e.endswith("-approved")]
+
     def markers(self):
         return list(config.SESSIONS_DIR.glob("*.ask-pending"))
 
@@ -104,12 +126,13 @@ class TestAnUnansweredAskIsNotRecordedAsApproved(AskOutcomeCase):
     def test_no_post_tool_use_means_no_approval(self):
         """A declined ask blocks the tool, so PostToolUse never fires for it."""
         self.ask()
-        self.assertNotIn(self.APPROVED, self.events())
+        self.assertEqual([], self.approvals(), "an unanswered ask was counted as approved")
 
     def test_a_different_tool_call_does_not_resolve_it(self):
         p = self.ask()
         self.approve({**p, "tool_use_id": "tu_other"})
-        self.assertNotIn(self.APPROVED, self.events())
+        self.assertEqual([], self.approvals(),
+                         "another tool call resolved a pending ask that was not its own")
 
 
 class TestItIsCheapAndSafeOnTheHotPath(AskOutcomeCase):
@@ -118,14 +141,16 @@ class TestItIsCheapAndSafeOnTheHotPath(AskOutcomeCase):
         return. It must never invent a row."""
         self.approve({"tool_name": "Task", "tool_input": {"subagent_type": "coder"},
                       "session_id": self.SID, "tool_use_id": "tu_never_asked"})
-        self.assertNotIn(self.APPROVED, self.events())
+        self.assertEqual([], self.approvals(),
+                         "a PostToolUse with no pending ask invented an approval row")
 
     def test_it_resolves_only_once(self):
         """The unlink IS the idempotency — a replayed PostToolUse cannot inflate the count."""
         p = self.ask()
         self.approve(p)
         self.approve(p)
-        self.assertEqual(1, self.events().count(self.APPROVED))
+        self.assertEqual([self.APPROVED], self.approvals(),
+                         "the replay was counted, or was counted under another nudge's name")
 
 
 class TestEveryToolFamilyThatCanAskCanAlsoRecordTheApproval(InAControlPlane):

--- a/tests/test_dispatch_ask_is_counted.py
+++ b/tests/test_dispatch_ask_is_counted.py
@@ -1,9 +1,11 @@
 """Every nudge charter emits is countable, including the dispatch one (#367).
 
-`_ask` leaves an `ask-pending` marker so the outcome can be tallied: `posttooluse_bash`
-clears it when the tool actually runs, and that clearing is recorded as `ask-approved`. It
-deliberately does not trace the ask itself — "callers trace their own event name, so they
-must not also record an 'ask' that never reached anybody".
+`_ask` leaves an `ask-pending` marker so the outcome can be tallied: `_ask_approved` clears
+it when the tool actually runs, and that clearing is recorded as `<kind>-approved` — named
+for the nudge that earned it since #375, so `dispatch-ask` pairs with
+`dispatch-ask-approved` rather than both guards sharing one counter. `_ask` deliberately
+does not trace the ask itself — "callers trace their own event name, so they must not also
+record an 'ask' that never reached anybody".
 
 Three sites called it. `pretooluse` traced `ask`, `pretooluse_edit` traces `routing-ask`,
 and `pretooluse_dispatch` traced nothing while still passing `data` — so its approvals were


### PR DESCRIPTION
Closes #375.

Implemented, adversarially reviewed, and re-verified after a findings round — in an ultracode workflow. Each reviewer reproduced the original symptom against the branch point, showed it gone, and mutation-tested every new test to confirm it can actually fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9