### PR TITLE
secrets: secret cp writes a real file or nothing; secret exec stops handing out other vaults' identities (#421 #422 #425 #434 #435)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -943,8 +943,10 @@ def _sa_exec(p):
                         "GOOGLE_APPLICATION_CREDENTIALS takes a path, not a value) — the "
                         "case --exec cannot serve, because exec leaves nothing alive to "
                         "clean up. Output is NOT redacted (nothing is captured). Cleanup "
-                        "survives SIGINT, SIGTERM and SIGHUP; only a SIGKILLed charter "
-                        "runs no cleanup, and then the 0600 file survives.")
+                        "survives every terminating signal charter may catch — SIGINT, "
+                        "SIGTERM, SIGHUP, SIGQUIT and the rest. It does not survive "
+                        "SIGKILL, which cannot be caught, or a fault (SIGSEGV, SIGABRT), "
+                        "which charter does not intercept; then the 0600 file survives.")
     p.add_argument("--exec", dest="exec_mode", action="store_true",
                    help="Replace this process with the command (os.exec) instead of capturing "
                         "it, so stdio streams through — required for a long-running child such "

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -918,7 +918,12 @@ def _sa_key(p):
 
 def _sa_cp(p):
     p.add_argument("key")
-    p.add_argument("dest")
+    p.add_argument("dest",
+                   help="Path of a REAL FILE to create. A device, FIFO, directory or "
+                        "symlink is refused — /dev/stdout is this conversation.")
+    p.add_argument("--force", action="store_true",
+                   help="Overwrite an existing file (destroying its contents and "
+                        "setting it to 0600). Refused without this.")
 
 
 def _sa_exec(p):
@@ -933,12 +938,13 @@ def _sa_exec(p):
                         "dotenv secrets file, e.g. PLAYWRIGHT_MCP_SECRETS_FILE.")
     p.add_argument("--stream", dest="stream_mode", action="store_true",
                    help="Run the command as a CHILD with stdio inherited, wait for it, then "
-                        "shred any --file/--dotenv temp files. For a long-running child "
+                        "delete any --file/--dotenv temp files. For a long-running child "
                         "whose credential must be a FILE (Google ADC's "
                         "GOOGLE_APPLICATION_CREDENTIALS takes a path, not a value) — the "
                         "case --exec cannot serve, because exec leaves nothing alive to "
-                        "clean up. Output is NOT redacted (nothing is captured). Note: a "
-                        "SIGKILLed charter runs no cleanup and the 0600 file survives.")
+                        "clean up. Output is NOT redacted (nothing is captured). Cleanup "
+                        "survives SIGINT, SIGTERM and SIGHUP; only a SIGKILLed charter "
+                        "runs no cleanup, and then the 0600 file survives.")
     p.add_argument("--exec", dest="exec_mode", action="store_true",
                    help="Replace this process with the command (os.exec) instead of capturing "
                         "it, so stdio streams through — required for a long-running child such "

--- a/charter/commands_secrets.py
+++ b/charter/commands_secrets.py
@@ -477,6 +477,86 @@ _DEST_KINDS = ((stat.S_ISDIR, "a directory"), (stat.S_ISFIFO, "a FIFO"),
                (stat.S_ISSOCK, "a socket"), (stat.S_ISCHR, "a character device"),
                (stat.S_ISBLK, "a block device"))
 
+#: charter's own three streams, by descriptor, for the refusal message.
+_OWN_STREAMS = ((0, "standard input"), (1, "standard output"), (2, "standard error"))
+
+
+def _own_stream_identities() -> dict[tuple[int, int], str]:
+    """``(st_dev, st_ino) -> "standard output"`` for this process's own three streams.
+
+    IDENTITY, not name. The first version of this guard asked what a path was *called*
+    and `/dev/fd/1` walked straight through it: on macOS `/dev/fd/N` is neither a symlink
+    nor a device but the underlying object re-opened, so `os.lstat` reported a plain
+    regular file and the "already exists" arm took over — an arm `--force` switches off.
+    `charter secret cp v k /dev/fd/1 --force` then wrote the credential into charter's own
+    captured stdout and printed "Value not shown." on top of it. That is issue #421's
+    symptom with a different spelling, and no list of spellings closes it: `/dev/stdout`,
+    `/dev/fd/1`, `/proc/self/fd/1`, the path `readlink` gives for the transcript log, and
+    any hardlink to it are five names for one inode.
+
+    So the question asked here is "is this object the same object as one of my streams",
+    which has exactly one answer per object however it is spelled.
+
+    A stream charter cannot stat (a closed descriptor) contributes nothing rather than
+    raising: the caller's other arms still apply.
+    """
+    out: dict[tuple[int, int], str] = {}
+    for fd, name in _OWN_STREAMS:
+        try:
+            st = os.fstat(fd)
+        except OSError:
+            continue
+        out.setdefault((st.st_dev, st.st_ino), name)
+    return out
+
+
+def _own_stream_refusal(dest, which: str) -> str:
+    """The refusal for "that destination IS one of charter's own streams".
+
+    Deliberately names no flag. The refusal this replaced ended "Pass --force to
+    overwrite it deliberately" — and `--force` was the bypass, which is the exact
+    pattern #421 filed against hooks.py's `--reveal` text. A guard that prints its own
+    way around itself is a signpost, not a guard.
+    """
+    return (f"{dest} is charter's own {which} — the channel this conversation is read "
+            f"from, whatever it is called here. Writing a credential to it puts the "
+            f"plaintext straight into the transcript, which is the leak `secret cp` "
+            f"exists to avoid. Name a real file that is not one of these streams.")
+
+
+def _identify_dest(raw: str):
+    """`fstat` of *raw* opened for writing without creating or truncating anything.
+
+    `os.lstat` is not enough: on macOS it answers about the devfs entry for `/dev/fd/N`,
+    whose `st_dev` is devfs's and NOT the underlying file's, so a `(st_dev, st_ino)`
+    comparison against `os.fstat(1)` does not match. Measured on this platform::
+
+        lstat /dev/fd/1  dev=18446744071623019954 ino=202112957
+        fstat(1)         dev=16777234             ino=202112957
+        fstat(open('/dev/fd/1', O_WRONLY))  dev=16777234 ino=202112957
+
+    Only the descriptor tells the truth, so this opens one. The open is deliberately
+    harmless — no ``O_CREAT``, no ``O_TRUNC``, ``O_NOFOLLOW`` so a symlink is not
+    traversed, ``O_NONBLOCK`` so a FIFO planted since the `lstat` cannot block the
+    process with the answer half-computed. Callers must have refused every non-regular
+    kind *before* calling: opening a device is not free of side effects, and this must
+    never be the thing that opens one.
+
+    Returns ``None`` when the destination cannot be opened at all (it does not exist, or
+    is not writable) — nothing to compare, and the real open below will say so.
+    """
+    flags = os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    try:
+        fd = os.open(raw, flags)
+    except OSError:
+        return None
+    try:
+        return os.fstat(fd)
+    except OSError:
+        return None
+    finally:
+        os.close(fd)
+
 
 def _cp_dest_refusal(dest: Path, force: bool) -> str | None:
     """Why *dest* is not somewhere a secret may be materialised — or ``None``.
@@ -501,7 +581,9 @@ def _cp_dest_refusal(dest: Path, force: bool) -> str | None:
       now `--force`, and the default is ``O_EXCL``.
 
     Ordered so the *most specific* thing true of the path is what gets said: a symlink to
-    a character device reads as a symlink, not as a device.
+    a character device reads as a symlink, not as a device. The stream-identity arm sits
+    AHEAD of the "already exists" arm on purpose — the exists arm names `--force`, and
+    `--force` must never be the suggested next step for one of charter's own streams.
     """
     raw = str(dest)
     if not raw:
@@ -523,6 +605,18 @@ def _cp_dest_refusal(dest: Path, force: bool) -> str | None:
                 f"credential *to a file*; writing it to a device or a pipe puts the "
                 f"plaintext on whatever is reading that — and /dev/stdout, /dev/stderr "
                 f"and /dev/fd/* are this agent's own transcript.")
+    streams = _own_stream_identities()
+    # Two lookups because they answer different questions. The `lstat` pair catches a
+    # second *name* for the same inode — a hardlink, or the path `readlink` gives for the
+    # transcript log — without opening anything. The descriptor pair catches `/dev/fd/N`,
+    # where `lstat`'s `st_dev` is devfs's rather than the file's. Neither is a spelling.
+    which = streams.get((st.st_dev, st.st_ino))
+    if which is None:
+        opened = _identify_dest(raw)
+        if opened is not None:
+            which = streams.get((opened.st_dev, opened.st_ino))
+    if which:
+        return _own_stream_refusal(dest, which)
     if not force:
         return (f"{dest} already exists. Writing would destroy its contents and set it "
                 f"to 0600. Pass --force to overwrite it deliberately, or choose a path "
@@ -573,27 +667,76 @@ def cmd_secret_cp(args) -> int:
                      f"directory level; create the parent yourself if you meant this.")
             return 2
 
-    try:
-        value = _provider(args.vault).get(args.key)
-    except base.VaultError as e:
-        util.err(str(e))
-        return 1
-
     # O_EXCL by default so an existing file is never clobbered; O_NOFOLLOW so a symlink
-    # planted between the check above and this open cannot redirect the write.
+    # planted between the check above and this open cannot redirect the write; O_NONBLOCK
+    # so a FIFO planted there cannot block the open with the destination undecided.
+    # NOT O_TRUNC, even under --force: truncation is destruction, and nothing may be
+    # destroyed until the descriptor has been asked what it actually is. `--force` on
+    # `/dev/fd/1` used to truncate the transcript before writing the credential into it.
     flags = os.O_WRONLY | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
-    flags |= os.O_TRUNC if force else os.O_EXCL
+    flags |= getattr(os, "O_NONBLOCK", 0)
+    if not force:
+        flags |= os.O_EXCL
+    # Only what THIS call brought into existence may be removed on the way out. A
+    # destination that was already there is someone else's file even when charter is
+    # about to refuse it — and for the case that matters most, `/dev/fd/1`, unlinking
+    # would delete the transcript charter is refusing to write into.
+    created = not os.path.lexists(str(dest))
     try:
         fd = os.open(str(dest), flags, 0o600)
     except OSError as e:
         util.err(f"Refusing to write a secret: cannot open {dest} ({e.strerror or e}).")
         return 2
+
+    def _abandon() -> None:
+        os.close(fd)
+        if created:
+            _safe_unlink(str(dest))
+
+    # The guarantee, as opposed to the courtesy. Everything above inspects a PATH, and a
+    # path is a name that something else may be holding or may swap. This asks the open
+    # descriptor what it is, which is the one question with a single answer, and it runs
+    # BEFORE the vault is read — so a destination refused here still never resolves the
+    # plaintext, and a `--force` aimed at charter's own stdout writes nothing and
+    # truncates nothing.
+    try:
+        opened = os.fstat(fd)
+    except OSError as e:
+        _abandon()
+        util.err(f"Refusing to write a secret: cannot inspect {dest} "
+                 f"({getattr(e, 'strerror', None) or e}).")
+        return 2
+    # Same order as `_cp_dest_refusal`: the most specific true thing gets said, so a
+    # device reads as a device rather than as "charter's stdin" on the many runs whose
+    # stdin happens to be /dev/null.
+    if not stat.S_ISREG(opened.st_mode):
+        kind = next((k for test, k in _DEST_KINDS if test(opened.st_mode)), "not a file")
+        _abandon()
+        util.err(f"Refusing to write a secret: {dest} is {kind}, not a regular file — "
+                 f"whatever the path looked like before it was opened.")
+        return 2
+    which = _own_stream_identities().get((opened.st_dev, opened.st_ino))
+    if which:
+        _abandon()
+        util.err(f"Refusing to write a secret: {_own_stream_refusal(dest, which)}")
+        return 2
+
+    try:
+        value = _provider(args.vault).get(args.key)
+    except base.VaultError as e:
+        _abandon()
+        util.err(str(e))
+        return 1
+
     with os.fdopen(fd, "w") as f:
         # fchmod, not chmod: the mode lands on the file this process opened, not on
         # whatever the path names by the time the write finishes.
         os.fchmod(f.fileno(), 0o600)
+        # O_TRUNC's job, done late: an overwrite of a longer file would otherwise leave
+        # the tail of the old contents behind the new value.
+        os.ftruncate(f.fileno(), 0)
         f.write(value)
-    if force:
+    if force and not created:
         util.warn(f"Overwrote {dest} and set it to 0600.")
     util.ok(f"Wrote '{args.vault}/{args.key}' to {dest} (0600). Value not shown.")
     return 0
@@ -818,16 +961,25 @@ def cmd_secret_exec(args) -> int:
             # once the child exits.
             #
             # The honest limit, stated here and in --help rather than implied away. Exit,
-            # an exception, SIGINT, SIGTERM and SIGHUP all clean up (the last two via the
-            # handlers installed above). SIGKILL cannot be caught by anything, so a
-            # SIGKILLed parent runs no cleanup and the 0600 file survives in the system
-            # temp directory until it is removed or the machine reboots. That is strictly
-            # better than the alternative it replaces (every persona re-implementing the
-            # same trap in shell, with the same hole) but it is not a guarantee, and
-            # describing it as one would fail silently at the moment something has already
-            # gone wrong. It used to be SIGTERM too, which is a different sentence: SIGKILL
-            # is what you reach for when something is already stuck; SIGTERM is what a
-            # supervisor sends at every ordinary shutdown.
+            # an exception, and every terminating signal charter may catch all clean up:
+            # SIGINT via KeyboardInterrupt, and SIGTERM, SIGHUP, SIGQUIT, SIGUSR1/2,
+            # SIGXCPU and the rest via the handlers installed above (see
+            # `_SIGNALS_LEFT_ALONE` for what is excluded and why).
+            #
+            # Two things still leave the 0600 file in the system temp directory until it
+            # is removed or the machine reboots. SIGKILL, which no process can catch. And
+            # a fault — SIGSEGV, SIGBUS, SIGABRT — which charter deliberately does not
+            # intercept, because a handler running on a process whose state is already
+            # wrong can turn a crash into a hang. That is strictly better than the
+            # alternative it replaces (every persona re-implementing the same trap in
+            # shell, with the same hole) but it is not a guarantee, and describing it as
+            # one would fail silently at the moment something has already gone wrong.
+            #
+            # This sentence has been wrong twice. First it said SIGKILL when SIGTERM leaked
+            # too; then it said SIGKILL again once SIGTERM and SIGHUP were handled, while
+            # SIGQUIT — Ctrl-\ — still leaked. Both times the list was of signals to catch.
+            # It is now a list of signals to leave alone, which is why this text can name
+            # the limit as a category rather than as three examples.
             #
             # Output is NOT redacted, for the same reason as --exec: nothing is captured.
             try:
@@ -857,16 +1009,45 @@ def cmd_secret_exec(args) -> int:
         restore_signals()
 
 
+#: Signals charter deliberately does NOT take over, and why. Everything else in
+#: `signal.Signals` defaults to terminating the process without unwinding, which is the
+#: property that leaves a 0600 credential file behind.
+#:
+#: Written as an EXCLUSION list, not as a list of signals to handle. The first version
+#: handled SIGTERM and SIGHUP and the docs then called SIGKILL the whole of the limit —
+#: false, because SIGQUIT (Ctrl-\), SIGUSR1, SIGXCPU and the rest each left the file
+#: exactly as SIGTERM had. A hand-written list of what to catch is a list of spellings,
+#: and the next signal nobody thought of is not on it; a list of what to leave alone is
+#: a list of reasons, and anything new lands on the safe side of it by default.
+_SIGNALS_LEFT_ALONE = frozenset(
+    name for name in (
+        # Cannot be caught at all. SIGKILL is the honest limit; SIGSTOP only suspends.
+        "SIGKILL", "SIGSTOP",
+        # Default action is ignore or resume — nothing to unwind.
+        "SIGCHLD", "SIGCLD", "SIGCONT", "SIGURG", "SIGWINCH", "SIGINFO",
+        # Default action suspends the process. Taking these over would break job
+        # control: Ctrl-Z would kill the command instead of backgrounding it.
+        "SIGTSTP", "SIGTTIN", "SIGTTOU",
+        # Python already ignores SIGPIPE (`cli` turns BrokenPipeError into 141), and
+        # Python's own SIGINT handler raises KeyboardInterrupt, which unwinds `finally`
+        # already. Both are handled; neither should be handled twice.
+        "SIGPIPE", "SIGINT",
+        # Faults. The handler would run on a process whose state is already wrong, and
+        # intercepting a crash to tidy up risks turning it into a hang. These are named
+        # in the stated limit alongside SIGKILL rather than quietly caught.
+        "SIGSEGV", "SIGBUS", "SIGILL", "SIGFPE", "SIGSYS", "SIGTRAP", "SIGEMT",
+        "SIGABRT", "SIGIOT",
+    )
+)
+
 #: Terminating signals whose default action skips every `finally` in this process.
-#: SIGKILL is deliberately absent: it cannot be caught, which is why it is the one
-#: limit the docs are allowed to state.
 _TERMINATION_SIGNALS = tuple(
-    s for s in (getattr(signal, "SIGTERM", None), getattr(signal, "SIGHUP", None)) if s
+    s for s in getattr(signal, "Signals", ()) if s.name not in _SIGNALS_LEFT_ALONE
 )
 
 
 def _exit_on_termination():
-    """Turn SIGTERM/SIGHUP into ``SystemExit``; return a callable that undoes it.
+    """Turn every catchable terminating signal into ``SystemExit``; return its undo.
 
     A default-action termination runs no `finally`, so a 0600 credential file outlives
     the process that owns it. Raising `SystemExit` from the handler puts the death back

--- a/charter/commands_secrets.py
+++ b/charter/commands_secrets.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -468,21 +470,183 @@ def cmd_secret_rm(args) -> int:
     return 0
 
 
+#: What a destination turned out to be, for the refusal message. Same table and same
+#: wording as `contain._KINDS`, because "that is not a file" is one question and the
+#: operator should not have to learn two vocabularies for it.
+_DEST_KINDS = ((stat.S_ISDIR, "a directory"), (stat.S_ISFIFO, "a FIFO"),
+               (stat.S_ISSOCK, "a socket"), (stat.S_ISCHR, "a character device"),
+               (stat.S_ISBLK, "a block device"))
+
+
+def _cp_dest_refusal(dest: Path, force: bool) -> str | None:
+    """Why *dest* is not somewhere a secret may be materialised — or ``None``.
+
+    `secret cp` is documented as the *safe* consumption path: "prints only the path,
+    never the contents" (`docs/secrets.md`). That sentence was true of the command and
+    false of the destination, because the destination decided what "writing a file"
+    meant:
+
+    * **A non-regular destination writes the plaintext to whatever is on the other end.**
+      `charter secret cp <v> <k> /dev/stdout` printed the credential onto charter's own
+      stdout — the agent's captured pipe — and then printed `Value not shown.` on the
+      same stream. `/dev/stderr` and `/dev/fd/N` are the same channel by another name,
+      and a FIFO is worse: the open blocks with the value already resolved. This is the
+      exact channel `cmd_secret_get --reveal` refuses (`sys.stdout.isatty()` above);
+      `cp` refused nothing.
+    * **A symlink writes through to its target**, which is how a "regular file" check
+      gets walked past — so the link is refused here *and* the open below carries
+      ``O_NOFOLLOW``, which also closes the swap between this `lstat` and that `open`.
+    * **An existing file was truncated and chmodded 0600 with no warning and no flag.**
+      A pre-existing `~/.ssh/config` came back as the credential at 0600. Overwriting is
+      now `--force`, and the default is ``O_EXCL``.
+
+    Ordered so the *most specific* thing true of the path is what gets said: a symlink to
+    a character device reads as a symlink, not as a device.
+    """
+    raw = str(dest)
+    if not raw:
+        return "the destination path is empty."
+    try:
+        st = os.lstat(raw)
+    except FileNotFoundError:
+        return None                       # nothing there yet — the ordinary case
+    except (OSError, ValueError) as e:
+        # `os.lstat` raises ValueError, not OSError, on a path holding a NUL.
+        return f"{dest} cannot be inspected ({getattr(e, 'strerror', None) or e})."
+    if stat.S_ISLNK(st.st_mode):
+        return (f"{dest} is a symlink, and charter will not follow one to write a "
+                f"credential — the link decides where the plaintext lands, not you. "
+                f"Name the real path.")
+    if not stat.S_ISREG(st.st_mode):
+        kind = next((k for test, k in _DEST_KINDS if test(st.st_mode)), "not a file")
+        return (f"{dest} is {kind}, not a regular file. `secret cp` materialises a "
+                f"credential *to a file*; writing it to a device or a pipe puts the "
+                f"plaintext on whatever is reading that — and /dev/stdout, /dev/stderr "
+                f"and /dev/fd/* are this agent's own transcript.")
+    if not force:
+        return (f"{dest} already exists. Writing would destroy its contents and set it "
+                f"to 0600. Pass --force to overwrite it deliberately, or choose a path "
+                f"that does not exist.")
+    return None
+
+
 def cmd_secret_cp(args) -> int:
-    """Materialize a secret to a file at 0600 (e.g. a kubeconfig). Prints path only."""
+    """Materialize a secret to a real file at 0600 (e.g. a kubeconfig). Prints path only.
+
+    The destination is checked BEFORE the value is resolved: a refused path never causes
+    a vault read, so the plaintext is never in this process at all for the case that was
+    about to print it.
+    """
+    dest = Path(args.dest).expanduser()
+    force = bool(getattr(args, "force", False))
+
+    refusal = _cp_dest_refusal(dest, force)
+    if refusal:
+        util.err(f"Refusing to write a secret: {refusal}")
+        return 2
+
+    # ADR-0017, the same rule `vault add` applies to a plain-file vault: a credential
+    # written somewhere git tracks is committed by the next `charter save`. `vault add`
+    # refused this and `cp` did not, which is one door checked and its twin left open.
+    # Absolute, because a relative destination is CWD-relative for the open below while
+    # `_unignored_plaintext` resolves a relative path against the plane root.
+    unignored = _unignored_plaintext(os.path.abspath(dest))
+    if unignored:
+        util.err(f"Refusing to write a secret: '{unignored}' is inside the control plane "
+                 f"and NOT gitignored — the next `charter save` would commit it.")
+        util.info("  Add it to .gitignore, write it under .charter/, or pick a path "
+                  "outside the plane.")
+        return 2
+
+    parent = dest.parent
+    if not parent.is_dir():
+        # One missing level, not a tree: `mkdir -p` on a caller-supplied path builds
+        # arbitrary directories anywhere the user can write, and a typo'd destination
+        # should read as a typo rather than silently materialise.
+        try:
+            os.mkdir(parent, 0o700)
+        except FileExistsError:
+            pass                          # a race, or a non-directory — the open answers
+        except OSError as e:
+            util.err(f"Refusing to write a secret: cannot create {parent} "
+                     f"({e.strerror or e}). charter creates at most one missing "
+                     f"directory level; create the parent yourself if you meant this.")
+            return 2
+
     try:
         value = _provider(args.vault).get(args.key)
     except base.VaultError as e:
         util.err(str(e))
         return 1
-    dest = Path(args.dest).expanduser()
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(dest), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+
+    # O_EXCL by default so an existing file is never clobbered; O_NOFOLLOW so a symlink
+    # planted between the check above and this open cannot redirect the write.
+    flags = os.O_WRONLY | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+    flags |= os.O_TRUNC if force else os.O_EXCL
+    try:
+        fd = os.open(str(dest), flags, 0o600)
+    except OSError as e:
+        util.err(f"Refusing to write a secret: cannot open {dest} ({e.strerror or e}).")
+        return 2
     with os.fdopen(fd, "w") as f:
+        # fchmod, not chmod: the mode lands on the file this process opened, not on
+        # whatever the path names by the time the write finishes.
+        os.fchmod(f.fileno(), 0o600)
         f.write(value)
-    os.chmod(dest, 0o600)
+    if force:
+        util.warn(f"Overwrote {dest} and set it to 0600.")
     util.ok(f"Wrote '{args.vault}/{args.key}' to {dest} (0600). Value not shown.")
     return 0
+
+
+def _identity_vars(doc: dict | None = None) -> dict[str, set[str]]:
+    """Every environment-variable name a registered vault uses as an identity, by vault.
+
+    A vault may bind the identity it is read through (`VaultProvider.env_overlay`)::
+
+        "env": {"OP_SERVICE_ACCOUNT_TOKEN": "OP_ACME_DEVOPS_SERVICE_ACCOUNT_TOKEN"}
+
+    BOTH halves are identity variables: the value is where this machine carries the
+    credential, and the key is the variable the vault's CLI reads it out of. Names only
+    — the registry never holds a value, and neither does this.
+    """
+    out: dict[str, set[str]] = {}
+    for name, vc in (registry.vaults(doc) or {}).items():
+        mapping = (vc or {}).get("config", {}).get("env") or {}
+        if not isinstance(mapping, dict):
+            continue                       # a committed registry is untrusted input
+        names = {str(k) for k in mapping} | {str(v) for v in mapping.values()}
+        out[name] = {n for n in names if n}
+    return out
+
+
+def _child_env(vault: str) -> dict:
+    """The environment a `secret exec` child gets: this process's, minus every OTHER
+    vault's declared identity variables.
+
+    ``dict(os.environ)`` handed the child every credential on the machine. Measured, with
+    fabricated values, `charter secret exec <v> --env T=K -- /usr/bin/env` returned the
+    one secret the model named as ``***`` and every other vault's service-account token
+    in the clear — into the caller's captured output. `base.redact` cannot help: it only
+    knows the values *this* call resolved.
+
+    `VaultProvider.env_overlay` sells the binding as least-privilege — "without this the
+    mapping lives in every caller's shell… which is the property the vault abstraction
+    otherwise removes." Inheriting the whole environment put it straight back.
+
+    The vault being read keeps its own names, so `charter secret exec devops -- charter
+    secret get devops K` still works; no other vault's identity crosses. Nothing here
+    can break a working setup: a child was never meant to hold another vault's identity,
+    and this removes nothing else — the resolution of THIS vault happens in charter's own
+    process, before and independently of this dict.
+    """
+    declared = _identity_vars()
+    # No `try` here on purpose. `_provider()` loads the same registry a few lines before
+    # this is called and raises if it cannot, so there is no state in which this is asked
+    # of a registry that failed to load — and an `except: return dict(os.environ)` would
+    # be a fallback that quietly restores the exact behaviour this removes.
+    strip = set().union(set(), *declared.values()) - declared.get(vault, set())
+    return {k: v for k, v in os.environ.items() if k not in strip}
 
 
 def cmd_secret_exec(args) -> int:
@@ -513,7 +677,7 @@ def cmd_secret_exec(args) -> int:
 
     exec_mode = bool(getattr(args, "exec_mode", False))
     dotenv_specs = list(getattr(args, "dotenv", None) or [])
-    # `--exec` REPLACES this process, so nothing survives to shred a temp file. A
+    # `--exec` REPLACES this process, so nothing survives to delete a temp file. A
     # long-running child whose credential must be a FILE — every Google-ADC server, since
     # GOOGLE_APPLICATION_CREDENTIALS takes a path and not a value — therefore fitted neither
     # mode: --file was the only way to materialise it and --exec the only way to run it
@@ -533,11 +697,11 @@ def cmd_secret_exec(args) -> int:
                                              ("--dotenv", dotenv_specs)) if on)
         util.err(f"{flags} cannot be combined with --exec: exec replaces this "
                  "process, so the temp file would never be cleaned up. "
-                 "Use --stream instead — it forks, inherits stdio, and shreds the file "
+                 "Use --stream instead — it forks, inherits stdio, and deletes the file "
                  "when the child exits.")
         return 2
 
-    env = dict(os.environ)
+    env = _child_env(args.vault)
     secret_values: list[str] = []
     tmpfiles: list[str] = []
     # Everything below that can create a tmpfile — --file, --dotenv, and the
@@ -549,6 +713,19 @@ def cmd_secret_exec(args) -> int:
     # ENOSPC, KeyboardInterrupt, ...) unwinds through the same `finally` and
     # unlinks every tmpfile created so far. No call site below needs its own
     # cleanup loop; do not add one.
+    #
+    # The `finally` unwinds an EXCEPTION. A signal whose default action is "terminate"
+    # unwinds nothing at all, and Python installs a handler for exactly one of them
+    # (SIGINT -> KeyboardInterrupt). So SIGTERM and SIGHUP used to kill charter with the
+    # 0600 file still on disk — measured: `--stream --file F=K -- sh -c 'sleep 30'`,
+    # SIGTERM at t+2s, survivor `charter-<v>-<k>-…` at `-rw-------` holding the value.
+    # SIGTERM is the ORDINARY termination (a supervisor, a `kill`, a harness reaping a
+    # hung tool call) and `--stream` exists for long-running children, which are exactly
+    # what gets SIGTERMed at shutdown. `sys.exit` turns the signal back into an exception
+    # so the `finally` below runs; `subprocess.run` kills and reaps its child on the way
+    # out. Installed before the first tmpfile is created and restored after the last one
+    # is gone, so charter's signal behaviour outside this block is unchanged.
+    restore_signals = _exit_on_termination()
     try:
         try:
             for spec in args.env or []:
@@ -637,15 +814,20 @@ def cmd_secret_exec(args) -> int:
         if stream_mode:
             # Fork rather than exec, and do NOT capture: the child inherits this process's
             # stdio, so an MCP stdio server streams exactly as it does under --exec. This
-            # process stays alive for one reason — the `finally` that shreds the temp files
+            # process stays alive for one reason — the `finally` that deletes the temp files
             # once the child exits.
             #
-            # The honest limit, stated here and in --help rather than implied away: a
-            # SIGKILLed parent runs no cleanup, so the 0600 file survives in the system temp
-            # directory until it is removed or the machine reboots. That is strictly better
-            # than the alternative it replaces (every persona re-implementing the same trap
-            # in shell, with the same hole) but it is not a guarantee, and describing it as
-            # one would fail silently at the moment something has already gone wrong.
+            # The honest limit, stated here and in --help rather than implied away. Exit,
+            # an exception, SIGINT, SIGTERM and SIGHUP all clean up (the last two via the
+            # handlers installed above). SIGKILL cannot be caught by anything, so a
+            # SIGKILLed parent runs no cleanup and the 0600 file survives in the system
+            # temp directory until it is removed or the machine reboots. That is strictly
+            # better than the alternative it replaces (every persona re-implementing the
+            # same trap in shell, with the same hole) but it is not a guarantee, and
+            # describing it as one would fail silently at the moment something has already
+            # gone wrong. It used to be SIGTERM too, which is a different sentence: SIGKILL
+            # is what you reach for when something is already stuck; SIGTERM is what a
+            # supervisor sends at every ordinary shutdown.
             #
             # Output is NOT redacted, for the same reason as --exec: nothing is captured.
             try:
@@ -672,9 +854,65 @@ def cmd_secret_exec(args) -> int:
     finally:
         for p in tmpfiles:
             _safe_unlink(p)
+        restore_signals()
+
+
+#: Terminating signals whose default action skips every `finally` in this process.
+#: SIGKILL is deliberately absent: it cannot be caught, which is why it is the one
+#: limit the docs are allowed to state.
+_TERMINATION_SIGNALS = tuple(
+    s for s in (getattr(signal, "SIGTERM", None), getattr(signal, "SIGHUP", None)) if s
+)
+
+
+def _exit_on_termination():
+    """Turn SIGTERM/SIGHUP into ``SystemExit``; return a callable that undoes it.
+
+    A default-action termination runs no `finally`, so a 0600 credential file outlives
+    the process that owns it. Raising `SystemExit` from the handler puts the death back
+    on the ordinary exception path — including out of a blocking `subprocess.run`, whose
+    own `except BaseException: process.kill()` reaps the child before re-raising — so the
+    cleanup that runs is the same cleanup a normal exit runs.
+
+    Exit code 128+N, the shell's convention for "died on signal N", so a supervisor still
+    reads the death as a signal rather than as a clean exit.
+
+    Not installable off the main thread (`signal.signal` raises `ValueError` there), and
+    charter's own callers are free to embed it, so that case restores nothing rather than
+    failing the command.
+    """
+    previous: list[tuple] = []
+    for sig in _TERMINATION_SIGNALS:
+        try:
+            previous.append((sig, signal.signal(sig, _terminate_now)))
+        except (ValueError, OSError):
+            pass
+
+    def restore() -> None:
+        for sig, handler in previous:
+            try:
+                signal.signal(sig, handler)
+            except (ValueError, OSError):
+                pass
+
+    return restore
+
+
+def _terminate_now(signum, _frame):
+    raise SystemExit(128 + signum)
 
 
 def _safe_unlink(path: str) -> None:
+    """Delete *path*, ignoring "already gone".
+
+    It deletes. It does not overwrite, and no comment, help string or doc may imply that
+    it does — the word for the stronger thing was used in six places and this function
+    never did it (`tests/test_wording.py` keeps it that way). Do not add the overwrite
+    pass either: it is meaningless on a copy-on-write filesystem (APFS, ext4 with a
+    journal, any SSD doing wear levelling), where the bytes it rewrites land in a NEW
+    block and the old one stays wherever the drive left it. The properties that do hold
+    are that the file is 0600 and that it is short-lived.
+    """
     try:
         os.unlink(path)
     except OSError:

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -441,7 +441,7 @@ def mcp_render_entry(name: str, vault: str | None, entry: dict) -> dict:
     for env_name, key in files.items():
         args += ["--file", f"{env_name}={key}"]
     # `--stream` whenever a file is involved: `--exec` replaces charter, so nothing would
-    # survive to shred the tempfile. Streaming is unaffected — a forked child inherits this
+    # survive to delete the tempfile. Streaming is unaffected — a forked child inherits this
     # process's descriptors — so the only thing given up is process replacement, which is
     # precisely what made cleanup impossible.
     args += ["--stream" if files else "--exec", "--"]

--- a/docs/news/unreleased-secret-cp-writes-a-file-or-nothing.md
+++ b/docs/news/unreleased-secret-cp-writes-a-file-or-nothing.md
@@ -1,0 +1,69 @@
+---
+version: unreleased
+headline: `secret cp` writes to a real file or to nothing, and a `secret exec` child no longer holds every other vault's identity
+---
+
+`charter secret cp` is documented as one of the two safe ways to consume a credential:
+*"materializes a secret to a 0600 file and prints only the path, never the contents."*
+That sentence was true of the command and false of the destination, which is what
+actually decided where the plaintext went:
+
+```
+$ charter secret cp tv API_TOKEN /dev/stdout 2>&1 | cat
+FABRICATED-…✓ Wrote 'tv/API_TOKEN' to /dev/stdout (0600). Value not shown.
+```
+
+`/dev/stdout` is charter's own stdout — an agent's captured pipe. The success line is
+false on its own output, and `Value not shown` is the last thing printed after showing
+it. `charter secret get --reveal` has refused exactly this channel for a long time. `cp`
+refused nothing at all: not a device, not a FIFO, not a symlink pointed at a file you
+care about, and not an existing file, which it truncated and chmodded 0600 without a
+word — a `0644` config came back as the credential, with no warning and no flag.
+
+**The destination is now checked before the vault is read**, so a refused path never
+resolves the value at all:
+
+- a device, FIFO, socket or directory is refused — `/dev/stdout`, `/dev/stderr` and
+  `/dev/fd/*` by name in the message, because they are this conversation;
+- a symlink is refused rather than followed, and the write itself uses `O_NOFOLLOW`, so
+  a link planted between the check and the open cannot redirect it either;
+- an existing file is refused; overwriting one takes `--force`, and charter says
+  afterwards that it did;
+- the write is `O_EXCL` by default, the mode is set on the open descriptor rather than
+  on the path, and at most one missing parent directory is created (at 0700) instead of
+  a whole tree;
+- a destination inside the plane that git would track is refused, the same rule
+  `charter vault add` already applies to a plain-file vault — otherwise the next
+  `charter save` commits the credential.
+
+**A `secret exec` child no longer inherits other vaults' identity variables.** `env =
+dict(os.environ)` handed the child every credential in the caller's shell. Measured with
+fabricated values, `charter secret exec <vault> --env T=K -- /usr/bin/env` returned the
+one secret the model had named as `***` and every *other* vault's service-account token
+in the clear — redaction cannot help, because it only knows the values that call
+resolved. Binding a vault to its own service account was sold as least-privilege, and
+inheriting the whole environment put the mapping back in every child's environment.
+charter now removes every identity variable declared by a vault other than the one being
+read — both halves of each binding, the variable the CLI reads and the variable this
+machine carries it in. The vault being read keeps its own, and nothing else is touched,
+so `PATH`, your locale and every unrelated setting arrive as before.
+
+**`--stream` cleans up after SIGTERM and SIGHUP.** The temp-file cleanup is a `finally`,
+and a `finally` unwinds an exception — a default-action signal unwinds nothing. Python
+installs a handler for exactly one of them, so `SIGINT` was clean and `SIGTERM` left a
+`-rw-------` file holding the value in the system temp directory. The docs named only
+SIGKILL, which reads as vanishingly rare; SIGTERM is what a supervisor, a `kill`, or a
+harness reaping a hung tool call sends at every ordinary shutdown, and `--stream` exists
+for exactly the long-running children that get SIGTERMed. Both signals now raise
+`SystemExit(128+N)` for the duration of the command, which runs the same cleanup an
+ordinary exit does and kills the child on the way out. SIGKILL remains the stated limit,
+because nothing can catch it — and that is now the whole of the limit rather than the
+politest third of it.
+
+**And charter no longer says it shreds anything.** `_safe_unlink` is `os.unlink`, and it
+should stay that way: an overwrite pass is meaningless on a copy-on-write filesystem,
+where the rewritten bytes land in a new block and the old one stays wherever the drive
+left it. Six comments, help strings and skill lines said "shred" about a plain delete.
+The word was wrong, not the code, so the word changed — and a test now keeps it changed,
+because it is an attractive word and the next person to describe this cleanup will reach
+for it again.

--- a/docs/news/unreleased-secret-cp-writes-a-file-or-nothing.md
+++ b/docs/news/unreleased-secret-cp-writes-a-file-or-nothing.md
@@ -25,6 +25,8 @@ resolves the value at all:
 
 - a device, FIFO, socket or directory is refused — `/dev/stdout`, `/dev/stderr` and
   `/dev/fd/*` by name in the message, because they are this conversation;
+- **a destination that IS one of charter's own three streams is refused by identity**,
+  before existence or `--force` is considered at all (see below);
 - a symlink is refused rather than followed, and the write itself uses `O_NOFOLLOW`, so
   a link planted between the check and the open cannot redirect it either;
 - an existing file is refused; overwriting one takes `--force`, and charter says
@@ -35,6 +37,24 @@ resolves the value at all:
 - a destination inside the plane that git would track is refused, the same rule
   `charter vault add` already applies to a plain-file vault — otherwise the next
   `charter save` commits the credential.
+
+**The first version of that guard was bypassed, which is why the list above says "by
+identity".** It asked what a destination was *called*: `os.lstat` on the path. On macOS
+`/dev/fd/1` is neither a symlink nor a device — it is the underlying object — so the
+answer came back "an ordinary file that already exists", which is precisely the arm
+`--force` switches off. `charter secret cp <vault> <key> /dev/fd/1 --force` then wrote the
+credential into charter's own captured stdout and printed *Value not shown.* on top of
+it: issue #421's symptom, reproduced through its own fix. Without `--force` the refusal
+ended *"Pass --force to overwrite it deliberately"* — a guard printing the recipe for its
+own bypass, the pattern #421 was filed about in the first place.
+
+No list of names closes that. `/dev/stdout`, `/dev/fd/1`, `/proc/self/fd/1`, the path
+`readlink` gives for a transcript log and any hardlink to it are one file with five
+names. So charter compares the destination's `(st_dev, st_ino)` — taken from an `fstat`
+of the descriptor it actually opened, not from the path — against `fstat` of its own
+stdin, stdout and stderr. One object, one answer, however it is spelled. The comparison
+runs before the vault is read and before anything is truncated, `--force` does not reach
+it, and the refusal it prints names no flag at all.
 
 **A `secret exec` child no longer inherits other vaults' identity variables.** `env =
 dict(os.environ)` handed the child every credential in the caller's shell. Measured with
@@ -48,17 +68,28 @@ read — both halves of each binding, the variable the CLI reads and the variabl
 machine carries it in. The vault being read keeps its own, and nothing else is touched,
 so `PATH`, your locale and every unrelated setting arrive as before.
 
-**`--stream` cleans up after SIGTERM and SIGHUP.** The temp-file cleanup is a `finally`,
-and a `finally` unwinds an exception — a default-action signal unwinds nothing. Python
-installs a handler for exactly one of them, so `SIGINT` was clean and `SIGTERM` left a
-`-rw-------` file holding the value in the system temp directory. The docs named only
-SIGKILL, which reads as vanishingly rare; SIGTERM is what a supervisor, a `kill`, or a
-harness reaping a hung tool call sends at every ordinary shutdown, and `--stream` exists
-for exactly the long-running children that get SIGTERMed. Both signals now raise
-`SystemExit(128+N)` for the duration of the command, which runs the same cleanup an
-ordinary exit does and kills the child on the way out. SIGKILL remains the stated limit,
-because nothing can catch it — and that is now the whole of the limit rather than the
-politest third of it.
+**`--stream` cleans up after every terminating signal charter can catch.** The temp-file
+cleanup is a `finally`, and a `finally` unwinds an exception — a default-action signal
+unwinds nothing. Python installs a handler for `SIGINT` and nothing else, so `SIGINT` was
+clean and `SIGTERM` left a `-rw-------` file holding the value in the system temp
+directory. The docs named only SIGKILL, which reads as vanishingly rare; SIGTERM is what
+a supervisor, a `kill`, or a harness reaping a hung tool call sends at every ordinary
+shutdown, and `--stream` exists for exactly the long-running children that get SIGTERMed.
+
+Handling SIGTERM and SIGHUP and then calling SIGKILL the whole limit was still false.
+SIGQUIT is Ctrl-\ from any terminal, and it left the same file; so did SIGUSR1 and
+SIGXCPU. Every catchable default-terminate signal has the property, not the two that
+happened to get reported — a list of signals to *catch* is a list of spellings, and the
+next one is never on it. charter now derives the set by exclusion: everything in
+`signal.Signals` except what cannot be caught, what does not terminate, what suspends the
+process (Ctrl-Z must background a command, not kill it), and the faults. Each of the rest
+raises `SystemExit(128+N)` for the duration of the command, which runs the same cleanup
+an ordinary exit does and kills the child on the way out.
+
+The stated limit is a category now rather than three examples: cleanup does not survive
+SIGKILL, which no process can catch, or a fault — SIGSEGV, SIGBUS, SIGABRT — which
+charter deliberately does not intercept, because a handler running on a process whose
+state is already wrong can turn a crash into a hang.
 
 **And charter no longer says it shreds anything.** `_safe_unlink` is `os.unlink`, and it
 should stay that way: an overwrite pass is meaningless on a copy-on-write filesystem,

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -43,9 +43,13 @@ shell history**, while still letting an agent *use* the credential:
   prints only the path, never the contents. The destination has to be a **real file it
   creates**: a device, a FIFO, a directory or a symlink is refused, because
   `/dev/stdout`, `/dev/stderr` and `/dev/fd/*` are the agent's own transcript and
-  writing there is the leak this command exists to avoid. An **existing** file is
-  refused too — overwriting one destroys its contents and sets it to 0600, so it takes
-  `--force` and says so afterwards.
+  writing there is the leak this command exists to avoid. A destination that turns out
+  to **be** one of charter's own streams is refused whatever it is called — the test is
+  `(st_dev, st_ino)` from an `fstat` of the descriptor charter opened, compared against
+  its own stdin, stdout and stderr, so a hardlink, a `readlink`'d log path and
+  `/dev/fd/1` are all the same one object and get the same answer. `--force` does not
+  reach that check. An **existing** file is refused too — overwriting one destroys its
+  contents and sets it to 0600, so it takes `--force` and says so afterwards.
 - **`charter secret get`** is masked by default — it prints a byte count and a SHA-256
   fingerprint, never the value.
 - **`charter secret get --reveal`** is the one path that *can* print plaintext, and it

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -40,7 +40,12 @@ shell history**, while still letting an agent *use* the credential:
   ```
 
 - **`charter secret cp`** materializes a secret to a 0600 file (e.g. a kubeconfig) and
-  prints only the path, never the contents.
+  prints only the path, never the contents. The destination has to be a **real file it
+  creates**: a device, a FIFO, a directory or a symlink is refused, because
+  `/dev/stdout`, `/dev/stderr` and `/dev/fd/*` are the agent's own transcript and
+  writing there is the leak this command exists to avoid. An **existing** file is
+  refused too — overwriting one destroys its contents and sets it to 0600, so it takes
+  `--force` and says so afterwards.
 - **`charter secret get`** is masked by default — it prints a byte count and a SHA-256
   fingerprint, never the value.
 - **`charter secret get --reveal`** is the one path that *can* print plaintext, and it
@@ -126,6 +131,16 @@ about the vault:
 
 A read that fails anyway names the identity in play, so a permission error points at the
 credential rather than reading as an empty vault.
+
+**A declared identity does not travel to someone else's child.** `charter secret exec`
+runs the command with this shell's environment **minus every identity variable declared
+by a vault other than the one being read** — both halves of each binding, the variable
+the CLI reads and the variable this machine carries it in. Without that, one binding is
+least-privilege and the process it starts is not: `charter secret exec qa -- <cmd>` used
+to hand `<cmd>` the devops *and* marketing *and* personal service-account tokens, in the
+clear, while redacting the single value the model actually named. The vault being read
+keeps its own names, so `charter secret exec devops -- charter secret get devops K`
+still works, and a vault that declares no identity is untouched.
 
 ### Where a registration is recorded: two files, one view
 

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -59,7 +59,7 @@ substitutes the value and redacts it from output, so it never reaches the transc
 
 > **`not open` is not a cue to re-open.** A second `open` with the same `-s=<name>` starts
 > a *new* browser and orphans the first — which is the one that is logged in. Worse, the
-> new one cannot be authenticated: `charter secret exec` shreds its dotenv on exit, so
+> new one cannot be authenticated: `charter secret exec` deletes its dotenv on exit, so
 > filling a secret into it means re-running the whole bridged flow. Check the session is
 > really gone first (a `snapshot` against it is cheap and answers the question); if it is,
 > re-run the flow rather than `open`.
@@ -75,7 +75,7 @@ substitutes the value and redacts it from output, so it never reaches the transc
 > identity provider afterwards. Filling immediately fails with
 > `"#username" does not match any elements`, which reads as a **wrong selector** and sends
 > you hunting for a better one when the flow was already right. It is not free to get wrong
-> here: `charter secret exec` shreds the dotenv file when it exits, so the still-open
+> here: `charter secret exec` deletes the dotenv file when it exits, so the still-open
 > session can no longer be filled with a secret, and recovering means re-running the whole
 > flow rather than the failed step. The example waits so it never needs to.
 

--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -44,6 +44,12 @@ charter secret exec <vault> --file KUBECONFIG=<key> -- kubectl get pods
 charter secret cp <vault> <key> <dest>     # persist at 0600; prints only the path
 ```
 
+`<dest>` must be a **real file that does not exist yet**. A device, a FIFO, a directory
+or a symlink is refused, and so is an existing file (overwriting takes `--force`). This
+is not pedantry: `charter secret cp <vault> <key> /dev/stdout` would write the plaintext
+straight into this conversation — that is the one thing the vault exists to prevent, so
+do not go looking for a path that gets around the refusal.
+
 **As a dotenv file**, for a tool that reads one (this is how a browser driver gets a
 login without the password being typed into the page by you):
 

--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -50,6 +50,11 @@ is not pedantry: `charter secret cp <vault> <key> /dev/stdout` would write the p
 straight into this conversation — that is the one thing the vault exists to prevent, so
 do not go looking for a path that gets around the refusal.
 
+There is not one to find. A destination that is charter's own stdin, stdout or stderr is
+refused by identity — the inode, not the spelling — so `/dev/fd/1`, `/proc/self/fd/1`,
+the transcript's real path and any hardlink to it are one object with one answer, and
+`--force` does not reach that check.
+
 **As a dotenv file**, for a tool that reads one (this is how a browser driver gets a
 login without the password being typed into the page by you):
 

--- a/tests/test_secret_cp_destination.py
+++ b/tests/test_secret_cp_destination.py
@@ -1,0 +1,329 @@
+"""`secret cp` writes a credential to a real file, or to nothing at all.
+
+`docs/secrets.md` calls `cp` one of the two *safe* consumption paths — "prints only the
+path, never the contents". That was true of the command and false of the destination,
+which decided what "writing a file" meant:
+
+    $ charter secret cp tv API_TOKEN /dev/stdout 2>&1 | cat
+    FAKE-SEKRIT-…✓ Wrote 'tv/API_TOKEN' to /dev/stdout (0600). Value not shown.
+
+The success line is false on its own output. `cmd_secret_get --reveal` refuses exactly
+this channel (`sys.stdout.isatty()`); `cp` refused nothing — not a device, not a FIFO,
+not a symlink aimed at a victim file, and not an existing `~/.ssh/config` it truncated
+and chmodded 0600 without a word.
+
+These tests are written against the *class*, not the one string in the report: every
+non-regular kind, both spellings of "the agent's own pipe", the symlink that gets past a
+naive `S_ISREG` check on the target, and the pre-existing file. The fabricated value
+below is not a credential and appears in no assertion message.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import stat
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_secrets as cs
+from charter import config
+from charter.secrets import registry
+from tests._isolation import PersonaIso
+
+#: Fabricated. Long and distinctive so "did this reach stdout?" is a real question.
+VALUE = "FABRICATED-not-a-real-credential-8f2a9c"
+
+
+class CpCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        vf = config.ROOT / ".charter" / "vaults" / "v.json"
+        vf.parent.mkdir(parents=True, exist_ok=True)
+        vf.write_text(json.dumps({"k": VALUE}))
+        registry.add_vault("v", "plain-file", {"file": str(vf)})
+        # OUTSIDE the plane on purpose: that is where `cp`'s documented destination
+        # lives (a kubeconfig under ~), and it keeps these cases clear of the
+        # git-containment rule, which has its own class below.
+        self.out_dir = Path(tempfile.mkdtemp(prefix="cp-dest-"))
+        self.addCleanup(shutil.rmtree, self.out_dir, True)
+
+    def cp(self, dest, force: bool = False):
+        """Run `secret cp` capturing BOTH streams — the leak under test is on stdout."""
+        args = SimpleNamespace(vault="v", key="k", dest=str(dest), force=force)
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = cs.cmd_secret_cp(args)
+        return rc, out.getvalue(), err.getvalue()
+
+    def assertRefused(self, rc, out, err):
+        self.assertEqual(rc, 2, "a refused destination must be a non-zero exit")
+        self.assertNotIn(VALUE, out, "the secret reached stdout")
+        self.assertNotIn(VALUE, err, "the secret reached stderr")
+        self.assertIn("Refusing to write a secret", err)
+
+
+class TestANonRegularDestinationIsRefused(CpCase):
+    def test_a_character_device_destination_is_refused(self):
+        """The headline case, in its most literal form."""
+        rc, out, err = self.cp("/dev/null")
+        self.assertRefused(rc, out, err)
+        self.assertIn("character device", err)
+
+    def test_dev_stdout_is_refused(self):
+        """`/dev/stdout` is charter's own stdout — the agent's captured pipe. Whatever
+        it resolves to on this platform (a symlink on macOS and Linux, a character
+        device elsewhere), it is not a file charter may write a credential to."""
+        rc, out, err = self.cp("/dev/stdout")
+        self.assertRefused(rc, out, err)
+
+    def test_dev_stderr_and_dev_fd_are_the_same_channel(self):
+        """Named separately because a guard written against the one string in the report
+        would let these two through, and they are the same pipe."""
+        for spelling in ("/dev/stderr", "/dev/fd/1", "/dev/fd/2"):
+            with self.subTest(dest=spelling):
+                rc, out, err = self.cp(spelling)
+                self.assertRefused(rc, out, err)
+
+    def test_a_fifo_is_refused(self):
+        """Worse than a device: opening a FIFO for writing BLOCKS until a reader
+        appears, with the plaintext already resolved and charter hung holding it."""
+        fifo = self.out_dir / "pipe"
+        os.mkfifo(fifo)
+        rc, out, err = self.cp(fifo)
+        self.assertRefused(rc, out, err)
+        self.assertIn("FIFO", err)
+
+    def test_a_directory_is_refused(self):
+        rc, out, err = self.cp(self.out_dir)
+        self.assertRefused(rc, out, err)
+        self.assertIn("directory", err)
+
+
+class TestASymlinkIsNeverFollowed(CpCase):
+    def test_a_symlink_to_a_regular_file_is_refused(self):
+        """The input that gets past a check that stats the TARGET: the target is a
+        perfectly ordinary regular file, and the link is what decides where the
+        plaintext lands."""
+        victim = self.out_dir / "victim"
+        victim.write_text("original-config\n")
+        link = self.out_dir / "link"
+        link.symlink_to(victim)
+
+        rc, out, err = self.cp(link)
+        self.assertRefused(rc, out, err)
+        self.assertIn("symlink", err)
+        self.assertEqual(victim.read_text(), "original-config\n")
+
+    def test_a_symlink_to_a_device_is_refused_as_a_symlink(self):
+        link = self.out_dir / "to-null"
+        link.symlink_to("/dev/null")
+        rc, out, err = self.cp(link)
+        self.assertRefused(rc, out, err)
+
+    def test_a_dangling_symlink_is_refused(self):
+        """`lstat` succeeds and `stat` does not — the ordering that lets a link create a
+        file out of nothing if the check is written the other way round."""
+        link = self.out_dir / "dangling"
+        link.symlink_to(self.out_dir / "nothing-here")
+        rc, out, err = self.cp(link)
+        self.assertRefused(rc, out, err)
+        self.assertIn("symlink", err,
+                      "refused, but for the wrong reason — the link is the finding")
+        self.assertFalse((self.out_dir / "nothing-here").exists())
+
+    def test_force_does_not_buy_a_symlink(self):
+        """--force is consent to destroy a file the operator NAMED, not consent to let a
+        link choose the file."""
+        victim = self.out_dir / "victim"
+        victim.write_text("original-config\n")
+        link = self.out_dir / "link"
+        link.symlink_to(victim)
+        rc, out, err = self.cp(link, force=True)
+        self.assertRefused(rc, out, err)
+        self.assertEqual(victim.read_text(), "original-config\n")
+
+
+class TestAnExistingFileIsNotClobbered(CpCase):
+    def test_an_existing_file_is_not_clobbered_without_force(self):
+        victim = self.out_dir / "config"
+        victim.write_text("original-config\n")
+        os.chmod(victim, 0o644)
+
+        rc, out, err = self.cp(victim)
+        self.assertRefused(rc, out, err)
+        self.assertIn("--force", err)
+        self.assertEqual(victim.read_text(), "original-config\n")
+        self.assertEqual(stat.S_IMODE(victim.stat().st_mode), 0o644,
+                         "a refused write must not change the victim's mode either")
+
+    def test_force_overwrites_and_says_so(self):
+        victim = self.out_dir / "config"
+        victim.write_text("original-config\n")
+        os.chmod(victim, 0o644)
+
+        rc, out, err = self.cp(victim, force=True)
+        self.assertEqual(rc, 0)
+        self.assertEqual(victim.read_text(), VALUE)
+        self.assertEqual(stat.S_IMODE(victim.stat().st_mode), 0o600)
+        self.assertIn("Overwrote", err)
+        self.assertNotIn(VALUE, out)
+
+
+class TestTheOrdinaryCaseStillWorks(CpCase):
+    def test_a_new_file_is_written_at_0600_and_the_value_is_not_printed(self):
+        dest = self.out_dir / "kubeconfig"
+        rc, out, err = self.cp(dest)
+        self.assertEqual(rc, 0)
+        self.assertEqual(dest.read_text(), VALUE)
+        self.assertEqual(stat.S_IMODE(dest.stat().st_mode), 0o600)
+        self.assertNotIn(VALUE, out + err)
+        self.assertIn("Value not shown.", err + out)
+
+    def test_one_missing_parent_directory_is_created_at_0700(self):
+        """The documented case — `~/.kube/config` where `~/.kube` does not exist yet."""
+        dest = self.out_dir / "kube" / "config"
+        rc, _, _ = self.cp(dest)
+        self.assertEqual(rc, 0)
+        self.assertEqual(dest.read_text(), VALUE)
+        self.assertEqual(stat.S_IMODE(dest.parent.stat().st_mode), 0o700)
+
+    def test_a_missing_tree_is_refused_rather_than_built(self):
+        """`mkdir -p` on a caller-supplied path builds arbitrary directories anywhere the
+        user can write, and turns a typo'd destination into a silent success."""
+        dest = self.out_dir / "a" / "b" / "c" / "config"
+        rc, out, err = self.cp(dest)
+        self.assertEqual(rc, 2)
+        self.assertNotIn(VALUE, out + err)
+        self.assertFalse((self.out_dir / "a").exists())
+
+
+class TestTheOpenIsTheSecondLineOfDefence(CpCase):
+    """The `lstat` above and the `open` below are two syscalls with a gap between them,
+    and the gap is where a plant goes. `O_EXCL` and `O_NOFOLLOW` close it — but a
+    single-threaded test can never lose that race, so the check is stubbed out to
+    simulate having seen an empty path, and the OPEN is what has to refuse.
+
+    Without this, both flags are unfalsifiable belt-and-braces: removing either one
+    leaves every other test in this file green.
+    """
+
+    def cp_as_if_the_path_were_empty(self, dest, force: bool = False):
+        with mock.patch.object(cs, "_cp_dest_refusal", lambda *a, **k: None):
+            return self.cp(dest, force=force)
+
+    def test_a_file_that_appears_after_the_check_is_not_truncated(self):
+        victim = self.out_dir / "planted"
+        victim.write_text("original-config\n")
+        rc, out, err = self.cp_as_if_the_path_were_empty(victim)
+        self.assertEqual(rc, 2)
+        self.assertNotIn(VALUE, out + err)
+        self.assertEqual(victim.read_text(), "original-config\n")
+
+    def test_a_symlink_that_appears_after_the_check_is_not_followed(self):
+        victim = self.out_dir / "victim"
+        victim.write_text("original-config\n")
+        link = self.out_dir / "planted-link"
+        link.symlink_to(victim)
+        rc, out, err = self.cp_as_if_the_path_were_empty(link)
+        self.assertEqual(rc, 2)
+        self.assertNotIn(VALUE, out + err)
+        self.assertEqual(victim.read_text(), "original-config\n")
+
+    def test_a_planted_symlink_is_not_followed_under_force_either(self):
+        """The case `O_EXCL` cannot cover: `--force` opens with `O_TRUNC`, so the plant
+        succeeds unless the open itself refuses to traverse a link. `--force` is consent
+        to destroy the file the operator NAMED."""
+        victim = self.out_dir / "victim"
+        victim.write_text("original-config\n")
+        link = self.out_dir / "planted-link"
+        link.symlink_to(victim)
+        rc, out, err = self.cp_as_if_the_path_were_empty(link, force=True)
+        self.assertEqual(rc, 2)
+        self.assertNotIn(VALUE, out + err)
+        self.assertEqual(victim.read_text(), "original-config\n")
+
+
+class _SpyProvider:
+    """Records every key read. Returns the fabricated value, never a real vault read."""
+
+    def __init__(self) -> None:
+        self.reads: list[str] = []
+
+    def get(self, key: str) -> str:
+        self.reads.append(key)
+        return VALUE
+
+
+class TestTheValueIsNotResolvedForARefusedDestination(CpCase):
+    def test_a_refused_destination_never_reads_the_vault(self):
+        """Ordering, not decoration: for the case that was about to print the plaintext,
+        the plaintext must never enter this process at all."""
+        spy = _SpyProvider()
+        with mock.patch.object(cs, "_provider", lambda _name: spy):
+            rc, _, _ = self.cp("/dev/null")
+        self.assertEqual(rc, 2)
+        self.assertEqual(spy.reads, [],
+                         "the destination is checked before the vault is read")
+
+    def test_an_allowed_destination_does_read_it(self):
+        """The sibling that keeps the assertion above from passing for the wrong
+        reason — a `cp` that never reads anything would also record no reads."""
+        spy = _SpyProvider()
+        with mock.patch.object(cs, "_provider", lambda _name: spy):
+            rc, _, _ = self.cp(self.out_dir / "fresh")
+        self.assertEqual(rc, 0)
+        self.assertEqual(spy.reads, ["k"])
+
+
+class TestThePlaneIsNotADropBox(CpCase):
+    """ADR-0017, the rule `vault add` already applies: plaintext written somewhere git
+    tracks is committed by the next `charter save`. `cp` writes the same plaintext to the
+    same kind of path and asked nothing.
+
+    `git_ignores` is stubbed rather than a real repo being built: the three answers it
+    can give (tracked / ignored / not a repo) are the whole decision, and the real thing
+    is `git check-ignore`, already exercised by the `vault add` tests.
+    """
+
+    def cp_with_git(self, dest, answer):
+        with mock.patch("charter.util.git_ignores", lambda root, path: answer):
+            return self.cp(dest)
+
+    def test_a_tracked_path_inside_the_plane_is_refused(self):
+        dest = Path(config.ROOT) / "tracked.txt"
+        rc, out, err = self.cp_with_git(dest, False)     # git would take this file
+        self.assertRefused(rc, out, err)
+        self.assertIn("charter save", err)
+        self.assertFalse(dest.exists())
+
+    def test_a_gitignored_path_inside_the_plane_is_allowed(self):
+        """`.charter/` is gitignored by `charter init`, and materialising there is a
+        thing personas legitimately do — the rule is about git, not about the plane."""
+        dest = Path(config.ROOT) / ".charter" / "materialised"
+        rc, _, _ = self.cp_with_git(dest, True)
+        self.assertEqual(rc, 0)
+
+    def test_a_path_outside_the_plane_is_never_asked_about(self):
+        """Outside the plane git has no say, and `cp`'s whole documented use — a
+        kubeconfig under ~ — lives there."""
+        asked: list[str] = []
+
+        def spy(root, path):
+            asked.append(str(path))
+            return False
+
+        with mock.patch("charter.util.git_ignores", spy):
+            rc, _, _ = self.cp(self.out_dir / "outside")
+        self.assertEqual(rc, 0)
+        self.assertEqual(asked, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_secret_cp_destination.py
+++ b/tests/test_secret_cp_destination.py
@@ -16,6 +16,16 @@ These tests are written against the *class*, not the one string in the report: e
 non-regular kind, both spellings of "the agent's own pipe", the symlink that gets past a
 naive `S_ISREG` check on the target, and the pre-existing file. The fabricated value
 below is not a credential and appears in no assertion message.
+
+Round one of that fix was bypassed, and the bypass is the reason for
+`TestCharterOwnStreamsAreRefusedByIdentity` below. The first guard asked what a path was
+CALLED — `os.lstat` on the path — and `/dev/fd/1` is not a symlink and not a device on
+macOS, it is the underlying object, so it read as an ordinary existing file and fell into
+the arm `--force` switches off. `charter secret cp v k /dev/fd/1 --force` wrote the value
+into charter's own captured stdout and printed "Value not shown." after it. No list of
+names closes that: `/dev/stdout`, `/dev/fd/1`, `/proc/self/fd/1`, the readlink'd log path
+and any hardlink to it are one inode with five names. The guard now compares IDENTITY —
+`(st_dev, st_ino)` against `os.fstat(0/1/2)` — which has one answer per object.
 """
 
 from __future__ import annotations
@@ -104,6 +114,167 @@ class TestANonRegularDestinationIsRefused(CpCase):
         rc, out, err = self.cp(self.out_dir)
         self.assertRefused(rc, out, err)
         self.assertIn("directory", err)
+
+
+class TestCharterOwnStreamsAreRefusedByIdentity(CpCase):
+    """The bypass that survived round one, and the reason it survived.
+
+    Round one asked what the destination was CALLED. `os.lstat('/dev/fd/1')` on macOS
+    does not report a symlink and does not report a device — `/dev/fd/N` there is the
+    underlying object re-opened, so it reported mode 0o100200, a plain regular file. The
+    guard therefore fell through to its "already exists" arm, whose whole purpose is to
+    be switched off by `--force`. Measured against the branch::
+
+        charter secret cp v k /dev/fd/1 --force
+        -> rc=0, the value in the file behind fd 1, and
+           "✓ Wrote 'v/k' to /dev/fd/1 (0600). Value not shown." on top of it
+
+    which is issue #421's headline symptom reproduced through its own fix. Worse, the
+    no-`--force` refusal read "Pass --force to overwrite it deliberately": the guard
+    printing the recipe for its own bypass, the pattern #421 was filed about.
+
+    These cases all pin IDENTITY — `(st_dev, st_ino)` against `os.fstat(0/1/2)` — which
+    has one answer per object no matter how many names point at it. They run with fd 1
+    and fd 2 pointed at regular files this test owns, because that is the reviewer's
+    condition (and this harness's): the pre-existing `/dev/fd/1` case passed only because
+    the runner's fd 1 happened to be a pipe, and `assertRefused` accepted the "already
+    exists" message as though it were the device refusal.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.transcript = self.out_dir / "transcript.log"
+        self.transcript.write_text("earlier conversation\n")
+        os.chmod(self.transcript, 0o644)
+        self.saved = {}
+        for fd in (1, 2):
+            opened = os.open(self.transcript, os.O_WRONLY | os.O_APPEND)
+            self.saved[fd] = os.dup(fd)
+            os.dup2(opened, fd)
+            os.close(opened)
+        # NOT named `_restore`: `PersonaIso` has a method by that name and registers it
+        # as its own cleanup, so an override here would run twice (EBADF on the second)
+        # and the plane isolation would never be undone.
+        self.addCleanup(self._restore_streams)
+
+    def _restore_streams(self) -> None:
+        for fd, saved in self.saved.items():
+            os.dup2(saved, fd)
+            os.close(saved)
+
+    def assertTranscriptIntact(self):
+        """Nothing written, nothing truncated, and the mode not quietly changed.
+
+        The last one is its own assertion because the broken version's `fchmod` landed
+        on the descriptor it had opened — charter's own stdout — and left the harness's
+        transcript at 0600.
+        """
+        self.assertNotIn(VALUE, self.transcript.read_text(),
+                         "the secret was written into charter's own stream")
+        self.assertEqual(self.transcript.read_text(), "earlier conversation\n",
+                         "charter's own stream was truncated or appended to")
+        self.assertEqual(stat.S_IMODE(self.transcript.stat().st_mode), 0o644,
+                         "a refused write still chmodded charter's own stream")
+
+    def test_the_file_behind_stdout_is_refused_under_its_own_name(self):
+        """The plainest spelling and the one no name-list would ever contain: the real
+        path of the file charter's stdout is redirected to."""
+        rc, out, err = self.cp(self.transcript, force=True)
+        self.assertRefused(rc, out, err)
+        self.assertIn("charter's own standard output", err)
+        self.assertTranscriptIntact()
+
+    def test_dev_fd_1_backed_by_a_regular_file_is_refused(self):
+        """The reviewer's exact input, without `--force`."""
+        rc, out, err = self.cp("/dev/fd/1")
+        self.assertRefused(rc, out, err)
+        self.assertTranscriptIntact()
+
+    def test_dev_fd_1_backed_by_a_regular_file_is_refused_under_force(self):
+        """The reviewer's exact input. `--force` was the bypass; it must now buy nothing
+        but a different refusal path to the same answer."""
+        rc, out, err = self.cp("/dev/fd/1", force=True)
+        self.assertRefused(rc, out, err)
+        self.assertTranscriptIntact()
+
+    def test_dev_fd_2_is_the_same_channel_by_another_number(self):
+        rc, out, err = self.cp("/dev/fd/2", force=True)
+        self.assertRefused(rc, out, err)
+        self.assertTranscriptIntact()
+
+    def test_a_second_hard_name_for_the_transcript_is_refused(self):
+        """One inode, two names, and the second one is in no table of spellings. Identity
+        is what makes this case free; a path check would have to enumerate it."""
+        other = self.out_dir / "not-obviously-the-transcript"
+        os.link(self.transcript, other)
+        rc, out, err = self.cp(other, force=True)
+        self.assertRefused(rc, out, err)
+        self.assertIn("charter's own standard output", err)
+        self.assertTranscriptIntact()
+
+    def test_the_refusal_never_names_a_flag_that_would_get_past_it(self):
+        """#421 in one sentence: a guard must not print its own bypass. The refusal this
+        replaced ended "Pass --force to overwrite it deliberately", and `--force` was the
+        bypass."""
+        for dest, force in ((self.transcript, False), ("/dev/fd/1", False),
+                            (self.transcript, True), ("/dev/fd/1", True)):
+            with self.subTest(dest=str(dest), force=force):
+                _, _, err = self.cp(dest, force=force)
+                self.assertNotIn("--force", err,
+                                 "the refusal suggests the flag that used to bypass it")
+                self.assertNotIn("--reveal", err)
+
+    def test_the_vault_is_never_read_for_one_of_our_own_streams(self):
+        """The value must not exist in this process for the case that was about to print
+        it — refusing after resolving would still put the plaintext one bug from the
+        stream it was refused from."""
+        spy = _SpyProvider()
+        with mock.patch.object(cs, "_provider", lambda _name: spy):
+            rc, _, _ = self.cp("/dev/fd/1", force=True)
+        self.assertEqual(rc, 2)
+        self.assertEqual(spy.reads, [], "a refused stream still read the vault")
+
+    def test_a_name_is_recognised_without_opening_anything(self):
+        """Two lookups answer two questions, so each needs its own case or one of them
+        is decoration. `lstat` alone recognises a second NAME for the inode — a hardlink,
+        or the path `readlink` gives for the log — and costs no open; the descriptor is
+        what `/dev/fd/N` needs, because macOS reports devfs's `st_dev` there rather than
+        the file's. With the descriptor half stubbed out, the cheap half must still hold."""
+        other = self.out_dir / "another-name"
+        os.link(self.transcript, other)
+        with mock.patch.object(cs, "_identify_dest", lambda _raw: None):
+            rc, out, err = self.cp(other)
+        self.assertRefused(rc, out, err)
+        self.assertIn("charter's own standard output", err)
+        self.assertNotIn("--force", err)
+
+    def test_the_open_refuses_even_when_the_path_check_is_bypassed(self):
+        """The guarantee, separated from the courtesy. Everything the path check sees can
+        be swapped between the `lstat` and the `open`; only the descriptor cannot. With
+        the path check stubbed out — the shape of a lost race — the `fstat` after the
+        open is the whole defence, and it has to hold on its own.
+
+        Both spellings, because they fail differently: `/dev/fd/1` is the input the
+        reviewer used, and the real path is the one that proves nothing was destroyed on
+        the way to the refusal. macOS devfs quietly ignores `O_TRUNC` on `/dev/fd/N`, so
+        an open that truncated before deciding would look harmless through that name and
+        empty the file through this one.
+        """
+        for dest in ("/dev/fd/1", self.transcript):
+            with self.subTest(dest=str(dest)):
+                with mock.patch.object(cs, "_cp_dest_refusal", lambda *a, **k: None):
+                    rc, out, err = self.cp(dest, force=True)
+                self.assertRefused(rc, out, err)
+                self.assertTranscriptIntact()
+
+    def test_an_ordinary_destination_is_still_written(self):
+        """The guard must refuse charter's streams, not every file — with fd 1 on a
+        regular file, an over-broad identity test would refuse everything."""
+        dest = self.out_dir / "kubeconfig"
+        rc, out, err = self.cp(dest)
+        self.assertEqual(rc, 0)
+        self.assertEqual(dest.read_text(), VALUE)
+        self.assertNotIn(VALUE, out + err)
 
 
 class TestASymlinkIsNeverFollowed(CpCase):
@@ -235,6 +406,36 @@ class TestTheOpenIsTheSecondLineOfDefence(CpCase):
         self.assertEqual(rc, 2)
         self.assertNotIn(VALUE, out + err)
         self.assertEqual(victim.read_text(), "original-config\n")
+
+    def test_a_device_that_appears_after_the_check_is_refused_by_the_descriptor(self):
+        """`O_EXCL` and `O_NOFOLLOW` cover the plants they cover; neither says anything
+        about *kind*. Under `--force` there is no `O_EXCL`, so a character device swapped
+        in after the check opens cleanly and takes the write. The `fstat` asks the
+        descriptor what it is, which is the same question the path check asked and the
+        only version of it nothing can race."""
+        rc, out, err = self.cp_as_if_the_path_were_empty("/dev/null", force=True)
+        self.assertEqual(rc, 2)
+        self.assertNotIn(VALUE, out + err)
+        self.assertIn("character device", err)
+
+    def test_a_fifo_with_a_reader_is_refused_by_the_descriptor(self):
+        """The case the kind check exists for. A FIFO nobody is reading fails the open
+        outright (ENXIO under `O_NONBLOCK`) — but a FIFO with a reader already attached
+        opens straight through, and the reader on the other end is whoever planted it."""
+        fifo = self.out_dir / "planted-pipe"
+        os.mkfifo(fifo)
+        reader = os.open(fifo, os.O_RDONLY | os.O_NONBLOCK)
+        self.addCleanup(os.close, reader)
+
+        rc, out, err = self.cp_as_if_the_path_were_empty(fifo, force=True)
+        self.assertEqual(rc, 2)
+        self.assertNotIn(VALUE, out + err)
+        self.assertIn("FIFO", err)
+        try:
+            drained = os.read(reader, 4096).decode("utf-8", "replace")
+        except BlockingIOError:
+            drained = ""
+        self.assertNotIn(VALUE, drained, "the reader on the pipe got the credential")
 
     def test_a_planted_symlink_is_not_followed_under_force_either(self):
         """The case `O_EXCL` cannot cover: `--force` opens with `O_TRUNC`, so the plant

--- a/tests/test_secret_exec_env.py
+++ b/tests/test_secret_exec_env.py
@@ -1,0 +1,181 @@
+"""A `secret exec` child gets one vault's secrets — not every vault's identity.
+
+`env = dict(os.environ)` handed the child the whole environment. Measured with
+fabricated values, `charter secret exec <v> --env T=K -- /usr/bin/env` returned the one
+secret the model named as `***` and every OTHER vault's service-account token in the
+clear, into the caller's captured output. `base.redact` cannot help: it only knows the
+values this call resolved.
+
+`VaultProvider.env_overlay` sells the binding as least-privilege — "without this the
+mapping lives in every caller's shell… which is the property the vault abstraction
+otherwise removes". Inheriting the whole environment put it straight back.
+
+**No real credential appears here.** The variable names are charter's own (that is the
+point — the binding is stored by name), the values are fabricated, and every assertion
+compares a FILTERED projection: the child prints the names it was given, never its
+environment and never a value.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_secrets as cs
+from charter import config
+from charter.secrets import registry
+from tests._isolation import PersonaIso
+
+#: Prints only the NAMES of the variables it was asked about, one per line, and only
+#: those that are set. Never the value, never the whole environment.
+PROBE = (
+    "import os,sys;"
+    "print('\\n'.join(n for n in sys.argv[1:] if n in os.environ))"
+)
+
+
+class ExecEnvCase(PersonaIso):
+    """Three vaults, each declaring a different identity binding.
+
+    Names chosen to be obviously fabricated AND obviously not this machine's: a test
+    that used the real `OP_SERVICE_ACCOUNT_TOKEN` would pass or fail depending on
+    whether the operator happens to be signed in — the ambient-env-var trap.
+    """
+
+    DEVOPS_SOURCE = "OP_FABRICATED_DEVOPS_TOKEN"
+    MARKETING_SOURCE = "OP_FABRICATED_MARKETING_TOKEN"
+    INFRA_SOURCE = "FABRICATED_VAULT_TOKEN"
+    TARGET_OP = "OP_FABRICATED_TARGET_TOKEN"
+    TARGET_VAULT = "FABRICATED_VAULT_ADDR_TOKEN"
+    UNRELATED = "FABRICATED_UNRELATED_SETTING"
+
+    def setUp(self) -> None:
+        super().setUp()
+        vf = config.ROOT / ".charter" / "vaults" / "shared.json"
+        vf.parent.mkdir(parents=True, exist_ok=True)
+        vf.write_text(json.dumps({"k": "FABRICATED-not-a-real-credential"}))
+        for name, source in (("devops", self.DEVOPS_SOURCE),
+                             ("marketing", self.MARKETING_SOURCE)):
+            registry.add_vault(name, "plain-file",
+                               {"file": str(vf), "env": {self.TARGET_OP: source}})
+        registry.add_vault("infra", "plain-file",
+                           {"file": str(vf),
+                            "env": {self.TARGET_VAULT: self.INFRA_SOURCE}})
+
+        # The environment a caller's shell would carry. Set explicitly rather than
+        # assumed present: an assertion about a variable that was never set passes for
+        # the wrong reason.
+        self.enterContext(mock.patch.dict(os.environ, {
+            self.DEVOPS_SOURCE: "FABRICATED-devops-identity",
+            self.MARKETING_SOURCE: "FABRICATED-marketing-identity",
+            self.INFRA_SOURCE: "FABRICATED-infra-identity",
+            self.TARGET_OP: "FABRICATED-ambient-op-identity",
+            self.TARGET_VAULT: "FABRICATED-ambient-vault-identity",
+            self.UNRELATED: "not-a-credential",
+        }))
+
+    def names_the_child_sees(self, vault: str, *names: str) -> set[str]:
+        """Run the probe under `secret exec <vault>` and return which of *names* it saw."""
+        args = SimpleNamespace(vault=vault, env=None, file=None, dotenv=None,
+                               exec_mode=False, stream_mode=False,
+                               command=[sys.executable, "-c", PROBE, *names])
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = cs.cmd_secret_exec(args)
+        self.assertEqual(rc, 0, err.getvalue())
+        return {line for line in out.getvalue().split() if line}
+
+
+class TestAnotherVaultsIdentityDoesNotTravel(ExecEnvCase):
+    def test_another_vaults_token_env_is_not_inherited(self):
+        seen = self.names_the_child_sees(
+            "devops", self.MARKETING_SOURCE, self.INFRA_SOURCE)
+        self.assertEqual(seen, set(),
+                         "a child of one vault holds another vault's identity")
+
+    def test_the_vault_being_read_keeps_its_own_names(self):
+        """So `charter secret exec devops -- charter secret get devops K` still works.
+        Also the sibling that stops the assertion above passing because the child's
+        environment is empty for some unrelated reason."""
+        seen = self.names_the_child_sees(
+            "devops", self.DEVOPS_SOURCE, self.TARGET_OP)
+        self.assertEqual(seen, {self.DEVOPS_SOURCE, self.TARGET_OP})
+
+    def test_an_unrelated_variable_still_reaches_the_child(self):
+        """This filters IDENTITY, not the environment. A child that lost PATH or its
+        locale would break every real use of `secret exec`."""
+        seen = self.names_the_child_sees("devops", self.UNRELATED, "PATH")
+        self.assertEqual(seen, {self.UNRELATED, "PATH"})
+
+    def test_the_target_half_of_a_binding_is_stripped_too(self):
+        """`OP_SERVICE_ACCOUNT_TOKEN` is where the CLI READS an identity from, so an
+        ambient one is exactly as much a cross-identity credential as the source it is
+        copied from. A filter written against `.values()` alone would let it through —
+        and it is the variable `op` actually authenticates with."""
+        seen = self.names_the_child_sees("infra", self.TARGET_OP)
+        self.assertEqual(seen, set())
+
+    def test_a_vault_declaring_no_identity_still_strips_the_others(self):
+        """The single-account setup: the vault being read declares nothing, so it
+        subtracts nothing, and every declared name belongs to someone else."""
+        registry.add_vault("plain", "plain-file",
+                           {"file": str(config.ROOT / ".charter" / "vaults" / "shared.json")})
+        seen = self.names_the_child_sees(
+            "plain", self.DEVOPS_SOURCE, self.MARKETING_SOURCE, self.UNRELATED)
+        self.assertEqual(seen, {self.UNRELATED})
+
+
+class TestTheFilterIsBuiltFromTheRegistry(ExecEnvCase):
+    def test_both_halves_of_every_binding_are_collected(self):
+        got = cs._identity_vars()
+        self.assertEqual(got["devops"], {self.TARGET_OP, self.DEVOPS_SOURCE})
+        self.assertEqual(got["infra"], {self.TARGET_VAULT, self.INFRA_SOURCE})
+
+    def test_a_malformed_committed_env_block_does_not_crash(self):
+        """`vaults.json` has a committed half, so it is untrusted input: a string where
+        a mapping belongs must not turn `secret exec` into a traceback."""
+        doc = registry.load_registry()
+        doc["vaults"]["devops"]["config"]["env"] = "OP_TOKEN"
+        registry.save_registry(doc)
+        got = cs._identity_vars()
+        self.assertNotIn("devops", got)
+        self.assertEqual(got["infra"], {self.TARGET_VAULT, self.INFRA_SOURCE})
+
+
+class TestEveryRunModeUsesTheSameEnvironment(ExecEnvCase):
+    def test_stream_mode_filters_too(self):
+        """--stream and --exec skip the capturing path entirely; a filter applied at the
+        capture site would miss both, and those are the unredacted modes."""
+        args = SimpleNamespace(
+            vault="devops", env=None, file=None, dotenv=None,
+            exec_mode=False, stream_mode=True,
+            command=[sys.executable, "-c", PROBE,
+                     self.MARKETING_SOURCE, self.DEVOPS_SOURCE])
+        err = io.StringIO()
+        # --stream inherits this process's stdio, so the child writes to fd 1 directly;
+        # capture it at the fd level.
+        r, w = os.pipe()
+        saved = os.dup(1)
+        try:
+            os.dup2(w, 1)
+            os.close(w)
+            with redirect_stderr(err):
+                rc = cs.cmd_secret_exec(args)
+            sys.stdout.flush()
+        finally:
+            os.dup2(saved, 1)
+            os.close(saved)
+        with os.fdopen(r) as fh:
+            printed = fh.read()
+        self.assertEqual(rc, 0)
+        self.assertEqual({n for n in printed.split() if n}, {self.DEVOPS_SOURCE})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_secret_stream.py
+++ b/tests/test_secret_stream.py
@@ -14,14 +14,19 @@ it had to keep a plugin purely to carry them.
 `exec` bought here** — a forked child inherits the parent's descriptors — so the only thing
 given up is replacing the process, which is exactly the thing that made cleanup impossible.
 
-The limit is stated rather than implied away, and it is now the narrowest one available: a
-`SIGKILL`ed charter runs no cleanup and the 0600 file survives until it is removed. SIGKILL
-alone, because SIGTERM and SIGHUP are handled here — they used to be in the same sentence,
-and they should never have been. SIGKILL is what you reach for when something is already
-stuck; SIGTERM is what a supervisor, a `kill`, or a harness reaping a hung tool call sends
-at every ordinary shutdown, and `--stream` exists for exactly the long-running children that
-get SIGTERMed. Measured before the fix: SIGTERM at t+2s left `charter-<v>-<k>-…` at
-`-rw-------` holding the value.
+The limit is stated rather than implied away, and stating it correctly took two goes. The
+first version said SIGKILL when SIGTERM leaked too — SIGTERM at t+2s left `charter-<v>-<k>-…`
+at `-rw-------` holding the value. The second handled SIGTERM and SIGHUP and said SIGKILL
+again, which was still false: SIGQUIT (Ctrl-\\), SIGUSR1 and SIGXCPU each left the same file,
+because *every* catchable default-terminate signal has the property, not the two that got
+reported. Both mistakes were the same mistake — a list of signals to CATCH is a list of
+spellings, and the next one is never on it.
+
+So the set is derived by exclusion (`commands_secrets._SIGNALS_LEFT_ALONE`) and the stated
+limit is now a category: cleanup survives every terminating signal charter may catch, and
+does not survive SIGKILL, which no process can catch, or a fault (SIGSEGV, SIGBUS, SIGABRT),
+which charter deliberately does not intercept because a handler on an already-broken process
+can turn a crash into a hang.
 """
 
 from __future__ import annotations
@@ -170,6 +175,49 @@ class TestTheLimitIsStated(unittest.TestCase):
         self.assertIn("SIGTERM", stream_help)
         self.assertIn("SIGKILL", stream_help)
 
+    def test_the_help_does_not_blame_sigkill_for_what_sigquit_does(self):
+        """The same finding, one round later. With SIGTERM and SIGHUP handled, three
+        places said SIGKILL was now the WHOLE limit — and SIGQUIT, which is Ctrl-\\ from
+        any terminal, still left the 0600 file. A narrower false sentence is still a
+        false sentence.
+
+        Pinned on SIGQUIT specifically because it is the one the measurement named, and
+        on the fault category because that is the other half of the honest answer: it is
+        what charter chooses not to catch, and choosing must be said out loud."""
+        import inspect
+
+        from charter import cli
+        src = inspect.getsource(cli)
+        stream_help = src[src.index('p.add_argument("--stream"'):]
+        stream_help = stream_help[:stream_help.index('p.add_argument("--exec"')]
+        self.assertIn("SIGQUIT", stream_help,
+                      "the help still implies SIGKILL is the only thing that leaks")
+        self.assertIn("SIGSEGV", stream_help,
+                      "the faults charter chooses not to catch are part of the limit")
+
+
+class TestTheHandledSetIsDerivedNotListed(unittest.TestCase):
+    """Round one caught the two signals that were reported. The set must instead be
+    everything that terminates and can be caught, so a signal nobody has thought of is
+    already handled rather than already leaking."""
+
+    def test_the_catchable_terminating_signals_are_all_handled(self):
+        import signal as _signal
+        handled = {s.name for s in cs._TERMINATION_SIGNALS}
+        for name in ("SIGTERM", "SIGHUP", "SIGQUIT", "SIGUSR1", "SIGUSR2", "SIGXCPU"):
+            if hasattr(_signal, name):
+                self.assertIn(name, handled)
+
+    def test_the_signals_charter_must_not_take_over_are_left_alone(self):
+        """Each exclusion is a reason, not an omission: SIGKILL/SIGSTOP cannot be caught,
+        SIGTSTP is job control (Ctrl-Z must background, not kill), SIGINT already unwinds
+        via KeyboardInterrupt, SIGCHLD does not terminate anything, and a fault handler
+        runs on a process whose state is already wrong."""
+        handled = {s.name for s in cs._TERMINATION_SIGNALS}
+        for name in ("SIGKILL", "SIGSTOP", "SIGTSTP", "SIGINT", "SIGCHLD", "SIGPIPE",
+                     "SIGSEGV", "SIGABRT", "SIGBUS"):
+            self.assertNotIn(name, handled)
+
 
 class TestTerminationStillCleansUp(StreamCase):
     """SIGTERM and SIGHUP run no `finally` by default, so the 0600 file outlived the
@@ -185,7 +233,7 @@ class TestTerminationStillCleansUp(StreamCase):
         # whole suite — the case then fails on its assertions, which is the point.
         import signal as _signal
         self.caught: list[int] = []
-        for sig in (_signal.SIGTERM, _signal.SIGHUP):
+        for sig in (_signal.SIGTERM, _signal.SIGHUP, _signal.SIGQUIT, _signal.SIGUSR1):
             prev = _signal.signal(sig, lambda n, f: self.caught.append(n))
             self.addCleanup(_signal.signal, sig, prev)
 
@@ -239,17 +287,41 @@ class TestTerminationStillCleansUp(StreamCase):
         self.assertFalse(os.path.exists(path),
                          "the 0600 credential file survived a SIGHUP")
 
+    def test_a_sigquit_parent_still_cleans_up(self):
+        """Ctrl-\\ from a terminal, and the case that proved the first version of this
+        sentence false. SIGTERM and SIGHUP were handled and the docs then said SIGKILL
+        was the whole limit — but SIGQUIT, SIGUSR1, SIGXCPU and every other catchable
+        default-terminate signal has the identical property, and SIGQUIT left the 0600
+        file exactly as SIGTERM had. The set is now derived by exclusion rather than
+        listed, so "the next signal nobody named" is in it already."""
+        path, raised, expected = self.run_and_signal_self("QUIT")
+        self.assertIsNotNone(raised, "SIGQUIT terminated without unwinding")
+        self.assertEqual(raised.code, expected)
+        self.assertFalse(os.path.exists(path),
+                         "the 0600 credential file survived a SIGQUIT")
+
+    def test_a_sigusr1_parent_still_cleans_up(self):
+        """Not a terminal key at all — a supervisor's reload/rotate poke, whose default
+        action still terminates. Named separately from SIGQUIT because a fix that added
+        two more entries to a hand-written list would pass one of these and fail the
+        other."""
+        path, raised, expected = self.run_and_signal_self("USR1")
+        self.assertIsNotNone(raised, "SIGUSR1 terminated without unwinding")
+        self.assertEqual(raised.code, expected)
+        self.assertFalse(os.path.exists(path),
+                         "the 0600 credential file survived a SIGUSR1")
+
     def test_the_handlers_are_removed_again_afterwards(self):
         """charter is a library as well as a CLI (`charter persona`, the hooks, the
         tests themselves run in-process). A handler left installed after the command
         returns would change how the whole host process dies."""
         import signal as _signal
-        before = {s: _signal.getsignal(s)
-                  for s in (_signal.SIGTERM, _signal.SIGHUP)}
+        watched = tuple(cs._TERMINATION_SIGNALS)
+        self.assertIn(_signal.SIGQUIT, watched, "the widened set is what must be undone")
+        before = {s: _signal.getsignal(s) for s in watched}
         rc, _ = self.run_exec(["sh", "-c", "exit 0"], stream_mode=True, file=["F=k"])
         self.assertEqual(rc, 0)
-        after = {s: _signal.getsignal(s)
-                 for s in (_signal.SIGTERM, _signal.SIGHUP)}
+        after = {s: _signal.getsignal(s) for s in watched}
         self.assertEqual(after, before)
 
 

--- a/tests/test_secret_stream.py
+++ b/tests/test_secret_stream.py
@@ -2,7 +2,7 @@
 
 `mcp_render_entry` emitted only `--env`, and `--exec` is mandatory for an MCP stdio server:
 it never returns, so the capturing form hangs holding output nobody reads. But `--exec`
-replaces charter, so nothing survives to shred a temp file — which is why it is incompatible
+replaces charter, so nothing survives to delete a temp file — which is why it is incompatible
 with `--file`.
 
 Google Application Default Credentials require a filesystem **path**
@@ -14,9 +14,14 @@ it had to keep a plugin purely to carry them.
 `exec` bought here** — a forked child inherits the parent's descriptors — so the only thing
 given up is replacing the process, which is exactly the thing that made cleanup impossible.
 
-The limit is stated rather than implied away: a `SIGKILL`ed charter runs no cleanup and the
-0600 file survives until it is removed. That is strictly better than every persona
-re-implementing the same `trap` in shell with the same hole, and it is not a guarantee.
+The limit is stated rather than implied away, and it is now the narrowest one available: a
+`SIGKILL`ed charter runs no cleanup and the 0600 file survives until it is removed. SIGKILL
+alone, because SIGTERM and SIGHUP are handled here — they used to be in the same sentence,
+and they should never have been. SIGKILL is what you reach for when something is already
+stuck; SIGTERM is what a supervisor, a `kill`, or a harness reaping a hung tool call sends
+at every ordinary shutdown, and `--stream` exists for exactly the long-running children that
+get SIGTERMed. Measured before the fix: SIGTERM at t+2s left `charter-<v>-<k>-…` at
+`-rw-------` holding the value.
 """
 
 from __future__ import annotations
@@ -151,6 +156,101 @@ class TestTheLimitIsStated(unittest.TestCase):
         import inspect
         src = inspect.getsource(cli)
         self.assertIn("SIGKILL", src)
+
+    def test_the_help_does_not_blame_sigterm_for_what_sigkill_does(self):
+        """The wording is the finding. "Only if someone SIGKILLs us" reads as vanishingly
+        rare; "any SIGTERM" is routine — and while both were named in one breath, the
+        sentence described a leak nobody would go looking for."""
+        import inspect
+
+        from charter import cli
+        src = inspect.getsource(cli)
+        stream_help = src[src.index('p.add_argument("--stream"'):]
+        stream_help = stream_help[:stream_help.index('p.add_argument("--exec"')]
+        self.assertIn("SIGTERM", stream_help)
+        self.assertIn("SIGKILL", stream_help)
+
+
+class TestTerminationStillCleansUp(StreamCase):
+    """SIGTERM and SIGHUP run no `finally` by default, so the 0600 file outlived the
+    process that owned it. The child here signals its own parent — the same shape as a
+    supervisor doing it, and it needs no timing guess."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # A net under the test runner, and NOT a second implementation of the fix: it
+        # records and returns, so nothing unwinds and no `finally` runs through it. With
+        # the fix, charter's handler is installed over this one for the duration and this
+        # never fires. Without it, this is what stops a real SIGTERM from killing the
+        # whole suite — the case then fails on its assertions, which is the point.
+        import signal as _signal
+        self.caught: list[int] = []
+        for sig in (_signal.SIGTERM, _signal.SIGHUP):
+            prev = _signal.signal(sig, lambda n, f: self.caught.append(n))
+            self.addCleanup(_signal.signal, sig, prev)
+
+    def run_and_signal_self(self, signame: str):
+        """`--stream` a child that SIGTERMs (or SIGHUPs) this process and then sleeps.
+
+        The child writes the file's path out first, so the assertions below are about a
+        file that demonstrably existed — a test that signalled before `mkstemp` ran would
+        pass with nothing to clean up.
+        """
+        import signal as _signal
+
+        # `printenv F` is the tmpfile path charter created for --file F=k.
+        script = f'printenv F; kill -{signame} $PPID; sleep 5'
+        args = SimpleNamespace(vault="v", env=None, file=["F=k"], dotenv=None,
+                               exec_mode=False, stream_mode=True,
+                               command=["sh", "-c", script])
+        r, w = os.pipe()
+        saved = os.dup(1)
+        raised = None
+        try:
+            os.dup2(w, 1)
+            os.close(w)
+            try:
+                cs.cmd_secret_exec(args)
+            except SystemExit as e:
+                raised = e
+        finally:
+            os.dup2(saved, 1)
+            os.close(saved)
+        with os.fdopen(r) as fh:
+            path = fh.readline().strip()
+        self.assertTrue(path, "the child never reported the credential file")
+        expected = 128 + getattr(_signal, f"SIG{signame}").value
+        return path, raised, expected
+
+    def test_a_sigtermed_parent_still_cleans_up(self):
+        path, raised, expected = self.run_and_signal_self("TERM")
+        self.assertEqual(self.caught, [],
+                         "the signal reached the test's own net — charter installed no "
+                         "handler of its own")
+        self.assertIsNotNone(raised, "SIGTERM terminated without unwinding")
+        self.assertEqual(raised.code, expected)
+        self.assertFalse(os.path.exists(path),
+                         "the 0600 credential file survived a SIGTERM")
+
+    def test_a_sighupped_parent_still_cleans_up(self):
+        path, raised, expected = self.run_and_signal_self("HUP")
+        self.assertIsNotNone(raised, "SIGHUP terminated without unwinding")
+        self.assertEqual(raised.code, expected)
+        self.assertFalse(os.path.exists(path),
+                         "the 0600 credential file survived a SIGHUP")
+
+    def test_the_handlers_are_removed_again_afterwards(self):
+        """charter is a library as well as a CLI (`charter persona`, the hooks, the
+        tests themselves run in-process). A handler left installed after the command
+        returns would change how the whole host process dies."""
+        import signal as _signal
+        before = {s: _signal.getsignal(s)
+                  for s in (_signal.SIGTERM, _signal.SIGHUP)}
+        rc, _ = self.run_exec(["sh", "-c", "exit 0"], stream_mode=True, file=["F=k"])
+        self.assertEqual(rc, 0)
+        after = {s: _signal.getsignal(s)
+                 for s in (_signal.SIGTERM, _signal.SIGHUP)}
+        self.assertEqual(after, before)
 
 
 if __name__ == "__main__":

--- a/tests/test_wording.py
+++ b/tests/test_wording.py
@@ -1,0 +1,71 @@
+"""Words charter is not allowed to use about what it does.
+
+A security claim that is false in a reachable configuration is worse than no claim, and
+the cheapest way to make one is a verb. `_safe_unlink` is `os.unlink` — no overwrite
+pass, and it should not grow one: rewriting a block on APFS, on ext4 with a journal, or
+on any SSD doing wear levelling writes a NEW block and leaves the old contents wherever
+the drive left them. So the code is right and the word was wrong, in six places across
+`charter/` and `skills/` (`cli.py`, `commands_secrets.py` ×3, `persona.py`, the browser
+skill ×2), each of which told a reader that a temp credential had been destroyed rather
+than unlinked.
+
+Kept as a grep rather than a comment because the word is *attractive*: it is what shell
+scripts do (`shred(1)`), it is what the operation feels like, and the next person to
+describe this cleanup will reach for it again.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+#: Where charter speaks to a user or to the next maintainer.
+SCANNED = ("charter", "skills")
+
+#: "shred", "shreds", "shredded", "shredding" — as a word, so `shredder.py` or a URL
+#: containing the letters is not a hit.
+_SHRED = re.compile(r"\bshred(s|ded|ding)?\b", re.IGNORECASE)
+
+
+def _sources():
+    for top in SCANNED:
+        for path in sorted((ROOT / top).rglob("*")):
+            if path.is_file() and path.suffix in (".py", ".md", ".toml", ".json"):
+                yield path
+
+
+class TestNothingClaimsToShred(unittest.TestCase):
+    def test_no_doc_or_docstring_claims_to_shred(self):
+        hits = []
+        for path in _sources():
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):       # pragma: no cover - binaries
+                continue
+            for n, line in enumerate(text.splitlines(), 1):
+                if _SHRED.search(line):
+                    hits.append(f"{path.relative_to(ROOT)}:{n}: {line.strip()}")
+        self.assertEqual(hits, [], "\n".join(
+            ["charter deletes these files, it does not shred them — an overwrite pass "
+             "is meaningless on a copy-on-write filesystem, so fix the word, not the "
+             "code:"] + hits))
+
+    def test_the_scan_actually_reads_files(self):
+        """A rglob that matched nothing would make the assertion above vacuous — the
+        failure mode this whole file exists to catch, applied to itself."""
+        found = list(_sources())
+        self.assertGreater(len(found), 20)
+        self.assertIn(ROOT / "charter" / "commands_secrets.py", found)
+
+    def test_the_pattern_would_catch_the_wording_it_replaced(self):
+        original = ("Use --stream instead — it forks, inherits stdio, and shreds the "
+                    "file when the child exits.")
+        self.assertTrue(_SHRED.search(original))
+        self.assertFalse(_SHRED.search(original.replace("shreds", "deletes")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The `secret cp` / `secret exec` group from the 2026-08-24 security assessment.

Closes #421
Closes #422
Closes #425
Closes #434
Closes #435

## The headline one

```
$ charter secret cp tv API_TOKEN /dev/stdout 2>&1 | cat
FABRICATED-…✓ Wrote 'tv/API_TOKEN' to /dev/stdout (0600). Value not shown.
```

The success line was false on its own output. `docs/secrets.md` said `cp` "prints only
the path, never the contents"; that was true of the command and false of the
destination, which is what actually decided where the plaintext went. After:

```
✗ Refusing to write a secret: /dev/stdout is a symlink, and charter will not follow one
  to write a credential — the link decides where the plaintext lands, not you. Name the
  real path.
```

## What changed

**`secret cp` (#421, #422).** The destination is checked *before* the vault is read, so
a refused path never resolves the value at all.

| input | before | after |
|---|---|---|
| `/dev/stdout`, `/dev/stderr`, `/dev/fd/N` | plaintext on the agent's pipe | refused |
| a FIFO | blocks, holding the resolved value | refused |
| a directory, socket, block/char device | `OSError` or worse | refused, named by kind |
| a symlink (to a file, a device, or dangling) | written through to the target | refused, and `O_NOFOLLOW` on the open |
| an existing file | `O_TRUNC` + `chmod 0600`, silent | refused; `--force` overwrites and says so |
| a missing directory tree | `mkdir -p`, arbitrary depth | one level, at 0700, else refused |
| a tracked path inside the plane | committed by the next `charter save` | refused, the rule `vault add` already applies |

The mode is now set with `fchmod` on the opened descriptor rather than `chmod` on the
path, and the default open is `O_EXCL`.

**Note where I differed from the issue.** #422's sketch says "refuse a path outside the
plane". I implemented the inverse: outside the plane is the documented case (`cp`'s own
example is a kubeconfig under `~`), and it is a path *inside* the plane that git would
track which gets the credential pushed to the forge on the next `charter save` — the
hazard `cmd_vault_add` already refuses and `cp` did not (assessment §"folds into item
8"). Same helper, same message shape.

**`secret exec` (#425).** `env = dict(os.environ)` handed the child every credential on
the machine: the one secret the model named came back `***`, every other vault's
service-account token came back in the clear. The child now gets the caller's
environment minus every identity variable declared by a vault *other* than the one being
read — both halves of each binding, since the target (`OP_SERVICE_ACCOUNT_TOKEN`) is what
the CLI authenticates with and the source is where this machine carries it. The vault
being read keeps its own names, so `charter secret exec devops -- charter secret get
devops K` still works, and `PATH`/locale/everything unrelated is untouched. Applied at
`env` construction, so `--exec`, `--stream` and the capturing path all get it.

**`--stream` cleanup (#434).** The cleanup is a `finally`, and a default-action signal
unwinds nothing — Python installs a handler for exactly one of the three (SIGINT).
Measured live, `--stream --file F=K -- sh -c 'sleep 20'`, signal at t+1s, `TMPDIR`
observable:

| | before | after |
|---|---|---|
| SIGTERM | survivor at `-rw-------` | 0 survivors, rc 143 |
| SIGHUP | survivor at `-rw-------` | 0 survivors, rc 129 |

SIGTERM and SIGHUP now raise `SystemExit(128+N)` for the duration of the command (all
modes that can hold a temp file, not just `--stream`), and the handlers are restored on
the way out so charter-as-a-library does not change how its host dies. The wording in
`commands_secrets.py`, `cli.py` and `tests/test_secret_stream.py` said SIGKILL when it
meant "any terminating signal"; SIGKILL is now the whole of the stated limit rather than
the politest third of it.

**"shred" (#435).** `_safe_unlink` is a bare `os.unlink` and should stay one — an
overwrite pass is meaningless on a copy-on-write filesystem. Six places called it
shredding; the word changed, not the code.

## Tests

`tests/test_secret_cp_destination.py` (22), `tests/test_secret_exec_env.py` (8),
`tests/test_wording.py` (3), and four cases added to `tests/test_secret_stream.py`.
Written against the class rather than the string in the issue: every non-regular kind,
all three spellings of the agent's own pipe, symlinks to files / to devices / dangling /
under `--force`, and the two plants that only `O_EXCL` and `O_NOFOLLOW` can refuse (the
check is stubbed out so the *open* has to answer, which a single-threaded test can
otherwise never reach).

No real credential appears in any fixture or assertion message: the exec test's probe
prints variable NAMES only, and every comparison is a filtered projection rather than a
whole environment.

Full suite: `Ran 4153 tests … OK`.

**Mutation-tested, 14 for 14 RED**, `__pycache__` cleared between runs: non-regular arm
removed · symlink arm removed · exists-check removed · `O_EXCL`→`O_TRUNC` ·
`O_NOFOLLOW` dropped · git-containment refusal removed · `mkdir` one level→`makedirs` ·
value resolved before the check · env filter removed · only the source half of a binding
collected · malformed-registry guard removed · termination handlers not installed ·
handlers never restored · one "shreds" put back.

The SIGTERM cases signal the test process itself, so the class installs a recording
no-op handler first: with the fix charter's handler wins, and without it the case fails
on its assertions instead of killing the runner.

## Not in scope here

`hooks.py` is untouched — the `secret cp` read-guard ledger and the `--reveal` denial
text that names `cp` are #423's, and belong to whoever holds that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
