### PR TITLE
`charter guard` is all-or-nothing across harnesses, and says what it could not express (#376)

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -921,6 +921,29 @@ def _as_rule(pattern: str) -> str:
     return f"Bash({p})"
 
 
+#: The one status in a `guard` result that no harness returns — charter's own word for a
+#: file that PASSED the check and then would not take the write. `Harness.apply_ask_rule`
+#: owns the other four; this one is produced by `_guard_apply` from an `OSError`, because
+#: only the caller knows the write was part of a transaction that had already committed
+#: elsewhere. Kept distinct from ``malformed`` on purpose: that one means the content is
+#: unparseable, and a file charter could not write is usually perfectly valid.
+_UNWRITABLE = "unwritable"
+
+
+def _say_write_failed(name: str, detail: str) -> None:
+    """Report a harness whose file passed the check and then refused the write.
+
+    Deliberately does not name a cause. *detail* carries the OS's own `strerror` beside the
+    path, which is the only account of it charter has; guessing between permissions,
+    ownership and a full disk would be the ADR 0009 failure of naming a cause charter only
+    inferred. The remedy is honest and does not need the cause: this is not charter's file
+    to repair, and re-running is what applies the rule once the write can happen.
+    """
+    util.err(f"{name}: could not write {detail} — left untouched.")
+    util.info("  charter asked every harness before writing any of them, so this arrived "
+              "AFTER the check. Re-run once that file can be written.")
+
+
 def _guard_apply(method: str, root: Path, pattern: str,
                  local: bool) -> tuple[list[tuple], bool]:
     """Give *pattern* to every harness that can hold it, or to none of them (#376).
@@ -943,10 +966,38 @@ def _guard_apply(method: str, root: Path, pattern: str,
     absent because a file is broken is somebody's five-minute fix; a rule absent because a
     harness has nowhere to put it is a standing fact `guard` states rather than resolves.
 
+    **Permanent is not the same as harness-wide, and #374 is why that matters here.**
+    opencode now also answers `unsupported` to one PATTERN — a `FLAT_ONLY_PERMISSIONS` key
+    with a real glob, `WebFetch(https://x/*)`, which opencode's config genuinely cannot
+    say. The line above still holds and the reason is unchanged: re-running never changes
+    it, so it is reported and stepped over, and Claude Code takes the rule it CAN express.
+    Worth saying because the enumeration used to read as a property of the harness alone,
+    and a later reader tempted to key the transaction off "does this harness ever support
+    anything" would now be keying it off the wrong question.
+
     What this does NOT claim: the commit phase writes several files in sequence with no
     rollback primitive, so an IO failure between them still leaves the plane uneven. That
     residue is why `_say_if_uneven` survives — it went from the ordinary outcome to the one
     charter cannot rule out.
+
+    **An IO failure is REPORTED, not raised.** The paragraph above was the design from the
+    start, and it was not true of the code: a `.claude/settings.json` or `opencode.json`
+    that parses and cannot be written — read-only, wrong owner, full disk — reached
+    `write_text` and the `OSError` escaped as a traceback, after the earlier harnesses had
+    already been written. The plane was split and charter said nothing at all, which is the
+    #369 failure with the message removed rather than moved. The commit call is wrapped
+    here, at the one place that knows how far the transaction had got, and the failure
+    becomes :data:`_UNWRITABLE` so it flows into the same uneven-landing report as a file
+    that changed underneath the command.
+
+    It is a status of charter's own, not a fifth answer asked of harnesses, and it is
+    deliberately NOT reported as ``malformed``: the file parses. Telling an operator their
+    valid JSON "is not valid" would send them to fix content that is fine, and the issue
+    names *malformed OR unwritable* as two triggers, not one.
+
+    The wrap is on the COMMIT phase alone. A check that fails this way is unreachable —
+    `dry_run` opens nothing for writing, and every harness already answers ``malformed``
+    to an `OSError` while reading — so a branch for it would be a branch no test can drive.
     """
     from .harness import registry
 
@@ -957,18 +1008,48 @@ def _guard_apply(method: str, root: Path, pattern: str,
     committed = []
     for h, status, detail in checked:
         if status == "added":
-            status, detail = getattr(h, method)(root, pattern, local=local)
+            try:
+                status, detail = getattr(h, method)(root, pattern, local=local)
+            except OSError as e:
+                status = _UNWRITABLE
+                detail = f"{detail} ({e.strerror or e.__class__.__name__})"
         committed.append((h, status, detail))
     return committed, False
 
 
-def _say_nothing_landed(results: list[tuple]) -> int:
+def _say_nothing_landed(results: list[tuple], pattern: str) -> int:
     """Report a `guard` command that wrote nowhere, and return its exit code.
 
     The `✗` used to sit beside a `✓`, and the operator had to work out which harnesses now
     disagreed (#369). It now means what every reader already assumed it meant, and saying
     so out loud is the point: somebody taught by the old behaviour goes and checks the
     other files otherwise, which is exactly the doubt the transaction exists to remove.
+
+    **"Nothing was written" is not "the rule is nowhere", and the difference had to be said
+    out loud.** This command aborts on a broken file whether or not an EARLIER command
+    already put the rule in place, and the commonest way to meet a broken file is to hit it
+    on a re-run — a bad merge, a teammate's machine. In that state the plane really is
+    uneven: `.claude/settings.json` holds the rule and `opencode.json` does not. The first
+    draft of this reported only what THIS command did, and an operator reading it had no way
+    to tell that case from a first attempt that reached nowhere. That was strictly less than
+    the per-harness `✓ already asking for …` the old half-writing loop printed — a
+    transaction that says less about the plane than the split it replaced. So both halves
+    are named: where the rule already stands, and where it would have gone.
+
+    **And a rule that already stands still outranks whatever it outranked (#374).** This
+    path replaces the loop, so it also replaces the loop's `_warn_if_outranking` call, and
+    dropping it silently was a real regression rather than a theoretical one: with
+    `.claude/settings.json` malformed and `opencode.json` already holding `plan_*`,
+    `charter guard allow mcp__plan` is blocked, and two of opencode's OWN denies are
+    allowed right now by a rule this operator is being told nothing about. Measured against
+    a `git archive origin/main` export, same plane, same command — main printed the line.
+
+    It fires on ``present`` ALONE, and not on the same two statuses the loop uses. That
+    filter is `_warn_if_outranking`'s "the rule is in force", and here only half of it
+    still holds: nothing was written, so an ``added`` harness's rule is NOT in force and
+    warning about its consequences would describe a rule that does not exist. Printed
+    after the "ALREADY in force" line and well below the malformed one, so the sentence
+    that needs acting on stays first — the other half of that filter's reasoning.
     """
     for h, status, detail in results:
         if status == "malformed":
@@ -977,6 +1058,14 @@ def _say_nothing_landed(results: list[tuple]) -> int:
     util.warn("  NOTHING was written, under any harness — `charter guard` is all-or-nothing "
               "across the harnesses that can hold a rule, so the plane is exactly as it was "
               "before this command.")
+    already = [h.name for h, status, _d in results if status == "present"]
+    if already:
+        util.info(f"  The rule is ALREADY in force under {', '.join(already)}, from an "
+                  f"earlier command — this run neither added it nor took it away. The plane "
+                  f"is uneven right now, and fixing the file above is what evens it up.")
+    for h, status, _d in results:
+        if status == "present":
+            _warn_if_outranking(h, pattern, status)
     pending = [h.name for h, status, _d in results if status == "added"]
     if pending:
         util.info(f"  {', '.join(pending)} would have taken the rule and did not. Re-run "
@@ -993,6 +1082,19 @@ def _say_where_it_cannot_reach(results: list[tuple]) -> None:
     above; what this adds is the word that stops a reader filing it beside the broken case.
     Their remedies are opposites: a malformed file is fixed and the command re-run, and
     re-running does nothing whatever here.
+
+    ``unsupported`` ONLY, and that is load-bearing rather than an accident of which status
+    was handy. Every other answer means the harness has somewhere to put the rule: widening
+    this to include ``present`` would print "Not in force under claude-code" over a rule
+    that is in force under claude-code — on the second run of any command, i.e. constantly.
+
+    The sentence deliberately says nothing about WHY, and #374 is what makes that pay. The
+    reason now varies by pattern as well as by harness — Codex has no command patterns at
+    all, opencode has no machine-local file, and since #374 opencode also cannot put a URL
+    glob under a `FLAT_ONLY_PERMISSIONS` key — and each harness has already printed its own
+    account of it on the line above. This adds only the word that files it as a limit
+    rather than a break; assembling the reason here would mean restating three of them, and
+    getting one wrong the day a fourth appears.
     """
     names = [h.name for h, status, _d in results if status == "unsupported"]
     if not names:
@@ -1018,13 +1120,21 @@ def _say_if_uneven(wrote: bool, refused: bool) -> None:
     between two writes, still splits the plane. That is now the only way here, and it is
     the one charter cannot rule out — which makes this message rarer and more important,
     not obsolete. Shared by both verbs so `ask` and `allow` cannot describe it differently.
+
+    The message names BOTH shapes of late refusal rather than the first one, because both
+    reach here and the second one used to reach nowhere: an unwritable file raised out of
+    `_guard_apply` before any of this ran. Naming the two is not charter guessing between
+    them — the line immediately above says which it was, in its own words ("is not valid"
+    against "could not write"). Saying only "changed underneath" would have been the wrong
+    cause printed with total confidence, for the case this round added.
     """
     if wrote and refused:
         util.warn("  The rule landed UNEVENLY — it is in force under the harnesses ticked "
                   "above and NOT under the one refused, from this one command. Every "
-                  "harness accepted it when charter asked, so that file changed underneath "
-                  "this command. Fix it and re-run; the harnesses that already have it "
-                  "will say so.")
+                  "harness accepted it when charter asked, so the refusal above arrived "
+                  "AFTER the check: that file changed underneath this command, or would "
+                  "not take the write. Fix what it names and re-run; the harnesses that "
+                  "already have it will say so.")
 
 
 def _refuse_unexpressible(pattern: str) -> str | None:
@@ -1207,7 +1317,7 @@ def cmd_guard_allow(args) -> int:
     root = Path(config.ROOT)
     results, blocked = _guard_apply("apply_allow_rule", root, pattern, local)
     if blocked:
-        return _say_nothing_landed(results)
+        return _say_nothing_landed(results, pattern)
     rc, wrote = 0, False
     for h, status, detail in results:
         if status == "added":
@@ -1219,6 +1329,9 @@ def cmd_guard_allow(args) -> int:
         elif status == "malformed":
             util.err(f"{h.name}: {detail} is not valid — left untouched.")
             util.info("  Fix it by hand, then re-run. charter never repairs these files.")
+            rc = 1
+        elif status == _UNWRITABLE:
+            _say_write_failed(h.name, detail)
             rc = 1
         else:
             util.info(f"  {h.name}: {detail} — nothing to relax there.")
@@ -1277,7 +1390,7 @@ def cmd_guard_ask(args) -> int:
     root = Path(config.ROOT)
     results, blocked = _guard_apply("apply_ask_rule", root, pattern, local)
     if blocked:
-        return _say_nothing_landed(results)
+        return _say_nothing_landed(results, pattern)
     rc, wrote = 0, False
     for h, status, detail in results:
         if status == "added":
@@ -1289,6 +1402,9 @@ def cmd_guard_ask(args) -> int:
         elif status == "malformed":
             util.err(f"{h.name}: {detail} is not valid — left untouched.")
             util.info("  Fix it by hand, then re-run. charter never repairs these files.")
+            rc = 1
+        elif status == _UNWRITABLE:
+            _say_write_failed(h.name, detail)
             rc = 1
         else:
             # Not a failure. The harness has no command-pattern permissions, so charter's

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -921,24 +921,110 @@ def _as_rule(pattern: str) -> str:
     return f"Bash({p})"
 
 
+def _guard_apply(method: str, root: Path, pattern: str,
+                 local: bool) -> tuple[list[tuple], bool]:
+    """Give *pattern* to every harness that can hold it, or to none of them (#376).
+
+    Returns ``(results, blocked)`` — one ``(harness, status, detail)`` per registered
+    harness in registration order, and whether the command wrote nothing because a harness
+    refused. Shared by both verbs through *method*, so `ask` and `allow` cannot come to
+    disagree about when a command has half-happened.
+
+    **Two phases, because aborting on the first refusal is not enough.** Claude Code is
+    first in the registry; by the time opencode refuses, Claude Code's file is written.
+    So every harness is asked first with ``dry_run=True`` and nothing is committed unless
+    all of them can take it. The check is the write path minus the write rather than a
+    validator of its own — `Harness.apply_ask_rule` records why.
+
+    **Only ``malformed`` blocks**, and that is the design rather than an implementation
+    detail. `unsupported` is a harness saying it has no such rule to write at all, which
+    is permanent: Codex answers it to every pattern, and opencode to every `--local` one,
+    so a transaction that stopped there would write nothing anywhere, forever. A rule
+    absent because a file is broken is somebody's five-minute fix; a rule absent because a
+    harness has nowhere to put it is a standing fact `guard` states rather than resolves.
+
+    What this does NOT claim: the commit phase writes several files in sequence with no
+    rollback primitive, so an IO failure between them still leaves the plane uneven. That
+    residue is why `_say_if_uneven` survives — it went from the ordinary outcome to the one
+    charter cannot rule out.
+    """
+    from .harness import registry
+
+    checked = [(h, *getattr(h, method)(root, pattern, local=local, dry_run=True))
+               for h in registry.all()]
+    if any(status == "malformed" for _h, status, _detail in checked):
+        return checked, True
+    committed = []
+    for h, status, detail in checked:
+        if status == "added":
+            status, detail = getattr(h, method)(root, pattern, local=local)
+        committed.append((h, status, detail))
+    return committed, False
+
+
+def _say_nothing_landed(results: list[tuple]) -> int:
+    """Report a `guard` command that wrote nowhere, and return its exit code.
+
+    The `✗` used to sit beside a `✓`, and the operator had to work out which harnesses now
+    disagreed (#369). It now means what every reader already assumed it meant, and saying
+    so out loud is the point: somebody taught by the old behaviour goes and checks the
+    other files otherwise, which is exactly the doubt the transaction exists to remove.
+    """
+    for h, status, detail in results:
+        if status == "malformed":
+            util.err(f"{h.name}: {detail} is not valid — left untouched.")
+            util.info("  Fix it by hand, then re-run. charter never repairs these files.")
+    util.warn("  NOTHING was written, under any harness — `charter guard` is all-or-nothing "
+              "across the harnesses that can hold a rule, so the plane is exactly as it was "
+              "before this command.")
+    pending = [h.name for h, status, _d in results if status == "added"]
+    if pending:
+        util.info(f"  {', '.join(pending)} would have taken the rule and did not. Re-run "
+                  f"once the file above parses.")
+    return 1
+
+
+def _say_where_it_cannot_reach(results: list[tuple]) -> None:
+    """Name the harnesses with nowhere to put the rule, as a limit and not as a failure.
+
+    All-or-nothing across the harnesses that CAN hold a rule leaves exactly one way for a
+    rule to be in force unevenly, and it is the honest one — so the uneven landing still
+    has to be visible, just no longer as a defect. Each such harness prints its own reason
+    above; what this adds is the word that stops a reader filing it beside the broken case.
+    Their remedies are opposites: a malformed file is fixed and the command re-run, and
+    re-running does nothing whatever here.
+    """
+    names = [h.name for h, status, _d in results if status == "unsupported"]
+    if not names:
+        return
+    util.info(f"  Not in force under {', '.join(names)} — nowhere to write it there, which "
+              f"is a standing limit of the harness rather than a failed write. Re-running "
+              f"will not change that.")
+
+
 def _say_if_uneven(wrote: bool, refused: bool) -> None:
     """Say so when one command left the rule in force under some harnesses and not others.
 
-    The refusal to touch a malformed file is per-harness, not per-command: the caller goes
-    on to the next harness, so a `✗` beside a `✓` means one invocation left the plane
-    holding the rule under opencode and not under Claude Code. An operator who sees the `✗`
-    reads it as "nothing was written" (#369), and a re-run after the fix then makes the
-    other harness's copy a duplicate write rather than a first one.
+    This was the ORDINARY outcome of a malformed config file: the refusal was per-harness,
+    so a `✗` beside a `✓` meant one invocation left the plane holding the rule under
+    opencode and not under Claude Code, and an operator reading the `✗` as "nothing was
+    written" (#369) then re-ran after the fix and made opencode's copy a duplicate write.
+    `_guard_apply` closed that: a harness that would refuse is found before anything is
+    written, and the command writes nowhere.
 
-    Making the command all-or-nothing is a two-phase apply across three file formats with
-    no rollback primitive — a design change, and not this one. Naming what actually
-    happened costs nothing and is true today. Shared by both verbs so `ask` and `allow`
-    cannot come to describe the same half-write differently.
+    It stays because the closure is not total, and pretending otherwise would be the same
+    species of overstatement. The commit phase writes several files one after another with
+    no rollback primitive, so a file that changed underneath the command, or an IO error
+    between two writes, still splits the plane. That is now the only way here, and it is
+    the one charter cannot rule out — which makes this message rarer and more important,
+    not obsolete. Shared by both verbs so `ask` and `allow` cannot describe it differently.
     """
     if wrote and refused:
         util.warn("  The rule landed UNEVENLY — it is in force under the harnesses ticked "
-                  "above and NOT under the one refused, from this one command. Fix that "
-                  "file and re-run; the harnesses that already have it will say so.")
+                  "above and NOT under the one refused, from this one command. Every "
+                  "harness accepted it when charter asked, so that file changed underneath "
+                  "this command. Fix it and re-run; the harnesses that already have it "
+                  "will say so.")
 
 
 def _refuse_unexpressible(pattern: str) -> str | None:
@@ -994,8 +1080,8 @@ def _load_json_settings(path: Path):
     return (doc, path) if isinstance(doc, dict) else (None, path)
 
 
-def add_permission_rule(root: Path, rule: str, bucket: str,
-                        local: bool = False) -> tuple[str, str]:
+def add_permission_rule(root: Path, rule: str, bucket: str, local: bool = False,
+                        dry_run: bool = False) -> tuple[str, str]:
     """Append *rule* to ``permissions.<bucket>`` in the plane's `.claude/settings.json`.
 
     Extracted from `cmd_guard_ask` when a second harness needed the same command: the
@@ -1004,11 +1090,14 @@ def add_permission_rule(root: Path, rule: str, bucket: str,
     and a `permissions` or bucket of the wrong type is somebody's deliberate structure —
     charter reports it and writes nothing HERE.
 
-    "Writes nothing here" is the whole of the promise, and the docstring used to overstate
-    it as "reports it and stops" (#369). The refusal is per-harness: the caller goes on to
-    the next one, so a malformed Claude Code file leaves the rule in force under opencode
-    and absent under Claude Code from a single command. That is worth knowing at this level
-    because it is what the callers have to say out loud.
+    "Writes nothing here" is the whole of the promise, and this function is deliberately
+    still not where the promise gets any bigger. The refusal remains per-harness — it
+    returns ``malformed`` and knows nothing about the other harnesses — but the CALLER no
+    longer steps over it: `_guard_apply` asks every harness with `dry_run=True` and writes
+    nowhere if any of them answers this way (#376), so a malformed Claude Code file no
+    longer leaves the rule in force under opencode. The docstring first claimed the stop
+    happened here ("reports it and stops"), then recorded that it did not happen at all
+    (#369). It happens one level up, where something can see every harness at once.
 
     Parameterised over the bucket when `guard allow` arrived: `ask` and `allow` are the
     same job with opposite verbs, and two copies of this function would eventually
@@ -1018,8 +1107,13 @@ def add_permission_rule(root: Path, rule: str, bucket: str,
     init`, so the rule is one person's, on one machine. Same reasoning one level down: the
     two files differ only in blast radius, so they must not differ in how carefully they
     are parsed or how firmly a malformed one is refused.
+
+    `dry_run=True` returns the answer and touches nothing — including `.gitignore`, which
+    `local` would otherwise amend before the settings file is even read. A check with a
+    side effect is not a check: the plane has to be exactly as it was when a transaction
+    decides not to commit.
     """
-    if local:
+    if local and not dry_run:
         _ensure_local_settings_ignored(root)
     settings, path = (_load_json_settings(Path(root) / LOCAL_SETTINGS) if local
                       else _load_settings(root))
@@ -1033,6 +1127,8 @@ def add_permission_rule(root: Path, rule: str, bucket: str,
         return "malformed", f"{path} (`permissions.{bucket}` is not a list)"
     if rule in entries:
         return "present", str(path)
+    if dry_run:
+        return "added", str(path)
     entries.append(rule)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(settings, indent=2) + "\n")
@@ -1072,14 +1168,16 @@ def _ensure_local_settings_ignored(root: Path) -> None:
                           "added by `charter guard --local`")
 
 
-def add_ask_rule(root: Path, rule: str, local: bool = False) -> tuple[str, str]:
+def add_ask_rule(root: Path, rule: str, local: bool = False,
+                 dry_run: bool = False) -> tuple[str, str]:
     """`permissions.ask` — force a prompt for *rule*."""
-    return add_permission_rule(root, rule, "ask", local=local)
+    return add_permission_rule(root, rule, "ask", local=local, dry_run=dry_run)
 
 
-def add_allow_rule(root: Path, rule: str, local: bool = False) -> tuple[str, str]:
+def add_allow_rule(root: Path, rule: str, local: bool = False,
+                   dry_run: bool = False) -> tuple[str, str]:
     """`permissions.allow` — stop prompting for *rule*."""
-    return add_permission_rule(root, rule, "allow", local=local)
+    return add_permission_rule(root, rule, "allow", local=local, dry_run=dry_run)
 
 
 def cmd_guard_allow(args) -> int:
@@ -1107,9 +1205,11 @@ def cmd_guard_allow(args) -> int:
     from .harness import registry
 
     root = Path(config.ROOT)
+    results, blocked = _guard_apply("apply_allow_rule", root, pattern, local)
+    if blocked:
+        return _say_nothing_landed(results)
     rc, wrote = 0, False
-    for h in registry.all():
-        status, detail = h.apply_allow_rule(root, pattern, local=local)
+    for h, status, detail in results:
         if status == "added":
             util.ok(f"{h.name}: allowing {h.allow_rule(pattern)} → {detail}")
             wrote = True
@@ -1143,6 +1243,7 @@ def cmd_guard_allow(args) -> int:
                   "prompt, never the secret, credential, plane-root or release denials.")
         util.info("  Nothing lifts those — by design. `charter docs show hooks` → *When a "
                   "guard is wrong* for what to do when one of them is wrong about you.")
+    _say_where_it_cannot_reach(results)
     _say_if_uneven(wrote, rc == 1)
     return rc
 
@@ -1174,9 +1275,11 @@ def cmd_guard_ask(args) -> int:
     from .harness import registry
 
     root = Path(config.ROOT)
+    results, blocked = _guard_apply("apply_ask_rule", root, pattern, local)
+    if blocked:
+        return _say_nothing_landed(results)
     rc, wrote = 0, False
-    for h in registry.all():
-        status, detail = h.apply_ask_rule(root, pattern, local=local)
+    for h, status, detail in results:
         if status == "added":
             util.ok(f"{h.name}: asking for {h.ask_rule(pattern)} → {detail}")
             wrote = True
@@ -1202,6 +1305,7 @@ def cmd_guard_ask(args) -> int:
             util.info("  These files are committed, so the rule applies to everyone on this "
                       "repo — no sync step, and nothing that can drift (ADR 0014).")
         _warn_if_shadowing(registry.get(registry.CLAUDE_CODE).ask_rule(pattern))
+    _say_where_it_cannot_reach(results)
     _say_if_uneven(wrote, rc == 1)
     return rc
 

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -150,10 +150,17 @@ class Harness:
         * ``malformed`` is a condition of a FILE. Somebody can fix it, and until they do,
           writing the other harnesses is what leaves the plane holding a rule here and not
           there from one command. It stops the whole command.
-        * ``unsupported`` is a standing property of the HARNESS. Re-running never changes
-          it — Codex answers it to every pattern there is — so treating it as a failure
-          would mean charter could never write a guard rule anywhere. It is reported and
-          stepped over, and the rule is honestly not in force there.
+        * ``unsupported`` is a standing property of the HARNESS **and this pattern**. Re-
+          running never changes it — Codex answers it to every pattern there is, opencode
+          to every `--local` one, and since #374 to a URL glob under one of the five
+          permissions opencode will only take a bare action for — so treating it as a
+          failure would mean charter could never write a guard rule anywhere. It is
+          reported and stepped over, and the rule is honestly not in force there.
+
+          "And this pattern" is worth the words. It read as harness-wide when only whole
+          harnesses answered it, and a transaction keyed off "does this harness support
+          anything" would still have passed every test then and be wrong now. What the
+          caller must key off is this answer, to this pattern, on this call.
 
         ``dry_run=True`` answers the same question and writes nothing: the status is what
         a real call would return, so the caller can ask every harness before committing to
@@ -161,6 +168,12 @@ class Harness:
         own — a second implementation of "can this harness take the rule" eventually
         answers differently from the one that writes, and a transaction whose check
         disagrees with its commit prints a tick either way.
+
+        Those four are the whole of what a harness answers. A write that RAISES is not a
+        fifth answer to add here: an implementation cannot know whether the command has
+        already written somebody else, which is the only thing that makes the failure worth
+        distinguishing. `commands._guard_apply` catches the `OSError` and reports it under a
+        status of its own, so a harness is free to let one out.
         """
         return "unsupported", f"{self.name} has no command-pattern permissions"
 

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -134,14 +134,33 @@ class Harness:
         """
         return None
 
-    def apply_ask_rule(self, root: Path, pattern: str,
-                       local: bool = False) -> tuple[str, str]:
+    def apply_ask_rule(self, root: Path, pattern: str, local: bool = False,
+                       dry_run: bool = False) -> tuple[str, str]:
         """Write the rule under *root*. ``(status, detail)``.
 
         ``"added"``, ``"present"``, ``"malformed"`` (refused, never repaired), or
         ``"unsupported"`` with a reason. A harness that cannot express command patterns
         says so: charter's own hook still guards the command, and the difference between
         naming that limit and staying quiet is the difference between a limit and a lie.
+
+        Two of those four are refusals, and they are **not the same refusal**. That
+        distinction is load-bearing rather than descriptive, because `charter guard` is
+        all-or-nothing across harnesses (#376) and has to decide which refusals stop it:
+
+        * ``malformed`` is a condition of a FILE. Somebody can fix it, and until they do,
+          writing the other harnesses is what leaves the plane holding a rule here and not
+          there from one command. It stops the whole command.
+        * ``unsupported`` is a standing property of the HARNESS. Re-running never changes
+          it — Codex answers it to every pattern there is — so treating it as a failure
+          would mean charter could never write a guard rule anywhere. It is reported and
+          stepped over, and the rule is honestly not in force there.
+
+        ``dry_run=True`` answers the same question and writes nothing: the status is what
+        a real call would return, so the caller can ask every harness before committing to
+        any of them. It has to be the write path minus the write, never a validator of its
+        own — a second implementation of "can this harness take the rule" eventually
+        answers differently from the one that writes, and a transaction whose check
+        disagrees with its commit prints a tick either way.
         """
         return "unsupported", f"{self.name} has no command-pattern permissions"
 
@@ -155,16 +174,20 @@ class Harness:
         """
         return self.ask_rule(pattern)
 
-    def apply_allow_rule(self, root: Path, pattern: str,
-                         local: bool = False) -> tuple[str, str]:
+    def apply_allow_rule(self, root: Path, pattern: str, local: bool = False,
+                         dry_run: bool = False) -> tuple[str, str]:
         """Write the allow rule under *root*. ``(status, detail)``, as
-        :meth:`apply_ask_rule`.
+        :meth:`apply_ask_rule` — same four answers, same meaning, same ``dry_run``.
 
         ``local=True`` asks for the harness's MACHINE-LOCAL file — a rule that is one
         person's, on one machine. A harness with no such file must return ``unsupported``
         and say why rather than falling back to a shared one: an `allow` rule widens what
         runs unprompted, so a silent fallback would publish a personal trust decision to
         everybody, which is the failure the flag exists to prevent.
+
+        That is also the sharpest case for ``unsupported`` not blocking anybody else:
+        opencode answers it to every ``--local`` rule, so a transaction that stopped on it
+        would turn the flag into a command that writes nothing at all.
         """
         return "unsupported", f"{self.name} has no command-pattern permissions"
 

--- a/charter/harness/claude_code.py
+++ b/charter/harness/claude_code.py
@@ -70,14 +70,16 @@ class ClaudeCodeHarness(Harness):
 
         return commands._as_rule(pattern)
 
-    def apply_ask_rule(self, root: Path, pattern: str,
-                       local: bool = False) -> tuple[str, str]:
+    def apply_ask_rule(self, root: Path, pattern: str, local: bool = False,
+                       dry_run: bool = False) -> tuple[str, str]:
         from .. import commands
 
-        return commands.add_ask_rule(root, self.ask_rule(pattern), local=local)
+        return commands.add_ask_rule(root, self.ask_rule(pattern), local=local,
+                                     dry_run=dry_run)
 
-    def apply_allow_rule(self, root: Path, pattern: str,
-                         local: bool = False) -> tuple[str, str]:
+    def apply_allow_rule(self, root: Path, pattern: str, local: bool = False,
+                         dry_run: bool = False) -> tuple[str, str]:
         from .. import commands
 
-        return commands.add_allow_rule(root, self.allow_rule(pattern), local=local)
+        return commands.add_allow_rule(root, self.allow_rule(pattern), local=local,
+                                       dry_run=dry_run)

--- a/charter/harness/opencode.py
+++ b/charter/harness/opencode.py
@@ -612,19 +612,20 @@ class OpenCodeHarness(Harness):
                  "config is ~/.config/opencode, which applies to every project on this "
                  "machine, so charter will not narrow a team rule into a broader one")
 
-    def apply_ask_rule(self, root: Path, pattern: str,
-                       local: bool = False) -> tuple[str, str]:
+    def apply_ask_rule(self, root: Path, pattern: str, local: bool = False,
+                       dry_run: bool = False) -> tuple[str, str]:
         if local:
             return "unsupported", self._NO_LOCAL
-        return self._apply_rule(root, pattern, "ask")
+        return self._apply_rule(root, pattern, "ask", dry_run=dry_run)
 
-    def apply_allow_rule(self, root: Path, pattern: str,
-                         local: bool = False) -> tuple[str, str]:
+    def apply_allow_rule(self, root: Path, pattern: str, local: bool = False,
+                         dry_run: bool = False) -> tuple[str, str]:
         if local:
             return "unsupported", self._NO_LOCAL
-        return self._apply_rule(root, pattern, "allow")
+        return self._apply_rule(root, pattern, "allow", dry_run=dry_run)
 
-    def _apply_rule(self, root: Path, pattern: str, decision: str) -> tuple[str, str]:
+    def _apply_rule(self, root: Path, pattern: str, decision: str,
+                    dry_run: bool = False) -> tuple[str, str]:
         """Write it into `opencode.json`, IF ABSENT and never repairing.
 
         A `permission` block of the wrong shape is somebody's deliberate structure, and
@@ -656,6 +657,20 @@ class OpenCodeHarness(Harness):
         rule that could not fire, this wrote a file that stops opencode running. It was
         introduced by #374's own fix, which gave `doom_loop` its new meaning — before it,
         `mcp__doom__loop` was an inert `bash` key and the file still loaded.
+
+        `dry_run` is the same restraint applied one step earlier, and for the same reason
+        this method is shared: every judgement above the write runs, and only the two
+        lines that touch the disk are skipped. `charter guard` asks every harness before
+        it writes any of them (#376), so this answer has to be the one the write would
+        give — and it is, because it is the same code arriving at it.
+
+        That sharing is what keeps the flat-only branch above honest under a transaction.
+        Its ``unsupported`` and its ``malformed`` are reached by the check exactly as the
+        write reaches them, so `_guard_apply` blocks the whole command on the second and
+        steps over the first — and a `WebFetch(https://x/*)` that opencode cannot express
+        does not stop Claude Code from taking the rule it CAN express. A separate
+        validator would have had to learn :data:`FLAT_ONLY_PERMISSIONS` a second time and
+        would have been the copy that went stale when opencode adds a sixth name.
         """
         tool, glob = self.ask_rule(pattern)
         p = Path(root) / "opencode.json"
@@ -690,6 +705,8 @@ class OpenCodeHarness(Harness):
             if block.get(glob) == decision:
                 return "present", str(p)
             block[glob] = decision
+        if dry_run:
+            return "added", str(p)
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(json.dumps(doc, indent=2) + "\n")
         return "added", str(p)

--- a/tests/test_guard_claims_its_reach.py
+++ b/tests/test_guard_claims_its_reach.py
@@ -19,16 +19,25 @@ The names are derived from `registry.KINDS` rather than written into the help st
 `registry.py`'s own docstring says why: a hardcoded literal is the thing that goes stale the
 day a harness is added, and this help would be one more place to remember.
 
-**A `✗` read as "nothing was written".** The refusal to touch a malformed file is
+**A `✗` read as "nothing was written".** The refusal to touch a malformed file was
 per-harness, so with `.claude/settings.json` corrupted the rule still landed in
 `opencode.json`: one invocation, rule in force under one harness and absent under the other,
-and a re-run after the fix makes opencode's copy a duplicate write rather than a first one.
-`add_permission_rule`'s docstring said charter "reports it and stops"; it reports and
-continues.
+and a re-run after the fix made opencode's copy a duplicate write rather than a first one.
+`add_permission_rule`'s docstring said charter "reports it and stops"; it reported and
+continued.
 
-Making it all-or-nothing is a two-phase apply across three file formats with no rollback
-primitive, which is a design change and not this one. What is fixed here is the claim: the
-output now says a rule landed unevenly, at the moment it happens.
+#369 fixed the claim and left the behaviour, so this file used to assert that half-write
+and the warning printed over it. **#376 made the behaviour all-or-nothing and those
+assertions had to go with it** — they pinned the thing that was fixed, and keeping them
+would have meant keeping the split. What is asserted instead is #369's actual guarantee,
+which outlived its implementation: an operator is never misled about how far one `guard`
+command reached. The `✗` now means what every reader already assumed it meant, and the
+tests below hold the output to that.
+
+Two of them are deliberately negative — the old warning must be *gone*, not merely joined
+by a new line — because the old sentence told the operator to go and reconcile two
+harnesses, and there is nothing to reconcile now. `test_guard_is_all_or_nothing.py` owns
+the transaction itself.
 """
 
 from __future__ import annotations
@@ -113,39 +122,57 @@ class GuardCase(PersonaIso):
         self.settings().write_text("{not json")
 
 
-class TestAPartialWriteSaysSo(GuardCase):
-    def test_the_precondition_that_one_harness_refuses_and_another_writes(self):
-        """Asserted on its own, so the message test below cannot pass in a world where
-        nothing was written at all."""
+class TestARefusalMeansNothingWasWritten(GuardCase):
+    def test_the_precondition_that_a_clean_run_writes_both_files(self):
+        """Asserted on its own, so every "opencode did not take it" below cannot pass in a
+        world where opencode never writes at all."""
         rc, _ = self.invoke(commands.cmd_guard_ask, pattern="foo *", local=False)
         self.assertEqual(rc, 0)
+        self.assertIn("foo *", json.dumps(json.loads(self.opencode().read_text())))
+
+    def test_the_refusal_stops_the_other_harness_too(self):
+        """The half-write itself. `.claude/settings.json` is refused, and #369's residue —
+        the rule in force under opencode from the same command — is what #376 removed."""
         self.corrupt_claude_settings()
-        rc, said = self.invoke(commands.cmd_guard_ask, pattern="bar *", local=False)
+        rc, _ = self.invoke(commands.cmd_guard_ask, pattern="bar *", local=False)
         self.assertEqual(rc, 1, "the malformed file is still refused")
         self.assertEqual(self.settings().read_text(), "{not json",
                          "and left byte-identical")
-        self.assertIn("bar *", json.dumps(json.loads(self.opencode().read_text())),
-                      "while another harness took the rule")
+        self.assertFalse(self.opencode().exists(),
+                         "another harness took a rule from a command that refused")
 
-    def test_an_uneven_landing_is_named(self):
+    def test_the_old_uneven_landing_warning_is_not_printed(self):
+        """Retired with the behaviour it described. It told the operator to reconcile two
+        harnesses that now cannot disagree, which is a search with no object at the end."""
         self.corrupt_claude_settings()
         _, said = self.invoke(commands.cmd_guard_ask, pattern="bar *", local=False)
-        self.assertIn("opencode", said)
-        self.assertRegex(said.lower(), r"in force|not in force|unevenly|some harnesses")
+        self.assertNotRegex(said.lower(), r"landed unevenly")
+        self.assertRegex(said.lower(), r"nothing was written")
 
     def test_guard_allow_says_it_too(self):
         self.corrupt_claude_settings()
         _, said = self.invoke(commands.cmd_guard_allow, pattern="bar *", local=False)
-        self.assertRegex(said.lower(), r"in force|not in force|unevenly|some harnesses")
+        self.assertNotRegex(said.lower(), r"landed unevenly")
+        self.assertRegex(said.lower(), r"nothing was written")
 
     def test_a_clean_write_says_nothing_about_uneven_landing(self):
-        """The message must be the exception, or it stops carrying information."""
+        """The message must be the exception, or it stops carrying information.
+
+        Narrowed from `unevenly|not in force` to the warning's own words: a clean run now
+        DOES say "Not in force under codex", and that is the honest standing limit #376
+        added rather than the half-write warning this guards against.
+        """
         _, said = self.invoke(commands.cmd_guard_ask, pattern="foo *", local=False)
-        self.assertNotRegex(said.lower(), r"unevenly|not in force")
+        self.assertNotRegex(said.lower(), r"landed unevenly")
 
     def test_the_docstring_says_the_refusal_is_per_harness(self):
-        """`add_permission_rule` said charter "reports it and stops". It reports and
-        continues to the next harness, and the next reader deserves the true sentence.
+        """`add_permission_rule` said charter "reports it and stops", and it did not.
+
+        Still the true sentence after #376, and for a reason worth keeping a test on: the
+        stop is real now, but it is not here. This function still refuses one file and
+        knows nothing about any other harness — `_guard_apply` is what turns three
+        per-harness refusals into one command that writes nowhere. A reader who found the
+        stop written into this docstring would look for it in the wrong layer.
 
         Asserted on the true claim rather than the absence of the old phrase, because the
         docstring now quotes that phrase in order to correct it — and a test that greps for

--- a/tests/test_guard_is_all_or_nothing.py
+++ b/tests/test_guard_is_all_or_nothing.py
@@ -14,9 +14,13 @@ Codex is registered. It keys off the two refusals being different in kind:
 
 * ``malformed`` is a condition of a FILE. Somebody can fix it in five minutes, and until
   they do, writing the other harnesses is what splits the plane. It **blocks the command**.
-* ``unsupported`` is a standing property of a HARNESS. Re-running changes nothing. It is
-  **reported and stepped over**, and the rule is genuinely not in force there — which is a
-  fact `guard` has to state rather than resolve.
+* ``unsupported`` is a standing property of a HARNESS and the pattern it was asked about.
+  Re-running changes nothing. It is **reported and stepped over**, and the rule is
+  genuinely not in force there — which is a fact `guard` has to state rather than resolve.
+  Since #374 opencode answers it to a pattern rather than to every call, which is why
+  `TestTheTransactionMeetsOpencodesMcpTranslation` drives the real harness rather than
+  another fake: what needs pinning is that a translation which now succeeds, and one that
+  now honestly cannot, each land on the side these two statuses mean.
 
 So the tests below come in pairs: the same fake harness refusing in each of the two ways,
 with opposite consequences for everybody else's files. A fix that collapsed the two would
@@ -39,6 +43,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
@@ -108,6 +113,30 @@ class _ChangedUnderneath(Harness):
 
     def apply_allow_rule(self, root, pattern, local=False, dry_run=False):
         return ("added" if dry_run else "malformed"), "/fake/config.json"
+
+
+class _Unwritable(Harness):
+    """A harness whose file passes the check and then raises on the write.
+
+    The chmod fixture in :class:`TestAWriteThatFailsIsReportedNotRaised` is the real
+    article and can be skipped (a process running as root writes a mode-444 file happily);
+    this one cannot, so the reporting path is pinned on every machine. It raises the error
+    a read-only file actually produces, `strerror` and all, rather than a bare `OSError`,
+    because the message charter prints quotes that string.
+    """
+
+    name = "fake-unwritable"
+
+    def _answer(self, dry_run: bool):
+        if dry_run:
+            return "added", "/fake/config.json"
+        raise PermissionError(13, "Permission denied", "/fake/config.json")
+
+    def apply_ask_rule(self, root, pattern, local=False, dry_run=False):
+        return self._answer(dry_run)
+
+    def apply_allow_rule(self, root, pattern, local=False, dry_run=False):
+        return self._answer(dry_run)
 
 
 class GuardCase(PersonaIso):
@@ -203,6 +232,26 @@ class TestTheWholeCommandOrNoneOfIt(GuardCase):
         self.assertRegex(said.lower(), r"nothing was written")
         self.assertNotRegex(said.lower(), r"landed unevenly")
 
+    def test_a_blocked_run_names_the_harnesses_that_would_have_taken_it(self):
+        """"Nothing was written" without this is a count, not an account.
+
+        The operator's next question after a refusal is which files to go and look at, and
+        the answer charter already has is the check phase's own result. Without a test the
+        line is decorative: emptying `pending` leaves every other test in the suite green,
+        so the second half of the promise "nothing was written, and here is what would
+        have taken it" could be deleted by accident.
+        """
+        self.break_file(self.opencode())
+        _, said = self.ask()
+        self.assertRegex(said.lower(), r"claude-code would have taken the rule")
+
+    def test_a_blocked_run_does_not_name_a_harness_that_could_never_take_it(self):
+        """Codex answers `unsupported` to every pattern. Listing it beside the harnesses
+        waiting on a fix would send somebody to re-run for a file that does not exist."""
+        self.break_file(self.opencode())
+        _, said = self.ask()
+        self.assertNotRegex(said.lower(), r"codex would have taken")
+
     def test_guard_allow_gets_the_same_transaction(self):
         """`ask` and `allow` are one job with opposite verbs — a transaction on one of them
         is the split this closes, reopened under the other name."""
@@ -223,6 +272,67 @@ class TestTheWholeCommandOrNoneOfIt(GuardCase):
                          .count("Bash(terraform apply *)"))
         self.assertEqual("ask", json.loads(self.opencode().read_text())
                          ["permission"]["bash"]["terraform apply *"])
+
+
+class TestABlockedRunSaysWhereTheRuleAlreadyStands(GuardCase):
+    """"Nothing was written" is not "the rule is nowhere", and only one of those is true.
+
+    The commonest way to meet a malformed config is not on a first attempt — it is on a
+    re-run over a plane that already holds the rule somewhere: a bad merge, a teammate's
+    machine, a file edited since. The transaction aborts either way, so the same sentence
+    covers two planes that could not be more different, and the operator's whole question
+    is which one they are on.
+
+    The half-writing loop this replaced answered it by accident: it printed `✓ claude-code:
+    already asking for …` beside the `✗`. A transaction that says LESS about the plane than
+    the split it removed is not an improvement, however much truer each sentence is on its
+    own. These tests hold the blocked run to naming both sides.
+    """
+
+    def already_under_claude_code_and_broken_under_opencode(self) -> None:
+        """The plane the tests below describe, established and then MEASURED.
+
+        Without the two assertions this is a fixture that might not have made the plane
+        uneven at all, and every "charter said so" below would be a claim about nothing.
+        """
+        rc, _ = self.ask()
+        self.assertEqual(0, rc, "the setup run did not land the rule anywhere")
+        self.break_file(self.opencode())
+        self.assertIn("Bash(terraform apply *)",
+                      json.loads(self.claude().read_text())["permissions"]["ask"],
+                      "the rule is not in force under claude-code, so nothing is uneven")
+        self.assertEqual("{not json", self.opencode().read_text(),
+                         "opencode's file parses, so the rule may still be in force there")
+
+    def test_it_names_the_harness_that_already_holds_the_rule(self):
+        self.already_under_claude_code_and_broken_under_opencode()
+        _, said = self.ask()
+        self.assertRegex(said.lower(), r"already in force under[^\n]*claude-code")
+
+    def test_it_says_the_plane_is_uneven_right_now(self):
+        """The state, not the command. "The plane is exactly as it was before this command"
+        is true of the COMMAND and says nothing about the plane, and a reader who takes it
+        for an all-clear stops looking exactly where the rule is missing."""
+        self.already_under_claude_code_and_broken_under_opencode()
+        _, said = self.ask()
+        self.assertRegex(said.lower(), r"uneven right now")
+
+    def test_a_first_attempt_that_reached_nowhere_says_no_such_thing(self):
+        """The other plane, and the one the sentence is already right about. A line that
+        printed on both would carry no information, which is how the old `✗` beside a `✓`
+        came to mean nothing."""
+        self.break_file(self.opencode())
+        _, said = self.ask()
+        self.assertRegex(said.lower(), r"nothing was written")
+        self.assertNotRegex(said.lower(), r"already in force")
+        self.assertNotRegex(said.lower(), r"uneven right now")
+
+    def test_both_verbs_say_it(self):
+        rc, _ = self.allow()
+        self.assertEqual(0, rc)
+        self.break_file(self.opencode())
+        _, said = self.allow()
+        self.assertRegex(said.lower(), r"already in force under[^\n]*claude-code")
 
 
 class TestUnsupportedIsNotAFailure(GuardCase):
@@ -280,6 +390,36 @@ class TestTheOperatorCanSeeWhichKindOfGapItIs(GuardCase):
         _, said = self.ask()
         self.assertRegex(said.lower(), r"fix it by hand")
         self.assertNotRegex(said.lower(), r"re-running will not change")
+
+    def test_a_harness_that_already_holds_the_rule_is_not_called_out_of_reach(self):
+        """The line names harnesses with NOWHERE to put the rule, and nothing else.
+
+        `present` is the status one keystroke away from `unsupported` in that filter, and
+        it is the one every harness answers on the second run of any command — so a filter
+        that admitted it would print "Not in force under claude-code" over a rule that is
+        in force under claude-code, constantly. Only a second run puts a real harness into
+        `present` while codex is still `unsupported`, which is why this test runs the
+        command twice.
+        """
+        self.ask()
+        _, said = self.ask()
+        self.assertRegex(said.lower(), r"not in force under[^\n]*codex")
+        self.assertNotRegex(said.lower(), r"not in force under[^\n]*claude-code")
+        self.assertNotRegex(said.lower(), r"not in force under[^\n]*opencode")
+
+    def test_the_second_run_really_does_answer_present(self):
+        """Precondition for the test above, and it has to name BOTH harnesses.
+
+        If the re-run wrote the rule afresh instead of finding it, `present` would never be
+        in those results and the filter above would never be asked the question. One
+        harness answering `present` is not enough either: the assertion above forbids
+        claude-code AND opencode from being called out of reach, and each half is only a
+        real question while that harness is really in the `present` state.
+        """
+        self.ask()
+        _, said = self.ask()
+        self.assertRegex(said.lower(), r"claude-code: already asking for")
+        self.assertRegex(said.lower(), r"opencode: already asking for")
 
     def test_a_standing_limit_alone_is_not_an_error(self):
         """Codex answers `unsupported` to every pattern. If that read as a failure, no
@@ -362,6 +502,100 @@ class TestTheOneSplitItCannotRuleOut(GuardCase):
         self.assertNotRegex(said.lower(), r"landed unevenly")
 
 
+class TestAWriteThatFailsIsReportedNotRaised(GuardCase):
+    """The other half of the trigger the issue named: a malformed OR UNWRITABLE file.
+
+    `_guard_apply`'s docstring said from the first commit that an IO failure between two
+    writes still leaves the plane uneven and that `_say_if_uneven` is what survives to
+    report it. It was not true of the code: `write_text` raised, the `OSError` went out
+    through `cmd_guard_ask` as a traceback, and everything below it — every `✓` already
+    earned, the uneven warning, the exit code — never ran. The operator got a stack trace
+    and a split plane, which is #369's failure with the message deleted rather than moved.
+
+    The split itself is NOT closed here and is not closable: there is no rollback
+    primitive, and a file that will not take a write cannot be found out about without
+    writing to it. What is closed is charter going silent about it.
+    """
+
+    def test_the_reporting_path_exists_at_all(self):
+        """Driven by a harness that raises on the write, so this cannot be skipped: the
+        chmod fixture below is the real article and root ignores mode bits."""
+        with self.with_harnesses(_Unwritable):
+            rc, said = self.ask()
+        self.assertEqual(1, rc)
+        self.assertRegex(said.lower(), r"could not write[^\n]*/fake/config\.json")
+        self.assertRegex(said.lower(), r"landed unevenly")
+        self.assertRegex(said.lower(), r"or would not take the write",
+                         "the uneven warning names only the cause it had before this case")
+
+    def test_it_quotes_the_operating_systems_own_reason(self):
+        """charter has no account of WHY a write failed beyond `strerror`, and inventing
+        one — permissions, ownership, a full disk — is naming a cause it only inferred."""
+        with self.with_harnesses(_Unwritable):
+            _, said = self.ask()
+        self.assertIn("Permission denied", said)
+
+    def test_it_is_not_reported_as_a_file_that_does_not_parse(self):
+        """The two refusals send the operator to different places. `malformed` says the
+        content is broken; a file charter could not write is usually perfectly valid, and
+        telling somebody their good JSON "is not valid" is a wrong cause stated with
+        total confidence."""
+        with self.with_harnesses(_Unwritable):
+            _, said = self.ask()
+        self.assertNotRegex(said.lower(), r"is not valid")
+
+    def test_it_says_re_running_is_the_remedy(self):
+        """The exact opposite of the standing-limit line, which is why both are printed.
+
+        A harness with nowhere to put the rule is told "Re-running will not change that".
+        A file that would not take the write is the other kind of gap entirely — nothing
+        about the harness is wrong and running the command again is precisely the fix —
+        and an operator who cannot tell the two apart re-runs the one that never helps and
+        gives up on the one that does.
+        """
+        with self.with_harnesses(_Unwritable):
+            _, said = self.ask()
+        self.assertRegex(said.lower(), r"re-run once that file can be written")
+
+    def test_the_harnesses_that_did_land_still_say_so(self):
+        with self.with_harnesses(_Unwritable):
+            _, said = self.ask()
+        self.assertRegex(said.lower(), r"claude-code: asking for")
+        self.assertIn("Bash(terraform apply *)",
+                      json.loads(self.claude().read_text())["permissions"]["ask"])
+
+    def test_both_verbs_report_it(self):
+        with self.with_harnesses(_Unwritable):
+            rc, said = self.allow()
+        self.assertEqual(1, rc)
+        self.assertRegex(said.lower(), r"could not write")
+
+    def test_a_real_read_only_file_reaches_that_path(self):
+        """The measurement behind the fake. A harness that raises proves the report; only
+        a real file proves a real `charter guard` can produce the raise at all.
+
+        The capability — can a write in THIS process be made to fail — is decided by the
+        attempt itself rather than by a probe beside it. Mode bits are advisory to root,
+        and a separate probe that answered wrongly would either skip this on a machine
+        that can run it (silently, forever) or claim a capability the machine lacks. Here
+        the run happens either way and the file's own content afterwards says which
+        machine this is.
+        """
+        oc = self.opencode()
+        oc.write_text("{}\n")
+        os.chmod(oc, 0o444)
+        try:
+            rc, said = self.ask()
+        finally:
+            os.chmod(oc, 0o644)
+        if oc.read_text() != "{}\n":
+            self.skipTest("this process wrote a mode-444 file it owns (running as root?), "
+                          "so no real write here can be made to fail")
+        self.assertEqual(1, rc)
+        self.assertRegex(said.lower(), r"could not write[^\n]*opencode\.json")
+        self.assertRegex(said.lower(), r"landed unevenly")
+
+
 class TestLocalKeepsItsOwnPromise(GuardCase):
     def test_a_harness_declining_the_local_file_does_not_block_the_one_that_has_one(self):
         """opencode answers `unsupported` to `--local` — its only uncommitted config is
@@ -381,6 +615,122 @@ class TestLocalKeepsItsOwnPromise(GuardCase):
         gitignore = self.root() / ".gitignore"
         body = gitignore.read_text() if gitignore.exists() else ""
         self.assertNotIn("/.claude/settings.local.json", body)
+
+
+class TestTheTransactionMeetsOpencodesMcpTranslation(GuardCase):
+    """#374 gave opencode a REAL rule for an MCP pattern, and the transaction spans it.
+
+    Before #374, `charter guard ask mcp__slack__send` fell through to `bash` under opencode
+    and wrote an inert rule under a tick. It now translates, and two new answers reach this
+    transaction from a harness that used to answer `added` to everything. Both are honest
+    outcomes rather than failures, and each has to land on the right side of the line:
+
+    * ``unsupported`` — :data:`opencode.FLAT_ONLY_PERMISSIONS` with a real glob. opencode's
+      `webfetch` takes a bare action and no pattern, so the rule genuinely cannot be
+      expressed there. That is a standing property of the harness and the pattern: re-running
+      changes nothing, so it must NOT stop Claude Code taking the rule it can express.
+    * ``malformed`` — one of those keys already holding an object. That is a file somebody
+      can fix, so it must stop everybody, exactly as an unparseable file does.
+
+    Asserted through the REAL opencode harness rather than a fake. A fake would only prove
+    the transaction sorts two strings it was handed; what is worth pinning is that the
+    harness whose translation changed still lands on the side these statuses mean.
+    """
+
+    def test_a_pattern_opencode_cannot_express_does_not_block_claude_code(self):
+        """`webfetch` is flat-only, so a URL glob has nowhere to go under opencode."""
+        rc, said = self.ask("WebFetch(https://example.com/*)")
+        self.assertEqual(0, rc)
+        self.assertIn("WebFetch(https://example.com/*)",
+                      json.loads(self.claude().read_text())["permissions"]["ask"])
+        self.assertFalse(self.opencode().exists(),
+                         "opencode cannot express this rule and must not have been written")
+        self.assertRegex(said.lower(), r"not in force under[^\n]*opencode")
+
+    def test_that_pattern_really_is_unsupported_under_opencode(self):
+        """Precondition. Without it the test above passes in a world where opencode
+        answered `added` and simply wrote somewhere this test does not look."""
+        status, _detail = registry.get(registry.OPENCODE).apply_ask_rule(
+            self.root(), "WebFetch(https://example.com/*)", dry_run=True)
+        self.assertEqual("unsupported", status)
+
+    def test_a_flat_only_key_holding_an_object_blocks_every_harness(self):
+        """The other half of the pair, and the reason the two cannot be collapsed. Same
+        harness, same command, a refusal of the other kind — and Claude Code's file must
+        not exist afterwards."""
+        self.opencode().write_text(
+            json.dumps({"permission": {"webfetch": {"*": "ask"}}}, indent=2) + "\n")
+        rc, said = self.ask("WebFetch(*)")
+        self.assertEqual(1, rc)
+        self.assertFalse(self.claude().exists(),
+                         "claude-code was written during a blocked run")
+        self.assertRegex(said.lower(), r"nothing was written")
+
+    def test_an_mcp_pattern_lands_under_both_harnesses_in_one_command(self):
+        """The ordinary case #374 created, driven end to end. opencode's key is the
+        translated name, not the operator's pattern, and Claude Code's is the pattern."""
+        rc, _ = self.ask("mcp__slack__send")
+        self.assertEqual(0, rc)
+        self.assertIn("mcp__slack__send",
+                      json.loads(self.claude().read_text())["permissions"]["ask"])
+        self.assertEqual({"slack_send": {"*": "ask"}},
+                         json.loads(self.opencode().read_text())["permission"])
+
+
+class TestABlockedRunStillSaysWhatTheStandingRuleOutranks(GuardCase):
+    """A rule that already stands still outranks what it outranked (#374), blocked or not.
+
+    The blocked path replaces the per-harness loop, so it also replaces the loop's
+    `_warn_if_outranking` call — and losing it was measured against a `git archive
+    origin/main` export rather than reasoned about: same plane, same command, main printed
+    the line and the first rebase of this branch did not. `charter guard allow mcp__plan`
+    with opencode already holding `plan_*` means two of opencode's OWN denies are allow
+    right now, which is the whole reason #374 prints anything at all.
+
+    The pair below is the filter: ``present`` warns because that rule is in force, and
+    ``added`` must not, because a blocked run wrote it nowhere and its consequences do not
+    exist yet. A fix that reinstated the loop's two-status filter wholesale would pass the
+    first and fail the second.
+    """
+
+    def already_under_opencode_and_broken_under_claude_code(self) -> None:
+        rc, _ = self.allow("mcp__plan")
+        self.assertEqual(0, rc, "the setup run did not land the rule anywhere")
+        self.break_file(self.claude())
+        self.assertEqual({"plan_*": {"*": "allow"}},
+                         json.loads(self.opencode().read_text())["permission"],
+                         "opencode does not hold the outranking rule, so nothing outranks")
+
+    def test_the_operator_is_told_what_the_standing_rule_decides_for_them(self):
+        self.already_under_opencode_and_broken_under_claude_code()
+        rc, said = self.allow("mcp__plan")
+        self.assertEqual(1, rc)
+        self.assertIn("plan_enter", said)
+        self.assertIn("plan_exit", said)
+
+    def test_the_line_that_needs_acting_on_still_comes_first(self):
+        """The other half of `_warn_if_outranking`'s own reasoning: a warning printed over
+        a malformed file must not bury the sentence that fixes it."""
+        self.already_under_opencode_and_broken_under_claude_code()
+        _, said = self.allow("mcp__plan")
+        self.assertLess(said.index("is not valid"), said.index("plan_enter"))
+
+    def test_a_rule_that_was_never_written_is_not_warned_about(self):
+        """Nothing landed, so there is nothing outranking anything. Warning here would
+        describe a consequence of a rule that does not exist — which is exactly why
+        `_warn_if_outranking` skips `unsupported` in the ordinary loop."""
+        self.break_file(self.claude())
+        rc, said = self.allow("mcp__plan")
+        self.assertEqual(1, rc)
+        self.assertRegex(said.lower(), r"nothing was written")
+        self.assertNotIn("plan_enter", said)
+
+    def test_a_clean_run_still_says_it_too(self):
+        """The path this one branched off. Guards against a fix that moved the warning
+        into the blocked path instead of adding it there."""
+        rc, said = self.allow("mcp__plan")
+        self.assertEqual(0, rc)
+        self.assertIn("plan_enter", said)
 
 
 if __name__ == "__main__":

--- a/tests/test_guard_is_all_or_nothing.py
+++ b/tests/test_guard_is_all_or_nothing.py
@@ -1,0 +1,387 @@
+"""One `charter guard` command lands under every harness that can hold the rule, or none.
+
+#369 fixed the *claim* and left the behaviour: `cmd_guard_ask` and `cmd_guard_allow`
+iterated `registry.all()` and wrote harness by harness, so a malformed `.claude/settings.json`
+left the rule in force under opencode and absent under Claude Code from one invocation, and
+the command said so at the end. #376 is the behaviour — the plane must not be left in a
+state one command did not intend.
+
+**The design question is what "all-or-nothing" means when a harness legitimately cannot
+express the rule.** `base.py` records `unsupported` as an honest answer rather than a
+failure, and Codex answers it to every pattern there is. So the transaction cannot key off
+"did this harness write" — that would mean charter never writes a guard rule anywhere while
+Codex is registered. It keys off the two refusals being different in kind:
+
+* ``malformed`` is a condition of a FILE. Somebody can fix it in five minutes, and until
+  they do, writing the other harnesses is what splits the plane. It **blocks the command**.
+* ``unsupported`` is a standing property of a HARNESS. Re-running changes nothing. It is
+  **reported and stepped over**, and the rule is genuinely not in force there — which is a
+  fact `guard` has to state rather than resolve.
+
+So the tests below come in pairs: the same fake harness refusing in each of the two ways,
+with opposite consequences for everybody else's files. A fix that collapsed the two would
+pass one of each pair and fail the other.
+
+**Two phases, and the check is the write path minus the write.** Claude Code is the FIRST
+harness in the registry, so aborting on the first refusal is not enough: by the time
+opencode refuses, Claude Code's file is already written. Every harness is asked first, with
+``dry_run=True``, and nothing is written unless all of them can take it. The check is the
+same code path as the write because a separate validator is a second answer to one question,
+and a transaction whose check disagrees with its commit prints a tick either way.
+
+What is NOT claimed: the commit phase writes several files in sequence with no rollback
+primitive, so an IO failure between them still leaves the plane uneven. That is why
+`_say_if_uneven` survives — it moved from the ordinary outcome to the one charter cannot
+rule out.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands, config
+from charter.harness import registry
+from charter.harness.base import Harness
+from tests._isolation import PersonaIso
+
+PATTERN = "terraform apply *"
+
+#: What each real harness writes, relative to the plane root. Named here rather than
+#: derived from the harness, so a bug that moved a file would fail these tests instead of
+#: relocating their assertions with it.
+CLAUDE_FILE = Path(".claude") / "settings.json"
+OPENCODE_FILE = Path("opencode.json")
+
+
+class _Unsupported(Harness):
+    """A harness with nowhere to put a command-pattern rule, ever.
+
+    Spelled out rather than inherited from :class:`Harness`'s default so that this test
+    keeps testing `unsupported` even if the base class one day answers something else.
+    """
+
+    name = "fake-unsupported"
+
+    def apply_ask_rule(self, root, pattern, local=False, dry_run=False):
+        return "unsupported", "fake-unsupported has no command-pattern permissions"
+
+    def apply_allow_rule(self, root, pattern, local=False, dry_run=False):
+        return "unsupported", "fake-unsupported has no command-pattern permissions"
+
+
+class _Refusing(Harness):
+    """A harness whose config file is somebody's to fix, and which writes nothing meanwhile.
+
+    Never touches the filesystem in either phase — so an assertion that the OTHER
+    harnesses' files are absent can only be about the transaction, never about this one
+    having cleaned up after itself.
+    """
+
+    name = "fake-refusing"
+
+    def apply_ask_rule(self, root, pattern, local=False, dry_run=False):
+        return "malformed", "/fake/config.json"
+
+    def apply_allow_rule(self, root, pattern, local=False, dry_run=False):
+        return "malformed", "/fake/config.json"
+
+
+class _ChangedUnderneath(Harness):
+    """A harness whose file passes the check and then refuses the write.
+
+    Not a hypothetical shape: the check reads the file and the commit re-reads it, so an
+    editor saving or a `git checkout` in between lands exactly here. It is the one uneven
+    landing this transaction cannot rule out, and a message kept for a case with no test on
+    it is a comment.
+    """
+
+    name = "fake-changed-underneath"
+
+    def apply_ask_rule(self, root, pattern, local=False, dry_run=False):
+        return ("added" if dry_run else "malformed"), "/fake/config.json"
+
+    def apply_allow_rule(self, root, pattern, local=False, dry_run=False):
+        return ("added" if dry_run else "malformed"), "/fake/config.json"
+
+
+class GuardCase(PersonaIso):
+    def root(self) -> Path:
+        return Path(config.ROOT)
+
+    def claude(self) -> Path:
+        return self.root() / CLAUDE_FILE
+
+    def opencode(self) -> Path:
+        return self.root() / OPENCODE_FILE
+
+    def local_settings(self) -> Path:
+        return self.root() / ".claude" / "settings.local.json"
+
+    def invoke(self, fn, **kw) -> tuple[int, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = fn(SimpleNamespace(**kw))
+        return rc, out.getvalue() + err.getvalue()
+
+    def ask(self, pattern: str = PATTERN, **kw):
+        return self.invoke(commands.cmd_guard_ask, pattern=pattern,
+                           local=kw.get("local", False))
+
+    def allow(self, pattern: str = PATTERN, **kw):
+        return self.invoke(commands.cmd_guard_allow, pattern=pattern,
+                           local=kw.get("local", False))
+
+    def break_file(self, p: Path) -> None:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{not json")
+
+    def with_harnesses(self, *extra: type):
+        """Run with *extra* appended to the registry, after every real harness."""
+        kinds = dict(registry.KINDS)
+        for cls in extra:
+            kinds[cls.name] = cls
+        return mock.patch.object(registry, "KINDS", kinds)
+
+
+class TestTheWholeCommandOrNoneOfIt(GuardCase):
+    def test_every_harness_takes_the_rule_when_nothing_is_broken(self):
+        """Precondition for every abort test below. Without this, "opencode.json was not
+        written" would pass in a world where opencode never writes at all."""
+        rc, _ = self.ask()
+        self.assertEqual(0, rc)
+        self.assertIn("Bash(terraform apply *)",
+                      json.loads(self.claude().read_text())["permissions"]["ask"])
+        self.assertEqual("ask", json.loads(self.opencode().read_text())
+                         ["permission"]["bash"]["terraform apply *"])
+
+    def test_a_refusal_from_the_first_harness_stops_the_second(self):
+        """Claude Code refuses; opencode must not gain the rule anyway.
+
+        The half-write #369 documented and left in place.
+        """
+        self.break_file(self.claude())
+        self.ask()
+        self.assertFalse(self.opencode().exists(),
+                         "opencode took a rule from a command that refused elsewhere")
+
+    def test_a_refusal_from_the_last_harness_stops_the_first(self):
+        """opencode refuses; Claude Code must not have been written BEFORE it was asked.
+
+        Claude Code is first in `registry.KINDS`, so this is the case a bail-on-first-error
+        loop cannot fix — the write has already happened by then. Only asking every harness
+        before writing any of them makes this pass.
+        """
+        self.break_file(self.opencode())
+        self.ask()
+        self.assertFalse(self.claude().exists(),
+                         "the first harness wrote before the last one was consulted")
+
+    def test_the_refused_file_is_still_byte_identical(self):
+        """charter never repairs a file it could not parse — the restraint the whole
+        refusal exists to keep."""
+        self.break_file(self.opencode())
+        self.ask()
+        self.assertEqual("{not json", self.opencode().read_text())
+
+    def test_a_command_that_wrote_nothing_exits_nonzero(self):
+        self.break_file(self.opencode())
+        rc, _ = self.ask()
+        self.assertEqual(1, rc)
+
+    def test_it_says_nothing_was_written_rather_than_naming_an_uneven_landing(self):
+        """The operator's remedy changed with the behaviour. "It landed unevenly, fix that
+        file and re-run" told them to go and reconcile two harnesses; there is nothing to
+        reconcile now, and repeating the old sentence would send them looking."""
+        self.break_file(self.opencode())
+        _, said = self.ask()
+        self.assertRegex(said.lower(), r"nothing was written")
+        self.assertNotRegex(said.lower(), r"landed unevenly")
+
+    def test_guard_allow_gets_the_same_transaction(self):
+        """`ask` and `allow` are one job with opposite verbs — a transaction on one of them
+        is the split this closes, reopened under the other name."""
+        self.break_file(self.opencode())
+        self.allow()
+        self.assertFalse(self.claude().exists())
+
+    def test_fixing_the_file_and_re_running_is_a_first_write_everywhere(self):
+        """The residue the issue names: after a half-write, the re-run makes one harness's
+        copy a duplicate rather than a first one. With nothing written the first time, the
+        second run is simply the write."""
+        self.break_file(self.opencode())
+        self.ask()
+        self.opencode().write_text("{}")
+        rc, _ = self.ask()
+        self.assertEqual(0, rc)
+        self.assertEqual(1, json.loads(self.claude().read_text())["permissions"]["ask"]
+                         .count("Bash(terraform apply *)"))
+        self.assertEqual("ask", json.loads(self.opencode().read_text())
+                         ["permission"]["bash"]["terraform apply *"])
+
+
+class TestUnsupportedIsNotAFailure(GuardCase):
+    """The distinction, asserted from both sides with the same fixture shape.
+
+    Each test registers ONE extra harness that refuses in ONE of the two ways, and asks
+    what happened to the real harnesses' files. A transaction keyed on anything coarser
+    than the status — "did it write", "was it a non-added answer" — passes one and fails
+    the other.
+    """
+
+    def test_a_harness_with_nowhere_to_put_the_rule_does_not_block_the_others(self):
+        with self.with_harnesses(_Unsupported):
+            rc, _ = self.ask()
+        self.assertEqual(0, rc)
+        self.assertIn("Bash(terraform apply *)",
+                      json.loads(self.claude().read_text())["permissions"]["ask"])
+        self.assertTrue(self.opencode().exists())
+
+    def test_a_harness_refusing_its_file_does_block_the_others(self):
+        with self.with_harnesses(_Refusing):
+            rc, _ = self.ask()
+        self.assertEqual(1, rc)
+        self.assertFalse(self.claude().exists())
+        self.assertFalse(self.opencode().exists())
+
+    def test_both_verbs_draw_the_line_in_the_same_place(self):
+        with self.with_harnesses(_Unsupported):
+            rc, _ = self.allow()
+        self.assertEqual(0, rc)
+        self.assertIn("Bash(terraform apply *)",
+                      json.loads(self.claude().read_text())["permissions"]["allow"])
+        with self.with_harnesses(_Refusing):
+            self.allow("git status *")
+        self.assertNotIn("Bash(git status *)",
+                         json.loads(self.claude().read_text())["permissions"]["allow"])
+
+
+class TestTheOperatorCanSeeWhichKindOfGapItIs(GuardCase):
+    """Two gaps that look identical in a listing and have opposite remedies.
+
+    A rule missing under a harness because a file is broken is fixed by fixing the file and
+    running the command again. A rule missing because the harness has no such rule is not
+    fixed by anything, and an operator who re-runs hoping is doing so because charter let
+    them believe the two were the same gap.
+    """
+
+    def test_a_standing_limit_is_named_as_one_and_not_as_a_remedy(self):
+        _, said = self.ask()
+        self.assertRegex(said.lower(), r"not in force under[^\n]*codex")
+        self.assertRegex(said.lower(), r"re-running will not change")
+
+    def test_a_broken_file_is_named_with_its_remedy_instead(self):
+        self.break_file(self.opencode())
+        _, said = self.ask()
+        self.assertRegex(said.lower(), r"fix it by hand")
+        self.assertNotRegex(said.lower(), r"re-running will not change")
+
+    def test_a_standing_limit_alone_is_not_an_error(self):
+        """Codex answers `unsupported` to every pattern. If that read as a failure, no
+        `charter guard` command could ever succeed."""
+        rc, _ = self.ask()
+        self.assertEqual(0, rc)
+
+
+class TestTheCheckIsTheWritePathMinusTheWrite(GuardCase):
+    """`dry_run` is not a validator of its own, and these are what stop it becoming one."""
+
+    def test_a_dry_run_answers_added_and_creates_nothing(self):
+        for name in ("claude-code", "opencode"):
+            with self.subTest(harness=name):
+                root = Path(config.ROOT) / name
+                root.mkdir(parents=True, exist_ok=True)
+                status, _ = registry.get(name).apply_ask_rule(root, PATTERN, dry_run=True)
+                self.assertEqual("added", status)
+                self.assertEqual([], list(root.rglob("*")),
+                                 "a check wrote something")
+
+    def test_a_dry_run_answers_present_once_the_rule_is_really_there(self):
+        for name in ("claude-code", "opencode"):
+            with self.subTest(harness=name):
+                root = Path(config.ROOT) / name
+                root.mkdir(parents=True, exist_ok=True)
+                registry.get(name).apply_ask_rule(root, PATTERN)
+                self.assertEqual("present", registry.get(name)
+                                 .apply_ask_rule(root, PATTERN, dry_run=True)[0])
+
+    def test_a_dry_run_answers_malformed_over_a_file_nobody_can_parse(self):
+        root = Path(config.ROOT) / "oc"
+        root.mkdir(parents=True, exist_ok=True)
+        (root / "opencode.json").write_text("{not json")
+        self.assertEqual("malformed", registry.get("opencode")
+                         .apply_ask_rule(root, PATTERN, dry_run=True)[0])
+
+    def test_every_registered_harness_answers_a_dry_run_without_writing(self):
+        """Iterated over the registry on purpose: a harness added tomorrow is covered the
+        day it is registered, not the day somebody remembers this file."""
+        for h in registry.all():
+            for verb in ("apply_ask_rule", "apply_allow_rule"):
+                with self.subTest(harness=h.name, verb=verb):
+                    root = Path(config.ROOT) / f"{h.name}-{verb}"
+                    root.mkdir(parents=True, exist_ok=True)
+                    status, _ = getattr(h, verb)(root, PATTERN, dry_run=True)
+                    self.assertIn(status, ("added", "present", "malformed", "unsupported"))
+                    self.assertEqual([], list(root.rglob("*")))
+
+
+class TestTheOneSplitItCannotRuleOut(GuardCase):
+    """The claim stops exactly where the guarantee does, and says so in the output.
+
+    The commit phase writes several files in sequence with no rollback primitive. A file
+    that changes between being checked and being written still splits the plane, and
+    `_say_if_uneven` survives #376 for that case alone — it went from the ordinary outcome
+    of a malformed config to the one charter cannot prevent. Without this test, the honest
+    residue and the message describing it are both unexercised, and "we kept the warning
+    for the rare case" is a sentence nobody can check.
+    """
+
+    def test_a_file_that_changes_between_the_check_and_the_write_is_named(self):
+        with self.with_harnesses(_ChangedUnderneath):
+            rc, said = self.ask()
+        self.assertEqual(1, rc)
+        self.assertRegex(said.lower(), r"landed unevenly")
+        self.assertRegex(said.lower(), r"changed underneath")
+
+    def test_the_harnesses_that_did_land_are_still_reported_as_landed(self):
+        """An operator told "unevenly" has to be able to see WHICH side each harness is on,
+        or the only safe reading is to check three files by hand."""
+        with self.with_harnesses(_ChangedUnderneath):
+            self.ask()
+        self.assertIn("Bash(terraform apply *)",
+                      json.loads(self.claude().read_text())["permissions"]["ask"])
+
+    def test_a_clean_run_never_says_it(self):
+        """The message has to stay the exception, or it stops carrying information."""
+        _, said = self.ask()
+        self.assertNotRegex(said.lower(), r"landed unevenly")
+
+
+class TestLocalKeepsItsOwnPromise(GuardCase):
+    def test_a_harness_declining_the_local_file_does_not_block_the_one_that_has_one(self):
+        """opencode answers `unsupported` to `--local` — its only uncommitted config is
+        machine-wide. Blocking on that would make `--local` write nothing at all, which is
+        the flag's whole purpose deleted."""
+        rc, _ = self.ask(local=True)
+        self.assertEqual(0, rc)
+        self.assertIn("Bash(terraform apply *)",
+                      json.loads(self.local_settings().read_text())["permissions"]["ask"])
+
+    def test_a_blocked_local_run_does_not_even_touch_gitignore(self):
+        """`--local`'s gitignore line is written at the point of use, before the settings
+        file is read. A check that writes it is a check with a side effect, and the plane
+        is no longer exactly as it was."""
+        self.break_file(self.local_settings())
+        self.ask(local=True)
+        gitignore = self.root() / ".gitignore"
+        body = gitignore.read_text() if gitignore.exists() else ""
+        self.assertNotIn("/.claude/settings.local.json", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #376.

Implemented, adversarially reviewed, and re-verified after a findings round — in an ultracode workflow. Each reviewer reproduced the original symptom against the branch point, showed it gone, and mutation-tested every new test to confirm it can actually fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9