### PR TITLE
MCP consent covers the whole entry, shows the destination, and is asked

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,10 @@ vault, and a `delegate-when` line saying what should be handed to it. `charter p
 sync-agents` turns each one into a real Claude Code sub-agent, so dispatching a role is
 ordinary delegation rather than a prompt trick. A persona whose `mcp.json` hands a vault
 value to a server names the destination it would reach and waits for `--approve-mcp`, which
-asks about each server after showing it. The approval covers the whole entry — command,
-args, `url`, `env`, keys — not the server's name, so a teammate re-pointing it lapses the
-approval rather than inheriting it.
+asks about each server after showing it. What gets recorded is a digest of the line you
+read — which names every key of the entry and the vault it would spend, not just the
+server's name — so a teammate re-pointing any of it lapses the approval rather than
+inheriting it.
 
 They compose the way people do: `extends:` inherits a parent's charter, `uses:` says this
 role routes work to that one, and `agent-tools` narrows what the generated sub-agent may

--- a/README.md
+++ b/README.md
@@ -119,9 +119,10 @@ A **persona** is a small named scope with its own charter, its own committed mem
 vault, and a `delegate-when` line saying what should be handed to it. `charter persona
 sync-agents` turns each one into a real Claude Code sub-agent, so dispatching a role is
 ordinary delegation rather than a prompt trick. A persona whose `mcp.json` hands a vault
-value to a server names the command it would run and waits for `--approve-mcp` — the
-approval covers the command and its arguments, not the server's name, so a teammate
-re-pointing it lapses the approval rather than inheriting it.
+value to a server names the destination it would reach and waits for `--approve-mcp`, which
+asks about each server after showing it. The approval covers the whole entry — command,
+args, `url`, `env`, keys — not the server's name, so a teammate re-pointing it lapses the
+approval rather than inheriting it.
 
 They compose the way people do: `extends:` inherits a parent's charter, `uses:` says this
 role routes work to that one, and `agent-tools` narrows what the generated sub-agent may

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -1049,9 +1049,11 @@ def _add_persona_parser(sub) -> None:
     sa.add_argument("--persona", help="Only sync this persona (default: all).")
     sa.add_argument("--approve-mcp", action="store_true",
                     help="Ask, per server, whether the MCP command the personas' mcp.json "
-                         "files name may receive the persona's vault value. Re-approve "
-                         "after ANY change to such an entry — command, args, url, env, "
-                         "secrets: the approval covers the whole entry.")
+                         "files name may receive the persona's vault value. What is "
+                         "recorded is a digest of the line printed above the question, so "
+                         "ANY change that changes that line — including the persona's "
+                         "vault, an env value, or a key charter does not read — lapses "
+                         "the approval and asks again.")
     sa.add_argument("--yes", action="store_true",
                     help="With --approve-mcp: approve every credentialed server without "
                          "asking. Required off a terminal, where nobody can be asked.")

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -1048,9 +1048,16 @@ def _add_persona_parser(sub) -> None:
                          help="Generate a Claude Code sub-agent (.claude/agents/<name>.md) per persona.")
     sa.add_argument("--persona", help="Only sync this persona (default: all).")
     sa.add_argument("--approve-mcp", action="store_true",
-                    help="Approve the MCP server commands the personas' mcp.json files "
-                         "name, so they receive the persona's vault value. Re-approve "
-                         "after any change to a server's command, args or secrets.")
+                    help="Ask, per server, whether the MCP command the personas' mcp.json "
+                         "files name may receive the persona's vault value. Re-approve "
+                         "after ANY change to such an entry — command, args, url, env, "
+                         "secrets: the approval covers the whole entry.")
+    sa.add_argument("--yes", action="store_true",
+                    help="With --approve-mcp: approve every credentialed server without "
+                         "asking. Required off a terminal, where nobody can be asked.")
+    sa.add_argument("--dry-run", action="store_true",
+                    help="With --approve-mcp: print the servers it would ask about and "
+                         "record nothing.")
     sa.set_defaults(func=commands_persona.cmd_persona_sync_agents)
 
     mig = psub.add_parser("migrate",

--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -1413,8 +1413,11 @@ def _approve_mcp(names: list[str], yes: bool, dry_run: bool) -> int:
         util.err("--approve-mcp hands a persona's vault value to a command a COMMITTED "
                  "file names, so it asks before recording — and there is no terminal to "
                  "ask on.")
-        util.info("  Re-run in a terminal, add --dry-run to see what would be asked, or "
-                  "pass --yes to approve every credentialed server unread.")
+        # Deliberately does NOT name `--yes` here. The flag exists and `--help` documents
+        # it, but a refusal that prints the flag defeating it is #421's shape: the reader
+        # of this line is as often an agent as an operator, and it would simply add it.
+        util.info("  Re-run in a terminal, or add --dry-run to see what it would ask "
+                  "about without recording anything.")
         return 1
     for n in names:
         declared = persona.mcp_credentialed(n)

--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -1409,8 +1409,10 @@ def _approve_mcp(names: list[str], yes: bool, dry_run: bool) -> int:
     The recorded set is replaced per persona, as `mcpseen.approve` documents, so a server
     the operator declines here stops being approved even if it was approved before.
 
-    **Both halves of every line printed here come from `mcpseen`.** The destination goes
-    through `mcpseen.describe` and the `persona/server` in front of it through
+    **Both halves of every line printed here come from `mcpseen`.** The destination is the
+    string `persona.mcp_credentialed` already rendered — the one whose SHA-256 is the
+    fingerprint recorded below, so the text on the screen and the text in the record are
+    the same text and cannot drift. The `persona/server` in front of it goes through
     `mcpseen.label`, because both are committed data and they share a row: a server name
     built out of blank codepoints, an ANSI erase or a hundred thousand characters is a
     line the operator cannot read just as surely as a padded `args` is. Interpolating
@@ -1432,7 +1434,7 @@ def _approve_mcp(names: list[str], yes: bool, dry_run: bool) -> int:
         if not declared:
             continue
         keep = []
-        for server, entry, fp in declared:
+        for server, _entry, fp, line in declared:
             if not fp:
                 # Every entry here needs consent, so `fingerprint` returns None for one
                 # reason only: `mcpseen.describe` cannot render a destination for it, and
@@ -1444,7 +1446,10 @@ def _approve_mcp(names: list[str], yes: bool, dry_run: bool) -> int:
                 continue
             # Printed BEFORE the question, not after the recording: an approval nobody
             # can see in the transcript is not consent, it is a flag that was typed.
-            util.info(f"  {mcpseen.label(n, server)} → {mcpseen.describe(entry)}")
+            # `line` came back from `mcp_credentialed` with the fingerprint that is its
+            # own SHA-256, so the string printed here and the string recorded below are
+            # the same one. Re-rendering it here is how they would come to differ.
+            util.info(f"  {mcpseen.label(n, server)} → {line}")
             if dry_run:
                 continue
             try:
@@ -1514,9 +1519,8 @@ def cmd_persona_sync_agents(args) -> int:
                   f"server(s): the committed `mcp.json` names the command that would "
                   f"receive it, and this one has not been approved on this machine.")
         for n, servers in sorted(withheld.items()):
-            for server, entry in servers:
-                util.info(f"  {mcpseen.label(n, server)} → "
-                          f"{mcpseen.describe(entry) or mcpseen.UNRENDERABLE}")
+            for server, line in servers:
+                util.info(f"  {mcpseen.label(n, server)} → {line or mcpseen.UNRENDERABLE}")
         util.info("  Read the command above. If it is what you expect, approve it with:")
         util.info("    charter persona sync-agents --approve-mcp")
     for n in written:

--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -1408,6 +1408,14 @@ def _approve_mcp(names: list[str], yes: bool, dry_run: bool) -> int:
 
     The recorded set is replaced per persona, as `mcpseen.approve` documents, so a server
     the operator declines here stops being approved even if it was approved before.
+
+    **Both halves of every line printed here come from `mcpseen`.** The destination goes
+    through `mcpseen.describe` and the `persona/server` in front of it through
+    `mcpseen.label`, because both are committed data and they share a row: a server name
+    built out of blank codepoints, an ANSI erase or a hundred thousand characters is a
+    line the operator cannot read just as surely as a padded `args` is. Interpolating
+    either of them raw is how this file put three hardened `describe` calls behind an
+    unescaped label.
     """
     if not (yes or dry_run or sys.stdin.isatty()):
         util.err("--approve-mcp hands a persona's vault value to a command a COMMITTED "
@@ -1431,19 +1439,22 @@ def _approve_mcp(names: list[str], yes: bool, dry_run: bool) -> int:
                 # recording an approval would be approving a blank line (#427). Said out
                 # loud rather than skipped — the server is declared and does want a
                 # credential, so the operator has to hear that it was refused one.
-                util.warn(f"  cannot approve {n}/{server} — {mcpseen.UNRENDERABLE}")
+                util.warn(f"  cannot approve {mcpseen.label(n, server)} — "
+                          f"{mcpseen.UNRENDERABLE}")
                 continue
             # Printed BEFORE the question, not after the recording: an approval nobody
             # can see in the transcript is not consent, it is a flag that was typed.
-            util.info(f"  {n}/{server} → {mcpseen.describe(entry)}")
+            util.info(f"  {mcpseen.label(n, server)} → {mcpseen.describe(entry)}")
             if dry_run:
                 continue
             try:
-                if not (yes or _confirm(f"    approve {n}/{server}? [y/N] ")):
-                    util.info(f"    skipped {n}/{server} — the vault stays withheld")
+                if not (yes or _confirm(
+                        f"    approve {mcpseen.label(n, server)}? [y/N] ")):
+                    util.info(f"    skipped {mcpseen.label(n, server)} — "
+                              f"the vault stays withheld")
                     continue
             except KeyboardInterrupt:
-                util.err(f"interrupted — nothing recorded for {n}")
+                util.err(f"interrupted — nothing recorded for {mcpseen.label(n)}")
                 return 130
             keep.append(fp)
         if not dry_run:
@@ -1504,7 +1515,7 @@ def cmd_persona_sync_agents(args) -> int:
                   f"receive it, and this one has not been approved on this machine.")
         for n, servers in sorted(withheld.items()):
             for server, entry in servers:
-                util.info(f"  {n}/{server} → "
+                util.info(f"  {mcpseen.label(n, server)} → "
                           f"{mcpseen.describe(entry) or mcpseen.UNRENDERABLE}")
         util.info("  Read the command above. If it is what you expect, approve it with:")
         util.info("    charter persona sync-agents --approve-mcp")

--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 
 from . import commands_secrets, config, mcpseen, persona, trace, util
 from .secrets import base, registry
@@ -1373,6 +1374,82 @@ def cmd_persona_gc(args) -> int:
     return 0
 
 
+def _confirm(prompt: str) -> bool:
+    """One y/N question. Anything that is not an explicit yes — including EOF — is no.
+
+    Defaulting to no is the whole reason this exists: the old `--approve-mcp` had no
+    answer but yes, so the failure direction has to be "the credential was withheld".
+
+    The question is written to **stderr**, where every other human-facing line charter
+    prints goes, rather than to stdout via ``input(prompt)``. `sync-agents > /dev/null`
+    would otherwise swallow the question and leave the operator watching a hang.
+    """
+    print(prompt, end="", file=sys.stderr, flush=True)
+    try:
+        answer = input()
+    except EOFError:
+        print("", file=sys.stderr)
+        return False
+    return answer.strip().lower() in ("y", "yes")
+
+
+def _approve_mcp(names: list[str], yes: bool, dry_run: bool) -> int:
+    """Record approvals for the MCP servers whose consent line the operator has READ.
+
+    `--approve-mcp` used to be a single non-interactive call that approved every
+    credentialed server of every persona and printed what it had approved AFTERWARDS
+    (#428) — a consent prompt with no way to answer no, and, for an `http` server whose
+    line rendered empty (#427), no way to see what the yes was for. Each server is now
+    shown and asked about on its own.
+
+    `--yes` keeps the old shape for scripts, and is REQUIRED off a tty: a flag that
+    silently means yes when nobody is there to be asked is the finding restored. `--dry-run`
+    shows the same lines and records nothing.
+
+    The recorded set is replaced per persona, as `mcpseen.approve` documents, so a server
+    the operator declines here stops being approved even if it was approved before.
+    """
+    if not (yes or dry_run or sys.stdin.isatty()):
+        util.err("--approve-mcp hands a persona's vault value to a command a COMMITTED "
+                 "file names, so it asks before recording — and there is no terminal to "
+                 "ask on.")
+        util.info("  Re-run in a terminal, add --dry-run to see what would be asked, or "
+                  "pass --yes to approve every credentialed server unread.")
+        return 1
+    for n in names:
+        declared = persona.mcp_credentialed(n)
+        if not declared:
+            continue
+        keep = []
+        for server, entry, fp in declared:
+            if not fp:
+                # Every entry here needs consent, so `fingerprint` returns None for one
+                # reason only: `mcpseen.describe` cannot render a destination for it, and
+                # recording an approval would be approving a blank line (#427). Said out
+                # loud rather than skipped — the server is declared and does want a
+                # credential, so the operator has to hear that it was refused one.
+                util.warn(f"  cannot approve {n}/{server} — {mcpseen.UNRENDERABLE}")
+                continue
+            # Printed BEFORE the question, not after the recording: an approval nobody
+            # can see in the transcript is not consent, it is a flag that was typed.
+            util.info(f"  {n}/{server} → {mcpseen.describe(entry)}")
+            if dry_run:
+                continue
+            try:
+                if not (yes or _confirm(f"    approve {n}/{server}? [y/N] ")):
+                    util.info(f"    skipped {n}/{server} — the vault stays withheld")
+                    continue
+            except KeyboardInterrupt:
+                util.err(f"interrupted — nothing recorded for {n}")
+                return 130
+            keep.append(fp)
+        if not dry_run:
+            mcpseen.approve(n, keep)
+    if dry_run:
+        util.info("  --dry-run: nothing approved. Re-run without it to be asked.")
+    return 0
+
+
 def cmd_persona_sync_agents(args) -> int:
     one = getattr(args, "persona", None)
     if one and not persona.load(one):
@@ -1387,15 +1464,10 @@ def cmd_persona_sync_agents(args) -> int:
     # it would write this run's agents without their credentials and only take effect on
     # the next run, which reads as the flag not working.
     if getattr(args, "approve_mcp", False):
-        for n in names:
-            declared = persona.mcp_credentialed(n)
-            if not declared:
-                continue
-            mcpseen.approve(n, [fp for _s, _e, fp in declared])
-            for server, entry, _fp in declared:
-                # Printed, not merely recorded: an approval nobody can see in the
-                # transcript is not consent, it is a flag that was typed.
-                util.info(f"  approved {n}/{server} → {mcpseen.describe(entry)}")
+        rc = _approve_mcp(names, yes=getattr(args, "yes", False),
+                          dry_run=getattr(args, "dry_run", False))
+        if rc:
+            return rc
 
     outcomes = {n: _write_agent(n) for n in names}
     written = [n for n, o in outcomes.items() if o == "written"]
@@ -1429,7 +1501,8 @@ def cmd_persona_sync_agents(args) -> int:
                   f"receive it, and this one has not been approved on this machine.")
         for n, servers in sorted(withheld.items()):
             for server, entry in servers:
-                util.info(f"  {n}/{server} → {mcpseen.describe(entry)}")
+                util.info(f"  {n}/{server} → "
+                          f"{mcpseen.describe(entry) or mcpseen.UNRENDERABLE}")
         util.info("  Read the command above. If it is what you expect, approve it with:")
         util.info("    charter persona sync-agents --approve-mcp")
     for n in written:

--- a/charter/mcpseen.py
+++ b/charter/mcpseen.py
@@ -18,13 +18,26 @@ the launchers real servers use (``npx``, ``uvx``, ``docker``, ``node``) is walke
 and a list excluding them refuses every MCP server anyone actually runs. The axis with an
 answer is not *what* the command is but *whether the operator has seen it*.
 
-**The whole entry, and only what was shown.** Two properties the mechanism is worthless
-without, and it shipped without both. The digest covers every key of the entry rather than
-the handful charter reads, because `persona.mcp_render_entry` passes the rest through to
-the harness — ``env`` did exactly that, so a committed edit could re-point an approved
-server's ``PATH`` with the approval intact (#426). And an entry :func:`describe` cannot
-render is not approvable at all, because the consent line IS the consent: an ``http``
-server used to print a blank one under the words "read the command above" (#427).
+**The record IS the line.** :func:`fingerprint` is the SHA-256 of what :func:`describe`
+printed and nothing else is mixed into it, so *two entries that render the same consent
+line have the same fingerprint*. That is one line of code and it is the whole of round
+four. Three earlier rounds kept two representations — a digest over the entry, a line over
+a list of fields — and every bypass since was one field that lived in the first and not the
+second: the vault name, ``env`` VALUES, ``cwd``, a clipped tail. Each time the operator was
+correctly re-asked and shown a line byte-identical to the one they had already approved,
+which is not consent but a second chance to make the same mistake. With one representation
+there is nothing left to fall out of step.
+
+The whole weight then rests on :func:`describe` being TOTAL — it loops over the entry's
+keys rather than over a list, because `persona.mcp_render_entry` hands every key it does
+not consume to the harness — and on an entry it cannot render not being approvable at all,
+because the consent line IS the consent: an ``http`` server used to print a blank one under
+the words "read the command above" (#427).
+
+**What this is, and is not.** A guard against a COMMIT — a committed file changing under an
+approval already given — answered by a person reading one line. ``SECURITY.md`` states the
+boundary and nothing here exceeds it: an attacker who already runs code as this user can
+edit the record under ``STATE_DIR``, the harness, or charter itself.
 
 **Machine-local and gitignored, deliberately.** Under ``STATE_DIR``, the same as
 :mod:`charter.guardseen` and for a sharper reason: if the approval travelled in git, the
@@ -59,15 +72,6 @@ FILE_NAME = "mcp-approved.json"
 #: Covers both reasons: no destination at all, and a destination too big to show in full.
 UNRENDERABLE = "(charter cannot show this entry in full — nothing to approve)"
 
-#: Longest single part — command, one arg, ``type``, ``url``, one ``env`` key — shown on a
-#: consent line. A part longer than this is CLIPPED with the cut announced; it is never
-#: dropped, so no part can push another part off the line. See :func:`describe`.
-#:
-#: :data:`MAX_LINE` still bounds how many such parts fit — and an entry that overflows it
-#: is refused whole rather than having a part dropped, so "no part pushes another off"
-#: holds in both directions.
-MAX_PART = 200
-
 #: The narrowest terminal charter assumes, and the most rows one PRINTED consent line may
 #: take on it. Their product is the hard ceiling on that line — label, decoration and
 #: destination together, because all three are on the same screen.
@@ -86,16 +90,19 @@ MAX_LABEL = MAX_NAME * 2 + 1
 #: care who put the columns on it.
 _DECORATION = len("• ") + len("  ") + len(" → ")
 
-#: Ceiling on the DESTINATION half — what :func:`describe` may return. An entry with so
-#: many parts that even their clipped forms do not fit is one the operator cannot be shown
-#: in full, so it is not renderable and (via :func:`fingerprint`) not approvable.
+#: Ceiling on the DESTINATION half — what :func:`describe` may return. Nothing is ever
+#: shortened to fit it: an entry whose full rendering is longer than this is one the
+#: operator cannot be shown in full, so it is not renderable and (via :func:`fingerprint`)
+#: not approvable. That is what :data:`UNRENDERABLE` has always said out loud, and round
+#: three's per-part clipping quietly contradicted it — a clipped part is a part of the
+#: entry the operator did not see, and :func:`fingerprint` now digests only what they did.
 #:
 #: This is a SCREEN, not a byte count, and that is the whole reason it exists. The
 #: operator answers the prompt printed *under* this line, so a line taller than the
 #: terminal has already scrolled the command it names off the top by the time the
 #: question is asked. Round two set it to 2000 — twenty-five rows of an 80-column tty —
 #: and nine args of 200 padding columns each fit inside it with the destination out of
-#: view. Escaping (see :func:`_safe`) makes such padding visible; it does not make it
+#: view. Escaping (see :func:`_esc`) makes such padding visible; it does not make it
 #: short, so the ceiling has to be the screen itself.
 #:
 #: The label and the decoration are SUBTRACTED rather than ignored, which is the round
@@ -131,30 +138,8 @@ def needs_consent(vault: str | None, entry: dict) -> bool:
                 or (isinstance(files, dict) and files))
 
 
-def _canon(value):
-    """Untrusted JSON as something :func:`json.dumps` renders deterministically.
-
-    Recursive and total, rather than a list of fields: the WHOLE entry is digested, so a
-    key charter does not know about yet cannot fall outside the fingerprint. ``env`` was
-    exactly that key (#426) — copied verbatim into the generated agent file by
-    `persona.mcp_render_entry`, handed to ``execvpe``, and invisible to the digest, so a
-    committed edit could add ``NODE_OPTIONS`` or re-point ``PATH`` on an already-approved
-    server without lapsing the approval.
-
-    A value JSON cannot carry is tagged rather than stringified, so an exotic object
-    cannot digest as the plain string that happens to be its ``repr``.
-    """
-    if isinstance(value, dict):
-        return {str(k): _canon(v) for k, v in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_canon(v) for v in value]
-    if value is None or isinstance(value, (str, bool, int, float)):
-        return value
-    return ["<not-json>", repr(value)]
-
-
 def fingerprint(vault: str | None, entry: dict) -> str | None:
-    """What the operator is being asked to approve, as one digest.
+    """What the operator is being asked to approve, as one digest — **of the line itself**.
 
     ``None`` when no approval can exist for this entry, which is two cases and both mean
     "render it without the vault wrapper":
@@ -162,26 +147,49 @@ def fingerprint(vault: str | None, entry: dict) -> str | None:
     * **Nothing to consent to** — no ``secrets`` and no ``secret_files``, or no vault. The
       entry is passed through untouched by `persona.mcp_render_entry`, so no credential is
       at stake and requiring approval would be a prompt about nothing.
-    * **Nothing to show** — :func:`describe` cannot render a destination for it, so the
-      operator would be approving a blank line (#427). An entry nobody can be shown is not
-      an entry anybody can approve. "Cannot be shown" is two properties and both are
-      decided on the ESCAPED line, not on the raw one: it renders as nothing (only ASCII
-      spaces survive :func:`_safe`), or it does not fit on the screen the question is
-      asked on (:data:`MAX_LINE`). Round two decided the first on ``str.isprintable``,
-      which is true of U+3164 HANGUL FILLER — so a line blank on every terminal got a
-      real digest and was approvable.
+    * **Nothing to show** — :func:`describe` cannot render this entry, so the operator
+      would be approving a blank line (#427). An entry nobody can be shown is not an entry
+      anybody can approve. "Cannot be shown" is two properties: it names no destination at
+      all (only ASCII spaces survive :func:`_safe`, so "renders as nothing" is decidable
+      rather than enumerable), or it does not fit on the screen the question is asked on
+      (:data:`MAX_LINE`). Round two decided the first on ``str.isprintable``, which is
+      true of U+3164 HANGUL FILLER — so a line blank on every terminal got a real digest
+      and was approvable.
 
-    **Every field of the entry is in here**, which is the point: approving a server by
-    name — or by five of its fields — lets a later commit re-point the same name at a
-    different binary, a different endpoint, or a different environment while the approval
-    stays valid. The vault (whose secrets) and the entry in full (where they go) both
-    change the digest.
+    **The digest is the SHA-256 of the consent line, and nothing else is mixed in.** That
+    is the whole of round four, and it is one line of code because the property is
+    structural rather than enumerated:
+
+        *two entries that render the same consent line have the same fingerprint.*
+
+    Rounds one to three digested a parallel representation of the entry — a list of
+    fields, then the whole entry through a canonicaliser — while :func:`describe` rendered
+    a different, shorter list. Every bypass since has been one instance of that one gap,
+    and each round closed the instance it was shown: the vault name was digested and never
+    printed; ``env`` VALUES were digested and only their KEYS printed; ``cwd`` — and
+    whatever the next committed key is — was digested and never printed; and the per-part
+    clip made two different ``args`` print the same tail. In each, the operator was asked
+    a second time under a line byte-identical to the one they had already approved, which
+    is not consent but a second chance to make the same mistake.
+
+    Hashing the line closes the gap in the only direction that cannot grow a new instance:
+    there is no second representation to fall out of step with. It moves the whole weight
+    onto :func:`describe` being TOTAL — a key it fails to print is a key a commit may
+    change with the approval intact — so `describe` renders every key of the entry by
+    construction rather than by enumeration, and `tests/test_mcp_approval.py` asserts that
+    directly.
+
+    What this is NOT: a guarantee that the operator understands the line, or that a
+    different mechanism cannot re-point the same command. `SECURITY.md` states charter's
+    actual scope — a guard against mistakes, not against an attacker who already runs code
+    as this user — and nothing here exceeds it.
     """
-    if not needs_consent(vault, entry) or not describe(entry):
+    if not needs_consent(vault, entry):
         return None
-    material = json.dumps({"vault": str(vault), "entry": _canon(entry)},
-                          sort_keys=True, ensure_ascii=False)
-    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+    line = describe(vault, entry)
+    if not line:
+        return None
+    return hashlib.sha256(line.encode("utf-8")).hexdigest()
 
 
 def _read() -> dict:
@@ -265,41 +273,126 @@ def _safe(text: str) -> str:
     reads exactly like one holding U+3164 — one more pair of different commands the
     operator cannot tell apart by reading the line. A Windows path shows as
     ``C:\\\\Users\\\\x``; that is the cost, and it is unambiguous.
+
+    **What this is for, and what it is not for.** Collapsing space runs and stripping the
+    ends is what makes "renders as nothing" decidable — and it is exactly why this is NOT
+    the function that renders a destination. It is lossy: ``a  b`` and ``a b`` come back
+    the same, and so do ``  /bin/sh`` and ``/bin/sh``. That was harmless while the digest
+    was computed from the entry; now that the digest IS the line (:func:`fingerprint`), a
+    lossy rendering would be an approval covering an entry the operator never saw. So this
+    is used for two things only — the ``persona/server`` label, where a name is an
+    identifier rather than a destination and is clipped anyway, and the "does this entry
+    name anything at all" test in :func:`describe`. The destination goes through
+    :func:`_esc`, which loses nothing.
     """
     out = "".join("\\\\" if c == "\\" else c if " " <= c <= "~" else _escape(c)
                   for c in text)
     return _SPACE_RUN.sub(" ", out).strip()
 
 
-def _clip(text: str, budget: int) -> str:
-    """*text* cut to *budget* characters with the cut ANNOUNCED, never silently.
+def _esc(text: str) -> str:
+    """*text* as printable ASCII, **reversibly** — the rendering the digest is taken over.
 
-    Used per part rather than on the finished line. Truncating the finished line is what
-    let a committed ``args`` of 600 characters produce a consent line naming neither the
-    ``env`` it sets nor the ``url`` it points at, because both are appended after ``args``
-    — so the important half of the line was the half that got cut.
+    The same complement argument as :func:`_safe`: printable ASCII is what a consent line
+    may hold and everything else is shown as its fixed-width escape. Two differences, both
+    forced by :func:`fingerprint` hashing the line rather than the entry:
 
-    The marker is ASCII, like everything else :func:`_safe` lets through, so that "a
-    consent line is printable ASCII" needs no footnote reading "except charter's own
-    ellipsis". A claim with an exception is a claim its test has to carve a hole in, and
-    the hole is where the next spelling goes.
+    * **nothing is lost.** No collapsing, no stripping, no clipping. Every codepoint of
+      *text* is recoverable from the output — ``\\\\`` for a real backslash, ``\\"`` for a
+      real quote, ``\\uXXXX``/``\\UXXXXXXXX`` for everything outside printable ASCII, and
+      itself for the rest — so the characters printed for a committed value determine that
+      value. `tests/test_mcp_approval.py` decodes the output and checks it round-trips,
+      which is what makes "reversible" a checked property rather than a claim.
+    * **the ASCII quote is escaped**, which is what lets an unescaped ``"`` be a delimiter
+      no committed byte can spell. :func:`describe` leans on that: charter's own words are
+      printed bare, committed strings are printed between quotes, and the two cannot be
+      confused for each other.
+
+    A run of spaces survives as a run of spaces. It is visible between the quotes that
+    :func:`_tok` and :func:`_val` put around it, and — being neither collapsed nor cut — it
+    counts its full width against :data:`MAX_LINE`, so padding is refused rather than
+    silently tidied away into a line that no longer says what would run.
     """
-    return text if len(text) <= budget else (
-        text[:budget] + f"... (+{len(text) - budget} more chars)")
+    return "".join("\\\\" if c == "\\" else '\\"' if c == '"'
+                   else c if " " <= c <= "~" else _escape(c) for c in text)
+
+
+def _tok(text: str) -> str:
+    """One argv word of the ``run`` segment: bare when it is one word, quoted when not.
+
+    ``run uvx some-reddit-mcp --read-only`` is the common case and it should read like the
+    command it is. A word that is empty, or that holds a space, is quoted instead, so the
+    single space between words stays a boundary the reader and the digest agree on:
+    ``run npx "-y" "my server"`` cannot be confused with three separate words. :func:`_esc`
+    escapes the quote itself, so a bare word can never begin with one and the two forms
+    stay tellable apart.
+    """
+    shown = _esc(text)
+    return shown if shown and " " not in shown else f'"{shown}"'
+
+
+def _val(value) -> str:
+    """Any JSON value as one self-delimiting piece of a consent line.
+
+    Strings are quoted, so charter's own bare words (``url``, ``env``, ``vault`` …) are
+    never confused with committed text that happens to spell them. ``true``/``false``/
+    ``null``/numbers keep their JSON spelling, so the string ``"true"`` and the boolean
+    ``true`` do not read the same. Lists and objects nest with their JSON punctuation, and
+    object keys are sorted, because JSON object order is not meaning — a prompt that fires
+    on a re-serialised file is a prompt the operator learns to answer without reading.
+
+    A value JSON cannot carry is tagged rather than stringified, so an exotic object
+    cannot read as the plain string that happens to be its ``repr``.
+    """
+    if isinstance(value, str):
+        return f'"{_esc(value)}"'
+    if value is None:
+        return "null"
+    if isinstance(value, bool):            # before int: bool IS an int
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return _esc(json.dumps(value))
+    if isinstance(value, (list, tuple)):
+        return "[" + ", ".join(_val(v) for v in value) + "]"
+    if isinstance(value, dict):
+        return "{" + ", ".join(f"{_val(str(k))}: {_val(v)}" for k, v in _sorted(value)) + "}"
+    return f"<not-json {_val(repr(value))}>"
+
+
+def _sorted(mapping: dict):
+    """*mapping*'s items in an order that depends on the items and not on the file."""
+    return sorted(mapping.items(), key=lambda kv: (str(kv[0]), _val(kv[1])))
+
+
+def _pairs(mapping: dict) -> str:
+    """A ``{VAR: value}`` map as ``"VAR"="value"``, the shape it reaches the process in.
+
+    Used for ``env``, ``secrets`` and ``secret_files`` so the line reads like the
+    ``secret exec --env VAR=key`` argv the answer authorises rather than like a summary of
+    it. Both halves go through :func:`_val`, so the ``=`` and the ``, `` between pairs stay
+    charter's punctuation: ``{"A": "b, C=d"}`` and ``{"A": "b", "C": "d"}`` are two
+    different environments and they print as two different lines.
+    """
+    return ", ".join(f"{_val(str(k))}={_val(v)}" for k, v in _sorted(mapping))
 
 
 def _name(part) -> str:
     """One half of a :func:`label`: printable ASCII, never wider than :data:`MAX_NAME`.
 
-    Clipped with a FIXED marker rather than with :func:`_clip`'s counted one. The count is
-    what the operator needs for a destination — how much of the command is off the line —
-    and it is exactly wrong here, because its own width grows with the input it describes.
-    A budget that a longer input makes longer is not a bound, and a bound is the only
-    thing standing between a committed name and the rows it costs.
+    Clipped with a FIXED marker, and a bound is the only thing standing between a
+    committed name and the rows it costs. A marker that counted what it cut would not be
+    one: its own width grows with the input it describes, and a budget a longer input
+    makes longer is not a budget.
 
-    A half that renders as nothing shows as ``""`` rather than as an invisible gap, the
-    same convention :func:`describe` uses for an ``env`` key, so ``reddit/""`` reads as a
-    server whose name is blank instead of as a missing word.
+    Clipped at all, unlike the destination, because a label is an IDENTIFIER — it says
+    where the entry was declared, not what would run — and it is not in the digest. The
+    destination is never shortened: see :data:`MAX_LINE`.
+
+    A half that renders as nothing shows as ``""`` rather than as an invisible gap, so
+    ``reddit/""`` reads as a server whose name is blank instead of as a missing word. On
+    the destination side :func:`_val` and :func:`_tok` reach the same place by quoting
+    everything committed, which is stronger: there, the empty string is one more value
+    that reads as itself.
     """
     shown = _safe(str(part))
     if len(shown) > MAX_NAME:
@@ -338,103 +431,138 @@ def label(*parts) -> str:
     return "/".join(_name(p) for p in parts)
 
 
-def describe(entry: dict) -> str:
-    """Where the credential would go, as the line that asks the operator to look at it.
+#: The keys :func:`describe` has a READABLE form for. It chooses how a key is shown and
+#: never whether it is shown: every other key of the entry is rendered too, generically,
+#: under its own quoted name. Adding a key here changes a line's wording, never its
+#: coverage — which is the difference between this and the enumerations of rounds one to
+#: three, each of which was walked past by the field it did not list.
+_READABLE = ("command", "args", "type", "url", "env", "secrets", "secret_files")
 
-    Names and keys only — a ``secrets`` map holds vault KEY names, never values, so this
-    is safe to print; and it IS printed, because the question the operator is answering is
-    "which credential goes where", and the line used to answer only the second half.
+#: Charter's own words on a consent line, each introducing one segment. They are printed
+#: BARE; every committed string is printed between quotes (:func:`_esc` escapes the quote
+#: itself), so no committed key can spell one of these and no segment can be mistaken for
+#: another. This tuple is documentation and a test's checklist, not a guard.
+_WORDS = ("run", "command", "args", "type", "url", "env", "secrets", "secret_files",
+          "vault")
 
-    **Which credential, not just which command.** ``secrets`` and ``secret_files`` are what
-    `persona.mcp_render_entry` turns into ``--env VAR=<vault key>`` and
-    ``--file VAR=<vault key>``, so the vault key named there decides *what value* the
-    command receives. They were in the digest and not on the line, which is finding three
-    of round three — a homoglyph re-point that lapses the approval and re-asks under a line
-    that reads the same — moved to the field that chooses the credential rather than the
-    destination: editing ``{"REDDIT_CLIENT_ID": "client-id"}`` to
-    ``{"REDDIT_CLIENT_ID": "aws-root-key"}`` in a committed ``mcp.json`` produced a
-    byte-identical consent line and a different fingerprint, so the operator was correctly
-    re-asked and correctly could not tell why. Being re-asked under an unchanged line is
-    not consent, it is a second chance to make the same mistake.
 
-    ``""`` when the entry has no destination to show, which :func:`fingerprint` turns into
-    "not approvable" — so a line the operator cannot read is a line nobody can consent to.
-    Two ways to get there:
+def _names_something(entry: dict) -> bool:
+    """Does this entry name a destination at all — a command, an argument, or a url?
 
-    * **Nothing named.** No ``command``, no ``args``, no ``url``. An ``http``/``sse``
-      server has no command, and building the line from ``command`` + ``args`` alone
-      rendered it as an EMPTY string under the words *"Read the command above"* (#427).
-      Falling back to ``url`` fixes the common case; ``""`` for the rest is the general
-      one. **A part that renders as nothing does not count as naming something** — and
-      after :func:`_safe` that is decidable rather than enumerable: every part comes back
-      as printable ASCII with all else escaped, so it is blank exactly when it held
-      nothing but ASCII spaces. Round one tested ``""`` and missed ``"   "``; round two
-      tested ``"   "`` and missed U+3164 HANGUL FILLER, which is printable, is not
-      whitespace, survives ``strip``, and shows as nothing. Neither is a special case
-      now — they are the same case, asked of the escaped form.
-    * **Too much named.** So many parts that even their clipped forms exceed
-      :data:`MAX_LINE` — :data:`MAX_ROWS` rows of an :data:`MAX_COLS`-column terminal.
-      Charter will not print a page of destination and call it a line the operator read,
-      and it will not print half of one either. Fail closed: withheld. The ceiling is a
-      screen because the operator answers the prompt printed UNDER this line: round two
-      set it to 2000 characters, twenty-five rows, and nine args of 200 padding columns
-      fit inside it with ``uvx evil-server`` scrolled off the top. Escaping makes padding
-      visible, which is necessary and not sufficient — visible padding scrolls a line just
-      as far as invisible padding does, so the length that is refused has to be the length
-      that does not fit.
-
-    **Every part is named; only its contents can be shortened.** Round one clipped the
-    FINISHED line at 600 characters, and both the ``[type url]`` and the ``(env: …)``
-    suffixes are appended after ``args`` — so ~600 characters of plausible ``args`` in a
-    committed file produced a consent line naming neither the ``env`` it set nor the
-    ``url`` it pointed at, while the approved render still carried both to ``execvpe``.
-    The comment that stood here claimed this was impossible because "the destination is at
-    the FRONT of the line"; that was true only of ``command``, and false of every field
-    that decides where a url-transport entry connects or which binary ``PATH`` resolves.
-    Each part now gets its own :data:`MAX_PART` budget and the suffixes are built from
-    already-clipped parts, so nothing appended to this line can be pushed out of it.
-
-    ``env`` keys are shown because they choose the destination as surely as ``command``
-    does: ``PATH`` decides which binary ``execvpe`` finds, ``NODE_OPTIONS`` decides what
-    it loads (#426).
-
-    The rule the three suffixes are instances of, said once so a fourth field does not
-    have to be found the way these were: **everything the digest covers that changes what
-    the vault hands over, or where it lands, is on the line.** ``env`` chooses the binary,
-    ``url`` chooses the endpoint, ``secrets`` and ``secret_files`` choose the credential.
-    A field that lapses an approval without changing the line spends the operator's second
-    look on a line they have already read.
+    Decided on the :func:`_safe` form, which is what makes it a decidable question rather
+    than a growing list: after escaping, a part is printable ASCII, and the ASCII space is
+    the only member of that range that renders as nothing. So a part is blank exactly when
+    it held nothing but ASCII spaces. Round one tested ``""`` and missed ``"   "``; round
+    two tested ``"   "`` and missed U+3164 HANGUL FILLER, which is printable, is not
+    whitespace, survives ``strip`` and shows as nothing. Neither is a special case here.
     """
-    def _shown(x) -> str:
-        # `or '""'`: a name that renders blank is still a name the harness would use, so
-        # it is printed as an empty string rather than left as an invisible gap in a list.
-        # Applied only to what actually reaches the line — an `env` VALUE never does, and
-        # escaping a megabyte nobody will read is work done on an attacker's behalf.
-        return _clip(_safe(str(x)), MAX_PART) or '""'
-
-    if not isinstance(entry, dict):
-        return ""
     raw = entry.get("args")
     argv = list(raw) if isinstance(raw, (list, tuple)) else ([raw] if raw else [])
-    parts = [str(entry.get("command") or "")] + [str(a) for a in argv]
-    dest = " ".join(p for p in (_clip(_safe(p), MAX_PART) for p in parts) if p)
-    url = _clip(_safe(str(entry.get("url") or "")), MAX_PART)
-    if url:
-        shown = f"{_clip(_safe(str(entry.get('type') or 'http')), MAX_PART)} {url}"
-        dest = f"{dest}  [{shown}]" if dest else shown
-    if not dest:
+    parts = [entry.get("command") or ""] + argv + [entry.get("url") or ""]
+    return any(_safe(str(p)) for p in parts)
+
+
+def describe(vault: str | None, entry: dict) -> str:
+    """The whole of what would be approved, as the line the operator is asked to read.
+
+    **This function IS the consent, and :func:`fingerprint` is its SHA-256.** That is the
+    invariant round four exists for, and it is the reason this returns a rendering of the
+    *entire* input rather than of the fields charter happens to know about:
+
+        *two entries that render the same consent line have the same fingerprint, and an
+        entry that renders a different line lapses the approval.*
+
+    Both halves of that only hold if nothing reaches the harness without reaching the
+    line, so the loop below is over ``entry`` — every key of it — instead of over a list
+    of fields. A key charter has never been taught prints under its own quoted name and
+    its JSON value: ``"cwd" "/tmp/attacker"``. `persona.mcp_render_entry` hands exactly
+    those unconsumed keys to the harness, and the harness sets them on the process that
+    ``execvpe``s the server, so a key it passes through and this line skipped would be a
+    committed edit with the approval intact. That was ``env`` in #426, ``cwd`` and the
+    vault after it, and it will be some other key next — which is why this is a loop.
+
+    **What the line says, in order.** ``run`` and the argv; then whichever of ``args``,
+    ``type``, ``url``, ``env``, ``secrets`` and ``secret_files`` are present and were not
+    already spent on ``run``; then every remaining key, sorted, under its quoted name;
+    then ``vault``. Charter's own words are bare and committed text is quoted, so the two
+    are never confused.
+
+    * **``env`` prints its VALUES, not only its keys.** The key was the half being shown
+      and the value is the half that decides: ``PATH`` chooses which binary ``execvpe``
+      finds, ``NODE_OPTIONS`` chooses what it loads. An ``env`` value is committed
+      plaintext out of ``mcp.json`` — it is not a vault value and never was, and this
+      module never opens a vault — so printing it discloses nothing that reading the repo
+      would not.
+    * **``vault`` is named.** ``vault:`` is a key of the committed ``persona.md``, so a
+      one-line commit re-points which credential is spent. The digest covered it from the
+      start and the line never did, so even a FIRST prompt could not say whose credential
+      was at stake — while printing charter's own word ``(vault: …)`` in front of the
+      variable name, where a reader has every reason to expect the vault to be.
+    * **``secrets``/``secret_files`` name the vault KEY.** They are what
+      `mcp_render_entry` turns into ``--env VAR=<vault key>`` and ``--file VAR=<vault
+      key>``, so the key named there decides *what value* the command receives. A vault
+      KEY name is not a credential; the value is, it is not in the entry, and it cannot
+      reach this line because it never reaches this process.
+
+    **Nothing is shortened.** Round three clipped each part to two hundred characters and
+    announced the cut, which bounded the line but was not one-to-one: two ``args`` that
+    agree on their first two hundred escaped characters and are the same length print the
+    same tail and, once the digest is the line, would share one approval. A part the
+    operator did not see is a part they did not consent to, so an entry whose full
+    rendering exceeds :data:`MAX_LINE` is refused instead — the same fail-closed answer
+    the ceiling has always given, applied to one more way of not being readable.
+
+    ``""`` when there is no line, which :func:`fingerprint` turns into "not approvable":
+
+    * **Nothing named** — no ``command``, no ``args``, no ``url``, or nothing among them
+      that renders as more than ASCII spaces. An ``http`` server has no command, and
+      building the line from ``command`` + ``args`` alone rendered it as an EMPTY string
+      under the words *"Read the command above"* (#427). See :func:`_names_something`.
+    * **Too much named** — the rendering does not fit on the screen the question is asked
+      on (:data:`MAX_LINE`: :data:`MAX_ROWS` rows of an :data:`MAX_COLS`-column terminal,
+      less the label and decoration beside it). Charter will not print a page of
+      destination and call it a line the operator read, and it will not print half of one
+      either. The ceiling is a screen because the operator answers the prompt printed
+      UNDER this line: round two set it to 2000 characters, twenty-five rows, and nine
+      args of 200 padding columns fit inside it with ``uvx evil-server`` scrolled off the
+      top.
+
+    **One equivalence is deliberate, and it is the only one.** An absent ``args`` and an
+    empty ``args`` both print as bare ``run <command>``, because both hand ``execvpe`` the
+    same argv — `mcp_render_entry` reads them through the same ``or []``. They share one
+    approval on purpose. Dict key ORDER is the same kind of non-difference and is sorted
+    away for the same reason. Everything else about the entry is on the line.
+    """
+    if not isinstance(entry, dict) or not _names_something(entry):
         return ""
-    env = entry.get("env")
-    if isinstance(env, dict) and env:
-        dest += "  (env: " + ", ".join(sorted(_shown(k) for k in env)) + ")"
-    for field, shown_as in (("secrets", "vault"), ("secret_files", "vault file")):
-        m = entry.get(field)
-        if isinstance(m, dict) and m:
-            # `VAR=key`, the shape `mcp_render_entry` builds — so the line reads like the
-            # `secret exec` argv the answer authorises rather than like a summary of it.
-            pairs = sorted(f"{_shown(var)}={_shown(key)}" for var, key in m.items())
-            dest += f"  ({shown_as}: " + ", ".join(pairs) + ")"
-    # Not truncated: refused. A line this long does not fit on the screen the question is
-    # asked on, and cutting it would put us back where round one was — deciding which half
-    # of the destination the operator gets to see. The digest covers every byte either way.
-    return "" if len(dest) > MAX_LINE else dest
+    spent, shown = set(), []
+
+    # `run`, the headline: the command and, when they are plain strings, its arguments.
+    # An argv that is not a list of strings is not an argv, so it prints under `args`
+    # instead of being flattened into words that would read like several of them.
+    command, argv = entry.get("command"), entry.get("args")
+    if isinstance(command, str):
+        spent.add("command")
+        words = [_tok(command)]
+        if isinstance(argv, (list, tuple)) and all(isinstance(a, str) for a in argv):
+            spent.add("args")
+            words += [_tok(a) for a in argv]
+        shown.append("run " + " ".join(words))
+
+    for key in _READABLE:
+        if key not in entry or key in spent:
+            continue
+        spent.add(key)
+        value = entry[key]
+        body = (_pairs(value) if key in ("env", "secrets", "secret_files")
+                and isinstance(value, dict) and value else _val(value))
+        shown.append(f"{key} {body}")
+
+    # Everything charter has not been taught. NOT a fallback for a case somebody thought
+    # of — this is the case, and the named ones above are its readable spellings.
+    for key in sorted((k for k in entry if k not in spent), key=str):
+        shown.append(f"{_val(str(key))} {_val(entry[key])}")
+
+    shown.append(f"vault {_val(str(vault))}")
+    line = "  ".join(shown)
+    return "" if len(line) > MAX_LINE else line

--- a/charter/mcpseen.py
+++ b/charter/mcpseen.py
@@ -68,14 +68,27 @@ UNRENDERABLE = "(charter cannot show this entry in full — nothing to approve)"
 #: holds in both directions.
 MAX_PART = 200
 
-#: The narrowest terminal charter assumes, and the most rows one consent line may take on
-#: it. Their product is the hard ceiling on the whole line.
+#: The narrowest terminal charter assumes, and the most rows one PRINTED consent line may
+#: take on it. Their product is the hard ceiling on that line — label, decoration and
+#: destination together, because all three are on the same screen.
 MAX_COLS = 80
 MAX_ROWS = 10
 
-#: Hard ceiling on the whole consent line. An entry with so many parts that even their
-#: clipped forms do not fit is one the operator cannot be shown in full, so it is not
-#: renderable and (via :func:`fingerprint`) not approvable. See :func:`describe`.
+#: Longest either half of the ``persona/server`` label prints as. See :func:`label`.
+MAX_NAME = 35
+
+#: The whole label as printed: both halves and the ``/`` between them.
+MAX_LABEL = MAX_NAME * 2 + 1
+
+#: Everything charter itself puts on a printed consent line and nobody committed: the
+#: ``• `` bullet `util.info` prefixes, the two-space indent, and the ``→`` with a space on
+#: each side. Counted here because the ceiling below is a screen, and a screen does not
+#: care who put the columns on it.
+_DECORATION = len("• ") + len("  ") + len(" → ")
+
+#: Ceiling on the DESTINATION half — what :func:`describe` may return. An entry with so
+#: many parts that even their clipped forms do not fit is one the operator cannot be shown
+#: in full, so it is not renderable and (via :func:`fingerprint`) not approvable.
 #:
 #: This is a SCREEN, not a byte count, and that is the whole reason it exists. The
 #: operator answers the prompt printed *under* this line, so a line taller than the
@@ -84,7 +97,13 @@ MAX_ROWS = 10
 #: and nine args of 200 padding columns each fit inside it with the destination out of
 #: view. Escaping (see :func:`_safe`) makes such padding visible; it does not make it
 #: short, so the ceiling has to be the screen itself.
-MAX_LINE = MAX_COLS * MAX_ROWS
+#:
+#: The label and the decoration are SUBTRACTED rather than ignored, which is the round
+#: after that one: a ceiling that bounds the part charter was looking at and not the line
+#: it prints is bounded by whatever the attacker puts in the other part. A committed
+#: server name of a hundred thousand characters printed twelve hundred rows in front of a
+#: destination that was itself comfortably inside the ceiling.
+MAX_LINE = MAX_COLS * MAX_ROWS - MAX_LABEL - _DECORATION
 
 #: Two or more ASCII spaces. After :func:`_safe` escapes every codepoint outside printable
 #: ASCII, the ASCII space is the ONLY character that can still reach a consent line and
@@ -259,16 +278,84 @@ def _clip(text: str, budget: int) -> str:
     let a committed ``args`` of 600 characters produce a consent line naming neither the
     ``env`` it sets nor the ``url`` it points at, because both are appended after ``args``
     — so the important half of the line was the half that got cut.
+
+    The marker is ASCII, like everything else :func:`_safe` lets through, so that "a
+    consent line is printable ASCII" needs no footnote reading "except charter's own
+    ellipsis". A claim with an exception is a claim its test has to carve a hole in, and
+    the hole is where the next spelling goes.
     """
     return text if len(text) <= budget else (
-        text[:budget] + f"… (+{len(text) - budget} more chars)")
+        text[:budget] + f"... (+{len(text) - budget} more chars)")
+
+
+def _name(part) -> str:
+    """One half of a :func:`label`: printable ASCII, never wider than :data:`MAX_NAME`.
+
+    Clipped with a FIXED marker rather than with :func:`_clip`'s counted one. The count is
+    what the operator needs for a destination — how much of the command is off the line —
+    and it is exactly wrong here, because its own width grows with the input it describes.
+    A budget that a longer input makes longer is not a bound, and a bound is the only
+    thing standing between a committed name and the rows it costs.
+
+    A half that renders as nothing shows as ``""`` rather than as an invisible gap, the
+    same convention :func:`describe` uses for an ``env`` key, so ``reddit/""`` reads as a
+    server whose name is blank instead of as a missing word.
+    """
+    shown = _safe(str(part))
+    if len(shown) > MAX_NAME:
+        shown = shown[:MAX_NAME - 3] + "..."
+    return shown or '""'
+
+
+def label(*parts) -> str:
+    """The ``persona/server`` a consent line puts in front of the destination.
+
+    :func:`describe` has been hardened three times, and this half of the same printed line
+    reached the terminal untouched on all three — which is this fix's own lesson arriving
+    at its own expense. Each round put the guard on the FIELD that was attacked rather
+    than on the SURFACE it is printed on, so the next spelling only had to move one field
+    over. It moved here.
+
+    The ``server`` half is the live one: it is a key of a committed ``mcp.json``, so it is
+    an arbitrary JSON string, of arbitrary length, in any script. Confirmed end to end
+    through ``sync-agents --approve-mcp`` before this existed — a server named with three
+    U+3164 HANGUL FILLERs printed ``reddit/ → uvx some-reddit-mcp`` with nothing between
+    the slash and the arrow; one carrying an ANSI erase wiped charter's own words standing
+    beside it and repainted the row from column zero; a bidi override reversed the line;
+    and a name of a hundred thousand characters printed twelve hundred rows before the
+    destination reached the screen, with :data:`MAX_LINE` satisfied throughout because
+    :func:`describe` never saw the name.
+
+    The ``persona`` half is *already* contained: it is a directory under ``personas/``, and
+    `persona.reference_ok` refuses any reference outside ``[a-z0-9][a-z0-9._-]*`` (#328),
+    so a persona whose name is not printable ASCII resolves to nothing and never reaches
+    this line. It goes through the same escape anyway, because charter joins guards rather
+    than choosing between them — this one still holds if that alphabet is ever widened.
+    And the half of it that is not hypothetical: `valid_name` bounds the ALPHABET and not
+    the LENGTH, so only the clip here keeps a 255-character persona directory off four
+    rows of the screen the question is asked on.
+    """
+    return "/".join(_name(p) for p in parts)
 
 
 def describe(entry: dict) -> str:
     """Where the credential would go, as the line that asks the operator to look at it.
 
     Names and keys only — a ``secrets`` map holds vault KEY names, never values, so this
-    is safe to print and the operator needs to see it to judge the request.
+    is safe to print; and it IS printed, because the question the operator is answering is
+    "which credential goes where", and the line used to answer only the second half.
+
+    **Which credential, not just which command.** ``secrets`` and ``secret_files`` are what
+    `persona.mcp_render_entry` turns into ``--env VAR=<vault key>`` and
+    ``--file VAR=<vault key>``, so the vault key named there decides *what value* the
+    command receives. They were in the digest and not on the line, which is finding three
+    of round three — a homoglyph re-point that lapses the approval and re-asks under a line
+    that reads the same — moved to the field that chooses the credential rather than the
+    destination: editing ``{"REDDIT_CLIENT_ID": "client-id"}`` to
+    ``{"REDDIT_CLIENT_ID": "aws-root-key"}`` in a committed ``mcp.json`` produced a
+    byte-identical consent line and a different fingerprint, so the operator was correctly
+    re-asked and correctly could not tell why. Being re-asked under an unchanged line is
+    not consent, it is a second chance to make the same mistake.
 
     ``""`` when the entry has no destination to show, which :func:`fingerprint` turns into
     "not approvable" — so a line the operator cannot read is a line nobody can consent to.
@@ -310,7 +397,21 @@ def describe(entry: dict) -> str:
     ``env`` keys are shown because they choose the destination as surely as ``command``
     does: ``PATH`` decides which binary ``execvpe`` finds, ``NODE_OPTIONS`` decides what
     it loads (#426).
+
+    The rule the three suffixes are instances of, said once so a fourth field does not
+    have to be found the way these were: **everything the digest covers that changes what
+    the vault hands over, or where it lands, is on the line.** ``env`` chooses the binary,
+    ``url`` chooses the endpoint, ``secrets`` and ``secret_files`` choose the credential.
+    A field that lapses an approval without changing the line spends the operator's second
+    look on a line they have already read.
     """
+    def _shown(x) -> str:
+        # `or '""'`: a name that renders blank is still a name the harness would use, so
+        # it is printed as an empty string rather than left as an invisible gap in a list.
+        # Applied only to what actually reaches the line — an `env` VALUE never does, and
+        # escaping a megabyte nobody will read is work done on an attacker's behalf.
+        return _clip(_safe(str(x)), MAX_PART) or '""'
+
     if not isinstance(entry, dict):
         return ""
     raw = entry.get("args")
@@ -325,10 +426,14 @@ def describe(entry: dict) -> str:
         return ""
     env = entry.get("env")
     if isinstance(env, dict) and env:
-        # `or '""'`: a key that renders blank is still a key the harness would set, so it
-        # is named as an empty string rather than left as an invisible gap in the list.
-        keys = sorted(_clip(_safe(str(k)), MAX_PART) or '""' for k in env)
-        dest += "  (env: " + ", ".join(keys) + ")"
+        dest += "  (env: " + ", ".join(sorted(_shown(k) for k in env)) + ")"
+    for field, shown_as in (("secrets", "vault"), ("secret_files", "vault file")):
+        m = entry.get(field)
+        if isinstance(m, dict) and m:
+            # `VAR=key`, the shape `mcp_render_entry` builds — so the line reads like the
+            # `secret exec` argv the answer authorises rather than like a summary of it.
+            pairs = sorted(f"{_shown(var)}={_shown(key)}" for var, key in m.items())
+            dest += f"  ({shown_as}: " + ", ".join(pairs) + ")"
     # Not truncated: refused. A line this long does not fit on the screen the question is
     # asked on, and cutting it would put us back where round one was — deciding which half
     # of the destination the operator gets to see. The digest covers every byte either way.

--- a/charter/mcpseen.py
+++ b/charter/mcpseen.py
@@ -18,6 +18,14 @@ the launchers real servers use (``npx``, ``uvx``, ``docker``, ``node``) is walke
 and a list excluding them refuses every MCP server anyone actually runs. The axis with an
 answer is not *what* the command is but *whether the operator has seen it*.
 
+**The whole entry, and only what was shown.** Two properties the mechanism is worthless
+without, and it shipped without both. The digest covers every key of the entry rather than
+the handful charter reads, because `persona.mcp_render_entry` passes the rest through to
+the harness — ``env`` did exactly that, so a committed edit could re-point an approved
+server's ``PATH`` with the approval intact (#426). And an entry :func:`describe` cannot
+render is not approvable at all, because the consent line IS the consent: an ``http``
+server used to print a blank one under the words "read the command above" (#427).
+
 **Machine-local and gitignored, deliberately.** Under ``STATE_DIR``, the same as
 :mod:`charter.guardseen` and for a sharper reason: if the approval travelled in git, the
 commit that declares the server could also declare that the server was approved, which is
@@ -45,35 +53,79 @@ from . import config
 #: One file per plane, under the state dir. Never committed — see the module docstring.
 FILE_NAME = "mcp-approved.json"
 
+#: Printed in place of a consent line for an entry :func:`describe` cannot render. Such an
+#: entry is reported as withheld and refused for approval, rather than silently dropped.
+UNRENDERABLE = "(names neither a command nor a url — nothing to approve)"
+
+#: Longest consent line printed. See :func:`describe`.
+MAX_LINE = 600
+
 
 def path() -> Path:
     return Path(config.STATE_DIR) / FILE_NAME
 
 
+def needs_consent(vault: str | None, entry: dict) -> bool:
+    """Would rendering *entry* hand *vault*'s value to the command a committed file names?
+
+    The one question that decides whether there is anything to consent to, asked in one
+    place so the approve path, the withheld report and the digest cannot disagree about
+    which servers are in scope. Kept separate from :func:`fingerprint` because a digest of
+    ``None`` now means "no approval can exist", which includes entries that ARE in scope
+    and must still be reported.
+    """
+    if not vault or not isinstance(entry, dict):
+        return False
+    secrets, files = entry.get("secrets"), entry.get("secret_files")
+    return bool((isinstance(secrets, dict) and secrets)
+                or (isinstance(files, dict) and files))
+
+
+def _canon(value):
+    """Untrusted JSON as something :func:`json.dumps` renders deterministically.
+
+    Recursive and total, rather than a list of fields: the WHOLE entry is digested, so a
+    key charter does not know about yet cannot fall outside the fingerprint. ``env`` was
+    exactly that key (#426) — copied verbatim into the generated agent file by
+    `persona.mcp_render_entry`, handed to ``execvpe``, and invisible to the digest, so a
+    committed edit could add ``NODE_OPTIONS`` or re-point ``PATH`` on an already-approved
+    server without lapsing the approval.
+
+    A value JSON cannot carry is tagged rather than stringified, so an exotic object
+    cannot digest as the plain string that happens to be its ``repr``.
+    """
+    if isinstance(value, dict):
+        return {str(k): _canon(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_canon(v) for v in value]
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return value
+    return ["<not-json>", repr(value)]
+
+
 def fingerprint(vault: str | None, entry: dict) -> str | None:
     """What the operator is being asked to approve, as one digest.
 
-    ``None`` when there is nothing to consent to: an entry with no ``secrets`` and no
-    ``secret_files`` is passed through untouched by `persona.mcp_render_entry`, so no
-    credential is at stake and requiring approval would be a prompt about nothing.
+    ``None`` when no approval can exist for this entry, which is two cases and both mean
+    "render it without the vault wrapper":
 
-    **Every field that decides where the value goes is in here**, which is the point:
-    approving a server by name would let a later edit re-point the same name at a different
-    binary. The vault (whose secrets), the command and args (who receives them), and the
-    full ``secrets`` / ``secret_files`` mappings (which keys, under which environment
-    variable names — both halves are chosen by the committed file) all change the digest.
+    * **Nothing to consent to** — no ``secrets`` and no ``secret_files``, or no vault. The
+      entry is passed through untouched by `persona.mcp_render_entry`, so no credential is
+      at stake and requiring approval would be a prompt about nothing.
+    * **Nothing to show** — :func:`describe` cannot render a destination for it, so the
+      operator would be approving a blank line (#427). An entry nobody can be shown is not
+      an entry anybody can approve.
+
+    **Every field of the entry is in here**, which is the point: approving a server by
+    name — or by five of its fields — lets a later commit re-point the same name at a
+    different binary, a different endpoint, or a different environment while the approval
+    stays valid. The vault (whose secrets) and the entry in full (where they go) both
+    change the digest.
     """
-    secrets = entry.get("secrets") or {}
-    files = entry.get("secret_files") or {}
-    if not (secrets or files) or not vault:
+    if not needs_consent(vault, entry) or not describe(entry):
         return None
-    material = json.dumps({
-        "vault": vault,
-        "command": entry.get("command"),
-        "args": list(entry.get("args") or []),
-        "secrets": sorted((str(k), str(v)) for k, v in secrets.items()),
-        "secret_files": sorted((str(k), str(v)) for k, v in files.items()),
-    }, sort_keys=True, ensure_ascii=False)
+    material = json.dumps({"vault": str(vault), "entry": _canon(entry)},
+                          sort_keys=True, ensure_ascii=False)
     return hashlib.sha256(material.encode("utf-8")).hexdigest()
 
 
@@ -105,11 +157,53 @@ def approve(persona_name: str, fingerprints) -> None:
     p.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
 
 
+def _safe(text: str) -> str:
+    """*text* with anything unprintable escaped, for a line an operator must trust.
+
+    Every field here comes out of a committed file and the line IS the consent: a ``\\r``
+    or an ``ESC[2K`` in ``args`` repaints it, and a U+202E bidi override reverses it, so
+    what the operator reads stops being what would run. ``str.isprintable`` covers that
+    whole class in one call — it is false for every Other and Separator codepoint, the
+    ASCII space excepted.
+    """
+    return "".join(c if c.isprintable() else f"\\u{ord(c):04x}" for c in text)
+
+
 def describe(entry: dict) -> str:
-    """The command as it would run, for the line that asks the operator to look at it.
+    """Where the credential would go, as the line that asks the operator to look at it.
 
     Names and keys only — a ``secrets`` map holds vault KEY names, never values, so this
     is safe to print and the operator needs to see it to judge the request.
+
+    ``""`` when the entry names neither a ``command`` nor a ``url``. An ``http``/``sse``
+    server has no command, and building the line from ``command`` + ``args`` alone
+    rendered it as an EMPTY string under the words *"Read the command above"* (#427).
+    Falling back to ``url`` fixes the common case; returning ``""`` for whatever is left
+    is the general one, and :func:`fingerprint` turns that into "not approvable", so a
+    blank consent line can never be consented to again.
+
+    ``env`` keys are shown because they choose the destination as surely as ``command``
+    does: ``PATH`` decides which binary ``execvpe`` finds, ``NODE_OPTIONS`` decides what
+    it loads (#426).
     """
-    parts = [str(entry.get("command") or "")] + [str(a) for a in (entry.get("args") or [])]
-    return " ".join(p for p in parts if p)
+    if not isinstance(entry, dict):
+        return ""
+    raw = entry.get("args")
+    argv = list(raw) if isinstance(raw, (list, tuple)) else ([raw] if raw else [])
+    parts = [str(entry.get("command") or "")] + [str(a) for a in argv]
+    dest = " ".join(_safe(p) for p in parts if p)
+    url = str(entry.get("url") or "").strip()
+    if url:
+        shown = f"{_safe(str(entry.get('type') or 'http'))} {_safe(url)}"
+        dest = f"{dest}  [{shown}]" if dest else shown
+    if not dest:
+        return ""
+    env = entry.get("env")
+    if isinstance(env, dict) and env:
+        dest += "  (env: " + ", ".join(sorted(_safe(str(k)) for k in env)) + ")"
+    # The destination is at the FRONT of the line, so a committed file padding `args` with
+    # a megabyte of text cannot scroll it off the operator's screen. The digest still
+    # covers every byte of the entry, truncated here or not.
+    if len(dest) > MAX_LINE:
+        dest = dest[:MAX_LINE] + f"… (+{len(dest) - MAX_LINE} more chars)"
+    return dest

--- a/charter/mcpseen.py
+++ b/charter/mcpseen.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from pathlib import Path
 
 from . import config
@@ -55,10 +56,21 @@ FILE_NAME = "mcp-approved.json"
 
 #: Printed in place of a consent line for an entry :func:`describe` cannot render. Such an
 #: entry is reported as withheld and refused for approval, rather than silently dropped.
-UNRENDERABLE = "(names neither a command nor a url — nothing to approve)"
+#: Covers both reasons: no destination at all, and a destination too big to show in full.
+UNRENDERABLE = "(charter cannot show this entry in full — nothing to approve)"
 
-#: Longest consent line printed. See :func:`describe`.
-MAX_LINE = 600
+#: Longest single part — command, one arg, ``type``, ``url``, one ``env`` key — shown on a
+#: consent line. A part longer than this is CLIPPED with the cut announced; it is never
+#: dropped, so no part can push another part off the line. See :func:`describe`.
+MAX_PART = 200
+
+#: Hard ceiling on the whole consent line. An entry with so many parts that even their
+#: clipped forms do not fit is one the operator cannot be shown in full, so it is not
+#: renderable and (via :func:`fingerprint`) not approvable. See :func:`describe`.
+MAX_LINE = 2000
+
+#: Two or more ASCII spaces — the one printable run :func:`_safe` must not pass through.
+_SPACE_RUN = re.compile(" {2,}")
 
 
 def path() -> Path:
@@ -158,15 +170,32 @@ def approve(persona_name: str, fingerprints) -> None:
 
 
 def _safe(text: str) -> str:
-    """*text* with anything unprintable escaped, for a line an operator must trust.
+    """*text* with anything unprintable escaped and its whitespace flattened.
 
     Every field here comes out of a committed file and the line IS the consent: a ``\\r``
     or an ``ESC[2K`` in ``args`` repaints it, and a U+202E bidi override reverses it, so
     what the operator reads stops being what would run. ``str.isprintable`` covers that
-    whole class in one call — it is false for every Other and Separator codepoint, the
-    ASCII space excepted.
+    whole class in one call — it is false for every Other and Separator codepoint, **the
+    ASCII space excepted**, and that one exception was a hole: ``command`` of three spaces
+    rendered a consent line that was truthy to charter and blank to the reader, which is
+    the very thing :func:`describe` promises can no longer be approved. Runs of ASCII
+    space are collapsed and the ends stripped, so a part made only of spaces comes back
+    empty and drops out of the line rather than padding it.
     """
-    return "".join(c if c.isprintable() else f"\\u{ord(c):04x}" for c in text)
+    out = "".join(c if c.isprintable() else f"\\u{ord(c):04x}" for c in text)
+    return _SPACE_RUN.sub(" ", out).strip()
+
+
+def _clip(text: str, budget: int) -> str:
+    """*text* cut to *budget* characters with the cut ANNOUNCED, never silently.
+
+    Used per part rather than on the finished line. Truncating the finished line is what
+    let a committed ``args`` of 600 characters produce a consent line naming neither the
+    ``env`` it sets nor the ``url`` it points at, because both are appended after ``args``
+    — so the important half of the line was the half that got cut.
+    """
+    return text if len(text) <= budget else (
+        text[:budget] + f"… (+{len(text) - budget} more chars)")
 
 
 def describe(entry: dict) -> str:
@@ -175,12 +204,31 @@ def describe(entry: dict) -> str:
     Names and keys only — a ``secrets`` map holds vault KEY names, never values, so this
     is safe to print and the operator needs to see it to judge the request.
 
-    ``""`` when the entry names neither a ``command`` nor a ``url``. An ``http``/``sse``
-    server has no command, and building the line from ``command`` + ``args`` alone
-    rendered it as an EMPTY string under the words *"Read the command above"* (#427).
-    Falling back to ``url`` fixes the common case; returning ``""`` for whatever is left
-    is the general one, and :func:`fingerprint` turns that into "not approvable", so a
-    blank consent line can never be consented to again.
+    ``""`` when the entry has no destination to show, which :func:`fingerprint` turns into
+    "not approvable" — so a line the operator cannot read is a line nobody can consent to.
+    Two ways to get there:
+
+    * **Nothing named.** No ``command``, no ``args``, no ``url``. An ``http``/``sse``
+      server has no command, and building the line from ``command`` + ``args`` alone
+      rendered it as an EMPTY string under the words *"Read the command above"* (#427).
+      Falling back to ``url`` fixes the common case; ``""`` for the rest is the general
+      one. **Whitespace does not count as naming something**: every part goes through
+      :func:`_safe`, which strips it, so a ``command`` of three spaces is a blank line and
+      is refused rather than approved. Round one tested `""` and missed `"   "`.
+    * **Too much named.** So many parts that even their clipped forms exceed
+      :data:`MAX_LINE`. Charter will not print a page of destination and call it a line
+      the operator read, and it will not print half of one either. Fail closed: withheld.
+
+    **Every part is named; only its contents can be shortened.** Round one clipped the
+    FINISHED line at 600 characters, and both the ``[type url]`` and the ``(env: …)``
+    suffixes are appended after ``args`` — so ~600 characters of plausible ``args`` in a
+    committed file produced a consent line naming neither the ``env`` it set nor the
+    ``url`` it pointed at, while the approved render still carried both to ``execvpe``.
+    The comment that stood here claimed this was impossible because "the destination is at
+    the FRONT of the line"; that was true only of ``command``, and false of every field
+    that decides where a url-transport entry connects or which binary ``PATH`` resolves.
+    Each part now gets its own :data:`MAX_PART` budget and the suffixes are built from
+    already-clipped parts, so nothing appended to this line can be pushed out of it.
 
     ``env`` keys are shown because they choose the destination as surely as ``command``
     does: ``PATH`` decides which binary ``execvpe`` finds, ``NODE_OPTIONS`` decides what
@@ -191,19 +239,20 @@ def describe(entry: dict) -> str:
     raw = entry.get("args")
     argv = list(raw) if isinstance(raw, (list, tuple)) else ([raw] if raw else [])
     parts = [str(entry.get("command") or "")] + [str(a) for a in argv]
-    dest = " ".join(_safe(p) for p in parts if p)
-    url = str(entry.get("url") or "").strip()
+    dest = " ".join(p for p in (_clip(_safe(p), MAX_PART) for p in parts) if p)
+    url = _clip(_safe(str(entry.get("url") or "")), MAX_PART)
     if url:
-        shown = f"{_safe(str(entry.get('type') or 'http'))} {_safe(url)}"
+        shown = f"{_clip(_safe(str(entry.get('type') or 'http')), MAX_PART)} {url}"
         dest = f"{dest}  [{shown}]" if dest else shown
     if not dest:
         return ""
     env = entry.get("env")
     if isinstance(env, dict) and env:
-        dest += "  (env: " + ", ".join(sorted(_safe(str(k)) for k in env)) + ")"
-    # The destination is at the FRONT of the line, so a committed file padding `args` with
-    # a megabyte of text cannot scroll it off the operator's screen. The digest still
-    # covers every byte of the entry, truncated here or not.
-    if len(dest) > MAX_LINE:
-        dest = dest[:MAX_LINE] + f"… (+{len(dest) - MAX_LINE} more chars)"
-    return dest
+        # `or '""'`: a key that renders blank is still a key the harness would set, so it
+        # is named as an empty string rather than left as an invisible gap in the list.
+        keys = sorted(_clip(_safe(str(k)), MAX_PART) or '""' for k in env)
+        dest += "  (env: " + ", ".join(keys) + ")"
+    # Not truncated: refused. A line this long is one no operator reads to the end, and
+    # cutting it would put us back where round one was — deciding which half of the
+    # destination the operator gets to see. The digest still covers every byte either way.
+    return "" if len(dest) > MAX_LINE else dest

--- a/charter/mcpseen.py
+++ b/charter/mcpseen.py
@@ -62,14 +62,33 @@ UNRENDERABLE = "(charter cannot show this entry in full — nothing to approve)"
 #: Longest single part — command, one arg, ``type``, ``url``, one ``env`` key — shown on a
 #: consent line. A part longer than this is CLIPPED with the cut announced; it is never
 #: dropped, so no part can push another part off the line. See :func:`describe`.
+#:
+#: :data:`MAX_LINE` still bounds how many such parts fit — and an entry that overflows it
+#: is refused whole rather than having a part dropped, so "no part pushes another off"
+#: holds in both directions.
 MAX_PART = 200
+
+#: The narrowest terminal charter assumes, and the most rows one consent line may take on
+#: it. Their product is the hard ceiling on the whole line.
+MAX_COLS = 80
+MAX_ROWS = 10
 
 #: Hard ceiling on the whole consent line. An entry with so many parts that even their
 #: clipped forms do not fit is one the operator cannot be shown in full, so it is not
 #: renderable and (via :func:`fingerprint`) not approvable. See :func:`describe`.
-MAX_LINE = 2000
+#:
+#: This is a SCREEN, not a byte count, and that is the whole reason it exists. The
+#: operator answers the prompt printed *under* this line, so a line taller than the
+#: terminal has already scrolled the command it names off the top by the time the
+#: question is asked. Round two set it to 2000 — twenty-five rows of an 80-column tty —
+#: and nine args of 200 padding columns each fit inside it with the destination out of
+#: view. Escaping (see :func:`_safe`) makes such padding visible; it does not make it
+#: short, so the ceiling has to be the screen itself.
+MAX_LINE = MAX_COLS * MAX_ROWS
 
-#: Two or more ASCII spaces — the one printable run :func:`_safe` must not pass through.
+#: Two or more ASCII spaces. After :func:`_safe` escapes every codepoint outside printable
+#: ASCII, the ASCII space is the ONLY character that can still reach a consent line and
+#: render as nothing — so collapsing this run is the whole blank class, not one member.
 _SPACE_RUN = re.compile(" {2,}")
 
 
@@ -126,7 +145,12 @@ def fingerprint(vault: str | None, entry: dict) -> str | None:
       at stake and requiring approval would be a prompt about nothing.
     * **Nothing to show** — :func:`describe` cannot render a destination for it, so the
       operator would be approving a blank line (#427). An entry nobody can be shown is not
-      an entry anybody can approve.
+      an entry anybody can approve. "Cannot be shown" is two properties and both are
+      decided on the ESCAPED line, not on the raw one: it renders as nothing (only ASCII
+      spaces survive :func:`_safe`), or it does not fit on the screen the question is
+      asked on (:data:`MAX_LINE`). Round two decided the first on ``str.isprintable``,
+      which is true of U+3164 HANGUL FILLER — so a line blank on every terminal got a
+      real digest and was approvable.
 
     **Every field of the entry is in here**, which is the point: approving a server by
     name — or by five of its fields — lets a later commit re-point the same name at a
@@ -169,20 +193,62 @@ def approve(persona_name: str, fingerprints) -> None:
     p.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
 
 
-def _safe(text: str) -> str:
-    """*text* with anything unprintable escaped and its whitespace flattened.
+def _escape(ch: str) -> str:
+    """One codepoint as an escape no other codepoint can also spell.
 
-    Every field here comes out of a committed file and the line IS the consent: a ``\\r``
-    or an ``ESC[2K`` in ``args`` repaints it, and a U+202E bidi override reverses it, so
-    what the operator reads stops being what would run. ``str.isprintable`` covers that
-    whole class in one call — it is false for every Other and Separator codepoint, **the
-    ASCII space excepted**, and that one exception was a hole: ``command`` of three spaces
-    rendered a consent line that was truthy to charter and blank to the reader, which is
-    the very thing :func:`describe` promises can no longer be approved. Runs of ASCII
-    space are collapsed and the ends stripped, so a part made only of spaces comes back
-    empty and drops out of the line rather than padding it.
+    Astral planes get the eight-digit ``\\U`` form rather than a long ``\\u``, because
+    ``\\u1f600`` is five hex digits: U+1F600 and the two characters U+1F60 + ``0`` would
+    render the same, and two different commands that read the same on a consent line is
+    the homoglyph finding with a different alphabet.
     """
-    out = "".join(c if c.isprintable() else f"\\u{ord(c):04x}" for c in text)
+    cp = ord(ch)
+    return f"\\u{cp:04x}" if cp <= 0xFFFF else f"\\U{cp:08x}"
+
+
+def _safe(text: str) -> str:
+    """*text* as printable ASCII — every other codepoint shown as its ``\\uXXXX`` escape.
+
+    Every field here comes out of a committed file and the line IS the consent, so the
+    question this answers is not "is this character printable" but "does what the operator
+    reads still say what would run". Two earlier spellings of this guard each matched
+    something narrower than that question, and each was walked past — in order:
+
+    * a ``\\r`` or an ``ESC[2K`` in ``args`` repaints the line and a U+202E bidi override
+      reverses it — caught by ``str.isprintable``, which is where round one stopped;
+    * ``str.isprintable`` is nonetheless **true** for U+3164 HANGUL FILLER, U+2800 BRAILLE
+      PATTERN BLANK and U+115F/U+1160. All are ``isspace() == False``, survive ``strip``,
+      and render as nothing on every terminal, so a ``command`` of three of them was a
+      line blank to the reader and truthy to charter — round one's ``"   "`` one spelling
+      on, and round two's regex over the ASCII space did not reach it;
+    * a U+0301 combining acute is printable and is neither, and repaints the rows above
+      and below the line; Cyrillic ``а``/``с`` are printable and are neither, and spell an
+      endpoint that reads identically to the ASCII one it re-points to, so an operator
+      re-asked about a homoglyph cannot see what changed.
+
+    No list of codepoints answers that, because the next spelling is always one codepoint
+    further out. The class that does is the **complement**: printable ASCII is what a
+    consent line may contain, and everything outside it — any category, any plane, any
+    combining mark, any lookalike — is shown as its escape rather than its glyph. MCP
+    commands, args, urls and env keys are ASCII in practice; anything else on a consent
+    line is a reason to show the escape, not the glyph.
+
+    Emptiness is then decided on the **escaped** form, which is what turns "renders as
+    nothing" from a growing list into a decidable question: the escaped string holds only
+    U+0020..U+007E, and the ASCII space is the only member of that range that renders as
+    nothing. Collapsing runs of it and stripping the ends therefore returns ``""`` **if
+    and only if** the part was nothing but ASCII spaces. That is an argument about the
+    whole class, not a sample of it — and `tests/test_mcp_approval.py` checks it by
+    sweeping every codepoint Python can hold rather than by listing four.
+
+    The backslash escapes to ``\\\\`` for the same reason the astral form is eight digits:
+    so that **every** ``\\uXXXX`` on a consent line is a codepoint that was really there.
+    Without it, a committed ``command`` holding the six literal characters ``\\u3164``
+    reads exactly like one holding U+3164 — one more pair of different commands the
+    operator cannot tell apart by reading the line. A Windows path shows as
+    ``C:\\\\Users\\\\x``; that is the cost, and it is unambiguous.
+    """
+    out = "".join("\\\\" if c == "\\" else c if " " <= c <= "~" else _escape(c)
+                  for c in text)
     return _SPACE_RUN.sub(" ", out).strip()
 
 
@@ -212,12 +278,23 @@ def describe(entry: dict) -> str:
       server has no command, and building the line from ``command`` + ``args`` alone
       rendered it as an EMPTY string under the words *"Read the command above"* (#427).
       Falling back to ``url`` fixes the common case; ``""`` for the rest is the general
-      one. **Whitespace does not count as naming something**: every part goes through
-      :func:`_safe`, which strips it, so a ``command`` of three spaces is a blank line and
-      is refused rather than approved. Round one tested `""` and missed `"   "`.
+      one. **A part that renders as nothing does not count as naming something** — and
+      after :func:`_safe` that is decidable rather than enumerable: every part comes back
+      as printable ASCII with all else escaped, so it is blank exactly when it held
+      nothing but ASCII spaces. Round one tested ``""`` and missed ``"   "``; round two
+      tested ``"   "`` and missed U+3164 HANGUL FILLER, which is printable, is not
+      whitespace, survives ``strip``, and shows as nothing. Neither is a special case
+      now — they are the same case, asked of the escaped form.
     * **Too much named.** So many parts that even their clipped forms exceed
-      :data:`MAX_LINE`. Charter will not print a page of destination and call it a line
-      the operator read, and it will not print half of one either. Fail closed: withheld.
+      :data:`MAX_LINE` — :data:`MAX_ROWS` rows of an :data:`MAX_COLS`-column terminal.
+      Charter will not print a page of destination and call it a line the operator read,
+      and it will not print half of one either. Fail closed: withheld. The ceiling is a
+      screen because the operator answers the prompt printed UNDER this line: round two
+      set it to 2000 characters, twenty-five rows, and nine args of 200 padding columns
+      fit inside it with ``uvx evil-server`` scrolled off the top. Escaping makes padding
+      visible, which is necessary and not sufficient — visible padding scrolls a line just
+      as far as invisible padding does, so the length that is refused has to be the length
+      that does not fit.
 
     **Every part is named; only its contents can be shortened.** Round one clipped the
     FINISHED line at 600 characters, and both the ``[type url]`` and the ``(env: …)``
@@ -252,7 +329,7 @@ def describe(entry: dict) -> str:
         # is named as an empty string rather than left as an invisible gap in the list.
         keys = sorted(_clip(_safe(str(k)), MAX_PART) or '""' for k in env)
         dest += "  (env: " + ", ".join(keys) + ")"
-    # Not truncated: refused. A line this long is one no operator reads to the end, and
-    # cutting it would put us back where round one was — deciding which half of the
-    # destination the operator gets to see. The digest still covers every byte either way.
+    # Not truncated: refused. A line this long does not fit on the screen the question is
+    # asked on, and cutting it would put us back where round one was — deciding which half
+    # of the destination the operator gets to see. The digest covers every byte either way.
     return "" if len(dest) > MAX_LINE else dest

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -459,32 +459,41 @@ def mcp_render_entry(name: str, vault: str | None, entry: dict) -> dict:
     return out
 
 
-def mcp_credentialed(name: str) -> list[tuple[str, dict, str]]:
-    """``(server, entry, fingerprint)`` for every server of *name* that would carry a
-    credential — i.e. declares ``secrets``/``secret_files`` against a real vault.
+def mcp_credentialed(name: str) -> list[tuple[str, dict, str, str]]:
+    """``(server, entry, fingerprint, consent line)`` for every server of *name* that would
+    carry a credential — i.e. declares ``secrets``/``secret_files`` against a real vault.
 
     The list `sync-agents --approve-mcp` records and the list it reports on are both
     derived from this one, so "what you were shown" and "what got approved" cannot drift
     apart — which is the failure mode of a consent prompt that computes its own list.
 
-    ``fingerprint`` may be ``None``: an entry `mcpseen.describe` cannot render is in scope
-    (it declares secrets against a vault) but can never be approved (#427). Membership is
-    decided by `mcpseen.needs_consent` rather than by the digest, so such an entry is
-    still REPORTED as withheld instead of vanishing from both lists at once.
+    **The LINE is returned, not just the entry**, and that is deliberate. `mcpseen`
+    fingerprints the consent line itself, so the line a caller prints and the digest it
+    records have to be the same string; handing back the entry and letting each caller
+    render its own is how they come to differ — the caller that forgot the vault would
+    print a line the digest does not match. There is one rendering per server here, and
+    both callers print that one.
+
+    ``fingerprint`` may be ``None``, and then the line is ``""``: an entry
+    `mcpseen.describe` cannot render is in scope (it declares secrets against a vault) but
+    can never be approved (#427). Membership is decided by `mcpseen.needs_consent` rather
+    than by the digest, so such an entry is still REPORTED as withheld instead of
+    vanishing from both lists at once.
     """
     vault = (resolve(name) or {}).get("meta", {}).get("vault")
     out = []
     for server, entry in sorted(mcp_servers(name).items()):
         if mcpseen.needs_consent(vault, entry):
-            out.append((server, entry, mcpseen.fingerprint(vault, entry)))
+            out.append((server, entry, mcpseen.fingerprint(vault, entry),
+                        mcpseen.describe(vault, entry)))
     return out
 
 
-def mcp_withheld(name: str) -> list[tuple[str, dict]]:
-    """The credentialed servers this operator has NOT approved — what `mcp_render_entry`
-    is about to render without its vault wrapper."""
+def mcp_withheld(name: str) -> list[tuple[str, str]]:
+    """``(server, consent line)`` for the credentialed servers this operator has NOT
+    approved — what `mcp_render_entry` is about to render without its vault wrapper."""
     ok = mcpseen.approved(name)
-    return [(s, e) for s, e, fp in mcp_credentialed(name) if fp not in ok]
+    return [(s, line) for s, _e, fp, line in mcp_credentialed(name) if fp not in ok]
 
 
 def lineage(name: str) -> list[str]:

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -433,6 +433,12 @@ def mcp_render_entry(name: str, vault: str | None, entry: dict) -> dict:
     # `args`, so a list holding the launchers real servers use (`npx`, `uvx`, `docker`) is
     # walked straight past by `args` alone, and a list excluding them refuses every server
     # anyone actually runs. See `mcpseen` for the full argument.
+    #
+    # The digest covers the WHOLE entry, not the fields charter happens to know about.
+    # `out` above keeps every key it does not consume — `env` among them — and hands them
+    # to the harness, which sets them on this process before `secret exec` reaches
+    # `execvpe`; so a fingerprint over an allowlist of five fields let a committed edit
+    # re-point an approved server's PATH or NODE_OPTIONS with the approval intact (#426).
     if mcpseen.fingerprint(vault, entry) not in mcpseen.approved(name):
         return out
     args = ["secret", "exec", vault]
@@ -460,13 +466,17 @@ def mcp_credentialed(name: str) -> list[tuple[str, dict, str]]:
     The list `sync-agents --approve-mcp` records and the list it reports on are both
     derived from this one, so "what you were shown" and "what got approved" cannot drift
     apart — which is the failure mode of a consent prompt that computes its own list.
+
+    ``fingerprint`` may be ``None``: an entry `mcpseen.describe` cannot render is in scope
+    (it declares secrets against a vault) but can never be approved (#427). Membership is
+    decided by `mcpseen.needs_consent` rather than by the digest, so such an entry is
+    still REPORTED as withheld instead of vanishing from both lists at once.
     """
     vault = (resolve(name) or {}).get("meta", {}).get("vault")
     out = []
     for server, entry in sorted(mcp_servers(name).items()):
-        fp = mcpseen.fingerprint(vault, entry)
-        if fp:
-            out.append((server, entry, fp))
+        if mcpseen.needs_consent(vault, entry):
+            out.append((server, entry, mcpseen.fingerprint(vault, entry)))
     return out
 
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -135,7 +135,7 @@ command it withheld from, which is the thing worth looking at.
 `--approve-mcp` asks **per server**, and prints the entry before it asks:
 
 ```
-  reddit/acme → http https://api.acme.example/mcp  (env: HTTPS_PROXY)
+  reddit/acme → http https://api.acme.example/mcp  (env: HTTPS_PROXY)  (vault: ACME_TOKEN=acme-token)
     approve reddit/acme? [y/N]
 ```
 
@@ -151,9 +151,20 @@ teammate re-pointing an existing server at a new binary, a new endpoint or a new
 the case this exists for.
 
 The printed line names every part of that destination, and **no part can push another one
-off it**. Each part — the command, each arg, the `url`, each `env` key — gets its own
-budget and is clipped on its own with the cut announced, so padding `args` in a committed
-file cannot scroll the `env` or the endpoint out of view.
+off it**. Each part — the command, each arg, the `url`, each `env` key, each vault key —
+gets its own budget and is clipped on its own with the cut announced, so padding `args` in
+a committed file cannot scroll the `env` or the endpoint out of view.
+
+**Which credential, and not only which command.** `secrets` and `secret_files` map an
+environment variable to a *vault key*, and that key decides which of the vault's values
+the command receives — so both are on the line as `VAR=key`, in the shape the `secret exec`
+argv is built from. They are in the digest too, so editing one lapses the approval and you
+are asked again; before they were shown, that second question arrived under a line
+identical to the one you had already approved, which is a second chance to make the same
+mistake rather than a chance to catch it. The rule the suffixes are instances of:
+everything the digest covers that changes what the vault hands over, or where it lands, is
+on the line. (Key *names*, never values — a value lives in the vault and never enters the
+process that prints this.)
 
 **The line is printable ASCII, and everything else is spelled out as `\uXXXX`.** Not
 "unprintable characters are escaped" — every codepoint outside `U+0020..U+007E` is,
@@ -166,11 +177,33 @@ anything else here is a reason to *show the escape* rather than the glyph. Escap
 also what makes "renders as nothing" answerable: charter decides it on the escaped line,
 where the ASCII space is the only character left that shows nothing.
 
+Read that claim precisely, because it is the kind of sentence this section has already had
+to withdraw twice: *everything on the row that came out of a committed file* is printable
+ASCII. The `•` and the `→` around it are charter's own punctuation, put there by charter
+and not by anyone's `mcp.json` — including the `...` that marks a clip, which is ASCII for
+exactly this reason. The test derives that set from a benign run rather than listing it.
+
 The escaping is one-to-one, which is the part that makes reading the line worth anything:
 astral codepoints use the eight-digit `\UXXXXXXXX` form (`\u1f600` is five hex digits and
 would also spell `U+1F60` followed by `0`), and a literal backslash is doubled, so every
 `\uXXXX` you see is a codepoint that was really there rather than six ASCII characters
 imitating one. A Windows path therefore shows as `C:\\Users\\x`.
+
+That covers the **whole** line, including the `persona/server` label in front of the
+arrow — the half that had gone to the terminal untouched while the destination beside it
+was hardened three times. A server name is a key of a committed `mcp.json`: an arbitrary
+string, of arbitrary length, in any script. So a server named with three U+3164 fillers no
+longer prints as `reddit/ → uvx`, one carrying an ANSI erase no longer wipes the words
+standing beside it, and one of a hundred thousand characters no longer puts twelve hundred
+rows in front of the destination. Both halves of the label are clipped to a fixed width
+and escaped the same way, and the destination's own budget is what is left of the screen
+once the label has been paid for — a ceiling on the part charter was looking at, rather
+than on the line it prints, is a ceiling the other part is free to walk past.
+
+(A persona name cannot reach that line hostile in the first place: `personas/` entries are
+held to `[a-z0-9][a-z0-9._-]*`. It goes through the same escape anyway — charter joins its
+guards rather than choosing between them — and the clip is not belt-and-braces at all,
+since that alphabet bounds the characters and not the length.)
 
 An entry charter cannot show in full cannot be approved at all and is reported as withheld.
 Two ways to get there: it names no destination (no `command`, no `args`, no `url` — a part

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -124,7 +124,7 @@ may have *these* keys from *that* vault:
 
 ```bash
 charter persona sync-agents               # writes the agents; names anything unapproved
-charter persona sync-agents --approve-mcp # after reading the command it printed
+charter persona sync-agents --approve-mcp # asks about each one, after showing it
 ```
 
 Until then the server is still declared in the generated agent — unchanged, minus the
@@ -132,11 +132,27 @@ vault wrapper — so the persona keeps working and the server fails at authentic
 than silently running with a credential nobody sanctioned. `sync-agents` prints the exact
 command it withheld from, which is the thing worth looking at.
 
-The approval covers the vault, the command, its args and the `secrets`/`secret_files`
-mappings together. **Change any of them and it lapses**, because the approval is of a
-command and not of a server name — a teammate re-pointing an existing server at a new
-binary is the case this exists for. The record is machine-local under `.charter/`: if it
-travelled in git, the same commit that declares a server could declare it approved.
+`--approve-mcp` asks **per server**, and prints the entry before it asks:
+
+```
+  reddit/acme → http https://api.acme.example/mcp  (env: HTTPS_PROXY)
+    approve reddit/acme? [y/N]
+```
+
+Anything but an explicit yes withholds, and declining a server that was approved before
+revokes it. `--dry-run` shows the same lines and records nothing. `--yes` approves every
+credentialed server without asking, and is **required** off a terminal — a flag that means
+yes where nobody can be asked is not consent.
+
+The approval covers the **whole entry**, against the vault: command, args, `url`, `env`,
+the `secrets`/`secret_files` mappings, and any other key the entry carries. **Change any of
+them and it lapses**, because the approval is of a destination and not of a server name — a
+teammate re-pointing an existing server at a new binary, a new endpoint or a new `PATH` is
+the case this exists for. An entry that names neither a `command` nor a `url` has no
+destination to show, so it cannot be approved at all; it is reported as withheld.
+
+The record is machine-local under `.charter/`: if it travelled in git, the same commit that
+declares a server could declare it approved.
 
 There is deliberately no allowlist of permitted commands. An MCP `command` is an arbitrary
 binary followed by arbitrary args, so any list containing the launchers real servers use

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -148,8 +148,15 @@ The approval covers the **whole entry**, against the vault: command, args, `url`
 the `secrets`/`secret_files` mappings, and any other key the entry carries. **Change any of
 them and it lapses**, because the approval is of a destination and not of a server name — a
 teammate re-pointing an existing server at a new binary, a new endpoint or a new `PATH` is
-the case this exists for. An entry that names neither a `command` nor a `url` has no
-destination to show, so it cannot be approved at all; it is reported as withheld.
+the case this exists for.
+
+The printed line names every part of that destination, and **no part can push another one
+off it**. Each part — the command, each arg, the `url`, each `env` key — gets its own
+budget and is clipped on its own with the cut announced, so padding `args` in a committed
+file cannot scroll the `env` or the endpoint out of view. An entry charter cannot show in
+full cannot be approved at all and is reported as withheld: one that names no destination
+(no `command`, no `args`, no `url` — whitespace does not count as naming something), and
+one with so many parts that even their clipped forms would not fit on a line anybody reads.
 
 The record is machine-local under `.charter/`: if it travelled in git, the same commit that
 declares a server could declare it approved.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -135,7 +135,7 @@ command it withheld from, which is the thing worth looking at.
 `--approve-mcp` asks **per server**, and prints the entry before it asks:
 
 ```
-  reddit/acme → http https://api.acme.example/mcp  (env: HTTPS_PROXY)  (vault: ACME_TOKEN=acme-token)
+  reddit/acme → type "http"  url "https://api.acme.example/mcp"  env "HTTPS_PROXY"="http://p.example:3128"  secrets "ACME_TOKEN"="acme-token"  vault "reddit"
     approve reddit/acme? [y/N]
 ```
 
@@ -144,27 +144,38 @@ revokes it. `--dry-run` shows the same lines and records nothing. `--yes` approv
 credentialed server without asking, and is **required** off a terminal — a flag that means
 yes where nobody can be asked is not consent.
 
-The approval covers the **whole entry**, against the vault: command, args, `url`, `env`,
-the `secrets`/`secret_files` mappings, and any other key the entry carries. **Change any of
-them and it lapses**, because the approval is of a destination and not of a server name — a
-teammate re-pointing an existing server at a new binary, a new endpoint or a new `PATH` is
-the case this exists for.
+**What is recorded is the line itself.** The fingerprint is the SHA-256 of the text
+printed above the question and nothing else is mixed into it, which makes two properties
+true at once and by construction: two entries that print the same line share one approval,
+and an entry that prints a different line lapses it. There is no second, shorter summary
+that can fall out of step with what you read — three earlier rounds of this feature each
+had one, and every bypass since has been one field that was in the digest and not on the
+line, which meant being re-asked under a line byte-identical to the one already approved.
 
-The printed line names every part of that destination, and **no part can push another one
-off it**. Each part — the command, each arg, the `url`, each `env` key, each vault key —
-gets its own budget and is clipped on its own with the cut announced, so padding `args` in
-a committed file cannot scroll the `env` or the endpoint out of view.
+That puts the weight on the line holding **everything**. It does. The renderer loops over
+the entry's keys rather than over a list of fields charter knows, so:
+
+* `command` and `args` print after `run`, one word per word — quoted when a word is empty
+  or contains a space, so where the words split is never in doubt;
+* `type`, `url`, `env`, `secrets` and `secret_files` print under their own names;
+* **`env` prints its values, not only its keys.** The value is the half that decides:
+  `PATH` chooses which binary `execvpe` finds, `NODE_OPTIONS` chooses what it loads. An
+  `env` value is committed plaintext out of `mcp.json` — not a vault value — so printing it
+  discloses nothing that reading the repo would not;
+* **the vault is named**, because `vault:` is a key of the committed `persona.md` and a
+  one-line commit there re-points which credential is spent;
+* **any key charter has never been taught** — `cwd`, `headers`, whatever comes next —
+  prints under its own quoted name with its JSON value, because `sync-agents` passes every
+  key it does not consume through to the harness.
+
+Charter's own words are printed bare and everything committed is printed between quotes,
+so a committed value cannot dress itself up as part of charter's sentence.
 
 **Which credential, and not only which command.** `secrets` and `secret_files` map an
-environment variable to a *vault key*, and that key decides which of the vault's values
-the command receives — so both are on the line as `VAR=key`, in the shape the `secret exec`
-argv is built from. They are in the digest too, so editing one lapses the approval and you
-are asked again; before they were shown, that second question arrived under a line
-identical to the one you had already approved, which is a second chance to make the same
-mistake rather than a chance to catch it. The rule the suffixes are instances of:
-everything the digest covers that changes what the vault hands over, or where it lands, is
-on the line. (Key *names*, never values — a value lives in the vault and never enters the
-process that prints this.)
+environment variable to a *vault key*, and that key decides which of the vault's values the
+command receives — so both are on the line as `"VAR"="key"`, in the shape the `secret exec`
+argv is built from. The credential's **value** is the one thing that is not on the line and
+cannot be: it is not in the entry, and the process that prints this never opens a vault.
 
 **The line is printable ASCII, and everything else is spelled out as `\uXXXX`.** Not
 "unprintable characters are escaped" — every codepoint outside `U+0020..U+007E` is,
@@ -180,14 +191,20 @@ where the ASCII space is the only character left that shows nothing.
 Read that claim precisely, because it is the kind of sentence this section has already had
 to withdraw twice: *everything on the row that came out of a committed file* is printable
 ASCII. The `•` and the `→` around it are charter's own punctuation, put there by charter
-and not by anyone's `mcp.json` — including the `...` that marks a clip, which is ASCII for
-exactly this reason. The test derives that set from a benign run rather than listing it.
+and not by anyone's `mcp.json`. The test derives that set from a benign run rather than
+listing it, with colour pinned off so the derivation cannot quietly absorb an escape
+sequence the environment happened to add.
 
-The escaping is one-to-one, which is the part that makes reading the line worth anything:
-astral codepoints use the eight-digit `\UXXXXXXXX` form (`\u1f600` is five hex digits and
-would also spell `U+1F60` followed by `0`), and a literal backslash is doubled, so every
-`\uXXXX` you see is a codepoint that was really there rather than six ASCII characters
-imitating one. A Windows path therefore shows as `C:\\Users\\x`.
+The escaping is **reversible**, which is the part that makes reading the line worth
+anything — and, now that the fingerprint is taken over the line, the part that makes the
+approval mean the entry. Astral codepoints use the eight-digit `\UXXXXXXXX` form
+(`\u1f600` is five hex digits and would also spell `U+1F60` followed by `0`); a literal
+backslash is doubled and a literal quote is `\"`, so every `\uXXXX` you see is a codepoint
+that was really there rather than six ASCII characters imitating one, and an unescaped
+quote is always charter's own delimiter. A Windows path therefore shows as `C:\\Users\\x`.
+Nothing is collapsed, stripped or shortened on the way: a run of spaces prints as a run of
+spaces and costs the columns it occupies, because a part that got tidied away is a part you
+did not consent to.
 
 That covers the **whole** line, including the `persona/server` label in front of the
 arrow — the half that had gone to the terminal untouched while the destination beside it
@@ -207,11 +224,19 @@ since that alphabet bounds the characters and not the length.)
 
 An entry charter cannot show in full cannot be approved at all and is reported as withheld.
 Two ways to get there: it names no destination (no `command`, no `args`, no `url` — a part
-that renders as nothing does not count as naming something), or it has so many parts that
-even their clipped forms **would not fit on one screen**. That ceiling is a screen and not
-a byte count on purpose: you answer the prompt printed *under* the line, so a line taller
-than the terminal has already scrolled the command it names off the top before the question
-reaches you.
+that renders as nothing does not count as naming something), or its full rendering **would
+not fit on one screen**. That ceiling is a screen and not a byte count on purpose: you
+answer the prompt printed *under* the line, so a line taller than the terminal has already
+scrolled the command it names off the top before the question reaches you. Nothing is ever
+trimmed to fit it — an earlier round clipped each part at two hundred characters and
+announced the cut, which bounded the line but let two different `args` print the same tail.
+Complete, or refused.
+
+**The scope, said plainly.** This is a guard against a *commit* — a file changing under an
+approval you already gave — answered by a person reading one line. It is not a guard
+against someone who can already run code as you: they can edit the approval record, the
+harness, or charter itself. `SECURITY.md` states charter's boundary and nothing on this
+page exceeds it.
 
 The record is machine-local under `.charter/`: if it travelled in git, the same commit that
 declares a server could declare it approved.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -153,10 +153,32 @@ the case this exists for.
 The printed line names every part of that destination, and **no part can push another one
 off it**. Each part — the command, each arg, the `url`, each `env` key — gets its own
 budget and is clipped on its own with the cut announced, so padding `args` in a committed
-file cannot scroll the `env` or the endpoint out of view. An entry charter cannot show in
-full cannot be approved at all and is reported as withheld: one that names no destination
-(no `command`, no `args`, no `url` — whitespace does not count as naming something), and
-one with so many parts that even their clipped forms would not fit on a line anybody reads.
+file cannot scroll the `env` or the endpoint out of view.
+
+**The line is printable ASCII, and everything else is spelled out as `\uXXXX`.** Not
+"unprintable characters are escaped" — every codepoint outside `U+0020..U+007E` is,
+whatever its category. A committed `args` can otherwise carry a `\r` that repaints the
+line, a bidi override that reverses it, a combining mark that repaints the rows around it,
+a U+3164 HANGUL FILLER that is printable and renders as nothing, or a Cyrillic `а` that
+makes `api.асme.example` indistinguishable from `api.acme.example` on the one line the
+decision rests on. MCP commands, args, urls and env keys are ASCII in practice, so
+anything else here is a reason to *show the escape* rather than the glyph. Escaping is
+also what makes "renders as nothing" answerable: charter decides it on the escaped line,
+where the ASCII space is the only character left that shows nothing.
+
+The escaping is one-to-one, which is the part that makes reading the line worth anything:
+astral codepoints use the eight-digit `\UXXXXXXXX` form (`\u1f600` is five hex digits and
+would also spell `U+1F60` followed by `0`), and a literal backslash is doubled, so every
+`\uXXXX` you see is a codepoint that was really there rather than six ASCII characters
+imitating one. A Windows path therefore shows as `C:\\Users\\x`.
+
+An entry charter cannot show in full cannot be approved at all and is reported as withheld.
+Two ways to get there: it names no destination (no `command`, no `args`, no `url` — a part
+that renders as nothing does not count as naming something), or it has so many parts that
+even their clipped forms **would not fit on one screen**. That ceiling is a screen and not
+a byte count on purpose: you answer the prompt printed *under* the line, so a line taller
+than the terminal has already scrolled the command it names off the top before the question
+reaches you.
 
 The record is machine-local under `.charter/`: if it travelled in git, the same commit that
 declares a server could declare it approved.

--- a/docs/news/unreleased-an-mcp-approval-covers-the-whole-entry.md
+++ b/docs/news/unreleased-an-mcp-approval-covers-the-whole-entry.md
@@ -48,7 +48,7 @@ the `env` keys it used to push off — here is the tail of one whose `--config` 
 characters:
 
 ```
-  … (+443 more chars)  [stdio https://evil.example/mcp]  (env: NODE_OPTIONS, PATH)
+  ... (+443 more chars)  [stdio https://evil.example/mcp]  (env: NODE_OPTIONS, PATH)
 ```
 
 **The consent line is printable ASCII, and everything else is spelled out.** The first two
@@ -67,6 +67,11 @@ and any plane, is shown as `\uXXXX`:
   reddit/acme   → http https://api.\u0430\u0441me.example/mcp
 ```
 
+Precisely: *everything on that row which came out of a committed file* is printable
+ASCII. The `•` and the `→` around it are charter's own punctuation — as is the `...` that
+marks a clip, which is ASCII rather than `…` for exactly this reason, so the claim needs
+no footnote and its test needs no hole cut in it.
+
 That closes three shapes at once. Blankness becomes decidable rather than enumerable,
 because on the escaped line the ASCII space is the only character left that shows nothing.
 A combining mark can no longer repaint the rows around the line. And a homoglyph re-point
@@ -79,6 +84,33 @@ eight-digit `\UXXXXXXXX` form, since `\u1f600` is five hex digits and would equa
 `U+1F60` followed by `0`, and a literal backslash is doubled, so a committed `command`
 holding the six ASCII characters `\u3164` cannot imitate one holding U+3164. Windows paths
 show as `C:\\Users\\x`.
+
+And it covers the whole line, not the destination half of it. The `persona/server` label
+printed in front of the arrow had gone to the terminal untouched while the destination
+beside it was hardened three times over — which is this fix's own lesson arriving at its
+own expense. A server name is a key of a committed `mcp.json`: an arbitrary string, of
+arbitrary length, in any script. Three fillers printed as `reddit/ → uvx`; an ANSI erase
+wiped charter's own words standing beside it; a hundred thousand characters put twelve
+hundred rows in front of the destination while the line's own ceiling was satisfied,
+because the function that enforced it never saw the name.
+
+Both halves of the label are now escaped and clipped to a fixed width, and the
+destination's ceiling is what is left of the screen once the label is paid for. A ceiling
+on the part you were looking at, rather than on the line you print, is a ceiling the other
+part walks past. (A persona name cannot be hostile to begin with — `personas/` entries are
+held to `[a-z0-9][a-z0-9._-]*` — but that alphabet bounds the characters and not the
+length, and it goes through the same escape regardless, because charter joins its guards
+rather than choosing between them.)
+
+**And the line says which credential, not only which command.** `secrets` and
+`secret_files` map an environment variable to a *vault key*, and that key is what decides
+which of the vault's values the command receives. They were in the digest and not on the
+line, so editing `{"REDDIT_CLIENT_ID": "client-id"}` to `{"REDDIT_CLIENT_ID": "aws-root-key"}`
+lapsed the approval, asked you again, and asked under a line byte-for-byte identical to the
+one you had already approved — the same shape as the homoglyph above, in the field that
+chooses the credential rather than the destination. Both now print as `VAR=key`, the shape
+the `secret exec` argv is built from. Key names only; a value lives in the vault and never
+enters the process that prints this line.
 
 **And the line has to fit on a screen.** The ceiling on the whole line used to be 2000
 characters — twenty-five rows of an 80-column terminal. Nine args of 200 invisible columns
@@ -96,7 +128,7 @@ server of every persona and printed what it had approved *afterwards*. It now pr
 server and asks about it, one at a time, before recording anything:
 
 ```
-  reddit/acme → http https://api.acme.example/mcp  (env: HTTPS_PROXY)
+  reddit/acme → http https://api.acme.example/mcp  (env: HTTPS_PROXY)  (vault: ACME_TOKEN=acme-token)
     approve reddit/acme? [y/N]
 ```
 

--- a/docs/news/unreleased-an-mcp-approval-covers-the-whole-entry.md
+++ b/docs/news/unreleased-an-mcp-approval-covers-the-whole-entry.md
@@ -1,14 +1,26 @@
 ---
 version: unreleased
-headline: An MCP approval covers the whole entry, and is now asked rather than assumed
+headline: An MCP approval is a digest of the line you read, and is now asked rather than assumed
 adopt: persona sync-agents --approve-mcp
 ---
 
 `charter persona sync-agents --approve-mcp` is the consent that lets a committed `mcp.json`
 hand a persona's vault value to the command it names. Three findings from the 2026-08-24
-audit each hollowed it out from a different side, and two rounds of review then found the
-same class of hole in the fixes themselves. All of it is fixed, and **every existing
+audit each hollowed it out from a different side, and four rounds of review then found the
+same class of hole in the fixes themselves — every round closed the instance it was shown,
+and every round an attacker found the next one. All of it is fixed, and **every existing
 approval lapses** — see the last section.
+
+**The record is now the line you read, and nothing else.** Rounds one to three kept two
+representations of the entry: a digest over all of it, and a printed line built from a list
+of seven fields. Every bypass since was one field that lived in the first and not the
+second — the persona's vault, `env` VALUES, `cwd`, a clipped tail — so the approval
+correctly lapsed, you were correctly asked again, and the line you were asked under was
+byte-identical to the one you had already approved. That is not consent; it is a second
+chance to make the same mistake. The fingerprint is now the SHA-256 of the printed line, so
+*two entries that print the same line share one approval* holds by construction, and the
+whole question becomes whether the line holds everything — which is now decided by a loop
+over the entry's keys instead of by a list of fields.
 
 **The digest covered five fields, so `env` was outside consent.** `fingerprint` hashed
 `vault`, `command`, `args`, `secrets` and `secret_files`, and its docstring claimed *"every
@@ -23,15 +35,16 @@ add this to an **already-approved** server and change nothing about the digest:
 `PATH` decides which binary `execvpe` finds; `NODE_OPTIONS` decides what it loads. The
 approval stayed valid and `charter persona lint` still said `✓ ok`. The fix is not "add
 `env`" — that is the same bug one field further out, which is exactly how this arrived one
-field past #330. The digest now covers the **entire entry**, recursively, so a key charter
-has not been taught about yet cannot fall outside it. Key order still does not matter; a
-re-serialised file will not nag you.
+field past #330. Consent now covers the **entire entry**: every key of it is printed on the
+line, and the line is what is hashed, so a key charter has not been taught about yet cannot
+fall outside either. Key order still does not matter; a re-serialised file will not nag
+you.
 
 **An `http` server's consent line was blank.** The line was built from `command` + `args`,
 and an `http`/`sse` entry has neither — so `sync-agents` printed an empty string under the
 words *"Read the command above."* The `url` was not in the digest either, which means two
-different endpoints shared one approval. Both are now covered: the line falls back to the
-URL, shows the `env` keys, and escapes anything outside printable ASCII (see below),
+different endpoints shared one approval. Both are now covered: the line names the `url` and
+the `type`, and escapes anything outside printable ASCII (see below),
 because a `\r` or a bidi override in a committed `args` can otherwise repaint the one line
 the whole decision rests on. An entry charter cannot render cannot be **approved** either —
 it is reported as withheld instead of silently approved blank.
@@ -42,14 +55,15 @@ front. That was true only of `command`. Both the `[type url]` and the `(env: …
 appended *after* `args`, so roughly 600 characters of plausible-looking `args` in a
 committed file produced a consent line naming neither the `PATH` it re-pointed nor the
 endpoint it connected to — while the entry the operator approved carried both through to
-`execvpe`. Every part now has its own budget and is clipped on its own, with the cut
-announced. `args` can be a megabyte long and the line still *ends* with the endpoint and
-the `env` keys it used to push off — here is the tail of one whose `--config` value is 643
-characters:
+`execvpe`. The second cut gave each part its own 200-character budget and announced the
+cut, which bounded the line but was not one-to-one: two `--config` payloads agreeing on
+their first 200 characters and equal in length printed the same text and the same
+`(+N more chars)` count.
 
-```
-  ... (+443 more chars)  [stdio https://evil.example/mcp]  (env: NODE_OPTIONS, PATH)
-```
+So nothing is shortened at all any more. The line is **complete or there is no line** — an
+entry whose full rendering does not fit on the screen the question is asked on is refused
+and reported as withheld, exactly as an unrenderable one always was. A padded part cannot
+shorten another part, because no part is ever shortened.
 
 **The consent line is printable ASCII, and everything else is spelled out.** The first two
 attempts at this guard matched something narrower and were walked past by the same attack
@@ -63,14 +77,16 @@ There is no list of codepoints that ends, so the rule is now the complement — 
 and any plane, is shown as `\uXXXX`:
 
 ```
-  reddit/reddit → \u3164\u3164\u3164
-  reddit/acme   → http https://api.\u0430\u0441me.example/mcp
+  reddit/reddit → run \u3164\u3164\u3164  type "stdio"  secrets "ACME_TOKEN"="acme-token"  vault "reddit"
+  reddit/acme   → type "http"  url "https://api.\u0430\u0441me.example/mcp"  …
 ```
 
 Precisely: *everything on that row which came out of a committed file* is printable
-ASCII. The `•` and the `→` around it are charter's own punctuation — as is the `...` that
-marks a clip, which is ASCII rather than `…` for exactly this reason, so the claim needs
-no footnote and its test needs no hole cut in it.
+ASCII. The `•` and the `→` around it are charter's own punctuation. (The test that pins
+this derives charter's own glyphs from a benign run — with colour pinned off, because
+`util` decides colour at import time from `stderr.isatty()`, and running the suite from a
+terminal used to fold charter's own escape sequences into the derived set and make the
+assertion unfailable for exactly the class it exists to catch.)
 
 That closes three shapes at once. Blankness becomes decidable rather than enumerable,
 because on the escaped line the ASCII space is the only character left that shows nothing.
@@ -79,11 +95,14 @@ becomes *readable*: `api.асme.example` already lapsed the approval and re-aske
 url is in the digest — but the old line was pixel-identical to `api.acme.example`, so
 being asked again told you nothing.
 
-The escape is one-to-one, or it would just move the problem: astral codepoints use the
+The escape is **reversible**, or it would just move the problem: astral codepoints use the
 eight-digit `\UXXXXXXXX` form, since `\u1f600` is five hex digits and would equally spell
-`U+1F60` followed by `0`, and a literal backslash is doubled, so a committed `command`
-holding the six ASCII characters `\u3164` cannot imitate one holding U+3164. Windows paths
-show as `C:\\Users\\x`.
+`U+1F60` followed by `0`; a literal backslash is doubled and a literal quote becomes `\"`,
+so a committed `command` holding the six ASCII characters `\u3164` cannot imitate one
+holding U+3164, and an unescaped quote is always charter's own delimiter. Windows paths
+show as `C:\\Users\\x`. Nothing is collapsed or stripped either: an earlier round tidied
+runs of ASCII spaces out of every part, so `"   --evil"` printed as `--evil` — a line that
+no longer said what would run.
 
 And it covers the whole line, not the destination half of it. The `persona/server` label
 printed in front of the arrow had gone to the terminal untouched while the destination
@@ -108,9 +127,28 @@ which of the vault's values the command receives. They were in the digest and no
 line, so editing `{"REDDIT_CLIENT_ID": "client-id"}` to `{"REDDIT_CLIENT_ID": "aws-root-key"}`
 lapsed the approval, asked you again, and asked under a line byte-for-byte identical to the
 one you had already approved — the same shape as the homoglyph above, in the field that
-chooses the credential rather than the destination. Both now print as `VAR=key`, the shape
-the `secret exec` argv is built from. Key names only; a value lives in the vault and never
-enters the process that prints this line.
+chooses the credential rather than the destination. Both now print as `"VAR"="key"`, the
+shape the `secret exec` argv is built from. The credential's **value** is the one thing not
+on the line and it cannot be: it is not in the entry, and the process that prints this
+never opens a vault.
+
+**And which vault, whose env, and every key charter has never been taught.** Three more of
+the same shape, closed together rather than one at a time. `vault:` is a key of the
+committed `persona.md`, so a one-line commit re-points which credential is spent — it was
+digested from the first commit and printed by none, so even the *first* prompt could not
+say whose credential was at stake, while the line printed charter's own word `(vault: …)`
+in front of the variable name. `env` printed its KEYS while the VALUE is the half that
+decides — `PATH` chooses which binary `execvpe` finds. And a key charter does not read at
+all (`cwd`, `headers`, whatever comes next) was passed through to the harness and never
+shown. All three are on the line now, and the last of them because the renderer loops over
+the entry's keys rather than over a list of fields:
+
+```
+  reddit/reddit → run uvx some-reddit-mcp  type "stdio"  env "PATH"="/usr/bin"  secrets "REDDIT_CLIENT_ID"="client-id"  "cwd" "/home/me/proj"  vault "reddit"
+```
+
+Charter's own words print bare and everything committed prints between quotes, so a
+committed value cannot dress itself up as part of charter's sentence.
 
 **And the line has to fit on a screen.** The ceiling on the whole line used to be 2000
 characters — twenty-five rows of an 80-column terminal. Nine args of 200 invisible columns
@@ -128,7 +166,7 @@ server of every persona and printed what it had approved *afterwards*. It now pr
 server and asks about it, one at a time, before recording anything:
 
 ```
-  reddit/acme → http https://api.acme.example/mcp  (env: HTTPS_PROXY)  (vault: ACME_TOKEN=acme-token)
+  reddit/acme → type "http"  url "https://api.acme.example/mcp"  env "HTTPS_PROXY"="http://p.example:3128"  secrets "ACME_TOKEN"="acme-token"  vault "reddit"
     approve reddit/acme? [y/N]
 ```
 
@@ -146,4 +184,10 @@ Nothing breaks loudly — that is the withholding design, and it is the failure 
 want — but a server will fail to authenticate rather than start, and `sync-agents` will name
 each one it withheld from. Run `charter persona sync-agents --approve-mcp`, read the lines,
 and answer. You are re-reading commands you already read once; the difference is that this
-time the answer covers where the credential goes, not five fields of it.
+time what gets recorded is a digest of the line in front of you.
+
+**And the scope, said plainly**, because a local page promising more than `SECURITY.md`
+does is itself a defect. This is a guard against a *commit* — a committed file changing
+under an approval you already gave — answered by a person reading one line. It is not a
+guard against someone who can already run code as you: they can edit the approval record,
+the harness, or charter itself.

--- a/docs/news/unreleased-an-mcp-approval-covers-the-whole-entry.md
+++ b/docs/news/unreleased-an-mcp-approval-covers-the-whole-entry.md
@@ -32,8 +32,27 @@ words *"Read the command above."* The `url` was not in the digest either, which 
 different endpoints shared one approval. Both are now covered: the line falls back to the
 URL, shows the `env` keys, and escapes anything unprintable, because a `\r` or a bidi
 override in a committed `args` can otherwise repaint the one line the whole decision rests
-on. An entry that names neither a command nor a URL cannot be rendered, and is therefore
-**not approvable** at all — it is reported as withheld instead of silently approved blank.
+on. An entry charter cannot render cannot be **approved** either — it is reported as
+withheld instead of silently approved blank.
+
+**And nothing on that line can push anything else off it.** The first cut at this clipped
+the finished line at 600 characters, on the reasoning that the destination sits at the
+front. That was true only of `command`. Both the `[type url]` and the `(env: …)` parts are
+appended *after* `args`, so roughly 600 characters of plausible-looking `args` in a
+committed file produced a consent line naming neither the `PATH` it re-pointed nor the
+endpoint it connected to — while the entry the operator approved carried both through to
+`execvpe`. Every part now has its own budget and is clipped on its own, with the cut
+announced, so `args` can be a megabyte long and the line still ends:
+
+```
+  uvx --config {aaaaaaaa… (+442 more chars)  [http https://evil.example/mcp]  (env: NODE_OPTIONS, PATH)
+```
+
+Two more shapes of the same trick close with it. Whitespace no longer counts as naming
+something — a `command` of three spaces used to render a line that was blank to the reader
+and truthy to charter, which is exactly the blank approval this section says is impossible.
+And an entry with so many parts that even their clipped forms overflow is refused rather
+than cut in half: charter will not decide which half of a destination you get to read.
 
 **`--approve-mcp` was its own answer.** One non-interactive call approved every credentialed
 server of every persona and printed what it had approved *afterwards*. It now prints each
@@ -48,7 +67,9 @@ Anything but an explicit yes — including EOF — withholds, and declining a se
 approved before **revokes** it. Two new flags: `--dry-run` prints the same lines and records
 nothing, and `--yes` keeps the old unattended shape for scripts. Off a terminal, `--yes` is
 now **required**: a flag that silently means yes where nobody can be asked is the finding
-restored.
+restored. The refusal you get off a terminal does not name `--yes` — `--help` does. A
+refusal that prints the flag defeating it is #421's shape, and the reader of that line is
+as often an agent as a person.
 
 **What to do after upgrading.** The digest changed, so every fingerprint recorded on this
 machine is stale and every credentialed MCP server is withheld until you approve it again.

--- a/docs/news/unreleased-an-mcp-approval-covers-the-whole-entry.md
+++ b/docs/news/unreleased-an-mcp-approval-covers-the-whole-entry.md
@@ -1,0 +1,59 @@
+---
+version: unreleased
+headline: An MCP approval covers the whole entry, and is now asked rather than assumed
+adopt: persona sync-agents --approve-mcp
+---
+
+`charter persona sync-agents --approve-mcp` is the consent that lets a committed `mcp.json`
+hand a persona's vault value to the command it names. Three findings from the 2026-08-24
+audit each hollowed it out from a different side. All three are fixed, and **every existing
+approval lapses** — see the last section.
+
+**The digest covered five fields, so `env` was outside consent.** `fingerprint` hashed
+`vault`, `command`, `args`, `secrets` and `secret_files`, and its docstring claimed *"every
+field that decides where the value goes is in here."* It was not. `mcp_render_entry` keeps
+every key it does not consume and writes it into the generated agent file, so a commit could
+add this to an **already-approved** server and change nothing about the digest:
+
+```json
+"env": {"PATH": "/tmp/attacker-bin", "NODE_OPTIONS": "--require /tmp/x.js"}
+```
+
+`PATH` decides which binary `execvpe` finds; `NODE_OPTIONS` decides what it loads. The
+approval stayed valid and `charter persona lint` still said `✓ ok`. The fix is not "add
+`env`" — that is the same bug one field further out, which is exactly how this arrived one
+field past #330. The digest now covers the **entire entry**, recursively, so a key charter
+has not been taught about yet cannot fall outside it. Key order still does not matter; a
+re-serialised file will not nag you.
+
+**An `http` server's consent line was blank.** The line was built from `command` + `args`,
+and an `http`/`sse` entry has neither — so `sync-agents` printed an empty string under the
+words *"Read the command above."* The `url` was not in the digest either, which means two
+different endpoints shared one approval. Both are now covered: the line falls back to the
+URL, shows the `env` keys, and escapes anything unprintable, because a `\r` or a bidi
+override in a committed `args` can otherwise repaint the one line the whole decision rests
+on. An entry that names neither a command nor a URL cannot be rendered, and is therefore
+**not approvable** at all — it is reported as withheld instead of silently approved blank.
+
+**`--approve-mcp` was its own answer.** One non-interactive call approved every credentialed
+server of every persona and printed what it had approved *afterwards*. It now prints each
+server and asks about it, one at a time, before recording anything:
+
+```
+  reddit/acme → http https://api.acme.example/mcp  (env: HTTPS_PROXY)
+    approve reddit/acme? [y/N]
+```
+
+Anything but an explicit yes — including EOF — withholds, and declining a server that was
+approved before **revokes** it. Two new flags: `--dry-run` prints the same lines and records
+nothing, and `--yes` keeps the old unattended shape for scripts. Off a terminal, `--yes` is
+now **required**: a flag that silently means yes where nobody can be asked is the finding
+restored.
+
+**What to do after upgrading.** The digest changed, so every fingerprint recorded on this
+machine is stale and every credentialed MCP server is withheld until you approve it again.
+Nothing breaks loudly — that is the withholding design, and it is the failure direction you
+want — but a server will fail to authenticate rather than start, and `sync-agents` will name
+each one it withheld from. Run `charter persona sync-agents --approve-mcp`, read the lines,
+and answer. You are re-reading commands you already read once; the difference is that this
+time the answer covers where the credential goes, not five fields of it.

--- a/docs/news/unreleased-an-mcp-approval-covers-the-whole-entry.md
+++ b/docs/news/unreleased-an-mcp-approval-covers-the-whole-entry.md
@@ -6,7 +6,8 @@ adopt: persona sync-agents --approve-mcp
 
 `charter persona sync-agents --approve-mcp` is the consent that lets a committed `mcp.json`
 hand a persona's vault value to the command it names. Three findings from the 2026-08-24
-audit each hollowed it out from a different side. All three are fixed, and **every existing
+audit each hollowed it out from a different side, and two rounds of review then found the
+same class of hole in the fixes themselves. All of it is fixed, and **every existing
 approval lapses** — see the last section.
 
 **The digest covered five fields, so `env` was outside consent.** `fingerprint` hashed
@@ -30,10 +31,10 @@ re-serialised file will not nag you.
 and an `http`/`sse` entry has neither — so `sync-agents` printed an empty string under the
 words *"Read the command above."* The `url` was not in the digest either, which means two
 different endpoints shared one approval. Both are now covered: the line falls back to the
-URL, shows the `env` keys, and escapes anything unprintable, because a `\r` or a bidi
-override in a committed `args` can otherwise repaint the one line the whole decision rests
-on. An entry charter cannot render cannot be **approved** either — it is reported as
-withheld instead of silently approved blank.
+URL, shows the `env` keys, and escapes anything outside printable ASCII (see below),
+because a `\r` or a bidi override in a committed `args` can otherwise repaint the one line
+the whole decision rests on. An entry charter cannot render cannot be **approved** either —
+it is reported as withheld instead of silently approved blank.
 
 **And nothing on that line can push anything else off it.** The first cut at this clipped
 the finished line at 600 characters, on the reasoning that the destination sits at the
@@ -42,17 +43,53 @@ appended *after* `args`, so roughly 600 characters of plausible-looking `args` i
 committed file produced a consent line naming neither the `PATH` it re-pointed nor the
 endpoint it connected to — while the entry the operator approved carried both through to
 `execvpe`. Every part now has its own budget and is clipped on its own, with the cut
-announced, so `args` can be a megabyte long and the line still ends:
+announced. `args` can be a megabyte long and the line still *ends* with the endpoint and
+the `env` keys it used to push off — here is the tail of one whose `--config` value is 643
+characters:
 
 ```
-  uvx --config {aaaaaaaa… (+442 more chars)  [http https://evil.example/mcp]  (env: NODE_OPTIONS, PATH)
+  … (+443 more chars)  [stdio https://evil.example/mcp]  (env: NODE_OPTIONS, PATH)
 ```
 
-Two more shapes of the same trick close with it. Whitespace no longer counts as naming
-something — a `command` of three spaces used to render a line that was blank to the reader
-and truthy to charter, which is exactly the blank approval this section says is impossible.
-And an entry with so many parts that even their clipped forms overflow is refused rather
-than cut in half: charter will not decide which half of a destination you get to read.
+**The consent line is printable ASCII, and everything else is spelled out.** The first two
+attempts at this guard matched something narrower and were walked past by the same attack
+in a new spelling each time. One escaped only what `str.isprintable` rejects and stripped
+runs of the ASCII space — which leaves U+3164 HANGUL FILLER, U+2800 BRAILLE PATTERN BLANK
+and U+115F/U+1160 straight through: all printable, none whitespace, all `strip`-proof, all
+blank on every terminal. A `command` of three of them rendered a line blank to the reader
+and truthy to charter, restoring the very blank approval this section calls impossible.
+There is no list of codepoints that ends, so the rule is now the complement — `U+0020` to
+`U+007E` is what a consent line may contain, and every other codepoint, in any category
+and any plane, is shown as `\uXXXX`:
+
+```
+  reddit/reddit → \u3164\u3164\u3164
+  reddit/acme   → http https://api.\u0430\u0441me.example/mcp
+```
+
+That closes three shapes at once. Blankness becomes decidable rather than enumerable,
+because on the escaped line the ASCII space is the only character left that shows nothing.
+A combining mark can no longer repaint the rows around the line. And a homoglyph re-point
+becomes *readable*: `api.асme.example` already lapsed the approval and re-asked you — the
+url is in the digest — but the old line was pixel-identical to `api.acme.example`, so
+being asked again told you nothing.
+
+The escape is one-to-one, or it would just move the problem: astral codepoints use the
+eight-digit `\UXXXXXXXX` form, since `\u1f600` is five hex digits and would equally spell
+`U+1F60` followed by `0`, and a literal backslash is doubled, so a committed `command`
+holding the six ASCII characters `\u3164` cannot imitate one holding U+3164. Windows paths
+show as `C:\\Users\\x`.
+
+**And the line has to fit on a screen.** The ceiling on the whole line used to be 2000
+characters — twenty-five rows of an 80-column terminal. Nine args of 200 invisible columns
+each fit under it as one 1837-character line: you saw `uvx evil-server`, twenty-two blank
+rows, then `(env: PATH)`, and by the time the prompt was printed the command had scrolled
+off the top. Escaping makes that padding visible, which is necessary and not sufficient —
+visible padding scrolls a line just as far. The ceiling is now the screen the question is
+asked on, ten rows of eighty columns, and an entry that overflows it is refused rather than
+cut in half: charter will not decide which half of a destination you get to read. Real
+entries are nowhere near it; a `docker run` server with three `env` keys is under 250
+characters.
 
 **`--approve-mcp` was its own answer.** One non-interactive call approved every credentialed
 server of every persona and printed what it had approved *afterwards*. It now prints each

--- a/tests/test_committed_config_and_credentials.py
+++ b/tests/test_committed_config_and_credentials.py
@@ -405,7 +405,12 @@ class SyncAgentsReportsWhatItWithheld(PersonaIso):
 
         from charter import commands_persona
         buf = io.StringIO()
-        args = SimpleNamespace(persona=None, approve_mcp=approve_mcp)
+        # `yes=True`: `--approve-mcp` now asks per server and REFUSES off a terminal
+        # (#428), so the unattended shape is the one spelled `--yes`. The asking itself is
+        # covered in tests/test_mcp_approval.py; what this class asserts is what the
+        # recorded approval does to the next render, which is unchanged.
+        args = SimpleNamespace(persona=None, approve_mcp=approve_mcp,
+                               yes=approve_mcp, dry_run=False)
         with redirect_stderr(buf):
             rc = commands_persona.cmd_persona_sync_agents(args)
         agent = Path(config.ROOT) / ".claude" / "agents" / "reddit.md"

--- a/tests/test_mcp_approval.py
+++ b/tests/test_mcp_approval.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import io
 import json
+import re
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -237,27 +238,157 @@ class AnHttpServerHasAConsentLine(ApprovalBase):
         mcpseen.approve(name, ["deadbeef" * 8])
         self.assertWithheld(self._render())
 
-    def test_a_whitespace_only_destination_is_a_blank_line_and_is_refused(self):
-        """#427's guard tested `""` and let `"   "` through: `describe` returned three
-        spaces, which is truthy, so `fingerprint` produced a real digest and a visually
-        blank consent line was approvable — the exact property the docstring denies."""
-        for blank in ("   ", " " * 601, " ", "\u00a0"):
+    def test_a_consent_line_is_printable_ascii_and_nothing_else(self):
+        """The class, swept — not a list, sampled. This guard has now been walked past
+        twice by the same attack in a new spelling: round one matched a NAME (`""`),
+        round two matched a CHARACTER (`str.isprintable` plus a regex over the ASCII
+        space) and U+3164 HANGUL FILLER walked through, being printable, not whitespace,
+        `strip`-proof, and blank on every terminal.
+
+        So the assertion is over the COMPLEMENT rather than over examples: printable
+        ASCII is what a consent line may contain, and `_safe` must escape every one of
+        the 1,114,112 codepoints Python can hold that is not in it. The second assertion
+        is the one that makes "renders as nothing" decidable: on the escaped form, blank
+        means all-ASCII-spaces and nothing else can spell it.
+        """
+        for cp in range(0x110000):
+            out = mcpseen._safe(chr(cp) * 3)
+            if not all(" " <= c <= "~" for c in out):
+                self.fail(f"U+{cp:04X} reached the consent line unescaped: {out!r}")
+            if (out == "") != (cp == 0x20):
+                self.fail(f"U+{cp:04X} renders as {out!r}: blank must mean ASCII space "
+                          f"and only ASCII space, or the next codepoint is the next bypass")
+
+    def test_two_different_commands_never_read_the_same(self):
+        """The homoglyph finding, generalised and swept. A consent line is worth reading
+        only if reading it DISTINGUISHES what would run, so the escaping has to be
+        one-to-one. Two ways it was not, both closed here: `\\u1f600` is five hex digits,
+        so U+1F600 and U+1F60 followed by `"0"` spelled the same escape; and a committed
+        `command` holding the six LITERAL characters `\\u3164` spelled the same line as
+        one holding U+3164, so the escape could be forged in plain ASCII."""
+        # The structural property that makes one-to-one hold for inputs of ANY length:
+        # every escape is a fixed-width form, so no escape is a prefix of another with
+        # the next input character glued on. `\\u1f600` is what violating it looks like.
+        form = re.compile(r"\\u[0-9a-f]{4}|\\U[0-9a-f]{8}")
+        seen = {}
+        for cp in range(0x110000):
+            ch = chr(cp)
+            if not (" " <= ch <= "~"):
+                esc = mcpseen._escape(ch)
+                if not form.fullmatch(esc):
+                    self.fail(f"U+{cp:04X} escapes to {esc!r}, which is not a fixed-width "
+                              f"form — a shorter escape plus the next character spells it")
+            out = mcpseen._safe("x" + ch + "x")
+            prior = seen.setdefault(out, cp)
+            if prior != cp:
+                self.fail(f"U+{prior:04X} and U+{cp:04X} both read as {out!r}")
+
+        # And the two concrete pairs the structure rules out, spelled in full so the
+        # reason survives a rewrite of the loop above.
+        self.assertNotEqual(mcpseen._safe(chr(0x1F600)), mcpseen._safe(chr(0x1F60) + "0"))
+        for literal in ("\\u3164", "\\U0001f600", "\\\\"):
+            out = mcpseen._safe("x" + literal + "x")
+            if out in seen:
+                self.fail(f"the literal text {literal!r} reads as U+{seen[out]:04X} — a "
+                          f"forged escape is a command the operator cannot identify")
+            self.assertNotEqual(out, mcpseen._safe("x" + chr(0x3164) + "x"))
+
+    def test_a_destination_that_renders_as_nothing_is_refused(self):
+        """The end-to-end half of the sweep above, through the real approval path. The
+        listed spellings are illustrations of the class, not the guard — the guard is
+        the sweep. `\u00a0`, `\u3164`, `\u2800`, `\u115f` and `\u1160` are each here
+        because a previous round of this fix shipped while one of them worked."""
+        blanks = ("   ", " " * 601, " ")
+        for blank in blanks:
             with self.subTest(blank=repr(blank)):
                 entry = {"type": "stdio", "command": blank, "args": ["  ", ""],
                          "url": "  ", "secrets": {"ACME_TOKEN": "acme-token"}}
-                line = mcpseen.describe(entry)
-                if blank == "\u00a0":
-                    # A non-breaking space is Separator, not ASCII space: `_safe` escapes
-                    # it, so it shows as a destination rather than reading as blank.
-                    self.assertIn("00a0", line)
-                    continue
-                self.assertEqual(line, "", "a blank line is no line")
+                self.assertEqual(mcpseen.describe(entry), "", "a blank line is no line")
                 self.assertIsNone(mcpseen.fingerprint(VAULT, entry))
+
+        for shown in ("\u00a0", "\u3164", "\u2800", "\u115f", "\u1160", "\u0301"):
+            with self.subTest(shown=repr(shown)):
+                # Not blank: SHOWN. A codepoint outside printable ASCII is a destination
+                # the operator gets to see spelled out, which is the whole point of
+                # escaping rather than of stripping.
+                line = mcpseen.describe({"type": "stdio", "command": shown * 3,
+                                         "secrets": {"ACME_TOKEN": "acme-token"}})
+                self.assertEqual(line, f"\\u{ord(shown):04x}" * 3)
 
         name = self._persona({"type": "stdio", "command": "   ",
                               "secrets": {"ACME_TOKEN": "acme-token"}})
         mcpseen.approve(name, ["deadbeef" * 8])
         self.assertWithheld(self._render())
+
+    def test_a_homoglyph_repoint_reads_differently_from_what_it_replaced(self):
+        """The re-prompt already fires — the digest covers the url, so re-pointing
+        `api.acme.example` at Cyrillic `api.асme.example` lapses the approval and the
+        operator IS asked again. What was missing is that the two lines were byte-for-byte
+        different and pixel-for-pixel identical, so reading the line could not tell the
+        operator what had changed. Escaping is what makes the re-prompt answerable."""
+        ascii_url = "https://api.acme.example/mcp"
+        cyrillic = "https://api.\u0430\u0441me.example/mcp"
+        self.assertNotEqual(ascii_url, cyrillic, "precondition: different strings")
+
+        lines = [mcpseen.describe(dict(HTTP, url=u)) for u in (ascii_url, cyrillic)]
+        self.assertNotEqual(lines[0], lines[1], "the two lines must READ differently")
+        self.assertIn("acme.example", lines[0])
+        self.assertIn("\\u0430\\u0441me.example", lines[1], "the lookalike is spelled out")
+        self.assertNotIn("\u0430", lines[1], "and the glyph itself never reaches the tty")
+
+    def test_padding_cannot_scroll_the_destination_off_the_screen(self):
+        """Finding 2, and the next spelling of it. Nine args of 200 invisible columns fit
+        under the old 2000-character ceiling as a 1837-character line: 22 blank rows on an
+        80x24 tty, with `uvx evil-server` scrolled off the top by the time the prompt was
+        answered. Escaping makes that padding visible — and visible padding scrolls a line
+        exactly as far, so the ceiling has to be the SCREEN the question is asked on.
+        Every filler below is refused for the same reason and not for four reasons."""
+        # Deliberately NOT `mcpseen.MAX_LINE`: the budget this test defends is a screen,
+        # so it is spelled here in rows and columns. Half of an 80x24 terminal, which
+        # leaves the prompt, the answer and some of the sync output visible with it.
+        screen = 80 * 12
+
+        for filler in ("x", "\u3164", "\u2800", " ", "\u0301", "\U0001f600", "\t"):
+            with self.subTest(filler=repr(filler)):
+                entry = dict(STDIO, args=["evil-server"] + [filler * 200] * 9,
+                             env={"PATH": "/tmp/attacker-bin"})
+                line = mcpseen.describe(entry)
+                # Two acceptable outcomes and no third: the padding collapses to nothing
+                # (only the ASCII space does that) and the line is short, or the line does
+                # not fit the screen and there is no line and no digest. What is refused
+                # in every case is the middle: a line long enough to scroll the command
+                # it names off the top of the terminal the prompt is printed on.
+                self.assertLessEqual(len(line), screen,
+                                     f"{len(line) // 80} rows of destination is a page "
+                                     f"the operator scrolls, not a line they read")
+                if line:
+                    self.assertTrue(line.startswith("uvx evil-server"), line[:40])
+                    self.assertIn("PATH", line, "and the env still shows")
+                else:
+                    self.assertIsNone(mcpseen.fingerprint(VAULT, entry))
+        self.assertLessEqual(mcpseen.MAX_LINE, mcpseen.MAX_COLS * mcpseen.MAX_ROWS,
+                             "the ceiling and the screen it names must agree")
+
+        name = self._persona(dict(STDIO, args=["evil-server"] + ["\u3164" * 200] * 9,
+                                  env={"PATH": "/tmp/attacker-bin"}))
+        mcpseen.approve(name, ["deadbeef" * 8])
+        self.assertWithheld(self._render())
+
+    def test_a_real_entry_still_renders_under_the_screen_ceiling(self):
+        """The other direction of the ceiling: fail-closed is only acceptable if it does
+        not close on the servers people actually run. A fat-but-honest docker entry with
+        several env keys still fits."""
+        line = mcpseen.describe({
+            "type": "stdio", "command": "docker",
+            "args": ["run", "-i", "--rm", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+                     "-e", "GITHUB_TOOLSETS", "ghcr.io/github/github-mcp-server", "stdio"],
+            "env": {"PATH": "/usr/local/bin:/usr/bin", "HTTPS_PROXY": "http://p.example:3128",
+                    "NODE_OPTIONS": "--max-old-space-size=4096"},
+            "secrets": {"GITHUB_PERSONAL_ACCESS_TOKEN": "gh-pat"}})
+        self.assertTrue(line.startswith("docker run -i --rm"), line[:40])
+        for named in ("ghcr.io/github/github-mcp-server", "PATH", "NODE_OPTIONS"):
+            self.assertIn(named, line)
+        self.assertLessEqual(len(line), mcpseen.MAX_LINE)
 
     def test_padding_with_spaces_cannot_indent_the_destination_out_of_view(self):
         line = mcpseen.describe(dict(STDIO, args=[" " * 600 + "--evil"]))
@@ -358,6 +489,51 @@ class ApproveMcpAsksBeforeItRecords(ApprovalBase):
         self.assertWrapped(rendered, "precondition: the operator did approve it")
         self.assertEqual(sorted(rendered.get("env") or {}), ["NODE_OPTIONS", "PATH"],
                          "what was approved is what the harness gets")
+
+    def test_the_operator_is_never_asked_under_a_line_that_prints_as_nothing(self):
+        """The reviewer's round-two input, end to end and in its own words. A committed
+        entry of `"\u3164" * 3` — HANGUL FILLER, printable, not whitespace, `strip`-proof,
+        blank on every terminal — produced `  reddit/reddit → ` and nothing else, a real
+        digest, and one prompt. Answering yes wrapped the entry in `charter secret exec`.
+
+        The fix is not "ask zero questions about it". It is that the line printed above
+        the question SAYS something, so that yes and no are both informed answers: the
+        codepoint is spelled out, the operator sees a command made of nothing but
+        escapes, and declining leaves the vault withheld."""
+        name = self._persona({"type": "stdio", "command": "\u3164" * 3,
+                              "args": ["\u3164" * 8],
+                              "secrets": {"ACME_TOKEN": "acme-token"}})
+        rc, err = self._sync(_Tty(), answers=["n"])
+        self.assertEqual(rc, 0)
+
+        # Two occurrences: the line above the prompt, and the same line in the withheld
+        # report afterwards. Both are read by a person, so both are asserted.
+        shown = [ln for ln in err.splitlines() if "reddit/reddit \u2192" in ln]
+        self.assertEqual(len(shown), 2, err)
+        for ln in shown:
+            dest = ln.split("\u2192", 1)[1].strip()
+            self.assertNotEqual(dest, "", "the operator was asked under a blank line")
+            self.assertTrue(all(" " <= c <= "~" for c in dest),
+                            f"a glyph the terminal gets to interpret reached it: {dest!r}")
+            self.assertIn("\\u3164", dest, "the codepoint is spelled out, not shown")
+        self.assertEqual(self.asked, 1, "and it was a real question, asked once")
+        self.assertEqual(mcpseen.approved(name), set(), "no is still no")
+        self.assertWithheld(self._render(name))
+
+    def test_invisible_padding_is_refused_before_anyone_is_asked(self):
+        """The other half of the same input: nine args of 200 blank columns fit under the
+        old 2000-character ceiling and pushed `uvx evil-server` off the top of an 80x24
+        screen. Over the screen ceiling there is no line, so there is no digest and no
+        question — the operator hears it was refused instead of answering blind."""
+        name = self._persona(dict(STDIO, command="uvx",
+                                  args=["evil-server"] + ["\u3164" * 200] * 9,
+                                  env={"PATH": "/tmp/attacker-bin"}))
+        rc, err = self._sync(_Tty(), answers=["y"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.asked, 0, "nothing showable, nothing to ask")
+        self.assertIn(mcpseen.UNRENDERABLE, err, "and the refusal is said out loud")
+        self.assertEqual(mcpseen.approved(name), set())
+        self.assertWithheld(self._render(name))
 
     def test_declining_revokes_an_approval_it_already_had(self):
         name = self._two_servers()

--- a/tests/test_mcp_approval.py
+++ b/tests/test_mcp_approval.py
@@ -18,24 +18,33 @@ side, and this module is the boundary for all three:
 Every test here asserts the withholding direction: the interesting outcome is always
 "the vault did NOT reach that command", never "sync-agents crashed".
 
-**Three rounds of review then found the same class of hole in the fixes themselves, and
-it was the same mistake every time: the guard was put on the FIELD that had just been
-attacked rather than on the SURFACE it is printed on.** Round one matched a NAME (``""``
-was blank, ``"   "`` was not). Round two matched a CHARACTER and a LIST (``str.isprintable``
-plus a regex over the ASCII space; a tuple of four blank strings) and U+3164 walked past
-both. Round three matched the right class — every codepoint outside printable ASCII — but
-matched it inside `describe`, while the ``persona/server`` label sharing that row went to
-the terminal untouched, and while `secrets` stayed in the digest and off the line.
+**Four rounds of review then found the same class of hole in the fixes themselves, and it
+was the same mistake every time: the guard was put on the FIELD that had just been attacked
+rather than on the SURFACE it is printed on.** Round one matched a NAME (``""`` was blank,
+``"   "`` was not). Round two matched a CHARACTER and a LIST (``str.isprintable`` plus a
+regex over the ASCII space; a tuple of four blank strings) and U+3164 walked past both.
+Round three matched the right class — every codepoint outside printable ASCII — but matched
+it inside `describe`, while the ``persona/server`` label sharing that row went to the
+terminal untouched, and while `secrets` stayed in the digest and off the line. Round three
+then shipped a LONGER LIST — seven fields on the line against a digest over the whole entry
+— and the vault, ``env`` VALUES, ``cwd`` and a clipped tail each walked past it in turn.
 
-So the tests that hold the line here are of two shapes and neither of them is a list of
-bad inputs: a SWEEP over all 1,114,112 codepoints for what `_safe` must catch, and a
-SURFACE assertion over the whole printed transcript of a real `sync-agents` run for where
-committed text is allowed to appear. A field added to the consent line later is covered by
-the second without anybody remembering to add it to the first.
+Round four stops adding fields. `fingerprint` is the SHA-256 of `describe`'s output, so
+*two entries that render the same consent line have the same fingerprint* is true by
+construction, and `describe` loops over the entry's keys rather than over a list. See
+`TheDigestIsTheLine`, which is where that property and its converse are asserted.
+
+So the tests that hold the line here are of three shapes and none of them is a list of bad
+inputs: a SWEEP over all 1,114,112 codepoints for what the escapes must catch (and, for
+`_esc`, that they are reversible); a SURFACE assertion over the whole printed transcript of
+a real `sync-agents` run for where committed text is allowed to appear; and a PROPERTY over
+the relation between the line and the digest. A field added to the consent line later is
+covered by all three without anybody remembering to add it to any of them.
 """
 
 from __future__ import annotations
 
+import hashlib
 import io
 import json
 import re
@@ -93,7 +102,34 @@ class ApprovalBase(PersonaIso):
         return persona.mcp_render_entry(name, VAULT, self._entry(name, server))
 
     def _approve(self, name="reddit"):
-        mcpseen.approve(name, [fp for _s, _e, fp in persona.mcp_credentialed(name) if fp])
+        mcpseen.approve(name, [fp for _s, _e, fp, _l in persona.mcp_credentialed(name) if fp])
+
+    def _sync(self, stdin, answers=None, **flags):
+        """A real `sync-agents --approve-mcp` run: its transcript and what it recorded.
+
+        On the base class rather than beside the tests that answer prompts, because the
+        end-to-end run is the only place that shows the LINE THE OPERATOR READS — and
+        three rounds of this fix were shipped on `describe` looking well-behaved in
+        isolation while the printed row said something else."""
+        from contextlib import redirect_stderr, redirect_stdout
+        buf, out = io.StringIO(), io.StringIO()
+        args = SimpleNamespace(persona=None, approve_mcp=True,
+                               yes=flags.get("yes", False),
+                               dry_run=flags.get("dry_run", False))
+        replies = list(answers or [])
+        self.asked = 0   # the question itself lands on stderr, with everything else
+
+        def fake_input(prompt=""):
+            self.asked += 1
+            if not replies:
+                raise EOFError
+            return replies.pop(0)
+
+        with mock.patch("sys.stdin", stdin), \
+                mock.patch("builtins.input", fake_input), \
+                redirect_stdout(out), redirect_stderr(buf):
+            rc = commands_persona.cmd_persona_sync_agents(args)
+        return rc, buf.getvalue()
 
     def assertWrapped(self, out, msg=""):
         self.assertEqual(out.get("command"), "charter", msg or "expected the vault wrapper")
@@ -185,12 +221,246 @@ class TheDigestCoversTheWholeEntry(ApprovalBase):
         self.assertIsNotNone(mcpseen.fingerprint(VAULT, dict(STDIO, weird=object())))
 
 
+def _unescape(shown: str) -> str:
+    """`mcpseen._esc` read backwards. A left inverse is what "reversible" MEANS, so the
+    property is checked by decoding rather than by asserting a shape."""
+    out, i = [], 0
+    while i < len(shown):
+        c = shown[i]
+        if c != "\\":
+            out.append(c)
+            i += 1
+        elif shown[i + 1] == "\\":
+            out.append("\\")
+            i += 2
+        elif shown[i + 1] == '"':
+            out.append('"')
+            i += 2
+        elif shown[i + 1] == "u":
+            out.append(chr(int(shown[i + 2:i + 6], 16)))
+            i += 6
+        elif shown[i + 1] == "U":
+            out.append(chr(int(shown[i + 2:i + 10], 16)))
+            i += 10
+        else:
+            raise AssertionError(f"undecodable escape at {shown[i:i + 8]!r}")
+    return "".join(out)
+
+
+class TheDigestIsTheLine(ApprovalBase):
+    """Round four, and the one property the three rounds before it each restated and each
+    left unimplemented.
+
+    Rounds one to three digested one representation of the entry and printed a different,
+    shorter one — a total digest against a line enumerating seven fields. Every bypass
+    since has been one instance of that single gap, and each round closed the instance it
+    was handed: the vault name, digested from the first commit and never printed; `env`
+    VALUES, digested while only their KEYS were shown; `cwd`, and whatever the next
+    committed key turns out to be; and a clipped tail that made two different `args` read
+    the same. In each, the operator was re-asked under a line byte-identical to the one
+    they had already approved — which is not consent, it is a second chance to make the
+    same mistake.
+
+    So there is no second representation any more. `fingerprint` is the SHA-256 of
+    `describe`'s output and nothing else is mixed in, which makes the first test below
+    true by construction rather than by inspection:
+
+        *two entries that render the same consent line have the same fingerprint.*
+
+    That moves the whole weight onto `describe` being TOTAL — a key it fails to print is a
+    key a commit may change with the approval intact — which is the second test, and it is
+    written over `entry.keys()` rather than over a list, so the key nobody has thought of
+    yet is covered without being found by hand.
+
+    What is NOT claimed here, because `SECURITY.md` does not claim it: that reading the
+    line makes the operator understand it, or that anything stops somebody who already
+    runs code as this user. This is a guard against a commit, answered by a person.
+    """
+
+    #: A rich entry: charter's readable fields, plus keys it has never been taught, plus a
+    #: nested one. Used by the totality test, so a field added to `describe` later does not
+    #: need to be added here to be covered — the loop is over the keys of this dict.
+    RICH = {
+        "type": "stdio", "command": "uvx", "args": ["some-reddit-mcp", "--read-only"],
+        "url": "https://api.acme.example/mcp",
+        "env": {"PATH": "/usr/bin", "NODE_OPTIONS": "--max-old-space-size=4096"},
+        "secrets": {"REDDIT_CLIENT_ID": "client-id"},
+        "secret_files": {"GOOGLE_APPLICATION_CREDENTIALS": "prod-sa-json"},
+        "cwd": "/home/me/proj",
+        "headers": {"Authorization": "Bearer whatever"},
+        "meta": {"transport": {"proxy": "http://ok.example"}},
+        "keepAlive": True, "timeout": 30, "note": None,
+    }
+
+    #: Pairs that MUST read differently, one axis each. Every one of them printed a single
+    #: identical line before this commit except where noted, and each was reproduced end to
+    #: end through `sync-agents --approve-mcp` on the branch this replaces.
+    DIFFERENT = [
+        ("the vault", ("reddit-low", dict(STDIO)), ("prod-aws", dict(STDIO))),
+        ("an env value", ("v", dict(STDIO, env={"PATH": "/usr/bin"})),
+                         ("v", dict(STDIO, env={"PATH": "/tmp/attacker-bin:/usr/bin"}))),
+        ("an env pair boundary", ("v", dict(STDIO, env={"A": "b, C=d"})),
+                                 ("v", dict(STDIO, env={"A": "b", "C": "d"}))),
+        ("an untaught key", ("v", dict(STDIO, cwd="/home/me/proj")),
+                            ("v", dict(STDIO, cwd="/tmp/attacker"))),
+        ("a clipped tail", ("v", dict(STDIO, args=["-c{" + "b" * 195 + '"allow": false}'])),
+                           ("v", dict(STDIO, args=["-c{" + "b" * 195 + '"allow": true }']))),
+        ("a run of spaces", ("v", dict(STDIO, args=["--x", "a b"])),
+                            ("v", dict(STDIO, args=["--x", "a  b"]))),
+        ("a leading space", ("v", dict(STDIO, command="/bin/sh")),
+                            ("v", dict(STDIO, command="  /bin/sh"))),
+        ("where the words split", ("v", dict(STDIO, command="a b", args=[])),
+                                  ("v", dict(STDIO, command="a", args=["b"]))),
+        ("an empty word", ("v", dict(STDIO, args=["x"])),
+                          ("v", dict(STDIO, args=["x", ""]))),
+        ("arg order", ("v", dict(STDIO, args=["mcp", "--allow", "x"])),
+                      ("v", dict(STDIO, args=["--allow", "x", "mcp"]))),
+        ("a homoglyph url", ("v", dict(HTTP, url="https://api.acme.example/mcp")),
+                            ("v", dict(HTTP, url="https://api.асme.example/mcp"))),
+        ("a forged escape", ("v", dict(STDIO, args=["\\u3164"])),
+                            ("v", dict(STDIO, args=["ㅤ"]))),
+        ("the vault key", ("v", dict(STDIO, secrets={"R": "client-id"})),
+                          ("v", dict(STDIO, secrets={"R": "aws-root-key"}))),
+        ("a nested value", ("v", dict(STDIO, meta={"t": {"proxy": "http://ok.example"}})),
+                           ("v", dict(STDIO, meta={"t": {"proxy": "http://evil.example"}}))),
+        ("a bool and its spelling", ("v", dict(STDIO, verify=True)),
+                                    ("v", dict(STDIO, verify="true"))),
+        ("an int and its spelling", ("v", dict(STDIO, port=1)),
+                                    ("v", dict(STDIO, port="1"))),
+        ("null and its spelling", ("v", dict(STDIO, note=None)),
+                                  ("v", dict(STDIO, note="null"))),
+        ("a committed key spelling charter's word",
+         ("v", dict(STDIO)), ("v", dict(STDIO, vault="prod-aws"))),
+        ("a committed value spelling a segment",
+         ("v", dict(STDIO, args=['x  vault "v"'])), ("v", dict(STDIO, args=["x"]))),
+    ]
+
+    #: Pairs that MUST read the same, and therefore share one approval. Both are
+    #: deliberate: neither can change the argv `execvpe` receives, and a prompt that fires
+    #: on a re-serialised file is a prompt the operator learns to answer without reading.
+    SAME = [
+        ("key order", ("v", {"command": "uvx", "args": ["m"], "secrets": {"A": "k"},
+                             "env": {"A": "1", "B": "2"}}),
+                      ("v", {"env": {"B": "2", "A": "1"}, "secrets": {"A": "k"},
+                             "args": ["m"], "command": "uvx"})),
+        ("an empty argv and none at all",
+         ("v", {"command": "uvx", "args": [], "secrets": {"A": "k"}}),
+         ("v", {"command": "uvx", "secrets": {"A": "k"}})),
+    ]
+
+    def test_two_entries_that_render_the_same_consent_line_have_the_same_fingerprint(self):
+        """The invariant, stated as the attacker stated it. It reddens on env values, on
+        `cwd`, on a clipped tail, on the vault and on every future key at once, which is
+        what makes it a property rather than a nineteenth instance.
+
+        Both directions are asserted over the same table, because a rule that only ever
+        fires one way is a rule nothing holds to the other: an entry that reads the same
+        must not lapse the approval, and an entry that reads differently must."""
+        cases = ([(f"{why} — same", a, b, True) for why, a, b in self.SAME]
+                 + [(f"{why} — different", a, b, False) for why, a, b in self.DIFFERENT])
+        for why, (v1, e1), (v2, e2), same in cases:
+            with self.subTest(why=why):
+                l1, l2 = mcpseen.describe(v1, e1), mcpseen.describe(v2, e2)
+                f1, f2 = mcpseen.fingerprint(v1, e1), mcpseen.fingerprint(v2, e2)
+                self.assertTrue(l1 and l2, "precondition: both are renderable")
+                self.assertEqual(l1 == l2, same, f"{l1!r}\n{l2!r}")
+                # The invariant itself, asserted on every pair rather than on the ones
+                # expected to collide: equal lines may never carry different digests.
+                self.assertEqual(f1 == f2, l1 == l2,
+                                 "the digest and the line must agree, always")
+
+    def test_every_key_of_the_entry_reaches_the_line(self):
+        """Totality — the half the invariant moves all the weight onto.
+
+        Hashing the line is only safe if the line holds everything the harness receives:
+        a key `describe` skips is a key a commit may change with the approval intact,
+        which is the bug with the arrow pointing the other way. `mcp_render_entry` passes
+        every key it does not consume straight through, so the test is over the KEYS of
+        the entry — including two nobody has ever named — and not over a list."""
+        keys = list(self.RICH) + ["a-key-charter-has-never-heard-of", "x-next-round"]
+        base = mcpseen.describe(VAULT, self.RICH)
+        self.assertTrue(base, "precondition: the rich entry renders")
+        for key in keys:
+            with self.subTest(key=key):
+                changed = dict(self.RICH)
+                changed[key] = ["a value nothing in charter reads", key]
+                self.assertNotEqual(mcpseen.describe(VAULT, changed), base,
+                                    f"`{key}` can be re-pointed under an unchanged line")
+                dropped = {k: v for k, v in self.RICH.items() if k != key}
+                if key in self.RICH:
+                    self.assertNotEqual(mcpseen.describe(VAULT, dropped), base,
+                                        f"`{key}` can be removed under an unchanged line")
+
+    def test_the_escape_is_reversible(self):
+        """What `_esc` has to be, now that the digest is taken over its output: a left
+        inverse exists, so the characters printed for a committed value determine that
+        value. Round three's escape was not — it collapsed runs of ASCII spaces and
+        stripped the ends, which is fine for deciding "does this render as nothing" and
+        wrong for deciding "is this the command I approved"."""
+        for cp in range(0x110000):
+            raw = "x" + chr(cp) + "\\\"" + chr(cp) * 2
+            shown = mcpseen._esc(raw)
+            if not all(" " <= c <= "~" for c in shown):
+                self.fail(f"U+{cp:04X} reached the consent line unescaped: {shown!r}")
+            if _unescape(shown) != raw:
+                self.fail(f"U+{cp:04X} does not survive the round trip: {shown!r}")
+        for raw in ("", " ", "   ", "  x  ", "a  b", '"', "\\", "\\u3164", "\\\\u3164",
+                    "\U0001f600", chr(0x1F60) + "0"):
+            self.assertEqual(_unescape(mcpseen._esc(raw)), raw, repr(raw))
+        # And the delimiter property the line's shape rests on: an UNESCAPED quote is
+        # charter's, so a committed value cannot close its own quotes and impersonate a
+        # whole segment. Escapes are removed first, since `\\"` is not a delimiter.
+        escapes = re.compile(r'\\\\|\\"|\\u[0-9a-f]{4}|\\U[0-9a-f]{8}')
+        for raw in ('a"b', "a\\", '"', '\\"', 'x"  vault "v', "\\" * 5 + '"'):
+            bare = escapes.sub("", mcpseen._esc(raw))
+            self.assertNotIn('"', bare, f"{raw!r} spells a delimiter")
+            self.assertNotIn("\\", bare, f"{raw!r} leaves a backslash no escape claims")
+
+    def test_the_line_printed_is_the_line_recorded(self):
+        """End to end, and the reason `mcp_credentialed` hands back the line rather than
+        the entry. Two renderings of the same entry — one for the prompt, one for the
+        digest — is exactly the drift this whole fix removes, so there is one."""
+        name = self._persona(dict(STDIO, env={"PATH": "/tmp/attacker-bin"}))
+        rc, err = self._sync(_Tty(), answers=["y"])
+        self.assertEqual(rc, 0)
+        shown = [ln for ln in err.splitlines() if "reddit/reddit →" in ln]
+        self.assertEqual(len(shown), 1, err)
+        line = shown[0].split("→", 1)[1].strip()
+        self.assertIn('"PATH"="/tmp/attacker-bin"', line, "the value, not only the key")
+        self.assertIn(f'vault "{VAULT}"', line, "whose credential is being spent")
+        self.assertEqual(mcpseen.approved(name),
+                         {hashlib.sha256(line.encode()).hexdigest()},
+                         "what was recorded is the sha256 of what was printed")
+
+    def test_re_pointing_the_vault_is_a_line_the_operator_can_see(self):
+        """Finding one, end to end. `vault:` is a key of the COMMITTED `persona.md`, so a
+        one-line commit re-points which credential is spent. It was digested from the
+        first commit and printed by none, so the operator was re-asked under a
+        byte-identical line — and could not have told which vault was at stake the FIRST
+        time either, while the line printed charter's own word `(vault: …)` in front of
+        the variable name, where a reader has every reason to expect the vault to be."""
+        name = self._persona()
+        self._approve()
+        self.assertWrapped(self._render(), "precondition: approved under vault `reddit`")
+        before = mcpseen.describe(VAULT, self._entry())
+
+        # `_render` is called with the vault the persona would resolve to; re-pointing
+        # `vault:` in persona.md is the same substitution one frame up.
+        after = mcpseen.describe("prod-aws", self._entry())
+        self.assertNotEqual(after, before, "the re-point has to be readable")
+        self.assertIn('vault "prod-aws"', after)
+        self.assertNotEqual(mcpseen.fingerprint("prod-aws", self._entry()),
+                            mcpseen.fingerprint(VAULT, self._entry()))
+        self.assertWithheld(persona.mcp_render_entry(name, "prod-aws", self._entry()),
+                            "and the approval does not travel with the entry")
+
+
 class AnHttpServerHasAConsentLine(ApprovalBase):
     """#427. `describe` fed the line the operator is told to read; for `http`/`sse` it fed
     an empty string."""
 
     def test_an_http_server_has_a_nonempty_consent_line(self):
-        line = mcpseen.describe(HTTP)
+        line = mcpseen.describe(VAULT, HTTP)
         self.assertIn("https://api.acme.example/mcp", line)
         other = dict(HTTP, url="https://evil.example.net/mcp")
         self.assertNotEqual(mcpseen.fingerprint(VAULT, HTTP),
@@ -198,7 +468,7 @@ class AnHttpServerHasAConsentLine(ApprovalBase):
                             "two endpoints must not share one approval")
 
     def test_the_consent_line_names_the_env_keys(self):
-        line = mcpseen.describe(dict(STDIO, env={"PATH": "/tmp/bin", "NODE_OPTIONS": "-r x"}))
+        line = mcpseen.describe(VAULT, dict(STDIO, env={"PATH": "/tmp/bin", "NODE_OPTIONS": "-r x"}))
         self.assertIn("PATH", line)
         self.assertIn("NODE_OPTIONS", line)
 
@@ -219,24 +489,26 @@ class AnHttpServerHasAConsentLine(ApprovalBase):
         module never opens a vault. The last assertion pins that — every token on the line
         came either out of the entry or out of charter's own words."""
         entry = dict(STDIO, secrets={"REDDIT_CLIENT_ID": "client-id"})
-        line = mcpseen.describe(entry)
+        line = mcpseen.describe(VAULT, entry)
         self.assertIn("uvx", line)
-        self.assertIn("REDDIT_CLIENT_ID=client-id", line)
+        self.assertIn('"REDDIT_CLIENT_ID"="client-id"', line)
 
         repointed = dict(STDIO, secrets={"REDDIT_CLIENT_ID": "aws-root-key"})
         self.assertNotEqual(mcpseen.fingerprint(VAULT, entry),
                             mcpseen.fingerprint(VAULT, repointed),
                             "precondition: re-pointing the credential does re-ask")
-        self.assertNotEqual(line, mcpseen.describe(repointed),
+        self.assertNotEqual(line, mcpseen.describe(VAULT, repointed),
                             "and the line it re-asks under has to have changed too")
 
         # `secret_files` is the same decision through a different mechanism (#190): a path
         # to a materialised file rather than a value. Same key, same need to show it.
-        files = mcpseen.describe(dict(STDIO, secret_files={"GOOGLE_APPLICATION_CREDENTIALS":
+        files = mcpseen.describe(VAULT, dict(STDIO, secret_files={"GOOGLE_APPLICATION_CREDENTIALS":
                                                           "prod-sa-json"}))
-        self.assertIn("GOOGLE_APPLICATION_CREDENTIALS=prod-sa-json", files)
+        self.assertIn('"GOOGLE_APPLICATION_CREDENTIALS"="prod-sa-json"', files)
 
-        charters_own = {"vault", "file", "env", "http", "more", "chars"}
+        # Charter's own words, plus the vault NAME — which is on the line as of round four
+        # and comes out of the committed `persona.md`, not out of any vault.
+        charters_own = set(mcpseen._WORDS) | {VAULT, "null", "true", "false"}
         for token in re.findall(r"[A-Za-z0-9_./-]{3,}", line):
             self.assertTrue(token in json.dumps(entry) or token in charters_own,
                             f"{token!r} reached the consent line from outside the entry")
@@ -247,42 +519,61 @@ class AnHttpServerHasAConsentLine(ApprovalBase):
         the operator something other than what would run."""
         for token in ("\rharmless", "\x1b[2Kharmless", "a‮b", "x\ny"):
             with self.subTest(token=token):
-                line = mcpseen.describe(dict(STDIO, args=[token]))
+                line = mcpseen.describe(VAULT, dict(STDIO, args=[token]))
                 self.assertNotIn("\r", line)
                 self.assertNotIn("\n", line)
                 self.assertNotIn("\x1b", line)
                 self.assertNotIn("‮", line)
                 self.assertIn("uvx", line, "the real command still shows")
 
-    def test_a_flood_of_args_cannot_push_the_env_or_the_url_off_the_line(self):
-        """The bypass round one shipped. `[type url]` and `(env: …)` are appended AFTER
-        `args`, and the finished line was cut at 600 characters — so ~600 characters of
-        plausible `args` in a committed file produced a consent line naming neither the
-        `env` it set nor the `url` it pointed at, while the approved render carried both
-        to `execvpe`. Each part now has its own budget, so padding one cannot cut another.
-        """
+    def test_nothing_a_long_part_hides_is_hidden_by_a_shorter_line(self):
+        """Round one cut the FINISHED line at 600 characters and both `[type url]` and
+        `(env: …)` were appended after `args`, so ~600 characters of plausible `args` in a
+        committed file produced a consent line naming neither the `env` it set nor the
+        `url` it pointed at. Round two gave each part its own 200-character budget and
+        announced the cut, which bounded the line but was not one-to-one: see
+        `test_a_clipped_tail_is_not_a_tail_anybody_read` below.
+
+        Round four's answer is neither. A line is complete or there is no line — so a
+        padded part cannot shorten another part, because no part is ever shortened."""
         entry = dict(STDIO, args=["x" * 100000], url="https://evil.example/mcp",
                      env={"PATH": "/tmp/attacker-bin", "NODE_OPTIONS": "-r /tmp/x.js"})
-        line = mcpseen.describe(entry)
-        self.assertTrue(line.startswith("uvx "), "the command stays at the front")
-        self.assertIn("more chars", line, "and the clipping is announced")
-        for named in ("PATH", "NODE_OPTIONS", "evil.example"):
+        self.assertEqual(mcpseen.describe(VAULT, entry), "",
+                         "an entry that cannot be shown in full is not shown at all")
+        self.assertIsNone(mcpseen.fingerprint(VAULT, entry))
+
+        # The same fields, at a size that fits: all of them are named, values included.
+        entry = dict(STDIO, args=["x" * 100], url="https://evil.example/mcp",
+                     env={"PATH": "/tmp/attacker-bin", "NODE_OPTIONS": "-r /tmp/x.js"})
+        line = mcpseen.describe(VAULT, entry)
+        self.assertTrue(line.startswith("run uvx "), "the command stays at the front")
+        self.assertNotIn("more chars", line, "and nothing was cut out of it")
+        for named in ("PATH", "/tmp/attacker-bin", "NODE_OPTIONS", "-r /tmp/x.js",
+                      "evil.example", "x" * 100):
             self.assertIn(named, line, f"{named} chooses the destination and must show")
 
-    def test_one_long_part_cannot_clip_a_later_part_of_its_own_kind(self):
-        """The next spelling: hiding does not need a different field to hide behind, only
-        an earlier one. A per-part budget answers both."""
-        line = mcpseen.describe(dict(STDIO, args=["z" * 100000, "--allow-remote-code"]))
-        self.assertIn("--allow-remote-code", line, "a later arg is still named")
-        line = mcpseen.describe(dict(STDIO, env={"A" * 100000: "1", "PATH": "/tmp/bin"}))
-        self.assertIn("PATH", line, "a later env key is still named")
+    def test_a_clipped_tail_is_not_a_tail_anybody_read(self):
+        """Finding four of round four, and the reason clipping is gone rather than fixed.
+
+        `_clip` cut each part at 200 characters and announced how many it had dropped —
+        which is not one-to-one: two args agreeing on their first 200 escaped characters
+        and equal in length printed the same text AND the same `(+N more chars)` count.
+        Two different `--config` payloads, one identical line. Round three could survive
+        that (the digest was taken over the entry); once the digest IS the line, it would
+        be one approval covering an entry the operator never saw."""
+        head = "--config {" + "b" * 195
+        a, b = head + '"allow_remote_code": false}', head + '"allow_remote_code": true }'
+        self.assertEqual(len(a), len(b), "precondition: same length, same clipped prefix")
+        lines = [mcpseen.describe(VAULT, dict(STDIO, args=[x])) for x in (a, b)]
+        self.assertNotEqual(lines[0], lines[1], "the tail that differs must be readable")
+        self.assertIn("allow_remote_code\\\": false", lines[0])
+        self.assertIn("allow_remote_code\\\": true", lines[1])
 
     def test_a_line_too_long_to_read_is_refused_rather_than_cut(self):
-        """Enough parts that even their clipped forms overflow. Cutting would put charter
-        back to choosing which half of the destination the operator sees, so it fails
-        closed instead: no line, no digest, no approval."""
+        """Cutting would put charter back to choosing which half of the destination the
+        operator sees, so it fails closed instead: no line, no digest, no approval."""
         flood = dict(STDIO, args=["y" * 60] * 200)
-        self.assertEqual(mcpseen.describe(flood), "")
+        self.assertEqual(mcpseen.describe(VAULT, flood), "")
         self.assertIsNone(mcpseen.fingerprint(VAULT, flood))
 
         name = self._persona(flood)
@@ -354,7 +645,7 @@ class AnHttpServerHasAConsentLine(ApprovalBase):
             with self.subTest(blank=repr(blank)):
                 entry = {"type": "stdio", "command": blank, "args": ["  ", ""],
                          "url": "  ", "secrets": {"ACME_TOKEN": "acme-token"}}
-                self.assertEqual(mcpseen.describe(entry), "", "a blank line is no line")
+                self.assertEqual(mcpseen.describe(VAULT, entry), "", "a blank line is no line")
                 self.assertIsNone(mcpseen.fingerprint(VAULT, entry))
 
         for shown in ("\u00a0", "\u3164", "\u2800", "\u115f", "\u1160", "\u0301"):
@@ -362,9 +653,10 @@ class AnHttpServerHasAConsentLine(ApprovalBase):
                 # Not blank: SHOWN. A codepoint outside printable ASCII is a destination
                 # the operator gets to see spelled out, which is the whole point of
                 # escaping rather than of stripping.
-                line = mcpseen.describe({"type": "stdio", "command": shown * 3,
-                                         "secrets": {"ACME_TOKEN": "acme-token"}})
-                self.assertEqual(line.split("  ")[0], f"\\u{ord(shown):04x}" * 3)
+                line = mcpseen.describe(VAULT, {"type": "stdio", "command": shown * 3,
+                                                "secrets": {"ACME_TOKEN": "acme-token"}})
+                self.assertEqual(line.split("  ")[0],
+                                 "run " + f"\\u{ord(shown):04x}" * 3)
 
         name = self._persona({"type": "stdio", "command": "   ",
                               "secrets": {"ACME_TOKEN": "acme-token"}})
@@ -381,7 +673,7 @@ class AnHttpServerHasAConsentLine(ApprovalBase):
         cyrillic = "https://api.\u0430\u0441me.example/mcp"
         self.assertNotEqual(ascii_url, cyrillic, "precondition: different strings")
 
-        lines = [mcpseen.describe(dict(HTTP, url=u)) for u in (ascii_url, cyrillic)]
+        lines = [mcpseen.describe(VAULT, dict(HTTP, url=u)) for u in (ascii_url, cyrillic)]
         self.assertNotEqual(lines[0], lines[1], "the two lines must READ differently")
         self.assertIn("acme.example", lines[0])
         self.assertIn("\\u0430\\u0441me.example", lines[1], "the lookalike is spelled out")
@@ -403,7 +695,7 @@ class AnHttpServerHasAConsentLine(ApprovalBase):
             with self.subTest(filler=repr(filler)):
                 entry = dict(STDIO, args=["evil-server"] + [filler * 200] * 9,
                              env={"PATH": "/tmp/attacker-bin"})
-                line = mcpseen.describe(entry)
+                line = mcpseen.describe(VAULT, entry)
                 # Two acceptable outcomes and no third: the padding collapses to nothing
                 # (only the ASCII space does that) and the line is short, or the line does
                 # not fit the screen and there is no line and no digest. What is refused
@@ -429,27 +721,45 @@ class AnHttpServerHasAConsentLine(ApprovalBase):
         """The other direction of the ceiling: fail-closed is only acceptable if it does
         not close on the servers people actually run. A fat-but-honest docker entry with
         several env keys still fits."""
-        line = mcpseen.describe({
+        line = mcpseen.describe(VAULT, {
             "type": "stdio", "command": "docker",
             "args": ["run", "-i", "--rm", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
                      "-e", "GITHUB_TOOLSETS", "ghcr.io/github/github-mcp-server", "stdio"],
             "env": {"PATH": "/usr/local/bin:/usr/bin", "HTTPS_PROXY": "http://p.example:3128",
                     "NODE_OPTIONS": "--max-old-space-size=4096"},
             "secrets": {"GITHUB_PERSONAL_ACCESS_TOKEN": "gh-pat"}})
-        self.assertTrue(line.startswith("docker run -i --rm"), line[:40])
-        for named in ("ghcr.io/github/github-mcp-server", "PATH", "NODE_OPTIONS"):
+        self.assertTrue(line.startswith("run docker run -i --rm"), line[:40])
+        for named in ("ghcr.io/github/github-mcp-server", "PATH", "/usr/local/bin:/usr/bin",
+                      "NODE_OPTIONS", "--max-old-space-size=4096"):
             self.assertIn(named, line)
         self.assertLessEqual(len(line), mcpseen.MAX_LINE)
 
-    def test_padding_with_spaces_cannot_indent_the_destination_out_of_view(self):
-        line = mcpseen.describe(dict(STDIO, args=[" " * 600 + "--evil"]))
-        self.assertTrue(line.startswith("uvx --evil"), line[:40])
+    def test_padding_with_spaces_is_shown_or_refused_but_never_tidied_away(self):
+        """Round three stripped and collapsed ASCII spaces out of every part, so
+        `"   ...   --evil"` printed as `--evil` — a line that no longer said what would
+        run, and (once the digest is the line) one approval covering both spellings.
+
+        Padding is committed content now, like any other: it is shown between the quotes
+        that mark the word's boundaries, it costs the columns it occupies, and enough of
+        it puts the entry over the screen ceiling and gets it refused."""
+        padded = mcpseen.describe(VAULT, dict(STDIO, args=["  --evil"]))
+        self.assertIn('"  --evil"', padded, "the padding is shown, not stripped")
+        self.assertNotEqual(padded, mcpseen.describe(VAULT, dict(STDIO, args=["--evil"])),
+                            "two different argv must not share one line")
+
+        line = mcpseen.describe(VAULT, dict(STDIO, args=[" " * 600 + "--evil"]))
+        self.assertIn(" " * 600, line, "600 columns of padding cost 600 columns")
+
+        # And past the ceiling there is no line at all, so nothing to answer blind.
+        entry = dict(STDIO, args=[" " * 6000 + "--evil"])
+        self.assertEqual(mcpseen.describe(VAULT, entry), "")
+        self.assertIsNone(mcpseen.fingerprint(VAULT, entry))
 
     def test_an_entry_with_no_destination_cannot_be_approved(self):
         """The general case behind #427: a line `describe` cannot render is not a line
         anyone can consent to, so no digest exists for it and nothing can wrap it."""
         blind = {"type": "http", "secrets": {"ACME_TOKEN": "acme-token"}}
-        self.assertEqual(mcpseen.describe(blind), "")
+        self.assertEqual(mcpseen.describe(VAULT, blind), "")
         self.assertIsNone(mcpseen.fingerprint(VAULT, blind))
 
         name = self._persona(blind)
@@ -467,27 +777,6 @@ class AnHttpServerHasAConsentLine(ApprovalBase):
 class ApproveMcpAsksBeforeItRecords(ApprovalBase):
     """#428. The flag used to be its own answer."""
 
-    def _sync(self, stdin, answers=None, **flags):
-        from contextlib import redirect_stderr, redirect_stdout
-        buf, out = io.StringIO(), io.StringIO()
-        args = SimpleNamespace(persona=None, approve_mcp=True,
-                               yes=flags.get("yes", False),
-                               dry_run=flags.get("dry_run", False))
-        replies = list(answers or [])
-        self.asked = 0   # the question itself lands on stderr, with everything else
-
-        def fake_input(prompt=""):
-            self.asked += 1
-            if not replies:
-                raise EOFError
-            return replies.pop(0)
-
-        with mock.patch("sys.stdin", stdin), \
-                mock.patch("builtins.input", fake_input), \
-                redirect_stdout(out), redirect_stderr(buf):
-            rc = commands_persona.cmd_persona_sync_agents(args)
-        return rc, buf.getvalue()
-
     def _two_servers(self, name="reddit"):
         self.make_persona(name, role="R", vault=VAULT, **{"delegate-when": "things"})
         self._write(name, {"reddit": dict(STDIO), "acme": dict(HTTP)})
@@ -504,7 +793,7 @@ class ApproveMcpAsksBeforeItRecords(ApprovalBase):
                         err.index("approve reddit/reddit?"), "asked in sorted order")
         # `acme` was answered yes, `reddit` no.
         approved = mcpseen.approved(name)
-        by_server = {s: fp for s, _e, fp in persona.mcp_credentialed(name)}
+        by_server = {s: fp for s, _e, fp, _l in persona.mcp_credentialed(name)}
         self.assertIn(by_server["acme"], approved)
         self.assertNotIn(by_server["reddit"], approved)
         self.assertWithheld(self._render(name, "reddit"), "the declined server stays dry")
@@ -522,18 +811,32 @@ class ApproveMcpAsksBeforeItRecords(ApprovalBase):
         the operator reads names neither the `PATH` it re-points nor the endpoint it
         connects to — and the render they approve carries both. The question is not
         whether `describe` is well-behaved in isolation but whether the line PRINTED
-        above the prompt names everything the approval hands over."""
-        name = self._persona({
+        above the prompt names everything the approval hands over.
+
+        Two outcomes and no third, asserted in that order. Padded past the screen the
+        question is asked on: no line, no question, nothing approved. Inside it: every
+        one of `env`'s KEYS **and VALUES** on the line the operator answers under, because
+        the value is the half that decides — `PATH` picks which binary `execvpe` finds."""
+        padded = {
             "type": "stdio", "command": "uvx",
             "args": ["--config", "{" + "a" * 640 + "}"],
             "env": {"PATH": "/tmp/attacker-bin", "NODE_OPTIONS": "--require /tmp/x.js"},
             "secrets": {"REDDIT_CLIENT_ID": "client-id"},
-        })
+        }
+        name = self._persona(padded)
+        rc, err = self._sync(_Tty(), answers=["y"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.asked, 0, "nothing showable, nothing to ask")
+        self.assertIn(mcpseen.UNRENDERABLE, err)
+        self.assertWithheld(self._render(name))
+
+        self._write(name, {"reddit": dict(padded, args=["--config", "{}"])})
         rc, err = self._sync(_Tty(), answers=["y"])
         self.assertEqual(rc, 0)
         shown = [ln for ln in err.splitlines() if "reddit/reddit →" in ln]
         self.assertEqual(len(shown), 1, err)
-        for named in ("PATH", "NODE_OPTIONS"):
+        for named in ("PATH", "/tmp/attacker-bin",
+                      "NODE_OPTIONS", "--require /tmp/x.js"):
             self.assertIn(named, shown[0],
                           f"{named} reaches execvpe, so it must reach the operator")
         rendered = self._render(name)
@@ -594,13 +897,27 @@ class ApproveMcpAsksBeforeItRecords(ApprovalBase):
         DERIVED from a benign run of the same command rather than listed here. A list
         would drift the first time a message gained a glyph, and this file has already
         watched two lists of characters be walked past.
+
+        **Colour is pinned off for the whole test, and that is a fix, not a tidy-up.**
+        `util._USE_COLOR` is `sys.stderr.isatty()` evaluated at IMPORT time — before this
+        test redirects stderr — so running the suite from a terminal put charter's own
+        ANSI codes into the benign transcript, ESC joined `ours`, and `stray` could never
+        contain it again. The derivation absorbed whatever the environment added, and it
+        absorbed precisely the class this test exists to catch: with `label` mutated to
+        raw interpolation and a hostile of `"ESC[2Kharmless"`, this failed under a pipe
+        and reported OK under a pty. Pinned, every ESC in the transcript is committed
+        text, and the assertion below has the same verdict in both.
         """
+        self.enterContext(mock.patch("charter.util._USE_COLOR", False))
         ours: set[str] = set()
         for benign in (dict(STDIO), {"type": "http", "secrets": dict(STDIO["secrets"])}):
             self._persona(benign)
             _rc, out = self._sync(_Tty(), answers=["n"])
             ours |= {c for c in out if not (" " <= c <= "~")}
         self.assertIn("→", ours, "precondition: the arrow is charter's own")
+        self.assertNotIn("\x1b", ours,
+                         "charter's own colour is in the derived set, so a committed "
+                         "escape sequence could never be stray again")
 
         hostiles = {
             "server name": ("\u3164" * 3, "a\x1b[2K\rharmless", "z" * 100000,
@@ -659,7 +976,7 @@ class ApproveMcpAsksBeforeItRecords(ApprovalBase):
         screen on the destination."""
         fat = {"type": "stdio", "command": "uvx", "args": ["a" * 90] * 8,
                "secrets": {"REDDIT_CLIENT_ID": "client-id"}}
-        self.assertEqual(mcpseen.describe(fat), "",
+        self.assertEqual(mcpseen.describe(VAULT, fat), "",
                          "a destination this size does not leave room for the label")
 
         name = "reddit"
@@ -714,15 +1031,15 @@ class ApproveMcpAsksBeforeItRecords(ApprovalBase):
         """
         blank, esc = "\u3164", "\\u3164"
         renders = {
-            "command": lambda s: mcpseen.describe({"command": s}),
-            "arg": lambda s: mcpseen.describe(dict(STDIO, args=[s])),
-            "type": lambda s: mcpseen.describe({"type": s, "url": "https://x.example"}),
-            "url": lambda s: mcpseen.describe({"type": "http", "url": s}),
-            "env key": lambda s: mcpseen.describe(dict(STDIO, env={s: "1"})),
-            "secrets var": lambda s: mcpseen.describe(dict(STDIO, secrets={s: "k"})),
-            "secrets vault key": lambda s: mcpseen.describe(dict(STDIO, secrets={"V": s})),
-            "secret_files var": lambda s: mcpseen.describe(dict(STDIO, secret_files={s: "k"})),
-            "secret_files vault key": lambda s: mcpseen.describe(
+            "command": lambda s: mcpseen.describe(VAULT, {"command": s}),
+            "arg": lambda s: mcpseen.describe(VAULT, dict(STDIO, args=[s])),
+            "type": lambda s: mcpseen.describe(VAULT, {"type": s, "url": "https://x.example"}),
+            "url": lambda s: mcpseen.describe(VAULT, {"type": "http", "url": s}),
+            "env key": lambda s: mcpseen.describe(VAULT, dict(STDIO, env={s: "1"})),
+            "secrets var": lambda s: mcpseen.describe(VAULT, dict(STDIO, secrets={s: "k"})),
+            "secrets vault key": lambda s: mcpseen.describe(VAULT, dict(STDIO, secrets={"V": s})),
+            "secret_files var": lambda s: mcpseen.describe(VAULT, dict(STDIO, secret_files={s: "k"})),
+            "secret_files vault key": lambda s: mcpseen.describe(VAULT, 
                 dict(STDIO, secret_files={"V": s})),
             "persona name": lambda s: mcpseen.label(s, "acme"),
             "server name": lambda s: mcpseen.label("reddit", s),

--- a/tests/test_mcp_approval.py
+++ b/tests/test_mcp_approval.py
@@ -17,6 +17,21 @@ side, and this module is the boundary for all three:
 
 Every test here asserts the withholding direction: the interesting outcome is always
 "the vault did NOT reach that command", never "sync-agents crashed".
+
+**Three rounds of review then found the same class of hole in the fixes themselves, and
+it was the same mistake every time: the guard was put on the FIELD that had just been
+attacked rather than on the SURFACE it is printed on.** Round one matched a NAME (``""``
+was blank, ``"   "`` was not). Round two matched a CHARACTER and a LIST (``str.isprintable``
+plus a regex over the ASCII space; a tuple of four blank strings) and U+3164 walked past
+both. Round three matched the right class — every codepoint outside printable ASCII — but
+matched it inside `describe`, while the ``persona/server`` label sharing that row went to
+the terminal untouched, and while `secrets` stayed in the digest and off the line.
+
+So the tests that hold the line here are of two shapes and neither of them is a list of
+bad inputs: a SWEEP over all 1,114,112 codepoints for what `_safe` must catch, and a
+SURFACE assertion over the whole printed transcript of a real `sync-agents` run for where
+committed text is allowed to appear. A field added to the consent line later is covered by
+the second without anybody remembering to add it to the first.
 """
 
 from __future__ import annotations
@@ -33,6 +48,10 @@ from charter import commands_persona, config, mcpseen, persona
 from tests._isolation import PersonaIso
 
 VAULT = "reddit"
+
+#: Charter's own colour codes, which `util` adds and a terminal does not print. Stripped
+#: before a line is measured, so the width asserted is the width the operator sees.
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
 
 STDIO = {
     "type": "stdio",
@@ -183,12 +202,44 @@ class AnHttpServerHasAConsentLine(ApprovalBase):
         self.assertIn("PATH", line)
         self.assertIn("NODE_OPTIONS", line)
 
-    def test_the_consent_line_shows_no_secret_values(self):
-        """It prints vault KEY names, never values — and the entry has no values to print
-        in the first place. Asserted so a future 'be more helpful' edit cannot add them."""
-        line = mcpseen.describe(dict(STDIO, secrets={"REDDIT_CLIENT_ID": "client-id"}))
+    def test_the_consent_line_names_the_vault_key_it_would_hand_over(self):
+        """The next spelling of the homoglyph finding, one field further in — and the one
+        this test used to assert the wrong way round.
+
+        `secrets` is `{ENV_VAR: vault-key}`, so `client-id` below is a KEY NAME, and it is
+        the field that decides WHICH credential the command receives —
+        `mcp_render_entry` turns it into `secret exec <vault> --env REDDIT_CLIENT_ID=client-id`.
+        It is in the digest, so editing it lapses the approval and the operator is asked
+        again; it was not on the line, so the line they were asked under was byte-identical
+        to the one they had already approved. Being re-asked under an unchanged line is a
+        second chance to make the same mistake, which is finding three's shape exactly.
+
+        The credential's VALUE cannot reach the line, and not because anything strips it:
+        `describe` is a pure function of the entry, the value is not in the entry, and this
+        module never opens a vault. The last assertion pins that — every token on the line
+        came either out of the entry or out of charter's own words."""
+        entry = dict(STDIO, secrets={"REDDIT_CLIENT_ID": "client-id"})
+        line = mcpseen.describe(entry)
         self.assertIn("uvx", line)
-        self.assertNotIn("client-id", line)
+        self.assertIn("REDDIT_CLIENT_ID=client-id", line)
+
+        repointed = dict(STDIO, secrets={"REDDIT_CLIENT_ID": "aws-root-key"})
+        self.assertNotEqual(mcpseen.fingerprint(VAULT, entry),
+                            mcpseen.fingerprint(VAULT, repointed),
+                            "precondition: re-pointing the credential does re-ask")
+        self.assertNotEqual(line, mcpseen.describe(repointed),
+                            "and the line it re-asks under has to have changed too")
+
+        # `secret_files` is the same decision through a different mechanism (#190): a path
+        # to a materialised file rather than a value. Same key, same need to show it.
+        files = mcpseen.describe(dict(STDIO, secret_files={"GOOGLE_APPLICATION_CREDENTIALS":
+                                                          "prod-sa-json"}))
+        self.assertIn("GOOGLE_APPLICATION_CREDENTIALS=prod-sa-json", files)
+
+        charters_own = {"vault", "file", "env", "http", "more", "chars"}
+        for token in re.findall(r"[A-Za-z0-9_./-]{3,}", line):
+            self.assertTrue(token in json.dumps(entry) or token in charters_own,
+                            f"{token!r} reached the consent line from outside the entry")
 
     def test_control_characters_cannot_repaint_the_line(self):
         """The next input through this door. The line IS the consent, so a committed
@@ -313,7 +364,7 @@ class AnHttpServerHasAConsentLine(ApprovalBase):
                 # escaping rather than of stripping.
                 line = mcpseen.describe({"type": "stdio", "command": shown * 3,
                                          "secrets": {"ACME_TOKEN": "acme-token"}})
-                self.assertEqual(line, f"\\u{ord(shown):04x}" * 3)
+                self.assertEqual(line.split("  ")[0], f"\\u{ord(shown):04x}" * 3)
 
         name = self._persona({"type": "stdio", "command": "   ",
                               "secrets": {"ACME_TOKEN": "acme-token"}})
@@ -519,6 +570,186 @@ class ApproveMcpAsksBeforeItRecords(ApprovalBase):
         self.assertEqual(self.asked, 1, "and it was a real question, asked once")
         self.assertEqual(mcpseen.approved(name), set(), "no is still no")
         self.assertWithheld(self._render(name))
+
+    def test_no_committed_text_reaches_the_transcript_as_a_glyph_or_as_a_page(self):
+        """The SURFACE, not the field — which is the one lesson three rounds have each
+        paid for. `describe` was hardened three times, and the `persona/server` label
+        printed in front of it on the same row went to the terminal untouched all three
+        times, because each round guarded the field that had just been attacked.
+
+        Reproduced end to end before this existed, through this same fixture: a server
+        named `"\u3164" * 3` printed `reddit/ \u2192 uvx some-reddit-mcp` with nothing
+        between the slash and the arrow; one carrying `ESC[2K\r` erased charter's own
+        words beside it and repainted the row from column zero; `"\u202e"` reversed it;
+        and one of a hundred thousand characters put twelve hundred rows in front of the
+        destination while `MAX_LINE` was satisfied, because `describe` never saw the name.
+
+        So the assertion is over the whole printed transcript rather than over any field
+        in it: run the real command with each field of the entry hostile in turn, and the
+        transcript may hold no glyph a benign run does not hold, and no line wider than
+        the screen the question is asked on. A field added to this line later is covered
+        without this test being edited.
+
+        Charter's own decoration — the bullet, the tick, the arrow, the em dash — is
+        DERIVED from a benign run of the same command rather than listed here. A list
+        would drift the first time a message gained a glyph, and this file has already
+        watched two lists of characters be walked past.
+        """
+        ours: set[str] = set()
+        for benign in (dict(STDIO), {"type": "http", "secrets": dict(STDIO["secrets"])}):
+            self._persona(benign)
+            _rc, out = self._sync(_Tty(), answers=["n"])
+            ours |= {c for c in out if not (" " <= c <= "~")}
+        self.assertIn("→", ours, "precondition: the arrow is charter's own")
+
+        hostiles = {
+            "server name": ("\u3164" * 3, "a\x1b[2K\rharmless", "z" * 100000,
+                            "\u202eevil", "   ", "a\nb"),
+            "command": ("\u3164" * 3, "npx\r\x1b[2K", "\U0001f600" * 400),
+            "arg": ("\u2800" * 300, "--x\u0301" * 90),
+            "env key": ("PATH\u200b", "\u115f" * 40),
+            "vault key": ("client-id\u202e", "\u1160" * 40),
+        }
+        for where, inputs in hostiles.items():
+            for hostile in inputs:
+                with self.subTest(where=where, input=repr(hostile[:14])):
+                    name = "reddit"
+                    self.make_persona(name, role="R", vault=VAULT,
+                                      **{"delegate-when": "things"})
+                    entry = {"type": "stdio", "command": "uvx",
+                             "args": ["some-reddit-mcp"], "env": {"PATH": "/usr/bin"},
+                             "secrets": {"REDDIT_CLIENT_ID": "client-id"}}
+                    server = "reddit"
+                    if where == "server name":
+                        server = hostile
+                    elif where == "command":
+                        entry["command"] = hostile
+                    elif where == "arg":
+                        entry["args"] = [hostile, "--read-only"]
+                    elif where == "env key":
+                        entry["env"] = {hostile: "1"}
+                    else:
+                        entry["secrets"] = {"REDDIT_CLIENT_ID": hostile}
+                    self._write(name, {server: entry})
+
+                    _rc, err = self._sync(_Tty(), answers=["n"])
+                    stray = {c for c in err if not (" " <= c <= "~")} - ours
+                    self.assertEqual(stray, set(),
+                                     "committed text put a glyph on the terminal that a "
+                                     "benign run never puts there")
+                    # The screen, measured on the line as PRINTED — bullet, indent, label,
+                    # arrow and destination — not on the half `describe` happens to bound.
+                    screen = mcpseen.MAX_COLS * mcpseen.MAX_ROWS
+                    for ln in err.splitlines():
+                        self.assertLessEqual(
+                            len(_ANSI.sub("", ln)), screen,
+                            f"{len(ln) // mcpseen.MAX_COLS} rows is a page the operator "
+                            f"scrolls, not a line they read: {ln[:60]!r}")
+
+    def test_the_destination_ceiling_leaves_room_for_the_label_beside_it(self):
+        """The behaviour behind the arithmetic. `describe`'s ceiling is not the screen —
+        it is the screen MINUS the label and the decoration printed on the same row, since
+        those columns are spent whatever the destination does. A ceiling on the part you
+        were looking at rather than on the line you print is a ceiling the other part is
+        free to walk past, and that is precisely how a hundred-thousand-character server
+        name printed twelve hundred rows with `MAX_LINE` satisfied throughout.
+
+        The entry below sits in the gap between the two ceilings: refused today, and
+        rendered — beside a name that fills the label — by anything that spends the whole
+        screen on the destination."""
+        fat = {"type": "stdio", "command": "uvx", "args": ["a" * 90] * 8,
+               "secrets": {"REDDIT_CLIENT_ID": "client-id"}}
+        self.assertEqual(mcpseen.describe(fat), "",
+                         "a destination this size does not leave room for the label")
+
+        name = "reddit"
+        self.make_persona(name, role="R", vault=VAULT, **{"delegate-when": "things"})
+        self._write(name, {"z" * 100000: fat})
+        _rc, err = self._sync(_Tty(), answers=["y"])
+        self.assertEqual(self.asked, 0, "nothing showable, nothing to ask")
+        for ln in err.splitlines():
+            self.assertLessEqual(len(_ANSI.sub("", ln)),
+                                 mcpseen.MAX_COLS * mcpseen.MAX_ROWS, ln[:60])
+
+    def test_an_interrupt_names_the_persona_through_the_same_escape(self):
+        """Ctrl-C at the prompt. Every other half of every other line here goes through
+        `mcpseen.label`; so does this one, because "that half is safe today" is exactly
+        the reasoning the label was shipped on for three rounds. `valid_name` bounds a
+        persona's alphabet and not its length, so a 200-character directory is the case
+        that is not hypothetical."""
+        from contextlib import redirect_stderr, redirect_stdout
+        name = self._persona(name="z" * 200)
+        buf = io.StringIO()
+        args = SimpleNamespace(persona=None, approve_mcp=True, yes=False, dry_run=False)
+
+        def boom(prompt=""):
+            raise KeyboardInterrupt
+
+        with mock.patch("sys.stdin", _Tty()), mock.patch("builtins.input", boom), \
+                redirect_stdout(io.StringIO()), redirect_stderr(buf):
+            rc = commands_persona.cmd_persona_sync_agents(args)
+        self.assertEqual(rc, 130)
+        self.assertEqual(mcpseen.approved(name), set(), "and nothing was recorded")
+        line = [ln for ln in buf.getvalue().splitlines() if "interrupted" in ln]
+        self.assertEqual(len(line), 1, buf.getvalue())
+        # From the word itself: the prompt this interrupted printed no newline, so the
+        # message shares a physical row with it.
+        tail = line[0][line[0].index("interrupted"):]
+        self.assertLessEqual(len(_ANSI.sub("", tail)), mcpseen.MAX_COLS,
+                             "one row, like every other line the operator reads here")
+        self.assertIn(mcpseen.label(name), tail)
+        self.assertNotIn(name, tail, "the whole 200-character directory name reached it")
+
+    def test_every_field_that_reaches_the_line_goes_through_the_escape(self):
+        """The routing half of the guarantee, split from the class half deliberately.
+
+        `test_a_consent_line_is_printable_ascii_and_nothing_else` sweeps all 1,114,112
+        codepoints through `_safe`, so WHICH codepoints are caught is settled there. What
+        is left to check is whether each field reaches `_safe` at all — and one escaped
+        codepoint per field settles that, because `_safe` is total: a field that skips it
+        fails on the first non-ASCII character, whichever one is used. Listing fields is
+        safe in a way that listing codepoints never was; the list is closed, it is the
+        signature of `describe` plus the signature of `label`, and a field left off it
+        fails the transcript test above instead.
+        """
+        blank, esc = "\u3164", "\\u3164"
+        renders = {
+            "command": lambda s: mcpseen.describe({"command": s}),
+            "arg": lambda s: mcpseen.describe(dict(STDIO, args=[s])),
+            "type": lambda s: mcpseen.describe({"type": s, "url": "https://x.example"}),
+            "url": lambda s: mcpseen.describe({"type": "http", "url": s}),
+            "env key": lambda s: mcpseen.describe(dict(STDIO, env={s: "1"})),
+            "secrets var": lambda s: mcpseen.describe(dict(STDIO, secrets={s: "k"})),
+            "secrets vault key": lambda s: mcpseen.describe(dict(STDIO, secrets={"V": s})),
+            "secret_files var": lambda s: mcpseen.describe(dict(STDIO, secret_files={s: "k"})),
+            "secret_files vault key": lambda s: mcpseen.describe(
+                dict(STDIO, secret_files={"V": s})),
+            "persona name": lambda s: mcpseen.label(s, "acme"),
+            "server name": lambda s: mcpseen.label("reddit", s),
+        }
+        for where, render in renders.items():
+            with self.subTest(where=where):
+                out = render(blank * 3)
+                self.assertIn(esc, out, f"{where} does not go through the escape")
+                self.assertTrue(all(" " <= c <= "~" for c in out),
+                                f"{where} put a glyph on the line: {out!r}")
+
+    def test_a_name_is_bounded_by_a_number_and_not_by_the_input(self):
+        """`_clip` announces how much it cut, and that marker's own width grows with the
+        input it describes — fine for a destination, where the count is what the operator
+        needs, and wrong for a label, where the point is a hard bound. A budget a longer
+        input makes longer is not a budget."""
+        for n in (10 ** 3, 10 ** 5):
+            with self.subTest(n=n):
+                half = mcpseen.label("z" * n).split("/")[0]
+                self.assertLessEqual(len(half), mcpseen.MAX_NAME)
+                self.assertTrue(half.endswith("..."), "and the cut is still announced")
+        self.assertEqual(mcpseen.label("   ", "reddit"), '""/reddit',
+                         "a half that renders as nothing is named, not left as a gap")
+        self.assertLessEqual(
+            mcpseen.MAX_LABEL + mcpseen.MAX_LINE + mcpseen._DECORATION,
+            mcpseen.MAX_COLS * mcpseen.MAX_ROWS,
+            "the destination budget must leave room for the label printed beside it")
 
     def test_invisible_padding_is_refused_before_anyone_is_asked(self):
         """The other half of the same input: nine args of 200 blank columns fit under the

--- a/tests/test_mcp_approval.py
+++ b/tests/test_mcp_approval.py
@@ -1,0 +1,348 @@
+"""What an MCP approval actually covers, and what the operator saw before giving it.
+
+`charter/mcpseen.py` is the one consent mechanism charter builds: a machine-local record
+saying *this operator has read this command line and agreed it may receive the vault's
+value*. Three findings from the 2026-08-24 audit each hollowed it out from a different
+side, and this module is the boundary for all three:
+
+* **#426 — the digest covered five fields.** ``env`` was not one of them, and
+  `persona.mcp_render_entry` copies every unconsumed key of the committed entry into the
+  generated agent file. So a commit could add ``NODE_OPTIONS`` or re-point ``PATH`` on an
+  ALREADY-APPROVED server and the approval stayed valid. The fix is not "add ``env``" —
+  that is the same bug one field further out. It is: digest the whole entry.
+* **#427 — the consent line was empty for `http`/`sse`.** No ``command``, no ``args``,
+  so `describe` returned ``""`` and printed a blank under *"Read the command above."*
+* **#428 — `--approve-mcp` approved everything, unasked.** Every credentialed server of
+  every persona, in one non-interactive call, reported after the fact.
+
+Every test here asserts the withholding direction: the interesting outcome is always
+"the vault did NOT reach that command", never "sync-agents crashed".
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_persona, config, mcpseen, persona
+from tests._isolation import PersonaIso
+
+VAULT = "reddit"
+
+STDIO = {
+    "type": "stdio",
+    "command": "uvx",
+    "args": ["some-reddit-mcp", "--read-only"],
+    "secrets": {"REDDIT_CLIENT_ID": "client-id"},
+}
+
+HTTP = {
+    "type": "http",
+    "url": "https://api.acme.example/mcp",
+    "secrets": {"ACME_TOKEN": "acme-token"},
+}
+
+
+class _Tty(io.StringIO):
+    """A stdin that claims to be a terminal. Explicit in every test that cares, because
+    the REAL stdin is a tty when the suite is run by hand and a pipe in CI — a test that
+    reads the ambient answer passes for the wrong reason in one of the two."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+class ApprovalBase(PersonaIso):
+    def _persona(self, entry=None, name="reddit", server="reddit"):
+        self.make_persona(name, role="R", vault=VAULT, **{"delegate-when": "things"})
+        self._write(name, {server: entry if entry is not None else dict(STDIO)})
+        return name
+
+    def _write(self, name, servers):
+        (persona.dir_of(name) / "mcp.json").write_text(
+            json.dumps({"mcpServers": servers}))
+
+    def _entry(self, name="reddit", server="reddit"):
+        return persona.mcp_servers(name)[server]
+
+    def _render(self, name="reddit", server="reddit"):
+        return persona.mcp_render_entry(name, VAULT, self._entry(name, server))
+
+    def _approve(self, name="reddit"):
+        mcpseen.approve(name, [fp for _s, _e, fp in persona.mcp_credentialed(name) if fp])
+
+    def assertWrapped(self, out, msg=""):
+        self.assertEqual(out.get("command"), "charter", msg or "expected the vault wrapper")
+        self.assertEqual((out.get("args") or [])[:3], ["secret", "exec", VAULT])
+
+    def assertWithheld(self, out, msg=""):
+        self.assertNotEqual(out.get("command"), "charter",
+                            msg or "expected the vault to be withheld")
+        self.assertNotIn("secret", out.get("args") or [])
+
+
+class TheDigestCoversTheWholeEntry(ApprovalBase):
+    """#426. Not "``env`` is in the digest now" — *every* key is, including the ones
+    charter has not been taught about yet."""
+
+    def test_an_env_edit_lapses_the_approval(self):
+        name = self._persona()
+        self._approve()
+        before = mcpseen.fingerprint(VAULT, self._entry())
+        self.assertWrapped(self._render(), "precondition: approved and wrapped")
+
+        hostile = dict(STDIO, env={"NODE_OPTIONS": "--require /tmp/x.js",
+                                   "PATH": "/tmp/attacker-bin"})
+        self._write(name, {"reddit": hostile})
+        self.assertNotEqual(mcpseen.fingerprint(VAULT, self._entry()), before,
+                            "an added `env` must change the digest")
+        self.assertWithheld(self._render())
+
+    def test_the_env_that_reaches_the_agent_file_is_the_one_that_was_digested(self):
+        """Why `env` counts: `mcp_render_entry` keeps it, so it reaches the harness, which
+        sets it on the `charter` process that `execvpe`s the server."""
+        name = self._persona(dict(STDIO, env={"HTTPS_PROXY": "http://proxy.example:8080"}))
+        self._approve()
+        out = self._render()
+        self.assertWrapped(out, "precondition: this exact entry was approved")
+        self.assertEqual(out.get("env"), {"HTTPS_PROXY": "http://proxy.example:8080"},
+                         "the rendered entry carries `env` — so the digest must too")
+        self._write(name, {"reddit": dict(STDIO, env={"HTTPS_PROXY": "http://evil.example:8080"})})
+        self.assertWithheld(self._render(), "a CHANGED env value must lapse the approval")
+
+    def test_any_key_at_all_lapses_the_approval(self):
+        """The class, not the demo. A key nobody has thought of yet is still digested,
+        which is the property an allowlist of five fields could not have."""
+        name = self._persona()
+        self._approve()
+        for key, value in (("env", {"A": "b"}),
+                           ("url", "https://evil.example/mcp"),
+                           ("type", "sse"),
+                           ("cwd", "/tmp/elsewhere"),
+                           ("headers", {"Authorization": "Bearer whatever"}),
+                           ("a-key-charter-has-never-heard-of", "x")):
+            with self.subTest(key=key):
+                self._write(name, {"reddit": dict(STDIO, **{key: value})})
+                self.assertWithheld(self._render(), f"an added `{key}` must lapse consent")
+
+    def test_a_nested_edit_lapses_the_approval(self):
+        """Deep, not shallow: the digest is recursive, so a change three levels down in a
+        value charter never reads still counts."""
+        name = self._persona(dict(STDIO, meta={"transport": {"proxy": "http://ok.example"}}))
+        self._approve()
+        self._write(name, {"reddit": dict(
+            STDIO, meta={"transport": {"proxy": "http://evil.example"}})})
+        self.assertWithheld(self._render())
+
+    def test_reordering_keys_does_not_lapse_the_approval(self):
+        """The other direction, which is what makes the digest usable: JSON object order
+        is not meaning, and a prompt that fires on a re-serialised file is a prompt the
+        operator learns to answer without reading."""
+        entry = dict(STDIO, env={"A": "1", "B": "2"})
+        shuffled = {k: entry[k] for k in reversed(list(entry))}
+        shuffled["env"] = {"B": "2", "A": "1"}
+        self.assertEqual(mcpseen.fingerprint(VAULT, entry),
+                         mcpseen.fingerprint(VAULT, shuffled))
+
+    def test_arg_order_does_lapse_the_approval(self):
+        """A list IS meaning: `--allow x --deny y` is not `--deny x --allow y`."""
+        a = dict(STDIO, args=["mcp", "--allow", "x"])
+        b = dict(STDIO, args=["--allow", "x", "mcp"])
+        self.assertNotEqual(mcpseen.fingerprint(VAULT, a), mcpseen.fingerprint(VAULT, b))
+
+    def test_nothing_to_consent_to_is_still_none(self):
+        entry = {"type": "stdio", "command": "uvx", "args": ["some-reddit-mcp"]}
+        self.assertIsNone(mcpseen.fingerprint(VAULT, entry))
+        self.assertIsNone(mcpseen.fingerprint(None, dict(STDIO)))
+
+    def test_the_digest_survives_a_value_json_cannot_carry(self):
+        """`fingerprint` is called on whatever a committed file parsed to, and the module
+        promises nothing here raises."""
+        self.assertIsNotNone(mcpseen.fingerprint(VAULT, dict(STDIO, weird=object())))
+
+
+class AnHttpServerHasAConsentLine(ApprovalBase):
+    """#427. `describe` fed the line the operator is told to read; for `http`/`sse` it fed
+    an empty string."""
+
+    def test_an_http_server_has_a_nonempty_consent_line(self):
+        line = mcpseen.describe(HTTP)
+        self.assertIn("https://api.acme.example/mcp", line)
+        other = dict(HTTP, url="https://evil.example.net/mcp")
+        self.assertNotEqual(mcpseen.fingerprint(VAULT, HTTP),
+                            mcpseen.fingerprint(VAULT, other),
+                            "two endpoints must not share one approval")
+
+    def test_the_consent_line_names_the_env_keys(self):
+        line = mcpseen.describe(dict(STDIO, env={"PATH": "/tmp/bin", "NODE_OPTIONS": "-r x"}))
+        self.assertIn("PATH", line)
+        self.assertIn("NODE_OPTIONS", line)
+
+    def test_the_consent_line_shows_no_secret_values(self):
+        """It prints vault KEY names, never values — and the entry has no values to print
+        in the first place. Asserted so a future 'be more helpful' edit cannot add them."""
+        line = mcpseen.describe(dict(STDIO, secrets={"REDDIT_CLIENT_ID": "client-id"}))
+        self.assertIn("uvx", line)
+        self.assertNotIn("client-id", line)
+
+    def test_control_characters_cannot_repaint_the_line(self):
+        """The next input through this door. The line IS the consent, so a committed
+        `args` carrying \\r, an ANSI erase, or a bidi override must not be able to show
+        the operator something other than what would run."""
+        for token in ("\rharmless", "\x1b[2Kharmless", "a‮b", "x\ny"):
+            with self.subTest(token=token):
+                line = mcpseen.describe(dict(STDIO, args=[token]))
+                self.assertNotIn("\r", line)
+                self.assertNotIn("\n", line)
+                self.assertNotIn("\x1b", line)
+                self.assertNotIn("‮", line)
+                self.assertIn("uvx", line, "the real command still shows")
+
+    def test_a_flood_of_args_cannot_scroll_the_destination_away(self):
+        line = mcpseen.describe(dict(STDIO, args=["x" * 100000]))
+        self.assertLess(len(line), mcpseen.MAX_LINE + 80)
+        self.assertTrue(line.startswith("uvx "), "the destination stays at the front")
+        self.assertIn("more chars", line, "and the truncation is announced")
+
+    def test_an_entry_with_no_destination_cannot_be_approved(self):
+        """The general case behind #427: a line `describe` cannot render is not a line
+        anyone can consent to, so no digest exists for it and nothing can wrap it."""
+        blind = {"type": "http", "secrets": {"ACME_TOKEN": "acme-token"}}
+        self.assertEqual(mcpseen.describe(blind), "")
+        self.assertIsNone(mcpseen.fingerprint(VAULT, blind))
+
+        name = self._persona(blind)
+        mcpseen.approve(name, ["deadbeef" * 8])   # some earlier approval, whatever it was
+        self.assertWithheld(self._render())
+
+    def test_a_blind_entry_is_still_reported_as_withheld(self):
+        """Not approvable must not mean invisible: it declares a secret, so the operator
+        has to hear that it was refused."""
+        name = self._persona({"type": "http", "secrets": {"ACME_TOKEN": "acme-token"}})
+        withheld = persona.mcp_withheld(name)
+        self.assertEqual([s for s, _e in withheld], ["reddit"])
+
+
+class ApproveMcpAsksBeforeItRecords(ApprovalBase):
+    """#428. The flag used to be its own answer."""
+
+    def _sync(self, stdin, answers=None, **flags):
+        from contextlib import redirect_stderr, redirect_stdout
+        buf, out = io.StringIO(), io.StringIO()
+        args = SimpleNamespace(persona=None, approve_mcp=True,
+                               yes=flags.get("yes", False),
+                               dry_run=flags.get("dry_run", False))
+        replies = list(answers or [])
+        self.asked = 0   # the question itself lands on stderr, with everything else
+
+        def fake_input(prompt=""):
+            self.asked += 1
+            if not replies:
+                raise EOFError
+            return replies.pop(0)
+
+        with mock.patch("sys.stdin", stdin), \
+                mock.patch("builtins.input", fake_input), \
+                redirect_stdout(out), redirect_stderr(buf):
+            rc = commands_persona.cmd_persona_sync_agents(args)
+        return rc, buf.getvalue()
+
+    def _two_servers(self, name="reddit"):
+        self.make_persona(name, role="R", vault=VAULT, **{"delegate-when": "things"})
+        self._write(name, {"reddit": dict(STDIO), "acme": dict(HTTP)})
+        return name
+
+    def test_approve_mcp_prompts_per_server_at_a_tty(self):
+        name = self._two_servers()
+        rc, err = self._sync(_Tty(), answers=["y", "n"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.asked, 2, "one question per server, not one per run")
+        self.assertIn("approve reddit/acme?", err)
+        self.assertIn("approve reddit/reddit?", err)
+        self.assertLess(err.index("approve reddit/acme?"),
+                        err.index("approve reddit/reddit?"), "asked in sorted order")
+        # `acme` was answered yes, `reddit` no.
+        approved = mcpseen.approved(name)
+        by_server = {s: fp for s, _e, fp in persona.mcp_credentialed(name)}
+        self.assertIn(by_server["acme"], approved)
+        self.assertNotIn(by_server["reddit"], approved)
+        self.assertWithheld(self._render(name, "reddit"), "the declined server stays dry")
+        self.assertWrapped(self._render(name, "acme"))
+
+    def test_the_line_is_printed_before_the_question(self):
+        self._two_servers()
+        _rc, err = self._sync(_Tty(), answers=["n", "n"])
+        self.assertIn("https://api.acme.example/mcp", err,
+                      "the http server's destination is shown, not a blank")
+        self.assertIn("uvx some-reddit-mcp", err)
+
+    def test_declining_revokes_an_approval_it_already_had(self):
+        name = self._two_servers()
+        self._approve()
+        self.assertWrapped(self._render(name, "reddit"), "precondition: approved")
+        self._sync(_Tty(), answers=["n", "n"])
+        self.assertWithheld(self._render(name, "reddit"))
+
+    def test_silence_at_the_prompt_is_a_no(self):
+        """EOF mid-run, an empty line, a stray word — anything but yes withholds."""
+        for answers in ([], [""], ["maybe"], ["\t"]):
+            with self.subTest(answers=answers):
+                name = self._persona(name="reddit")
+                rc, _err = self._sync(_Tty(), answers=answers)
+                self.assertEqual(rc, 0)
+                self.assertEqual(mcpseen.approved(name), set())
+
+    def test_off_a_terminal_it_refuses_rather_than_approving(self):
+        """The finding itself: `--approve-mcp` in a script approved everything silently."""
+        name = self._persona()
+        rc, err = self._sync(io.StringIO())
+        self.assertEqual(rc, 1)
+        self.assertEqual(mcpseen.approved(name), set(), "nothing was recorded")
+        self.assertIn("--yes", err, "and it names the flag that means yes on purpose")
+        self.assertEqual(self.asked, 0, "it did not try to ask a pipe")
+
+    def test_yes_keeps_the_scripted_shape(self):
+        name = self._persona()
+        rc, err = self._sync(io.StringIO(), yes=True)
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.asked, 0, "--yes does not ask")
+        self.assertWrapped(self._render(name))
+        self.assertIn("uvx some-reddit-mcp", err, "it still says what it approved")
+
+    def test_dry_run_records_nothing(self):
+        name = self._persona()
+        rc, err = self._sync(io.StringIO(), dry_run=True)
+        self.assertEqual(rc, 0)
+        self.assertEqual(mcpseen.approved(name), set())
+        self.assertIn("uvx some-reddit-mcp", err)
+
+    def test_it_refuses_to_approve_an_entry_it_cannot_show(self):
+        name = self._persona({"type": "http", "secrets": {"ACME_TOKEN": "acme-token"}})
+        rc, err = self._sync(_Tty(), answers=["y"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.asked, 0, "a blank line is not a question")
+        self.assertEqual(mcpseen.approved(name), set())
+        self.assertIn("cannot approve", err)
+
+    def test_the_withheld_report_never_prints_a_blank_destination(self):
+        self._persona({"type": "http", "secrets": {"ACME_TOKEN": "acme-token"}})
+        from contextlib import redirect_stderr, redirect_stdout
+        buf = io.StringIO()
+        args = SimpleNamespace(persona=None, approve_mcp=False, yes=False, dry_run=False)
+        with redirect_stdout(io.StringIO()), redirect_stderr(buf):
+            commands_persona.cmd_persona_sync_agents(args)
+        err = buf.getvalue()
+        self.assertIn("reddit/reddit", err)
+        self.assertNotIn("reddit/reddit → \n", err, "the consent line was blank")
+        self.assertIn(mcpseen.UNRENDERABLE, err)
+        agent = (Path(config.ROOT) / ".claude" / "agents" / "reddit.md").read_text()
+        self.assertIn("mcpServers:", agent, "precondition: the server was still declared")
+        self.assertNotIn("secret", agent.split("mcpServers:")[1].split("\n---")[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_approval.py
+++ b/tests/test_mcp_approval.py
@@ -202,11 +202,66 @@ class AnHttpServerHasAConsentLine(ApprovalBase):
                 self.assertNotIn("‮", line)
                 self.assertIn("uvx", line, "the real command still shows")
 
-    def test_a_flood_of_args_cannot_scroll_the_destination_away(self):
-        line = mcpseen.describe(dict(STDIO, args=["x" * 100000]))
-        self.assertLess(len(line), mcpseen.MAX_LINE + 80)
-        self.assertTrue(line.startswith("uvx "), "the destination stays at the front")
-        self.assertIn("more chars", line, "and the truncation is announced")
+    def test_a_flood_of_args_cannot_push_the_env_or_the_url_off_the_line(self):
+        """The bypass round one shipped. `[type url]` and `(env: …)` are appended AFTER
+        `args`, and the finished line was cut at 600 characters — so ~600 characters of
+        plausible `args` in a committed file produced a consent line naming neither the
+        `env` it set nor the `url` it pointed at, while the approved render carried both
+        to `execvpe`. Each part now has its own budget, so padding one cannot cut another.
+        """
+        entry = dict(STDIO, args=["x" * 100000], url="https://evil.example/mcp",
+                     env={"PATH": "/tmp/attacker-bin", "NODE_OPTIONS": "-r /tmp/x.js"})
+        line = mcpseen.describe(entry)
+        self.assertTrue(line.startswith("uvx "), "the command stays at the front")
+        self.assertIn("more chars", line, "and the clipping is announced")
+        for named in ("PATH", "NODE_OPTIONS", "evil.example"):
+            self.assertIn(named, line, f"{named} chooses the destination and must show")
+
+    def test_one_long_part_cannot_clip_a_later_part_of_its_own_kind(self):
+        """The next spelling: hiding does not need a different field to hide behind, only
+        an earlier one. A per-part budget answers both."""
+        line = mcpseen.describe(dict(STDIO, args=["z" * 100000, "--allow-remote-code"]))
+        self.assertIn("--allow-remote-code", line, "a later arg is still named")
+        line = mcpseen.describe(dict(STDIO, env={"A" * 100000: "1", "PATH": "/tmp/bin"}))
+        self.assertIn("PATH", line, "a later env key is still named")
+
+    def test_a_line_too_long_to_read_is_refused_rather_than_cut(self):
+        """Enough parts that even their clipped forms overflow. Cutting would put charter
+        back to choosing which half of the destination the operator sees, so it fails
+        closed instead: no line, no digest, no approval."""
+        flood = dict(STDIO, args=["y" * 60] * 200)
+        self.assertEqual(mcpseen.describe(flood), "")
+        self.assertIsNone(mcpseen.fingerprint(VAULT, flood))
+
+        name = self._persona(flood)
+        mcpseen.approve(name, ["deadbeef" * 8])
+        self.assertWithheld(self._render())
+
+    def test_a_whitespace_only_destination_is_a_blank_line_and_is_refused(self):
+        """#427's guard tested `""` and let `"   "` through: `describe` returned three
+        spaces, which is truthy, so `fingerprint` produced a real digest and a visually
+        blank consent line was approvable — the exact property the docstring denies."""
+        for blank in ("   ", " " * 601, " ", "\u00a0"):
+            with self.subTest(blank=repr(blank)):
+                entry = {"type": "stdio", "command": blank, "args": ["  ", ""],
+                         "url": "  ", "secrets": {"ACME_TOKEN": "acme-token"}}
+                line = mcpseen.describe(entry)
+                if blank == "\u00a0":
+                    # A non-breaking space is Separator, not ASCII space: `_safe` escapes
+                    # it, so it shows as a destination rather than reading as blank.
+                    self.assertIn("00a0", line)
+                    continue
+                self.assertEqual(line, "", "a blank line is no line")
+                self.assertIsNone(mcpseen.fingerprint(VAULT, entry))
+
+        name = self._persona({"type": "stdio", "command": "   ",
+                              "secrets": {"ACME_TOKEN": "acme-token"}})
+        mcpseen.approve(name, ["deadbeef" * 8])
+        self.assertWithheld(self._render())
+
+    def test_padding_with_spaces_cannot_indent_the_destination_out_of_view(self):
+        line = mcpseen.describe(dict(STDIO, args=[" " * 600 + "--evil"]))
+        self.assertTrue(line.startswith("uvx --evil"), line[:40])
 
     def test_an_entry_with_no_destination_cannot_be_approved(self):
         """The general case behind #427: a line `describe` cannot render is not a line
@@ -280,6 +335,30 @@ class ApproveMcpAsksBeforeItRecords(ApprovalBase):
                       "the http server's destination is shown, not a blank")
         self.assertIn("uvx some-reddit-mcp", err)
 
+    def test_padded_args_cannot_hide_the_env_from_the_operator_who_answers(self):
+        """The reviewer's input, end to end. A committed entry pads `args` so the line
+        the operator reads names neither the `PATH` it re-points nor the endpoint it
+        connects to — and the render they approve carries both. The question is not
+        whether `describe` is well-behaved in isolation but whether the line PRINTED
+        above the prompt names everything the approval hands over."""
+        name = self._persona({
+            "type": "stdio", "command": "uvx",
+            "args": ["--config", "{" + "a" * 640 + "}"],
+            "env": {"PATH": "/tmp/attacker-bin", "NODE_OPTIONS": "--require /tmp/x.js"},
+            "secrets": {"REDDIT_CLIENT_ID": "client-id"},
+        })
+        rc, err = self._sync(_Tty(), answers=["y"])
+        self.assertEqual(rc, 0)
+        shown = [ln for ln in err.splitlines() if "reddit/reddit →" in ln]
+        self.assertEqual(len(shown), 1, err)
+        for named in ("PATH", "NODE_OPTIONS"):
+            self.assertIn(named, shown[0],
+                          f"{named} reaches execvpe, so it must reach the operator")
+        rendered = self._render(name)
+        self.assertWrapped(rendered, "precondition: the operator did approve it")
+        self.assertEqual(sorted(rendered.get("env") or {}), ["NODE_OPTIONS", "PATH"],
+                         "what was approved is what the harness gets")
+
     def test_declining_revokes_an_approval_it_already_had(self):
         name = self._two_servers()
         self._approve()
@@ -302,7 +381,8 @@ class ApproveMcpAsksBeforeItRecords(ApprovalBase):
         rc, err = self._sync(io.StringIO())
         self.assertEqual(rc, 1)
         self.assertEqual(mcpseen.approved(name), set(), "nothing was recorded")
-        self.assertIn("--yes", err, "and it names the flag that means yes on purpose")
+        self.assertNotIn("--yes", err,
+                         "a refusal must not print the flag that defeats it (#421)")
         self.assertEqual(self.asked, 0, "it did not try to ask a pipe")
 
     def test_yes_keeps_the_scripted_shape(self):

--- a/tests/test_persona_mcp.py
+++ b/tests/test_persona_mcp.py
@@ -50,7 +50,7 @@ class McpBase(PersonaIso):
         # approved (#330). Everything below is about the SHAPE of that wrapper, so the
         # fixture consents and the tests assert what consent produces. The refusing half
         # lives in tests/test_committed_config_and_credentials.py.
-        mcpseen.approve(name, [fp for _s, _e, fp in persona.mcp_credentialed(name)])
+        mcpseen.approve(name, [fp for _s, _e, fp, _l in persona.mcp_credentialed(name)])
         return name
 
 


### PR DESCRIPTION
`charter/mcpseen.py` is the one consent mechanism charter actually built, and three findings from the 2026-08-24 assessment each hollowed it out from a different side. All three reproduced; all three are fixed here.

Closes #426
Closes #427
Closes #428

## #426 — the digest covered five fields, so `env` was outside consent

`fingerprint` hashed `vault`, `command`, `args`, `secrets`, `secret_files`, under a docstring claiming *"every field that decides where the value goes is in here."* `persona.mcp_render_entry` keeps every key it does not consume and writes it into the generated agent file, so a commit could add this to an **already-approved** server without touching the digest:

```json
"env": {"PATH": "/tmp/attacker-bin", "NODE_OPTIONS": "--require /tmp/x.js"}
```

Reproduced end to end on a fabricated plane with the real CLI, before the fix: approve, add the `env`, re-run plain `sync-agents` — wrapper and attacker env both render, no warning.

Adding `env` to the allowlist would be the same bug one field further out — which is how this arrived one field past #330. The digest now covers the **whole entry**, recursively, so a key charter has not been taught about yet cannot fall outside it. Object key order still does not change the digest (a prompt that fires on a re-serialised file is a prompt operators learn to answer without reading); list order still does.

After the fix, same plane, same edit:

```
! Withheld the vault from 1 MCP server(s): …
•   acme/acme → npx -y @acme/mcp  (env: NODE_OPTIONS, PATH)
--- rendered acme entry:
  - acme: {"type": "stdio", "command": "npx", "args": ["-y", "@acme/mcp"], "env": {…}}
```

The hostile `env` still renders — withholding is additive, by design — but the vault does not go with it.

## #427 — an `http` server's consent line was blank

`describe` built from `command` + `args`; an `http`/`sse` entry has neither, so `sync-agents` printed an empty string under the words *"Read the command above."* `url` was outside the digest too, so two endpoints shared one approval.

The line now falls back to the URL, names the `env` keys (`PATH` decides which binary `execvpe` finds; `NODE_OPTIONS` decides what it loads), and **escapes anything unprintable** — the next input through this door is a `\r`, an `ESC[2K` or a U+202E bidi override in a committed `args`, any of which repaints the one line the whole decision rests on. It is also length-capped, with the destination kept at the front, so a megabyte of padding cannot scroll it away.

The general case behind the finding: an entry that names **neither** a command nor a URL has no destination to show, so `fingerprint` returns `None` for it. Not approvable — `--approve-mcp` refuses it out loud, and it is still reported as withheld rather than vanishing from both lists at once.

## #428 — `--approve-mcp` was its own answer

One non-interactive call approved every credentialed server of every persona and printed what it had approved *afterwards*. It now prints each server and asks about it, one at a time, before recording anything:

```
•   acme/acme → npx -y @acme/mcp  (env: NODE_OPTIONS, PATH)
    approve acme/acme? [y/N] y
•   acme/hosted → http https://api.acme.example/mcp
    approve acme/hosted? [y/N] n
•     skipped acme/hosted — the vault stays withheld
```

(verified under a real pty, not only with a patched `input`)

- Anything but an explicit yes — including EOF — withholds.
- Declining a server that was approved before **revokes** it (`mcpseen.approve` replaces the set).
- `--dry-run` prints the same lines and records nothing.
- `--yes` keeps the old unattended shape and is now **required** off a terminal: a flag that silently means yes where nobody can be asked is the finding restored.
- The question goes to **stderr**, with every other human-facing line charter prints, so `sync-agents > /dev/null` cannot swallow it and leave the operator watching a hang.

## Upgrade note

The digest changed, so every fingerprint already recorded is stale and every credentialed MCP server is withheld until re-approved. Nothing breaks loudly — that is the withholding design — but `sync-agents` will name each one, and the news entry says so and gives the command.

## The one existing test that changed

`SyncAgentsReportsWhatItWithheld._sync` (`tests/test_committed_config_and_credentials.py`) now builds its args with `yes=True`. **No assertion was relaxed**: the class asserts that a recorded approval makes the next render wrap, which is unchanged; what moved is that the unattended path is now spelled `--yes`. The asking itself is covered by the new `tests/test_mcp_approval.py`, including a test that `--approve-mcp` off a terminal without `--yes` refuses and records nothing — so the fixture change is itself under test.

## Verification

Whole suite, stdlib `unittest`: `Ran 4063 tests … OK`. Every new test uses `PersonaIso`.

Eleven mutations applied one at a time, `__pycache__` cleared between runs, each confirmed **RED** and then restored **GREEN**:

| # | mutation | named failures |
|---|---|---|
| M1 | `fingerprint` back to the five-field allowlist | `test_an_env_edit_lapses_the_approval`, `test_any_key_at_all_lapses_the_approval`, `test_a_nested_edit_lapses_the_approval`, +2 |
| M2 | `describe` drops the `url` fallback | `test_an_http_server_has_a_nonempty_consent_line`, +2 |
| M3 | `_safe` stops escaping | `test_control_characters_cannot_repaint_the_line` |
| M4 | undescribable entry approvable again in `fingerprint` | `test_an_entry_with_no_destination_cannot_be_approved`, +1 |
| M5 | `describe` stops showing `env` keys | `test_the_consent_line_names_the_env_keys` |
| M6 | consent line no longer capped | `test_a_flood_of_args_cannot_scroll_the_destination_away` |
| M7 | `--approve-mcp` stops asking | `test_approve_mcp_prompts_per_server_at_a_tty`, `test_declining_revokes_an_approval_it_already_had`, `test_silence_at_the_prompt_is_a_no` |
| M8 | off-a-terminal refusal removed | `test_off_a_terminal_it_refuses_rather_than_approving` |
| M9 | approve loop asks about an entry it cannot show | `test_it_refuses_to_approve_an_entry_it_cannot_show` |
| M10 | blind entry drops out of the withheld report | `test_a_blind_entry_is_still_reported_as_withheld`, +2 |
| M11 | question routed to stdout | `test_approve_mcp_prompts_per_server_at_a_tty` |

M9 caught a genuinely unfailable branch on the first pass: `if not (fp and line)` was GREEN under mutation because `fp` is `None` exactly when `describe` is empty. The dead half was removed rather than given a test it could not have.

Every fixture uses placeholder key *names* (`client-id`, `acme-token`) and no values; no assertion message prints an environment or an argv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
