### PR TITLE
secrets: record every credential hand-out; workspaces: contain the committed default (#441, #442)

### DIFF
--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -1378,6 +1378,18 @@ def cmd_trace(args) -> int:
         if warns:
             print(f"  secret warnings ({len(warns)}): "
                   + ", ".join(w.get("file", "") for w in warns[-5:]))
+        # Credential hand-outs get their own line rather than only a tally, for the same
+        # reason denials do: "which command received the prod token" is a question somebody
+        # asks under pressure, and an aggregate that hides the answer one `charter trace`
+        # invocation deeper is an aggregate they will not trust twice (#441).
+        uses = [e for e in events if e["event"] in trace.SECRET_USE_EVENTS]
+        if uses:
+            print(f"  credentials handed out ({len(uses)}):")
+            for e in uses[-5:]:
+                keys = ",".join(e.get("key_names") or ()) or "-"
+                where = e.get("argv0") or e.get("dest") or "this terminal"
+                print(f"    {e.get('ts', '')}  {e['event']:14} "
+                      f"{e.get('vault', '?')}/{keys} → {where}")
         return 0
     shown = events[-args.n:] if getattr(args, "n", 0) else events
     for e in shown:

--- a/charter/commands_secrets.py
+++ b/charter/commands_secrets.py
@@ -5,6 +5,12 @@ The overriding rule here: **secret values must not leak into the model.**
 - ``list`` shows keys only, ``get`` is masked by default;
 - ``get --reveal`` refuses a non-interactive stdout (an agent) unless ``--force``;
 - the real consumption paths are ``exec`` (inject + redact) and ``cp`` (0600 file).
+
+And the rule's shadow: **every route by which a value leaves this process records that it
+did.** ``exec``, ``cp`` and ``get --reveal`` each write one ``charter trace`` event naming
+the vault, the key and the command — never a value (#441, and see
+:func:`_trace_secret_use`). A plane that hands out credentials and cannot say afterwards
+which command got which one has the audit half of the story missing.
 """
 
 from __future__ import annotations
@@ -433,6 +439,66 @@ def cmd_secret_audit(args) -> int:
     return 1 if stale else 0
 
 
+# --------------------------------------------------------------------------- #
+# the access record — WHICH command got WHICH credential (#441)                #
+# --------------------------------------------------------------------------- #
+# The vocabulary is `trace.SECRET_USE_EVENTS`, and there are exactly three routes by which
+# a plaintext leaves this process: a child's environment or a temp file (`exec`), a file on
+# disk (`cp`), and a terminal (`get --reveal`). All three record. `secret get` WITHOUT
+# `--reveal` does not, because nothing left — it prints a length and a digest.
+#
+# Recording two of the three would have been worse than recording none. An operator who
+# greps the trace for `secret-exec` and `secret-cp`, finds nothing, and concludes the token
+# never left the vault has been told something false by a record that looks complete.
+
+
+def _value_free(field, values: list[str]):
+    """*field* with every value in *values* replaced by ``***``, at any depth.
+
+    Recurses through dicts, lists and tuples rather than checking a list of field names
+    charter happens to record today: the next field added to a record is the one nobody
+    scrubs, and a rule about *shapes* covers a field that has not been written yet.
+    """
+    if isinstance(field, str):
+        return base.redact(field, values)
+    if isinstance(field, dict):
+        return {_value_free(k, values): _value_free(v, values) for k, v in field.items()}
+    if isinstance(field, (list, tuple)):
+        return [_value_free(v, values) for v in field]
+    return field
+
+
+def _trace_secret_use(event: str, resolved: list[str], **fields) -> None:
+    """Record that a credential was handed out — WHICH command, WHICH names, never a value.
+
+    `charter trace` knew about `secret-warn`, the scanner that notices a value in a file it
+    is about to commit, and about nothing charter itself handed out. So after the fact
+    there was no answer to *"which command received the prod token"* — the cheapest
+    observability a plane holding credentials can have, and the one it did not have (#441).
+
+    **Names, and one argv element.** `vault`, the key names, the environment variable names
+    they were bound to, and ``argv[0]``. Not the rest of argv: charter never substitutes a
+    value into a command line, but the caller may have *typed* one there, and a record
+    whose purpose is to hold no values must not copy a line that might.
+
+    *resolved* is the values this call actually read, and it is used for exactly one thing:
+    removing them from the fields above, at any depth, before anything is written. That is
+    belt and braces over the rule that only names are passed in — the half that still holds
+    when somebody adds a field here in a year. Its bound is stated rather than implied: it
+    can only remove values **this call resolved**, so it is not a filter that makes an
+    arbitrary payload safe to record, and nothing may be passed here on the strength of it.
+
+    Best-effort and silent, like every other trace site: observability must never break the
+    thing it observes, and a credential that was successfully delivered must not be turned
+    into a failure by the bookkeeping about it.
+    """
+    try:
+        from . import trace
+        trace.record(event, **{k: _value_free(v, resolved) for k, v in fields.items()})
+    except Exception:
+        pass
+
+
 def cmd_secret_get(args) -> int:
     try:
         value = _provider(args.vault).get(args.key)
@@ -455,6 +521,10 @@ def cmd_secret_get(args) -> int:
             "or pass --force if you truly intend to print it."
         )
         return 2
+    # Before the write, not after: the record of a credential leaving must not depend on
+    # the write that sends it away succeeding (a closed pipe, a full terminal).
+    _trace_secret_use("secret-reveal", [value], vault=args.vault, key_names=[args.key],
+                      forced=bool(args.force))
     util.warn("Revealing secret plaintext to this terminal.")
     sys.stdout.write(value if value.endswith("\n") else value + "\n")
     return 0
@@ -728,6 +798,12 @@ def cmd_secret_cp(args) -> int:
         util.err(str(e))
         return 1
 
+    # Before the write, and deliberately: from here on a plaintext is in this process with
+    # a descriptor open on its destination, so this is the last point at which the record
+    # is guaranteed to be made. Recorded after `f.write` returned, a partial write
+    # interrupted by ENOSPC or a signal would leave the value on disk and no trace of it.
+    _trace_secret_use("secret-cp", [value], vault=args.vault, key_names=[args.key],
+                      dest=str(dest), overwrote=bool(force and not created))
     with os.fdopen(fd, "w") as f:
         # fchmod, not chmod: the mode lands on the file this process opened, not on
         # whatever the path names by the time the write finishes.
@@ -846,6 +922,11 @@ def cmd_secret_exec(args) -> int:
 
     env = _child_env(args.vault)
     secret_values: list[str] = []
+    # The access record's payload, accumulated beside `secret_values` in the same three
+    # loops so a route that resolves a value and forgets to name it is a visible omission
+    # rather than a silent one (#441). Names only — see `_trace_secret_use`.
+    key_names: list[str] = []
+    env_names: list[str] = []
     tmpfiles: list[str] = []
     # Everything below that can create a tmpfile — --file, --dotenv, and the
     # subprocess.run call that consumes them — is one `try` with a single
@@ -879,6 +960,8 @@ def cmd_secret_exec(args) -> int:
                 val = prov.get(key)
                 env[name] = val
                 secret_values.append(val)
+                key_names.append(key)
+                env_names.append(name)
             for spec in args.file or []:
                 name, sep, key = spec.partition("=")
                 if not sep or not name:
@@ -886,6 +969,8 @@ def cmd_secret_exec(args) -> int:
                     return 2
                 val = prov.get(key)
                 secret_values.append(val)
+                key_names.append(key)
+                env_names.append(name)
                 fd, path = tempfile.mkstemp(prefix=f"charter-{args.vault}-{key}-")
                 # Register for cleanup *before* writing: a failure mid-write
                 # (ENOSPC, EIO, a lone surrogate in the value) would otherwise
@@ -916,9 +1001,11 @@ def cmd_secret_exec(args) -> int:
 
             for envvar, entries in grouped.items():
                 lines = []
+                env_names.append(envvar)
                 for name, key in entries:
                     val = prov.get(key)
                     secret_values.append(val)
+                    key_names.append(key)
                     # Tier 3 writes an escaped form; redaction must match what
                     # is actually in the file, not just the raw value.
                     escaped = val.replace("\r", "\\r").replace("\n", "\\n")
@@ -939,6 +1026,32 @@ def cmd_secret_exec(args) -> int:
         except base.VaultError as e:
             util.err(str(e))
             return 1
+
+        # ONE site, above the branch, and that placement is the whole of the guarantee.
+        # Three modes launch the child below — `execvpe`, a streaming `subprocess.run`, a
+        # capturing one — and a record placed inside them would be three records kept in
+        # step by hand, with a fourth mode arriving unrecorded. Everything that runs a
+        # command passes through here.
+        #
+        # Above `execvpe` for a second reason: exec REPLACES this process, so a record
+        # written after it is a record that is never written. And above all three because
+        # the event being recorded is "charter handed these credentials to this command",
+        # which is already true at this line — a child that segfaults on its first
+        # instruction still received them.
+        #
+        # A run that resolves NOTHING is still recorded, with empty name lists. `secret
+        # exec` with no `--env`/`--file`/`--dotenv` hands out no credential, but it does
+        # run a command inside charter's vault machinery, and a trace that showed the
+        # credentialed runs and hid the others would answer "what did this vault do" with
+        # a filtered list that looks whole.
+        _trace_secret_use(
+            "secret-exec", secret_values,
+            vault=args.vault,
+            key_names=sorted(set(key_names)),
+            env_names=sorted(set(env_names)),
+            argv0=command[0],
+            mode="exec" if exec_mode else ("stream" if stream_mode else "capture"),
+        )
 
         if exec_mode:
             # Replaces this process: stdio is inherited untouched, so a

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -266,6 +266,17 @@ def cmd_workspace_default(args) -> int:
         workspace.clear_declared_default()
         util.ok("Cleared the declared default workspace.")
         return 0
+    # The name FIRST, and separately from "does it exist". `workspace_dir(name).exists()`
+    # accepted `../../esc` — the directory is really there, it is simply not a workspace —
+    # and wrote it into a committed file every future session reads (#442). "A path that
+    # exists" was never the question being asked (the same note `persona.py` keeps at
+    # #337). It is asked here as well as in `set_declared_default` because a refusal a user
+    # sees has to be a sentence rather than a traceback.
+    if not workspace.valid_name(name):
+        util.err(f"'{name}' is not a workspace name (letters, digits, '.', '_', '-'; "
+                 "must not start with a dot). This file is committed and read on every "
+                 "session start, so a value that is not a name is refused here.")
+        return 1
     if not workspace.workspace_dir(name).exists():
         util.err(f"no workspace '{name}' (create it: charter workspace create {name})")
         return 1

--- a/charter/contain.py
+++ b/charter/contain.py
@@ -3,14 +3,23 @@
 Charter validated a name when a human typed it and never when it read one from a
 committed file (#328). `valid_name` lives in :mod:`charter.persona` and
 :mod:`charter.workspace` and is called from six places, all of them commands. The reading
-side — `extends:`, `uses:`, `[persona] default`, a `workspace.json` repo name, an
-`inventory/repos.json` name — joined the value onto a path with nothing in between, so a
-committed file could name a target outside the directory charter meant to look in.
+side — `extends:`, `uses:`, `[persona] default`, `[workspace] default`, a committed
+`workspaces/.default`, a `workspace.json` repo name, an `inventory/repos.json` name —
+joined the value onto a path with nothing in between, so a committed file could name a
+target outside the directory charter meant to look in.
+
+The last two arrived a round later (#442) and are the reason this list is written out
+rather than described. Every argument above had already been made and shipped for the
+*persona* default; the workspace twin, two rungs of the same precedence ladder, was simply
+not on anybody's list — so a plane's `[workspace] default` and its committed
+`workspaces/.default` reached `workspace_dir()` unchecked while the persona rung beside
+them was gated. A guard that covers "the sites we thought of" is a guard that grows a new
+hole every time a noun is added; the enumeration is what makes the omission visible.
 
 :mod:`charter.docsrc` already had the answer and it was never reused: a topic is matched
 against a shape before it becomes a page, because ``charter docs show ../../etc/passwd``
 "must not be a file-read primitive wearing a documentation command". This module is that
-idea, extracted so the five reading sites share one implementation instead of four
+idea, extracted so the reading sites share one implementation instead of four
 near-misses and a fifth that forgets.
 
 **Two questions, kept apart on purpose.**

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -13,6 +13,7 @@ import re
 import tomllib
 from pathlib import Path
 
+from . import contain
 from .root import MARKER
 
 #: Layout version this engine understands.
@@ -80,8 +81,53 @@ def exclude_of(cfg: dict, index: int = 0) -> set[str]:
     return set(_forge_at(cfg, index).get("exclude") or ())
 
 
+#: The alphabet ``charter workspace create`` mints workspace names in.
+#:
+#: Lives here, and not in :mod:`charter.workspace`, for one reason: ``charter.toml`` is
+#: parsed during ``config``'s own bootstrap, so a rung that asked ``workspace.valid_name``
+#: would be asking a module that ``config`` has not finished importing yet.
+#: :func:`charter.workspace.valid_name` delegates to :func:`workspace_name_ok` below, so
+#: the resolver and the creation-time check are one rule rather than two kept in step by
+#: hand — the divergence :mod:`charter.contain` exists to stop.
+WORKSPACE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def workspace_name_ok(name) -> bool:
+    """Can *name* name a workspace this plane contains?
+
+    Two questions, asked in :mod:`charter.contain`'s order and for its reasons.
+    :func:`contain.segment_ok` is *containment* — could this string name one entry in a
+    directory at all — and it is the half that still holds if the alphabet below is ever
+    widened. :data:`WORKSPACE_NAME_RE` is the *alphabet*, and it is the right rule here
+    because charter mints workspace names itself: a value outside it cannot name a
+    workspace ``workspace create`` produced, so the resolver and lint agree by
+    construction.
+
+    ``isinstance`` first because a hand-edited ``charter.toml`` can put a TOML array or
+    table where a name goes, and this module is imported by every command including
+    ``charter --version``.
+    """
+    return (isinstance(name, str) and contain.segment_ok(name)
+            and WORKSPACE_NAME_RE.match(name) is not None)
+
+
 def default_workspace_of(cfg: dict, fallback: str) -> str:
-    return (cfg.get("workspace") or {}).get("default") or fallback
+    """The workspace this plane lands on when nothing else decided — ``[workspace] default``.
+
+    **Validated, because ``charter.toml`` is committed.** The value used to be returned
+    verbatim, and `config.DEFAULT_WORKSPACE` is joined onto `WORKSPACES_DIR` by
+    `workspace.workspace_dir` and by `commands._first_clone_dest` — so
+    ``default = "../../esc"`` in a teammate's ``charter.toml`` made `workspace vision` and
+    `workspace current` read a `workspace.md` the plane does not contain, and pointed the
+    first clone of `charter init` outside it (#442). The write and listing sides already
+    refused; only the reading side was open, which is #328's shape one noun over.
+
+    Degrades to *fallback* rather than raising, the contract :func:`frame_of` keeps for
+    every key it cannot make sense of: a ``charter.toml`` charter disagrees with never
+    stops charter from running. A blank value is absence, like its persona twin below."""
+    val = (cfg.get("workspace") or {}).get("default")
+    val = str(val).strip() if isinstance(val, (str, int, float)) else ""
+    return val if workspace_name_ok(val) else fallback
 
 
 def default_persona_of(cfg: dict) -> str | None:

--- a/charter/trace.py
+++ b/charter/trace.py
@@ -37,6 +37,19 @@ import json
 from . import config, session as _sessions
 
 
+#: The events that record a credential leaving charter's own process, one per way out —
+#: a child's environment or a temp file, a file on disk, a terminal (#441).
+#:
+#: Here rather than in :mod:`charter.commands_secrets` because two readers need it: the
+#: writer, and ``charter trace --summary``, which gives hand-outs the same billing as guard
+#: denials. A summary that highlighted denials and warnings while leaving credential
+#: hand-outs to the generic per-event tally would imply they are the less notable thing.
+#:
+#: Every row is names only. A trace file sits inside the plane, readable by the agent whose
+#: behaviour it records, so the record of a secret must never become a second copy of it.
+SECRET_USE_EVENTS = ("secret-exec", "secret-cp", "secret-reveal")
+
+
 def _session(session: str | None = None) -> str:
     """Delegate to the ONE resolver (`session.bucket`) rather than re-deriving it.
 

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -30,9 +30,8 @@ import re
 import time
 from pathlib import Path
 
-from . import config, contain, util
+from . import config, contain, instance, util
 
-_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 _SESSION_MAX_AGE = 30 * 86400  # prune per-session pointers older than this
 _LEGACY_ROOT = config.ROOT / "repos"  # the pre-rename clone root
 
@@ -79,7 +78,14 @@ def _read(f: Path) -> str | None:
 
 
 def valid_name(name: str) -> bool:
-    return bool(name) and name not in (".", "..") and _NAME_RE.match(name) is not None
+    """Can *name* name a workspace? **The one place that answers this.**
+
+    Delegates to :func:`instance.workspace_name_ok` rather than keeping a second regex
+    here, because ``[workspace] default`` is read during ``config``'s bootstrap — before
+    this module can be imported — and two copies of the rule are how a reading site and a
+    creation site come to disagree (:mod:`charter.contain`).
+    """
+    return instance.workspace_name_ok(name)
 
 
 def _unreadable(fn) -> bool:
@@ -202,21 +208,48 @@ def default_file() -> Path:
 
 
 def declared_default() -> str | None:
-    """The workspace nominated by `charter workspace default`, or ``None``."""
+    """The workspace nominated by `charter workspace default`, or ``None``.
+
+    **Gated like every other committed file charter reads a name out of.** This dotfile is
+    ordinarily committable (see :func:`set_declared_default`), so the value is a
+    teammate's, and `resolve()` hands whatever it returns to `workspace_dir()`, which joins
+    it onto ``workspaces/``. Unguarded, ``../../esc`` here made `workspace current`,
+    `workspace vision` and `read_manifest` report content from outside the plane (#442).
+    `valid_name` is the same rule `persona.default_persona` keeps for its own twin.
+
+    Two checks, not one, because they answer different questions. `file_refusal` is about
+    the *path*: this rung is read by `resolve()` on every status-line paint, so a FIFO
+    committed at ``workspaces/.default`` would hang the paint rather than cost it a value.
+    `valid_name` is about the *name* inside it. Neither stands in for the other.
+
+    Never raises: a hook may cost a session its briefing and never its turn.
+    """
+    f = default_file()
+    if contain.file_refusal(f):
+        return None
     try:
-        val = default_file().read_text().strip()
+        val = f.read_text().strip()
     except OSError:
         return None
-    return val or None
+    return val if val and valid_name(val) else None
 
 
 def set_declared_default(name: str) -> None:
+    """Nominate *name*. Raises ``ValueError`` for a name :func:`declared_default` would
+    refuse to read back — writing a value the reader discards is a setting that silently
+    does nothing, which is worse than an error."""
+    name = name.strip()
+    if not valid_name(name):
+        raise ValueError(
+            f"invalid workspace name '{name}' "
+            "(use letters, digits, '.', '_', '-'; must not start with a dot)"
+        )
     # A fixed name directly under `workspaces/`, which the default ignore rule
     # (`/workspaces/*/*`) does not match — so it is an ordinarily committable path, and a
     # link there redirects this write (#349).
     d = contain.writable(default_file())
     d.parent.mkdir(parents=True, exist_ok=True)
-    d.write_text(name.strip() + "\n")
+    d.write_text(name + "\n")
 
 
 def clear_declared_default() -> None:
@@ -674,9 +707,15 @@ def manifest_path(name: str) -> Path:
 
 
 def read_manifest(name: str) -> dict:
-    """The committed manifest ({name, description, repos:[{name,branch}], …}), or {}."""
+    """The committed manifest ({name, description, repos:[{name,branch}], …}), or {}.
+
+    Gated like :func:`read_charter`, and for the same reason: `workspace.json` is committed,
+    and this is where `restore` and `fork` learn which repos to clone."""
+    p = manifest_path(name)
+    if contain.dir_refusal(p.parent) or contain.file_refusal(p):
+        return {}
     try:
-        return json.loads(manifest_path(name).read_text())
+        return json.loads(p.read_text())
     except (OSError, ValueError):
         return {}
 
@@ -920,7 +959,20 @@ def read_charter(name: str) -> str:
     # `workspace.md` is committed, and the SessionStart digest reads one per workspace on
     # this plane for its vision line — so an entry that blocks costs every session its
     # briefing, and one that never ends costs more than that (#336).
-    if contain.file_refusal(cf):
+    #
+    # BOTH questions, which is `file_refusal`'s own stated precondition ("a path that is
+    # not a link cannot have moved relative to the directory it was listed from, which the
+    # caller checked once with `dir_refusal`") and what `persona.definition_refusal` has
+    # always asked. Asking only the file half left the variant the file half structurally
+    # cannot see: when the DIRECTORY is the link, `workspace.md` inside it is an ordinary
+    # regular file with nothing to object to. Measured on 0.51.0 — a committed
+    # `workspaces/evil -> ../../esc` with `[workspace] default = "evil"`, a legal workspace
+    # name, printed the outside charter through `workspace vision` (#442). Containing the
+    # NAME does not contain this; the name was never the wrong part.
+    #
+    # The fast path in `within_data` is one `lstat` here, because `workspaces/` is itself a
+    # data root — so the SessionStart digest pays a syscall per workspace, not a resolve.
+    if contain.dir_refusal(cf.parent) or contain.file_refusal(cf):
         return ""
     return cf.read_text() if cf.exists() else ""
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -330,6 +330,13 @@ session or terminal pane. Defaults to `"default"` (and `default` always exists �
 clone` creates it on first use). See `docs/personas.md`'s sibling in spirit, workspaces,
 for the full precedence chain.
 
+**A workspace name, not a path.** This file is committed, so the value is whoever last
+edited it — and charter joins it onto `workspaces/`. It must therefore be a name `charter
+workspace create` would mint (letters, digits, `.`, `_`, `-`; not starting with a dot).
+Anything else degrades to `"default"`, the same way a `[frame]` key charter cannot make
+sense of degrades to its shipped value. The committed `workspaces/.default` file, written
+by `charter workspace default`, is held to the identical rule.
+
 ## `[charter].version` — pinning the CLI
 
 **Opt-in.** Absent, charter does nothing: you track whatever you have installed. Present,

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -297,4 +297,16 @@ that adds no handler behaves identically, so it says nothing — a row that fire
 version lag is a row people learn to scroll past.
 
 Seeing what actually happened: `charter trace` reports guard denials, tool approvals, secret
-warnings and memory writes for the session.
+warnings, **credential hand-outs** and memory writes for the session.
+
+The hand-outs are the three ways a value leaves charter's own process, one event each —
+`secret-exec` (a child's environment or a temp file), `secret-cp` (a file on disk) and
+`secret-reveal` (`secret get --reveal`, a terminal). Each row carries the vault, the key
+**names**, and for `exec` the environment variable names and `argv[0]`. It never carries a
+value, and never the rest of the command line: charter does not substitute a secret into
+argv, but a caller may have typed one there. `secret get` without `--reveal` records
+nothing, because nothing left — it prints a length and a digest.
+
+So the question `charter trace` can now answer is *which command received the prod token*.
+The one it cannot is what that command then did with it; a credential delivered to a
+process is that process's from then on.

--- a/docs/news/unreleased-credential-handouts-are-recorded.md
+++ b/docs/news/unreleased-credential-handouts-are-recorded.md
@@ -1,0 +1,37 @@
+---
+version: unreleased
+headline: charter trace can now answer "which command received the prod token"
+---
+
+`charter trace` recorded guard denials, tool approvals, memory writes, and `secret-warn` —
+the scanner that spots a credential in a file about to be committed. It recorded nothing
+about the credentials charter itself handed out. So after the fact there was no answer to
+the first question anybody asks: *which command received the prod token*. `charter secret
+audit` looks like the place to find it and is not; it is a rotation-age report.
+
+Every route by which a value leaves charter's own process now writes one line:
+
+- `secret-exec` — a child's environment or a temp file, in all three launch modes
+  (captured, `--stream`, `--exec`).
+- `secret-cp` — a file on disk, with the destination, which is the thing you have to go and
+  delete.
+- `secret-reveal` — `secret get --reveal`, a terminal.
+
+Each line carries the vault, the key **names**, and for `exec` the environment variable
+names and `argv[0]`. `charter trace --summary` gives them their own section beside guard
+denials rather than a number in a tally.
+
+**No line carries a value, and that is a rule about shapes rather than a list of fields.**
+Whatever is recorded is stripped of every value the call resolved, at any depth, before
+anything is written — so the field somebody adds next year is covered by the rule that is
+already there. The rest of `argv` is deliberately not recorded: charter never substitutes a
+secret into a command line, but you might have typed one there, and a file whose purpose is
+to hold no values must not copy a line that might.
+
+Two things it does not claim. It cannot say what a command *did* with a credential once it
+had it — a secret delivered to a process is that process's from then on. And `secret get`
+without `--reveal` records nothing, because nothing left: it prints a length and a digest.
+
+Recording two of the three routes would have been worse than recording none. Grepping for
+`secret-exec` and `secret-cp`, finding nothing, and concluding the token never left the
+vault is a false answer from a record that looks complete.

--- a/docs/news/unreleased-workspace-default-is-contained.md
+++ b/docs/news/unreleased-workspace-default-is-contained.md
@@ -1,0 +1,37 @@
+---
+version: unreleased
+headline: A committed `[workspace] default` is now a workspace name, not a path
+---
+
+`[persona] default` in `charter.toml` and `personas/.default` have been checked since
+0.48.0: `charter.toml` is committed, so the value is a teammate's, and *"a path that
+exists" was never the question being asked*. Their workspace twins — `[workspace] default`
+and `workspaces/.default` — sat two rungs over on the same ladder and were checked by
+nothing at all.
+
+Both returned the committed value verbatim into `workspace_dir()`, which joins it onto
+`workspaces/`. With `default = "../../esc"` in a plane's `charter.toml`, `charter workspace
+current` printed `../../esc`, `charter workspace vision` printed a charter from outside the
+plane, and `charter init` aimed its first clone there. `charter workspace default ../../esc`
+was accepted and written, because the only gate was "does that directory exist" — and it
+does; it is simply not a workspace.
+
+Both rungs now ask the same question `charter workspace create` asks, and it is literally
+the same function rather than a second copy of it: a value that is not a workspace name
+degrades to the built-in `default`, which is the contract `[frame]` already keeps for every
+key charter cannot make sense of. `charter workspace default` refuses a name its own reader
+would discard, instead of writing a setting that silently does nothing.
+
+**The name was never the only way in.** `workspaces/<ws>` could itself be a committed
+symlink pointing out of the plane, with a perfectly legal name in front of it — and then
+`workspace.md` and `workspace.json` inside it are ordinary regular files with nothing about
+them to object to. `read_charter` and `read_manifest` now ask about the directory as well as
+the file, which is what `persona.py` has always done and what `contain.file_refusal`
+documents as its own precondition. A plane that symlinks a workspace directory to somewhere
+outside `workspaces/`, `personas/` or its persona state will find those two reads refused;
+that is the same trade personas have made since 0.48.0.
+
+Honest scope: this is a containment break, not a confidentiality one. There was no
+exfiltration channel — the bytes landed in your own terminal — it did not reach SessionStart,
+and it could not reach a vault. `SECURITY.md`'s framing holds: guard rails against mistakes
+and committed accidents, not against an attacker with shell access as your user.

--- a/tests/test_names_from_files_are_contained.py
+++ b/tests/test_names_from_files_are_contained.py
@@ -1,13 +1,13 @@
 """A name charter reads OUT OF A FILE must name one entry inside its own base, or nothing.
 
-#328: `valid_name` exists in `charter/persona.py:41` and `charter/workspace.py:81` and is
+#328: `valid_name` exists in `charter/persona.py` and `charter/workspace.py` and was
 called from six places — `persona create`, `workspace create`/`rename`, the `--piece`
 argument, `workspace.ensure`. Every one of them is a command handling a name a human just
 typed. **No parser called either function.** On the reading side the same values were
 joined onto a path or handed to argv with nothing in between, so a committed file could
 name a target outside the directory charter meant to look in.
 
-The five instances this file covers, all one omission:
+The instances this file covers, all one omission:
 
 * **#337** — `extends:` and `[persona] default` resolve through `def_path()`, which joins
   onto `PERSONAS_DIR` and asks only whether the result exists. A reference with parent
@@ -18,6 +18,14 @@ The five instances this file covers, all one omission:
   `git checkout` and a **credentialed** `git pull` run in whatever that landed on.
 * **#325** — the same field from `inventory/repos.json` becoming a `git clone` destination.
 * **#335** — an inventory `ssh_url` returned unchanged into the `git clone` argv.
+* **#442** — the WORKSPACE twin of `[persona] default`, in both its rungs: `[workspace]
+  default` in `charter.toml` and a committed `workspaces/.default`. Both joined onto
+  `workspaces/` by `workspace_dir()`, so `workspace current`, `workspace vision` and
+  `read_manifest` reported content from outside the plane, and `charter init` aimed its
+  first clone there. Every argument for gating the persona rung had already been made and
+  shipped; the workspace rung, two ladders over, was simply not on anybody's list. That is
+  the reason these tables are written out — an omission is only visible against an
+  enumeration.
 
 **Two populations, two shape rules, one containment rule.** Charter mints persona names
 (`persona create` enforces `valid_name`), so a persona reference outside that alphabet
@@ -42,8 +50,16 @@ just as load-bearing: it is what catches a fix that contains names by refusing a
 
 The tables are the point of the file. They cover every entry point that takes a name from
 a file, so the *next* parser to skip containment fails here rather than shipping — which
-is how #323's fix was made durable, and how this one omission came to wear five issue
+is how #323's fix was made durable, and how this one omission came to wear six issue
 numbers.
+
+**It did not catch #442, and that is worth stating rather than quietly fixing.** The
+workspace rungs shipped ungated for four releases after this file claimed to cover "every
+entry point that takes a name from a file". A table only catches an omission somebody
+compares against it, so it is a place to record a rule, not a mechanism that enforces one.
+The nearest thing to a mechanism is the last case in `WorkspaceDefaultTests`, which asserts
+that the check a *reader* makes and the check `workspace create` makes are the same
+function — an agreement that holds without anyone rereading a list.
 """
 
 from __future__ import annotations
@@ -55,8 +71,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-from charter import (commands, commands_workspace, config, contain, inventory, persona,
-                     workspace)
+from charter import (commands, commands_workspace, config, contain, instance, inventory,
+                     persona, workspace)
 from tests._isolation import PersonaIso
 
 #: Hostile references, by the shape that makes them hostile. Every entry point below is
@@ -520,6 +536,249 @@ class CloneUrlTests(unittest.TestCase):
             res = commands._clone_one(r, wd)
         self.assertNotEqual(res["status"], "ok")
         self.assertEqual(calls, [], f"a refused URL still reached git: {calls!r}")
+
+
+#: Names `charter workspace create` accepts, and therefore the only ones either committed
+#: workspace rung can legitimately carry. `default` is in the list on purpose: it is the
+#: built-in fallback, and a containment fix that refused it would break every plane.
+_REAL_WORKSPACE_NAMES = ("default", "alpha", "a.b-c", "ws_1", "x", "Web2")
+
+
+class WorkspaceDefaultTests(PersonaIso):
+    """#442: the two committed rungs that name the workspace a session lands on.
+
+    `[workspace] default` (charter.toml) and `workspaces/.default` are the workspace twins
+    of `[persona] default` and `personas/.default`, and only the persona pair was gated.
+    Both returned the committed value verbatim into `workspace_dir()`, which joins it onto
+    `workspaces/`.
+
+    The canary is planted OUTSIDE `workspaces/` and asserted present before each refusal,
+    for the reason this file's header gives: a refusal because the target happened not to
+    exist proves nothing. Both readers are exercised — a charter is markdown and a manifest
+    is JSON, and they fail differently.
+    """
+
+    def setUp(self):
+        super().setUp()
+        config.WORKSPACES_DIR.mkdir(parents=True, exist_ok=True)
+        outside = self.tmp / "outside"
+        outside.mkdir(parents=True, exist_ok=True)
+        (outside / "workspace.md").write_text(
+            "---\nname: outside\n---\n\n## Vision\nCANARY-VISION-FROM-OUTSIDE\n")
+        (outside / "workspace.json").write_text(
+            json.dumps({"name": "outside",
+                        "repos": [{"name": "CANARY-REPO", "branch": "main"}]}))
+        self.canary = outside
+        # And one genuinely outside the plane, reached by an absolute name.
+        beyond = Path(tempfile.mkdtemp(prefix="beyond-plane-ws-"))
+        (beyond / "workspace.md").write_text(
+            "---\nname: beyond\n---\n\n## Vision\nCANARY-BEYOND-THE-PLANE\n")
+        self.beyond = str(beyond)
+        self.addCleanup(lambda: __import__("shutil").rmtree(beyond, ignore_errors=True))
+
+    def _hostile_names(self):
+        """Every hostile value, each proven to reach real content first."""
+        rel = "../outside"
+        self.assertTrue((config.WORKSPACES_DIR / rel / "workspace.md").is_file(),
+                        "PRECONDITION: '../outside' must reach the canary charter from "
+                        "WORKSPACES_DIR, or a refusal proves only that it was missing")
+        self.assertTrue((config.WORKSPACES_DIR / rel / "workspace.json").is_file(),
+                        "PRECONDITION: the canary manifest must be reachable too")
+        self.assertTrue((Path(self.beyond) / "workspace.md").is_file(),
+                        "PRECONDITION: the absolute name must reach a real charter")
+        return (rel, self.beyond)
+
+    def _resolve(self):
+        # The plane root: outside every workspace tree, which is the case the declared
+        # default exists for and the one the rungs below actually decide.
+        return workspace.resolve(cwd=str(config.ROOT))
+
+    def _declare_in_toml(self, value):
+        (config.ROOT / "charter.toml").write_text(
+            f'schema = 1\n\n[workspace]\ndefault = "{value}"\n')
+        # `config.DEFAULT_WORKSPACE` is derived at load, so the file has to be re-read the
+        # way a fresh process would read it.
+        config.use(config.ROOT)
+
+    # -- rung 1: `[workspace] default` in charter.toml ---------------------- #
+    def test_charter_toml_default_cannot_name_a_directory_outside_workspaces(self):
+        for name in self._hostile_names():
+            with self.subTest(name=name):
+                self._declare_in_toml(name)
+                self.assertEqual(config.DEFAULT_WORKSPACE,
+                                 config.DEFAULT_WORKSPACE_FALLBACK,
+                                 f"[workspace] default = {name!r} became the plane's default")
+                self.assertNotEqual(self._resolve(), name)
+
+    def test_charter_toml_default_reads_no_charter_from_outside(self):
+        for name in self._hostile_names():
+            with self.subTest(name=name):
+                self._declare_in_toml(name)
+                self.assertNotIn("CANARY", workspace.read_charter(self._resolve()))
+                self.assertEqual(workspace.read_manifest(self._resolve()), {})
+
+    def test_every_traversing_shape_degrades_to_the_fallback(self):
+        for name in _TRAVERSING:
+            with self.subTest(name=name):
+                got = instance.default_workspace_of({"workspace": {"default": name}},
+                                                    "fallback-ws")
+                self.assertEqual(got, "fallback-ws",
+                                 f"{name!r} was accepted as a workspace name")
+
+    def test_charter_toml_default_still_names_a_real_workspace(self):
+        """The benign half, and it is what catches a fix that contains names by refusing
+        all of them."""
+        for name in _REAL_WORKSPACE_NAMES:
+            with self.subTest(name=name):
+                got = instance.default_workspace_of({"workspace": {"default": name}},
+                                                    "fallback-ws")
+                self.assertEqual(got, name)
+
+    def test_a_declared_workspaces_charter_is_still_read(self):
+        """The precondition for every refusal above: this path really does read a charter,
+        so "no canary" is a refusal rather than a reader that never ran."""
+        self._declare_in_toml("alpha")
+        workspace.ensure("alpha")
+        workspace.scaffold_charter("alpha", vision="REAL-VISION-INSIDE-THE-PLANE")
+        self.assertEqual(self._resolve(), "alpha")
+        self.assertIn("REAL-VISION-INSIDE-THE-PLANE", workspace.read_charter("alpha"))
+
+    # -- rung 2: the committed `workspaces/.default` dotfile ---------------- #
+    def test_the_default_dotfile_cannot_name_a_directory_outside_workspaces(self):
+        for name in self._hostile_names():
+            with self.subTest(name=name):
+                workspace.default_file().write_text(name + "\n")
+                self.assertIsNone(workspace.declared_default(),
+                                  f"workspaces/.default = {name!r} became the default")
+                self.assertNotEqual(self._resolve(), name)
+                self.assertNotIn("CANARY", workspace.read_charter(self._resolve()))
+
+    def test_the_default_dotfile_still_names_a_real_workspace(self):
+        for name in _REAL_WORKSPACE_NAMES:
+            with self.subTest(name=name):
+                workspace.default_file().write_text(name + "\n")
+                self.assertEqual(workspace.declared_default(), name)
+
+    def test_a_dotfile_that_is_itself_a_link_out_of_the_plane_is_refused(self):
+        """The dotfile has two hostile shapes and they are caught by two different checks.
+        Above: the CONTENT is not a name — `valid_name` refuses it. Here: the content is a
+        perfectly ordinary name and the FILE is a link to somewhere the plane does not
+        contain, which only `contain.file_refusal` sees.
+
+        The distinction is asserted rather than assumed. The planted content is `alpha`, a
+        real workspace that exists — so if this were caught by the name check it would not
+        be caught at all, and a fix that dropped `file_refusal` would still pass.
+
+        A directory would NOT make this case: `read_text` raises `IsADirectoryError`, which
+        the `except OSError` already swallows, so the test would pass with the guard
+        removed. The other shape a name check cannot see is a FIFO, whose whole failure is
+        that it never returns — it is pinned under a watchdog in
+        `tests/test_plane_reads_are_bounded.py` rather than here.
+        """
+        workspace.ensure("alpha")
+        outside = Path(tempfile.mkdtemp(prefix="ws-default-link-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(outside, ignore_errors=True))
+        planted = outside / "pointer"
+        planted.write_text("alpha\n")
+        workspace.default_file().symlink_to(planted)
+        self.assertEqual(planted.read_text().strip(), "alpha")
+        self.assertTrue(workspace.valid_name("alpha"),
+                        "PRECONDITION: the planted content must be a LEGAL name, or the "
+                        "name check would refuse it and this proves nothing about "
+                        "containment")
+        self.assertTrue(workspace.workspace_dir("alpha").is_dir(),
+                        "PRECONDITION: and it must name a workspace that really exists")
+        self.assertIsNone(workspace.declared_default(),
+                          "a committed link at workspaces/.default was followed out of "
+                          "the plane")
+        self.assertEqual(self._resolve(), config.DEFAULT_WORKSPACE)
+
+    # -- the setter, which writes the file rung 2 reads ---------------------- #
+    def test_the_setter_refuses_a_name_that_is_not_a_name(self):
+        """`workspace_dir(name).exists()` was the only gate, and `../../esc` exists — the
+        directory is really there, it is simply not a workspace. A setter that writes a
+        value its own reader discards is a setting that silently does nothing."""
+        workspace.ensure("alpha")
+        # `""` is left out on purpose and is not a hole: to this command an empty name is
+        # "no name given", which is its READ form — `charter workspace default` prints the
+        # current one and writes nothing. The write assertion below still covers it.
+        for name in self._hostile_names() + tuple(n for n in _TRAVERSING if n):
+            with self.subTest(name=name):
+                workspace.clear_declared_default()
+                rc = commands_workspace.cmd_workspace_default(
+                    SimpleNamespace(name=name, clear=False))
+                self.assertEqual(rc, 1, f"`workspace default {name!r}` was accepted")
+                self.assertFalse(workspace.default_file().exists(),
+                                 f"{name!r} was written to workspaces/.default")
+
+    def test_the_setter_still_accepts_a_real_workspace(self):
+        workspace.ensure("alpha")
+        rc = commands_workspace.cmd_workspace_default(
+            SimpleNamespace(name="alpha", clear=False))
+        self.assertEqual(rc, 0)
+        self.assertEqual(workspace.declared_default(), "alpha")
+
+    def test_the_writer_refuses_too(self):
+        """Two layers, and neither is redundant — the command is what a human sees a
+        sentence from, and this is what a future caller that skips the command hits."""
+        for name in _TRAVERSING:
+            with self.subTest(name=name):
+                with self.assertRaises(ValueError):
+                    workspace.set_declared_default(name)
+
+    # -- the next spelling: a legal NAME whose DIRECTORY is the link -------- #
+    def test_a_symlinked_workspace_directory_reads_nothing_from_outside(self):
+        """The spelling that survives every name check, asked because containing a name is
+        not the same as containing a read.
+
+        `evil` is a name `workspace create` would mint. The escape is a committed
+        `workspaces/evil -> ../../outside`, after which `workspaces/evil/workspace.md` is an
+        ORDINARY REGULAR FILE — `file_refusal` inspects it with `lstat`, finds nothing to
+        object to, and reads it. That is the variant `contain.dir_refusal` exists for and
+        `persona.definition_refusal` has always asked; the workspace readers asked only the
+        file half. Measured on 0.51.0: `read_charter` returned the outside vision and
+        `read_manifest` the outside repo list.
+        """
+        link = config.WORKSPACES_DIR / "evil"
+        link.symlink_to(self.canary, target_is_directory=True)
+        self.assertTrue((link / "workspace.md").is_file(),
+                        "PRECONDITION: the link must reach a real charter")
+        self.assertFalse((link / "workspace.md").is_symlink(),
+                         "PRECONDITION: the FILE must not be a link — if it were, the "
+                         "per-file check would catch it and this case would prove nothing")
+        self.assertTrue(workspace.valid_name("evil"),
+                        "PRECONDITION: the name must be one charter would mint, or this "
+                        "is just the name check again under another spelling")
+        self._declare_in_toml("evil")
+        self.assertEqual(self._resolve(), "evil",
+                         "PRECONDITION: the name is legal, so it must still resolve — "
+                         "the read is what has to refuse")
+        self.assertNotIn("CANARY", workspace.read_charter("evil"))
+        self.assertEqual(workspace.read_manifest("evil"), {})
+
+    def test_a_real_workspace_directory_is_still_read(self):
+        """The benign half of the case above: an ordinary directory under `workspaces/`
+        must keep answering, or the guard has closed the hole by closing the feature."""
+        workspace.ensure("alpha")
+        workspace.scaffold_charter("alpha", vision="REAL-VISION-INSIDE-THE-PLANE")
+        workspace.write_manifest("alpha", {"name": "alpha",
+                                           "repos": [{"name": "api", "branch": "main"}]})
+        self.assertIn("REAL-VISION-INSIDE-THE-PLANE", workspace.read_charter("alpha"))
+        self.assertEqual(workspace.read_manifest("alpha")["repos"],
+                         [{"name": "api", "branch": "main"}])
+
+    # -- the two checks are one rule ---------------------------------------- #
+    def test_the_creation_check_and_the_reading_check_are_the_same_function(self):
+        """#328's tell was two copies of a rule drifting apart. `workspace create` enforces
+        `valid_name`; both rungs above ask `instance.workspace_name_ok`. If those ever
+        disagree, a name charter cannot create becomes a name charter will resolve."""
+        for name in _TRAVERSING + _REAL_WORKSPACE_NAMES + ("..x", ".hidden", "a b"):
+            with self.subTest(name=name):
+                self.assertEqual(workspace.valid_name(name),
+                                 instance.workspace_name_ok(name))
+                if not workspace.valid_name(name):
+                    with self.assertRaises(ValueError):
+                        workspace.ensure(name)
 
 
 if __name__ == "__main__":

--- a/tests/test_plane_reads_are_bounded.py
+++ b/tests/test_plane_reads_are_bounded.py
@@ -145,6 +145,28 @@ class PlaneReadsAreBounded(PersonaIso):
         self.assertEqual("", self.completes(lambda: workspace.read_vision("other"),
                                             "read_vision on a FIFO workspace.md"))
 
+    def test_a_fifo_workspace_default_pointer_does_not_block(self):
+        """`workspaces/.default` is the workspace twin of `personas/.default` above, and it
+        is read by `workspace.resolve()` — which the status line calls on every paint to
+        answer "where am I". It was the last committed dotfile charter opened by name
+        without asking `contain` what it was (#442).
+
+        The manifest is here too because it is the other file a resolved workspace name
+        leads to, and `restore` reads it to decide which repos to clone.
+        """
+        workspace.ensure("other")
+        self.fifo(workspace.default_file())
+        self.assertIsNone(self.completes(workspace.declared_default,
+                                         "declared_default on a FIFO .default"))
+        self.completes(lambda: workspace.resolve(cwd=str(config.ROOT)),
+                       "workspace.resolve over a FIFO .default")
+
+        manifest = workspace.manifest_path("other")
+        manifest.unlink(missing_ok=True)
+        self.fifo(manifest)
+        self.assertEqual({}, self.completes(lambda: workspace.read_manifest("other"),
+                                            "read_manifest on a FIFO workspace.json"))
+
     def test_a_fifo_mcp_declaration_does_not_block_sync_agents(self):
         """`personas/<name>/mcp.json` is the third committed file `persona.py` opens by
         listing rather than by asking. `mcp_servers` already refuses to raise on a stray

--- a/tests/test_secret_dotenv.py
+++ b/tests/test_secret_dotenv.py
@@ -264,13 +264,21 @@ class _StubProvider:
         return self.values[key]
 
 
-class DotenvExec(unittest.TestCase):
+class DotenvExec(PersonaIso):
+    """`PersonaIso`, not a bare `TestCase`: `cmd_secret_exec` records the hand-out in the
+    session trace (#441), and a fixture that has not redirected `config` appends that row
+    to the plane the suite resolved to — the developer's own (#372, #402)."""
+
     def setUp(self) -> None:
+        super().setUp()
         self.provider = _StubProvider({"pw-user": "svc_qa",
                                        "pw-pass": 'p"ass\\word'})
-        self._orig = commands_secrets._provider
+        # NOT `self._orig`: `PersonaIso` keeps the config snapshot it restores under that
+        # name, and shadowing it made every test in this class error in teardown.
+        self._orig_provider = commands_secrets._provider
         commands_secrets._provider = lambda _name: self.provider
-        self.addCleanup(lambda: setattr(commands_secrets, "_provider", self._orig))
+        self.addCleanup(
+            lambda: setattr(commands_secrets, "_provider", self._orig_provider))
         self._td = tempfile.TemporaryDirectory()
         self.tmpdir = self._td.name
         self.addCleanup(self._td.cleanup)

--- a/tests/test_secret_exec.py
+++ b/tests/test_secret_exec.py
@@ -15,6 +15,7 @@ from contextlib import redirect_stderr
 from types import SimpleNamespace
 
 from charter import commands_secrets
+from tests._isolation import PersonaIso
 
 
 class _StubProvider:
@@ -29,8 +30,13 @@ class _StubProvider:
         return self.values[key]
 
 
-class SecretExecMode(unittest.TestCase):
+class SecretExecMode(PersonaIso):
+    """`PersonaIso`, not a bare `TestCase`: `cmd_secret_exec` records the hand-out in the
+    session trace (#441), and a fixture that has not redirected `config` appends that row
+    to the plane the suite resolved to — the developer's own (#372, #402)."""
+
     def setUp(self) -> None:
+        super().setUp()
         self.provider = _StubProvider({"kibana-user": "svc_logs",
                                        "kibana-pass": "s3cr3t-value"})
         self._orig_provider = commands_secrets._provider

--- a/tests/test_secret_handouts_are_recorded.py
+++ b/tests/test_secret_handouts_are_recorded.py
@@ -1,0 +1,414 @@
+"""Every credential charter hands out is recorded, and no record holds a value (#441).
+
+`charter trace` knew about `secret-warn` — the scanner that spots a value in a file about
+to be committed — and about nothing charter itself handed over. So the question an
+operator asks after a bad afternoon, *"which command received the prod token"*, had no
+answer anywhere in the plane. `secret audit` is a rotation-age report, not access logging.
+
+**Two properties, and they pull in opposite directions**, which is why both are pinned here
+rather than one being assumed from the other:
+
+1. *Completeness* — every route by which a plaintext leaves charter's process records that
+   it did. There are three: a child's environment or a temp file (`exec`, in each of its
+   three launch modes), a file on disk (`cp`), and a terminal (`get --reveal`).
+2. *Emptiness* — no record holds a value. A trace file lives inside the plane and is
+   readable by the agent whose behaviour it records, so a record of a secret that copied
+   the secret would be a fresh leak wearing an audit trail's clothes.
+
+**Where the assertions are made.** Emptiness is asserted against the **bytes of the trace
+file**, never against the parsed fields. A field-by-field check is a list of the spellings
+somebody thought of, and the next field added is the one that is not on it; the file is the
+one place every spelling must arrive. `TraceHoldsNoValue` therefore also drives the
+recorder directly with a value buried in a nested dict, a tuple and a list — shapes no
+caller passes today, so that the rule under test is about shapes and not about the fields
+`cmd_secret_exec` happens to record this month.
+
+**The values here are fabricated** and are constructed to be unmissable in a diff of the
+trace file. Nothing in this module asserts on a whole environment or a whole argv — that is
+how a suite log came to hold live 1Password tokens — and no assertion message is given the
+file's contents to print.
+
+`PersonaIso` throughout: the trace writes through `config.PERSONA_STATE_DIR`, and a fixture
+that does not redirect it appends to the developer's own plane (#372, #402).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_secrets, config, trace
+from tests._isolation import PersonaIso
+
+#: Fabricated. Long, unique, and shaped so a partial copy is still recognisable.
+_VALUE = "FABRICATED-SECRET-VALUE-0f1e2d3c4b5a-DO-NOT-LOG"
+_OTHER = "FABRICATED-SECOND-VALUE-9a8b7c6d5e4f-DO-NOT-LOG"
+
+#: The one session every test in this file writes to and reads back.
+_SESSION = "handout-session"
+
+
+class _StubProvider:
+    """A vault that answers with fabricated values and remembers what was asked."""
+
+    def __init__(self, values: dict[str, str]):
+        self.values = values
+        self.asked: list[str] = []
+
+    def get(self, key: str) -> str:
+        self.asked.append(key)
+        return self.values[key]
+
+    def keys(self):
+        return sorted(self.values)
+
+
+class _HandoutCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        self.provider = _StubProvider({"prod-token": _VALUE, "prod-user": _OTHER})
+        self.enterContext(mock.patch.object(commands_secrets, "_provider",
+                                            lambda _name: self.provider))
+        # A fixed session id so `trace.read` looks in the file the handlers wrote, without
+        # depending on whatever `$CHARTER_SESSION_ID` the developer's shell carries — an
+        # ambient value is how a test comes to pass for a reason it does not state.
+        self.enterContext(mock.patch.dict(os.environ,
+                                          {"CHARTER_SESSION_ID": _SESSION,
+                                           "CLAUDE_CODE_SESSION_ID": _SESSION}))
+
+    # -- reading the record ------------------------------------------------- #
+    def events(self, kind: str | None = None) -> list[dict]:
+        evs = trace.read(_SESSION)
+        return [e for e in evs if kind is None or e["event"] == kind]
+
+    def trace_bytes(self) -> str:
+        """The raw trace file. The lowest layer every recorded field must pass through."""
+        f = config.PERSONA_STATE_DIR / "trace" / f"{_SESSION}.jsonl"
+        return f.read_text() if f.exists() else ""
+
+    def assert_no_value_in_the_trace(self) -> None:
+        """Neither fabricated value appears anywhere in the file.
+
+        Asserted with `assertNotIn`'s message suppressed: a failing `assertNotIn` prints
+        the haystack, and the haystack in the real defect this guards is a live credential.
+        """
+        text = self.trace_bytes()
+        for name, value in (("prod-token", _VALUE), ("prod-user", _OTHER)):
+            self.assertTrue(
+                value not in text,
+                f"the value of '{name}' reached the trace file — "
+                f"contents deliberately not printed")
+
+    @staticmethod
+    def exec_args(**kw):
+        base = {"vault": "prod", "env": None, "file": None, "dotenv": None,
+                "command": [], "exec_mode": False, "stream_mode": False}
+        base.update(kw)
+        return SimpleNamespace(**base)
+
+
+class SecretExecIsRecorded(_HandoutCase):
+    """#441's own case: `cmd_secret_exec` against a fabricated vault."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.runs: list[list[str]] = []
+
+        def fake_run(argv, **kw):
+            self.runs.append(list(argv))
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+        self.enterContext(mock.patch.object(commands_secrets.subprocess, "run", fake_run))
+
+    def test_the_trace_holds_the_vault_the_key_names_and_argv0(self):
+        commands_secrets.cmd_secret_exec(self.exec_args(
+            env=["PROD_TOKEN=prod-token"], command=["--", "/usr/bin/env"]))
+        evs = self.events("secret-exec")
+        self.assertEqual(len(evs), 1, "exactly one hand-out event per run")
+        e = evs[0]
+        self.assertEqual(e["vault"], "prod")
+        self.assertEqual(e["key_names"], ["prod-token"])
+        self.assertEqual(e["env_names"], ["PROD_TOKEN"])
+        self.assertEqual(e["argv0"], "/usr/bin/env")
+        self.assertEqual(e["mode"], "capture")
+
+    def test_the_trace_does_not_hold_the_value(self):
+        commands_secrets.cmd_secret_exec(self.exec_args(
+            env=["PROD_TOKEN=prod-token", "PROD_USER=prod-user"],
+            command=["--", "/usr/bin/env"]))
+        self.assertTrue(self.provider.asked,
+                        "PRECONDITION: the vault must actually have been read, or "
+                        "'no value in the trace' proves only that none was resolved")
+        self.assert_no_value_in_the_trace()
+
+    def test_the_rest_of_argv_is_not_recorded(self):
+        """charter never substitutes a value into a command line — but a caller may have
+        typed one there, and a record whose purpose is to hold no values must not copy a
+        line that might."""
+        argv = ["/bin/sh", "-c", f"echo {_VALUE}"]
+        commands_secrets.cmd_secret_exec(self.exec_args(
+            env=["PROD_TOKEN=prod-token"], command=["--", *argv]))
+        self.assertEqual(self.runs, [argv],
+                         "PRECONDITION: the whole command must really have been run")
+        self.assert_no_value_in_the_trace()
+        e = self.events("secret-exec")[0]
+        self.assertEqual(e["argv0"], argv[0])
+        # Every element PAST argv[0], asserted absent from the whole record rather than
+        # from a field named in advance — the point is that none of them is anywhere.
+        recorded = json.dumps(e)
+        for element in argv[1:]:
+            self.assertTrue(element not in recorded,
+                            f"argv[{argv.index(element)}] reached the trace record")
+
+    def test_a_run_that_resolves_nothing_is_still_recorded(self):
+        """A `secret exec` with no `--env`/`--file`/`--dotenv` hands out no credential, but
+        it does run a command inside the vault machinery. A trace that showed the
+        credentialed runs and hid the others answers "what did this vault do" with a
+        filtered list that reads as a whole one."""
+        commands_secrets.cmd_secret_exec(self.exec_args(command=["--", "/bin/true"]))
+        evs = self.events("secret-exec")
+        self.assertEqual([e["key_names"] for e in evs], [[]])
+        self.assertEqual(evs[0]["argv0"], "/bin/true")
+
+    def test_a_vault_that_refuses_records_no_handout(self):
+        """Nothing was handed out, so nothing is claimed. The event means "this command
+        received these credentials", and a run that resolved none did not."""
+        from charter.secrets import base
+
+        def boom(_key):
+            raise base.VaultError("no such key")
+
+        with mock.patch.object(self.provider, "get", boom):
+            rc = commands_secrets.cmd_secret_exec(self.exec_args(
+                env=["PROD_TOKEN=prod-token"], command=["--", "/bin/true"]))
+        self.assertEqual(rc, 1)
+        self.assertEqual(self.events("secret-exec"), [])
+
+    def test_the_record_is_written_before_the_child_runs(self):
+        """Placement, asserted rather than assumed. `--exec` replaces the process, so a
+        record written after the launch is a record never written; and a child that dies on
+        its first instruction still received the credentials."""
+        seen: list[int] = []
+
+        def fake_run(argv, **kw):
+            seen.append(len(self.events("secret-exec")))
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+        with mock.patch.object(commands_secrets.subprocess, "run", fake_run):
+            commands_secrets.cmd_secret_exec(self.exec_args(
+                env=["PROD_TOKEN=prod-token"], command=["--", "/bin/true"]))
+        self.assertEqual(seen, [1],
+                         "the hand-out must be on record before the child is launched")
+
+
+class EveryLaunchModeRecords(_HandoutCase):
+    """The completeness half. Three modes launch a child, and all three go through one
+    recording site — so a fourth mode added below that site is recorded by construction
+    rather than by somebody remembering."""
+
+    def _dotenv_dir(self):
+        return str(self.tmp)
+
+    def test_capture_mode(self):
+        with mock.patch.object(commands_secrets.subprocess, "run",
+                               lambda argv, **kw: SimpleNamespace(
+                                   stdout="", stderr="", returncode=0)):
+            commands_secrets.cmd_secret_exec(self.exec_args(
+                env=["PROD_TOKEN=prod-token"], command=["--", "/bin/true"]))
+        self.assertEqual([e["mode"] for e in self.events("secret-exec")], ["capture"])
+        self.assert_no_value_in_the_trace()
+
+    def test_stream_mode(self):
+        with mock.patch.object(commands_secrets.subprocess, "run",
+                               lambda argv, **kw: SimpleNamespace(returncode=0)):
+            commands_secrets.cmd_secret_exec(self.exec_args(
+                env=["PROD_TOKEN=prod-token"], command=["--", "/bin/true"],
+                stream_mode=True))
+        self.assertEqual([e["mode"] for e in self.events("secret-exec")], ["stream"])
+        self.assert_no_value_in_the_trace()
+
+    def test_exec_mode(self):
+        with mock.patch.object(commands_secrets.os, "execvpe", lambda f, a, e: None):
+            commands_secrets.cmd_secret_exec(self.exec_args(
+                env=["PROD_TOKEN=prod-token"], command=["--", "/bin/true"],
+                exec_mode=True))
+        self.assertEqual([e["mode"] for e in self.events("secret-exec")], ["exec"])
+        self.assert_no_value_in_the_trace()
+
+    def test_a_file_credential_names_its_key_and_its_variable(self):
+        with mock.patch.object(commands_secrets.subprocess, "run",
+                               lambda argv, **kw: SimpleNamespace(
+                                   stdout="", stderr="", returncode=0)):
+            commands_secrets.cmd_secret_exec(self.exec_args(
+                file=["GOOGLE_APPLICATION_CREDENTIALS=prod-token"],
+                command=["--", "/bin/true"]))
+        e = self.events("secret-exec")[0]
+        self.assertEqual(e["key_names"], ["prod-token"])
+        self.assertEqual(e["env_names"], ["GOOGLE_APPLICATION_CREDENTIALS"])
+        self.assert_no_value_in_the_trace()
+
+    def test_a_dotenv_credential_names_every_key_it_merged(self):
+        with mock.patch.object(commands_secrets.subprocess, "run",
+                               lambda argv, **kw: SimpleNamespace(
+                                   stdout="", stderr="", returncode=0)):
+            commands_secrets.cmd_secret_exec(self.exec_args(
+                dotenv=["SECRETS_FILE=USER:prod-user", "SECRETS_FILE=TOKEN:prod-token"],
+                command=["--", "/bin/true"]))
+        e = self.events("secret-exec")[0]
+        self.assertEqual(e["key_names"], ["prod-token", "prod-user"])
+        self.assertEqual(e["env_names"], ["SECRETS_FILE"])
+        self.assert_no_value_in_the_trace()
+
+
+class SecretCpIsRecorded(_HandoutCase):
+    """`secret cp` materialises a value as a file. The record names the destination —
+    which is the thing an operator has to go and delete."""
+
+    def test_a_written_credential_is_recorded_with_its_destination(self):
+        dest = self.tmp / "out" / "kubeconfig"
+        rc = commands_secrets.cmd_secret_cp(SimpleNamespace(
+            vault="prod", key="prod-token", dest=str(dest), force=False))
+        self.assertEqual(rc, 0)
+        self.assertEqual(dest.read_text(), _VALUE,
+                         "PRECONDITION: the credential must really have been written")
+        self.assertEqual(stat.S_IMODE(dest.stat().st_mode), 0o600)
+        e = self.events("secret-cp")
+        self.assertEqual(len(e), 1)
+        self.assertEqual((e[0]["vault"], e[0]["key_names"]), ("prod", ["prod-token"]))
+        self.assertEqual(e[0]["dest"], str(dest))
+        self.assert_no_value_in_the_trace()
+
+    def test_a_refused_destination_records_nothing(self):
+        """The refusal path never resolves the value, so there is no hand-out to record —
+        and a record here would report a credential written to a file that does not
+        contain one."""
+        target = self.tmp / "already-there"
+        target.write_text("existing\n")
+        rc = commands_secrets.cmd_secret_cp(SimpleNamespace(
+            vault="prod", key="prod-token", dest=str(target), force=False))
+        self.assertEqual(rc, 2)
+        self.assertEqual(self.events("secret-cp"), [])
+        self.assertEqual(self.provider.asked, [],
+                         "a refused destination must not even read the vault")
+
+
+class SecretRevealIsRecorded(_HandoutCase):
+    """The third route out, and the one an incomplete fix would have left silent.
+
+    Recording `exec` and `cp` but not `--reveal` would be worse than recording none: an
+    operator who greps for the two, finds nothing and concludes the token never left the
+    vault has been misled by a record that looks complete.
+    """
+
+    @staticmethod
+    def _args(**kw):
+        base = {"vault": "prod", "key": "prod-token", "reveal": True, "force": True}
+        base.update(kw)
+        return SimpleNamespace(**base)
+
+    def test_reveal_records_the_handout(self):
+        commands_secrets.cmd_secret_get(self._args())
+        e = self.events("secret-reveal")
+        self.assertEqual(len(e), 1)
+        self.assertEqual((e[0]["vault"], e[0]["key_names"]), ("prod", ["prod-token"]))
+        self.assert_no_value_in_the_trace()
+
+    def test_the_masked_form_records_nothing(self):
+        """`secret get` without `--reveal` prints a length and a digest. Nothing left, so
+        nothing is recorded — an event here would report a hand-out that did not happen."""
+        commands_secrets.cmd_secret_get(self._args(reveal=False))
+        self.assertEqual(self.events("secret-reveal"), [])
+
+    def test_a_refused_reveal_records_nothing(self):
+        """Refused for non-interactive stdout: the value was resolved but never left."""
+        commands_secrets.cmd_secret_get(self._args(force=False))
+        self.assertEqual(self.events("secret-reveal"), [])
+
+
+class TraceHoldsNoValue(_HandoutCase):
+    """The emptiness half, tested at the recorder rather than at its callers.
+
+    Everything above pins the fields `cmd_secret_exec` records TODAY. This pins the rule
+    that will still be here when somebody adds a field: whatever shape is handed to
+    `_trace_secret_use`, a value this call resolved does not reach the file.
+    """
+
+    def test_a_value_buried_in_any_shape_is_removed(self):
+        for label, payload in (
+            ("a plain string", _VALUE),
+            ("inside a longer string", f"Authorization: Bearer {_VALUE}"),
+            ("a list", ["a", _VALUE, "b"]),
+            ("a tuple", ("a", _VALUE)),
+            ("a dict value", {"header": _VALUE}),
+            ("a dict key", {_VALUE: "header"}),
+            ("nested two deep", {"outer": [{"inner": (_VALUE,)}]}),
+        ):
+            with self.subTest(shape=label):
+                commands_secrets._trace_secret_use(
+                    "secret-exec", [_VALUE], vault="prod", probe=payload)
+                self.assert_no_value_in_the_trace()
+
+    def test_the_scrub_is_not_vacuous(self):
+        """The positive control. Without it every case above would also pass against a
+        recorder that wrote nothing at all, or against a `_value_free` that returned the
+        empty string for everything."""
+        commands_secrets._trace_secret_use(
+            "secret-exec", [_VALUE], vault="prod", probe={"outer": [{"inner": [_VALUE]}]})
+        e = self.events("secret-exec")[0]
+        self.assertEqual(e["probe"], {"outer": [{"inner": ["***"]}]},
+                         "the shape must survive; only the value is removed")
+        self.assertEqual(e["vault"], "prod")
+
+    def test_a_field_carrying_no_value_is_left_alone(self):
+        commands_secrets._trace_secret_use(
+            "secret-exec", [_VALUE], vault="prod", key_names=["prod-token"], argv0="kubectl")
+        e = self.events("secret-exec")[0]
+        self.assertEqual((e["key_names"], e["argv0"]), (["prod-token"], "kubectl"))
+
+    def test_a_recorder_failure_never_fails_the_command(self):
+        """Observability must not break the thing it observes: a credential successfully
+        delivered must not become a failed command because the bookkeeping threw."""
+        with mock.patch.object(trace, "record", side_effect=RuntimeError("disk full")), \
+             mock.patch.object(commands_secrets.subprocess, "run",
+                               lambda argv, **kw: SimpleNamespace(
+                                   stdout="", stderr="", returncode=0)):
+            rc = commands_secrets.cmd_secret_exec(self.exec_args(
+                env=["PROD_TOKEN=prod-token"], command=["--", "/bin/true"]))
+        self.assertEqual(rc, 0)
+
+
+class SummaryNamesTheHandouts(_HandoutCase):
+    """`charter trace --summary` gives hand-outs the same billing as guard denials.
+
+    A summary that called out denials and secret warnings while leaving credential
+    hand-outs to the generic per-event tally would imply they are the less notable thing.
+    """
+
+    def test_the_summary_names_the_command_and_the_key_but_no_value(self):
+        import io
+        from contextlib import redirect_stdout
+
+        from charter import commands_persona
+
+        with mock.patch.object(commands_secrets.subprocess, "run",
+                               lambda argv, **kw: SimpleNamespace(
+                                   stdout="", stderr="", returncode=0)):
+            commands_secrets.cmd_secret_exec(self.exec_args(
+                env=["PROD_TOKEN=prod-token"], command=["--", "/usr/bin/kubectl"]))
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            commands_persona.cmd_trace(SimpleNamespace(session=_SESSION, summary=True, n=0))
+        out = buf.getvalue()
+        self.assertIn("credentials handed out", out)
+        self.assertIn("prod/prod-token", out)
+        self.assertIn("/usr/bin/kubectl", out)
+        self.assertTrue(_VALUE not in out, "the summary printed a value")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #441
Closes #442

Two committed-input defects from the 2026-08-24 audit. Both reproduced first; neither was refuted.

## #441 — no trace event records which command received which secret

`charter trace` recorded `secret-warn` (the scanner that spots a value in a file about to be committed) and nothing charter itself handed out. `cmd_secret_audit` looks like the place to find it and is a rotation-age report. So the first question anybody asks after a bad afternoon — *which command received the prod token* — had no answer.

**All three routes by which a plaintext leaves charter's process now record one event.** `secret-exec` (a child's environment or a temp file), `secret-cp` (a file on disk, with its destination), `secret-reveal` (`get --reveal`, a terminal). `secret get` without `--reveal` records nothing, because nothing left.

The issue asked for two of the three. Recording two would have been worse than recording none: grepping for `secret-exec` and `secret-cp`, finding nothing, and concluding the token never left the vault is a false answer from a record that *looks* complete.

**Names only, and the rule is about shapes rather than fields.** The record carries vault, key names, env var names, `argv[0]`, and the launch mode. Not the rest of argv — charter never substitutes a value into a command line, but the caller may have typed one there. On top of that, `_value_free` strips every value *this call resolved* out of the payload at any depth (dicts, lists, tuples, dict keys), so the field somebody adds next year is covered by a rule that is already there. Its bound is stated in the docstring rather than implied: it can only remove values this call resolved, so it is not a filter that makes an arbitrary payload safe to record.

**One recording site, above the branch.** Three modes launch a child (`execvpe`, streaming `subprocess.run`, capturing `subprocess.run`). The record is made once, above all three — so it survives `--exec` replacing the process, it is already written when a child segfaults on its first instruction, and a fourth mode added below it is recorded by construction. A test asserts the ordering by having the fake `subprocess.run` read the trace back.

`charter trace --summary` gives hand-outs their own section beside guard denials, rather than a number in a tally.

## #442 — `[workspace] default` and `workspaces/.default` are unguarded reading sites

Reproduced by both routes, matching the issue exactly:

```
[workspace] default = "../../esc"
  resolve()     : ../../esc
  read_charter  : '---\nname: esc\n---\n\n## Vision\nCANARY-VISION-CONTENT\n'
  read_manifest : {'repos': [{'name': 'CANARY-REPO', 'branch': 'main'}]}
```

Both rungs now ask `instance.workspace_name_ok` and degrade to the built-in `default` — the contract `frame_of` keeps for every key charter cannot make sense of. `charter workspace default` refuses a name its own reader would discard, instead of writing a setting that silently does nothing.

**The rule is one function, not two copies.** `workspace.valid_name` now delegates to `instance.workspace_name_ok`, so a reading site and `workspace create` cannot drift — the divergence #328 was actually about. It lives in `instance` because `charter.toml` is parsed during `config`'s own bootstrap, before `charter.workspace` can be imported (`workspace.py` touches `config.ROOT` at module level). A test asserts the two answers are equal across the whole table.

Both sites are added to `contain.py`'s enumerated list and to `test_names_from_files_are_contained.py`.

### And the next spelling, because the name was never the only way in

Asked directly: *what still gets through?* Answer, measured on `main`:

```
workspaces/evil -> ../../esc          # a committed symlink
[workspace] default = "evil"          # a name `workspace create` would mint
  read_charter  : '...CANARY-VISION...'
  read_manifest : {'repos': [{'name': 'CANARY-REPO'}]}
```

`evil` passes every name check there is. The escape is the *directory*, after which `workspace.md` inside it is an ordinary regular file that `file_refusal`'s `lstat` has nothing to object to. That variant is exactly what `contain.dir_refusal` exists for, what `file_refusal`'s own docstring names as its precondition ("which the caller checked once with `dir_refusal`"), and what `persona.definition_refusal` has always asked. The workspace readers asked only the file half.

`read_charter` and `read_manifest` now ask both. The `within_data` fast path applies here (a workspace directory's parent *is* a data root), so the SessionStart digest pays one `lstat` per workspace, not a resolve.

## Honest scope

Kept in the news entry rather than implied away: #442 is a containment break, not a confidentiality one — no exfiltration channel, the bytes land in your own terminal, it does not reach SessionStart, it cannot reach a vault. And #441's record cannot say what a command *did* with a credential once it had it. A plane that symlinks a workspace directory out of `workspaces/`/`personas/`/persona-state will now find those two reads refused — the same trade personas have made since 0.48.0.

## Tests

`tests/test_secret_handouts_are_recorded.py` (new, 21 cases) and 12 new cases across `test_names_from_files_are_contained.py` and `test_plane_reads_are_bounded.py`.

- **Emptiness is asserted against the bytes of the trace file**, never field by field — a field list is a list of spellings, the file is where every spelling must arrive. Assertion messages deliberately do not print the file.
- **Preconditions asserted, not assumed.** Every canary is proven reachable before charter is asked to refuse it; the symlink case additionally asserts the file is *not* a link (or the per-file check would catch it and the case would prove nothing) and that the name *is* legal (or it would just be the name check again).
- **A test that could not fail was caught and replaced.** `workspaces/.default` as a *directory* passes with or without the guard, because `read_text` raises `IsADirectoryError` into the existing `except OSError`. Replaced with a symlink-out case whose planted content is `alpha` — a real, existing workspace — so only `file_refusal` can refuse it. The FIFO half (the shape whose failure is that it never returns) went to `test_plane_reads_are_bounded.py`, under its watchdog.
- Two fixtures (`test_secret_exec.SecretExecMode`, `test_secret_dotenv.DotenvExec`) moved onto `PersonaIso`: they now reach a trace write, and the `RealPlaneWrite` tripwire caught them writing into the operator's real `.charter/`.

Full suite: `Ran 4564 tests ... OK`.

## Mutation testing

16 mutations, each applied, run, restored, `__pycache__` cleared between runs.

| Mutation | Result |
| --- | --- |
| `default_workspace_of` drops the name gate | RED (8) |
| `declared_default` drops `valid_name` | RED (2) |
| `declared_default` drops `file_refusal` | RED (2) |
| the setter drops its name gate | RED (5) |
| `set_declared_default` drops its raise | RED (7) |
| `read_charter` drops `dir_refusal` | RED (1) |
| `read_manifest` drops both refusals | RED (2) |
| `workspace_name_ok` always says yes | RED (23) |
| `workspace_name_ok` keeps only the alphabet | **GREEN — intended** |
| `cmd_secret_exec` records nothing | RED |
| `argv0` becomes the whole command line | RED (1) |
| `_value_free` stops recursing into dicts | RED (4) |
| `_value_free` stops redacting strings | RED (8) |
| the exec record moves below the launch | RED (3) |
| `cmd_secret_cp` records nothing | RED |
| `get --reveal` records nothing | RED (1) |
| the masked `get` records a hand-out too | RED (1) |

The one deliberate GREEN: dropping `contain.segment_ok` and keeping the alphabet passes, because the alphabet alone closes every case that exists today. `segment_ok` is the half that holds only if `WORKSPACE_NAME_RE` is ever widened — which is what its docstring claims and no more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
