### PR TITLE
frame v2 (2/3): the frame owns the surface

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -944,6 +944,59 @@ def _frame_env(fid: str, h) -> dict[str, str]:
     return env
 
 
+#: The variables whose value must be THIS frame's rather than whichever launcher
+#: happened to start the shared tmux server — the whole of what `_frame_identity_env`
+#: puts on a tmux command line.
+#:
+#: Named one at a time rather than globbed on a `CHARTER_` prefix, because the list is a
+#: PROMISE about what reaches `/proc/<pid>/cmdline` and a prefix match would quietly keep
+#: that promise for a variable nobody has invented yet. Each is here for a reason a second
+#: frame makes real:
+#:
+#: * ``CHARTER_SESSION_ID`` — the frame's own id, and #411 itself.
+#: * ``CHARTER_HARNESS`` — two frames may run two different harnesses.
+#: * ``CHARTER_ROOT`` — two frames may be two different PLANES, and a harness reading the
+#:   other one's root writes into a control plane nobody in this frame chose.
+#: * ``CHARTER_WORKSPACE`` — `workspace.resolve` puts this above every pointer, so an
+#:   inherited pin outranks the frame's own answer and `charter ws use` cannot move it.
+#:
+#: None of the four is ever a credential. That is the property that makes putting them on
+#: an argv acceptable at all — see :func:`_frame_identity_env`.
+_FRAME_IDENTITY = ("CHARTER_SESSION_ID", "CHARTER_HARNESS", "CHARTER_ROOT",
+                   "CHARTER_WORKSPACE")
+
+
+def _frame_identity_env(env: dict[str, str]) -> dict[str, str]:
+    """Just the part of *env* that has to travel on a tmux COMMAND LINE, and no more.
+
+    **A tmux `-e` is argv, and argv is not private.** `_frame_env` is
+    ``dict(os.environ, …)`` — the operator's whole environment, `SSH_AUTH_SOCK`, API
+    tokens, vault service-account tokens and all. Handed to `subprocess.run(env=…)` that
+    is an ordinary child environment, readable only by the owner via `/proc/<pid>/environ`.
+    Expanded into ``-e NAME=VALUE`` argv elements it becomes the tmux client's COMMAND
+    LINE: world-readable in `/proc/<pid>/cmdline` on Linux for as long as the client runs,
+    visible to `ps` for every local user, and recorded permanently by exec-audit and
+    process-accounting tooling. Measured on a real environment: 138 argv elements, 7,696
+    bytes, carrying two live service-account tokens. `charter claude` is the default path,
+    so that would have been every launch on every machine.
+
+    So only :data:`_FRAME_IDENTITY` travels, and the rest keeps arriving exactly the way
+    it always did — through the tmux client's own environment on charter's server, and
+    through the operator's already-running server on theirs.
+
+    **Every name is emitted, including the ones that are absent, as ``NAME=``.** An
+    inherited value is as wrong as a stale one: a launcher that pinned `$CHARTER_WORKSPACE`
+    starts the shared server with it, and the NEXT frame — which pinned nothing — would
+    otherwise inherit that pin and have `workspace.resolve` rank it above its own
+    pointers. Measured against tmux 3.7c: ``-e FOO=`` leaves the variable set and empty
+    rather than unset, which is what charter's own readers already treat as absent
+    (`workspace.resolve` and `root.find_root` both test the value for truth, not for
+    presence). Being explicit in both directions is what makes a frame's charter identity
+    the launcher's answer rather than half of somebody else's.
+    """
+    return {name: env.get(name, "") for name in _FRAME_IDENTITY}
+
+
 def _remain_on_exit_argv(*, socket: str, harness_pane: str) -> list[str]:
     """`set-option -p`: keep THIS pane in place after its program exits, and no other.
 
@@ -1053,6 +1106,10 @@ def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, argv: list[
                  "and pane id — cannot scope the frame to it")
         return 1
     harness_pane = harness_pane.strip()
+    # What tells a process inside this frame apart from one that merely inherited its id
+    # (ADR 0019, `state.record_harness_pane`). Recorded before the harness is started, so
+    # the very first status line it spawns can already answer.
+    state.record_harness_pane(fid, harness_pane)
 
     def _close_window() -> None:
         tmuxctl.run("closing the frame's window",
@@ -1522,11 +1579,17 @@ def cmd_launch(args) -> int:
     # this call is what starts the server. Every frame after the first on `SOCKET` finds
     # it already running, and its harness would inherit the FIRST frame's
     # `$CHARTER_SESSION_ID` — #411, measured against tmux 3.7c; see `layout.session_argv`.
+    #
+    # `_frame_identity_env(env)` and NEVER `env`: a `-e` is argv, and argv is world-
+    # readable. The rest of the environment still reaches the harness the way it always
+    # did, through the client this call is run with. See `_frame_identity_env`.
+    #
     # Withheld below `SESSION_ENV_FLOOR`, where `-e` is a parse error rather than a
     # missing feature and would take the whole launch down with it.
-    session_cmd = layout.session_argv(session=fid, conf=str(conf_path), socket=SOCKET,
-                                      cols=cols, rows=rows, harness_argv=argv,
-                                      env=env if v >= tmuxctl.SESSION_ENV_FLOOR else None)
+    session_cmd = layout.session_argv(
+        session=fid, conf=str(conf_path), socket=SOCKET, cols=cols, rows=rows,
+        harness_argv=argv,
+        env=_frame_identity_env(env) if v >= tmuxctl.SESSION_ENV_FLOOR else None)
     proc = tmuxctl.run("starting the frame", session_cmd, env=env)
     if proc.returncode != 0:
         return 1
@@ -1535,6 +1598,10 @@ def cmd_launch(args) -> int:
         util.err("charter frame: tmux started the session but did not report a pane id "
                  "— cannot scope the exit-code hook to it")
         return 1
+    # See the identical call on the operator's-tmux path: this is what lets a status line
+    # tell "I am this frame's harness" from "I inherited this frame's id", which below
+    # `SESSION_ENV_FLOOR` a second frame on this shared server genuinely does.
+    state.record_harness_pane(fid, harness_pane)
 
     frame = config.FRAME
     conf_path.write_text(conf_text(hotkey=frame["hotkey"], mouse=frame["mouse"],
@@ -1658,8 +1725,15 @@ def cmd_launch(args) -> int:
                      f"detached; reattach manually if you must: "
                      f"tmux -L {SOCKET} attach -t {fid}")
         else:
-            panes = _draw_panels(SOCKET, slots=slots, fid=fid, harness_pane=harness_pane,
-                                 env=env, v=v)
+            # `pane_env` on this path too, since #411: a panel splits off a server that
+            # may have been started by ANOTHER launcher, so `$CHARTER_WORKSPACE` and
+            # `$CHARTER_ROOT` reach it from that launcher unless charter states them.
+            # Identity only — a `-e` is argv (see `_frame_identity_env`) — and withheld
+            # below `PANE_ENV_FLOOR`, where `split-window` cannot parse the flag.
+            panes = _draw_panels(
+                SOCKET, slots=slots, fid=fid, harness_pane=harness_pane, env=env, v=v,
+                pane_env=(_frame_identity_env(env)
+                          if v >= tmuxctl.PANE_ENV_FLOOR else None))
             for slot, pane_id in panes.items():
                 # This panel's OWN `pane-died` hook, so a panel whose process dies
                 # outright is brought back instead of leaving a hole for the frame's

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -959,11 +959,18 @@ def _frame_env(fid: str, h) -> dict[str, str]:
 #:   other one's root writes into a control plane nobody in this frame chose.
 #: * ``CHARTER_WORKSPACE`` — `workspace.resolve` puts this above every pointer, so an
 #:   inherited pin outranks the frame's own answer and `charter ws use` cannot move it.
+#: * ``CHARTER_PERSONA`` — the same rung one module over: `persona._resolved` ranks it
+#:   above the per-session pointer, the per-terminal pointer AND the active-persona file.
+#:   An inherited pin therefore reaches the harness *and the frame's own `right` panel*,
+#:   which draws persona chips, and `charter persona use` cannot move either. It is here
+#:   because it meets the criterion above, not because anything was observed breaking —
+#:   the criterion is what this list is for, and applying it unevenly is how the next
+#:   variable gets forgotten.
 #:
-#: None of the four is ever a credential. That is the property that makes putting them on
+#: None of the five is ever a credential. That is the property that makes putting them on
 #: an argv acceptable at all — see :func:`_frame_identity_env`.
 _FRAME_IDENTITY = ("CHARTER_SESSION_ID", "CHARTER_HARNESS", "CHARTER_ROOT",
-                   "CHARTER_WORKSPACE")
+                   "CHARTER_WORKSPACE", "CHARTER_PERSONA")
 
 
 def _frame_identity_env(env: dict[str, str]) -> dict[str, str]:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1517,8 +1517,16 @@ def cmd_launch(args) -> int:
     status_path = fdir / "exit"
     conf_path.write_text(_PLACEHOLDER_CONF)
 
+    # `env=` and not merely `tmuxctl.run(env=env)` below: the second only sets what the
+    # tmux CLIENT runs with, and a client's environment reaches the new pane ONLY when
+    # this call is what starts the server. Every frame after the first on `SOCKET` finds
+    # it already running, and its harness would inherit the FIRST frame's
+    # `$CHARTER_SESSION_ID` — #411, measured against tmux 3.7c; see `layout.session_argv`.
+    # Withheld below `SESSION_ENV_FLOOR`, where `-e` is a parse error rather than a
+    # missing feature and would take the whole launch down with it.
     session_cmd = layout.session_argv(session=fid, conf=str(conf_path), socket=SOCKET,
-                                      cols=cols, rows=rows, harness_argv=argv)
+                                      cols=cols, rows=rows, harness_argv=argv,
+                                      env=env if v >= tmuxctl.SESSION_ENV_FLOOR else None)
     proc = tmuxctl.run("starting the frame", session_cmd, env=env)
     if proc.returncode != 0:
         return 1

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -828,6 +828,12 @@ def check_frame() -> Result:
                            "install tmux (or your package manager). Without it, "
                            "charter <harness> --no-frame still runs the harness bare.")
     missing = frame_slots.unimplemented(config.FRAME["slots"])
+    # A blank status line is the one frame behaviour that shows the operator NOTHING —
+    # ADR 0019's own rule is that a surface which vanished for an invisible reason is the
+    # worst outcome available, so the reason is said out loud on the surface built to
+    # answer on demand. Appended to whatever else this row reports rather than replacing
+    # it: it is a statement of fact about right now, never a warning.
+    quiet = _statusline_suppressed_note()
     if v < tmuxctl.FLOOR:
         # Not "the hotkey menu is disabled" — nothing disables it. `cmd_launch` warns
         # and continues, and `conf_text` emits the bind unchanged; what is actually at
@@ -837,11 +843,36 @@ def check_frame() -> Result:
         hint = tmuxctl.below_floor_message(v)
         if missing:
             hint += " " + commands_frame_no_renderer(missing)
-        return Result(name, WARN, detail=f"tmux {v[0]}.{v[1]}", hint=hint)
+        return Result(name, WARN, detail=f"tmux {v[0]}.{v[1]}", hint=hint + quiet)
     if missing:
         return Result(name, WARN, detail=f"tmux {v[0]}.{v[1]}",
-                      hint=commands_frame_no_renderer(missing))
-    return Result(name, OK, detail=f"tmux {v[0]}.{v[1]}")
+                      hint=commands_frame_no_renderer(missing) + quiet)
+    return Result(name, OK, detail=f"tmux {v[0]}.{v[1]}",
+                  hint=quiet.strip() or None)
+
+
+def _statusline_suppressed_note() -> str:
+    """`" …"` naming the frame this session's status line is being blanked for, or `""`.
+
+    Asks the same question `statusline.main` asks, through the same function, so the two
+    can never disagree about whether a line is suppressed — the failure this note exists
+    to make impossible is an operator seeing a blank footer and finding nothing anywhere
+    that admits it is deliberate. `charter doctor` runs in the operator's own shell, whose
+    stdout may well be a tty, so the tty rung of `a_frame_owns_this_surface` is deliberately
+    not consulted here: the question is "is this session's footer being suppressed", not
+    "would MY stdout be".
+    """
+    import os
+
+    from .frame import state as frame_state
+
+    fid = os.environ.get("CHARTER_SESSION_ID", "")
+    if not fid or not frame_state.is_live(fid, pane=os.environ.get("TMUX_PANE", "")):
+        return ""
+    return (f" This session's status line is intentionally blank: frame {fid} is drawing "
+            f"the plane instead (ADR 0019). `charter statusline` still runs — it records "
+            f"this session's token usage — and still prints in full when you run it "
+            f"yourself.")
 
 
 def commands_frame_no_renderer(missing: list[str]) -> str:

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -134,13 +134,18 @@ def respawn_argv(*, socket: str, harness_pane: str, env: dict[str, str],
 
     *env* rides on `-e`, one `NAME=VALUE` argv element each, sorted so the command is
     the same on every launch. This is the only way charter's own variables
-    (`CHARTER_SESSION_ID`, `CHARTER_HARNESS`) can reach the harness here: the
-    private-server path gets them because `new-session` starts the server and the server
-    inherits the launcher's environment, and there is no equivalent on a server that is
-    already running and is not charter's. The alternative tmux offers — `set-environment
-    -t <session>` — would reach the harness AND hand every new shell the operator opens
-    in that session a frame id that is not theirs, which is the identity collision
+    (`CHARTER_SESSION_ID`, `CHARTER_HARNESS`) can reach the harness here. The
+    alternative tmux offers — `set-environment -t <session>` — would reach the harness
+    AND hand every new shell the operator opens in that session a frame id that is not
+    theirs, which is the identity collision
     `docs/superpowers/specs/2026-08-21-harness-wrapper-design.md` removed `WINDOWID` for.
+
+    **This used to add "the private-server path gets them because `new-session` starts
+    the server and the server inherits the launcher's environment", and that was #411.**
+    It is true only of the launch that actually starts the server; every later frame on
+    charter's shared private server finds it running and inherits the FIRST launcher's
+    environment instead. `session_argv` now carries the same `-e` for the same reason —
+    see its docstring for what was measured.
 
     Measured against tmux 3.7c: `respawn-pane -e` REPLACES the pane's environment rather
     than adding to whatever `new-window -e` set, so everything the harness needs is on
@@ -158,7 +163,8 @@ def respawn_argv(*, socket: str, harness_pane: str, env: dict[str, str],
 
 
 def session_argv(*, session: str, conf: str, socket: str, cols: int, rows: int,
-                 harness_argv: list[str]) -> list[str]:
+                 harness_argv: list[str],
+                 env: dict[str, str] | None = None) -> list[str]:
     """The `new-session` command that starts the frame's tmux server, harness inside it.
 
     Detached (`-d`): this is launched from a script with no tty to hand tmux, not typed
@@ -168,9 +174,36 @@ def session_argv(*, session: str, conf: str, socket: str, cols: int, rows: int,
     That id is the whole fix the module docstring describes: the caller must capture it
     off stdout and pass it to `panel_argvs`, because a `session:0.0`-style index stops
     naming the harness after the very first split.
+
+    *env* rides on `-e`, exactly as it does for :func:`respawn_argv` and
+    :func:`panel_argvs`, and **#411 is what it is here for.** It used to be absent
+    because passing the launcher's environment to the tmux CLIENT was believed to be
+    enough — "`new-session` starts the server and the server inherits the launcher's
+    environment", as `respawn_argv`'s own docstring put it. That is true of the launch
+    that STARTS the server and of no other: every frame on charter's private server
+    shares one server (see `commands_frame`'s module docstring), so a second frame's
+    `new-session` finds it already running, and tmux builds the new pane's environment
+    from the SERVER's global environment — captured from whichever launcher happened to
+    start it, possibly days ago.
+
+    Measured against tmux 3.7c, two frames on one private socket, reading the harness
+    shell's own `$CHARTER_SESSION_ID`: the second frame's harness reported
+    ``default-58069`` while its own session was ``default-58696``, and
+    ``show-environment -g CHARTER_SESSION_ID`` held the first frame's id. Everything
+    keyed on that variable then went to the wrong frame — `charter ws use` wrote the
+    first frame's workspace pointer, and every hook bumped the first frame's version, so
+    the second frame's panels were never told anything had changed. The panels
+    themselves were already right: `commands_frame._session_id_env_argv` ties the id to
+    the SESSION, which `split-window` honours (measured on the same server), so this
+    closes the one pane that call cannot reach — the one `new-session` itself creates.
+
+    ``None`` means "carry nothing", which is what a tmux below
+    `tmuxctl.SESSION_ENV_FLOOR` gets: `-e` is not a flag `new-session` degrades on, it is
+    one it refuses, and refusing takes the whole launch with it.
     """
     return _tmux(socket, "-f", conf, "new-session", "-d", "-s", session,
                 "-x", str(cols), "-y", str(rows), "-P", "-F", "#{pane_id}",
+                *_env_argv(env),
                 "--", *harness_argv)
 
 

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -147,10 +147,25 @@ def respawn_argv(*, socket: str, harness_pane: str, env: dict[str, str],
     environment instead. `session_argv` now carries the same `-e` for the same reason —
     see its docstring for what was measured.
 
-    Measured against tmux 3.7c: `respawn-pane -e` REPLACES the pane's environment rather
-    than adding to whatever `new-window -e` set, so everything the harness needs is on
-    THIS call. Every `-e` lands before the `--` — they are `respawn-pane`'s own options,
-    and must never be grafted onto the harness's own argv.
+    **`respawn-pane -e` ADDS to the pane's environment; it does not replace it.** This
+    said the opposite ("REPLACES ... so everything the harness needs is on THIS call"),
+    which is why this call carries `dict(os.environ, ...)` whole. Re-measured against tmux
+    3.7c: a server started with `FOO`/`BAZ` in its environment, respawned with only
+    `-e BAR=…`, produced a pane holding all three and a full-length `$PATH`. So the `-e`
+    set is an OVERLAY on whatever the pane would have inherited anyway.
+
+    That matters twice. It means a caller may carry only the variables that must differ
+    (which `session_argv` and `panel_argvs` on charter's own server now do — see
+    `commands_frame._frame_identity_env`, and note that a `-e` is argv and argv is
+    world-readable). And it means this call site's full-environment pass is a CHOICE
+    rather than a requirement: on the operator's server the base the overlay lands on is
+    THEIR tmux server's environment, which may predate this plane entirely, so charter
+    states everything rather than trusting it. That choice keeps the operator's whole
+    environment on a tmux command line, which is a real exposure with a real reason and
+    is not this issue's to change unmeasured.
+
+    Every `-e` lands before the `--` — they are `respawn-pane`'s own options, and must
+    never be grafted onto the harness's own argv.
 
     *cwd* is `-c`, and it is not optional. A pane in a server charter did not start
     inherits its start directory from the SESSION's, which is wherever the operator
@@ -267,14 +282,24 @@ def panel_argvs(*, slots: list[str], session: str, socket: str,
     correct that (an index would renumber under the very next split, same failure the
     module docstring already measures for the harness pane).
 
-    *env* is `-e`, and is only ever passed inside a tmux charter did not start. A pane
-    created on somebody else's server inherits THAT SERVER's environment — whatever
-    their shell had when they first ran `tmux`, possibly days ago and in another plane —
-    and a panel resolves the plane it draws (`config.STATE_DIR` among it) from its own.
-    On charter's own server the panels inherit the launcher's environment because
-    `new-session` is what starts that server, so nothing is passed and the command is
-    unchanged. See `respawn_argv` for the same mechanism carrying the same values to the
-    harness.
+    *env* is `-e`. On somebody else's server it carries the launcher's environment whole,
+    because a pane created there inherits THAT SERVER's — whatever their shell had when
+    they first ran `tmux`, possibly days ago and in another plane — and a panel resolves
+    the plane it draws (`config.STATE_DIR` among it) from its own.
+
+    **On charter's own server it carries charter's identity and nothing else, and the
+    sentence that used to be here was wrong.** It said the panels inherit the launcher's
+    environment "because `new-session` is what starts that server" — true of the launch
+    that starts it and of no other (#411; see :func:`session_argv`). Every later frame's
+    panels inherited the FIRST launcher's, and `$CHARTER_WORKSPACE` is the sharp one:
+    `workspace.resolve` ranks it above every pointer, so a panel that inherited another
+    launcher's pin could not be moved by `charter ws use` at all. `$CHARTER_SESSION_ID`
+    was already correct there by a different route — `commands_frame._session_id_env_argv`
+    ties it to the SESSION, which tmux applies to panes split later — and this fixes the
+    rest of the identity alongside it.
+
+    Only `commands_frame._FRAME_IDENTITY` travels, never the whole environment: a `-e` is
+    argv, and argv is world-readable. See `commands_frame._frame_identity_env`.
     """
     cmds: list[list[str]] = []
     for slot in slots:

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -206,6 +206,61 @@ def clear_exit(fid: str) -> None:
         return
 
 
+def record_harness_pane(fid: str, pane: str) -> None:
+    """Write down which tmux pane this frame runs its harness in.
+
+    One fact, for one question `$CHARTER_SESSION_ID` alone cannot answer: **is this
+    process the harness of that frame, or merely a process that inherited its id?** The
+    two are not the same, and reading them as the same is how suppression (ADR 0019)
+    blanks the wrong status line:
+
+    * Below ``tmuxctl.SESSION_ENV_FLOOR`` charter cannot put the frame id on
+      `new-session`, so a SECOND frame's harness on the shared private server inherits the
+      FIRST frame's id (#411). Without this file it would look exactly like frame one's
+      own harness and go blank, while its panels followed frame one — leaving that
+      operator no correct surface at all, where before they at least had a correct status
+      line.
+    * An operator who exports ``CHARTER_SESSION_ID`` in a shell rc (a per-shell id of
+      their own, say) gets a frame directory minted by the first hook that fires
+      (`notify.plane_changed` calls `bump` for any id) and a pid that is permanently live,
+      because it is their own shell's. A directory plus a live pid is not proof of a
+      frame; a pane a launcher actually started one in is.
+
+    `$TMUX_PANE` is what the other side reads, and tmux sets it in every process it starts
+    in a pane — measured 2026-08-24 through a real Claude Code `statusLine` command inside
+    a tmux pane, which reported ``PANE=[%0]``, so it survives the harness's own spawning
+    of the command. Same atomic-write, never-raise shape as :func:`record_server`, and
+    for the same reason: a launch is not worth failing over a bookkeeping file. A frame
+    whose pane could not be recorded simply never suppresses, which is the safe direction
+    — a duplicated status line rather than a missing one.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    tmp = d / "harness.tmp"
+    try:
+        tmp.write_text(f"{pane}\n")
+        os.replace(tmp, d / "harness")
+    except OSError:
+        return
+
+
+def harness_pane(fid: str) -> str | None:
+    """The pane *fid* runs its harness in, or ``None`` when charter does not know.
+
+    ``None`` for a frame launched by a charter that predates :func:`record_harness_pane`,
+    for a directory that is not a frame's at all, and for a file that cannot be read —
+    three different reasons, deliberately one answer, because every caller does the same
+    safe thing with it (see :func:`is_live`: no proof, no suppression)."""
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        return (d / "harness").read_text().strip() or None
+    except (OSError, ValueError):
+        return None
+
+
 def record_server(fid: str, server: str) -> None:
     """Write down which tmux server this frame's session (or window) lives on.
 
@@ -423,37 +478,55 @@ def _launcher_is_alive(pid: int) -> bool:
     return True
 
 
-def is_live(fid: str) -> bool:
-    """Is *fid* a frame of THIS plane that is still running? Asks two questions, cheaply.
+def is_live(fid: str, *, pane: str | None = None) -> bool:
+    """Is *fid* a frame of THIS plane that is running, and is *pane* its harness?
 
-    :func:`reap` asks the same pair to decide what to delete; this asks them to decide
-    what to *draw* (ADR 0019 — `statusline.main` blanks its output inside a frame, and a
-    frame that has ended must not keep it blank forever). Both callers need an answer on
-    a hot path — `reap` runs at every launch, this one runs every time Claude Code
-    repaints its footer — so neither may shell out to tmux for it. The frame id ends in
-    the launcher's own pid (:func:`frame_id`), so ``os.kill(pid, 0)`` answers it with a
-    syscall and no subprocess at all.
+    The question ADR 0019 asks before it draws nothing at all, so every way of being wrong
+    here costs somebody a surface. Four things are checked and each one is the only guard
+    against a failure that really happens:
 
-    **The directory is asked about first, and it is not redundant.** The value reaching
-    here comes from ``$CHARTER_SESSION_ID``, which a harness that is not a frame also
-    sets — Claude Code's own session id is a UUID, and a UUID whose last group happens to
-    be all digits parses as a pid perfectly well. A frame that exists has a directory
-    (``cmd_launch`` creates and bumps it before any pane is split); an id that never named
-    one is not this plane's frame whatever its digits say. It also keeps the SUITE honest:
-    a test that isolates ``config.STATE_DIR`` (every test that touches plane state does)
-    finds no frame directory there, so suppression cannot switch itself on because of
-    whatever frame the developer's own terminal happens to be sitting in.
+    * **A server marker a LAUNCHER wrote** (:func:`frame_server`). This is also the whole
+      of "is there a frame directory here at all", and deliberately not a second check:
+      the marker cannot exist without the directory, so a separate ``is_dir()`` would be a
+      guard no mutation could turn red — the shape this suite has been bitten by before.
+      What it rules out, in one read: an id that names nothing here (``$CHARTER_SESSION_ID``
+      is not a frame's variable alone — every harness that knows its own session sets it,
+      and Claude Code's UUID can end in an all-digit group that parses as a pid); an id
+      :func:`frame_dir` refuses outright; and a directory no launcher made — :func:`bump`
+      creates one on demand and `notify.plane_changed` calls it from seven hook sites for
+      whatever id is in the environment, so an operator who exports ``CHARTER_SESSION_ID``
+      in a shell rc gets a directory minted by their first tool call, carrying their own
+      shell's permanently-live pid. Only `cmd_launch` records a server. (A frame from a
+      charter old enough to predate the marker answers ``None`` too, and gets a duplicated
+      status line — which is exactly what it had.) It also keeps the SUITE honest: every
+      test that touches plane state repoints ``config.STATE_DIR``, so suppression cannot
+      switch itself on because of whatever frame the developer's terminal is sitting in.
+    * **A launcher pid still running.** The id ends in it (:func:`frame_id`), so
+      ``os.kill(pid, 0)`` answers with a syscall and no tmux subprocess on a path that
+      runs every time Claude Code repaints its footer. Without it, a directory left by a
+      crashed launcher would blank that plane's status line forever.
+    * **The harness pane, when the caller offers one** (:func:`harness_pane`). The
+      previous three establish that a live frame exists somewhere; only this one
+      establishes that the process asking is *inside* it. `is_live` is called by a
+      status line that would otherwise vanish, and a process can hold a frame id it
+      merely inherited — see :func:`record_harness_pane` for the two ways that happens
+      and what each one costs.
 
-    Both halves must be true, and each is the sole guard against one real failure: without
-    the pid, a stale directory left by a frame that crashed would blank the status line on
-    that plane forever; without the directory, an id that is not a frame id at all could
-    blank it by coincidence.
+    *pane* is optional because :func:`reap`'s question is the frame's existence, not any
+    process's membership of it. ``None`` means "do not ask", not "assume yes".
+
+    Every unknown answers ``False``, which for the status line means "render" — a
+    duplicated line is recoverable in a way a line that vanished for an invisible reason
+    is not.
     """
-    d = frame_dir(fid)
-    if d is None or not d.is_dir():
+    if frame_server(fid) is None:
         return False
     pid = _launcher_pid(fid)
-    return pid is not None and _launcher_is_alive(pid)
+    if pid is None or not _launcher_is_alive(pid):
+        return False
+    if pane is not None and harness_pane(fid) != pane:
+        return False
+    return True
 
 
 def reap(live: set[str], *, server: str) -> list[str]:

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -423,6 +423,39 @@ def _launcher_is_alive(pid: int) -> bool:
     return True
 
 
+def is_live(fid: str) -> bool:
+    """Is *fid* a frame of THIS plane that is still running? Asks two questions, cheaply.
+
+    :func:`reap` asks the same pair to decide what to delete; this asks them to decide
+    what to *draw* (ADR 0019 — `statusline.main` blanks its output inside a frame, and a
+    frame that has ended must not keep it blank forever). Both callers need an answer on
+    a hot path — `reap` runs at every launch, this one runs every time Claude Code
+    repaints its footer — so neither may shell out to tmux for it. The frame id ends in
+    the launcher's own pid (:func:`frame_id`), so ``os.kill(pid, 0)`` answers it with a
+    syscall and no subprocess at all.
+
+    **The directory is asked about first, and it is not redundant.** The value reaching
+    here comes from ``$CHARTER_SESSION_ID``, which a harness that is not a frame also
+    sets — Claude Code's own session id is a UUID, and a UUID whose last group happens to
+    be all digits parses as a pid perfectly well. A frame that exists has a directory
+    (``cmd_launch`` creates and bumps it before any pane is split); an id that never named
+    one is not this plane's frame whatever its digits say. It also keeps the SUITE honest:
+    a test that isolates ``config.STATE_DIR`` (every test that touches plane state does)
+    finds no frame directory there, so suppression cannot switch itself on because of
+    whatever frame the developer's own terminal happens to be sitting in.
+
+    Both halves must be true, and each is the sole guard against one real failure: without
+    the pid, a stale directory left by a frame that crashed would blank the status line on
+    that plane forever; without the directory, an id that is not a frame id at all could
+    blank it by coincidence.
+    """
+    d = frame_dir(fid)
+    if d is None or not d.is_dir():
+        return False
+    pid = _launcher_pid(fid)
+    return pid is not None and _launcher_is_alive(pid)
+
+
 def reap(live: set[str], *, server: str) -> list[str]:
     """Remove state for frames of *server* that are gone. Returns what was removed.
 

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -67,6 +67,23 @@ FLOOR = (3, 2)
 #: two constants.
 RESIZE_HOOK_FLOOR = (3, 3)
 
+#: The first tmux release in which `new-session` accepts `-e` at all — the VERSION is
+#: read from tmux's own published CHANGES file (github.com/tmux/tmux, "CHANGES FROM 3.1c
+#: TO 3.2"): "Add -e flag for new-session to set environment variables, like the same
+#: flag for new-window." Confirmed present in this machine's 3.7c man page
+#: (``new-session … [-e environment]``, "-e takes the form 'VARIABLE=value'").
+#:
+#: Numerically equal to `FLOOR` and deliberately a SECOND constant, for the same reason
+#: `RESIZE_HOOK_FLOOR` is: it is a different fact about tmux and it will not necessarily
+#: move with the other. `FLOOR` is where charter WARNS; this is where a `new-session`
+#: carrying `-e` stops being a command tmux can parse — below it the flag is not degraded
+#: but rejected outright ("unknown option"), which would take the whole launch down on a
+#: tmux that `below_floor_message` explicitly still allows to launch. `cmd_launch`
+#: therefore omits the environment below this line and accepts what that costs there:
+#: the harness of a SECOND frame on charter's shared private server inherits the FIRST
+#: frame's environment, exactly as every frame did before #411.
+SESSION_ENV_FLOOR = (3, 2)
+
 #: The session-scoped tmux environment variable carrying the interpreter that runs
 #: charter from inside a frame — `"$CHARTER_PY" -m charter …`, never a bare `charter`
 #: off `$PATH`. Defined HERE, not in either of the two modules that build text around it

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -78,11 +78,32 @@ RESIZE_HOOK_FLOOR = (3, 3)
 #: move with the other. `FLOOR` is where charter WARNS; this is where a `new-session`
 #: carrying `-e` stops being a command tmux can parse — below it the flag is not degraded
 #: but rejected outright ("unknown option"), which would take the whole launch down on a
-#: tmux that `below_floor_message` explicitly still allows to launch. `cmd_launch`
-#: therefore omits the environment below this line and accepts what that costs there:
-#: the harness of a SECOND frame on charter's shared private server inherits the FIRST
-#: frame's environment, exactly as every frame did before #411.
+#: tmux that `below_floor_message` explicitly still allows to launch.
+#:
+#: **What that costs below 3.2, stated exactly.** #411 stays unfixed there: the harness of
+#: a SECOND frame on charter's shared private server goes on inheriting the FIRST frame's
+#: `$CHARTER_SESSION_ID`, so `charter ws use` writes the first frame's workspace pointer
+#: and hooks bump the first frame's version — that frame's panels do not follow it. (Its
+#: PANELS still get their own id: `commands_frame._session_id_env_argv` ties that to the
+#: session, which tmux applies to panes split later, so the two halves disagree.)
+#:
+#: An earlier version of this comment said that was "exactly as every frame did before
+#: #411", and that was wrong in the direction that matters. Suppression (ADR 0019) keys on
+#: the same variable, so on the id alone that operator's status line would ALSO have gone
+#: blank against a frame that is not theirs — leaving no correct surface at all, where
+#: before they at least had a correct footer. `state.is_live` takes the harness PANE as
+#: well for exactly this band: below 3.2 the second frame's harness holds the first
+#: frame's id but sits in a pane the first frame never recorded, so its status line keeps
+#: drawing.
 SESSION_ENV_FLOOR = (3, 2)
+
+#: The first tmux release in which `split-window` (and `new-window`, and `respawn-pane`)
+#: accepts `-e` — VERSION read from tmux's own published CHANGES ("CHANGES FROM 2.9 TO
+#: 3.0"): "Add a -e flag to new-window, split-window, respawn-window, respawn-pane to set
+#: environment variables." LOWER than :data:`SESSION_ENV_FLOOR`, because `new-session`
+#: only grew the same flag two releases later — two flags, two facts, two constants, the
+#: same reason `RESIZE_HOOK_FLOOR` is not folded into `FLOOR`.
+PANE_ENV_FLOOR = (3, 0)
 
 #: The session-scoped tmux environment variable carrying the interpreter that runs
 #: charter from inside a frame — `"$CHARTER_PY" -m charter …`, never a bare `charter`

--- a/charter/glstate.py
+++ b/charter/glstate.py
@@ -187,9 +187,20 @@ def read_for(dirs, branches: dict) -> dict:
 def maybe_spawn(dirs, workspace: str | None = None) -> None:
     """Kick off a detached background refresh if the cache is stale. Non-blocking.
 
-    ``workspace`` is passed to the child explicitly (via ``--workspace``) because
-    the status line's env is scrubbed — the child couldn't otherwise resolve the
-    session's active workspace on its own.
+    ``workspace`` is passed to the child explicitly (via ``--workspace``), and the reason
+    written here for years — "the status line's env is scrubbed" — is **false**. Measured
+    2026-08-24 against Claude Code 2.1.241 with a real `statusLine` command: the
+    environment arrives intact, `$CHARTER_WORKSPACE` included. (Same false belief appeared
+    in :mod:`charter.statusline` and :mod:`charter.session`; all three are corrected
+    together rather than one at a time, because a claim in three places is a claim
+    somebody will re-derive from whichever copy survives.)
+
+    Passing it explicitly is still right, for a better reason: the status line resolves
+    the workspace for the SESSION — from the payload's `session_id` and `cwd`, which are
+    not this process's — while the child would resolve it for ITSELF, from its own
+    environment and its own directory. A refresh keyed to a different workspace than the
+    row it is refreshing is the defect; an environment variable was never what stood
+    between them.
     """
     now = time.time()
     try:

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -332,7 +332,26 @@ FRAME_SLOTS = ("top", "bottom", "left", "right")
 #: impossible by construction rather than merely unlikely. Only the ``toml_key`` spelling
 #: is ever honoured — the underscore form is not accepted as a second, undocumented alias.
 FRAME_FIELDS = {
-    "slots": (["top", "bottom"], "slots"),
+    #: All four edges, because the frame now OWNS the surface (ADR 0019): inside a frame
+    #: `charter statusline` draws nothing, so whatever the frame does not show is not
+    #: shown anywhere. Two one-line strips are not a frame — they are the status line
+    #: again, in a worse shape — and that is exactly how the first release of this was
+    #: reported: *"only top and bottom single lines added, no left right sidebar."*
+    #: `slots.SLOTS` has had `left` (repo rows) and `right` (persona chips) since #385;
+    #: they were built, tested and switched off. `layout.visible_slots` drops the two
+    #: side panels first on any shortage against `min_cols`/`min_rows`, so a narrow
+    #: terminal degrades to exactly the frame this default used to be.
+    #:
+    #: **The ORDER is the geometry, not a reading order.** `layout.panel_argvs` splits
+    #: each slot off the harness pane in list order, so a slot listed after `left`/`right`
+    #: gets only the width they left behind. Measured against tmux 3.7c in a 200x50
+    #: window: this order gives a 200-column `bottom`, with the side panels 46 rows tall
+    #: between the two strips; `["top", "left", "right", "bottom"]` instead gives 48-row
+    #: side panels and a `bottom` of **154 columns**, inset between them. `bottom` is the
+    #: row that carries the one alert and the command that fixes it, and `slots._bottom`
+    #: drops whole fields when it runs out of width — so the 46 columns belong to it and
+    #: not to two side panels that are already truncating their own 22.
+    "slots": (["top", "bottom", "left", "right"], "slots"),
     #: Off by default: tmux's `set -g mouse on` takes over drag-select, so turning this on
     #: trades the operator's terminal text-selection for clickable panels. That trade
     #: belongs to a later release that actually ships clickable panels, not this one.

--- a/charter/session.py
+++ b/charter/session.py
@@ -28,26 +28,36 @@ _SAFE = re.compile(r"[^A-Za-z0-9._-]")
 def current(explicit: str | None = None) -> str | None:
     """This session's id, or ``None`` when there is not one.
 
-    ``explicit`` first — the status line receives the id in its stdin payload, and Claude
-    Code never puts its own session id in the environment at all. (It passes the
-    environment on: measured 2026-08-24 against Claude Code 2.1.241, a `statusLine`
-    command saw every variable exported to the harness. It simply has nothing of its own
-    to put there. An earlier version of this line said the environment was *scrubbed*,
-    which is a different and false claim — see :mod:`charter.statusline`'s own docstring
-    for the measurement.) Then ``$CHARTER_SESSION_ID``, which any harness sets when it
-    knows its own session (opencode's plugin reads it off ``shell.env``'s
-    ``input.sessionID``, per invocation — one server hosts many sessions, so nothing may
-    be cached). Then ``$CLAUDE_CODE_SESSION_ID``, kept so no session already running
-    regresses the day the neutral name ships.
+    ``explicit`` first — the status line receives the id in its stdin payload, which is
+    the only source that is certainly THIS session's. Then ``$CHARTER_SESSION_ID``, which
+    any harness sets when it knows its own session (opencode's plugin reads it off
+    ``shell.env``'s ``input.sessionID``, per invocation — one server hosts many sessions,
+    so nothing may be cached). Then ``$CLAUDE_CODE_SESSION_ID``, kept so no session
+    already running regresses the day the neutral name ships.
 
-    **Inside a frame that variable holds the FRAME's id, and that is deliberate** — see
-    ADR 0019 and ``docs/frame.md``. `charter <harness>` exports the frame id here, so
-    every process the frame contains (the agent's own shell, each panel, any `charter`
-    command typed inside it) agrees about which charter session it belongs to, which is
-    why `charter ws use` in the agent's shell moves the panels. Claude Code's own session
-    id keys what arrives by payload — the usage history, the trace — and the frame id keys
-    what a process can only read off its environment; they are two identities with two
-    jobs, not one identity with a bug.
+    **Two earlier versions of this paragraph were wrong in opposite directions, so both
+    are recorded rather than quietly replaced.** It first said Claude Code *scrubs* the
+    environment; it then said Claude Code has no session id in the environment *at all*.
+    Measured 2026-08-24 against Claude Code 2.1.241 through a real `statusLine` command:
+    the environment arrives intact AND carries ``CLAUDE_CODE_SESSION_ID`` (a UUID), which
+    is exactly why the third rung above exists and reads it. Neither claim survives a
+    probe; the fallback chain below is the whole truth.
+
+    **Inside a frame, ``$CHARTER_SESSION_ID`` holds the FRAME's id — so it SHADOWS Claude
+    Code's own, which is present one rung down.** Deliberate (ADR 0019, ``docs/frame.md``):
+    the two ids compete for one slot and the frame wins it, so every process the frame
+    contains — the agent's shell, each panel, any `charter` command typed inside it —
+    answers this question identically. That is what makes `charter ws use` in the agent's
+    shell move the panels, and nothing else could: the per-terminal pointer is keyed by
+    ``$TMUX_PANE`` and those processes are in different panes.
+
+    What the shadowing costs, stated because it is not obvious from here: everything keyed
+    on :func:`current` becomes per-FRAME for the life of that frame. `workspace.set_active`
+    writes its pointer and its **session lock** under the frame's id, so the lock belongs
+    to the frame rather than to the Claude Code conversation inside it — resume the same
+    conversation in a new frame and it is a new key, with no lock and no pointer. What
+    still keys on Claude Code's own id is what arrives by payload and never reads the
+    environment: the token-usage history and the session trace.
 
     Sanitised, because the value becomes a filename.
     """

--- a/charter/session.py
+++ b/charter/session.py
@@ -28,12 +28,26 @@ _SAFE = re.compile(r"[^A-Za-z0-9._-]")
 def current(explicit: str | None = None) -> str | None:
     """This session's id, or ``None`` when there is not one.
 
-    ``explicit`` first — the status line receives the id in its stdin payload rather than
-    its environment, which Claude Code scrubs. Then ``$CHARTER_SESSION_ID``, which any
-    harness sets when it knows its own session (opencode's plugin reads it off
-    ``shell.env``'s ``input.sessionID``, per invocation — one server hosts many sessions,
-    so nothing may be cached). Then ``$CLAUDE_CODE_SESSION_ID``, kept so no session
-    already running regresses the day the neutral name ships.
+    ``explicit`` first — the status line receives the id in its stdin payload, and Claude
+    Code never puts its own session id in the environment at all. (It passes the
+    environment on: measured 2026-08-24 against Claude Code 2.1.241, a `statusLine`
+    command saw every variable exported to the harness. It simply has nothing of its own
+    to put there. An earlier version of this line said the environment was *scrubbed*,
+    which is a different and false claim — see :mod:`charter.statusline`'s own docstring
+    for the measurement.) Then ``$CHARTER_SESSION_ID``, which any harness sets when it
+    knows its own session (opencode's plugin reads it off ``shell.env``'s
+    ``input.sessionID``, per invocation — one server hosts many sessions, so nothing may
+    be cached). Then ``$CLAUDE_CODE_SESSION_ID``, kept so no session already running
+    regresses the day the neutral name ships.
+
+    **Inside a frame that variable holds the FRAME's id, and that is deliberate** — see
+    ADR 0019 and ``docs/frame.md``. `charter <harness>` exports the frame id here, so
+    every process the frame contains (the agent's own shell, each panel, any `charter`
+    command typed inside it) agrees about which charter session it belongs to, which is
+    why `charter ws use` in the agent's shell moves the panels. Claude Code's own session
+    id keys what arrives by payload — the usage history, the trace — and the frame id keys
+    what a process can only read off its environment; they are two identities with two
+    jobs, not one identity with a bug.
 
     Sanitised, because the value becomes a filename.
     """

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -2106,8 +2106,8 @@ def a_frame_owns_this_surface() -> bool:
     test can pin. Everything below this line is `main`'s alone; `render` is unchanged and
     every test of it still means what it meant.
 
-    Two conditions, and both were measured rather than assumed (2026-08-24, Claude Code
-    2.1.241, darwin — see the module docstring):
+    Three conditions. The first two were measured rather than assumed (2026-08-24, Claude
+    Code 2.1.241, darwin — see the module docstring):
 
     * **stdout is not a tty.** Claude Code invokes this command with its stdout piped, so
       a tty means a human ran `charter statusline` by hand and wants to see the thing they
@@ -2131,6 +2131,31 @@ def a_frame_owns_this_surface() -> bool:
     Read with a ``""`` default rather than ``None``, deliberately: absent means "not in
     any pane", which is an answer — not a reason to stop asking the question.
 
+    * **the harness is Claude Code.** Suppression removes a DUPLICATE, and only Claude
+      Code has the surface being duplicated. **opencode has no status bar, so charter
+      wires the plane in as an on-demand slash command** whose body is
+      ``!`echo '{}' | charter statusline` `` (`harness/opencode.py`'s ``COMMAND``) — and
+      that invocation satisfies every other condition here perfectly: its stdout is a
+      pipe because it is a shell substitution, its `$CHARTER_SESSION_ID` is the live
+      frame's, and its `$TMUX_PANE` IS the recorded harness pane, because opencode is
+      what runs there. Without this rung `/charter` answered with a blank line inside a
+      frame (reproduced), and there is no duplicate anywhere for that to have removed:
+      `/charter` puts plane state into the **agent's context**, which no panel can do —
+      a panel draws to a pane the model never reads.
+
+      This is ADR 0019's own argument one step further, not a special case bolted on: the
+      ADR already holds that codex and opencode are different surfaces from Claude Code's
+      footer. The tty rung was built to protect "a human asked for this" and cannot cover
+      it, because opencode's own wiring makes the human's ask a pipe. (codex is untouched
+      either way — it uses `charter statusline --watch`, which returns before any of this.)
+
+      Asked LAST, and that ordering is the whole cost argument: inside a frame
+      `$CHARTER_HARNESS` is always set (`commands_frame._frame_env`, and
+      `_FRAME_IDENTITY` states it even when empty), so on the only path that reaches this
+      line `harness.current()` is one environment lookup. Every `detect()` fallback behind
+      it is an env lookup or a constant too — no subprocess on a path that runs every time
+      the footer repaints.
+
     Never raises. Everything it touches is ambient, and every failure means "no frame"
     (which renders) rather than a status line that vanished for a reason nobody can see.
     """
@@ -2141,7 +2166,10 @@ def a_frame_owns_this_surface() -> bool:
         if not fid:
             return False
         from .frame import state as frame_state
-        return frame_state.is_live(fid, pane=os.environ.get("TMUX_PANE", ""))
+        if not frame_state.is_live(fid, pane=os.environ.get("TMUX_PANE", "")):
+            return False
+        from . import harness
+        return harness.current() == harness.CLAUDE_CODE
     except Exception:
         return False
 

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -30,15 +30,22 @@ declares the layout; all width math lives in :mod:`charter.tui`, whose nodes
 guarantee that no emitted line ever exceeds the terminal width — overflow is
 truncated with ``…``, never wrapped (a wrap shears every column below it).
 
-Note: Claude Code does **not** pass the session's environment to the status
-line, so an ``$CHARTER_WORKSPACE``-pinned session shows the active-file/default here
-even though its commands honor the env var. Cosmetic only.
+**On this command's environment.** This used to say Claude Code does "not pass the
+session's environment to the status line", and that an ``$CHARTER_WORKSPACE``-pinned
+session therefore showed the default here. **Measured false** (2026-08-24, Claude Code
+2.1.241, darwin): a `statusLine` command started with both variables exported saw
+``SID=[probe-frame-99999] WS=[probews]`` — Claude Code spawns this command with its own
+process environment, exactly as it spawns every other subprocess. The same probe measured
+the other half this module now depends on: **stdout is a pipe, never a tty**. Both facts
+are load-bearing for :func:`main`'s frame check, so they are written down as measurements
+rather than left as beliefs — the previous sentence here was a belief, and it was wrong.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -273,6 +280,34 @@ def _cache_hint(streak: int) -> str | None:
             f"churns the prefix; prefer {_R}{_BOLD}/rewind{_R}{_DIM} over /compact{_R}")
 
 
+def record_usage(payload: dict) -> list[int]:
+    """Write this turn's cache numbers into the session's trend; return the trend.
+
+    Public, and the reason is ADR 0019. Inside a frame :func:`main` draws nothing, but it
+    still has to *run*: Claude Code's per-turn payload is the only place these numbers
+    exist — ``hooks.py`` has zero references to usage, and no other charter surface is
+    handed them — so a "suppression" that stopped invoking this command would delete the
+    record rather than merely hide a duplicate of it. Splitting the write out of
+    :func:`_context_gauge` is what lets the blank path keep the record without drawing a
+    character, and keeps the extraction of ``read``/``write``/``hit`` in ONE place so the
+    drawing path and the recording path cannot come to disagree about what a turn was.
+
+    Reads nothing that is not in *payload*, so a caller that does not intend to draw pays
+    one file read and one file write and nothing else — no git, no forge, no persona scan.
+    ``[]`` when the payload carries no live numbers, which is every turn early in a
+    session and right after ``/compact``: there is nothing to record then, and recording a
+    zero would be inventing a turn.
+    """
+    cw = (payload or {}).get("context_window") or {}
+    cu = cw.get("current_usage") or {}
+    read = cu.get("cache_read_input_tokens") or 0
+    write = cu.get("cache_creation_input_tokens") or 0
+    if not (read or write):
+        return []
+    hit = round(100 * read / (read + write))
+    return _record_turn((payload or {}).get("session_id") or "", hit, read, write)
+
+
 def _context_gauge(payload: dict) -> list[str]:
     """Live **context + prompt-cache health** from the status-line payload.
 
@@ -310,7 +345,7 @@ def _context_gauge(payload: dict) -> list[str]:
         out.append(f"{_DIM}cache{_R} {col}{hit}%{_R}")
         try:
             sid = payload.get("session_id") or ""
-            trend = _record_turn(sid, hit, read, write)
+            trend = record_usage(payload)
             # Rebuilds are the dominant cost and are invisible in the ratio — surface them
             # cumulatively so the price of a mid-task switch stays on screen.
             n, cost = _rebuilds(_history(sid))
@@ -2036,6 +2071,50 @@ def watch(interval: float = WATCH_INTERVAL) -> int:
         out.flush()
 
 
+def a_frame_owns_this_surface() -> bool:
+    """Is this invocation drawing INTO a live frame, which already draws all of it?
+
+    ADR 0019. Inside a frame the panels carry what the status line carries, so charter
+    would otherwise print the same repos, personas and alerts twice on one screen — once
+    on the edges tmux gave it, once again in Claude Code's own footer just above them.
+
+    **Here at the command edge, deliberately, and never inside :func:`render`.** The check
+    reads ambient state — an environment variable, a directory, a pid — so a `render` that
+    consulted it would answer differently depending on which terminal the developer
+    happened to type `python3 -m unittest` in: the eight-plus `test_statusline_*` modules
+    call `render` directly, and this project's own suite now runs inside a frame. A
+    property that changes with the room the developer is standing in is not a property a
+    test can pin. Everything below this line is `main`'s alone; `render` is unchanged and
+    every test of it still means what it meant.
+
+    Two conditions, and both were measured rather than assumed (2026-08-24, Claude Code
+    2.1.241, darwin — see the module docstring):
+
+    * **stdout is not a tty.** Claude Code invokes this command with its stdout piped, so
+      a tty means a human ran `charter statusline` by hand and wants to see the thing they
+      asked for — a frame on the same screen is no reason to hand them a blank line.
+    * **``$CHARTER_SESSION_ID`` names a live frame of this plane.** The frame launcher
+      exports the frame id under that name (`commands_frame._frame_env`) and Claude Code
+      passes its own environment to this command intact, so the variable is here to be
+      read. :func:`charter.frame.state.is_live` is what decides "live", by the pid the id
+      ends in — no tmux call on a path that runs every time the footer repaints, and no
+      stale directory left by a crashed frame blanking this plane's status line forever.
+
+    Never raises. Everything it touches is ambient, and every failure means "no frame"
+    (which renders) rather than a status line that vanished for a reason nobody can see.
+    """
+    try:
+        if sys.stdout.isatty():
+            return False
+        fid = os.environ.get("CHARTER_SESSION_ID", "")
+        if not fid:
+            return False
+        from .frame import state as frame_state
+        return frame_state.is_live(fid)
+    except Exception:
+        return False
+
+
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(prog="charter statusline", add_help=True)
     ap.add_argument("--watch", action="store_true",
@@ -2053,6 +2132,23 @@ def main(argv=None) -> int:
         payload = json.load(sys.stdin)
     except Exception:
         payload = {}
+    if a_frame_owns_this_surface():
+        # **Draw nothing; record anyway — and do not "clean this up".** It looks like a
+        # command that has been switched off and could therefore be unwired from
+        # `.claude/settings.json` altogether. It is the opposite: it is a command kept
+        # running for its side effect. Claude Code's payload is the only source of this
+        # session's token usage — `hooks.py` never sees those fields — so unwiring the
+        # command destroys the record, silently, and nothing would notice until somebody
+        # went looking for a history that had stopped being written months earlier.
+        # ADR 0019 says this in prose; this comment says it where the deletion would
+        # happen. `print()` and not `return 0` alone: Claude Code reads a line from this
+        # command, and an empty one is how it is told there is nothing to show.
+        try:
+            record_usage(payload)
+        except Exception:
+            pass          # the record is best-effort; a footer is not worth a crash
+        print()
+        return 0
     # Defense in depth (FINDING M9): `render()` itself is guarded end-to-end, but this
     # is the outermost boundary of the whole subprocess — it must never crash even if a
     # future bug (or a monkeypatch, or an import-time surprise) reaches past render's

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -280,6 +280,30 @@ def _cache_hint(streak: int) -> str | None:
             f"churns the prefix; prefer {_R}{_BOLD}/rewind{_R}{_DIM} over /compact{_R}")
 
 
+def _usage_numbers(payload: dict) -> tuple[str, int, int, int] | None:
+    """``(session_id, cache_read, cache_write, hit%)`` out of a status-line payload, or
+    ``None`` when this turn carries no live numbers.
+
+    The one place that knows where those numbers live and what counts as a turn having
+    any. :func:`record_usage` and :func:`_context_gauge` both go through it — a claim the
+    first version of this split made in a docstring and did not deliver, leaving the
+    gauge extracting `read`/`write`/`hit` a second time from the same payload. Two
+    extractions is how the drawn number and the recorded number come to disagree about
+    the same turn.
+
+    ``None`` and not zeros: early in a session, and right after ``/compact``, the payload
+    has no usage at all, and a zero recorded there would be an invented turn (and a
+    ``0/0`` divided).
+    """
+    cu = ((payload or {}).get("context_window") or {}).get("current_usage") or {}
+    read = cu.get("cache_read_input_tokens") or 0
+    write = cu.get("cache_creation_input_tokens") or 0
+    if not (read or write):
+        return None
+    return ((payload or {}).get("session_id") or "", read, write,
+            round(100 * read / (read + write)))
+
+
 def record_usage(payload: dict) -> list[int]:
     """Write this turn's cache numbers into the session's trend; return the trend.
 
@@ -289,8 +313,9 @@ def record_usage(payload: dict) -> list[int]:
     handed them — so a "suppression" that stopped invoking this command would delete the
     record rather than merely hide a duplicate of it. Splitting the write out of
     :func:`_context_gauge` is what lets the blank path keep the record without drawing a
-    character, and keeps the extraction of ``read``/``write``/``hit`` in ONE place so the
-    drawing path and the recording path cannot come to disagree about what a turn was.
+    character. The extraction itself lives in :func:`_usage_numbers`, which both paths
+    call, so the drawn number and the recorded number cannot come to disagree about what
+    a turn was.
 
     Reads nothing that is not in *payload*, so a caller that does not intend to draw pays
     one file read and one file write and nothing else — no git, no forge, no persona scan.
@@ -298,14 +323,11 @@ def record_usage(payload: dict) -> list[int]:
     session and right after ``/compact``: there is nothing to record then, and recording a
     zero would be inventing a turn.
     """
-    cw = (payload or {}).get("context_window") or {}
-    cu = cw.get("current_usage") or {}
-    read = cu.get("cache_read_input_tokens") or 0
-    write = cu.get("cache_creation_input_tokens") or 0
-    if not (read or write):
+    nums = _usage_numbers(payload)
+    if nums is None:
         return []
-    hit = round(100 * read / (read + write))
-    return _record_turn((payload or {}).get("session_id") or "", hit, read, write)
+    sid, read, write, hit = nums
+    return _record_turn(sid, hit, read, write)
 
 
 def _context_gauge(payload: dict) -> list[str]:
@@ -333,18 +355,15 @@ def _context_gauge(payload: dict) -> list[str]:
     if isinstance(pct, (int, float)):
         col = _GREEN if pct < 50 else (_YELLOW if pct < 80 else _RED)
         out.append(f"{_DIM}ctx{_R} {col}{int(pct)}%{_R}")
-    cu = cw.get("current_usage") or {}
-    read = cu.get("cache_read_input_tokens") or 0
-    write = cu.get("cache_creation_input_tokens") or 0
-    if read or write:
-        hit = round(100 * read / (read + write))
+    nums = _usage_numbers(payload)
+    if nums is not None:
+        sid, _read, _write, hit = nums
         # <50% sustained = the prefix is churning; that's the expensive failure mode.
         col = _GREEN if hit >= 80 else (_YELLOW if hit >= 50 else _RED)
         # Dim label, coloured number — the exact shape `ctx NN%` above uses, so the two
         # session gauges read as a pair rather than as a word and a symbol.
         out.append(f"{_DIM}cache{_R} {col}{hit}%{_R}")
         try:
-            sid = payload.get("session_id") or ""
             trend = record_usage(payload)
             # Rebuilds are the dominant cost and are invisible in the ratio — surface them
             # cumulatively so the price of a mid-task switch stays on screen.
@@ -2093,12 +2112,24 @@ def a_frame_owns_this_surface() -> bool:
     * **stdout is not a tty.** Claude Code invokes this command with its stdout piped, so
       a tty means a human ran `charter statusline` by hand and wants to see the thing they
       asked for — a frame on the same screen is no reason to hand them a blank line.
-    * **``$CHARTER_SESSION_ID`` names a live frame of this plane.** The frame launcher
-      exports the frame id under that name (`commands_frame._frame_env`) and Claude Code
-      passes its own environment to this command intact, so the variable is here to be
-      read. :func:`charter.frame.state.is_live` is what decides "live", by the pid the id
-      ends in — no tmux call on a path that runs every time the footer repaints, and no
-      stale directory left by a crashed frame blanking this plane's status line forever.
+    * **``$CHARTER_SESSION_ID`` names a live frame of this plane, and this process is
+      inside it.** The frame launcher exports the frame id under that name
+      (`commands_frame._frame_env`) and Claude Code passes its own environment to this
+      command intact, so the variable is here to be read.
+
+    **Holding the id is not the same as being in the frame, and the difference is the
+    whole reason `$TMUX_PANE` is passed down.** A process can inherit a frame id it does
+    not belong to — most sharply below `tmuxctl.SESSION_ENV_FLOOR`, where charter cannot
+    put the id on `new-session` and a SECOND frame's harness on the shared private server
+    inherits the FIRST frame's (#411). Suppressing on the id alone would blank that
+    operator's footer while their panels followed another frame: no correct surface at
+    all, where before they at least had a correct status line. tmux sets `$TMUX_PANE` in
+    every process it starts in a pane and it survives the harness's own spawning of this
+    command (measured through a real `statusLine` invocation: ``PANE=[%0]``), so comparing
+    it against the pane the launcher recorded answers "is this frame mine" exactly.
+
+    Read with a ``""`` default rather than ``None``, deliberately: absent means "not in
+    any pane", which is an answer — not a reason to stop asking the question.
 
     Never raises. Everything it touches is ambient, and every failure means "no frame"
     (which renders) rather than a status line that vanished for a reason nobody can see.
@@ -2110,7 +2141,7 @@ def a_frame_owns_this_surface() -> bool:
         if not fid:
             return False
         from .frame import state as frame_state
-        return frame_state.is_live(fid)
+        return frame_state.is_live(fid, pane=os.environ.get("TMUX_PANE", ""))
     except Exception:
         return False
 

--- a/docs/adr/0019-the-frame-owns-the-surface.md
+++ b/docs/adr/0019-the-frame-owns-the-surface.md
@@ -60,15 +60,16 @@ Three conditions, all cheap enough for a path that runs every time the footer re
   statusline` and wants the thing they asked for; a frame elsewhere on the screen is no
   reason to answer them with a blank line. (Measured 2026-08-24, Claude Code 2.1.241: the
   command's stdout is a pipe, and its environment is Claude Code's own, passed intact.)
-* **`$CHARTER_SESSION_ID` names a directory under this plane's frame state.** Any harness
-  that knows its own session sets that variable, not only a frame; an id that never named
-  a frame directory here is not this plane's frame whatever it parses as.
 * **the launcher pid at the end of that id is still a running process.** A frame id is
   `<workspace>-<launcher pid>`, so `os.kill(pid, 0)` answers "is that frame alive" with
   one syscall and no tmux subprocess. Without it, a directory left behind by a crashed
   launcher would blank this plane's status line forever, with nothing on screen to say
   why. `state.reap` already asks the same question for the same reason.
-* **a server marker a LAUNCHER wrote.** A directory is not proof that a frame exists:
+* **`$CHARTER_SESSION_ID` names a frame directory here that a LAUNCHER wrote a server
+  marker into** — one read, not two, because the marker cannot exist without the
+  directory and a separate `is_dir()` would be a guard no mutation could turn red. Any
+  harness that knows its own session sets that variable, not only a frame. And a directory
+  alone is not proof that a frame exists:
   `state.bump` creates one on demand and `notify.plane_changed` calls it from seven hook
   sites for whatever id is in the environment — so an operator who exports
   `CHARTER_SESSION_ID` in a shell rc gets a directory minted by their first tool call,
@@ -81,6 +82,17 @@ Three conditions, all cheap enough for a path that runs every time the footer re
   there would take away the one correct surface that operator still had. tmux sets
   `$TMUX_PANE` in every process it starts in a pane, and it survives the harness's own
   spawning of this command (measured: a real `statusLine` invocation reported `PANE=[%0]`).
+
+* **the harness is Claude Code.** Suppression removes a duplicate, and only Claude Code
+  has the surface being duplicated. **A harness with no status bar of its own is never
+  suppressed**, which is this ADR's own premise applied one step further rather than an
+  exception to it: opencode has no footer, so charter wires the plane in as an on-demand
+  `/charter` slash command whose body pipes `charter statusline` through a shell
+  substitution. That invocation is piped, carries the live frame's id, and runs in the
+  recorded harness pane — every other condition here, satisfied perfectly — and blanking
+  it removes nothing, because `/charter` puts plane state into the **agent's context**,
+  which no panel can do: a panel draws to a pane the model never reads. codex is untouched
+  from either direction; `charter statusline --watch` returns before any of this.
 
 Every failure answers "not in a frame", which renders. A status line that vanished for a
 reason nobody can see is the worst outcome available here — which is also why `charter

--- a/docs/adr/0019-the-frame-owns-the-surface.md
+++ b/docs/adr/0019-the-frame-owns-the-surface.md
@@ -1,0 +1,155 @@
+# The frame owns the surface
+
+ADR 0018 settled what charter draws when it *runs* a harness: tmux composes the
+rectangles, charter fills only the edges, and the harness's own pane is never read,
+parsed or drawn by charter at all. It answers "what may charter draw". It never had to
+answer the question that arrives the moment charter's edges are actually filled in:
+**charter has two surfaces now, and inside a frame they are the same surface twice.**
+
+`charter statusline` is Claude Code's footer — repos, branches, CI, persona chips,
+alerts, todos. Since #385 the frame's panels are built out of the same renderers, on
+purpose, so that a fix lands in both at once. The result, inside a frame, is the plane's
+state drawn on the top strip, again on the bottom strip, again in the sidebars, and then
+one more time in Claude Code's own footer three lines below them.
+
+## The decision
+
+**Inside a live frame, `charter statusline` prints an empty line. The frame's panels are
+the surface, and there is exactly one of it.**
+
+Outside a frame nothing changes at all: the status line is still Claude Code's footer,
+still the only charter surface most sessions ever have, and every one of its renderers is
+untouched.
+
+## Suppression means "render nothing", never "stop running"
+
+This is the part that will look like dead code, so it is the part written down hardest.
+
+The suppressed command still reads its payload and still records this turn's token usage
+(`statusline.record_usage`). Claude Code's per-turn JSON is the **only** place those
+numbers exist: it carries `context_window.current_usage` to the `statusLine` command and
+nowhere else, and `charter/hooks.py` has zero references to any usage field — measured,
+not assumed. The session's cache-hit history, its prefix-rebuild count and their
+cumulative token cost are all reconstructed from what `_record_turn` wrote.
+
+So the tempting cleanup — "this command prints nothing inside a frame, take it out of
+`.claude/settings.json`" — does not remove a duplicate. It deletes the record, silently,
+and nothing notices until somebody goes looking for a history that stopped being written
+months earlier. **This is a command kept running for its side effect.** That sentence is
+the reason this ADR exists rather than a comment.
+
+## The decision lives at the command edge, not in `render()`
+
+`statusline.render` is called directly by eight-plus `test_statusline_*` modules. The
+frame check reads ambient state — an environment variable, a directory, a pid — and this
+project's own suite now runs inside a frame. A check inside `render` would therefore make
+those modules pass or fail according to which terminal the developer typed `python3 -m
+unittest` in. A property that changes with the room you are standing in is not a property
+a test can pin.
+
+`statusline.main` is the whole command, and putting it there means no existing test of
+`render` changes meaning. (`is_live` also requires the frame's directory to exist under
+`config.STATE_DIR`, which every isolated test repoints — so a test that isolates plane
+state cannot accidentally suppress itself either.)
+
+## What counts as "inside a live frame"
+
+Three conditions, all cheap enough for a path that runs every time the footer repaints:
+
+* **stdout is not a tty.** Claude Code pipes it. A tty means a human typed `charter
+  statusline` and wants the thing they asked for; a frame elsewhere on the screen is no
+  reason to answer them with a blank line. (Measured 2026-08-24, Claude Code 2.1.241: the
+  command's stdout is a pipe, and its environment is Claude Code's own, passed intact.)
+* **`$CHARTER_SESSION_ID` names a directory under this plane's frame state.** Any harness
+  that knows its own session sets that variable, not only a frame; an id that never named
+  a frame directory here is not this plane's frame whatever it parses as.
+* **the launcher pid at the end of that id is still a running process.** A frame id is
+  `<workspace>-<launcher pid>`, so `os.kill(pid, 0)` answers "is that frame alive" with
+  one syscall and no tmux subprocess. Without it, a directory left behind by a crashed
+  launcher would blank this plane's status line forever, with nothing on screen to say
+  why. `state.reap` already asks the same question for the same reason.
+
+Every failure answers "not in a frame", which renders. A status line that vanished for a
+reason nobody can see is the worst outcome available here.
+
+## The frame must therefore SHOW what it suppresses
+
+The shipped `[frame] slots` default moves from `["top", "bottom"]` to all four edges.
+This is part of the same decision, not a separate improvement: once the status line is
+blank inside a frame, an edge the frame does not fill is information that is not on the
+screen at all. Two one-line strips were the status line again, in a worse shape — which
+is exactly how the first release of the frame was reported: *"only top and bottom single
+lines added, no left right sidebar, feeling — nothing delivered."*
+
+`left` (repo rows) and `right` (persona chips) have had renderers since #385; they were
+built, tested and switched off. `layout.visible_slots` drops both on any shortage against
+`min_cols`/`min_rows`, so a narrow terminal degrades to exactly the frame this default
+used to be.
+
+The order of that list is the split order and therefore the geometry — measured against
+tmux 3.7c in a 200×50 window: `["top", "bottom", "left", "right"]` gives a full-width
+200-column bottom row with 46-row side panels between the strips, while `["top", "left",
+"right", "bottom"]` gives 48-row side panels and a bottom row of 154 columns, inset
+between them. The bottom row carries the one alert and the command that fixes it, and
+`slots._bottom` drops whole fields when it runs out of width, so those 46 columns are
+worth more there than two extra rows are to a sidebar that is already truncating.
+
+## `$CHARTER_SESSION_ID` inside a frame: decided, not inherited
+
+The frame launcher exports the frame id under `$CHARTER_SESSION_ID` — the variable
+`charter.session.current()` already owns. That collision was load-bearing and
+undocumented: panels follow `charter ws use` **only** because of it, since
+`workspace.set_active` writes a per-session pointer under `session.current()` and a panel
+reads it back under the same name. (The per-*terminal* pointer cannot do this job: it is
+keyed by `$TMUX_PANE`, and the harness and each panel are different panes.)
+
+**Kept, deliberately: one variable, one meaning — "the charter session this process
+belongs to". Inside a frame, that is the frame.** Every process the frame contains — the
+agent's shell, each panel, any `charter` command typed inside it — agrees on one identity,
+which is what makes a switch made in the harness visible on the edges.
+
+There are then two session identities in a framed session, and they key different things:
+
+* **Claude Code's own session id** keys everything that arrives by payload — the usage
+  history above, the session trace. It reaches charter through stdin, never the
+  environment.
+* **the frame id** keys everything a process can only read off its environment — the
+  workspace pointer, the frame's version counter, the gather cache.
+
+Two identities with two jobs, not one identity with a bug. Pinned by
+`tests/test_frame_owns_the_surface.py`, which asserts that a panel follows a `ws use` made
+under the frame's id and does *not* follow one made under any other.
+
+That rule sends a bill, and #411 was it: charter's private tmux server is shared by every
+frame on the machine, so only the first launch's `new-session` starts it, and tmux builds
+a later session's pane environment from the SERVER's global one. Measured against tmux
+3.7c, a second frame's harness read the *first* frame's `$CHARTER_SESSION_ID` — so
+`charter ws use` wrote the first frame's pointer and every hook bumped the first frame's
+version, while the second frame's panels sat waiting for a change recorded somewhere else.
+`layout.session_argv` now carries the frame's environment on `-e`, the same way the
+operator's-tmux path already did.
+
+## Consequences, including the ones that cost something
+
+* **A framed Claude Code session has no context/cache gauge on any surface.** The status
+  line is where `ctx NN%` and `cache NN%` were drawn, and it is now blank inside a frame;
+  `slots._top` deliberately does not call `_context_gauge`, because that renderer is gated
+  at every branch on a per-turn payload no panel is ever handed (#385 established this and
+  left the decision here). This ADR keeps the *recording* alive so a panel can be given
+  one, and names what such a panel would still need: the usage file is keyed by Claude
+  Code's session id, which a panel does not know — only the suppressing `statusline.main`
+  sees both ids at once, so it is the one place that could write the mapping. That is a
+  surface decision with a width budget attached, and it belongs to the release that draws
+  it, not to this one.
+* **codex and opencode get no context gauge either, and for a harder reason: nothing feeds
+  them one.** Neither invokes `charter statusline` with a per-turn payload, so there is no
+  usage recorded to draw from at all. Their frames show everything else.
+* **A human can still ask.** `charter statusline` at a terminal, and `charter statusline
+  --watch`, render exactly as before, frame or no frame.
+* **Nothing outside a frame changes.** No renderer was modified, no test of `render`
+  changed meaning, and a session with no frame draws exactly what it drew before.
+* **One more surface has to stay in step.** ADR 0018 kept charter out of the harness's
+  pane; this one puts charter's whole plane-state surface inside panels charter draws. A
+  fact worth showing now has one place to be shown in a frame, and a `[frame] slots` list
+  that excludes that edge is an operator choosing not to see it — which `charter
+  frame-probe` and `charter doctor` already report.

--- a/docs/adr/0019-the-frame-owns-the-surface.md
+++ b/docs/adr/0019-the-frame-owns-the-surface.md
@@ -68,9 +68,24 @@ Three conditions, all cheap enough for a path that runs every time the footer re
   one syscall and no tmux subprocess. Without it, a directory left behind by a crashed
   launcher would blank this plane's status line forever, with nothing on screen to say
   why. `state.reap` already asks the same question for the same reason.
+* **a server marker a LAUNCHER wrote.** A directory is not proof that a frame exists:
+  `state.bump` creates one on demand and `notify.plane_changed` calls it from seven hook
+  sites for whatever id is in the environment — so an operator who exports
+  `CHARTER_SESSION_ID` in a shell rc gets a directory minted by their first tool call,
+  carrying their own shell's permanently-live pid. Only `cmd_launch` records a server.
+* **the harness pane the launcher recorded matches this process's `$TMUX_PANE`.** The
+  four conditions above establish that a live frame exists; only this one establishes
+  that the process asking is *inside* it. A process can hold an id it merely inherited —
+  most sharply below `tmuxctl.SESSION_ENV_FLOOR`, where charter cannot put the frame id on
+  `new-session` and a second frame's harness inherits the first frame's (#411). Blanking
+  there would take away the one correct surface that operator still had. tmux sets
+  `$TMUX_PANE` in every process it starts in a pane, and it survives the harness's own
+  spawning of this command (measured: a real `statusLine` invocation reported `PANE=[%0]`).
 
 Every failure answers "not in a frame", which renders. A status line that vanished for a
-reason nobody can see is the worst outcome available here.
+reason nobody can see is the worst outcome available here — which is also why `charter
+doctor`'s frame row says so when a session's line is being suppressed, rather than leaving
+a blank footer to be explained by reading source.
 
 ## The frame must therefore SHOW what it suppresses
 
@@ -108,17 +123,28 @@ belongs to". Inside a frame, that is the frame.** Every process the frame contai
 agent's shell, each panel, any `charter` command typed inside it — agrees on one identity,
 which is what makes a switch made in the harness visible on the edges.
 
-There are then two session identities in a framed session, and they key different things:
+**They are not two variables with two jobs. They are two ids competing for one slot, and
+the frame is chosen to win it.** An earlier draft of this ADR argued the comfortable
+version — that Claude Code's id "reaches charter through stdin, never the environment" —
+and it is false: measured 2026-08-24 against Claude Code 2.1.241, `$CLAUDE_CODE_SESSION_ID`
+is right there in the environment, and `session.current()` reads it one rung below
+`$CHARTER_SESSION_ID`. Inside a frame the frame id **shadows** it.
 
-* **Claude Code's own session id** keys everything that arrives by payload — the usage
-  history above, the session trace. It reaches charter through stdin, never the
-  environment.
-* **the frame id** keys everything a process can only read off its environment — the
-  workspace pointer, the frame's version counter, the gather cache.
+Choosing that deliberately is still the right answer, because the alternative is worse:
+the harness and its panels are different panes and different processes, and the frame id
+is the only name all of them can agree on. But it has to be argued as what it is, and it
+has a consequence the comfortable version hides:
 
-Two identities with two jobs, not one identity with a bug. Pinned by
-`tests/test_frame_owns_the_surface.py`, which asserts that a panel follows a `ws use` made
-under the frame's id and does *not* follow one made under any other.
+* **Everything keyed on `session.current()` becomes per-FRAME for the life of the frame** —
+  the workspace pointer, and `workspace.set_active`'s **session lock** with it. The lock
+  belongs to the frame rather than to the Claude Code conversation inside it: resume the
+  same conversation in a new frame and it is a new key, with no lock and no pointer
+  carried over.
+* **What still keys on Claude Code's own id is what arrives by payload and never reads the
+  environment**: the token-usage history this ADR keeps alive, and the session trace.
+
+Pinned by `tests/test_frame_owns_the_surface.py`, which asserts that a panel follows a
+`ws use` made under the frame's id and does *not* follow one made under any other.
 
 That rule sends a bill, and #411 was it: charter's private tmux server is shared by every
 frame on the machine, so only the first launch's `new-session` starts it, and tmux builds
@@ -126,8 +152,29 @@ a later session's pane environment from the SERVER's global one. Measured agains
 3.7c, a second frame's harness read the *first* frame's `$CHARTER_SESSION_ID` — so
 `charter ws use` wrote the first frame's pointer and every hook bumped the first frame's
 version, while the second frame's panels sat waiting for a change recorded somewhere else.
-`layout.session_argv` now carries the frame's environment on `-e`, the same way the
-operator's-tmux path already did.
+`layout.session_argv` now carries the frame's identity on `-e`, the same way the
+operator's-tmux path already carried it.
+
+**Only the identity, and that is a security boundary rather than an economy.** A tmux `-e`
+becomes the client's command line: world-readable in `/proc/<pid>/cmdline`, visible to
+`ps`, recorded permanently by exec-audit tooling. `_frame_env` is the operator's entire
+environment — measured at 138 argv elements and 7,696 bytes on a real machine, carrying
+two live service-account tokens — so charter puts exactly four names there
+(`commands_frame._FRAME_IDENTITY`: the frame id, the harness, the plane root, the
+workspace pin), each one a value that must be *this* frame's rather than whichever
+launcher started the shared server, and none of them ever a credential. Everything else
+keeps reaching the harness the way it always did, through the tmux client's own
+environment. Each of the four is emitted even when the launcher does not have it
+(`NAME=`), because inheriting a value is as wrong as carrying a stale one — a pinned
+`$CHARTER_WORKSPACE` outranks every pointer in `workspace.resolve`, so an inherited pin
+would make `charter ws use` unable to move that frame at all.
+
+The inside-a-tmux path still passes the whole environment, deliberately and now
+documented: there the `-e` overlay lands on the operator's own tmux server environment,
+which may predate this plane entirely, so charter states everything rather than trusting
+it. That is a real exposure with a real reason; narrowing it needs its own measurement of
+what a harness may safely inherit from a server charter does not own, and this ADR does
+not pretend to have made it.
 
 ## Consequences, including the ones that cost something
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -192,15 +192,50 @@ Below `[frame]`'s `min-cols`/`min-rows`, the side panels (`left`/`right`) are th
 drop — any shortage costs them, since neither can spare its own divider. A further shortage
 in rows drops `top` too. Below half of either floor, every panel drops and the harness
 simply gets the whole terminal, the same choice `charter`'s own status line makes when it
-runs out of width. `left`/`right` are accepted in configuration and sized, but nothing
-renders in them yet — asking for one leaves the harness pane holding that space instead of
-a dead, unwritten-to pane, and `charter frame-probe`/`charter doctor` name it.
+runs out of width. So a narrow terminal degrades to the two strips on its own; nothing has
+to be configured for it.
+
+## The status line goes quiet inside a frame
+
+**Inside a frame, `charter statusline` prints nothing.** The panels are built out of the
+status line's own renderers, so leaving both on drew the plane's state on the edges and
+then again in Claude Code's footer three lines below them. The frame owns the surface
+(ADR 0019); outside a frame the status line is unchanged in every respect.
+
+Two things it does anyway, and they are deliberate:
+
+- **It keeps running, and keeps recording.** Claude Code passes this session's token usage
+  to the `statusLine` command and nowhere else — no hook ever sees those numbers — so the
+  command still reads its payload and still writes the cache-hit and prefix-rebuild
+  history. Unwiring `statusLine` from `.claude/settings.json` because it "prints nothing
+  now" would delete that record rather than remove a duplicate.
+- **A human asking still gets an answer.** Run `charter statusline` yourself in any
+  terminal, or `charter statusline --watch`, and it renders in full. Only the piped
+  invocation — which is how Claude Code calls it — goes blank, and only while a frame with
+  this session's id is actually running.
+
+The honest cost: `ctx NN%` and `cache NN%` lived on the status line, and no panel draws
+them yet, so a framed Claude Code session does not show them. codex and opencode never
+showed them at all — nothing feeds either one a per-turn usage payload to draw from.
+
+## One frame, one charter session
+
+`charter <harness>` exports the frame's id as `$CHARTER_SESSION_ID`, the same variable
+every charter command reads to answer "which session am I". That is on purpose: inside a
+frame, the frame **is** the charter session. The agent's shell, each panel and any
+`charter` command typed inside the frame all agree on one identity, which is why
+`charter workspace use <name>` typed at the agent moves the panels too — the pointer is
+written under the frame's id and the panels read it back under the same one.
+
+Claude Code's own session id has not gone anywhere; it arrives in the status line's stdin
+payload and keys what comes with it (the usage history, the session trace). Two ids, two
+jobs. See ADR 0019.
 
 ## Configuring it
 
 ```toml
 [frame]
-slots = ["top", "bottom"]
+slots = ["top", "bottom", "left", "right"]
 mouse = false
 hotkey = "F2"
 history-limit = 50000
@@ -214,6 +249,14 @@ modifiers and then a key (`F2`, `Up`, `PPage`, `a`, `/`). Anything else falls ba
 cannot make sense of it. That check is not cosmetic: this value is interpolated into tmux
 configuration that `source-file` *executes*, and `charter.toml` is a committed, shared
 file that arrives from someone else's machine.
+
+All four edges are on by default. `top` and `bottom` are one-line strips; `left` (repo
+rows) and `right` (persona chips) are 22-column sidebars, and both drop themselves on a
+terminal too small for them (see above). The **order** is the order the panes are split
+in, and therefore the geometry: with `bottom` before the sidebars its row spans the whole
+frame and the sidebars sit between the two strips, while listing it last leaves it only
+the width the sidebars did not take. The bottom row is where an alert and the command that
+fixes it appear, so the shipped order gives it the full width.
 
 `slots`/`mouse`/`hotkey` are spelled the same on both sides. `history-limit`, `min-cols`
 and `min-rows` are the three that are not: charter.toml spells them with a hyphen: the

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -214,9 +214,19 @@ Two things it does anyway, and they are deliberate:
   invocation — which is how Claude Code calls it — goes blank, and only while a frame with
   this session's id is actually running.
 
+**Only Claude Code's footer goes quiet, because it is the only one being duplicated.**
+opencode has no status bar, so charter wires the plane in as an on-demand `/charter`
+command instead — and that renders in full inside a frame, as it does everywhere else.
+It is not a duplicate of anything: `/charter` puts the plane into the **agent's own
+context**, which no panel can do, because a panel draws to a pane the model never reads.
+codex is unaffected in either direction — `charter statusline --watch` never consults any
+of this.
+
 The honest cost: `ctx NN%` and `cache NN%` lived on the status line, and no panel draws
 them yet, so a framed Claude Code session does not show them. codex and opencode never
 showed them at all — nothing feeds either one a per-turn usage payload to draw from.
+(opencode's `/charter` is not a way around that: it renders the same status line, which
+has no numbers to show without a payload.)
 
 ## One frame, one charter session
 

--- a/docs/news/unreleased-a-second-frame-is-its-own-frame.md
+++ b/docs/news/unreleased-a-second-frame-is-its-own-frame.md
@@ -1,0 +1,37 @@
+---
+version: unreleased
+headline: A second frame on the same machine no longer answers to the first one's id
+---
+
+Switching workspace from inside `charter claude` updated the status line and left the
+frame's panels showing the workspace they launched with. The panels were not stale for
+want of repainting — they were reading the right pointer under the wrong name.
+
+**Every frame on charter's own server is a session on ONE shared tmux server**, which
+means exactly one launch per machine is the launch whose `new-session` actually starts
+that server. charter carried its own variables to the harness by handing them to the tmux
+client and letting the server inherit them — true of that first launch and of no other.
+For every frame after it, tmux builds the new pane's environment from the SERVER's global
+one, captured from whichever launcher started it, possibly days earlier.
+
+Measured against tmux 3.7c with two frames on one socket: the second frame's harness
+reported the FIRST frame's `$CHARTER_SESSION_ID`, while `show-environment -g` held the
+same first id. Everything keyed on that variable then went to the wrong frame —
+`charter workspace use` wrote the first frame's workspace pointer, and every hook bumped
+the first frame's version counter, so the second frame's panels waited for a change that
+was being recorded next door. The status line kept up because it falls through to a
+per-terminal pointer keyed by the pane, which the harness's own `ws use` had written.
+
+The frame's environment now rides on `new-session -e`, one `NAME=VALUE` per variable, the
+same way the inside-your-own-tmux path already carried it on `respawn-pane -e`. The panels
+were never the problem — they take their id from a session-scoped `set-environment` that
+tmux does apply to panes split later — so this closes the one pane that call cannot reach:
+the one `new-session` itself creates.
+
+`new-session -e` arrived in tmux 3.2, and charter still launches below that (it warns and
+degrades rather than refusing). Below 3.2 the flag is not ignored, it is a parse error
+that would take the whole launch down, so the environment is withheld there and a second
+frame behaves exactly as every frame did before this fix.
+
+Nothing to adopt: upgrading is the whole of it. A frame already running keeps whatever id
+it was started with — start it again to pick this up.

--- a/docs/news/unreleased-a-second-frame-is-its-own-frame.md
+++ b/docs/news/unreleased-a-second-frame-is-its-own-frame.md
@@ -29,9 +29,19 @@ tmux does apply to panes split later — so this closes the one pane that call c
 the one `new-session` itself creates.
 
 `new-session -e` arrived in tmux 3.2, and charter still launches below that (it warns and
-degrades rather than refusing). Below 3.2 the flag is not ignored, it is a parse error
-that would take the whole launch down, so the environment is withheld there and a second
-frame behaves exactly as every frame did before this fix.
+degrades rather than refusing). Below 3.2 the flag is not ignored, it is a parse error that
+would take the whole launch down, so the environment is withheld there — and on tmux 3.0
+or 3.1 a second frame's panels go on following the first frame, exactly as they did before
+this fix. What does **not** happen there is the status line going quiet against somebody
+else's frame: charter now records which pane each frame runs its harness in, and a process
+holding an inherited frame id is sitting in a pane that frame never claimed. So that
+operator keeps the correct footer they already had, rather than losing it as well.
+
+The same recorded pane closes a quieter case at every tmux version: an operator who
+exports `CHARTER_SESSION_ID` in their shell rc used to be one hook away from a frame
+directory minted in their name, with their own shell's pid at the end of it — permanently
+live, permanently "a running frame". Suppression now asks for a frame a launcher actually
+made and a pane it actually started.
 
 Nothing to adopt: upgrading is the whole of it. A frame already running keeps whatever id
 it was started with — start it again to pick this up.

--- a/docs/news/unreleased-the-frame-owns-the-surface.md
+++ b/docs/news/unreleased-the-frame-owns-the-surface.md
@@ -1,0 +1,68 @@
+---
+version: unreleased
+headline: Inside a frame the status line goes quiet and the frame fills all four edges
+---
+
+The frame's panels are built out of the status line's own renderers, on purpose, so a fix
+to a repo row or an alert lands on both surfaces at once. Turned on together that drew the
+plane's state on the top strip, again on the bottom strip, and once more in Claude Code's
+own footer three lines below them. **The frame owns the surface now (ADR 0019): inside a
+frame `charter statusline` prints an empty line, and the panels are the one place the
+plane's state appears.** Outside a frame nothing changes — same footer, same renderers,
+same everything.
+
+**Suppressed does not mean switched off, and this is the part worth reading before
+tidying anything.** The command still runs and still records. Claude Code passes this
+session's token usage to the `statusLine` command and to nothing else — no hook ever sees
+those numbers — and the cache-hit trend, the prefix-rebuild count and its cumulative token
+cost are all reconstructed from what that command writes down. Unwiring `statusLine` from
+`.claude/settings.json` because it "prints nothing now" would not remove a duplicate; it
+would delete the record, silently, and nothing would notice until somebody went looking
+for a history that stopped months earlier.
+
+Three things have to be true before a line goes blank, and each one is guarding against a
+different way of getting it wrong:
+
+- **stdout is a pipe**, which is how Claude Code calls it. Run `charter statusline`
+  yourself in a terminal, or `charter statusline --watch`, and you get the full render —
+  a frame elsewhere on your screen is no reason to answer you with a blank line.
+- **`$CHARTER_SESSION_ID` names a frame directory on this plane.** That variable is set by
+  any harness that knows its own session, not only by a frame.
+- **the launcher named at the end of that id is still running.** A frame id ends in its
+  launcher's pid, so `os.kill(pid, 0)` settles it with one syscall and no tmux call on a
+  path that runs every time the footer repaints. Without it, a directory left behind by a
+  crashed launcher would blank that plane's status line forever with nothing on screen to
+  explain why.
+
+**And because the frame now has to show what it suppresses, it fills all four edges by
+default.** `[frame] slots` ships as `["top", "bottom", "left", "right"]` — `left` is
+narrow repo rows, `right` is persona chips, and both have had renderers since the parity
+release; they were built, tested and switched off. Two one-line strips were the status
+line again in a worse shape, which is exactly how the first frame release was reported:
+*"only top and bottom single lines added, no left right sidebar."* A terminal below
+`[frame] min-cols`/`min-rows` still drops the sidebars first and ends up with the frame it
+used to have, so nothing has to be configured for a small window.
+
+The order of that list is the order the panes are split in, which makes it the geometry.
+Measured against tmux 3.7c at 200×50: the shipped order gives a full-width 200-column
+bottom row with 46-row sidebars between the two strips; moving `bottom` to the end instead
+gives 48-row sidebars and a bottom row of 154 columns inset between them. The bottom row
+is the one that carries an alert and the command that fixes it, and it drops whole fields
+when it runs out of width, so it gets the columns.
+
+**One thing is genuinely lost and worth saying plainly:** `ctx NN%` and `cache NN%` lived
+on the status line, and no panel draws them yet, so a framed Claude Code session does not
+show them. The recording is kept alive precisely so a panel can be given one. codex and
+opencode never had them at all — neither is handed a per-turn usage payload, so there has
+never been anything to draw from.
+
+`$CHARTER_SESSION_ID` is also settled and documented rather than left as an accident:
+inside a frame it holds the FRAME's id, so the agent's shell, every panel and every
+`charter` command typed inside the frame agree on one charter session. That is why
+`charter workspace use <name>` at the agent moves the panels — the pointer is written
+under the frame's id and the panels read it back under the same one. Claude Code's own
+session id still arrives in the status line's payload and still keys what comes with it.
+`docs/frame.md` and ADR 0019 carry the whole rule.
+
+Nothing to adopt: upgrading is the whole of it. A plane that has pinned `[frame] slots` in
+its own `charter.toml` keeps exactly what it pinned.

--- a/docs/news/unreleased-the-frame-owns-the-surface.md
+++ b/docs/news/unreleased-the-frame-owns-the-surface.md
@@ -20,7 +20,13 @@ cost are all reconstructed from what that command writes down. Unwiring `statusL
 would delete the record, silently, and nothing would notice until somebody went looking
 for a history that stopped months earlier.
 
-Three things have to be true before a line goes blank, and each one is guarding against a
+**Only Claude Code's footer is affected**, because it is the only one with a duplicate to
+remove. opencode has no status bar, so charter wires the plane in as an on-demand
+`/charter` command — that goes on rendering in full inside a frame, and it has to: it puts
+the plane into the agent's own context, which no panel can do, since a panel draws to a
+pane the model never reads. codex, which uses `charter statusline --watch`, is untouched.
+
+Four things have to be true before a line goes blank, and each one is guarding against a
 different way of getting it wrong:
 
 - **stdout is a pipe**, which is how Claude Code calls it. Run `charter statusline`
@@ -28,6 +34,7 @@ different way of getting it wrong:
   a frame elsewhere on your screen is no reason to answer you with a blank line.
 - **`$CHARTER_SESSION_ID` names a frame directory on this plane.** That variable is set by
   any harness that knows its own session, not only by a frame.
+- **the harness is Claude Code** — see above.
 - **the launcher named at the end of that id is still running.** A frame id ends in its
   launcher's pid, so `os.kill(pid, 0)` settles it with one syscall and no tmux call on a
   path that runs every time the footer repaints. Without it, a directory left behind by a

--- a/tests/test_frame_config.py
+++ b/tests/test_frame_config.py
@@ -52,11 +52,30 @@ class FrameDefaults(unittest.TestCase):
     def test_a_valid_slots_override_actually_takes_effect(self):
         """Companion to the test above: a *different* valid override must actually be
         honoured, not just filtered. Every slot name is in the shipped default now, so
-        "shares no element with it" is no longer available to anything — what rules a
-        default-returning stub out here is the list itself: two entries, in an order the
-        default does not have them in."""
+        "shares no element with it" is no longer available to anything; what rules a
+        default-returning stub out here is the length.
+
+        `["right", "left"]` and not `["left", "right"]`, and that is the whole point of
+        the pair below it: the first draft of this claimed to check an order "the default
+        does not have them in" while using the order the default DOES have them in."""
         f = instance.frame_of({"frame": {"slots": ["left", "right"]}})
         self.assertEqual(f["slots"], ["left", "right"])
+
+    def test_the_operators_own_slot_order_is_kept_exactly(self):
+        """**Order is geometry, so order is a promise.** `layout.panel_argvs` splits each
+        slot off the harness pane in list order, so `["top", "left", "right", "bottom"]`
+        and `["top", "bottom", "left", "right"]` are two different frames from the same
+        four names — measured on tmux 3.7c at 200x50, a 154-column bottom row inset
+        between the sidebars versus a full-width 200-column one (see
+        `instance.FRAME_FIELDS`).
+
+        Nothing pinned that. A `frame_of` that re-sorted an operator's `slots` into the
+        shipped order — silently handing them a frame they did not ask for — passed the
+        entire suite, including the test above, because every list it was ever given was
+        already in the default's relative order. `["right", "left"]` is the shortest list
+        that is not."""
+        f = instance.frame_of({"frame": {"slots": ["right", "left"]}})
+        self.assertEqual(f["slots"], ["right", "left"])
 
     def test_a_malformed_section_falls_back_instead_of_raising(self):
         """`config` is imported by every command including `charter --version`, so a bad

--- a/tests/test_frame_config.py
+++ b/tests/test_frame_config.py
@@ -3,6 +3,11 @@
 Defaults are the shipped behaviour, so they are asserted rather than assumed: `mouse` is
 off because `set -g mouse on` takes over drag-select, and breaking the operator's copy to
 enable a feature v1 does not ship is a bad trade.
+
+`slots` is all four edges since #386, and the reason is the same kind of trade read the
+other way: inside a frame `charter statusline` draws nothing (ADR 0019), so an edge the
+frame does not fill is information nobody sees at all. The order is asserted too, because
+it is the split order and therefore the geometry — see `instance.FRAME_FIELDS`.
 """
 
 from __future__ import annotations
@@ -16,7 +21,7 @@ from charter import instance
 class FrameDefaults(unittest.TestCase):
     def test_an_absent_section_yields_the_shipped_defaults(self):
         f = instance.frame_of({})
-        self.assertEqual(f["slots"], ["top", "bottom"])
+        self.assertEqual(f["slots"], ["top", "bottom", "left", "right"])
         self.assertIs(f["mouse"], False)
         self.assertEqual(f["hotkey"], "F2")
         self.assertEqual(f["history_limit"], 50000)
@@ -27,25 +32,29 @@ class FrameDefaults(unittest.TestCase):
         f = instance.frame_of({"frame": {"mouse": True, "hotkey": "F5"}})
         self.assertIs(f["mouse"], True)
         self.assertEqual(f["hotkey"], "F5")
-        self.assertEqual(f["slots"], ["top", "bottom"])
+        self.assertEqual(f["slots"], ["top", "bottom", "left", "right"])
 
     def test_an_unknown_slot_is_dropped_rather_than_carried(self):
         """A typo must not reach a tmux argv. Dropping is louder than it looks: the slot
         simply does not appear, and `doctor` has the config to report.
 
-        By itself this does not distinguish "filtered" from "ignored": `["top",
-        "sideways", "bottom"]` filters to `["top", "bottom"]`, which is byte-identical to
-        the default, so a stub that always returns the default would also pass this one.
-        `test_a_valid_slots_override_actually_takes_effect` below is what rules that out.
+        Until #386 this could not tell "filtered" from "ignored" on its own: the default
+        was `["top", "bottom"]`, so `["top", "sideways", "bottom"]` filtered to something
+        byte-identical to it and a stub that always returned the default passed too. The
+        shipped default is all four edges now, so the two answers differ and this test
+        distinguishes them by itself; `test_a_valid_slots_override_actually_takes_effect`
+        below stays, because that is a property worth pinning on purpose rather than by
+        the luck of what the default happens to be this release.
         """
         f = instance.frame_of({"frame": {"slots": ["top", "sideways", "bottom"]}})
         self.assertEqual(f["slots"], ["top", "bottom"])
 
     def test_a_valid_slots_override_actually_takes_effect(self):
         """Companion to the test above: a *different* valid override must actually be
-        honoured, not just filtered. `["left", "right"]` shares no elements with the
-        default `["top", "bottom"]`, so a stub that always returns the default — which
-        would still pass the "unknown slot is dropped" test above — fails this one."""
+        honoured, not just filtered. Every slot name is in the shipped default now, so
+        "shares no element with it" is no longer available to anything — what rules a
+        default-returning stub out here is the list itself: two entries, in an order the
+        default does not have them in."""
         f = instance.frame_of({"frame": {"slots": ["left", "right"]}})
         self.assertEqual(f["slots"], ["left", "right"])
 
@@ -60,7 +69,7 @@ class FrameDefaults(unittest.TestCase):
         final `isinstance(value, type(default))` type check is deleted: without it, the
         string `"lots"` would be assigned straight into `history_limit`."""
         f = instance.frame_of({"frame": {"slots": "top", "history-limit": "lots"}})
-        self.assertEqual(f["slots"], ["top", "bottom"])
+        self.assertEqual(f["slots"], ["top", "bottom", "left", "right"])
         self.assertEqual(f["history_limit"], 50000)
 
     def test_a_bool_does_not_satisfy_a_non_bool_default(self):

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1929,8 +1929,8 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertEqual(rc, 0)
         session_cmd = next(c for c in fake.calls if "new-session" in c)
         self.assertEqual(sorted(_carried_env(session_cmd)),
-                         ["CHARTER_HARNESS", "CHARTER_ROOT", "CHARTER_SESSION_ID",
-                          "CHARTER_WORKSPACE"],
+                         ["CHARTER_HARNESS", "CHARTER_PERSONA", "CHARTER_ROOT",
+                          "CHARTER_SESSION_ID", "CHARTER_WORKSPACE"],
                          "only charter's own identity may ride on a tmux command line")
 
     def test_an_identity_variable_the_launcher_lacks_is_carried_as_empty(self):
@@ -1976,8 +1976,8 @@ class Launch(PersonaIso, unittest.TestCase):
             carried = _carried_env(cmd)
             self.assertEqual(carried.get("CHARTER_SESSION_ID"), fake.fid)
             self.assertEqual(sorted(carried),
-                             ["CHARTER_HARNESS", "CHARTER_ROOT", "CHARTER_SESSION_ID",
-                              "CHARTER_WORKSPACE"],
+                             ["CHARTER_HARNESS", "CHARTER_PERSONA", "CHARTER_ROOT",
+                              "CHARTER_SESSION_ID", "CHARTER_WORKSPACE"],
                              "a panel's -e is argv too — identity only")
 
     def test_below_the_pane_env_floor_the_panels_carry_nothing(self):

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1855,12 +1855,54 @@ class Launch(PersonaIso, unittest.TestCase):
 
     def test_charter_session_id_reaches_the_harness_environment(self):
         """Task 8's `notify.plane_changed` reads `$CHARTER_SESSION_ID` back out of the
-        running harness's own environment — this is the one place it is ever set."""
+        running harness's own environment — this is the one place it is ever set.
+
+        This asserts the environment handed to the tmux CLIENT, and on its own that
+        proved nothing about the harness: #411 is a frame whose harness read a DIFFERENT
+        frame's id while this test stayed green. The client's environment reaches the
+        pane only when this call is what starts the server. See the two tests below."""
         fake = _FakeTmux(exit_code=0)
         rc = _launch(fake)
         self.assertEqual(rc, 0)
         self.assertIsNotNone(fake.new_session_env)
         self.assertEqual(fake.new_session_env.get("CHARTER_SESSION_ID"), fake.fid)
+
+    def test_the_frame_id_rides_on_the_new_session_command_not_only_its_client(self):
+        """#411, and the half the test above cannot see. Every frame on charter's private
+        server shares ONE tmux server, so only the first launch's `new-session` starts it
+        — for every later frame tmux builds the new pane's environment from the SERVER's
+        global one, which belongs to whichever launcher started it. Measured against tmux
+        3.7c: a second frame's harness reported the FIRST frame's `$CHARTER_SESSION_ID`,
+        so `charter ws use` wrote the first frame's workspace pointer and every hook
+        bumped the first frame's version — the second frame's panels were never told
+        anything had changed.
+
+        `-e` is what fixes it, and it must land before `--`: after it, it is not a tmux
+        option at all, it is two more arguments handed to the harness."""
+        fake = _FakeTmux(exit_code=0)
+        rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        session_cmd = next(c for c in fake.calls if "new-session" in c)
+        pair = f"CHARTER_SESSION_ID={fake.fid}"
+        self.assertIn(pair, session_cmd,
+                      "the harness pane's own environment must carry this frame's id")
+        self.assertEqual(session_cmd[session_cmd.index(pair) - 1], "-e")
+        self.assertLess(session_cmd.index(pair), session_cmd.index("--"),
+                        "-e is new-session's own option — after `--` it is the "
+                        "harness's argv")
+
+    def test_below_the_env_floor_the_launch_carries_nothing_rather_than_failing(self):
+        """`new-session -e` arrived in tmux 3.2 (`tmuxctl.SESSION_ENV_FLOOR`, read from
+        tmux's own CHANGES). Below that it is not a flag that degrades, it is one that
+        makes the command a parse error — and `below_floor_message` explicitly still lets
+        a pre-3.2 operator launch. So the environment is withheld there and the frame
+        still starts, which is exactly what every frame did before #411."""
+        fake = _FakeTmux(exit_code=0)
+        rc = _launch(fake, version=(3, 1))
+        self.assertEqual(rc, 0)
+        session_cmd = next(c for c in fake.calls if "new-session" in c)
+        self.assertNotIn("-e", session_cmd,
+                         "a tmux that cannot parse -e must be handed none")
 
     def test_columns_and_lines_are_stripped_from_the_environment_handed_to_tmux(self):
         """Belt and braces alongside every pane measuring its own tty (`frame/slots.py`,
@@ -3253,11 +3295,18 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
                          "a 60x8 tmux window has no room for a panel")
 
     def test_the_panels_are_split_off_the_harness_pane(self):
+        """The slot list is pinned here rather than left to the shipped default: this
+        test's subject is that every split targets the harness pane's id, and reading the
+        count off `config.FRAME` made it fail the day the default changed (#386 turned all
+        four edges on) for a reason that has nothing to do with what it checks."""
         fake = _FakeOperatorTmux(exit_code=0,
-                                 panel_pane_ids={"top": "%8", "bottom": "%9"})
-        _launch_inside(fake)
+                                 panel_pane_ids={"top": "%8", "bottom": "%9",
+                                                 "left": "%10", "right": "%11"})
+        with mock.patch.dict(config.FRAME,
+                             {"slots": ["top", "bottom", "left", "right"]}):
+            _launch_inside(fake)
         splits = [c for c in fake.calls if "split-window" in c]
-        self.assertEqual(len(splits), 2, f"one per configured slot: {splits}")
+        self.assertEqual(len(splits), 4, f"one per configured slot: {splits}")
         for cmd in splits:
             self.assertEqual(cmd[cmd.index("-t") + 1], "%7",
                              "every split targets the harness pane's id — tmux "

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1141,6 +1141,25 @@ def _outside_tmux():
     return mock.patch.dict(os.environ, stripped, clear=True)
 
 
+def _carried_env(cmd: list[str]) -> dict[str, str]:
+    """The `-e NAME=VALUE` pairs in *cmd*, as a dict — the ONLY thing a test here may
+    assert an environment against.
+
+    Never `assertIn(pair, cmd)` or `assertNotIn("-e", cmd)`: unittest prints the whole
+    sequence on failure, and on the operator's-tmux path that sequence is the operator's
+    entire environment. A failing assertion would print their live tokens into the test
+    log, which in CI is a public artifact — the very exposure `commands_frame
+    ._frame_identity_env` exists to prevent, reintroduced by the tests that check it.
+    Projecting first keeps a failure message to names and charter's own values.
+    """
+    out = {}
+    for i, part in enumerate(cmd):
+        if part == "-e" and i + 1 < len(cmd):
+            name, _, value = cmd[i + 1].partition("=")
+            out[name] = value
+    return out
+
+
 def _launch(fake: _FakeTmux, *, cols=200, rows=50, version=(3, 7), harness="claude",
            rest=(), which=None):
     _refuse_the_real_plane()
@@ -1883,25 +1902,112 @@ class Launch(PersonaIso, unittest.TestCase):
         rc = _launch(fake)
         self.assertEqual(rc, 0)
         session_cmd = next(c for c in fake.calls if "new-session" in c)
+        self.assertEqual(_carried_env(session_cmd).get("CHARTER_SESSION_ID"), fake.fid,
+                         "the harness pane's own environment must carry this frame's id")
         pair = f"CHARTER_SESSION_ID={fake.fid}"
-        self.assertIn(pair, session_cmd,
-                      "the harness pane's own environment must carry this frame's id")
-        self.assertEqual(session_cmd[session_cmd.index(pair) - 1], "-e")
         self.assertLess(session_cmd.index(pair), session_cmd.index("--"),
                         "-e is new-session's own option — after `--` it is the "
                         "harness's argv")
+
+    def test_nothing_but_charters_own_identity_reaches_the_command_line(self):
+        """**A `-e` is argv, and argv is not private.** `/proc/<pid>/cmdline` is
+        world-readable to every local user for as long as the tmux client runs, `ps` shows
+        it, and exec-audit tooling records it forever. `_frame_env` is
+        `dict(os.environ, ...)` — measured on a real environment at 138 elements and 7,696
+        bytes, carrying two live service-account tokens — so expanding THAT into `-e`
+        pairs would have put every secret in the operator's shell on the command line of
+        the default `charter claude` path.
+
+        Asserted as a set of NAMES, never by scanning for any particular secret: a test
+        that looked for `TOKEN` would pass for the next variable nobody thought of. And
+        the assertion message carries names only — a failure here must not print the
+        values it exists to keep off a command line."""
+        fake = _FakeTmux(exit_code=0)
+        with mock.patch.dict(os.environ, {"MY_FAKE_TOKEN": "sk-super-secret",
+                                          "SSH_AUTH_SOCK": "/tmp/agent.sock"}):
+            rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        session_cmd = next(c for c in fake.calls if "new-session" in c)
+        self.assertEqual(sorted(_carried_env(session_cmd)),
+                         ["CHARTER_HARNESS", "CHARTER_ROOT", "CHARTER_SESSION_ID",
+                          "CHARTER_WORKSPACE"],
+                         "only charter's own identity may ride on a tmux command line")
+
+    def test_an_identity_variable_the_launcher_lacks_is_carried_as_empty(self):
+        """Absent is a value here, and inheriting is the bug. A launcher that pinned
+        `$CHARTER_WORKSPACE` starts the shared server carrying it; the NEXT frame, which
+        pinned nothing, would otherwise inherit that pin — and `workspace.resolve` ranks
+        `$CHARTER_WORKSPACE` above every pointer, so `charter ws use` could not move it.
+        Measured against tmux 3.7c: `-e FOO=` leaves the variable set and empty, which is
+        what charter's own readers already treat as absent."""
+        fake = _FakeTmux(exit_code=0)
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CHARTER_WORKSPACE", None)
+            rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        session_cmd = next(c for c in fake.calls if "new-session" in c)
+        self.assertEqual(_carried_env(session_cmd).get("CHARTER_WORKSPACE"), "",
+                         "an identity variable must be stated, not left to be inherited")
+
+    def test_the_harness_pane_is_recorded_for_this_frame(self):
+        """What lets a status line tell "I am this frame's harness" from "I inherited this
+        frame's id" (ADR 0019, `state.record_harness_pane`). Not recorded, `is_live`
+        answers `None != <pane>` and no frame ever suppresses — a duplicated status line,
+        which nobody reports as a bug and no other test would notice."""
+        fake = _FakeTmux(exit_code=0)
+        rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        self.assertEqual(state.harness_pane(fake.fid), fake.pane_id)
+
+    def test_the_panels_are_told_the_frames_identity_too(self):
+        """#411's other half, and the one that outlives the tmux floor. A panel splits off
+        a server another launcher may have started, so `$CHARTER_WORKSPACE` and
+        `$CHARTER_ROOT` reach it from THAT launcher — and `workspace.resolve` ranks
+        `$CHARTER_WORKSPACE` above every pointer, so an inherited pin makes `charter ws
+        use` unable to move that panel at all. (`$CHARTER_SESSION_ID` was already right
+        there by a different route — `_session_id_env_argv` ties it to the session — which
+        is exactly why the two halves could disagree.)"""
+        fake = _FakeTmux(exit_code=0)
+        rc = _launch(fake)
+        self.assertEqual(rc, 0)
+        splits = [c for c in fake.calls if "split-window" in c]
+        self.assertTrue(splits, "no panel was drawn at all")
+        for cmd in splits:
+            carried = _carried_env(cmd)
+            self.assertEqual(carried.get("CHARTER_SESSION_ID"), fake.fid)
+            self.assertEqual(sorted(carried),
+                             ["CHARTER_HARNESS", "CHARTER_ROOT", "CHARTER_SESSION_ID",
+                              "CHARTER_WORKSPACE"],
+                             "a panel's -e is argv too — identity only")
+
+    def test_below_the_pane_env_floor_the_panels_carry_nothing(self):
+        """`split-window -e` arrived in tmux 3.0 — two releases before `new-session` grew
+        the same flag, which is why `PANE_ENV_FLOOR` is its own constant. Below it the
+        panels are drawn without one rather than not drawn at all."""
+        fake = _FakeTmux(exit_code=0)
+        rc = _launch(fake, version=(2, 9))
+        self.assertEqual(rc, 0)
+        splits = [c for c in fake.calls if "split-window" in c]
+        self.assertTrue(splits, "the panels must still be drawn")
+        for cmd in splits:
+            self.assertEqual(_carried_env(cmd), {})
 
     def test_below_the_env_floor_the_launch_carries_nothing_rather_than_failing(self):
         """`new-session -e` arrived in tmux 3.2 (`tmuxctl.SESSION_ENV_FLOOR`, read from
         tmux's own CHANGES). Below that it is not a flag that degrades, it is one that
         makes the command a parse error — and `below_floor_message` explicitly still lets
         a pre-3.2 operator launch. So the environment is withheld there and the frame
-        still starts, which is exactly what every frame did before #411."""
+        still starts.
+
+        What that costs is #411, unfixed, on tmux 3.0/3.1 only: a second frame's harness
+        goes on inheriting the first frame's id. What it must NOT cost any more is the
+        status line — see `state.is_live`'s harness-pane check, which is what keeps that
+        operator's footer visible rather than blanking it against another frame."""
         fake = _FakeTmux(exit_code=0)
         rc = _launch(fake, version=(3, 1))
         self.assertEqual(rc, 0)
         session_cmd = next(c for c in fake.calls if "new-session" in c)
-        self.assertNotIn("-e", session_cmd,
+        self.assertEqual(_carried_env(session_cmd), {},
                          "a tmux that cannot parse -e must be handed none")
 
     def test_columns_and_lines_are_stripped_from_the_environment_handed_to_tmux(self):
@@ -3293,6 +3399,20 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
         size.assert_not_called()
         self.assertFalse([c for c in fake.calls if "split-window" in c],
                          "a 60x8 tmux window has no room for a panel")
+
+    def test_the_harness_pane_is_recorded_on_this_path_too(self):
+        """ADR 0019's suppression asks `state.harness_pane(fid)` whether the process
+        holding a frame id is actually inside that frame; a path that forgot to record it
+        would answer `None` and quietly never suppress — a duplicated status line nobody
+        would report as a bug. Written down here rather than assumed shared, because the
+        two launch paths capture their pane id in two different places and only one of
+        them had a test."""
+        fake = _FakeOperatorTmux(exit_code=0, pane_id="%7",
+                                 panel_pane_ids={"top": "%8", "bottom": "%9",
+                                                 "left": "%10", "right": "%11"})
+        _launch_inside(fake)
+        fid = state.frame_id("demo", os.getpid())
+        self.assertEqual(state.harness_pane(fid), "%7")
 
     def test_the_panels_are_split_off_the_harness_pane(self):
         """The slot list is pinned here rather than left to the shipped default: this

--- a/tests/test_frame_owns_the_surface.py
+++ b/tests/test_frame_owns_the_surface.py
@@ -4,8 +4,8 @@ Two properties, and the second is the one that will look like dead code to a fut
 reader: the command **keeps running**. Claude Code's per-turn payload is the only place
 this session's token usage exists (`hooks.py` has no reference to any usage field), so a
 suppression that unwired the command would delete the record rather than hide a
-duplicate. `RecordsWhileBlank` below is what a "this command prints nothing, remove it"
-change has to get past.
+duplicate. `FrameOwnsTheSurface.test_the_turn_is_still_recorded_while_the_line_is_blank`
+is what a "this command prints nothing, remove it" change has to get past.
 
 **Every fixture id ends in a pid that is really that pid.** `state.is_live` reads the
 number at the end of a frame id and asks whether that process exists, so `something-1`
@@ -75,10 +75,16 @@ class FrameOwnsTheSurface(PersonaIso, unittest.TestCase):
     _PANE = "%7"
 
     def _run(self, *, fid: str | None, tty: bool = False, pane: str = _PANE,
-             payload: dict | None = None) -> str:
+             harness: str = "claude-code", payload: dict | None = None) -> str:
         env = {"CHARTER_SESSION_ID": fid} if fid else {}
         if pane:
             env["TMUX_PANE"] = pane
+        if harness:
+            # Stated, never left to `harness.current()`'s detection fallback: suppression
+            # only ever applies to the harness whose surface the panels duplicate, so a
+            # test that did not say which harness it was would be asserting about
+            # whatever the developer's own terminal happened to look like.
+            env["CHARTER_HARNESS"] = harness
         out = _Tty() if tty else io.StringIO()
         with mock.patch.dict(os.environ, env, clear=True), \
              mock.patch("sys.stdin", io.StringIO(json.dumps(payload or _PAYLOAD))), \
@@ -198,6 +204,25 @@ class FrameOwnsTheSurface(PersonaIso, unittest.TestCase):
 
     def test_outside_a_frame_nothing_changes_at_all(self):
         self.assertIn("charter", self._run(fid=None))
+
+    def test_a_harness_with_no_status_bar_of_its_own_is_never_suppressed(self):
+        """opencode has no footer for a panel to duplicate, so charter wires the plane in
+        as an on-demand `/charter` slash command whose body is
+        ``!`echo '{}' | charter statusline` `` (`harness/opencode.py`'s `COMMAND`).
+
+        That invocation satisfies every OTHER condition perfectly — its stdout is a pipe
+        because it is a shell substitution, its `$CHARTER_SESSION_ID` is the live frame's,
+        and its `$TMUX_PANE` IS the recorded harness pane, because opencode is what runs
+        there. Suppressing it removed nothing and cost everything: `/charter` exists to put
+        plane state into the AGENT'S CONTEXT, which no panel can do — a panel draws to a
+        pane the model never reads. Reproduced as a blank line before this rung existed."""
+        self.assertIn("charter", self._run(fid=self._a_live_frame(), harness="opencode"))
+
+    def test_a_harness_charter_cannot_identify_is_not_suppressed_either(self):
+        """The safe direction, stated as a property rather than left to luck: an unknown
+        (or absent) harness answers "not the surface being duplicated", so the worst case
+        is the duplicate line this release removes — never a surface that vanished."""
+        self.assertIn("charter", self._run(fid=self._a_live_frame(), harness=""))
 
 
 class SuppressionSaysSoOnDemand(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_owns_the_surface.py
+++ b/tests/test_frame_owns_the_surface.py
@@ -1,0 +1,202 @@
+"""ADR 0019 — inside a frame the frame draws, and `charter statusline` does not.
+
+Two properties, and the second is the one that will look like dead code to a future
+reader: the command **keeps running**. Claude Code's per-turn payload is the only place
+this session's token usage exists (`hooks.py` has no reference to any usage field), so a
+suppression that unwired the command would delete the record rather than hide a
+duplicate. `RecordsWhileBlank` below is what a "this command prints nothing, remove it"
+change has to get past.
+
+**Every fixture id ends in a pid that is really that pid.** `state.is_live` reads the
+number at the end of a frame id and asks whether that process exists, so `something-1`
+is `launchd` — permanently alive — and a fixture named that way makes "the frame was
+gone, so it rendered" unfailable. Live means `os.getpid()`, this very process; dead means
+`_a_dead_pid()`, a child that has exited and been reaped.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+from charter import statusline, workspace
+from charter.frame import slots, state
+
+from tests._isolation import PersonaIso
+
+
+def _a_dead_pid() -> int:
+    """A real pid that has exited and been reaped — see `tests/test_frame_state.py`,
+    which needs this for the same reason and says why a made-up number is a guess about
+    the machine rather than a fact about it."""
+    p = subprocess.Popen([sys.executable, "-c", "pass"])
+    p.wait()
+    return p.pid
+
+
+class _Tty(io.StringIO):
+    """A captured stdout that answers `isatty()` the way a terminal does. `io.StringIO`
+    says False, which is exactly the piped case, so a test of the tty branch cannot use
+    the plain one."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+#: One turn's worth of what Claude Code actually sends: a session id and the token
+#: counters `_context_gauge`/`record_usage` read. The numbers are what makes the
+#: recording assertions below observable at all — a payload without them records
+#: nothing, correctly, and would make every recording test pass for the wrong reason.
+_PAYLOAD = {
+    "session_id": "cc-session-1",
+    "context_window": {"used_percentage": 42,
+                       "current_usage": {"cache_read_input_tokens": 90_000,
+                                         "cache_creation_input_tokens": 10_000}},
+}
+
+
+class FrameOwnsTheSurface(PersonaIso, unittest.TestCase):
+    """`statusline.main` with a payload on stdin, exactly as Claude Code invokes it.
+
+    `PersonaIso` is load-bearing rather than hygiene here: `state.is_live` looks for the
+    frame's directory under `config.STATE_DIR`, so an isolated plane is what keeps this
+    module's own answers independent of whether the developer ran the suite from inside
+    a real frame — the property that let this check live at the command edge at all.
+    """
+
+    def _run(self, *, fid: str | None, tty: bool = False,
+             payload: dict | None = None) -> str:
+        env = {"CHARTER_SESSION_ID": fid} if fid else {}
+        out = _Tty() if tty else io.StringIO()
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch("sys.stdin", io.StringIO(json.dumps(payload or _PAYLOAD))), \
+             redirect_stdout(out):
+            rc = statusline.main([])
+        self.assertEqual(rc, 0, "the status line exits 0 whatever it decides to draw")
+        return out.getvalue()
+
+    def _a_live_frame(self) -> str:
+        """A frame directory on THIS plane whose launcher is this test process."""
+        fid = f"demo-{os.getpid()}"
+        state.bump(fid)               # creates the directory `is_live` looks for
+        return fid
+
+    # -- blank inside a frame ---------------------------------------------------- #
+
+    def test_inside_a_live_frame_the_line_is_blank(self):
+        self.assertEqual(self._run(fid=self._a_live_frame()).strip(), "")
+
+    def test_inside_a_live_frame_nothing_is_even_rendered(self):
+        """Not merely "the output was empty": a `render` that returned an empty string
+        for some unrelated reason would satisfy the test above. The frame path must not
+        reach the renderer at all — that is what makes suppression cost nothing rather
+        than gather the whole plane and throw it away every ten seconds."""
+        with mock.patch.object(statusline, "render") as render:
+            self._run(fid=self._a_live_frame())
+        render.assert_not_called()
+
+    # -- and still recording ----------------------------------------------------- #
+
+    def test_the_turn_is_still_recorded_while_the_line_is_blank(self):
+        """The reason the command is kept wired at all (ADR 0019). Claude Code's payload
+        is the only source of these numbers — nothing in `hooks.py` sees them — so a
+        change that stopped invoking `charter statusline` inside a frame would delete
+        the history, not merely the duplicate line."""
+        self._run(fid=self._a_live_frame())
+        self.assertEqual(statusline._history("cc-session-1"), [(90_000, 10_000)])
+
+    def test_a_payload_with_no_numbers_records_nothing_rather_than_a_zero(self):
+        """The other half, and what stops the test above from passing against a recorder
+        that writes on every call: early in a session (and right after `/compact`) the
+        payload carries no usage at all, and a recorded zero would be an invented turn."""
+        self._run(fid=self._a_live_frame(), payload={"session_id": "cc-session-1"})
+        self.assertEqual(statusline._history("cc-session-1"), [])
+
+    # -- and drawing everywhere else --------------------------------------------- #
+
+    def test_a_human_asking_at_a_terminal_still_gets_the_line(self):
+        """Claude Code pipes this command's stdout; a tty means somebody typed
+        `charter statusline` themselves, and a frame elsewhere on the screen is no
+        reason to answer them with a blank line."""
+        self.assertIn("charter", self._run(fid=self._a_live_frame(), tty=True))
+
+    def test_a_frame_whose_launcher_is_gone_does_not_blank_it_forever(self):
+        """A frame directory outlives a crashed launcher until some later launch reaps
+        it. Reading the directory alone as "a frame is running" would leave this plane's
+        status line blank for every session afterwards, with nothing on screen to say
+        why. The pid at the end of the id is what answers it, with no tmux call on a
+        path that runs every time the footer repaints."""
+        fid = f"demo-{_a_dead_pid()}"
+        state.bump(fid)
+        self.assertIn("charter", self._run(fid=fid))
+
+    def test_an_id_that_names_no_frame_on_this_plane_renders(self):
+        """`$CHARTER_SESSION_ID` is not a frame's variable alone — any harness that knows
+        its own session sets it (`charter.session.current`), and a UUID's last group can
+        be all digits. A live frame has a directory; an id that never named one here is
+        not this plane's frame, whatever its digits parse as."""
+        self.assertIn("charter", self._run(fid=f"demo-{os.getpid()}"))
+
+    def test_outside_a_frame_nothing_changes_at_all(self):
+        self.assertIn("charter", self._run(fid=None))
+
+
+class PanelFollowsWorkspaceUse(PersonaIso, unittest.TestCase):
+    """`charter ws use` inside a frame moves that frame's panels (#411).
+
+    This is the collision #386 had to decide, pinned. The launcher exports the frame id
+    under `$CHARTER_SESSION_ID` — the variable `charter.session.current` already owns —
+    so the agent's shell, every panel, and every `charter` command typed inside the frame
+    agree about which charter session they belong to. `workspace.set_active` writes its
+    per-session pointer under that id and `slots._top` reads it back under the same one.
+    Nothing else connects the two: the per-TERMINAL pointer is keyed by `$TMUX_PANE`, and
+    the harness and each panel are different panes, so it is structurally unable to carry
+    a switch from one to the other.
+    """
+
+    def _top(self, fid: str) -> str:
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": fid}, clear=True):
+            return slots._top(fid)
+
+    def test_the_top_panel_follows_a_switch_made_inside_the_frame(self):
+        """Switched TWICE, and both are asserted. One switch alone passes against a
+        panel that read the workspace once at launch and never again, as long as the
+        launch happened to be in the workspace the test switched to; a second switch
+        to a different name is what makes the panel prove it is still reading."""
+        fid = f"demo-{os.getpid()}"
+        workspace.ensure("alpha")
+        workspace.ensure("beta")
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": fid}, clear=True):
+            workspace.set_active("alpha")
+        self.assertIn("alpha", self._top(fid))
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": fid}, clear=True):
+            workspace.set_active("beta", force=True)
+        self.assertIn("beta", self._top(fid))
+
+    def test_a_switch_made_under_another_id_does_not_move_this_frame(self):
+        """The other direction, and the shape of #411 itself: writer and reader agreeing
+        is the whole mechanism, so a pointer written under a DIFFERENT session id must
+        leave this frame's panel exactly where it was. Without this, a `resolve()` that
+        ignored the session pointer entirely — and answered from some global — would
+        still pass the test above."""
+        fid = f"demo-{os.getpid()}"
+        workspace.ensure("alpha")
+        workspace.ensure("beta")
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": fid}, clear=True):
+            workspace.set_active("alpha")
+        with mock.patch.dict(os.environ,
+                             {"CHARTER_SESSION_ID": "someone-elses-frame-1234"},
+                             clear=True):
+            workspace.set_active("beta")
+        self.assertIn("alpha", self._top(fid))
+        self.assertNotIn("beta", self._top(fid))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_owns_the_surface.py
+++ b/tests/test_frame_owns_the_surface.py
@@ -70,9 +70,15 @@ class FrameOwnsTheSurface(PersonaIso, unittest.TestCase):
     a real frame — the property that let this check live at the command edge at all.
     """
 
-    def _run(self, *, fid: str | None, tty: bool = False,
+    #: The pane the fixture frames below record as their harness's, and the one
+    #: `_run` claims to be in unless a test deliberately says otherwise.
+    _PANE = "%7"
+
+    def _run(self, *, fid: str | None, tty: bool = False, pane: str = _PANE,
              payload: dict | None = None) -> str:
         env = {"CHARTER_SESSION_ID": fid} if fid else {}
+        if pane:
+            env["TMUX_PANE"] = pane
         out = _Tty() if tty else io.StringIO()
         with mock.patch.dict(os.environ, env, clear=True), \
              mock.patch("sys.stdin", io.StringIO(json.dumps(payload or _PAYLOAD))), \
@@ -81,10 +87,17 @@ class FrameOwnsTheSurface(PersonaIso, unittest.TestCase):
         self.assertEqual(rc, 0, "the status line exits 0 whatever it decides to draw")
         return out.getvalue()
 
-    def _a_live_frame(self) -> str:
-        """A frame directory on THIS plane whose launcher is this test process."""
+    def _a_live_frame(self, *, pane: str = _PANE) -> str:
+        """A frame the way `cmd_launch` leaves one: a directory, a recorded server, a
+        recorded harness pane, and a launcher pid that is this very test process.
+
+        Written out longhand rather than hidden behind one call, because each of the
+        four is separately load-bearing in `state.is_live` and a test that removes one
+        (there are three below) has to be able to say which."""
         fid = f"demo-{os.getpid()}"
-        state.bump(fid)               # creates the directory `is_live` looks for
+        state.bump(fid)                          # the directory
+        state.record_server(fid, "charter")      # proof a LAUNCHER made it
+        state.record_harness_pane(fid, pane)     # which pane is this frame's harness
         return fid
 
     # -- blank inside a frame ---------------------------------------------------- #
@@ -134,6 +147,12 @@ class FrameOwnsTheSurface(PersonaIso, unittest.TestCase):
         path that runs every time the footer repaints."""
         fid = f"demo-{_a_dead_pid()}"
         state.bump(fid)
+        # COMPLETE in every other respect, and that is the point: a fixture missing the
+        # server marker or the pane would be refused before the pid was ever consulted,
+        # and this test would pass with the liveness check deleted outright. Measured —
+        # it did, until the marker check was added underneath it.
+        state.record_server(fid, "charter")
+        state.record_harness_pane(fid, self._PANE)
         self.assertIn("charter", self._run(fid=fid))
 
     def test_an_id_that_names_no_frame_on_this_plane_renders(self):
@@ -143,8 +162,71 @@ class FrameOwnsTheSurface(PersonaIso, unittest.TestCase):
         not this plane's frame, whatever its digits parse as."""
         self.assertIn("charter", self._run(fid=f"demo-{os.getpid()}"))
 
+    def test_a_directory_no_launcher_made_is_not_a_frame(self):
+        """A directory is not proof of frame-ness, and this is the operator it protects:
+        someone who exports `CHARTER_SESSION_ID=proj-$$` in their shell rc. The first
+        hook that fires calls `notify.plane_changed` -> `state.bump`, which MINTS the
+        directory, and the pid in that id is their own live shell — so directory-plus-pid
+        is satisfied, permanently, for a frame that never existed. Only `cmd_launch`
+        writes a server marker."""
+        fid = f"demo-{os.getpid()}"
+        state.bump(fid)                          # exactly what a hook does, and no more
+        state.record_harness_pane(fid, self._PANE)
+        self.assertIsNone(state.frame_server(fid), "fixture no longer matches a hook")
+        self.assertIn("charter", self._run(fid=fid))
+
+    def test_a_process_that_merely_inherited_the_id_is_not_inside_the_frame(self):
+        """The regression this guard exists for, and it is one this PR would otherwise
+        have CAUSED. Below `tmuxctl.SESSION_ENV_FLOOR` charter cannot put the frame id on
+        `new-session`, so a second frame's harness on the shared private server inherits
+        the FIRST frame's id (#411) — live, on this plane, launcher running, every other
+        condition satisfied. Suppressing there blanks a footer whose panels are already
+        following another frame: no correct surface at all, where before this change that
+        operator at least had a correct status line.
+
+        The pane is what tells them apart: tmux gives each pane its own `$TMUX_PANE`, and
+        only one of them is the pane the launcher recorded."""
+        fid = self._a_live_frame()
+        self.assertIn("charter", self._run(fid=fid, pane="%99"))
+
+    def test_no_pane_at_all_is_not_inside_the_frame_either(self):
+        """`$TMUX_PANE` absent is an ANSWER — "not in any pane" — not a reason to stop
+        asking. Read as "unknown, carry on" instead, a process holding an inherited id
+        outside tmux entirely would suppress."""
+        fid = self._a_live_frame()
+        self.assertIn("charter", self._run(fid=fid, pane=""))
+
     def test_outside_a_frame_nothing_changes_at_all(self):
         self.assertIn("charter", self._run(fid=None))
+
+
+class SuppressionSaysSoOnDemand(PersonaIso, unittest.TestCase):
+    """A blank footer is the one frame behaviour that shows nothing at all, so something
+    has to admit it is deliberate. ADR 0019's own rule is that a surface which vanished
+    for an invisible reason is the worst outcome available — `charter doctor`'s frame row
+    is the surface built to answer on demand."""
+
+    def _row(self, env: dict):
+        from charter import doctor
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)):
+            return doctor.check_frame()
+
+    def test_the_frame_row_names_the_frame_that_is_drawing_instead(self):
+        fid = f"demo-{os.getpid()}"
+        state.bump(fid)
+        state.record_server(fid, "charter")
+        state.record_harness_pane(fid, "%7")
+        row = self._row({"CHARTER_SESSION_ID": fid, "TMUX_PANE": "%7"})
+        self.assertIn(fid, row.hint or "",
+                      "a suppressed status line must be explained somewhere")
+        self.assertIn("blank", (row.hint or "").lower())
+
+    def test_a_session_that_is_not_suppressed_is_not_told_that_it_is(self):
+        """The control, and the one that fails if the row simply always says it: an
+        ordinary session's frame row must carry no such note."""
+        row = self._row({})
+        self.assertNotIn("blank", (row.hint or "").lower())
 
 
 class PanelFollowsWorkspaceUse(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -218,6 +218,12 @@ _TERM_CANDIDATES = tuple(dict.fromkeys(
 #: so "not probed yet" and "probed, and the answer is False" stay distinguishable.
 _PANE_DIED_FIRES: list[bool] = []
 
+#: Whether THIS tmux's `new-session` accepts `-e` at all. Probed once per process, the
+#: same shape as `_PANE_DIED_FIRES` and for the same reason: it is a property of the
+#: binary on this machine rather than of any one test, and `-e` arrived in tmux 3.2
+#: (`tmuxctl.SESSION_ENV_FLOOR`) while charter still launches below that.
+_NEW_SESSION_TAKES_ENV: list[bool] = []
+
 #: How long ONE forked client gets to register with tmux before this gives up on it.
 #:
 #: Generous on purpose, and NOT the thing that detects a refusal: a refused `tmux attach`
@@ -2661,6 +2667,96 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
                          "`server` marker — if it has stopped doing that, `state.reap`'s "
                          "migration case changed and the isolation this class rests on "
                          "is no longer being exercised by anything")
+
+
+class ASecondFrameOnTheSharedServer(_TmuxServerFixture, PersonaIso):
+    """#411 — what a `new-session` inherits when the server is ALREADY running.
+
+    Every frame on charter's own server is a session on ONE shared server
+    (`commands_frame`'s module docstring), so exactly one launch per machine is the one
+    whose `new-session` actually starts it. That distinction was invisible in the code
+    until it cost a frame: `layout.respawn_argv`'s docstring said charter's own variables
+    reach the harness "because `new-session` starts the server and the server inherits
+    the launcher's environment", which is true of the first launch and of no other.
+
+    No mock can observe this. It is tmux's own rule about where a new pane's environment
+    comes from, and the whole `-e` on `layout.session_argv` exists because of it — so it
+    is measured here, against a real server with a real second session on it, and will
+    fail loudly if tmux ever changes it (at which point the flag stops being necessary,
+    which is worth being told rather than left carrying forever).
+    """
+
+    #: Not `CHARTER_SESSION_ID`: this class is measuring TMUX's inheritance rule, and
+    #: charter's own variable may be present in the test runner's environment already
+    #: (the suite runs inside a frame on this project), which would leave the "inherited"
+    #: assertion able to pass on a value neither session set.
+    _VAR = "CHARTER_INTEG_PROBE"
+
+    def _session_reading_the_var(self, name: str, *, client_value: str,
+                                 carry: str | None = None) -> str:
+        """A session on `SOCKET` whose pane writes `$_VAR` out; returns what it wrote.
+
+        *client_value* is what the tmux CLIENT process is started with — the thing a
+        launcher controls without `-e`. *carry* is `-e`, or `None` for a call that
+        passes none. The pane sleeps afterwards so the SERVER stays up for the next
+        session: a server that empties shuts itself down, and a second `new-session`
+        against a dead server would start a fresh one and quietly measure nothing.
+        """
+        out = os.path.join(self._gate_dir, f"env-{name}")
+        args = ["new-session", "-d", "-s", name, "-x", "80", "-y", "24",
+                "-P", "-F", "#{pane_pid}"]
+        if carry is not None:
+            args += ["-e", f"{self._VAR}={carry}"]
+        args += ["--", "sh", "-c",
+                 f'printf "%s" "${self._VAR}" > {out}; exec sleep 60']
+        r = _tmux(*args, env=dict(os.environ, **{self._VAR: client_value}))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.addCleanup(_kill_pid, r.stdout.strip())
+        self.assertTrue(_await_file(out),
+                        f"the pane for session {name} never wrote its environment out")
+        return Path(out).read_text()
+
+    def _require_new_session_env(self) -> None:
+        """Skip unless `new-session -e` is a flag this tmux knows.
+
+        Capability, never a version string (this module's own rule). `-e` arrived in
+        tmux 3.2 and `commands_frame.cmd_launch` withholds the environment below
+        `tmuxctl.SESSION_ENV_FLOOR` precisely because an older tmux does not degrade on
+        it — it refuses the command outright. A machine there cannot measure the fix,
+        and says which flag it lacked rather than failing as though charter were wrong.
+        """
+        if not _NEW_SESSION_TAKES_ENV:
+            r = _tmux("new-session", "-d", "-s", "envprobe", "-e", "X=1", "--", "true")
+            _NEW_SESSION_TAKES_ENV.append(r.returncode == 0)
+            _tmux("kill-session", "-t", "envprobe")
+        if not _NEW_SESSION_TAKES_ENV[0]:
+            self.skipTest("this tmux's `new-session` does not accept `-e`, so the "
+                          "environment charter carries with it cannot be measured here")
+
+    def test_a_later_session_inherits_the_servers_environment_not_its_own_clients(self):
+        """The defect, reproduced as tmux's own behaviour. The second launcher exports a
+        different value and tmux hands its pane the FIRST one — which is why a second
+        frame's harness read another frame's id, wrote another frame's workspace pointer,
+        and bumped another frame's version while its own panels waited for a change that
+        was being recorded somewhere else."""
+        self.assertEqual(self._session_reading_the_var("first", client_value="one"),
+                         "one", "the launch that STARTS the server does set it")
+        self.assertEqual(
+            self._session_reading_the_var("second", client_value="two"), "one",
+            "if tmux now gives a later session its own client's environment, the `-e` "
+            "in `layout.session_argv` is no longer load-bearing — say so rather than "
+            "carrying a flag nothing needs")
+
+    def test_the_e_flag_is_what_gets_a_later_session_its_own_value(self):
+        """The fix, measured against the same server in the same state. Same two
+        sessions, same client environments; the only difference is the `-e` that
+        `layout.session_argv` now carries."""
+        self._require_new_session_env()
+        self.assertEqual(self._session_reading_the_var("first", client_value="one"),
+                         "one")
+        self.assertEqual(
+            self._session_reading_the_var("second", client_value="two", carry="two"),
+            "two", "`-e` did not reach the pane `new-session` itself creates")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #386. Also closes #411, which turned out to be the bill for the very collision #386 was required to decide.

## Inside a live frame, `charter statusline` prints an empty line

The panels are built out of the status line's own renderers (#385), so with both on charter drew the plane's state on the edges and then again in Claude Code's footer three lines below them. ADR 0019 (`docs/adr/0019-the-frame-owns-the-surface.md`) records the decision, its sequel relationship to ADR 0018, and the part that will otherwise be "cleaned up" by someone who does not know why.

**Suppression means render empty, never stop running.** Claude Code passes this session's token usage to the `statusLine` command and to nothing else — `hooks.py` has zero references to any usage field — so the blank path still reads its payload and still records (`statusline.record_usage`, split out of `_context_gauge` so the drawing and recording paths cannot disagree about what a turn was). Unwiring `statusLine` from `.claude/settings.json` because it "prints nothing now" would delete the history, silently. That is said in the ADR, in `docs/frame.md`, and in a comment at the exact line where the deletion would happen.

**The decision is in `statusline.main`, never in `render()`.** The check reads ambient state and this suite now runs inside a frame; inside `render` it would make eight-plus `test_statusline_*` modules pass or fail according to which terminal the developer typed `unittest` in. No existing test of `render` changed meaning.

Three conditions, each the sole guard against one real failure:

| condition | what it prevents |
| --- | --- |
| stdout is not a tty | a human running `charter statusline` by hand getting a blank line |
| `$CHARTER_SESSION_ID` names a frame directory **on this plane** | an id that is not a frame's blanking the line by coincidence — and it keeps the suite honest, since every isolated test repoints `config.STATE_DIR` |
| the launcher pid at the end of that id is alive (`os.kill(pid, 0)`, no tmux call) | a directory left by a crashed launcher blanking a plane's status line forever |

Measured 2026-08-24 against Claude Code 2.1.241 with a real `statusLine` probe: the command's stdout is a **pipe**, and its environment is Claude Code's own, **passed intact** (`SID=[probe-frame-99999] WS=[probews]`). That corrects a module docstring that claimed the opposite — it said Claude Code does not pass the session's environment to the status line, which was never true.

## `[frame] slots` now ships as all four edges

Part of the same decision: once the status line is blank inside a frame, an edge the frame does not fill is information that is not on the screen at all. `left` (repo rows) and `right` (persona chips) have had renderers since #385 — built, tested, switched off. `layout.visible_slots` still drops both first on any shortage, so a narrow terminal degrades to exactly the frame this default used to be.

The order is the split order and therefore the geometry. Measured on tmux 3.7c at 200x50:

| `slots` order | bottom row | side panels |
| --- | --- | --- |
| `["top", "bottom", "left", "right"]` (shipped) | **200 cols**, full width | 46 rows, between the strips |
| `["top", "left", "right", "bottom"]` | 154 cols, inset between the sidebars | 48 rows |

The bottom row is the one that carries the single alert and the command that fixes it, and `slots._bottom` drops whole fields when it runs out of width — so the 46 columns are worth more there than two extra rows are to a sidebar already truncating its own 22.

## `$CHARTER_SESSION_ID`: decided, documented, pinned — and #411

Kept deliberately. One variable, one meaning: *the charter session this process belongs to*; inside a frame, that is the frame. It is why `charter workspace use` typed at the agent moves the panels — `set_active` writes the per-session pointer under `session.current()` and a panel reads it back under the same name. (The per-terminal pointer is keyed by `$TMUX_PANE` and is structurally unable to do this: harness and panels are different panes.) Claude Code's own session id still keys everything that arrives by payload. Two ids, two jobs.

**#411 is that rule's bill, reproduced with two real frames.** Every frame on charter's private server is a session on one shared tmux server, so exactly one launch per machine is the one whose `new-session` actually starts it — and tmux builds a later session's pane environment from the SERVER's global one. Measured on tmux 3.7c: the second frame's harness reported `CHARTER_SESSION_ID=default-58069` while its own session was `default-58696`, with `show-environment -g` holding the first id. So `charter ws use` wrote the *first* frame's pointer and every hook bumped the *first* frame's version, while the second frame's panels waited for a change recorded next door. The status line kept up because it falls through to the per-terminal pointer.

Fixed by carrying the frame's **identity** on `new-session -e` — four names, never the environment; see the security note below. The panels were never wrong — a session-scoped `set-environment` does reach panes split later (measured) — so this closes the one pane that call cannot reach: the one `new-session` itself creates. Withheld below `tmuxctl.SESSION_ENV_FLOOR` (3.2, read from tmux's own CHANGES), where `-e` is a parse error rather than a missing feature and would take the whole launch down on a tmux `below_floor_message` still allows to launch.

Verified end to end in a real frame before and after: `charter workspace use beta` plus the real `charter hook posttooluse-bash` moved frame B's top panel `default` → `beta` while frame A's stayed on `alpha`.

## Review round: four blocking findings, all fixed on this branch

- **A `-e` is argv, and argv is not private.** The first version passed `_frame_env` (`dict(os.environ, …)`) — measured at 138 argv elements, 7,696 bytes, two live service-account tokens, on the default `charter claude` path, world-readable via `/proc/<pid>/cmdline`. Now only `commands_frame._FRAME_IDENTITY` travels: **26 elements, 175 bytes, no secrets**. Everything else still reaches the harness through the tmux client's own environment. The tests that check this project the `-e` pairs before asserting — `assertIn(pair, cmd)` printed the reviewer's real tokens into a test log when a mutation made it fail.
- **Below tmux 3.2 the first version made #411 strictly worse.** Suppression keys on `$CHARTER_SESSION_ID`, which below the floor a second frame's harness inherits from the first — so its footer blanked against someone else's frame, on top of panels already following it. `state.is_live` now also asks whether this process is *inside* the frame, comparing `$TMUX_PANE` against the pane the launcher recorded. Measured: tmux sets `$TMUX_PANE` in every process it starts in a pane, and it survives the harness spawning the `statusLine` command (`PANE=[%0]`). Both prose claims about what the floor costs are corrected.
- **A directory was never proof of frame-ness.** `state.bump` mints one for any id from seven hook sites, so an operator exporting `CHARTER_SESSION_ID` in a shell rc got a permanently "live" frame and a blank footer forever. `is_live` now requires a server marker, which only `cmd_launch` writes — and which subsumes the old `is_dir()` check, so that one is removed rather than left as a guard no mutation could turn red.
- **`session.py` swapped one false docstring for another.** Claude Code *does* export `CLAUDE_CODE_SESSION_ID` (measured). The frame id **shadows** it rather than keying a separate question — still the right choice, now argued as what it is, with the consequence stated: everything keyed on `session.current()` is per-frame for the frame's life, `workspace.set_active`'s session **lock** included. ADR 0019's argument is rewritten. The same belief is corrected in `glstate.py`, and `respawn_argv`'s "`-e` REPLACES the pane's environment" is corrected too — re-measured, it is an overlay.

Also from the review: slot **order** is now pinned (`["right", "left"]`; the previous test claimed to check an order the default does not have while using the one it does, and a `frame_of` that re-sorted an operator's slots passed the whole suite); panels on the private path carry the same identity, closing a `$CHARTER_WORKSPACE` inheritance that made `ws use` unable to move them at all; `record_usage`'s "ONE place" claim is delivered by `_usage_numbers` instead of asserted; and `charter doctor`'s frame row now **says** when a session's status line is deliberately blank.

**Still open, deliberately, and named rather than fixed silently:** the inside-your-own-tmux path still passes the whole environment on `respawn-pane -e`/`split-window -e` — pre-existing, and load-bearing there because the overlay lands on the operator's own server environment, which may predate this plane. Narrowing it needs its own measurement of what a harness may safely inherit from a server charter does not own. Worth its own issue.

## Review round 2: one blocking finding, fixed

**Inside a `charter opencode` frame, `/charter` returned a blank line.** opencode has no status bar, so charter wires the plane in as an on-demand slash command whose body is `` !`echo '{}' | charter statusline` `` — and that satisfied every suppression condition perfectly: stdout is a pipe (it is a shell substitution), `$CHARTER_SESSION_ID` is the live frame's, and `$TMUX_PANE` **is** the recorded harness pane, because opencode is what runs there. Blanking it removed nothing: `/charter` puts plane state into the **agent's context**, which no panel can do — a panel draws to a pane the model never reads.

The tty rung was built for "a human asked for this" and cannot reach this, because opencode's own wiring makes the human's ask a pipe. The predicate the check actually wants is *"this output is the Claude Code footer that the panels duplicate"*, so it now asks that: `harness.current() == harness.CLAUDE_CODE`. That is ADR 0019's own argument one step further — the ADR already holds codex and opencode are different surfaces — rather than an exception bolted on.

Asked **last**, which is the cost argument: inside a frame `$CHARTER_HARNESS` is always stated (`_FRAME_IDENTITY` emits it even when empty), so the only path reaching that line pays one environment lookup, and every `detect()` behind it is an env lookup or a constant — no subprocess on a path that runs every repaint.

Measured after the fix:

| invocation | before | after |
| --- | --- | --- |
| opencode `/charter` in its own frame | blank | **renders** |
| codex in a frame | renders | renders |
| unknown/absent harness in a frame | blank | **renders** (safe direction) |
| Claude Code footer in its own frame | blank | blank |
| any harness, no frame | renders | renders |

Also from this round: **`CHARTER_PERSONA` joins `_FRAME_IDENTITY`** — it met that constant's own criterion and was missing (`persona._resolved` ranks it above the per-session pointer, the per-terminal pointer *and* the active-persona file, so an inherited pin reached the next frame's harness and its `right` panel, which draws persona chips, unmovable by `charter persona use`); ADR 0019's condition list no longer describes `is_live`'s directory check differently from `is_live`'s own docstring; and the test module's docstring no longer names a class that never existed. `docs/frame.md`, ADR 0019 and the news entry now all state that **a harness with no status bar of its own is never suppressed** — none of the three mentioned it.

Left alone deliberately: the two operator-tmux call sites that still put the whole environment in argv are #446.

## Honest limits, recorded rather than papered over

- **A framed Claude Code session has no `ctx`/`cache` gauge on any surface.** `_context_gauge` is gated at every branch on a per-turn payload no panel is ever handed, and #385 deliberately left that decision to this issue. This PR keeps the *recording* alive so a panel can be given one, and names what such a panel still needs: the usage file is keyed by Claude Code's session id, which a panel does not know — only the suppressing `main` sees both ids at once. Drawing it is a surface decision with a width budget attached and belongs to the release that draws it.
- **codex and opencode get no context gauge either, for a harder reason: nothing feeds them one.** Neither invokes `charter statusline` with a per-turn payload, so no usage is recorded for them at all.

## Tests

`tests/test_frame_owns_the_surface.py` (10), plus 2 in `test_frame_launcher.py` and 2 real-tmux ones in `test_frame_tmux_integration.py`. Every fixture id ends in a pid that really is that pid — `os.getpid()` for live, a reaped child for dead — never `-1`, which is `launchd` and would make "the frame was gone, so it rendered" unfailable.

Eleven mutations applied, each confirmed RED then restored GREEN with `__pycache__` cleared between runs: the suppression branch; the tty check; the pid-liveness half of `is_live`; its directory half; `record_usage` on the blank path; `record_usage`'s own record; `new-session`'s `env=`; its version gate; the `slots` default; `set_active`'s session-pointer write; and `slots._top` resolving live.

Full suite: **4067 tests, OK** (4039 before). Twenty-eight mutations across both rounds, each confirmed RED then restored GREEN — including the reviewer's own `frame_of` re-sort, and two of the first round's that the new server-marker guard had silently **masked** (their fixtures were completed so the pid check is again the only thing deciding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9

