### PR TITLE
secrets: a fingerprint you cannot check a guess against, and a vault that is 0600 before the plaintext (#436, #437)

### DIFF
--- a/charter/commands_secrets.py
+++ b/charter/commands_secrets.py
@@ -15,7 +15,6 @@ which command got which one has the audit half of the story missing.
 
 from __future__ import annotations
 
-import hashlib
 import os
 import re
 import signal
@@ -26,7 +25,7 @@ import tempfile
 from pathlib import Path
 
 from . import config, util
-from .secrets import base, registry
+from .secrets import base, fingerprint, registry
 
 
 # --------------------------------------------------------------------------- #
@@ -393,7 +392,11 @@ def cmd_secret_set(args) -> int:
     except base.VaultError as e:
         util.err(str(e))
         return 1
-    util.ok(f"Set '{args.key}' in vault '{args.vault}' ({len(value)} bytes). Value not shown.")
+    # Banded, not counted, for the same reason `get` is (#436): this line is printed into
+    # whatever ran the command — an agent's transcript for `--from-file`, where the length
+    # of a value nobody in the conversation has seen is the one thing it would disclose.
+    util.ok(f"Set '{args.key}' in vault '{args.vault}' "
+            f"({fingerprint.size_band(value)}). Value not shown.")
     return 0
 
 
@@ -507,8 +510,10 @@ def cmd_secret_get(args) -> int:
         return 1
 
     if not args.reveal:
-        digest = hashlib.sha256(value.encode()).hexdigest()[:12]
-        print(f"{args.vault}/{args.key}: present · {len(value)} bytes · sha256:{digest}")
+        # NOT a hash of the value. `sha256(value)[:12]` plus the exact byte count turned
+        # this line into an offline verification oracle for a guessed value — see
+        # `secrets/fingerprint.py` (#436).
+        print(f"{args.vault}/{args.key}: present · {fingerprint.masked(value)}")
         print("(value hidden — use `charter secret exec`/`cp` to consume it, or --reveal to print)")
         return 0
 

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -307,10 +307,22 @@ _READERS = frozenset("cat less more head tail bat nl tac xxd od strings grep rg 
 #: `.edm` is the pre-rename spelling, kept for the reason :data:`_CHARTER_PROGS` keeps the
 #: old binary name.
 #:
+#: `fingerprint.key` is here because reading it un-does `secret get`'s masking (#436).
+#: The masked line carries `HMAC(plane key, value)` rather than a hash of the value, so a
+#: guess cannot be checked against it — *unless the reader also holds the key*, at which
+#: point the offline wordlist check is back exactly as it was. That file is the whole
+#: strength of the fingerprint, so it belongs on the same side of this guard as the vaults
+#: themselves. It matters most for the providers that have no vault file at all: a
+#: 1Password-backed secret has nothing here to deny, and the key would have been the one
+#: readable thing standing between a fingerprint and the value it describes.
+#:
 #: Known limit, and the reason the tool gate does NOT reuse this as its only answer: this
 #: is a name, and a plane with `$CHARTER_HOME` set keeps its vaults somewhere this pattern
-#: cannot spell. `toolgate._resolves_into` asks the filesystem instead.
-_VAULT_PATH_RE = re.compile(r"\.(?:charter|edm)(?:/(?:vaults/|browser|active-)|/?$)")
+#: cannot spell. `toolgate._resolves_into` asks the filesystem instead — and `_control_roots`
+#: already derives the state directory from `config.STATE_DIR`, so the key file is inside
+#: the tool gate's surface on such a plane without being named there.
+_VAULT_PATH_RE = re.compile(
+    r"\.(?:charter|edm)(?:/(?:vaults/|browser|active-|fingerprint)|/?$)")
 
 
 #: `edm` is charter's pre-rename name. Kept because this is a security guard and the cost

--- a/charter/secrets/base.py
+++ b/charter/secrets/base.py
@@ -40,6 +40,147 @@ def vault_file_path(configured):
     return p if p.is_absolute() else (Path(_config.ROOT) / p)
 
 
+#: Every bit that lets an account other than the owner reach a directory. The guard is
+#: written as this mask rather than as a comparison against a list of bad modes (0755,
+#: 0750, 0775, …) on purpose: a literal set of bad values is a spelling, and the next mode
+#: nobody listed walks straight past it. ``mode & _OTHERS`` is the property.
+#:
+#: **What the mask still cannot see, said out loud rather than left to be discovered.**
+#: A POSIX mode is not the whole access-control story on either platform charter runs on.
+#: macOS extended ACLs (``chmod +a "user:bob allow read,list"``) and Linux POSIX.1e ACLs
+#: (``setfacl -m u:bob:rx``) grant another account full access while ``st_mode`` still
+#: reads 0700 — so a directory this function calls private can be readable by someone
+#: else, and `loose_dirs` will not report it. That is a real hole and it is not closed
+#: here: reading an ACL means `acl_get_file`, which is not in the standard library on
+#: either platform, and shelling out to `ls -le`/`getfacl` from a health check that
+#: `doctor` runs at every session start is a worse trade than the gap. SECURITY.md's
+#: framing applies unchanged — guard rails, not guarantees.
+_OTHERS = 0o077
+
+
+def make_private_dir(p) -> None:
+    """Create directory *p*, and **every level of it charter has to create**, at 0700.
+
+    ``Path.mkdir(parents=True, mode=0o700)`` does not do this, which is what the first
+    cut of #437 assumed. CPython's ``pathlib`` applies *mode* to the **leaf only** — the
+    missing parents are created by a bare recursive ``self.parent.mkdir(parents=True,
+    exist_ok=True)``, i.e. at ``0o777 & ~umask``. Measured on a plane where charter
+    created every level itself, for a vault configured at ``.charter/vaults/team/prod.json``::
+
+        .charter               0755
+        .charter/vaults        0755      <-- lists every vault name, machine-wide
+        .charter/vaults/team   0700
+
+    So the directory the fix was *about* — the one holding the vault names — came out
+    world-listable on the very path where charter, not the operator, chose the mode. The
+    leaf was 0700 and the claim was still false.
+
+    Each missing level is created individually and chmod-ed explicitly. The chmod is not
+    redundant with ``os.mkdir``'s *mode*: mkdir's argument is masked by the umask, so a
+    process running under ``umask 077`` is fine but one under a permissive-in-the-wrong-
+    direction umask is not guaranteed the bits it asked for. The chmod cannot open the
+    directory wider than 0700 — it names 0700 outright — so there is no window in which
+    the directory is looser than it ends up.
+
+    **A directory that already exists is left exactly as it is.** Not an oversight and not
+    laziness: a vault's ``file`` may name any path on this machine (see
+    :meth:`VaultProvider.file_path`), so "tighten whatever directory we land in" is how
+    charter would come to chmod ``~/`` or a shared team directory unprompted, with nobody
+    watching — the #331 defect with a fresh coat of paint. charter tightens what it
+    creates and **reports** what it did not; :meth:`PlainFileProvider.health` is where the
+    report comes out.
+    """
+    import os
+    from pathlib import Path
+
+    p = Path(p)
+    missing = []
+    cur = p
+    while not cur.exists():
+        missing.append(cur)
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    for d in reversed(missing):
+        try:
+            d.mkdir(mode=0o700)
+        except FileExistsError:
+            # Someone else created it between the walk and here. It is now a directory
+            # charter did NOT create, and the rule above applies to it: leave its mode.
+            continue
+        try:
+            os.chmod(d, 0o700)
+        except OSError:
+            pass
+
+
+def loose_dirs(leaf, stop) -> list:
+    """The directories from *leaf* up to and including *stop* that any account other than
+    the owner can reach, as a list of ``(path, mode)``, outermost last.
+
+    Answers the half of :func:`make_private_dir` that charter deliberately does not fix:
+    a ``.charter/vaults/`` that predates the fix keeps its 0755, because tightening a
+    directory charter did not create is the thing that must not happen unprompted. Naming
+    it on a health line is the honest alternative to either silently chmod-ing it or
+    claiming in a news entry that it cannot happen.
+
+    *stop* bounds the walk so this reports the plane's own directories and not ``/Users``
+    or ``/``, which are 0755 on every machine and are nobody's defect. A *leaf* that is
+    not underneath *stop* at all — a vault whose ``file`` points somewhere else entirely,
+    which is a supported configuration — yields just *leaf* itself: charter has an opinion
+    about the directory it puts a vault in, and none about that directory's ancestors on
+    someone else's filesystem layout.
+
+    The mask is ``mode & 0o077``, never a comparison against known-bad modes. 0755 is the
+    one everybody thinks of; 0705, 0711, 0730 and 0701 all list or traverse just as well
+    and appear on no such list.
+    """
+    import os
+    import stat as _stat
+    from pathlib import Path
+
+    leaf = Path(leaf)
+    try:
+        stop_rp = Path(stop).resolve()
+    except OSError:
+        stop_rp = None
+
+    chain, cur, seen = [], leaf, set()
+    while True:
+        chain.append(cur)
+        try:
+            rp = cur.resolve()
+        except OSError:
+            break
+        if rp == stop_rp or rp in seen or cur.parent == cur:
+            break
+        seen.add(rp)
+        cur = cur.parent
+    # Not underneath *stop*: the walk ran to the filesystem root without meeting it, so
+    # keep only the directory charter itself chose.
+    if stop_rp is None or not any(_same(c, stop_rp) for c in chain):
+        chain = chain[:1]
+
+    out = []
+    for d in chain:
+        try:
+            st = os.stat(d)
+        except OSError:
+            continue
+        if _stat.S_ISDIR(st.st_mode) and _stat.S_IMODE(st.st_mode) & _OTHERS:
+            out.append((d, _stat.S_IMODE(st.st_mode)))
+    return out
+
+
+def _same(p, resolved) -> bool:
+    from pathlib import Path
+
+    try:
+        return Path(p).resolve() == resolved
+    except OSError:
+        return False
+
+
 class VaultProvider(ABC):
     """One configured vault, backed by a concrete provider.
 

--- a/charter/secrets/fingerprint.py
+++ b/charter/secrets/fingerprint.py
@@ -54,6 +54,8 @@ import os
 import stat
 from pathlib import Path
 
+from .base import make_private_dir
+
 #: 256 bits, matching the HMAC's own block security. Read back and length-checked on
 #: every use, so a truncated file (a create interrupted midway) is regenerated rather
 #: than quietly used as a short key.
@@ -92,7 +94,7 @@ def _key() -> bytes | None:
         return existing
 
     try:
-        p.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        make_private_dir(p.parent)
         new = os.urandom(KEY_BYTES)
         # Same descriptor-first discipline as the vault writer (#437): the mode argument
         # to `os.open` is ignored for an inode that already exists, so a leftover

--- a/charter/secrets/fingerprint.py
+++ b/charter/secrets/fingerprint.py
@@ -1,0 +1,167 @@
+"""The masked shape of a secret: a keyed fingerprint and a size band.
+
+`charter secret get` without `--reveal` has to say *something* about the value, because
+the questions it exists to answer are real ones — "is this present", "is it the same value
+the other vault has", "did the whole token land or half of it". What it printed was::
+
+    audit2/WEAK: present · 11 bytes · sha256:323725e8eff4
+
+which answers a fourth question nobody meant to expose: **"is the value `Summer2024!`?"**
+An unsalted, un-keyed SHA-256 prefix is a function of the value and nothing else, so
+anyone holding that line — an agent transcript, a pasted terminal, a ticket, a log
+shipped off the machine — can run a wordlist against it offline, with no further access
+to charter. The byte count prefilters the list and the digest confirms the hit. Decisive
+against a human-chosen password; the digest is the whole attack, and 48 bits is plenty to
+confirm with (#436).
+
+Two changes, one per half of that line.
+
+**The digest is keyed.** ``hmac(plane_key, value)`` instead of ``sha256(value)``, where
+*plane_key* is 32 random bytes generated on first use and kept 0600 under ``.charter/``.
+The fingerprint stays stable and comparable *within one control plane*, which is all
+anyone ever compares — is this the same value as before, is it the same value that vault
+has — and stops being computable by anyone who does not hold the key. Comparability
+*across* planes is the loss, and it is the same property as the attack: a digest that
+means the same thing on every machine is an oracle on every machine.
+
+**The size is a band, not a count.** ``8–15 bytes`` instead of ``11 bytes``. A band still
+distinguishes "empty", "a password", "a token", "a PEM file" — the reason a human reads
+it — while giving a wordlist about one bit to filter on instead of ten.
+
+Neither of these makes `secret get` safe to paste. SECURITY.md's framing holds: guard
+rails, not guarantees. The claim here is narrow and testable — *the masked line is not a
+function of the value alone*, so it cannot be checked against a guess offline. Two things
+that claim does **not** cover, said out loud rather than left to be discovered:
+
+- **Whoever holds the key holds the oracle.** The offline check comes back intact for
+  anyone who can read ``.charter/fingerprint.key``. That is why `hooks._VAULT_PATH_RE`
+  denies it to the harness's file-reading tools alongside ``.charter/vaults/`` — it
+  matters most for a 1Password-backed vault, which has no vault file on this machine and
+  where the key would otherwise be the only readable thing between the line and the value.
+  A shell running as you still reads it, as it reads everything else you own.
+- **Within one plane it is still an equality oracle.** Someone who can run
+  `charter secret set` here can store a guess and compare fingerprints. They can also run
+  `charter secret get --reveal --force` and read the value outright, so this grants them
+  nothing they did not already have — but it is the reason the key is per-plane and not
+  per-vault. Per-vault salting would close it and would also break the one comparison the
+  fingerprint exists to serve: *do these two vaults hold the same value*.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+import stat
+from pathlib import Path
+
+#: 256 bits, matching the HMAC's own block security. Read back and length-checked on
+#: every use, so a truncated file (a create interrupted midway) is regenerated rather
+#: than quietly used as a short key.
+KEY_BYTES = 32
+
+KEY_FILE = "fingerprint.key"
+
+
+def key_path() -> Path:
+    """Where the plane's fingerprint key lives — resolved per call, never cached.
+
+    ``config.STATE_DIR`` is rebound by ``tests/_isolation.py`` (and by ``$CHARTER_HOME``),
+    so a module-level constant would pin the real ``.charter/`` into every test process.
+    """
+    from .. import config
+
+    return Path(config.STATE_DIR) / KEY_FILE
+
+
+def _key() -> bytes | None:
+    """The plane's fingerprint key, generating it on first use. ``None`` if it cannot be
+    read or created — a read-only ``.charter/``, a plane state directory that does not
+    exist and cannot be made.
+
+    ``None`` means callers print **no fingerprint at all**. It must never mean "fall back
+    to an unkeyed digest": a fallback that restores the property the key exists to remove
+    is the bug wearing the fix's clothes, and it would fire in exactly the constrained
+    environments nobody watches.
+    """
+    p = key_path()
+    try:
+        existing = p.read_bytes()
+    except OSError:
+        existing = b""
+    if len(existing) == KEY_BYTES:
+        return existing
+
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        new = os.urandom(KEY_BYTES)
+        # Same descriptor-first discipline as the vault writer (#437): the mode argument
+        # to `os.open` is ignored for an inode that already exists, so a leftover
+        # world-readable key file would keep its mode. fchmod the descriptor, read the
+        # mode back off it, and refuse to write key material into a file that is still
+        # readable by other accounts.
+        fd = os.open(str(p), os.O_WRONLY | os.O_CREAT, 0o600)
+        try:
+            try:
+                os.fchmod(fd, 0o600)
+            except OSError:
+                pass
+            if stat.S_IMODE(os.fstat(fd).st_mode) & 0o077:
+                return None
+            os.ftruncate(fd, 0)
+            os.write(fd, new)
+        finally:
+            os.close(fd)
+        return new
+    except OSError:
+        return None
+
+
+def fingerprint(value: str) -> str | None:
+    """A 12-hex-character keyed fingerprint of *value*, or ``None`` when this plane has
+    no key and none can be made.
+
+    Keyed, so it is not reproducible from *value* alone. Truncated to 48 bits because the
+    only comparison anyone makes with it is against another fingerprint printed by the
+    same plane, and a preimage search is off the table without the key regardless of
+    length.
+    """
+    k = _key()
+    if k is None:
+        return None
+    return hmac.new(k, value.encode("utf-8"), "sha256").hexdigest()[:12]
+
+
+def size_band(value: str) -> str:
+    """The size of *value* as a power-of-two band: ``empty``, ``1–15 bytes``,
+    ``16–31 bytes``, … ``1024+ bytes``.
+
+    Bands, not counts, because an exact length is the prefilter half of the offline
+    check — it cuts a wordlist by an order of magnitude before the digest is consulted at
+    all. A band leaves roughly one bit.
+
+    The first band deliberately starts at 1 rather than continuing the doubling downward:
+    a "1 byte"/"2–3 bytes" label would pin very short values almost exactly, and nothing a
+    reader does with this line needs that resolution. ``empty`` stays its own label
+    because a stored empty value is a real, actionable mistake (`secret set` refuses one
+    outright for the same reason) and blurring it into "short" would hide it.
+
+    Counted in **UTF-8 bytes**, which is what the word "bytes" claimed and `len()` on a
+    `str` did not: the old line called 3 characters of Cyrillic "3 bytes" when the file
+    held 6.
+    """
+    n = len(value.encode("utf-8"))
+    if n == 0:
+        return "empty"
+    if n < 16:
+        return "1–15 bytes"
+    if n >= 1024:
+        return "1024+ bytes"
+    lo = 1 << (n.bit_length() - 1)
+    return f"{lo}–{(lo << 1) - 1} bytes"
+
+
+def masked(value: str) -> str:
+    """The half-line describing *value* without disclosing it: size band, and the keyed
+    fingerprint when this plane has one."""
+    fp = fingerprint(value)
+    return f"{size_band(value)} · fp:{fp}" if fp else size_band(value)

--- a/charter/secrets/plain_file.py
+++ b/charter/secrets/plain_file.py
@@ -13,7 +13,7 @@ import os
 import stat
 from pathlib import Path
 
-from .base import SecretNotFound, VaultError, VaultProvider
+from .base import SecretNotFound, VaultError, VaultProvider, loose_dirs, make_private_dir
 
 
 def _short(p: Path) -> str:
@@ -82,7 +82,7 @@ class PlainFileProvider(VaultProvider):
         sentence above true — warning and writing anyway leaves the value world-readable
         with a warning scrolled off the top of somebody's log.
         """
-        p.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        make_private_dir(p.parent)
         fd = os.open(str(p), os.O_WRONLY | os.O_CREAT, 0o600)
         try:
             try:
@@ -221,4 +221,41 @@ class PlainFileProvider(VaultProvider):
             return False, str(e)
         mode = stat.S_IMODE(pp.stat().st_mode)
         perms = "" if mode == 0o600 else f", perms {oct(mode)[-3:]} (want 600)"
-        return True, f"{count} secret(s){perms}"
+        return True, f"{count} secret(s){perms}{self._loose_dir_note(pp)}"
+
+    @staticmethod
+    def _loose_dir_note(pp: Path) -> str:
+        """The other-readable directories holding this vault, named — never chmod-ed.
+
+        A directory charter creates is 0700 (:func:`base.make_private_dir`). One that was
+        already there when charter arrived keeps whatever mode it has, and the common case
+        is exactly the one that matters: a ``.charter/vaults/`` created before 0.51.x, or
+        by ``mkdir -p`` at the umask default, sits at 0755 and lists every vault name on
+        the plane to every account on the machine. `set` does not fix it, because a
+        vault's ``file`` can name any path on this machine and charter chmod-ing a
+        directory it did not create — a home directory, a shared team directory — is the
+        #331 defect over again.
+
+        So it is REPORTED. This is the same posture the file mode above already takes on
+        the read-only paths: `health`, `keys` and `ages` name a loose mode rather than
+        silently fixing it, because a health check that writes is the defect regardless of
+        what it writes.
+
+        Never raises: a health line that can throw is a `doctor` that cannot run. The
+        catch is `Exception`, not `BaseException`, deliberately — `tests/_planeguard.py`
+        signals a test reaching the real ``.charter/`` with a `BaseException` precisely so
+        that fallbacks like this one cannot turn it into a quiet empty string.
+        """
+        from .. import config
+
+        try:
+            loose = loose_dirs(pp.parent, config.STATE_DIR)
+        except Exception:
+            return ""
+        if not loose:
+            return ""
+        # Terse on purpose: this lands in a `charter vault list` table row, and the reason
+        # charter does not fix it itself is a paragraph, which belongs in `docs/secrets.md`
+        # and not in a column. The row carries what is wrong and what to type.
+        named = ", ".join(f"{_short(d)} {oct(m)[-3:]}" for d, m in loose)
+        return f", listed by other accounts: {named} (want 700 — chmod 700)"

--- a/charter/secrets/plain_file.py
+++ b/charter/secrets/plain_file.py
@@ -227,17 +227,26 @@ class PlainFileProvider(VaultProvider):
     def _loose_dir_note(pp: Path) -> str:
         """The other-readable directories holding this vault, named — never chmod-ed.
 
-        A directory charter creates is 0700 (:func:`base.make_private_dir`). One that was
-        already there when charter arrived keeps whatever mode it has, and the common case
-        is exactly the one that matters: a ``.charter/vaults/`` created before 0.51.x, or
-        by ``mkdir -p`` at the umask default, sits at 0755 and lists every vault name on
-        the plane to every account on the machine. `set` does not fix it, because a
-        vault's ``file`` can name any path on this machine and charter chmod-ing a
-        directory it did not create — a home directory, a shared team directory — is the
-        #331 defect over again.
+        A directory *this writer* creates is 0700 (:func:`base.make_private_dir`) — a
+        narrower statement than "a directory charter creates", and the narrowing is the
+        point: `.charter/` itself is normally made by the registry write inside `charter
+        vault add`, at the umask default, and so lands here as a directory to report
+        rather than one already fixed (#470).
 
-        So it is REPORTED. This is the same posture the file mode above already takes on
-        the read-only paths: `health`, `keys` and `ages` name a loose mode rather than
+        A directory that was already there when charter arrived keeps whatever mode it
+        has, and the common case is exactly the one that matters: a ``.charter/vaults/``
+        created before 0.51.x, or by ``mkdir -p`` at the umask default, sits at 0755 and
+        lists every vault name on the plane to every account on the machine. `set` does
+        not fix it, because a vault's ``file`` can name any path on this machine and
+        charter chmod-ing a directory it did not create — a home directory, a shared team
+        directory — is the #331 defect over again.
+
+        So it is REPORTED — on the string `health` returns, which `charter vault list`
+        prints as its STATUS column. `charter doctor` keeps only the boolean from
+        `health()` and drops this string, so the note does not reach it (#471).
+
+        This is the same posture the file mode above already takes on the read-only
+        paths: `health`, `keys` and `ages` name a loose mode rather than
         silently fixing it, because a health check that writes is the defect regardless of
         what it writes.
 

--- a/charter/secrets/plain_file.py
+++ b/charter/secrets/plain_file.py
@@ -53,15 +53,63 @@ class PlainFileProvider(VaultProvider):
             raise VaultError(f"vault file {p} must be a JSON object of key -> secret")
         return data
 
+    def _write_private(self, p: Path, payload: dict) -> None:
+        """Write *payload* as JSON into *p*, with *p* provably 0600 before a byte of it
+        lands — or write nothing at all.
+
+        `os.open(..., O_CREAT|O_TRUNC, 0o600)` does NOT do this, which is what the old
+        version of this method claimed (#437). The mode argument applies **only when the
+        call creates the inode**; for a file that already exists it is ignored entirely,
+        so a vault someone hand-authored at 0644 stayed 0644 for the whole of `json.dump`
+        and was chmod-ed to 0600 only afterwards. Measured: pre-existing 0644, mode while
+        the plaintext was on disk 0644, mode after `set` 0600, same inode throughout.
+
+        So the order is inverted, and the mode is settled on the **descriptor**, not the
+        path:
+
+        1. open ``O_WRONLY|O_CREAT`` *without* ``O_TRUNC`` — the file still holds only its
+           previous contents, which are no more exposed than they already were;
+        2. ``fchmod`` that descriptor to 0600 — the inode we hold, so nothing swapped at
+           the path in between is affected and nothing at the path can be affected instead;
+        3. ``fstat`` the same descriptor and **read the mode back**. A chmod that returned
+           successfully is not evidence the bits changed: a mount with fixed permissions
+           (exFAT, many SMB shares) accepts it and reports the old mode;
+        4. only then ``ftruncate`` and write.
+
+        If step 3 still shows a group- or other-accessible mode, this raises before the
+        truncate, so the previous contents survive and the plaintext never reaches a file
+        charter could not make private. Refusing is the only outcome that keeps the
+        sentence above true — warning and writing anyway leaves the value world-readable
+        with a warning scrolled off the top of somebody's log.
+        """
+        p.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        fd = os.open(str(p), os.O_WRONLY | os.O_CREAT, 0o600)
+        try:
+            try:
+                os.fchmod(fd, 0o600)
+            except OSError:
+                pass                      # report the mode we actually have, below
+            mode = stat.S_IMODE(os.fstat(fd).st_mode)
+            if mode & 0o077:
+                raise VaultError(
+                    f"refusing to write {_short(p)}: it is mode {oct(mode)[-3:]} and "
+                    f"charter could not make it 0600, so the plaintext would be readable "
+                    f"by other accounts on this machine. Nothing was written.\n"
+                    f"  Filesystems with fixed permissions (exFAT, many network mounts) "
+                    f"cannot hold a plain-file vault — point the vault at a path on a "
+                    f"filesystem that keeps modes, or use a provider that does not store "
+                    f"plaintext.")
+            os.ftruncate(fd, 0)
+            with os.fdopen(fd, "w") as f:
+                fd = -1                   # fdopen owns it now; closing twice is a bug
+                json.dump(payload, f, indent=2, ensure_ascii=False)
+                f.write("\n")
+        finally:
+            if fd >= 0:
+                os.close(fd)
+
     def _save(self, data: dict) -> None:
-        p = self.path
-        p.parent.mkdir(parents=True, exist_ok=True)
-        # Create with 0600 from the start so the plaintext is never briefly world-readable.
-        fd = os.open(str(p), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        with os.fdopen(fd, "w") as f:
-            json.dump(data, f, indent=2, ensure_ascii=False)
-            f.write("\n")
-        os.chmod(p, 0o600)
+        self._write_private(self.path, data)
 
     @staticmethod
     def _tighten(p: Path) -> None:
@@ -80,8 +128,11 @@ class PlainFileProvider(VaultProvider):
 
         Moving it here keeps the protection where the plaintext actually is: `get` takes
         secret values out of the file, and a vault charter has read the secrets of is one
-        charter has to leave at 0600. `set`/`delete` need no call — `_save` recreates the
-        file at 0600 with `O_CREAT` and chmods it again.
+        charter has to leave at 0600. `set`/`delete` need no call for a different reason
+        than the one this used to give: not because `O_CREAT` "recreates the file at 0600"
+        — it does not, the mode argument is ignored for an inode that already exists
+        (#437) — but because :meth:`_write_private` settles the mode on the descriptor and
+        reads it back before it writes anything.
 
         The read-only paths — `health`, `keys`, `ages` — now REPORT a loose mode instead
         of silently fixing it. `health()` already had that branch; `_tighten` running
@@ -138,13 +189,9 @@ class PlainFileProvider(VaultProvider):
             return {}
 
     def _save_meta(self, meta: dict) -> None:
-        p = self._meta_path
-        p.parent.mkdir(parents=True, exist_ok=True)
-        fd = os.open(str(p), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        with os.fdopen(fd, "w") as f:
-            json.dump(meta, f, indent=2)
-            f.write("\n")
-        os.chmod(p, 0o600)
+        # Same writer as the vault itself. The sidecar holds key NAMES and dates, not
+        # values, but it sits in the same directory and had the same in-place bug.
+        self._write_private(self._meta_path, meta)
 
     def ages(self) -> dict:
         """key -> age in days since last set (None if set before tracking existed)."""

--- a/charter/secrets/reference.py
+++ b/charter/secrets/reference.py
@@ -42,7 +42,7 @@ from pathlib import Path
 from urllib.parse import urlsplit
 
 from .. import util
-from .base import SecretNotFound, VaultError, VaultProvider
+from .base import SecretNotFound, VaultError, VaultProvider, make_private_dir
 
 
 def _op_argv(uri: str, config: dict) -> tuple[list[str], str]:
@@ -158,7 +158,7 @@ class ReferenceProvider(VaultProvider):
 
     def _save(self, data: dict) -> None:
         p = self.path
-        p.parent.mkdir(parents=True, exist_ok=True)
+        make_private_dir(p.parent)
         p.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
         os.chmod(p, 0o600)
 

--- a/charter/secrets/registry.py
+++ b/charter/secrets/registry.py
@@ -171,12 +171,34 @@ def shared_files_outside_plane() -> list[str]:
 
 
 def _write(path, doc: dict, mode: int) -> None:
+    """Write *doc* to *path* at *mode*, with the mode in force before the content is.
+
+    The mode argument to `os.open` is ignored for an inode that already exists, so this
+    used to write the local registry into whatever mode the file already had and chmod it
+    afterwards — the same mistake `PlainFileProvider._write_private` documents at length
+    (#437). Settled on the descriptor, before the truncate, for the same reasons.
+
+    Unlike the vault writer this does not refuse a mode it could not set: *mode* is 0644
+    for the SHARED half, which is committed and meant to be world-readable, so "still has
+    group bits" is not an error condition here. This file carries provider config, paths
+    and environment variable NAMES — never a value — which is what makes the weaker
+    posture the right one rather than an oversight.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
-    with os.fdopen(fd, "w") as f:
-        json.dump(doc, f, indent=2, ensure_ascii=False)
-        f.write("\n")
-    os.chmod(path, mode)
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT, mode)
+    try:
+        try:
+            os.fchmod(fd, mode)
+        except OSError:
+            pass
+        os.ftruncate(fd, 0)
+        with os.fdopen(fd, "w") as f:
+            fd = -1
+            json.dump(doc, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+    finally:
+        if fd >= 0:
+            os.close(fd)
 
 
 def save_registry(doc: dict) -> None:

--- a/docs/news/unreleased-a-fingerprint-you-cannot-check-a-guess-against.md
+++ b/docs/news/unreleased-a-fingerprint-you-cannot-check-a-guess-against.md
@@ -1,0 +1,54 @@
+---
+version: unreleased
+headline: Masked `secret get` stops being an offline check against a guessed value
+---
+
+`charter secret get` without `--reveal` printed this:
+
+```
+audit2/WEAK: present · 11 bytes · sha256:323725e8eff4
+```
+
+Both halves of that are functions of the value and nothing else. The byte count filters a
+wordlist down to the eleven-character entries; the digest confirms which one it is. Nobody
+needs charter, the machine, or the vault to do it — the line is enough, wherever it ended
+up. And this line goes places the value never does: an agent's transcript, a pasted
+terminal in a chat, a screenshot in a ticket. It was documented as a *reassurance* — "a
+byte count and a SHA-256 fingerprint, never the value" — and it was one, right up until
+somebody who had the line also had a wordlist.
+
+It now prints:
+
+```
+audit2/WEAK: present · 1–15 bytes · fp:9c41a0b7e5d2
+```
+
+**The fingerprint is keyed, not hashed.** `HMAC-SHA256(plane key, value)`, where the plane
+key is 32 random bytes generated the first time a plane needs one and kept 0600 under
+`.charter/`. It stays stable and comparable inside one control plane, which is the only
+comparison anyone actually makes with it — *is this still the value I set*, *does that
+other vault hold the same one* — and it is not computable by anyone who does not hold the
+key. The same value fingerprints differently on a different machine, and that is the
+point: a digest that means the same thing everywhere is an oracle everywhere.
+
+**The size is a band.** `1–15 bytes`, `32–63 bytes`, `1024+ bytes`. Enough to tell an
+empty value from a password from a PEM file, which is what a reader wants it for. Not
+enough to prefilter a wordlist. `charter secret set` reports the same band for the same
+reason — with `--from-file` that line lands in the transcript of an agent that has never
+seen the value, and the length was the one thing it disclosed.
+
+If `.charter/` cannot hold a key — read-only, or no state directory and none can be made —
+the fingerprint is left off the line entirely. It is never replaced by an unkeyed one; a
+fallback that quietly restores the property the key exists to remove would fire in exactly
+the locked-down environments nobody is watching.
+
+Keying it moves the secret rather than removing it, so `.charter/fingerprint.key` is now
+denied to file-reading tools on the same terms as `.charter/vaults/`. That matters most
+where there is no vault file at all: a 1Password-backed secret keeps nothing on this
+machine, and the key would have been the only readable thing standing between the printed
+line and the value it describes. A shell running as you still reads it, as it reads
+everything else you own — `SECURITY.md` has not changed its mind about what these guards
+are. And inside one plane the fingerprint is still an equality oracle: anyone who can
+`charter secret set` a guess can compare. They can also `--reveal --force` and read the
+value outright, so it is not a step up for them; it is the reason the key is per-plane and
+not per-vault, which is what keeps the two-vaults comparison answerable at all.

--- a/docs/news/unreleased-a-vault-charter-cannot-make-private.md
+++ b/docs/news/unreleased-a-vault-charter-cannot-make-private.md
@@ -1,0 +1,40 @@
+---
+version: unreleased
+headline: A plain-file vault is 0600 before the plaintext goes in, not after
+---
+
+`charter secret set` on a plain-file vault opened it `O_CREAT|O_TRUNC, 0o600` and chmod-ed
+it to 0600 once the write returned. The comment above that line said the plaintext "is
+never briefly world-readable", and it was wrong about its own mechanism: the mode argument
+to `open(2)` applies **only when the call creates the inode**. For a vault someone had
+hand-authored — or restored from a backup, or copied off another machine, all of which
+land at the umask default — it was ignored outright. Measured on a 0644 vault: mode while
+the plaintext was on disk, 0644. Mode afterwards, 0600. Same inode throughout.
+
+The window is milliseconds and it takes an already-loose file to open it, so this is a
+small bug. The confident sentence explaining why it could not happen is the larger one.
+
+The order is now inverted, and the mode is settled on the **descriptor** rather than the
+path. charter opens the file without truncating it, `fchmod`s that descriptor, `fstat`s
+the same descriptor to read the mode back, and only then truncates and writes. Reading it
+back matters: a chmod that returns successfully is not evidence the bits moved — a mount
+with fixed permissions, exFAT or many network shares, accepts the call and reports the old
+mode. Working on the descriptor rather than the name matters for the usual reason: it is
+the object being written, not whatever the path happens to point at by the time the write
+lands.
+
+**If the file still cannot be made private, charter writes nothing and says so.** The
+previous contents survive, and the error names the file and why. The alternative — warn
+and write anyway — leaves the credential world-readable with the warning scrolled off the
+top of somebody's log, which is how this class of thing survives in the first place. A
+plain-file vault on a filesystem that cannot hold a mode was never storing a private file;
+now it says so instead of pretending.
+
+A vault directory charter creates for itself is 0700 rather than the umask default, so
+`.charter/vaults/` no longer lists every vault name you have to every account on the
+machine. The rotation sidecar goes through the same writer.
+
+None of this is about the plaintext. A plain-file vault stores values in the clear, that
+is documented in four places, and it remains the accepted trade-off for the provider whose
+entire job is "a JSON file you can also edit by hand". The fix is to the mode, and to the
+docstring that was sure the mode was already fine.

--- a/docs/news/unreleased-a-vault-charter-cannot-make-private.md
+++ b/docs/news/unreleased-a-vault-charter-cannot-make-private.md
@@ -30,14 +30,26 @@ top of somebody's log, which is how this class of thing survives in the first pl
 plain-file vault on a filesystem that cannot hold a mode was never storing a private file;
 now it says so instead of pretending.
 
-**Every directory charter creates** on the way to a vault file is 0700 rather than the
-umask default — not just the last one. The first cut of this said `mkdir(parents=True,
-mode=0o700)` and that is the same bug one level up: `pathlib` applies `mode` to the
-**leaf only**, and creates the missing parents at `0o777 & ~umask`. Measured on a plane
-where charter created every level itself, for a vault at `.charter/vaults/team/prod.json`:
-`.charter` 0755, `.charter/vaults` 0755, `.charter/vaults/team` 0700. The leaf was
-private and the directory the fix was *about* — the one holding the vault names — was
-world-listable. Each level is now created and chmod-ed individually.
+**Every directory the vault writers create** on the way to a vault file is 0700 rather
+than the umask default — not just the last one. The first cut of this said
+`mkdir(parents=True, mode=0o700)` and that is the same bug one level up: `pathlib` applies
+`mode` to the **leaf only**, and creates the missing parents at `0o777 & ~umask`. Measured
+on a plane where charter created every level itself, for a vault at
+`.charter/vaults/team/prod.json`: `.charter` 0755, `.charter/vaults` 0755,
+`.charter/vaults/team` 0700. The leaf was private and the directory the fix was *about* —
+the one holding the vault names — was world-listable. Each level is now created and
+chmod-ed individually.
+
+**Known remaining case: `.charter/` itself, when something else creates it first.** The
+0700 walk lives in the secrets writers, and on the default flow they are not what creates
+the state directory — `charter vault add` writes the local registry first, and that write
+makes `.charter/` with no mode of its own. So under `umask 022` the state directory is
+0755 and under `umask 077` it is 0700: the umask decides that one level, and the fix above
+decides every level below it. `.charter/vaults/`, the directory that lists vault names, is
+0700 either way, and `charter vault list` names the loose `.charter` on the health line
+like any other. Filed as [#470](https://github.com/diazoxide/charter/issues/470) rather
+than fixed here, because moving state-directory creation onto this walk touches the
+registry, persona and workspace writers and none of those are this entry's subject.
 
 **A directory that was already there keeps its mode, and charter says so instead of
 fixing it.** A `.charter/vaults/` that predates this, or one made by `mkdir -p` at the
@@ -45,8 +57,15 @@ umask default, is 0755 before `secret set` and 0755 after. That is deliberate: a
 `file` can name any path on the machine, so "tighten whatever directory we land in" is how
 charter would come to chmod a home directory or a shared team directory unprompted, with
 nobody watching — the defect #331 was filed about. What charter does instead is name it,
-on the vault's health line and so in `doctor` and `charter vault list`: `listed by other
-accounts: .charter/vaults 755 (want 700)`. The remedy is one `chmod 700`, run by you.
+on the vault's health line — which is the `STATUS` column of `charter vault list`:
+`listed by other accounts: .charter/vaults 755 (want 700)`. The remedy is one `chmod 700`,
+run by you.
+
+That line reaches `charter vault list` and nothing else. `charter doctor` asks each vault
+whether it is *reachable* and drops the rest of the health detail, so a loose directory
+appears in neither `doctor` nor `doctor --json`. Getting it onto doctor's green line is
+[#471](https://github.com/diazoxide/charter/issues/471); this entry no longer claims it is
+already there.
 
 The rotation sidecar goes through the same writer.
 

--- a/docs/news/unreleased-a-vault-charter-cannot-make-private.md
+++ b/docs/news/unreleased-a-vault-charter-cannot-make-private.md
@@ -30,9 +30,25 @@ top of somebody's log, which is how this class of thing survives in the first pl
 plain-file vault on a filesystem that cannot hold a mode was never storing a private file;
 now it says so instead of pretending.
 
-A vault directory charter creates for itself is 0700 rather than the umask default, so
-`.charter/vaults/` no longer lists every vault name you have to every account on the
-machine. The rotation sidecar goes through the same writer.
+**Every directory charter creates** on the way to a vault file is 0700 rather than the
+umask default — not just the last one. The first cut of this said `mkdir(parents=True,
+mode=0o700)` and that is the same bug one level up: `pathlib` applies `mode` to the
+**leaf only**, and creates the missing parents at `0o777 & ~umask`. Measured on a plane
+where charter created every level itself, for a vault at `.charter/vaults/team/prod.json`:
+`.charter` 0755, `.charter/vaults` 0755, `.charter/vaults/team` 0700. The leaf was
+private and the directory the fix was *about* — the one holding the vault names — was
+world-listable. Each level is now created and chmod-ed individually.
+
+**A directory that was already there keeps its mode, and charter says so instead of
+fixing it.** A `.charter/vaults/` that predates this, or one made by `mkdir -p` at the
+umask default, is 0755 before `secret set` and 0755 after. That is deliberate: a vault's
+`file` can name any path on the machine, so "tighten whatever directory we land in" is how
+charter would come to chmod a home directory or a shared team directory unprompted, with
+nobody watching — the defect #331 was filed about. What charter does instead is name it,
+on the vault's health line and so in `doctor` and `charter vault list`: `listed by other
+accounts: .charter/vaults 755 (want 700)`. The remedy is one `chmod 700`, run by you.
+
+The rotation sidecar goes through the same writer.
 
 None of this is about the plaintext. A plain-file vault stores values in the clear, that
 is documented in four places, and it remains the accepted trade-off for the provider whose

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -15,6 +15,21 @@ you, can read the file directly. `charter` does not pretend otherwise: the vault
 registry and every vault file live under `.charter/` (gitignored — never committed, never
 synced anywhere by `charter` itself).
 
+Every directory charter **creates** on the way to a vault file is 0700, each level of it,
+so the directory listing your vault *names* is not readable by other accounts either. A
+directory that **already existed** keeps the mode it has — a `.charter/vaults/` made by
+hand or by an older charter is 0755 before `secret set` and 0755 after. charter will not
+chmod a directory it did not create (a vault's `--file` can name any path on this machine,
+and silently tightening someone's home or a shared team directory is worse than the thing
+it fixes), so it reports it instead — on the vault's health line, and therefore in
+`charter doctor` and `charter vault list`:
+
+```
+devops: 3 secret(s), listed by other accounts: .charter/vaults 755 (want 700 — chmod 700)
+```
+
+One `chmod 700 .charter/vaults` clears it.
+
 If you want encryption at rest, use your **OS keychain** (macOS Keychain, a real
 password manager, or a proper secrets backend) to hold the credential, and treat
 `charter`'s vault as a *thin, disposable staging area* your agent reads from — or wait

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -15,20 +15,35 @@ you, can read the file directly. `charter` does not pretend otherwise: the vault
 registry and every vault file live under `.charter/` (gitignored — never committed, never
 synced anywhere by `charter` itself).
 
-Every directory charter **creates** on the way to a vault file is 0700, each level of it,
-so the directory listing your vault *names* is not readable by other accounts either. A
-directory that **already existed** keeps the mode it has — a `.charter/vaults/` made by
-hand or by an older charter is 0755 before `secret set` and 0755 after. charter will not
-chmod a directory it did not create (a vault's `--file` can name any path on this machine,
-and silently tightening someone's home or a shared team directory is worse than the thing
-it fixes), so it reports it instead — on the vault's health line, and therefore in
-`charter doctor` and `charter vault list`:
+Every directory **the vault writers create** on the way to a vault file is 0700, each
+level of it and not just the last, so the directory listing your vault *names* is not
+readable by other accounts either. A directory that **already existed** keeps the mode it
+has — a `.charter/vaults/` made by hand or by an older charter is 0755 before `secret set`
+and 0755 after. charter will not chmod a directory it did not create (a vault's `--file`
+can name any path on this machine, and silently tightening someone's home or a shared team
+directory is worse than the thing it fixes), so it reports it instead, on the vault's
+health line — which is the `STATUS` column of `charter vault list`:
 
 ```
 devops: 3 secret(s), listed by other accounts: .charter/vaults 755 (want 700 — chmod 700)
 ```
 
 One `chmod 700 .charter/vaults` clears it.
+
+**Two limits on that sentence, both measured rather than assumed.**
+
+`.charter/` itself is usually *not* one of the directories the vault writers create. On
+the default flow, `charter vault add` writes the local registry before any vault file
+exists, and that write creates `.charter/` with no mode of its own — so under `umask 022`
+the state directory comes out 0755 and stays there, and under `umask 077` it comes out
+0700. The umask decides that one level; charter decides every level below it. The report
+above still names it (`listed by other accounts: .charter 755`) and one `chmod 700
+.charter` clears it — but the paragraph above is a claim about the vault writers, and the
+state directory is not theirs to create — [#470](https://github.com/diazoxide/charter/issues/470).
+
+And the report reaches `charter vault list` only. `charter doctor` asks each vault
+whether it is *reachable* and discards the rest of the health line, so a loose directory
+shows up in neither `doctor` nor `doctor --json` — [#471](https://github.com/diazoxide/charter/issues/471).
 
 If you want encryption at rest, use your **OS keychain** (macOS Keychain, a real
 password manager, or a proper secrets backend) to hold the credential, and treat

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -50,8 +50,37 @@ shell history**, while still letting an agent *use* the credential:
   `/dev/fd/1` are all the same one object and get the same answer. `--force` does not
   reach that check. An **existing** file is refused too — overwriting one destroys its
   contents and sets it to 0600, so it takes `--force` and says so afterwards.
-- **`charter secret get`** is masked by default — it prints a byte count and a SHA-256
-  fingerprint, never the value.
+- **`charter secret get`** is masked by default — it prints a size band and a keyed
+  fingerprint, never the value:
+
+  ```
+  devops/API_TOKEN: present · 32–63 bytes · fp:9c41a0b7e5d2
+  ```
+
+  The fingerprint is `HMAC-SHA256(plane key, value)`, not a hash of the value, and the
+  plane key is 32 random bytes generated on first use and kept 0600 in `.charter/`. That
+  matters because this line travels: into an agent's transcript, a pasted terminal, a
+  ticket. An unkeyed digest plus an exact byte count — what charter printed before
+  0.51.x — is checkable **offline**, so a wordlist run against that line confirms a
+  guessed password with no further access to charter at all. Keyed, it is only comparable
+  to another fingerprint printed by this same plane, which is the only comparison anyone
+  actually makes: *is this still the value I set*, *does that vault hold the same one*.
+  The same value fingerprints differently on a different machine, deliberately. The size
+  is banded for the same reason — an exact length prefilters a wordlist; `32–63 bytes`
+  barely does.
+
+  If `.charter/` is read-only and no key can be made, the fingerprint is **omitted** —
+  never replaced by an unkeyed one.
+
+  The key is the whole strength of this, so `.charter/fingerprint.key` is denied to
+  file-reading tools on the same terms as `.charter/vaults/` — which matters most for a
+  1Password-backed vault, where there is no vault file on the machine and the key would
+  be the only readable thing between the printed line and the value. A shell running as
+  you reads it, as it reads everything else you own; this is a guard rail, not a
+  guarantee. And within one plane the fingerprint remains an equality oracle: anyone who
+  can `charter secret set` a guess can compare. They can also `--reveal --force`, so it
+  is not a step up for them — it is the reason the key is per-plane rather than
+  per-vault, which is what keeps "do these two vaults hold the same value" answerable.
 - **`charter secret get --reveal`** is the one path that *can* print plaintext, and it
   deliberately refuses to do so to a **non-interactive stdout** (the exact channel
   through which a value would leak straight into an agent's context) unless you pass

--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -71,10 +71,21 @@ so a command that echoes it still cannot leak it into the transcript.
 charter secret get <vault> <key>       # masked: size band + keyed fingerprint
 ```
 
-The fingerprint is keyed to this control plane, not a hash of the value, so it cannot be
-checked against a guess — and the size is a band, not a count. Compare two of them to ask
-"same value?"; there is nothing else to do with one, and nothing to be gained by
-recomputing it.
+The fingerprint is `HMAC(plane key, value)`, not a hash of the value, and the size is a
+band, not a count. So the line is safe to *carry* — pasted into a ticket, left in a
+transcript, shipped in a log, it cannot be checked against a guess by anyone who does not
+hold this plane's key. Compare two of them to ask "same value?"; that is the only thing
+one is for.
+
+**Inside this plane it is still an equality oracle, and that is not closed.** Anyone who
+can run `charter secret set` here can store a guess in a vault of their own and compare
+its masked line to a target vault's — which confirms the guess. No guard denies that; it
+is a deliberate trade, because per-vault salting would close it and would also break the
+one comparison the fingerprint exists to serve. So: **never store a candidate value in
+order to compare fingerprints with another vault.** Confirming someone's password is
+exactly the outcome the masking exists to prevent, and doing it from inside the plane is
+the one route still open. If you need to know whether two vaults agree, compare the two
+vaults' own lines — never a line from a value you supplied.
 
 ## Hard rules
 
@@ -82,6 +93,9 @@ recomputing it.
   Forcing it puts the value in context, which is the one outcome the vault exists to
   prevent. Use `exec` or `cp`.
 - Never echo a secret, write it into a tracked file, or pass it as a literal argument.
+- **Never store a value in order to compare its fingerprint against another vault's.**
+  That confirms a guess, which is the one thing masking exists to stop, and it is the
+  route the keyed fingerprint does *not* close.
 - Never put a secret in memory, a persona charter, a workspace charter, or a commit
   message. The vault is the only place for one.
 - If the vault or key does not exist, say so and ask for it to be added — do not work

--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -68,8 +68,13 @@ so a command that echoes it still cannot leak it into the transcript.
 **Just checking one is present:**
 
 ```bash
-charter secret get <vault> <key>       # masked: length + sha256 prefix
+charter secret get <vault> <key>       # masked: size band + keyed fingerprint
 ```
+
+The fingerprint is keyed to this control plane, not a hash of the value, so it cannot be
+checked against a guess — and the size is a band, not a count. Compare two of them to ask
+"same value?"; there is nothing else to do with one, and nothing to be gained by
+recomputing it.
 
 ## Hard rules
 

--- a/tests/test_docs_claims_carry_their_residual.py
+++ b/tests/test_docs_claims_carry_their_residual.py
@@ -1,0 +1,155 @@
+"""Documents that assert the masked line is uncheckable must also carry what it misses.
+
+`charter secret get`'s masked line is `HMAC(plane key, value)` plus a size band, so it is
+not a function of the value alone and **cannot be checked against a guess offline**. True,
+tested in `test_secret_get_masked.py`, and it is the whole of #436's fix.
+
+It leaves a residual, and the residual is not hypothetical — it was executed on this
+branch. Someone who can run `charter secret set` here stores a guess in a vault of their
+own and compares its masked line to a target vault's; equal lines confirm the guess. No
+guard denies either half. `fingerprint.py` and `docs/secrets.md` said so; the version of
+`skills/secrets/SKILL.md` that shipped in round one did not, and told the model instead
+that the fingerprint "cannot be checked against a guess" with no qualifier at all and
+that there is "nothing to be gained by recomputing it".
+
+**That file is the one document here the model acts on rather than merely reads**, which
+is why its omission is the blocking one: a false assurance in a skill is not a doc bug, it
+is an instruction to stop being careful about the exact operation that still works.
+
+Round one also shipped a news entry claiming `.charter/vaults/` "no longer lists every
+vault name you have to every account on the machine", which was false for every plane that
+already existed — a pre-existing 0755 directory is 0755 after `secret set` — and false
+even for a fresh one, because `mkdir(parents=True, mode=0o700)` sets the leaf only.
+`test_vault_dir_mode.py` fixed the second half in code; the first half is a residual
+charter deliberately does not fix, so the entry has to say so.
+
+**What this test is, honestly.** It is a spelling check, and spelling checks are what this
+codebase keeps getting bypassed on. It cannot tell a real qualifier from a sentence that
+merely contains the right words, and someone determined to reintroduce an overclaim can
+write around it. What it does catch is the way the defect actually arrived both times:
+somebody edits the confident half of a paragraph and drops the qualifying half, or writes
+a fresh assurance and never adds one. The *behavioural* claims are pinned by
+`test_secret_get_masked.py` and `test_vault_dir_mode.py`, and one of them — the in-plane
+oracle itself — is executed below, so the sentence and the behaviour cannot drift apart
+without something here going red.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from charter import config
+from charter.secrets.fingerprint import masked
+from charter.secrets.plain_file import PlainFileProvider
+
+from tests._isolation import PersonaIso
+
+DOCS = Path(__file__).resolve().parent.parent
+
+#: Where the "not checkable against a guess" assurance is made. Each must carry the
+#: residual alongside it.
+CLAIM_DOCS = (
+    "skills/secrets/SKILL.md",
+    "docs/secrets.md",
+    "charter/secrets/fingerprint.py",
+    "docs/news/unreleased-a-fingerprint-you-cannot-check-a-guess-against.md",
+)
+
+#: The claim: some form of "this line cannot be checked against a guessed value".
+_CLAIM = re.compile(r"against a guess|checkable|not computable|not reproducible", re.I)
+
+#: The residual: some form of "inside this plane, `secret set` a guess and compare".
+_RESIDUAL = re.compile(r"equality oracle|set` a guess|store a guess|guess (?:in a vault|"
+                       r"and compare)|compare fingerprints", re.I)
+
+
+def flat(rel: str) -> str:
+    """A document with its line wrapping collapsed.
+
+    Every pattern here spans a sentence, and a sentence in these files spans a line break
+    wherever the wrap happens to fall. Matching the raw text would make this test fail on
+    a reflow and — much worse — pass on a document whose qualifier was deleted and whose
+    remaining text simply rewrapped past the pattern.
+    """
+    return re.sub(r"\s+", " ", (DOCS / rel).read_text())
+
+
+class EveryAssuranceCarriesItsResidual(unittest.TestCase):
+
+    def test_the_fingerprint_claim_never_stands_alone(self) -> None:
+        for rel in CLAIM_DOCS:
+            with self.subTest(doc=rel):
+                text = flat(rel)
+                self.assertTrue(
+                    _CLAIM.search(text),
+                    f"{rel} no longer makes the claim this test exists to qualify — if "
+                    f"the wording moved, move this test with it rather than deleting it")
+                self.assertTrue(
+                    _RESIDUAL.search(text),
+                    f"{rel} tells the reader the masked line cannot be checked against a "
+                    f"guess and never says that inside one plane it still can. That is "
+                    f"the #436 attack, intact, and it was demonstrated on this branch.")
+
+    def test_the_skill_says_what_to_do_about_it(self) -> None:
+        """A residual stated to the model is not enough; the model needs the instruction.
+
+        `docs/secrets.md` can describe a limit and leave the reader to judge. A skill is
+        loaded *as behaviour*, so the sentence that matters there is the imperative, not
+        the description.
+        """
+        text = flat("skills/secrets/SKILL.md")
+        self.assertRegex(
+            text, r"never store a (?:candidate |guess )?value in\s+order to compare",
+            "SKILL.md describes the in-plane oracle but never tells the model not to use "
+            "it — the one document here that is acted on rather than believed")
+
+    def test_the_directory_claim_is_scoped_to_what_charter_creates(self) -> None:
+        text = flat("docs/news/unreleased-a-vault-charter-cannot-make-private.md")
+        self.assertNotRegex(
+            text, r"`\.charter/vaults/` no longer lists every vault name",
+            "the unscoped claim is false for every plane that already exists")
+        self.assertRegex(
+            text, r"[Aa] directory that was already there keeps its mode",
+            "the entry must say what happens to a directory charter did not create")
+        self.assertIn(
+            "listed by other accounts", text,
+            "and must name the report that replaces the fix it cannot make")
+
+
+class TheResidualIsRealAndStillOpen(PersonaIso):
+    """The oracle the documents now admit to, executed.
+
+    This is the test that stops the paragraphs above from being a matter of opinion. If
+    somebody closes the in-plane oracle later — per-vault salting, a guard on `secret
+    set` — this goes RED and the documents saying "still open" become the thing to fix.
+    A doc test alone could never notice that, and a stale *reassurance* is the failure
+    mode this whole file is about, in the other direction.
+    """
+
+    def test_a_fabricated_guess_is_confirmed_by_comparing_masked_lines(self) -> None:
+        vd = Path(config.VAULTS_DIR)
+        # Not a real credential anywhere: a fabricated string, and the assertions below
+        # compare fingerprints rather than reporting either value.
+        secret = "fabricated-value-not-a-credential"
+        PlainFileProvider("victim", {"file": str(vd / "victim.json")}).set("P", secret)
+
+        attacker = PlainFileProvider("scratch", {"file": str(vd / "scratch.json")})
+        target = masked(secret)
+
+        attacker.set("G", "a-wrong-guess")
+        self.assertNotEqual(masked(attacker.get("G")), target,
+                            "a wrong guess must not match, or the oracle is a constant "
+                            "and this test proves nothing")
+
+        attacker.set("G", secret)
+        self.assertEqual(
+            masked(attacker.get("G")), target,
+            "the in-plane equality oracle is what SKILL.md, docs/secrets.md and "
+            "fingerprint.py now tell the reader is still open. It just closed — which is "
+            "good news and makes those three documents wrong; update them.")
+
+
+if __name__ == "__main__":       # pragma: no cover
+    unittest.main()

--- a/tests/test_docs_claims_carry_their_residual.py
+++ b/tests/test_docs_claims_carry_their_residual.py
@@ -57,6 +57,14 @@ CLAIM_DOCS = (
     "docs/news/unreleased-a-fingerprint-you-cannot-check-a-guess-against.md",
 )
 
+#: Where the directory-mode claims are made — "every level is 0700" and "and charter
+#: reports the ones it did not create". Both overreached in round two: the first swallowed
+#: `.charter/` itself (#470), the second put the report in `doctor` (#471).
+DIR_CLAIM_DOCS = (
+    "docs/secrets.md",
+    "docs/news/unreleased-a-vault-charter-cannot-make-private.md",
+)
+
 #: The claim: some form of "this line cannot be checked against a guessed value".
 _CLAIM = re.compile(r"against a guess|checkable|not computable|not reproducible", re.I)
 
@@ -116,6 +124,62 @@ class EveryAssuranceCarriesItsResidual(unittest.TestCase):
         self.assertIn(
             "listed by other accounts", text,
             "and must name the report that replaces the fix it cannot make")
+
+    def test_the_directory_claim_does_not_swallow_the_state_directory(self) -> None:
+        """"Every directory charter creates" is false one level up, and was shipped anyway.
+
+        `make_private_dir` is reached from the three secrets writers and from nowhere
+        else. On the default flow `charter vault add` writes the local registry first,
+        which creates `.charter/` through a bare `mkdir(parents=True, exist_ok=True)`, so
+        the state directory is the umask's to decide and not charter's (#470). Both
+        documents said "every directory charter creates", and `.charter` is one of the
+        three levels the news entry's own before-measurement lists as broken.
+
+        The behaviour is pinned in `test_vault_dir_mode.TheOrderTheCliActuallyUses`, which
+        drives `registry.add_vault` and measures the result under two umasks. This case
+        only stops the sentence from drifting back off it.
+        """
+        for rel in DIR_CLAIM_DOCS:
+            with self.subTest(doc=rel):
+                text = flat(rel)
+                # `assertNotRegex` renders the whole flattened document into the failure
+                # message, which buries the sentence at fault under twelve screens of the
+                # ones that are fine. These files are long enough that the search has to
+                # be run by hand and only the match reported.
+                hit = re.search(r"[Ee]very directory charter \*{0,2}creates", text)
+                self.assertIsNone(
+                    hit,
+                    f"{rel} says {hit.group(0)!r}: every directory charter creates on the "
+                    f"way to a vault file is 0700. `.charter/` is not one of them on the "
+                    f"default flow — scope the sentence to the vault writers (#470)"
+                    if hit else "")
+                self.assertIsNotNone(
+                    re.search(r"issues/470", text),
+                    f"{rel} must name the level the walk does not cover, and where it is "
+                    f"tracked, rather than leaving the reader to measure it")
+
+    def test_no_document_claims_the_loose_directory_note_reaches_doctor(self) -> None:
+        """`check_vaults` does ``healthy, _ = prov.health()``. The detail is dropped.
+
+        `_loose_dir_note` also never sets ``healthy`` False — on purpose, since the check
+        runs from the SessionStart hook — so there is no path at all by which the note
+        reaches `doctor` or `doctor --json`, and two documents said there was (#471).
+        Pinned behaviourally by `test_vault_dir_mode.TheOrderTheCliActuallyUses.
+        test_doctor_is_not_where_it_appears`.
+        """
+        for rel in DIR_CLAIM_DOCS:
+            with self.subTest(doc=rel):
+                text = flat(rel)
+                hit = re.search(r"and (?:so |therefore )?in `?(?:charter )?doctor`?", text)
+                self.assertIsNone(
+                    hit,
+                    f"{rel} says {hit.group(0)!r} — the loose-directory note does not "
+                    f"appear in `doctor`: `check_vaults` keeps only the healthy flag "
+                    f"and drops the detail (#471)" if hit else "")
+                self.assertIsNotNone(
+                    re.search(r"issues/471", text),
+                    f"{rel} must say where the note actually appears and where the gap "
+                    f"is tracked")
 
 
 class TheResidualIsRealAndStillOpen(PersonaIso):

--- a/tests/test_plain_file.py
+++ b/tests/test_plain_file.py
@@ -1,0 +1,285 @@
+"""A plain-file vault is never group- or other-readable while it holds new plaintext (#437).
+
+`_save` used to open the vault `O_WRONLY|O_CREAT|O_TRUNC, 0o600` and chmod it afterwards,
+with a docstring claiming the plaintext "is never briefly world-readable". The mode
+argument to `open(2)` applies **only when the call creates the inode**. For a vault
+someone had hand-authored at 0644 it was ignored outright, so the whole of `json.dump`
+ran against a world-readable file and the chmod landed after the value was already on
+disk. Measured before the fix: pre-existing 0644, mode while the plaintext was on disk
+0644, mode after `set` 0600, same inode throughout.
+
+**The plain-file vault storing plaintext at rest is a documented, accepted trade-off and
+is not what this file tests.** The defect is the mode, and the sentence that was wrong
+about why the mode was safe.
+
+The property: *at the moment the plaintext is handed to the file that will hold it, that
+file is not accessible to group or other.* Two things follow from stating it that way.
+
+**The observation is on the descriptor, not on the path.** A `Path.stat()` of the vault
+would report the wrong file entirely for a temp-file-plus-`os.replace` implementation —
+which is the other reasonable fix — and would say nothing about what happens to a file
+swapped in at the path mid-write. `os.fstat(fd)` asks about the object actually being
+written, identified by `(st_dev, st_ino)`.
+
+**The instrumentation sits under every spelling of "write a file", and says so when it
+misses.** A spy on `json.dump` — the fix the issue suggested testing with — is blind to
+`Path.write_text`, to a bare `os.write`, and to the deletion of the guard it is pinning.
+This wraps `io.open` (which `os.fdopen`, `open()` and `Path.open` all reach) and
+`os.write`, and then asserts the watch actually saw the plaintext go by. If a future
+implementation writes through some path none of that covers, this test goes RED asking to
+be extended rather than passing on having observed nothing.
+"""
+
+from __future__ import annotations
+
+import builtins
+import io
+import json
+import os
+import shutil
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import config
+from charter.secrets import registry
+from charter.secrets.base import VaultError
+from charter.secrets.plain_file import PlainFileProvider
+from tests._isolation import PersonaIso
+
+#: Fabricated, and shaped so it cannot be mistaken for anyone's credential. Its only job
+#: is to be findable in the bytes handed to a descriptor.
+PLAINTEXT = "FABRICATED-437-not-a-credential"
+
+
+class _Watch:
+    """Every mode held by every file that plaintext was written into, while it was.
+
+    Keyed by `(st_dev, st_ino)` from an `fstat` of the descriptor being written, so one
+    reused file-descriptor NUMBER across two files does not merge two records, and two
+    names for one inode do not split one.
+    """
+
+    def __init__(self, marker: str) -> None:
+        self.marker = marker.encode()
+        self.records: dict[tuple, dict] = {}
+        self.saw_open = 0
+
+    def note(self, fd: int, data) -> None:
+        if isinstance(data, str):
+            data = data.encode("utf-8", "replace")
+        try:
+            st = os.fstat(fd)
+        except (OSError, ValueError):
+            return
+        rec = self.records.setdefault((st.st_dev, st.st_ino),
+                                      {"bytes": bytearray(), "modes": []})
+        rec["bytes"].extend(data)
+        rec["modes"].append(stat.S_IMODE(st.st_mode))
+
+    def loose_modes(self) -> list[int]:
+        """Modes that were in force on a file at a moment the plaintext was going into
+        it, that another account on the machine could have read through."""
+        out = []
+        for rec in self.records.values():
+            if self.marker in bytes(rec["bytes"]):
+                out += [m for m in rec["modes"] if m & 0o077]
+        return out
+
+    def saw_the_plaintext(self) -> bool:
+        return any(self.marker in bytes(r["bytes"]) for r in self.records.values())
+
+
+class _SpyFile:
+    def __init__(self, f, watch: _Watch) -> None:
+        self._f, self._w = f, watch
+
+    def write(self, data):
+        try:
+            self._w.note(self._f.fileno(), data)
+        except (OSError, ValueError, AttributeError):
+            pass
+        return self._f.write(data)
+
+    def writelines(self, lines):
+        for line in lines:
+            self.write(line)
+
+    def __getattr__(self, name):
+        return getattr(self._f, name)
+
+    def __enter__(self):
+        self._f.__enter__()
+        return self
+
+    def __exit__(self, *exc):
+        return self._f.__exit__(*exc)
+
+
+class _Watching:
+    """Mixin: `self.watching()` installs the watch for the rest of the test."""
+
+    def watching(self, marker: str = PLAINTEXT) -> _Watch:
+        """Install the watch for the duration of the test."""
+        watch = _Watch(marker)
+        real_io_open, real_os_write = io.open, os.write
+
+        def io_open(*a, **kw):
+            f = real_io_open(*a, **kw)
+            if "r" not in (kw.get("mode") or (a[1] if len(a) > 1 else "r")):
+                watch.saw_open += 1
+                return _SpyFile(f, watch)
+            return f
+
+        def os_write(fd, data):
+            watch.note(fd, data)
+            return real_os_write(fd, data)
+
+        self.enterContext(mock.patch.object(io, "open", io_open))
+        self.enterContext(mock.patch.object(builtins, "open", io_open))
+        self.enterContext(mock.patch.object(os, "write", os_write))
+        return watch
+
+
+class _WriteObservingCase(_Watching, unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="edm-plainfile-"))
+        self.addCleanup(lambda: shutil.rmtree(self.tmp, ignore_errors=True))
+        self.vault = self.tmp / "v.json"
+
+    def provider(self) -> PlainFileProvider:
+        return PlainFileProvider("t", {"file": str(self.vault)})
+
+
+class APreexistingLooseVault(_WriteObservingCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.vault.write_text(json.dumps({"OLD": "already here"}) + "\n")
+        os.chmod(self.vault, 0o644)
+        self.inode = self.vault.stat().st_ino
+
+    def test_a_preexisting_loose_vault_is_tightened_before_the_write(self):
+        watch = self.watching()
+        self.provider().set("NEW", PLAINTEXT)
+        self.assertTrue(
+            watch.saw_the_plaintext(),
+            "the watch never saw the plaintext reach a descriptor — `_save` now writes "
+            "through a path this test does not observe, so it is not bounding anything. "
+            "Extend the watch; do not delete the test.")
+        self.assertEqual(
+            watch.loose_modes(), [],
+            "the plaintext was written into a file that was still group- or "
+            "other-accessible at that moment")
+
+    def test_the_vault_is_0600_when_the_dust_settles(self):
+        self.provider().set("NEW", PLAINTEXT)
+        self.assertEqual(stat.S_IMODE(self.vault.stat().st_mode), 0o600)
+
+    def test_delete_takes_the_same_path(self):
+        prov = self.provider()
+        prov.set("NEW", PLAINTEXT)
+        os.chmod(self.vault, 0o644)
+        watch = self.watching(marker="already here")
+        prov.delete("NEW")
+        self.assertTrue(watch.saw_the_plaintext(), "the watch observed no write at all")
+        self.assertEqual(watch.loose_modes(), [],
+                         "`delete` rewrites the REMAINING secrets, and did so into a "
+                         "loose file")
+
+    def test_the_existing_secrets_survive(self):
+        prov = self.provider()
+        prov.set("NEW", PLAINTEXT)
+        self.assertEqual(prov.get("OLD"), "already here")
+        self.assertEqual(prov.get("NEW"), PLAINTEXT)
+
+
+class AVaultThatCannotBeMadePrivate(_WriteObservingCase):
+    """A filesystem with fixed permissions — exFAT, many network mounts — accepts the
+    chmod and reports the old mode. Reading the mode back off the descriptor is what
+    tells the two cases apart; a chmod that returned 0 does not."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.before = json.dumps({"OLD": "already here"}) + "\n"
+        self.vault.write_text(self.before)
+        os.chmod(self.vault, 0o644)
+
+    def test_nothing_is_written_when_the_mode_cannot_be_settled(self):
+        watch = self.watching()
+        with mock.patch.object(os, "fchmod", lambda *a: None):
+            with self.assertRaises(VaultError) as caught:
+                self.provider().set("NEW", PLAINTEXT)
+        self.assertIn("could not make it 0600", str(caught.exception),
+                      "refused for some other reason than the one under test")
+        self.assertFalse(watch.saw_the_plaintext(),
+                         "the value reached the file charter had just refused to write")
+        self.assertEqual(self.vault.read_text(), self.before,
+                         "the previous contents were destroyed by a write that then "
+                         "refused to happen")
+
+    def test_the_refusal_names_the_file_and_says_nothing_was_written(self):
+        with mock.patch.object(os, "fchmod", lambda *a: None):
+            with self.assertRaises(VaultError) as caught:
+                self.provider().set("NEW", PLAINTEXT)
+        msg = str(caught.exception)
+        self.assertIn(self.vault.name, msg)
+        self.assertIn("Nothing was written", msg)
+        self.assertNotIn(PLAINTEXT, msg)
+
+
+class AVaultCharterCreatesItself(_WriteObservingCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.vault = self.tmp / "fresh" / "v.json"
+
+    def test_a_new_vault_is_0600_and_its_directory_is_0700(self):
+        watch = self.watching()
+        self.provider().set("NEW", PLAINTEXT)
+        self.assertTrue(watch.saw_the_plaintext())
+        self.assertEqual(watch.loose_modes(), [])
+        self.assertEqual(stat.S_IMODE(self.vault.stat().st_mode), 0o600)
+        self.assertEqual(stat.S_IMODE(self.vault.parent.stat().st_mode), 0o700,
+                         "a directory charter creates to hold plaintext vaults lists "
+                         "every vault name to every account on the machine")
+
+    def test_the_rotation_sidecar_is_0600_too(self):
+        prov = self.provider()
+        prov.set("NEW", PLAINTEXT)
+        self.assertEqual(stat.S_IMODE(prov._meta_path.stat().st_mode), 0o600)
+
+
+class TheVaultRegistryTakesTheSamePath(_Watching, PersonaIso):
+    """`registry._write` had the identical in-place bug — #437 names it, and calls it
+    cosmetic by comparison because the registry carries provider config, paths and
+    environment variable NAMES, never a value.
+
+    So it refuses nothing (the SHARED half is deliberately 0644 and committed), but the
+    mode still has to be in force before the content is. Tested through the local half,
+    which is the one that is meant to be 0600.
+    """
+
+    def test_the_local_registry_is_0600_before_its_content_lands(self):
+        path = Path(config.VAULTS_REGISTRY)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"vaults": {}}\n')
+        os.chmod(path, 0o644)
+
+        watch = self.watching(marker="MARKER-437-registry")
+        registry.save_registry({"vaults": {"MARKER-437-registry": {"provider": "x"}}})
+        self.assertTrue(watch.saw_the_plaintext(),
+                        "the watch never saw the registry content reach a descriptor")
+        self.assertEqual(watch.loose_modes(), [])
+        self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+
+    def test_the_shared_registry_stays_committable(self):
+        """The other half is meant to be world-readable; tightening it here would break
+        the thing it exists for."""
+        registry.save_shared({"vaults": {"team": {"provider": "reference"}}})
+        path = Path(config.SHARED_VAULTS)
+        self.assertEqual(stat.S_IMODE(path.stat().st_mode) & 0o044, 0o044)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plain_file.py
+++ b/tests/test_plain_file.py
@@ -241,8 +241,8 @@ class AVaultCharterCreatesItself(_WriteObservingCase):
         self.assertEqual(watch.loose_modes(), [])
         self.assertEqual(stat.S_IMODE(self.vault.stat().st_mode), 0o600)
         self.assertEqual(stat.S_IMODE(self.vault.parent.stat().st_mode), 0o700,
-                         "a directory charter creates to hold plaintext vaults lists "
-                         "every vault name to every account on the machine")
+                         "a directory the vault writer creates to hold plaintext vaults "
+                         "lists every vault name to every account on the machine")
 
     def test_the_rotation_sidecar_is_0600_too(self):
         prov = self.provider()

--- a/tests/test_secret_get_masked.py
+++ b/tests/test_secret_get_masked.py
@@ -1,0 +1,276 @@
+"""The masked `charter secret get` line must not confirm a guessed value (#436).
+
+What it printed was `present · 11 bytes · sha256:323725e8eff4` — an unsalted, un-keyed
+SHA-256 prefix of the value plus its exact byte count. Both halves are pure functions of
+the value, so the line is checkable **offline**: the length prefilters a wordlist and the
+48-bit digest confirms the hit, with no further access to charter. The audit demonstrated
+it end to end against a fabricated `Summer2024!`.
+
+**The property under test is not "the digest is not sha256".** That is a spelling, and the
+next spelling — `sha256(value)[12:24]`, blake2b, md5, a constant salt baked into the
+source, base64 instead of hex — walks straight past a test written that way, while still
+being exactly as checkable offline as before.
+
+The property is: **the printed line is not a function of the value alone.** So the test
+that carries the weight runs the same value through two control planes whose only
+difference is the key file and requires the fingerprints to differ. Every keyless
+construction there is fails that, including ones nobody has thought of, because a pure
+function of the value cannot produce two answers for one value. Stability within a plane
+is asserted alongside it, so "print random bytes" is not a passing answer either.
+
+The second property is about the size: **the exact byte length must not be recoverable.**
+Tested as indistinguishability — every length inside a band prints the same text — and
+paired with a boundary assertion so a `size_band` that returns a constant fails too.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import re
+import stat
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_secrets, config
+from charter.secrets import fingerprint, registry
+from tests._isolation import PersonaIso
+
+#: Fabricated. Chosen to look like the kind of value the offline check is decisive
+#: against — a human password inside a wordlist — without being anyone's credential.
+GUESSABLE = "Summer2024!"
+
+_FP = re.compile(r"fp:([0-9a-f]+)")
+
+
+class TheFingerprintIsNotAFunctionOfTheValue(PersonaIso):
+    """The core property. Nothing here mentions a hash algorithm by name."""
+
+    def _in_plane(self, state_dir: Path, value: str) -> str:
+        with mock.patch.object(config, "STATE_DIR", state_dir):
+            return fingerprint.masked(value)
+
+    def _fp(self, state_dir: Path, value: str) -> str:
+        line = self._in_plane(state_dir, value)
+        m = _FP.search(line)
+        self.assertIsNotNone(m, f"no fingerprint in {line!r} — a plane with a writable "
+                                f"state dir must produce one")
+        return m.group(1)
+
+    def test_two_planes_fingerprint_one_value_differently(self):
+        """The whole point. A keyless digest — of any algorithm, at any offset, with any
+        constant salt, in any encoding — is a pure function of the value and therefore
+        cannot answer differently in two planes. This fails for all of them."""
+        a = self._fp(self.tmp / "plane-a", GUESSABLE)
+        b = self._fp(self.tmp / "plane-b", GUESSABLE)
+        self.assertNotEqual(
+            a, b,
+            "the same value fingerprinted identically in two control planes, so the "
+            "fingerprint is computable from the value alone — which is what makes the "
+            "masked line an offline check against a guess")
+
+    def test_one_plane_fingerprints_one_value_the_same_way_twice(self):
+        """The other half: "print something unpredictable" is not a fix. The fingerprint
+        has a job — is this the same value as before — and it still has to do it."""
+        home = self.tmp / "plane-stable"
+        self.assertEqual(self._fp(home, GUESSABLE), self._fp(home, GUESSABLE))
+
+    def test_one_plane_fingerprints_two_values_differently(self):
+        home = self.tmp / "plane-distinct"
+        self.assertNotEqual(self._fp(home, GUESSABLE), self._fp(home, GUESSABLE + "!"))
+
+    def test_no_keyless_digest_of_the_value_reproduces_the_printed_fingerprint(self):
+        """The filed regression, widened past the one algorithm that was filed. Every
+        hash stdlib guarantees, over the value and over the value with charter's own name
+        as a constant salt — none of them may contain the printed fingerprint anywhere,
+        at any offset."""
+        printed = self._fp(self.tmp / "plane-c", GUESSABLE)
+        raw = GUESSABLE.encode()
+        candidates = [raw, b"charter" + raw, raw + b"charter"]
+        checked = 0
+        for algo in sorted(hashlib.algorithms_guaranteed):
+            for material in candidates:
+                try:
+                    digest = hashlib.new(algo, material).hexdigest()
+                except TypeError:
+                    continue                      # shake_* needs an explicit length
+                checked += 1
+                self.assertNotIn(printed, digest,
+                                 f"the printed fingerprint is recoverable from the value "
+                                 f"alone via {algo}")
+        self.assertGreater(checked, 10, "the digest sweep did not actually run")
+
+    def test_a_plane_that_cannot_hold_a_key_prints_no_fingerprint_at_all(self):
+        """The fallback must not restore the property the key removes. A read-only or
+        unusable state directory means LESS information, never an unkeyed digest — that
+        fallback would fire in exactly the locked-down environments nobody is watching."""
+        blocker = self.tmp / "not-a-directory"
+        blocker.write_text("")
+        line = self._in_plane(blocker / "state", GUESSABLE)
+        self.assertNotIn("fp:", line)
+        self.assertNotIn(hashlib.sha256(GUESSABLE.encode()).hexdigest()[:12], line)
+        self.assertFalse(re.search(r"[0-9a-f]{8}", line),
+                         f"{line!r} still carries something digest-shaped")
+
+    def test_the_key_file_is_0600(self):
+        home = self.tmp / "plane-perm"
+        with mock.patch.object(config, "STATE_DIR", home):
+            fingerprint.fingerprint(GUESSABLE)
+            path = fingerprint.key_path()
+        self.assertTrue(path.exists())
+        self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+
+    def _loose_key_file(self, home: Path) -> Path:
+        """A key file left over at 0644 and the wrong length, so the next call has to
+        regenerate it — the case where the mode argument to `os.open` is ignored (#437)."""
+        home.mkdir(parents=True, exist_ok=True)
+        with mock.patch.object(config, "STATE_DIR", home):
+            path = fingerprint.key_path()
+        path.write_bytes(b"leftover")
+        os.chmod(path, 0o644)
+        return path
+
+    def test_a_leftover_loose_key_file_is_tightened_before_it_is_rewritten(self):
+        home = self.tmp / "plane-relax"
+        path = self._loose_key_file(home)
+        self.assertIsNotNone(self._fp(home, GUESSABLE))
+        self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+        self.assertEqual(len(path.read_bytes()), fingerprint.KEY_BYTES)
+
+    def test_no_key_is_written_into_a_file_charter_could_not_make_private(self):
+        """`os.fchmod` returning successfully is not evidence the bits moved — a mount
+        with fixed permissions accepts it and reports the old mode. The mode is read back
+        off the descriptor, and a key that would have landed world-readable is not
+        generated at all: no fingerprint beats a fingerprint whose key anyone can read."""
+        home = self.tmp / "plane-fixed-perms"
+        path = self._loose_key_file(home)
+        with mock.patch.object(os, "fchmod", lambda *a: None):
+            line = self._in_plane(home, GUESSABLE)
+        self.assertNotIn("fp:", line)
+        self.assertEqual(path.read_bytes(), b"leftover",
+                         "key material was written into a file charter had just found it "
+                         "could not make private")
+
+
+class TheSizeIsABandNotACount(unittest.TestCase):
+    """No plane state involved — `size_band` is a pure function of the value."""
+
+    def test_every_length_inside_a_band_prints_the_same_text(self):
+        """Indistinguishability is the property: a reader of the line cannot tell 9 bytes
+        from 15. Asserting the literal string `"8–15 bytes"` would instead be a tautology
+        against the constant under test."""
+        for lo, hi in ((1, 15), (16, 31), (32, 63), (64, 127)):
+            bands = {fingerprint.size_band("x" * n) for n in range(lo, hi + 1)}
+            self.assertEqual(len(bands), 1,
+                             f"lengths {lo}..{hi} printed {len(bands)} different labels: "
+                             f"{sorted(bands)}")
+
+    def test_neighbouring_bands_still_differ(self):
+        """Paired with the test above so `return "some bytes"` is not a passing answer:
+        the label has to keep telling a password from a PEM file."""
+        seen = [fingerprint.size_band("x" * n) for n in (0, 1, 16, 32, 64, 2048)]
+        self.assertEqual(len(set(seen)), len(seen), f"bands collapsed: {seen}")
+
+    def test_an_empty_value_is_still_called_out(self):
+        self.assertEqual(fingerprint.size_band(""), "empty")
+        self.assertNotEqual(fingerprint.size_band("x"), "empty")
+
+    def test_the_band_counts_utf8_bytes_not_characters(self):
+        """`len()` on a `str` counted characters while the label said "bytes"; three
+        Cyrillic characters occupy six bytes in the file."""
+        self.assertEqual(fingerprint.size_band("а" * 8), fingerprint.size_band("x" * 16))
+
+
+class TheCommandActuallyPrintsIt(PersonaIso):
+    """End to end through `cmd_secret_get`, so the helper being correct while the command
+    still prints the old line is a failure and not a green suite."""
+
+    def setUp(self):
+        super().setUp()
+        vf = config.VAULTS_DIR / "audit.json"
+        registry.add_vault("audit", "plain-file", {"file": str(vf)})
+        self.prov = registry.provider_for("audit")
+
+    def _get(self, key: str) -> str:
+        buf = io.StringIO()
+        args = SimpleNamespace(vault="audit", key=key, reveal=False, force=False)
+        with redirect_stdout(buf):
+            rc = commands_secrets.cmd_secret_get(args)
+        self.assertEqual(rc, 0)
+        return buf.getvalue()
+
+    def test_the_masked_line_carries_no_hash_of_the_value(self):
+        self.prov.set("WEAK", GUESSABLE)
+        out = self._get("WEAK")
+        self.assertIn("present", out)
+        self.assertNotIn("sha256:", out)
+        self.assertNotIn(hashlib.sha256(GUESSABLE.encode()).hexdigest()[:12], out)
+
+    def test_the_masked_line_does_not_disclose_the_exact_length(self):
+        """Two values a reader could tell apart by length before, in one band now: strip
+        the fingerprints and the two lines must be the same string."""
+        self.prov.set("A", "x" * 9)
+        self.prov.set("B", "y" * 15)
+        a = _FP.sub("fp:-", self._get("A")).replace("audit/A", "audit/K")
+        b = _FP.sub("fp:-", self._get("B")).replace("audit/B", "audit/K")
+        self.assertEqual(a, b, "the masked line still distinguishes a 9-byte value from a "
+                              "15-byte one")
+
+    def test_the_value_itself_is_never_printed(self):
+        self.prov.set("WEAK", GUESSABLE)
+        self.assertNotIn(GUESSABLE, self._get("WEAK"))
+
+
+class TheKeyIsAsProtectedAsAVault(PersonaIso):
+    """Keying the fingerprint moves the secret, it does not remove it.
+
+    A reader who holds `.charter/fingerprint.key` can compute the fingerprint of a guess
+    and the offline check is back, unchanged. So the key has to sit on the same side of
+    the read guard as the vault files — and it did not: the guard denied
+    `.charter/vaults/devops.json` and allowed `.charter/fingerprint.key`, which for a
+    1Password-backed vault (no vault file on disk at all) was the only readable thing
+    between the printed line and the value.
+    """
+
+    def _read(self, path: str, tool: str = "Read", **extra):
+        from charter import hooks
+        from tests._isolation import run_hook
+
+        ti = {"file_path": path} if tool == "Read" else {"path": path, **extra}
+        r = run_hook(hooks.pretooluse_read,
+                     {"tool_name": tool, "tool_input": ti, "session_id": "s", "cwd": "/tmp"})
+        return (r or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+
+    def _bash(self, command: str):
+        from charter import hooks
+        from tests._isolation import run_hook
+
+        r = run_hook(hooks.pretooluse,
+                     {"tool_name": "Bash", "tool_input": {"command": command},
+                      "session_id": "s", "cwd": "/tmp"})
+        return (r or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+
+    def test_reading_the_key_is_denied_like_reading_a_vault(self):
+        self.assertEqual(self._read(f".charter/{fingerprint.KEY_FILE}"), "deny")
+        self.assertEqual(self._read(f"/home/me/plane/.charter/{fingerprint.KEY_FILE}"),
+                         "deny")
+
+    def test_the_legacy_state_directory_name_is_covered_too(self):
+        """`.edm/` is the pre-rename spelling the guard deliberately still answers for."""
+        self.assertEqual(self._read(f".edm/{fingerprint.KEY_FILE}"), "deny")
+
+    def test_catting_the_key_is_denied(self):
+        self.assertEqual(self._bash(f"cat .charter/{fingerprint.KEY_FILE}"), "deny")
+
+    def test_the_registry_is_still_readable(self):
+        """The carve-out the guard already had must survive: `.charter/vaults.json` holds
+        provider config and paths, never values, and hard-denying it broke ordinary work."""
+        self.assertNotEqual(self._read(".charter/vaults.json"), "deny")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vault_dir_mode.py
+++ b/tests/test_vault_dir_mode.py
@@ -21,13 +21,24 @@ plane where charter created every level itself, vault at ``.charter/vaults/team/
 **The property is not "the leaf is 0700".** That is a spelling, and this file exists
 because the leaf *was* 0700 while the claim was false. The property is:
 
-    every directory charter itself creates on the way to a vault file satisfies
+    every directory **the vault writers** create on the way to a vault file satisfies
     ``mode & 0o077 == 0``
 
 — asserted over the whole chain, at whatever depth the vault is configured, so a fix that
 covers two levels and not three goes RED. Modes are tested through that mask and never
 against a list of known-bad values: 0755 is the one everybody pictures, while 0705, 0711,
 0730 and 0701 list or traverse just as well and appear on no such list.
+
+**"The vault writers", not "charter", and the qualifier is load-bearing.** The 0700 walk
+lives in :func:`base.make_private_dir`, which only the three secrets writers call. On the
+default CLI flow they are not what creates ``.charter/``: ``charter vault add`` writes the
+local registry first, through a bare ``path.parent.mkdir(parents=True, exist_ok=True)``,
+so the state directory is already there — at the umask default — before any vault file is
+written. Every class below except :class:`TheOrderTheCliActuallyUses` gives the vault
+writer the first move, which is the order a direct ``PlainFileProvider(...).set()``
+produces and not the order the CLI produces, and under that fixture the writer creates
+``.charter/`` too. That class exists so the difference is pinned rather than hidden: it
+reproduces the registry-first ordering and asserts what is true under it (#470).
 
 The second property is the honest half, and it is asserted rather than merely documented:
 
@@ -195,12 +206,19 @@ class NoInstantAtWhichItIsWider(PersonaIso):
 
 
 class UmaskCannotDecideThis(PersonaIso):
-    """The mode charter asks for is the mode it gets, whatever the umask is.
+    """The mode the vault writer asks for is the mode it gets, whatever the umask is.
 
     ``os.mkdir``'s *mode* argument is masked by the umask, which makes the result a
     property of the ambient environment rather than of charter. Both directions matter: a
     permissive umask must not widen the directory, and a restrictive one must not leave
     charter a directory it cannot then use.
+
+    Scoped to the levels :func:`make_private_dir` creates, and the scope is not a detail:
+    the chain below starts at a per-umask subdirectory *underneath* ``.charter/`` for
+    exactly that reason. On the real CLI flow the umask does decide ``.charter/`` itself,
+    because the registry write creates it first (#470) — asserted in
+    :class:`TheOrderTheCliActuallyUses`, which is where the honest version of this class
+    name lives.
     """
 
     def test_every_umask_yields_exactly_0700(self) -> None:
@@ -451,6 +469,182 @@ class MakePrivateDirItself(PersonaIso):
         self.assertEqual(stat.S_IMODE(pre.stat().st_mode), 0o755, "not charter's to fix")
         for d in (pre / "a", pre / "a" / "b"):
             self.assertEqual(stat.S_IMODE(d.stat().st_mode), 0o700, f"{d} is charter's")
+
+
+class TheOrderTheCliActuallyUses(PersonaIso):
+    """The registry write goes first, so ``.charter/`` is not the vault writer's to choose.
+
+    Every other class here calls a provider's ``set()`` against a plane where
+    ``.charter/`` does not exist yet, so :func:`make_private_dir` wins the race to create
+    it and the state directory comes out 0700. That is the fixture manufacturing the
+    condition it claims to observe, in the favourable direction: on the flow ``charter
+    vault add`` prints as its own first step, the local registry is written *before* any
+    secret is set, and ``registry._write`` does ``path.parent.mkdir(parents=True,
+    exist_ok=True)`` with no mode. Under ``umask 022`` that leaves ``.charter`` at 0755,
+    and no later ``secret set`` touches it — charter does not chmod a directory it did not
+    create, which is the same rule that protects a home directory (#331).
+
+    So this class drives ``registry.add_vault`` first, which is the real call, and pins
+    all three halves of what the documents now say:
+
+    * the levels the vault writers create are 0700 whatever the umask is — unchanged, and
+      that is the fix;
+    * ``.charter/`` itself is whatever the umask left it — the residual, open as #470;
+    * it is *reported* rather than silently fine, on the health line ``charter vault list``
+      prints.
+
+    The middle one is a defect pinned on purpose. If it goes RED because #470 landed, that
+    is good news and the thing to fix is `docs/secrets.md` and the news entry, which
+    currently tell the reader it is open.
+    """
+
+    def _fresh_plane(self, tag: str, um: int):
+        """Enter a brand-new plane root, with *um* in force for everything created in it.
+
+        Both have to be per-case: a umask set after ``.charter/`` exists changes nothing,
+        which would make a loop over umasks assert the first iteration four times.
+        """
+        root = self.tmp / f"plane-{tag}"
+        root.mkdir()
+        prev = config.use(root)
+        self.addCleanup(config.restore, prev)
+        old = os.umask(um)
+        self.addCleanup(os.umask, old)
+        return root
+
+    @staticmethod
+    def _add_vault(name: str, rel: str) -> Path:
+        """Register a vault through the call ``charter vault add`` makes.
+
+        Not a hand-rolled ``mkdir``: the point of this class is that the *registry* is
+        what creates ``.charter/``, so it has to be the registry doing it. If that ever
+        stops being true, these cases stop reproducing the CLI and say so rather than
+        quietly asserting something else.
+        """
+        from charter.secrets import registry
+
+        vf = Path(config.STATE_DIR) / rel
+        registry.add_vault(name, "plain-file", {"file": str(vf)})
+        return vf
+
+    def test_the_vault_directories_are_private_even_when_the_registry_went_first(self):
+        """The fix, in the ordering the CLI produces rather than the one the fixture did."""
+        for um in (0o000, 0o022, 0o077):
+            with self.subTest(umask=oct(um)):
+                self._fresh_plane(f"v{um:03o}", um)
+                sd = Path(config.STATE_DIR)
+                self.assertFalse(sd.exists(), "precondition: nothing has made it yet")
+                vf = self._add_vault("devops", "vaults/team/prod.json")
+                self.assertTrue(
+                    sd.is_dir(),
+                    "the registry write did not create STATE_DIR, so this case no longer "
+                    "reproduces the CLI ordering and everything below it is vacuous")
+                self.assertFalse(
+                    vf.parent.exists(),
+                    "the vault directory already exists, so make_private_dir will not be "
+                    "the thing that creates it and the assertion below proves nothing")
+
+                PlainFileProvider("devops", {"file": str(vf)}).set("K", "value-one")
+
+                chain = modes_up_to(vf.parent, sd / "vaults")
+                self.assertGreaterEqual(len(chain), 2, "a one-element chain is vacuous")
+                for p, mode in chain.items():
+                    self.assertEqual(
+                        mode, 0o700,
+                        f"under umask {oct(um)}, {p} came out {oct(mode)[-3:]} — the "
+                        f"registry going first must not cost the levels below it")
+                self.assertEqual(stat.S_IMODE(vf.stat().st_mode), 0o600, "and the file")
+
+    def test_the_state_directory_itself_is_decided_by_the_umask(self):
+        """The residual, executed. `.charter/` is the registry's to create, not the walk's.
+
+        Asserted as *the umask decides it* — two umasks, two different modes — and not
+        merely as "0755 under 022". A regression that hardcoded 0755 would satisfy the
+        second and not the first, and the property is the dependence, not the value.
+        """
+        seen = {}
+        for um in (0o022, 0o077):
+            self._fresh_plane(f"s{um:03o}", um)
+            self._add_vault("devops", "vaults/team/prod.json")
+            seen[um] = stat.S_IMODE(Path(config.STATE_DIR).stat().st_mode)
+
+        self.assertNotEqual(
+            seen[0o022], seen[0o077],
+            f"`.charter/` came out {oct(seen[0o022])[-3:]} under both umasks. If charter "
+            f"now chooses this mode itself, #470 is fixed — good news, and docs/secrets.md "
+            f"and docs/news/unreleased-a-vault-charter-cannot-make-private.md both still "
+            f"tell the reader it is open. Update them and delete this case.")
+        self.assertEqual(seen[0o077], 0o700, "umask 077 masks the group and other bits")
+        self.assertEqual(
+            seen[0o022] & 0o077, 0o055,
+            f"the measurement in #470: umask 022 leaves `.charter` at "
+            f"{oct(seen[0o022])[-3:]}, other-readable and other-traversable")
+
+    def test_the_loose_state_directory_is_named_where_the_docs_say_it_is(self):
+        """Reported, not silently accepted — and reported in `charter vault list`.
+
+        The two claims travel together: charter declines to chmod a directory it did not
+        create *because* it names it instead. A residual nothing reports is just a hole.
+        """
+        import argparse
+        import io
+        from contextlib import redirect_stdout
+
+        from charter.commands_secrets import cmd_vault_list
+        from charter.secrets import registry
+
+        self._fresh_plane("report", 0o022)
+        vf = self._add_vault("devops", "vaults/team/prod.json")
+        PlainFileProvider("devops", {"file": str(vf)}).set("K", "value-one")
+
+        sd = Path(config.STATE_DIR)
+        self.assertEqual(stat.S_IMODE(sd.stat().st_mode) & 0o077, 0o055,
+                         "precondition: there is something to report")
+
+        _, detail = registry.provider_for("devops").health()
+        self.assertIn("listed by other accounts", detail)
+        self.assertIn(".charter 755", detail,
+                      f"the health line must name the level that is loose, not merely "
+                      f"that one is: {detail!r}")
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cmd_vault_list(argparse.Namespace())
+        out = buf.getvalue()
+        self.assertIn("listed by other accounts: .charter 755", out,
+                      "`charter vault list`'s STATUS column is where docs/secrets.md now "
+                      "says this appears, so that is where it has to appear")
+
+    def test_doctor_is_not_where_it_appears(self):
+        """The other narrowed sentence, pinned as the limit it is (#471).
+
+        `check_vaults` does ``healthy, _ = prov.health()`` and drops the detail, and
+        `_loose_dir_note` never sets ``healthy`` False — deliberately, since this check
+        runs from the SessionStart hook. So no path carries the note into `doctor`, and
+        the docs no longer say one does.
+        """
+        from charter import doctor
+        from charter.secrets import registry
+
+        self._fresh_plane("doctor", 0o022)
+        vf = self._add_vault("devops", "vaults/team/prod.json")
+        PlainFileProvider("devops", {"file": str(vf)}).set("K", "value-one")
+
+        self.assertIn("listed by other accounts",
+                      registry.provider_for("devops").health()[1],
+                      "precondition: the health line carries the note, so doctor had "
+                      "something to drop")
+
+        res = doctor.check_vaults()
+        rendered = res.render()
+        self.assertNotIn(
+            "listed by other accounts", rendered,
+            f"doctor now carries the loose-directory note. #471 is fixed — good news, and "
+            f"docs/secrets.md and the news entry both still say it does not. Update them "
+            f"and delete this case. Got: {rendered!r}")
+        self.assertEqual(res.status, doctor.OK,
+                         "and it stays a green line: a loose directory is an operator's "
+                         "decision, not an unreachable vault")
 
 
 if __name__ == "__main__":       # pragma: no cover

--- a/tests/test_vault_dir_mode.py
+++ b/tests/test_vault_dir_mode.py
@@ -1,0 +1,457 @@
+"""The directories charter creates for a vault do not list vault names to other accounts.
+
+Round one of #437 fixed the vault *file* and wrote a news entry saying `.charter/vaults/`
+"no longer lists every vault name you have to every account on the machine". The code
+under that sentence was ``p.parent.mkdir(parents=True, exist_ok=True, mode=0o700)``, and
+the sentence was false twice over.
+
+**Once because `mode` reaches the leaf only.** CPython's ``pathlib.Path.mkdir`` creates a
+missing parent with a bare recursive ``self.parent.mkdir(parents=True, exist_ok=True)`` —
+no *mode* — so every level above the last comes out at ``0o777 & ~umask``. Measured on a
+plane where charter created every level itself, vault at ``.charter/vaults/team/prod.json``::
+
+    .charter               0755
+    .charter/vaults        0755      <-- the directory the fix was about
+    .charter/vaults/team   0700
+
+**Once because a directory that already exists ignores `mode` entirely.** A
+``.charter/vaults/`` made by an older charter or by ``mkdir -p`` is 0755 before
+``secret set`` and 0755 after, and nothing reported it.
+
+**The property is not "the leaf is 0700".** That is a spelling, and this file exists
+because the leaf *was* 0700 while the claim was false. The property is:
+
+    every directory charter itself creates on the way to a vault file satisfies
+    ``mode & 0o077 == 0``
+
+— asserted over the whole chain, at whatever depth the vault is configured, so a fix that
+covers two levels and not three goes RED. Modes are tested through that mask and never
+against a list of known-bad values: 0755 is the one everybody pictures, while 0705, 0711,
+0730 and 0701 list or traverse just as well and appear on no such list.
+
+The second property is the honest half, and it is asserted rather than merely documented:
+
+    a directory charter did NOT create keeps its mode exactly, and is reported
+
+Both halves matter. Tightening whatever directory a vault lands in is not an improvement —
+a vault's ``file`` may name any path on this machine, so it is how charter would come to
+chmod a home directory or a shared team directory unprompted (#331). Reporting is the
+only alternative that does not require charter to be wrong about one of the two.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import config
+from charter.secrets import fingerprint
+from charter.secrets.base import loose_dirs, make_private_dir
+from charter.secrets.plain_file import PlainFileProvider
+from charter.secrets.reference import ReferenceProvider
+
+from tests._isolation import PersonaIso
+
+#: Modes that let *some* other account do *something* with a directory. Deliberately more
+#: than "0755": 0705 and 0701 grant other without group, 0711 grants traverse without
+#: read, 0730 grants a group write. A guard written against a literal list is the failure
+#: this suite keeps finding, so these exist to prove the guard is the mask and not a list.
+LOOSE_MODES = (0o755, 0o750, 0o705, 0o701, 0o711, 0o730, 0o775, 0o777, 0o707)
+
+#: Modes reachable only by the owner. 0700 is the target; the others must not be reported
+#: as loose merely for differing from it.
+PRIVATE_MODES = (0o700, 0o500, 0o300, 0o100)
+
+
+def modes_up_to(leaf, stop) -> dict:
+    """``{path: mode}`` for every directory from *leaf* up to and including *stop*."""
+    out, cur, stop_rp = {}, Path(leaf), Path(stop).resolve()
+    while True:
+        out[cur] = stat.S_IMODE(cur.stat().st_mode)
+        if cur.resolve() == stop_rp or cur.parent == cur:
+            return out
+        cur = cur.parent
+
+
+class EveryLevelCharterCreates(PersonaIso):
+    """The property, over the whole chain, at several depths."""
+
+    def test_a_plane_charter_builds_from_nothing_has_no_reachable_level(self) -> None:
+        """The headline case: `.charter/` itself does not exist yet, so every level in the
+        chain is charter's own choice and none of it is inherited from the fixture."""
+        sd = Path(config.STATE_DIR)
+        self.assertFalse(sd.exists(), "precondition: charter creates every level here")
+        vf = sd / "vaults" / "devops.json"
+        PlainFileProvider("v", {"file": str(vf)}).set("K", "value-one")
+
+        chain = modes_up_to(vf.parent, sd)
+        self.assertGreaterEqual(
+            len(chain), 2,
+            "a one-element chain makes this vacuous — the defect was the level ABOVE the "
+            "leaf, so a chain that does not contain one proves nothing")
+        for p, mode in chain.items():
+            self.assertEqual(mode & 0o077, 0,
+                             f"{p} is {oct(mode)[-3:]}: another account on this machine "
+                             f"can reach the directory holding the vault names")
+
+    def test_depth_does_not_decide_it(self) -> None:
+        """Three, four and six levels below the plane. The round-one fix passes at depth
+        one and fails at every depth beyond it, so depth is the axis that separates a fix
+        for the property from a fix for the example."""
+        sd = Path(config.STATE_DIR)
+        for rel in ("vaults/devops.json",
+                    "vaults/team/prod.json",
+                    "vaults/a/b/c/deep.json"):
+            with self.subTest(rel=rel):
+                vf = sd / rel
+                PlainFileProvider("v", {"file": str(vf)}).set("K", "value-one")
+                for p, mode in modes_up_to(vf.parent, sd).items():
+                    self.assertEqual(mode & 0o077, 0, f"{p} is {oct(mode)[-3:]}")
+
+    def test_the_intermediate_level_specifically(self) -> None:
+        """The exact measurement from the report, kept as its own case.
+
+        The tests above cover it, but they cover it alongside the leaf — and a regression
+        restoring ``mkdir(parents=True, mode=…)`` leaves the leaf green. Naming the
+        intermediate level makes the failure say which level went wrong.
+        """
+        vf = Path(config.STATE_DIR) / "vaults" / "team" / "prod.json"
+        PlainFileProvider("v", {"file": str(vf)}).set("K", "value-one")
+        vaults = Path(config.STATE_DIR) / "vaults"
+        self.assertEqual(
+            stat.S_IMODE(vaults.stat().st_mode) & 0o077, 0,
+            f"{vaults} is {oct(stat.S_IMODE(vaults.stat().st_mode))[-3:]} — it is the "
+            f"directory that lists every vault name, which is what the fix was about")
+
+    def test_a_reference_vault_gets_the_same_directory(self) -> None:
+        """A reference vault holds no plaintext — and the same directory listing.
+
+        Its file is `op://…` URIs, so its own mode is a smaller matter; the directory is
+        not, because it names your vault layout either way. It went through a plain
+        ``mkdir(parents=True, exist_ok=True)`` with no mode argument at all.
+        """
+        vf = Path(config.STATE_DIR) / "vaults" / "team.json"
+        ReferenceProvider("t", {"file": str(vf)}).set("K", "op://Eng/deploy/token")
+        for p, mode in modes_up_to(vf.parent, config.STATE_DIR).items():
+            self.assertEqual(mode & 0o077, 0, f"{p} is {oct(mode)[-3:]}")
+
+    def test_the_fingerprint_key_directory_too(self) -> None:
+        """`.charter/` holds `fingerprint.key`, whose secrecy is the whole of #436. The
+        key file is 0600, but a 0755 directory around it is still the plane advertising
+        that the file is there, and it is created by the same call."""
+        self.assertIsNotNone(fingerprint.fingerprint("value-one"),
+                             "no key was made, so this asserts nothing about its home")
+        sd = Path(config.STATE_DIR)
+        self.assertEqual(stat.S_IMODE(sd.stat().st_mode) & 0o077, 0,
+                         f"{sd} is {oct(stat.S_IMODE(sd.stat().st_mode))[-3:]}")
+
+
+class NoInstantAtWhichItIsWider(PersonaIso):
+    """The directory is private *when it is created*, not private a moment afterwards.
+
+    Final-state assertions cannot tell ``mkdir(0o700)`` from ``mkdir()`` followed by a
+    chmod: both end at 0700, and only one of them is ever 0755. That gap is the exact
+    shape #437 was filed about one level down — the vault file was opened at the wrong
+    mode and chmod-ed after the plaintext was already in it — so a directory fix that
+    reproduces it while passing the tests would be the same defect wearing the fix's
+    clothes.
+
+    Observed at the syscall, not inferred: every ``os.mkdir`` charter issues is required
+    to name a mode with no group or other bits. And the watch **asserts it saw something**
+    — a future implementation that creates directories through some call this does not
+    wrap makes this test say so rather than pass on having observed nothing.
+    """
+
+    def test_every_mkdir_charter_issues_names_a_private_mode(self) -> None:
+        seen = []
+        real = os.mkdir
+
+        def spy(path, mode=0o777, *a, **kw):
+            seen.append((str(path), mode))
+            return real(path, mode, *a, **kw)
+
+        vf = Path(config.STATE_DIR) / "vaults" / "team" / "prod.json"
+        with mock.patch.object(os, "mkdir", spy):
+            PlainFileProvider("v", {"file": str(vf)}).set("K", "value-one")
+
+        self.assertTrue(seen, "no os.mkdir was observed at all — charter created these "
+                              "directories through a call this watch does not wrap, so "
+                              "the assertion below would have been vacuous")
+        made = {p for p, _ in seen}
+        for level in (config.STATE_DIR, str(vf.parent.parent), str(vf.parent)):
+            self.assertIn(str(level), made,
+                          "a level charter created was not seen being created")
+        for path, mode in seen:
+            self.assertEqual(
+                mode & 0o077, 0,
+                f"os.mkdir({path}, {oct(mode)}) — the directory exists at a mode another "
+                f"account can reach before any chmod could narrow it")
+
+
+class UmaskCannotDecideThis(PersonaIso):
+    """The mode charter asks for is the mode it gets, whatever the umask is.
+
+    ``os.mkdir``'s *mode* argument is masked by the umask, which makes the result a
+    property of the ambient environment rather than of charter. Both directions matter: a
+    permissive umask must not widen the directory, and a restrictive one must not leave
+    charter a directory it cannot then use.
+    """
+
+    def test_every_umask_yields_exactly_0700(self) -> None:
+        # 0o000: mkdir(0o700) survives this, but a regression to `mkdir()` with no mode
+        #        gives 0o777 — so this is the case that catches "stopped passing a mode".
+        # 0o377: strips owner-write and owner-execute from mkdir's own argument, leaving
+        #        0o400, a directory charter cannot write the vault into. The explicit
+        #        chmod is what makes the outcome charter's decision rather than the shell's.
+        sd = Path(config.STATE_DIR)
+        for um in (0o000, 0o022, 0o077, 0o377):
+            with self.subTest(umask=oct(um)):
+                old = os.umask(um)
+                try:
+                    vf = sd / f"u{um:03o}" / "vaults" / "team" / "prod.json"
+                    PlainFileProvider("v", {"file": str(vf)}).set("K", "value-one")
+                    chain = modes_up_to(vf.parent, sd / f"u{um:03o}")
+                finally:
+                    os.umask(old)
+                for p, mode in chain.items():
+                    self.assertEqual(
+                        mode, 0o700,
+                        f"under umask {oct(um)}, {p} came out {oct(mode)[-3:]}")
+
+
+class ADirectoryCharterDidNotCreate(PersonaIso):
+    """It keeps its mode, and it is named. Neither half is optional."""
+
+    def _scaffold(self, tag: str, mode: int) -> Path:
+        """A fresh vault directory whose every ancestor inside the plane is 0700.
+
+        The fixture has to own the whole chain, because the thing under test *walks* the
+        chain: leave `.charter/` at the mkdir default and the report names it, and the
+        test would be reading its own scaffolding back rather than the directory it set.
+        The first version of this file did exactly that and passed the loose cases for
+        the wrong reason.
+        """
+        vd = Path(config.STATE_DIR) / f"{tag}{mode:03o}" / "vaults"
+        vd.mkdir(parents=True)
+        cur = vd
+        while True:
+            os.chmod(cur, 0o700)
+            if cur.resolve() == Path(config.STATE_DIR).resolve():
+                break
+            cur = cur.parent
+        return vd
+
+    def _preexisting(self, mode: int, tag: str = "d"):
+        """A vault directory that was already there, at *mode*, when charter arrived —
+        so what follows measures what ``secret set`` does to a directory it did not make.
+
+        Only used with modes the owner can still write, which is every mode in
+        `LOOSE_MODES`; `_then_chmod` covers the rest.
+        """
+        vd = self._scaffold(tag, mode)
+        os.chmod(vd, mode)
+        self.addCleanup(lambda p=vd: os.chmod(p, 0o700))
+        prov = PlainFileProvider("demo", {"file": str(vd / "demo.json")})
+        prov.set("K", "value-one")
+        return vd, prov
+
+    def _then_chmod(self, mode: int, tag: str = "c"):
+        """Vault written into a private directory, which is then set to *mode*.
+
+        The corpus of owner-only modes includes 0500, 0300 and 0100 — directories charter
+        cannot write into at all — so the write has to happen first. `health()` only
+        reads, and every one of those modes still permits the traverse it needs.
+        """
+        vd = self._scaffold(tag, mode)
+        prov = PlainFileProvider("demo", {"file": str(vd / "demo.json")})
+        prov.set("K", "value-one")
+        os.chmod(vd, mode)
+        self.addCleanup(lambda p=vd: os.chmod(p, 0o700))
+        return vd, prov
+
+    def test_charter_does_not_chmod_it(self) -> None:
+        for mode in LOOSE_MODES:
+            with self.subTest(mode=oct(mode)):
+                vd, _ = self._preexisting(mode)
+                self.assertEqual(
+                    stat.S_IMODE(vd.stat().st_mode), mode,
+                    "charter must not silently chmod a directory it did not create — a "
+                    "vault's --file can name any path on this machine (#331)")
+
+    def test_health_names_every_loose_mode(self) -> None:
+        """Reported for the *property*, not for a list of known-bad modes."""
+        for mode in LOOSE_MODES:
+            with self.subTest(mode=oct(mode)):
+                _, prov = self._then_chmod(mode, tag="h")
+                ok, detail = prov.health()
+                self.assertTrue(ok, "a loose directory is a warning, not an unreachable "
+                                    "vault — doctor runs health() from SessionStart and "
+                                    "must not turn this into a red line")
+                self.assertIn("listed by other accounts", detail)
+                self.assertIn(oct(mode)[-3:], detail,
+                              "the report must name the mode it found, or the operator "
+                              "cannot tell it from the mode charter wants")
+
+    def test_health_is_silent_when_no_other_account_can_reach_it(self) -> None:
+        """Otherwise the check is a constant, and a constant reports nothing."""
+        for mode in PRIVATE_MODES:
+            with self.subTest(mode=oct(mode)):
+                _, prov = self._then_chmod(mode, tag="q")
+                _, detail = prov.health()
+                self.assertNotIn("listed by other accounts", detail)
+
+    def test_the_vault_file_is_still_0600_beside_a_loose_directory(self) -> None:
+        """The directory finding must not have displaced the #437 fix it sits beside."""
+        vd, _ = self._preexisting(0o755, tag="f")
+        self.assertEqual(stat.S_IMODE((vd / "demo.json").stat().st_mode), 0o600)
+
+
+class LooseDirsIsBounded(PersonaIso):
+    """`loose_dirs` reports the plane, not the machine.
+
+    ``/``, ``/Users`` and ``/tmp`` are 0755 everywhere and are nobody's defect; a check
+    that names them is a check operators learn to ignore, which is what #171 and #55 cost.
+    """
+
+    def test_it_stops_at_the_plane_state_directory(self) -> None:
+        vd = Path(config.VAULTS_DIR)
+        vd.mkdir(parents=True)
+        sd = Path(config.STATE_DIR)
+        self.addCleanup(lambda: os.chmod(sd, 0o700))
+        os.chmod(sd, 0o755)
+        os.chmod(vd, 0o755)
+        found = {p.resolve() for p, _ in loose_dirs(vd, sd)}
+        self.assertIn(vd.resolve(), found)
+        self.assertIn(sd.resolve(), found, "the bound is inclusive: .charter itself is a "
+                                           "directory charter creates and owns")
+        self.assertNotIn(sd.resolve().parent, found,
+                         "the walk must stop at the plane, not climb to the filesystem "
+                         "root naming every 0755 directory on the way")
+
+    def test_a_vault_outside_the_plane_reports_only_its_own_directory(self) -> None:
+        """Pointing --file outside the plane is a configuration charter recommends.
+
+        charter has an opinion about the directory holding a vault and none at all about
+        that directory's ancestors on someone else's filesystem layout — so a walk that
+        never meets the plane must not run all the way to ``/``.
+        """
+        outside = Path(tempfile.mkdtemp(prefix="edm-outside-"))
+        self.addCleanup(lambda: os.chmod(outside, 0o700))
+        os.chmod(outside, 0o755)
+        found = [p for p, _ in loose_dirs(outside, config.STATE_DIR)]
+        self.assertEqual([p.resolve() for p in found], [outside.resolve()])
+
+
+class TheLimitOfAPosixMode(PersonaIso):
+    """The next spelling, named and pinned: an ACL the mode does not show.
+
+    ``mode & 0o077`` is the property this file tests everywhere else, and it is the right
+    property for a POSIX mode. It is not the whole of "can another account reach this
+    directory". macOS extended ACLs and Linux POSIX.1e ACLs both grant access that
+    ``st_mode`` does not reflect: measured here, a directory at 0700 with
+    ``chmod +a "everyone allow read,list,search"`` reports ``st_mode`` 0700 while every
+    account on the machine can list it — which is precisely the exposure `make_private_dir`
+    and `loose_dirs` exist to prevent, arriving by a spelling neither of them can read.
+
+    **This test asserts the gap rather than the fix.** Reading an ACL needs `acl_get_file`,
+    which the standard library does not expose on either platform, and shelling out to
+    `ls -le` from a health check that `doctor` runs at every session start costs more than
+    the gap does. So the limit is accepted, documented on `base._OTHERS`, and pinned here
+    so it cannot quietly stop being true in either direction: if someone teaches
+    `loose_dirs` to read ACLs, this goes RED and the docstring saying it cannot is the
+    thing to fix.
+    """
+
+    def _acl(self, d: Path) -> None:
+        r = subprocess.run(["chmod", "+a", "everyone allow read,list,search", str(d)],
+                           capture_output=True, text=True)
+        if r.returncode != 0:
+            self.skipTest(f"no extended-ACL support here: {r.stderr.strip()[:80]}")
+
+    @unittest.skipUnless(sys.platform == "darwin", "chmod +a is macOS's ACL spelling")
+    def test_an_acl_grants_access_the_mode_does_not_show(self) -> None:
+        vd = Path(config.VAULTS_DIR)
+        PlainFileProvider("v", {"file": str(vd / "demo.json")}).set("K", "value-one")
+        self.assertEqual(stat.S_IMODE(vd.stat().st_mode), 0o700, "charter made this one")
+
+        self._acl(vd)
+        listing = subprocess.run(["ls", "-led", str(vd)], capture_output=True, text=True)
+        self.assertIn("everyone", listing.stdout,
+                      "the ACL did not take, so nothing below is being measured")
+
+        self.assertEqual(
+            stat.S_IMODE(vd.stat().st_mode) & 0o077, 0,
+            "st_mode still reads private — this is the gap, and if this line ever fails "
+            "it means the platform started reflecting ACLs in the mode, which would be "
+            "good news and would make base._OTHERS's docstring wrong")
+        self.assertEqual(
+            loose_dirs(vd, config.STATE_DIR), [],
+            "loose_dirs reports nothing, because a POSIX mode is all it reads. Documented "
+            "on base._OTHERS as an accepted limit; if this list stops being empty, ACL "
+            "awareness has arrived and that docstring needs updating with it.")
+
+
+class MakePrivateDirItself(PersonaIso):
+    """Two behaviours of the helper the provider tests cannot show directly."""
+
+    def test_it_leaves_an_existing_leaf_alone(self) -> None:
+        d = Path(config.STATE_DIR) / "pre"
+        d.mkdir(parents=True)
+        self.addCleanup(lambda: os.chmod(d, 0o700))
+        os.chmod(d, 0o755)
+        make_private_dir(d)
+        self.assertEqual(stat.S_IMODE(d.stat().st_mode), 0o755)
+
+    def test_a_directory_that_appears_mid_walk_is_left_alone(self) -> None:
+        """The race branch: the walk said "missing", the mkdir said "already there".
+
+        Reachable only by losing a race with another process, so it is reached here
+        through the one seam that makes the race deterministic — `Path.exists` is made to
+        answer False for a directory that is really there at 0755, which is precisely what
+        the losing side of the race observes.
+
+        The seam manufactures the *timing*, not the outcome under test: what is asserted
+        is what `make_private_dir` does once `mkdir` has raised `FileExistsError`, and it
+        must be the same thing it does for any other directory it did not create — leave
+        the mode alone. A chmod here would let a concurrent charter, or an operator's
+        `mkdir -p` landing at the wrong moment, be enough to make charter tighten a
+        directory it was never asked to touch.
+        """
+        d = Path(config.STATE_DIR) / "raced"
+        d.mkdir(parents=True)
+        self.addCleanup(lambda: os.chmod(d, 0o700))
+        os.chmod(d, 0o755)
+
+        real_exists = Path.exists
+
+        def blind(self, *a, **kw):
+            return False if self == d else real_exists(self, *a, **kw)
+
+        with mock.patch.object(Path, "exists", blind):
+            make_private_dir(d)
+
+        self.assertEqual(
+            stat.S_IMODE(d.stat().st_mode), 0o755,
+            "mkdir raised FileExistsError, so this directory is one charter did NOT "
+            "create, and charter does not chmod those (#331)")
+
+    def test_it_creates_the_levels_below_an_existing_one(self) -> None:
+        """The mixed case: part of the chain is the operator's, the rest is charter's."""
+        pre = Path(config.STATE_DIR) / "pre"
+        pre.mkdir(parents=True)
+        self.addCleanup(lambda: os.chmod(pre, 0o700))
+        os.chmod(pre, 0o755)
+        make_private_dir(pre / "a" / "b")
+        self.assertEqual(stat.S_IMODE(pre.stat().st_mode), 0o755, "not charter's to fix")
+        for d in (pre / "a", pre / "a" / "b"):
+            self.assertEqual(stat.S_IMODE(d.stat().st_mode), 0o700, f"{d} is charter's")
+
+
+if __name__ == "__main__":       # pragma: no cover
+    unittest.main()

--- a/tests/test_vault_path_re_only_widens.py
+++ b/tests/test_vault_path_re_only_widens.py
@@ -1,0 +1,101 @@
+"""`_VAULT_PATH_RE` must never deny less than the version before it.
+
+This branch edits a security regex, which is the change most able to make a guard weaker
+while looking like it makes it stronger — one badly placed alternation, one group that
+turns a required trailing slash into an optional one, and paths that used to be denied
+stop being denied, silently, with no test in the suite complaining because every test
+asserts what the NEW pattern catches.
+
+So the property is differential:
+
+    for a corpus of operands, everything the previous pattern denied is still denied
+
+`BASELINE` is the pattern as it stood on `origin/main` before the `fingerprint`
+alternative was added, kept here as a fixture rather than read from git — a test that
+shells out to `git show` is a test that stops running in a tarball, in a shallow clone,
+and in CI on a detached tree. It is frozen deliberately: it is a record of a past
+guarantee, not a copy of the current source, and it must NOT be updated when the live
+pattern changes. Updating it is exactly how a differential test becomes a tautology.
+
+**The corpus is the weak part, and saying so is the point.** A differential test can only
+compare the two patterns on inputs somebody wrote down, so it proves "not weaker on these"
+and never "not weaker". What it does bound is the regression that actually happens:
+someone edits the pattern for one new case and quietly loses an old one. The unbounded
+question — which spellings neither pattern catches — is the tool gate's job, which asks
+the filesystem rather than the string; `test_plane_reads_are_contained.py` carries that
+half, and `hooks.py` names the limit above the pattern.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+
+from charter.hooks import _VAULT_PATH_RE
+
+#: `origin/main`'s pattern at the point this branch forked. Frozen; never update it.
+BASELINE = re.compile(r"\.(?:charter|edm)(?:/(?:vaults/|browser|active-)|/?$)")
+
+#: Operands to compare the two patterns on. Everything the baseline matched here must
+#: still match; the new alternative adds matches and is allowed to.
+CORPUS = (
+    ".charter/vaults/devops.json",
+    ".charter/vaults/team/prod.json",
+    "./.charter/vaults/devops.json",
+    "/Users/x/proj/.charter/vaults/devops.json",
+    ".edm/vaults/devops.json",
+    ".charter/browser",
+    ".charter/browser/profiles",
+    ".edm/browser",
+    ".charter/active-persona",
+    ".edm/active-persona",
+    ".charter",
+    ".charter/",
+    ".edm",
+    ".edm/",
+    "~/.charter",
+    "/Users/x/proj/.charter/",
+    # Not matched by either, and listed so a change that starts matching them shows up as
+    # a deliberate widening rather than as noise: the registry and the state subtree are
+    # ordinary reads, and denying them was a real regression once (#443's other half).
+    ".charter/vaults.json",
+    ".charter/state/session.json",
+    "charter/secrets/base.py",
+    "docs/secrets.md",
+    # The new alternative. Denied now, not before — the one direction that is allowed.
+    ".charter/fingerprint.key",
+    ".edm/fingerprint.key",
+)
+
+
+class TheGuardOnlyWidens(unittest.TestCase):
+
+    def test_nothing_the_previous_pattern_denied_is_allowed_now(self) -> None:
+        lost = [s for s in CORPUS if BASELINE.search(s) and not _VAULT_PATH_RE.search(s)]
+        self.assertEqual(
+            lost, [],
+            "this branch's pattern denies LESS than origin/main's on these operands. A "
+            "security branch that is weaker than the branch it merges into must not merge.")
+
+    def test_the_baseline_is_not_a_copy_of_the_live_pattern(self) -> None:
+        """Otherwise the comparison above is `x == x` and holds no matter what happens.
+
+        The two patterns are supposed to differ by exactly the alternative this branch
+        added. If they ever become identical, either the branch's change was reverted or
+        somebody 'fixed' this fixture by pasting the current source into it.
+        """
+        self.assertNotEqual(BASELINE.pattern, _VAULT_PATH_RE.pattern)
+        gained = [s for s in CORPUS if _VAULT_PATH_RE.search(s) and not BASELINE.search(s)]
+        self.assertIn(".charter/fingerprint.key", gained,
+                      "the fingerprint key is the whole point of the change under test")
+
+    def test_the_corpus_exercises_both_answers(self) -> None:
+        """A corpus every pattern matches, or none matches, compares nothing."""
+        self.assertTrue(any(BASELINE.search(s) for s in CORPUS))
+        self.assertTrue(any(not _VAULT_PATH_RE.search(s) for s in CORPUS),
+                        "no operand in the corpus is allowed, so a pattern that denied "
+                        "literally everything would pass every assertion in this file")
+
+
+if __name__ == "__main__":       # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Closes #436
Closes #437

Both reproduced first, exactly as filed.

## #436 — the masked line was an offline check against a guess

```
audit2/WEAK: present · 11 bytes · sha256:323725e8eff4
```

The length prefilters a wordlist and the 48-bit digest confirms the hit, with no
further access to charter. It is a hygiene defect rather than an escalation —
anyone who can run `secret exec` already holds a better oracle, and the
assessment's own second pass says so — but this line travels where the value
never does: an agent's transcript, a pasted terminal, a screenshot in a ticket.

**Now:**

```
audit2/WEAK: present · 1–15 bytes · fp:9c41a0b7e5d2
```

- `HMAC-SHA256(plane key, value)[:12]`, the key 32 random bytes generated on
  first use and kept 0600 under `.charter/`. Stable and comparable inside one
  plane — the only comparison anyone makes with it — and not computable by
  anyone without the key.
- Power-of-two size band instead of an exact count, counted in UTF-8 bytes
  (`len()` on a `str` counted characters while the label said bytes).
  `secret set` bands too: with `--from-file` that line lands in the transcript of
  an agent that has never seen the value.
- No key possible → **no fingerprint**, never an unkeyed one.
- `.charter/fingerprint.key` joins `.charter/vaults/` behind the read guard.
  It was not there, and the guard's own denial names the path it refused; for a
  1Password vault — nothing on disk to deny — the key was the only readable
  thing between the printed line and the value.

### The property, not the spelling

"assert the digest ≠ `sha256(value)[:12]`" is a spelling. `blake2b(b"charter" +
value)[12:24]` walks past it and is exactly as checkable offline. The test that
carries the weight runs one value through two planes whose only difference is
the key file and requires the fingerprints to differ — which no pure function of
the value can do, including constructions nobody has thought of. Stability
within a plane is asserted alongside it so "print random bytes" does not pass
either. The filed regression is kept as a backstop, widened to every hash
`hashlib` guarantees over three constant-salt spellings.

Length is tested as indistinguishability (all lengths in a band print one
label), paired with a boundary assertion so a constant label fails too.

## #437 — the vault was at its old mode while the plaintext went in

`O_CREAT|O_TRUNC, 0o600` ignores the mode argument for an inode that already
exists. Measured on a 0644 vault: 0644 while the plaintext was on disk, 0600
after, same inode. Two docstrings asserted the opposite, and that false premise
was the stated reason `_tighten` is skipped on the write path.

The mode is now settled on the **descriptor**: open without `O_TRUNC`, `fchmod`,
`fstat` the same fd and **read the mode back**, then truncate and write. Reading
it back is the point — a chmod that returns 0 is not evidence the bits moved on
a mount with fixed permissions (exFAT, many network shares). If the mode is
still loose charter writes nothing and says so, and the previous contents
survive; warning and writing anyway leaves the credential world-readable with
the warning scrolled off the top of a log.

Both docstrings corrected in the same commit. A vault directory charter creates
is 0700. `registry._write` — named in the issue, carries paths and env variable
NAMES rather than values — takes the same descriptor-first path, without the
refusal, because its shared half is deliberately 0644 and committed.

**Not touched:** the plain-file vault stores plaintext at rest. Documented,
accepted, and not the defect.

### Instrumented at a layer every spelling reaches

A spy on `json.dump` (what the issue suggested) is blind to `Path.write_text`, a
bare `os.write`, and the deletion of the guard it pins. The test wraps `io.open`
— which `os.fdopen`, `open()` and `Path.open` all reach — and `os.write`,
records the mode from an `fstat` of the descriptor being written, and keys
records by `(st_dev, st_ino)` so a temp-file-plus-`os.replace` implementation is
measured on the right file. It then asserts the watch **actually saw** the
plaintext, so an implementation writing through a path it does not observe goes
RED asking to be extended rather than passing on having seen nothing.

## Mutation testing

12 mutants, `__pycache__` cleared between every run, restore verified green each
time.

| # | Mutation | Expected | Got |
|---|---|---|---|
| M1 | `_save` reverted to the filed defect | RED | RED (5 failures) |
| M2 | chmod the PATH before open, no read-back | RED | RED (2) |
| M3 | same guard, plaintext via `Path.write_text` | **GREEN** | GREEN |
| M4 | vault directory left at the umask default | RED | RED (1) |
| M5 | fingerprint back to `sha256(value)[:12]` | RED | RED (7) |
| M6 | `blake2b(salt+value)[12:24]` — the next spelling | RED | RED (6) |
| M7 | unkeyed digest as the no-key fallback | RED | RED (2) |
| M8 | size band back to the exact count | RED | RED (2) |
| M9 | size band collapsed to one constant | RED | RED (2) |
| M10 | key file written without reading its mode back | RED | RED (1) |
| M11 | `registry._write` reverted | RED | RED (1) |
| M12 | `fingerprint.key` dropped from the read guard | RED | RED (3) |

M3 is the one that had to stay green: it is what shows the watch is not pinned
to `json.dump` or `os.fdopen`.

## What is the next spelling of this that still gets through?

Stated in `docs/secrets.md` and in the module rather than left to be found:

- **Whoever holds the key holds the oracle.** The read guard denies it to
  file-reading tools; a shell running as you reads it, as it reads everything
  else you own. `SECURITY.md`'s framing is unchanged.
- **Within one plane the fingerprint is still an equality oracle.** Anyone who
  can `secret set` a guess can compare — and can also `--reveal --force`, so it
  is not a step up for them. It is the reason the key is per-plane rather than
  per-vault: per-vault salting would close it and break the one comparison the
  fingerprint exists for.
- **`.charter/vaults/` on planes that already exist keeps its old mode.** Only a
  directory charter creates is 0700; silently chmod-ing a directory charter did
  not create is the #331 mistake.
- **`config.py`'s state-dir migration** has the same in-place pattern, on a file
  holding paths. Left alone deliberately — it is one line in a migration path
  another change is likely touching.

## Suite

`python3 -m unittest discover -s tests` → **Ran 4557 tests … OK**. stdlib only,
`PersonaIso` for anything touching plane state, no network, no real credential
in any fixture or assertion message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
