### PR TITLE
frame: the top slot shows the dev-channel chip too

### DIFF
--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -146,6 +146,16 @@ def _top(fid: str) -> str:
     that reads the same on every frame on this machine all day — it is a fact about the
     install, not about where you are standing. The workspace and the persona ARE the
     answer, so a density that dropped either would leave a row not earning its line.
+
+    **The version carries the dev-channel chip, `statusline._dev_chip()` (#457).** #386
+    made a frame suppress the status line entirely, and `_brand` is the only OTHER place
+    the `dev` word was ever drawn — so a framed session on the dev channel had the word
+    nowhere on screen: the surface that knew was blanked, and this one, which replaced
+    it, never imported `channel` at all. The chip follows the version rather than getting
+    a branch of its own, for the same reason `_brand`'s docstring gives: it is a fact
+    about the version, not a fourth thing on this row, so it goes exactly where the
+    version goes — including out, at `terse`, since a density that meant to buy back a
+    whole line does not mean to keep half of it.
     """
     from .. import __version__, statusline, workspace
     ws = workspace.resolve()
@@ -153,7 +163,8 @@ def _top(fid: str) -> str:
     pin = "*" if src == "$CHARTER_WORKSPACE" else ""
     persona = statusline._persona_line() or ""
     left = f" ⬢ {ws}{pin}"
-    right = persona if verbosity(fid) == "terse" else f"{persona}  charter {__version__} "
+    right = (persona if verbosity(fid) == "terse"
+             else f"{persona}  charter {__version__}{statusline._dev_chip()} ")
     return tui.truncate(f"{left}  {right}", _width())
 
 

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1746,6 +1746,27 @@ def _session_strip(payload: dict, sid: str | None) -> str:
     return f"{_DIM} · {_R}".join(parts) if parts else ""
 
 
+def _dev_chip() -> str:
+    """`` dev``, dimmed, glued right after a version — when THIS plane is on the dev
+    channel. Empty string otherwise, so a caller can interpolate it unconditionally.
+
+    Split out of `_brand` (#457) so a second surface that glues the literal word
+    `charter` onto `__version__` — `frame.slots._top`, and whatever grows the idiom
+    next — calls this rather than re-deriving `channel.is_dev()` and the try/except
+    around it a second time. A fix to what the chip says, or when it fires, then lands
+    everywhere `charter {version}` is rendered, the moment it lands here.
+
+    See `_brand`'s own docstring for the full argument for why this is about the
+    CHANNEL and not the build — that reasoning is not repeated per caller.
+    """
+    from . import channel
+    try:
+        dev = channel.is_dev()
+    except Exception:
+        dev = False
+    return f" {_DIM}dev{_R}" if dev else ""
+
+
 def _brand() -> str:
     """`⬢ charter x.y.z`, plus `dev` on the dev channel, plus `↑ a.b.c` when something
     newer is cached.
@@ -1767,14 +1788,8 @@ def _brand() -> str:
     it. A plane that declares dev while still running the PyPI wheel renders `dev ↑a1b2c3d`,
     because `update.newer_head` counts "installed from no commit at all" as behind.
     """
-    from . import __version__, channel, update
-    out = f"{_DIM}⬢ charter {__version__}{_R}"
-    try:
-        dev = channel.is_dev()
-    except Exception:
-        dev = False
-    if dev:
-        out += f" {_DIM}dev{_R}"
+    from . import __version__, update
+    out = f"{_DIM}⬢ charter {__version__}{_R}{_dev_chip()}"
     try:
         update.maybe_spawn()
         newer = update.newer_than(__version__)

--- a/docs/news/unreleased-the-frame-said-nothing-about-dev.md
+++ b/docs/news/unreleased-the-frame-said-nothing-about-dev.md
@@ -1,0 +1,27 @@
+---
+version: unreleased
+headline: Inside a frame, the dev channel had nowhere left to say so
+---
+
+Two changes landed separately and were each correct on their own. The dev channel's chip
+went on the status line's brand (`⬢ charter 0.51.0 dev`) and nowhere else, because the
+brand was the only place a version was rendered. Then the frame took over that surface
+entirely: inside a frame, `charter statusline` prints an empty line, and the top panel
+draws identity instead. Nobody rewired the chip onto the panel that replaced the line it
+used to live on, and no test caught it, because each change's own tests only ever looked
+at the surface it touched.
+
+The result: a framed session on the dev channel showed `charter 0.51.0` on its top strip
+and nothing else — the one place that knew which channel this plane was on had gone
+quiet, and the panel that took over never asked.
+
+**The chip now lives in one function, `_dev_chip()`, and both surfaces call it.** The top
+panel renders `charter 0.51.0 dev` beside your workspace and persona, exactly the word the
+status line already used, dimmed the same way. It follows the version rather than getting
+a row of its own: a terse panel that already decided the version doesn't earn its columns
+drops the chip with it, the same as before.
+
+A version string glued straight to the word `charter` is now a checked shape across the
+whole package — not a list of the two places this bug lived, but the literal pattern that
+caused it, so the next surface that grows one is covered on the day it's written rather
+than the day someone remembers to add it somewhere.

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -319,6 +319,18 @@ class TerseSaysLess(PersonaIso, unittest.TestCase):
         self.assertNotIn(__version__, terse)
         self.assertIn("⬢", terse, "the workspace mark is the answer top exists to give")
 
+    def test_top_drops_the_dev_chip_too_when_it_drops_the_version(self):
+        """#457: the dev-channel chip follows the version rather than getting a rule of
+        its own — it is a fact ABOUT the version (`_dev_chip`'s own docstring), so a
+        density that already decided the version does not earn its columns must not
+        keep half of it around. On a plane declaring `[update] channel = "dev"`, `normal`
+        carries both the version and the word `dev`; `minimal` carries neither."""
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}):
+            normal = self._render("top", "normal")
+            terse = self._render("top", "minimal")
+        self.assertIn("dev", normal)
+        self.assertNotIn("dev", terse)
+
     def test_bottom_keeps_exactly_one_field(self):
         with mock.patch("charter.statusline._todo_count", return_value=3), \
              mock.patch("charter.statusline._alerts",

--- a/tests/test_version_shows_channel.py
+++ b/tests/test_version_shows_channel.py
@@ -1,0 +1,285 @@
+"""#457: every surface that renders `charter {version}` for a human also renders the
+channel beside it.
+
+`statusline._brand` had the `dev` chip (#454); `frame/slots.py:_top` did not — it never
+imported `channel`, or anything that does, at all. #386 made a frame SUPPRESS the status
+line, so the two gaps stacked: inside a frame on the dev channel there was no indication
+of the channel anywhere on screen. Neither #454 nor #386 could have caught this alone,
+because each only tests the surface it touched.
+
+**The fix is one function, `statusline._dev_chip()`, called from both places** — not two
+copies of `channel.is_dev()` and its try/except. `_brand` and `_top` differ in
+punctuation and colour around it but not in the one fact that matters: whether this
+process's plane is on the dev channel. See `_dev_chip`'s own docstring, and `_brand`'s
+(which it defers to), for why that is a CHANNEL fact and not a build fact.
+
+**The property test, and where it stops.** `EveryCharterVersionIdiomShowsTheChannel`
+below walks the whole package's AST (the same technique
+`tests/test_self_relaunch_argv.py`'s `_hand_built_relaunch_argvs` already established in
+this suite, for the identical reason a grep would not do) for the exact idiom `_brand`
+and `_top` share: the bare name `__version__`, interpolated with the literal word
+`charter` glued directly in front of it. That is deliberately narrower than "every place
+`__version__` appears" — this package interpolates it in a dozen other places
+(`report.py`'s JSON export, `hooks.py`'s and `doctor.py`'s pin/plugin-drift warnings,
+`statusline._alerts`'s pinned-version alert, `commands_report._warn_if_stale`'s
+staleness nudge) that are answering "does what's running match what's declared", not
+"which channel is this plane on" — a different question `_brand`'s docstring is not
+making a claim about. A scanner broad enough to flag all of those too would have to
+judge INTENT, which no syntax-level check can do honestly; a scanner narrowed by a
+hand-picked exclusion list for each of them would just be today's two-item allowlist
+wearing a longer coat. The "charter {version}" idiom is not a guess at that boundary —
+it is the literal shape of the bug: `_top`'s line was `f"... charter {__version__} "`
+with nothing else in the expression naming a channel at all, and every one of the
+excluded sites above fails that literal test on its own text (see each one's inline
+comment in `_charter_version_idiom_sites`'s docstring). One real site DOES match the
+idiom and isn't fixed here: `commands_report._warn_if_stale` — filed as #458 rather than
+folded into this PR (out of #457's stated scope) or silently exempted, and carried below
+as a named, sourced `_KNOWN_GAPS` entry so fixing #458 is "implement the chip, delete
+the line" and the property test itself proves that fix.
+
+Frame ids are `<workspace>-<launcher pid>` (`frame/state.py:frame_id`), and pid 1 is
+`launchd` — permanently alive on this machine. `_top` does not consult liveness at all
+(`verbosity` only reads `state.density`), so no fixture below needs a dead pid; `_fid()`
+still builds one from `os.getpid()` rather than a literal `-1`, so a test copied
+somewhere that DOES check liveness inherits a safe fixture rather than an unfailable one.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import charter
+from charter import config, statusline
+from charter.frame import slots
+
+from tests._isolation import PersonaIso
+
+#: The package this test process actually imported — not a path guessed from
+#: `__file__`'s neighbours, matching `tests/test_self_relaunch_argv.py`'s own `_PKG`.
+_PKG = Path(charter.__file__).resolve().parent
+
+
+def _fid() -> str:
+    return f"vshow-{os.getpid()}"
+
+
+class DevChipUnit(unittest.TestCase):
+    """`statusline._dev_chip()` in isolation: the one fact both surfaces defer to."""
+
+    def test_dev_channel_renders_the_word_dev(self):
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}):
+            self.assertIn("dev", statusline._dev_chip())
+
+    def test_stable_channel_renders_nothing(self):
+        with mock.patch.object(config, "UPDATE", {"channel": "stable"}):
+            self.assertEqual(statusline._dev_chip(), "")
+
+    def test_a_channel_lookup_failure_renders_nothing_rather_than_raising(self):
+        """`_brand`/`_top` both call this with no guard of their own around it — the same
+        trust `_right` places in `_persona_chips`'s internal swallow. If `_dev_chip` ever
+        let an exception through, both callers would need a try/except apiece, which is
+        exactly the duplication this helper exists to remove."""
+        with mock.patch("charter.channel.is_dev", side_effect=RuntimeError("boom")):
+            self.assertEqual(statusline._dev_chip(), "")
+
+
+class BrandCallsTheSharedChipRatherThanReassemblingIt(unittest.TestCase):
+    """`_brand` used to derive `channel.is_dev()` and the ``if dev:`` branch itself. A
+    fix to what the chip says must land in both surfaces the moment it lands here —
+    pinned by handing `_dev_chip` a value nothing in `_brand` could have produced on its
+    own, the same technique `RightRenderer.test_calls_persona_chips_rather_than_
+    reassembling_it` already uses for `_persona_chips`."""
+
+    def test_the_chips_return_value_reaches_the_rendered_line_untouched(self):
+        with mock.patch("charter.statusline._dev_chip",
+                        return_value=" SENTINEL-CHIP-0xF00D"), \
+             mock.patch("charter.update.maybe_spawn", lambda: None), \
+             mock.patch("charter.update.newer_than", lambda v: None):
+            out = statusline._brand()
+        self.assertIn("SENTINEL-CHIP-0xF00D", out)
+
+
+class TopRendersTheChannelBesideTheVersion(PersonaIso, unittest.TestCase):
+    """`frame/slots.py:_top` — the surface #457 is actually about. Same behaviour
+    `_brand` already had (see `tests/test_dev_channel.py`'s
+    `TheRenderPathNeverReachesTheNetwork`), now pinned on the frame's own renderer."""
+
+    def setUp(self):
+        super().setUp()
+        self.fid = _fid()
+
+    def test_a_dev_plane_shows_dev_beside_the_version(self):
+        from charter import __version__
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}):
+            out = slots.render("top", self.fid)
+        self.assertIn(__version__, out)
+        self.assertIn("dev", out)
+
+    def test_a_stable_plane_shows_no_dev_chip(self):
+        with mock.patch.object(config, "UPDATE", {"channel": "stable"}):
+            out = slots.render("top", self.fid)
+        self.assertNotIn("dev", out)
+
+    def test_top_calls_the_shared_chip_rather_than_reassembling_it(self):
+        with mock.patch("charter.statusline._dev_chip",
+                        return_value=" SENTINEL-CHIP-0xF00D"):
+            out = slots.render("top", self.fid)
+        self.assertIn("SENTINEL-CHIP-0xF00D", out)
+
+    def test_a_chip_lookup_failure_still_yields_a_line_rather_than_an_exception(self):
+        """`_top` carries no guard of its own around the call — the same trust `_brand`
+        and `_right` already place in the helpers they call (`_dev_chip`'s own docstring
+        promises never to raise; this is the consumer side of that promise)."""
+        with mock.patch("charter.channel.is_dev", side_effect=RuntimeError("boom")):
+            out = slots.render("top", self.fid)
+        self.assertIn("charter", out)
+
+
+# --------------------------------------------------------------------------- #
+# the whole-tree property                                                     #
+# --------------------------------------------------------------------------- #
+def _calls_dev_chip(expr: ast.AST) -> bool:
+    """True if *expr* contains a call recognisable as the shared helper — bare
+    `_dev_chip()`, or qualified as `statusline._dev_chip()` / any other attribute access
+    ending in that name."""
+    return any(
+        (isinstance(n, ast.Attribute) and n.attr == "_dev_chip")
+        or (isinstance(n, ast.Name) and n.id == "_dev_chip")
+        for n in ast.walk(expr))
+
+
+def _charter_version_idiom_sites(pkg_root: Path) -> list[tuple[str, int, str, bool]]:
+    """Every f-string in the package that glues the literal word ``"charter"`` directly
+    onto the BARE name ``__version__`` — the exact idiom `_brand` and `_top` both had —
+    together with whether that SAME f-string also calls `_dev_chip()`.
+
+    An AST walk rather than a grep, for the reason `_hand_built_relaunch_argvs` in
+    `tests/test_self_relaunch_argv.py` already gives for the identical choice: a line
+    break, a different quote style, or the word appearing in a docstring (this module's
+    own, for instance) defeats a regex. The AST sees the shape however it is spelled or
+    wrapped, and sees nothing in prose.
+
+    Two structural choices keep this from also flagging every other site that happens to
+    mention `__version__`:
+
+    * The interpolated value must be the BARE name, not a call — so `charter --version`'s
+      own line (`cli.py`: ``f"charter {channel.build_label()}"``) never matches. That
+      command's whole job is naming the exact build, which is deliberately NOT this
+      chip's job (see `_brand`'s docstring, and the issue this test guards).
+    * The literal text immediately before it, in the SAME joined string, must end with
+      ``"charter"``. This is what excludes the drift/staleness diagnostics that also
+      mention both words: `hooks.py`'s pin-conflict messages read "Working on
+      {__version__}" (not "charter"); `doctor.py`'s stale-plugin warning reads "charter
+      is {__version__}" (the word "is" sits between them); `statusline._alerts`'s
+      pinned-version alert glues an ANSI reset between "charter" and the version
+      (``{_DIM}charter{_R} {__version__}``), which is a SEPARATE constant, not text
+      ending in "charter". None of those three needs to change for this test to pass —
+      they are a different property from the one #457 is about, not an oversight here.
+
+    Returns ``(file, line, source, has_chip)`` tuples so a failure names the exact site.
+    """
+    sites = []
+    for path in sorted(pkg_root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.JoinedStr):
+                continue
+            values = node.values
+            for i, v in enumerate(values):
+                if not (isinstance(v, ast.FormattedValue)
+                        and isinstance(v.value, ast.Name)
+                        and v.value.id == "__version__"):
+                    continue
+                prev = values[i - 1] if i > 0 else None
+                if not (isinstance(prev, ast.Constant) and isinstance(prev.value, str)
+                        and prev.value.rstrip().endswith("charter")):
+                    continue
+                has_chip = any(
+                    isinstance(w, ast.FormattedValue) and _calls_dev_chip(w.value)
+                    for w in values)
+                sites.append((str(path.relative_to(pkg_root.parent)), node.lineno,
+                              ast.unparse(node), has_chip))
+    return sites
+
+
+#: One real site the scanner finds that this PR deliberately does not touch: the same
+#: idiom, the same missing chip, but a different feature (a staleness nudge in `charter
+#: report`, comparing the running version against the latest published one — not
+#: identifying the channel). Filed upstream as #458 rather than folded in here (out of
+#: #457's stated scope) or silently exempted with no trace. Keyed by file rather than
+#: line, so a routine edit elsewhere in the file doesn't rot the entry, and paired with
+#: the exact source substring so a DIFFERENT, unrelated idiom landing in the same file
+#: later is not silently swallowed by this one's exemption.
+_KNOWN_GAPS = {
+    "charter/commands_report.py": "you are on charter",
+}
+
+
+class EveryCharterVersionIdiomShowsTheChannel(unittest.TestCase):
+    """The property `unimplemented()` models for slots: a NEW site is covered on the
+    day it is written, not the day someone remembers to add it to a list."""
+
+    def test_the_scanner_finds_both_fixed_sites(self):
+        """First, that the detector is not vacuous — `_brand` and `_top` are the two
+        sites #457 exists because of, so a scanner that found neither would prove
+        nothing by finding zero offenders below."""
+        sites = _charter_version_idiom_sites(_PKG)
+        found = {f for f, _ln, _src, _chip in sites}
+        self.assertIn("charter/statusline.py", found)
+        self.assertIn("charter/frame/slots.py", found)
+
+    def test_both_fixed_sites_call_the_chip(self):
+        sites = _charter_version_idiom_sites(_PKG)
+        by_file = {f: chip for f, _ln, _src, chip in sites}
+        self.assertTrue(by_file.get("charter/statusline.py"),
+                        "_brand's idiom no longer calls _dev_chip")
+        self.assertTrue(by_file.get("charter/frame/slots.py"),
+                        "_top's idiom no longer calls _dev_chip")
+
+    def test_no_charter_version_idiom_anywhere_skips_the_channel(self):
+        """The rule: every site matching the idiom calls `_dev_chip`, except the
+        documented, sourced, upstream-filed exceptions in `_KNOWN_GAPS`. A NEW site
+        that glues "charter" onto the bare version and forgets the chip — the exact
+        shape of #457 itself — fails here on the day it is written."""
+        sites = _charter_version_idiom_sites(_PKG)
+        offenders = []
+        for f, line, src, has_chip in sites:
+            if has_chip:
+                continue
+            gap = _KNOWN_GAPS.get(f)
+            if gap is not None and gap in src:
+                continue
+            offenders.append((f, line, src))
+        self.assertEqual(
+            offenders, [],
+            "a `charter {version}` idiom with no channel chip beside it — call "
+            "`statusline._dev_chip()` in the same f-string, or add a sourced, "
+            "upstream-filed entry to _KNOWN_GAPS if this one is a different "
+            "property (#457's test module explains the distinction):\n" +
+            "\n".join(f"  {f}:{line}  {src}" for f, line, src in offenders))
+
+    def test_a_known_gap_still_matches_the_source_it_was_filed_against(self):
+        """The other direction: if #458 lands and `commands_report._warn_if_stale`
+        starts calling `_dev_chip`, the exemption above stops being needed — and this
+        test is what notices, rather than the exemption quietly outliving its reason
+        and starting to shadow a real, different regression in the same file."""
+        sites = _charter_version_idiom_sites(_PKG)
+        by_file = {f: (has_chip, src) for f, _ln, src, has_chip in sites}
+        for f, gap in _KNOWN_GAPS.items():
+            with self.subTest(file=f):
+                self.assertIn(f, by_file, f"{f} no longer has ANY charter-version "
+                             "idiom — the _KNOWN_GAPS entry is stale, remove it")
+                has_chip, src = by_file[f]
+                self.assertIn(gap, src, f"{f}'s idiom no longer reads {gap!r} — "
+                             "the _KNOWN_GAPS entry no longer matches what it was "
+                             "filed against, update or remove it")
+                self.assertFalse(has_chip, f"{f} now calls _dev_chip — #458 is "
+                                "fixed, delete this _KNOWN_GAPS entry")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `frame/slots.py:_top` rendered the raw `__version__` with no channel awareness, and #386 made a frame suppress the status line entirely — the one other place the `dev` chip lived (`statusline._brand`, added by #454). Together, a framed session on the dev channel had **no indication of its channel anywhere on screen**.
- `_brand`'s dev-chip logic is split into a shared `statusline._dev_chip()`, called from both `_brand` and `slots._top`, so a future change to what the chip says lands in both surfaces at once (matching how `_left`/`_right` already call into `statusline` rather than reassembling facts).
- The chip follows the version exactly the way `_top`'s own docstring already argues the version does: shown at normal density, dropped at `terse` along with it.
- `channel.channel()` is already memoised per process (a `config.UPDATE` dict read, no file I/O); `_dev_chip()` adds no subprocess, network, or per-render file read.

## Property test

Added `tests/test_version_shows_channel.py`, a whole-package AST scan (same technique as `tests/test_self_relaunch_argv.py`'s `_hand_built_relaunch_argvs`) that finds every `f"...charter {__version__}..."` idiom in the package and fails if it doesn't also call `_dev_chip()` in the same expression — rather than pinning today's two call sites by name. A new surface that grows this idiom fails on the day it's written.

The scan is deliberately narrower than "every place `__version__` appears": the package interpolates it in ~10 other places (JSON export, pin/staleness/plugin-drift diagnostics in `hooks.py`/`doctor.py`/`statusline._alerts`) that answer a different question ("does what's running match what's declared", not "which channel is this plane on") and correctly don't match the idiom on their own text. One real site *does* match and isn't fixed here — `commands_report._warn_if_stale` — carried as a named, sourced exception pointing at #458 (filed separately, out of this issue's scope).

Mutation-tested every guard (apply → RED → restore → GREEN, `__pycache__` cleared between runs):
1. `_dev_chip()`'s `if dev` gate removed (always-on) → RED (5 tests)
2. `_dev_chip()`'s condition inverted → RED (9 tests)
3. `_top` reverted to the original bug (chip dropped from the f-string) → RED, including the property test itself catching the exact real-world regression
4. `_brand` stops calling the shared helper (inlines its own copy) → RED (reuse test + property test's `has_chip` check)
5. Chip leaks into the `terse` branch → RED (density test)
6. Property test's idiom-precision filter removed → RED, and the offender list is exactly the drift/staleness sites named above — confirms the filter is load-bearing, not vacuous
7. `_KNOWN_GAPS` exception removed → RED, naming exactly the one real, live gap (`commands_report.py`)

## Verification

Rendered `slots._top` for a plane on each channel directly (not just via the test suite):

```
stable:  ⬢ default    charter 0.51.0
dev:     ⬢ default    charter 0.51.0 dev
terse (dev):  ⬢ default
```

## Also found, filed separately (not fixed here)

- #458 — `commands_report._warn_if_stale` has the same idiom, no chip. Carried as a `_KNOWN_GAPS` exception in the new test.
- #459 — `test_statusline_brand.py:UpdateIndicator` and `test_version_lock.py:AutoSync` don't isolate `config.UPDATE`, so they fail for real on any checkout whose actual control plane declares `channel = "dev"` — confirmed pre-existing on a clean `origin/main` worktree, root-caused, unrelated to this change.

## Test plan

- [x] `python3 -m unittest discover -s tests` — 4541 tests, same 6 pre-existing failures as an unmodified `origin/main` worktree (all `test_statusline_brand.py`/`test_version_lock.py`, root-caused to #459), zero new failures
- [x] `tests/test_version_shows_channel.py` — 12/12 passing
- [x] `tests/test_frame_density.py::TerseSaysLess::test_top_drops_the_dev_chip_too_when_it_drops_the_version` — new, passing
- [x] Mutation-tested every guard listed above

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9