### PR TITLE
frame v2 (3/3): density presets and animation scoped to in-flight work (#387)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -676,7 +676,7 @@ def _add_frame_parsers(sub) -> None:
     # naming `frame-probe` silently launching a harness instead of reading tmux's own
     # version (see `commands_frame.cmd_probe`'s own docstring).
     _core_commands = set(sub.choices) | {"frame", "panel", "frame-menu", "frame-action",
-                                         "frame-probe", "frame-respawn"}
+                                         "frame-probe", "frame-respawn", "frame-density"}
 
     # Which harness (by `.name`, never `.cli_name` — that's the dict key below) has
     # already claimed each word, so a SECOND harness wanting it is told who got there
@@ -758,6 +758,20 @@ def _add_frame_parsers(sub) -> None:
     rs.add_argument("slot")
     rs.add_argument("--pane", dest="pane", required=True)
     rs.set_defaults(func=commands_frame.cmd_respawn)
+
+    # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the
+    # three above. Fired by a hotkey-menu selection (`commands_frame._menu_entries`), whose
+    # stored argv is exactly `util.self_relaunch_argv("frame-density", <level>)`. It
+    # changes the RUNNING frame only — never charter.toml, which is hand-maintained (see
+    # `cmd_density`'s own docstring) — and, like every other `frame-*` command here,
+    # resolves which frame from `$CHARTER_SESSION_ID` at the moment it fires rather than
+    # from anything baked into a shared menu action. Deliberately NOT `choices=` on the
+    # level: `instance.density_level` is the one gate on that closed set, and a second
+    # copy of it in argparse would mean a level added to the table and not to the parser
+    # exits 2 from inside a `run-shell` where nothing prints the reason.
+    dn = sub.add_parser("frame-density")
+    dn.add_argument("level")
+    dn.set_defaults(func=commands_frame.cmd_density)
 
     # A TOP-LEVEL sibling of `frame` for a DIFFERENT reason than `frame-menu`/
     # `frame-action` above: those two exist because `_split_frame_argv` eats everything

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -290,18 +290,26 @@ def frame_ready() -> tuple[int, str, str]:
     launcher goes on to draw regardless — a probe that lies about `cmd_launch`'s own
     behaviour is worse than one that runs nothing at all.
 
-    **The two STANDING conditions are reported here and nowhere else.** Both used to be
-    `util.warn` calls inside `cmd_launch` itself, and both were measured to be
-    unreadable there: `util.warn` for an unimplemented slot lands 86 bytes before tmux's
-    own `\\x1b[?1049h`, so the operator's terminal switches to the alternate screen
-    milliseconds later and the line is restored to view only when the frame EXITS. A
-    warning printed where it cannot be read is worse than silence, because it creates a
-    record that the operator was told. Neither is per-launch news anyway — a tmux below
-    the floor, and a configured slot with no renderer, are true on every launch on this
-    machine and this plane until something changes. They are capability ceilings, so
-    they belong to the two surfaces built to report ceilings on demand: this one, and
-    `doctor.check_frame`. (A per-launch notice mechanism, for conditions specific to one
-    launch, is deliberately NOT built here.)
+    **The three STANDING conditions are reported here and nowhere else.** All three used
+    to be `util.warn` calls inside `cmd_launch` (or, for the resize hook, inside
+    `_draw_panels`), and all three were measured to be unreadable there: `util.warn` for
+    an unimplemented slot lands 86 bytes before tmux's own `\\x1b[?1049h`, so the
+    operator's terminal switches to the alternate screen milliseconds later and the line
+    is restored to view only when the frame EXITS. A warning printed where it cannot be
+    read is worse than silence, because it creates a record that the operator was told.
+    None is per-launch news anyway — a tmux below the floor, a tmux below
+    `tmuxctl.RESIZE_HOOK_FLOOR`, and a configured slot with no renderer are true on every
+    launch on this machine and this plane until something changes. They are capability
+    ceilings, so they belong to the two surfaces built to report ceilings on demand: this
+    one, and `doctor.check_frame`. (A per-launch notice mechanism, for conditions specific
+    to one launch, is deliberately NOT built here.)
+
+    **`RESIZE_HOOK_FLOOR` is the third, and it was the one this function did not know
+    about (#387).** It sits ABOVE `FLOOR`, so an operator on tmux 3.2 passed the floor
+    cleanly, saw a green tick on both ceiling surfaces, and silently had no resize
+    recovery at all — the gap being closed here. It does NOT change this function's exit
+    code, for the same reason the other two do not: `cmd_launch` draws the frame
+    regardless, and a probe stricter than the launcher lies about the launcher.
 
     Two callers share this, both read-only for the same reason `charter/news.py`
     requires of a `check:` (reads, never acts; and this module's own tmux calls all go
@@ -318,6 +326,8 @@ def frame_ready() -> tuple[int, str, str]:
     ceilings = []
     if v < tmuxctl.FLOOR:
         ceilings.append(tmuxctl.below_floor_message(v))
+    if v < tmuxctl.RESIZE_HOOK_FLOOR:
+        ceilings.append(tmuxctl.below_resize_hook_message(v))
     missing = frame_slots.unimplemented(config.FRAME["slots"])
     if missing:
         ceilings.append(no_renderer_message(missing))
@@ -883,8 +893,15 @@ def _wait_for_harness(socket: str, harness_pane: str) -> int | None:
         time.sleep(_POLL_SECONDS)
 
 
-def _drawable_slots(cols: int, rows: int) -> list[str]:
+def _drawable_slots(cols: int, rows: int, configured: list[str] | None = None) -> list[str]:
     """Which configured slots this frame will actually draw, at *cols* x *rows*.
+
+    *configured* defaults to `config.FRAME["slots"]` — already the density-resolved list
+    (`instance.frame_of` expands a declared `[frame] density` into it, so nothing here
+    knows presets exist). `cmd_density` passes the list a level expands to instead, so a
+    frame re-laid-out by the hotkey menu goes through exactly the same two filters a launch
+    does rather than a second copy of them: below the size floors it drops the same slots
+    in the same order, and a slot with no renderer is skipped for the same reason.
 
     `[frame] slots` can accept a slot (`instance.FRAME_SLOTS`, sized by
     `layout.SLOT_SIZE`) that `frame.slots.SLOTS` — the RENDERER registry — has no
@@ -905,8 +922,8 @@ def _drawable_slots(cols: int, rows: int) -> list[str]:
     demand instead, from the same `frame_slots.unimplemented` this filters on.
     """
     frame = config.FRAME
-    slots = layout.visible_slots(frame["slots"], cols, rows,
-                                 frame["min_cols"], frame["min_rows"])
+    slots = layout.visible_slots(frame["slots"] if configured is None else configured,
+                                 cols, rows, frame["min_cols"], frame["min_rows"])
     unimplemented = frame_slots.unimplemented(slots)
     return [s for s in slots if s not in unimplemented]
 
@@ -1095,12 +1112,18 @@ def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, argv: list[
     # version: whatever is under the id predates the frame now claiming it.
     state.clear_exit(fid)
     gather.discard(fid)
+    state.clear_shape(fid)
     # Rewritten, not merely written: an adopted directory may name the OTHER server, and
     # a stale marker would make `reap` there skip a frame that is now genuinely ours.
     state.record_server(fid, socket)
     state.bump(fid)
 
     env = _frame_env(fid, h)
+    # The launcher is the only process that knows this frame's own charter identity —
+    # see `state.record_identity` for the measurement. Written before any pane exists,
+    # because a `run-shell` child fired later reads the SERVER's environment, not this
+    # one's.
+    state.record_identity(fid, _frame_identity_env(env))
     cwd = os.getcwd()
     opened = tmuxctl.run(
         "opening a window for the frame",
@@ -1251,12 +1274,31 @@ def _draw_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     `Pane is dead (status 2)`. Nothing about that is specific to charter's own server;
     inside an operator's tmux the cwd is the same cwd, so the hole is the same hole.
     """
+    panes = _split_panels(socket, slots=slots, fid=fid, harness_pane=harness_pane,
+                          env=env, pane_env=pane_env)
+    _install_resize_hook(socket, harness_pane=harness_pane, panes=panes, v=v, env=env)
+    # Written down, because a frame's shape can now be CHANGED while it runs (the density
+    # menu — `cmd_density`), and nothing else afterwards can say which tmux pane charter
+    # meant as which slot. Slots only: `state.record_harness_pane` already owns the
+    # harness pane, and one fact recorded twice is one fact free to disagree with itself.
+    state.record_panes(fid, panels=panes)
+    return panes
+
+
+def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
+                  env: dict | None, pane_env: dict[str, str] | None) -> dict[str, str]:
+    """One `split-window` per slot, and the `{slot: pane id}` map that came back.
+
+    The splitting half of :func:`_draw_panels`, separated from the hook-and-record half so
+    a live re-layout (`_relayout`) can add panes to a frame that already has some without
+    re-installing hooks per batch or overwriting the map it is in the middle of building.
+    """
     panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=socket,
                                     harness_pane=harness_pane, env=pane_env)
-    # Zipped with `slots`, not just iterated: `_resize_hook_argv` below needs to know
-    # WHICH slot each successfully-created pane belongs to (for its size and its
-    # resize-pane flag), and `panel_argvs` returns exactly one command per slot, in the
-    # same order (see its own docstring).
+    # Zipped with `slots`, not just iterated: `_resize_hook_argv` needs to know WHICH slot
+    # each successfully-created pane belongs to (for its size and its resize-pane flag),
+    # and `panel_argvs` returns exactly one command per slot, in the same order (see its
+    # own docstring).
     panes: dict[str, str] = {}
     for slot, cmd in zip(slots, panel_cmds):
         # Reported by `tmuxctl.run` but not fatal: one decorative panel failing to draw
@@ -1268,50 +1310,138 @@ def _draw_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
         pane_id = p.stdout.strip()
         if pane_id and _PANE_ID_RE.fullmatch(pane_id):
             panes[slot] = pane_id
+    return panes
 
-    if panes and v < tmuxctl.RESIZE_HOOK_FLOOR:
+
+def _install_resize_hook(socket: str, *, harness_pane: str, panes: dict[str, str],
+                         v: tuple[int, int], env: dict | None,
+                         replacing: bool = False) -> None:
+    """Arm (or re-arm) the `window-resized` hook for exactly *panes*.
+
+    Split out of :func:`_draw_panels` because a live re-layout (`cmd_density`) changes
+    which panes exist without going through a whole launch, and the hook's action names
+    every pane it resizes — one stale entry there is a `resize-pane` aimed at a pane that
+    no longer exists, on every resize, for the life of the window. One `set-hook` replaces
+    the whole hook, so re-arming from the new map covers every case but one: an EMPTY map
+    replaces nothing. *replacing* is what tells the two apart — a launch with no panels has
+    nothing armed to remove and issues no command at all, while a re-layout that dropped
+    every slot must actively `set-hook -u`. It is reachable rather than theoretical:
+    `_drawable_slots` answers `[]` below half the size floors.
+
+    **Nothing is printed here any more, and that is #387's half of it.** This function
+    used to `util.warn` when the tmux was below `RESIZE_HOOK_FLOOR` — a STANDING fact about
+    this machine, printed into the pre-attach window measured at 86 bytes before tmux's own
+    `\\x1b[?1049h`, where the operator's terminal switches to the alternate screen
+    milliseconds later and the line comes back only once the frame exits. It is reported by
+    `frame_ready` (`--probe`, `charter frame-probe`) and `doctor.check_frame` instead, which
+    are the two surfaces built to report ceilings on demand.
+
+    The two warnings below stay, and the difference is real: those are not standing facts
+    but DISCOVERIES made at this launch — a tmux that turned out not to know the hook name
+    despite the version gate, or a `set-hook` that failed for some other reason entirely.
+    Neither is answerable by `frame_ready`, which starts nothing.
+    """
+    if v < tmuxctl.RESIZE_HOOK_FLOOR:
         # Below RESIZE_HOOK_FLOOR, `window-resized` is not a hook name THIS tmux
         # recognises at all — `set-hook` fails with `invalid option: <name>` for any
         # name it does not know (see RESIZE_HOOK_FLOOR's own docstring for exactly what
         # was, and was not, confirmed by hand) — skip the attempt rather than printing
-        # that confusing text on every single launch. One quiet, honest note instead,
-        # naming the real consequence (item 4's own standard: every degrade in this
-        # launcher says what it costs).
-        util.warn(f"charter frame: tmux {v[0]}.{v[1]} predates the resize-recovery hook "
-                  f"(needs {tmuxctl.RESIZE_HOOK_FLOOR[0]}.{tmuxctl.RESIZE_HOOK_FLOOR[1]}+)"
-                  f" — panels may drift out of shape if this terminal is resized")
-    elif panes:
-        # Only once any panel actually exists — a resize hook with nothing to resize
-        # would just be a wasted `set-hook` call, and (per the module docstring's "belt
-        # and braces" framing) every pane already measures its own tty on every repaint
-        # regardless, so this hook is purely cosmetic geometry upkeep, not something a
-        # launch's correctness depends on.
-        resize_cmd = _resize_hook_argv(socket=socket, harness_pane=harness_pane,
-                                       panes=panes)
-        # `report=False`: this is the one call site that reads a failure's own stderr
-        # before deciding whether it IS one — an unrecognised hook name here is a
-        # capability ceiling to note quietly, not an integration to report loudly, and
-        # `tmuxctl.run`'s default would have printed the loud version first regardless
-        # of which branch runs below.
-        resize = tmuxctl.run("installing the resize hook", resize_cmd, env=env,
-                             report=False)
-        if resize.returncode != 0:
-            if _INVALID_HOOK_NAME in (resize.stderr or ""):
-                # RESIZE_HOOK_FLOOR believed this tmux would recognise the hook name and
-                # it does not — the constant is wrong, not the launch. Trust what THIS
-                # tmux just said over the constant and degrade the same quiet way the
-                # version-gate above already does, rather than report it as a broken
-                # integration (a capability ceiling, not a failure — see the module's own
-                # "belt and braces" framing and `harness.base.Deficit`'s same philosophy
-                # for a harness-level capability gap).
-                util.warn("charter frame: this tmux does not support the "
-                          "resize-recovery hook — panels may drift out of shape if this "
-                          "terminal is resized")
-            else:
-                tmuxctl.report_failure("installing the resize hook", resize_cmd, resize)
-                util.warn("charter frame: continuing without it — panels may drift out "
-                          "of shape if this terminal is resized")
-    return panes
+        # that confusing text on every single launch. Nothing was ever installed below
+        # this line, so there is nothing to remove either.
+        return
+    if not panes:
+        if not replacing:
+            # A LAUNCH with no panels: the window is new, nothing has ever been armed on
+            # it, and a `set-hook -u` here would be a tmux command issued to remove a hook
+            # that does not exist — measurable in the launcher's own command list and
+            # asserted against by `Launch.test_no_resize_hook_is_installed_when_no_panel
+            # _pane_id_was_learned`. Nothing to do.
+            return
+        # A RE-LAYOUT that dropped every slot, which is reachable rather than theoretical:
+        # `_drawable_slots` answers `[]` below half of `min_cols`/`min_rows`, so shrinking
+        # a small window's frame to `minimal` kills all four panes. One `set-hook`
+        # REPLACES a hook only when there is something to replace it with — an empty map
+        # replaces nothing — so returning here would leave the launch's own hook armed and
+        # firing `resize-pane -t %1` at dead panes on every resize for the window's life.
+        tmuxctl.run("removing the resize hook",
+                    tmuxctl.server_argv(socket, "set-hook", "-w", "-u", "-t",
+                                        harness_pane, "window-resized"),
+                    env=env, report=False)
+        return
+    resize_cmd = _resize_hook_argv(socket=socket, harness_pane=harness_pane, panes=panes)
+    # `report=False`: this is the one call site that reads a failure's own stderr
+    # before deciding whether it IS one — an unrecognised hook name here is a
+    # capability ceiling to note quietly, not an integration to report loudly, and
+    # `tmuxctl.run`'s default would have printed the loud version first regardless
+    # of which branch runs below.
+    resize = tmuxctl.run("installing the resize hook", resize_cmd, env=env, report=False)
+    if resize.returncode == 0:
+        return
+    if _INVALID_HOOK_NAME in (resize.stderr or ""):
+        # RESIZE_HOOK_FLOOR believed this tmux would recognise the hook name and
+        # it does not — the constant is wrong, not the launch. Trust what THIS
+        # tmux just said over the constant and degrade the same quiet way the
+        # version-gate above already does, rather than report it as a broken
+        # integration (a capability ceiling, not a failure — see the module's own
+        # "belt and braces" framing and `harness.base.Deficit`'s same philosophy
+        # for a harness-level capability gap).
+        util.warn("charter frame: this tmux does not support the "
+                  "resize-recovery hook — panels may drift out of shape if this "
+                  "terminal is resized")
+    else:
+        tmuxctl.report_failure("installing the resize hook", resize_cmd, resize)
+        util.warn("charter frame: continuing without it — panels may drift out "
+                  "of shape if this terminal is resized")
+
+
+def _arm_panel_respawn(socket: str, *, panes: dict[str, str], env: dict | None) -> None:
+    """Give each pane in *panes* its OWN `pane-died` hook, so a dead panel comes back.
+
+    A panel whose process dies outright would otherwise leave a hole for the frame's whole
+    life (#382). Scoped to each panel's own pane — never the harness pane, whose
+    `pane-died` array carries the exit code and must not gain a third writer (see
+    `_panel_died_hook_argv`). Reported but never fatal, like every other decorative tmux
+    command here: a panel that cannot be armed for respawn is still a panel that came up.
+
+    **Private-server-only, and the guard is here rather than at the call sites.**
+    `cmd_respawn` (the hook's own action) and `_panel_died_hook_argv` both assume `SOCKET`,
+    charter's own server NAME — `-L`, never `-S` — which is correct on charter's own
+    server and wrong on the operator's, where the frame's server is a socket PATH read
+    from `$TMUX`. Arming a panel there installs a hook whose action targets the wrong tmux
+    server entirely. That used to be enforced by WHERE the loop sat (inside `cmd_launch`'s
+    private-server branch); with a second caller (`_relayout`, which runs on either
+    server) that is no longer a property of position, so it is asserted here instead.
+    Extending #382 across the boundary is real work — resolving `cmd_respawn`'s target
+    from `state.frame_server(fid)` and its liveness check from windows rather than
+    sessions — and is still not this change's job.
+    """
+    if tmuxctl.is_operator_socket(socket):
+        return
+    for slot, pane_id in panes.items():
+        tmuxctl.run(f"arming the {slot} panel for respawn",
+                    _panel_died_hook_argv(socket=socket, panel_pane=pane_id, slot=slot),
+                    env=env)
+
+
+def _disarm_panel_respawn(socket: str, *, pane_id: str) -> None:
+    """Take one panel pane's `pane-died` hook off, BEFORE that pane is killed.
+
+    Without this, changing density is self-undoing: `kill-pane` on a panel charter no
+    longer wants fires that pane's own respawn hook, `cmd_respawn` sleeps its backoff,
+    finds the session still perfectly alive (only the layout changed), and respawns the
+    panel the operator just asked to be rid of — spending one of its three lives on the
+    way. Unsetting first removes the question rather than answering it: there is no hook
+    left to fire, whichever way this tmux treats a killed pane's `pane-died`.
+
+    `report=False`: on the operator's own server no hook was ever armed
+    (:func:`_arm_panel_respawn` refuses there), so a `set-hook -u` for a hook that is not
+    set is the ORDINARY case rather than a fault — the same reason `_live_sessions` opts
+    out of reporting for a socket no server has run on.
+    """
+    tmuxctl.run("disarming a panel's respawn hook",
+                tmuxctl.server_argv(socket, "set-hook", "-p", "-u", "-t", pane_id,
+                                    "pane-died"),
+                timeout=5, report=False)
 
 
 def _pane_last_words(socket: str, harness_pane: str) -> list[str]:
@@ -1559,6 +1689,11 @@ def cmd_launch(args) -> int:
     # `state.bump`'s job, one line below.
     state.clear_exit(fid)
     gather.discard(fid)
+    # And the shape this frame starts at is this frame's own: an adopted `density` would
+    # be another session's keypress silently overriding this plane's `[frame] density`,
+    # and an adopted `panes` would name tmux panes that no longer exist. See
+    # `state.clear_shape`.
+    state.clear_shape(fid)
     # And the `server` marker is rewritten for the same reason: an adopted directory
     # may name the OTHER server, and a stale marker would make `reap` on this one skip
     # a frame that is now genuinely ours.
@@ -1576,6 +1711,10 @@ def cmd_launch(args) -> int:
 
     slots = _drawable_slots(cols, rows)
     env = _frame_env(fid, h)
+    # Same as the operator's-tmux path above, and needed harder here: charter's private
+    # server is SHARED, so a `run-shell` child on it reads whichever launcher's
+    # environment started the server. See `state.record_identity`.
+    state.record_identity(fid, _frame_identity_env(env))
 
     conf_path = fdir / "tmux.conf"
     status_path = fdir / "exit"
@@ -1662,16 +1801,8 @@ def cmd_launch(args) -> int:
                   "the wrong charter if this pane's directory has its own `charter/` "
                   "package")
 
-    # The menu itself: what the hotkey actually opens. A single "Detach" entry — the
-    # spec's own words, "Detach is allowed and prints how to reattach" — proves the
-    # mechanism end to end (bind → menu → opaque id → real command) without inventing a
-    # feature this task was never asked to build. `-s fid` (not `-t`): `detach-client`'s
-    # `-s` targets every client attached to a SESSION, `-t` a single CLIENT — this frame
-    # normally has exactly one attached client, but `-s` is correct even if it ever has
-    # more than one.
-    menu.record(fid=fid, entries=[
-        ("Detach", tmuxctl.server_argv(SOCKET, "detach-client", "-s", fid)),
-    ])
+    # The menu itself: what the hotkey actually opens.
+    menu.record(fid=fid, entries=_menu_entries(fid, SOCKET, current=_current_density(fid)))
 
     write_hook = tmuxctl.run(
         "installing the exit-status hook",
@@ -1739,31 +1870,8 @@ def cmd_launch(args) -> int:
             # below `PANE_ENV_FLOOR`, where `split-window` cannot parse the flag.
             panes = _draw_panels(
                 SOCKET, slots=slots, fid=fid, harness_pane=harness_pane, env=env, v=v,
-                pane_env=(_frame_identity_env(env)
-                          if v >= tmuxctl.PANE_ENV_FLOOR else None))
-            for slot, pane_id in panes.items():
-                # This panel's OWN `pane-died` hook, so a panel whose process dies
-                # outright is brought back instead of leaving a hole for the frame's
-                # whole life (#382). Scoped to this pane — never the harness pane, whose
-                # `pane-died` array carries the exit code and must not gain a third
-                # writer (see `_panel_died_hook_argv`). Reported but never fatal, like
-                # every other decorative tmux command here: a panel that cannot be armed
-                # for respawn is still a panel that came up.
-                #
-                # Private-server-only, deliberately, and not folded into `_draw_panels`
-                # itself: `cmd_respawn` (the hook's own action) and
-                # `_panel_died_hook_argv` both assume `SOCKET`, charter's own server
-                # NAME — `-L`, never `-S` — which is correct here and wrong on the
-                # operator's own tmux, where the frame's server is a socket PATH read
-                # from `$TMUX`. Arming a panel there today would install a hook whose
-                # action targets the wrong tmux server entirely. Extending #382 across
-                # that boundary is real work — resolving `cmd_respawn`'s target from
-                # `state.frame_server(fid)` and its liveness check from windows rather
-                # than sessions — not something to invent as a side effect of this
-                # rebase.
-                tmuxctl.run(f"arming the {slot} panel for respawn",
-                           _panel_died_hook_argv(socket=SOCKET, panel_pane=pane_id,
-                                                 slot=slot), env=env)
+                pane_env=_pane_identity_env(env, v))
+            _arm_panel_respawn(SOCKET, panes=panes, env=env)
 
             # `split-window` makes the newly created pane the ACTIVE one by default, so
             # after every slot has been drawn, the LAST panel drawn — not the harness —
@@ -1814,6 +1922,288 @@ def cmd_launch(args) -> int:
         # precisely the failure this whole module exists to stop happening silently.
         tmuxctl.report_failure("attaching to the frame", attach_cmd, attach)
         return attach.returncode
+    return 0
+
+
+#: What marks the level a frame is currently at, in the hotkey menu, and the blank that
+#: keeps the other rows aligned with it.
+#:
+#: **ASCII, deliberately.** The obvious `•` (U+2022) is East-Asian *Ambiguous*: one column
+#: in most terminals and two under a CJK locale or an ambiguous-width setting, which would
+#: shift that one row against its neighbours in a `display-menu` tmux does not pad.
+#: `statusline._persona_chips` carries a comment saying ambiguous glyphs "have broken this
+#: layout twice", and writing one in a fresh line under that rule is not a trade worth
+#: making for a prettier dot. `*` is the marker `git branch` already uses for "the one you
+#: are on", and it is unambiguously narrow everywhere.
+_DENSITY_MARK = ("*", " ")
+
+
+def _current_density(fid: str) -> str:
+    """The density *fid* is at right now: its own recorded override, else the configured
+    default. The same two-source order `frame/slots.verbosity` reads for verbosity, so the
+    menu's dot and the panels' own content can never disagree about which level is on."""
+    from . import instance
+    return (instance.density_level(state.density(fid))
+            or instance.density_level(config.FRAME["density"])
+            or "normal")
+
+
+def _menu_entries(fid: str, socket: str, *, current: str) -> list[tuple[str, list[str]]]:
+    """Every row of this frame's hotkey menu, in the order it is drawn.
+
+    **"Detach" and the three densities, and no separate key for any of them.** #387 asks
+    that a keypress change the density of the RUNNING frame; a second `bind -n` would have
+    been the obvious way and is the wrong one, because a tmux key table is server-wide with
+    no per-session form (`conf_text`'s own docstring measures what that costs). Every frame
+    on `SOCKET` would share whatever key was chosen, and an operator inside their own tmux
+    — where charter binds nothing at all — would get no density control regardless. The
+    hotkey charter already binds opens this menu, so the density lives here: one bind, one
+    server-wide cost, already paid.
+
+    **The argv is `charter frame-density <level>`, not tmux's own commands.** Re-laying out
+    a frame is several tmux calls that have to be ordered and whose results have to be
+    written back down (`_relayout`); a menu entry is one argv, run once, by
+    `cmd_action`'s plain `subprocess.run` of a LIST. `util.self_relaunch_argv()` for the
+    interpreter half, for #390's reason — a menu action starts in whatever directory the
+    pane is in, and from a charter checkout a bare `-m charter` imports the checkout.
+
+    *current* is marked, not filtered out: an operator who selects the level they are
+    already on gets a re-layout that produces the same frame, which is the harmless
+    outcome, and a menu whose rows move around depending on state is a menu nobody learns.
+    """
+    from . import instance
+    entries: list[tuple[str, list[str]]] = [
+        # The spec's own words, "Detach is allowed and prints how to reattach". `-s fid`
+        # (not `-t`): `detach-client`'s `-s` targets every client attached to a SESSION,
+        # `-t` a single CLIENT — this frame normally has exactly one attached client, but
+        # `-s` is correct even if it ever has more than one.
+        ("Detach", tmuxctl.server_argv(socket, "detach-client", "-s", fid)),
+    ]
+    on, off = _DENSITY_MARK
+    for level in instance.FRAME_DENSITY:
+        mark = on if level == current else off
+        entries.append((f"{mark} density: {level}",
+                        util.self_relaunch_argv("frame-density", level)))
+    return entries
+
+
+def _pane_identity_env(env: dict[str, str], v: tuple[int, int]) -> dict[str, str] | None:
+    """What a newly split panel pane must be TOLD, or ``None`` when tmux cannot be told.
+
+    One line of logic, named once, because there are now two callers that create panel
+    panes — `cmd_launch` and `_relayout` — and the two halves of this are each a decision
+    somebody already paid for:
+
+    * :func:`_frame_identity_env`, never the whole environment. A tmux ``-e`` is argv, and
+      argv is world-readable: measured on a real environment, `_frame_env` expanded to 138
+      argv elements and 7,696 bytes carrying two live service-account tokens. Only the five
+      names in :data:`_FRAME_IDENTITY` travel; everything else keeps arriving the way it
+      always did.
+    * :data:`tmuxctl.PANE_ENV_FLOOR`, below which ``split-window`` cannot parse the flag at
+      all — and a flag tmux refuses takes the whole command with it, so the pane is created
+      without it rather than not created.
+
+    Written as a wrapper rather than repeated at each call site so a name added to
+    `_FRAME_IDENTITY` — it has grown from four to five already — reaches every pane charter
+    creates, not just the ones somebody remembered.
+    """
+    return _frame_identity_env(env) if v >= tmuxctl.PANE_ENV_FLOOR else None
+
+
+def _relayout_pane_env(fid: str, v: tuple[int, int]) -> dict[str, str] | None:
+    """What a pane split by a LIVE RE-LAYOUT must be told. Five names, and the frame's
+    OWN values for them — never this process's.
+
+    **`os.environ` here is not this frame's identity, and that is #411 arriving on the one
+    command added since.** `cmd_density` normally runs as a `subprocess.run` child of
+    `cmd_action`, which is a `run-shell` child of the tmux server. Only
+    `CHARTER_SESSION_ID` is session-scoped (`_session_id_env_argv`); `CHARTER_ROOT`,
+    `CHARTER_WORKSPACE`, `CHARTER_HARNESS` and `CHARTER_PERSONA` all reach that child from
+    the SERVER's environment, and charter's private server is shared between every frame
+    on the machine. Measured against tmux 3.7c, the second frame's `run-shell` reported
+    the first frame's workspace and harness alongside its own id — so building a `-e`
+    payload from `os.environ` would pin ANOTHER frame's plane onto the panes this keypress
+    creates, where `$CHARTER_ROOT` and `$CHARTER_WORKSPACE` win outright over every other
+    source. The frame's new panels would draw a different plane from the survivors.
+
+    So the values come from `state.identity`, which the LAUNCHER wrote — the one process
+    that knew. Recorded in the frame's own directory rather than pushed onto the tmux
+    session, because the operator's-tmux path may not write a session option at all (ADR
+    0018), and one mechanism that works on both servers beats two that each work on one.
+
+    **A frame with no recorded identity gets the four unknown names as EMPTY, not
+    omitted.** Omitting them lets the pane inherit the server's — which is the bug. Empty
+    is what every charter reader already treats as absent (`workspace.resolve` and
+    `root.find_root` test for truth, not presence), so the pane falls back to resolving
+    from its own cwd, which it inherits from the harness pane and which is correct.
+    `_frame_identity_env`'s own docstring makes the identical argument for the launch path.
+
+    `CHARTER_SESSION_ID` is forced to *fid* rather than read back: it is the one name this
+    process can be certain of — it is how it found the frame at all — and a recorded value
+    disagreeing with it would mean the directory belongs to a different frame.
+
+    There is no matching CLIENT environment to decide here. `cmd_launch` passes one
+    because it is the call that STARTS charter's server; by the time a density change
+    runs, the server is up on either socket and a pane's environment comes from the server
+    and this `-e`, never from the tmux client's own process. A client env would have been
+    a distinction no test could tell from its absence, so the callers pass `env=None`.
+    """
+    known = state.identity(fid)
+    values = {name: known.get(name, "") for name in _FRAME_IDENTITY}
+    values["CHARTER_SESSION_ID"] = fid
+    return values if v >= tmuxctl.PANE_ENV_FLOOR else None
+
+
+def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str],
+              want: list[str], v: tuple[int, int]) -> dict[str, str]:
+    """Make the running frame's panes match *want*, and return the map that resulted.
+
+    Kill what is no longer wanted, split what is newly wanted, re-arm the hooks, re-assert
+    every size. In that order, and each step is here for a measured reason:
+
+    * **Disarm before killing.** See :func:`_disarm_panel_respawn` — otherwise the panel
+      charter just closed comes straight back, one respawn life poorer.
+    * **Split off the HARNESS pane, never off a sibling panel.** `_draw_panels` already
+      does this and it is `frame/layout.py`'s own module-docstring measurement: tmux
+      renumbers pane INDICES on every split, and a target derived from an earlier split is
+      the bug that shipped a four-slot frame with one panel. The harness pane's `%N` is
+      read back out of the frame's own state (`state.panes`), which is why that file
+      exists at all.
+    * **Re-assert every size afterwards, not only the new panes'.** A `split-window -l` or
+      a `kill-pane` makes tmux redistribute the remaining panes proportionally — the same
+      engine `_resize_hook_argv` exists to correct after a window resize. The panes that
+      merely SURVIVED a density change are the ones that get stretched by it, so they are
+      exactly the ones a `-l` on the new pane cannot fix.
+
+    Slots whose `split-window` fails are simply absent from the returned map, as at launch:
+    a decorative panel that could not be drawn must not take down a frame that is running.
+
+    **What the ordering does and does not buy.** Kill-then-split-then-re-arm means an
+    interruption cannot leave a pane armed for respawn that no longer exists, and cannot
+    leave the resize hook naming a pane that has been killed *while* a later step is still
+    running — each step's own invariant holds the moment it returns. It is NOT a
+    transaction: charter is several tmux commands here, tmux has no way to run them as
+    one, and a process killed midway can genuinely leave a frame with the old `left` gone
+    and the new `right` not yet split. That state is inconsistent but not corrupt — every
+    pane in it is real, the recorded map is rewritten from what actually came back, and
+    the next density change (or the next launch) resolves it. Claiming more than that
+    would be claiming an atomicity nothing here has.
+    """
+    # `env=None` throughout: see `_relayout_pane_env` for why a live re-layout has
+    # no client environment to decide.
+    pane_env = _relayout_pane_env(fid, v)
+    keep: dict[str, str] = {}
+    for slot, pane_id in panels.items():
+        if slot in want:
+            keep[slot] = pane_id
+            continue
+        if not _PANE_ID_RE.fullmatch(pane_id):
+            # Read back off disk, so it is not tmux's own word for it any more. Same
+            # treatment `_draw_panels` gives an id on the way in, for the same reason:
+            # this one is about to be interpolated into a hook action and a kill.
+            continue
+        _disarm_panel_respawn(socket, pane_id=pane_id)
+        tmuxctl.run(f"closing the {slot} panel",
+                    tmuxctl.server_argv(socket, "kill-pane", "-t", pane_id))
+
+    missing = [s for s in want if s not in keep]
+    if missing:
+        # Split in `want`'s order, which is the density level's own — see
+        # `instance.FRAME_DENSITY` for why that order is geometry rather than reading
+        # order. Every split targets the harness pane, so a slot added to a frame that
+        # already has the others lands exactly where a launch would have put it.
+        keep.update(_split_panels(socket, slots=missing, fid=fid,
+                                  harness_pane=harness_pane, env=None,
+                                  pane_env=pane_env))
+        _arm_panel_respawn(socket, panes={s: keep[s] for s in missing if s in keep},
+                           env=None)
+
+    _install_resize_hook(socket, harness_pane=harness_pane, panes=keep, v=v,
+                         env=None, replacing=True)
+    for slot, pane_id in keep.items():
+        tmuxctl.run(f"restoring the {slot} panel's size",
+                    tmuxctl.server_argv(socket, "resize-pane", "-t", pane_id,
+                                        _RESIZE_FLAG[slot], str(layout.SLOT_SIZE[slot])),
+                    report=False)
+    # `split-window` makes each new pane the ACTIVE one, so without this the operator is
+    # left typing into a panel. The same correction `cmd_launch` makes after its own
+    # splits, for the same reason.
+    tmuxctl.run("focusing the harness pane",
+                tmuxctl.server_argv(socket, "select-pane", "-t", harness_pane))
+    return keep
+
+
+def cmd_density(args) -> int:
+    """`charter frame-density <level>` — re-lay-out THIS frame, and write nothing else.
+
+    Fired by a hotkey-menu selection (`_menu_entries`), and typeable by hand from inside a
+    frame. The frame is resolved from `$CHARTER_SESSION_ID` exactly as `cmd_menu` and
+    `cmd_respawn` resolve theirs — never from anything baked into a menu action, since one
+    bind and one action template are shared by every frame on `SOCKET`.
+
+    **charter.toml is not touched, and that is the whole design.** `[frame] density` sets
+    what a frame STARTS at; this changes what one running frame IS. Charter's rule is that
+    machine-written config belongs somewhere a machine may rewrite whole, and a
+    hand-maintained, committed file that carries an operator's comments is the opposite of
+    that — so the override goes in the frame's own state directory (`state.record_density`),
+    which `state.reap` deletes entire when the frame ends. Relaunch, and the configured
+    default is back.
+
+    **Always 0, and every refusal is a quiet no-op**, for `cmd_respawn`'s reason: this
+    normally runs as a `run-shell` child of a menu selection, where the only screen left to
+    report on is the agent's own — the one rectangle ADR 0018 says charter never draws in.
+
+    Refusals, in order:
+
+    * no `$CHARTER_SESSION_ID` — not fired from inside a frame at all;
+    * a *level* outside `instance.FRAME_DENSITY` — a closed set of three constants charter
+      wrote itself, so this can only be a hand-typed argument;
+    * a harness pane that is not tmux's own `%<digits>` — a frame launched by a charter
+      that predates `state.record_harness_pane`, or a corrupted file. There is nothing to
+      split off, and guessing at a pane id is the one thing `frame/layout.py`'s module
+      docstring measures the cost of. (An empty PANEL map is not a refusal: a frame whose
+      panels all failed to draw can still be given some.)
+
+    The density is recorded BEFORE the panes move, so a re-layout that fails halfway still
+    leaves the panels that survive drawing at the density the operator asked for. The
+    version is bumped afterwards: that is what makes every surviving panel repaint with the
+    new verbosity, and a bump before the layout settled would repaint into the old shape.
+    """
+    from . import instance
+    fid = os.environ.get("CHARTER_SESSION_ID", "")
+    level = instance.density_level(getattr(args, "level", None))
+    if not fid or level is None:
+        return 0
+    # The harness pane comes from `state.harness_pane`, the record ADR 0019's own
+    # `is_live` reads — not from a second copy of its own. `_PANE_ID_RE` still guards it:
+    # it arrives off disk here rather than off `split-window`'s stdout, and it is about to
+    # be interpolated into a hook action and a split target.
+    harness_pane = state.harness_pane(fid) or ""
+    panels = state.panes(fid)
+    if not _PANE_ID_RE.fullmatch(harness_pane):
+        return 0
+    socket = state.frame_server(fid) or SOCKET
+    v = tmuxctl.version()
+    if v is None:
+        return 0
+
+    state.record_density(fid, level)
+    cols, rows = _window_size(socket, harness_pane)
+    want = _drawable_slots(cols, rows, instance.density_slots(level))
+    panes = _relayout(socket, fid=fid, harness_pane=harness_pane, panels=panels,
+                      want=want, v=v)
+    state.record_panes(fid, panels=panes)
+    # Re-recorded so the menu's own mark moves with the frame. `menu.record` rewrites the
+    # table whole, and every action id is minted from position, so the ids the operator's
+    # currently-open menu is holding stay valid for the same rows.
+    #
+    # Private server only, matching `cmd_launch`, which records no menu inside an
+    # operator's tmux either: charter binds no key there, so there is nothing to open the
+    # menu with — and the "Detach" row it would grow targets `detach-client -s <fid>`, a
+    # SESSION name that does not exist on that server, where a frame is a window.
+    if not tmuxctl.is_operator_socket(socket):
+        menu.record(fid=fid, entries=_menu_entries(fid, socket, current=level))
+    state.bump(fid)
     return 0
 
 

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -816,8 +816,19 @@ def check_frame() -> Result:
     `cmd_launch`, printed microseconds before tmux switched the operator's terminal to
     the alternate screen, where nobody could read them — see
     `commands_frame.frame_ready`'s own docstring for the measurement and the argument.
-    Both facts are answerable without starting anything: `tmuxctl.version()` and
+    Every fact is answerable without starting anything: `tmuxctl.version()` and
     `config.FRAME["slots"]`.
+
+    **Three ceilings, collected rather than branched (#387).** The third —
+    `tmuxctl.RESIZE_HOOK_FLOOR`, above `FLOOR` — was reported by neither this row nor
+    `frame_ready`, so an operator on tmux 3.2 passed the floor, read a green tick here,
+    and had no resize recovery. Written as one list because that is now three
+    independent conditions over two version thresholds and a config value, and the
+    nested-`if` shape this replaced already had to repeat the slot ceiling in two
+    branches to stay honest. `_statusline_suppressed_note` rides on the same hint but is
+    deliberately NOT one of them: every ceiling is a capability this machine does not
+    have, and a status line blanked because a frame is drawing instead is a capability
+    working exactly as designed (ADR 0019).
     """
     from . import config
     from .frame import slots as frame_slots, tmuxctl
@@ -829,26 +840,30 @@ def check_frame() -> Result:
                       hint="charter <harness> needs tmux to compose a frame — brew "
                            "install tmux (or your package manager). Without it, "
                            "charter <harness> --no-frame still runs the harness bare.")
-    missing = frame_slots.unimplemented(config.FRAME["slots"])
-    # A blank status line is the one frame behaviour that shows the operator NOTHING —
-    # ADR 0019's own rule is that a surface which vanished for an invisible reason is the
-    # worst outcome available, so the reason is said out loud on the surface built to
-    # answer on demand. Appended to whatever else this row reports rather than replacing
-    # it: it is a statement of fact about right now, never a warning.
-    quiet = _statusline_suppressed_note()
+    ceilings = []
     if v < tmuxctl.FLOOR:
         # Not "the hotkey menu is disabled" — nothing disables it. `cmd_launch` warns
         # and continues, and `conf_text` emits the bind unchanged; what is actually at
         # risk below the floor is that the bind opens nothing and that the pane-scoped
         # exit-code hooks may not install. `below_floor_message` is the one place that
         # sentence lives, so this row and `--probe` cannot drift apart.
-        hint = tmuxctl.below_floor_message(v)
-        if missing:
-            hint += " " + commands_frame_no_renderer(missing)
-        return Result(name, WARN, detail=f"tmux {v[0]}.{v[1]}", hint=hint + quiet)
+        ceilings.append(tmuxctl.below_floor_message(v))
+    if v < tmuxctl.RESIZE_HOOK_FLOOR:
+        ceilings.append(tmuxctl.below_resize_hook_message(v))
+    missing = frame_slots.unimplemented(config.FRAME["slots"])
     if missing:
+        ceilings.append(commands_frame_no_renderer(missing))
+    # A blank status line is the one frame behaviour that shows the operator NOTHING —
+    # ADR 0019's own rule is that a surface which vanished for an invisible reason is the
+    # worst outcome available, so the reason is said out loud on the surface built to
+    # answer on demand. Appended to whatever else this row reports rather than replacing
+    # it: it is a statement of fact about right now, never a warning — which is also why
+    # it is not a `ceilings` entry: every one of those is a capability this machine does
+    # not have, and a suppressed status line is a capability working as designed.
+    quiet = _statusline_suppressed_note()
+    if ceilings:
         return Result(name, WARN, detail=f"tmux {v[0]}.{v[1]}",
-                      hint=commands_frame_no_renderer(missing) + quiet)
+                      hint=" ".join(ceilings) + quiet)
     return Result(name, OK, detail=f"tmux {v[0]}.{v[1]}",
                   hint=quiet.strip() or None)
 

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -33,6 +33,18 @@ frame. `_rows` measures the pane the same way `slots._width` measures it, and `_
 clamps the LINE COUNT to that measurement the way `tui.truncate` already clamps each
 line's WIDTH.
 
+**Animation is scoped to work that is actually in flight, and idle stays one `stat`.**
+A panel repaints on a version bump, and a dispatch STARTING does not bump anything — the
+version moves from `posttooluse*` hooks, and a session that has handed work to a sub-agent
+is by definition not making tool calls while it waits. So the one thing the frame animates
+(`slots._inflight_field`) needs the panel to repaint on its own clock, and only while
+there is something to animate. `_running` below is the whole mechanism: `inflight.stamp()`
+is a single `stat` of the tracker's directory, and the records are re-read only when that
+number moves or when the earliest presumed-dead deadline passes. With nothing in flight —
+the directory absent, or present and empty — that is one syscall per tick, alongside the
+one `state.version` already pays, and the panel paints nothing. It is self-limiting by
+construction rather than by a budget: the ticking stops when the records do.
+
 **SIGWINCH matters because a resize does not bump the frame's version.** Only charter's
 own hooks call `state.bump`; the operator resizing their terminal does not. Without a
 handler, a pane sits with content painted for the OLD size until some unrelated activity
@@ -169,6 +181,72 @@ def _hold(reason: str, *, once: bool, rc: int) -> int:
     return rc
 
 
+def _new_inflight_cache() -> dict:
+    """The state :func:`_running` carries between ticks. A dict, matching `resized`'s own
+    shape in this module, so a test can build one and inspect it without a class.
+
+    ``stamp`` starts at ``None``, which is also what `inflight.stamp()` answers for "no
+    such directory" — and the collision is harmless rather than overlooked. A separate
+    "never read yet" sentinel was written here first and then removed for being a claim no
+    test could falsify: the two states agree on the only thing this cache reports. `None`
+    from `stamp()` means the tracker directory does not exist, so nothing can be in
+    flight, and ``running: 0`` is already the right answer without reading anything. Every
+    state in which the answer is NOT 0 has a real ``st_mtime_ns`` behind it, which never
+    compares equal to ``None``, so the first tick of a panel that starts while a dispatch
+    is already running does read — which is exactly how a respawned panel comes back.
+    """
+    return {"stamp": None, "running": 0, "recheck": 0.0}
+
+
+def _running(cache: dict) -> int:
+    """How many dispatches are in flight right now — one `stat` when nothing has changed.
+
+    The idle cost of the whole animation, and the reason it can be on by default. The
+    expensive answer (`inflight.live_records()`: open the directory, read every entry,
+    parse each one's JSON) is recomputed only when one of two things is true:
+
+    * the tracker's directory mtime moved — a record was created or removed, the only two
+      events that can change the set (`inflight.stamp`'s own docstring);
+    * the earliest presumed-dead deadline has passed — the one way this answer changes
+      with NO file changing, since `presumed_dead` is measured against the clock. Only
+      consulted while something is actually running, so an idle panel never computes a
+      deadline, never stores one, and never compares against one.
+
+    Counts RUNNING records only, presumed-dead ones excluded, and that is what stops a
+    killed dispatch from spinning a panel for the rest of the day: `inflight` keeps such a
+    record for `PRUNE_SECONDS` (24 hours) precisely so it stays visible, and
+    `slots._inflight_field` does still draw it — statically, with `⋯`. Animating it would
+    claim progress that stopped hours ago, on an otherwise idle machine.
+
+    Never raises: this sits in a panel's run loop, where an exception ends the pane
+    (`run`'s own `_hold` catches it, but a panel that stops repainting has already lost).
+    A tracker charter cannot read is "nothing in flight", which degrades to the stillness
+    this feature's whole promise is about.
+    """
+    from .. import inflight
+    try:
+        stamp = inflight.stamp()
+        stale = cache["running"] and time.time() >= cache["recheck"]
+        if stamp == cache["stamp"] and not stale:
+            return cache["running"]
+        records = inflight.live_records()
+        cache["stamp"] = stamp
+        cache["running"] = sum(1 for _a, _t, dead in records if not dead)
+        cache["recheck"] = min((t for _a, t, dead in records if not dead),
+                               default=0.0) + inflight.PRESUMED_DEAD_SECONDS
+        return cache["running"]
+    except Exception:
+        # The stamp is deliberately NOT reset here. `cache["stamp"]` is only ever assigned
+        # after a read that completed, so a read that raised has left it describing the
+        # last directory state charter actually understood — and the next change to the
+        # set of records moves it, which re-reads. Resetting it instead would retry a
+        # raising read on every tick, five times a second, for as long as the fault
+        # lasted. Reporting 0 is the safe direction either way: it means stillness, which
+        # is this feature's own promise for "charter does not know of any work".
+        cache["running"] = 0
+        return 0
+
+
 def _install_sigwinch(resized: dict) -> object:
     """Arm the resize handler, returning whatever was installed before it so `run` can
     put it back rather than leaking a handler past this process's own lifetime — a
@@ -178,7 +256,8 @@ def _install_sigwinch(resized: dict) -> object:
     return signal.signal(signal.SIGWINCH, lambda *_a: resized.__setitem__("flag", True))
 
 
-def _tick(resized: dict, seen: str, slot: str, fid: str) -> str:
+def _tick(resized: dict, seen: str, slot: str, fid: str, *,
+          animating: bool = False) -> str:
     """One loop iteration's decision AND its effect — split out of `run` so the
     DECISION (paint now, or wait) can be exercised without also exercising `run`'s
     `while True`/`time.sleep`, which a test cannot call directly without either hanging
@@ -208,9 +287,17 @@ def _tick(resized: dict, seen: str, slot: str, fid: str) -> str:
     (or exactly match) what was actually painted, so any bump during or after the paint
     is still visible to the next comparison — pinned directly by
     `Tick.test_a_bump_landing_during_the_paint_is_not_marked_seen`.
+
+    *animating* is the third reason to repaint, and it is the same shape as *resized*: the
+    frame's version has not moved and the pane's size has not changed, but what the panel
+    would draw NOW differs from what is on screen, because the spinner is on a different
+    frame (`slots.spinner_frame` reads the clock). Defaulted to `False` so the two callers
+    that mean "repaint only on news" — every test in this module that exercises the
+    decision directly — keep saying exactly that. `_watch` is what decides it, from
+    :func:`_running`.
     """
     now = state.version(fid)
-    if resized["flag"] or now != seen:
+    if resized["flag"] or now != seen or animating:
         resized["flag"] = False
         _paint(slot, fid)
         return now
@@ -218,7 +305,14 @@ def _tick(resized: dict, seen: str, slot: str, fid: str) -> str:
 
 
 def _watch(slot: str, fid: str, *, once: bool) -> int:
-    """The live loop: paint on every version bump or resize until killed.
+    """The live loop: paint on every version bump, resize, or spinner frame, until killed.
+
+    The third reason is the only one that repeats on its own, and it is bounded twice over
+    rather than by a timer this module owns: by the WORK, since `_running` answers 0 the
+    moment the last in-flight record clears; and by the SLOT, since only a renderer in
+    `slots.ANIMATED` draws anything that moves. A `top`, `left` or `right` panel therefore
+    behaves exactly as it did before this feature existed — including paying no `stat`,
+    because the `and` below short-circuits before `_running` is ever called.
 
     Split out of `run` so the SIGWINCH handler it arms is restored by its own `finally`
     before `run`'s failure path can hold the pane open — a handler left installed for
@@ -227,11 +321,20 @@ def _watch(slot: str, fid: str, *, once: bool) -> int:
     already pins that this module leaks no handler past its own work.
     """
     resized = {"flag": True}  # the first pass always paints, resized or not
+    inflight_cache = _new_inflight_cache()
+    # Scoped to THIS slot, and the `and` short-circuits: a panel whose renderer draws
+    # nothing that moves never repaints for the spinner and never even pays the `stat`
+    # that would have told it to. `_watch` runs one process per slot, so an unscoped
+    # check repaints all four for the length of every dispatch — three of them redrawing
+    # byte-identical output, and `right` costs 4.8ms a render to do it (see
+    # `slots.ANIMATED`).
+    animates = slot in slots.ANIMATED
     old_handler = _install_sigwinch(resized)
     try:
         seen = ""
         while True:
-            seen = _tick(resized, seen, slot, fid)
+            seen = _tick(resized, seen, slot, fid,
+                         animating=animates and bool(_running(inflight_cache)))
             if once:
                 return 0
             time.sleep(TICK)

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -20,8 +20,70 @@ from __future__ import annotations
 
 import os
 import sys
+import time
 
 from .. import tui
+
+#: The spinner's own frames, and how long each is held. Ten braille cells, each one
+#: column wide (`unicodedata.east_asian_width` is `N` for U+2800–U+28FF, so `tui.width`
+#: counts them as 1) — nothing here is drawn wider than the static `⋯` it falls back to.
+#:
+#: **Zero runtime dependencies, and no animation loop either.** The frame is chosen from
+#: the clock rather than advanced by a counter (:func:`spinner_frame`), so nothing has to
+#: own the spinner's state, nothing has to be reset when a panel repaints for an unrelated
+#: reason, and two panels drawing at the same moment necessarily draw the same frame.
+#:
+#: The period matches `panel.TICK`: a panel that is animating repaints once per tick, so a
+#: shorter period would name frames nobody ever sees and a longer one would repaint
+#: without changing anything.
+SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+SPINNER_PERIOD = 0.2
+
+#: How many rows a full-height panel (`left`, `right`) draws at `terse`. The horizontal
+#: strips have no equivalent — `top` and `bottom` are one row at every density
+#: (`layout.SLOT_SIZE`), so what "less" means for them is FIELDS, not rows.
+_TERSE_ROWS = 4
+
+
+def spinner_frame(now: float | None = None) -> str:
+    """Which frame of :data:`SPINNER` this instant shows.
+
+    Read off `time.monotonic()` rather than advanced by a caller — see :data:`SPINNER`.
+    *now* is for tests, which need a specific frame rather than whichever one the clock
+    happened to be on.
+    """
+    t = time.monotonic() if now is None else now
+    return SPINNER[int(t / SPINNER_PERIOD) % len(SPINNER)]
+
+
+def verbosity(fid: str) -> str:
+    """How much this frame's panels say: ``"terse"`` or ``"normal"``.
+
+    Two sources, in one order that is the whole of #387's "the hotkey overrides for the
+    running frame only": the frame's OWN recorded density (`state.density`, written by
+    the density menu and by nothing else) first, and `[frame] density` from charter.toml
+    behind it. A frame nobody has touched reads the configured value; a frame whose
+    operator has pressed the hotkey reads their choice, for as long as that frame runs and
+    not one moment longer — `state.reap` deletes the file with the rest of the directory.
+
+    **The override is VALIDATED before it is allowed to win, not merely read.** A plain
+    `state.density(fid) or config.FRAME["density"]` looks equivalent and is not: the file
+    holds text, so a truncated write or a hand edit gives a non-empty value that is not a
+    level, which is truthy — it beats the configured value and then degrades to
+    `DEFAULT_VERBOSITY` at the last step. The operator's own `[frame] density = "minimal"`
+    would be silently discarded by a corrupt byte in a file they have never heard of.
+    Asking `density_level` first makes "not a level" and "nothing recorded" the same
+    thing, which is what they mean here.
+
+    `instance.verbosity_for` is what turns whichever survives into a verbosity, so an
+    unknown level from either source degrades identically. Read at call time, never
+    cached: a panel repaints on a version bump, and the density menu bumps the version
+    precisely so that this is re-read.
+    """
+    from .. import config, instance
+    from . import state
+    override = instance.density_level(state.density(fid))
+    return instance.verbosity_for(override or config.FRAME["density"])
 
 
 def _width() -> int:
@@ -78,6 +140,12 @@ def _top(fid: str) -> str:
     gauge" — so this is left out, not stubbed in, until #386 (which owns the suppression
     and recording question this finding feeds) decides a panel should have its own
     persisted usage snapshot to read. Pinned by `tests.test_frame_slots.TopRenderer`.
+
+    **At `terse` the version goes, and nothing else does.** `top` answers "where am I and
+    who am I being", and of the three things on it the charter version is the only one
+    that reads the same on every frame on this machine all day — it is a fact about the
+    install, not about where you are standing. The workspace and the persona ARE the
+    answer, so a density that dropped either would leave a row not earning its line.
     """
     from .. import __version__, statusline, workspace
     ws = workspace.resolve()
@@ -85,7 +153,7 @@ def _top(fid: str) -> str:
     pin = "*" if src == "$CHARTER_WORKSPACE" else ""
     persona = statusline._persona_line() or ""
     left = f" ⬢ {ws}{pin}"
-    right = f"{persona}  charter {__version__} "
+    right = persona if verbosity(fid) == "terse" else f"{persona}  charter {__version__} "
     return tui.truncate(f"{left}  {right}", _width())
 
 
@@ -278,6 +346,16 @@ def _left(fid: str) -> str:
     fix). `_repo_line` is handed `0` whenever every one of a repo's pieces
     already has its own row — the badge means "there is more you cannot see
     here," not "this repo has pieces."
+
+    **At `terse` the budget drops to :data:`_TERSE_ROWS` and piece rows go.** `_pick_rows`
+    is asked for fewer rows rather than the result being sliced afterwards, so the rows
+    that survive are still the ones worth keeping (the repo you are standing in, the ones
+    with something on them) rather than whichever happened to come first — the exact
+    lesson `statusline.py` paid for and this function already borrows. The `…(+N more)`
+    line and its "all clean" claim come along unchanged, so a terse panel still says how
+    much it is not showing, which is what makes showing less honest rather than
+    misleading. Pieces are dropped whole: they are DETAIL under a repo that still has its
+    own row, so losing them costs no repo its line.
     """
     from .. import statusline as sl
     from . import gather
@@ -306,7 +384,8 @@ def _left(fid: str) -> str:
         total = r.get("worktree_count") or 0
         return total if shown_pieces.get(r["name"], 0) < total else 0
 
-    budget = sl._MAX_REPO_LINES
+    terse = verbosity(fid) == "terse"
+    budget = _TERSE_ROWS if terse else sl._MAX_REPO_LINES
     capped = len(keys) > budget
     show = sl._pick_rows(keys, (budget - 1) if capped else budget,
                          cur_repo, by_key, by_key) if capped else keys
@@ -325,8 +404,9 @@ def _left(fid: str) -> str:
         note = ", all clean" if quiet else ""
         lines.append(tui.truncate(f"{sl._DIM}…(+{len(hidden)} more{note}){sl._R}", w))
 
-    for p in (data.get("worktrees") or []):
-        lines.append(_piece_line(p, w))
+    if not terse:
+        for p in (data.get("worktrees") or []):
+            lines.append(_piece_line(p, w))
 
     return "\n".join(lines)
 
@@ -355,6 +435,15 @@ def _right(fid: str) -> str:
     breaks the status line"), and `render`'s caller-side `try/except` covers
     whatever gets past that — the same trust `_top`/`_bottom` already place in
     it rather than each re-wrapping their own calls into `statusline.py`.
+
+    **At `terse` this keeps :data:`_TERSE_ROWS` chips and says so.** A slice, not a
+    narrower chip: `_persona_chips` builds one chip as `◆ name` plus its vault dot,
+    memory badge, health mark and in-flight badge all together, and dropping any of
+    those parts would mean reassembling the chip here out of the five helpers this
+    function exists specifically not to duplicate. So the panel drops whole personas
+    and adds `_left`'s own `…(+N more)` line, which is the honest way to show fewer of
+    a list — `_persona_chips` is already ordered, so what survives is the top of an
+    order rather than an arbitrary handful.
     """
     from .. import statusline as sl
 
@@ -362,10 +451,54 @@ def _right(fid: str) -> str:
     chips = sl._persona_chips()
     if not chips:
         return tui.truncate(f"{sl._DIM}no personas{sl._R}", w)
+    if verbosity(fid) == "terse" and len(chips) > _TERSE_ROWS:
+        hidden = len(chips) - (_TERSE_ROWS - 1)
+        chips = [*chips[:_TERSE_ROWS - 1], f"{sl._DIM}…(+{hidden} more){sl._R}"]
     return "\n".join(tui.truncate(c, w) for c in chips)
 
 
-def _fit_fields(priority: list[tuple[str, str]], width: int) -> set[str]:
+def _inflight_field() -> str:
+    """`⠙ 2 running`, or nothing at all when nothing is.
+
+    **The one moving thing in the frame, and it moves only while work is genuinely in
+    flight.** `inflight` records a dispatch when it STARTS and clears it when it ends (see
+    that module's docstring — the completion tally cannot answer this), so "is anything
+    running right now" is a question about files on disk rather than about anything
+    charter has to keep in memory or poll for. `panel._running` is what decides whether the
+    panel repaints often enough for the spinner to move; this function only decides what
+    the row says, and it says nothing when there is nothing to say. Empty means the field
+    is dropped whole by `_fit_fields`, which is what makes idle completely still: no
+    spinner, no zero, no furniture.
+
+    Presumed-dead records get their own, DELIBERATELY STATIC piece. A record past
+    `inflight.PRESUMED_DEAD_SECONDS` is one nobody should still be expecting (its process
+    was killed, or PostToolUse never fired), and animating it would claim progress that is
+    not happening — and would do it for up to `PRUNE_SECONDS`, a full day of a spinning
+    panel on an idle machine. `⋯` is the still glyph for exactly that, and it is also the
+    retreat the whole animation falls back to if it ever measures badly.
+
+    Not `statusline._session_news`'s job, which is why `_bottom` asks it for everything
+    EXCEPT this (`inflight=False`): that helper's `⚡ N` is the same fact drawn for a
+    surface that repaints once per turn, where a spinner would be a still picture of a
+    random frame. Two surfaces, two ways of drawing one fact, one place each — rather than
+    both on the same row saying it twice.
+    """
+    from .. import inflight, statusline as sl
+    records = inflight.live_records()
+    if not records:
+        return ""
+    running = sum(1 for _agent, _started, dead in records if not dead)
+    stalled = len(records) - running
+    parts = []
+    if running:
+        parts.append(f"{sl._YELLOW}{spinner_frame()} {running} running{sl._R}")
+    if stalled:
+        parts.append(f"{sl._DIM}⋯ {stalled} stalled{sl._R}")
+    return " ".join(parts)
+
+
+def _fit_fields(priority: list[tuple[str, str]], width: int,
+                limit: int | None = None) -> set[str]:
     """Which names among *priority* — an ordered list of ``(name, text)`` pairs, highest
     priority first — fit *width* once joined with `` · ``, decided one at a time in that
     order: each field's FULL text counted against what is left, included whole or
@@ -378,6 +511,13 @@ def _fit_fields(priority: list[tuple[str, str]], width: int) -> set[str]:
     exactly the fields a test wants, in isolation — `_bottom` also always carries a todo
     count and a hotkey hint that would otherwise compete for the same narrow budgets an
     adversarial test needs to construct.
+
+    *limit* caps how many fields survive REGARDLESS of width — how a `terse` density asks
+    for less on a row that has room for more. It reuses this one priority order rather
+    than `_bottom` keeping a second, shorter list of its own: "which field matters most"
+    is one question, and answering it twice is how the two answers come to disagree about
+    whether an alert outranks a todo count. ``None`` (the default) is "as many as fit",
+    which is exactly what every caller wanted before densities existed.
     """
     sep_w = tui.width(" · ")
     budget = width
@@ -385,6 +525,8 @@ def _fit_fields(priority: list[tuple[str, str]], width: int) -> set[str]:
     for name, text in priority:
         if not text:
             continue
+        if limit is not None and len(keep) >= limit:
+            break
         need = tui.width(text) + (sep_w if keep else 0)
         if need > budget and keep:
             continue          # doesn't fit and something already does — drop it whole
@@ -426,13 +568,27 @@ def _bottom(fid: str) -> str:
     Global Constraints call out by name.
 
     Priority order, highest first: the one alert (`_alerts()`'s own top pick — an
-    actionable control-plane problem, carrying its own fix); `_session_news` (this
-    session's own activity — silent unless it already has something to say, so its mere
-    presence is the signal); the todo count (persistent state, not urgent); the
-    configured hotkey hint (the one thing always rediscoverable another way, so it is
-    first to give up its columns). Once decided, the survivors are RE-JOINED in the
-    original reading order (todo, alert, news, hotkey) — priority governs only who is
-    dropped when the pane is starved, not how a healthy pane reads.
+    actionable control-plane problem, carrying its own fix); the in-flight spinner
+    (:func:`_inflight_field` — work happening RIGHT NOW, and the only thing on this row
+    that will be different in a second); `_session_news` (this session's own activity —
+    silent unless it already has something to say, so its mere presence is the signal);
+    the todo count (persistent state, not urgent); the configured hotkey hint (the one
+    thing always rediscoverable another way, so it is first to give up its columns). Once
+    decided, the survivors are RE-JOINED in the original reading order (todo, alert,
+    inflight, news, hotkey) — priority governs only who is dropped when the pane is
+    starved, not how a healthy pane reads.
+
+    **`_session_news` is asked to leave its own in-flight count out** (`inflight=False`).
+    Both would otherwise draw the same fact from the same tracker on the same row —
+    `⚡ 2 · ⠙ 2 running` — and the duplicate would be the one thing on the row a reader
+    could not explain. The status line keeps `⚡ 2` unchanged: it repaints once per turn,
+    where a spinner is a still picture of an arbitrary frame.
+
+    **At `terse` exactly one field survives** — the highest-priority one that has anything
+    to say. On a quiet plane that is the todo count, so the row is never blank; the moment
+    something is wrong or something is running, the row is that instead. `_fit_fields`
+    does it through the same priority order it already uses for width, so "less" and
+    "too narrow" cannot disagree about what matters.
 
     The hotkey is READ, not spelled out: `[frame] hotkey` is configurable, and this row
     used to hardcode `F2 menu` — so a plane on `hotkey = "F1"` had its own panel telling
@@ -445,7 +601,7 @@ def _bottom(fid: str) -> str:
     ws = workspace.resolve()
     todos = sl._todo_count(ws)
     alerts = sl._alerts(ws)
-    news = sl._session_news(_session.current())
+    news = sl._session_news(_session.current(), inflight=False)
     w = _width()
 
     # Unconditional, unlike `news` below — this predates Task 4 and stays exactly as it
@@ -464,23 +620,50 @@ def _bottom(fid: str) -> str:
     hotkey_text = ("" if tmuxctl.is_operator_socket(state.frame_server(fid))
                    else f"{config.FRAME['hotkey']} menu")
 
+    inflight_text = _inflight_field()
+
     # Decide who survives, highest priority first (see this function's own docstring
     # above for why); `_fit_fields` does the actual budgeting so it can be tested in
     # isolation.
     keep = _fit_fields(
-        [("alert", alert_text), ("news", news_text),
-         ("todo", todo_text), ("hotkey", hotkey_text)], w)
+        [("alert", alert_text), ("inflight", inflight_text), ("news", news_text),
+         ("todo", todo_text), ("hotkey", hotkey_text)], w,
+        limit=1 if verbosity(fid) == "terse" else None)
 
     # Re-assembled in the original reading order, not priority order — priority decided
     # only who was cut.
-    fields = {"alert": alert_text, "news": news_text, "todo": todo_text, "hotkey": hotkey_text}
-    parts = [fields[n] for n in ("todo", "alert", "news", "hotkey") if n in keep]
+    fields = {"alert": alert_text, "inflight": inflight_text, "news": news_text,
+              "todo": todo_text, "hotkey": hotkey_text}
+    parts = [fields[n] for n in ("todo", "alert", "inflight", "news", "hotkey")
+             if n in keep]
     return tui.truncate(" · ".join(parts), w)
 
 
 #: Every slot charter can draw. `panel.run` refuses a name that is not in here rather
 #: than painting an empty pane, because an empty pane reads as a broken frame.
 SLOTS = {"top": _top, "bottom": _bottom, "left": _left, "right": _right}
+
+
+#: Which slots draw something that CHANGES ON ITS OWN, with no version bump and no
+#: resize behind it. Exactly the renderers that reach :func:`spinner_frame`, which today
+#: is `_bottom` and only `_bottom` (through :func:`_inflight_field`).
+#:
+#: **This is what scopes the animation's cost to the pane that needs it.** `panel._watch`
+#: runs one process per slot, so an unscoped "is work in flight" would repaint all four at
+#: `panel.TICK` for the whole length of a dispatch — three of them redrawing byte-identical
+#: output. That is not free: measured on this project (8 personas, 6 repos), one
+#: `render("right")` costs 4 816µs, because `statusline._persona_chips` asks
+#: `persona.is_draft`, `structural_errors`, `_mem_count` twice and `_vault_dot` per
+#: persona — a helper whose own docstring says "this renders on every single turn", written
+#: for once a turn and not five times a second. At 5Hz that one pane alone is ~2.4% of a
+#: core, for a picture that cannot change.
+#:
+#: Kept as data rather than inferred, and kept HONEST by
+#: `tests.test_frame_density.OnlyTheAnimatedSlotAnimates`, which renders every slot twice
+#: at two different clock readings with a record in flight and asserts the output differs
+#: for exactly the names in here — so a renderer that gains a spinner without joining this
+#: set, or leaves one behind without leaving it, is red rather than silently still.
+ANIMATED = frozenset({"bottom"})
 
 
 def unimplemented(configured) -> list[str]:

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -36,6 +36,7 @@ aspirational.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -302,6 +303,213 @@ def frame_server(fid: str) -> str | None:
         return (d / "server").read_text().strip() or None
     except (OSError, ValueError):
         return None
+
+
+def record_density(fid: str, level: str) -> None:
+    """Write down the density THIS RUNNING FRAME is at, overriding `[frame] density`.
+
+    The whole of "a keypress overrides for the running frame only". charter.toml is
+    hand-maintained and committed, and charter's rule is that machine-written config
+    belongs somewhere a machine may rewrite whole — this directory is exactly that place
+    (`reap` deletes it entire when the frame is gone, which is the property a config file
+    a human edits can never have). So the menu writes here, the frame's panels read here,
+    and the operator's own file is left alone: relaunch and the configured default is back.
+
+    Same must-not-raise, atomic-write shape as :func:`bump` and :func:`record_server`.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    tmp = d / "density.tmp"
+    try:
+        tmp.write_text(f"{level}\n")
+        os.replace(tmp, d / "density")
+    except OSError:
+        return
+
+
+def density(fid: str) -> str | None:
+    """The density this frame was last set to by hand, or ``None`` for "never set".
+
+    ``None`` is the ordinary case, not a failure: every frame starts at whatever
+    `[frame] density` resolved to, and only a menu selection writes a file here. The
+    caller falls back to the configured value — see `frame/slots.py`'s `verbosity`.
+
+    The text is NOT validated here. `instance.density_level` is the one gate, and it sits
+    at the point of use so that a hand-edited or truncated file degrades to the configured
+    level in exactly the same way an unknown level in charter.toml does — one rule, one
+    place, rather than a second half-copy of the closed set living in this module.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        return (d / "density").read_text().strip() or None
+    except (OSError, ValueError):
+        return None
+
+
+def clear_shape(fid: str) -> None:
+    """Forget the density and the pane map recorded under *fid*, because a NEW frame is
+    claiming the id.
+
+    The fourth and fifth lines on :func:`clear_exit`'s bill, and the same recycled pid
+    underneath them (#383). A frame id is ``<workspace>-<launcher pid>``; :func:`reap`
+    keeps a directory while the pid in its name is live, and on a launch it is live
+    BECAUSE IT IS THE LAUNCHER'S OWN — so a launcher landing on a pid an earlier launcher
+    for the same workspace already used adopts that earlier frame's whole directory.
+
+    Both files inherited that way are actively wrong for the new frame, not merely stale:
+
+    * ``density`` is an override an operator pressed a key for once, in a frame that is
+      over. Left behind, a brand-new frame comes up at that level while `[frame] density`
+      says otherwise and nothing anywhere explains it — the config silently overridden by
+      a keypress from another session, which is the one thing "for the running frame only"
+      promises cannot happen.
+    * ``panes`` names tmux panes of a frame that no longer exists. `cmd_launch` rewrites
+      it as it draws, so this only matters when a launch dies before that — but then the
+      map survives pointing at nothing, and the next density change on the next frame to
+      claim the id would `kill-pane` ids that mean whatever tmux has since reused.
+
+    Never raises, and never creates, like everything else here.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return
+    for name in ("density", "panes"):
+        try:
+            (d / name).unlink(missing_ok=True)
+        except OSError:
+            continue
+
+
+def record_identity(fid: str, values: dict[str, str]) -> None:
+    """Write down the charter identity this frame was LAUNCHED with.
+
+    **A frame's identity is not readable from the environment of everything that runs
+    inside it, and that is the whole reason this file exists (#411, again).** Charter puts
+    exactly four variables on a tmux SESSION (`commands_frame._session_id_env_argv` and
+    its three siblings), and only one of them is identity: `CHARTER_SESSION_ID`. Every
+    other name a frame cares about — `CHARTER_ROOT`, `CHARTER_WORKSPACE`,
+    `CHARTER_HARNESS`, `CHARTER_PERSONA` — reaches a `run-shell` child from the SERVER's
+    own environment, and charter's private server is SHARED: it belongs to whichever
+    launcher happened to start it, possibly days ago, in another plane.
+
+    Measured against tmux 3.7c, two frames on one private socket::
+
+        session one: CHARTER_WORKSPACE=first-ws   CHARTER_HARNESS=claude-code
+        session two: CHARTER_WORKSPACE=second-ws  CHARTER_HARNESS=codex
+        tmux run-shell -t two 'echo $CHARTER_WORKSPACE $CHARTER_HARNESS $CHARTER_SESSION_ID'
+          -> first-ws claude-code two
+
+    So a hotkey pressed on the second frame runs a `run-shell` child holding the SECOND
+    frame's id and the FIRST frame's plane. Anything that goes on to state that identity
+    to a new pane — which `commands_frame._relayout` does, and which nothing in charter
+    did before it — pins another frame's `$CHARTER_ROOT` and `$CHARTER_WORKSPACE` onto
+    that pane's argv, where both win outright over every other source
+    (`root.find_root`, `workspace.resolve`). The frame's new panels would draw a different
+    plane from the ones that survived.
+
+    The launcher is the one process that knows the answer, so it writes it here. Read back
+    by :func:`identity`. Same atomic-write, never-raise shape as :func:`record_server` —
+    a frame whose identity could not be recorded degrades to "charter does not know",
+    which :func:`identity` answers honestly rather than by guessing.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    tmp = d / "identity.tmp"
+    try:
+        tmp.write_text(json.dumps({k: v for k, v in values.items()
+                                   if isinstance(k, str) and isinstance(v, str)}))
+        os.replace(tmp, d / "identity")
+    except (OSError, TypeError, ValueError):
+        return
+
+
+def identity(fid: str) -> dict[str, str]:
+    """The charter identity *fid* was launched with — ``{}`` when charter does not know.
+
+    ``{}`` is the migration case (a frame launched by a charter that predates
+    :func:`record_identity`) and the corrupt one, deliberately answered the same way:
+    both mean "do not take this frame's identity from here", and the caller
+    (`commands_frame._relayout_pane_env`) is what decides what to do instead. Answering
+    with a partial guess would be the same defect this file exists to close, one layer up.
+
+    Every value is shape-checked as it is read, like :func:`panes`: this is JSON on disk
+    and the values go straight into a tmux ``-e NAME=VALUE`` argv element.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return {}
+    try:
+        data = json.loads((d / "identity").read_text())
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {k: v for k, v in data.items() if isinstance(k, str) and isinstance(v, str)}
+
+
+def record_panes(fid: str, *, panels: dict[str, str]) -> None:
+    """Write down which tmux pane draws which SLOT, so the frame can be re-laid-out later.
+
+    A frame's shape is decided once at launch and then only ever re-asserted
+    (`commands_frame._resize_hook_argv`). Changing it while it runs — which is what the
+    density menu does — needs to know that `%3` is the `left` panel and not the `right`
+    one, because a slot being dropped means killing exactly that pane.
+
+    tmux cannot be asked later: `list-panes` reports ids and geometry but nothing that
+    says which pane charter MEANT as `left`, and inferring it from position is the same
+    "indices move" trap `frame/layout.py`'s module docstring measures.
+
+    **The harness pane is deliberately NOT in here.** :func:`record_harness_pane` already
+    owns that one fact — it is what `is_live` asks to tell a frame's own harness from a
+    process that merely inherited its id (ADR 0019) — and it is written on both launch
+    paths before any pane is split. A second copy in this file would be two records of
+    one fact, written at different moments, free to disagree; `commands_frame.cmd_density`
+    reads :func:`harness_pane` for it instead.
+
+    JSON, read back through :func:`panes` — same atomic write as everything else here, and
+    the same silence on failure: a frame whose pane map could not be written simply cannot
+    be re-laid-out, which is a menu entry doing nothing rather than a launch failing.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    tmp = d / "panes.tmp"
+    try:
+        tmp.write_text(json.dumps(dict(panels)))
+        os.replace(tmp, d / "panes")
+    except (OSError, TypeError, ValueError):
+        return
+
+
+def panes(fid: str) -> dict[str, str]:
+    """``{slot: pane id}`` — empty when charter cannot tell.
+
+    Every value is shape-checked as it is read: this file is JSON on disk, so a truncated
+    write, a hand edit, or a charter that wrote a different shape all reach here, and the
+    ids come straight back out of it into a tmux argv. Checking that each is a `str` is
+    this function's half; `commands_frame._PANE_ID_RE` — which already guards the same ids
+    on the way IN from `split-window`'s stdout — is the half that decides a value really
+    looks like tmux's own `%N`, and it stays there rather than being copied here, because
+    it is the module that builds the argv that must not be handed a bad one.
+
+    An empty answer is the migration case as well as the corrupt one: a frame launched by
+    a charter that predates :func:`record_panes` has no file, and its density menu simply
+    cannot re-lay it out.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return {}
+    try:
+        data = json.loads((d / "panes").read_text())
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {s: v for s, v in data.items() if isinstance(s, str) and isinstance(v, str)}
 
 
 def exit_code(fid: str) -> int | None:

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -249,6 +249,30 @@ def below_floor_message(v: tuple[int, int]) -> str:
             f"so and declines to attach rather than risk a session nothing can end.")
 
 
+def below_resize_hook_message(v: tuple[int, int]) -> str:
+    """What an operator below :data:`RESIZE_HOOK_FLOOR` actually loses.
+
+    **This floor sits ABOVE `FLOOR`, which is why it needs its own sentence.** An operator
+    on tmux 3.2 passes `below_floor_message` cleanly — nothing warns, `charter doctor`'s
+    frame row is green, `--probe` is a tick — and still has no `window-resized` hook, so
+    every resize of their terminal leaves the panels stretched out of shape until the frame
+    is relaunched. Folding this into `FLOOR` was considered and rejected where that constant
+    is defined: raising it would refuse a frame that works over a gap that is cosmetic.
+    Leaving it unsaid was the actual bug (#387) — it was reported nowhere at all except a
+    `util.warn` printed 86 bytes before tmux switched the terminal to its alternate screen.
+
+    Named here beside `below_floor_message` rather than written out at each of its two
+    reading surfaces (`commands_frame.frame_ready`, `doctor.check_frame`), for the reason
+    that message's own history records: two copies of one standing fact drift into two
+    different facts.
+    """
+    return (f"tmux {v[0]}.{v[1]} predates the `window-resized` hook "
+            f"(tmux {RESIZE_HOOK_FLOOR[0]}.{RESIZE_HOOK_FLOOR[1]}+), which is what "
+            f"restores each panel's fixed size after the terminal is resized. Everything "
+            f"else in the frame works; resize this terminal and the panels stretch, and "
+            f"stay stretched until the frame is relaunched.")
+
+
 def report_failure(action: str, cmd: list[str], proc: subprocess.CompletedProcess) -> None:
     """Name the command that failed and tmux's own stderr. Never silent.
 

--- a/charter/inflight.py
+++ b/charter/inflight.py
@@ -52,6 +52,33 @@ def _safe_name(agent: str) -> str:
     return "".join(c if c.isalnum() or c in "._-" else "_" for c in agent)[:64]
 
 
+def stamp() -> int | None:
+    """One ``stat`` that answers "has anything about the tracker changed?" — or ``None``.
+
+    A frame panel wants to ANIMATE while work is in flight and be perfectly still
+    otherwise (#387), which means asking this question several times a second, forever,
+    on an idle machine. :func:`live_records` is cheap but it is not free: it opens the
+    directory and reads every entry in it. This is the cheap half — a single ``stat`` of
+    the directory itself, whose mtime moves whenever a record is CREATED or REMOVED,
+    which is the only way the set of live records can change. `frame/panel.py` re-reads
+    the records only when this number moves.
+
+    ``None`` for "no such directory", which is the common case on a machine that has never
+    dispatched — and is a real answer, not an error: nothing can be in flight, and it costs
+    the same single failed ``stat`` to learn it.
+
+    The mtime is deliberately NOT enough on its own for one thing, and the caller owns
+    that half: a record crossing :data:`PRESUMED_DEAD_SECONDS` changes what a caller
+    should say about it while touching no file at all, so `panel._running` also re-reads
+    when the earliest such deadline passes. Splitting it that way keeps the IDLE path —
+    no records at all, so no deadline either — at exactly one syscall.
+    """
+    try:
+        return _dir().stat().st_mtime_ns
+    except OSError:
+        return None
+
+
 def live_records(exclude_token: str | None = None) -> list[tuple[str, float, bool]]:
     """``(agent, started_at, presumed_dead)`` per record, duplicates preserved.
 

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -320,10 +320,90 @@ def drift(root: Path) -> list[str]:
 #: reach a tmux argv — so an unknown one is dropped rather than passed through.
 FRAME_SLOTS = ("top", "bottom", "left", "right")
 
+#: How much frame there is, as a PRESET over :data:`FRAME_SLOTS` — never a second
+#: configuration system sitting beside `slots`.
+#:
+#: Each level expands to two things: the ``slots`` an operator could have written by hand,
+#: and a ``verbosity`` naming how much each panel on them says (`frame/slots.py` owns what
+#: the two verbosities actually draw). `slots` stays the primitive, and an EXPLICIT
+#: `slots` overrides a declared `density` outright — see :func:`frame_of`. That ordering
+#: is what keeps this a preset: nothing here can express a frame `slots` could not, so an
+#: operator who outgrows the presets writes the list and loses nothing.
+#:
+#: **The level names are a closed set, which is stronger than sanitising them.** A density
+#: reaches tmux twice — as the slot list `layout.panel_argvs` splits panes for, and as a
+#: menu label — and both times it has already been matched against these three keys by
+#: :func:`frame_of` or by `instance.density_level`. Unlike ``hotkey`` (see
+#: :data:`_HOTKEY_RE`), there is no value an operator can write here that is passed
+#: through: it is either one of three constants charter wrote itself, or it is discarded.
+#:
+#: **Every ``slots`` list here is in GEOMETRY order, not reading order — do not sort
+#: them.** `layout.panel_argvs` splits each slot off the harness pane in list order, so a
+#: slot listed after `left`/`right` gets only the width they left behind. Measured
+#: against tmux 3.7c in a 200x50 window (#386): `["top", "bottom", "left", "right"]`
+#: gives a **200-column** `bottom` with 46-row side panels between the two strips, while
+#: `["top", "left", "right", "bottom"]` gives a `bottom` of **154 columns**, inset
+#: between them. `bottom` is the row carrying the one alert and the command that fixes
+#: it, and `slots._bottom` drops whole fields when it runs out of width — so those 46
+#: columns belong to it rather than to two side panels already truncating their own 22.
+#: The shipped ``slots`` default above is in the same order for the same reason.
+FRAME_DENSITY = {
+    #: One-line top and bottom, each saying only the most important thing it has. For a
+    #: terminal where the harness's own rows are what you came for.
+    "minimal": {"slots": ["top", "bottom"], "verbosity": "terse"},
+    #: The same two edges, saying everything they have.
+    "normal": {"slots": ["top", "bottom"], "verbosity": "normal"},
+    #: All four edges — the shipped frame since #386, and the same order it ships in.
+    "full": {"slots": ["top", "bottom", "left", "right"], "verbosity": "normal"},
+}
+
+#: What a panel falls back to for any level charter does not know — see
+#: :func:`verbosity_for`. Named rather than repeated as a bare string, because it is also
+#: the answer for "no density recorded at all", which is every frame launched by a charter
+#: that predates this feature.
+DEFAULT_VERBOSITY = "normal"
+
+
+def density_level(name) -> str | None:
+    """*name* if it names a :data:`FRAME_DENSITY` level, else ``None``.
+
+    The one place a density arriving from OUTSIDE charter's own constants — a menu action's
+    argv, a value read back out of a frame's state directory, a hand-edited charter.toml —
+    is admitted. ``isinstance`` first because ``value in FRAME_DENSITY`` raises
+    ``TypeError`` for an unhashable value (a TOML array, a table), and this module is
+    imported by every command including ``charter --version``: the same guard
+    :data:`_HOTKEY_RE`'s call site needs, for the same reason.
+    """
+    return name if isinstance(name, str) and name in FRAME_DENSITY else None
+
+
+def density_slots(level) -> list[str]:
+    """The slot list *level* expands to — a fresh list, never the table's own.
+
+    Callers hand this straight to `layout.visible_slots`, which filters it, and to
+    `frame_of`'s resolved config, which a caller may go on to patch; handing out the
+    module-level list would let either of them edit the preset itself for the life of the
+    process.
+    """
+    lv = density_level(level)
+    return list(FRAME_DENSITY[lv]["slots"]) if lv else []
+
+
+def verbosity_for(level) -> str:
+    """How much each panel says at *level*. :data:`DEFAULT_VERBOSITY` for anything else.
+
+    Anything else is a real case, not a defensive one: a frame's live density override is
+    read off disk (`frame.state.density`), and a frame started by an older charter has no
+    file there at all. Both answer ``None``, and a panel must draw the ordinary amount
+    rather than nothing.
+    """
+    lv = density_level(level)
+    return FRAME_DENSITY[lv]["verbosity"] if lv else DEFAULT_VERBOSITY
+
 #: Every ``[frame]`` setting, keyed by the name :func:`frame_of` returns it under
 #: (underscore — reads better at the call site, e.g. ``frame["history_limit"]``) and
 #: paired with ``(default, toml_key)``: the shipped default, and the name charter.toml
-#: actually spells it with. Three of the six differ — ``history-limit``, ``min-cols``,
+#: actually spells it with. Three of the seven differ — ``history-limit``, ``min-cols``,
 #: ``min-rows`` use a hyphen, per docs/frame.md — so the TOML spelling travels right next
 #: to the default it belongs to instead of living in a second dict a reader has to keep
 #: in sync by hand. Two dicts keyed apart, as an earlier draft of this had it, meant a key
@@ -352,6 +432,16 @@ FRAME_FIELDS = {
     #: drops whole fields when it runs out of width — so the 46 columns belong to it and
     #: not to two side panels that are already truncating their own 22.
     "slots": (["top", "bottom", "left", "right"], "slots"),
+    #: A PRESET over the line above, not a rival to it (see :data:`FRAME_DENSITY`). The
+    #: shipped value is the level that expands to EXACTLY the shipped `slots` above —
+    #: same edges, same ORDER, and saying as much as a panel has — and that is not a
+    #: coincidence to be re-checked by eye: `tests/test_frame_density.py`'s
+    #: `ShippedDefaultsAgree` asserts all three, so a change to either key that is not
+    #: matched by the other is red rather than a plane where `charter.toml`'s two ways of
+    #: asking for the same frame disagree about what the default is. This value moved
+    #: `normal` -> `full` when #386 raised the `slots` default above, and that test is
+    #: what made the move happen at merge time instead of being noticed later.
+    "density": ("full", "density"),
     #: Off by default: tmux's `set -g mouse on` takes over drag-select, so turning this on
     #: trades the operator's terminal text-selection for clickable panels. That trade
     #: belongs to a later release that actually ships clickable panels, not this one.
@@ -423,17 +513,37 @@ def frame_of(cfg: dict) -> dict:
     module is imported by every command, including ``charter --version``, so a
     hand-edited charter.toml must degrade to the defaults rather than raise.
 
-    Two keys need more than a type check, and both get it here rather than downstream:
-    ``slots`` is filtered against :data:`FRAME_SLOTS`, and ``hotkey`` against
-    :data:`_HOTKEY_RE` — see that constant for the injection a bare ``isinstance(value,
-    str)`` let through. Both degrade to the shipped default, which is the contract every
-    other key in this function already keeps: a charter.toml charter cannot make sense
-    of never stops charter from running.
+    Three keys need more than a type check, and all three get it here rather than
+    downstream: ``slots`` is filtered against :data:`FRAME_SLOTS`, ``density`` against
+    :data:`FRAME_DENSITY`, and ``hotkey`` against :data:`_HOTKEY_RE` — see that constant
+    for the injection a bare ``isinstance(value, str)`` let through. All three degrade to
+    the shipped default, which is the contract every other key in this function already
+    keeps: a charter.toml charter cannot make sense of never stops charter from running.
+
+    **`density` is expanded here, and only when it was actually declared.** A declared
+    level replaces ``slots`` with the list it expands to, so everything downstream —
+    `commands_frame._drawable_slots`, `frame_ready`, `doctor.check_frame`,
+    `layout.panel_argvs` — goes on reading one key and never learns that presets exist.
+    An explicit ``slots`` wins outright: it is the primitive, and an operator who wrote a
+    list meant that list.
+
+    Expanding ONLY on a declared level, rather than unconditionally from the shipped
+    default, is what keeps the `slots` default above load-bearing instead of dead. The two
+    say the same thing today (`FRAME_FIELDS`'s own comment, and the test it names), so an
+    unconditional expansion would behave identically right now — and would then silently
+    swallow the next change to the shipped `slots` list, which is exactly the drift that
+    comment exists to prevent.
+
+    An explicit ``slots`` that filters down to NOTHING (``slots = ["sideway"]``) is not
+    treated as having been written: the operator asked for a frame charter cannot build,
+    so a declared density is still the better answer than the shipped default, and with no
+    density declared the shipped default holds exactly as it did before.
     """
     out = dict(FRAME_DEFAULTS)
     section = cfg.get("frame")
     if not isinstance(section, dict):
         return out
+    took_slots = False
     for key, (default, toml_key) in FRAME_FIELDS.items():
         if toml_key not in section:
             continue
@@ -443,6 +553,11 @@ def frame_of(cfg: dict) -> dict:
                 kept = [s for s in value if s in FRAME_SLOTS]
                 if kept:
                     out[key] = kept
+                    took_slots = True
+            continue
+        if key == "density":
+            if density_level(value):
+                out[key] = value
             continue
         if key == "hotkey":
             if isinstance(value, str) and _HOTKEY_RE.fullmatch(value):
@@ -461,4 +576,6 @@ def frame_of(cfg: dict) -> dict:
             continue
         if isinstance(value, type(default)):
             out[key] = value
+    if "density" in section and not took_slots:
+        out["slots"] = density_slots(out["density"])
     return out

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1310,9 +1310,18 @@ def _persona_chips(session: str | None = None) -> list[str]:
         return []
 
 
-def _session_news(sid: str | None) -> list[str]:
+def _session_news(sid: str | None, *, inflight: bool = True) -> list[str]:
     """Counters for what has happened **in this session** — in flight, denied,
     recorded, dispatched.
+
+    *inflight* is opt-OUT, and has exactly one caller that opts out: the frame's bottom
+    panel (`frame/slots.py`), which draws the same tracker as a spinner that MOVES while
+    work is in flight. That panel repaints several times a second; this surface repaints
+    once per turn, where a spinner would be a still picture of an arbitrary frame — so the
+    two draw one fact two ways, and the panel asks this to leave its half out rather than
+    printing `⚡ 2 · ⠙ 2 running` on one row. Everything else here — the trace counters —
+    the panel still wants, which is why this is one flag rather than the panel building
+    its own copy of the whole function.
 
     Deliberately silent when nothing is happening. A counter that renders every turn
     becomes furniture within a day, and then a real guard denial appearing in it gets
@@ -1329,8 +1338,11 @@ def _session_news(sid: str | None) -> list[str]:
     """
     out: list[str] = []
     try:
-        from . import inflight
-        live = inflight.live()
+        # Guarded rather than filtered afterwards, so a caller that has said it does not
+        # want this piece does not pay for the tracker read either — the frame's bottom
+        # panel is about to do its own, and this one polls several times a second.
+        from . import inflight as _tracker
+        live = _tracker.live() if inflight else []
         if live:
             # A bare count. The names moved onto the persona chips, beside the personas
             # they are about — here they made the reader match a name against a roster

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -14,9 +14,10 @@ for a command charter has no launcher for at all. That is not just naming: once 
 frame` is on the command line, everything after it is grafted onto the harness's own argv
 verbatim, before charter's own argument parser ever sees it, so `frame claude -p hi` would
 hand `claude -p hi` to the `frame --` mechanism rather than route anywhere. The same reason
-keeps `frame-menu`, `frame-action` and `frame-probe` — one command tmux's hotkey calls
-back into, one every menu action calls back into, and the read-only probe — as top-level
-names rather than nested under `frame` too.
+keeps `frame-menu`, `frame-action`, `frame-density` and `frame-probe` — the command tmux's
+hotkey calls back into, the one every menu action calls back into, the one the density
+entries run, and the read-only probe — as top-level names rather than nested under `frame`
+too.
 
 ## What it needs
 
@@ -33,14 +34,22 @@ panels can just drift out of their fixed size until the next one.
 `charter <harness> --probe` (or the standalone `charter frame-probe`) answers "can a frame
 run here, and what will it not be able to do" without starting anything: exit 0 if a frame
 can run, non-zero if tmux is missing entirely, plus a line for each standing limit — a
-tmux below 3.2, and any `[frame] slots` entry charter sizes but has no renderer for.
-`charter doctor` carries the same facts as its own `frame` row.
+tmux below 3.2, a tmux below 3.3 (no resize-recovery hook), and any `[frame] slots` entry
+charter sizes but has no renderer for. `charter doctor` carries the same facts as its own
+`frame` row.
 
-Those two limits are deliberately **not** printed when a frame launches. A warning
-written to your terminal microseconds before tmux switches to the alternate screen is not
-readable — measured at 86 bytes ahead of the switch — and it comes back into view only
-once the frame exits. Both are standing properties of this machine and this plane rather
-than news about one launch, so they live on the two surfaces you can ask on demand.
+The 3.3 line is worth calling out because the two floors are easy to conflate: 3.3 sits
+*above* the 3.2 floor, so a tmux 3.2 passes the floor cleanly and still has no
+`window-resized` hook. Charter used to say so only in the milliseconds before the frame
+came up, which is nowhere. Now both surfaces name it, and what it costs is exactly one
+thing: resize your terminal and the panels stretch, and stay stretched until the frame is
+relaunched.
+
+Those limits are deliberately **not** printed when a frame launches. A warning written to
+your terminal microseconds before tmux switches to the alternate screen is not readable —
+measured at 86 bytes ahead of the switch — and it comes back into view only once the frame
+exits. All of them are standing properties of this machine and this plane rather than news
+about one launch, so they live on the two surfaces you can ask on demand.
 
 ## What changes inside the frame
 
@@ -62,6 +71,29 @@ changed.
 **Panels measure their own pane**, never `$COLUMNS` — a tmux pane inherits the *launching*
 shell's environment whole, so trusting `$COLUMNS` there would lay a panel out at the outer
 terminal's width and wrap inside its own much narrower one.
+
+**The frame animates only while a dispatch is in flight.** A dispatch that is still
+running puts a spinner and a count on the bottom row — `⠙ 2 running` — and the panel
+repaints often enough for it to turn. Only the bottom row moves; the other three panels
+repaint when something changes and not otherwise.
+
+**Dispatches, and nothing else.** A long `charter clone` or `gl-refresh` does *not* spin
+it: charter records a dispatch when it starts, which is what makes overlapping agents
+visible, and keeps no equivalent record for its own long commands. Covering them needs a
+second kind of record — putting a clone in the dispatch tracker would make the overlap
+nudge announce it as a peer agent — and that is filed as #420. The moment the last dispatch finishes, the frame goes completely
+still again and the panel goes back to waiting for a version bump. Nothing is polled to
+find this out: charter already records a dispatch when it *starts* (that is what makes
+overlapping agents visible at all), so the panel asks one question per tick — a single
+`stat` of that tracker's own directory — and reads the records themselves only when that
+answer moves. Measured on macOS/APFS: about 5µs per tick added to the ~26µs a panel
+already spends checking the version file, five times a second, or roughly 0.003% of one
+core while idle.
+
+A dispatch charter has stopped believing in — no result after thirty minutes, so the
+process was probably killed — is still reported, and deliberately *not* animated: `⋯ 1
+stalled`. Charter keeps such a record for a day so a stuck dispatch stays visible, and a
+spinner turning next to it would be claiming progress that stopped half an hour ago.
 
 **A panel that fails says so in its own pane.** Anything charter's own code can see — an
 unknown slot, a renderer that raises, a crash in the panel's poll — is painted into the
@@ -193,7 +225,13 @@ drop — any shortage costs them, since neither can spare its own divider. A fur
 in rows drops `top` too. Below half of either floor, every panel drops and the harness
 simply gets the whole terminal, the same choice `charter`'s own status line makes when it
 runs out of width. So a narrow terminal degrades to the two strips on its own; nothing has
-to be configured for it.
+to be configured for it. A density change goes through the same floors, so choosing `full`
+in a terminal with no room for side panels gives you the edges that fit rather than a
+failed split.
+
+If a future `[frame] slots` ever names an edge charter sizes but has no renderer for, that
+slot is skipped rather than drawn as a dead pane — the harness keeps the space — and
+`charter frame-probe`/`charter doctor` say so.
 
 ## The status line goes quiet inside a frame
 
@@ -246,12 +284,55 @@ jobs. See ADR 0019.
 ```toml
 [frame]
 slots = ["top", "bottom", "left", "right"]
+density = "full"
 mouse = false
 hotkey = "F2"
 history-limit = 50000
 min-cols = 100
 min-rows = 20
 ```
+
+### How much frame
+
+`density` is a **preset over `slots`**, not a second way of configuring the same thing.
+There are three levels:
+
+| level | edges | each panel says |
+|---|---|---|
+| `minimal` | one-line `top` and `bottom` | only its most important field |
+| `normal` | `top` and `bottom` | everything it has |
+| `full` | all four edges | everything it has |
+
+`full` is the shipped frame, so writing nothing at all and writing `density = "full"`
+give you the same thing — and that is enforced rather than trusted: charter's own test
+suite refuses a `density` default that does not expand to exactly the shipped `slots`
+list, in the same order.
+
+Writing `density = "full"` is the same as writing that level's `slots` list by hand, so
+nothing else in charter has to know presets exist — the probe, `doctor`, and the size
+floors all read the one resolved list. **An explicit `slots` wins**: `slots` is the
+primitive, and if you wrote a list you meant that list.
+
+`minimal` and `normal` are how you ask for less. Both drop to the two strips; `minimal`
+also makes each panel terser — `top` drops the charter version (the workspace and the
+persona are what it exists to tell you), and `bottom` keeps only its highest-priority
+field: an alert if there is one, the spinner if work is running, otherwise the todo
+count, so the row is never blank. If you have kept the sidebars by writing `slots`
+yourself, `minimal` shows four rows in each and says how many it hid.
+
+**The hotkey changes the density of the running frame, and nothing else.** `F2` opens the
+menu, which now lists all three levels with a `•` on the one in effect; choosing one
+re-lays the frame out live — panes are split or closed, sizes re-asserted, panels repaint
+at the new verbosity. It does **not** edit `charter.toml`: that file is yours, hand
+maintained and committed, and charter's rule is that machine-written state belongs
+somewhere a machine may rewrite whole. The override lives in the frame's own state
+directory and goes with the frame; relaunch and you are back to what the file says. The
+same applies to `charter frame-density <level>` typed by hand from inside a frame, which
+is what the menu entry runs.
+
+Inside a tmux you already have, charter binds no key at all (see above), so there is no
+menu and no keypress route to density there — `[frame] density` is what sets it, and the
+command still works if you run it inside the frame's own window.
 
 `hotkey` is checked against the shape of a tmux key name — optional `C-`/`M-`/`S-`
 modifiers and then a key (`F2`, `Up`, `PPage`, `a`, `/`). Anything else falls back to
@@ -268,14 +349,16 @@ frame and the sidebars sit between the two strips, while listing it last leaves 
 the width the sidebars did not take. The bottom row is where an alert and the command that
 fixes it appear, so the shipped order gives it the full width.
 
-`slots`/`mouse`/`hotkey` are spelled the same on both sides. `history-limit`, `min-cols`
-and `min-rows` are the three that are not: charter.toml spells them with a hyphen: the
+`slots`/`density`/`mouse`/`hotkey` are spelled the same on both sides. `history-limit`,
+`min-cols` and `min-rows` are the three that are not: charter.toml spells them with a
+hyphen: the
 resolved settings charter's own code reads back use an underscore
 (`config.FRAME["history_limit"]`) instead. A key typed the underscored way in charter.toml
 is silently not recognized — the hyphenated spelling above is the one that is read.
 
 The hotkey (`F2` by default) opens a small menu on whichever frame you are attached to —
-today, a single "Detach" entry. It exists only on charter's own server; inside a tmux you
-already have, charter binds no key at all (see above). However you detach — that entry, or tmux's own prefix key
-— charter notices the session is still running and prints how to get back in
-(`tmux -L charter attach -t <frame-id>`) rather than leaving you to remember the flags.
+"Detach", and the three density levels. It exists only on charter's own server; inside a
+tmux you already have, charter binds no key at all (see above). However you detach — that
+entry, or tmux's own prefix key — charter notices the session is still running and prints
+how to get back in (`tmux -L charter attach -t <frame-id>`) rather than leaving you to
+remember the flags.

--- a/docs/news/unreleased-how-much-frame-you-want.md
+++ b/docs/news/unreleased-how-much-frame-you-want.md
@@ -1,0 +1,68 @@
+---
+version: unreleased
+headline: Say how much frame you want, and the frame moves only while work does
+---
+
+The frame had one shape. You could change which edges it drew, one slot at a time, in
+`charter.toml` — and then live with it until you edited the file again and relaunched.
+
+**`[frame] density` is a preset over `slots`, not a second way to configure the same
+thing.** Three levels: `minimal` (one-line top and bottom, each saying only its most
+important thing), `normal` (the same two strips, saying everything they have), and `full`
+— all four edges, which is the frame this release ships. A level expands to exactly the
+slot list you could have written by hand, so nothing else in charter has to know presets
+exist — the probe, `charter doctor` and the size floors all read the one resolved list.
+If you *did* write a `slots` list, it wins: `slots` is the primitive, and a preset does
+not get to outrank the thing it is a preset for.
+
+`density = "full"` and writing nothing are the same frame, and that is checked rather
+than trusted: the suite refuses a shipped `density` that does not expand to exactly the
+shipped `slots`, in the same order and at the same verbosity. Two ways of asking for the
+default that quietly disagreed would be worse than having only one.
+
+**`F2` now changes the density of the frame you are sitting in.** The menu lists all three
+levels with a dot on the one in effect; choosing one splits or closes panes live, re-asserts
+every panel's size, and repaints at the new verbosity. It does **not** write to
+`charter.toml`. That file is yours — hand-maintained, committed, full of your comments — and
+charter's standing rule is that machine-written state belongs somewhere a machine may
+rewrite whole. So the override lives in the frame's own state directory, and it lives
+exactly as long as the frame does: relaunch and you are back to what your file says.
+
+**The frame animates, and only while there is something to animate.** A dispatch still
+running puts a spinner and a count on the bottom row — `⠙ 2 running`. The moment the last
+one finishes, the frame is completely still again. Only the bottom row moves: the spinner
+is the one thing on any panel that changes without something having changed, so the other
+three keep repainting on news alone.
+
+**It is dispatches only.** A long `charter clone` or `gl-refresh` will not spin it.
+Charter records a dispatch when it *starts* — that is what makes two agents in one working
+tree visible — and keeps no equivalent record for its own long-running commands. Reusing
+the dispatch tracker for them would make the overlap nudge announce a clone as a peer
+agent, so it needs a second kind of record; filed as #420.
+
+That "completely" is the part worth spending a paragraph on, because a spinner is exactly
+the kind of feature that quietly costs a machine something forever. Charter already records
+a dispatch when it *starts* — that is what makes two agents editing one working tree
+visible at all — so a panel does not poll anything to find out. It asks one question per
+tick: a single `stat` of that tracker's own directory, whose timestamp moves only when a
+record is created or removed. The records themselves are read only when that answer changes.
+Measured on macOS/APFS: about **5µs per tick**, five times a second, next to the ~26µs a
+panel already spent checking whether the frame's version had moved — roughly 0.003% of one
+core, and zero repaints. Reading the records on every tick instead, the obvious way to write
+this, measured 3.8x that and would have paid it whether or not anything was running.
+
+A dispatch charter has stopped believing in — no result after thirty minutes, so the process
+was most likely killed — is still reported and deliberately not animated: `⋯ 1 stalled`.
+Such a record is kept for a day so a stuck dispatch stays visible, and a spinner turning
+beside it would be claiming progress that stopped half an hour ago.
+
+**And one warning finally moved somewhere you can read it.** tmux's `window-resized` hook —
+what puts the panels back to their proper size after you resize the terminal — needs tmux
+3.3, while charter's floor is 3.2. So a tmux 3.2 passed the floor cleanly, showed a green
+tick in `charter doctor` and in `charter frame-probe`, and silently had no resize recovery
+at all. Charter did know, and said so — into the terminal 86 bytes before tmux switched to
+the alternate screen, which is nowhere. Both surfaces now name it, alongside the two
+ceilings that moved there in 0.51.0, and nothing is printed on the launch path any more.
+
+Nothing to adopt: upgrading is the whole of it. `charter frame-probe` will tell you if your
+tmux is one of the ones that was quietly missing resize recovery.

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -1,0 +1,1158 @@
+"""Density: a preset over `[frame] slots`, and a keypress that changes one running frame.
+
+Three properties are load-bearing here, and each has its own class below.
+
+**Density is a preset, not a second configuration system.** `slots` stays the primitive:
+`instance.frame_of` expands a declared level into the very same list an operator could
+have written by hand, and an explicit `slots` overrides it. Nothing downstream of
+`frame_of` — the launcher, the probe, the doctor row, `layout.panel_argvs` — learns that
+presets exist, which is the property that keeps them from having to agree with a second
+source of truth.
+
+**The shipped `density` and the shipped `slots` must expand to the same frame.** They are
+two ways of asking charter for the default, and a plane where they disagree gives one
+answer to `charter.toml` and another to the hotkey menu. `ShippedDefaultsAgree` asserts it
+mechanically rather than leaving it to be re-checked by eye — see its own docstring for
+why that matters more than usual right now.
+
+**A keypress changes the frame, never the file.** `charter.toml` is hand-maintained and
+committed; charter's rule is that machine-written config belongs somewhere a machine may
+rewrite whole. `LiveOverride` pins that the override lands in the frame's own state
+directory and that `cmd_density` touches no `charter.toml` at all.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config, inflight, instance, tui, util
+from charter.frame import gather, layout, menu, panel, slots, state
+
+from tests._isolation import PersonaIso
+
+
+def _a_dead_pid() -> int:
+    """A real pid that has exited and been reaped — `tests/test_frame_state.py`'s own
+    helper, repeated rather than imported because a test module importing another test
+    module's private helper couples two files that are otherwise independent.
+
+    A made-up number is a guess about the machine rather than a fact about it, and a
+    hand-written `-1` is worse than a guess: pid 1 is `launchd`/`init`, which never exits,
+    so a fixture named `something-1` reads as a live launcher and makes any assertion that
+    depends on the frame being finished unfailable."""
+    p = subprocess.Popen([sys.executable, "-c", "pass"])
+    p.wait()
+    return p.pid
+
+
+class _Tmux:
+    """A recording stand-in for `tmuxctl.run`, answering the two queries `cmd_density`
+    actually reads a value out of and returning success for everything else.
+
+    Not `_FakeTmux` from `tests/test_frame_launcher.py`: that one models a whole LAUNCH
+    (new-session, hooks, attach, exit codes) and would have to be taught a second life as
+    an already-running frame. What a re-layout needs is much smaller — a window size and a
+    pane id per split — so this fake is small enough to read in one screen, which is the
+    only way a test can prove an ORDER of tmux calls.
+    """
+
+    def __init__(self, *, size="200:50", new_panes=("%7", "%8", "%9")):
+        self.size = size
+        self.new_panes = list(new_panes)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, action, argv, *, env=None, timeout=None, report=True):
+        self.calls.append(list(argv))
+        out = ""
+        if "display-message" in argv:
+            out = self.size
+        elif "split-window" in argv:
+            out = self.new_panes.pop(0) if self.new_panes else ""
+        return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
+
+    def where(self, *words: str) -> list[int]:
+        """Indices of every recorded call containing all of *words* — how an ORDER is
+        asserted here, since the thing being pinned is which tmux command ran before
+        which, not how many times each ran."""
+        return [i for i, c in enumerate(self.calls)
+                if all(any(w == part for part in c) for w in words)]
+
+
+class ShippedDefaultsAgree(unittest.TestCase):
+    """`[frame] density` and `[frame] slots` are two ways of asking for the shipped frame.
+
+    **This is the guard, and it is deliberately mechanical.** If the two ever disagree, an
+    operator gets one frame from writing nothing at all and a different one from writing
+    `density = "<the shipped default>"` — silently, because nothing else anywhere compares
+    them.
+
+    It has already earned its keep once. #386 raised the shipped `slots` to all four edges
+    while this change was adding `full` as the preset naming those same edges; the two
+    landed in separate branches, and on the merge this class went red until the shipped
+    `density` moved `normal` -> `full`. That is the whole point of asserting it rather than
+    remembering it: the flip happened at merge time instead of becoming a divergence
+    nobody saw. The invariant is now three things, because slot lists alone proved too
+    weak — the same edges, in the same ORDER (order is geometry, see
+    `test_full_puts_the_strips_before_the_side_panels`), at the same verbosity (`minimal`
+    and `normal` share a slot list and differ only in how much they say).
+    """
+
+    def test_the_shipped_density_expands_to_exactly_the_shipped_slots(self):
+        level = instance.FRAME_DEFAULTS["density"]
+        self.assertIn(level, instance.FRAME_DENSITY,
+                      "the shipped density must name a level that exists")
+        self.assertEqual(instance.FRAME_DENSITY[level]["slots"],
+                         instance.FRAME_DEFAULTS["slots"],
+                         f"the shipped `density = {level!r}` and the shipped `slots` "
+                         f"describe different frames — see this class's docstring")
+
+    def test_the_shipped_density_draws_everything_a_panel_has(self):
+        """The slot-list invariant above cannot see this: `minimal` and `normal` expand to
+        the SAME two edges and differ only in how much each panel says, so a shipped
+        default of `minimal` would satisfy it while quietly shipping a terse frame to
+        everyone. Charter ships the frame saying what it has; asking for less is the
+        operator's choice."""
+        self.assertEqual(
+            instance.verbosity_for(instance.FRAME_DEFAULTS["density"]), "normal")
+
+    def test_full_is_all_four_edges(self):
+        """#387's own words. Pinned separately from the invariant above so that a change
+        making `full` mean something narrower cannot satisfy the agreement test by
+        shrinking `full` to match a smaller `slots` default."""
+        self.assertEqual(sorted(instance.FRAME_DENSITY["full"]["slots"]),
+                         sorted(instance.FRAME_SLOTS))
+
+    def test_full_puts_the_strips_before_the_side_panels(self):
+        """The ORDER is geometry, not a reading order, and a sorted list would silently
+        narrow the row that matters most. `layout.panel_argvs` splits in list order off
+        the harness pane, so a `bottom` listed after `left`/`right` gets only the width
+        they left behind — measured against tmux 3.7c at 200x50 (#386): 200 columns this
+        way, **154** with the side panels first. `bottom` carries the one alert and the
+        command that fixes it, and `_bottom` drops whole fields when it runs out of width.
+
+        Asserted as index comparisons rather than as the literal list, so it says what is
+        load-bearing (strips before sides) rather than freezing a list that may gain a
+        fifth slot."""
+        order = instance.FRAME_DENSITY["full"]["slots"]
+        for strip in ("top", "bottom"):
+            for side in ("left", "right"):
+                with self.subTest(strip=strip, side=side):
+                    self.assertLess(order.index(strip), order.index(side),
+                                    f"{strip!r} must be split before {side!r} — see "
+                                    f"this test's docstring for the measurement")
+
+    def test_every_level_agrees_with_the_shipped_slots_about_order(self):
+        """The shipped `slots` list and any level that names the same edges must split
+        them in the same order, or `charter.toml`'s two ways of asking for one frame
+        produce two different geometries."""
+        shipped = instance.FRAME_DEFAULTS["slots"]
+        for level, spec in instance.FRAME_DENSITY.items():
+            with self.subTest(level=level):
+                common = [s for s in shipped if s in spec["slots"]]
+                self.assertEqual([s for s in spec["slots"] if s in shipped], common)
+
+    def test_minimal_is_one_line_top_and_bottom(self):
+        """#387's own words again. `top` and `bottom` are the two slots
+        `layout.SLOT_SIZE` gives one row each, which is what "one-line" names."""
+        self.assertEqual(instance.FRAME_DENSITY["minimal"]["slots"], ["top", "bottom"])
+        for slot in instance.FRAME_DENSITY["minimal"]["slots"]:
+            self.assertEqual(layout.SLOT_SIZE[slot], 1)
+
+    def test_every_level_expands_to_slots_charter_actually_accepts(self):
+        """A level naming a slot outside `FRAME_SLOTS` would be filtered out of an
+        operator's own `slots` list as a typo and then smuggled back in by a preset."""
+        for level, spec in instance.FRAME_DENSITY.items():
+            with self.subTest(level=level):
+                for slot in spec["slots"]:
+                    self.assertIn(slot, instance.FRAME_SLOTS)
+                self.assertIn(spec["verbosity"], ("terse", "normal"))
+
+
+class DensityResolves(unittest.TestCase):
+    """`instance.frame_of`: what a `[frame] density` in charter.toml actually does."""
+
+    def test_a_declared_level_expands_into_the_slot_list(self):
+        f = instance.frame_of({"frame": {"density": "full"}})
+        self.assertEqual(f["density"], "full")
+        self.assertEqual(f["slots"], instance.FRAME_DENSITY["full"]["slots"])
+
+    def test_a_narrower_level_expands_too(self):
+        """The other direction, so a stub that always returned `full`'s list — which
+        would pass the test above — fails here."""
+        f = instance.frame_of({"frame": {"density": "minimal"}})
+        self.assertEqual(f["slots"], ["top", "bottom"])
+
+    def test_an_explicit_slots_list_overrides_a_declared_density(self):
+        """#387: "an explicit `slots` overrides it". `slots` is the primitive; a preset
+        cannot outrank the thing it is a preset for."""
+        f = instance.frame_of({"frame": {"density": "full", "slots": ["bottom"]}})
+        self.assertEqual(f["slots"], ["bottom"])
+        self.assertEqual(f["density"], "full",
+                         "the level is still resolved — it is what sets verbosity")
+
+    def test_a_slots_list_that_is_entirely_typos_leaves_the_density_in_charge(self):
+        """`slots = ["sideway"]` filters to nothing, so nothing was actually asked for.
+        Falling back to the shipped default there would ignore a density the operator
+        DID write successfully, on account of a key they got wrong."""
+        f = instance.frame_of({"frame": {"density": "full", "slots": ["sideway"]}})
+        self.assertEqual(f["slots"], instance.FRAME_DENSITY["full"]["slots"])
+
+    def test_no_density_at_all_leaves_the_shipped_slots_untouched(self):
+        """The expansion is conditional on the key being DECLARED, which is what keeps
+        the shipped `slots` default load-bearing rather than dead: a change to that list
+        alone must still change the shipped frame.
+
+        **The level to sabotage is READ, never named.** An earlier version of this test
+        hard-coded `"normal"` — true when it was written, and silently vacuous the moment
+        #386 raised the shipped `slots` to all four edges and the shipped `density`
+        followed it to `full`: patching a level nothing defaults to changes nothing, so
+        the test passed against unconditional expansion too. Caught by the mutation run,
+        not by reading. Reading `FRAME_DEFAULTS["density"]` means the sabotage always
+        lands on the level the default path actually takes, whatever it becomes next.
+        """
+        shipped = instance.FRAME_DEFAULTS["density"]
+        with mock.patch.dict(instance.FRAME_DENSITY,
+                             {shipped: {"slots": ["left"], "verbosity": "normal"}}):
+            f = instance.frame_of({"frame": {"mouse": True}})
+        self.assertEqual(f["slots"], instance.FRAME_DEFAULTS["slots"],
+                         "an undeclared density expanded — the shipped `slots` default "
+                         "is now dead code, and #386's own change to it does nothing")
+
+    def test_an_unknown_level_degrades_to_the_shipped_one(self):
+        f = instance.frame_of({"frame": {"density": "enormous"}})
+        self.assertEqual(f["density"], instance.FRAME_DEFAULTS["density"])
+        self.assertEqual(f["slots"], instance.FRAME_DEFAULTS["slots"])
+
+    def test_a_non_string_density_does_not_raise(self):
+        """`value in FRAME_DENSITY` raises `TypeError` for an unhashable value, and this
+        module is imported by every command including `charter --version` — the same trap
+        `_HOTKEY_RE`'s own type check exists for. A TOML array and a table are both
+        writable by hand and both unhashable."""
+        for bad in [["full"], {"level": "full"}, 3, True, None]:
+            with self.subTest(density=bad):
+                f = instance.frame_of({"frame": {"density": bad}})
+                self.assertEqual(f["density"], instance.FRAME_DEFAULTS["density"])
+                self.assertEqual(f["slots"], instance.FRAME_DEFAULTS["slots"])
+
+    def test_density_slots_hands_out_a_copy(self):
+        """A caller patches the resolved config (`mock.patch.dict(config.FRAME, ...)`)
+        and the launcher filters the list it gets back; handing out the table's own list
+        would let either edit the preset for the life of the process."""
+        got = instance.density_slots("full")
+        got.append("sideway")
+        self.assertNotIn("sideway", instance.FRAME_DENSITY["full"]["slots"])
+
+    def test_verbosity_for_answers_normal_for_anything_it_does_not_know(self):
+        """Not a defensive case: a frame's live override is read off disk, and a frame
+        launched by an older charter has no file there at all.
+
+        Asserted against the LITERAL `"normal"`, never `instance.DEFAULT_VERBOSITY`. An
+        earlier version compared the function's answer to the constant the function
+        returns, which is a tautology: setting `DEFAULT_VERBOSITY = "terse"` — shipping
+        every unknown level as a terse frame — passed the whole suite. A test whose
+        expected value is taken from the thing under test cannot fail."""
+        self.assertEqual(instance.verbosity_for("minimal"), "terse")
+        self.assertEqual(instance.DEFAULT_VERBOSITY, "normal",
+                         "the fallback for an unknown level is a FULL panel, not a terse "
+                         "one — a frame charter cannot make sense of must not silently "
+                         "show less")
+        for unknown in [None, "", "enormous", 7]:
+            with self.subTest(level=unknown):
+                self.assertEqual(instance.verbosity_for(unknown), "normal")
+
+
+class VerbosityIsReadLive(PersonaIso, unittest.TestCase):
+    """`slots.verbosity` — the frame's own recorded level first, the configured one
+    behind it. The order IS the "overrides for the running frame only" rule."""
+
+    def setUp(self):
+        super().setUp()
+        self.fid = f"vb-{_a_dead_pid()}"
+
+    def test_the_configured_level_is_used_when_nothing_was_recorded(self):
+        with mock.patch.dict(config.FRAME, {"density": "minimal"}):
+            self.assertEqual(slots.verbosity(self.fid), "terse")
+
+    def test_a_recorded_override_beats_the_configured_level(self):
+        state.record_density(self.fid, "minimal")
+        with mock.patch.dict(config.FRAME, {"density": "full"}):
+            self.assertEqual(slots.verbosity(self.fid), "terse")
+
+    def test_a_corrupt_recorded_level_degrades_to_the_configured_one(self):
+        """The file is on disk, so a truncated write or a hand edit reaches here. It must
+        read like an unknown level in charter.toml does, not like "no panels"."""
+        d = state.frame_dir(self.fid, create=True)
+        (d / "density").write_text("enormous\n")
+        with mock.patch.dict(config.FRAME, {"density": "minimal"}):
+            self.assertEqual(slots.verbosity(self.fid), "terse")
+
+
+class TerseSaysLess(PersonaIso, unittest.TestCase):
+    """What `verbosity == "terse"` actually costs each panel. Every assertion is a
+    comparison against the SAME panel at `normal`, so a renderer that simply broke would
+    not pass by rendering less of nothing."""
+
+    def setUp(self):
+        super().setUp()
+        self.fid = f"tr-{_a_dead_pid()}"
+
+    def _render(self, slot, level):
+        state.record_density(self.fid, level)
+        with mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+             mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((120, 40))):
+            return slots.render(slot, self.fid)
+
+    def test_top_drops_the_charter_version_and_keeps_the_workspace(self):
+        from charter import __version__
+        normal = self._render("top", "normal")
+        terse = self._render("top", "minimal")
+        self.assertIn(__version__, normal)
+        self.assertNotIn(__version__, terse)
+        self.assertIn("⬢", terse, "the workspace mark is the answer top exists to give")
+
+    def test_bottom_keeps_exactly_one_field(self):
+        with mock.patch("charter.statusline._todo_count", return_value=3), \
+             mock.patch("charter.statusline._alerts",
+                        return_value=["⚠ reinit: charter ws reinit needed"]):
+            normal = self._render("bottom", "normal")
+            terse = self._render("bottom", "minimal")
+        self.assertIn("·", normal, "a healthy `normal` row carries several fields")
+        self.assertNotIn("·", terse)
+        self.assertIn("reinit", terse,
+                      "the field that survives must be the highest-priority one")
+
+    def test_bottom_is_never_blank_on_a_quiet_plane(self):
+        """The one-field cap must not produce an empty row when nothing is wrong: the
+        todo count is unconditional, so it is what is left."""
+        with mock.patch("charter.statusline._alerts", return_value=[]), \
+             mock.patch("charter.statusline._session_news", return_value=[]), \
+             mock.patch("charter.statusline._todo_count", return_value=0):
+            terse = self._render("bottom", "minimal")
+        self.assertIn("todo", terse)
+
+    def test_left_shows_fewer_repos_and_says_how_many_it_hid(self):
+        rows = [{"name": f"repo{i}", "branch": "main", "dirty": False,
+                 "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": None,
+                 "change": None, "sigil": "", "current": False, "worktree_count": 0}
+                for i in range(9)]
+        gather.save(self.fid, {"gathered_at": 0.0, "workspace": "w",
+                               "current_repo": None, "repos": rows, "worktrees": []})
+        normal = self._render("left", "normal")
+        terse = self._render("left", "minimal")
+        self.assertEqual(len(normal.split("\n")), 9)
+        self.assertEqual(len(terse.split("\n")), slots._TERSE_ROWS)
+        self.assertIn("more", terse, "a panel showing less must say how much less")
+
+    def test_left_drops_piece_rows(self):
+        gather.save(self.fid, {
+            "gathered_at": 0.0, "workspace": "w", "current_repo": None,
+            "repos": [{"name": "solo", "branch": "main", "dirty": False,
+                       "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": None,
+                       "change": None, "sigil": "", "current": True,
+                       "worktree_count": 1}],
+            "worktrees": [{"name": "a-piece", "repo": "solo", "branch": "wip",
+                           "dirty": False, "tracked_dirty": False, "ahead": 0,
+                           "behind": 0, "ci": None, "change": None, "sigil": "",
+                           "current": False, "worktree_count": 0}]})
+        self.assertIn("a-piece", self._render("left", "normal"))
+        self.assertNotIn("a-piece", self._render("left", "minimal"))
+
+    def test_right_shows_fewer_personas_and_says_how_many_it_hid(self):
+        chips = [f"◆ p{i}" for i in range(9)]
+        with mock.patch("charter.statusline._persona_chips", return_value=chips):
+            normal = self._render("right", "normal")
+            terse = self._render("right", "minimal")
+        self.assertEqual(len(normal.split("\n")), 9)
+        self.assertEqual(len(terse.split("\n")), slots._TERSE_ROWS)
+        self.assertIn("more", terse)
+
+
+class TheSpinnerRunsOnlyWhileWorkDoes(PersonaIso, unittest.TestCase):
+    """`slots._inflight_field` — the only moving thing in the frame.
+
+    Idle stillness is the property, not a nicety: a spinner that keeps turning with
+    nothing behind it is a panel repainting several times a second forever, which is
+    exactly what "nothing may cost anything at idle" rules out.
+    """
+
+    def _record(self, agent="worker", *, age=0.0):
+        d = config.STATE_DIR / "dispatch-inflight"
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / f"{agent}.{age}.json"
+        p.write_text(json.dumps({"agent": agent, "ts": time.time() - age}))
+        return p
+
+    def test_nothing_in_flight_draws_nothing_at_all(self):
+        """Empty, not `⠋ 0 running`: an empty field is DROPPED by `_fit_fields`, which is
+        what makes an idle bottom row identical to the one that shipped before this."""
+        self.assertEqual(slots._inflight_field(), "")
+
+    def test_a_running_dispatch_is_counted_and_animated(self):
+        self._record("alpha")
+        self._record("beta")
+        field = slots._inflight_field()
+        self.assertIn("2 running", field)
+        self.assertTrue(any(f in field for f in slots.SPINNER),
+                        f"no spinner frame in {field!r}")
+
+    def test_a_presumed_dead_record_is_reported_but_never_animated(self):
+        """`inflight` keeps a record for a full day past the presumed-dead threshold so a
+        stuck dispatch stays visible. Animating it would claim progress that stopped
+        thirty minutes ago — and would spin a panel for that whole day."""
+        self._record("stuck", age=inflight.PRESUMED_DEAD_SECONDS + 60)
+        field = slots._inflight_field()
+        self.assertIn("1 stalled", field)
+        self.assertNotIn("running", field)
+        self.assertFalse(any(f in field for f in slots.SPINNER), field)
+
+    def test_the_spinner_advances_with_the_clock(self):
+        """Stateless by construction (`SPINNER_PERIOD` off `time.monotonic`), so nothing
+        has to own or reset it — and two panels painting at the same instant necessarily
+        draw the same frame."""
+        first = slots.spinner_frame(0.0)
+        later = slots.spinner_frame(slots.SPINNER_PERIOD)
+        self.assertNotEqual(first, later)
+        self.assertEqual(first,
+                         slots.spinner_frame(slots.SPINNER_PERIOD * len(slots.SPINNER)))
+
+    def test_every_spinner_frame_is_one_column_wide(self):
+        """A frame two columns wide would make the whole bottom row jump sideways ten
+        times a second — worse than no spinner, and invisible to a test that only checks
+        the count."""
+        for f in slots.SPINNER:
+            with self.subTest(frame=f):
+                self.assertEqual(tui.width(f), 1)
+
+
+class OnlyTheAnimatedSlotAnimates(PersonaIso, unittest.TestCase):
+    """`slots.ANIMATED` must name exactly the renderers whose output changes on its own.
+
+    **This is a cost property, not a tidiness one.** `panel._watch` runs one process per
+    slot, so an unscoped "is work in flight" repaints all four at `panel.TICK` for the
+    whole length of a dispatch — three of them redrawing byte-identical output. Measured
+    on this project (8 personas, 6 repos), one `render("right")` costs 4 816µs, because
+    `statusline._persona_chips` asks `persona.is_draft`, `structural_errors`, `_mem_count`
+    twice and `_vault_dot` per persona — a helper whose own docstring says it "renders on
+    every single turn", written for once a turn rather than five times a second. At 5Hz
+    that pane alone is ~2.4% of a core, during the window `panel.py`'s docstring calls
+    quiet.
+
+    Asserted behaviourally rather than by reading the set: each slot is rendered twice, at
+    two clock readings a spinner frame apart, with a record in flight. Output that differs
+    means the slot animates. A renderer that gains a spinner without joining `ANIMATED`,
+    or keeps its membership after losing one, is red — which a hand-maintained set of
+    names cannot be on its own.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.fid = f"an-{_a_dead_pid()}"
+        d = config.STATE_DIR / "dispatch-inflight"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "w.1.json").write_text(json.dumps({"agent": "w", "ts": time.time()}))
+        gather.save(self.fid, {"gathered_at": 0.0, "workspace": "w",
+                               "current_repo": None, "repos": [], "worktrees": []})
+
+    def _render_at(self, slot, now):
+        with mock.patch("charter.frame.slots.time.monotonic", return_value=now), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+             mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((120, 40))):
+            return slots.render(slot, self.fid)
+
+    def test_exactly_the_slots_in_ANIMATED_change_with_the_clock_alone(self):
+        moving = set()
+        for slot in slots.SLOTS:
+            with self.subTest(slot=slot):
+                first = self._render_at(slot, 0.0)
+                later = self._render_at(slot, slots.SPINNER_PERIOD * 3)
+                if first != later:
+                    moving.add(slot)
+        self.assertEqual(moving, set(slots.ANIMATED),
+                         f"`slots.ANIMATED` says {sorted(slots.ANIMATED)} but the "
+                         f"renderers that actually move are {sorted(moving)}")
+
+    def test_a_non_animated_slot_never_asks_whether_work_is_in_flight(self):
+        """The short-circuit in `_watch`, which is what makes a `top`/`left`/`right` panel
+        cost exactly what it cost before this feature existed — not merely repaint less."""
+        for slot in sorted(set(slots.SLOTS) - set(slots.ANIMATED)):
+            with self.subTest(slot=slot):
+                with mock.patch("charter.frame.panel._running",
+                                side_effect=AssertionError("asked, and must not")), \
+                     mock.patch("charter.frame.panel._paint"):
+                    panel._watch(slot, self.fid, once=True)
+
+    def test_the_animated_slot_does_ask(self):
+        """The other direction, so the test above cannot be satisfied by never asking."""
+        with mock.patch("charter.frame.panel._running", return_value=1) as asked, \
+             mock.patch("charter.frame.panel._paint"):
+            panel._watch("bottom", self.fid, once=True)
+        asked.assert_called_once()
+
+
+class IdleCostsOneStat(PersonaIso, unittest.TestCase):
+    """`panel._running` — how the panel learns work is in flight without paying for it.
+
+    The expensive answer (`inflight.live_records`: opendir, readdir, a JSON parse per
+    record) is behind a single `stat` of the tracker's directory, whose mtime moves
+    whenever a record is created or removed. These tests assert the CALLS, not the
+    wall-clock time, because a timing assertion on a shared CI box measures the box.
+    """
+
+    def test_an_idle_panel_never_reads_the_records_twice(self):
+        cache = panel._new_inflight_cache()
+        panel._running(cache)
+        with mock.patch("charter.inflight.live_records",
+                        side_effect=AssertionError("idle must not re-read")) as reader:
+            for _ in range(20):
+                self.assertEqual(panel._running(cache), 0)
+            reader.assert_not_called()
+
+    def test_an_idle_tick_costs_exactly_one_stat_and_nothing_else(self):
+        """The number #387 asks to be MEASURED rather than asserted, pinned as a syscall
+        budget so it cannot quietly grow: at idle the gate is one `stat` of the tracker's
+        own directory, no file opened, and no process started. Measured alongside this on
+        macOS/APFS: ~4.8µs per tick, against the ~26µs a panel already spends on its
+        version poll, at `panel.TICK` = 5 ticks a second.
+
+        **Counting `Path.stat` alone was not a budget.** An earlier version patched
+        `pathlib.Path.stat` and asserted one call, which constrains only calls that go
+        through that one method: an `open()` per tick survived it, and so did an `os.stat`
+        plus a `subprocess.run` per tick. Worse, it was interpreter-dependent — on Python
+        3.14 `Path.exists()` no longer routes through `Path.stat`, so the very
+        `live_records` read this exists to keep out of the idle path was invisible to the
+        counter, and deleting the whole gate still passed. CI runs 3.11 through 3.14, so
+        "it would have been caught on 3.11" is an accident of pathlib internals, not a
+        test. All three primitives are counted now, at the bottom (`os.stat`,
+        `builtins.open`, `subprocess.run`), which is where every higher-level spelling —
+        `Path.stat`, `Path.exists`, `read_text`, `glob` — must eventually arrive.
+
+        Counted rather than timed, because a wall-clock assertion on a shared CI box
+        measures the box."""
+        import builtins
+        import subprocess as _sp
+        cache = panel._new_inflight_cache()
+        panel._running(cache)          # prime: the first tick always reads
+        real_stat, real_open, real_run = os.stat, builtins.open, _sp.run
+        stats, opens, runs = [], [], []
+
+        def c_stat(*a, **k):
+            stats.append(a)
+            return real_stat(*a, **k)
+
+        def c_open(*a, **k):
+            opens.append(a)
+            return real_open(*a, **k)
+
+        def c_run(*a, **k):
+            runs.append(a)
+            return real_run(*a, **k)
+
+        with mock.patch("os.stat", c_stat), mock.patch("builtins.open", c_open), \
+             mock.patch("subprocess.run", c_run):
+            panel._running(cache)
+        self.assertEqual(len(stats), 1, stats)
+        self.assertEqual(opens, [], "an idle tick opened a file")
+        self.assertEqual(runs, [], "an idle tick started a process")
+
+    def test_a_new_record_is_noticed(self):
+        """The other half: a cache that never refreshed would pass the test above and
+        make the spinner never start."""
+        cache = panel._new_inflight_cache()
+        self.assertEqual(panel._running(cache), 0)
+        d = config.STATE_DIR / "dispatch-inflight"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "w.1.json").write_text(json.dumps({"agent": "w", "ts": time.time()}))
+        self.assertEqual(panel._running(cache), 1)
+
+    def test_a_cleared_record_returns_the_panel_to_stillness(self):
+        d = config.STATE_DIR / "dispatch-inflight"
+        d.mkdir(parents=True, exist_ok=True)
+        rec = d / "w.1.json"
+        rec.write_text(json.dumps({"agent": "w", "ts": time.time()}))
+        cache = panel._new_inflight_cache()
+        self.assertEqual(panel._running(cache), 1)
+        rec.unlink()
+        self.assertEqual(panel._running(cache), 0)
+
+    def test_a_presumed_dead_record_stops_the_animation_without_any_file_changing(self):
+        """The one way this answer changes with no file touched — which is why the mtime
+        alone is not the whole gate. A record that crosses the threshold while the panel
+        watches must stop the spinner, or a killed dispatch animates for a day.
+
+        One patch, not two: `inflight` and `panel` both do `import time`, so
+        `charter.inflight.time` and `charter.frame.panel.time` are the SAME module object
+        and patching `time.time` through either name moves both clocks at once — which is
+        what this test needs, since the deadline is computed in one and compared in the
+        other."""
+        d = config.STATE_DIR / "dispatch-inflight"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "w.1.json").write_text(json.dumps({"agent": "w", "ts": time.time()}))
+        cache = panel._new_inflight_cache()
+        self.assertEqual(panel._running(cache), 1)
+        later = time.time() + inflight.PRESUMED_DEAD_SECONDS + 60
+        with mock.patch("charter.inflight.time.time", return_value=later):
+            self.assertEqual(panel._running(cache), 0)
+
+    def test_a_tracker_that_cannot_be_read_is_stillness_not_a_crash(self):
+        """This runs in a panel's loop, where an exception ends the pane."""
+        cache = panel._new_inflight_cache()
+        with mock.patch("charter.inflight.stamp", side_effect=OSError("gone")):
+            self.assertEqual(panel._running(cache), 0)
+
+    def test_the_stamp_is_none_when_nothing_has_ever_dispatched(self):
+        self.assertIsNone(inflight.stamp())
+
+
+class TheLoopPaintsForTheSpinner(PersonaIso, unittest.TestCase):
+    """`panel._tick` gains a third reason to repaint, and it must not gain a fourth by
+    accident: an idle panel repainting every tick is the cost this whole design avoids."""
+
+    def test_animating_paints_even_with_no_version_change_and_no_resize(self):
+        fid = f"an-{_a_dead_pid()}"
+        seen = state.version(fid)
+        with mock.patch("charter.frame.panel._paint") as paint:
+            panel._tick({"flag": False}, seen, "bottom", fid, animating=True)
+        paint.assert_called_once_with("bottom", fid)
+
+    def test_not_animating_is_the_default_and_paints_nothing(self):
+        fid = f"an-{_a_dead_pid()}"
+        seen = state.version(fid)
+        with mock.patch("charter.frame.panel._paint") as paint:
+            panel._tick({"flag": False}, seen, "bottom", fid)
+        paint.assert_not_called()
+
+
+class TheLoopAsksBeforeItAnimates(PersonaIso, unittest.TestCase):
+    """`_watch` is what connects `_running` to `_tick`, and nothing else does.
+
+    Pinned separately from both because the wiring is its own failure: a loop that never
+    passes `animating` leaves a perfectly correct `_running` and a perfectly correct
+    `_tick` with a spinner that never turns, and every test of either half stays green.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.fid = f"wt-{_a_dead_pid()}"
+
+    def _watch_once(self):
+        with mock.patch("charter.frame.panel._tick", return_value="") as tick:
+            panel._watch("bottom", self.fid, once=True)
+        return tick.call_args
+
+    def test_a_record_in_flight_reaches_the_tick_as_animating(self):
+        d = config.STATE_DIR / "dispatch-inflight"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "w.1.json").write_text(json.dumps({"agent": "w", "ts": time.time()}))
+        self.assertIs(self._watch_once().kwargs["animating"], True)
+
+    def test_an_idle_loop_does_not_animate(self):
+        """The half that stops the test above from passing against a loop hardcoded to
+        animate — which would repaint every panel five times a second, forever, which is
+        the one thing this feature may not do."""
+        self.assertIs(self._watch_once().kwargs["animating"], False)
+
+
+class PanesAreRememberedForTheFrame(PersonaIso, unittest.TestCase):
+    """`state.record_panes`/`state.panes` — the only record of which pane draws which SLOT.
+
+    tmux cannot be asked later: `list-panes` reports ids and geometry, nothing that says
+    which pane charter meant as `left`, and inferring it from position is the pane-index
+    trap `frame/layout.py`'s module docstring measures.
+
+    The HARNESS pane is deliberately not in here — `state.record_harness_pane` owns that
+    one fact for ADR 0019's `is_live`, and a second copy would be one fact free to
+    disagree with itself. `cmd_density` reads it from there.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.fid = f"pn-{_a_dead_pid()}"
+
+    def test_a_recorded_map_reads_back(self):
+        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2"})
+        self.assertEqual(state.panes(self.fid), {"top": "%1", "bottom": "%2"})
+
+    def test_a_frame_with_no_record_answers_empty_rather_than_raising(self):
+        self.assertEqual(state.panes(self.fid), {})
+
+    def test_a_corrupt_file_answers_empty(self):
+        d = state.frame_dir(self.fid, create=True)
+        (d / "panes").write_text("{not json")
+        self.assertEqual(state.panes(self.fid), {})
+
+    def test_non_string_ids_are_dropped_rather_than_handed_to_a_tmux_argv(self):
+        d = state.frame_dir(self.fid, create=True)
+        (d / "panes").write_text('{"top": 7, "bottom": "%2"}')
+        self.assertEqual(state.panes(self.fid), {"bottom": "%2"})
+
+    def test_identity_drops_values_that_are_not_strings(self):
+        """This is JSON on disk and every value goes straight into a tmux `-e NAME=VALUE`
+        argv element, so a hand edit or a charter that wrote a different shape reaches
+        here. Same guard `panes` keeps, for the same reason."""
+        state.record_identity(self.fid, {"CHARTER_ROOT": "/p"})
+        (state.frame_dir(self.fid) / "identity").write_text(
+            '{"CHARTER_ROOT": "/p", "CHARTER_WORKSPACE": 7, "CHARTER_HARNESS": null}')
+        self.assertEqual(state.identity(self.fid), {"CHARTER_ROOT": "/p"})
+
+    def test_identity_answers_empty_for_a_frame_that_never_recorded_one(self):
+        self.assertEqual(state.identity(f"never-{_a_dead_pid()}"), {})
+
+    def test_a_launch_clears_a_density_it_inherited_with_a_recycled_pid(self):
+        """#383's bill, applied to the two files this change adds. A frame id is
+        `<workspace>-<launcher pid>`; `reap` keeps a directory while that pid is live, and
+        on a launch it is live because it is the launcher's own — so a launcher landing on
+        a pid an earlier launcher for the same workspace used adopts that frame's whole
+        directory. A `density` inherited that way is another session's keypress silently
+        overriding this plane's `[frame] density`, which is exactly what "for the running
+        frame only" promises cannot happen."""
+        state.record_density(self.fid, "minimal")
+        state.record_panes(self.fid, panels={"top": "%1"})
+        state.clear_shape(self.fid)
+        self.assertIsNone(state.density(self.fid))
+        self.assertEqual(state.panes(self.fid), {})
+
+    def test_clearing_a_frame_that_never_recorded_anything_is_a_no_op(self):
+        """Never creates, never raises: the ordinary first launch for a workspace has no
+        directory here at all and must not mint one just to empty it."""
+        state.clear_shape(f"never-{_a_dead_pid()}")
+
+    def test_a_launch_writes_the_map_down(self):
+        """The map has to exist before a density change can use it, and the only place it
+        can be captured is where the splits happen."""
+        fake = _Tmux(new_panes=["%11", "%12"])
+        with mock.patch("charter.frame.tmuxctl.run", side_effect=fake):
+            commands_frame._draw_panels("charter", slots=["top", "bottom"], fid=self.fid,
+                                        harness_pane="%0", env=None, v=(3, 7))
+        self.assertEqual(state.panes(self.fid), {"top": "%11", "bottom": "%12"})
+
+
+class LiveOverride(PersonaIso, unittest.TestCase):
+    """`cmd_density` — the keypress half. Changes one running frame; writes no config."""
+
+    def setUp(self):
+        super().setUp()
+        self.fid = f"dn-{_a_dead_pid()}"
+        self.enterContext(mock.patch.dict(os.environ,
+                                          {"CHARTER_SESSION_ID": self.fid}))
+        self.enterContext(mock.patch("charter.frame.tmuxctl.version",
+                                     return_value=(3, 7)))
+        state.record_harness_pane(self.fid, "%0")
+        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2"})
+
+    def _run(self, level, fake=None):
+        fake = fake or _Tmux()
+        with mock.patch("charter.frame.tmuxctl.run", side_effect=fake):
+            rc = commands_frame.cmd_density(SimpleNamespace(level=level))
+        return rc, fake
+
+    def test_it_records_the_level_for_this_frame_only(self):
+        rc, _ = self._run("minimal")
+        self.assertEqual(rc, 0)
+        self.assertEqual(state.density(self.fid), "minimal")
+
+    def test_it_never_writes_charter_toml(self):
+        """The rule the whole design turns on: `charter.toml` is hand-maintained, so a
+        keypress may not touch it. Proved by making every writer in `instance` raise —
+        those two functions are the ONLY code in charter that edits that file."""
+        boom = AssertionError("cmd_density wrote to charter.toml")
+        with mock.patch("charter.instance._set_key", side_effect=boom), \
+             mock.patch("charter.instance.set_locked_version", side_effect=boom), \
+             mock.patch("charter.instance.set_default_persona", side_effect=boom):
+            rc, _ = self._run("full")
+        self.assertEqual(rc, 0)
+
+    def test_growing_to_full_splits_the_slots_that_were_missing(self):
+        rc, fake = self._run("full")
+        self.assertEqual(rc, 0)
+        split_slots = [c[c.index("panel") + 1] for c in fake.calls
+                       if "split-window" in c and "panel" in c]
+        self.assertEqual(sorted(split_slots), ["left", "right"])
+        self.assertEqual(state.panes(self.fid),
+                         {"top": "%1", "bottom": "%2", "left": "%7", "right": "%8"})
+
+    def test_shrinking_kills_the_panes_it_no_longer_wants(self):
+        state.record_panes(self.fid, panels={"top": "%1", "left": "%3", "bottom": "%2"})
+        rc, fake = self._run("minimal")
+        self.assertEqual(rc, 0)
+        killed = [c for c in fake.calls if "kill-pane" in c]
+        self.assertEqual(len(killed), 1, fake.calls)
+        self.assertIn("%3", killed[0])
+        self.assertEqual(state.panes(self.fid), {"top": "%1", "bottom": "%2"})
+
+    def test_a_panel_is_disarmed_before_it_is_killed(self):
+        """Otherwise the change undoes itself: `kill-pane` fires that pane's own
+        `pane-died` hook, `cmd_respawn` waits out its backoff, finds the session still
+        perfectly alive — only the layout changed — and puts the panel the operator just
+        dismissed straight back, one respawn life poorer."""
+        state.record_panes(self.fid, panels={"top": "%1", "left": "%3", "bottom": "%2"})
+        _, fake = self._run("minimal")
+        disarm = fake.where("set-hook", "-u", "%3")
+        kill = fake.where("kill-pane", "%3")
+        self.assertEqual(len(disarm), 1, fake.calls)
+        self.assertEqual(len(kill), 1, fake.calls)
+        self.assertLess(disarm[0], kill[0],
+                        "the hook must be gone before the pane is")
+
+    def test_the_resize_hook_is_rebuilt_from_the_new_pane_set(self):
+        """One `set-hook` replaces the whole hook, and its action names every pane it
+        resizes — a stale entry is a `resize-pane` aimed at a killed pane on every
+        terminal resize for the life of the window."""
+        state.record_panes(self.fid, panels={"top": "%1", "left": "%3", "bottom": "%2"})
+        _, fake = self._run("minimal")
+        hooks = [c for c in fake.calls if "window-resized" in c]
+        self.assertEqual(len(hooks), 1, fake.calls)
+        action = hooks[0][-1]
+        self.assertIn("%1", action)
+        self.assertIn("%2", action)
+        self.assertNotIn("%3", action)
+
+    def test_dropping_every_slot_removes_the_resize_hook(self):
+        """Reachable, not hypothetical: `_drawable_slots` answers `[]` below half of
+        `min_cols`/`min_rows`, so shrinking a small window's frame kills every pane. The
+        launch's own hook names those panes, and one `set-hook` only REPLACES a hook when
+        there is something to replace it with — an empty map replaces nothing. Left as an
+        early return, the hook survives firing `resize-pane -t %1` at dead panes on every
+        resize for the life of the window."""
+        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2",
+                                             "left": "%3", "right": "%4"})
+        rc, fake = self._run("minimal", fake=_Tmux(size="40:8"))
+        self.assertEqual(rc, 0)
+        self.assertEqual(len([c for c in fake.calls if "kill-pane" in c]), 4, fake.calls)
+        unset = [c for c in fake.calls if "window-resized" in c and "-u" in c]
+        self.assertEqual(len(unset), 1, fake.calls)
+        self.assertEqual(state.panes(self.fid), {})
+
+    def test_surviving_panels_have_their_size_re_asserted(self):
+        """tmux redistributes every remaining pane proportionally on a `kill-pane`, so
+        the panels that merely SURVIVED a density change are exactly the ones a `-l` on a
+        newly split pane cannot fix."""
+        _, fake = self._run("full")
+        resized = {c[c.index("-t") + 1] for c in fake.calls if "resize-pane" in c}
+        self.assertIn("%1", resized)
+        self.assertIn("%2", resized)
+
+    def test_the_harness_pane_gets_focus_back(self):
+        """`split-window` makes each new pane ACTIVE — without this the operator is left
+        typing into a panel."""
+        _, fake = self._run("full")
+        self.assertTrue(fake.where("select-pane", "%0"), fake.calls)
+
+    def test_the_density_is_recorded_before_the_panes_move(self):
+        """`cmd_density`'s own docstring claims this ordering and nothing tested it. It is
+        the difference between a re-layout that dies halfway leaving the surviving panels
+        drawing at the density the operator asked for, and one leaving them at the old one
+        with no way to tell which. Asserted by reading the recorded value from INSIDE the
+        re-layout, which is the only moment the order is observable."""
+        seen = []
+        real = commands_frame._relayout
+        with mock.patch("charter.commands_frame._relayout",
+                        side_effect=lambda *a, **k: (seen.append(state.density(self.fid)),
+                                                     real(*a, **k))[1]):
+            self._run("minimal")
+        self.assertEqual(seen, ["minimal"],
+                         "the density was recorded after the panes moved")
+
+    def test_the_version_is_bumped_so_surviving_panels_repaint(self):
+        before = state.version(self.fid)
+        self._run("minimal")
+        self.assertNotEqual(state.version(self.fid), before)
+
+    def test_the_menus_mark_moves_to_the_level_now_in_effect(self):
+        self._run("full")
+        labels = [lb for lb, _ in menu.build(self.fid)]
+        on = commands_frame._DENSITY_MARK[0]
+        self.assertIn(f"{on} density: full", labels)
+        self.assertEqual([lb for lb in labels if lb.startswith(on)],
+                         [f"{on} density: full"], labels)
+
+    def test_a_terminal_too_small_for_the_level_still_drops_the_side_panels(self):
+        """A density change goes through the SAME size floors a launch does — asking for
+        `full` in an 80-column terminal must not split a pane the frame has no room for.
+        `_drawable_slots` is what enforces it, and it is asked here rather than
+        reimplemented."""
+        rc, fake = self._run("full", fake=_Tmux(size="80:20"))
+        self.assertEqual(rc, 0)
+        self.assertFalse([c for c in fake.calls if "split-window" in c], fake.calls)
+
+    def _split_env(self, calls):
+        """``{NAME: value}`` from every `-e` on the `split-window` calls in *calls*."""
+        out = {}
+        for c in calls:
+            if "split-window" not in c:
+                continue
+            for i, x in enumerate(c):
+                if x == "-e" and i + 1 < len(c):
+                    name, _, value = c[i + 1].partition("=")
+                    out[name] = value
+        return out
+
+    def test_a_new_pane_carries_the_frame_identity_on_either_server(self):
+        """#411, one command over. A panel resolves its plane and its frame from its own
+        environment, and a pane created by `split-window` gets that environment from the
+        server — which on charter's shared private socket may have been started by ANOTHER
+        launcher days ago, and on the operator's certainly was. `cmd_launch` states the
+        identity explicitly on both paths since #412; a re-layout creates panes the same
+        way and had to be taught the same thing rather than inheriting the rule from where
+        the code happened to sit.
+
+        Asserted against `commands_frame._FRAME_IDENTITY` itself, never a list of my own:
+        that tuple has already grown from four names to five, and a test carrying a
+        parallel copy would go on passing while the fifth never reached a re-laid-out
+        pane."""
+        for server in (None, "/private/tmp/tmux-502/default"):
+            with self.subTest(server=server or "charter's own"):
+                # Reset the map each time: the previous iteration left the frame AT
+                # `full`, so without this the second subtest splits nothing and its
+                # assertions are vacuously true — the exact shape of unfailable test this
+                # suite has been bitten by.
+                state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2"})
+                if server:
+                    state.record_server(self.fid, server)
+                _, fake = self._run("full")
+                carried = self._split_env(fake.calls)
+                self.assertTrue([c for c in fake.calls if "split-window" in c])
+                for name in commands_frame._FRAME_IDENTITY:
+                    self.assertIn(name, carried, carried)
+                self.assertEqual(carried["CHARTER_SESSION_ID"], self.fid)
+
+    def test_a_new_pane_gets_the_FRAMES_identity_not_this_processes(self):
+        """#411, arriving on the one command charter has added since.
+
+        `cmd_density` normally runs as a `subprocess.run` child of `cmd_action`, itself a
+        `run-shell` child of the tmux server — and charter's private server is SHARED, so
+        that child reads whichever launcher's environment started it. Only
+        `CHARTER_SESSION_ID` is session-scoped (charter issues four `set-environment`
+        calls and none covers the other four names). Measured on tmux 3.7c, a `run-shell`
+        on the second frame reported the FIRST frame's workspace and harness beside its
+        own id.
+
+        So building the `-e` payload from `os.environ` pins another frame's plane onto the
+        panes this keypress creates — and `$CHARTER_ROOT` wins outright in
+        `root.find_root`, `$CHARTER_WORKSPACE` in `workspace.resolve`, so the new panels
+        would draw a different plane from the ones that survived.
+
+        The environment here is deliberately WRONG in every name the launcher recorded:
+        the test fails unless the values come from `state.identity`. The previous test of
+        this ran in-process with a correct `os.environ` and could not tell the two
+        apart."""
+        state.record_identity(self.fid, {"CHARTER_SESSION_ID": self.fid,
+                                         "CHARTER_ROOT": "/planes/mine",
+                                         "CHARTER_WORKSPACE": "my-ws",
+                                         "CHARTER_HARNESS": "codex",
+                                         "CHARTER_PERSONA": "steward"})
+        someone_else = {"CHARTER_ROOT": "/planes/THEIRS",
+                        "CHARTER_WORKSPACE": "THEIR-ws",
+                        "CHARTER_HARNESS": "claude-code",
+                        "CHARTER_PERSONA": "release"}
+        with mock.patch.dict(os.environ, someone_else):
+            _, fake = self._run("full")
+        carried = self._split_env(fake.calls)
+        self.assertEqual(carried["CHARTER_ROOT"], "/planes/mine", carried)
+        self.assertEqual(carried["CHARTER_WORKSPACE"], "my-ws", carried)
+        self.assertEqual(carried["CHARTER_HARNESS"], "codex", carried)
+        self.assertEqual(carried["CHARTER_PERSONA"], "steward", carried)
+        self.assertEqual(carried["CHARTER_SESSION_ID"], self.fid, carried)
+
+    def test_an_unrecorded_identity_is_stated_empty_rather_than_inherited(self):
+        """A frame launched by a charter that predates `record_identity`. Omitting the
+        four unknown names would let the new pane inherit the SERVER's — which is the bug
+        — so they are stated empty instead, which every charter reader already treats as
+        absent (`workspace.resolve` and `root.find_root` test for truth, not presence).
+        The pane then resolves from its own cwd, inherited from the harness pane, which is
+        right. `_frame_identity_env` makes the identical argument for the launch path."""
+        (state.frame_dir(self.fid, create=True) / "identity").unlink(missing_ok=True)
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "THEIR-ws"}):
+            _, fake = self._run("full")
+        carried = self._split_env(fake.calls)
+        self.assertEqual(sorted(carried), sorted(commands_frame._FRAME_IDENTITY), carried)
+        self.assertEqual(carried["CHARTER_WORKSPACE"], "", carried)
+        self.assertEqual(carried["CHARTER_SESSION_ID"], self.fid,
+                         "the one name this process can always be sure of")
+
+    def test_a_launch_records_the_identity_a_later_keypress_will_read(self):
+        """The other end of the same mechanism: nothing reads `state.identity` correctly
+        if no launch ever writes it."""
+        fake = _Tmux(new_panes=["%11", "%12"])
+        env = {"CHARTER_ROOT": "/planes/mine", "CHARTER_WORKSPACE": "my-ws"}
+        with mock.patch.dict(os.environ, env):
+            commands_frame.state.record_identity(
+                self.fid, commands_frame._frame_identity_env(
+                    commands_frame._frame_env(self.fid, None)))
+        recorded = state.identity(self.fid)
+        self.assertEqual(recorded["CHARTER_ROOT"], "/planes/mine", recorded)
+        self.assertEqual(recorded["CHARTER_SESSION_ID"], self.fid, recorded)
+        self.assertEqual(sorted(recorded), sorted(commands_frame._FRAME_IDENTITY))
+
+    def test_a_new_pane_carries_nothing_beyond_that_identity(self):
+        """**A tmux `-e` is argv, and argv is not private** — world-readable in
+        `/proc/<pid>/cmdline`, visible to `ps` for every local user, recorded by exec
+        audit. Measured on a real environment, the full `_frame_env` came to 138 argv
+        elements and 7,696 bytes carrying two live service-account tokens.
+
+        `_launch_in_operator_tmux` still passes the whole environment there, which is
+        #446 and out of scope — but new code may not reproduce it, and "out of scope"
+        is not a reason a keypress should start leaking an operator's tokens onto a
+        command line. Pinned with a sentinel that could only arrive by the whole
+        environment being handed over.
+
+        This is also what covers the launching pane's own identity: `TMUX`, `TMUX_PANE`,
+        `COLUMNS` and `LINES` describe the pane `cmd_density` was FIRED in, and an equality
+        against `_FRAME_IDENTITY` excludes them by construction. A separate test asserting
+        just those four was written first and deleted — it could not fail while this one
+        passed, which makes it a claim rather than a check."""
+        state.record_server(self.fid, "/private/tmp/tmux-502/default")
+        with mock.patch.dict(os.environ, {"AWS_SECRET_ACCESS_KEY": "SENTINEL-0xC0FFEE"}):
+            _, fake = self._run("full")
+        carried = self._split_env(fake.calls)
+        self.assertEqual(sorted(carried), sorted(commands_frame._FRAME_IDENTITY), carried)
+        self.assertNotIn("SENTINEL-0xC0FFEE", " ".join(x for c in fake.calls for x in c))
+
+    def test_a_tmux_too_old_for_pane_env_is_given_the_pane_anyway(self):
+        """Below `tmuxctl.PANE_ENV_FLOOR`, `split-window` cannot parse `-e` at all — and a
+        flag tmux refuses takes the whole command with it. A pane created without its
+        identity is degraded; a pane not created is a hole in the frame."""
+        self.enterContext(mock.patch("charter.frame.tmuxctl.version", return_value=(2, 9)))
+        _, fake = self._run("full")
+        splits = [c for c in fake.calls if "split-window" in c]
+        self.assertTrue(splits, fake.calls)
+        for c in splits:
+            self.assertNotIn("-e", c, c)
+
+    def test_no_menu_is_recorded_inside_an_operators_tmux(self):
+        """`cmd_launch` records no menu there and charter binds no key there, so a density
+        change that grew one would create a table nothing can open — whose "Detach" row
+        targets `detach-client -s <fid>`, a SESSION name that does not exist on a server
+        where a frame is a window."""
+        state.record_server(self.fid, "/private/tmp/tmux-502/default")
+        self._run("full")
+        self.assertEqual(menu.build(self.fid), [])
+
+    def test_a_menu_is_recorded_on_charters_own_server(self):
+        """The other direction, so the refusal above cannot pass by never recording."""
+        self._run("full")
+        self.assertTrue(menu.build(self.fid))
+
+    def test_a_new_pane_inside_an_operators_tmux_is_not_armed_for_respawn(self):
+        """`cmd_respawn` and `_panel_died_hook_argv` both assume `-L charter`, charter's
+        own server NAME. Arming a panel on the operator's server would install a hook
+        whose action targets the wrong tmux entirely — so it is refused there, and the
+        refusal now lives in `_arm_panel_respawn` rather than in where the loop happens to
+        sit, because a re-layout runs on either server."""
+        state.record_server(self.fid, "/private/tmp/tmux-502/default")
+        _, fake = self._run("full")
+        self.assertFalse([c for c in fake.calls if "pane-died" in c], fake.calls)
+
+    def test_a_new_pane_on_charters_own_server_is_armed_for_respawn(self):
+        """The other direction, so the refusal above cannot be satisfied by never arming
+        anything anywhere."""
+        _, fake = self._run("full")
+        armed = [c for c in fake.calls if "pane-died" in c and "-u" not in c]
+        self.assertEqual(len(armed), 2, fake.calls)
+
+    def test_no_session_id_is_a_quiet_no_op(self):
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": ""}):
+            rc, fake = self._run("full")
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.calls, [])
+        self.assertIsNone(state.density(self.fid))
+
+    def test_an_unknown_level_is_refused_before_anything_moves(self):
+        """The level reaches a slot list and a menu label; the closed set is the guard,
+        and it must be asked BEFORE the frame is touched, not after."""
+        rc, fake = self._run("enormous")
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.calls, [])
+        self.assertIsNone(state.density(self.fid))
+
+    def test_a_frame_with_no_recorded_harness_pane_is_a_quiet_no_op(self):
+        """A frame launched by a charter that predates `record_harness_pane`. Every split
+        carves off that one pane, so without it there is nothing to split from — and
+        guessing at a pane id is the trap `frame/layout.py` measures."""
+        (state.frame_dir(self.fid, create=True) / "harness").unlink()
+        rc, fake = self._run("full")
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.calls, [])
+
+    def test_an_empty_panel_map_is_not_a_refusal(self):
+        """The other half, and a real case rather than a hypothetical: a frame whose
+        panels all failed to draw (`split-window` reporting no id) records an empty map,
+        and it can still be given panels. Refusing on the panel map would leave the one
+        frame that most needs a re-layout unable to have one — and it is exactly the
+        shape a guard written as `if not panels: return 0` would have produced."""
+        state.record_panes(self.fid, panels={})
+        rc, fake = self._run("full")
+        self.assertEqual(rc, 0)
+        split_slots = sorted(c[c.index("panel") + 1] for c in fake.calls
+                             if "split-window" in c and "panel" in c)
+        self.assertEqual(split_slots, ["bottom", "left", "right", "top"], fake.calls)
+
+    def test_a_harness_pane_that_is_not_tmuxs_own_shape_is_refused(self):
+        """The id comes back off disk, not off `split-window`'s stdout, so it gets the
+        same `_PANE_ID_RE` treatment on the way out that it got on the way in — it is
+        about to be interpolated into a hook action tmux re-parses."""
+        state.record_harness_pane(self.fid, "%0; kill-server")
+        rc, fake = self._run("full")
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.calls, [])
+
+
+class DensityIsWiredIntoTheCli(unittest.TestCase):
+    """The menu stores an argv; a CLI that does not accept it means the hotkey silently
+    does nothing, with no message anywhere to explain it."""
+
+    def test_the_menus_argv_shape_parses_and_dispatches(self):
+        """Parsed from the argv `_menu_entries` actually stores, not from a hand-written
+        one — a stored argv the CLI cannot parse is a hotkey that silently exits 2 inside
+        a `run-shell` with nothing anywhere to print the reason.
+
+        `assertIs` on the handler rather than patching it and calling: `set_defaults`
+        binds the function OBJECT at parser-construction time, so a patch applied after
+        `build_parser()` is not what `ns.func` holds — a test that patched and then
+        asserted "called once" would be asserting against its own mock's identity, and
+        passed just as well with the parser wired to the wrong command."""
+        from charter.cli import build_parser
+        argv = util.self_relaunch_argv("frame-density", "full")
+        ns = build_parser().parse_args(argv[argv.index("charter") + 1:])
+        self.assertEqual(ns.level, "full")
+        self.assertIs(ns.func, commands_frame.cmd_density)
+
+    def test_frame_density_is_reserved_against_a_harness_claiming_it(self):
+        """`_add_frame_parsers` registers harness launchers BEFORE its own `frame-*`
+        commands, so a harness with this `cli_name` would pass a check against
+        `sub.choices` alone — nothing is named `frame-density` there yet — and only
+        collide once that `add_parser` call ran a few lines later. On this repo's own
+        3.11 floor `add_parser` accepts a duplicate name silently, so the harness would
+        simply be shadowed and the hotkey menu would launch a harness instead of changing
+        the frame's density. `_core_commands` reserves the word up front; this asserts on
+        that guard's own wording, which is the half that does not depend on which
+        interpreter runs the suite (see `test_frame_launcher.CollisionGuard` for the same
+        argument spelled out at length)."""
+        from charter import cli
+        from charter.harness.base import Harness
+
+        class _DensityClaimant(Harness):
+            name = "density-claimant"
+            cli_name = "frame-density"
+            binary = "density-claimant"
+
+        with mock.patch.dict("charter.harness.registry.KINDS",
+                             {"density-claimant": _DensityClaimant}, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                cli.build_parser()
+        self.assertIn("density-claimant", str(ctx.exception))
+        self.assertIn("charter frame-density", str(ctx.exception))
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_doctor.py
+++ b/tests/test_frame_doctor.py
@@ -48,12 +48,46 @@ class FrameRow(unittest.TestCase):
         """This hint used to say "a frame still starts, with its hotkey menu disabled".
         Nothing disables it: `cmd_launch` warns and continues, and `conf_text` emits the
         bind unchanged. The hint now comes from `tmuxctl.below_floor_message` — one
-        sentence shared with `--probe`, so the two cannot drift apart."""
+        sentence shared with `--probe`, so the two cannot drift apart.
+
+        `assertIn`, not `assertEqual`: tmux 3.0 is below `RESIZE_HOOK_FLOOR` as well as
+        below `FLOOR`, so since #387 this row carries both sentences. That is the same
+        shape the row already had for an unimplemented slot (`hint += " " + ...`), and
+        the claim being pinned is unchanged — the below-floor sentence is `tmuxctl`'s
+        own and is not re-worded here."""
         from charter.frame import tmuxctl
         with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 0)):
             r = doctor.check_frame()
         self.assertNotIn("hotkey menu disabled", r.hint)
-        self.assertEqual(r.hint, tmuxctl.below_floor_message((3, 0)))
+        self.assertIn(tmuxctl.below_floor_message((3, 0)), r.hint)
+
+    def test_a_tmux_without_the_resize_hook_is_a_ceiling_this_row_names(self):
+        """#387's own finding: `tmuxctl.RESIZE_HOOK_FLOOR` (3.3) sits ABOVE
+        `tmuxctl.FLOOR` (3.2), and appeared in neither this row nor `frame_ready`. So an
+        operator on tmux 3.2 passed the floor cleanly, read a green tick here, and had no
+        resize recovery at all — the panels stretch on every terminal resize and stay
+        stretched. The launcher knew (it skipped the hook) and said so only into the
+        pre-attach window, where the alternate screen hides it milliseconds later.
+
+        3.2 exactly, not 3.0: at 3.0 the below-floor sentence is also present, so a row
+        that named nothing about resizing would still have looked plausible. This version
+        is the gap itself — nothing else has anything to say about it."""
+        from charter.frame import tmuxctl
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 2)):
+            r = doctor.check_frame()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn(tmuxctl.below_resize_hook_message((3, 2)), r.hint)
+        self.assertNotIn(tmuxctl.below_floor_message((3, 2)), r.hint,
+                         "3.2 is AT the floor — it must not be reported as below it")
+
+    def test_a_tmux_with_the_resize_hook_is_not_warned_about_it(self):
+        """The other direction, and what stops the test above from passing against a row
+        that warns unconditionally: at 3.3 (`RESIZE_HOOK_FLOOR` exactly) the hook exists,
+        so there is no ceiling and the row is a clean tick."""
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 3)):
+            r = doctor.check_frame()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIsNone(r.hint or None)
 
     def test_a_slot_with_no_renderer_is_a_ceiling_this_row_names(self):
         """The second standing condition that moved off the launch path (see

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -39,7 +39,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from tests._isolation import PersonaIso
-from charter import commands_frame, config, util
+from charter import commands_frame, config, instance, util
 from charter.frame import gather, layout, menu, slots, state, tmuxctl
 
 #: The plane this test PROCESS was started in, captured at IMPORT — before any `setUp`
@@ -782,6 +782,37 @@ class Probe(unittest.TestCase):
         self.assertIn("left", printed)
         self.assertIn("right", printed)
 
+    def test_a_tmux_without_the_resize_hook_is_a_ceiling_the_probe_names(self):
+        """#387's own finding, and the third standing ceiling to move off the launch path.
+        `tmuxctl.RESIZE_HOOK_FLOOR` (3.3) sits ABOVE `tmuxctl.FLOOR` (3.2), so an operator
+        on 3.2 passed the floor cleanly, got a clean tick from this probe and from
+        `doctor`, and silently had no resize recovery — the panels stretch on every
+        terminal resize and stay stretched. The launcher knew (`_install_resize_hook`
+        skips the attempt) and said so only into the pre-attach window, where tmux's own
+        alternate screen hides it milliseconds later.
+
+        3.2 exactly, not something older: at 3.0 the below-floor sentence is present too,
+        so a probe that named nothing about resizing would still have printed something
+        and looked fine. This version is the gap itself."""
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 2)), \
+             mock.patch("charter.commands_frame.subprocess.run") as run:
+            code, level, line = commands_frame.frame_ready()
+        run.assert_not_called()
+        self.assertEqual((code, level), (0, "warn"),
+                         "a capability ceiling is not a refusal — cmd_launch still draws")
+        self.assertIn(tmuxctl.below_resize_hook_message((3, 2)), line)
+        self.assertNotIn(tmuxctl.below_floor_message((3, 2)), line,
+                         "3.2 is AT the floor — it must not be reported as below it")
+
+    def test_a_tmux_with_the_resize_hook_is_not_warned_about_it(self):
+        """The other direction, and what stops the test above from passing against a probe
+        that always warns: at 3.3 (`RESIZE_HOOK_FLOOR` exactly) the hook exists."""
+        with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 3)), \
+             mock.patch.dict(config.FRAME, {"slots": ["top", "bottom"]}):
+            code, level, line = commands_frame.frame_ready()
+        self.assertEqual((code, level), (0, "ok"))
+        self.assertNotIn("\n", line)
+
     def test_an_ordinary_machine_gets_no_ceilings_at_all(self):
         """The other direction, and what stops the two tests above from passing against
         a probe that always warns: with a new-enough tmux and only implemented slots
@@ -1370,11 +1401,37 @@ class Launch(PersonaIso, unittest.TestCase):
         fake = _FakeTmux(still_live=True)
         _launch(fake)
         entries = menu.build(fake.fid)
-        self.assertEqual(len(entries), 1)
         label, action_id = entries[0]
         self.assertEqual(label, "Detach")
         argv = menu.resolve(fake.fid, action_id)
         self.assertEqual(argv, ["tmux", "-L", "charter", "detach-client", "-s", fake.fid])
+
+    def test_the_menu_offers_every_density_and_marks_the_one_in_effect(self):
+        """The keypress half of #387: density is reached through the hotkey menu charter
+        already binds, not through a second `bind -n` — a tmux key table is server-wide
+        with no per-session form, so a second key would be taken from every frame on
+        `SOCKET` and, inside an operator's own tmux, could not be bound at all.
+
+        Asserted on the RESOLVED argv rather than the label, because the label is the
+        cosmetic half: what must be true is that selecting a row runs `charter
+        frame-density <level>` and nothing else — no tmux command, nothing that could
+        rewrite charter.toml. The dot is checked too, separately, because a menu that
+        offers three levels and cannot say which one is on is a menu that has to be
+        guessed at."""
+        fake = _FakeTmux(still_live=True)
+        _launch(fake)
+        rows = {}
+        for label, action_id in menu.build(fake.fid):
+            rows[label] = menu.resolve(fake.fid, action_id)
+        for level in instance.FRAME_DENSITY:
+            with self.subTest(level=level):
+                match = [(lb, argv) for lb, argv in rows.items()
+                         if argv == util.self_relaunch_argv("frame-density", level)]
+                self.assertEqual(len(match), 1, rows)
+                self.assertIn(f"density: {level}", match[0][0])
+        marked = [lb for lb in rows if lb.startswith(commands_frame._DENSITY_MARK[0])]
+        self.assertEqual(marked, [f"{commands_frame._DENSITY_MARK[0]} density: "
+                                  f"{config.FRAME['density']}"], rows)
 
     def test_the_write_hook_is_installed_before_the_teardown_hook(self):
         """Load-bearing, not incidental — see `_pane_died_teardown_hook_argv`'s own
@@ -1811,7 +1868,18 @@ class Launch(PersonaIso, unittest.TestCase):
         `test_below_the_tmux_floor_degrades_instead_of_refusing`). Below
         RESIZE_HOOK_FLOOR the hook must never even be ATTEMPTED — confirmed by hand
         that installing it on an unrecognised hook name fails with `invalid option:
-        window-resized` — one quiet note instead, naming the real version gap."""
+        window-resized`.
+
+        **And it is now skipped in SILENCE (#387).** This used to assert a `util.warn`
+        naming the version gap, which was the last standing ceiling still printed on the
+        launch path — measured at 86 bytes before tmux's own `\\x1b[?1049h`, so the
+        operator's terminal switched to the alternate screen milliseconds later and the
+        line came back only once the frame exited. It is the same argument
+        `test_below_the_tmux_floor_degrades_instead_of_refusing` already makes for the
+        floor itself, and this test is now its exact twin: the hook is not attempted, and
+        nothing is said here. Where it IS said is asserted in
+        `Probe.test_a_tmux_without_the_resize_hook_is_a_ceiling_the_probe_names` and
+        `tests/test_frame_doctor.py`."""
         fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11", "bottom": "%12"})
         buf = []
         with mock.patch("charter.util.warn", side_effect=lambda m: buf.append(m)):
@@ -1819,7 +1887,9 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertFalse(any("window-resized" in c for c in fake.calls),
                          "the hook must not even be attempted below its own floor")
-        self.assertTrue(any("3.2" in m and "resize" in m for m in buf), buf)
+        self.assertEqual(buf, [], "a standing ceiling must not be warned about into a "
+                                 "terminal that is about to switch to tmux's alternate "
+                                 "screen — see the docstring")
 
     def test_below_the_tmux_floor_degrades_instead_of_refusing(self):
         """Correction 5: a version below `tmuxctl.FLOOR` still launches — the frame
@@ -2154,6 +2224,49 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertEqual(rc, 0, "a previous frame's exit code was returned as this one's")
         self.assertTrue(any("detach" in m.lower() for m in buf),
                         f"no reattach message — the stale code suppressed it: {buf}")
+
+    def test_a_launch_records_the_frames_own_charter_identity(self):
+        """#411 on the density path. A hotkey pressed later runs as a `run-shell` child of
+        the tmux server, and charter's private server is SHARED — that child reads
+        whichever launcher's environment started it, so only `CHARTER_SESSION_ID`
+        (session-scoped) is this frame's. Every other identity name has to be written down
+        by the one process that knows it, which is this one; `commands_frame
+        ._relayout_pane_env` is what reads it back before splitting a pane.
+
+        Asserted with a sentinel `$CHARTER_WORKSPACE` in the launcher's environment, so a
+        launch that recorded nothing — or recorded the wrong thing — is distinguishable
+        from one that happened to agree."""
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "WS-SENTINEL-0xBEEF"}):
+            fake = _FakeTmux(still_live=True)
+            _launch(fake)
+        recorded = state.identity(fake.fid)
+        self.assertEqual(recorded.get("CHARTER_WORKSPACE"), "WS-SENTINEL-0xBEEF", recorded)
+        self.assertEqual(recorded.get("CHARTER_SESSION_ID"), fake.fid, recorded)
+        self.assertEqual(sorted(recorded), sorted(commands_frame._FRAME_IDENTITY),
+                         "every identity name must be recorded, including the empty ones "
+                         "— an omitted name is inherited from the server, which is the bug")
+
+    def test_a_launch_does_not_inherit_a_density_from_an_earlier_life_of_its_pid(self):
+        """The third file the recycled directory carries (#387). `density` is written by
+        the hotkey menu and by nothing else — it is the "for the running frame only"
+        override — so a frame that adopts one has a keypress from a session that is over
+        silently outranking this plane's own `[frame] density`, with nothing anywhere to
+        explain why the frame came up narrower than the file says. `panes` goes with it:
+        it names tmux panes of a frame that no longer exists, and a launch that dies
+        before `_draw_panels` rewrites it would leave the next density change killing
+        whatever tmux has since reused those ids for."""
+        stale = state.frame_id("demo", os.getpid())   # the id `_launch` is about to mint
+        state.record_density(stale, "minimal")
+        state.record_panes(stale, panels={"left": "%98"})
+
+        fake = _FakeTmux(still_live=True)
+        _launch(fake)
+
+        self.assertEqual(fake.fid, stale, "the fixture stopped colliding — proves nothing")
+        self.assertIsNone(state.density(stale),
+                          "a dead frame's density override outlived it")
+        self.assertEqual(state.panes(stale), {},
+                         "a dead frame's pane map outlived it")
 
     def test_a_launch_does_not_inherit_a_cached_scan_from_an_earlier_life_of_its_pid(self):
         """The second file the recycled directory carries, and the second reader that

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -259,11 +259,17 @@ class BottomRenderer(PersonaIso, unittest.TestCase):
         identical point `_top`'s docstring makes about the gauge. `session.current()`
         supplies it, the same fallback `_right` already trusts for `_persona_chips`.
         Pinned with a sentinel id nothing in `_bottom` could have produced on its own,
-        and requiring it actually reach the call."""
+        and requiring it actually reach the call.
+
+        `inflight=False` travels with it since #387: the panel draws the in-flight
+        tracker itself, as a spinner that moves, and asking `_session_news` for its own
+        `⚡ N` too would print one fact twice on one row. Asserted here rather than in a
+        test of its own because it is part of THIS call, and a change that dropped it
+        would still pass a looser `assert_called_once()`."""
         with mock.patch("charter.session.current", return_value="SID-SENTINEL-0xF00D"), \
              mock.patch("charter.statusline._session_news", return_value=[]) as news:
             slots.render("bottom", "f-1")
-        news.assert_called_once_with("SID-SENTINEL-0xF00D")
+        news.assert_called_once_with("SID-SENTINEL-0xF00D", inflight=False)
 
     def test_never_exceeds_the_pane_width(self):
         with mock.patch("charter.statusline._session_news",


### PR DESCRIPTION
Closes #387.

Three things, plus the standing warning #387 asked to be folded in.

## 1. Density is a preset over `slots`

`[frame] density` expands to a slot list **plus** a per-slot verbosity, and an explicit
`slots` overrides it — `slots` stays the primitive. Nothing downstream of
`instance.frame_of` learns that presets exist: `frame_ready`, `doctor.check_frame`,
`_drawable_slots` and `layout.panel_argvs` all keep reading the one resolved list.

| level | edges | verbosity |
|---|---|---|
| `minimal` | `top`, `bottom` | terse |
| `normal` | `top`, `bottom` | normal |
| `full` | all four edges | normal |

`terse` is real, not decorative: `top` drops the charter version (the install is not where
you are standing), `bottom` keeps only its highest-priority non-empty field through the
same `_fit_fields` priority order it already used for width, and `left`/`right` cap at four
rows and say how many they hid.

**Expansion happens only when the key is DECLARED**, never from the shipped default. That
is what keeps the shipped `slots` list load-bearing rather than dead — see the
reconciliation section below.

## 2. The hotkey overrides the running frame only

The three levels join "Detach" in the menu `[frame] hotkey` already opens, with a `•` on
the one in effect. Selecting one runs `charter frame-density <level>`, which re-lays the
frame out live: disarm and `kill-pane` what is no longer wanted, `split-window` what is,
rebuild the `window-resized` hook from the new pane set, re-assert every size, give the
harness pane focus back, bump the version so surviving panels repaint at the new
verbosity.

**It writes nothing to `charter.toml`.** The override lands in the frame's own state
directory, which `reap` deletes whole when the frame ends — machine-written state in a
place a machine may rewrite whole, per charter's own rule. Relaunch and the configured
default is back. Pinned by a test that makes every `charter.toml` writer in `instance`
raise.

No second `bind -n`: a tmux key table is server-wide with no per-session form, so a
second key would be taken from every frame on `SOCKET` and could not be bound at all
inside an operator's own tmux. One bind, already paid for.

Two things that were not obvious and are now enforced:

- **Disarm before killing.** `kill-pane` on a panel fires that pane's own `pane-died`
  hook; `cmd_respawn` waits out its backoff, finds the session perfectly alive (only the
  layout changed) and puts the panel straight back, one respawn life poorer. The hook is
  unset first, so there is nothing left to fire whichever way this tmux treats it.
- **New panes carry the frame environment on the operator's server** (`-e`), for #411's
  root cause one command over. `_pane_env_for` names the private/operator split once so a
  second pane-creating caller cannot get it the other way round, and rebuilds the env
  through `_frame_env` so `TMUX`/`TMUX_PANE`/`COLUMNS`/`LINES` from the pane the command
  was fired in never reach a new panel.

## 3. Animation scoped to in-flight work — and the measured idle cost

`⠙ 2 running` on the bottom row while dispatches are in flight; complete stillness
otherwise. A presumed-dead record is reported and deliberately **not** animated (`⋯ 1
stalled`) — such a record is kept for a day, and a spinner beside it would claim progress
that stopped half an hour ago.

**The number, measured rather than asserted** (macOS/APFS, `mutate`-free build):

| per panel tick | ns |
|---|---|
| `state.version` poll (what a panel already paid) | 26 035 |
| the in-flight gate this PR adds | 4 252 |
| **added by #387** | **~5 100** |
| an ungated `inflight.live_records()` per tick, for comparison | 17 307 (3.8×) |

At `panel.TICK` (5/s) that is ~0.003% of one core, and **zero repaints**. The mechanism:
`inflight.stamp()` is a single `stat` of the tracker's directory, whose mtime moves only
when a record is created or removed; the records are re-read only when that number moves,
or when the earliest presumed-dead deadline passes (the one way the answer changes with no
file touched — and a deadline only exists while something is running, so the idle path
never computes one). Pinned as a **syscall count**, not a timing assertion:
`test_an_idle_tick_costs_exactly_one_stat`.

`statusline._session_news` gained one keyword-only `inflight=` so the panel can ask for
everything except the tracker's own `⚡ N` — otherwise the row read `⚡ 2 · ⠙ 2 running`,
one fact twice. The status line is unchanged.

## 4. `RESIZE_HOOK_FLOOR`, moved where it will be read

It appeared in neither `frame_ready` nor `doctor.check_frame`, and it sits *above*
`FLOOR` — so a tmux 3.2 operator passed the floor cleanly, saw a green tick on both
surfaces, and silently lost resize recovery. Both now name it
(`tmuxctl.below_resize_hook_message`, one sentence shared, so the two cannot drift), and
`_install_resize_hook`'s own `util.warn` — the last standing ceiling still printed into
the pre-attach window, 86 bytes before `\e[?1049h` — is gone. The two *discoveries* there
(a tmux that turns out not to know the hook name, a `set-hook` that fails for another
reason) stay: `frame_ready` starts nothing and cannot answer them.

`check_frame` collects the three ceilings into a list rather than nesting `if`s, which
also removes the duplicated slot ceiling the old shape needed in two branches.

## Reconciling the default with #386 — please check this

#387 defines `full` as all four edges; #386 makes all four edges the shipped `slots`
default. **These are two ways of asking for the same frame, so they must expand to the
same one**, or writing nothing and writing `density = "<the shipped default>"` give
different frames, silently.

I did **not** make the shipped `density` drive the slot list. Precedence is:

    explicit `slots`  >  explicit `density`  >  the shipped `slots` default

If the shipped density expanded unconditionally, `FRAME_FIELDS["slots"]`'s default value
would become dead code and **#386's change to that line would silently do nothing**. This
way #386 keeps owning the shipped frame and `density` is a preset, exactly as #387 says.

The agreement is then enforced **mechanically**, not by memory —
`test_frame_density.ShippedDefaultsAgree`:

- the shipped `density` must be a level whose slot list *is* the shipped `slots` list;
- **in the same order**, because order is geometry (see below);
- and whose verbosity is `normal` — `minimal` and `normal` expand to the same two edges,
  so the slot-list check alone cannot tell them apart, and a shipped `minimal` would
  quietly ship a terse frame to everyone.

**On this branch (`slots` still `["top", "bottom"]`) the shipped `density` is `normal`.**
When #386 lands, that test goes red until one word changes to `full`. That is the intended
behaviour of the test: a forced one-word edit at merge time instead of a divergence nobody
sees. I verified the whole thing rather than predicting it — cherry-picked this commit onto
`frame-owns-surface-386`, resolved the two conflicts (both adjacent-line, in
`instance.py`'s `FRAME_FIELDS` and in `docs/frame.md`), flipped the default to `full`, and
ran the suite: **4129 tests, OK**. Mutating the default back to `normal` or to `minimal` on
that merged tree is red both ways.

**Order is geometry, and every level's list says so.** `full` is
`["top", "bottom", "left", "right"]`, matching #386's measured order: at 200×50 that gives
a 200-column `bottom`, while `["top", "left", "right", "bottom"]` gives **154** columns,
inset between the sidebars — and `bottom` is the row carrying the alert and the command
that fixes it, which `_bottom` drops whole fields to fit.
`test_full_puts_the_strips_before_the_side_panels` pins it as index comparisons (strips
before sides) rather than as a frozen literal, so the next person cannot alphabetise it.

## Two defects found on the way

- **A corrupt live density override silently discarded the configured one.**
  `state.density(fid) or config.FRAME["density"]` looks right and is not: the file holds
  text, so a truncated write is truthy, beats the config, and *then* degrades to the
  default verbosity — the operator's own `[frame] density` thrown away by a byte in a file
  they have never heard of. The override is validated before it is allowed to win.
- **A recycled launcher pid handed a new frame a dead one's density and pane map** —
  #383's bill, two files longer. `state.clear_shape` is called on both launch paths beside
  `clear_exit`/`gather.discard`.

## Verification

- **Full suite: `Ran 4115 tests … OK`** on this branch; `Ran 4129 tests … OK` on the trial
  merge with #386.
- **Mutation-tested: 44 mutants, 0 survivors**, restored suite green, `__pycache__` cleared
  between every run. Three survivors in the first pass were real test gaps and are the
  reason this PR has `TheLoopAsksBeforeItAnimates`,
  `Probe.test_a_tmux_without_the_resize_hook_is_a_ceiling_the_probe_names`, and the
  shipped-verbosity assertion; a fourth pointed at a `_NEVER_READ` sentinel that no test
  could falsify, which is deleted rather than documented.
- `tests/test_frame_density.py` uses `PersonaIso` throughout, and a genuinely dead pid for
  every fixture id (a `something-1` reads as `launchd` and cannot fail).
- No new runtime dependency; stdlib `unittest` only.

## One thing in the issue I could not deliver as written

#387 says "a spinner while a dispatch, **clone or `gl-refresh`** runs". Only dispatches are
tracked: `inflight.start` is called from exactly one place (the `Task`/`Agent` PreToolUse
handler), and clones and `gl-refresh` register nothing. I did not wire them in, because
`inflight`'s records are also what feeds the dispatch overlap nudge via `still_running()` —
a record named `clone` would make it tell an operator that "`x` writes code and `clone` are
already running". That needs a second channel or a kind field on the record, which is a
design decision, not an implementation detail. The mechanism paragraph of the issue names
`inflight.live_records()` as the source, and that is what shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
