### PR TITLE
Refuse a plane-root reset that would delete unpushed commits (#401)

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -402,11 +402,13 @@ def _stranded_push(root) -> tuple[str, str] | None:
     # it deletes this commit without a trace — the specific way #373's memories were lost.
     # A reader told only "it is unpushed" runs exactly that command next.
     #
-    # Describing it is not preventing it. `hooks._plane_root_branch_reason` refuses a branch
-    # move in the root and could refuse this too — its docstring left `reset` out for want of
-    # evidence, and #373 is the evidence. That is #401, kept separate because it is a new
-    # REFUSAL on the Bash path with its own false-positive cost (`git reset HEAD -- <path>`
-    # is an unstage and must stay runnable), not a fix to this row.
+    # Describing it is not preventing it, and since #401 something does prevent it:
+    # `hooks._plane_root_reset_reason` refuses that command in the plane root while the
+    # commits it would delete are on no remote. This row stays exactly as it was. The guard
+    # only fires when someone types the command, and it deliberately measures a narrower
+    # thing than this row reports — `--soft`/`--mixed` and an unstage go through, and so
+    # does everything from a shell charter is not inside. Saying it here is still the only
+    # way the operator hears about a stranded commit BEFORE reaching for the reset.
     return ("a memory commit was committed but never pushed",
             f"Push it with `charter save` before anything runs `git reset --hard "
             f"origin/{branch}` in {root}, which would delete it silently.{where}")

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -728,15 +728,44 @@ def _ssh_prefix_hosts(forges: dict[str, object]) -> dict[str, str]:
     return out
 
 
-#: git subcommands that move HEAD from one branch to another. Deliberately short: `reset`,
-#: `rebase` and `merge` also rewrite the shared tree, but the evidence in #157 is about
-#: SWITCHING, and ADR 0008 asked for the command set to follow evidence rather than
-#: imagination. Widening it later is cheap; a guard that over-blocks gets disabled once and
-#: then protects nothing.
+#: git subcommands that move HEAD from one branch to another. Deliberately short: `rebase`
+#: and `merge` also rewrite the shared tree, but the evidence in #157 is about SWITCHING,
+#: and ADR 0008 asked for the command set to follow evidence rather than imagination.
+#: Widening it later is cheap; a guard that over-blocks gets disabled once and then
+#: protects nothing. `reset` was on that list of maybes until #373 supplied its evidence —
+#: it now has its own guard, with its own subject and its own remedy (see
+#: :func:`_plane_root_reset_reason`), because "HEAD moved between branches" and "commits
+#: were destroyed" are two findings and only one sentence can be the denial.
 _BRANCH_MOVERS = ("checkout", "switch")
 
 #: Flags that make one of the above CREATE a branch rather than move to an existing one.
 _BRANCH_CREATORS = ("-b", "-B", "-c", "-C")
+
+#: `git reset` modes that overwrite the WORKING TREE as they move HEAD. These are the forms
+#: that DESTROY: reset off a commit with one of them and the files that commit introduced
+#: are deleted from disk, leaving the reflog as the only copy of content that was never
+#: pushed.
+#:
+#: `--soft` and `--mixed` (the default) are deliberately absent. They take the branch off
+#: the same commits, but every byte stays in the working tree — so the very next `charter
+#: save` commits and pushes that content again, which is a recovery charter performs by
+#: itself without anyone knowing a commit was ever dropped. Denying them would buy nothing
+#: and would cost `git reset --soft HEAD~1`, the ordinary amend.
+#:
+#: `--merge` and `--keep` are in for the reason `--hard` is: both reset the tree to the
+#: target, so the dropped commits' files leave the disk exactly as `--hard` leaves it.
+#: Listing only `--hard` would leave a five-character bypass on the one refusal that
+#: exists because content was lost.
+_RESET_TREE_MODES = ("--hard", "--merge", "--keep")
+
+#: Global git options that take a SEPARATE value token, so a guard reading "the first
+#: non-flag argument" as the subcommand must step over the value too. Without this,
+#: `git -c commit.gpgsign=false reset --hard origin/main` presents `commit.gpgsign=false`
+#: as its subcommand, every guard below reads an invocation it has never heard of and
+#: stands aside, and a refusal is one flag wide. Not hypothetical: this repo's own commit
+#: convention is `git -c commit.gpgsign=false commit`, so `git -c …` is a form agents type
+#: already.
+_GIT_VALUE_OPTS = ("-c", "--config-env", "--git-dir", "--work-tree", "--namespace")
 
 
 def _git_target(cwd: str, args: list[str]) -> tuple[Path, list[str]]:
@@ -759,6 +788,49 @@ def _git_target(cwd: str, args: list[str]) -> tuple[Path, list[str]]:
         rest.append(args[i])
         i += 1
     return target, rest
+
+
+def _plane_root_git(cmd: str, cwd: str, root: Path):
+    """Yield ``(subcommand, args-after-it)`` for every git invocation in *cmd* that acts on
+    the PLANE ROOT — the walk both plane-root guards share.
+
+    Factored out rather than copied when the reset guard arrived (#401). Everything in here
+    is a trap one of the two guards already fell into once, and a second hand-written copy
+    of it would fall into them again on its own schedule: the `cd` tracking is #183's fix,
+    the `-C` handling is what stops the guard being scoped to the cwd, and `_GIT_VALUE_OPTS`
+    is what stops `git -c x=y <sub>` reading as a subcommand nobody guards. A guard's blind
+    spot is invisible — it looks exactly like the guard being present and never firing — so
+    the two of them share one pair of eyes.
+
+    The subcommand is yielded raw; deciding which ones matter is each guard's own business.
+    """
+    here = cwd
+    for _toks in _segment_argv(cmd):
+        prog, _env, args = _split_env(_toks)
+        base = os.path.basename(prog or "")
+        # A `cd` earlier in the SAME command moves where the later segments run. Without
+        # this the guard refused `cd workspaces/<ws>/<repo> && git checkout -b x` — which is
+        # the workflow its own denial message recommends, so the first time someone obeyed
+        # the message they were told they were doing the forbidden thing (#183).
+        if base == "cd":
+            dest = next((a for a in args[1:] if not a.startswith("-")), None)
+            if dest:
+                here = str(Path(here or ".") / dest) if not os.path.isabs(dest) else dest
+            continue
+        if base != "git":
+            continue
+        target, rest = _git_target(here, args)
+        i = 0
+        while i < len(rest) and rest[i].startswith("-"):
+            i += 2 if rest[i] in _GIT_VALUE_OPTS else 1
+        if i >= len(rest):
+            continue                        # global options only: no subcommand to judge
+        try:
+            if target.resolve() != root:
+                continue
+        except OSError:
+            continue
+        yield rest[i], rest[i + 1:]
 
 
 def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
@@ -789,32 +861,9 @@ def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
     except OSError:
         return None
 
-    here = cwd
-    for _toks in _segment_argv(cmd):
-        prog, _env, args = _split_env(_toks)
-        base = os.path.basename(prog or "")
-        # A `cd` earlier in the SAME command moves where the later segments run. Without
-        # this the guard refused `cd workspaces/<ws>/<repo> && git checkout -b x` — which is
-        # the workflow its own denial message recommends, so the first time someone obeyed
-        # the message they were told they were doing the forbidden thing (#183).
-        if base == "cd":
-            dest = next((a for a in args[1:] if not a.startswith("-")), None)
-            if dest:
-                here = str(Path(here or ".") / dest) if not os.path.isabs(dest) else dest
-            continue
-        if base != "git":
-            continue
-        target, rest = _git_target(here, args)
-        sub = next((a for a in rest if not a.startswith("-")), "")
+    for sub, post in _plane_root_git(cmd, cwd, root):
         if sub not in _BRANCH_MOVERS:
             continue
-        try:
-            if target.resolve() != root:
-                continue
-        except OSError:
-            continue
-
-        post = rest[rest.index(sub) + 1:]
         # `--` separates refs from PATHS, and only what follows it is a path. Treating the
         # token itself as proof of a file restore let two real branch moves through:
         # `git checkout <branch> --` and `git checkout -b <new> --` both switch — verified
@@ -851,6 +900,132 @@ def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
             f"symptom looks like an unrelated bug. Branch work belongs in a workspace "
             f"clone: `charter workspace create <task>`, then `charter clone <repo>`. "
             f"Returning the root to its default branch is always allowed.")
+    return None
+
+
+def _unpushed_at_risk(root: Path, target: str) -> tuple[int, str] | None:
+    """``(commits destroyed, upstream ref)`` if resetting *root* to *target* would take
+    commits off the branch that exist NOWHERE ELSE, else ``None``.
+
+    One question, one git call::
+
+        git rev-list --count HEAD --not <target> @{upstream} --
+
+    which counts commits reachable from HEAD but from neither the reset target nor the
+    tracked upstream — precisely "what this command would delete and no remote has a copy
+    of". Three things fall out of asking it that way rather than asking `doctor`'s
+    ``ahead`` count on its own:
+
+    * **`git reset --hard HEAD` stays allowed.** It destroys uncommitted work, which is a
+      different hazard with a different owner (`doctor` already counts dirty files), and it
+      takes no commit off the branch. The count comes back 0 and the guard says nothing.
+    * **A synced root stays unguarded.** `git reset --hard HEAD~1` over a commit that is on
+      the remote is recoverable in one fetch, so it is ordinary work and not this guard's
+      business.
+    * **A path is not a ref.** `git reset --hard <file>` is a thing people type, reaching for
+      "throw away my edit to this one". Left to itself git will read that operand as a
+      *pathspec* and answer with a count of the commits that touched the file — a denial
+      about a command that does nothing. Two things in the operand list stop it: the
+      trailing ``--`` marks everything before it as revisions, and `@{upstream}` cannot be a
+      path either, so git fails the whole call. The ``--`` is redundant against today's
+      operand list and stays anyway, because whether an unstage keeps working should not
+      depend on which other refs happen to be in it.
+
+    ``None`` on any non-zero exit, which is also the honest answer for a root with no
+    tracking branch: `@{upstream}` does not resolve, charter cannot say what is or is not
+    published, and a guard that fired on a plane `git init`-ed by hand would be refusing
+    on a fact it does not have. That is the same silence `doctor` keeps about drift there.
+
+    Never raises: this is on the ``PreToolUse`` path, where an exception is a broken turn.
+    """
+    from . import util as _util
+    from .doctor import _git_in
+    try:
+        r = _git_in(root, "rev-list", "--count", "HEAD", "--not", target, "@{upstream}", "--")
+        if r.returncode != 0:
+            return None
+        n = int(r.stdout.strip() or 0)
+        if n <= 0:
+            return None
+        up = _git_in(root, "rev-parse", "--abbrev-ref", "@{upstream}")
+        name = up.stdout.strip() if up.returncode == 0 else ""
+    except (_util.ProcTimeout, OSError, ValueError):
+        return None
+    return n, name or "its upstream"
+
+
+def _plane_root_reset_reason(cmd: str, cwd: str) -> str | None:
+    """Deny a `git reset` that would DESTROY unpushed commits in the plane root (#401).
+
+    #157 gave the branch guard its evidence and #373 gives this one its own: eleven memory
+    commits were destroyed in a single session by `git reset --hard origin/main` run in the
+    plane root. That is not an exotic command — it is the standard move on noticing a branch
+    is ahead of its remote for reasons you did not intend, which is exactly the state a
+    protected-branch rejection of the reactive memory push leaves behind. #373 taught
+    `doctor` and the status line to *name* the hazard every turn. Naming is not preventing,
+    and the plane root already had a guard one subcommand away from covering it.
+
+    Three narrowings keep it a guard rather than a cage. The first two are about commands
+    that must keep running; the third is about the denial not being a dead end:
+
+    * **Only the modes that destroy.** See `_RESET_TREE_MODES`: `--soft` and `--mixed` leave
+      the content on disk for the next `charter save` to re-land, so they are allowed.
+    * **Only a reset that actually drops something unpublished.** `_unpushed_at_risk` is the
+      whole condition — no ref (`git reset --hard` discards uncommitted work only), a path
+      (`git reset HEAD -- <file>`, the unstage, the commonest `reset` there is), a target of
+      `HEAD`, or a root already level with its remote — each of those leaves the guard
+      silent. In the ordinary case it never speaks.
+    * **The remedy stays executable, and the guard clears itself.** `charter save` pushes
+      the commits; the moment they land, the count is 0 and the same reset runs. The denial
+      says both that and how to see what would have been lost, because a refusal whose
+      subject you cannot inspect is one you route around.
+
+    Costs at most one `rev-list` per candidate, and a candidate needs a `reset`, a
+    tree-overwriting mode and a ref, all aimed at the plane root — so the Bash path's common
+    case still exits on a string comparison.
+    """
+    # This is the SECOND guard on the plane root, and it runs on every Bash call the first
+    # one let through, so it does not pay for a shell parse it cannot use. Sound rather than
+    # heuristic: the only thing below that can deny is a subcommand token equal to `reset`,
+    # and a token cannot be in the argv without its characters being in the string.
+    if "reset" not in cmd:
+        return None
+    from . import config as _cfg
+    try:
+        root = Path(_cfg.ROOT).resolve()
+    except OSError:
+        return None
+
+    for sub, post in _plane_root_git(cmd, cwd, root):
+        if sub != "reset":
+            continue
+        if not any(a in _RESET_TREE_MODES for a in post):
+            continue
+        # Same reading of `--` the branch guard settled on: what FOLLOWS the separator is
+        # what makes it a path form, not the token's presence. Anything after it and this
+        # is `git reset <ref> -- <paths>`, which rewrites the index for those paths and
+        # never moves HEAD.
+        if "--" in post:
+            cut = post.index("--")
+            if post[cut + 1:]:
+                continue
+            post = post[:cut]
+        target = next((a for a in post if not a.startswith("-")), None)
+        if target is None:
+            continue    # `git reset --hard` with no ref moves HEAD nowhere: no commit dies
+        at_risk = _unpushed_at_risk(root, target)
+        if not at_risk:
+            continue
+        n, upstream = at_risk
+        commits = "commit" if n == 1 else "commits"
+        return (
+            f"would delete {n} {commits} from the PLANE ROOT that {'is' if n == 1 else 'are'} "
+            f"not on {upstream}, and this reset overwrites the working tree — their content "
+            f"leaves the disk with the reflog as the only copy. An unpushed commit here is "
+            f"usually a memory commit whose push a protected branch refused, which is how "
+            f"eleven of them were lost. See exactly what would go: "
+            f"`git -C {root} log --oneline '@{{upstream}}..HEAD'`. Keep it: `charter save` "
+            f"pushes it, and this reset stops being refused the moment it lands.")
     return None
 
 
@@ -1324,6 +1499,15 @@ def pretooluse() -> int:
     if branch:
         _deny("PreToolUse", branch)
         _trace("deny", sid, reason="plane-root-branch", cmd=head)
+        return 0
+    # A3b: and refuse a `git reset` in the root that would destroy commits no remote has
+    # (#401). Same gate, a separate guard: A3's subject is "HEAD moved between branches"
+    # and this one's is "commits were destroyed" — different prose, different remedy, and
+    # this one only speaks when it has measured that something really would be lost.
+    wipe = _plane_root_reset_reason(cmd, cwd) if _cfg.HAS_CONTROL_PLANE else None
+    if wipe:
+        _deny("PreToolUse", wipe)
+        _trace("deny", sid, reason="plane-root-reset", cmd=head)
         return 0
     # A4: an unattended run may not publish (#299). It used to matter that this ran before
     # the clone nudge — that nudge matched `tag`/`push` and stopped releases by accident

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -40,6 +40,12 @@ rule while one who reads a bare refusal files an issue.
   matcher at all.
 - **Plane-root branch move.** The plane is not a work tree (ADR 0008); a branch switch there
   is almost always meant for a clone.
+- **Plane-root history wipe.** A `git reset --hard` (or `--merge`/`--keep`) in the plane root
+  that would take commits off the branch which no remote has a copy of — the command that
+  destroyed eleven memory commits in one session. Only that: the unstage
+  (`git reset HEAD -- <path>`), `--soft`/`--mixed`, a reset with no ref, and any reset over
+  commits that are already pushed all run untouched. It clears itself — `charter save` lands
+  the commits and the same command is allowed.
 - **One credential.** SSH to a forge, `GIT_SSH_COMMAND`, `-S`/`--gpg-sign`, and the
   `core.sshCommand` family that reaches the same transport by another road (`-c`,
   `--config-env`, `GIT_CONFIG_KEY_n`, and a `git config` write of it). This one *is*
@@ -49,7 +55,7 @@ rule while one who reads a bare refusal files an issue.
   push tags, or `gh release create` / `gh pr merge`. `bypassPermissions` means *stop asking
   me*, not *stop knowing things*, and a published version number can never be reused.
 
-A sixth path is not a guard but an allowance: a binary the **active persona** declares in
+A seventh path is not a guard but an allowance: a binary the **active persona** declares in
 `tools:` runs without a prompt while that persona is active, and only then.
 
 ## When a guard is wrong
@@ -73,11 +79,13 @@ the harness's tools — they govern what an agent does with your authority insid
 Your own shell is on the other side of that boundary and always was. Open a terminal and run
 it. Nothing is being worked around: the rule never applied to you.
 
-Two guards name a narrower move first, and it is usually the one you want:
+Three guards name a narrower move first, and it is usually the one you want:
 
 - **Release floor** — re-run the step **attended**. This is a mode, and it is yours to set.
 - **One credential** — `charter git-policy --apply` configures every clone for the token
   transport, which is what most denials of it are actually asking for.
+- **Plane-root history wipe** — `charter save`. The guard is measuring commits that exist
+  nowhere else; push them and it stops firing, on that command and every other one.
 
 **If a guard is wrong about you *every time*, that is not an override problem.** It means
 charter is holding a policy your organisation does not — an org that mandates signed

--- a/docs/news/unreleased-a-reset-that-would-delete-unpushed-commits.md
+++ b/docs/news/unreleased-a-reset-that-would-delete-unpushed-commits.md
@@ -1,0 +1,40 @@
+---
+version: unreleased
+headline: A `git reset --hard` in the plane root that would delete unpushed commits is now refused
+---
+
+0.51.0 taught `charter doctor` and the status line to name the hazard: a memory commit sitting
+on a local `main` that never reached the remote, and *"push it before anything runs `git reset
+--hard origin/main` here, which would delete it silently."* That is a warning. Eleven commits
+were lost to exactly that command, in a session that had the warning in front of it.
+
+Naming a hazard is not preventing it, and the plane root already had a guard one subcommand
+away. `checkout` and `switch` were refused there; `reset` was left out for want of evidence
+about which commands count. The evidence arrived.
+
+**What is refused.** A `git reset --hard` — or `--merge`, or `--keep` — in the plane root,
+when charter can see that it would take commits off the branch that **no remote has a copy
+of**. The denial says how many, points at `git -C <plane> log --oneline '@{upstream}..HEAD'`
+so you can read what would have gone, and names `charter save` as the way to keep them.
+
+**It clears itself.** The condition is measured, not remembered: push the commits and the same
+`git reset --hard origin/main` runs, because there is nothing left to lose.
+
+**Almost every `reset` is untouched**, which is the whole design. `git reset HEAD -- <path>` is
+an unstage and is the most common `reset` an agent types — it moves no commit and is allowed.
+`--soft` and `--mixed` take the branch off the same commits but leave every byte in the working
+tree, so the next `charter save` re-commits and re-pushes that content by itself; they are
+allowed too. `git reset --hard` with no ref throws away uncommitted work and no commits at all
+— a different hazard, one `doctor` already counts — and is allowed. A reset over commits that
+are already on the remote is one fetch from recovery, so it is ordinary work and the guard
+stays quiet through it. On a plane with no tracking branch charter cannot say what is
+published, so it says nothing rather than guessing.
+
+**A hole in the older guard closed on the way past.** Both plane-root guards read "the first
+non-flag argument" as the subcommand, so `git -c commit.gpgsign=false checkout feature` in the
+root presented `commit.gpgsign=false` as its subcommand and walked through. That is the form
+this repo's own commit convention teaches. The two guards now share one walk over the command
+— the `cd` tracking, the `-C` retargeting and the global-option handling in one place, because
+a guard's blind spot looks exactly like a guard that is present and never fires.
+
+Nothing to adopt: upgrading is the whole of it.

--- a/tests/test_a_denial_names_its_override.py
+++ b/tests/test_a_denial_names_its_override.py
@@ -23,8 +23,8 @@ the agent — and there is deliberately no switch charter can read. That is not 
 * A `PreToolUse` hook governs the harness's tools. The operator's own shell was never on
   that side of the line, so running it there works around nothing.
 
-**Appended in `_deny`, not at the five call sites**, which is the assertion with the most
-value here: a sixth guard added tomorrow carries the override without anyone remembering to,
+**Appended in `_deny`, not at the six call sites**, which is the assertion with the most
+value here: a seventh guard added tomorrow carries the override without anyone remembering to,
 and the trace tally keys — computed from the reason BEFORE it reaches `_deny` — cannot drift.
 """
 
@@ -32,12 +32,13 @@ from __future__ import annotations
 
 import ast
 import re
+import subprocess
 import unittest
 from pathlib import Path
 
 from tests._isolation import PersonaIso, run_hook
 from tests.test_hooks import InAControlPlane
-from charter import hooks, trace
+from charter import config, hooks, trace
 
 DOC = Path(__file__).resolve().parents[1] / "docs" / "hooks.md"
 SECTION = "## When a guard is wrong"
@@ -52,15 +53,56 @@ DENIALS = {
                           {"tool_input": {"command": "git clone git@github.com:a/b.git"}}),
     "plane-root-branch": (hooks.pretooluse,
                           {"tool_input": {"command": "git checkout -b feature"}}),
+    "plane-root-reset": (hooks.pretooluse,
+                         {"tool_input": {"command": "git reset --hard origin/main"}}),
     "release-floor": (hooks.pretooluse,
                       {"tool_input": {"command": "gh release create v9.9.9"},
                        "permission_mode": "bypassPermissions"}),
 }
 
 
+def _root_ahead_of_its_upstream(case) -> None:
+    """Give the tmp plane a real upstream and one commit that never reached it.
+
+    The only denial here whose condition is a fact about the WORLD rather than about the
+    command: the reset guard measures whether commits would actually be destroyed, and
+    stands aside when they would not. A bare tmp plane is that "would not", so without this
+    the fixture would land in the `assertIsNotNone` above as "never reached the guard" —
+    which is exactly the failure the precondition assertion exists to name.
+    """
+    root = Path(config.ROOT)
+    if (root / ".git").exists():
+        return
+    remote = root / "origin.git"
+
+    def git(*args, cwd=root):
+        subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True)
+
+    subprocess.run(["git", "init", "-q", "--bare", "-b", "main", str(remote)],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "init", "-q", "-b", "main", str(root)],
+                   check=True, capture_output=True)
+    for k, v in (("commit.gpgsign", "false"), ("user.email", "t@e"), ("user.name", "t")):
+        git("config", k, v)
+    git("remote", "add", "origin", str(remote))
+    (root / "README").write_text("plane\n")
+    git("add", "-A")
+    git("commit", "-qm", "init")
+    git("push", "-q", "-u", "origin", "main")
+    (root / "memory.md").write_text("learned\n")
+    git("add", "-A")
+    git("commit", "-qm", "memory: one")
+
+
+#: Fixture work a denial needs before its command is refusable. Keyed rather than folded
+#: into `setUp` so each guard's precondition stays visible next to the guard.
+SETUP = {"plane-root-reset": _root_ahead_of_its_upstream}
+
+
 class DenialCase(InAControlPlane):
     def reason(self, name: str, sid: str = "s") -> str:
         handler, payload = DENIALS[name]
+        SETUP.get(name, lambda _case: None)(self)
         r = run_hook(handler, {"cwd": str(self.tmp), "session_id": sid, **payload})
         self.assertIsNotNone(r, f"{name}: fixture never reached the guard")
         out = r["hookSpecificOutput"]
@@ -70,9 +112,9 @@ class DenialCase(InAControlPlane):
 
 
 class TestEveryDenialNamesTheOverride(DenialCase):
-    def test_all_five_of_them(self):
-        """The precondition is the count: five guards deny, and all five must say it."""
-        self.assertEqual(5, len(DENIALS))
+    def test_all_six_of_them(self):
+        """The precondition is the count: six guards deny, and all six must say it."""
+        self.assertEqual(6, len(DENIALS))
         for name in DENIALS:
             with self.subTest(guard=name):
                 self.assertIn(hooks._OVERRIDE_NOTE, self.reason(name))
@@ -117,6 +159,7 @@ class TestTheTallyKeysAreUnchanged(DenialCase):
             "vault-read": "reads a vault/secret file directly (would print plaintext)",
             "single-credential": "single-credential",
             "plane-root-branch": "plane-root-branch",
+            "plane-root-reset": "plane-root-reset",
             "release-floor": "release-floor"}
 
     def test_each_guard_still_traces_the_key_it_always_did(self):
@@ -174,7 +217,7 @@ class TestANewGuardCannotForgetIt(PersonaIso):
     def test_every_deny_call_passes_prose_and_not_a_prebuilt_message(self):
         """Precondition for the test above: the call sites really do exist and route here."""
         calls = re.findall(r"_deny\(\s*\"PreToolUse\"", self._source())
-        self.assertGreaterEqual(len(calls), 5, "precondition: the guards were not found")
+        self.assertGreaterEqual(len(calls), 6, "precondition: the guards were not found")
 
 
 class TestTheDocumentationExists(unittest.TestCase):

--- a/tests/test_plane_root_branch_guard.py
+++ b/tests/test_plane_root_branch_guard.py
@@ -93,6 +93,17 @@ class TestSwitchingBranchesInTheRootIsRefused(PlaneRootCase):
         self.assertEqual(_decision(self.run_cmd(f"git -C {self.root} checkout feature",
                                                 cwd=self.clone)), "deny")
 
+    def test_a_global_config_flag_does_not_walk_past_it(self):
+        """`git -c <key>=<value> <sub>` puts a non-flag token where the subcommand is
+        expected, and the guard read the FIRST non-flag argument as the subcommand — so it
+        saw `advice.detachedHead=false`, recognised nothing, and stood aside. A one-flag
+        bypass, in the form this repo's own commit convention teaches
+        (`git -c commit.gpgsign=false commit`). Found while giving `reset` a guard of its
+        own (#401), which would have inherited the same blind spot."""
+        self.assertEqual(
+            _decision(self.run_cmd("git -c advice.detachedHead=false checkout feature")),
+            "deny")
+
     def test_the_denial_names_the_alternative(self):
         """A refusal that only says no gets worked around. The remedy is the same one
         `doctor` prints: the work belongs in a workspace clone."""

--- a/tests/test_plane_root_reset_guard.py
+++ b/tests/test_plane_root_reset_guard.py
@@ -1,0 +1,263 @@
+"""A `git reset` that would destroy unpushed commits in the plane root is REFUSED (#401).
+
+#373 lost eleven memory commits to one `git reset --hard origin/main` typed in the plane
+root. Nothing about that command is exotic: it is the standard move on noticing a branch is
+ahead of its remote for reasons you did not intend, and that is precisely the state a
+protected-branch rejection of charter's reactive memory push leaves behind. #373 closed the
+half that *describes* the hazard — `doctor` and the status line both name it now, the status
+line every turn. Describing is not preventing, and the plane-root guard that could prevent it
+matched on `checkout`/`switch` alone.
+
+The whole design risk here is the other direction, so most of this file is about what stays
+allowed. `reset` is not a rare command and it is not usually destructive: the unstage
+(`git reset HEAD -- <path>`) is the single most common one an agent types, `--soft HEAD~1` is
+an amend, and `--hard` with no ref throws away uncommitted work and no commits at all. A
+guard that refused those would be worked around within a day and would then protect nothing.
+
+So the condition is measured, not assumed: **this reset, in the plane root, would take
+commits off the branch that no remote has a copy of.** Every test below is either that fact
+being true and the command refused, or that fact being false and the same command allowed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+from charter import config, hooks
+from tests._isolation import PersonaIso, run_hook
+
+
+def _decision(r) -> str | None:
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+
+
+def _reason(r) -> str:
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
+
+
+class PlaneRootAheadCase(PersonaIso):
+    """A plane root that tracks a real upstream and is two commits ahead of it.
+
+    A bare repo stands in for the forge because the fact under test — "no remote has a copy
+    of this commit" — is not expressible in a repo with no remote at all. `origin/main` here
+    is a genuine already-fetched ref, which is the only thing the guard ever reads: it must
+    never reach the network, and a test whose fixture faked the ref would not prove that.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.HAS_CONTROL_PLANE = True
+        self.root = Path(config.ROOT)
+        self.remote = self.tmp / "origin.git"
+        self._git("init", "-q", "--bare", "-b", "main", str(self.remote))
+        self._git("init", "-q", "-b", "main", str(self.root))
+        self._in(self.root, "config", "commit.gpgsign", "false")
+        self._in(self.root, "config", "user.email", "t@e")
+        self._in(self.root, "config", "user.name", "t")
+        self._in(self.root, "remote", "add", "origin", str(self.remote))
+        self.commit("README", "plane\n", "init")
+        self._in(self.root, "push", "-q", "-u", "origin", "main")
+        # The two that only exist here — memory commits, in the shape #373 lost them.
+        self.commit("personas/p/memory/one.md", "learned one\n", "memory: one")
+        self.commit("personas/p/memory/two.md", "learned two\n", "memory: two")
+        self.clone = config.WORKSPACES_DIR / "ws" / "svc"
+        self.clone.mkdir(parents=True, exist_ok=True)
+        self._git("init", "-q", "-b", "main", str(self.clone))
+
+    def commit(self, rel: str, body: str, msg: str) -> None:
+        p = self.root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+        self._in(self.root, "add", "-A")
+        self._in(self.root, "commit", "-qm", msg)
+
+    def land(self) -> None:
+        """Push what is here, which is the remedy the denial names."""
+        self._in(self.root, "push", "-q", "origin", "main")
+
+    @staticmethod
+    def _git(*args):
+        return subprocess.run(["git", *args], check=True, capture_output=True, text=True)
+
+    @staticmethod
+    def _in(where, *args):
+        return subprocess.run(["git", "-C", str(where), *args], check=True,
+                              capture_output=True, text=True)
+
+    def run_cmd(self, cmd: str, cwd: Path | None = None):
+        return run_hook(hooks.pretooluse, {
+            "tool_input": {"command": cmd},
+            "cwd": str(cwd if cwd is not None else self.root),
+            "session_id": "s"})
+
+
+class TestThePreconditionHolds(PlaneRootAheadCase):
+    """A fixture that stopped being two commits ahead would make every denial below
+    unfailable while still passing. Asserted rather than assumed."""
+
+    def test_the_root_is_two_commits_ahead_of_its_upstream(self):
+        r = subprocess.run(["git", "-C", str(self.root), "rev-list", "--count",
+                            "@{upstream}..HEAD"], capture_output=True, text=True)
+        self.assertEqual("2", r.stdout.strip())
+
+
+class TestDestroyingUnpushedCommitsIsRefused(PlaneRootAheadCase):
+    def test_reset_hard_to_the_upstream_is_denied(self):
+        """The exact command from #373."""
+        self.assertEqual(_decision(self.run_cmd("git reset --hard origin/main")), "deny")
+
+    def test_reset_hard_backwards_is_denied(self):
+        self.assertEqual(_decision(self.run_cmd("git reset --hard HEAD~2")), "deny")
+
+    def test_dropping_only_one_of_them_is_denied(self):
+        """One unpublished commit is enough; the guard is not counting to a threshold."""
+        self.assertEqual(_decision(self.run_cmd("git reset --hard HEAD~1")), "deny")
+
+    def test_the_other_tree_overwriting_modes_are_denied_too(self):
+        """`--keep` and `--merge` reset the tree to the target exactly as `--hard` does, so
+        the dropped commits' files leave the disk the same way. Listing only `--hard` would
+        leave a five-character bypass on the one refusal that exists because content was
+        lost."""
+        for mode in ("--keep", "--merge"):
+            self.assertEqual(_decision(self.run_cmd(f"git reset {mode} origin/main")),
+                             "deny", mode)
+
+    def test_it_fires_from_a_workspace_clone_via_dash_c(self):
+        """`git -C <plane> reset --hard origin/main` is how a session standing somewhere
+        else reaches the shared tree."""
+        self.assertEqual(_decision(self.run_cmd(f"git -C {self.root} reset --hard origin/main",
+                                                cwd=self.clone)), "deny")
+
+    def test_a_global_config_flag_does_not_walk_past_the_guard(self):
+        """`git -c <k>=<v> <sub>` is a form agents type already — it is this repo's own
+        commit convention. A guard that read `commit.gpgsign=false` as the subcommand would
+        be one flag wide."""
+        self.assertEqual(
+            _decision(self.run_cmd("git -c advice.detachedHead=false reset --hard origin/main")),
+            "deny")
+
+    def test_a_flag_after_the_ref_is_still_the_same_command(self):
+        """git's own parser accepts options after operands, and does the same thing."""
+        self.assertEqual(_decision(self.run_cmd("git reset origin/main --hard")), "deny")
+
+
+class TestTheDenialCanBeActedOn(PlaneRootAheadCase):
+    def test_it_says_how_many_commits_and_that_they_are_unpublished(self):
+        reason = _reason(self.run_cmd("git reset --hard origin/main"))
+        self.assertIn("2 commits", reason)
+        self.assertIn("origin/main", reason)
+
+    def test_it_names_the_command_that_shows_what_would_be_lost(self):
+        """A refusal whose subject you cannot inspect is one you route around."""
+        reason = _reason(self.run_cmd("git reset --hard origin/main"))
+        self.assertIn("@{upstream}..HEAD", reason)
+        self.assertIn(str(self.root), reason)
+
+    def test_it_names_charter_save_as_the_way_to_keep_them(self):
+        self.assertIn("charter save", _reason(self.run_cmd("git reset --hard origin/main")))
+
+    def test_the_guard_clears_itself_once_the_commits_land(self):
+        """The remedy has to actually end the refusal, or the denial is a dead end. Pushing
+        is what the denial tells you to do, and after it the same command runs."""
+        self.assertEqual(_decision(self.run_cmd("git reset --hard origin/main")), "deny")
+        self.land()
+        self.assertIsNone(_decision(self.run_cmd("git reset --hard origin/main")))
+
+
+class TestItDoesNotOverreach(PlaneRootAheadCase):
+    def test_unstaging_a_path_is_allowed(self):
+        """The single most common `reset` an agent types. It rewrites the index for one
+        path and moves no commit anywhere."""
+        (self.root / "scratch").write_text("x\n")
+        self._in(self.root, "add", "scratch")
+        self.assertIsNone(_decision(self.run_cmd("git reset HEAD -- scratch")))
+
+    def test_unstaging_a_bare_path_is_allowed(self):
+        """Without the trailing `--` in the guard's own rev-list, git reads this operand as
+        a pathspec and answers with a count — and the unstage gets denied."""
+        (self.root / "README").write_text("changed\n")
+        self._in(self.root, "add", "README")
+        self.assertIsNone(_decision(self.run_cmd("git reset README")))
+
+    def test_a_hard_reset_of_a_path_is_not_read_as_a_ref(self):
+        """The operand is a FILE — someone reaching for "throw away my edit to this one".
+        git refuses `--hard` with paths outright, so nothing happens either way, and a
+        charter denial claiming commits were about to die would be about nothing. Left to
+        itself git reads such an operand as a *pathspec* and answers with a count, so the
+        path here is deliberately one an unpushed commit introduced: the case where a
+        pathspec reading comes back non-zero. What is pinned is the outcome, not which of
+        the guard's two defences produced it."""
+        (self.root / "personas/p/memory/two.md").write_text("edited\n")
+        self.assertIsNone(_decision(
+            self.run_cmd("git reset --hard personas/p/memory/two.md")))
+
+    def test_a_separator_with_paths_after_it_is_not_a_ref_move(self):
+        """`--` means what follows is a path, and the operands before it stop being the
+        subject. Same reading the branch guard settled on."""
+        self.assertIsNone(_decision(self.run_cmd("git reset --hard origin/main -- README")))
+
+    def test_reset_hard_with_no_ref_is_allowed(self):
+        """It discards uncommitted work — a different hazard, with an owner already
+        (`doctor` counts dirty files) — and takes no commit off the branch."""
+        self.assertIsNone(_decision(self.run_cmd("git reset --hard")))
+
+    def test_reset_hard_to_head_is_allowed(self):
+        """Same command spelled out. No commit leaves the branch."""
+        self.assertIsNone(_decision(self.run_cmd("git reset --hard HEAD")))
+
+    def test_soft_and_mixed_resets_are_allowed(self):
+        """They take the branch off the same commits but leave every byte in the working
+        tree, so the next `charter save` commits and pushes that content again. Denying
+        them would buy nothing and would cost the ordinary amend."""
+        for cmd in ("git reset --soft HEAD~1", "git reset --mixed HEAD~1",
+                    "git reset HEAD~1", "git reset origin/main"):
+            self.assertIsNone(_decision(self.run_cmd(cmd)), cmd)
+
+    def test_resetting_a_published_commit_away_is_allowed(self):
+        """Once everything is on the remote, `git reset --hard HEAD~1` is recoverable in one
+        fetch. That is ordinary work, and the guard must be silent through it."""
+        self.land()
+        self.assertIsNone(_decision(self.run_cmd("git reset --hard HEAD~1")))
+        self.assertIsNone(_decision(self.run_cmd("git reset --hard origin/main")))
+
+    def test_resetting_inside_a_workspace_clone_is_allowed(self):
+        """A clone is where destructive git belongs; nothing here is shared."""
+        self.assertIsNone(_decision(self.run_cmd("git reset --hard HEAD~1", cwd=self.clone)))
+
+    def test_a_root_with_no_upstream_is_not_guessed_about(self):
+        """`@{upstream}` does not resolve, so charter cannot say what is published and does
+        not pretend to — the same silence `doctor` keeps about drift on a plane that was
+        `git init`-ed by hand."""
+        self._in(self.root, "branch", "--unset-upstream")
+        self.assertIsNone(_decision(self.run_cmd("git reset --hard HEAD~1")))
+
+    def test_committing_and_reading_in_the_root_stay_allowed(self):
+        for cmd in ("git commit -m x", "git status", "git log --oneline"):
+            self.assertIsNone(_decision(self.run_cmd(cmd)), cmd)
+
+    def test_a_commit_message_mentioning_the_command_is_not_the_command(self):
+        """The prose trap every guard in this module has had to survive."""
+        self.assertIsNone(_decision(
+            self.run_cmd('git commit -m "docs: never run git reset --hard origin/main"')))
+
+    def test_a_cd_into_a_clone_first_moves_where_the_reset_lands(self):
+        """#183's fix, which the shared walk carries for both plane-root guards: a `cd` in
+        the same command moves where the later segments run."""
+        self.assertIsNone(_decision(
+            self.run_cmd(f"cd {self.clone} && git reset --hard HEAD~1")))
+
+
+class TestItIsScopedToAPlane(PlaneRootAheadCase):
+    def test_no_control_plane_means_no_opinion(self):
+        """The plugin installs per user and this handler runs everywhere. Outside a plane
+        there is no plane root, and denying there explains a control plane that does not
+        exist on that machine."""
+        config.HAS_CONTROL_PLANE = False
+        self.assertIsNone(_decision(self.run_cmd("git reset --hard origin/main")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The plane-root guard denied `checkout` and `switch` and left `reset` out — its own
docstring said why: *"ADR 0008 asked for the command set to follow evidence rather than
imagination."* #373 is the evidence. Eleven memory commits destroyed in one session by
`git reset --hard origin/main` in the plane root, which is the standard move on finding a
branch ahead of its remote for reasons you did not intend — exactly the state a
protected-branch rejection of the reactive memory push leaves behind. #373 closed the half
that *describes* the hazard. This is the half that prevents it.

## The three decisions the issue asked for

**Which forms.** `--hard`, `--merge` and `--keep` — the modes that overwrite the working
tree, so the dropped commits' files leave the disk with the reflog as the only copy.
`--soft` and `--mixed` are deliberately out: they take the branch off the same commits but
leave every byte in the tree, so the next `charter save` commits and pushes that content
again. That is a recovery charter performs by itself, and denying them would cost the
ordinary `git reset --soft HEAD~1` amend for nothing. `--merge`/`--keep` are in for the
reason `--hard` is — listing only `--hard` leaves a five-character bypass on the one
refusal that exists because content was lost.

**Conditional or unconditional.** Conditional, and measured precisely rather than by proxy:

```
git rev-list --count HEAD --not <target> @{upstream} --
```

Commits reachable from HEAD but from neither the reset target nor the tracked upstream —
"what this command would delete and no remote has a copy of". One call, only once a reset
with a tree mode and a ref is aimed at the plane root. It reads `@{upstream}` from an
already-fetched ref and never touches the network, the same fact `doctor.check_plane_root`
reads for `ahead_n`. Asking it this way rather than `ahead > 0` is what keeps
`git reset --hard HEAD` (throw away uncommitted work) and `git reset --hard HEAD~1` on a
synced root allowed, and what makes the count in the denial the number that would actually
be lost.

**The remedy stays executable.** The denial names the count, `git -C <plane> log --oneline
'@{upstream}..HEAD'` to read what would go, and `charter save` to keep it. And the guard
**clears itself**: once the commits land the count is 0 and the same reset runs.

## What stays allowed — the whole design risk

`git reset HEAD -- <path>` and `git reset <path>` (the unstage, the commonest reset an
agent types); `--soft`/`--mixed`; `git reset --hard` with no ref (uncommitted work only, a
different hazard `doctor` already counts); `git reset --hard <file>`, which git rejects
anyway and about which charter now says nothing rather than claiming commits were about to
die; any reset over commits already on the remote; anything in a workspace clone; and
everything on a root with no tracking branch, where charter cannot say what is published so
it does not guess. `TestItDoesNotOverreach` is the largest class in the new file for that
reason.

## Kept separate from the branch guard, but not duplicated

Separate function, separate prose, separate remedy, separate trace key
(`plane-root-reset`) — the issue's reasoning, unchanged. What is shared is the *walk* over
the command: `_plane_root_git` now yields `(subcommand, args-after-it)` for every git
invocation aimed at the root, carrying the `cd` tracking (#183's fix) and the `-C`
retargeting for both guards. A hand-written second copy would have re-acquired those blind
spots on its own schedule, and a guard's blind spot looks exactly like a guard that is
present and never fires.

**A hole in the older guard closed on the way past.** Both guards read "the first non-flag
argument" as the subcommand, so `git -c commit.gpgsign=false checkout feature` in the root
presented `commit.gpgsign=false` as its subcommand and walked straight through — the form
this repo's own commit convention teaches. `_GIT_VALUE_OPTS` steps over the value.
`test_a_global_config_flag_does_not_walk_past_it` pins it on the branch guard;
`..._the_guard` pins it on the reset guard.

## Verification

Full suite: `Ran 4066 tests ... OK` (stdlib `unittest`, no pytest).

Ten mutations applied to `charter/hooks.py`, each RED, each restored to GREEN, with
`__pycache__` cleared between runs:

| mutation | caught by |
| --- | --- |
| guard unwired from `pretooluse` | 11 reset-guard tests + all three override-note tests |
| `_RESET_TREE_MODES` → `("--hard",)` | `test_the_other_tree_overwriting_modes_are_denied_too` |
| `--soft` added to `_RESET_TREE_MODES` | `test_soft_and_mixed_resets_are_allowed` |
| `rev-list` stops excluding `@{upstream}` | `test_resetting_a_published_commit_away_is_allowed`, `test_a_root_with_no_upstream_is_not_guessed_about` |
| `if n <= 0` → `if n < 0` (a zero count denies) | `test_reset_hard_to_head_is_allowed`, `test_the_guard_clears_itself_once_the_commits_land` |
| `_GIT_VALUE_OPTS` → `()` | the `-c` test on **both** guards |
| a missing ref defaults to `@{upstream}` | `test_reset_hard_with_no_ref_is_allowed` |
| the `--` path-form skip removed | `test_a_separator_with_paths_after_it_is_not_a_ref_move` |
| the plane-root check dropped | `test_resetting_inside_a_workspace_clone_is_allowed`, `test_a_cd_into_a_clone_first_moves_where_the_reset_lands`, and the branch guard's clone test |
| the `"reset" not in cmd` fast path inverted | 11 reset-guard tests |

One mutation did **not** go red and is written down rather than papered over: dropping the
trailing `--` from the `rev-list` operand list. It is redundant against today's list —
`@{upstream}` cannot be read as a path either, so git already fails the whole call on a
path operand. The token stays, and its docstring now says it is belt-and-braces, because
whether an unstage keeps working should not depend on which other refs happen to be in the
operand list. `test_a_hard_reset_of_a_path_is_not_read_as_a_ref` pins the outcome either
way.

Also updated: `docs/hooks.md` (the guard list, the count, and the narrower-move-first
section), the `#401` forward reference in `doctor._stranded_push`, and
`tests/test_a_denial_names_its_override.py`, which counts the denials and now finds six.

Closes #401
