### PR TITLE
tests: refuse any write into the developer's real .charter/ (#402)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,12 @@ command.
 
 - **Tests first, and they must fail first.** Every behavioural change lands with a test
   that fails without the fix. The suite is plain `unittest` — no fixtures framework, no
-  network, no writing outside a tempdir.
+  network, no writing outside a tempdir. That last one is enforced rather than asked for:
+  a checkout inside a control plane resolves to *that* plane, so `tests/_planeguard.py`
+  refuses any write into the real `.charter/` and fails the test that tried. Derive from
+  `tests._isolation.PersonaIso` and it never comes up; a test that spawns a subprocess has
+  to hand it the throwaway plane as `$CHARTER_ROOT`, which no guard in this process can do
+  for you.
 - **Comments explain *why*.** The codebase leans hard on this: a comment that restates the
   code earns nothing, one that records the failure a line prevents is worth several
   paragraphs of docs. Read a few modules before writing your first one.

--- a/docs/news/unreleased-the-suite-cannot-write-into-your-plane.md
+++ b/docs/news/unreleased-the-suite-cannot-write-into-your-plane.md
@@ -1,0 +1,52 @@
+---
+version: unreleased
+headline: charter's own test suite can no longer write into your `.charter/` — a test that tries fails by name
+---
+
+A charter checkout resolves its control plane the way every command does, so running the suite
+from a checkout that lives inside your plane points `config.STATE_DIR` at *your* `.charter/`.
+Any test that reaches a real handler without redirecting it writes there — into live vaults,
+session pointers, and the frame state of running sessions.
+
+That has now happened three separate times, each found by hand, months apart, by someone who
+happened to look. A fixture wrote into the real `vaults.json` and orphaned every vault
+registered on that machine. Three plain `unittest.TestCase` classes in the frame launcher ran
+`state.reap` — an `rmtree` of every frame directory the tmux server does not report live, and
+their faked server reported none — against whatever frames the developer had open, including
+the unread `exit` file 0.51.0 added a rule to protect. Each was fixed where it was found.
+
+**The fix this time is a tripwire rather than a fourth patch.** At import of the `tests`
+package — before any test module is collected, so nothing can opt out by forgetting a base
+class — every call that could create, delete or replace something under the real state
+directory is wrapped. A test that reaches it now fails, by name, on the line that reached it,
+having changed nothing: the refusal happens *before* the call is delegated, so a live frame's
+`exit` file is still there afterwards.
+
+Three details are the whole of whether it works.
+
+- **`shutil.rmtree` is refused at its own front door**, not left to the primitives underneath
+  it. Its recursion deletes with `os.unlink(name, dir_fd=fd)` — a bare filename against an
+  open directory, which no path-based check can resolve. `reap` deletes exactly that way, so a
+  guard watching only the primitives would have watched the one call it exists to catch go
+  straight past.
+- **The refusal is not an `Exception`.** charter's write paths are wrapped in `except OSError`
+  fallbacks so a degraded environment cannot break a command — `record_push` ends in one, and
+  `reap` calls `rmtree(..., ignore_errors=True)`. A tripwire those can catch reports nothing
+  and the test goes green over a deleted plane.
+- **Reads are untouched.** Some tests exercise the real plane on purpose — that `render()`
+  survives a real environment, say — and that is legitimate; writing is the part no test has
+  any business doing.
+
+Turning it on found a fourth instance immediately, in a file nobody had suspected: a case
+asserting the argv of a plane push had every git call faked but `commit_push` itself real, and
+its last act deletes `.charter/plane-push.json` — your own record of a plane commit that never
+reached the forge, the one `doctor` reads to tell you about it. The suite erased it on every
+run, and `record_push`'s `except OSError: pass` guaranteed you would never hear about it.
+
+One half of this the guard cannot see, and says so where a reader will find it: a subprocess
+resolves its own plane from its own environment, so a `tmux run-shell` hook or a spawned
+`charter` is unaffected by isolating the parent. Those still have to be handed the throwaway
+plane as `$CHARTER_ROOT`, the way the frame integration tests already do.
+
+This only ever reached you if you run charter's suite from a checkout inside your plane —
+which is to say, if you work on charter. Nothing to adopt: upgrading is the whole of it.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -29,3 +29,11 @@ os.environ["XDG_CONFIG_HOME"] = os.path.join(_SANDBOX, "xdg")
 os.environ["CODEX_HOME"] = os.path.join(_SANDBOX, "codex")
 os.makedirs(os.environ["XDG_CONFIG_HOME"], exist_ok=True)
 os.makedirs(os.environ["CODEX_HOME"], exist_ok=True)
+
+# The same move for the one directory that CANNOT be redirected away from every test —
+# some tests read the real plane on purpose — but that none of them may write to. See
+# `tests/_planeguard.py`: after this line, a write into the developer's own `.charter/`
+# fails the test that made it instead of quietly deleting a running frame's state (#402).
+from . import _planeguard      # noqa: E402  (env above must be set before charter loads)
+
+_planeguard.install()

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -1,0 +1,190 @@
+"""Suite-wide tripwire: no test may WRITE into the developer's real ``.charter/``.
+
+`PersonaIso` isolates a test that remembers to derive from it. Nothing made the
+*forgetting* visible, so the same defect kept arriving in a new file: the suite wrote
+fixture data into a contributor's real ``.charter/vaults.json`` and orphaned every vault
+on that machine (#recorded in `_isolation.py`), and later three plain `unittest.TestCase`
+classes ran the real `cmd_launch` — `state.reap`'s ``rmtree`` of every frame directory the
+tmux server does not report live — against whatever frames the developer had open (#402).
+Both were found by hand, months apart, by someone who happened to look.
+
+This makes the class of mistake self-reporting instead. Every call that could CREATE,
+DELETE or REPLACE something under the real state directory is wrapped once, at import of
+the `tests` package — before any test module is collected, so no test can opt out by
+forgetting a base class. A test that reaches the real plane now fails, by name, on the
+line that reached it, having changed nothing.
+
+**Only writes.** Reads are untouched: a test may legitimately look at the real plane (that
+`render()` survives a real environment, say), and `_isolation.isolate_state_dir` exists for
+exactly that shape. Writing is the part no test in this suite has any business doing.
+
+**Only the state directory.** ``.charter/`` is per-developer, gitignored, and holds live
+session state — frame directories, the vault registry, session pointers. The rest of the
+plane (``personas/``, ``docs/``, ``workspaces/``) is committed content some tests do
+legitimately generate into a tmp root, and guarding the real copies of those would trade
+this defect for a stream of false alarms.
+
+**Raised as a `BaseException`, deliberately.** charter is full of `except Exception`
+fallbacks that turn an unreachable path into a degraded one — `config.derive` catches
+everything so a malformed `charter.toml` cannot break import, `root.find_root` swallows
+`OSError`. A tripwire those can catch is a tripwire that reports "no vault configured"
+instead of failing. `unittest` still records a `BaseException` against the test that raised
+it, so the failure keeps its name.
+
+**What this cannot see: a subprocess.** A `tmux run-shell` hook, or any spawned `charter`,
+resolves its own plane from its own environment, so isolating this process does nothing for
+it — the parent must hand the throwaway plane across the boundary with ``$CHARTER_ROOT`` on
+the child's (or the tmux server's) environment, the way `PanelIntegration` and
+`MenuIntegration` in `test_frame_tmux_integration.py` do. This guard is silent about that
+half by construction, and saying so here is the point: it is not a licence to skip the env.
+"""
+
+from __future__ import annotations
+
+import builtins
+import io
+import os
+import shutil
+
+#: The state directory of the plane this test PROCESS resolved at import — before any
+#: `setUp` could repoint `charter.config`, so unavoidably the developer's real one.
+#:
+#: A TUPLE, because one directory has two spellings a caller may use: the path as written
+#: and the path with every symlink resolved. A checkout under a symlinked home (or under
+#: macOS's ``/tmp`` → ``/private/tmp``) makes those differ, and a guard that knew only the
+#: resolved one would wave through every write spelled the other way — silence that reads
+#: exactly like safety. Computed once, at install; the per-call check is a string compare.
+_REAL: tuple[str, ...] = ()
+
+
+class RealPlaneWrite(BaseException):
+    """A test tried to write into the developer's own control-plane state directory."""
+
+
+def _explain(op: str, path) -> str:
+    return (
+        f"REFUSED: {op} {path}\n"
+        f"This test is writing into the developer's REAL control-plane state directory "
+        f"({_REAL[0]}) — live vaults, session pointers, and the frame state of running "
+        f"sessions. Derive the test case from `tests._isolation.PersonaIso`, or, if it "
+        f"deliberately exercises the real plane, call "
+        f"`tests._isolation.isolate_state_dir(self)` to redirect just this directory. "
+        f"A subprocess needs the throwaway plane passed to it as $CHARTER_ROOT.")
+
+
+def _hits(path, dir_fd=None) -> bool:
+    """Does *path* land inside the real state directory?
+
+    ``dir_fd`` is answered ``False``: the path is then relative to an open directory this
+    cannot resolve, and guessing against the cwd would refuse the wrong calls. The one
+    caller that uses it is `shutil.rmtree`'s fd-based recursion, which is refused whole at
+    its own front door below — so nothing is lost by declining to guess here.
+
+    On the hot path: this runs on every `open` in the suite, so an already-absolute,
+    already-normal path is answered by string compares alone. `os.path.abspath` — a
+    `getcwd` syscall per call — is reached only by a relative path or one containing
+    ``..``, which is where it is actually needed.
+    """
+    if not _REAL or dir_fd is not None:
+        return False
+    try:
+        p = os.fspath(path)
+    except TypeError:
+        return False                      # an int fd, or something not a path at all
+    if isinstance(p, bytes):
+        p = os.fsdecode(p)
+    for real in _REAL:
+        if p == real or p.startswith(real + os.sep):
+            return True
+    if p.startswith(os.sep) and os.pardir not in p:
+        return False
+    p = os.path.abspath(p)
+    return any(p == real or p.startswith(real + os.sep) for real in _REAL)
+
+
+def _guard_os(name: str, *, arg: int = 0, both: bool = False) -> None:
+    """Wrap ``os.<name>``, watching the argument(s) naming the path it would change.
+
+    *arg* because the created path is not always the first one: ``os.symlink(target,
+    link)`` and ``os.link(src, dst)`` both CREATE their SECOND argument and only read
+    their first. *both* because ``os.rename``/``os.replace`` change two paths at once —
+    the source vanishes and the destination is overwritten — so watching either alone
+    leaves a way in.
+    """
+    original = getattr(os, name)
+
+    def guarded(*args, **kw):
+        watched = (0, 1) if both else (arg,)
+        for i in watched:
+            if len(args) > i and _hits(args[i], kw.get("dir_fd")):
+                raise RealPlaneWrite(_explain(f"os.{name}", args[i]))
+        return original(*args, **kw)
+
+    guarded.__name__ = name
+    setattr(os, name, guarded)
+
+
+def install() -> None:
+    """Wrap every write primitive. Idempotent; called once at `tests` package import."""
+    global _REAL
+    if _REAL:
+        return
+    from charter import config
+    try:
+        written = os.path.abspath(str(config.STATE_DIR))
+        resolved = os.path.realpath(written)
+    except (OSError, ValueError):         # no resolvable plane: nothing to protect
+        return
+    _REAL = (written,) if written == resolved else (written, resolved)
+
+    # `os.mkdir` covers `Path.mkdir` AND `os.makedirs` (which calls the module global by
+    # name, so it goes through this wrapper too) — one wrapper, both spellings.
+    # `os.remove`/`os.unlink` are distinct objects, so both are wrapped.
+    for name in ("mkdir", "rmdir", "remove", "unlink", "truncate", "chmod"):
+        _guard_os(name)
+    for name in ("rename", "replace"):
+        _guard_os(name, both=True)
+    for name in ("symlink", "link"):
+        _guard_os(name, arg=1)
+
+    # `shutil.rmtree` is wrapped at its FRONT DOOR rather than left to the primitives
+    # above. On every platform that avoids symlink attacks it recurses with
+    # `os.unlink(entry.name, dir_fd=topfd)` — a bare NAME plus a directory fd, which no
+    # path-based check can resolve. `state.reap` deletes exactly this way, so a guard that
+    # only watched the primitives would have watched the one call it exists to catch go
+    # past. The path handed to `rmtree` itself is a real path, and refusing there is
+    # earlier anyway: nothing is scanned, let alone removed.
+    original_rmtree = shutil.rmtree
+
+    def rmtree(path, *args, **kw):
+        if _hits(path):
+            raise RealPlaneWrite(_explain("shutil.rmtree", path))
+        return original_rmtree(path, *args, **kw)
+
+    shutil.rmtree = rmtree
+
+    # `builtins.open` and `io.open` are the same function object but two separate module
+    # attributes, looked up independently at call time: `Path.open` (and so `write_text`,
+    # `write_bytes`) calls `io.open`, while charter's own code calls the builtin. Missing
+    # either one leaves half the writes unwatched.
+    original_open = builtins.open
+
+    def open_(file, mode="r", *args, **kw):
+        if any(c in mode for c in "wxa+") and _hits(file):
+            raise RealPlaneWrite(_explain(f"open(..., {mode!r})", file))
+        return original_open(file, mode, *args, **kw)
+
+    builtins.open = open_
+    io.open = open_
+
+    # The low-level `os.open`, used by `tempfile` and by anything wanting O_EXCL. Only the
+    # flags that can create or shorten a file are refused; O_RDONLY passes.
+    original_os_open = os.open
+    writing = os.O_WRONLY | os.O_RDWR | os.O_CREAT | os.O_APPEND | os.O_TRUNC
+
+    def os_open(path, flags, *args, **kw):
+        if flags & writing and _hits(path, kw.get("dir_fd")):
+            raise RealPlaneWrite(_explain("os.open", path))
+        return original_os_open(path, flags, *args, **kw)
+
+    os.open = os_open

--- a/tests/test_persona_memory_sync.py
+++ b/tests/test_persona_memory_sync.py
@@ -7,6 +7,7 @@ import unittest
 from pathlib import Path
 
 from charter import config, persona, commands_persona
+from tests._isolation import PersonaIso
 
 _KEYS = ("ROOT", "PERSONAS_DIR", "STATE_DIR", "PERSONA_STATE_DIR", "ACTIVE_PERSONA_FILE")
 
@@ -69,7 +70,7 @@ if __name__ == "__main__":
     unittest.main()
 
 
-class EveryPlaneCommitOffersTheForgeToken(unittest.TestCase):
+class EveryPlaneCommitOffersTheForgeToken(PersonaIso):
     """charter's headline rule is one credential: each repo's own forge's token over
     HTTPS, never SSH. `commands.commit_push` obeyed it; `cmd_persona_memory_sync` had
     grown a second committer that ran `git push origin HEAD` — over SSH — on the ONE
@@ -80,6 +81,15 @@ class EveryPlaneCommitOffersTheForgeToken(unittest.TestCase):
     `tests/test_persona_memory_sync.py` only ever passed `no_push=True`, so the push argv
     — the only place the difference was visible — was never exercised. This asserts the
     argv, which is what the two implementations disagreed about.
+
+    `PersonaIso`, not `unittest.TestCase`, and not for tidiness: every git call here is
+    faked, which made the class read as pure argv inspection — but `commit_push` is REAL,
+    and its last act on the pushed path is `planegit.record_push`, which DELETES
+    `<STATE_DIR>/plane-push.json`. Unisolated, that is the developer's own record of a
+    stranded push, the one `doctor` reads to tell them their plane never reached the
+    forge; the suite erased it on every run and `record_push`'s own `except OSError: pass`
+    guaranteed silence. Found by `tests/_planeguard.py` rather than by hand, which is what
+    that guard is for.
     """
 
     def test_memory_sync_delegates_to_the_one_committer(self):

--- a/tests/test_plane_write_guard.py
+++ b/tests/test_plane_write_guard.py
@@ -1,0 +1,220 @@
+"""The suite-wide tripwire that refuses writes into the developer's real `.charter/`.
+
+Every case below installs a THROWAWAY directory as "the real plane" and asserts against
+that, never against the operator's actual one. The alternative — pointing a case at the
+live `config.STATE_DIR` to prove `rmtree` is refused — would delete a machine's vaults and
+running frames the first time the guard regressed, which is the exact accident this file
+exists to prevent. The fixture tree is populated and asserted intact afterwards, so a
+guard that raised *after* delegating would still be caught.
+"""
+
+from __future__ import annotations
+
+import builtins
+import io
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import config, root
+from tests import _planeguard
+
+
+class WhatIsGuarded(unittest.TestCase):
+    """The two facts that decide whether the guard is pointed at anything at all."""
+
+    def test_the_guarded_directory_is_this_machines_own_plane_state(self):
+        """Installed against the plane the test PROCESS resolved, not some later one.
+
+        Recomputed from `root.find_root` rather than read off `config.STATE_DIR`, which
+        any `PersonaIso` case may have repointed by the time this runs.
+        """
+        state = str(config.derive(root.find_root())["STATE_DIR"])
+        self.assertIn(os.path.abspath(state), _planeguard._REAL,
+                      "the guard is watching a directory that is not this plane's state")
+
+    def test_every_write_primitive_is_wrapped_at_package_import(self):
+        """No test can opt out by forgetting a base class, because nothing opted IN.
+
+        Named one by one: each of these is a way to create or destroy a file that some
+        part of charter actually uses, and a list that drifts short is a guard with a
+        door left open. `os.makedirs` is deliberately absent — it calls the module-level
+        `mkdir` by name, so it goes through that wrapper.
+        """
+        guarded = {"tests._planeguard"}
+        for owner, name in ((os, "mkdir"), (os, "rmdir"), (os, "remove"), (os, "unlink"),
+                            (os, "rename"), (os, "replace"), (os, "symlink"), (os, "link"),
+                            (os, "truncate"), (os, "chmod"), (os, "open"),
+                            (shutil, "rmtree"), (builtins, "open"), (io, "open")):
+            with self.subTest(call=f"{owner.__name__}.{name}"):
+                fn = getattr(owner, name)
+                self.assertIn(getattr(fn, "__module__", None), guarded,
+                              f"{owner.__name__}.{name} is unwrapped — writes through it "
+                              f"reach the real plane unseen")
+
+
+class _FakePlane(unittest.TestCase):
+    """A throwaway directory installed as "the real plane" for the duration of one test."""
+
+    def setUp(self):
+        self.plane = Path(tempfile.mkdtemp(prefix="guard-fake-plane-"))
+        self.addCleanup(shutil.rmtree, self.plane, True)
+        self.elsewhere = Path(tempfile.mkdtemp(prefix="guard-elsewhere-"))
+        self.addCleanup(shutil.rmtree, self.elsewhere, True)
+
+        # A populated tree, so "refused" and "deleted, then refused" are distinguishable.
+        # The frame is NOT named `<workspace>-<pid>`: nothing here calls `reap`, so the
+        # name means nothing, and a name that LOOKS like a frame id would invite a reader
+        # to think liveness was being tested. (A `-1` suffix would be worse still — pid 1
+        # is launchd, permanently alive, so anything keying off it can never fail.)
+        (self.plane / "frame" / "a-frame-still-on-screen").mkdir(parents=True)
+        (self.plane / "frame" / "a-frame-still-on-screen" / "exit").write_text("0\n")
+        (self.plane / "vaults.json").write_text("{}")
+        self.enterContext(mock.patch.object(
+            _planeguard, "_REAL", (str(self.plane), str(self.plane.resolve()))))
+
+    def assertPlaneIntact(self):
+        exit_file = self.plane / "frame" / "a-frame-still-on-screen" / "exit"
+        self.assertEqual(exit_file.read_text(), "0\n")
+        self.assertEqual((self.plane / "vaults.json").read_text(), "{}")
+
+
+class WritesAreRefused(_FakePlane):
+    def test_reap_cannot_delete_a_live_frames_state(self):
+        """The #402 accident itself: `frame.state.reap` rmtree's a frame directory the
+        tmux server did not report live, and a faked server reports none.
+
+        `shutil.rmtree` is checked at its own front door because its recursion deletes via
+        `os.unlink(name, dir_fd=fd)` — a bare filename against an open directory, which no
+        path-based check can resolve. Asserting the tree is still there is therefore the
+        whole test: a guard that only watched the primitives passes the raise assertion
+        and fails this one.
+        """
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            shutil.rmtree(self.plane / "frame" / "a-frame-still-on-screen")
+        self.assertPlaneIntact()
+
+    def test_a_frame_directory_cannot_be_minted(self):
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            (self.plane / "frame" / "demo-2").mkdir(parents=True)
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            os.makedirs(self.plane / "frame" / "demo-3")
+        self.assertFalse((self.plane / "frame" / "demo-2").exists())
+        self.assertFalse((self.plane / "frame" / "demo-3").exists())
+
+    def test_a_record_cannot_be_deleted(self):
+        """`planegit.record_push` unlinks `plane-push.json` on a successful push — the
+        developer's own record of a stranded plane, erased by a test that only meant to
+        inspect an argv."""
+        rec = self.plane / "vaults.json"
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            rec.unlink(missing_ok=True)
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            os.remove(rec)
+        self.assertPlaneIntact()
+
+    def test_a_file_cannot_be_written_over(self):
+        for mode in ("w", "a", "x", "r+"):
+            with self.subTest(mode=mode), self.assertRaises(_planeguard.RealPlaneWrite):
+                builtins.open(self.plane / "vaults.json", mode)
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            (self.plane / "vaults.json").write_text("clobbered")
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            os.open(self.plane / "vaults.json", os.O_WRONLY | os.O_TRUNC)
+        self.assertPlaneIntact()
+
+    def test_a_file_cannot_be_moved_in_or_out(self):
+        """Both ends of a rename: the source vanishes and the destination is overwritten,
+        so watching one argument leaves the other as a way in."""
+        outside = self.elsewhere / "spare"
+        outside.write_text("x")
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            os.rename(self.plane / "vaults.json", outside)
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            os.replace(outside, self.plane / "vaults.json")
+        self.assertPlaneIntact()
+        self.assertEqual(outside.read_text(), "x")
+
+    def test_a_link_cannot_be_planted(self):
+        """`os.symlink(target, link)` CREATES its second argument and only reads its
+        first — the opposite of every other call here."""
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            os.symlink(self.elsewhere, self.plane / "planted")
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            os.link(self.plane / "vaults.json", self.plane / "hard")
+        self.assertFalse((self.plane / "planted").is_symlink())
+        self.assertFalse((self.plane / "hard").exists())
+
+    def test_a_relative_path_reaches_the_plane_too(self):
+        """A test that `chdir`s into the plane writes with no plane prefix in the string
+        at all, and a check that only compared prefixes would wave it straight through."""
+        here = os.getcwd()
+        self.addCleanup(os.chdir, here)
+        os.chdir(self.plane)
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            os.mkdir("frame/demo-4")
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            os.mkdir(os.path.join("frame", os.pardir, "demo-5"))
+        os.chdir(here)
+        self.assertFalse((self.plane / "frame" / "demo-4").exists())
+        self.assertFalse((self.plane / "demo-5").exists())
+
+
+class WhatIsStillAllowed(_FakePlane):
+    """A guard that refused everything would pass every case above and stop the suite
+    dead. These are the calls that must keep working."""
+
+    def test_reading_the_real_plane_is_untouched(self):
+        self.assertEqual((self.plane / "vaults.json").read_text(), "{}")
+        self.assertIn("vaults.json", os.listdir(self.plane))
+        with builtins.open(self.plane / "vaults.json") as fh:
+            self.assertEqual(fh.read(), "{}")
+        self.assertEqual(os.stat(self.plane / "vaults.json").st_size, 2)
+
+    def test_writing_anywhere_else_is_untouched(self):
+        (self.elsewhere / "d").mkdir()
+        (self.elsewhere / "d" / "f").write_text("ok")
+        os.replace(self.elsewhere / "d" / "f", self.elsewhere / "g")
+        self.assertEqual((self.elsewhere / "g").read_text(), "ok")
+        shutil.rmtree(self.elsewhere / "d")
+        self.assertFalse((self.elsewhere / "d").exists())
+
+    def test_a_path_that_merely_starts_with_the_planes_name_is_not_inside_it(self):
+        """`<plane>-sibling` shares the plane's string prefix and is a different
+        directory; a `startswith` with no separator would refuse it."""
+        sibling = Path(str(self.plane) + "-sibling")
+        self.addCleanup(shutil.rmtree, sibling, True)
+        sibling.mkdir()
+        (sibling / "f").write_text("ok")
+        self.assertEqual((sibling / "f").read_text(), "ok")
+
+
+class TheRefusalCannotBeSwallowed(_FakePlane):
+    def test_it_is_not_an_exception(self):
+        """charter's write paths are wrapped in `except OSError` / `except Exception`
+        fallbacks that exist so a degraded environment cannot break a command —
+        `record_push` ends in `except OSError: pass`. A tripwire those can catch reports
+        nothing and the test goes green over a deleted plane."""
+        self.assertFalse(issubclass(_planeguard.RealPlaneWrite, Exception))
+        try:
+            os.mkdir(self.plane / "swallowed")
+        except Exception:                                  # noqa: BLE001 — the point
+            self.fail("`except Exception` swallowed the tripwire")
+        except _planeguard.RealPlaneWrite:
+            pass
+        self.assertFalse((self.plane / "swallowed").exists())
+
+    def test_it_names_the_path_and_the_way_out(self):
+        with self.assertRaises(_planeguard.RealPlaneWrite) as caught:
+            os.mkdir(self.plane / "frame" / "demo-5")
+        msg = str(caught.exception)
+        self.assertIn(str(self.plane / "frame" / "demo-5"), msg)
+        self.assertIn("PersonaIso", msg)
+        self.assertIn("CHARTER_ROOT", msg)      # the half PersonaIso cannot fix
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_statusline_layout_scope.py
+++ b/tests/test_statusline_layout_scope.py
@@ -168,7 +168,7 @@ class DegradesCleanly(PersonaIso):
                 statusline.render(bad)
 
 
-class BrandFits(unittest.TestCase):
+class BrandFits(PersonaIso):
     """The brand must be present-and-correct or absent — never truncated.
 
     A real session rendered `⬢ charter 0.10…`: `_with_brand` fits-or-drops and never


### PR DESCRIPTION
## What the issue asked, and what was actually there

**Both halves #402 names are already fixed on `main`.** Measured rather than assumed: an
instrumented run (every write primitive replaced with a recorder before collection, so the
observation destroyed nothing) recorded **zero** touches resolving into the real plane from
either file.

- `test_frame_launcher.py` — `MissingHarnessBinary` and `BypassRouting` derive from
  `PersonaIso`, and `_refuse_the_real_plane()` sits on both helpers that reach `cmd_launch`.
- `test_frame_tmux_integration.py` — `MenuFormatIntegration` and `MenuClientIntegration`
  derive from `PersonaIso` and carry `$CHARTER_ROOT` onto the `new-session` that starts
  their tmux server, which is the half `PersonaIso` cannot do. No `menu-fmt-integ*` or
  `menu-client-integ-*` directories are left in this machine's plane.

The #381/#383 rounds the issue calls "prior art on unmerged branches" have since landed. So
this PR does not re-fix them.

## What is not fixed is the shape

The same defect has arrived three times, in three unrelated files, each found by hand months
apart, each fixed only where it was found: the real `vaults.json` orphaned; three launcher
classes running `state.reap` against live frames; and — found by this PR — a fourth. The
issue's own history is the argument for a guard rather than a fourth patch.

## The guard

`tests/_planeguard.py` wraps every call that can create, delete or replace something under
the real `config.STATE_DIR`, at import of the `tests` package — before any module is
collected, so **nothing can opt out by forgetting a base class**. The refusal is raised
*before* the call is delegated, so a live frame's unread `exit` file is still there
afterwards.

Three details decide whether it works:

- **`shutil.rmtree` is refused at its front door**, not left to the primitives beneath it.
  Its recursion deletes with `os.unlink(name, dir_fd=fd)` — a bare name against an open
  directory, which no path-based check can resolve. `reap` deletes exactly that way, so a
  guard watching only the primitives would have watched the one call it exists to catch go
  straight past.
- **The refusal is not an `Exception`.** `record_push` ends in `except OSError: pass`;
  `reap` calls `rmtree(..., ignore_errors=True)`. A catchable tripwire reports nothing and
  the test goes green over a deleted plane.
- **Reads are untouched.** Tests that exercise the real plane on purpose keep working;
  `isolate_state_dir` remains the way to redirect just this directory.

## It found a fourth instance on the first run

`test_persona_memory_sync.EveryPlaneCommitOffersTheForgeToken` fakes every git call but runs
the **real** `commit_push`, whose `record_push` unlinks the real
`.charter/plane-push.json` — the developer's own record of a plane commit that never reached
the forge, the one `doctor` reads to tell them about it. Erased on every suite run, and
`except OSError: pass` guaranteed silence. Now `PersonaIso`.

## Mutation testing

Thirteen mutations, each RED then GREEN, `__pycache__` cleared between runs:

| # | mutation | goes red |
|---|---|---|
| M1 | unwrap `os.unlink` | wrapped-primitives + record-deletion |
| M2 | remove the `rmtree` front door | reap case (tree actually deleted) |
| M3 | `rename` watches one end only | move-in-or-out |
| M4 | `symlink` watches its target, not its link | link-planted |
| M5 | prefix compare without a separator | `<plane>-sibling` refused |
| M6 | relative paths never resolved | chdir-into-plane |
| M7 | refusal made an `Exception` | not-swallowed |
| M8 | only mode `"w"` counts as a write | modes `a`, `x`, `r+` |
| M9 | `os.open` write flags zeroed | `O_WRONLY\|O_TRUNC` |
| M10 | `install()` never called | 27 failures |
| M11 | guard points at the wrong directory | which-directory |
| M12 | revert the `PersonaIso` fix above | `test_every_push_offers_the_forge_token` |
| M13 | **re-introduce #402 itself** | see below |

M13 is the decisive one: `PersonaIso` taken off `MissingHarnessBinary` **and** that module's
own `_refuse_the_real_plane` disabled, run against a fake plane holding a frame directory
named for a *verifiably dead* pid — not `-1`, because pid 1 is launchd and is never reaped,
which would have made the case unfailable. The tripwire caught `state.reap`'s
`shutil.rmtree`, and the frame's unread `exit` file survived:

```
File "charter/frame/state.py", line 497, in reap
    shutil.rmtree(d, ignore_errors=True)
File "tests/_planeguard.py", line 161, in rmtree
    raise RealPlaneWrite(_explain("shutil.rmtree", path))
tests._planeguard.RealPlaneWrite: REFUSED: shutil.rmtree …/fakeplane/.charter/frame/default-90000
…
fake frame state intact: True
```

## The half it cannot see

A subprocess resolves its own plane from its own environment, so a `tmux run-shell` hook or
a spawned `charter` is untouched by isolating the parent. Said in the module docstring, in
the refusal message itself, and in CONTRIBUTING — it is not a licence to skip
`$CHARTER_ROOT`.

## Suite

```
Ran 4053 tests in 112.350s
OK
```

Real plane verified unchanged after the run: same two live frame directories, same mtimes,
nothing minted. Cost is not measurable — the hot path answers an already-absolute path with
string compares and reaches `abspath` only for a relative one.

Closes #402


---

## Correction — the "Ran 4053 tests … OK" above was not actually green

An independent reviewer caught this before merge. **CI on this PR was red on 3.11/3.12/3.13/3.14**, every job `FAILED (errors=212, skipped=1)` with `REFUSED: os.mkdir …/.charter/cache`. The "OK" reported in the Suite section above was a false green produced by an environment coincidence, not by the code being correct.

What actually happened: my real plane's `.charter/cache/update.json` had a `ts` inside `update.REFRESH_TTL` (`charter/update.py:27`), so `update.maybe_spawn()` returned at its cooldown brake *before* it ever reached the guarded `lock.parent.mkdir(parents=True)` call — the exact line this PR's own `_planeguard` exists to catch. A cold or absent update cache reaches that `mkdir` on every call, which is what CI's fresh runners have and what my workstation, by coincidence, did not.

The actual defect the coincidence hid: `tests/test_statusline_layout_scope.py:171` — `BrandFits` subclassed plain `unittest.TestCase` instead of `PersonaIso`. That is a **fifth instance of exactly the shape #402 is about** (`_with_brand()` → `_brand()` → `update.maybe_spawn()` → the guarded `mkdir` on the real `STATE_DIR/cache`, plus a detached `charter _version-check` subprocess that reaches PyPI). Fixed with a one-word change — `PersonaIso` was already imported in that module, so this needed no new import.

Re-verified from a pristine `git archive` extraction of this commit, run with cwd inside that fresh checkout so `root.find_root()` resolves to it (not to `~/.charter` or this repo's own `.charter/`) — meaning the update cache is provably absent, not just assumed cold:

```
$ python3 -m unittest discover -s tests
Ran 4053 tests in 115.585s
OK
```

and the sharpest single check — the module that alone produced all 212 errors under the false-green commit:

```
$ python3 -m unittest tests.test_statusline_layout_scope
Ran 35 tests in 0.498s
OK
```

No `.charter/` directory was created anywhere outside the tests' own temp dirs in either run.

**Sixth-instance check:** searched every call site that reaches `statusline.render()`, `statusline._brand()`/`_with_brand()`, `update.maybe_spawn()`, or `glstate.maybe_spawn()` directly. Every other site is already isolated — via `PersonaIso`, the `isolate_state_dir()` helper, or an inline `config.STATE_DIR` redirect paired with a `maybe_spawn` patch. Confirmed both by manual audit and by the full-suite run above producing zero guard refusals.
