### PR TITLE
A read-back charter could not make is not a missing secret (#399)

### DIFF
--- a/charter/secrets/onepassword.py
+++ b/charter/secrets/onepassword.py
@@ -237,7 +237,9 @@ class OnePasswordProvider(VaultProvider):
 
         Verified afterwards: a concurrent writer can land between the read and the write
         and drop this field, and silently losing a credential somebody believes they
-        stored is worse than failing.
+        stored is worse than failing. That verification has **two** failure modes, and
+        they are reported as two things (#399): a read-back that came back and DISAGREED,
+        and a read-back that could not be made at all.
 
         **One read** (#355). Values, presence and ids are three questions with one answer
         — :meth:`_document` — rather than three ``op item get`` calls that could return
@@ -247,7 +249,48 @@ class OnePasswordProvider(VaultProvider):
         fields = self._fields_of(doc)
         fields[key] = value
         self._write(fields, ids=self._ids_of(doc), creating=doc is None)
-        if self.get(key) != value:
+        try:
+            got = self.get(key)
+        except VaultError as e:
+            # A read-back that could not be MADE is not a secret that is not there (#399).
+            # `get` answers a failed `op read` with `SecretNotFound`, which is the right
+            # answer on a read path and a lie on this one: charter has just written the
+            # credential, so letting that raise escape tells the operator "no secret
+            # 'NEW_KEY'" about the very key it stored a moment ago — the #322 species
+            # again, a failure arriving as a benign absence, here on the write path where
+            # the absence is also demonstrably false.
+            #
+            # `SecretNotFound`'s own words are therefore NOT repeated into this message.
+            # They are a diagnosis this branch exists to contradict, and quoting a wrong
+            # diagnosis inside a right one is how an operator ends up believing the wrong
+            # half. What `op` actually justifies saying is the exit status and its
+            # ambiguity. Any OTHER `VaultError` describes something charter did check, so
+            # that one is quoted verbatim; `raise ... from e` keeps the original either way.
+            #
+            # The likeliest cause is named because the race it comes from is now the
+            # ORDINARY outcome rather than a corner of one: #355 made the write in that
+            # race unconditionally `op item create`, so another writer creating the item
+            # after charter proved it absent leaves two items sharing a title, and reading
+            # a field by title cannot say which is meant. A rate limit or an expired
+            # session arrives in the same shape — hence a cause offered with the command
+            # that confirms it, never asserted.
+            why = ("`op read` exited non-zero, which it does both for a field that is "
+                   "not there and for every way a read can fail, so charter cannot tell "
+                   "which happened"
+                   if isinstance(e, SecretNotFound) else str(e))
+            raise VaultError(
+                f"wrote '{key}' to 1Password item '{self.op_item}' in "
+                f"'{self.op_vault}' but could not read it back, so charter cannot "
+                f"confirm what the item now holds — {why}. The likeliest cause is TWO "
+                f"items titled '{self.op_item}' in '{self.op_vault}': another writer "
+                f"creating it between charter proving it absent and charter's own `op "
+                f"item create` leaves the title ambiguous, and a field read by title "
+                f"then fails. `op item list --vault {self.op_vault}` shows whether the "
+                f"title appears twice; a rate limit or an expired `op` session looks the "
+                f"same from here. Do not treat this as the secret being absent — "
+                f"1Password keeps item history, so check the item before re-provisioning "
+                f"anything.") from e
+        if got != value:
             raise VaultError(
                 f"wrote '{key}' to 1Password item '{self.op_item}' but reading it back "
                 f"did not return what was written. Another writer may have replaced the "

--- a/docs/news/unreleased-a-write-charter-could-not-verify.md
+++ b/docs/news/unreleased-a-write-charter-could-not-verify.md
@@ -1,0 +1,57 @@
+---
+version: unreleased
+headline: A 1Password write charter could not verify no longer reports the secret as missing
+---
+
+`charter secret set` on a 1Password vault writes the field and then reads it back, because a
+concurrent writer can drop it and silently losing a credential you believe you stored is
+worse than failing. When that read-back **failed** rather than disagreed, charter told you
+the opposite of what had happened:
+
+```
+$ charter secret set devops NEW_KEY --stdin
+✗ no secret 'NEW_KEY' in vault 'devops'
+    (field 'NEW_KEY' of 1Password item 'charter-devops' in 'Eng')
+```
+
+The credential had just been written. The message came from the read-back's own `op read`
+exiting non-zero, which is the right answer on a read path — `charter secret get` really is
+being asked whether a secret is there — and a lie on this one.
+
+It now says what actually happened, names the likeliest cause, and gives you the command
+that confirms it:
+
+```
+$ charter secret set devops NEW_KEY --stdin
+✗ wrote 'NEW_KEY' to 1Password item 'charter-devops' in 'Eng' but could not read it back, so
+charter cannot confirm what the item now holds — `op read` exited non-zero, which it does
+both for a field that is not there and for every way a read can fail, so charter cannot tell
+which happened. The likeliest cause is TWO items titled 'charter-devops' in 'Eng': another
+writer creating it between charter proving it absent and charter's own `op item create`
+leaves the title ambiguous, and a field read by title then fails. `op item list --vault Eng`
+shows whether the title appears twice; a rate limit or an expired `op` session looks the same
+from here. Do not treat this as the secret being absent — 1Password keeps item history, so
+check the item before re-provisioning anything.
+```
+
+**Why the duplicate is named first.** 0.51.0 collapsed the write path onto one `op item get`,
+which made the write in the create/create race unconditionally `op item create` — trading a
+silent replacement of another writer's secret for a loud duplicate item. That trade is right,
+and it made the failing read-back the ordinary outcome of that race rather than a corner of
+it. 0.51.0's own note said the sentence you got when it happened was still wrong; this is
+that sentence.
+
+**A read-back that disagreed is still reported as disagreement.** Two different things went
+wrong, and they need opposite responses — check the item's previous versions for a value
+somebody replaced, versus find out why the vault stopped answering — so they stay two
+messages.
+
+**Nothing here says your secret was lost.** A read charter could not make says nothing about
+what the item holds, which is exactly why it no longer pretends to. If you hit this, look at
+the item in 1Password before re-provisioning anything: 1Password keeps item history, and the
+expensive mistake is rotating a credential that was fine.
+
+Reads are unchanged, and so are the `plain-file` and `op://` reference providers — this is in
+the native 1Password provider, the one where charter owns the item.
+
+Nothing to adopt: upgrading is the whole of it.

--- a/tests/test_op_readback_failure_is_not_a_missing_secret.py
+++ b/tests/test_op_readback_failure_is_not_a_missing_secret.py
@@ -1,0 +1,289 @@
+"""A read-back charter could not MAKE is never reported as a missing secret (#399).
+
+`OnePasswordProvider.set()` writes the field and then reads it back, because a concurrent
+writer can drop it and silently losing a credential somebody believes they stored is worse
+than failing. That verification has two failure modes and used to have one message::
+
+    self._write(fields, ids=self._ids_of(doc), creating=doc is None)
+    if self.get(key) != value:
+        raise VaultError("wrote '<key>' … but reading it back did not return what was
+                          written. …")
+
+Only reachable when the read-back **comes back and disagrees**. When the read-back
+*fails*, `self.get(key)` raises first — `SecretNotFound`, the right answer on a read path —
+and the operator is told the opposite of what happened, about the very key charter stored
+a moment ago::
+
+    $ charter secret set devops NEW_KEY …
+    no secret 'NEW_KEY' in vault 'devops'
+        (field 'NEW_KEY' of 1Password item 'charter-devops' in 'Eng')
+
+That is #322's species — a failure arriving as a benign absence — on the write path, where
+the absence is also demonstrably false. `_fields` refuses to call an unreadable vault
+empty for the same reason; this is the same rule applied to the write path's own read.
+
+**The failing read-back is not hypothetical.** #355 made the write in the create/create
+race unconditionally `op item create`, trading a silent replacement of another writer's
+secret for a loud duplicate item — the right trade, and it means two items can now share a
+title, after which `op read op://Eng/charter-devops/NEW_KEY` is ambiguous and exits
+non-zero. `ADuplicateTitleRace` below drives exactly that race, with every `op` call
+before the read-back exiting 0. `AReadBackThatFailsForAnyOtherReason` drives a rate limit,
+which is the same shape without the duplicate, so nothing here is keyed to duplicates.
+
+`test_an_item_proved_absent_is_never_edited` in `test_op_reads_the_item_once` reaches this
+same race and deliberately swallows the raise — documented there, because that file is
+about which `op` calls charter makes. The text the operator ends up reading is this file.
+
+The fake is that module's `FakeOp`, which already models both halves: `op` answering
+`item get` differently under `--reveal`, and a writer landing between two of charter's
+calls. Fixture values are inert strings, never credentials.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_secrets
+from charter.secrets import base
+from charter.secrets.onepassword import OnePasswordProvider
+from tests.test_op_reads_the_item_once import ITEM, FakeOp, OpCase
+
+#: What `op` writes when a service account has been rate-limited — quoted from #322, an
+#: operator's own `op` output. It exits 1, the same code as "no such item", which is the
+#: whole reason the exit status cannot classify what happened. Nothing asserts on this
+#: text; charter must not be matching on `op`'s English here any more than in `_fields`.
+RATE_LIMITED = "[ERROR] 2026/08/20 11:02:31 Too many requests. Your client has been rate-limited."
+
+KEY = "NEW_KEY"
+VALUE = "v-fixture"
+
+
+class ReadBackCase(OpCase):
+    """The write reaches its read-back, and the read-back cannot be made.
+
+    Every subclass asserts its own preconditions, because both ways this file could pass
+    while proving nothing are silent: a fake that never got as far as writing, and a
+    read-back that quietly succeeded.
+    """
+
+    def failing_set(self, op, p):
+        """Run the `set` that must fail, and return the error it raised."""
+        with self.assertRaises(base.VaultError) as caught:
+            p.set(KEY, VALUE)
+        self.assertIn("read", op.subs(), "the read-back never happened")
+        return caught.exception
+
+    def with_op(self, cls, **kw):
+        """`OpCase.make`, with a subclassed `op` behind it — the three lines are spelled
+        out rather than routed through `make`, which would build a fake only to discard it
+        and leave two objects that look interchangeable and are not."""
+        kw.setdefault("raw_fields", [dict(f) for f in self.ADOPTED])
+        op = cls(**kw)
+        # No `env` binding, for the reason `OpCase.make` records: `env_overlay` would then
+        # read this process's environment, and the suite runs inside a charter frame.
+        p = OnePasswordProvider("devops", {"op-vault": "Eng"})
+        p.runner = op
+        return op, p
+
+
+class ADuplicateTitleRace(ReadBackCase):
+    """Another writer creates the item the moment after charter proved it ABSENT.
+
+    charter creates too — #355's deliberate choice — so the vault now holds two items
+    titled `charter-devops` and reading a field by that title is ambiguous. Every `op`
+    call up to the read-back exits 0.
+    """
+
+    def race(self):
+        """The hook fires on the LISTING, which is what proves absence: landing it any
+        earlier would make charter see the item and report a failed read instead, which is
+        a different case. `self.landed` records that it really fired — a hook wired to a
+        subcommand nobody calls would leave every assertion below true for the boring
+        reason that there was no race at all."""
+        self.landed: list[int] = []
+
+        def concurrent_create(op, sub, i):
+            if sub == "item list" and i == 0:
+                op.titles.append(ITEM)
+                op.raw_fields = [{"id": "OTHER_SECRET", "label": "OTHER_SECRET",
+                                  "type": "CONCEALED", "value": "other-fixture"}]
+                self.landed.append(i)
+
+        return self.make(raw_fields=[], titles=[], after=concurrent_create)
+
+    def test_the_precondition_the_race_really_produced_the_ambiguity(self):
+        """Otherwise this class is about nothing: the other writer must have landed, the
+        write must have been a `create` against a title now taken, and no `op` call before
+        the read-back may have failed — a failure earlier would raise for its own reasons
+        and never reach the read-back at all."""
+        op, p = self.race()
+        self.failing_set(op, p)
+        self.assertEqual(self.landed, [0], "the other writer never landed")
+        self.assertEqual(op.duplicates, 1,
+                         "the vault does not hold two items with the same title, so the "
+                         "read-back had nothing to be ambiguous about")
+        self.assertEqual(op.subs(), ["item get", "item list", "item create", "read"])
+
+    def test_the_operator_is_not_told_the_secret_is_missing(self):
+        """The bug, stated as the damage. charter has just written the credential."""
+        op, p = self.race()
+        e = self.failing_set(op, p)
+        self.assertNotIn(f"no secret '{KEY}'", str(e),
+                         "charter reported the key it had just written as missing")
+        self.assertNotIsInstance(
+            e, base.SecretNotFound,
+            "a caller classifying by exception type is told this vault has no such "
+            "secret, moments after charter wrote it")
+
+    def test_the_message_says_what_actually_happened(self):
+        op, p = self.race()
+        e = self.failing_set(op, p)
+        self.assertIn(f"wrote '{KEY}' to 1Password item '{ITEM}'", str(e))
+        self.assertIn("could not read it back", str(e))
+
+    def test_the_message_names_the_duplicate_and_how_to_see_it(self):
+        """The likeliest cause, with the command that confirms it — not asserted as fact,
+        because a rate limit and an expired session reach here identically."""
+        op, p = self.race()
+        e = self.failing_set(op, p)
+        self.assertIn(f"TWO items titled '{ITEM}'", str(e))
+        self.assertIn("op item list --vault Eng", str(e))
+
+    def test_the_failure_does_not_echo_ops_output(self):
+        """`op`'s stderr can echo the assignment it was given, and on a read path its
+        stdout IS the secret. The provider withholds both everywhere else; a new message
+        is a new place to leak them."""
+        op, p = self.race()
+        e = self.failing_set(op, p)
+        self.assertNotIn(VALUE, str(e))
+        self.assertNotIn("other-fixture", str(e))
+
+
+class AReadBackThatFailsForAnyOtherReason(ReadBackCase):
+    """Same shape, no duplicate item: `op read` simply fails.
+
+    Without this, the guard could be keyed to the duplicate race and still pass — and the
+    rate limit reported in #322 and #354 arrives exactly here, on the call that decides
+    whether an operator believes their credential was stored.
+    """
+
+    class RateLimitsTheReadBack(FakeOp):
+        def _answer(self, sub, reveal, input, argv):
+            if sub == "read":
+                return SimpleNamespace(returncode=1, stdout="", stderr=RATE_LIMITED)
+            return super()._answer(sub, reveal, input, argv)
+
+    def rate_limited(self):
+        return self.with_op(self.RateLimitsTheReadBack)
+
+    def test_the_precondition_the_write_really_landed(self):
+        """The sharpest statement of the bug: the item HOLDS the value, and only the
+        read-back failed. There is no duplicate here, so nothing else can explain it."""
+        op, p = self.rate_limited()
+        self.failing_set(op, p)
+        self.assertEqual(op.value_of(KEY), VALUE,
+                         "the field never landed, so this is not a read-back failure")
+        self.assertEqual(op.duplicates, 0, "a duplicate would be a different case")
+
+    def test_it_is_still_not_reported_as_a_missing_secret(self):
+        op, p = self.rate_limited()
+        e = self.failing_set(op, p)
+        self.assertNotIn(f"no secret '{KEY}'", str(e))
+        self.assertNotIsInstance(e, base.SecretNotFound)
+        self.assertIn("could not read it back", str(e))
+
+    def test_the_message_does_not_claim_op_said_the_field_is_absent(self):
+        """`op read` exiting non-zero means "not there" OR "could not read". charter has
+        no way to tell, and says so rather than picking one."""
+        op, p = self.rate_limited()
+        e = self.failing_set(op, p)
+        self.assertIn("cannot tell which happened", str(e))
+
+
+class ADisagreeingReadBackStillSaysSo(ReadBackCase):
+    """The other failure mode, kept distinct.
+
+    The pre-existing message is the right one when the read-back COMES BACK and returns
+    something else — a concurrent writer replaced the value. A fix that routed both modes
+    through one sentence would satisfy every assertion above and lose the distinction this
+    issue is about.
+    """
+
+    class AnswersWithSomethingElse(FakeOp):
+        def _answer(self, sub, reveal, input, argv):
+            proc = super()._answer(sub, reveal, input, argv)
+            if sub == "read" and proc.returncode == 0:
+                return SimpleNamespace(returncode=0, stdout="somebody-elses-value",
+                                       stderr="")
+            return proc
+
+    def disagreeing(self):
+        return self.with_op(self.AnswersWithSomethingElse)
+
+    def test_the_precondition_the_read_back_really_succeeded(self):
+        """It has to COME BACK. A fake whose read merely failed differently would send
+        this class through the branch above and assert nothing about disagreement."""
+        op, p = self.disagreeing()
+        self.failing_set(op, p)
+        self.assertEqual(op.value_of(KEY), VALUE, "the write never landed")
+        self.assertEqual(p.get(KEY), "somebody-elses-value",
+                         "the read-back did not succeed, so nothing disagreed")
+
+    def test_it_reports_disagreement_not_an_unreadable_item(self):
+        op, p = self.disagreeing()
+        e = self.failing_set(op, p)
+        self.assertIn("did not return what was written", str(e))
+        self.assertNotIn("could not read it back", str(e))
+
+
+class TheOrdinaryWriteIsUnchanged(OpCase):
+    """The control. A guard that failed every `set` would satisfy the whole file above."""
+
+    def test_a_set_still_succeeds_and_says_nothing(self):
+        op, p = self.make()
+        p.set(KEY, VALUE)
+        self.assertEqual(op.value_of(KEY), VALUE)
+        self.assertIn("read", op.subs(), "the read-back was skipped")
+
+
+class TheOperatorSeesIt(ReadBackCase):
+    """What `charter secret set` prints, end to end. `_provider` is stubbed rather than the
+    registry populated, so this is about `cmd_secret_set`'s contract with a provider."""
+
+    def _set(self, p) -> tuple[int, str]:
+        out, err = io.StringIO(), io.StringIO()
+        args = SimpleNamespace(vault="devops", key=KEY, value=VALUE, from_file=None,
+                               stdin=False, allow_empty=False)
+        with mock.patch.object(commands_secrets, "_provider", lambda _n: p), \
+             redirect_stdout(out), redirect_stderr(err):
+            code = commands_secrets.cmd_secret_set(args)
+        return code, out.getvalue() + err.getvalue()
+
+    def _race(self):
+        def concurrent_create(op, sub, i):
+            if sub == "item list" and i == 0:
+                op.titles.append(ITEM)
+        return self.make(raw_fields=[], titles=[], after=concurrent_create)
+
+    def test_the_command_does_not_tell_the_operator_the_secret_is_missing(self):
+        op, p = self._race()
+        code, text = self._set(p)
+        self.assertNotEqual(code, 0, "a scripted caller would treat the write as done")
+        self.assertNotIn(f"no secret '{KEY}'", text)
+        self.assertIn("could not read it back", text)
+        self.assertEqual(op.duplicates, 1, "the race never produced the ambiguity")
+
+    def test_a_successful_set_still_reports_success(self):
+        _, p = self.make()
+        code, text = self._set(p)
+        self.assertEqual(code, 0)
+        self.assertIn("Set 'NEW_KEY'", text)
+        self.assertNotIn(VALUE, text, "the command echoed the secret")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`OnePasswordProvider.set()` writes the field and then reads it back. That verification had
two failure modes and one message, reachable only when the read-back **comes back and
disagrees**. When the read-back *fails*, `self.get(key)` raises first — `SecretNotFound`,
the right answer on a read path — and the operator is told the opposite of what happened,
about the key charter has just written:

```
$ charter secret set devops NEW_KEY --stdin
✗ no secret 'NEW_KEY' in vault 'devops'
    (field 'NEW_KEY' of 1Password item 'charter-devops' in 'Eng')
```

That is #322's species — a failure arriving as a benign absence — on the write path, where
the absence is also demonstrably false. `_fields` refuses to call an unreadable vault empty
for the same reason; this applies the rule to the write path's own read.

## Reproduced first

Against `main`, through the fake from #355's `tests/test_op_reads_the_item_once.py`, with
every `op` call before the read-back exiting 0:

```
raised: SecretNotFound
message: no secret 'NEW_KEY' in vault 'devops' (field 'NEW_KEY' of 1Password item 'charter-devops' in 'Eng')
duplicate items now in the vault: 1
calls: ['item get', 'item list', 'item create', 'read']
```

## What changed

`set()` distinguishes a read-back that DISAGREED from one that could not be MADE. The
second names the duplicate title as the likeliest cause — #355 made the write in the
create/create race unconditionally `op item create`, so the duplicate is now the ordinary
outcome of that race rather than a corner of it — and gives the command that confirms it. A
rate limit and an expired session arrive identically, so the cause is offered, never
asserted:

```
✗ wrote 'NEW_KEY' to 1Password item 'charter-devops' in 'Eng' but could not read it back,
so charter cannot confirm what the item now holds — `op read` exited non-zero, which it
does both for a field that is not there and for every way a read can fail, so charter
cannot tell which happened. The likeliest cause is TWO items titled 'charter-devops' in
'Eng': another writer creating it between charter proving it absent and charter's own `op
item create` leaves the title ambiguous, and a field read by title then fails. `op item
list --vault Eng` shows whether the title appears twice; a rate limit or an expired `op`
session looks the same from here. Do not treat this as the secret being absent — 1Password
keeps item history, so check the item before re-provisioning anything.
```

One deliberate deviation from the issue's suggested shape: `SecretNotFound`'s own words are
**not** quoted into the message. They are the diagnosis this branch exists to contradict,
and quoting a wrong diagnosis inside a right one is how an operator ends up believing the
wrong half. What `op` actually justifies saying is the exit status and its ambiguity. Any
*other* `VaultError` describes something charter did check, so that one is quoted verbatim;
`raise ... from e` keeps the original either way. The disagreement message is untouched.

## Tests

`tests/test_op_readback_failure_is_not_a_missing_secret.py`, 13 tests: the duplicate-title
race; a rate-limited read-back, so nothing is keyed to duplicates and the sharpest
precondition holds (`op.value_of(KEY) == VALUE` — the item HOLDS the value and only the
read-back failed); the disagreement message pinned as a separate sentence; the ordinary
write as a control; and what `charter secret set` prints end to end. Every class asserts its
own preconditions, because both ways this file could pass while proving nothing are silent.

**Mutation-tested.** Each applied, `__pycache__` cleared, run, restored, re-run green:

| # | mutation | result |
|---|---|---|
| A | revert `set()` to `if self.get(key) != value:` (pre-fix) | RED ×6 |
| B | the `except` branch re-raises the original | RED ×6 |
| C | quote `SecretNotFound`'s words into the message (`why = str(e)`) | RED ×4 |
| D | drop the duplicate-item guidance and `op item list` | RED ×1 |
| E | route the disagreement branch through "could not read it back" | RED ×1 |
| F | raise `SecretNotFound` from the new branch | RED ×2 |
| G | `if got != value:` → `if True:` (fails every write) | RED ×2, the controls |
| H | the concurrent writer never lands (fixture) | RED ×5 |
| I | the rate-limited read-back quietly succeeds (fixture) | RED ×3 |
| J | `cmd_secret_set` swallows the failure and exits 0 | RED ×1 |

Full suite: `Ran 4052 tests in 145.820s` / `OK`.

News: `docs/news/unreleased-a-write-charter-could-not-verify.md`. No version bumped, no
stamp, no tag. `0.51.0-op-asks-once.md` is left as it stands — it was accurate about 0.51.0,
and it is the entry that named this issue as still open.

Closes #399
