### PR TITLE
guard: read a rule back the way the harness's file spells it (#395)

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1321,10 +1321,10 @@ def cmd_guard_allow(args) -> int:
     rc, wrote = 0, False
     for h, status, detail in results:
         if status == "added":
-            util.ok(f"{h.name}: allowing {h.allow_rule(pattern)} → {detail}")
+            util.ok(f"{h.name}: allowing {h.rule_text(pattern)} → {detail}")
             wrote = True
         elif status == "present":
-            util.ok(f"{h.name}: already allowing {h.allow_rule(pattern)}.")
+            util.ok(f"{h.name}: already allowing {h.rule_text(pattern)}.")
             wrote = True
         elif status == "malformed":
             util.err(f"{h.name}: {detail} is not valid — left untouched.")
@@ -1394,10 +1394,10 @@ def cmd_guard_ask(args) -> int:
     rc, wrote = 0, False
     for h, status, detail in results:
         if status == "added":
-            util.ok(f"{h.name}: asking for {h.ask_rule(pattern)} → {detail}")
+            util.ok(f"{h.name}: asking for {h.rule_text(pattern)} → {detail}")
             wrote = True
         elif status == "present":
-            util.ok(f"{h.name}: already asking for {h.ask_rule(pattern)}.")
+            util.ok(f"{h.name}: already asking for {h.rule_text(pattern)}.")
             wrote = True
         elif status == "malformed":
             util.err(f"{h.name}: {detail} is not valid — left untouched.")

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -131,8 +131,45 @@ class Harness:
         The operator types one sentence — `charter guard ask "git push *"` — and never
         learns three syntaxes. ADR 0014: charter writes the harness's rules and keeps no
         list of its own, which only holds if the translation lives here.
+
+        The RETURN TYPE is the harness's, not charter's: a string where the harness's
+        rules are strings, a structure where they are structures. :meth:`rule_text` is
+        what a human is shown, so the writer never has to trade the shape it needs for
+        one that happens to print.
         """
         return None
+
+    def rule_text(self, pattern: str) -> str:
+        """*pattern* as this harness's own FILE spells it — the line `guard` prints.
+
+        `guard` prints what it wrote so the operator can read it back against the file,
+        and 0.49.0's argument for that is a guard's whole worth: *"a guard whose output
+        cannot be trusted is worse than no guard, because the tick is what stops you
+        checking"*. Since #374 the read-back also carries a name the operator never
+        typed — charter TRANSLATES an MCP pattern for opencode, and cannot check that
+        their `mcp` block spells the server the same way — so this line is the only thing
+        standing between a mistyped server and a rule that is inert for it.
+
+        Separate from :meth:`ask_rule` because the two answer different questions.
+        `ask_rule` answers the writer, in whatever shape that harness's file needs;
+        this answers a human, in the spelling they will go looking for. Interpolating
+        the first into a sentence is how opencode's `(tool, glob)` pair reached the
+        operator as ``('slack_send', '*')`` — Python's repr of a 2-tuple, a thing that
+        appears in no `opencode.json` ever written (#395).
+
+        The default covers a harness whose rule already IS its spelling. A harness whose
+        rule is structural must override: the base class does not know how that file
+        writes it down, and a generic join would print a plausible shape nothing holds —
+        the same defect in a different costume. ``""`` when there is no rule at all, and
+        `guard` never prints this for a rule that was not written.
+
+        One rendering serves both verbs, because it names WHERE the rule lives and the
+        surrounding sentence carries the decision ("asking for" / "allowing"). That holds
+        while :meth:`allow_rule` keeps its shared default; `TestBothVerbsTranslateTheSameWay`
+        is what fails the day a harness overrides it.
+        """
+        rule = self.ask_rule(pattern)
+        return rule if isinstance(rule, str) else ""
 
     def apply_ask_rule(self, root: Path, pattern: str, local: bool = False,
                        dry_run: bool = False) -> tuple[str, str]:

--- a/charter/harness/opencode.py
+++ b/charter/harness/opencode.py
@@ -495,11 +495,11 @@ class OpenCodeHarness(Harness):
         What charter cannot check is that opencode's `mcp` block names the server the same
         way. That is the contract Claude Code's rule already has — the name is the
         operator's, not charter's guess — and `guard` prints what it wrote so they can read
-        it back. Which is what makes that read-back load-bearing rather than cosmetic: it
-        currently renders as the repr of this tuple (`('slack_send', '*')`) and not as
-        anything `opencode.json` holds, so it is the one line an operator cannot check the
-        translation against. Filed as #395 rather than fixed here — the return type is
-        the harness rule interface, and three harnesses answer it.
+        it back. Which is what makes that read-back load-bearing rather than cosmetic, and
+        why the pair returned here is no longer what gets printed: it rendered as this
+        tuple's repr (`('slack_send', '*')`), which appears in no `opencode.json` there
+        has ever been. :meth:`rule_text` spells it the way the file does (#395); this
+        stays the pair `_apply_rule` writes from.
 
         The whole-server glob is as tight as opencode's own names allow and no tighter:
         `_` is both the separator `toolName` joins with and a legal character either side
@@ -539,6 +539,35 @@ class OpenCodeHarness(Harness):
                 if p.startswith(prefix) and p.endswith(")"):
                     return oc_id, p[len(prefix):-1]
         return "bash", p
+
+    def rule_text(self, pattern: str) -> str:
+        """The rule as `opencode.json` holds it: ``permission.slack_send."*"``.
+
+        A path into the file, so the operator can open it and land on the same key. The
+        base default would have printed :meth:`ask_rule`'s pair, and a 2-tuple's repr
+        (`('slack_send', '*')`) is not a spelling anything on disk uses — which mattered
+        the day #374 started translating `mcp__slack__send` into a name the operator
+        never typed and charter cannot verify against their `mcp` block (#395).
+
+        **The shape follows the write, because `_apply_rule` chooses between two.** A
+        :data:`FLAT_ONLY_PERMISSIONS` key takes a bare action and holds no glob at all —
+        the file says ``"doom_loop": "ask"`` — so printing ``permission.doom_loop."*"``
+        would send the reader looking for a key that is not there, over the one rule
+        shape where charter's own writer already had to know better. The object form is
+        kept when the glob is not `*`, which is the case `_apply_rule` REFUSES: nothing
+        is written, `guard` prints nothing, and the description stays true to what was
+        asked rather than quietly implying the glob was dropped.
+
+        The glob is JSON-quoted rather than pasted bare. It carries the operator's own
+        words — ``permission.bash."git push *"`` — and a spaced pattern run together with
+        a dotted path is unreadable at exactly the moment the line is being read
+        carefully. `json.dumps` is what wrote the file, so the quoting the reader sees
+        here is the quoting the file uses.
+        """
+        tool, glob = self.ask_rule(pattern)
+        if tool in FLAT_ONLY_PERMISSIONS and glob == "*":
+            return f"permission.{tool}"
+        return f"permission.{tool}.{json.dumps(glob)}"
 
     def rule_outranks(self, pattern: str) -> str:
         """opencode's own permission names this rule will decide for too, or ``""``.

--- a/docs/news/unreleased-guard-reads-back-the-key-the-file-holds.md
+++ b/docs/news/unreleased-guard-reads-back-the-key-the-file-holds.md
@@ -1,0 +1,48 @@
+---
+version: unreleased
+headline: `charter guard` reads a rule back the way opencode's file spells it
+---
+
+`charter guard` prints what it wrote so you can check it, and for opencode it was printing
+a Python tuple:
+
+```
+$ charter guard allow 'mcp__slack__send'
+✓ claude-code: allowing mcp__slack__send → …/.claude/settings.json
+✓ opencode: allowing ('slack_send', '*') → …/opencode.json
+```
+
+`opencode.json` holds `{"permission": {"slack_send": {"*": "allow"}}}`. It has never held
+anything spelled `('slack_send', '*')` — that is charter's own `(permission, glob)` pair,
+interpolated straight into the sentence. The file was correct in every case; the one line
+you were meant to check it against was not.
+
+That was cosmetic until the release that started TRANSLATING these rules. `mcp__slack__send`
+becomes `slack_send` for opencode, and charter cannot check that your own `mcp` block spells
+the server the same way — so this read-back is the only thing standing between a mistyped
+server and a rule that is inert for it. A name you never typed needs a readable read-back
+more than one you did, not less.
+
+Both verbs, and the "already asking / already allowing" sentences too, now name the key the
+way the file does:
+
+```
+✓ opencode: allowing permission.slack_send."*" → …/opencode.json
+✓ opencode: allowing permission.bash."git push *" → …/opencode.json
+✓ opencode: allowing permission.doom_loop → …/opencode.json
+```
+
+The third one is not a shortened version of the others. Five of opencode's permissions take
+a bare `ask`/`allow`/`deny` and hold no pattern at all, so charter writes the flat form
+there — and printing `permission.doom_loop."*"` would send you looking for a key that is not
+in the file. The rendering follows the shape that was written, over the one rule shape where
+getting it wrong stops opencode loading the project.
+
+Claude Code's line is unchanged: its rule is a string and already printed as one. The split
+is now explicit in the harness interface — `ask_rule` answers the writer in whatever shape
+that harness's file needs, and a new `rule_text` answers a human in the spelling they will
+go looking for. A harness whose rule is structural has to say how it is spelled; the base
+class prints nothing rather than guessing at a shape no file holds, which is the defect this
+fixes wearing different clothes.
+
+Found while reviewing the opencode MCP translation (#395).

--- a/tests/test_guard_rule_read_back.py
+++ b/tests/test_guard_rule_read_back.py
@@ -1,0 +1,349 @@
+"""`charter guard` prints the rule the way the harness's FILE spells it (#395).
+
+The line under test is the tick:
+
+    ✓ opencode: allowing ('slack_send', '*') → …/opencode.json
+
+`Harness.ask_rule` returns the harness's rule in the harness's own shape — a string for
+Claude Code, a `(permission, glob)` pair for opencode — and `cmd_guard_ask` /
+`cmd_guard_allow` interpolated it straight into that sentence. So opencode's operator was
+shown Python's repr of a 2-tuple: a spelling that appears in no `opencode.json` there has
+ever been, which holds `{"permission": {"slack_send": {"*": "allow"}}}`.
+
+That was cosmetic until #374, which made the same line load-bearing. #374 TRANSLATES an
+MCP pattern rather than writing it verbatim — `mcp__slack__send` becomes `slack_send` —
+and charter cannot check that the operator's own `mcp` block spells the server the same
+way. The read-back became the only thing standing between a mistyped server and a rule
+that is inert for it, and 0.49.0's argument for printing what was written ("a guard whose
+output cannot be trusted is worse than no guard, because the tick is what stops you
+checking") applies harder to a name the operator did not type than to one they did.
+
+The fix is `Harness.rule_text`, a rendering for humans beside `ask_rule`'s structure for
+the writer — the cheap half of the two the issue names, and deliberately so: making a rule
+a string across all three harnesses would trade opencode's writer out of the shape it
+needs to choose the file's form.
+
+**So these tests are about FINDABILITY, not about a wording.** Asserting the string
+`permission.slack_send."*"` would pass just as happily over a rendering that had drifted
+from what `_apply_rule` writes — which is the whole defect, one costume over. They write
+the rule for real and then follow the printed text into the file it names, so a rendering
+that cannot be followed fails no matter how plausible it reads.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import commands, config
+from charter.harness import registry
+from charter.harness.base import Harness
+from tests._isolation import PersonaIso
+
+#: Patterns spanning every shape charter's translation can produce, with the verb left
+#: out — one rendering serves both, which `TestBothVerbsAreShownTheSamePlace` pins.
+PATTERNS = (
+    "mcp__slack__send",      # translated MCP tool id — the name the operator never typed
+    "mcp__slack",            # whole server, so the KEY carries the glob
+    "git push *",            # falls through to `bash`, and the glob carries spaces
+    "Read(./secrets/**)",    # a `TOOL_NAMES` id with a path glob
+    "mcp__doom__loop",       # a flat-only permission: the file holds no glob at all
+    "WebFetch(*)",           # the other reachable flat-only one
+)
+
+
+def _segments(text: str) -> list[str]:
+    """``permission.bash."git push *"`` → ``["permission", "bash", "git push *"]``.
+
+    A JSON-quoted segment is decoded with the stdlib decoder rather than stripped of its
+    quotes, so a glob containing a `.` or a `"` comes back as one segment and this
+    walker cannot be the reason a test passes.
+    """
+    out: list[str] = []
+    i = 0
+    while i < len(text):
+        if text[i] == '"':
+            seg, i = json.JSONDecoder().raw_decode(text, i)
+            out.append(seg)
+        else:
+            j = text.find(".", i)
+            j = len(text) if j < 0 else j
+            out.append(text[i:j])
+            i = j
+        if i < len(text):
+            if text[i] != ".":
+                raise AssertionError(f"{text!r} is not a dotted path at {i}")
+            i += 1
+    return out
+
+
+def _at_the_dotted_path(doc: dict, text: str):
+    """What `opencode.json` holds at the path the operator was shown, or raise."""
+    here = doc
+    for seg in _segments(text):
+        if not isinstance(here, dict) or seg not in here:
+            raise AssertionError(f"{text!r} is not in {json.dumps(doc)}")
+        here = here[seg]
+    return here
+
+
+def _in_the_rule_list(doc: dict, text: str):
+    """Claude Code's file is a list of rule strings, so the whole text is the entry."""
+    for bucket in ("ask", "allow"):
+        for rule in doc.get("permissions", {}).get(bucket, []):
+            if rule == text:
+                return bucket
+    raise AssertionError(f"{text!r} is in no bucket of {json.dumps(doc)}")
+
+
+#: How to find a harness's printed text inside the file it named, per harness.
+#:
+#: A locator per harness rather than one generic matcher, because "findable" means
+#: something different in a list of rule strings than in a nested permission object, and
+#: a matcher loose enough to cover both (a substring test) would pass over the tuple repr
+#: this file exists about — `('slack_send', '*')` contains `slack_send`.
+#:
+#: ``None`` is a claim, not a skip: that harness writes no rule at all, and
+#: `test_the_harness_with_no_locator_really_writes_nothing` holds it to that.
+LOCATORS = {
+    registry.CLAUDE_CODE: (".claude/settings.json", _in_the_rule_list),
+    registry.OPENCODE: ("opencode.json", _at_the_dotted_path),
+    registry.CODEX: None,
+}
+
+
+class TestTheWalkersTheseTestsLeanOn(unittest.TestCase):
+    """Anti-vacuity, first: everything below is worthless if these find anything."""
+
+    def test_a_quoted_segment_survives_a_dot_and_a_space(self):
+        self.assertEqual(_segments('permission.bash."git push *"'),
+                         ["permission", "bash", "git push *"])
+        self.assertEqual(_segments('permission.read."./a.b/**"'),
+                         ["permission", "read", "./a.b/**"])
+        self.assertEqual(_segments("permission.doom_loop"), ["permission", "doom_loop"])
+
+    def test_a_path_that_is_not_in_the_document_raises(self):
+        doc = {"permission": {"slack_send": {"*": "ask"}}}
+        self.assertEqual(_at_the_dotted_path(doc, 'permission.slack_send."*"'), "ask")
+        with self.assertRaises(AssertionError):
+            _at_the_dotted_path(doc, 'permission.slack_recv."*"')
+        with self.assertRaises(AssertionError):
+            _at_the_dotted_path(doc, "('slack_send', '*')")
+        # A path one segment short lands on the object rather than on the decision, so
+        # the callers' `== "ask"` is what tells the two shapes apart — this walker
+        # returning something is not the same as it finding the rule.
+        self.assertEqual(_at_the_dotted_path(doc, "permission.slack_send"),
+                         {"*": "ask"})
+
+    def test_a_rule_that_is_in_no_bucket_raises(self):
+        doc = {"permissions": {"ask": ["Bash(git push *)"]}}
+        self.assertEqual(_in_the_rule_list(doc, "Bash(git push *)"), "ask")
+        with self.assertRaises(AssertionError):
+            _in_the_rule_list(doc, "Bash(git pull *)")
+
+
+class TestTheTextNamesWhereTheRuleLanded(PersonaIso):
+    """Write the rule, then follow the printed line into the file it names.
+
+    One fresh plane per pattern and verb, so a key an earlier rule left behind cannot be
+    the thing a later assertion finds.
+    """
+
+    def plane(self, *parts: str) -> Path:
+        root = Path(config.ROOT) / "planes" / "-".join(parts).replace("/", "_")
+        root.mkdir(parents=True, exist_ok=True)
+        return root
+
+    def test_every_harness_in_the_registry_has_a_locator(self):
+        """A fourth harness fails here rather than silently going unchecked — the same
+        reason `registry.KINDS` is iterated everywhere instead of harnesses being named
+        one by one."""
+        self.assertEqual(set(LOCATORS), set(registry.KINDS))
+
+    def test_the_harness_with_no_locator_really_writes_nothing(self):
+        """`None` above says "answers no rule", and that has to be checked or it becomes
+        a way to excuse a harness from this file."""
+        h = registry.get(registry.CODEX)
+        for pattern in PATTERNS:
+            with self.subTest(pattern=pattern):
+                root = self.plane("codex", pattern)
+                self.assertEqual(h.apply_ask_rule(root, pattern)[0], "unsupported")
+                self.assertEqual(h.rule_text(pattern), "")
+
+    def test_the_printed_text_leads_to_the_rule_that_was_written(self):
+        """The whole point. Every harness, every pattern, both verbs: what `guard` would
+        print has to lead to the decision that is actually in the file."""
+        for name, locator in LOCATORS.items():
+            if locator is None:
+                continue
+            filename, find = locator
+            h = registry.get(name)
+            for verb, decision in (("apply_ask_rule", "ask"),
+                                   ("apply_allow_rule", "allow")):
+                for pattern in PATTERNS:
+                    with self.subTest(harness=name, verb=verb, pattern=pattern):
+                        root = self.plane(name, verb, pattern)
+                        status, detail = getattr(h, verb)(root, pattern)
+                        if status != "added":
+                            continue
+                        doc = json.loads((root / filename).read_text())
+                        text = h.rule_text(pattern)
+                        self.assertTrue(text, f"{name} printed nothing for {pattern}")
+                        self.assertEqual(find(doc, text), decision,
+                                         f"{name}: {text!r} does not lead to the rule "
+                                         f"in {detail}")
+
+    def test_the_flat_only_shape_is_shown_flat(self):
+        """`_apply_rule` picks between two shapes; the rendering has to pick the same
+        one. `doom_loop` takes a bare action, so the file holds no glob key — printing
+        `permission.doom_loop."*"` would send the reader looking for a key that is not
+        there, over the one rule shape charter's own writer already knew better about."""
+        h = registry.get(registry.OPENCODE)
+        root = self.plane("shape", "flat")
+        self.assertEqual(h.apply_ask_rule(root, "mcp__doom__loop")[0], "added")
+        self.assertEqual(json.loads((root / "opencode.json").read_text()),
+                         {"permission": {"doom_loop": "ask"}})
+        self.assertEqual(h.rule_text("mcp__doom__loop"), "permission.doom_loop")
+
+    def test_the_object_shape_is_shown_with_its_glob(self):
+        """The other branch, so the flat one above is a choice rather than the answer to
+        everything."""
+        h = registry.get(registry.OPENCODE)
+        root = self.plane("shape", "object")
+        self.assertEqual(h.apply_ask_rule(root, "mcp__slack__send")[0], "added")
+        self.assertEqual(h.rule_text("mcp__slack__send"), 'permission.slack_send."*"')
+
+    def test_a_glob_carrying_spaces_is_quoted_the_way_the_file_quotes_it(self):
+        """`git push *` run together with a dotted path is unreadable at exactly the
+        moment the line is being read carefully."""
+        h = registry.get(registry.OPENCODE)
+        self.assertEqual(h.rule_text("git push *"), 'permission.bash."git push *"')
+
+
+class TestBothVerbsAreShownTheSamePlace(unittest.TestCase):
+    """One rendering for `ask` and `allow`, because it names WHERE the rule lives and the
+    sentence around it carries the decision.
+
+    The sibling of `TestBothVerbsTranslateTheSameWay` in
+    `test_guard_opencode_mcp_rule.py`, and it fails in the same circumstance: a harness
+    that overrides `allow_rule` away from `base`'s shared default would have two
+    spellings and one renderer, and this is what says so rather than letting the allow
+    line quietly describe the ask rule.
+    """
+
+    def test_no_harness_spells_the_two_verbs_differently(self):
+        for h in registry.all():
+            for pattern in PATTERNS:
+                with self.subTest(harness=h.name, pattern=pattern):
+                    self.assertEqual(h.allow_rule(pattern), h.ask_rule(pattern))
+
+
+class TestNoHarnessPrintsAPythonRepr(unittest.TestCase):
+    """The shape of the defect, named directly, for a harness added later."""
+
+    def test_what_guard_would_print_is_a_string_from_every_harness(self):
+        for h in registry.all():
+            for pattern in PATTERNS:
+                with self.subTest(harness=h.name, pattern=pattern):
+                    self.assertIsInstance(h.rule_text(pattern), str)
+
+    def test_the_base_renders_a_structural_rule_as_nothing_rather_than_a_guess(self):
+        """A harness whose rule is a structure MUST override `rule_text`. The base class
+        does not know how that harness's file writes it down, and both available guesses
+        are the defect again: `str()` is the tuple repr, and a generic join would print a
+        plausible path nothing on disk holds. An empty line is visibly broken, which is
+        the only honest thing a class that does not know can print."""
+
+        class Structural(Harness):
+            name = "structural"
+
+            def ask_rule(self, pattern):
+                return ("some_key", "*")
+
+        self.assertEqual(Structural().rule_text("mcp__x__y"), "")
+
+    def test_a_harness_whose_rule_is_already_a_string_needs_no_override(self):
+        """The default earns its place: Claude Code's rule IS its spelling."""
+        h = registry.get(registry.CLAUDE_CODE)
+        self.assertEqual(h.rule_text("git push *"), h.ask_rule("git push *"))
+        self.assertEqual(h.rule_text("git push *"), "Bash(git push *)")
+
+
+class TestThroughTheCommand(PersonaIso):
+    """End to end, because the operator reads the command's output, not a method.
+
+    **All four sentences, not one.** `guard` prints a rule from four places — `added` and
+    `present`, each for `ask` and for `allow` — and each is its own interpolation of its
+    own method call. A first pass here covered the `allow`/`added` and `ask`/`present`
+    pair, and reverting either of the other two to `ask_rule` put the tuple straight back
+    in front of an operator with the suite still green.
+    """
+
+    #: (command, decision, the word the tick uses, the word the second run uses).
+    VERBS = ((commands.cmd_guard_ask, "ask", "asking for", "already asking for"),
+             (commands.cmd_guard_allow, "allow", "allowing", "already allowing"))
+
+    def invoke(self, fn, **kw) -> tuple[int, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = fn(SimpleNamespace(**kw))
+        return rc, out.getvalue() + err.getvalue()
+
+    def opencode_line(self, out: str, word: str) -> str:
+        """The one line reporting opencode's rule. Not every `opencode:` line — the
+        collision caveat wears the same prefix — and not every line carrying the word,
+        because Claude Code's tick uses the same sentence."""
+        lines = [ln for ln in out.splitlines()
+                 if "opencode:" in ln and f" {word} " in f"{ln} "]
+        self.assertEqual(len(lines), 1, out)
+        return lines[0]
+
+    def clean(self) -> None:
+        """Back to a plane with no rules, so the next case is `added` and not `present`."""
+        for rel in ("opencode.json", ".claude/settings.json"):
+            p = Path(config.ROOT) / rel
+            if p.exists():
+                p.unlink()
+
+    def test_every_sentence_that_reports_a_rule_names_the_key_in_the_file(self):
+        for fn, decision, added, present in self.VERBS:
+            for word, again in ((added, False), (present, True)):
+                with self.subTest(verb=decision, sentence=word):
+                    if not again:
+                        self.clean()
+                    rc, out = self.invoke(fn, pattern="mcp__slack__send", local=False)
+                    self.assertEqual(rc, 0, out)
+                    line = self.opencode_line(out, word)
+                    self.assertIn('permission.slack_send."*"', line)
+                    doc = json.loads((Path(config.ROOT) / "opencode.json").read_text())
+                    self.assertEqual(
+                        _at_the_dotted_path(doc, 'permission.slack_send."*"'), decision,
+                        f"{line} does not lead to the rule in the file")
+
+    def test_no_sentence_shows_the_repr_of_charters_own_data_structure(self):
+        """The defect verbatim. `('slack_send', '*')` even contains the translated name,
+        so a test that only looked for `slack_send` passed straight over it — which is
+        why the assertion is on the repr's own punctuation."""
+        for fn, decision, added, present in self.VERBS:
+            for word, again in ((added, False), (present, True)):
+                with self.subTest(verb=decision, sentence=word):
+                    if not again:
+                        self.clean()
+                    _rc, out = self.invoke(fn, pattern="mcp__slack__send", local=False)
+                    line = self.opencode_line(out, word)
+                    self.assertNotIn("('slack_send', '*')", line)
+                    self.assertNotIn("(", line)
+
+    def test_claude_codes_line_did_not_move_to_fix_opencodes(self):
+        """The half that was already right. Its rule is a string and prints as one."""
+        _rc, out = self.invoke(commands.cmd_guard_ask, pattern="git push *", local=False)
+        line = [ln for ln in out.splitlines() if "claude-code:" in ln][0]
+        self.assertIn("Bash(git push *)", line)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The line that could not be checked

```
$ charter guard allow 'mcp__slack__send'
✓ claude-code: allowing mcp__slack__send → …/.claude/settings.json
✓ opencode: allowing ('slack_send', '*') → …/opencode.json      # before
✓ opencode: allowing permission.slack_send."*" → …/opencode.json  # after
```

`Harness.ask_rule` returns the harness's rule in the harness's own shape — a string for
Claude Code, a `(permission, glob)` pair for opencode — and the four sentences
`cmd_guard_ask`/`cmd_guard_allow` print a rule from interpolated it straight in. So
opencode's operator was shown Python's repr of a 2-tuple, a spelling that appears in no
`opencode.json` there has ever been (`{"permission": {"slack_send": {"*": "allow"}}}`).

Cosmetic until #374, which made that line load-bearing: #374 TRANSLATES an MCP pattern
rather than writing it verbatim, and charter cannot check the operator's own `mcp` block
spells the server the same way. The read-back is now all that stands between a mistyped
server and a rule that is inert for it — and 0.49.0's argument for printing what was
written applies harder to a name the operator did not type than to one they did.

## What changed

**`Harness.rule_text(pattern) -> str`** — the cheap half of the two options #395 names, and
deliberately so: making a rule a string across all three harnesses would trade opencode's
writer out of the shape `_apply_rule` needs to choose the file's form. `ask_rule` stays
structural for the writer; `rule_text` answers a human in the spelling they will go looking
for.

**opencode renders a path into its own file** — `permission.slack_send."*"`,
`permission.bash."git push *"` — and follows the shape that was WRITTEN. A
`FLAT_ONLY_PERMISSIONS` key takes a bare action and holds no glob, so `mcp__doom__loop`
reads back as `permission.doom_loop`; printing `permission.doom_loop."*"` would send the
reader after a key that is not there, over the one rule shape where charter's own writer
already had to know better. The glob is quoted by the same `json.dumps` that wrote the file.

**The base default** covers a harness whose rule already is its spelling — Claude Code's
line does not move. A structural rule renders as `""` rather than a guess: `str()` is the
tuple repr again, and a generic join would print a plausible path nothing on disk holds.

## Tests

`tests/test_guard_rule_read_back.py` is about FINDABILITY, not wording. It writes the rule
for real and then FOLLOWS the printed text into the file it names — a locator per harness
(a substring test would pass over `('slack_send', '*')`, which contains `slack_send`) —
across every registered harness, both verbs, and every translation shape. A rendering that
drifts from `_apply_rule` fails however plausible it reads. A fourth harness fails
`test_every_harness_in_the_registry_has_a_locator` rather than going unchecked.

Suite: `Ran 4055 tests` … `OK`.

**Eleven mutations, each RED then GREEN**, `__pycache__` cleared between runs:

| # | mutation | caught by |
|---|---|---|
| 1–4 | each of the four printed sentences reverted to `ask_rule`/`allow_rule` | `TestThroughTheCommand` (both verbs × added/present — a first pass covered only two of the four and mutations 1 and 3 survived it) |
| 5 | opencode's override removed, base default takes over | 18 failures incl. the pre-existing `test_the_operator_is_shown_the_name_that_was_written` |
| 6 | flat-only branch dropped: always the object form | `test_the_flat_only_shape_is_shown_flat` + the walk |
| 7 | flat form used for every key | `test_the_object_shape_is_shown_with_its_glob` + the walk |
| 8 | glob pasted bare instead of JSON-quoted | the walk over `Read(./secrets/**)` |
| 9 | base renders a structural rule with `str()` again | `test_the_base_renders_a_structural_rule_as_nothing_rather_than_a_guess` |
| 10 | rendering keyed by the operator's pattern, not the written name | the walk, every pattern |
| 11 | the translation's own glob widened `*` → `**` | the literal-shape tests, so the walk cannot be circular |

Closes #395
