### PR TITLE
hooks: a denial charter cannot write is not an allow, and a file restore is not a branch move (#438, #461)

### DIFF
--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import sys
 import time
 from pathlib import Path
@@ -132,26 +133,55 @@ def _deny(event: str, reason: str) -> int:
             "permissionDecision": "deny",
             "permissionDecisionReason": text,
         }})
+        # A WRITE IS NOT A DELIVERY, and this line is the whole of #438's second half.
+        # `print` to a PIPE block-buffers: the JSON lands in an 8KiB userspace buffer, the
+        # call returns cleanly, and the `except` below never runs — so the first version of
+        # this fix returned 0 on a real broken pipe and the tool call proceeded, byte for
+        # byte what it replaced. The failure surfaced only when the interpreter flushed at
+        # shutdown, too late for any handler to answer and worth exactly 120: a NON-blocking
+        # status. Only an unbuffered stdout — a terminal, or a test that stubs `print` —
+        # raised where the code expected it, which made the buffered pipe (the real hook's
+        # real stdout, one end of a harness pipe) the one shape nothing covered.
+        #
+        # Flushing here moves the answer to "did the harness get this?" back inside the
+        # `try`, where the guard can still act on it.
+        sys.stdout.flush()
     except Exception:  # noqa: BLE001 - the channel, not the verdict
         _undelivered_deny.append(text)
-        # stderr is what exit 2 hands to the model, so the reason still arrives.
+        # stderr is what exit 2 hands to the model, so the reason still arrives — and it is
+        # flushed for the reason above: buffered is not delivered, and a reason discovered
+        # to be undeliverable at shutdown is a refusal with no reason.
         try:
             print(text, file=sys.stderr)
+            sys.stderr.flush()
         except Exception:  # noqa: BLE001 - best effort; the exit status is the guard
-            pass
+            _mute(sys.stderr)
         # And stop the interpreter trying to flush the dead stream on the way out: a failed
         # shutdown flush REPLACES the exit status with 120, which is in the "tool call
         # proceeds" bucket — the same fd-level move, and the same guard, as `cli.main`.
-        try:
-            fd = os.open(os.devnull, os.O_WRONLY)
-            try:
-                os.dup2(fd, sys.stdout.fileno())
-            finally:
-                os.close(fd)
-        except Exception:  # noqa: BLE001 - no real pipe under test; nothing to suppress
-            pass
+        _mute(sys.stdout)
         return DENY_EXIT
     return 0
+
+
+def _mute(stream) -> None:
+    """Point *stream*'s file descriptor at ``/dev/null`` so a later flush cannot fail.
+
+    A `BrokenPipeError` raised while the interpreter flushes on the way out REPLACES the
+    process's exit status with 120 — a non-blocking hook error, i.e. an allow. So the last
+    thing :func:`_deny` does with a dead channel is make sure nothing tries to use it again:
+    the exit status is the only thing left carrying the refusal, and it has to survive
+    shutdown. Best effort by construction — under a test's `StringIO` there is no fd to
+    replace and nothing to suppress.
+    """
+    try:
+        fd = os.open(os.devnull, os.O_WRONLY)
+        try:
+            os.dup2(fd, stream.fileno())
+        finally:
+            os.close(fd)
+    except Exception:  # noqa: BLE001 - no real pipe here; nothing to suppress
+        pass
 
 
 #: The one host permission mode that means NOBODY IS WATCHING. Deliberately not a set that
@@ -808,15 +838,96 @@ def _ssh_prefix_hosts(forges: dict[str, object]) -> dict[str, str]:
 #: were destroyed" are two findings and only one sentence can be the denial.
 _BRANCH_MOVERS = ("checkout", "switch")
 
-#: Flags that make one of the above CREATE a branch rather than move to an existing one.
-_BRANCH_CREATORS = ("-b", "-B", "-c", "-C")
+#: Options that make one of the above CREATE a branch rather than move to an existing one.
+#: The operand of one of these is a NAME TO CREATE — never a path to restore, however much
+#: it looks like one.
+#:
+#: `--orphan` was the round-one bypass and is the reason the rest of this section exists:
+#: `git checkout --orphan README` in the plane root answers *"Switched to a new branch
+#: 'README'"* and HEAD moves, but `--orphan` matched neither the creator list nor
+#: `--detach`, so the operand was handed to :func:`_checkout_operand_kind`, came back
+#: `"path"`, and the restore carve-out let a branch creation through. Its long-form
+#: siblings `--create`/`--force-create` (`git switch -c`/`-C`) are here for the same
+#: reason: a list of SPELLINGS is only ever as long as the last audit.
+_BRANCH_CREATOR_OPTS = frozenset({"-b", "-B", "-c", "-C",
+                                  "--orphan", "--create", "--force-create"})
 
 #: `--detach` takes the root OFF its branch with no operand at all — `git checkout --detach`
 #: and `git switch --detach` both answer "HEAD is now at …", verified. The guard used to
 #: require an operand, so the one spelling of a HEAD move that needs no argument was the one
 #: it could not see. It is a ref move, never a restore, and it suppresses the file-restore
-#: carve-out below for exactly that reason.
-_DETACH = "--detach"
+#: carve-out below for exactly that reason. `-d` is git's own short form of it and detaches
+#: identically — verified: `git checkout -d feature` and `git switch -d feature` both answer
+#: "HEAD is now at <sha>".
+_DETACH_OPTS = frozenset({"--detach", "-d"})
+
+#: Options a **restore** accepts — from `git checkout -h` and `git restore -h` (git 2.50),
+#: keeping only the ones that cannot move HEAD.
+#:
+#: This is an ALLOWLIST, and that direction is the whole point. The guard used to ask "is
+#: this option one of the four I know move HEAD?", which answers "no" for every option git
+#: gains after the question was written, and answered "no" for `--orphan`, `--track` and
+#: `--guess` the day it was written. It now asks "is every option here one I can show a
+#: restore accepts?", so an option charter has never heard of keeps the guard shut rather
+#: than opening it. The cost is a false denial on a new restore-only flag; the remedy is in
+#: the message and needs no options at all (`git restore <path>`, `git checkout -- <path>`),
+#: and both stay allowed in the plane root.
+_RESTORE_OPTS = frozenset({
+    "--ours", "--theirs", "--force", "--merge", "--patch", "--quiet", "--progress",
+    "--conflict", "--overlay", "--ignore-skip-worktree-bits", "--pathspec-from-file",
+    "--pathspec-file-nul", "--recurse-submodules", "--overwrite-ignore",
+    "--ignore-other-worktrees", "--source", "--staged", "--worktree", "--ignore-unmerged",
+})
+
+#: The same list in git's short spelling, as LETTERS — because `-fq` is one token and
+#: `-bREADME` is one token, and reading either as "an option I do not recognise, so
+#: harmless" is how `git checkout -bREADME` walked past this guard: `-bREADME` is not `-b`,
+#: `wants` came out empty, and "no operand means nothing moves" allowed a branch creation.
+#: `-2`/`-3` are `--ours`/`--theirs`; the letters absent from here (`b`, `d`, `t`, `l` …)
+#: are absent on purpose.
+_RESTORE_SHORTS = frozenset("fmpq23")
+
+
+def _checkout_opt_kind(tok: str) -> str:
+    """Classify one option of a `git checkout`/`git switch`: ``"create"``, ``"detach"``,
+    ``"restore"`` or ``"unknown"``.
+
+    Value forms are the subject. git's parser takes an option's value ATTACHED as readily as
+    separated — `-bREADME` is `-b README`, `--orphan=README` is `--orphan README`, and
+    `-fq` is two options in one token — all verified against git 2.50, all of which move
+    HEAD or make a restore what it is. A guard that compares whole tokens to `"-b"` sees
+    none of them, which is the bypass this function exists to close: it normalises to the
+    option NAME first, then answers.
+
+    ``"unknown"`` is not ``"restore"``. Anything this cannot place is treated as capable of
+    moving HEAD, so the fail-closed default belongs to the option charter has never seen —
+    `--track`, `--guess`, and whatever git adds next — rather than to a fixed list of bad
+    ones going stale.
+    """
+    if tok.startswith("--"):
+        name = tok.split("=", 1)[0]
+        # `--no-x` is git's negation of `--x`. Normalised rather than listed, and it stays
+        # on the same side of the fence as `--x`: `--no-orphan` is refused with `--orphan`,
+        # which costs nothing real and cannot be a way in.
+        if name.startswith("--no-"):
+            name = "--" + name[len("--no-"):]
+        if name in _BRANCH_CREATOR_OPTS:
+            return "create"
+        if name in _DETACH_OPTS:
+            return "detach"
+        return "restore" if name in _RESTORE_OPTS else "unknown"
+    # A short cluster is read left to right, exactly as git's parser reads it, and stops at
+    # the first letter that decides: `-b` swallows the rest of the token as the new branch's
+    # name, so `-qbREADME` is `-q -b README` and not three unrecognised letters.
+    for ch in tok[1:]:
+        if f"-{ch}" in _BRANCH_CREATOR_OPTS:
+            return "create"
+        if f"-{ch}" in _DETACH_OPTS:
+            return "detach"
+        if ch not in _RESTORE_SHORTS:
+            return "unknown"
+    return "restore"
+
 
 #: How many trailing operands of a `git checkout <tree-ish> <paths…>` the guard will resolve
 #: before it stops and keeps refusing. One local `ls-files` each, on the `PreToolUse` path,
@@ -886,7 +997,11 @@ def _plane_root_git(cmd: str, cwd: str, root: Path):
     spot is invisible — it looks exactly like the guard being present and never firing — so
     the two of them share one pair of eyes.
 
-    The subcommand is yielded raw; deciding which ones matter is each guard's own business.
+    Yields ``(subcommand, args-after-it, git's-own-options-before-it)``. The subcommand is
+    yielded raw; deciding which ones matter is each guard's own business. The leading
+    options come along because one of them can DEFINE the subcommand — `git -c
+    alias.co=checkout co feature` switches branches, verified — and only a guard that
+    resolves aliases needs them.
     """
     here = cwd
     for _toks in _segment_argv(cmd):
@@ -914,7 +1029,7 @@ def _plane_root_git(cmd: str, cwd: str, root: Path):
                 continue
         except OSError:
             continue
-        yield rest[i], rest[i + 1:]
+        yield rest[i], rest[i + 1:], rest[:i]
 
 
 def _checkout_operand_kind(root: Path, op: str) -> str:
@@ -978,6 +1093,134 @@ def _checkout_operand_kind(root: Path, op: str) -> str:
     return "path" if path else "neither"
 
 
+#: Subcommands charter takes to be git's own, so it does not have to ask whether they are
+#: aliases. **A cost list, never a safety list**: a name missing from it costs one
+#: `git config --get`, and a name wrongly in it can only be wrong about a person who
+#: shadowed a git builtin with an alias of the same name — which git itself ignores
+#: ("alias.status is a builtin, skipping"). Everything that MOVES HEAD is deliberately
+#: absent, so the resolution below still runs for `checkout` and `switch`.
+_GIT_KNOWN_SUBCOMMANDS = frozenset({
+    "add", "am", "annotate", "apply", "archive", "bisect", "blame", "branch", "bundle",
+    "cat-file", "check-ignore", "cherry", "cherry-pick", "clean", "clone", "commit",
+    "config", "describe", "diff", "difftool", "fetch", "for-each-ref", "format-patch",
+    "fsck", "gc", "grep", "help", "init", "log", "ls-files", "ls-remote", "ls-tree",
+    "merge", "merge-base", "mergetool", "mv", "notes", "pull", "push", "range-diff",
+    "rebase", "reflog", "remote", "repack", "replace", "rerere", "reset", "restore",
+    "rev-list", "rev-parse", "revert", "rm", "shortlog", "show", "show-ref", "sparse-checkout",
+    "stash", "status", "submodule", "symbolic-ref", "tag", "update-index", "update-ref",
+    "verify-commit", "version", "whatchanged", "worktree",
+})
+
+#: How many alias hops the guard follows. git resolves an alias to an alias (verified:
+#: `ck = co`, `co = checkout` switches branches), so one hop is not enough and unbounded
+#: is a loop.
+_MAX_ALIAS_HOPS = 4
+
+
+def _inline_aliases(pre: list[str]) -> dict[str, str]:
+    """Aliases defined ON THE COMMAND LINE: ``git -c alias.co=checkout co feature``.
+
+    No repo config knows about these, so a guard that only asked `git config` would miss the
+    one spelling of an alias that needs no setup at all — verified against git 2.50, which
+    answers "Switched to branch 'feature'". git rejects the attached form
+    (`-calias.co=checkout` → "unknown option"), so only `-c <name>=<value>` is read here.
+    """
+    out: dict[str, str] = {}
+    for j, tok in enumerate(pre[:-1]):
+        if tok != "-c":
+            continue
+        name, sep, body = pre[j + 1].partition("=")
+        if sep and name.lower().startswith("alias."):
+            out[name[len("alias."):]] = body
+    return out
+
+
+def _resolve_git_alias(root: Path, sub: str, post: list[str], pre: list[str]):
+    """Follow git ALIASES to the subcommand that will really run: ``("checkout", [...])``.
+
+    `git checkout` is not the only way to spell `git checkout`. With `co = checkout` in any
+    config git reads — and that alias is on a large share of developer machines — `git co
+    feature` in the plane root answers "Switched to branch 'feature'" and this guard never
+    saw a `checkout` at all. Measured, along with `ck = co` (git follows the chain),
+    `sw = switch -c` (an alias carrying options, which the operand rule then has to read
+    together with the caller's own), and the command-line form above.
+
+    That is the same defect as `--orphan`, one layer out: the guard was matching the
+    SPELLING of a branch move rather than asking what the command does. So it asks — of git,
+    for this repo, and only for a subcommand it does not already take to be git's own, which
+    keeps `git status`/`git commit`/`git log` on a set lookup instead of a subprocess.
+
+    **What this does not reach**, stated because a guard's limits belong next to it rather
+    than in a claim somewhere that it has none:
+
+    * `!`-aliases that are not a plain `git …` — `co = !sh -c '…'` runs a shell charter does
+      not read, and it stands aside rather than refusing every shell alias in the plane root
+      (`s = !git status` style aliases are common and harmless). `co = !git checkout` IS
+      followed: the body is read as the git command it is.
+    * `--config-env=alias.co=VAR`, where the body is in the environment.
+    * A git that will not answer. As everywhere else in this guard, unreadable is not a
+      licence to skip — but here there is nothing yet to refuse: charter has no reason to
+      believe the command is a branch move, so it is out of scope rather than allowed.
+    """
+    from . import util as _util
+    from .doctor import _git_in
+    inline = _inline_aliases(pre)
+    seen: set[str] = set()
+    for _ in range(_MAX_ALIAS_HOPS):
+        if sub in _BRANCH_MOVERS or sub in _GIT_KNOWN_SUBCOMMANDS or sub in seen:
+            return sub, post
+        seen.add(sub)
+        body = inline.get(sub)
+        if body is None:
+            try:
+                r = _git_in(root, "config", "--get", f"alias.{sub}")
+            except (_util.ProcTimeout, OSError, ValueError):
+                return sub, post
+            body = r.stdout.strip() if r.returncode == 0 else ""
+        if not body:
+            return sub, post
+        shell = body.startswith("!")
+        try:
+            toks = shlex.split(body[1:] if shell else body)
+        except ValueError:
+            return sub, post
+        if shell:
+            # `!git checkout` is a git command wearing a shell alias's clothes; anything
+            # else is a shell charter does not read.
+            if not toks or os.path.basename(toks[0]) != "git":
+                return sub, post
+            toks = toks[1:]
+        if not toks:
+            return sub, post
+        # The caller's own arguments are appended to the expansion, exactly as git appends
+        # them — which is why `sw = switch -c` plus `git sw neu` has to be judged as
+        # `switch -c neu` and not as two unrelated halves.
+        sub, post = toks[0], toks[1:] + post
+    return sub, post
+
+
+def _created_branch(opts: list[str], classes: list[str], wants: list[str]) -> str | None:
+    """The name a branch-creating `checkout`/`switch` would create, for the DENIAL TEXT.
+
+    Named rather than guessed at, because the name can be inside the option token: git takes
+    a short option's value attached (`-bREADME`) and a long option's after `=`
+    (`--orphan=README`), and in both the operand list is empty. A message that fell back to
+    "switch branches" there would be describing a different command from the one it is
+    refusing.
+    """
+    first = next((o for o, c in zip(opts, classes) if c == "create"), None)
+    if first is None:
+        return wants[0] if wants else None
+    if first.startswith("--"):
+        if "=" in first:
+            return first.split("=", 1)[1] or None
+    else:
+        for i, ch in enumerate(first[1:], start=1):
+            if f"-{ch}" in _BRANCH_CREATOR_OPTS:
+                return first[i + 1:] or (wants[0] if wants else None)
+    return wants[0] if wants else None
+
+
 def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
     """Deny a git command that would move the PLANE ROOT between branches (#157).
 
@@ -1006,6 +1249,13 @@ def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
       path and not a revision" opens the gate. The ambiguous case — a file and a branch
       sharing a name — stays DENIED and the message says so.
 
+      **The operand is only half the command.** What an operand MEANS depends on the
+      options beside it: `README` is a path after `--ours` and a branch to create after
+      `--orphan`, and `git checkout --orphan README` answers "Switched to a new branch
+      'README'". So the carve-out also requires every option present to be one
+      :func:`_checkout_opt_kind` can place as restore-only — an allowlist, so an option
+      charter has never heard of keeps the guard shut instead of opening it.
+
     Costs one `git symbolic-ref` only once a candidate is found, plus two read-only git
     questions per operand of a `checkout` that is not the remedy, bounded by
     :data:`_MAX_CHECKOUT_OPERANDS` — this runs on every Bash call, and the common case still
@@ -1017,9 +1267,28 @@ def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
     except OSError:
         return None
 
-    for sub, post in _plane_root_git(cmd, cwd, root):
+    for sub, post, pre in _plane_root_git(cmd, cwd, root):
         if sub not in _BRANCH_MOVERS:
-            continue
+            # …yet. `co = checkout` is on half the developer machines in the world, and
+            # `git co feature` moves the plane root's HEAD exactly as far (#461, round two).
+            sub, post = _resolve_git_alias(root, sub, post, pre)
+            if sub not in _BRANCH_MOVERS:
+                continue
+        # Every option, classified before anything else looks at the operands: what an
+        # operand MEANS depends on the options beside it (`README` is a path after `--ours`
+        # and a branch to create after `--orphan`), so a rule that reads the operand first
+        # is reading it without the half of the command that decides.
+        opts = [a for a in post if a.startswith("-") and a not in ("-", "--")]
+        classes = [_checkout_opt_kind(o) for o in opts]
+        creating = "create" in classes
+        detaching = "detach" in classes
+        # The carve-out below opens only on a command charter can show is a restore, OPTIONS
+        # INCLUDED. `all()` of an empty list is True, so the bare spellings — `git checkout
+        # README`, `git checkout -- <paths>` — are unaffected; one option nobody has placed
+        # is enough to keep the guard speaking.
+        restore_shaped = all(c == "restore" for c in classes)
+        unplaced = next((o for o, c in zip(opts, classes) if c == "unknown"), None)
+
         # `--` separates refs from PATHS, and only what follows it is a path. Treating the
         # token itself as proof of a file restore let two real branch moves through:
         # `git checkout <branch> --` and `git checkout -b <new> --` both switch — verified
@@ -1030,18 +1299,23 @@ def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
         # something after it means paths, and `git checkout <tree-ish> -- <paths>` leaves
         # HEAD where it was. Nothing after it means the separator is decoration on a branch
         # move, and the operands before it still count.
+        #
+        # `restore_shaped` gates even this: `git checkout -b neu -- README` is refused by
+        # git today ("fatal: 'README' is not a commit and a branch 'neu' cannot be created
+        # from it"), and a carve-out that depends on git continuing to refuse something is a
+        # bypass waiting for a release note.
         if "--" in post:
             cut = post.index("--")
             if post[cut + 1:]:
-                continue                    # paths follow: a restore, HEAD does not move
-            post = post[:cut]               # a trailing bare `--` still switches
-        creating = any(a in _BRANCH_CREATORS for a in post)
-        detaching = _DETACH in post
+                if restore_shaped:
+                    continue                # paths follow: a restore, HEAD does not move
+            else:
+                post = post[:cut]           # a trailing bare `--` still switches
         # A bare `-` is a REF (the previous branch), not a flag — and `git checkout -` is
         # what makes a six-switch session cheap to repeat, so reading it as a flag would
         # leave the guard blind to the cheapest form of the thing it exists to stop.
         wants = [a for a in post if a == "-" or not a.startswith("-")]
-        if not wants and not (creating or detaching):
+        if not wants and not (creating or detaching) and restore_shaped:
             continue  # bare `git checkout` moves nothing
 
         if not creating and wants:
@@ -1059,10 +1333,12 @@ def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
 
         # Is this `checkout` the RESTORE half of the overload (#461)? Only `checkout` is
         # asked: `git switch` takes branches and nothing else, which is why it exists.
-        # `--detach` and `-b`/`-B` are ref moves whatever the operand looks like, so
-        # neither reaches this.
+        # `restore_shaped` is what keeps a ref move out of here whatever the operand looks
+        # like — `--detach`, `-b`/`-B`, `--orphan`, `-bREADME` and every option nobody has
+        # placed all fail it, and `git checkout --orphan README` was exactly a ref move
+        # whose operand reads as a path.
         kind = "rev"
-        if sub == "checkout" and wants and not creating and not detaching:
+        if sub == "checkout" and wants and restore_shaped:
             kind = _checkout_operand_kind(root, wants[0])
             if len(wants) == 1:
                 restore = kind == "path"
@@ -1109,8 +1385,24 @@ def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
                 f"would move HEAD in the PLANE ROOT — charter could not ask git whether "
                 f"'{wants[0]}' is a path or a revision here, and a guard that opened "
                 f"because it failed to ask is no guard. ")
+        elif unplaced is not None and not creating and not detaching:
+            # Say the true thing, which is narrower than "this switches branches": charter
+            # does not know what `{unplaced}` does, and an option it cannot place is an
+            # option that might move HEAD (`--orphan` did). Asserting a switch here would
+            # repeat #461's other half — a denial that is right to refuse and wrong about
+            # why still sends the operator to the wrong remedy.
+            opening = (
+                f"cannot read this `git {sub}` as a file restore in the PLANE ROOT: it does "
+                f"not recognise the option '{unplaced}', and an option charter cannot place "
+                f"is one that may move HEAD — `git checkout --orphan <file>` reads exactly "
+                f"like a restore and creates a branch. Only a form charter can show is a "
+                f"restore opens that gate. "
+                + (f"(A restore needs no options here: `git restore {wants[0]}` and "
+                   f"`git checkout -- {wants[0]}` are both allowed.) " if wants else ""))
         else:
-            moving = (f"create '{wants[0]}'" if creating and wants
+            created = _created_branch(opts, classes, wants) if creating else None
+            moving = (f"create '{created}'" if created
+                      else "create a branch" if creating
                       else "detach HEAD" if detaching and not wants
                       else f"switch to '{wants[0]}'" if wants else "switch branches")
             opening = f"would {moving} in the PLANE ROOT. "
@@ -1216,7 +1508,7 @@ def _plane_root_reset_reason(cmd: str, cwd: str) -> str | None:
     except OSError:
         return None
 
-    for sub, post in _plane_root_git(cmd, cwd, root):
+    for sub, post, _pre in _plane_root_git(cmd, cwd, root):
         if sub != "reset":
             continue
         if not any(a in _RESET_TREE_MODES for a in post):

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -969,6 +969,21 @@ def _git_target(cwd: str, args: list[str]) -> tuple[Path, list[str]]:
     `git -C <path>` is how a session standing in a workspace reaches the shared tree, so a
     guard that only looked at the cwd would leave the door open from every clone.
 
+    **A `-C` is resolved against the SHELL's directory**, which is what *cwd* carries. It
+    used to be `Path(args[i + 1])`, so a relative one resolved against whatever directory
+    the hook process happened to be started in — a directory the command being judged has
+    nothing to do with. `git -C ../../.. checkout feature` from a workspace clone moves the
+    PLANE ROOT's HEAD (verified end to end against git 2.50: *"Switched to branch
+    'feature'"*, and the root's `symbolic-ref` follows), and the guard was reading it as a
+    command against a path three levels above the hook's cwd, found something that was not
+    the plane root, and stood aside. `git -C . checkout feature` typed in the root itself
+    landed the same way, and so did `cd .. && git -C <root-name> checkout feature`.
+
+    Joining onto the running *target* rather than onto *cwd* is also what git itself does
+    when a command carries several: *"each subsequent non-absolute `-C <path>` is
+    interpreted relative to the preceding one"* — verified, `git -C ../.. -C .` from a
+    subdirectory answers the top level.
+
     *args* is `_invocation`'s argv, which INCLUDES the program — dropping it here is what
     lets the caller take "the first non-flag token" as the subcommand rather than as `git`.
     """
@@ -976,8 +991,11 @@ def _git_target(cwd: str, args: list[str]) -> tuple[Path, list[str]]:
     rest: list[str] = []
     i = 1 if args else 0
     while i < len(args):
+        # Only the separated form: git rejects the attached one outright ("unknown option:
+        # -C.", verified), so reading `-C.` as a directory would be inventing a command.
         if args[i] == "-C" and i + 1 < len(args):
-            target = Path(args[i + 1])
+            val = args[i + 1]
+            target = Path(val) if os.path.isabs(val) else target / val
             i += 2
             continue
         rest.append(args[i])
@@ -1237,8 +1255,12 @@ def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
     * **Only the root.** A workspace clone is where branch work belongs, so it is never
       touched, whether reached by cwd or by ``git -C``.
     * **The remedy stays executable.** `doctor` prints *"Put the root back:
-      `git -C <plane> checkout main`"*, so returning to the plane's default branch is
-      always allowed. A guard that blocks the fix it recommends teaches people to bypass it.
+      `git -C <plane> checkout main`"*, and that command is always allowed. A guard that
+      blocks the fix it recommends teaches people to bypass it. What earns the carve-out is
+      the command leaving HEAD ATTACHED to the default branch, not the default branch's
+      name appearing in the argv: `git checkout --detach main` names it too and takes the
+      root off every branch, and while the carve-out gated on the operand alone that
+      spelling walked past all of the `--detach` handling below.
     * **A file restore is not a branch move** (#461). `git checkout <path>` restores a path
       and never touches HEAD — the same operation `git restore <path>` performs, which this
       guard has always allowed. Refusing one spelling of an operation charter permits is a
@@ -1304,13 +1326,24 @@ def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
         # git today ("fatal: 'README' is not a commit and a branch 'neu' cannot be created
         # from it"), and a carve-out that depends on git continuing to refuse something is a
         # bypass waiting for a release note.
-        if "--" in post:
+        #
+        # And `sub == "checkout"` gates it, because **`git switch` has no path half for a
+        # `--` to introduce**. That is the whole reason `switch` exists, and it makes the
+        # separator mean the opposite thing there: `git switch -- feature` and
+        # `git switch -q -- feature` answer "Switched to branch 'feature'" — verified
+        # against git 2.50 — so reading "something follows the separator" as "these are
+        # paths" turned a three-character token into a bypass of the branch guard on the one
+        # subcommand that can only ever move HEAD. Found by generating the corpus rather
+        # than listing it; no hand-written row had this shape.
+        if sub == "checkout" and "--" in post:
             cut = post.index("--")
             if post[cut + 1:]:
                 if restore_shaped:
                     continue                # paths follow: a restore, HEAD does not move
             else:
                 post = post[:cut]           # a trailing bare `--` still switches
+        # A `switch` needs no rewriting here: `wants` already drops the separator, so
+        # `git switch -- feature` arrives at the rest of the rule as the branch move it is.
         # A bare `-` is a REF (the previous branch), not a flag — and `git checkout -` is
         # what makes a six-switch session cheap to repeat, so reading it as a flag would
         # leave the guard blind to the cheapest form of the thing it exists to stop.
@@ -1318,18 +1351,34 @@ def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
         if not wants and not (creating or detaching) and restore_shaped:
             continue  # bare `git checkout` moves nothing
 
-        if not creating and wants:
-            from . import util as _util
-            from .doctor import _plane_default_branch
-            try:
-                default = _plane_default_branch(root)
-            except (_util.ProcTimeout, OSError):
-                # A git that will not answer is not a licence to skip the guard — and it
-                # used to be worse than that: this raised straight out of a `PreToolUse`
-                # handler, which is a broken turn rather than a verdict.
-                default = None
-            if default is not None and wants[0] == default:
-                continue  # the documented remedy — must stay runnable
+        from . import util as _util
+        from .doctor import _plane_default_branch
+        try:
+            default = _plane_default_branch(root)
+        except (_util.ProcTimeout, OSError):
+            # A git that will not answer is not a licence to skip the guard — and it
+            # used to be worse than that: this raised straight out of a `PreToolUse`
+            # handler, which is a broken turn rather than a verdict.
+            default = None
+        # The documented remedy — `doctor` prints `git -C <plane> checkout main` — has to
+        # stay runnable. What makes a command that remedy is not the NAME beside it: it is
+        # that the command leaves HEAD **attached to the default branch**. The carve-out
+        # used to gate on `not creating` and the operand's spelling alone, so every detach
+        # that happened to name the default branch walked through it — and past every piece
+        # of `--detach` handling above. Measured against git 2.50, all of these answer
+        # "HEAD is now at <sha>" and take the root off `main`: `git checkout --detach main`,
+        # `git switch -d main`, `git checkout -qd main`, `git checkout -dq main`,
+        # `git checkout --detach main --`, `git switch --detach -- main`, and the same
+        # through an alias.
+        #
+        # `restore_shaped` is the whole gate, and it is the property rather than a longer
+        # list of spellings: it holds only when EVERY option present is one charter can
+        # place as restore-only, so an option classed `create` or `detach` fails it, and so
+        # does one charter has never heard of. What is left is a plain attach —
+        # `git checkout main`, `git switch main`, `git checkout -f main`, `git checkout -q
+        # main` — which is exactly what `doctor` recommends, options and all.
+        if restore_shaped and wants and default is not None and wants[0] == default:
+            continue  # the documented remedy — must stay runnable
 
         # Is this `checkout` the RESTORE half of the overload (#461)? Only `checkout` is
         # asked: `git switch` takes branches and nothing else, which is why it exists.
@@ -1401,17 +1450,31 @@ def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
                    f"`git checkout -- {wants[0]}` are both allowed.) " if wants else ""))
         else:
             created = _created_branch(opts, classes, wants) if creating else None
+            # `--detach <ref>` is a DETACH and not a switch, however ordinary the ref beside
+            # it looks. Saying "switch to 'main'" for `git checkout --detach main` would be
+            # #461's other half again: a refusal that is right and a sentence that is wrong
+            # about what the command does — and here it would read as a denial of the one
+            # command the last sentence promises is allowed.
             moving = (f"create '{created}'" if created
                       else "create a branch" if creating
-                      else "detach HEAD" if detaching and not wants
+                      else f"detach HEAD at '{wants[0]}'" if detaching and wants
+                      else "detach HEAD" if detaching
                       else f"switch to '{wants[0]}'" if wants else "switch branches")
             opening = f"would {moving} in the PLANE ROOT. "
+        # Name the spelling rather than promising a category. "Returning the root to its
+        # default branch is always allowed" is not true of every command with the default
+        # branch in it — `git checkout --detach main` is refused three lines up — and a
+        # closing sentence that overclaims is how the carve-out came to be read as being
+        # about the operand.
+        back = (f"`git checkout {default}` — putting the root back on its default branch — "
+                f"is always allowed." if default else
+                "Putting the root back on its default branch is always allowed.")
         return (
             f"{opening}The plane root is one working tree every session "
             f"shares — two agents here silently clobber each other's branches, and the "
             f"symptom looks like an unrelated bug. Branch work belongs in a workspace "
             f"clone: `charter workspace create <task>`, then `charter clone <repo>`. "
-            f"Returning the root to its default branch is always allowed.")
+            f"{back}")
     return None
 
 

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -88,12 +88,70 @@ _OVERRIDE_NOTE = (
 )
 
 
-def _deny(event: str, reason: str) -> None:
-    _emit({"hookSpecificOutput": {
-        "hookEventName": event,
-        "permissionDecision": "deny",
-        "permissionDecisionReason": f"charter guard: {reason}{_OVERRIDE_NOTE}",
-    }})
+#: The exit status that BLOCKS a tool call: the harness reads 2 from a `PreToolUse` hook as
+#: "refused", with stderr as the reason. Every OTHER non-zero status is a non-blocking
+#: error and the tool call **proceeds** — which is why the fallback below has to be exactly
+#: this number and cannot be "any failure exit". `cli.main` turns a `BrokenPipeError` into
+#: 141 (128 + SIGPIPE), the correct answer for `charter … | head` and the wrong one here.
+DENY_EXIT = 2
+
+#: Denials this process decided and could not WRITE (#438).
+#:
+#: `_deny` refuses by printing JSON on stdout, so a hook whose stdout is gone has said
+#: nothing at all — and a `PreToolUse` hook that says nothing is an ALLOW. That is the one
+#: direction a guard may not fail in, and it is a different question from the rest of this
+#: module's silent-on-error discipline: a tally that misses a row costs a row, a denial that
+#: misses its channel costs the thing the denial exists to stop.
+#:
+#: Recorded here rather than only returned, so the fallback cannot be lost by a call site
+#: that forgets to propagate it — `dispatch` checks this list at the process boundary, which
+#: is the only place an exit status means anything, and every present and future `_deny`
+#: call is covered by construction.
+_undelivered_deny: list[str] = []
+
+
+def _deny(event: str, reason: str) -> int:
+    """Refuse the tool call; return the exit status the handler should return.
+
+    ``0`` when the verdict went out as JSON on stdout (the normal path — the JSON *is* the
+    refusal and the process exits cleanly). :data:`DENY_EXIT` when writing it failed, which
+    is the whole point of the return value: the emit is a `print`, a `print` to a closed
+    pipe raises, and until #438 that exception either propagated (`cli.main` → 141 → tool
+    proceeds) or was swallowed by a caller's `except Exception: return 0` (→ tool
+    proceeds). Both spellings of "the guard broke" meant "allowed".
+
+    Reachability is low and the direction is what matters: the two sibling vault guards
+    failed in *opposite* directions, in a module that argues at length that they must never
+    disagree. So this is fixed once, here, for every guard rather than at the call site the
+    audit happened to look at.
+    """
+    text = f"charter guard: {reason}{_OVERRIDE_NOTE}"
+    try:
+        _emit({"hookSpecificOutput": {
+            "hookEventName": event,
+            "permissionDecision": "deny",
+            "permissionDecisionReason": text,
+        }})
+    except Exception:  # noqa: BLE001 - the channel, not the verdict
+        _undelivered_deny.append(text)
+        # stderr is what exit 2 hands to the model, so the reason still arrives.
+        try:
+            print(text, file=sys.stderr)
+        except Exception:  # noqa: BLE001 - best effort; the exit status is the guard
+            pass
+        # And stop the interpreter trying to flush the dead stream on the way out: a failed
+        # shutdown flush REPLACES the exit status with 120, which is in the "tool call
+        # proceeds" bucket — the same fd-level move, and the same guard, as `cli.main`.
+        try:
+            fd = os.open(os.devnull, os.O_WRONLY)
+            try:
+                os.dup2(fd, sys.stdout.fileno())
+            finally:
+                os.close(fd)
+        except Exception:  # noqa: BLE001 - no real pipe under test; nothing to suppress
+            pass
+        return DENY_EXIT
+    return 0
 
 
 #: The one host permission mode that means NOBODY IS WATCHING. Deliberately not a set that
@@ -753,6 +811,20 @@ _BRANCH_MOVERS = ("checkout", "switch")
 #: Flags that make one of the above CREATE a branch rather than move to an existing one.
 _BRANCH_CREATORS = ("-b", "-B", "-c", "-C")
 
+#: `--detach` takes the root OFF its branch with no operand at all — `git checkout --detach`
+#: and `git switch --detach` both answer "HEAD is now at …", verified. The guard used to
+#: require an operand, so the one spelling of a HEAD move that needs no argument was the one
+#: it could not see. It is a ref move, never a restore, and it suppresses the file-restore
+#: carve-out below for exactly that reason.
+_DETACH = "--detach"
+
+#: How many trailing operands of a `git checkout <tree-ish> <paths…>` the guard will resolve
+#: before it stops and keeps refusing. One local `ls-files` each, on the `PreToolUse` path,
+#: so the work an agent can ask for here is bounded. Past it the answer is "refused", which
+#: costs nothing real: the bulk spelling of a bulk restore is `git checkout -- <paths…>`,
+#: and everything after a `--` is already allowed without asking git anything.
+_MAX_CHECKOUT_OPERANDS = 32
+
 #: `git reset` modes that overwrite the WORKING TREE as they move HEAD. These are the forms
 #: that DESTROY: reset off a commit with one of them and the files that commit introduced
 #: are deleted from disk, leaving the reflog as the only copy of content that was never
@@ -845,6 +917,67 @@ def _plane_root_git(cmd: str, cwd: str, root: Path):
         yield rest[i], rest[i + 1:]
 
 
+def _checkout_operand_kind(root: Path, op: str) -> str:
+    """What ``git checkout <op>`` would make of *op* in *root*: ``"rev"``, ``"path"``,
+    ``"both"``, ``"neither"`` or ``"unknown"`` — **asked of git**, never inferred from the
+    spelling.
+
+    `git checkout` is two commands wearing one name. ``git checkout <rev>`` moves HEAD;
+    ``git checkout <pathspec>`` restores files and moves nothing — the same operation
+    `git restore <pathspec>` performs, which charter has always allowed. The plane-root
+    guard read the second as the first and refused `git checkout charter.toml` with a
+    confident, detailed, wrong explanation of what the command does (#461). `git switch`
+    exists precisely because this overload is confusing; the guard should not inherit the
+    confusion, and it cannot resolve it by matching command *shape*.
+
+    git's own rule, so this asks git's own questions:
+
+    * ``rev-parse --verify --quiet <op>^{commit}`` — does the operand resolve to a commit?
+      Branches, tags, ``HEAD~1`` and raw SHAs all do; ``charter.toml`` does not.
+    * ``ls-files --error-unmatch -- <op>`` — does it name something git TRACKS? That is the
+      right question rather than `os.path.exists`: an untracked file is not restorable
+      (``error: pathspec … did not match any file(s) known to git``), while ``.``,
+      ``src/*.py`` and ``:/`` are pathspecs that match plenty and exist as no single file.
+
+    ``"path"`` — and only ``"path"`` — is the answer that lets a command through, and it is
+    an *affirmative* demonstration rather than the absence of a bad spelling: git cannot
+    read the operand as a commit, and can read it as a tracked path. Everything else keeps
+    guarding, which is what makes the unresolvable cases safe:
+
+    * ``"both"`` is the genuinely ambiguous case a file and a branch sharing a name creates.
+      Verified against git: it resolves in favour of the BRANCH and answers "Switched to
+      branch". Refusing is right there, and the denial says *ambiguous* rather than
+      asserting a branch.
+    * ``"neither"`` is not an allow. A remote-only branch (``git checkout lonely`` with only
+      ``origin/lonely``) answers neither question, and git's DWIM creates a local branch and
+      moves HEAD — verified. Its one overlap with a tracked path is the case git itself
+      refuses: *"fatal: 'x' could be both a local file and a tracking branch"*. A shell form
+      charter did not resolve (``git checkout "$BR"``, ``$(…)``) lands here too. There is no
+      spelling of a branch move that becomes an allow by being unreadable.
+    * ``"unknown"`` is a git that could not be run or did not answer in time — kept denied
+      for the same reason: a guard that opened because it failed to ask is the fail-open
+      shape #438 is about.
+    """
+    from . import util as _util
+    from .doctor import _git_in
+    # `-` is `@{-1}`, the previous branch — a ref, and the cheapest form of the repeated
+    # switch this guard exists to stop. Never a pathspec, and never handed to git here,
+    # where it would be read as an option rather than as an operand.
+    if op == "-":
+        return "rev"
+    try:
+        rev = _git_in(root, "rev-parse", "--verify", "--quiet",
+                      f"{op}^{{commit}}").returncode == 0
+        path = _git_in(root, "ls-files", "--error-unmatch", "--", op).returncode == 0
+    except (_util.ProcTimeout, OSError, ValueError):
+        return "unknown"
+    if rev and path:
+        return "both"
+    if rev:
+        return "rev"
+    return "path" if path else "neither"
+
+
 def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
     """Deny a git command that would move the PLANE ROOT between branches (#157).
 
@@ -854,7 +987,7 @@ def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
     reading and dismissing `doctor`'s warning each time, while two background agents in one
     tree silently clobber each other through exactly this.
 
-    Three things keep it a guard rather than a cage:
+    Four things keep it a guard rather than a cage:
 
     * **Only branch moves.** `git commit` is untouched — `charter save` commits here by
       design, and advancing HEAD along the branch you are on is not the failure.
@@ -863,9 +996,20 @@ def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
     * **The remedy stays executable.** `doctor` prints *"Put the root back:
       `git -C <plane> checkout main`"*, so returning to the plane's default branch is
       always allowed. A guard that blocks the fix it recommends teaches people to bypass it.
+    * **A file restore is not a branch move** (#461). `git checkout <path>` restores a path
+      and never touches HEAD — the same operation `git restore <path>` performs, which this
+      guard has always allowed. Refusing one spelling of an operation charter permits is a
+      false positive, not a policy, and the denial was confidently *wrong about what the
+      command does*: an operator following its advice would go create a workspace clone to
+      restore one file. Which of the two a `checkout` is gets resolved by
+      :func:`_checkout_operand_kind`, by asking git, and only a positive "this is a tracked
+      path and not a revision" opens the gate. The ambiguous case — a file and a branch
+      sharing a name — stays DENIED and the message says so.
 
-    Costs one `git symbolic-ref` only once a candidate is found — this runs on every Bash
-    call, and the common case exits on a string comparison.
+    Costs one `git symbolic-ref` only once a candidate is found, plus two read-only git
+    questions per operand of a `checkout` that is not the remedy, bounded by
+    :data:`_MAX_CHECKOUT_OPERANDS` — this runs on every Bash call, and the common case still
+    exits on a string comparison.
     """
     from . import config as _cfg
     try:
@@ -892,22 +1036,86 @@ def _plane_root_branch_reason(cmd: str, cwd: str) -> str | None:
                 continue                    # paths follow: a restore, HEAD does not move
             post = post[:cut]               # a trailing bare `--` still switches
         creating = any(a in _BRANCH_CREATORS for a in post)
+        detaching = _DETACH in post
         # A bare `-` is a REF (the previous branch), not a flag — and `git checkout -` is
         # what makes a six-switch session cheap to repeat, so reading it as a flag would
         # leave the guard blind to the cheapest form of the thing it exists to stop.
         wants = [a for a in post if a == "-" or not a.startswith("-")]
-        if not wants and not creating:
+        if not wants and not (creating or detaching):
             continue  # bare `git checkout` moves nothing
 
         if not creating and wants:
+            from . import util as _util
             from .doctor import _plane_default_branch
-            if wants[0] == _plane_default_branch(root):
+            try:
+                default = _plane_default_branch(root)
+            except (_util.ProcTimeout, OSError):
+                # A git that will not answer is not a licence to skip the guard — and it
+                # used to be worse than that: this raised straight out of a `PreToolUse`
+                # handler, which is a broken turn rather than a verdict.
+                default = None
+            if default is not None and wants[0] == default:
                 continue  # the documented remedy — must stay runnable
 
-        moving = f"create '{wants[0]}'" if creating and wants else (
-            f"switch to '{wants[0]}'" if wants else "switch branches")
+        # Is this `checkout` the RESTORE half of the overload (#461)? Only `checkout` is
+        # asked: `git switch` takes branches and nothing else, which is why it exists.
+        # `--detach` and `-b`/`-B` are ref moves whatever the operand looks like, so
+        # neither reaches this.
+        kind = "rev"
+        if sub == "checkout" and wants and not creating and not detaching:
+            kind = _checkout_operand_kind(root, wants[0])
+            if len(wants) == 1:
+                restore = kind == "path"
+            else:
+                # `git checkout <tree-ish> <paths…>` and `git checkout <paths…>` are both
+                # restores; HEAD stays put in each — verified: `checkout feature README`
+                # answers "Updated 1 path from <sha>" and leaves the branch alone.
+                #
+                # The trailing operands are RESOLVED rather than assumed to be paths, and
+                # that is not pedantry: charter's tokeniser flattens `git checkout
+                # $(echo feature)` into five tokens, so "more than one operand means a
+                # restore" would have handed every command substitution a free pass at the
+                # branch guard — a new spelling of the same misreading this fix is about.
+                # Every trailing operand has to be something git tracks; anything else and
+                # the guard keeps speaking.
+                rest = wants[1:]
+                restore = (len(rest) <= _MAX_CHECKOUT_OPERANDS
+                           and all(_checkout_operand_kind(root, w) == "path" for w in rest))
+            if restore:
+                continue                      # `git restore <path>`, spelled the old way
+
+        # Say what charter actually knows. The denial this replaces asserted a branch
+        # switch for every operand it saw, including a file — and being confidently wrong
+        # about what the command does is most of #461: an operator following that advice
+        # goes and creates a workspace clone in order to restore one file.
+        if kind == "both":
+            opening = (
+                f"cannot tell what `git checkout {wants[0]}` does in the PLANE ROOT — it is "
+                f"AMBIGUOUS: '{wants[0]}' is both a tracked path here and a name git "
+                f"resolves to a commit, so it could be a file restore or a ref move, and "
+                f"git breaks that tie in favour of the REF — this would switch the root. "
+                f"Say which you meant and it runs: `git restore {wants[0]}` (or "
+                f"`git checkout -- {wants[0]}`) restores the file, and charter allows that "
+                f"here in either spelling. ")
+        elif kind == "neither":
+            opening = (
+                f"would move HEAD in the PLANE ROOT: '{wants[0]}' is not a path this tree "
+                f"tracks, so `git checkout` reads it as a revision — and a branch of that "
+                f"name on a remote is checked out here as a new local branch. (Meant the "
+                f"file? `git restore {wants[0]}` is allowed, and would tell you git has "
+                f"never heard of that path either.) ")
+        elif kind == "unknown":
+            opening = (
+                f"would move HEAD in the PLANE ROOT — charter could not ask git whether "
+                f"'{wants[0]}' is a path or a revision here, and a guard that opened "
+                f"because it failed to ask is no guard. ")
+        else:
+            moving = (f"create '{wants[0]}'" if creating and wants
+                      else "detach HEAD" if detaching and not wants
+                      else f"switch to '{wants[0]}'" if wants else "switch branches")
+            opening = f"would {moving} in the PLANE ROOT. "
         return (
-            f"would {moving} in the PLANE ROOT, which is one working tree every session "
+            f"{opening}The plane root is one working tree every session "
             f"shares — two agents here silently clobber each other's branches, and the "
             f"symptom looks like an unrelated bug. Branch work belongs in a workspace "
             f"clone: `charter workspace create <task>`, then `charter clone <repo>`. "
@@ -1363,6 +1571,13 @@ def pretooluse_read() -> int:
     Known limit, shared with the Bash guard and stated rather than papered over: a `Grep`
     rooted at the repo top searches vault files as collateral. Denying every broad search is
     untenable, so this checks the path the caller actually named.
+
+    **The `except` covers the READING of the payload and nothing else** (#438). It used to
+    wrap the whole body, `_deny` included, so any exception out of the refusal itself
+    returned 0 — an allow. `pretooluse`, the sibling guard on the same invariant, has no
+    such wrapper, so the two failed in opposite directions in a module that argues above
+    that they must never disagree about what a vault is. Deciding is fallible and is
+    excused; *refusing* is not, and now cannot be: see :func:`_deny`.
     """
     data = _read_stdin()
     _touch_piece(data)
@@ -1376,17 +1591,18 @@ def pretooluse_read() -> int:
         # out of it — so a Grep rooted at the DIRECTORY `.charter/vaults` would otherwise
         # walk past a guard that stops every file inside it. Appending cannot create a false
         # positive: `.charter/vaults.json/` still has no `vaults/` in it.
-        if not any(_VAULT_PATH_RE.search(t) or _VAULT_PATH_RE.search(t + "/")
-                   for t in targets):
-            return 0
-        reason = ("reads a vault/secret file directly (would print plaintext). "
-                  "Use `charter … secret exec`/`cp` instead of reading `.charter/`")
-        _deny("PreToolUse", reason)
-        _trace("deny", data.get("session_id"), reason=reason[:70],
-               cmd=(data.get("tool_name") or "")[:40])
+        hit = any(_VAULT_PATH_RE.search(t) or _VAULT_PATH_RE.search(t + "/")
+                  for t in targets)
     except Exception:
         return 0
-    return 0
+    if not hit:
+        return 0
+    reason = ("reads a vault/secret file directly (would print plaintext). "
+              "Use `charter … secret exec`/`cp` instead of reading `.charter/`")
+    rc = _deny("PreToolUse", reason)
+    _trace("deny", data.get("session_id"), reason=reason[:70],
+           cmd=(data.get("tool_name") or "")[:40])
+    return rc
 
 
 def _piece_announcement(data: dict) -> str | None:
@@ -1479,9 +1695,9 @@ def pretooluse() -> int:
     # A: a secret would leak into the conversation → hard DENY (a real safety invariant).
     leak = _leak_reason(cmd)
     if leak:
-        _deny("PreToolUse", leak)
+        rc = _deny("PreToolUse", leak)
         _trace("deny", sid, reason=leak[:70], cmd=head)
-        return 0
+        return rc
     # A2: golden rule — one credential (each forge's token over HTTPS); no SSH, no signing.
     #
     # Gated on there being a control plane at all. The plugin is installed per USER or per
@@ -1497,39 +1713,39 @@ def pretooluse() -> int:
     hit = _single_credential_hit(cmd) if _cfg.HAS_CONTROL_PLANE else None
     if hit:
         shape, detail = hit
-        _deny("PreToolUse", _SINGLE_CREDENTIAL_FIX + detail)
+        rc = _deny("PreToolUse", _SINGLE_CREDENTIAL_FIX + detail)
         # `reason` stays the stable tally key it has always been; `shape` is the new field
         # that says WHICH trigger matched (#289). Additive on purpose — an existing trace
         # reader keeps working, and the question "what tripped this 335 times" becomes
         # answerable from the same records.
         _trace("deny", sid, reason="single-credential", shape=shape, cmd=head)
-        return 0
+        return rc
     # A3: the plane root is one shared working tree — refuse a branch move in it (#157).
     # Same gate as A2, and for the same reason: outside a plane there is no plane root, and
     # denying there would explain a control plane that does not exist on that machine.
     branch = _plane_root_branch_reason(cmd, cwd) if _cfg.HAS_CONTROL_PLANE else None
     if branch:
-        _deny("PreToolUse", branch)
+        rc = _deny("PreToolUse", branch)
         _trace("deny", sid, reason="plane-root-branch", cmd=head)
-        return 0
+        return rc
     # A3b: and refuse a `git reset` in the root that would destroy commits no remote has
     # (#401). Same gate, a separate guard: A3's subject is "HEAD moved between branches"
     # and this one's is "commits were destroyed" — different prose, different remedy, and
     # this one only speaks when it has measured that something really would be lost.
     wipe = _plane_root_reset_reason(cmd, cwd) if _cfg.HAS_CONTROL_PLANE else None
     if wipe:
-        _deny("PreToolUse", wipe)
+        rc = _deny("PreToolUse", wipe)
         _trace("deny", sid, reason="plane-root-reset", cmd=head)
-        return 0
+        return rc
     # A4: an unattended run may not publish (#299). It used to matter that this ran before
     # the clone nudge — that nudge matched `tag`/`push` and stopped releases by accident
     # until 0.46.0 turned its unattended `ask` into an `allow`. The nudge is gone (#371);
     # this guard stands on its own, which is what "on purpose" was always supposed to mean.
     pub = _release_floor_reason(cmd, data) if _cfg.HAS_CONTROL_PLANE else None
     if pub:
-        _deny("PreToolUse", pub)
+        rc = _deny("PreToolUse", pub)
         _trace("deny", sid, reason="release-floor", cmd=head)
-        return 0
+        return rc
     # B WAS HERE: the clone-commit nudge, removed in #371 — see the note where it lived.
     # Nothing on this handler asks any more; every remaining verdict is a deny or an allow.
     # fall through to the allow-only persona tool-gate (unchanged behaviour)
@@ -2940,10 +3156,10 @@ def pretooluse_edit() -> int:
     # the agent to approve a write that widens the agent's own permissions is no guard.
     state = _state_write_reason(data)
     if state:
-        _deny("PreToolUse", state)
+        rc = _deny("PreToolUse", state)
         _trace("deny", data.get("session_id"), reason=state[:70],
                cmd=(data.get("tool_name") or "")[:40])
-        return 0
+        return rc
     names = _route_mark_take(data.get("session_id"))
     if not names:
         return 0
@@ -3324,6 +3540,10 @@ def dispatch(name: str, plugin_version: str | None) -> int:
     README.md promised "a plugin newer than the CLI says so loudly at session start". It
     now rides out as `systemMessage`, which renders at exit 0 and blocks nothing.
     """
+    # One hook is one process, so this list belongs to this call. Cleared rather than
+    # assumed empty because the handlers are also driven in-process by the test suite, and
+    # a leftover row there would turn an unrelated later hook into a refusal.
+    _undelivered_deny.clear()
     _queue_plugin_notices(name, plugin_version)
     fn = _HANDLERS.get(name)
     if fn is None:
@@ -3334,5 +3554,12 @@ def dispatch(name: str, plugin_version: str | None) -> int:
     # A handler that emitted nothing would swallow the message with it — sessionstart
     # stays silent when there is no persona, no memory and no news to inject.
     if _pending_system:
-        _emit({})
-    return rc
+        try:
+            _emit({})
+        except Exception:  # noqa: BLE001 - an injection is not worth a broken turn
+            pass
+    # A denial charter decided and could not WRITE is not an allow (#438). The handlers all
+    # return `_deny`'s status already; this is the backstop that makes it true of the ones
+    # written after this line, since a guard's fail-open is invisible — it looks exactly
+    # like the guard being present and never firing.
+    return DENY_EXIT if _undelivered_deny else rc

--- a/docs/adr/0008-the-plane-root-is-not-a-work-tree.md
+++ b/docs/adr/0008-the-plane-root-is-not-a-work-tree.md
@@ -64,9 +64,12 @@ answered as narrowly as the evidence supports:
   over-blocks is disabled once and then protects nothing.
 * **`git commit` is untouched.** `charter save` commits here by design, and advancing HEAD
   along the branch you are on was never the failure.
-* **Returning to the default branch is always allowed.** The warning's own remedy is
-  `git -C <plane> checkout main`; a guard that blocks the fix it recommends is a trap, and
-  would be routed around within a session.
+* **Putting the root back ON its default branch is always allowed.** The warning's own
+  remedy is `git -C <plane> checkout main`; a guard that blocks the fix it recommends is a
+  trap, and would be routed around within a session. *On*, not *named*: the carve-out asked
+  only whether the operand was the default branch, and `git checkout --detach main` names it
+  while leaving HEAD attached to nothing — a detach that walked straight through the remedy.
+  What earns the carve-out is the whole command, options included.
 
 What does **not** change: the warning stays, because it is what explains the denial when one
 arrives, and because it still covers the states prevention cannot — a root left dirty, or

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -39,7 +39,13 @@ rule while one who reads a bare refusal files an issue.
 - **Vault read.** The same invariant on the `Read`/`Grep` tools, which never reach the Bash
   matcher at all.
 - **Plane-root branch move.** The plane is not a work tree (ADR 0008); a branch switch there
-  is almost always meant for a clone.
+  is almost always meant for a clone. `--detach` counts, with or without an operand.
+  Restoring a file does **not**: `git checkout` is two commands wearing one name, and which
+  one you typed is settled by asking git whether the operand resolves as a revision or names
+  a path it tracks — so `git checkout <path>` and `git checkout <tree-ish> -- <paths>` run
+  here exactly as `git restore <path>` always has. Where a branch and a tracked file share a
+  name the answer is genuinely ambiguous, git breaks the tie in favour of the ref, and the
+  denial says *that* and names the two unambiguous spellings rather than assuming a branch.
 - **Plane-root history wipe.** A `git reset --hard` (or `--merge`/`--keep`) in the plane root
   that would take commits off the branch which no remote has a copy of — the command that
   destroyed eleven memory commits in one session. Only that: the unstage
@@ -278,6 +284,15 @@ Neither has a secret surface to scan, by construction.
 
 Hooks swallow their exceptions. A tally that breaks a turn is worse than a tally that
 misses a row, and none of this is load-bearing for the work itself.
+
+**A denial is the exception, and it is load-bearing.** A guard refuses by printing one JSON
+object on stdout, so a hook that cannot write has said nothing — and a `PreToolUse` hook
+that says nothing is an *allow*. Deciding is still allowed to fail: a payload charter cannot
+parse is an allow, as it always was. Refusing is not. When the verdict is deny and the write
+fails, the process exits **2** with the reason on stderr, which is the harness's other
+refusal channel — every other non-zero status is a non-blocking error and the tool call goes
+ahead. That is why the number is 2 and not "any failure": `charter … | head` legitimately
+exits 141, and 141 lets the call through (#438).
 
 The deliberate exception is version skew, in **both** directions — that is the failure shape
 this project keeps paying for, so it is the one thing a hook says out loud, once, at session

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -46,6 +46,17 @@ rule while one who reads a bare refusal files an issue.
   here exactly as `git restore <path>` always has. Where a branch and a tracked file share a
   name the answer is genuinely ambiguous, git breaks the tie in favour of the ref, and the
   denial says *that* and names the two unambiguous spellings rather than assuming a branch.
+  The options are read the same way round: the restore gate opens only when every option
+  present is one charter can place as restore-only, because an option decides what its
+  operand means — `git checkout --orphan README` creates a branch called `README`. An option
+  charter cannot place is refused rather than assumed harmless, value forms included
+  (`-bREADME`, `--orphan=README`), which costs a false denial on a restore-only flag nobody
+  has added to the list yet; `git restore <path>` needs no flags and is always allowed.
+  Aliases are followed before the guard stands aside — `co = checkout` makes `git co
+  feature` the same branch move — including chains, aliases carrying their own options,
+  `!git checkout`, and `git -c alias.co=checkout co …`. A `!`-alias that is not a plain
+  `git …` is not read (refusing every shell alias here would refuse `s = !git status`), and
+  neither is `--config-env`.
 - **Plane-root history wipe.** A `git reset --hard` (or `--merge`/`--keep`) in the plane root
   that would take commits off the branch which no remote has a copy of — the command that
   destroyed eleven memory commits in one session. Only that: the unstage
@@ -293,6 +304,12 @@ fails, the process exits **2** with the reason on stderr, which is the harness's
 refusal channel — every other non-zero status is a non-blocking error and the tool call goes
 ahead. That is why the number is 2 and not "any failure": `charter … | head` legitimately
 exits 141, and 141 lets the call through (#438).
+
+A write into a buffer is not a delivery, and that distinction is the whole of the fix: a
+hook's stdout is a pipe, `print` to a pipe block-buffers, so a `print` into a *broken* pipe
+returns cleanly and the error only surfaces when the interpreter flushes at exit — where it
+is worth 120, another status that lets the call through. So the verdict is flushed inside
+the guard, while "the harness did not get this" can still become a refusal.
 
 The deliberate exception is version skew, in **both** directions — that is the failure shape
 this project keeps paying for, so it is the one thing a hook says out loud, once, at session

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -39,7 +39,11 @@ rule while one who reads a bare refusal files an issue.
 - **Vault read.** The same invariant on the `Read`/`Grep` tools, which never reach the Bash
   matcher at all.
 - **Plane-root branch move.** The plane is not a work tree (ADR 0008); a branch switch there
-  is almost always meant for a clone. `--detach` counts, with or without an operand.
+  is almost always meant for a clone. `--detach` counts — with an operand, without one, and
+  with the plane's own default branch as the operand, which is the one spelling that used to
+  slip past. What is always allowed is putting the root back **on** its default branch
+  (`git checkout main`), which is a different thing from naming that branch:
+  `git checkout --detach main` names it and leaves HEAD attached to nothing.
   Restoring a file does **not**: `git checkout` is two commands wearing one name, and which
   one you typed is settled by asking git whether the operand resolves as a revision or names
   a path it tracks — so `git checkout <path>` and `git checkout <tree-ish> -- <paths>` run
@@ -56,7 +60,11 @@ rule while one who reads a bare refusal files an issue.
   feature` the same branch move — including chains, aliases carrying their own options,
   `!git checkout`, and `git -c alias.co=checkout co …`. A `!`-alias that is not a plain
   `git …` is not read (refusing every shell alias here would refuse `s = !git status`), and
-  neither is `--config-env`.
+  neither is `--config-env`. The **route** does not change the verdict either: the cwd, a
+  `cd` earlier in the same command, and `git -C <path>` — absolute or relative, and relative
+  now means *relative to the shell*, which is the fix for `git -C ../../.. checkout <branch>`
+  reaching the root from a clone. `git --git-dir=<plane>/.git` is a route this guard does
+  **not** yet follow ([#477](https://github.com/diazoxide/charter/issues/477)).
 - **Plane-root history wipe.** A `git reset --hard` (or `--merge`/`--keep`) in the plane root
   that would take commits off the branch which no remote has a copy of — the command that
   destroyed eleven memory commits in one session. Only that: the unstage

--- a/docs/news/unreleased-a-denial-charter-cannot-write.md
+++ b/docs/news/unreleased-a-denial-charter-cannot-write.md
@@ -26,6 +26,14 @@ The number matters and it is not "any failure" — every other non-zero status i
 non-blocking error and the call goes ahead, which is exactly how the 141 above let one
 through.
 
+**A write is not a delivery.** The first version of this fix asked "did the write raise?",
+and on the one channel a hook actually has — a pipe — the answer is no. `print` to a pipe
+block-buffers: the JSON goes into a userspace buffer, the call returns cleanly, and the
+`BrokenPipeError` arrives when the interpreter flushes on the way out, which is worth exit
+120 and lets the tool call through. Measured: identical behaviour to the code it replaced.
+charter now flushes the verdict while the guard can still act on the answer, so "the harness
+has it" is a question asked at a point where "no" can still become a refusal.
+
 **Deciding is still allowed to fail; refusing is not.** The `except` in the vault guard was
 narrowed, not deleted: a payload charter cannot parse is still an allow, still silent, still
 not a broken turn. That distinction is now written into `docs/hooks.md` beside the

--- a/docs/news/unreleased-a-denial-charter-cannot-write.md
+++ b/docs/news/unreleased-a-denial-charter-cannot-write.md
@@ -1,0 +1,40 @@
+---
+version: unreleased
+headline: A denial charter cannot write is no longer an allow
+---
+
+charter's guards refuse by printing one JSON object on stdout. A hook that cannot print has
+said nothing, and a `PreToolUse` hook that says nothing is an **allow** — so every way that
+write could fail was a way a guard failed open.
+
+Both spellings were in the tree at once, on the same invariant. The vault guard for
+`Read`/`Grep` wrapped its whole body — the refusal included — in `except Exception: return
+0`, so a `BrokenPipeError` out of `print` returned a clean zero and the vault was read. Its
+sibling on Bash had no wrapper, so the same exception propagated to `charter`'s top level,
+which quite correctly turns `BrokenPipeError` into exit 141 for `charter … | head`. 141 is a
+*non-blocking* hook error: the tool call proceeds. Two guards on one rule, failing in
+opposite directions, in a module that argues at length that they must never disagree about
+what a vault is.
+
+Reachability was low — the bodies are a few dict lookups, a `str()` and a regex — and the
+direction is the point. Found by the 2026-08-24 security audit (#438).
+
+**A decided denial now reaches the harness by some channel, or the process exits refusing.**
+When the JSON write fails, charter writes the reason to stderr and exits **2**, which is the
+harness's other refusal channel: it blocks the tool call and hands the model the reason.
+The number matters and it is not "any failure" — every other non-zero status is a
+non-blocking error and the call goes ahead, which is exactly how the 141 above let one
+through.
+
+**Deciding is still allowed to fail; refusing is not.** The `except` in the vault guard was
+narrowed, not deleted: a payload charter cannot parse is still an allow, still silent, still
+not a broken turn. That distinction is now written into `docs/hooks.md` beside the
+"hooks swallow their exceptions" rule it qualifies.
+
+**And it holds for the guard nobody has written yet.** The fallback is not something each
+call site has to remember to propagate: an undelivered denial is recorded, and the hook's
+own entrypoint refuses on it. A fail-open is invisible from the outside — it looks exactly
+like a guard that is present and never fires — so it is closed at the one place every guard
+passes through.
+
+Nothing to adopt: upgrading is the whole of it.

--- a/docs/news/unreleased-checkout-a-file-in-the-plane-root.md
+++ b/docs/news/unreleased-checkout-a-file-in-the-plane-root.md
@@ -72,4 +72,36 @@ where the branch name is inside the option token and the operand list is empty. 
 now, and the denial names the branch it would create rather than falling back to "switch
 branches".
 
+**And the carve-out that keeps the remedy runnable was reading a name, not a command.**
+`doctor` prints *"Put the root back: `git -C <plane> checkout main`"*, so the guard has
+always stood aside when the operand is the plane's default branch. It stood aside for
+`git checkout --detach main` too — which names that branch and leaves HEAD attached to
+nothing at all. `git switch -d main`, `git checkout -qd main`, `git checkout --detach main
+--` and the same through an alias all went the same way, straight past every line of the
+`--detach` handling above. What earns the carve-out now is the command leaving HEAD
+**attached** to the default branch, which is a property of the whole invocation rather than
+of one token in it, and the closing line of the denial names the spelling it promises
+(`git checkout main`) instead of promising a category. In the same sweep: `git switch --
+feature` switched branches and was read as a restore, because `--` introduces paths on a
+`checkout` and `git switch` has no path half for it to introduce.
+
+**The route to the plane root is part of the command.** A relative `git -C` was resolved
+against the directory the *hook process* was started in rather than the shell's, so
+`git -C ../../.. checkout feature` from a workspace clone moved the plane root's HEAD and
+was allowed — verified end to end, "Switched to branch 'feature'" and the root's HEAD
+follows. So did `git -C . checkout feature` typed in the root, and `cd .. && git -C <root>
+checkout feature`. The cwd, a `cd` earlier in the same command and `-C` in every combination
+now name the same repository the shell would name. One route is still open and is filed
+rather than fixed here: `git --git-dir=<plane>/.git checkout <branch>` reaches the root's
+refs and neither plane-root guard follows it —
+[#477](https://github.com/diazoxide/charter/issues/477).
+
+**How the last three of those were found.** Not by reading the code: the corpus that judges
+this guard is now the PRODUCT of its axes — subcommand × option × operand × where the `--`
+goes — rather than a list somebody typed, and each row's expected verdict comes from running
+it against real git and watching HEAD. `--detach` had rows and `main` had rows;
+`--detach main` had none, and neither did `switch --`. Alongside it, a second corpus crosses
+commands with every ROUTE to the root, and a third loads the guard as it stands on `main` and
+requires that nothing it refuses is allowed here.
+
 Nothing to adopt: upgrading is the whole of it.

--- a/docs/news/unreleased-checkout-a-file-in-the-plane-root.md
+++ b/docs/news/unreleased-checkout-a-file-in-the-plane-root.md
@@ -35,14 +35,41 @@ restore. Everything else is still refused — including a branch that exists onl
 (git's DWIM checks it out here as a new local branch), a name git has never heard of, and
 anything charter could not resolve, such as `git checkout "$BR"`.
 
+**The operand is only half the command, and the first cut of this read only that half.**
+What an operand means depends on the options beside it: `README` is a path after `--ours`
+and a *branch to create* after `--orphan` — `git checkout --orphan README` answers
+"Switched to a new branch 'README'". So the same rule now applies to the options, in the
+same direction: the gate opens only when every option present is one charter can place as
+restore-only, and an option it cannot place keeps the guard shut. That covers the value
+forms git accepts, where the branch name hides inside the option token (`-bREADME`,
+`--orphan=README`), and it covers the option git adds next, which no list of bad flags
+could. A restore-only flag charter has not heard of yet is refused here until someone adds
+it — and the two spellings that need no flags at all, `git restore <path>` and
+`git checkout -- <path>`, are always allowed.
+
 **The genuinely ambiguous case stays denied, and now says so.** Where a branch and a tracked
 file share a name, git breaks the tie in favour of the ref — it really does switch. That is
 the one case where refusing is right, so the denial no longer asserts a branch; it says the
 command is ambiguous and names the two spellings that are not:
 `git restore <name>` and `git checkout -- <name>`, both allowed.
 
+**And `git checkout` is not the only way to spell `git checkout`.** With `co = checkout` in
+your config — an alias on a large share of developer machines — `git co feature` moved the
+plane root's HEAD and this guard never saw a `checkout` at all. It now asks git what the
+subcommand really is before standing aside: config aliases, aliases to aliases, aliases
+carrying their own options (`sw = switch -c`), `!git checkout`, and the setup-free
+`git -c alias.zz=checkout zz feature` all reach the same rule now, and `git co <file>` is
+still a restore. Two things it deliberately does not reach, so you know where the edge is: a
+`!`-alias that is not a plain `git …` (refusing every shell alias in the plane root would
+refuse `s = !git status` too), and `--config-env`, where the body is in an environment
+variable. Ordinary commands cost nothing — charter only asks about a subcommand it does not
+already take to be git's own, so `git status` and `git commit` are still a set lookup.
+
 **The same misreading was making the guard too narrow, too.** It required an operand, so
-`git checkout --detach` and `git switch --detach` — which take the root off its branch with
-no operand at all — walked past it. They are refused now.
+`git checkout --detach`, `git switch --detach` and their short form `-d` — which take the
+root off its branch with no operand at all — walked past it. So did `git checkout -bREADME`,
+where the branch name is inside the option token and the operand list is empty. All refused
+now, and the denial names the branch it would create rather than falling back to "switch
+branches".
 
 Nothing to adopt: upgrading is the whole of it.

--- a/docs/news/unreleased-checkout-a-file-in-the-plane-root.md
+++ b/docs/news/unreleased-checkout-a-file-in-the-plane-root.md
@@ -1,0 +1,48 @@
+---
+version: unreleased
+headline: `git checkout <file>` in the plane root is a file restore again, not a refused branch switch
+---
+
+```
+$ git checkout charter.toml
+charter guard: would switch to 'charter.toml' in the PLANE ROOT, which is one working
+tree every session shares — two agents here silently clobber each other's branches …
+```
+
+`charter.toml` is a file. `git checkout <path>` restores a path; `git checkout <branch>`
+moves HEAD. The guard read the first as the second, and `git restore charter.toml` — the
+modern, unambiguous spelling of the *same* operation — was allowed the whole time. So this
+was never a policy against restoring a file in the plane root. It was charter refusing one
+of the two ways git spells an operation it permits.
+
+Which makes the denial worse than the inconvenience: it was confident, detailed, and wrong
+about what the command does. An operator who believed it would go and create a workspace
+clone in order to restore one file, and the message's escape hatch — *"run it yourself, in
+your own terminal"* — is the right answer for a guard correctly refusing an agent and the
+wrong outcome for one that has misread the command.
+
+**The guard now asks git.** `git checkout` is two commands wearing one name, and git itself
+disambiguates by whether the operand resolves as a revision and by `--`. charter asks the
+same two questions of the same repo — does this resolve to a commit, and does git track a
+path by this name — instead of matching the shape of the command. `git checkout <path>`,
+`git checkout .`, `git checkout <tree-ish> -- <paths>` and `git checkout <tree-ish> <paths>`
+all run in the plane root now. `git switch` is untouched: it takes branches and nothing
+else, which is why it exists.
+
+**Only a positive answer opens the gate**, and that is what keeps this a narrowing rather
+than a hole. A name git cannot read as a commit *and* can read as a tracked path is a
+restore. Everything else is still refused — including a branch that exists only on a remote
+(git's DWIM checks it out here as a new local branch), a name git has never heard of, and
+anything charter could not resolve, such as `git checkout "$BR"`.
+
+**The genuinely ambiguous case stays denied, and now says so.** Where a branch and a tracked
+file share a name, git breaks the tie in favour of the ref — it really does switch. That is
+the one case where refusing is right, so the denial no longer asserts a branch; it says the
+command is ambiguous and names the two spellings that are not:
+`git restore <name>` and `git checkout -- <name>`, both allowed.
+
+**The same misreading was making the guard too narrow, too.** It required an operand, so
+`git checkout --detach` and `git switch --detach` — which take the root off its branch with
+no operand at all — walked past it. They are refused now.
+
+Nothing to adopt: upgrading is the whole of it.

--- a/tests/test_a_deny_survives_a_broken_channel.py
+++ b/tests/test_a_deny_survives_a_broken_channel.py
@@ -1,0 +1,257 @@
+"""A denial charter cannot WRITE is not an allow (#438).
+
+`_deny` refuses by printing one JSON object on stdout. A hook that prints nothing has said
+nothing, and a `PreToolUse` hook that says nothing is an ALLOW — so every way the write can
+fail was a way the guard failed **open**:
+
+* `pretooluse_read` wrapped its whole body, `_deny` included, in `except Exception: return
+  0`. A `BrokenPipeError` out of `print` is an `Exception`; the vault read went through.
+* `pretooluse`, the sibling guard on the same invariant, had no wrapper — so the same
+  exception propagated to `cli.main`, which quite correctly turns `BrokenPipeError` into
+  141 for `charter … | head`. 141 is a *non-blocking* hook error: the tool call proceeds.
+
+Two guards on one invariant failing in opposite directions, in a module that argues at
+length that they must never disagree. Reachability is low (the bodies are dict gets, a
+`str()` and a regex) and the direction is the whole point: the fix is not "make this body
+not raise", it is "a decided denial reaches the harness by SOME channel or the process
+exits refusing".
+
+The other channel is the exit status. 2 blocks the tool call with stderr as the reason;
+every other non-zero status is a non-blocking error and the call goes ahead — which is why
+these assert on the number and not merely on "non-zero".
+
+Property under test, stated so the tests can be checked against it: **whenever a guard
+decides to deny and the JSON channel is unusable, the hook process refuses.** Not "the
+vault guard does not crash".
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from unittest import mock
+
+from charter import config, hooks
+from tests._isolation import PersonaIso
+
+#: A payload that MUST be denied, per handler that can deny one.
+#: The Bash guard's entry is the secret-leak rule, which needs no control plane and no repo
+#: — `_leak_reason` is unconditional on purpose (see `pretooluse`), so this table stays
+#: about the channel rather than about any one guard's preconditions.
+DENIALS = {
+    "pretooluse-read": {"tool_name": "Read",
+                        "tool_input": {"file_path": ".charter/vaults/devops.json"},
+                        "session_id": "s"},
+    "pretooluse": {"tool_name": "Bash",
+                   "tool_input": {"command": "cat .charter/vaults/devops.json"},
+                   "session_id": "s"},
+    "pretooluse-edit": {"tool_name": "Write",
+                        "tool_input": {"file_path": "STATE_DIR/vaults.json",
+                                       "content": "{}"},
+                        "session_id": "s"},
+}
+
+
+class BrokenChannelCase(PersonaIso):
+    """Every case here drives `hooks.dispatch`, the real process entrypoint, because the
+    exit status is the thing under test and a handler's return value only becomes an exit
+    status there."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.HAS_CONTROL_PLANE = True
+        # Module state, and this suite drives the handlers in ONE process — a row left by
+        # one case would turn an unrelated later hook into a refusal.
+        hooks._undelivered_deny.clear()
+        self.addCleanup(hooks._undelivered_deny.clear)
+
+    def dispatch(self, name: str, payload: dict, broken: bool = False):
+        """Run one hook the way `charter hook <name>` does; return (rc, stdout, stderr).
+
+        *broken* replaces `builtins.print` — the lowest layer every emission in this module
+        reaches, `_emit`'s own call — rather than `_emit` or `_deny`, so a future emitter
+        that spells the write differently is still covered, and so the test cannot pass by
+        stubbing out the code it is meant to exercise. Only **stdout** is broken, which is
+        the real condition: a reader that went away closes the one pipe, and stderr is a
+        different file descriptor that keeps working. A blunter stub that broke both would
+        make the stderr assertion below unfalsifiable.
+        """
+        payload = dict(payload)
+        ti = dict(payload.get("tool_input") or {})
+        if str(ti.get("file_path", "")).startswith("STATE_DIR/"):
+            ti["file_path"] = str(config.STATE_DIR / ti["file_path"].split("/", 1)[1])
+            payload["tool_input"] = ti
+        out, err = io.StringIO(), io.StringIO()
+        old = sys.stdin
+        sys.stdin = io.StringIO(json.dumps(payload))
+        real_print = print
+        def broken_print(*args, **kw):
+            if kw.get("file") in (None, sys.stdout):
+                raise BrokenPipeError(32, "Broken pipe")
+            return real_print(*args, **kw)
+        try:
+            with redirect_stdout(out), redirect_stderr(err):
+                if broken:
+                    with mock.patch("builtins.print", side_effect=broken_print):
+                        rc = hooks.dispatch(name, None)
+                else:
+                    rc = hooks.dispatch(name, None)
+        finally:
+            sys.stdin = old
+        return rc, out.getvalue(), err.getvalue()
+
+
+class TestABrokenPipeDoesNotTurnADenyIntoAnAllow(BrokenChannelCase):
+    def test_every_denying_hook_refuses_by_exit_status(self):
+        """The load-bearing one, and a table rather than one case: the audit found this in
+        the vault guard, and the defect is the shape, not the guard."""
+        for name, payload in DENIALS.items():
+            with self.subTest(hook=name):
+                hooks._undelivered_deny.clear()
+                rc, _, _ = self.dispatch(name, payload, broken=True)
+                self.assertEqual(rc, hooks.DENY_EXIT, name)
+
+    def test_the_status_is_the_one_the_harness_reads_as_blocking(self):
+        """A contract pin, not a behaviour test, and said plainly rather than dressed up:
+        the number cannot be derived from anything in this repo, it is the harness's. 2
+        blocks the tool call with stderr as the reason; **every** other non-zero status is a
+        non-blocking error and the call proceeds — so an assertion of merely "non-zero"
+        would have passed on 1, on the 120 a failed shutdown flush produces, and on
+        `cli.main`'s 141-for-SIGPIPE, which are the three numbers this issue is about."""
+        self.assertEqual(hooks.DENY_EXIT, 2)
+        self.assertNotIn(hooks.DENY_EXIT, (0, 1, 120, 141))
+
+    def test_the_backstop_covers_a_call_site_that_drops_the_status(self):
+        """The redundancy, tested as itself. Returning `_deny`'s status is a discipline
+        every call site has to keep; `dispatch` refusing on an undelivered denial is the
+        part that holds when one does not — and a guard written after this line is exactly
+        the one nobody will remember to check."""
+        def forgetful():
+            hooks._deny("PreToolUse", "a guard that drops the status")
+            return 0
+
+        with mock.patch.dict(hooks._HANDLERS, {"pretooluse-read": forgetful}):
+            rc, _, _ = self.dispatch("pretooluse-read", DENIALS["pretooluse-read"],
+                                     broken=True)
+        self.assertEqual(rc, hooks.DENY_EXIT)
+
+    def test_the_reason_still_reaches_the_model_on_stderr(self):
+        """Exit 2 hands stderr to the model. A refusal with no reason is the bare "no" this
+        module's guards are written not to give."""
+        rc, _, err = self.dispatch("pretooluse-read", DENIALS["pretooluse-read"], broken=True)
+        self.assertEqual(rc, hooks.DENY_EXIT)
+        self.assertIn("secret exec", err)
+
+    def test_the_deny_helper_reports_the_status_to_its_caller(self):
+        """One layer down: `_deny` is what every guard calls, and its return value is what a
+        handler propagates. Pinned separately so a handler that starts discarding it fails
+        here rather than only through the process boundary."""
+        with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            self.assertEqual(hooks._deny("PreToolUse", "x"), 0)
+            with mock.patch("builtins.print",
+                            side_effect=BrokenPipeError(32, "Broken pipe")):
+                self.assertEqual(hooks._deny("PreToolUse", "x"), hooks.DENY_EXIT)
+
+
+class TestItDidNotBreakTheWorkingCase(BrokenChannelCase):
+    def test_an_intact_channel_still_denies_as_json_at_exit_zero(self):
+        """Guards the guard. A fix that made every denial exit 2 would pass every test
+        above and change what a denial IS — the JSON verdict is the normal channel, and it
+        carries the reason the agent reads."""
+        for name, payload in DENIALS.items():
+            with self.subTest(hook=name):
+                hooks._undelivered_deny.clear()
+                rc, out, _ = self.dispatch(name, payload)
+                self.assertEqual(rc, 0, name)
+                decision = json.loads(out)["hookSpecificOutput"]["permissionDecision"]
+                self.assertEqual(decision, "deny", name)
+
+    def test_an_allowed_call_is_untouched_by_a_broken_channel(self):
+        """The other half of the direction: a hook with nothing to say must not start
+        refusing because a write it never made would have failed."""
+        rc, _, _ = self.dispatch("pretooluse-read",
+                                 {"tool_name": "Read",
+                                  "tool_input": {"file_path": "README.md"},
+                                  "session_id": "s"},
+                                 broken=True)
+        self.assertEqual(rc, 0)
+
+    def test_a_later_hook_does_not_inherit_an_earlier_refusal(self):
+        """`_undelivered_deny` is module state. If it leaked between dispatches, the test
+        above would pass for the wrong reason and a real session's next hook would refuse
+        an unrelated tool call."""
+        self.dispatch("pretooluse-read", DENIALS["pretooluse-read"], broken=True)
+        rc, _, _ = self.dispatch("pretooluse-read",
+                                 {"tool_name": "Read",
+                                  "tool_input": {"file_path": "README.md"},
+                                  "session_id": "s"})
+        self.assertEqual(rc, 0)
+
+
+class TestTheParseIsStillAllowedToFail(BrokenChannelCase):
+    """The `except` in `pretooluse_read` was not deleted, it was NARROWED — deciding is
+    fallible and stays excused; refusing is not. A fix that removed the wrapper outright
+    would make a malformed payload break the turn, which is the failure mode the rest of
+    this module is written to avoid."""
+
+    def test_a_payload_that_cannot_be_read_is_not_a_broken_turn(self):
+        class Hostile:
+            def __contains__(self, _):
+                raise RuntimeError("boom")
+
+            def get(self, *_a, **_k):
+                raise RuntimeError("boom")
+
+        with mock.patch.object(hooks, "_CONTENT_TOOLS", Hostile()):
+            rc, out, _ = self.dispatch("pretooluse-read", DENIALS["pretooluse-read"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.strip(), "")
+
+
+class TestNoOtherHookHidesADenyInsideAnExcept(unittest.TestCase):
+    """`pretooluse_read` was the only one, and this is what keeps that true.
+
+    Structural rather than behavioural on purpose: a fail-open is invisible from the
+    outside — it looks exactly like the guard being present and never firing — so the shape
+    is pinned where it can be introduced. `dispatch`'s backstop covers a `_deny` whose
+    status a new call site forgets to return; this covers the other spelling, a `_deny`
+    sitting inside a `try` that swallows it.
+    """
+
+    def test_every_deny_call_is_inside_a_function_that_returns_its_status(self):
+        import ast
+        import inspect
+
+        src = inspect.getsource(hooks)
+        tree = ast.parse(src)
+        # Collect the `_deny(...)` calls that are NOT bound to a name — a bare expression
+        # statement discards the status, which is the shape that fails open.
+        discarded = [n.lineno for n in ast.walk(tree)
+                     if isinstance(n, ast.Expr) and isinstance(n.value, ast.Call)
+                     and isinstance(n.value.func, ast.Name) and n.value.func.id == "_deny"]
+        self.assertEqual(discarded, [], f"_deny status discarded at lines {discarded}")
+
+    def test_no_try_block_encloses_a_deny_call(self):
+        import ast
+        import inspect
+
+        tree = ast.parse(inspect.getsource(hooks))
+        bad = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Try):
+                continue
+            for handler in node.handlers:
+                del handler
+            for child in ast.walk(ast.Module(body=node.body, type_ignores=[])):
+                if (isinstance(child, ast.Call) and isinstance(child.func, ast.Name)
+                        and child.func.id == "_deny"):
+                    bad.append(child.lineno)
+        self.assertEqual(bad, [], f"_deny called inside a try/except at lines {bad}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_deny_survives_a_broken_channel.py
+++ b/tests/test_a_deny_survives_a_broken_channel.py
@@ -23,17 +23,31 @@ these assert on the number and not merely on "non-zero".
 Property under test, stated so the tests can be checked against it: **whenever a guard
 decides to deny and the JSON channel is unusable, the hook process refuses.** Not "the
 vault guard does not crash".
+
+**Round two.** The first fix satisfied every assertion in this file and left the real
+condition untouched: `print` block-buffers into a PIPE, so the write into a broken one
+succeeds, `_deny` returned 0, and the `BrokenPipeError` arrived at interpreter shutdown —
+worth 120, which is non-blocking. The tests passed because they stubbed `builtins.print`,
+and a stub raises where an unbuffered stdout raises, i.e. at a terminal. They manufactured
+the one condition under which the code worked. What closes it is a `sys.stdout.flush()`
+inside `_deny`'s `try` — "the harness has it" is a question that has to be asked while the
+guard can still act on the answer — and what proves it is `TestARealBrokenPipeRefuses`: a
+child process, a real `os.pipe()`, the read end closed, nothing patched.
 """
 
 from __future__ import annotations
 
 import io
 import json
+import os
+import subprocess
 import sys
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
 from unittest import mock
 
+import charter
 from charter import config, hooks
 from tests._isolation import PersonaIso
 
@@ -55,6 +69,142 @@ DENIALS = {
 }
 
 
+class RealPipeCase(PersonaIso):
+    """The property against a REAL broken pipe: a hook process whose stdout is a pipe with
+    no reader.
+
+    This class exists because the first fix for #438 passed every test in this file and
+    **did nothing at all** to the condition it was written for. `print` BLOCK-BUFFERS when
+    stdout is a pipe, which is what a hook's stdout is: the JSON went into an 8KiB userspace
+    buffer, `print` returned cleanly, `_deny`'s `except` never ran, the handler returned 0,
+    and the `BrokenPipeError` surfaced only when the interpreter flushed on the way out —
+    where it is worth 120, a NON-BLOCKING status, and the tool call proceeds. Measured on
+    the branch and on `origin/main`: both exited 120 with an empty stderr, byte for byte
+    identical.
+
+    The tests below it reached `DENY_EXIT` only because stubbing `builtins.print` makes the
+    write raise *at the call*, which is what an UNBUFFERED stdout does — a terminal, not a
+    pipe. **The test manufactured the one condition under which the code worked.** So the
+    channel here is a real `os.pipe()` with the read end closed, in a real child process,
+    and nothing is patched.
+    """
+
+    #: `config.use` rather than an env var, because the child must not touch the developer's
+    #: real `.charter/` and this is the same seam `PersonaIso` uses in-process.
+    CHILD = ("import sys;"
+             "from pathlib import Path;"
+             "from charter import config, hooks;"
+             "config.use(Path(sys.argv[1]));"
+             "setattr(config, 'HAS_CONTROL_PLANE', True);"
+             "sys.exit(hooks.dispatch(sys.argv[2], None))")
+
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        self.env = {**os.environ,
+                    "PYTHONPATH": str(Path(charter.__file__).resolve().parent.parent)}
+        # Buffering is the subject, so it is not left to the ambient environment: with this
+        # set the child's stdout is unbuffered and the bug is invisible again.
+        self.env.pop("PYTHONUNBUFFERED", None)
+
+    def run_hook_process(self, name: str, payload: dict, *,
+                         break_stdout: bool = False, break_stderr: bool = False):
+        """Run `charter hook <name>` as its own process; return (rc, stdout, stderr).
+
+        A broken channel is spelled the way the world spells it: `os.pipe()`, close the read
+        end, hand the write end to the child. Every write then gets `EPIPE` — no mock, no
+        stub, and nothing in the child knows it is under test.
+        """
+        payload = dict(payload)
+        ti = dict(payload.get("tool_input") or {})
+        if str(ti.get("file_path", "")).startswith("STATE_DIR/"):
+            ti["file_path"] = str(config.STATE_DIR / ti["file_path"].split("/", 1)[1])
+            payload["tool_input"] = ti
+        dead = []
+
+        def channel():
+            r, w = os.pipe()
+            os.close(r)                       # no reader: the next write is EPIPE
+            dead.append(w)
+            return w
+
+        out = channel() if break_stdout else subprocess.PIPE
+        err = channel() if break_stderr else subprocess.PIPE
+        try:
+            p = subprocess.run([sys.executable, "-c", self.CHILD, str(self.tmp), name],
+                               input=json.dumps(payload), text=True, stdout=out,
+                               stderr=err, env=self.env, timeout=60)
+        finally:
+            for fd in dead:
+                os.close(fd)
+        return p.returncode, p.stdout or "", p.stderr or ""
+
+
+class TestARealBrokenPipeRefuses(RealPipeCase):
+    def test_the_childs_stdout_is_block_buffered_which_is_why_the_stub_saw_nothing(self):
+        """The premise, pinned first, because every assertion below depends on it and it is
+        the thing the round-one test got wrong. A pipe is block-buffered: no line buffering,
+        no write-through, not a tty. A `print` into it SUCCEEDS with the pipe already
+        broken."""
+        probe = ("import sys;"
+                 "print(sys.stdout.line_buffering, sys.stdout.write_through,"
+                 " sys.stdout.isatty(), file=sys.stderr)")
+        r = subprocess.run([sys.executable, "-c", probe], text=True, env=self.env,
+                           stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=60)
+        self.assertEqual(r.stderr.split(), ["False", "False", "False"])
+
+    def test_a_denial_into_a_dead_pipe_exits_blocking(self):
+        """The load-bearing one, and the exact command from the round-two report: a real
+        pipe, its reader gone. Before the flush went inside `_deny`'s `try` this was 120."""
+        for name, payload in DENIALS.items():
+            with self.subTest(hook=name):
+                rc, _, err = self.run_hook_process(name, payload, break_stdout=True)
+                self.assertEqual(rc, hooks.DENY_EXIT, err[-400:])
+
+    def test_it_is_none_of_the_three_statuses_that_mean_the_tool_proceeds(self):
+        """Said as itself rather than folded into the line above: 120 (a failed shutdown
+        flush) and 141 (`cli.main`'s SIGPIPE) are what this actually returned, and both let
+        the call through. An assertion of "non-zero" would have passed on either."""
+        rc, _, _ = self.run_hook_process("pretooluse-read", DENIALS["pretooluse-read"],
+                                         break_stdout=True)
+        self.assertNotIn(rc, (0, 120, 141))
+
+    def test_the_reason_reaches_the_model_on_stderr(self):
+        """Exit 2 hands stderr to the model, so this is the whole content of the refusal.
+        Measured empty on both the branch and `origin/main` before the fix."""
+        _, _, err = self.run_hook_process("pretooluse-read", DENIALS["pretooluse-read"],
+                                          break_stdout=True)
+        self.assertIn("secret exec", err)
+
+    def test_both_channels_dead_still_exits_blocking(self):
+        """Nothing left but the exit status — and it has to survive interpreter shutdown,
+        which is where a second failed flush would replace it with 120. This is what
+        `_mute` is for, and it covers stderr because a harness that closed one pipe usually
+        closed both."""
+        rc, _, _ = self.run_hook_process("pretooluse-read", DENIALS["pretooluse-read"],
+                                         break_stdout=True, break_stderr=True)
+        self.assertEqual(rc, hooks.DENY_EXIT)
+
+    def test_an_intact_pipe_still_denies_as_json_at_exit_zero(self):
+        """The control, and it is not decoration: it runs down the same block-buffered pipe
+        as the case above, so together they say the difference is the broken reader and not
+        the flush. A fix that exited 2 on every denial would pass every other test here."""
+        rc, out, _ = self.run_hook_process("pretooluse-read", DENIALS["pretooluse-read"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            json.loads(out)["hookSpecificOutput"]["permissionDecision"], "deny")
+
+    def test_an_allowed_call_down_a_dead_pipe_is_still_allowed(self):
+        """The other direction, in a real process: a hook with nothing to say must not start
+        refusing because a write it never made would have failed."""
+        rc, _, _ = self.run_hook_process(
+            "pretooluse-read",
+            {"tool_name": "Read", "tool_input": {"file_path": "README.md"},
+             "session_id": "s"},
+            break_stdout=True)
+        self.assertEqual(rc, 0)
+
+
 class BrokenChannelCase(PersonaIso):
     """Every case here drives `hooks.dispatch`, the real process entrypoint, because the
     exit status is the thing under test and a handler's return value only becomes an exit
@@ -72,13 +222,19 @@ class BrokenChannelCase(PersonaIso):
     def dispatch(self, name: str, payload: dict, broken: bool = False):
         """Run one hook the way `charter hook <name>` does; return (rc, stdout, stderr).
 
-        *broken* replaces `builtins.print` — the lowest layer every emission in this module
-        reaches, `_emit`'s own call — rather than `_emit` or `_deny`, so a future emitter
-        that spells the write differently is still covered, and so the test cannot pass by
-        stubbing out the code it is meant to exercise. Only **stdout** is broken, which is
-        the real condition: a reader that went away closes the one pipe, and stderr is a
-        different file descriptor that keeps working. A blunter stub that broke both would
-        make the stderr assertion below unfalsifiable.
+        *broken* replaces `builtins.print` so the write raises **at the call**.
+
+        Read that sentence as the limitation it is: an in-process stub is an UNBUFFERED
+        stdout, and a hook's stdout is a pipe, which block-buffers. These cases therefore
+        pin that each handler propagates `_deny`'s status once the write has failed — they
+        cannot and do not show that a real pipe's write fails at all, and round one shipped
+        believing they did. `TestARealBrokenPipeRefuses` above is where the property is
+        tested; this class is the per-handler table underneath it, kept because it covers
+        every handler cheaply and because `_undelivered_deny`'s backstop has no other seam.
+
+        Only **stdout** is broken here: a reader that went away closes the one pipe, and
+        stderr is a different file descriptor that keeps working. A blunter stub that broke
+        both would make the stderr assertion below unfalsifiable.
         """
         payload = dict(payload)
         ti = dict(payload.get("tool_input") or {})

--- a/tests/test_plane_root_checkout_is_two_commands.py
+++ b/tests/test_plane_root_checkout_is_two_commands.py
@@ -1,0 +1,329 @@
+"""`git checkout <path>` restores a file; the plane-root guard read it as a branch switch
+and refused it (#461).
+
+`git checkout` is two commands wearing one name. ``git checkout <rev>`` moves HEAD;
+``git checkout <pathspec>`` restores files and moves nothing — the same operation
+``git restore <pathspec>`` performs, which this guard has always allowed. So charter was not
+holding a policy against restoring a file in the plane root; it was refusing **one of the
+two ways git spells an operation it permits**, which is a false positive.
+
+Worse than the inconvenience: the denial was confident, detailed, and *wrong about what the
+command does*. An operator following its advice would go and create a workspace clone in
+order to restore one file, and the message's escape hatch — "run it yourself, in your own
+terminal" — is the right answer for a guard that is correctly refusing an agent and the
+wrong outcome for one that has simply misread the command.
+
+**Every row below is a real git invocation whose effect was measured, not assumed.** Each
+was run against git 2.50 in a scratch repo with HEAD recorded before and after; the
+docstrings quote what git actually answered. That is the shape #401 established for
+`reset`, and it is the only way to tell a guard's decision from git's behaviour — the two
+had drifted apart here precisely because nothing compared them.
+
+The ambiguous case is asserted as **still denied**, so the fix cannot be over-applied into
+"any operand that happens to name a file is safe".
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import config, hooks
+from tests._isolation import PersonaIso, run_hook
+
+
+def _decision(r) -> str | None:
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+
+
+def _reason(r) -> str:
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
+
+
+class CheckoutCase(PersonaIso):
+    """A plane root that is a REAL git repo, because the guard now asks git what an operand
+    is. A fixture that only pretended to be a repo would make every operand unresolvable,
+    every answer a denial, and the whole file unfalsifiable.
+
+    Four names, chosen so each bucket of the rule has a witness:
+      * ``README``  — a tracked path, and no ref of that name.
+      * ``feature`` — a branch, and no path of that name.
+      * ``ambig``   — BOTH: a tracked file and a branch. The one git resolves in favour of
+                      the branch, and the one that must stay denied.
+      * ``main``    — the default branch, the documented remedy.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.HAS_CONTROL_PLANE = True
+        self.root = Path(config.ROOT)
+        self._git("init", "-q", "-b", "main", str(self.root))
+        (self.root / "README").write_text("plane\n")
+        (self.root / "ambig").write_text("both\n")
+        (self.root / "notes").mkdir()
+        (self.root / "notes" / "a.md").write_text("a\n")
+        self._in(self.root, "add", "-A")
+        self._in(self.root, "-c", "commit.gpgsign=false", "-c", "user.email=t@e",
+                 "-c", "user.name=t", "commit", "-qm", "init")
+        self._in(self.root, "branch", "feature")
+        self._in(self.root, "branch", "ambig")
+
+    @staticmethod
+    def _git(*args):
+        return subprocess.run(["git", *args], check=True, capture_output=True, text=True)
+
+    @staticmethod
+    def _in(where, *args):
+        return subprocess.run(["git", "-C", str(where), *args], check=True,
+                              capture_output=True, text=True)
+
+    def run_cmd(self, cmd: str, cwd: Path | None = None):
+        return run_hook(hooks.pretooluse, {
+            "tool_input": {"command": cmd},
+            "cwd": str(cwd if cwd is not None else self.root),
+            "session_id": "s"})
+
+
+class TestRestoringAFileIsNotABranchSwitch(CheckoutCase):
+    """git: `git checkout README` → "Updated 1 path from the index", HEAD unchanged."""
+
+    def test_the_reported_case(self):
+        """The literal command from the issue: a tracked file in the plane root."""
+        self.assertIsNone(_decision(self.run_cmd("git checkout README")))
+
+    def test_the_modern_spelling_of_it_is_still_allowed(self):
+        """`git restore README` was always allowed. Two spellings of one operation getting
+        two different verdicts is what made this a false positive rather than a policy."""
+        self.assertIsNone(_decision(self.run_cmd("git restore README")))
+
+    def test_a_directory_pathspec_is_a_restore(self):
+        """git: `git checkout notes` → "Updated 1 path from the index"."""
+        self.assertIsNone(_decision(self.run_cmd("git checkout notes")))
+
+    def test_a_dot_pathspec_is_a_restore(self):
+        """git: `git checkout .` → "Updated 2 paths from the index". A `.` is not a branch
+        by any reading, and the guard refused it."""
+        self.assertIsNone(_decision(self.run_cmd("git checkout .")))
+
+    def test_a_restore_from_another_tree_ish_is_allowed(self):
+        """git: `git checkout feature README` → "Updated 1 path from <sha>", HEAD
+        unchanged. Two operands: the first is the tree read from, the rest are paths."""
+        self.assertIsNone(_decision(self.run_cmd("git checkout feature README")))
+
+    def test_a_restore_flag_does_not_make_it_a_switch(self):
+        """git: `git checkout --ours README` → "Updated 1 path from the index". Allowed by
+        the rule rather than by a list of restore-only flags — nothing here knows `--ours`
+        exists, and it does not have to."""
+        self.assertIsNone(_decision(self.run_cmd("git checkout --ours README")))
+
+    def test_it_still_works_through_a_dash_C(self):
+        """The guard's reach is unchanged by this fix: a restore reached from a clone via
+        `git -C <plane>` is a restore too."""
+        clone = config.WORKSPACES_DIR / "ws" / "svc"
+        clone.mkdir(parents=True, exist_ok=True)
+        self._git("init", "-q", "-b", "main", str(clone))
+        self.assertIsNone(_decision(
+            self.run_cmd(f"git -C {self.root} checkout README", cwd=clone)))
+
+
+class TestARefMoveIsStillRefused(CheckoutCase):
+    """The half that must not move, asserted with the REASON and not only the status —
+    a denial that arrives from a different guard would otherwise read as this one working.
+    """
+
+    def _denied_as_the_branch_guard(self, cmd: str):
+        r = self.run_cmd(cmd)
+        self.assertEqual(_decision(r), "deny", cmd)
+        self.assertIn("PLANE ROOT", _reason(r), cmd)
+        return _reason(r)
+
+    def test_a_branch_is_still_a_branch(self):
+        """git: `git checkout feature` → "Switched to branch 'feature'"."""
+        self._denied_as_the_branch_guard("git checkout feature")
+
+    def test_switch_is_untouched(self):
+        """`git switch` takes branches and nothing else — it exists because this overload
+        is confusing — so the operand rule is asked of `checkout` only."""
+        self._denied_as_the_branch_guard("git switch feature")
+
+    def test_a_commit_ish_that_is_not_a_branch_is_still_a_ref_move(self):
+        """git: `git checkout HEAD~0` detaches. Resolving as a COMMIT is the test, not
+        resolving as a branch — a tag or a raw sha moves HEAD just as far."""
+        self._denied_as_the_branch_guard("git checkout HEAD~0")
+
+    def test_the_previous_branch_shorthand_is_still_a_ref_move(self):
+        """`-` is `@{-1}`, and it is what made the six-switch session in #157 cheap to
+        repeat. It is never handed to git as an operand here, where it would read as an
+        option."""
+        self._denied_as_the_branch_guard("git checkout -")
+
+    def test_creating_a_branch_is_still_refused(self):
+        for flag in ("-b", "-B"):
+            self._denied_as_the_branch_guard(f"git checkout {flag} chore/x")
+
+    def test_creating_a_branch_named_after_a_tracked_file_is_still_refused(self):
+        """`-b` is a ref move whatever the operand looks like, so the operand rule must not
+        be reached at all — otherwise `git checkout -b README` would resolve as a path and
+        walk straight past the guard."""
+        self._denied_as_the_branch_guard("git checkout -b README")
+
+    def test_an_unresolvable_operand_is_still_refused(self):
+        """The fail-closed direction, and the one that matters for the next bypass: only a
+        POSITIVE "git tracks this path and cannot read it as a commit" opens the gate. A
+        name git has never heard of — a typo, or a branch that exists only on a remote,
+        where git's DWIM creates it locally and switches (verified: "Switched to a new
+        branch 'lonely'") — is not that."""
+        self._denied_as_the_branch_guard("git checkout nosuch-branch")
+
+    def test_a_shell_form_charter_cannot_resolve_is_still_refused(self):
+        """`git checkout "$BR"` and `git checkout $(pick)` reach the guard as literal
+        tokens. There is no spelling of a branch move that becomes an allow by being
+        unreadable."""
+        for cmd in ('git checkout "$BR"', "git checkout $(pick)"):
+            self._denied_as_the_branch_guard(cmd)
+
+    def test_a_command_substitution_does_not_become_a_multi_operand_restore(self):
+        """**This is where the next bypass was.** charter's tokeniser flattens
+        `git checkout $(echo feature)` into `['git','checkout','$','(','echo','feature',')']`
+        — five operands. A rule that read "more than one operand" as "a restore" would have
+        allowed it, and in a real shell it switches the plane root's branch. So the trailing
+        operands are resolved against git rather than assumed, and `(` is not a tracked
+        path."""
+        self._denied_as_the_branch_guard("git checkout $(echo feature)")
+
+    def test_a_redirection_glued_to_the_operands_does_not_excuse_a_switch(self):
+        """Same class, ordinary spelling: whatever the tokeniser leaves alongside the
+        branch name has to answer git's question too."""
+        self._denied_as_the_branch_guard("git checkout feature 2>/dev/null")
+
+    def test_two_operands_that_are_not_a_restore_are_still_refused(self):
+        """git: `git checkout feature main` → "error: pathspec 'main' did not match any
+        file(s) known to git". Refusing something git refuses costs nothing; allowing it
+        because it had two operands would be the assumption above."""
+        self._denied_as_the_branch_guard("git checkout feature main")
+
+    def test_a_restore_of_more_paths_than_the_guard_will_resolve_is_refused(self):
+        """The bounded-work end of the same rule. Past `_MAX_CHECKOUT_OPERANDS` the guard
+        stops asking and keeps refusing — and the escape is the spelling that needs no
+        questions at all, asserted here so the cap cannot become a dead end."""
+        many = " ".join(["README"] * (hooks._MAX_CHECKOUT_OPERANDS + 2))
+        self._denied_as_the_branch_guard(f"git checkout {many}")
+        self.assertIsNone(_decision(self.run_cmd(f"git checkout -- {many}")))
+
+    def test_a_git_that_cannot_be_asked_is_still_refused(self):
+        """A guard that opened because it failed to ask is the fail-open shape #438 is
+        about. `README` is the one operand in this fixture that the rule otherwise allows,
+        so this can only pass by failing closed."""
+        from charter import util
+
+        with mock.patch("charter.doctor._git_in",
+                        side_effect=util.ProcTimeout("git", 5)):
+            r = self.run_cmd("git checkout README")
+        self.assertEqual(_decision(r), "deny")
+        self.assertIn("could not ask git", _reason(r))
+
+
+class TestTheAmbiguousCaseStaysDenied(CheckoutCase):
+    """`ambig` is both a tracked file and a branch.
+
+    git: `git checkout ambig` → "Switched to branch 'ambig'". The ref wins, so refusing is
+    correct here — and this is the case that stops the fix being over-applied into "any
+    operand that names a file is safe".
+    """
+
+    def test_it_is_denied(self):
+        self.assertEqual(_decision(self.run_cmd("git checkout ambig")), "deny")
+
+    def test_the_message_says_ambiguous_rather_than_asserting_a_branch(self):
+        """The half of #461 that is about the prose. A guard that is right to refuse and
+        wrong about why still sends the operator to the wrong remedy."""
+        reason = _reason(self.run_cmd("git checkout ambig"))
+        self.assertIn("AMBIGUOUS", reason)
+        self.assertIn("git restore ambig", reason)
+
+    def test_the_unambiguous_spellings_of_the_same_restore_run(self):
+        """And the message's advice has to be true: both forms it names must be allowed."""
+        self.assertIsNone(_decision(self.run_cmd("git checkout -- ambig")))
+        self.assertIsNone(_decision(self.run_cmd("git restore ambig")))
+
+
+class TestDetachWasTheOtherHalfOfTheMisreading(CheckoutCase):
+    """The same guard was too NARROW where it was too broad, and for the same reason —
+    matching command shape. It required an operand, so the one HEAD move that needs no
+    operand at all was invisible to it.
+
+    git: `git checkout --detach` → "HEAD is now at <sha>", off `main`. Same for
+    `git switch --detach`.
+    """
+
+    def test_checkout_detach_with_no_operand_is_refused(self):
+        r = self.run_cmd("git checkout --detach")
+        self.assertEqual(_decision(r), "deny")
+        self.assertIn("detach HEAD", _reason(r))
+
+    def test_switch_detach_with_no_operand_is_refused(self):
+        self.assertEqual(_decision(self.run_cmd("git switch --detach")), "deny")
+
+    def test_detach_at_a_named_ref_is_refused(self):
+        self.assertEqual(_decision(self.run_cmd("git checkout --detach feature")), "deny")
+
+    def test_detach_does_not_let_a_path_operand_excuse_it(self):
+        """`--detach` is never a restore, so the operand rule must not be reached — a
+        `--detach` with a tracked path is nonsense git rejects, and reading it as a restore
+        would be a two-word bypass on the case above."""
+        self.assertEqual(_decision(self.run_cmd("git checkout --detach README")), "deny")
+
+
+class TestTheRemedyAndTheRestOfTheGuardAreUnchanged(CheckoutCase):
+    def test_returning_to_the_default_branch_is_still_allowed(self):
+        """`doctor` prints exactly this. A guard that blocks the fix it recommends is a
+        trap, and that carve-out predates this change."""
+        self._in(self.root, "checkout", "-q", "feature")
+        self.assertIsNone(_decision(self.run_cmd("git checkout main")))
+
+    def test_a_bare_checkout_is_still_ignored(self):
+        self.assertIsNone(_decision(self.run_cmd("git checkout")))
+
+    def test_committing_in_the_root_is_still_allowed(self):
+        self.assertIsNone(_decision(self.run_cmd("git commit -m x")))
+
+    def test_a_commit_message_mentioning_checkout_is_still_not_a_switch(self):
+        self.assertIsNone(_decision(
+            self.run_cmd('git commit -m "docs: explain git checkout main"')))
+
+    def test_switching_inside_a_workspace_clone_is_still_allowed(self):
+        clone = config.WORKSPACES_DIR / "ws" / "svc"
+        clone.mkdir(parents=True, exist_ok=True)
+        self._git("init", "-q", "-b", "main", str(clone))
+        self.assertIsNone(_decision(self.run_cmd("git checkout -b feature/x", cwd=clone)))
+
+    def test_no_control_plane_means_no_opinion(self):
+        config.HAS_CONTROL_PLANE = False
+        self.assertIsNone(_decision(self.run_cmd("git checkout feature")))
+
+
+class TestTheOperandRuleAsksGit(CheckoutCase):
+    """The helper on its own, against the four fixture names. Kept because the guard above
+    can only show three of the five answers, and `unknown` has to be reachable by something
+    other than the guard's own message."""
+
+    def test_each_fixture_name_resolves_the_way_git_resolves_it(self):
+        for op, expected in (("README", "path"), ("notes", "path"), (".", "path"),
+                             ("feature", "rev"), ("HEAD", "rev"), ("-", "rev"),
+                             ("ambig", "both"), ("nosuch-branch", "neither")):
+            with self.subTest(op=op):
+                self.assertEqual(hooks._checkout_operand_kind(self.root, op), expected)
+
+    def test_a_git_that_will_not_answer_is_unknown_not_a_path(self):
+        from charter import util
+
+        with mock.patch("charter.doctor._git_in",
+                        side_effect=util.ProcTimeout("git", 5)):
+            self.assertEqual(hooks._checkout_operand_kind(self.root, "README"), "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plane_root_checkout_is_two_commands.py
+++ b/tests/test_plane_root_checkout_is_two_commands.py
@@ -30,13 +30,29 @@ had thought of, so a spelling nobody thought of had no row at all, and that is t
 `TestGitItselfIsTheOracle` closes: it runs each spelling against real git in a throwaway
 copy of this fixture and requires that anything which MOVED HEAD is denied. The expected
 verdict is not written down; git supplies it.
+
+**Round three, and the same shape one level up.** Asking git for the verdict fixed who
+decides; it did not fix who chooses the questions, and the corpus was still 41 rows a person
+had typed. Both holes round three found are COMBINATIONS of axes that were each already
+covered: `--detach` had rows and `main` had rows, but `git checkout --detach main` — which
+walked through the "returning to the default branch is always allowed" carve-out and past
+every line of the `--detach` handling — had none; `git switch` had rows and `--` had rows,
+but `git switch -- feature` had none, and `switch` has no path half for a separator to
+introduce. So the corpus is now the PRODUCT of its axes (`_generated_corpus`), a second one
+crosses commands with every ROUTE to the plane root — where a relative `git -C` was being
+resolved against the hook process's cwd rather than the shell's — and a third loads the
+guard as it stands on `origin/main` and requires that nothing it refuses is allowed here.
 """
 
 from __future__ import annotations
 
+import importlib.util
+import itertools
+import os
 import shlex
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -44,6 +60,47 @@ from unittest import mock
 
 from charter import config, hooks
 from tests._isolation import PersonaIso, run_hook
+
+
+#: ---------------------------------------------------------------------------------------
+#: The corpus, as a PRODUCT of axes rather than a list somebody typed.
+#:
+#: Every bypass this guard has had was a spelling nobody thought to type: `--orphan README`,
+#: `-bREADME`, `-fq`, `git checkout --detach main`, `git switch -- feature`. A written list
+#: is only ever as long as the last audit, and round two's oracle inherited that shape — it
+#: asked real git for the verdict, which was the right idea, but it asked about 41 rows a
+#: person had chosen. Two of the three holes round three found are combinations of axes that
+#: were each already present: `--detach` had rows, `main` had rows, and `--detach main` had
+#: none.
+#:
+#: So the axes are named and crossed. Adding one option or one operand adds every
+#: combination of it, and no combination can be added with the wrong expected answer,
+#: because the expected answer is not written down at all — git supplies it.
+_SUBS = ("checkout", "switch")
+
+#: One witness per option CLASS the rule knows — none, restore-only, detach, create, and an
+#: option charter cannot place — in each spelling git's parser accepts: long, short, and a
+#: cluster in BOTH orders, since a cluster is read left to right and `-qd` meets a different
+#: letter first than `-dq`.
+_OPTS = ("", "-q", "--ours", "--detach", "-d", "-qd", "-dq", "-b", "--orphan")
+
+#: One witness per operand CLASS: the plane's DEFAULT BRANCH — the remedy's name, and the
+#: one the carve-out used to hand a free pass to whatever stood beside it — another branch,
+#: a name that is both a branch and a tracked file, and a tracked file.
+_OPERANDS = ("main", "feature", "ambig", "README")
+
+#: Where `--` goes. It is an axis and not a footnote because it does not mean the same thing
+#: on both subcommands: `checkout` has a path half for a separator to introduce and `switch`
+#: has none, so `git switch -- feature` is a branch move wearing a restore's punctuation.
+_SHAPES = ("git {sub} {opt} {op}", "git {sub} {opt} {op} --", "git {sub} {opt} -- {op}")
+
+
+def _generated_corpus() -> tuple[str, ...]:
+    """Every ``{sub} × {opt} × {operand} × {shape}``, deduplicated, order preserved."""
+    out: dict[str, None] = {}
+    for sub, opt, op, shape in itertools.product(_SUBS, _OPTS, _OPERANDS, _SHAPES):
+        out[" ".join(shape.format(sub=sub, opt=opt, op=op).split())] = None
+    return tuple(out)
 
 
 def _decision(r) -> str | None:
@@ -131,14 +188,21 @@ class CheckoutCase(PersonaIso):
             self._oracle_n = 0
             # A copy of the live fixture, so any per-class setUp (aliases, extra branches)
             # is part of what git is asked about.
-            shutil.copytree(self.root, self._oracle_base / "template")
+            tpl = self._oracle_base / "template"
+            shutil.copytree(self.root, tpl)
+            # `git init`'s sample hooks are most of the bytes in a fixture this small and
+            # nothing here runs one. Dropping them is what keeps a generated corpus of a
+            # couple of hundred spellings affordable — the copy below happens once per row.
+            shutil.rmtree(tpl / ".git" / "hooks", ignore_errors=True)
+            # Read once, not once per row: every scratch below is a fresh copy of this
+            # template, so they all start from the same HEAD.
+            self._oracle_before = self._head(tpl)
         self._oracle_n += 1
         scratch = self._oracle_base / f"run-{self._oracle_n}"
         shutil.copytree(self._oracle_base / "template", scratch)
-        before = self._head(scratch)
         subprocess.run(shlex.split(cmd), cwd=scratch, capture_output=True, text=True,
                        timeout=60)
-        return self._head(scratch) != before
+        return self._head(scratch) != self._oracle_before
 
 
 class TestRestoringAFileIsNotABranchSwitch(CheckoutCase):
@@ -210,6 +274,28 @@ class TestARefMoveIsStillRefused(CheckoutCase):
         """`git switch` takes branches and nothing else — it exists because this overload
         is confusing — so the operand rule is asked of `checkout` only."""
         self._denied_as_the_branch_guard("git switch feature")
+
+    def test_a_separator_does_not_give_switch_a_path_half_it_does_not_have(self):
+        """Found by the generated corpus, not by anyone reading the code.
+
+        `--` introduces PATHS on a `checkout`, and the rule reads "something after the
+        separator, therefore a restore". `git switch` has no path half for a separator to
+        introduce — that is most of why it exists — so on `switch` the same three characters
+        are punctuation in front of a branch name. Measured against git 2.50:
+        `git switch -- feature` and `git switch -q -- ambig` both answer "Switched to
+        branch", and both were allowed in the plane root.
+        """
+        for cmd in ("git switch -- feature", "git switch -q -- ambig",
+                    "git switch -- ambig", "git switch --detach -- main"):
+            with self.subTest(cmd=cmd):
+                self._denied_as_the_branch_guard(cmd)
+
+    def test_but_the_remedy_survives_the_separator(self):
+        """`git switch -- main` puts the root back on its default branch, separator and all
+        — verified, "Switched to branch 'main'" — and the line above must not have turned
+        every `switch --` into a refusal."""
+        self._in(self.root, "checkout", "-q", "feature")
+        self.assertIsNone(_decision(self.run_cmd("git switch -- main")))
 
     def test_a_commit_ish_that_is_not_a_branch_is_still_a_ref_move(self):
         """git: `git checkout HEAD~0` detaches. Resolving as a COMMIT is the test, not
@@ -358,6 +444,42 @@ class TestDetachWasTheOtherHalfOfTheMisreading(CheckoutCase):
         would be a two-word bypass on the case above."""
         self.assertEqual(_decision(self.run_cmd("git checkout --detach README")), "deny")
 
+    def test_the_default_branch_beside_a_detach_does_not_excuse_it_either(self):
+        """Round three's hole, by name.
+
+        The remedy carve-out — "returning the root to its default branch is always allowed"
+        — gated on `not creating` and the operand's spelling, so `main` standing beside a
+        `--detach` reached `continue` and skipped every line of the `--detach` handling
+        above. Measured against git 2.50: each of these answers "HEAD is now at <sha>" and
+        HEAD goes from `branch:main` to detached. The remedy is a command that leaves HEAD
+        ATTACHED to the default branch, not one with the default branch's name in it.
+        """
+        for cmd in ("git checkout --detach main", "git switch -d main",
+                    "git checkout -qd main", "git checkout -dq main",
+                    "git checkout --detach main --", "git switch --detach -- main",
+                    "git checkout --detach=main main"):
+            with self.subTest(cmd=cmd):
+                r = self.run_cmd(cmd)
+                self.assertEqual(_decision(r), "deny", cmd)
+                self.assertIn("PLANE ROOT", _reason(r), cmd)
+
+    def test_a_detach_with_an_operand_is_described_as_a_detach(self):
+        """Not "switch to 'main'". A refusal that is right and a sentence that is wrong about
+        what the command does is the other half of #461 — and here the wrong sentence would
+        name the exact command the denial's own last line promises is allowed."""
+        r = self.run_cmd("git checkout --detach main")
+        self.assertIn("detach HEAD at 'main'", _reason(r))
+        self.assertNotIn("switch to", _reason(r))
+
+    def test_the_denial_names_the_spelling_it_promises_rather_than_a_category(self):
+        """The closing sentence used to read "Returning the root to its default branch is
+        always allowed", printed underneath a refusal of `git checkout --detach main` —
+        which is a command that returns the root to its default branch by name and is
+        refused. It now names the spelling that is actually allowed, and the test asserts
+        that spelling really is."""
+        self.assertIn("`git checkout main`", _reason(self.run_cmd("git checkout --detach main")))
+        self.assertIsNone(_decision(self.run_cmd("git checkout main")))
+
 
 class TestTheRemedyAndTheRestOfTheGuardAreUnchanged(CheckoutCase):
     def test_returning_to_the_default_branch_is_still_allowed(self):
@@ -408,7 +530,13 @@ class TestGitItselfIsTheOracle(CheckoutCase):
 
     #: Argv-able only: the shell forms (`$(…)`, `2>/dev/null`) belong to the tokeniser
     #: tests above, where the point is what charter sees rather than what git does.
-    CORPUS = (
+    #:
+    #: **Named rows, and the smaller half of the corpus.** Each one is a spelling that was
+    #: once a live bypass or is a promise charter makes in prose, kept by name so a
+    #: regression reads as itself in the failure output. The bulk of the coverage is
+    #: `_generated_corpus()` below, because a hand-written list is only ever as long as the
+    #: last audit — every bypass this guard has had was a spelling nobody typed here.
+    NAMED = (
         # Ref moves, in every spelling of the value that git accepts.
         "git checkout feature", "git checkout ambig", "git checkout HEAD~0",
         "git checkout -b chore/x", "git checkout -b README", "git checkout -bREADME",
@@ -430,6 +558,8 @@ class TestGitItselfIsTheOracle(CheckoutCase):
         "git checkout --conflict=merge README", "git restore README",
     )
 
+    CORPUS = NAMED + _generated_corpus()
+
     #: What charter PROMISES is allowed. Every one is also run past git below, so the
     #: promise and the behaviour cannot drift apart silently.
     PROMISED_RESTORES = ("git checkout README", "git checkout .", "git checkout notes",
@@ -450,9 +580,16 @@ class TestGitItselfIsTheOracle(CheckoutCase):
         # "test that cannot fail" shape. These are the counts and the names measured
         # against git 2.50, so a fixture that stops reproducing the conditions (no branch
         # to switch to, say) fails here rather than passing silently.
-        self.assertGreaterEqual(len(movers), 20, movers)
+        self.assertGreaterEqual(len(movers), 90, len(movers))
+        # Named witnesses, one per bypass this guard has actually had, so a fixture that
+        # stops producing that shape fails loudly instead of quietly covering less. The
+        # last two are round three's: a detach whose operand is the default branch walked
+        # through the remedy carve-out, and `--` on a `switch` — which has no path half for
+        # a separator to introduce — was read as "paths follow, so this is a restore".
         for must in ("git checkout --orphan README", "git checkout -bREADME",
-                     "git switch -cneu", "git checkout -d feature"):
+                     "git switch -cneu", "git checkout -d feature",
+                     "git checkout --detach main", "git switch -d main",
+                     "git switch -- feature", "git switch -q -- ambig"):
             self.assertIn(must, movers)
 
     def test_no_promised_restore_moves_head_and_every_one_is_allowed(self):
@@ -462,6 +599,178 @@ class TestGitItselfIsTheOracle(CheckoutCase):
             with self.subTest(cmd=cmd):
                 self.assertFalse(self.moves_head(cmd), cmd)
                 self.assertIsNone(_decision(self.run_cmd(cmd)), cmd)
+
+
+class TestEveryRouteToThePlaneRootIsTheSameRoute(CheckoutCase):
+    """A command that moves the plane root's HEAD is denied **however the root is reached**.
+
+    The guard's subject is a repository, not a directory, and there is more than one way for
+    one shell command to name it: the cwd, `git -C <path>`, a `cd` earlier in the same
+    command, and every combination. The oracle above holds the command still and varies its
+    spelling; this holds the command still and varies the ROUTE — and it is where the second
+    of round three's holes lived.
+
+    `_git_target` read `git -C <path>` as ``Path(args[i + 1])``, so a RELATIVE `-C` was
+    resolved against the directory the hook process happened to be started in rather than
+    against the shell's. Measured end to end against git 2.50 from a workspace clone:
+    `git -C ../../.. checkout feature` answers *"Switched to branch 'feature'"* and the
+    plane root's `symbolic-ref` follows it — while the guard was looking three levels above
+    the hook's cwd, finding something that was not the plane root, and standing aside.
+    `git -C . checkout feature` typed in the root itself, and `cd .. && git -C <root>
+    checkout feature`, landed the same way.
+
+    So the routes are an axis too, crossed with commands whose effect **git decides** — the
+    same oracle as above, run on the bare command once, because a route cannot change what a
+    command does to HEAD.
+    """
+
+    #: `(subcommand, rest)`, kept split so the alias route can put the subcommand inside
+    #: `-c alias.…=` where no `checkout` token survives in the argv at all.
+    COMMANDS = (
+        ("checkout", "feature"), ("switch", "feature"), ("checkout", "-b chore/x"),
+        ("checkout", "--detach main"), ("switch", "-d main"), ("checkout", "--orphan README"),
+        ("switch", "-- feature"), ("checkout", "ambig"),
+        # Not movers — carried through the same loop so the routes are exercised on the
+        # allowed half too, and a route that started refusing every restore fails here.
+        ("checkout", "README"), ("restore", "README"), ("checkout", "main"),
+    )
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.clone = config.WORKSPACES_DIR / "ws" / "svc"
+        self.clone.mkdir(parents=True, exist_ok=True)
+        self._git("init", "-q", "-b", "main", str(self.clone))
+        # How a session in the clone spells the plane root without naming it absolutely.
+        self.up = os.path.relpath(self.root, self.clone)
+        self.assertTrue(self.up.startswith(".."), self.up)
+
+    def routes(self, sub: str, rest: str):
+        """``(label, cwd, command)`` for every way one shell command reaches the root."""
+        tail = f"{sub} {rest}".strip()
+        yield "cwd is the root", self.root, f"git {tail}"
+        yield "-C, absolute", self.clone, f"git -C {self.root} {tail}"
+        yield "-C, relative", self.clone, f"git -C {self.up} {tail}"
+        yield "-C .", self.root, f"git -C . {tail}"
+        yield "-C, relative, twice", self.clone, f"git -C {self.up} -C . {tail}"
+        yield "cd into the root", self.root.parent, f"cd {self.root.name} && git {tail}"
+        yield ("cd out, -C back in", self.root,
+               f"cd .. && git -C {self.root.name} {tail}")
+        yield ("an alias, from the clone", self.clone,
+               f"git -C {self.up} -c alias.zz={sub} zz {rest}".strip())
+
+    def test_a_head_move_is_denied_by_every_route(self):
+        movers = []
+        for sub, rest in self.COMMANDS:
+            bare = f"git {sub} {rest}".strip()
+            if not self.moves_head(bare):
+                continue
+            movers.append(bare)
+            for label, cwd, cmd in self.routes(sub, rest):
+                with self.subTest(route=label, cmd=cmd):
+                    r = self.run_cmd(cmd, cwd=cwd)
+                    self.assertEqual(_decision(r), "deny", f"{label}: {cmd}")
+                    self.assertIn("PLANE ROOT", _reason(r), cmd)
+        # Non-vacuity: if git stopped moving HEAD for these — a fixture with no second
+        # branch, say — the loop above would assert nothing and still pass.
+        self.assertGreaterEqual(len(movers), 7, movers)
+
+    def test_a_restore_is_allowed_by_every_route(self):
+        """The routes do not become a way to refuse what charter permits. Widening the
+        guard's reach and narrowing what it refuses are the two halves of this change, and a
+        route that only ever denied would look like the first while undoing the second."""
+        for sub, rest in (("checkout", "README"), ("restore", "README")):
+            bare = f"git {sub} {rest}"
+            self.assertFalse(self.moves_head(bare), bare)
+            for label, cwd, cmd in self.routes(sub, rest):
+                with self.subTest(route=label, cmd=cmd):
+                    self.assertIsNone(_decision(self.run_cmd(cmd, cwd=cwd)), f"{label}: {cmd}")
+
+    def test_a_route_that_does_not_reach_the_root_is_still_not_the_root(self):
+        """The reach is not "anything with a `-C` in it". A relative `-C` that lands in the
+        clone is a clone command, and branch work in a clone is the thing charter tells
+        people to do."""
+        for cmd in ("git -C . checkout -b feature/x",
+                    f"git -C {self.clone} checkout -b feature/x",
+                    "cd .. && git -C svc checkout -b feature/x"):
+            with self.subTest(cmd=cmd):
+                self.assertIsNone(_decision(self.run_cmd(cmd, cwd=self.clone)), cmd)
+
+
+class TestNeverWeakerThanTheGuardThatShips(CheckoutCase):
+    """**Nothing `origin/main`'s guard denies may be allowed here** unless git itself shows
+    the command does not move HEAD.
+
+    Two rounds of this fix were strictly weaker than the code they replaced on inputs nobody
+    had a row for — round one on `git checkout --orphan README`, round three on
+    `git checkout --detach main` — and both times every test in the file passed. The reason
+    is structural: a fix that *narrows* a guard is reviewed by reading the narrowing, and the
+    narrowing is exactly where the accidental widening hides.
+
+    So the previous implementation is loaded and asked the same questions. It is a
+    REFERENCE, not a spec: where the two disagree, git breaks the tie. A disagreement is a
+    finding only when `origin/main` refused something this guard allows **and git moves HEAD
+    for it** — anything else is #461's false positive being removed on purpose, and those
+    are collected and asserted to be restores rather than waved through.
+
+    This is a cross-check, not the property: `TestGitItselfIsTheOracle` and
+    `TestEveryRouteToThePlaneRootIsTheSameRoute` carry the property, and both run everywhere.
+    This one needs the repository's history, so it reports rather than runs where there is
+    none — an `actions/checkout` at depth 1 has no `origin/main` to load.
+    """
+
+    #: Refs to load the shipped guard from, in order. `main` is here for a clone whose
+    #: remote is not called `origin`.
+    BASELINE_REFS = ("origin/main", "main")
+
+    def shipped(self):
+        repo = Path(hooks.__file__).resolve().parent.parent
+        if not (repo / ".git").exists():
+            self.skipTest(f"no git history at {repo}: nothing to compare against")
+        for ref in self.BASELINE_REFS:
+            r = subprocess.run(["git", "-C", str(repo), "show", f"{ref}:charter/hooks.py"],
+                               capture_output=True, text=True)
+            if r.returncode == 0:
+                break
+        else:
+            self.skipTest(f"none of {self.BASELINE_REFS} resolves in {repo}")
+        # Loaded under a name INSIDE the package, so its `from . import config` binds the
+        # same, already-isolated `charter.config` this test is running against — the
+        # baseline judges the same fixture from the same `ROOT`.
+        src = Path(tempfile.mkdtemp(prefix="edm-shipped-")) / "shipped_hooks.py"
+        self.addCleanup(shutil.rmtree, src.parent, ignore_errors=True)
+        src.write_text(r.stdout)
+        spec = importlib.util.spec_from_file_location("charter._shipped_hooks", src)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = mod
+        self.addCleanup(sys.modules.pop, spec.name, None)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_no_input_the_shipped_guard_denies_is_allowed_here(self):
+        shipped = self.shipped()
+        root = str(self.root)
+        denied_by_shipped, relaxed, weaker = 0, [], []
+        for cmd in TestGitItselfIsTheOracle.CORPUS:
+            if shipped._plane_root_branch_reason(cmd, root) is None:
+                continue
+            denied_by_shipped += 1
+            if hooks._plane_root_branch_reason(cmd, root) is not None:
+                continue
+            (weaker if self.moves_head(cmd) else relaxed).append(cmd)
+        # The finding. Named in full, because "the branch is weaker than main" is the one
+        # verdict that blocks unconditionally.
+        self.assertEqual(weaker, [], f"allowed here, denied by main, and git MOVES HEAD: "
+                                     f"{weaker}")
+        # Non-vacuity in both directions: a baseline that denied nothing would make the loop
+        # empty, and a fix that relaxed nothing would mean #461 is not fixed at all.
+        self.assertGreaterEqual(denied_by_shipped, 100, denied_by_shipped)
+        self.assertGreaterEqual(len(relaxed), 4, relaxed)
+        # Every relaxation is a restore charter can name, not merely "something that did not
+        # move HEAD this time": each is `git restore`-able, which is the sentence the news
+        # entry makes.
+        for cmd in relaxed:
+            with self.subTest(cmd=cmd):
+                self.assertFalse(self.moves_head(cmd), cmd)
 
 
 class TestAnOptionCharterCannotPlaceKeepsTheGuardShut(CheckoutCase):

--- a/tests/test_plane_root_checkout_is_two_commands.py
+++ b/tests/test_plane_root_checkout_is_two_commands.py
@@ -21,11 +21,23 @@ had drifted apart here precisely because nothing compared them.
 
 The ambiguous case is asserted as **still denied**, so the fix cannot be over-applied into
 "any operand that happens to name a file is safe".
+
+**Round two.** The first cut of this read the operand and not the options, and `git checkout
+--orphan README` — a branch creation whose operand is a tracked file — walked through the
+restore carve-out. `origin/main` refused it: the fix was strictly weaker than the code it
+replaced, on the very command it is named after. Every row here asserted a verdict somebody
+had thought of, so a spelling nobody thought of had no row at all, and that is the defect
+`TestGitItselfIsTheOracle` closes: it runs each spelling against real git in a throwaway
+copy of this fixture and requires that anything which MOVED HEAD is denied. The expected
+verdict is not written down; git supplies it.
 """
 
 from __future__ import annotations
 
+import shlex
+import shutil
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -60,16 +72,23 @@ class CheckoutCase(PersonaIso):
         (self.tmp / "charter.toml").write_text("schema = 1\n")
         config.HAS_CONTROL_PLANE = True
         self.root = Path(config.ROOT)
-        self._git("init", "-q", "-b", "main", str(self.root))
-        (self.root / "README").write_text("plane\n")
-        (self.root / "ambig").write_text("both\n")
-        (self.root / "notes").mkdir()
-        (self.root / "notes" / "a.md").write_text("a\n")
-        self._in(self.root, "add", "-A")
-        self._in(self.root, "-c", "commit.gpgsign=false", "-c", "user.email=t@e",
+        self.build_repo(self.root)
+
+    def build_repo(self, where: Path) -> None:
+        """The fixture, as a function, so the oracle in `TestGitItselfIsTheOracle` can run
+        real git commands against the SAME repo the guard is judging rather than a
+        hand-rolled second one that could drift from it."""
+        where.mkdir(parents=True, exist_ok=True)
+        self._git("init", "-q", "-b", "main", str(where))
+        (where / "README").write_text("plane\n")
+        (where / "ambig").write_text("both\n")
+        (where / "notes").mkdir(exist_ok=True)
+        (where / "notes" / "a.md").write_text("a\n")
+        self._in(where, "add", "-A")
+        self._in(where, "-c", "commit.gpgsign=false", "-c", "user.email=t@e",
                  "-c", "user.name=t", "commit", "-qm", "init")
-        self._in(self.root, "branch", "feature")
-        self._in(self.root, "branch", "ambig")
+        self._in(where, "branch", "feature")
+        self._in(where, "branch", "ambig")
 
     @staticmethod
     def _git(*args):
@@ -85,6 +104,41 @@ class CheckoutCase(PersonaIso):
             "tool_input": {"command": cmd},
             "cwd": str(cwd if cwd is not None else self.root),
             "session_id": "s"})
+
+    # --- git as the oracle ------------------------------------------------------------
+    # Shared rather than owned by one class: the point of asking real git what a command
+    # does is lost if only one test file's worth of spellings gets to ask.
+
+    def _head(self, where: Path) -> str:
+        r = subprocess.run(["git", "-C", str(where), "symbolic-ref", "-q", "--short", "HEAD"],
+                           capture_output=True, text=True)
+        if r.returncode == 0:
+            return "branch:" + r.stdout.strip()
+        return "detached:" + subprocess.run(
+            ["git", "-C", str(where), "rev-parse", "HEAD"],
+            capture_output=True, text=True).stdout.strip()
+
+    def moves_head(self, cmd: str) -> bool:
+        """Run *cmd* in a throwaway copy of this fixture and report whether HEAD moved.
+
+        The copy lives OUTSIDE the plane root, which is the tmp directory itself: copying
+        the root into a subdirectory of the root is a recursive copy that never ends. It hung
+        the suite once, which is why this note is here.
+        """
+        if getattr(self, "_oracle_base", None) is None:
+            self._oracle_base = Path(tempfile.mkdtemp(prefix="edm-oracle-"))
+            self.addCleanup(shutil.rmtree, self._oracle_base, ignore_errors=True)
+            self._oracle_n = 0
+            # A copy of the live fixture, so any per-class setUp (aliases, extra branches)
+            # is part of what git is asked about.
+            shutil.copytree(self.root, self._oracle_base / "template")
+        self._oracle_n += 1
+        scratch = self._oracle_base / f"run-{self._oracle_n}"
+        shutil.copytree(self._oracle_base / "template", scratch)
+        before = self._head(scratch)
+        subprocess.run(shlex.split(cmd), cwd=scratch, capture_output=True, text=True,
+                       timeout=60)
+        return self._head(scratch) != before
 
 
 class TestRestoringAFileIsNotABranchSwitch(CheckoutCase):
@@ -114,10 +168,18 @@ class TestRestoringAFileIsNotABranchSwitch(CheckoutCase):
         self.assertIsNone(_decision(self.run_cmd("git checkout feature README")))
 
     def test_a_restore_flag_does_not_make_it_a_switch(self):
-        """git: `git checkout --ours README` → "Updated 1 path from the index". Allowed by
-        the rule rather than by a list of restore-only flags — nothing here knows `--ours`
-        exists, and it does not have to."""
-        self.assertIsNone(_decision(self.run_cmd("git checkout --ours README")))
+        """git: `git checkout --ours README` → "Updated 1 path from the index".
+
+        `--ours` is on `_RESTORE_OPTS` and has to be: since #461's round two the carve-out
+        opens only for a command whose options are ALL placed as restore-only, because an
+        option decides what its operand means (`--orphan README` creates a branch called
+        README). The list is the cost of that direction — a restore-only flag charter has
+        not heard of is refused here until someone adds it, and the two spellings that need
+        no flags at all stay allowed."""
+        for cmd in ("git checkout --ours README", "git checkout -f README",
+                    "git checkout -q README", "git checkout --conflict=merge README"):
+            with self.subTest(cmd=cmd):
+                self.assertIsNone(_decision(self.run_cmd(cmd)))
 
     def test_it_still_works_through_a_dash_C(self):
         """The guard's reach is unchanged by this fix: a restore reached from a clone via
@@ -165,10 +227,19 @@ class TestARefMoveIsStillRefused(CheckoutCase):
             self._denied_as_the_branch_guard(f"git checkout {flag} chore/x")
 
     def test_creating_a_branch_named_after_a_tracked_file_is_still_refused(self):
-        """`-b` is a ref move whatever the operand looks like, so the operand rule must not
-        be reached at all — otherwise `git checkout -b README` would resolve as a path and
-        walk straight past the guard."""
-        self._denied_as_the_branch_guard("git checkout -b README")
+        """A ref move is a ref move whatever the operand looks like, so the operand rule
+        must not be reached at all — otherwise each of these resolves `README` as a path and
+        walks straight past the guard.
+
+        **`--orphan` is the row that was missing, and it was a live bypass**: measured
+        against git 2.50, `git checkout --orphan README` answers "Switched to a new branch
+        'README'" and HEAD moves off the plane root's branch. `origin/main` denied it and
+        the first version of this fix allowed it — the branch was weaker than the code it
+        was replacing, on the very command the fix is named after.
+        """
+        for flag in ("-b", "-B", "--orphan"):
+            with self.subTest(flag=flag):
+                self._denied_as_the_branch_guard(f"git checkout {flag} README")
 
     def test_an_unresolvable_operand_is_still_refused(self):
         """The fail-closed direction, and the one that matters for the next bypass: only a
@@ -264,6 +335,17 @@ class TestDetachWasTheOtherHalfOfTheMisreading(CheckoutCase):
         self.assertEqual(_decision(r), "deny")
         self.assertIn("detach HEAD", _reason(r))
 
+    def test_the_short_form_is_the_same_detach_and_says_so(self):
+        """git: `git checkout -d` → "HEAD is now at <sha>", and `git switch -d` likewise —
+        both with no operand at all. The allowlist would refuse them either way, as an
+        option it cannot place; the reason it is *named* as a detach is that the denial has
+        to describe the command it is refusing."""
+        for cmd in ("git checkout -d", "git switch -d"):
+            with self.subTest(cmd=cmd):
+                r = self.run_cmd(cmd)
+                self.assertEqual(_decision(r), "deny")
+                self.assertIn("detach HEAD", _reason(r))
+
     def test_switch_detach_with_no_operand_is_refused(self):
         self.assertEqual(_decision(self.run_cmd("git switch --detach")), "deny")
 
@@ -303,6 +385,292 @@ class TestTheRemedyAndTheRestOfTheGuardAreUnchanged(CheckoutCase):
     def test_no_control_plane_means_no_opinion(self):
         config.HAS_CONTROL_PLANE = False
         self.assertIsNone(_decision(self.run_cmd("git checkout feature")))
+
+
+class TestGitItselfIsTheOracle(CheckoutCase):
+    """The corpus test, with **real git as the oracle**: for every spelling below, run it in
+    a throwaway copy of the plane root, look at HEAD before and after, and require that
+    anything which MOVED HEAD is denied.
+
+    This exists because round one's guard was strictly weaker than the code it replaced on
+    one input (`git checkout --orphan README`), and no test in this file could have noticed:
+    each row asserted a verdict somebody wrote down, so a spelling nobody thought of had no
+    row. Here the expected verdict is not written down at all — git supplies it. A new
+    spelling is one line, and it cannot be added with the wrong answer.
+
+    One direction only, on purpose. "HEAD moved ⇒ denied" is the security property;
+    "HEAD stayed ⇒ allowed" is not, and must not be asserted, because over-refusing in the
+    plane root is a cost and not a hole (`git checkout --guess README` is refused here and
+    `git restore README` does the job). The restores charter positively promises are
+    asserted as allowed in `TestRestoringAFileIsNotABranchSwitch`, and repeated below
+    against the oracle so the pair cannot drift.
+    """
+
+    #: Argv-able only: the shell forms (`$(…)`, `2>/dev/null`) belong to the tokeniser
+    #: tests above, where the point is what charter sees rather than what git does.
+    CORPUS = (
+        # Ref moves, in every spelling of the value that git accepts.
+        "git checkout feature", "git checkout ambig", "git checkout HEAD~0",
+        "git checkout -b chore/x", "git checkout -b README", "git checkout -bREADME",
+        "git checkout -B README", "git checkout -BREADME",
+        "git checkout --orphan README", "git checkout --orphan=README",
+        "git checkout --orphan README --", "git checkout -qbREADME",
+        "git checkout --detach", "git checkout --detach feature", "git checkout -d feature",
+        "git checkout -d", "git switch -d",
+        "git checkout -f feature", "git checkout -q feature", "git checkout -fq feature",
+        "git checkout --guess feature", "git checkout -m feature",
+        "git switch feature", "git switch -c neu", "git switch -cneu",
+        "git switch --orphan neu", "git switch --orphan=neu",
+        "git switch --detach feature", "git switch -d feature",
+        # Restores and no-ops: nothing here may move HEAD, and the guard's verdict on them
+        # is deliberately not asserted from this list.
+        "git checkout", "git checkout README", "git checkout .", "git checkout notes",
+        "git checkout feature README", "git checkout -- README",
+        "git checkout --ours README", "git checkout -f README", "git checkout -q README",
+        "git checkout --conflict=merge README", "git restore README",
+    )
+
+    #: What charter PROMISES is allowed. Every one is also run past git below, so the
+    #: promise and the behaviour cannot drift apart silently.
+    PROMISED_RESTORES = ("git checkout README", "git checkout .", "git checkout notes",
+                         "git checkout feature README", "git checkout -- README",
+                         "git restore README", "git checkout --ours README")
+
+    def test_every_spelling_that_moves_head_is_denied(self):
+        movers = []
+        for cmd in self.CORPUS:
+            with self.subTest(cmd=cmd):
+                if not self.moves_head(cmd):
+                    continue
+                movers.append(cmd)
+                r = self.run_cmd(cmd)
+                self.assertEqual(_decision(r), "deny", f"git moved HEAD for: {cmd}")
+                self.assertIn("PLANE ROOT", _reason(r), cmd)
+        # A corpus in which git moved nothing would make the loop above vacuous — the
+        # "test that cannot fail" shape. These are the counts and the names measured
+        # against git 2.50, so a fixture that stops reproducing the conditions (no branch
+        # to switch to, say) fails here rather than passing silently.
+        self.assertGreaterEqual(len(movers), 20, movers)
+        for must in ("git checkout --orphan README", "git checkout -bREADME",
+                     "git switch -cneu", "git checkout -d feature"):
+            self.assertIn(must, movers)
+
+    def test_no_promised_restore_moves_head_and_every_one_is_allowed(self):
+        """The other half, and the reason the fix is not "deny everything": these are the
+        sentences charter's denial message and news entry make true."""
+        for cmd in self.PROMISED_RESTORES:
+            with self.subTest(cmd=cmd):
+                self.assertFalse(self.moves_head(cmd), cmd)
+                self.assertIsNone(_decision(self.run_cmd(cmd)), cmd)
+
+
+class TestAnOptionCharterCannotPlaceKeepsTheGuardShut(CheckoutCase):
+    """The property behind the `--orphan` bypass, tested as the property.
+
+    `--orphan` got through because the guard held a list of the four flags it knew moved
+    HEAD and treated everything else as harmless — so every option git has that was not on
+    that list, and every option git adds next, was a candidate bypass. The rule is now the
+    other way round: the restore carve-out opens only when every option present is one
+    charter can place as restore-only.
+
+    `--nonesuch-that-git-does-not-have` is in here as the *future* spelling: it stands for
+    whatever git adds after this commit, and it is refused today.
+    """
+
+    def _denied(self, cmd: str) -> str:
+        r = self.run_cmd(cmd)
+        self.assertEqual(_decision(r), "deny", cmd)
+        self.assertIn("PLANE ROOT", _reason(r), cmd)
+        return _reason(r)
+
+    def test_an_unrecognised_option_does_not_open_the_restore_carve_out(self):
+        for cmd in ("git checkout --guess README", "git checkout --track README",
+                    "git checkout --nonesuch-that-git-does-not-have README",
+                    "git checkout -t README", "git checkout -l README"):
+            with self.subTest(cmd=cmd):
+                self._denied(cmd)
+
+    def test_the_denial_names_the_option_rather_than_asserting_a_switch(self):
+        """#461's other half was a denial that was right to refuse and wrong about why.
+        charter does not know that `--guess README` switches — it knows it cannot read the
+        command as a restore, and that is what it says, with the two spellings that work."""
+        reason = self._denied("git checkout --guess README")
+        self.assertIn("--guess", reason)
+        self.assertIn("git restore README", reason)
+        self.assertNotIn("would switch to", reason)
+
+    def test_an_unrecognised_option_with_no_operand_is_not_a_bare_checkout(self):
+        """`git checkout -bREADME` has no operand at all — the whole command is one token
+        after `checkout` — and "no operand means nothing moves" allowed it. git: "Switched
+        to a new branch 'README'"."""
+        for cmd in ("git checkout -bREADME", "git checkout -BREADME",
+                    "git switch -cneu", "git checkout -qbREADME"):
+            with self.subTest(cmd=cmd):
+                self._denied(cmd)
+
+    def test_an_unplaced_option_alone_does_not_get_the_bare_checkout_pass(self):
+        """`git checkout` with nothing after it moves nothing, and that pass used to be
+        granted on "no operand" alone — which is how `-bREADME` got it, the branch name
+        being inside the option. It now also requires every option to be placed, so the next
+        option git adds that needs no operand does not inherit the pass either; `--detach`
+        was one such option, and it walked past this guard for a year.
+
+        The contrast matters as much as the denial: `-p` is a restore option, so an
+        interactive restore in the plane root is still allowed."""
+        self._denied("git checkout --nonesuch-that-git-does-not-have")
+        self.assertIsNone(_decision(self.run_cmd("git checkout -p")))
+
+    def test_the_denial_names_the_branch_hidden_inside_the_option(self):
+        """The name is in the option token, so a message built from the operands would name
+        nothing. A guard that cannot say what it is refusing is teaching people to ignore
+        it."""
+        self.assertIn("create 'README'", self._denied("git checkout -bREADME"))
+        self.assertIn("create 'README'", self._denied("git checkout --orphan=README"))
+
+    def test_the_value_forms_of_a_creator_are_the_same_creator(self):
+        for cmd in ("git checkout --orphan=README", "git switch --orphan=neu",
+                    "git switch --create=neu", "git checkout --no-orphan README"):
+            with self.subTest(cmd=cmd):
+                self._denied(cmd)
+
+    def test_a_separator_does_not_launder_a_branch_creation(self):
+        """`git checkout -b neu -- README` is refused by git today, and the carve-out used
+        to allow it on the strength of "something follows `--`". A guard that is safe only
+        while git keeps rejecting something is a bypass waiting for a release note."""
+        for cmd in ("git checkout -b neu -- README", "git checkout --orphan neu -- README",
+                    "git checkout --orphan README --"):
+            with self.subTest(cmd=cmd):
+                self._denied(cmd)
+
+    def test_the_option_classifier_places_git_2_50s_own_option_list(self):
+        """The helper against git's own `-h` output, one layer down from the guard, so the
+        allowlist's contents are asserted somewhere other than by their effect."""
+        for tok, expected in (("-b", "create"), ("-B", "create"), ("-c", "create"),
+                              ("-C", "create"), ("--orphan", "create"),
+                              ("--orphan=x", "create"), ("-bx", "create"),
+                              ("--create", "create"), ("--force-create", "create"),
+                              ("--detach", "detach"), ("-d", "detach"),
+                              ("--no-detach", "detach"),
+                              ("--ours", "restore"), ("--theirs", "restore"),
+                              ("-2", "restore"), ("-3", "restore"), ("-f", "restore"),
+                              ("-fq", "restore"), ("--conflict=merge", "restore"),
+                              ("--no-quiet", "restore"), ("--pathspec-from-file=x",
+                                                          "restore"),
+                              ("--track", "unknown"), ("-t", "unknown"),
+                              ("--guess", "unknown"), ("--no-guess", "unknown"),
+                              ("-l", "unknown"), ("--brand-new-git-flag", "unknown")):
+            with self.subTest(tok=tok):
+                self.assertEqual(hooks._checkout_opt_kind(tok), expected)
+
+
+class TestAnAliasIsAnotherSpellingOfTheSameCommand(CheckoutCase):
+    """`git checkout` is not the only way to spell `git checkout`.
+
+    This is the answer to "what is the next spelling of this that still gets through?" for
+    the round-two fix, and it was not hypothetical: with `co = checkout` — an alias on a
+    large share of developer machines — `git co feature` in the plane root answered
+    "Switched to branch 'feature'" and the guard never saw a `checkout`. `origin/main` was
+    equally blind, so this is not a regression; it is the same defect one layer out, the
+    guard matching a SPELLING rather than asking what the command does.
+
+    Every alias below was run against real git 2.50 with HEAD recorded before and after.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._in(self.root, "config", "alias.co", "checkout")
+        self._in(self.root, "config", "alias.ck", "co")           # an alias to an alias
+        self._in(self.root, "config", "alias.sw", "switch -c")    # carrying its own option
+        self._in(self.root, "config", "alias.bang", "!git checkout")
+        self._in(self.root, "config", "alias.shell", "!echo checkout")
+
+    def _denied(self, cmd: str) -> str:
+        """Denied — and, for the spellings git can be asked about here, only counted as a
+        pass once real git has been shown to move HEAD for it."""
+        r = self.run_cmd(cmd)
+        self.assertEqual(_decision(r), "deny", cmd)
+        self.assertIn("PLANE ROOT", _reason(r), cmd)
+        return _reason(r)
+
+    def _really_moves_and_is_denied(self, cmd: str) -> None:
+        self.assertTrue(self.moves_head(cmd), f"git did not move HEAD for: {cmd}")
+        self._denied(cmd)
+
+    def test_a_plain_alias_is_followed(self):
+        """git: `git co feature` → "Switched to branch 'feature'"."""
+        self._really_moves_and_is_denied("git co feature")
+
+    def test_an_alias_chain_is_followed(self):
+        """git follows `ck` → `co` → `checkout` and switches. One hop would not have."""
+        self._really_moves_and_is_denied("git ck feature")
+
+    def test_an_alias_that_carries_its_own_options_is_judged_with_them(self):
+        """git: `git sw neu` → "Switched to a new branch 'neu'". The alias supplies `-c` and
+        the caller supplies the name, so neither half read alone is a branch creation."""
+        self._really_moves_and_is_denied("git sw neu")
+
+    def test_an_alias_defined_on_the_command_line_is_followed(self):
+        """git: `git -c alias.zz=checkout zz feature` → "Switched to branch 'feature'". No
+        config on disk has ever heard of `zz`, which is what makes this the cheapest
+        spelling of all — it needs no setup."""
+        self._really_moves_and_is_denied("git -c alias.zz=checkout zz feature")
+
+    def test_a_bang_alias_that_is_a_git_command_is_followed(self):
+        """git: `git bang feature` → "Switched to branch 'feature'". `!git checkout` is a
+        git command wearing a shell alias's clothes."""
+        self._really_moves_and_is_denied("git bang feature")
+
+    def test_an_alias_does_not_turn_a_restore_into_a_switch(self):
+        """The direction that keeps this from being a cage: git: `git co README` → "Updated
+        1 path from the index", HEAD unchanged. Following the alias means the operand rule
+        runs, not that the command is refused."""
+        self.assertFalse(self.moves_head("git co README"))
+        self.assertIsNone(_decision(self.run_cmd("git co README")))
+
+    def test_a_shell_alias_charter_cannot_read_is_out_of_scope_not_refused(self):
+        """The limit, asserted so it is a decision rather than an accident: `!echo checkout`
+        is a shell command charter does not run and cannot read. Refusing every `!` alias in
+        the plane root would refuse `s = !git status` and its cousins, which is a cage; the
+        guard stands aside, and `docs/hooks.md` says so rather than claiming otherwise."""
+        self.assertIsNone(_decision(self.run_cmd("git shell feature")))
+
+    def test_an_ordinary_command_costs_no_alias_lookup(self):
+        """The cost half. `git status` in the plane root must not spend a subprocess asking
+        whether `status` is an alias — this guard runs on every Bash call."""
+        with mock.patch("charter.doctor._git_in") as asked:
+            self.assertIsNone(_decision(self.run_cmd("git status")))
+        self.assertEqual(asked.call_args_list, [])
+
+    def test_a_git_that_will_not_answer_does_not_break_the_turn(self):
+        """`_plane_default_branch` raising out of a `PreToolUse` handler was a broken turn
+        rather than a verdict, and the alias lookup is one more place that could do it."""
+        from charter import util
+
+        with mock.patch("charter.doctor._git_in", side_effect=util.ProcTimeout("git", 5)):
+            self.assertIsNone(_decision(self.run_cmd("git co feature")))
+
+    def test_the_resolver_reports_what_git_would_run(self):
+        """One layer down, so the table is asserted somewhere other than by its effect."""
+        cases = (
+            ("co", ["feature"], [], ("checkout", ["feature"])),
+            ("ck", ["feature"], [], ("checkout", ["feature"])),
+            ("sw", ["neu"], [], ("switch", ["-c", "neu"])),
+            ("bang", ["feature"], [], ("checkout", ["feature"])),
+            ("shell", ["feature"], [], ("shell", ["feature"])),
+            ("status", [], [], ("status", [])),
+            ("zz", ["feature"], ["-c", "alias.zz=checkout"], ("checkout", ["feature"])),
+        )
+        for sub, post, pre, expected in cases:
+            with self.subTest(sub=sub):
+                self.assertEqual(hooks._resolve_git_alias(self.root, sub, post, pre),
+                                 expected)
+
+    def test_an_alias_loop_terminates(self):
+        """`a = b`, `b = a` is a config a person can write, and a guard that follows it for
+        ever is a hung `PreToolUse` hook — every tool call in the session."""
+        self._in(self.root, "config", "alias.aa", "bb")
+        self._in(self.root, "config", "alias.bb", "aa")
+        self.assertIsNone(_decision(self.run_cmd("git aa feature")))
 
 
 class TestTheOperandRuleAsksGit(CheckoutCase):


### PR DESCRIPTION
Two guards in `charter/hooks.py` that failed the same way the last four rounds failed: they matched a **spelling** instead of testing the **property**.

Closes #438
Closes #461

---

## #438 — a denial charter cannot write was an allow

`_deny` refuses by printing one JSON object on stdout. A hook that cannot print has said nothing, and a `PreToolUse` hook that says nothing is an **allow**. Both spellings of that were in the tree at once, on the same invariant:

| guard | what a `BrokenPipeError` out of `print` did | result |
|---|---|---|
| `pretooluse_read` (Read/Grep) | caught by `except Exception: return 0` around the whole body, `_deny` included | exit 0, vault read |
| `pretooluse` (Bash) | propagated to `cli.main`, which correctly turns it into 141 for `charter … \| head` | exit 141 — a *non-blocking* hook error; call proceeds |

Two sibling guards on one rule failing in opposite directions, in a module that argues at `:1170` that they must never disagree.

**The property, named:** *whenever a guard decides to deny and the JSON channel is unusable, the hook process refuses.* Not "this body does not raise".

- `_deny` returns the exit status the handler owes: `0` on the normal JSON path, `DENY_EXIT = 2` when the write fails. 2 is the harness's other refusal channel (blocks the call, hands stderr to the model); **every other non-zero status is a non-blocking error and the call goes ahead**, which is exactly how the 141 above let one through. The tests assert the number, not "non-zero".
- On the fallback path stdout is redirected to `/dev/null` at the fd level, because a failed shutdown flush *replaces* the exit status with 120 — another number in the "proceeds" bucket. Same move, and same guard, as `cli.main` already makes.
- The `except` in `pretooluse_read` was **narrowed, not deleted**: a payload charter cannot parse is still an allow, still silent, still not a broken turn. Deciding is fallible; refusing is not.
- An undelivered denial is also recorded, and `dispatch` refuses on it. That is the part that covers the guard nobody has written yet — a fail-open is invisible from the outside, so it is closed at the one place every guard passes through, not at each call site.

The coordinator asked for a sweep of the other entry points: `pretooluse_read` was the only one hiding a deny inside a `try`. `pretooluse_dispatch`'s `except Exception` wraps a *nudge* (`_ask`), which is the deliberate posture and stays. Two AST tests now pin the shape — no bare `_deny(...)` expression statement, and no `_deny` call inside a `try` — so the next one fails here rather than in an audit.

## #461 — `git checkout <file>` is a file restore, not a branch switch

`git restore charter.toml` was allowed the whole time. So charter was never holding a policy against restoring a file in the plane root; it was refusing **one of the two ways git spells an operation it permits** — and the denial was confident, detailed, and wrong about what the command does.

**The property:** git disambiguates by whether the operand resolves as a revision and by `--`. So charter asks git the same questions, in the same repo, instead of matching command shape:

- `rev-parse --verify --quiet <op>^{commit}` — does it resolve to a commit?
- `ls-files --error-unmatch -- <op>` — does git *track* a path by that name? (Not `os.path.exists`: an untracked file is not restorable, while `.`, `src/*.py` and `:/` are pathspecs that match plenty and exist as no single file.)

Only `path` — cannot be read as a commit, **can** be read as a tracked path — opens the gate. That is an affirmative demonstration, not the absence of a bad spelling, so everything unresolvable stays refused: a remote-only branch (git's DWIM checks it out here as a *new local branch* — verified), a name git has never heard of, `git checkout "$BR"`, and a git that times out.

| invocation | measured effect (git 2.50) | verdict |
|---|---|---|
| `git checkout README` | Updated 1 path from the index | allow |
| `git checkout .` / `notes` / `--ours README` | restore, HEAD unchanged | allow |
| `git checkout feature README` | Updated 1 path from `<sha>`, HEAD unchanged | allow |
| `git checkout feature` / `-` / `HEAD~0` | Switched to branch / detached | **deny** |
| `git checkout ambig` (file **and** branch) | "Switched to branch 'ambig'" — ref wins | **deny, as ambiguous** |
| `git checkout nosuch` / `"$BR"` | unresolvable → DWIM or error | **deny** |
| `git checkout --detach` / `git switch --detach` | "HEAD is now at …" | **deny (was allowed)** |

**The ambiguous case stays denied and now says so.** The message no longer asserts a branch; it says the command is ambiguous, that git breaks the tie in favour of the ref, and names the two spellings that are not ambiguous — `git restore <name>` and `git checkout -- <name>`, both of which are asserted allowed in the same test class, so the advice cannot rot.

**Two things the same misreading was hiding, found while fixing it:**

1. **Too narrow.** `--detach` takes the root off its branch with no operand at all, and the guard required an operand. Both `checkout --detach` and `switch --detach` walked past it.
2. **The next bypass, closed before it shipped.** charter's tokeniser flattens `git checkout $(echo feature)` into `['git','checkout','$','(','echo','feature',')']`. A rule that read "more than one operand ⇒ a restore" — which is what git's behaviour suggests — would have handed **every command substitution** a free pass at the branch guard. Trailing operands are resolved against git instead, bounded by `_MAX_CHECKOUT_OPERANDS`; `(` is not a tracked path. There is a test named for it.

Also fixed on the way past: `_plane_default_branch` could raise `ProcTimeout` straight out of the `PreToolUse` handler — a broken turn rather than a verdict.

## Overclaiming text, changed in the same commit

- `docs/hooks.md` → *When a hook fails* said flatly "Hooks swallow their exceptions … none of this is load-bearing." A denial is load-bearing, and the section now says which half is excused (deciding) and which is not (refusing), with the exit-2 contract and why the number cannot be "any failure".
- `docs/hooks.md` → *The guards* now states that a restore runs in the plane root, that `--detach` counts, and what happens on a shared name.
- Two `docs/news/unreleased-*.md` entries.

## Verification

- `python3 -m unittest discover -s tests` → **Ran 4574 tests … OK** (46 of them new; stdlib `unittest`, `PersonaIso`, no network, no non-stdlib import).
- Every git behaviour in the #461 tests was **measured** in a scratch repo with HEAD recorded before and after, including the DWIM and file-plus-branch cases — not inferred from the docs.
- **Mutation-tested, 11 mutants, all killed**, `__pycache__` cleared between runs, GREEN restored after each:

| mutant | killed by |
|---|---|
| `_deny` loses its exit-status fallback | 1 |
| `pretooluse_read` swallows its own deny again | 1 (the AST test — the `dispatch` backstop keeps behaviour correct, which is the redundancy working) |
| `dispatch` drops the undelivered-deny backstop | 1 |
| `DENY_EXIT` becomes 141 | 1 |
| any single operand counts as a restore | 8 |
| trailing operands assumed to be paths | 5 |
| `--detach` stops counting as a ref move | 3 |
| an unaskable git reads as a path | 2 |
| the ambiguous case described as a plain switch | 1 |
| an ambiguous operand counts as a restore | 3 |
| the restore carve-out reverted entirely | 6 |

## What is the next spelling that still gets through?

Stated rather than left for the next audit, and consistent with `SECURITY.md`'s "guard rails, not guarantees":

- **A command charter's tokeniser cannot see as a `git` invocation at all** — `sh -c 'git checkout feature'`, an alias, a script. That residual is older and wider than this guard and is unchanged by this PR.
- **A git alias defined on the command line** — `git -c alias.z='checkout feature' z` really does switch the branch (verified: *"Switched to branch 'feature'"*), and `_plane_root_git` yields `('z', [])`, which is in neither `_BRANCH_MOVERS` nor `_RESET_TREE_MODES`. Both plane-root guards are blind to it. Pre-existing and not reachable through anything this PR adds — the same shape `docs/hooks.md` already documents for the tool-gate (`git -c alias.z=clean z -xfd`) — so it is filed separately rather than guessed at here.
- **TOCTOU** — the guard asks git now and the command runs a moment later. An agent that creates a branch named after a tracked file between the two turns a `path` into a `both`; the window buys it a denial, not an allow, so it fails in the safe direction.

None of these are made reachable by this change; the set of allowed commands here strictly shrinks except for the file-restore forms.
