### PR TITLE
docs: a 1Password vault is one item, everywhere it is described (#400)

### DIFF
--- a/charter/commands_secrets.py
+++ b/charter/commands_secrets.py
@@ -181,8 +181,15 @@ def cmd_vault_add(args) -> int:
     if not prov.available:
         util.warn(f"  provider '{args.provider}' is not implemented yet — registered for later use.")
     elif args.provider == "1password":
-        util.info(f"  charter creates one 1Password item per secret, tagged "
-                  f"'charter:{args.name}', in vault '{cfg['op-vault']}'.")
+        # Name the ITEM. This is the one moment the operator learns where to look in the
+        # 1Password UI, and the schema is one item per vault whose concealed fields are
+        # the secrets — not one item per secret, which is what this said until #400 and
+        # what sent people hunting for a `charter-<vault>-<KEY>` that charter has not
+        # created for several releases. `prov.op_item` rather than the config, so an
+        # adopted `--op-item` is named as itself and the default resolves in one place.
+        util.info(f"  charter keeps this vault in one 1Password item, "
+                  f"'{prov.op_item}' in vault '{cfg['op-vault']}', tagged "
+                  f"'charter:{args.name}' — each secret a concealed field of it.")
         util.info(f"  add secrets with: charter secret set {args.name} <key> --stdin")
     elif args.provider == "reference":
         util.info(f"  stores op:// or vault:// URIs; values are fetched at read time.")

--- a/charter/secrets/onepassword.py
+++ b/charter/secrets/onepassword.py
@@ -2,8 +2,9 @@
 
 The sibling :mod:`reference` provider points *at* a secret someone else created
 (``op://vault/item/field``). This one owns the whole lifecycle — ``charter secret set``
-creates the item, ``rm`` deletes it — so a credential can be provisioned for a persona
-without opening the 1Password UI.
+creates the item and writes the field, ``rm`` removes the field — so a credential can be
+provisioned for a persona without opening the 1Password UI. The item is the vault, so
+nothing here deletes it; see :meth:`OnePasswordProvider.delete`.
 
 Schema: **one item per vault**, whose custom fields are the secrets.
 

--- a/docs/news/unreleased-a-1password-vault-is-one-item.md
+++ b/docs/news/unreleased-a-1password-vault-is-one-item.md
@@ -1,0 +1,52 @@
+---
+version: unreleased
+headline: The docs now describe the 1Password layout charter actually uses
+---
+
+A `1password` vault is **one 1Password item whose concealed fields are the secrets**. It
+has been that for several releases. `docs/secrets.md` went on describing the layout it
+replaced — one item per secret, `charter-<vault>-<KEY>`, the value in that item's
+`password` field — and `charter vault add --provider 1password` said the same thing in its
+own output, at the one moment you are told where your credentials are about to live.
+
+```
+$ charter vault add devops --provider 1password --op-vault Engineering
+  ✓ Vault 'devops' registered (provider: 1password) [local only].
+  • charter creates one 1Password item per secret, tagged 'charter:devops', in vault 'Engineering'.
+```
+
+So you go looking in 1Password for `charter-devops-KUBECONFIG`, and there is no such item.
+There is `charter-devops`, with a concealed field called `KUBECONFIG`. The registration
+hint now names it:
+
+```
+  • charter keeps this vault in one 1Password item, 'charter-devops' in vault
+    'Engineering', tagged 'charter:devops' — each secret a concealed field of it.
+```
+
+Point `--op-item` at an item you already curate and the hint names *that* item, since the
+`charter-<vault>` default is not what will be written.
+
+The doc did more than lag. It carried a paragraph arguing that one item per vault "is
+wrong here", on the grounds that `op item get --format json` conceals values and a
+read-modify-write would therefore write masks back over every sibling secret. That hazard
+is real; it is why `secret set` and `secret rm` fetch with `--reveal` and why nothing else
+does. It is the reason for a flag, not a reason against the schema — and anyone reasoning
+about the provider from that page started from the opposite of the design.
+
+Two smaller claims on the same page were stale for the same reason and are corrected:
+`secret list` reads the fields of your vault's item rather than filtering 1Password by the
+`charter:<vault>` tag, and `charter secret rm` removes a field — the item is the vault, and
+charter never deletes it.
+
+## What to do about it
+
+**Nothing, unless you registered a 1Password vault long enough ago to be on the old
+layout.** If you did, those `charter-<vault>-<KEY>` items are still in 1Password with your
+credentials in them, and charter does not read them. It will not call such a vault
+healthy-and-empty either — `charter vault list` counts the leftovers and says so, and
+`charter doctor` marks the vault unhealthy. Re-register each credential with `charter
+secret set`, then delete the old items.
+
+No behaviour changed here beyond the sentence `vault add` prints. What was wrong was what
+charter told you about itself.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -208,8 +208,9 @@ something that rides along inside `add`.
 If 1Password is where your credentials belong, you have two shapes to choose between,
 and the difference is who owns the item:
 
-- **`1password`** — charter owns it. `secret set` creates the item, `rm` deletes it, so
-  a credential can be provisioned for a persona without opening the 1Password UI.
+- **`1password`** — charter owns it. `secret set` creates the item and writes the field,
+  `rm` removes the field, so a credential can be provisioned for a persona without
+  opening the 1Password UI. The item itself is the vault and charter never deletes it.
 - **`reference`** — someone else owns it. charter stores only a pointer to an item that
   already exists. Right when the credential is shared with people or systems beyond
   charter, or when a human should stay in charge of rotating it.
@@ -221,6 +222,7 @@ A `1password` vault is **one 1Password item whose custom fields are the secrets*
 ```
 charter vault 'devops', key 'AWS_ACCESS_KEY_ID'
     → item  charter-devops   (override with --op-item)
+      tagged charter, charter:devops
       field AWS_ACCESS_KEY_ID, concealed
 ```
 
@@ -240,20 +242,23 @@ charter secret set devops KUBECONFIG --from-file ~/.kube/prod.yaml
 charter secret exec devops --file KUBECONFIG=KUBECONFIG -- kubectl get pods
 ```
 
-Schema — **one 1Password item per secret**, not one per vault:
+**One item per key came first, and was replaced.** It gave each secret its own item,
+`charter-<vault>-<KEY>`, with the value in that item's `password` field. It could describe
+nothing but that shape, so anyone whose 1Password already looked different kept a separate
+file of `op://` URIs alongside their vault to work around it.
 
-| charter | 1Password |
-| --- | --- |
-| vault `devops`, key `KUBECONFIG` | item `charter-devops-KUBECONFIG` |
-| | tagged `charter`, `charter:devops` |
-| | value in the item's `password` field |
+It was chosen to avoid one specific hazard, and that hazard is real: `op item get
+--format json` **conceals** values unless asked otherwise, so a naive read-modify-write
+of a multi-field item would write masks back over every sibling secret. The answer is
+`--reveal`. That flag is why the write path survives the round-trip, and why it exists at
+all — `set` and `rm` pass it, and nothing else does, because nothing else has any business
+pulling a whole vault's values into memory.
 
-One item per *vault* is the tidier-looking design and it is wrong here. Updating one
-field of a multi-field item means a read-modify-write through a JSON template, a
-template **replaces** the item rather than merging, and `op item get --format json`
-*conceals* values unless asked otherwise — so round-tripping would overwrite every
-sibling secret with a mask. One item per key removes the interaction: each write
-touches exactly the credential it was asked to touch.
+If you registered a vault under the old schema, its `charter-<vault>-<KEY>` items are
+still in 1Password and charter no longer reads them. It will not call such a vault
+healthy-and-empty either: `charter vault list` counts the leftovers and says what to do
+with them, and `charter doctor` marks the vault unhealthy rather than fine. Re-register
+each credential with `charter secret set`, then delete the old items.
 
 Deliberate properties:
 
@@ -261,9 +266,11 @@ Deliberate properties:
   get logged in your command history, and can be visible to other processes on your
   machine". Writes pipe a JSON template on **stdin** (`op item create -`,
   `op item edit <item>`); only names are ever passed as arguments.
-- **charter lists only what charter created.** `secret list` filters by the
-  `charter:<vault>` tag, so a shared 1Password vault your team also fills by hand is
-  never listed — far less offered for deletion.
+- **charter looks at one item and no others.** `secret list` reads the fields of this
+  vault's item, so a shared 1Password vault your team also fills by hand shows you
+  nothing but the item you pointed charter at. The `charter:<vault>` tag marks what
+  charter wrote; it is how `vault list` recognises leftovers from the old schema, not a
+  filter the listing runs through.
 - **Errors withhold `op`'s output.** Its stderr can echo what it was given, and on a
   read path its stdout *is* the secret; failures report the exit status only.
 - **Pin the account** with `--account` when signed into more than one. Otherwise an

--- a/tests/test_op_schema_is_told_the_same_everywhere.py
+++ b/tests/test_op_schema_is_told_the_same_everywhere.py
@@ -1,0 +1,163 @@
+"""A 1Password vault is ONE item whose concealed fields are the secrets — everywhere.
+
+`tests/test_onepassword_single_item.py` pins the provider's behaviour. This module pins
+the two places that *describe* it to an operator, because both went on describing the
+schema it replaced (#400).
+
+`docs/secrets.md` carried a "Schema — **one 1Password item per secret**" table mapping
+vault `devops` / key `KUBECONFIG` onto an item `charter-devops-KUBECONFIG`, and then
+argued at length that one item per vault "is wrong here". Neither half survived the
+code: `OnePasswordProvider` writes one item per vault by exactly the read-modify-write
+that paragraph called wrong, and `health()` carries a `_legacy_items()` path whose whole
+job is to find leftovers of the layout that table presented as current. An operator
+following it looks for an item charter has not created for several releases.
+
+`charter vault add --provider 1password` said the same thing in its own output — "charter
+creates one 1Password item per secret" — at the one moment an operator is told where
+their credentials will live.
+
+Wrong documentation of a credential store is not a cosmetic failure: it sends someone
+looking for a secret in a place nothing put one, and the natural next move is to write it
+again somewhere else.
+"""
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import commands_secrets
+from charter.secrets.onepassword import OnePasswordProvider
+from tests._isolation import PersonaIso
+
+ROOT = Path(__file__).resolve().parents[1]
+SECRETS_DOC = (ROOT / "docs" / "secrets.md").read_text()
+
+
+class TestTheDocDescribesTheSchemaTheCodeImplements(unittest.TestCase):
+    """Prose, pinned only where drifting would send someone to the wrong item."""
+
+    def test_it_does_not_claim_one_item_per_secret(self):
+        """The removed schema, stated as current. This is the sentence #400 was filed
+        about, and the one an operator acts on."""
+        self.assertNotIn("item per secret", SECRETS_DOC)
+
+    def test_it_does_not_advertise_the_per_key_item_title(self):
+        """`charter-<vault>-<KEY>` is what `_legacy_items` hunts for, so the doc may name
+        it as history — never as the item to go and look in. The old table's worked
+        example was `charter-devops-KUBECONFIG`."""
+        self.assertNotIn("charter-devops-KUBECONFIG", SECRETS_DOC)
+
+    def test_it_names_the_item_a_vault_actually_lives_in(self):
+        """`charter-<vault>`, the `--op-item` override, and what the fields are.
+
+        The three negatives above can all be satisfied by deleting text, so this pins the
+        replacement: an operator must still be able to read off which item to open and
+        what they will find in it. Green before the fix as well as after — the worked
+        example it pins predates #400; what was wrong was the table underneath it.
+
+        `(?!-)` is load-bearing. `charter-devops-KUBECONFIG` *contains* `charter-devops`,
+        so a plain substring check reads the stale per-key title as the right answer and
+        the assertion stops being able to fail.
+        """
+        self.assertRegex(SECRETS_DOC, r"charter-devops(?!-)")
+        self.assertIn("--op-item", SECRETS_DOC)
+        self.assertIn("custom fields are the secrets", SECRETS_DOC)
+
+    def test_it_does_not_argue_against_the_schema_in_force(self):
+        """The doc did not merely lag; it made the case *against* one item per vault. The
+        concealment hazard that argument rests on is real and is handled — `set()` and
+        `delete()` fetch with `--reveal` — so it survives as the reason that flag exists,
+        not as a reason the schema is wrong."""
+        self.assertNotIn("One item per *vault* is the tidier-looking design", SECRETS_DOC)
+        self.assertIn("--reveal", SECRETS_DOC)
+
+
+class _FakeOp:
+    """Stands in for the `op` CLI. `health()` shells out, and `vault add` calls it.
+
+    The suite must answer the same on a laptop with 1Password installed and on a bare
+    runner — hence this, and the `shutil.which` stub below.
+    """
+
+    def __init__(self, title: str) -> None:
+        self.title = title
+
+    def __call__(self, argv, input=None, **kw):
+        bare = [a for a in argv if not a.startswith("--")]
+        if bare[:3] == ["op", "item", "get"]:
+            return SimpleNamespace(returncode=0, stderr="", stdout=json.dumps({
+                "id": "itm1", "title": self.title, "category": "PASSWORD",
+                "fields": [{"id": "KUBECONFIG", "label": "KUBECONFIG",
+                            "type": "CONCEALED", "value": "x"}]}))
+        if bare[:3] == ["op", "item", "list"]:
+            return SimpleNamespace(returncode=0, stderr="",
+                                   stdout=json.dumps([{"title": self.title}]))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+
+def _args(name: str, **kw) -> SimpleNamespace:
+    return SimpleNamespace(name=name, provider="1password", file=None,
+                           op_vault=kw.pop("op_vault", "Engineering"),
+                           op_item=kw.pop("op_item", None), account=None,
+                           persona=None, force=False, share=False)
+
+
+class TestRegistrationSaysWhereTheSecretsWillLive(PersonaIso):
+    """`charter vault add --provider 1password` is where an operator learns the layout."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        import charter.secrets.onepassword as mod
+        real_which = mod.shutil.which
+        mod.shutil.which = lambda n: "/usr/local/bin/op" if n == "op" else None
+        self.addCleanup(lambda: setattr(mod.shutil, "which", real_which))
+
+    def _add(self, name: str, item_title: str, **kw) -> str:
+        real_runner = OnePasswordProvider.__dict__["runner"]
+        OnePasswordProvider.runner = _FakeOp(item_title)
+        self.addCleanup(lambda: setattr(OnePasswordProvider, "runner", real_runner))
+        err = io.StringIO()
+        with redirect_stderr(err):
+            rc = commands_secrets.cmd_vault_add(_args(name, **kw))
+        self.assertEqual(rc, 0, err.getvalue())
+        return err.getvalue()
+
+    def _schema_line(self, out: str) -> str:
+        """The line that describes the LAYOUT, isolated from the rest of the output.
+
+        Asserting over the whole of `out` would be unfailable: `health()` runs on the same
+        command and its detail already names the item ("no secrets yet in item
+        'charter-devops'"), so every item-naming assertion below passed against the old
+        one-item-per-secret text too. Verified by mutation, which is the only reason this
+        helper exists.
+        """
+        lines = [ln for ln in out.splitlines() if "concealed field" in ln]
+        self.assertEqual(len(lines), 1, f"expected one layout line, got:\n{out}")
+        return lines[0]
+
+    def test_it_names_the_single_item_the_vault_lives_in(self):
+        """The name to type into the 1Password search box. Naming only the op-vault
+        leaves the operator to guess it, and the guess the old text invited was
+        `charter-devops-KUBECONFIG`."""
+        line = self._schema_line(self._add("devops", "charter-devops"))
+        self.assertIn("'charter-devops'", line)
+
+    def test_it_does_not_claim_one_item_per_secret(self):
+        out = self._add("devops", "charter-devops")
+        self.assertNotIn("item per secret", out)
+
+    def test_an_adopted_item_is_named_as_itself(self):
+        """`--op-item` points charter at an item somebody already curates. Printing the
+        `charter-<vault>` default there would name an item that does not exist and will
+        never be created."""
+        line = self._schema_line(self._add("devops", "team-kube", op_item="team-kube"))
+        self.assertIn("'team-kube'", line)
+        self.assertNotIn("charter-devops", line)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`docs/secrets.md` documented the one-item-per-secret 1Password schema the code
replaced, and argued against the one it uses. Verified against the code first.

## What the code does

`OnePasswordProvider` writes **one item per vault** — `charter-<vault>`, or an
adopted `--op-item` — with each secret a CONCEALED custom field of it
(`_write`, `charter/secrets/onepassword.py`). `set()` and `delete()` are
read-modify-write through a JSON template on stdin. `health()` carries
`_legacy_items()`, whose whole job is to find `charter-<vault>-<KEY>` leftovers
of the schema the doc still presented as current.

## What the doc said

A "Schema — **one 1Password item per secret**" table mapping vault `devops` /
key `KUBECONFIG` onto item `charter-devops-KUBECONFIG`, value in that item's
`password` field, followed by a paragraph arguing one item per vault "is wrong
here". Line 206 of the same file already said "One item per vault", so the page
contradicted itself.

The concealment hazard that argument rests on is real and is handled — `set()`
and `delete()` fetch with `--reveal`. It survives as the reason the flag exists,
not as the schema, and the rewrite says that.

## Same claim, in code, user-facing

`charter vault add --provider 1password` printed it too, at the one moment an
operator learns where their credentials will live, and named no item at all:

```
• charter creates one 1Password item per secret, tagged 'charter:devops', in vault 'Engineering'.
```

Now:

```
• charter keeps this vault in one 1Password item, 'charter-devops' in vault
  'Engineering', tagged 'charter:devops' — each secret a concealed field of it.
```

Resolved through `prov.op_item`, so an adopted `--op-item` is named as itself
rather than as a `charter-<vault>` default that will never be written.

## Also corrected, same cause

- `secret list` reads the fields of one item; it does not filter 1Password by the
  `charter:<vault>` tag. That tag is how `vault list` recognises legacy items.
- `secret rm` removes a **field**. The item is the vault and nothing deletes it —
  which the provider's own module docstring had backwards against `delete()`'s.

## Tests

`tests/test_op_schema_is_told_the_same_everywhere.py` (7 tests). Mutation-tested,
`__pycache__` cleared between runs:

| mutation | result |
| --- | --- |
| `docs/secrets.md` reverted to `origin/main` | RED ×3 (`item per secret`, `charter-devops-KUBECONFIG`, the "wrong here" argument); restored → GREEN |
| `vault add` hint reverted to the old sentence | RED ×3 (names no item, adopted item unnamed, claims one per secret); restored → GREEN |
| hint hardcodes `charter-{args.name}` instead of `prov.op_item` | RED ×1 (adopted `--op-item`); restored → GREEN |
| the doc's worked-example block deleted rather than corrected | RED ×1 (the positive pin); restored → GREEN |

One assertion was **unfailable on the first attempt** and is worth naming:
`health()` runs on the same command and its detail already contains
`'charter-devops'`, so asserting the item name over the whole of stderr passed
against the old text too. The CLI assertions now isolate the layout line
(`_schema_line`), which is what made the mutation above go red. Likewise
`charter-devops-KUBECONFIG` *contains* `charter-devops`, so the doc's positive
pin uses `charter-devops(?!-)` rather than a substring — otherwise the stale
title satisfied it.

Suite: `Ran 4046 tests in 132.936s` / `OK`.

## Not done

The issue also flags
`personas/steward/memory/onepasswordprovider-set-issues-three-separate-op.md` as
stale after #355. Left alone on purpose: `personas/` is live plane state other
sessions write to concurrently, and the issue itself asks for it to be curated
rather than edited from a code branch.

Closes #400
