### PR TITLE
0.51.0 — a frame in the tmux you already have

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.50.1",
+  "version": "0.51.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.50.1"
+__version__ = "0.51.0"

--- a/docs/news/0.51.0-a-dead-panel-says-why.md
+++ b/docs/news/0.51.0-a-dead-panel-says-why.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.51.0
 headline: A panel that dies now says why, and comes back
 ---
 

--- a/docs/news/0.51.0-a-frame-in-the-tmux-you-already-have.md
+++ b/docs/news/0.51.0-a-frame-in-the-tmux-you-already-have.md
@@ -1,0 +1,60 @@
+---
+version: 0.51.0
+headline: Started inside tmux, the frame opens a window in your server instead of nesting one inside it
+---
+
+`charter claude` used to start its own tmux server no matter where you ran it. From inside a
+tmux session that meant two tmux layers and two prefix keys, one wrapped in the other, and
+the documented answer was to give the frame up: *"If you already live in tmux, `charter
+<harness> --no-frame` is the honest answer for now."*
+
+It no longer nests. charter reads `$TMUX` and opens **one window on your server**, in the
+session you were already in, with the identical layout inside it. One tmux, one prefix key,
+your own window list. `charter claude` switches you to that window and waits; when the
+harness exits, charter closes the window, tmux puts you back where you were, and `charter
+claude` exits with the harness's own code.
+
+**charter is a guest there and behaves like one: it writes nothing of yours.** Not a server
+option, not a session option, not a key binding. That is the whole promise, and the rest of
+this entry is its price — said out loud, because every item is something the frame does on
+charter's own server and does not do here.
+
+- **Your scrollback and mouse settings win.** `history-limit` and `mouse` are session
+  options in tmux, so setting them for the frame would set them for every other window in
+  that session. `[frame] history-limit` and `[frame] mouse` are ignored inside your tmux.
+- **No hotkey.** Key tables in tmux are server-wide with no per-window form, so any key
+  charter bound would be taken from every window you have open. The bottom panel drops its
+  hotkey hint to match, rather than advertising a key that does nothing. The menu's one
+  entry is "Detach", and your own prefix key already does that better.
+- **Your status bar stays.** The frame gets the window, not the screen.
+- **If `charter` itself is killed while the harness runs**, the harness keeps running and its
+  window stays in your window list — close it with your own `prefix-&`. On charter's private
+  server a teardown hook handles that case; here a hook that closed the window would destroy
+  the pane before charter could read the exit code out of it, so charter watches and does the
+  closing itself.
+- **charter asks tmux four times a second** whether the harness is still there, for the life
+  of the frame. You are already attached, so there is no `attach` call to block on, and this
+  is what replaces it. A `pane-died` hook signalling `wait-for` would be cheaper and was
+  refused: tmux runs a hook array in index order with no way to interleave a read, so the
+  wake would race the teardown for the exit code it exists to collect. Four asks a second is
+  a cost; a lost exit code is a defect.
+
+**The panels are sized against the window, not the pane you typed in.** `os.get_terminal_size()`
+inside a tmux measures the pane charter was launched from, which is a fraction of the window
+whenever you have a split open — so charter asks tmux for the window's own dimensions
+instead. Without that, opening the frame from a split would drop side panels a full-width
+window has ample room for.
+
+**A `$TMUX` that no tmux answers on is not a tmux you are inside.** A value captured by `env`
+and re-exported, or a `tmux kill-server` under a running script, leaves the variable set and
+the server gone. charter checks before it builds anything and falls back to its own private
+server.
+
+A command that dies before the frame is drawn is reported on this path too — see *A framed
+command that dies instantly now says so*, elsewhere in this release — and there the wording
+is if anything an understatement. You are attached to your own server the whole time, but
+charter never switches you to the frame's window: it is opened, filled with a corpse, and
+closed again without your screen changing at all.
+
+`docs/frame.md` carries the whole contract. Nothing to adopt: run `charter claude` from
+inside tmux and you get the second path.

--- a/docs/news/0.51.0-a-frame-that-dies-instantly-says-so.md
+++ b/docs/news/0.51.0-a-frame-that-dies-instantly-says-so.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.51.0
 headline: A framed command that dies instantly now says so, instead of nothing at all
 ---
 

--- a/docs/news/0.51.0-a-memory-push-that-did-not-land.md
+++ b/docs/news/0.51.0-a-memory-push-that-did-not-land.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.51.0
 headline: A memory commit that never reached the remote now says so, every turn, until it does
 ---
 

--- a/docs/news/0.51.0-an-approval-names-its-nudge.md
+++ b/docs/news/0.51.0-an-approval-names-its-nudge.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.51.0
 headline: An approval names the nudge that earned it
 ---
 

--- a/docs/news/0.51.0-guard-is-all-or-nothing.md
+++ b/docs/news/0.51.0-guard-is-all-or-nothing.md
@@ -1,0 +1,58 @@
+---
+version: 0.51.0
+headline: A guard rule now lands under every harness or under none, and says where it could not reach
+---
+
+`charter guard ask 'rm -rf *'` walked the harnesses in registration order and refused each
+broken file on its own. Claude Code is first, so a malformed `.claude/settings.json` printed
+a `✗` — and charter carried on to opencode, which took the rule. One command, and the plane
+now asked for that pattern under opencode and not under Claude Code.
+
+The `✗` reads as *nothing was written* (#369). So the operator fixed the JSON, re-ran, and
+opencode's copy became a duplicate write rather than a first one — while the interval
+between the two commands was spent believing a rule was nowhere when it was already half in
+force.
+
+**Every harness is now asked before any of them is written.** `guard` runs the write path
+with the write removed — the same code, `dry_run=True`, not a validator of its own that
+could come to disagree with it — and commits only if all of them can take the rule. A
+malformed file anywhere means nothing lands anywhere, and the report says that in as many
+words instead of leaving it to be inferred from which ticks appeared:
+
+```
+✗ claude-code: /plane/.claude/settings.json is not valid — left untouched.
+  Fix it by hand, then re-run. charter never repairs these files.
+  NOTHING was written, under any harness — `charter guard` is all-or-nothing across the
+  harnesses that can hold a rule, so the plane is exactly as it was before this command.
+```
+
+**"Nothing was written" is not "the rule is nowhere", and both halves are printed.** The
+commonest way to meet a broken config is on a re-run, where an earlier command already put
+the rule somewhere — so the plane genuinely is uneven, and a report that described only
+*this* command would say less about it than the half-writing loop it replaced. charter names
+where the rule already stands, and which harnesses would have taken it and did not.
+
+**A harness with nowhere to put the rule is a limit, not a failure, and is now labelled as
+one.** Codex has no command-pattern permissions at all, opencode has no machine-local file
+for `--local`, and since #374 opencode cannot express a URL glob under the permission keys
+that take a bare decision. None of that blocks the transaction — those answers are permanent,
+so a command that stopped for them would write nothing anywhere, forever. They are reported
+and stepped over, under a sentence whose whole job is to stop you filing them beside the
+broken case: *nowhere to write it there … re-running will not change that.* The two remedies
+are opposites, and the old output gave you no way to tell them apart.
+
+**A file that parses and will not take the write no longer raises a traceback.** Read-only,
+wrong owner, full disk — the `OSError` escaped out of the middle of the loop with the earlier
+harnesses already written, which is #369 with the message deleted rather than moved. It is
+now caught where something knows how far the transaction had got, and reported as its own
+outcome. Deliberately not as `malformed`: the file is perfectly valid, and telling you your
+JSON "is not valid" would send you to fix content that is fine.
+
+**One uneven landing survives, and is now the only one.** Committing writes several files in
+sequence across three formats with no rollback primitive, so a file that changes underneath
+the command — or an IO failure between two writes — still splits the plane. The warning for it stays, and
+it went from the *ordinary* outcome of a broken config to the one case charter cannot rule
+out. That makes it rarer and more worth reading, not obsolete.
+
+Nothing to adopt: upgrading is the whole of it. A `--local` run also no longer touches your
+`.gitignore` before deciding it cannot proceed — a check with a side effect is not a check.

--- a/docs/news/0.51.0-op-asks-once.md
+++ b/docs/news/0.51.0-op-asks-once.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.51.0
 headline: A 1Password write asks op for the item once instead of three times
 ---
 

--- a/docs/news/0.51.0-opencode-mcp-guard-rules.md
+++ b/docs/news/0.51.0-opencode-mcp-guard-rules.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.51.0
 headline: An MCP guard rule now fires under opencode, and says what else it decides
 ---
 

--- a/docs/news/0.51.0-reap-keeps-a-live-frame.md
+++ b/docs/news/0.51.0-reap-keeps-a-live-frame.md
@@ -1,0 +1,43 @@
+---
+version: 0.51.0
+headline: Cleaning up dead frames no longer deletes a live one out from under its launcher
+---
+
+Every `charter frame` launch first reaps the state of frames whose tmux session is gone. A
+frame outlives its session by a moment, though, and that moment is the one that matters: the
+harness exits, tmux tears the session down, and the launcher is still there — about to read
+the exit code out of the frame's directory so it can exit with it. A second launch landing in
+that window saw no session, called the frame dead, and deleted the file the first launcher
+was on its way to read.
+
+**A live session is no longer the only thing that keeps a frame.** A frame id is
+`<workspace>-<launcher pid>`, so charter now asks whether that launcher is still running and
+keeps the directory while it is. `os.kill(pid, 0)` is the question — signal 0 sends nothing —
+and two of its answers are read carefully. `EPERM` means the process exists and is not ours
+to signal, which is *alive*: reading it as gone would make every frame another user launched
+reapable while it was still running. Off POSIX the pid is taken at its word, because there
+`os.kill(pid, 0)` maps to `TerminateProcess` and would kill whatever the name happened to
+hold. A directory whose name carries no pid at all — debris, something hand-made, a name
+minted by an older charter — stays reapable, since nothing may become undeletable merely
+because charter cannot read anything out of it.
+
+**That rule sends a bill, and a launch is where it is paid.** Pids get recycled — Linux wraps
+at `kernel.pid_max`, 32768 by default — so a launcher for the same workspace really does land
+on a pid an earlier launcher used, and mints the same frame id. The new rule then keeps that
+earlier directory, because the pid in its name is live: it is ours. So a launch now clears the
+two files that would otherwise be inherited:
+
+- **`exit`**, or the launcher reads a dead frame's code back as its own and returns it — a
+  harness running perfectly well, detached, reported as having failed with someone else's
+  number.
+- **the cached `gather` scan**, or every panel is served a dead frame's repos, branches and CI
+  until the session's first hook fires. That read has no freshness check and needs none — it
+  is the hot path a panel polls — so nothing would have corrected it, and what sat on screen
+  could be a scan from another day.
+
+A launch beginning is the one moment that can be certain about this: whatever is recorded
+under the id was recorded before this frame existed. The `version` counter is deliberately
+left alone — panels compare it against their last reading, and moving it is `bump`'s job, one
+line further down.
+
+Nothing to adopt: upgrading is the whole of it.

--- a/docs/news/0.51.0-the-suite-stays-out-of-your-trace.md
+++ b/docs/news/0.51.0-the-suite-stays-out-of-your-trace.md
@@ -1,0 +1,45 @@
+---
+version: 0.51.0
+headline: charter's own test suite no longer writes into your trace, so `--summary` counts your session
+---
+
+`charter trace --summary` reported **581 guard denials** for one session. 556 of them were
+recorded while charter's own test suite ran. The headline number an operator is meant to read
+as *what happened here* was dominated by noise nobody in that session had produced, and there
+was nothing on the line to say so.
+
+A suite run resolves its plane exactly the way every other command does — walk up for
+`charter.toml`, then hop outward through `workspaces/`. So a charter checkout that lives
+inside somebody's control plane resolves to **that** plane, and any test reaching a real
+handler without redirecting `config` appends to the developer's own
+`.charter/persona-state/trace/`, under the ambient `$CHARTER_SESSION_ID`: the live session
+bucket `--summary` reads.
+
+**The fix is at the writer, and both fixes at the reader were refused.** Nothing filters and
+nothing is marked; every row in a session's file is still counted without exception.
+
+- *Drop the suite's rows from the count.* Then "quiet because nothing happened" and "quiet
+  because we filtered" print identically — the one confusion an observability tool may not
+  create.
+- *Mark them instead, and say "556 of these were the test suite".* Honest to read, but the
+  mark has to come from something the runtime can see: an env var or a config key. That is an
+  override the observed agent could set on its own denials. `hooks._OVERRIDE_NOTE` spends a
+  paragraph refusing exactly that trade for the guards themselves, and the record of a guard
+  does not get a weaker rule than the guard.
+
+Two fixtures were the whole of it, with the same shape each: they hand-picked the `config`
+attributes they redirected and both missed `PERSONA_STATE_DIR`, which is the one the trace
+writes through. They now redirect through `config.use` instead of lengthening a list by one —
+`config.DERIVED` exists as the single definition of what follows from a root precisely so that
+a fixture cannot miss one, and #227 moved `test_plugin` onto the same seam after the same
+failure.
+
+The invariant now has a test of its own, with a positive control beside it: a fixture carrying
+the exact defect, kept so the probe is known to *see* a leak rather than merely to report
+none. Its probe method is deliberately not named `test_*`, since discovery would otherwise run
+the leak for real, into the developer's plane, every suite run.
+
+This only ever reached you if you run charter's suite from a checkout inside your plane —
+which is to say, if you work on charter. Nothing to adopt: upgrading is the whole of it. Rows
+already in your store are left exactly as they are, because they are a record of what charter
+observed and they genuinely were written.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.50.1",
+            "command": "charter hook sessionstart --plugin-version 0.51.0",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.50.1",
+            "command": "charter hook userpromptsubmit --plugin-version 0.51.0",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.50.1",
+            "command": "charter hook pretooluse --plugin-version 0.51.0",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.50.1",
+            "command": "charter hook pretooluse-read --plugin-version 0.51.0",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.50.1"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.51.0"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.50.1",
+            "command": "charter hook pretooluse-edit --plugin-version 0.51.0",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-bash --plugin-version 0.50.1",
+            "command": "charter hook posttooluse-bash --plugin-version 0.51.0",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.50.1",
+            "command": "charter hook posttooluse --plugin-version 0.51.0",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.50.1",
+            "command": "charter hook posttooluse-skill --plugin-version 0.51.0",
             "timeout": 5
           }
         ]
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.50.1",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.51.0",
             "timeout": 5
           }
         ]
@@ -128,7 +128,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-message --plugin-version 0.50.1",
+            "command": "charter hook posttooluse-message --plugin-version 0.51.0",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.50.1"
+version = "0.51.0"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Cuts **0.51.0**. Ten PRs since `v0.50.1`.

## The four version files, moved together

| file | |
|---|---|
| `pyproject.toml` | `0.50.1` → `0.51.0` |
| `charter/__init__.py` | `0.50.1` → `0.51.0` |
| `.claude-plugin/plugin.json` | `0.50.1` → `0.51.0` |
| `hooks/hooks.json` | **all 11** `--plugin-version` flags |

Eleven, not the nine the persona charter's prose names — counted with `grep`, which is
what that paragraph tells you to do instead of trusting the number written beside it.
`tests/test_plugin.py::TestVersionsMoveInLockstep` passes; re-grepping the four files for
`0.50.1` returns nothing.

## Four news entries written

The charter's gate — *read the merged PRs since the last tag, and check every user-visible
one has an entry* — found 6 entries for 10 PRs. No CI check enforces this, by design. The
four missing:

- `0.51.0-guard-is-all-or-nothing.md` — **#376**. A malformed `.claude/settings.json` used
  to leave the rule in force under opencode and absent under Claude Code from one command.
  Now every harness is asked with `dry_run=True` before any is written.
- `0.51.0-a-frame-in-the-tmux-you-already-have.md` — **#381**. `$TMUX` set means one window
  on your server, not a nested one. Documents what it costs: `[frame] history-limit` and
  `[frame] mouse` ignored, no hotkey, four polls a second in place of `attach`.
- `0.51.0-reap-keeps-a-live-frame.md` — **#383**. A frame outlives its session by the moment
  the launcher needs to read `exit`; reap now keeps a directory while its launcher pid lives,
  and a launch clears the `exit`/`gather` a recycled pid would otherwise inherit.
- `0.51.0-the-suite-stays-out-of-your-trace.md` — **#372**. Two fixtures hand-picked their
  `config` attributes and missed `PERSONA_STATE_DIR`; 556 of one session's 581 denials were
  charter's own suite. Fixed at the writer — nothing filters, nothing is marked.

`charter news stamp 0.51.0` then moved all ten onto the version, and
`charter news --for 0.51.0` renders — the same call the `guard` job makes, so the guard and
the Release body cannot disagree.

## Why minor

**#381 is new surface.** `charter <harness>` inside tmux now has a second path with its own
contract, and two `[frame]` config keys are deliberately inert on it.

## Verification

`python3 -m unittest discover -s tests` → **Ran 4039 tests … OK**, on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9