### PR TITLE
Pin what CI runs, pin the run site, and stop refusing the half that is safe (#443, #455, #456)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+# What makes a SHA pin maintainable instead of merely frozen.
+#
+# Every `uses:` in `.github/workflows/` is pinned to a full commit SHA (#443), which is the
+# only ref a third party cannot move under charter's feet. The cost of that is that a
+# security fix upstream does not arrive on its own — so this opens the pull request that
+# moves each pin, and a human reads the diff and merges it. Deliberate, reviewed, and not
+# automatic: that is the same bargain `charter update` makes with the operator.
+#
+# `github-actions` only. charter's runtime has zero dependencies (`pyproject.toml` says
+# `dependencies = []`, and `tests/test_packaging.py` holds it there), so there is no `pip`
+# ecosystem here to watch.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,9 @@ name: release
 #
 # Bumping a pin: read the diff for the range, then put the new SHA and its tag
 # here. Dependabot opens that pull request (`.github/dependabot.yml`); it does
-# not merge it. `tests/test_workflows.py` fails on any ref that is not 40 hex.
+# not merge it. `tests/test_workflows.py` reads these files as YAML — not as lines of
+# text — and fails on any ref that is not a full commit SHA, an image digest, or a file
+# tracked in this repository.
 #
 # Trigger: push a version tag.
 #   git tag v0.1.0 && git push origin v0.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,10 @@ name: release
 # Bumping a pin: read the diff for the range, then put the new SHA and its tag
 # here. Dependabot opens that pull request (`.github/dependabot.yml`); it does
 # not merge it. `tests/test_workflows.py` reads these files as YAML — not as lines of
-# text — and fails on any ref that is not a full commit SHA, an image digest, or a file
-# tracked in this repository.
+# text — and fails on any ref written here that is not a full commit SHA, an image digest,
+# or a file tracked in this repository. `container:`/`services:` count as refs, in both
+# shapes GitHub writes an image in: the `image:` mapping and the bare scalar shorthand.
+# What it does NOT reach is what a pinned action's own tree then names — see #473.
 #
 # Trigger: push a version tag.
 #   git tag v0.1.0 && git push origin v0.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,20 @@
 name: release
-# Publishes to PyPI via Trusted Publishing (OIDC) — there is no API token
+# Publishes to PyPI via Trusted Publishing (OIDC) — there is no PyPI API token
 # anywhere: not in the repo, not in Actions secrets, not on a laptop. PyPI
 # verifies GitHub's signed identity claim for this exact repo + workflow +
-# environment, so a leaked secret cannot be used to publish charter.
+# environment, so there is no publishing credential to leak.
+#
+# That moves the question rather than answering it, and this file has to answer
+# the moved one: what CAN publish charter is code running inside the `publish`
+# job, because the OIDC token is minted there on demand and the claim it carries
+# is genuine. Every `uses:` below is therefore pinned to a full commit SHA, with
+# the tag it resolved to in a trailing comment. A floating ref — `@v4`, or
+# `@release/v1`, which is a BRANCH head and not a tag — is a promise by whoever
+# can move it, and moving it is the whole of CVE-2025-30066 (#443).
+#
+# Bumping a pin: read the diff for the range, then put the new SHA and its tag
+# here. Dependabot opens that pull request (`.github/dependabot.yml`); it does
+# not merge it. `tests/test_workflows.py` fails on any ref that is not 40 hex.
 #
 # Trigger: push a version tag.
 #   git tag v0.1.0 && git push origin v0.1.0
@@ -23,10 +35,10 @@ jobs:
     name: Verify the tag matches the packaged version, and that it has notes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       # Pinned rather than inherited: both steps below run charter itself, which needs
       # 3.11+ for tomllib. The runner's default `python` is a version nobody here chose.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
       - name: Compare the git tag to pyproject.toml
@@ -63,8 +75,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run the suite
@@ -75,15 +87,15 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
       - name: Build
         run: pipx run build
       - name: Validate metadata renders on PyPI
         run: pipx run twine check dist/*
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
           path: dist/
@@ -96,13 +108,18 @@ jobs:
       name: pypi
       url: https://pypi.org/p/charter-cp
     permissions:
+      # A job-level `permissions:` REPLACES the workflow's, it does not add to it — so
+      # this line is the whole grant: `contents` is `none` here, not the `read` above.
+      # That is deliberate and must stay. This job never checks the repository out; it
+      # downloads the artifact `build` produced, which `actions/download-artifact` reads
+      # from the same run with the runtime token, needing no `GITHUB_TOKEN` scope at all.
       id-token: write        # REQUIRED: mints the OIDC token PyPI verifies
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   announce:
     name: Create the GitHub Release from the shipped news entry
@@ -113,8 +130,8 @@ jobs:
       # `test` and `build` — which run the repository's own code — never hold write.
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
       - name: Publish the notes charter already ships

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,10 @@ permissions:
 # reason: this workflow runs on every push and pull request, so a moved tag executes here
 # first and on the widest trigger — with a token that is read-only, which bounds the damage
 # without removing it. Dependabot moves these (`.github/dependabot.yml`);
-# `tests/test_workflows.py` reads these files as YAML and refuses any ref that is not a
-# full commit SHA, an image digest, or a file tracked in this repository.
+# `tests/test_workflows.py` reads these files as YAML and refuses any ref written here that
+# is not a full commit SHA, an image digest, or a file tracked in this repository — a
+# `container:`/`services:` image included, in either of the two shapes GitHub accepts one.
+# It does not reach a pinned action's own refs; that boundary is stated in #473.
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,13 @@ on:
 permissions:
   contents: read
 
+# Every `uses:` is pinned to a full commit SHA with its tag in a trailing comment, for the
+# reason `release.yml`'s header gives at length. It applies here too and for the same
+# reason: this workflow runs on every push and pull request, so a moved tag executes here
+# first and on the widest trigger — with a token that is read-only, which bounds the damage
+# without removing it. Dependabot moves these (`.github/dependabot.yml`);
+# `tests/test_workflows.py` refuses any ref that is not 40 hex characters.
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -18,8 +25,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run the suite
@@ -36,8 +43,9 @@ jobs:
     # anything. Dev builds are never published: PyPI forbids local version identifiers, so
     # real dev releases would burn 0.52.0.dev1, .dev2, … permanently and irreversibly at a
     # rate of hundreds a month; and running the release workflow on every push to main
-    # would multiply exactly the `id-token: write`-with-unpinned-third-party-actions
-    # exposure #443 is open about.
+    # would run the job that holds `id-token: write` — the credential that can publish
+    # charter — on every merge. Its actions are SHA-pinned now (#443), which bounds what
+    # can run beside that token rather than making it a thing to do hundreds of times.
     #
     # So it holds NO id-token, writes nothing, and uses only first-party actions. `uv` is
     # installed with pip rather than through a setup action for that same reason: the
@@ -50,7 +58,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
       # No checkout: the point is to install the way a user does — from the git URL — and

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,8 @@ permissions:
 # reason: this workflow runs on every push and pull request, so a moved tag executes here
 # first and on the widest trigger — with a token that is read-only, which bounds the damage
 # without removing it. Dependabot moves these (`.github/dependabot.yml`);
-# `tests/test_workflows.py` refuses any ref that is not 40 hex characters.
+# `tests/test_workflows.py` reads these files as YAML and refuses any ref that is not a
+# full commit SHA, an image digest, or a file tracked in this repository.
 
 jobs:
   test:

--- a/charter/commands_update.py
+++ b/charter/commands_update.py
@@ -165,6 +165,10 @@ def dev_install_argv() -> tuple[str, list[str] | None]:
     ``str.format`` call between a committed config file and an install command. There is no
     format call on this path, so there is nothing to reach through.
 
+    "This path" means both ends of it — the argv is built here without interpolation and
+    :func:`_sync_dev` runs it without any either. Saying it of the build site alone is what
+    #455 was: true, and not the sentence anybody was relying on.
+
     A fresh list per call, never the table's own: the caller hands it to `util.run`, and a
     module-level list handed out is a module-level list something can edit for the life of
     the process (same reason `instance.density_slots` copies).
@@ -175,7 +179,20 @@ def dev_install_argv() -> tuple[str, list[str] | None]:
 
 
 def _sync_dev() -> tuple[bool, str]:
-    """Install :data:`DEV_SPEC` through whichever tool owns this install."""
+    """Install :data:`DEV_SPEC` through whichever tool owns this install.
+
+    **The run site of the no-interpolation rule, and it is pinned here too (#455).**
+    :func:`dev_install_argv` builds the argv with no format call; this function hands that
+    argv to `util.run` element for element — nothing interpolated, nothing appended,
+    nothing re-split, no shell. Both halves matter and only the first used to be pinned: a
+    `str.format` added *here* survived the whole suite, because the build-site canary never
+    reaches this line. `tests/test_dev_update_command.py` now watches the argv at the
+    subprocess boundary, which is where every spelling of "run it" has to arrive.
+
+    Compare :func:`_sync_to`, which legitimately DOES interpolate — ``a.format(version=…)``
+    with a version resolved from PyPI. The dev spec must never travel that line, which is
+    why these are two functions and not one with a flag.
+    """
     name, argv = dev_install_argv()
     if argv is None:
         return False, (f"charter was not installed by uv or pipx, so charter will not "
@@ -418,6 +435,46 @@ def _update_dev(args, installed: str) -> int:
     return 0
 
 
+def _update_dev_on_a_checkout(args) -> int:
+    """The half of :func:`_update_dev` that is safe over the tree you are editing.
+
+    `cmd_update` does two independent things on the dev channel: it moves the **CLI**, and
+    it force-refreshes the **plugin**. Only the first is unsafe on a charter checkout. The
+    plugin is a separate artifact under ``~/.claude/plugins/`` — outside this tree, and
+    refreshed from a marketplace clone that is not this tree either.
+
+    Refusing both was #456. `doctor`'s `plugin files` row names ``charter update`` as the
+    fix; on a checkout that command refused — on the machine most likely to be tracking the
+    dev channel at all, because a maintainer is who wants it. A remedy that refuses when
+    followed costs the reader the next hint too, so the hint is made true here rather than
+    replaced with a second command to know about.
+
+    **The CLI refusal is not weakened, it is stated.** Nothing on this path installs
+    anything: the operator's charter already IS this checkout, moved by git.
+
+    Two more things it deliberately does not do. It does not move the harness artifact —
+    `_move_harness` writes into the plane root, and on a charter checkout the plane root is
+    the tree being edited, which is the same objection one directory over. And it does not
+    stamp an update baseline, because nothing moved for a news range to be measured from.
+    """
+    from . import plugincache
+
+    util.warn("this is a charter checkout — the CLI here is the tree you are editing, so "
+              "nothing was installed over it.")
+    util.info("  the charter you run is this checkout, moved by git:  charter version")
+    if not plugincache.available():
+        util.info("  no `claude` on PATH either, so there is no plugin to refresh — "
+                  "there is nothing this command can do from here.")
+        return 0
+    util.info("  the plugin lives outside this tree, so that half still runs:")
+    _refresh_plugin()
+    if getattr(args, "bump", False):
+        util.warn("--bump moves this plane's `[charter] version` pin, which names a "
+                  "PUBLISHED release. A dev build has no such number, so the pin was left "
+                  "alone.")
+    return 0
+
+
 def cmd_update(args) -> int:
     from . import channel, doctor, instance, news
 
@@ -435,18 +492,24 @@ def cmd_update(args) -> int:
         util.info("  the entry naming `update` is the defect:  charter news --pending")
         return 2
 
+    explicit = (getattr(args, "to", None) or "").strip()
+
     if doctor._is_charter_checkout(config.ROOT):
         # `CONTRIBUTING.md` tells contributors to run `python3 -m charter …` from the
         # clone. Installing over that is never what "let me try the update command" meant,
         # and the failure is silent: the news phase would hand off to a binary that is not
         # the tree being edited, and report on it as though it were.
+        #
+        # The CLI half. NOT the plugin half — see `_update_dev_on_a_checkout`, which runs
+        # for the one shape of this command that has something left to do here.
+        if channel.is_dev() and not explicit:
+            return _update_dev_on_a_checkout(args)
         util.err("this is a charter checkout — refusing to install over the tree you are "
                  "editing.")
         util.info("  what you probably want:  charter version")
         return 2
 
     installed = _installed_version()
-    explicit = (getattr(args, "to", None) or "").strip()
     if channel.is_dev() and not explicit:
         return _update_dev(args, installed)
     if channel.is_dev():

--- a/docs/news/unreleased-a-dev-channel-that-publishes-nothing.md
+++ b/docs/news/unreleased-a-dev-channel-that-publishes-nothing.md
@@ -29,10 +29,12 @@ Three things change on `dev` and nothing else does:
 identifiers, so real dev releases would have to burn `0.52.0.dev1`, `.dev2`, … permanently,
 at a rate of hundreds a month, irreversibly — a namespace you cannot take back. And
 publishing on every merge means running the release workflow on every merge, and that
-workflow holds `id-token: write` alongside unpinned third-party actions (#443). Publishing
-on every commit would multiply exactly the exposure that issue is open about. So nothing is
-published: CI installs `git+…@main` on every push to `main`, checks the installed `charter
---version` runs, and holds no `id-token` at all. The same coverage, without the artifact.
+workflow is the one that holds `id-token: write` — the credential that can publish charter.
+Its actions are now pinned to commit SHAs (#443, closed in this same release), which bounds
+what can run beside that token; it does not make running the job hundreds of times a month
+a good idea. So nothing is published: CI installs `git+…@main` on every push to `main`,
+checks the installed `charter --version` runs, and holds no `id-token` at all. The same
+coverage, without the artifact.
 
 **`charter --version` tells you which build you are on, and it is the install talking.**
 

--- a/docs/news/unreleased-every-action-that-can-publish-charter-is-pinned.md
+++ b/docs/news/unreleased-every-action-that-can-publish-charter-is-pinned.md
@@ -60,14 +60,31 @@ operator, for the same reason.
 
 The same rule now covers `container:` and `services:` images, which were never in these
 files and were never checked either: `image: node:18` runs a third party's bytes inside the
-job exactly as a step does, and a tag is a tag.
+job exactly as a step does, and a tag is a tag. **In both shapes GitHub writes one**, which
+is where the first version of this stopped: `container:` takes a mapping with an `image:`
+in it *or* a bare scalar — "when you only specify a container image, you can omit the
+`image` keyword" — and `services:` gives every child the same pair. A key list of `uses`
+and `image` knew the long form only, so `container: evil/img:latest` added to the `publish`
+job read as no reference at all and left the whole suite green. It is the spelling problem
+one level in, and the answer is the same one: a reference now carries what it *is* — an
+action or an image — and the rules select on that rather than on the key that spelled it.
 
-Two things this deliberately does not claim. It cannot check that a pinned SHA is a real
+Three things this deliberately does not claim. It cannot check that a pinned SHA is a real
 commit of the repo beside it, or that its `# v1.14.2` comment is honest — both need the
 network, and no test in this suite makes a network call; a wrong-but-well-formed SHA fails
-in CI on the next run, loudly. And pinning says nothing about a `run:` step that pipes a
+in CI on the next run, loudly. Pinning says nothing about a `run:` step that pipes a
 script off the internet. There is none in these files, and pinning would not save you from
 one if there were.
+
+And — the known remaining case, filed as **#473** rather than quietly assumed — what is
+enforced here is *every reference charter writes*, which is narrower than *every byte that
+runs in the publishing job*. `uses: owner/action@<sha>` pins that action's tree; it does not
+pin what that tree then names, and a Docker action's `Dockerfile` starts `FROM` a tag its
+publisher rewrites. A **local** `uses: ./x` is followed into its `action.yml` and its refs
+checked like the caller's; a remote one is not followed at all, because that tree is not in
+this repository and reading it needs the network. Closing that needs a different mechanism
+than a unit test — a scheduled job that resolves the pins, or vendoring the actions that
+stand next to `id-token: write`. #473 holds the reproduction and the options.
 
 `release.yml`'s header used to end *"so a leaked secret cannot be used to publish charter"*
 — true, and answering the smaller question. It now says which question is the real one and

--- a/docs/news/unreleased-every-action-that-can-publish-charter-is-pinned.md
+++ b/docs/news/unreleased-every-action-that-can-publish-charter-is-pinned.md
@@ -22,7 +22,7 @@ from being different code, inside a job where `ACTIONS_ID_TOKEN_REQUEST_URL` is 
 That is the mechanism of CVE-2025-30066 exactly, and SHA pinning is what separated the
 victims from everybody else.
 
-**All thirteen `uses:` in both workflows now name a commit**, with the tag it resolved to
+**All fourteen `uses:` in both workflows now name a commit**, with the tag it resolved to
 beside it:
 
 ```yaml
@@ -32,16 +32,35 @@ beside it:
 **The rule that gets tested is not "the string does not say v4".** `tests/test_workflows.py`
 asks the property: given only this ref, can the bytes it resolves to change without a
 commit landing in this repository? A full commit SHA is a content address, an image digest
-is a content address, a path inside this repo moves only when this repo does — everything
-else is a promise by a third party, however it is spelled. The scanner walks every YAML
-file under `.github/` rather than the two workflows that exist today, and it fails closed:
-it counts `uses:` at the byte level and refuses to pass unless it produced a ref for every
-one, so a spelling it does not understand fails the suite instead of being skipped by it.
+is a content address, a file **tracked in this repo** moves only when this repo does —
+everything else is a promise by a third party, however it is spelled.
+
+**And the check reads YAML rather than grepping for `uses:`, because the first version of
+it grepped and that was a hole.** It matched the key with a regex and cross-checked itself
+by counting the literal bytes `uses:`. Both are one spelling. `- "uses": evil/action@main`
+contains neither, parses to a genuine step of the `publish` job, and passed the whole file
+green — as did `- 'uses':`, the explicit key `- ? uses` / `: …`, and `"\x75ses"`. So the
+test now carries a small YAML reader for the subset these files are written in, and
+anything outside that subset — a flow mapping, an anchor, an alias, a merge key, a tag, an
+explicit key, a `uses:` whose value is on the next line — raises by name instead of being
+skipped. `TheKeyHasManySpellings` is the corpus of every spelling that used to get through,
+and it asserts *which* outcome each one gets, so no case can pass because some other check
+happened to trip. The second hole was the same mistake in a second place: the file list came
+from a tree walk with a hardcoded skip list (`node_modules`, `dist`, `.venv`), so
+`uses: ./node_modules/probe` was waved through as "in this tree" while the skip list
+guaranteed its `action.yml` was never read. The file list now comes from `git ls-files`, a
+local `uses: ./x` has to resolve to a file in it, and a local action that is not tracked
+here is not a pin — nor is one reached through a symlink, which git stores as a name and
+not as bytes.
 
 **A pin freezes a security fix out as effectively as it freezes an attacker out**, so
 `.github/dependabot.yml` now opens the pull request that moves each one. It opens it; a
 person still reads the diff and merges it. Same bargain `charter update` makes with the
 operator, for the same reason.
+
+The same rule now covers `container:` and `services:` images, which were never in these
+files and were never checked either: `image: node:18` runs a third party's bytes inside the
+job exactly as a step does, and a tag is a tag.
 
 Two things this deliberately does not claim. It cannot check that a pinned SHA is a real
 commit of the repo beside it, or that its `# v1.14.2` comment is honest — both need the

--- a/docs/news/unreleased-every-action-that-can-publish-charter-is-pinned.md
+++ b/docs/news/unreleased-every-action-that-can-publish-charter-is-pinned.md
@@ -1,0 +1,58 @@
+---
+version: unreleased
+headline: Every action in charter's CI is pinned to a commit, starting with the two that stand next to the publishing token
+---
+
+charter publishes to PyPI with Trusted Publishing, so there is no API token anywhere: not
+in the repo, not in Actions secrets, not on a laptop. That is worth having and it is not
+the whole question. What it means is that nothing needs to *steal* a credential to publish
+charter — the `publish` job mints a genuine OIDC token on demand, and PyPI verifies a claim
+about repo + workflow + environment that is entirely true. **So whatever code runs in that
+job can publish charter.** The credential question becomes a code question.
+
+Until now that job named its code by floating refs:
+
+```yaml
+- uses: actions/download-artifact@v4                # a tag its owner can retarget
+- uses: pypa/gh-action-pypi-publish@release/v1      # a BRANCH head, not a tag at all
+```
+
+`release/v1` has no `refs/tags` entry — it is `refs/heads/release/v1`, one force-push away
+from being different code, inside a job where `ACTIONS_ID_TOKEN_REQUEST_URL` is ambient.
+That is the mechanism of CVE-2025-30066 exactly, and SHA pinning is what separated the
+victims from everybody else.
+
+**All thirteen `uses:` in both workflows now name a commit**, with the tag it resolved to
+beside it:
+
+```yaml
+- uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+```
+
+**The rule that gets tested is not "the string does not say v4".** `tests/test_workflows.py`
+asks the property: given only this ref, can the bytes it resolves to change without a
+commit landing in this repository? A full commit SHA is a content address, an image digest
+is a content address, a path inside this repo moves only when this repo does — everything
+else is a promise by a third party, however it is spelled. The scanner walks every YAML
+file under `.github/` rather than the two workflows that exist today, and it fails closed:
+it counts `uses:` at the byte level and refuses to pass unless it produced a ref for every
+one, so a spelling it does not understand fails the suite instead of being skipped by it.
+
+**A pin freezes a security fix out as effectively as it freezes an attacker out**, so
+`.github/dependabot.yml` now opens the pull request that moves each one. It opens it; a
+person still reads the diff and merges it. Same bargain `charter update` makes with the
+operator, for the same reason.
+
+Two things this deliberately does not claim. It cannot check that a pinned SHA is a real
+commit of the repo beside it, or that its `# v1.14.2` comment is honest — both need the
+network, and no test in this suite makes a network call; a wrong-but-well-formed SHA fails
+in CI on the next run, loudly. And pinning says nothing about a `run:` step that pipes a
+script off the internet. There is none in these files, and pinning would not save you from
+one if there were.
+
+`release.yml`'s header used to end *"so a leaked secret cannot be used to publish charter"*
+— true, and answering the smaller question. It now says which question is the real one and
+what this file does about it.
+
+Nothing to adopt: this is charter's own pipeline, and it applies from the next release
+cut.

--- a/docs/news/unreleased-update-on-a-checkout-refreshes-the-plugin.md
+++ b/docs/news/unreleased-update-on-a-checkout-refreshes-the-plugin.md
@@ -1,0 +1,60 @@
+---
+version: unreleased
+headline: On a charter checkout, `charter update` now does the half it safely can instead of refusing both
+---
+
+Found on the first real use of the dev channel, switching a maintainer's own plane over:
+
+```
+$ charter doctor
+  !  plugin files   installed 18cdb73, marketplace 38c6671 — skills/browser/SKILL.md, …
+        → this plane tracks the dev channel and its plugin does not. … Run: charter update
+
+$ charter update
+✗ this is a charter checkout — refusing to install over the tree you are editing.
+```
+
+`doctor` named the fix; the fix refused. There was no flag for the half that would have
+worked, so the operator was left to reconstruct `marketplace update` → `uninstall` →
+`install` by hand.
+
+**The refusal is right and it stays.** Installing a wheel over the tree you are editing is
+never what "let me try the update command" meant, and the failure is silent when it happens
+— the news phase hands off to a binary that is not the tree you are working in and reports
+on it as though it were.
+
+**But `update` does two independent things, and only one of them was unsafe here.** It
+moves the **CLI**, and it force-refreshes the **plugin**. The plugin is a separate artifact
+under `~/.claude/plugins/`, entirely outside the checkout, refreshed from a marketplace
+clone that is not the checkout either. On the dev channel, `charter update` in a charter
+checkout now skips the CLI install, says so, and refreshes the plugin:
+
+```
+!  this is a charter checkout — the CLI here is the tree you are editing, so nothing was
+   installed over it.
+   the charter you run is this checkout, moved by git:  charter version
+   the plugin lives outside this tree, so that half still runs:
+✓  plugin: reinstalled charter@charter — it loads on the NEXT session.
+```
+
+No new flag, because `--plugin-only` would have been a second thing to know and would have
+left `doctor`'s existing hint wrong. This makes the hint true where it is read.
+
+**It bit exactly the wrong person, which is why it was worth fixing rather than
+documenting.** A charter checkout is where a maintainer works, and a maintainer is the
+person most likely to want the dev channel at all — so the guard blocked the remedy in
+precisely the case the feature was built for. A remedy that refuses when followed is worse
+than no remedy, because it costs the reader their trust in the next hint too.
+
+Three things it does not do. It does not install the CLI — that is the guard, intact. It
+does not move the harness artifact, because `_move_harness` writes into the plane root, and
+on a charter checkout the plane root *is* the tree being protected. And it does not pretend:
+with no `claude` on PATH there is no plugin to refresh either, and it says that instead of
+reporting a refresh that did not happen.
+
+Everything else still refuses outright, with the message and the exit code it always had:
+a stable-channel checkout, where the released plugin is what pairs with the released CLI,
+and `charter update --to X.Y.Z` anywhere in a checkout, because that names a published CLI
+and installing it is the one thing that cannot happen here.
+
+Nothing to adopt — upgrading is the whole of it.

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -25,8 +25,11 @@ their next session, so get an explicit yes before running it.
 **A host's command.** Claude Code's plugin and Codex's belong to the host, so charter names
 the command rather than running it. Hand that command to the person and let them run it.
 
-**A charter checkout.** `update` refuses, because installing over the tree being edited is
-never what was meant. `charter version` is the read-only view.
+**A charter checkout.** The CLI there is the tree being edited, so `update` never installs
+over it — that refusal stays. What it does instead depends on what is left to do: on the
+**dev channel** it refreshes the Claude Code plugin, which lives outside the tree, and says
+that is all it did; on stable, and whenever `--to` names a version, it refuses outright.
+`charter version` is the read-only view either way.
 
 ## Adopt what the version brought
 

--- a/tests/test_dev_update_command.py
+++ b/tests/test_dev_update_command.py
@@ -18,12 +18,53 @@ goes through, and the tests assert on the argv it was handed.
 from __future__ import annotations
 
 import argparse
+import contextlib
+import os
+import subprocess
 import unittest
 from pathlib import Path
 from unittest import mock
 
 from charter import __version__, commands_update, config, hooks, update, util
 from tests._isolation import PersonaIso
+
+
+@contextlib.contextmanager
+def exec_trap():
+    """Record every argv this process hands the operating system, however it is spelled.
+
+    Yields the list of argvs seen.
+
+    **Not a `util.run` counter.** Instrumenting one function pins that function's current
+    spelling, not the property — this suite has already watched a `Path.stat` counter miss
+    an `open()` and a `subprocess.run`. What has to be true here is about *execution*, so
+    the recorder sits where every way of starting a process arrives: `subprocess.run` is
+    recorded, and `Popen` plus the `os.exec*`/`spawn` family raise rather than run, so a
+    refactor onto one of them fails the test instead of slipping past it.
+
+    Residual, named rather than papered over: a C-level or `ctypes` spawn would still get
+    through, and no test in this suite can see one.
+    """
+    seen: list[list[str]] = []
+
+    def record(argv, *a, **kw):
+        assert not kw.get("shell"), "a shell was requested on a path that must not have one"
+        seen.append(list(argv))
+        return subprocess.CompletedProcess(list(argv), 0, "", "")
+
+    def refuse(*a, **kw):
+        raise AssertionError(
+            "a process was started by a spelling this trap does not record — the argv it "
+            "was given is unexamined, which is the hole #455 was about")
+
+    with contextlib.ExitStack() as st:
+        st.enter_context(mock.patch.object(subprocess, "run", record))
+        st.enter_context(mock.patch.object(subprocess, "Popen", refuse))
+        for name in ("execv", "execve", "execvp", "execvpe", "posix_spawn",
+                     "posix_spawnp", "spawnv", "spawnvp", "system"):
+            if hasattr(os, name):
+                st.enter_context(mock.patch.object(os, name, refuse))
+        yield seen
 
 
 class Ran:
@@ -96,6 +137,70 @@ class TheDevRequirementIsAConstant(unittest.TestCase):
             name, argv = commands_update.dev_install_argv()
         self.assertEqual(name, "unknown")
         self.assertIsNone(argv)
+
+
+class TheRunSiteRunsTheArgvItWasHanded(unittest.TestCase):
+    """#455: the same claim, pinned at the site that actually executes.
+
+    `dev_install_argv`'s docstring says there is no format call on this path, and the canary
+    above proves it where the argv is BUILT. It says nothing about where the argv is RUN —
+    the reviewer of PR #454 put `.format()` back into `_sync_dev` and all 4415 tests stayed
+    green, because no test ever looked at what left that function.
+
+    So the property is stated as a property of the boundary rather than of a line of code:
+    **the argv charter hands the operating system on this path is, element for element, the
+    argv `dev_install_argv` returned.** That is one assertion and it forbids all of it —
+    interpolation, appending, re-splitting, joining into a shell string — including the
+    spellings nobody has thought of yet, which is the difference between this and a list of
+    forbidden characters.
+    """
+
+    def _run(self, argv):
+        with mock.patch.object(commands_update, "dev_install_argv",
+                               return_value=("uv", list(argv))), \
+                mock.patch.object(commands_update.shutil, "which",
+                                  return_value="/usr/bin/uv"), \
+                exec_trap() as seen:
+            commands_update._sync_dev()
+        return seen
+
+    def test_a_brace_bearing_argv_reaches_the_process_unchanged(self):
+        """The canary carries the placeholders a `str.format` would consume. A format call
+        added to `_sync_dev` either raises on the unknown key or rewrites the element, and
+        both are visible here — where today they are invisible, because `DEV_SPEC` has no
+        braces for one to bite on."""
+        canary = ["uv", "tool", "install", "--force",
+                  "git+https://example.invalid/{version}@{ref}"]
+        self.assertEqual(self._run(canary), [canary])
+
+    def test_nothing_is_appended_to_the_argv_on_the_way_out(self):
+        """Interpolation is one way for a value to enter this command; an extra element is
+        another, and the equality above forbids both. Spelled out separately because an
+        appended `--index-url` is the shape that would not look like a bug in review."""
+        canary = ["uv", "tool", "install", "--force", "git+https://example.invalid/x"]
+        self.assertEqual(self._run(canary), [canary])
+
+    def test_the_real_dev_install_argv_arrives_at_the_process_verbatim(self):
+        """End to end, with the module's own table, against the literal string `docs`
+        tells a person to type. Written out rather than compared to `DEV_SPEC` so this is
+        an independent statement of what runs, not the constant agreeing with itself."""
+        with mock.patch.object(commands_update, "installer_for", return_value=("uv", [])), \
+                mock.patch.object(commands_update.shutil, "which",
+                                  return_value="/usr/bin/uv"), \
+                exec_trap() as seen:
+            ok, detail = commands_update._sync_dev()
+        self.assertEqual(seen, [["uv", "tool", "install", "--force",
+                                 "git+https://github.com/diazoxide/charter@main"]])
+        self.assertTrue(ok)
+
+    def test_an_install_charter_does_not_own_starts_no_process_at_all(self):
+        """The refusal is a refusal, not a fallback into some other command."""
+        with mock.patch.object(commands_update, "dev_install_argv",
+                               return_value=("unknown", None)), \
+                exec_trap() as seen:
+            ok, detail = commands_update._sync_dev()
+        self.assertFalse(ok)
+        self.assertEqual(seen, [])
 
 
 class TheDevInstallRunsTheGitCommand(PersonaIso):
@@ -210,6 +315,11 @@ class TheProbeAndCheckoutRefusalsStillHold(PersonaIso):
     installing over the tree you are editing is never what "let me try the update command"
     meant, and it is *more* tempting to get wrong on a channel whose whole point is running
     unreleased code.
+
+    #456 split the checkout case in two without weakening it. The CLI install still never
+    happens on a checkout — that is what every test below asserts, on both channels and
+    with and without an explicit target. What changed is that the plugin half, which lives
+    outside the tree, is no longer refused along with it.
     """
 
     def setUp(self):
@@ -218,22 +328,88 @@ class TheProbeAndCheckoutRefusalsStillHold(PersonaIso):
         config.use(self.tmp)
         self.ran = Ran()
         self.enterContext(mock.patch.object(commands_update.util, "run", self.ran))
+        # The CLI half, watched by name as well as by argv. `self.ran.calls` says no
+        # command ran; this says the function that would have run one was never entered,
+        # so a failure names WHICH guard let go rather than only that something did.
+        self.sync = self.enterContext(mock.patch.object(commands_update, "_sync_dev"))
+        self.sync_to = self.enterContext(mock.patch.object(commands_update, "_sync_to"))
 
-    def _args(self):
-        return argparse.Namespace(to=None, bump=False)
+    def _args(self, **kw):
+        return argparse.Namespace(**{"to": None, "bump": False, **kw})
+
+    @contextlib.contextmanager
+    def _on_a_checkout(self, claude=True):
+        from charter import doctor, plugincache
+        with mock.patch.object(doctor, "_is_charter_checkout", return_value=True), \
+                mock.patch.object(plugincache, "available", return_value=claude), \
+                mock.patch.object(commands_update, "_refresh_plugin") as refresh, \
+                mock.patch.object(commands_update, "_move_harness") as harness_:
+            yield refresh, harness_
+
+    def _installed_nothing(self):
+        self.sync.assert_not_called()
+        self.sync_to.assert_not_called()
+        self.assertEqual(self.ran.calls, [])
 
     def test_a_news_probe_cannot_install_a_dev_build(self):
         from charter import news
         with mock.patch.object(news, "probing", return_value=True), \
                 mock.patch.object(news, "refuse_mutation"):
             self.assertEqual(commands_update.cmd_update(self._args()), 2)
-        self.assertEqual(self.ran.calls, [])
+        self._installed_nothing()
 
     def test_a_charter_checkout_cannot_install_over_itself(self):
-        from charter import doctor
-        with mock.patch.object(doctor, "_is_charter_checkout", return_value=True):
+        """The guard #456 says must stay. The CLI is the tree; nothing is installed on it,
+        on either channel and whatever else the command goes on to do."""
+        for channel in ("dev", "stable"):
+            with self.subTest(channel=channel):
+                (self.tmp / "charter.toml").write_text(
+                    f'schema = 1\n[update]\nchannel = "{channel}"\n')
+                config.use(self.tmp)
+                with self._on_a_checkout():
+                    commands_update.cmd_update(self._args())
+                self._installed_nothing()
+
+    def test_a_dev_checkout_still_gets_the_plugin_half(self):
+        """#456. `doctor`'s `plugin files` row names `charter update` as the fix and a
+        maintainer reads that row standing in a checkout — so the command has to do the
+        part that is safe here instead of refusing the whole thing."""
+        with self._on_a_checkout() as (refresh, harness_):
+            self.assertEqual(commands_update.cmd_update(self._args()), 0)
+        refresh.assert_called_once()
+        # NOT the harness artifact: `_move_harness` writes into the plane root, which on a
+        # charter checkout is the same tree the CLI refusal is protecting.
+        harness_.assert_not_called()
+        self._installed_nothing()
+
+    def test_an_explicit_target_on_a_checkout_is_still_refused_outright(self):
+        """`--to X.Y.Z` asks for a published CLI to be installed, which is exactly the half
+        that cannot happen here. Answering 0 and quietly doing something else would be a
+        command reporting success for a thing it did not do."""
+        with self._on_a_checkout() as (refresh, _):
+            self.assertEqual(commands_update.cmd_update(self._args(to="0.50.1")), 2)
+        refresh.assert_not_called()
+        self._installed_nothing()
+
+    def test_a_stable_checkout_is_refused_the_way_it_always_was(self):
+        """`_refresh_plugin` is the dev channel's mechanism — on stable the released plugin
+        is what pairs with the released CLI, which is what `doctor` says there. So this
+        path has nothing safe left to do and says so, exit code and all."""
+        (self.tmp / "charter.toml").write_text('schema = 1\n[update]\nchannel = "stable"\n')
+        config.use(self.tmp)
+        with self._on_a_checkout() as (refresh, _):
             self.assertEqual(commands_update.cmd_update(self._args()), 2)
-        self.assertEqual(self.ran.calls, [])
+        refresh.assert_not_called()
+        self._installed_nothing()
+
+    def test_with_no_claude_on_path_it_says_there_is_nothing_to_do(self):
+        """The honest end of the same branch. A plane with no Claude Code has no plugin to
+        refresh either, and reporting a refresh that did not happen is the overclaim this
+        repository keeps having to unwrite."""
+        with self._on_a_checkout(claude=False) as (refresh, _):
+            self.assertEqual(commands_update.cmd_update(self._args()), 0)
+        refresh.assert_not_called()
+        self._installed_nothing()
 
 
 class APinAndTheDevChannelAreNotSettledSilently(PersonaIso):

--- a/tests/test_plugin_freshness.py
+++ b/tests/test_plugin_freshness.py
@@ -499,6 +499,39 @@ class DoctorReportsFreshnessOnBothChannels(PersonaIso):
         self.assertIn("skills/secrets/SKILL.md", res.detail)
         self.assertIn("charter update", res.hint)
 
+    def test_the_command_this_hint_names_works_where_the_hint_gets_read(self):
+        """#456: the hint and the command it names, pinned together in one test.
+
+        Apart, both were green and the pair was broken. This row said *Run: charter
+        update*; `charter update` in a charter checkout answered *refusing to install over
+        the tree you are editing* and exited 2. A checkout is where a maintainer stands,
+        and a maintainer is the person most likely to be on the dev channel at all — so the
+        remedy refused in precisely the case the feature exists for.
+
+        A remedy that refuses when followed is worse than no remedy, because it costs the
+        reader their trust in the next hint too. Hence one test across both modules: what
+        the row tells you to type, and what typing it does from there.
+        """
+        import argparse
+
+        from charter import commands_update
+        left = tree(self.tmp / "a", PLUGIN)
+        right = tree(self.tmp / "b", {**PLUGIN, "skills/secrets/SKILL.md": "moved on\n"})
+        hint = self._check(left, right, channel="dev").hint
+        typed = hint.split("Run:", 1)[1].strip()          # the literal a reader copies
+        self.assertEqual(typed, "charter update")
+
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}), \
+                mock.patch.object(doctor, "_is_charter_checkout", return_value=True), \
+                mock.patch.object(plugincache, "available", return_value=True), \
+                mock.patch.object(commands_update, "_sync_dev") as installed, \
+                mock.patch.object(commands_update, "_refresh_plugin") as refreshed:
+            code = commands_update.cmd_update(argparse.Namespace(to=None, bump=False))
+        self.assertEqual(code, 0, f"`{typed}` still refuses where doctor prints it")
+        refreshed.assert_called_once()
+        # And it stays refused for the half that is actually unsafe here.
+        installed.assert_not_called()
+
     def test_drift_on_the_stable_channel_is_reported_in_detail_not_in_a_hint(self):
         """`Result.render` drops the hint entirely at OK, so guidance written there would
         be invisible while looking shipped — which is the failure ADR 0013 is about, and an

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -16,6 +16,15 @@ is a path in this tree that an `npm install` rewrites. `uses:` is not the only k
 names somebody else's code, so `container:`/`services:`/`runs.image` are held to the same
 rule: `image: node:18` runs third-party bytes inside the job exactly as a step does.
 
+**And a container key has two shapes, which is the spelling problem again one level in.**
+`container:` takes a mapping with an `image:` in it *or* a bare scalar — GitHub: "when you
+only specify a container image, you can omit the `image` keyword" — and `services:` gives
+every child the same pair. A key set of `("uses", "image")` knew the long form only, so
+`container: evil/img:latest` on the `publish` job read as no reference at all and left this
+whole file green. Both shapes are read now, and `Ref.kind` says what a reference *is*
+(`ACTION` or `IMAGE`) so the rule tests select on that rather than on the key that spelled
+it. The corpus below holds every shape, in both directions.
+
 **Why this reads YAML instead of grepping for `uses:`.** The first version of this file
 matched the key with `^\\s*(?:-\\s+)?uses\\s*:` and counted the literal bytes `uses:` as its
 fail-closed cross-check. Both are one spelling of the key. YAML has many, and GitHub loads
@@ -59,13 +68,26 @@ action stays benign — it is charter's own code, reviewed the way the rest of i
 nothing at all about a `run:` step that pipes a script off the internet: pinning is not a
 defence against one, and there is none in these files today.
 
-**The next place to look**, since that is the question this file exists to keep asking. Not
-another spelling of the key — those are now read structurally and the corpus holds them —
-but the two mismatches a reader like this always has with the real one: what counts as a
-line break (`ALineBreakIsTheOtherHalfOfTheSpellingProblem`, which shows the mismatch runs
-the safe way round), and a ref that is well formed here and means something else on the
-runner, such as a branch somebody named after a 40-character hex string. Both are stated
-above rather than quietly assumed.
+**What this checks is the refs written in this repository, one hop deep into local
+actions and no hops at all into remote ones** (#473). `uses: owner/action@<sha>` pins that
+action's tree; it does not pin what that tree then names. A Docker action builds from a
+`Dockerfile` whose `FROM` is a tag its publisher rewrites, and a composite action has its
+own `uses:` lines — neither is in this repository, neither can be read without the network,
+and both run in the job holding `id-token: write`. So the property this file enforces is
+"every reference charter *writes* is a content address", which is narrower than "every byte
+that runs in the publishing job is pinned", and the gap between those two sentences is
+where the next look goes.
+
+**The next place to look**, since that is the question this file exists to keep asking. The
+transitive hop above is the first. Then the two mismatches a reader like this always has
+with the real one: what counts as a line break — see
+`ALineBreakIsTheOtherHalfOfTheSpellingProblem`, which shows the mismatch runs the safe way
+round — and a ref that is well formed here and means something else on the runner, such as a
+branch somebody named after a 40-character hex string. And last, this reader judges a key by
+its **name**, not by its position in GitHub's workflow schema, so an action input that
+happens to be called `container:` reads here as a job container. That is a false alarm
+somebody resolves in one look, which is the direction this file always takes when it has to
+guess — all of it stated rather than quietly assumed.
 """
 
 from __future__ import annotations
@@ -93,6 +115,23 @@ _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 #: `image` is `jobs.<id>.container.image`, `services.<id>.image`, or a Docker action's
 #: `runs.image` — all of which run third-party bytes inside the job just as a step does.
 _CODE_KEYS = ("uses", "image")
+
+#: The key that introduces a job container. It takes **two shapes**, and that is the whole
+#: point of naming it separately: a mapping with an `image:` in it, which `_CODE_KEYS`
+#: already reads, or a bare scalar — `container: node:18` — which GitHub documents as the
+#: shorthand ("when you only specify a container image, you can omit the `image` keyword").
+#: A key set that knew only the long form knew one spelling of the key again.
+_CONTAINER = "container"
+
+#: The key whose every child is a container, in the same two shapes. `services.<id>.image`
+#: is the documented long form; `services:\n  redis: redis:7` is the string shorthand the
+#: workflow schema and the runner both accept, resolved exactly like `container:`.
+_SERVICES = "services"
+
+#: What a reference *is*, as opposed to what key spelled it. `immutable` judges an action
+#: ref; `immutable_image` judges an image. Tests select on this, not on the key name, so a
+#: new spelling of either kind is judged the moment the reader emits it.
+ACTION, IMAGE = "action", "image"
 
 #: A block-scalar header: `|`, `>`, with any chomping/indent indicator and a comment.
 _BLOCK_HEADER = re.compile(r"^[|>][-+0-9]*\s*(?:#.*)?$")
@@ -224,16 +263,27 @@ class Ref(NamedTuple):
     line: int
     key: str
     ref: str
+    kind: str   # ACTION or IMAGE — what it names, not which key spelled it
 
 
 def scan_text(text: str) -> list[Ref]:
-    """Every `uses:`/`image:` value in a YAML document written in the accepted subset.
+    """Every reference to somebody else's code in a YAML document written in the subset.
 
-    Raises `Unparsed` on the first construct outside it. There is no "skip what I do not
-    understand" path, by design: that path is the bypass.
+    An action ref (`uses:`) or an image, in each of the shapes GitHub accepts an image in:
+    `image:`, a scalar `container:`, and a scalar under `services:`.
+
+    Raises `Unparsed` on the first construct outside the subset. There is no "skip what I
+    do not understand" path, by design: that path is the bypass.
     """
     found: list[Ref] = []
     block_indent: int | None = None
+    #: The column of a `container:`/`services:`/`services.<id>:` key whose value is a
+    #: nested node, and the column of `services:`'s children. Both exist so a *scalar*
+    #: written under such a key — the shorthand, wrapped onto the following line — is seen
+    #: rather than dropped as an anonymous value.
+    image_block: int | None = None
+    services_col: int | None = None
+    service_id_col: int | None = None
 
     for line, raw in enumerate(text.splitlines(), 1):
         if block_indent is not None:
@@ -246,9 +296,20 @@ def scan_text(text: str) -> list[Ref]:
         if raw.strip() in ("---", "..."):
             raise Unparsed(line, "a document marker — this reader loads one document")
 
-        i = len(raw) - len(raw.lstrip(" "))
+        indent = i = len(raw) - len(raw.lstrip(" "))
         if i >= len(raw) or raw[i] == "#":
             continue                          # blank or whole-line comment
+
+        # A sequence item's scalar is a value, not the shorthand: `ports:\n  - 6379:6379`
+        # lives inside a service block and names no image.
+        had_dash = raw[i] == "-" and (i + 1 >= len(raw) or raw[i + 1] == " ")
+
+        # Close every container scope this line has stepped back out of, before anything
+        # in it is judged. Scope is indentation, which is what it is in the real parser.
+        if image_block is not None and indent <= image_block:
+            image_block = None
+        if services_col is not None and indent <= services_col:
+            services_col = service_id_col = None
 
         while raw[i] == "-" and (i + 1 >= len(raw) or raw[i + 1] == " "):
             i += 1
@@ -270,11 +331,25 @@ def scan_text(text: str) -> list[Ref]:
         while j < len(raw) and raw[j] == " ":
             j += 1
         if j >= len(raw) or raw[j] != ":" or (j + 1 < len(raw) and raw[j + 1] not in " \t"):
+            if image_block is not None and indent > image_block and not had_dash:
+                # A bare scalar inside a `container:`/`services:` node *is* the image —
+                # the shorthand, wrapped onto the next line. Dropping it as an anonymous
+                # value is how `container:\n  evil/img:latest` would walk past.
+                raise Unparsed(line, "a container image on a line of its own")
             _trailing(raw, i, line)           # a sequence item's own scalar value
             continue
 
         if name == "<<":
             raise Unparsed(line, "a merge key")
+
+        # Which of the two container shapes is this key in? `container:` and every direct
+        # child of `services:` take an image inline *or* a mapping holding `image:`, and
+        # both shapes have to be judged — knowing only the mapping was the last bypass.
+        is_service_id = (services_col is not None and key_col > services_col
+                         and (service_id_col is None or key_col == service_id_col))
+        if is_service_id:
+            service_id_col = key_col
+        names_image = name == _CONTAINER or is_service_id
 
         value = raw[j + 1:]
         k = len(value) - len(value.lstrip(" "))
@@ -283,13 +358,21 @@ def scan_text(text: str) -> list[Ref]:
         if not tail or tail.startswith("#"):
             if name in _CODE_KEYS:
                 raise Unparsed(line, f"a `{name}:` whose value is not on its own line")
+            if names_image or name == _SERVICES:
+                image_block = key_col         # a nested node: watch it for a bare scalar
+            if name == _SERVICES:
+                services_col, service_id_col = key_col, None
             continue                          # a nested block follows
         if _BLOCK_HEADER.match(tail):
-            if name in _CODE_KEYS:
+            if name in _CODE_KEYS or names_image or name == _SERVICES:
                 raise Unparsed(line, f"a `{name}:` written as a block scalar")
             block_indent = key_col
             continue
         if tail[0] == "[":
+            if name in _CODE_KEYS or names_image or name == _SERVICES:
+                # A flow sequence is not a shape any of these keys takes, so it is the
+                # third way to write a value this reader would otherwise walk past.
+                raise Unparsed(line, f"a `{name}:` whose value is a flow sequence")
             close = tail.find("]")
             if close < 0:
                 raise Unparsed(line, "a flow collection spanning lines")
@@ -300,10 +383,15 @@ def scan_text(text: str) -> list[Ref]:
         if tail[0] in _INDICATORS:
             raise Unparsed(line, _INDICATORS[tail[0]])
 
+        if name == _SERVICES:
+            raise Unparsed(line, "a `services:` whose value is not a mapping")
+
         ref, end = _scalar(tail, 0, line)
         _trailing(tail, end, line)
-        if name in _CODE_KEYS and ref:
-            found.append(Ref(line, name, ref))
+        if ref and name in _CODE_KEYS:
+            found.append(Ref(line, name, ref, IMAGE if name == "image" else ACTION))
+        elif ref and names_image:
+            found.append(Ref(line, name, ref, IMAGE))
 
     return found
 
@@ -489,15 +577,16 @@ class TheScannerSeesEverything(unittest.TestCase):
         actions = {r.ref.rpartition("@")[0] for r in refs}
         self.assertIn("pypa/gh-action-pypi-publish", actions)
         self.assertIn("actions/download-artifact", actions)
-        self.assertEqual([r for r in refs if not r.ref.rpartition("@")[1]], [],
-                         "a step in release.yml came out with no ref at all")
+        self.assertEqual(
+            [r for r in refs if r.kind == ACTION and not r.ref.rpartition("@")[1]], [],
+            "a step in release.yml came out with no ref at all")
 
 
 class EveryActionIsPinnedToSomethingImmutable(unittest.TestCase):
     def test_no_workflow_runs_a_ref_its_owner_can_move(self):
         found = closure()
         for name, ref in found.refs:
-            if ref.key == "image":
+            if ref.kind == IMAGE:
                 continue
             if is_local(ref.ref):
                 continue
@@ -509,8 +598,11 @@ class EveryActionIsPinnedToSomethingImmutable(unittest.TestCase):
                     f"header for why (#443).")
 
     def test_no_job_runs_a_container_image_its_publisher_can_move(self):
+        """Selected on what the ref *is*, not on the key that spelled it, so both shapes
+        of `container:`/`services:` — the `image:` mapping and the bare-scalar shorthand —
+        arrive here without this test naming either one."""
         for name, ref in closure().refs:
-            if ref.key != "image":
+            if ref.kind != IMAGE:
                 continue
             with self.subTest(file=name, line=ref.line):
                 self.assertTrue(
@@ -658,6 +750,23 @@ class TheKeyHasManySpellings(unittest.TestCase):
          _steps('      - uses: evil/action@main # v1\n'), "evil/action@main"),
         ("a container image",
          "jobs:\n  publish:\n    container:\n      image: node:18\n", "node:18"),
+        # The second shape of the same key, and the bypass this corpus grew for. GitHub:
+        # "when you only specify a container image, you can omit the `image` keyword".
+        ("a container image in the shorthand",
+         "jobs:\n  publish:\n    container: evil/img:latest\n", "evil/img:latest"),
+        ("a container image in the shorthand, quoted",
+         "jobs:\n  publish:\n    container: 'evil/img:latest'\n", "evil/img:latest"),
+        ("a container image in the shorthand, hex-escaped key",
+         'jobs:\n  publish:\n    "\\x63ontainer": evil/img:latest\n', "evil/img:latest"),
+        ("a container image in the shorthand, docker://",
+         "jobs:\n  publish:\n    container: docker://evil/img:latest\n",
+         "docker://evil/img:latest"),
+        ("a service image in the shorthand",
+         "jobs:\n  publish:\n    services:\n      redis: evil/redis:latest\n",
+         "evil/redis:latest"),
+        ("a service image in the long form",
+         "jobs:\n  publish:\n    services:\n      redis:\n        image: evil/redis:latest\n",
+         "evil/redis:latest"),
     ]
 
     REFUSED = [
@@ -694,6 +803,31 @@ class TheKeyHasManySpellings(unittest.TestCase):
         ("a second colon the reader would have to guess about",
          _steps('      - uses: evil/action@main: extra\n'),
          "two values on one line, or a scalar this reader misread"),
+        # The shorthand's own escape hatches: an image is still an image when YAML puts it
+        # on the following line or folds it, and neither shape is guessed at.
+        ("a shorthand image on the next line",
+         "jobs:\n  publish:\n    container:\n      evil/img:latest\n",
+         "a container image on a line of its own"),
+        ("a shorthand service image on the next line",
+         "jobs:\n  publish:\n    services:\n      redis:\n        evil/redis:latest\n",
+         "a container image on a line of its own"),
+        ("a shorthand image folded",
+         "jobs:\n  publish:\n    container: >-\n      evil/img:latest\n",
+         "a `container:` written as a block scalar"),
+        ("a shorthand image as a literal block",
+         "jobs:\n  publish:\n    services:\n      redis: |-\n        evil/redis:latest\n",
+         "a `redis:` written as a block scalar"),
+        ("a services node that is not a mapping of containers",
+         "jobs:\n  publish:\n    services: evil/redis:latest\n",
+         "a `services:` whose value is not a mapping"),
+        ("a services node folded",
+         "jobs:\n  publish:\n    services: >-\n      redis: evil/redis:latest\n",
+         "a `services:` written as a block scalar"),
+        ("a step ref in a flow sequence", _steps('      - uses: [evil/action@main]\n'),
+         "a `uses:` whose value is a flow sequence"),
+        ("a shorthand image in a flow sequence",
+         "jobs:\n  publish:\n    container: [evil/img:latest]\n",
+         "a `container:` whose value is a flow sequence"),
     ]
 
     def test_every_spelling_of_the_key_is_read_and_refused(self):
@@ -702,7 +836,7 @@ class TheKeyHasManySpellings(unittest.TestCase):
                 refs = scan_text(text)
                 self.assertEqual([r.ref for r in refs], [expected],
                                  f"{name}: the reader did not extract the value")
-                rule = immutable_image if refs[0].key == "image" else immutable
+                rule = immutable_image if refs[0].kind == IMAGE else immutable
                 self.assertFalse(rule(refs[0].ref),
                                  f"{name}: extracted but judged pinned")
 
@@ -714,6 +848,59 @@ class TheKeyHasManySpellings(unittest.TestCase):
                 self.assertEqual(caught.exception.what, expected,
                                  f"{name}: refused, but for a different reason than the "
                                  f"one this case exists to exercise")
+
+    def test_a_digest_pinned_container_survives_both_of_its_shapes(self):
+        """The other half for the image keys. `test_a_pinned_step_survives_every_spelling`
+        skips them because their rule is `immutable_image`, so without this a reader that
+        refused every `container:` outright would pass the corpus above and be useless.
+        Both shapes, plus the keys that sit beside an image and are not one."""
+        digest = "@sha256:" + "b" * 64
+        for name, text in (
+            ("the shorthand", f"jobs:\n  p:\n    container: node{digest}\n"),
+            ("the mapping", f"jobs:\n  p:\n    container:\n      image: node{digest}\n"),
+            ("a service, shorthand",
+             f"jobs:\n  p:\n    services:\n      redis: redis{digest}\n"),
+            ("a service, mapping and its neighbours",
+             f"jobs:\n  p:\n    services:\n      redis:\n        image: redis{digest}\n"
+             f"        ports:\n          - 6379:6379\n        env:\n          X: y\n"),
+            ("a container beside its options",
+             f"jobs:\n  p:\n    container:\n      image: node{digest}\n"
+             f"      options: --cpus 2\n      credentials:\n        username: u\n"),
+        ):
+            with self.subTest(shape=name):
+                refs = scan_text(text)
+                self.assertEqual([r.ref for r in refs], [
+                    ("node" if "service" not in name else "redis") + digest], name)
+                self.assertEqual(refs[0].kind, IMAGE, name)
+                self.assertTrue(immutable_image(refs[0].ref), name)
+
+    def test_the_scope_of_a_container_block_ends_where_its_indentation_does(self):
+        """Both container scopes close on dedent, and that is load-bearing in each
+        direction. A bare scalar *inside* a container node is the shorthand and stops the
+        suite; the same shape outside one is an ordinary wrapped value this reader has
+        always let through, and it must stay let through. A key at the column the service
+        ids used is a key, not a fourth service — scope is indentation here because it is
+        indentation in the real parser."""
+        sha, digest = "a" * 40, "@sha256:" + "b" * 64
+        text = (f"jobs:\n  p:\n    container:\n      image: node{digest}\n"
+                f"    steps:\n      - uses: actions/checkout@{sha}\n"
+                f"      - run: echo hi\n")
+        self.assertEqual([(r.kind, r.ref) for r in scan_text(text)],
+                         [(IMAGE, f"node{digest}"), (ACTION, f"actions/checkout@{sha}")])
+
+        wrapped = (f"jobs:\n  p:\n    container:\n      image: node{digest}\n"
+                   f"    name: a job name that\n      wraps onto a second line\n"
+                   f"    steps:\n      - uses: actions/checkout@{sha}\n")
+        self.assertEqual([r.ref for r in scan_text(wrapped)],
+                         [f"node{digest}", f"actions/checkout@{sha}"],
+                         "a wrapped value outside the container node was refused as if it "
+                         "were the image shorthand")
+
+        beside = (f"jobs:\n  p:\n    services:\n      redis:\n        image: r{digest}\n"
+                  f"    env:\n      TOKEN: not-an-image\n")
+        self.assertEqual([(r.key, r.ref) for r in scan_text(beside)],
+                         [("image", f"r{digest}")],
+                         "a key beside the services block was read as another service")
 
     def test_a_pinned_step_survives_every_spelling_too(self):
         """The corpus above would pass against a reader that refused everything. This is

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -7,10 +7,46 @@ code, chosen by whoever can move the ref. `pypa/gh-action-pypi-publish@release/v
 BRANCH head, so it is a force-push away from being different code; `@v4` is a tag its owner
 can retarget. That is the whole of CVE-2025-30066.
 
-**The property, and it is not "the string does not say v4".** A ref is acceptable when
-naming it a second time cannot get you different bytes: a full commit SHA (a content
-address), an image digest, or a path inside this repository, which moves only with a commit
-to this repository. Everything else is a promise by a third party, whatever it is spelled.
+**The property, and it is not "the string does not say v4".** A reference is acceptable
+when naming it a second time cannot get you different bytes: a full commit SHA (a content
+address), an image digest, or a path to a file **tracked in this repository**, which moves
+only with a commit here. Everything else is a promise by a third party, whatever it is
+spelled — and "in the working tree" is not the same claim as "tracked": `./node_modules/x`
+is a path in this tree that an `npm install` rewrites. `uses:` is not the only key that
+names somebody else's code, so `container:`/`services:`/`runs.image` are held to the same
+rule: `image: node:18` runs third-party bytes inside the job exactly as a step does.
+
+**Why this reads YAML instead of grepping for `uses:`.** The first version of this file
+matched the key with `^\\s*(?:-\\s+)?uses\\s*:` and counted the literal bytes `uses:` as its
+fail-closed cross-check. Both are one spelling of the key. YAML has many, and GitHub loads
+them all: `- "uses": evil/action@main` contains neither the bare key nor the byte sequence
+`uses:`, parses to a genuine step, and was invisible to every test below. So was
+`- 'uses':`, so was the explicit key `- ? uses` / `: …`, and so was `"\\x75ses"`. Matching
+one spelling of a thing is the failure this repository keeps re-learning; the answer is to
+read the structure, not the bytes.
+
+So `scan_text` is a small YAML reader for the **subset this repository writes** — block
+mappings and sequences, plain and quoted scalars with real escape handling, block scalars
+skipped as the opaque text they are. Anything outside that subset is not guessed at and not
+ignored: it raises `Unparsed`, which fails the suite by name. A flow mapping, an anchor, an
+alias, a merge key, a tag, an explicit key, a document marker, a `uses:` whose value is on
+another line — every one of those can carry a step past a line-oriented reader, so every
+one of them stops this test until a person either rewrites the file in the subset or
+teaches the reader that construct on purpose. `TheKeyHasManySpellings` is the corpus that
+holds it to that, and it asserts *which* outcome each spelling gets, so no case can pass
+because some unrelated check happened to trip.
+
+**Nothing is trusted for being on disk.** The set of files to read is everything under
+`.github/` plus every `action.y*ml` in `git ls-files`, and every local `uses: ./x` must
+resolve to a file in that index — a local composite action runs in the calling job with the
+calling job's token, so its own `uses:` lines are checked exactly like the caller's, and a
+path this repository does not track is not "a path that moves only with a commit here". The
+first version walked the tree with a hardcoded list of directories to skip (`node_modules`,
+`dist`, `.venv`), which is the same mistake in a second place: `uses: ./node_modules/probe`
+was accepted as immutable while the skip list guaranteed its `action.yml` was never read.
+There is deliberately no second walk from the refs: GitHub resolves a local `uses:` to a
+directory's `action.y*ml` or to a file under `.github/workflows/`, both of which the seed
+list already holds, and a test pins that invariant rather than leaving it as a comment.
 
 **What this cannot check**, stated because a guard that overclaims is the defect twice
 over. That a pinned SHA is a real commit of the repository beside it, or that its trailing
@@ -18,23 +54,29 @@ over. That a pinned SHA is a real commit of the repository beside it, or that it
 network call; a wrong-but-well-formed SHA fails in CI on the next run, loudly, which is the
 failure mode you want from an unresolvable ref. That a ref which *is* 40 hex characters is
 an object name rather than a branch somebody named after one — GitHub resolves it as a
-commit, and the case is theoretical, but it is not excluded here. And nothing at all about
-a `run:` step that pipes a script off the internet: pinning is not a defence against one,
-and there is none in these files today.
+commit, and the case is theoretical, but it is not excluded here. That a tracked local
+action stays benign — it is charter's own code, reviewed the way the rest of it is. And
+nothing at all about a `run:` step that pipes a script off the internet: pinning is not a
+defence against one, and there is none in these files today.
 
-**Fail-closed on anything unparsed.** The scanner counts `uses:` tokens at the byte level
-and requires that it produced a ref for every one of them, so a spelling it does not
-understand — a flow mapping, a folded scalar, a new file type — fails the suite instead of
-being silently skipped. That is the shape of failure this repository keeps re-learning: a
-guard that scans for one spelling passes happily on the next one.
+**The next place to look**, since that is the question this file exists to keep asking. Not
+another spelling of the key — those are now read structurally and the corpus holds them —
+but the two mismatches a reader like this always has with the real one: what counts as a
+line break (`ALineBreakIsTheOtherHalfOfTheSpellingProblem`, which shows the mismatch runs
+the safe way round), and a ref that is well formed here and means something else on the
+runner, such as a branch somebody named after a 40-character hex string. Both are stated
+above rather than quietly assumed.
 """
 
 from __future__ import annotations
 
 import os
 import re
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
+from typing import NamedTuple
 
 REPO = Path(__file__).resolve().parents[1]
 GITHUB = REPO / ".github"
@@ -44,79 +86,263 @@ GITHUB = REPO / ".github"
 #: would be a second spelling of the same pin, and two spellings is how audits drift.
 _SHA = re.compile(r"^[0-9a-f]{40}$")
 
-#: An OCI digest, for a `docker://` step. None today; the predicate answers for one anyway,
-#: so adding one does not require also remembering to teach this file about it.
+#: An OCI digest, for a `docker://` step or a `container:`/`services:` image.
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 
-#: `uses:` as a block-mapping key, with or without a leading sequence dash.
-_USES = re.compile(r"^\s*(?:-\s+)?uses\s*:\s*(.+?)\s*$")
+#: The keys that name code somebody else wrote. `uses` is a step or a reusable workflow;
+#: `image` is `jobs.<id>.container.image`, `services.<id>.image`, or a Docker action's
+#: `runs.image` — all of which run third-party bytes inside the job just as a step does.
+_CODE_KEYS = ("uses", "image")
+
+#: A block-scalar header: `|`, `>`, with any chomping/indent indicator and a comment.
+_BLOCK_HEADER = re.compile(r"^[|>][-+0-9]*\s*(?:#.*)?$")
+
+#: A local reference: a path, resolved by GitHub against the repository root.
+_LOCAL = re.compile(r"^\.{1,2}/")
 
 
-def _strip_comment(line: str) -> str:
-    """Everything before the first ``#``.
+class Unparsed(Exception):
+    """A construct the reader does not model.
 
-    Crude on purpose. It is applied to the ref scan AND to the token count, so the two
-    always see the same bytes — a `uses:` inside a comment is invisible to both rather than
-    a phantom the parity check would trip over. The trailing `# v4.4.0` on every pin is
-    exactly what it is here to remove.
+    Never swallowed and never guessed at. It carries a line number and a name for the
+    construct, and it fails the suite — because a YAML shape this file does not understand
+    is exactly where the next step hides.
     """
-    return line.split("#", 1)[0]
+
+    def __init__(self, line: int, what: str) -> None:
+        super().__init__(f"line {line}: {what}")
+        self.line = line
+        self.what = what
 
 
-#: Directories with nothing CI runs in them, and every reason not to walk them: git's
-#: object store, and the worktrees other agents are working in — each a full second copy of
-#: this repository, whose `.github/` is not the one that runs.
-_PRUNE = {".git", "__pycache__", "node_modules", "dist", "worktrees", ".venv"}
+# --------------------------------------------------------------------------- scalars
+
+#: YAML 1.2's double-quoted escapes. Present so that `"\x75ses"` — which is the key `uses`
+#: to every real parser — is the key `uses` here too.
+_ESCAPES = {
+    "0": "\0", "a": "\a", "b": "\b", "t": "\t", "\t": "\t", "n": "\n", "v": "\v",
+    "f": "\f", "r": "\r", "e": "\x1b", " ": " ", '"': '"', "/": "/", "\\": "\\",
+    "N": "\x85", "_": "\xa0", "L": "\u2028", "P": "\u2029",
+}
+_HEX = {"x": 2, "u": 4, "U": 8}
+
+#: Characters that begin a YAML construct this reader does not model. Each one is a way to
+#: introduce a mapping key out of line-oriented view, so each one stops the suite.
+_INDICATORS = {
+    "{": "a flow mapping",
+    "[": "a flow collection in key position",
+    "&": "an anchor",
+    "*": "an alias",
+    "!": "a tag",
+    "?": "an explicit key",
+    "%": "a directive",
+    "@": "a reserved indicator",
+    "`": "a reserved indicator",
+}
 
 
-def _yaml_files() -> list[Path]:
-    """Every file CI can take a `uses:` from, found by walking rather than by name.
+def _double_quoted(s: str, i: int, line: int) -> tuple[str, int]:
+    out: list[str] = []
+    i += 1
+    while i < len(s):
+        c = s[i]
+        if c == '"':
+            return "".join(out), i + 1
+        if c != "\\":
+            out.append(c)
+            i += 1
+            continue
+        i += 1
+        if i >= len(s):
+            raise Unparsed(line, "a double-quoted scalar folded onto the next line")
+        e = s[i]
+        if e in _HEX:
+            width = _HEX[e]
+            digits = s[i + 1:i + 1 + width]
+            if len(digits) != width or any(d not in "0123456789abcdefABCDEF" for d in digits):
+                raise Unparsed(line, f"a malformed \\{e} escape")
+            out.append(chr(int(digits, 16)))
+            i += 1 + width
+        elif e in _ESCAPES:
+            out.append(_ESCAPES[e])
+            i += 1
+        else:
+            raise Unparsed(line, f"an escape this reader does not know: \\{e}")
+    raise Unparsed(line, "an unterminated double-quoted scalar")
 
-    Two populations, and missing either one is a hole:
 
-    * everything under `.github/` — a list of the two workflows that exist today is a list
-      somebody adds a third file beside;
-    * every `action.yml` / `action.yaml` in the tree, because a **local** composite action
-      is `uses: ./tools/thing`, which this file rightly calls immutable — it moves only with
-      a commit here — and whatever *that* file runs is executing in the calling job with the
-      calling job's token. Trusting the path and never reading the file is how a pinned
-      workflow ends up running `evil/action@main` one hop away.
+def _single_quoted(s: str, i: int, line: int) -> tuple[str, int]:
+    out: list[str] = []
+    i += 1
+    while i < len(s):
+        if s[i] == "'":
+            if s[i + 1:i + 2] == "'":
+                out.append("'")
+                i += 2
+                continue
+            return "".join(out), i + 1
+        out.append(s[i])
+        i += 1
+    raise Unparsed(line, "an unterminated single-quoted scalar")
+
+
+def _plain(s: str, i: int) -> tuple[str, int]:
+    """A plain scalar, stopping where YAML stops it: at `: `, at ` #`, or at end of line.
+
+    A bare `:` that is not followed by a space does not end it — `https://example` is one
+    scalar — and a `#` that is not preceded by a space does not start a comment, which is
+    why `SECURITY.md#reporting` survives intact.
     """
-    found = {p for p in GITHUB.rglob("*") if p.is_file() and p.suffix in (".yml", ".yaml")}
-    for dirpath, dirnames, filenames in os.walk(REPO):
-        dirnames[:] = [d for d in dirnames if d not in _PRUNE]
-        for name in filenames:
-            if name in ("action.yml", "action.yaml"):
-                found.add(Path(dirpath) / name)
-    return sorted(found)
+    start = i
+    while i < len(s):
+        if s[i] == ":" and (i + 1 >= len(s) or s[i + 1] in " \t"):
+            break
+        if s[i] == "#" and i > start and s[i - 1] in " \t":
+            break
+        i += 1
+    return s[start:i].rstrip(), i
 
 
-def _scan(path: Path) -> tuple[list[tuple[int, str]], int]:
-    """``([(line number, ref)], number of `uses:` tokens seen)``."""
-    refs: list[tuple[int, str]] = []
-    tokens = 0
-    for n, raw in enumerate(path.read_text().splitlines(), 1):
-        code = _strip_comment(raw)
-        tokens += code.count("uses:")
-        m = _USES.match(code)
-        if m:
-            refs.append((n, m.group(1)))
-    return refs, tokens
+def _scalar(s: str, i: int, line: int) -> tuple[str, int]:
+    if s[i] == '"':
+        return _double_quoted(s, i, line)
+    if s[i] == "'":
+        return _single_quoted(s, i, line)
+    return _plain(s, i)
+
+
+def _trailing(s: str, i: int, line: int) -> None:
+    """Assert nothing but blanks and a comment follow — the line held one value, not two."""
+    rest = s[i:].strip()
+    if rest and not rest.startswith("#"):
+        raise Unparsed(line, "two values on one line, or a scalar this reader misread")
+
+
+# --------------------------------------------------------------------------- the reader
+
+class Ref(NamedTuple):
+    line: int
+    key: str
+    ref: str
+
+
+def scan_text(text: str) -> list[Ref]:
+    """Every `uses:`/`image:` value in a YAML document written in the accepted subset.
+
+    Raises `Unparsed` on the first construct outside it. There is no "skip what I do not
+    understand" path, by design: that path is the bypass.
+    """
+    found: list[Ref] = []
+    block_indent: int | None = None
+
+    for line, raw in enumerate(text.splitlines(), 1):
+        if block_indent is not None:
+            if not raw.strip() or len(raw) - len(raw.lstrip(" ")) > block_indent:
+                continue                      # opaque block-scalar content
+            block_indent = None
+
+        if "\t" in raw:
+            raise Unparsed(line, "a tab character")
+        if raw.strip() in ("---", "..."):
+            raise Unparsed(line, "a document marker — this reader loads one document")
+
+        i = len(raw) - len(raw.lstrip(" "))
+        if i >= len(raw) or raw[i] == "#":
+            continue                          # blank or whole-line comment
+
+        while raw[i] == "-" and (i + 1 >= len(raw) or raw[i + 1] == " "):
+            i += 1
+            while i < len(raw) and raw[i] == " ":
+                i += 1
+            if i >= len(raw) or raw[i] == "#":
+                break
+        if i >= len(raw) or raw[i] == "#":
+            continue                          # a lone `-`: the node is on the next line
+
+        key_col = i
+        if raw[i] in _INDICATORS:
+            raise Unparsed(line, _INDICATORS[raw[i]])
+        if raw[i] in "|>":
+            raise Unparsed(line, "a block scalar in key position")
+
+        name, i = _scalar(raw, i, line)
+        j = i
+        while j < len(raw) and raw[j] == " ":
+            j += 1
+        if j >= len(raw) or raw[j] != ":" or (j + 1 < len(raw) and raw[j + 1] not in " \t"):
+            _trailing(raw, i, line)           # a sequence item's own scalar value
+            continue
+
+        if name == "<<":
+            raise Unparsed(line, "a merge key")
+
+        value = raw[j + 1:]
+        k = len(value) - len(value.lstrip(" "))
+        tail = value[k:]
+
+        if not tail or tail.startswith("#"):
+            if name in _CODE_KEYS:
+                raise Unparsed(line, f"a `{name}:` whose value is not on its own line")
+            continue                          # a nested block follows
+        if _BLOCK_HEADER.match(tail):
+            if name in _CODE_KEYS:
+                raise Unparsed(line, f"a `{name}:` written as a block scalar")
+            block_indent = key_col
+            continue
+        if tail[0] == "[":
+            close = tail.find("]")
+            if close < 0:
+                raise Unparsed(line, "a flow collection spanning lines")
+            if "{" in tail[:close] or ":" in tail[:close]:
+                raise Unparsed(line, "a mapping inside a flow sequence")
+            _trailing(tail, close + 1, line)
+            continue                          # a flow sequence of scalars: no keys in it
+        if tail[0] in _INDICATORS:
+            raise Unparsed(line, _INDICATORS[tail[0]])
+
+        ref, end = _scalar(tail, 0, line)
+        _trailing(tail, end, line)
+        if name in _CODE_KEYS and ref:
+            found.append(Ref(line, name, ref))
+
+    return found
+
+
+# --------------------------------------------------------------------------- the rule
+
+def _unquote(ref: str) -> str:
+    ref = ref.strip()
+    if len(ref) >= 2 and ref[0] == ref[-1] and ref[0] in "'\"":
+        return ref[1:-1]
+    return ref
+
+
+def is_local(ref: str) -> bool:
+    """Does this reference name a path in this repository rather than somebody's repo?"""
+    return bool(_LOCAL.match(_unquote(ref)))
+
+
+def local_target(ref: str) -> str | None:
+    """The repo-relative path a local reference names, or None if it leaves the tree.
+
+    `uses: ./x` is resolved by GitHub against the repository root, not against the file
+    holding it. A path that normalises to something outside the root is not "in this tree"
+    however it is spelled, so it gets no immutability credit here.
+    """
+    rel = os.path.normpath(_unquote(ref))
+    if os.path.isabs(rel) or rel == ".." or rel.startswith(".." + os.sep):
+        return None
+    return Path(rel).as_posix()
 
 
 def immutable(ref: str) -> bool:
-    """Can this ref be made to mean different bytes by someone other than us?
+    """Can this third-party reference be made to mean different bytes by its owner?
 
-    True when it cannot: a path inside this repository, an image digest, or `owner/repo`
-    (optionally with a subdirectory) at a full commit SHA.
+    True when it cannot: an image digest, or `owner/repo` (optionally with a subdirectory)
+    at a full commit SHA. Local references are not this function's question — they are
+    `local_target`'s, because the answer depends on whether the file is tracked here.
     """
-    ref = ref.strip()
-    if ref.startswith("'") and ref.endswith("'") and len(ref) >= 2:
-        ref = ref[1:-1]
-    elif ref.startswith('"') and ref.endswith('"') and len(ref) >= 2:
-        ref = ref[1:-1]
-    if ref.startswith("./") or ref.startswith("../"):
-        return True                       # in this tree; moves only with a commit here
+    ref = _unquote(ref)
     if ref.startswith("docker://"):
         _, _, tail = ref.partition("docker://")
         _, sep, digest = tail.rpartition("@")
@@ -127,52 +353,194 @@ def immutable(ref: str) -> bool:
     return bool(_SHA.match(rev))
 
 
+def immutable_image(ref: str) -> bool:
+    """A container image is a content address only when it names a digest.
+
+    `node:18` is a tag its publisher rewrites, exactly like `@v4` — and `container.image`
+    runs in the job beside whatever token the job holds.
+    """
+    ref = _unquote(ref)
+    if ref.startswith("docker://"):
+        ref = ref.partition("docker://")[2]
+    _, sep, digest = ref.rpartition("@")
+    return bool(sep) and bool(_DIGEST.match(digest))
+
+
+# --------------------------------------------------------------------------- the files
+
+def tracked() -> set[str]:
+    """Every path in this repository's index: the set of files that move only with a commit.
+
+    This replaces a hardcoded list of directories to skip. A denylist of `node_modules`,
+    `dist`, `.venv` is a guess at where untracked code lives; the index is the answer.
+    """
+    out = subprocess.run(
+        ["git", "-C", str(REPO), "ls-files", "-z"],
+        capture_output=True, check=True, text=True)
+    return {p for p in out.stdout.split("\0") if p}
+
+
+def _action_files(rel: str, index: set[str]) -> list[str]:
+    """The tracked file(s) a local reference resolves to, in the two shapes GitHub allows.
+
+    A directory holding `action.yml`/`action.yaml`, or a reusable workflow under
+    `.github/workflows/`. There is no third shape, and that is load-bearing: both of these
+    are already in `seed_files`, so a local reference never names a file this scan would
+    otherwise miss and there is no second walk to get wrong. `TheFileListComesFromTheIndex`
+    holds that invariant, so widening this function without widening the seed list fails.
+    """
+    if rel.endswith((".yml", ".yaml")):
+        return [rel] if rel in index and rel.startswith(".github/workflows/") else []
+    return [c for c in (f"{rel}/action.yml", f"{rel}/action.yaml") if c in index]
+
+
+def seed_files(root: Path = REPO, index: set[str] | None = None) -> list[Path]:
+    """Where a `uses:` can enter CI, from two sources rather than one walk.
+
+    Everything under `.github/` on disk — a workflow added but not yet committed is still a
+    workflow somebody is about to run, and a list of the two files that exist today is a
+    list somebody adds a third file beside. Plus every tracked `action.y*ml` anywhere in
+    the tree, because a composite action runs inside the calling job.
+
+    `root` and `index` are arguments rather than globals so the traversal can be exercised
+    against a tree built for the purpose. This repository has no `action.yml` today, and a
+    guard whose only input is a repository that never triggers it is a guard nobody has
+    ever seen work.
+    """
+    index = tracked() if index is None else index
+    github = root / ".github"
+    found = {p for p in github.rglob("*") if p.is_file() and p.suffix in (".yml", ".yaml")}
+    for rel in index:
+        if os.path.basename(rel) in ("action.yml", "action.yaml"):
+            found.add(root / rel)
+    return sorted(found)
+
+
+def _no_symlink(path: Path) -> None:
+    """A tracked symlink moves with a commit; the bytes it points at need not.
+
+    Git stores a symlink as its target string, so `./tools/act` can be a committed link
+    into `node_modules` — immutable as a name, and not as code.
+    """
+    if os.path.realpath(path) != str(path):
+        raise Unparsed(0, f"{path} is reached through a symlink")
+
+
+class Closure(NamedTuple):
+    refs: list[tuple[str, Ref]]        # (repo-relative file, ref)
+    local: list[tuple[str, Ref, str]]  # (file, ref, resolved repo-relative target)
+
+
+def closure(root: Path = REPO, index: set[str] | None = None) -> Closure:
+    """Every reference CI can reach, and every local reference's resolved target.
+
+    A local composite action runs inside the calling job with the calling job's token, so
+    its own `uses:` lines are checked exactly like the caller's — they are here because
+    every file a local reference can name is already in `seed_files`, not because this
+    function walks a second time. `_action_files` is what makes that true.
+    """
+    index = tracked() if index is None else index
+    refs: list[tuple[str, Ref]] = []
+    local: list[tuple[str, Ref, str]] = []
+
+    for path in seed_files(root, index):
+        _no_symlink(path)
+        name = path.relative_to(root).as_posix()
+        for ref in scan_text(path.read_text()):
+            refs.append((name, ref))
+            if ref.key == "uses" and is_local(ref.ref):
+                local.append((name, ref, local_target(ref.ref) or ref.ref))
+    return Closure(refs, local)
+
+
+# --------------------------------------------------------------------------- tests
+
 class TheScannerSeesEverything(unittest.TestCase):
     """A checker that found nothing would pass every test below it."""
 
     def test_the_workflows_are_where_this_thinks_they_are(self):
-        names = {p.relative_to(REPO).as_posix() for p in _yaml_files()}
+        names = {p.relative_to(REPO).as_posix() for p in seed_files()}
         self.assertIn(".github/workflows/release.yml", names)
         self.assertIn(".github/workflows/test.yml", names)
 
     def test_it_finds_actions_to_check_at_all(self):
-        found = sum(len(_scan(p)[0]) for p in _yaml_files())
-        self.assertGreater(found, 0, "no `uses:` found anywhere — the scanner is broken, "
-                                     "and a broken scanner passes every other test here")
+        self.assertGreater(len(closure().refs), 0,
+                           "no `uses:` found anywhere — the scanner is broken, and a "
+                           "broken scanner passes every other test here")
 
-    def test_every_uses_token_produced_a_ref(self):
-        """Fail-closed. A `uses:` written in a shape the scanner does not parse — a flow
-        mapping, a folded scalar — must fail the suite, not be skipped by it."""
-        for p in _yaml_files():
-            refs, tokens = _scan(p)
-            with self.subTest(file=p.relative_to(REPO).as_posix()):
-                self.assertEqual(len(refs), tokens,
-                                 f"{tokens} `uses:` tokens but {len(refs)} parsed — an "
-                                 f"unrecognised spelling in {p.name} would go unchecked")
+    def test_every_file_is_written_in_the_subset_this_reader_understands(self):
+        """Fail-closed, and this is the whole of it. There is no path where a construct is
+        skipped: anything the reader does not model raises, so a shape that could carry a
+        step past it stops the suite instead of being waved through by it."""
+        for path in seed_files():
+            with self.subTest(file=path.relative_to(REPO).as_posix()):
+                try:
+                    scan_text(path.read_text())
+                except Unparsed as exc:
+                    self.fail(f"{path.relative_to(REPO)}: {exc}. Rewrite it in the subset "
+                              f"tests/test_workflows.py reads, or teach the reader this "
+                              f"construct deliberately — do not delete the check.")
+
+    def test_it_reads_the_pins_that_are_actually_in_release_yml(self):
+        """Anchored to the file, so a reader that silently stops finding things is caught.
+        `publish` is the job holding `id-token: write`."""
+        text = (GITHUB / "workflows" / "release.yml").read_text()
+        refs = scan_text(text)
+        actions = {r.ref.rpartition("@")[0] for r in refs}
+        self.assertIn("pypa/gh-action-pypi-publish", actions)
+        self.assertIn("actions/download-artifact", actions)
+        self.assertEqual([r for r in refs if not r.ref.rpartition("@")[1]], [],
+                         "a step in release.yml came out with no ref at all")
 
 
 class EveryActionIsPinnedToSomethingImmutable(unittest.TestCase):
     def test_no_workflow_runs_a_ref_its_owner_can_move(self):
-        for p in _yaml_files():
-            for line, ref in _scan(p)[0]:
-                with self.subTest(file=p.relative_to(REPO).as_posix(), line=line):
-                    self.assertTrue(
-                        immutable(ref),
-                        f"{ref} is a ref somebody else can move. Pin it to a full commit "
-                        f"SHA with the tag in a trailing comment — see release.yml's "
-                        f"header for why (#443).")
+        found = closure()
+        for name, ref in found.refs:
+            if ref.key == "image":
+                continue
+            if is_local(ref.ref):
+                continue
+            with self.subTest(file=name, line=ref.line):
+                self.assertTrue(
+                    immutable(ref.ref),
+                    f"{ref.ref} is a ref somebody else can move. Pin it to a full commit "
+                    f"SHA with the tag in a trailing comment — see release.yml's "
+                    f"header for why (#443).")
+
+    def test_no_job_runs_a_container_image_its_publisher_can_move(self):
+        for name, ref in closure().refs:
+            if ref.key != "image":
+                continue
+            with self.subTest(file=name, line=ref.line):
+                self.assertTrue(
+                    immutable_image(ref.ref),
+                    f"{ref.ref} is an image tag. `container:`/`services:` run third-party "
+                    f"bytes in the job exactly as a step does; name a @sha256: digest.")
+
+    def test_every_local_action_is_a_file_committed_to_this_repository(self):
+        """`uses: ./x` earns its immutability from being *tracked*, not from being on disk.
+        `./node_modules/probe` is a path in this tree that an `npm install` rewrites."""
+        index = tracked()
+        for name, ref, target in closure().local:
+            with self.subTest(file=name, line=ref.line):
+                self.assertTrue(
+                    _action_files(target, index),
+                    f"{ref.ref} names no file tracked in this repository. A local action "
+                    f"runs in the calling job with the calling job's token; if it is not "
+                    f"committed here, 'it moves only with a commit here' is false.")
 
     def test_every_pin_says_which_version_it_is(self):
         """The SHA is the security property; the trailing tag is what makes it
         maintainable. Without it nobody can tell whether the pin is a year stale, and a pin
         nobody dares move is how an unpatched action outlives the reason it was pinned."""
-        for p in _yaml_files():
-            for n, raw in enumerate(p.read_text().splitlines(), 1):
-                m = _USES.match(_strip_comment(raw))
-                if not m or not _SHA.match(m.group(1).rpartition("@")[2]):
+        for path in seed_files():
+            lines = path.read_text().splitlines()
+            for ref in scan_text(path.read_text()):
+                if not _SHA.match(_unquote(ref.ref).rpartition("@")[2]):
                     continue
-                with self.subTest(file=p.relative_to(REPO).as_posix(), line=n):
-                    _, sep, comment = raw.partition("#")
+                with self.subTest(file=path.relative_to(REPO).as_posix(), line=ref.line):
+                    _, sep, comment = lines[ref.line - 1].partition("#")
                     self.assertTrue(sep and comment.strip(),
                                     "a SHA pin with no `# <tag>` beside it")
 
@@ -188,7 +556,7 @@ class TheRuleIsAboutMovability(unittest.TestCase):
     """The predicate itself, on the spellings a "does it say v4" check would wave through.
 
     Not a denylist of bad strings — that is the guard this repository has now watched fail
-    four times. Each case below asks the same one question: *given only this ref, can the
+    five times. Each case below asks the same one question: *given only this ref, can the
     bytes it resolves to change without a commit landing here?*
     """
 
@@ -214,18 +582,309 @@ class TheRuleIsAboutMovability(unittest.TestCase):
             with self.subTest(ref=ref):
                 self.assertFalse(immutable(ref), ref)
 
-    def test_a_local_action_is_ours_to_move_and_nobody_elses(self):
-        self.assertTrue(immutable("./.github/actions/setup"))
-        self.assertTrue(immutable("./.github/workflows/reusable.yml"))
-
     def test_an_image_digest_is_a_content_address_too(self):
         self.assertTrue(immutable("docker://alpine@sha256:" + "b" * 64))
+        self.assertTrue(immutable_image("alpine@sha256:" + "b" * 64))
+        self.assertFalse(immutable_image("node:18"))
+        self.assertFalse(immutable_image("node:18@sha256:" + "b" * 63))
 
     def test_quoting_does_not_change_the_answer(self):
         """YAML lets the same value be written three ways, and a scanner that only knows
         one of them is a scanner with two holes in it."""
         self.assertTrue(immutable('"actions/checkout@' + "a" * 40 + '"'))
         self.assertFalse(immutable("'actions/checkout@v4'"))
+
+    def test_a_local_reference_is_recognised_however_it_is_spelled(self):
+        for ref in ("./.github/actions/setup", '"./tools/act"', "'../x'", "./x/action.yml"):
+            with self.subTest(ref=ref):
+                self.assertTrue(is_local(ref))
+        self.assertFalse(is_local("actions/checkout@" + "a" * 40))
+
+    def test_a_path_that_leaves_the_repository_is_not_in_this_tree(self):
+        """`immutable` used to return True for anything starting `../`, on the grounds that
+        it was "in this tree". `../../evil` is not in this tree."""
+        self.assertIsNone(local_target("../../evil"))
+        self.assertIsNone(local_target("./a/../../evil"))
+        self.assertEqual(local_target("./.github/actions/setup"), ".github/actions/setup")
+        self.assertEqual(local_target('"./tools/act"'), "tools/act")
+
+    def test_a_local_reference_earns_nothing_from_merely_existing_on_disk(self):
+        """The bypass this replaces, as a unit: `./node_modules/probe` resolves to a path,
+        and that path is not in the index, so it is not a pin."""
+        self.assertEqual(local_target("./node_modules/probe"), "node_modules/probe")
+        self.assertEqual(_action_files("node_modules/probe", {"README.md"}), [])
+        self.assertEqual(_action_files("tools/act", {"tools/act/action.yml"}),
+                         ["tools/act/action.yml"])
+
+
+def _steps(*lines: str) -> str:
+    """A step list in the shape release.yml writes one, so indentation is realistic."""
+    return "jobs:\n  publish:\n    steps:\n" + "".join(lines)
+
+
+class TheKeyHasManySpellings(unittest.TestCase):
+    """The corpus. Every entry is a way to write `uses` that a real YAML parser resolves to
+    the key `uses`, and that the first version of this file could not see.
+
+    Each case asserts **which** outcome it gets — parsed-and-refused, or refused as
+    unparsed — because "the suite went red" is not evidence that this check did it. A case
+    that flipped from parsed to unparsed would still be safe but would mean the reader had
+    quietly stopped reading, and that is worth knowing.
+    """
+
+    SEEN = [
+        # (name, yaml, the value the reader must extract)
+        ("a bare key",
+         _steps('      - uses: evil/action@main\n'), "evil/action@main"),
+        ("a double-quoted key",
+         _steps('      - "uses": evil/action@main\n'), "evil/action@main"),
+        ("a single-quoted key",
+         _steps("      - 'uses': evil/action@main\n"), "evil/action@main"),
+        ("a hex-escaped key",
+         _steps('      - "\\x75ses": evil/action@main\n'), "evil/action@main"),
+        ("a unicode-escaped key",
+         _steps('      - "\\u0075ses": evil/action@main\n'), "evil/action@main"),
+        ("space before the colon",
+         _steps('      - uses : evil/action@main\n'), "evil/action@main"),
+        ("space before the colon, quoted",
+         _steps('      - "uses"  : evil/action@main\n'), "evil/action@main"),
+        ("the dash on its own line",
+         _steps('      -\n        uses: evil/action@main\n'), "evil/action@main"),
+        ("a double-quoted value",
+         _steps('      - uses: "evil/action@main"\n'), "evil/action@main"),
+        ("a single-quoted value",
+         _steps("      - uses: 'evil/action@main'\n"), "evil/action@main"),
+        ("a value that looks like a comment anchor",
+         _steps('      - uses: evil/action@main # v1\n'), "evil/action@main"),
+        ("a container image",
+         "jobs:\n  publish:\n    container:\n      image: node:18\n", "node:18"),
+    ]
+
+    REFUSED = [
+        ("an explicit key", _steps('      - ? uses\n        : evil/action@main\n'),
+         "an explicit key"),
+        ("a flow mapping step", _steps('      - {uses: evil/action@main}\n'),
+         "a flow mapping"),
+        ("a flow mapping value", "jobs:\n  publish:\n    steps: [{uses: e/a@main}]\n",
+         "a mapping inside a flow sequence"),
+        ("an implicit pair in a flow sequence",
+         "jobs:\n  publish:\n    steps: [uses: evil/action@main]\n",
+         "a mapping inside a flow sequence"),
+        ("an anchored step", _steps('      - &s\n        uses: evil/action@main\n'),
+         "an anchor"),
+        ("an aliased step", _steps('      - *s\n'), "an alias"),
+        ("a merge key", _steps('      - <<: *s\n        name: x\n'), "a merge key"),
+        ("a tagged step", _steps('      - !!map\n        uses: evil/action@main\n'),
+         "a tag"),
+        ("an aliased value", _steps('      - uses: *pin\n'), "an alias"),
+        ("a value on the next line", _steps('      - uses:\n          evil/action@main\n'),
+         "a `uses:` whose value is not on its own line"),
+        ("a folded value", _steps('      - uses: >-\n          evil/action@main\n'),
+         "a `uses:` written as a block scalar"),
+        ("a literal value", _steps('      - uses: |-\n          evil/action@main\n'),
+         "a `uses:` written as a block scalar"),
+        ("a second document", "jobs: {}\n---\njobs:\n  p:\n    steps:\n"
+                              "      - uses: evil/action@main\n", "a flow mapping"),
+        ("a tab where a space belongs", _steps('      -\tuses: evil/action@main\n'),
+         "a tab character"),
+        ("a folded double-quoted key", _steps('      - "us\\\n        es": e/a@main\n'),
+         "a double-quoted scalar folded onto the next line"),
+        ("a flow sequence left open", "jobs:\n  p:\n    steps: [\n      uses: e/a@main]\n",
+         "a flow collection spanning lines"),
+        ("a second colon the reader would have to guess about",
+         _steps('      - uses: evil/action@main: extra\n'),
+         "two values on one line, or a scalar this reader misread"),
+    ]
+
+    def test_every_spelling_of_the_key_is_read_and_refused(self):
+        for name, text, expected in self.SEEN:
+            with self.subTest(spelling=name):
+                refs = scan_text(text)
+                self.assertEqual([r.ref for r in refs], [expected],
+                                 f"{name}: the reader did not extract the value")
+                rule = immutable_image if refs[0].key == "image" else immutable
+                self.assertFalse(rule(refs[0].ref),
+                                 f"{name}: extracted but judged pinned")
+
+    def test_every_construct_outside_the_subset_stops_the_suite_by_name(self):
+        for name, text, expected in self.REFUSED:
+            with self.subTest(spelling=name):
+                with self.assertRaises(Unparsed) as caught:
+                    scan_text(text)
+                self.assertEqual(caught.exception.what, expected,
+                                 f"{name}: refused, but for a different reason than the "
+                                 f"one this case exists to exercise")
+
+    def test_a_pinned_step_survives_every_spelling_too(self):
+        """The corpus above would pass against a reader that refused everything. This is
+        the other half: the same spellings, pinned, must come out clean."""
+        sha = "a" * 40
+        for name, text, _ in self.SEEN:
+            if "image" in name:
+                continue
+            with self.subTest(spelling=name):
+                refs = scan_text(text.replace("evil/action@main", f"actions/checkout@{sha}"))
+                self.assertEqual(len(refs), 1)
+                self.assertTrue(immutable(refs[0].ref), name)
+
+
+class TheSubsetIsWideEnoughToWriteAWorkflowIn(unittest.TestCase):
+    """The other direction. A reader that raised on everything would satisfy every check
+    above and be useless — these are constructs this repository's files actually contain,
+    and each one must read clean.
+    """
+
+    def test_the_shapes_the_real_files_use(self):
+        for name, text in (
+            ("a flow sequence of scalars", 'on:\n  push:\n    tags: ["v*"]\n'),
+            ("a matrix", 'matrix:\n  python-version: ["3.11", "3.12"]\n'),
+            ("an expression value", "with:\n  python-version: ${{ matrix.python }}\n"),
+            ("a url with a colon in it", "url: https://pypi.org/p/charter-cp\n"),
+            ("a url with a fragment", "url: https://x/SECURITY.md#reporting\n"),
+            ("a comment after a value", "id-token: write        # REQUIRED: mints it\n"),
+            ("a block scalar", "run: |\n  echo hi\n  # uses: evil/action@main\n"),
+            ("a folded block scalar", "description: >\n  a b\n  c\n"),
+            ("a keyless block", "on:\n  push:\n  pull_request:\n"),
+            ("an if expression",
+             "if: github.event_name == 'push' && github.ref == 'refs/heads/main'\n"),
+            ("a dropdown of plain items",
+             "options:\n  - macOS\n  - Windows (WSL)\n  - Other\n"),
+            ("a whole-line comment at depth", "jobs:\n  p:\n    # a note\n    x: 1\n"),
+        ):
+            with self.subTest(shape=name):
+                self.assertEqual(scan_text(text), [], name)
+
+    def test_a_block_scalar_hides_nothing_and_invents_nothing(self):
+        """`run:` content is opaque text, so a `uses:` inside a shell heredoc is neither a
+        step nor a false alarm — and the block ends where the indentation does."""
+        text = ("steps:\n"
+                "  - run: |\n"
+                "      echo 'uses: evil/action@main'\n"
+                "  - uses: actions/checkout@" + "a" * 40 + "\n")
+        self.assertEqual([r.ref for r in scan_text(text)],
+                         ["actions/checkout@" + "a" * 40])
+
+
+class ALineBreakIsTheOtherHalfOfTheSpellingProblem(unittest.TestCase):
+    """Where does a line begin? A reader that works line by line has already answered that,
+    usually without noticing — and this repository has been bitten by exactly that answer
+    before, by an escape that handled `\n` and let U+2028, U+2029 and U+0085 through.
+
+    Here the relationship runs the safe way round, and it is worth stating as a property
+    rather than trusting: `str.splitlines` breaks on a **superset** of what a YAML parser
+    calls a line break. So every separator GitHub honours is one this reader has already
+    honoured, and it cannot be handed a key on a line it never looked at. The cost of the
+    superset is the opposite mistake — see the second test — and the opposite mistake is a
+    false alarm somebody reads, not a step somebody misses.
+    """
+
+    def test_every_separator_a_parser_honours_this_reader_honours_first(self):
+        for sep in ("\n", "\r\n", "\r", "\u2028", "\u2029", "\x85", "\x0b", "\x0c"):
+            with self.subTest(separator=repr(sep)):
+                text = "steps:" + sep + "  - uses: evil/action@main" + sep
+                self.assertEqual([r.ref for r in scan_text(text)], ["evil/action@main"],
+                                 "a step on the far side of this separator was not read")
+
+    def test_splitting_too_eagerly_shows_up_as_a_finding_not_a_blind_spot(self):
+        """U+2028 is a break to `str.splitlines` and not one in YAML 1.2, so a scalar
+        containing it comes apart here and not on the runner. That surfaces a ref which is
+        not really a step — noise a person resolves in one look — rather than swallowing
+        one that is. Stated because the inverse would be the bug."""
+        text = "steps:\n  - run: echo\u2028uses: evil/action@main\n"
+        self.assertEqual([r.ref for r in scan_text(text)], ["evil/action@main"])
+
+
+class TheFileListComesFromTheIndex(unittest.TestCase):
+    def test_the_workflows_are_tracked(self):
+        index = tracked()
+        self.assertIn(".github/workflows/release.yml", index)
+        self.assertIn(".github/workflows/test.yml", index)
+
+    def test_untracked_directories_need_no_denylist(self):
+        """The hole this replaces: `_PRUNE = {"node_modules", "dist", ".venv", …}` was a
+        guess at where untracked code lives, and `uses: ./node_modules/probe` walked past
+        it. Nothing in those directories is in the index, so nothing needs naming."""
+        index = tracked()
+        self.assertFalse([p for p in index
+                          if p.split("/")[0] in ("node_modules", "dist", ".venv")])
+
+    def test_a_local_reference_resolves_only_to_files_the_seed_list_already_holds(self):
+        """Why there is no second walk. Every shape `_action_files` can return is either
+        under `.github/` or is a directory's `action.y*ml` — both already seeds. Widen it
+        to a third shape without widening `seed_files` and this fails, which is the only
+        thing standing between "no walk needed" and "a file nobody reads"."""
+        index = {"tools/act/action.yml", "tools/act/action.yaml", "docs/x.yaml",
+                 ".github/workflows/reusable.yml", "tools/rogue.yml"}
+        resolved = [hop for rel in ("tools/act", "tools/missing", "docs/x.yaml",
+                                    "tools/rogue.yml", ".github/workflows/reusable.yml")
+                    for hop in _action_files(rel, index)]
+        self.assertEqual(sorted(resolved), [".github/workflows/reusable.yml",
+                                            "tools/act/action.yaml", "tools/act/action.yml"])
+        for hop in resolved:
+            self.assertTrue(
+                hop.startswith(".github/") or hop.rsplit("/", 1)[-1].startswith("action."),
+                f"{hop} is a shape seed_files does not collect")
+        self.assertEqual(_action_files("tools/rogue.yml", index), [],
+                         "a reusable workflow outside .github/workflows is not one")
+
+    def test_a_tracked_action_file_anywhere_is_a_seed(self):
+        """A composite action does not have to live under `.github/`, and the seed list has
+        to find one wherever it is. Driven off a synthetic index because this repository has
+        none today — a check that only fires on a file nobody has written is not a check."""
+        seeds = seed_files(REPO, {"tools/act/action.yml", "docs/notes.yaml", "README.md"})
+        self.assertIn(REPO / "tools/act/action.yml", seeds)
+        self.assertNotIn(REPO / "docs/notes.yaml", seeds)
+        self.assertIn(GITHUB / "workflows" / "release.yml", seeds)
+
+
+class ALocalActionIsFollowedIntoTheFileItNames(unittest.TestCase):
+    """`uses: ./x` is code running in the calling job with the calling job's token. The
+    traversal is exercised against a tree built here, because charter has no local action
+    to exercise it with and an untested traversal is how `./node_modules/probe` got in.
+    """
+
+    def _tree(self, tmp: Path, action: str) -> None:
+        (tmp / ".github/workflows").mkdir(parents=True)
+        (tmp / ".github/workflows/w.yml").write_text(
+            "jobs:\n  j:\n    steps:\n      - uses: ./tools/act\n")
+        (tmp / "tools/act").mkdir(parents=True)
+        (tmp / "tools/act/action.yml").write_text(
+            "runs:\n  using: composite\n  steps:\n" + action)
+
+    def test_a_local_actions_own_uses_is_checked_like_the_callers(self):
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(os.path.realpath(raw))
+            self._tree(tmp, "    - uses: evil/action@main\n")
+            found = closure(tmp, {".github/workflows/w.yml", "tools/act/action.yml"})
+            refs = {(name, r.ref) for name, r in found.refs}
+            self.assertIn(("tools/act/action.yml", "evil/action@main"), refs,
+                          "the local action's own `uses:` was never read")
+            self.assertFalse(immutable("evil/action@main"))
+
+    def test_the_hop_is_only_taken_to_a_tracked_file(self):
+        """The bypass, end to end: the action file exists on disk and is not in the index,
+        so it is reported as an unresolved local reference rather than followed and
+        trusted."""
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(os.path.realpath(raw))
+            self._tree(tmp, "    - uses: evil/action@main\n")
+            found = closure(tmp, {".github/workflows/w.yml"})
+            self.assertEqual([t for _, _, t in found.local], ["tools/act"])
+            self.assertEqual(_action_files("tools/act", {".github/workflows/w.yml"}), [])
+            self.assertNotIn("evil/action@main", {r.ref for _, r in found.refs})
+
+    def test_a_file_reached_through_a_symlink_is_refused(self):
+        """Git tracks a symlink as its target string. The link moves only with a commit;
+        what it points at does not, so the file it resolves to is not this repository's."""
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(os.path.realpath(raw))
+            (tmp / "real").mkdir()
+            (tmp / "real/action.yml").write_text("runs:\n")
+            (tmp / "link").symlink_to(tmp / "real")
+            _no_symlink(tmp / "real/action.yml")          # the plain path is fine
+            with self.assertRaises(Unparsed) as caught:
+                _no_symlink(tmp / "link/action.yml")
+            self.assertIn("symlink", caught.exception.what)
 
 
 if __name__ == "__main__":

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,232 @@
+"""Every action CI runs is named by something nobody else can move (#443).
+
+`release.yml`'s `publish` job holds `id-token: write`, and PyPI's Trusted Publishing
+verifies the token minted there as charter's genuine publisher — the claim is real, so
+whatever code runs in that job can publish charter. A `uses:` on a floating ref is that
+code, chosen by whoever can move the ref. `pypa/gh-action-pypi-publish@release/v1` is a
+BRANCH head, so it is a force-push away from being different code; `@v4` is a tag its owner
+can retarget. That is the whole of CVE-2025-30066.
+
+**The property, and it is not "the string does not say v4".** A ref is acceptable when
+naming it a second time cannot get you different bytes: a full commit SHA (a content
+address), an image digest, or a path inside this repository, which moves only with a commit
+to this repository. Everything else is a promise by a third party, whatever it is spelled.
+
+**What this cannot check**, stated because a guard that overclaims is the defect twice
+over. That a pinned SHA is a real commit of the repository beside it, or that its trailing
+`# v1.2.3` is that commit's tag — both need the network, and no test in this suite makes a
+network call; a wrong-but-well-formed SHA fails in CI on the next run, loudly, which is the
+failure mode you want from an unresolvable ref. That a ref which *is* 40 hex characters is
+an object name rather than a branch somebody named after one — GitHub resolves it as a
+commit, and the case is theoretical, but it is not excluded here. And nothing at all about
+a `run:` step that pipes a script off the internet: pinning is not a defence against one,
+and there is none in these files today.
+
+**Fail-closed on anything unparsed.** The scanner counts `uses:` tokens at the byte level
+and requires that it produced a ref for every one of them, so a spelling it does not
+understand — a flow mapping, a folded scalar, a new file type — fails the suite instead of
+being silently skipped. That is the shape of failure this repository keeps re-learning: a
+guard that scans for one spelling passes happily on the next one.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+GITHUB = REPO / ".github"
+
+#: A full git object name: the only ref that is a content address rather than a promise.
+#: Lowercase, because that is what every tool that prints one emits — an uppercase variant
+#: would be a second spelling of the same pin, and two spellings is how audits drift.
+_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+#: An OCI digest, for a `docker://` step. None today; the predicate answers for one anyway,
+#: so adding one does not require also remembering to teach this file about it.
+_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+#: `uses:` as a block-mapping key, with or without a leading sequence dash.
+_USES = re.compile(r"^\s*(?:-\s+)?uses\s*:\s*(.+?)\s*$")
+
+
+def _strip_comment(line: str) -> str:
+    """Everything before the first ``#``.
+
+    Crude on purpose. It is applied to the ref scan AND to the token count, so the two
+    always see the same bytes — a `uses:` inside a comment is invisible to both rather than
+    a phantom the parity check would trip over. The trailing `# v4.4.0` on every pin is
+    exactly what it is here to remove.
+    """
+    return line.split("#", 1)[0]
+
+
+#: Directories with nothing CI runs in them, and every reason not to walk them: git's
+#: object store, and the worktrees other agents are working in — each a full second copy of
+#: this repository, whose `.github/` is not the one that runs.
+_PRUNE = {".git", "__pycache__", "node_modules", "dist", "worktrees", ".venv"}
+
+
+def _yaml_files() -> list[Path]:
+    """Every file CI can take a `uses:` from, found by walking rather than by name.
+
+    Two populations, and missing either one is a hole:
+
+    * everything under `.github/` — a list of the two workflows that exist today is a list
+      somebody adds a third file beside;
+    * every `action.yml` / `action.yaml` in the tree, because a **local** composite action
+      is `uses: ./tools/thing`, which this file rightly calls immutable — it moves only with
+      a commit here — and whatever *that* file runs is executing in the calling job with the
+      calling job's token. Trusting the path and never reading the file is how a pinned
+      workflow ends up running `evil/action@main` one hop away.
+    """
+    found = {p for p in GITHUB.rglob("*") if p.is_file() and p.suffix in (".yml", ".yaml")}
+    for dirpath, dirnames, filenames in os.walk(REPO):
+        dirnames[:] = [d for d in dirnames if d not in _PRUNE]
+        for name in filenames:
+            if name in ("action.yml", "action.yaml"):
+                found.add(Path(dirpath) / name)
+    return sorted(found)
+
+
+def _scan(path: Path) -> tuple[list[tuple[int, str]], int]:
+    """``([(line number, ref)], number of `uses:` tokens seen)``."""
+    refs: list[tuple[int, str]] = []
+    tokens = 0
+    for n, raw in enumerate(path.read_text().splitlines(), 1):
+        code = _strip_comment(raw)
+        tokens += code.count("uses:")
+        m = _USES.match(code)
+        if m:
+            refs.append((n, m.group(1)))
+    return refs, tokens
+
+
+def immutable(ref: str) -> bool:
+    """Can this ref be made to mean different bytes by someone other than us?
+
+    True when it cannot: a path inside this repository, an image digest, or `owner/repo`
+    (optionally with a subdirectory) at a full commit SHA.
+    """
+    ref = ref.strip()
+    if ref.startswith("'") and ref.endswith("'") and len(ref) >= 2:
+        ref = ref[1:-1]
+    elif ref.startswith('"') and ref.endswith('"') and len(ref) >= 2:
+        ref = ref[1:-1]
+    if ref.startswith("./") or ref.startswith("../"):
+        return True                       # in this tree; moves only with a commit here
+    if ref.startswith("docker://"):
+        _, _, tail = ref.partition("docker://")
+        _, sep, digest = tail.rpartition("@")
+        return bool(sep) and bool(_DIGEST.match(digest))
+    owner, sep, rev = ref.rpartition("@")
+    if not sep or owner.count("/") < 1:
+        return False                      # no ref at all, or not `owner/repo`
+    return bool(_SHA.match(rev))
+
+
+class TheScannerSeesEverything(unittest.TestCase):
+    """A checker that found nothing would pass every test below it."""
+
+    def test_the_workflows_are_where_this_thinks_they_are(self):
+        names = {p.relative_to(REPO).as_posix() for p in _yaml_files()}
+        self.assertIn(".github/workflows/release.yml", names)
+        self.assertIn(".github/workflows/test.yml", names)
+
+    def test_it_finds_actions_to_check_at_all(self):
+        found = sum(len(_scan(p)[0]) for p in _yaml_files())
+        self.assertGreater(found, 0, "no `uses:` found anywhere — the scanner is broken, "
+                                     "and a broken scanner passes every other test here")
+
+    def test_every_uses_token_produced_a_ref(self):
+        """Fail-closed. A `uses:` written in a shape the scanner does not parse — a flow
+        mapping, a folded scalar — must fail the suite, not be skipped by it."""
+        for p in _yaml_files():
+            refs, tokens = _scan(p)
+            with self.subTest(file=p.relative_to(REPO).as_posix()):
+                self.assertEqual(len(refs), tokens,
+                                 f"{tokens} `uses:` tokens but {len(refs)} parsed — an "
+                                 f"unrecognised spelling in {p.name} would go unchecked")
+
+
+class EveryActionIsPinnedToSomethingImmutable(unittest.TestCase):
+    def test_no_workflow_runs_a_ref_its_owner_can_move(self):
+        for p in _yaml_files():
+            for line, ref in _scan(p)[0]:
+                with self.subTest(file=p.relative_to(REPO).as_posix(), line=line):
+                    self.assertTrue(
+                        immutable(ref),
+                        f"{ref} is a ref somebody else can move. Pin it to a full commit "
+                        f"SHA with the tag in a trailing comment — see release.yml's "
+                        f"header for why (#443).")
+
+    def test_every_pin_says_which_version_it_is(self):
+        """The SHA is the security property; the trailing tag is what makes it
+        maintainable. Without it nobody can tell whether the pin is a year stale, and a pin
+        nobody dares move is how an unpatched action outlives the reason it was pinned."""
+        for p in _yaml_files():
+            for n, raw in enumerate(p.read_text().splitlines(), 1):
+                m = _USES.match(_strip_comment(raw))
+                if not m or not _SHA.match(m.group(1).rpartition("@")[2]):
+                    continue
+                with self.subTest(file=p.relative_to(REPO).as_posix(), line=n):
+                    _, sep, comment = raw.partition("#")
+                    self.assertTrue(sep and comment.strip(),
+                                    "a SHA pin with no `# <tag>` beside it")
+
+    def test_something_is_watching_the_pins_for_updates(self):
+        """A pin freezes a security fix out as effectively as it freezes an attacker out.
+        Dependabot opens the pull request that moves one; a human still merges it."""
+        cfg = GITHUB / "dependabot.yml"
+        self.assertTrue(cfg.is_file(), "SHA-pinned actions with nothing watching them")
+        self.assertIn("github-actions", cfg.read_text())
+
+
+class TheRuleIsAboutMovability(unittest.TestCase):
+    """The predicate itself, on the spellings a "does it say v4" check would wave through.
+
+    Not a denylist of bad strings — that is the guard this repository has now watched fail
+    four times. Each case below asks the same one question: *given only this ref, can the
+    bytes it resolves to change without a commit landing here?*
+    """
+
+    def test_a_full_sha_is_the_only_accepted_third_party_ref(self):
+        self.assertTrue(immutable("actions/checkout@" + "a" * 40))
+        self.assertTrue(immutable("owner/repo/sub/dir@" + "0" * 40))
+
+    def test_near_misses_are_not_pins(self):
+        for ref in (
+            "actions/checkout@v4",                     # a tag its owner can retarget
+            "actions/checkout@v4.4.0",                 # an exact tag is still a tag
+            "pypa/gh-action-pypi-publish@release/v1",  # a branch head
+            "actions/checkout@main",
+            "actions/checkout@" + "a" * 39,            # short
+            "actions/checkout@" + "a" * 41,            # long
+            "actions/checkout@" + "A" * 40,            # not the spelling any tool emits
+            "actions/checkout@" + "g" * 40,            # 40 chars, not hex
+            "actions/checkout",                        # no ref at all
+            "actions/checkout@${{ env.PIN }}",         # resolved at run time, elsewhere
+            "docker://alpine:3.20",                    # a tag on an image is a tag
+            "docker://alpine@sha256:" + "a" * 63,      # short digest
+        ):
+            with self.subTest(ref=ref):
+                self.assertFalse(immutable(ref), ref)
+
+    def test_a_local_action_is_ours_to_move_and_nobody_elses(self):
+        self.assertTrue(immutable("./.github/actions/setup"))
+        self.assertTrue(immutable("./.github/workflows/reusable.yml"))
+
+    def test_an_image_digest_is_a_content_address_too(self):
+        self.assertTrue(immutable("docker://alpine@sha256:" + "b" * 64))
+
+    def test_quoting_does_not_change_the_answer(self):
+        """YAML lets the same value be written three ways, and a scanner that only knows
+        one of them is a scanner with two holes in it."""
+        self.assertTrue(immutable('"actions/checkout@' + "a" * 40 + '"'))
+        self.assertFalse(immutable("'actions/checkout@v4'"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #443
Closes #455
Closes #456

Three issues from the 2026-08-24 audit and from the first real use of the dev channel. Full
suite green: **4548 tests, OK**, stdlib `unittest`, no network.

## #443 — every action CI runs is pinned to a commit

`release.yml`'s `publish` job holds `id-token: write`. Trusted Publishing means there is no
PyPI token to steal — and that moves the question rather than answering it: the OIDC token
is minted on demand and PyPI verifies a claim that is entirely genuine, so **whatever code
runs in that job can publish charter**. It named that code with floating refs:

- `pypa/gh-action-pypi-publish@release/v1` — `refs/heads/release/v1`, a **branch head**, no
  such tag exists;
- `actions/download-artifact@v4` — a tag its owner can retarget.

All 13 `uses:` in both workflows now name a full commit SHA with the tag it resolved to in
a trailing comment, e.g. `pypa/gh-action-pypi-publish@dc37677… # v1.14.2`. Resolved from
each floating ref's current target, so **no version changed** — only the ref did.

`.github/dependabot.yml` (new) opens the pull request that moves a pin. A pin freezes a
security fix out as effectively as it freezes an attacker out; Dependabot opens it, a human
still merges it.

**Permissions audit.** `release.yml` already carried workflow-level `contents: read` with
`announce` narrowing to `contents: write` on that job alone. What was missing was the
statement that `publish`'s job-level block **replaces** the workflow's rather than adding
to it — so it holds `id-token: write` and *nothing else*, including no `contents`, which is
correct because it never checks out and `download-artifact` reads same-run artifacts with
the runtime token. That is now a comment where someone would otherwise "fix" it.

### The test asks the property, not the spelling

`tests/test_workflows.py`: *given only this ref, can the bytes it resolves to change
without a commit landing in this repository?* A full commit SHA, an image digest, or an
in-repo path — everything else is a third party's promise, however spelled.

- It **walks** every YAML under `.github/` plus every `action.yml`/`action.yaml` in the
  tree, not the two workflow files that exist today. A local composite action is
  `uses: ./tools/thing`, correctly immutable, and whatever *that* file runs executes in the
  calling job with the calling job's token.
- It **fails closed**: `uses:` tokens are counted at the byte level and the test refuses to
  pass unless a ref was parsed for every one, so a flow mapping or a folded scalar fails the
  suite instead of being silently skipped.
- It also requires each SHA to carry a `# <tag>` comment, and requires something to be
  watching the pins.

**Named, not claimed:** it cannot check that a SHA is a real commit of the repo beside it or
that the tag comment is honest — both need the network. A wrong-but-well-formed SHA fails
in CI loudly on the next run. It says nothing about a `run:` step piping a script off the
internet; there is none.

`release.yml`'s header used to end *"a leaked secret cannot be used to publish charter"* —
true, and answering the smaller question. Rewritten to answer the real one. The dev-channel
news entry and `test.yml`'s comment, both of which cite #443 as an open exposure and both
of which ship in this same unreleased set, are updated to say what is now true.

## #455 — the run site of the no-interpolation rule

`dev_install_argv`'s docstring claims *"there is no format call on this path"*, pinned by a
canary at the **build** site. #454's reviewer put `.format()` back into `_sync_dev` — the
site that actually runs the argv — and it survived all 4415 tests.

Now stated as a property of the boundary: **the argv charter hands the operating system on
this path is, element for element, the argv `dev_install_argv` returned.** One equality
forbids interpolation, appending, re-splitting and shell-joining together, including the
spellings nobody has thought of — which is the difference between this and a list of
forbidden characters.

The recorder sits at `subprocess.run`, with `subprocess.Popen` and the `os.exec*`/`spawn`
family trapped to raise. A counter on `util.run` would pin `_sync_dev`'s *current spelling*,
not the property — the same mistake as the `Path.stat` counter that missed an `open()`.
Residual named in the docstring: a `ctypes`-level spawn is not visible to any test here.

## #456 — the remedy that refused when followed

```
$ charter doctor
  !  plugin files  … Run: charter update
$ charter update
✗ this is a charter checkout — refusing to install over the tree you are editing.
```

`cmd_update` does two independent things and only one is unsafe on a checkout. The plugin
lives in `~/.claude/plugins/`, outside the tree, refreshed from a clone that is not the tree
either. On a **dev-channel checkout** `update` now skips the CLI install, says so, and
refreshes the plugin:

```
!  this is a charter checkout — the CLI here is the tree you are editing, so nothing was
   installed over it.
   the charter you run is this checkout, moved by git:  charter version
   the plugin lives outside this tree, so that half still runs:
✓  plugin: … — it loads on the NEXT session.
```

Option (1) from the issue: no new flag, and it makes doctor's existing hint true instead of
adding a second thing to know.

**The CLI refusal is not weakened.** It is asserted on both channels, with and without
`--to`, by name (`_sync_dev`/`_sync_to` never entered) *and* at the argv layer (no command
ran at all). Still refused outright, with the original message and exit code: a stable
checkout, and `--to X.Y.Z` anywhere in a checkout — that names a published CLI, which is
exactly the half that cannot happen here. Also not done: `_move_harness`, because it writes
into the plane root, which on a charter checkout is the tree being protected. And with no
`claude` on PATH it says there is nothing to do rather than reporting a refresh that did not
happen.

One test spans `doctor`'s hint text and `cmd_update`'s behaviour, because apart they were
both green while the pair was broken. `skills/update/SKILL.md`'s sentence "`update`
refuses" is rewritten in the same commit — a doc promising what the code no longer does is
itself the bug.

## Mutation testing

13 mutations, each applied → confirmed RED → restored → confirmed GREEN, `__pycache__`
cleared between runs:

| # | Mutation | Killed by |
|---|---|---|
| M1 | one action back to `@v4` | `test_no_workflow_runs_a_ref_its_owner_can_move` |
| M2 | a NEW workflow file with `@main` | same (proves the walk, not a hardcoded pair) |
| M3 | `- {uses: …}` flow mapping | `test_every_uses_token_produced_a_ref` (fail-closed) |
| M4 | `dependabot.yml` deleted | `test_something_is_watching_the_pins_for_updates` |
| M5 | a SHA with no `# tag` comment | `test_every_pin_says_which_version_it_is` |
| M6 | composite action under `.github/actions/` | pinning test |
| M14 | local composite action in `tools/` | pinning test (the hop outside `.github/`) |
| M7 | `.format()` at the run site (**the exact #455 mutation**) | run-site canary |
| M8 | an element appended to the argv | run-site canary ×3 |
| M9 | argv joined into one string | run-site canary ×3 |
| M10 | blanket checkout refusal restored | dev-checkout test **and** the doctor-hint test |
| M11 | `_move_harness()` on the checkout path | `test_a_dev_checkout_still_gets_the_plugin_half` |
| M12 | `--to` also taking the plugin-only path | `test_an_explicit_target_…_refused_outright` |
| M13 | CLI install reinstated on the checkout path | `test_a_charter_checkout_cannot_install_over_itself` (both channels) |

## What is the next spelling that still gets through?

- **#443:** a ref that *is* 40 hex characters but is a branch named after one — theoretical,
  GitHub resolves it as a commit, and it is named in the module docstring rather than
  claimed away. A `run:` step that curls a script is not covered by pinning at all.
- **#455:** an exec that never reaches `subprocess` or `os` — a `ctypes` spawn. Named, not
  covered.
- **#456:** none found; the parse of doctor's hint (`split("Run:")`) fails loudly if the
  hint's wording changes, which is the coupling this fix wants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
