### PR TITLE
frame: the guest-tmux path stops leaking the environment, learns to respawn, and a flaky death is diagnosed (#446, #408, #409)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -781,11 +781,15 @@ def _add_frame_parsers(sub) -> None:
     # two above. Fired by a PANEL pane's own `pane-died` hook (#382,
     # `commands_frame._panel_died_hook_argv`) — never typed by an operator, and never by
     # the harness pane's hooks, which carry the exit code instead. The frame it belongs
-    # to is resolved from `$CHARTER_SESSION_ID` at the moment the hook fires, exactly
-    # like `frame-menu`; only the slot and the pane to revive travel on the argv.
+    # to travels on the argv (`--frame`), unlike `frame-menu`'s: this hook is armed on
+    # the operator's own tmux too (#408), where `$CHARTER_SESSION_ID` is a session option
+    # charter is not allowed to write. Optional, not required, so a hook installed by a
+    # charter that predates #408 — already sitting in a running frame's pane options,
+    # outliving the upgrade — still resolves its frame from the environment.
     rs = sub.add_parser("frame-respawn")
     rs.add_argument("slot")
     rs.add_argument("--pane", dest="pane", required=True)
+    rs.add_argument("--frame", dest="frame", default=None)
     rs.set_defaults(func=commands_frame.cmd_respawn)
 
     # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -627,7 +627,63 @@ _RESPAWN_ATTEMPTS = 3
 _RESPAWN_BACKOFF = (1.0, 2.0, 4.0)
 
 
-def _panel_died_hook_argv(*, socket: str, panel_pane: str, slot: str) -> list[str]:
+#: A frame id as `state.frame_id` mints one — the same alphabet, asked here rather than
+#: assumed. `_panel_died_hook_argv` interpolates the id into an action string tmux
+#: re-parses, so it gets the treatment `_PANE_ID_RE` already gives a pane id: safe
+#: because it was CHECKED, not because of where it came from. `cmd_respawn` reads the id
+#: back off that same argv, so a frame whose id could not survive the trip is one whose
+#: panels are better left unarmed than armed with a hook that names something else.
+_FRAME_ID_RE = re.compile(r"[A-Za-z0-9._-]+")
+
+#: Every character that means something to one of the THREE parsers a `pane-died` action
+#: passes through, and the whole of that set for those three grammars. Not a list of
+#: inputs known to be bad: a list of the only characters that can change what the text
+#: says on the way from `set-hook`'s argv to `/bin/sh`'s.
+#:
+#: The action is stored as a single `set-hook` argument, so nothing parses it until the
+#: hook fires. Then, in order:
+#:
+#: 1. **tmux expands `#{…}` FORMATS in it.** That is not incidental — it is the whole
+#:    mechanism `_pane_died_write_hook_argv` uses to get `#{pane_dead_status}` into a
+#:    shell. Measured against tmux 3.7c with the same shape a path would have: an action
+#:    holding the literal text ``/opt/py#{pane_id}/x`` reached the shell as
+#:    ``/opt/py%1/x``. `#` is therefore as load-bearing as a quote, and MORE dangerous
+#:    than one: `#{pane_title}` expands to text the program running in that pane sets
+#:    for itself with an escape sequence. This is the parser a first version of this
+#:    guard missed entirely, having named itself after quotes and then looked only for
+#:    quote characters — the exact failure this codebase keeps paying for, a guard
+#:    matching a spelling instead of the property.
+#: 2. **tmux parses the result as a command line.** Inside `'…'` everything is literal
+#:    except `'` itself.
+#: 3. **`/bin/sh -c` parses the inner text.** The interpreter path sits inside `"…"`,
+#:    where POSIX gives meaning to exactly `$`, `` ` ``, `\` and `"`.
+#:
+#: Measured against tmux 3.7c, both directions. An interpreter at
+#: ``…/a b;c&d(e)f*g-h,i=j+k@l:m[n]o{p}q!r%s^t~u/fake py`` — every other ASCII
+#: punctuation character, plus a space — was reached and received exactly
+#: ``-P -m charter frame-respawn top --pane %1 --frame demo-1``, byte for byte. An
+#: interpreter under ``…/plain $(touch CANARY) dir/py`` created the canary: the `$( )`
+#: really does execute, so this refusal is a guard and not a formality.
+_ACTION_METACHARACTERS = "#'\"$`\\"
+
+
+def _action_word_is_safe(word: str) -> bool:
+    """Does *word* still say what it says after all three parses
+    :data:`_ACTION_METACHARACTERS` describes?
+
+    The property, not a spelling: a word survives if it carries no character any of those
+    three grammars reads as anything but itself, and no control character (a newline is a
+    tmux command separator; the rest are unprintable in a `show-hooks` a human has to be
+    able to read). Whitespace is left to the caller — the interpreter path is
+    double-quoted for the shell and may hold spaces; every word after it is bare and may
+    not.
+    """
+    return bool(word) and not any(
+        c in _ACTION_METACHARACTERS or ord(c) < 0x20 or ord(c) == 0x7F for c in word)
+
+
+def _panel_died_hook_argv(*, socket: str, panel_pane: str, slot: str,
+                          fid: str) -> list[str] | None:
     """`pane-died`, scoped to ONE PANEL pane: bring that panel back.
 
     **Not the harness pane's hook array, and this is the property to keep.** The two
@@ -649,25 +705,59 @@ def _panel_died_hook_argv(*, socket: str, panel_pane: str, slot: str) -> list[st
     the command deliberately SLEEPS for its backoff, and a blocking `run-shell` in a
     hook stalls tmux's command queue for that whole time.
 
-    **Single-quoted, so tmux does not eat the `$`.** `_pane_died_write_hook_argv`'s
-    docstring measures the opposite case — an unescaped `$` inside a tmux DOUBLE-quoted
-    argument is consumed by tmux's own parsing before any shell sees it. Single quotes
-    are what `conf_text`'s hotkey bind already uses for the identical job, and the exact
-    action string this function builds was run end to end against tmux 3.7c: the hook
-    fires, `/bin/sh` expands `$CHARTER_PY` itself, and the argv arrives intact with
-    `$CHARTER_SESSION_ID` present in the spawned shell's environment.
+    **`tmuxctl.server_argv`, and #408 is what a hand-built `["tmux", "-L", socket, …]`
+    cost.** This line spelled `-L` itself. Charter reaches two servers — its own by NAME
+    and the operator's by SOCKET PATH — so on the inside-a-tmux path (#381) the same
+    string that names the operator's socket was being handed to tmux as a server NAME,
+    which would arm a hook against a server that may not exist or, worse, may be some
+    other frame's private one. Rather than teach a second place the difference, the
+    difference is asked of the one place that already answers it. `cmd_respawn` had the
+    identical bug at the other end of the same mechanism and now resolves its server the
+    same single way (`state.frame_server`, `_frame_is_live`).
 
-    Only two values are interpolated and both are safe BY CONSTRUCTION, not by
-    good behaviour: *panel_pane* is tmux's own `%<digits>`, already checked against
-    `_PANE_ID_RE` by `cmd_launch` before it is kept, and *slot* is a key of
-    `frame_slots.SLOTS` — `cmd_launch` filters everything else out (`unimplemented`)
-    before a pane is ever split for it. Nothing operator- or plane-derived reaches this
-    text, which is the same rule the module docstring's "constant string" section sets
-    for `status_path`.
+    **The interpreter is interpolated, not read from `$CHARTER_PY`, and that is what makes
+    the operator's server reachable at all.** `_charter_py_env_argv` delivers it with
+    `set-environment -t <session>`, and `_launch_in_operator_tmux` may not write a session
+    option — it is the operator's session, and every new shell they opened would carry it.
+    Measured against tmux 3.7c: a `run-shell` fired by a PANE-scoped hook sees the SESSION
+    environment (`$CHARTER_PY` set that way arrived intact) and does NOT see the pane's own
+    `-e` environment (a `CHARTER_PY` carried on `split-window -e` read back empty). So
+    there is no out-of-band channel on that server, and the value has to travel in the
+    text. `--frame` travels for the same reason: `cmd_respawn` used to read
+    `$CHARTER_SESSION_ID` out of its own environment, which is `_session_id_env_argv`'s
+    session option and equally unavailable there.
+
+    ``None`` back means charter will not arm this pane, and every value that reaches the
+    text is what decides — never where it came from. *panel_pane* must be tmux's own
+    `%<digits>` (`_PANE_ID_RE`), *slot* a key of `frame_slots.SLOTS`, *fid* a
+    `state.frame_id` (`_FRAME_ID_RE`), and every word including the interpreter path must
+    pass :func:`_action_word_is_safe`. `sys.executable` is the one that is genuinely
+    machine-shaped: a path holding a space, `;`, `&`, `(` or `*` was measured to survive
+    all three parses byte for byte and is armed; one holding `$( )` was measured to
+    EXECUTE, and one holding `#{…}` to be rewritten by tmux's own format expansion before
+    any shell saw it, and both are refused. `_arm_panel_respawn` reports the refusal rather
+    than swallowing
+    it — a frame without panel respawn is a frame that still works, and an operator told
+    why beats a hook that quietly runs something else.
+
+    **Single-quoted for tmux, double-quoted for the shell.** `_pane_died_write_hook_argv`'s
+    docstring measures the opposite case — an unescaped `$` inside a tmux DOUBLE-quoted
+    argument is consumed by tmux's own parsing before any shell sees it. Single quotes are
+    what `conf_text`'s hotkey bind already uses for the identical job; the inner `"…"` is
+    what lets an interpreter path with a space through, and
+    :data:`_ACTION_METACHARACTERS` is the complete set of characters any of the three
+    parsers involved would read as something other than themselves.
     """
-    action = (f"run-shell -b '\"${_CHARTER_PY_ENV}\" -m charter frame-respawn "
-              f"{slot} --pane {panel_pane}'")
-    return ["tmux", "-L", socket, "set-hook", "-p", "-t", panel_pane, "pane-died", action]
+    words = util.self_relaunch_argv("frame-respawn", slot, "--pane", panel_pane,
+                                    "--frame", fid)
+    if (not _PANE_ID_RE.fullmatch(panel_pane) or slot not in frame_slots.SLOTS
+            or not _FRAME_ID_RE.fullmatch(fid)
+            or not all(_action_word_is_safe(w) for w in words)
+            or any(w.split() != [w] for w in words[1:])):
+        return None
+    action = f"""run-shell -b '"{words[0]}" {" ".join(words[1:])}'"""
+    return tmuxctl.server_argv(socket, "set-hook", "-p", "-t", panel_pane, "pane-died",
+                               action)
 
 
 #: Which `resize-pane` flag re-asserts a slot's fixed dimension: `-y` (rows) for the
@@ -870,6 +960,28 @@ def _live_windows(socket: str) -> set[str] | None:
     return {line.strip() for line in out.stdout.splitlines() if line.strip()}
 
 
+def _frame_is_live(socket: str, fid: str) -> bool:
+    """Is the frame *fid* still running on *socket*? One question, one place — #408.
+
+    A frame is a SESSION on charter's own private server and a WINDOW in the operator's,
+    so "is it still there" is two different queries and `tmuxctl.is_operator_socket` is
+    the same single discriminator that already turns a server into `-L` or `-S`.
+    `cmd_respawn` asked `_live_sessions(SOCKET)` unconditionally, which on the operator's
+    server is a question about a server that is not theirs: it answers "no such session"
+    for a frame that is on screen, so a panel that died there could never have been
+    brought back even once the hook reached charter.
+
+    ``False`` for a server that did not answer at all (`_live_windows`'s ``None``), and
+    that direction is deliberate: the only caller is about to RESPAWN something, and
+    respawning into a server charter could not reach is the outcome with a cost. Not
+    respawning costs a panel that was already dead.
+    """
+    if tmuxctl.is_operator_socket(socket):
+        live = _live_windows(socket)
+        return live is not None and fid in live
+    return fid in _live_sessions(socket)
+
+
 def _wait_for_harness(socket: str, harness_pane: str) -> int | None:
     """Block until the harness in *harness_pane* is over. Its exit code, or ``None``.
 
@@ -933,10 +1045,11 @@ def _frame_env(fid: str, h) -> dict[str, str]:
 
     Shared by both paths deliberately, because they deliver it by opposite mechanisms
     and only the CONTENT is the same: on charter's own server it is handed to
-    `new-session`, whose server inherits it whole; inside an operator's tmux the server
-    is already running and is not charter's, so it rides on `respawn-pane -e` instead
-    (see `layout.respawn_argv`). A second copy of "what a framed harness's environment
-    is" would be two answers to one question.
+    `new-session` as the tmux CLIENT's environment, which the server inherits whole if
+    this is the call that starts it; inside an operator's tmux the server is already
+    running and is not charter's, so nothing of this reaches a pane except by being
+    NAMED (`_guest_harness_env`, `_pane_identity_env`). A second copy of "what a framed
+    harness's environment is" would be two answers to one question.
 
     COLUMNS/LINES go, and that is belt and braces rather than the fix itself: every pane
     (harness or panel) measures its OWN tty (`frame/slots.py`, `frame/panel.py`), so a
@@ -945,13 +1058,20 @@ def _frame_env(fid: str, h) -> dict[str, str]:
     among them — and both variables describe the LAUNCHING terminal, not any pane the
     frame creates.
 
-    TMUX/TMUX_PANE go for a sharper reason, and only matter on the inside-a-tmux path:
-    they describe the pane `charter` was TYPED in. tmux sets both itself for a pane it
-    creates, and carrying the launcher's own values across would tell the harness — and
-    `session.terminal()`, which reads `TMUX_PANE` — that it is running in a pane it is
-    not. That is the identity collision `WINDOWID` was removed for
+    TMUX/TMUX_PANE go for a sharper reason: they describe the pane `charter` was TYPED
+    in. tmux sets both itself for a pane it creates, and carrying the launcher's own
+    values across would tell the harness — and `session.terminal()`, which reads
+    `TMUX_PANE` — that it is running in a pane it is not. That is the identity collision
+    `WINDOWID` was removed for
     (`docs/superpowers/specs/2026-08-21-harness-wrapper-design.md`), reached through a
     different variable.
+
+    **Both removals are now only about charter's own server**, and that is worth saying
+    rather than leaving the reader to work out: since #446 nothing on the operator's
+    server is handed a variable that was not named, so a stale `COLUMNS` or a borrowed
+    `TMUX_PANE` cannot reach a pane there whether or not it is popped here. They stay
+    popped because the private-server path still hands this dict to `new-session` as a
+    client environment, and the server born from it inherits every name in it.
     """
     env = dict(os.environ, CHARTER_SESSION_ID=fid)
     for stale in ("COLUMNS", "LINES", "TMUX", "TMUX_PANE"):
@@ -1021,6 +1141,48 @@ def _frame_identity_env(env: dict[str, str]) -> dict[str, str]:
     return {name: env.get(name, "") for name in _FRAME_IDENTITY}
 
 
+def _guest_harness_env(env: dict[str, str]) -> dict[str, str]:
+    """What the HARNESS pane must be told on a server charter does not own — #446.
+
+    :func:`_frame_identity_env` plus `$PATH`, and the whole difference between the two
+    servers is in that one extra name. On charter's own private server the base the `-e`
+    overlays is a server SOME charter launcher started, so its `$PATH` is a charter
+    launcher's. On the operator's it is a server THEY started, possibly weeks ago, in
+    another shell — and `cmd_launch` has already resolved the harness binary
+    (`shutil.which(h.binary)`) against charter's OWN `$PATH`. Handing the pane a
+    different one would make that check a promise charter cannot keep: the frame comes
+    up, the exec fails, and the operator gets `_UNKNOWN_DEATH_CODE` for a binary charter
+    said it had found.
+
+    **This used to be `dict(os.environ, …)` whole, and that is the defect.** Measured on
+    one real environment: 129 argv elements, 7,773 bytes, four live 1Password
+    service-account tokens and an npm auth token — in `/proc/<pid>/cmdline`, world-readable
+    to every local user on Linux and recorded permanently by exec-audit tooling. See
+    :func:`_frame_identity_env` for the argument in full; it is the same argument, and
+    #412 closed only the half of it that was on charter's own server.
+
+    **Measured against tmux 3.7c, and the measurement is why `PATH` is belt and braces
+    rather than the fix.** A pane's `$PATH` comes from the tmux CLIENT that issued the
+    command, not from the server: a server started with `PATH=/server/bin`, a
+    `respawn-pane` issued by a client with `PATH=/respawnclient/bin`, produced a pane
+    holding `/respawnclient/bin` — and an explicit `-e PATH=/explicit/bin` on that same
+    command did NOT survive, tmux overwrites it after applying the `-e` set (read out of
+    the pane by `python3`, not by a shell, to rule out any shell's own normalisation).
+    So on this tmux the pane already has charter's own `$PATH` and stating it changes
+    nothing. It is carried anyway because no measurement says an older tmux applies the
+    same rule, and the cost of being wrong in the two directions is not symmetric: one
+    redundant argv pair carrying a value that is never a credential, against a harness
+    that cannot be executed at all.
+
+    Empty is not carried — `-e PATH=` would state an EMPTY `$PATH`, which is strictly
+    worse than inheriting one. A charter running without `$PATH` has nothing to say here.
+    """
+    values = _frame_identity_env(env)
+    if env.get("PATH"):
+        values["PATH"] = env["PATH"]
+    return values
+
+
 def _remain_on_exit_argv(*, socket: str, harness_pane: str) -> list[str]:
     """`set-option -p`: keep THIS pane in place after its program exits, and no other.
 
@@ -1071,10 +1233,16 @@ def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, argv: list[
     every window on their server to reach a redundant menu is a worse trade than no key
     — `frame/slots.py` drops the hotkey hint from the bottom panel to match.
 
-    **The exit code travels without hooks here, and that is a real difference.** The
-    private-server path needs `pane-died[0]`/`pane-died[1]` because it blocks in
-    `attach` and has nothing else watching; this launcher is awake for the whole life of
-    the frame (`_wait_for_harness`), so it reads the status and closes the window
+    Two things that ARE written are charter's own and reach nothing of theirs, both
+    PANE-scoped and both on a pane charter created in a window charter created:
+    `remain-on-exit` on the harness pane (`_remain_on_exit_argv`), and each panel pane's
+    own `pane-died` respawn hook (`_arm_panel_respawn`, #408 — it refused here until the
+    hook could name this server rather than charter's).
+
+    **The harness's exit code travels without hooks here, and that is a real
+    difference.** The private-server path needs `pane-died[0]`/`pane-died[1]` because it
+    blocks in `attach` and has nothing else watching; this launcher is awake for the whole
+    life of the frame (`_wait_for_harness`), so it reads the status and closes the window
     itself. Installing the teardown hook as well would actively LOSE the exit code: a
     hook array runs in index order and `kill-window` would destroy the pane before this
     process's next ask. The cost is honest and bounded — if this launcher is itself
@@ -1156,8 +1324,8 @@ def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, argv: list[
 
     started = tmuxctl.run(
         "starting the harness in it",
-        layout.respawn_argv(socket=socket, harness_pane=harness_pane, env=env, cwd=cwd,
-                            harness_argv=argv))
+        layout.respawn_argv(socket=socket, harness_pane=harness_pane,
+                            env=_guest_harness_env(env), cwd=cwd, harness_argv=argv))
     if started.returncode != 0:
         # The placeholder is still running in a window the operator never asked for and
         # would never learn the purpose of. Take it back.
@@ -1192,12 +1360,13 @@ def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, argv: list[
 
     cols, rows = _window_size(socket, harness_pane)
     slots = _drawable_slots(cols, rows)
-    # *env* is what the tmux CLIENT process runs with (nothing depends on it here — the
-    # server is already up and is not charter's); *pane_env* is what each panel's own
-    # process gets, which on somebody else's server has to be carried explicitly. See
-    # `layout.panel_argvs`.
-    _draw_panels(socket, slots=slots, fid=fid, harness_pane=harness_pane,
-                 env=None, v=v, pane_env=env)
+    # *pane_env* is what each panel's own process gets, which on somebody else's server
+    # has to be carried explicitly — identity and nothing else, the same five names the
+    # private-server path carries, for `_pane_identity_env`'s own reason. It used to be
+    # the whole environment here (#446): see `_guest_harness_env`.
+    panes = _draw_panels(socket, slots=slots, fid=fid, harness_pane=harness_pane,
+                         env=None, v=v, pane_env=_pane_identity_env(env, v))
+    _arm_panel_respawn(socket, fid=fid, panes=panes, env=None)
     tmuxctl.run("focusing the harness pane",
                 tmuxctl.server_argv(socket, "select-pane", "-t", harness_pane))
     # `select-window`, never `attach`: the operator has a client already, on this very
@@ -1394,7 +1563,8 @@ def _install_resize_hook(socket: str, *, harness_pane: str, panes: dict[str, str
                   "of shape if this terminal is resized")
 
 
-def _arm_panel_respawn(socket: str, *, panes: dict[str, str], env: dict | None) -> None:
+def _arm_panel_respawn(socket: str, *, fid: str, panes: dict[str, str],
+                       env: dict | None) -> None:
     """Give each pane in *panes* its OWN `pane-died` hook, so a dead panel comes back.
 
     A panel whose process dies outright would otherwise leave a hole for the frame's whole
@@ -1403,24 +1573,26 @@ def _arm_panel_respawn(socket: str, *, panes: dict[str, str], env: dict | None) 
     `_panel_died_hook_argv`). Reported but never fatal, like every other decorative tmux
     command here: a panel that cannot be armed for respawn is still a panel that came up.
 
-    **Private-server-only, and the guard is here rather than at the call sites.**
-    `cmd_respawn` (the hook's own action) and `_panel_died_hook_argv` both assume `SOCKET`,
-    charter's own server NAME — `-L`, never `-S` — which is correct on charter's own
-    server and wrong on the operator's, where the frame's server is a socket PATH read
-    from `$TMUX`. Arming a panel there installs a hook whose action targets the wrong tmux
-    server entirely. That used to be enforced by WHERE the loop sat (inside `cmd_launch`'s
-    private-server branch); with a second caller (`_relayout`, which runs on either
-    server) that is no longer a property of position, so it is asserted here instead.
-    Extending #382 across the boundary is real work — resolving `cmd_respawn`'s target
-    from `state.frame_server(fid)` and its liveness check from windows rather than
-    sessions — and is still not this change's job.
+    **This used to refuse outright on the operator's server, and #408 is that refusal.**
+    `cmd_respawn` and `_panel_died_hook_argv` both spelled `-L SOCKET` by hand, so arming
+    a panel inside the operator's tmux would have installed a hook aimed at a different
+    server; backing out was right at the time and left a panel that dies there dead for
+    the life of the frame, with no message, no respawn and no backoff. Both ends now build
+    their argv through `tmuxctl.server_argv` and resolve liveness through `_frame_is_live`,
+    so the same hook is correct on either server and there is nothing left here to refuse.
+
+    A pane charter will not arm (`_panel_died_hook_argv` returning ``None`` — see its own
+    docstring for what fails that check) is NAMED rather than skipped in silence: the
+    operator loses respawn for that panel and this is the only place that could say so.
     """
-    if tmuxctl.is_operator_socket(socket):
-        return
     for slot, pane_id in panes.items():
-        tmuxctl.run(f"arming the {slot} panel for respawn",
-                    _panel_died_hook_argv(socket=socket, panel_pane=pane_id, slot=slot),
-                    env=env)
+        cmd = _panel_died_hook_argv(socket=socket, panel_pane=pane_id, slot=slot, fid=fid)
+        if cmd is None:
+            util.warn(f"charter frame: the {slot} panel will not be brought back if it "
+                      "dies — charter cannot build a respawn hook it can be sure tmux "
+                      "and the shell will read the way it means it")
+            continue
+        tmuxctl.run(f"arming the {slot} panel for respawn", cmd, env=env)
 
 
 def _disarm_panel_respawn(socket: str, *, pane_id: str) -> None:
@@ -1433,10 +1605,12 @@ def _disarm_panel_respawn(socket: str, *, pane_id: str) -> None:
     way. Unsetting first removes the question rather than answering it: there is no hook
     left to fire, whichever way this tmux treats a killed pane's `pane-died`.
 
-    `report=False`: on the operator's own server no hook was ever armed
-    (:func:`_arm_panel_respawn` refuses there), so a `set-hook -u` for a hook that is not
-    set is the ORDINARY case rather than a fault — the same reason `_live_sessions` opts
-    out of reporting for a socket no server has run on.
+    `report=False`: a pane charter declined to arm (`_panel_died_hook_argv` returning
+    ``None``) has no hook to unset, and a frame launched by a charter that predates #382
+    has none either, so a `set-hook -u` for a hook that is not set is an ORDINARY case
+    rather than a fault — the same reason `_live_sessions` opts out of reporting for a
+    socket no server has run on. Until #408 the ordinary case was the whole of the
+    operator's server, where nothing was ever armed at all.
     """
     tmuxctl.run("disarming a panel's respawn hook",
                 tmuxctl.server_argv(socket, "set-hook", "-p", "-u", "-t", pane_id,
@@ -1871,7 +2045,7 @@ def cmd_launch(args) -> int:
             panes = _draw_panels(
                 SOCKET, slots=slots, fid=fid, harness_pane=harness_pane, env=env, v=v,
                 pane_env=_pane_identity_env(env, v))
-            _arm_panel_respawn(SOCKET, panes=panes, env=env)
+            _arm_panel_respawn(SOCKET, fid=fid, panes=panes, env=env)
 
             # `split-window` makes the newly created pane the ACTIVE one by default, so
             # after every slot has been drawn, the LAST panel drawn — not the harness —
@@ -2115,8 +2289,8 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
         keep.update(_split_panels(socket, slots=missing, fid=fid,
                                   harness_pane=harness_pane, env=None,
                                   pane_env=pane_env))
-        _arm_panel_respawn(socket, panes={s: keep[s] for s in missing if s in keep},
-                           env=None)
+        _arm_panel_respawn(socket, fid=fid,
+                           panes={s: keep[s] for s in missing if s in keep}, env=None)
 
     _install_resize_hook(socket, harness_pane=harness_pane, panes=keep, v=v,
                          env=None, replacing=True)
@@ -2279,10 +2453,26 @@ def cmd_respawn(args) -> int:
     no-op for the same reason: there is no screen left to report it on that is not the
     agent's own.
 
+    **Which server, and #408.** This resolved nothing: it spelled `["tmux", "-L", SOCKET,
+    …]` and asked `_live_sessions(SOCKET)`, so a hook fired inside the operator's own tmux
+    would have talked to charter's private server about a session that is not there — the
+    other half of the mismatch `_panel_died_hook_argv` had. The server comes from
+    `state.frame_server(fid)`, which the launcher records for every frame on either socket,
+    and both the liveness question and the respawn argv are built from it through the one
+    place that knows `-L` from `-S` (`_frame_is_live`, `tmuxctl.server_argv`).
+
+    **The frame comes off the argv first, and the environment only as a fallback.**
+    `--frame` is what the hook passes now: on the operator's server there IS no
+    `$CHARTER_SESSION_ID` to read, because that variable is a session option
+    (`_session_id_env_argv`) and charter writes none there. The fallback is kept for a
+    frame armed by a charter that predates this, whose hooks are already installed and
+    outlive the upgrade.
+
     Refusals, in the order they are checked:
 
-    * no `$CHARTER_SESSION_ID` — not fired by a frame at all, so there is no frame to
-      resolve or count against (`cmd_menu` treats the same gap the same way);
+    * no frame on the argv and no `$CHARTER_SESSION_ID` — not fired by a frame at all, so
+      there is no frame to resolve or count against (`cmd_menu` treats the same gap the
+      same way);
     * a *slot* with no renderer — bringing it back would recreate exactly the
       permanently-dead pane `cmd_launch`'s `unimplemented` filter exists to prevent;
     * a *pane* that is not tmux's own `%<digits>` — the value arrived through text tmux
@@ -2301,11 +2491,12 @@ def cmd_respawn(args) -> int:
     finish, and a respawn into a session that no longer exists (one failure report per
     panel, for nothing being wrong) is avoided rather than reported.
     """
-    fid = os.environ.get("CHARTER_SESSION_ID", "")
+    fid = getattr(args, "frame", None) or os.environ.get("CHARTER_SESSION_ID", "")
     if not fid or args.slot not in frame_slots.SLOTS:
         return 0
     if not _PANE_ID_RE.fullmatch(args.pane or ""):
         return 0
+    socket = state.frame_server(fid) or SOCKET
     attempt = state.respawn_attempt(fid, args.slot)
     if attempt is None or attempt > _RESPAWN_ATTEMPTS:
         return 0
@@ -2314,12 +2505,12 @@ def cmd_respawn(args) -> int:
     # `_RESPAWN_ATTEMPTS` alone degrades to "wait the longest backoff again" instead of
     # an IndexError inside a tmux hook, where nothing would print it.
     time.sleep(_RESPAWN_BACKOFF[min(attempt, len(_RESPAWN_BACKOFF)) - 1])
-    if fid not in _live_sessions(SOCKET):
+    if not _frame_is_live(socket, fid):
         return 0
     tmuxctl.run(
         f"bringing the {args.slot} panel back",
-        ["tmux", "-L", SOCKET, "respawn-pane", "-t", args.pane, "--",
-         *layout.panel_command(slot=args.slot, session=fid)])
+        tmuxctl.server_argv(socket, "respawn-pane", "-t", args.pane, "--",
+                            *layout.panel_command(slot=args.slot, session=fid)))
     return 0
 
 

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -740,6 +740,19 @@ def _panel_died_hook_argv(*, socket: str, panel_pane: str, slot: str,
     it — a frame without panel respawn is a frame that still works, and an operator told
     why beats a hook that quietly runs something else.
 
+    **Four clauses, and each is on its own.** `;` is deliberately NOT in
+    :data:`_ACTION_METACHARACTERS` — it changes nothing inside the action's single quotes
+    — so a `;` in the pane, the slot or the frame id is caught by that value's own shape
+    check and by nothing else. Measured on tmux 3.7c with `_FRAME_ID_RE` widened to
+    `re.compile(r".+")` and a frame id carrying no whitespace anywhere,
+    ``demo-1;>/…/CANARY``: the hook armed, the panel died, and the canary file existed —
+    tmux keeps the `;` literal and `/bin/sh` does not. As shipped that input is not armed
+    and no canary appears. The clauses are pinned one at a time in
+    `tests/test_frame_launcher.py::PanelRespawnHook`, each case built so that no OTHER
+    clause could be what refused it; a first version of those tests used hostile values
+    that all carried a SPACE, and three of the four clauses could then be deleted outright
+    with the whole suite still green.
+
     **Single-quoted for tmux, double-quoted for the shell.** `_pane_died_write_hook_argv`'s
     docstring measures the opposite case — an unescaped `$` inside a tmux DOUBLE-quoted
     argument is consumed by tmux's own parsing before any shell sees it. Single quotes are
@@ -777,7 +790,16 @@ _RESIZE_FLAG = {"top": "-y", "bottom": "-y", "left": "-x", "right": "-x"}
 #: the same as `split-window` reporting no id at all (see the empty-string check right
 #: below this) — that one panel simply gets no resize-hook entry, rather than gambling
 #: that whatever the string actually was cannot corrupt the action tmux re-parses.
-_PANE_ID_RE = re.compile(r"%\d+")
+#:
+#: **`[0-9]`, not `\d`, and the difference is the property.** Python's `\d` is Unicode by
+#: default: `re.fullmatch(r"%\d+", "%١٢")` is a MATCH, and so is the fullwidth `"%１１"`.
+#: Neither is a pane id tmux ever minted, and neither is dangerous on its own — a
+#: Unicode digit carries no meaning to any of the three parsers a hook action passes
+#: through — but the check is here to say "this is tmux's own word for a pane", and a
+#: class that also admits Arabic-Indic digits is answering a different question. The
+#: same spelling-instead-of-the-property gap this module keeps paying for, caught before
+#: it cost anything rather than after.
+_PANE_ID_RE = re.compile(r"%[0-9]+")
 
 #: tmux's own answer, verbatim, for a `set-hook` call naming an event this binary does
 #: not recognise at all — confirmed by hand against a real tmux 3.7c with a fabricated

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1137,6 +1137,19 @@ def _frame_identity_env(env: dict[str, str]) -> dict[str, str]:
     (`workspace.resolve` and `root.find_root` both test the value for truth, not for
     presence). Being explicit in both directions is what makes a frame's charter identity
     the launcher's answer rather than half of somebody else's.
+
+    **Shadowing is all there is: `-e` is purely ADDITIVE and cannot REMOVE a name.** The
+    obvious-looking alternative is a bare `-e NAME` with no `=`, and it is not an unset —
+    measured on the same tmux, and the measurement is worse than a refusal would have
+    been: tmux ACCEPTS it, returns 0, prints nothing, and leaves the inherited value
+    exactly where it was. There is no `-u`/`-r` counterpart on any of the three commands
+    charter puts a `-e` on either. So a variable already in the server's or session's
+    environment can only be OVERWRITTEN with an explicit empty value, which is what the
+    line below emits for every absent name; a future reader reaching for the bare form
+    would be choosing inheritance, silently, and would get no error to tell them. Pinned
+    in `tests/test_frame_tmux_integration.py::ASecondFrameOnTheSharedServer::
+    test_a_bare_e_name_cannot_take_a_variable_away`, which will say so if tmux ever
+    grows the unset this wants.
     """
     return {name: env.get(name, "") for name in _FRAME_IDENTITY}
 
@@ -1186,17 +1199,52 @@ def _guest_harness_env(env: dict[str, str]) -> dict[str, str]:
 def _remain_on_exit_argv(*, socket: str, harness_pane: str) -> list[str]:
     """`set-option -p`: keep THIS pane in place after its program exits, and no other.
 
-    PANE-scoped, which is the only scope that works on a server charter is a guest on.
-    `remain-on-exit` is a window option in tmux with a global default; `-g` there would
-    leave every pane the operator closes hanging around as a dead pane, and `-w` would do
-    it to every pane in a window charter does not own until it does. `-p` names one pane
-    — the harness's — and tmux keeps it, and its `#{pane_dead_status}`, until charter has
-    read the status and closed the window itself.
+    PANE-scoped, and armed at the one moment nothing else can cover: between the window
+    being created and the harness being started into it. `_panel_remain_on_exit_argv`
+    arms the whole of charter's own window later, when the panels are drawn — but that is
+    after `layout.respawn_argv` has already put the harness in, and a harness that dies
+    in the gap is exactly the early death #384 is about. `-p` here holds the harness pane,
+    and its `#{pane_dead_status}`, from before its program exists.
 
-    Charter's own private server arms the same setting globally instead
+    `-g` is the scope that must never be used on somebody else's server: it would leave
+    every pane the OPERATOR closes hanging around as a dead pane, in every window they
+    have open. Charter's own private server arms it globally on purpose
     (`_PLACEHOLDER_CONF`), because there is nothing on that server that is not charter's.
     """
     return tmuxctl.server_argv(socket, "set-option", "-p", "-t", harness_pane,
+                               "remain-on-exit", "on")
+
+
+def _panel_remain_on_exit_argv(*, socket: str, harness_pane: str) -> list[str]:
+    """`set-option -w`: keep dead panes in CHARTER'S OWN WINDOW, and in no other.
+
+    **Without this a panel's respawn hook cannot fire at all, and #408 was only half
+    fixed.** tmux runs `pane-died` only for a pane that DIED AND STAYED — with
+    `remain-on-exit` off, the pane is destroyed, its pane-scoped hook is destroyed with
+    it, and nothing runs. Measured on tmux 3.7c against a server left at tmux's own
+    default (which is what an operator's tmux is): a panel pane armed exactly as
+    `_arm_panel_respawn` arms it, dying exactly as a panel dies, reached no shell and
+    left no pane — and the same run with this one option set reached the shell and kept
+    the pane. Charter's private server never showed it because `_PLACEHOLDER_CONF` sets
+    `remain-on-exit` server-globally there, so every pane on it already stays.
+
+    **WINDOW-scoped, not per panel pane, and the reason is a race rather than a
+    preference.** A pane option can only be set on a pane that already exists, so a
+    `set-option -p` after each `split-window` leaves every panel unprotected for the
+    milliseconds between tmux starting its program and charter arming it — and a panel
+    that dies in that gap (a bad interpreter, an import error) is precisely the one #382
+    is about. The window is armed BEFORE the first split, so a pane created into it is
+    born covered. It also covers the panes a later `_relayout` adds without arming
+    anything twice.
+
+    The scope is charter's own window and reaches nothing of the operator's — measured,
+    not reasoned: `-w -t <a pane id>` resolves to that pane's window, and after this runs
+    charter's window reads `on` while the operator's own window still reads the global
+    default and their own panes still vanish when their programs exit. `kill-pane` also
+    still destroys a pane this is holding, which is what lets `cmd_density` drop a slot
+    (see `_disarm_panel_respawn`) rather than leave a corpse behind in the frame.
+    """
+    return tmuxctl.server_argv(socket, "set-option", "-w", "-t", harness_pane,
                                "remain-on-exit", "on")
 
 
@@ -1233,11 +1281,15 @@ def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, argv: list[
     every window on their server to reach a redundant menu is a worse trade than no key
     — `frame/slots.py` drops the hotkey hint from the bottom panel to match.
 
-    Two things that ARE written are charter's own and reach nothing of theirs, both
-    PANE-scoped and both on a pane charter created in a window charter created:
-    `remain-on-exit` on the harness pane (`_remain_on_exit_argv`), and each panel pane's
-    own `pane-died` respawn hook (`_arm_panel_respawn`, #408 — it refused here until the
-    hook could name this server rather than charter's).
+    Three things that ARE written are charter's own and reach nothing of theirs, because
+    every one of them is scoped to a pane charter created or to the window charter
+    created: `remain-on-exit` on the harness pane (`_remain_on_exit_argv`, PANE-scoped);
+    `remain-on-exit` on the frame's own window, so a dead PANEL stays long enough for its
+    hook to run (`_panel_remain_on_exit_argv`, WINDOW-scoped — measured to leave the
+    operator's own windows at their own default); and each panel pane's own `pane-died`
+    respawn hook (`_arm_panel_respawn`, PANE-scoped, #408 — it refused here until the
+    hook could name this server rather than charter's, and then never fired here until
+    the window kept the corpse it has to fire from).
 
     **The harness's exit code travels without hooks here, and that is a real
     difference.** The private-server path needs `pane-died[0]`/`pane-died[1]` because it
@@ -1461,7 +1513,22 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     The splitting half of :func:`_draw_panels`, separated from the hook-and-record half so
     a live re-layout (`_relayout`) can add panes to a frame that already has some without
     re-installing hooks per batch or overwriting the map it is in the middle of building.
+
+    **The one funnel every panel pane charter creates comes out of, which is why
+    `remain-on-exit` is armed here** — before the first `split-window`, so no panel is
+    ever born into a window that would throw its corpse away and its respawn hook with it
+    (`_panel_remain_on_exit_argv`, #408). Both launch paths and every density change
+    reach panels through this function; arming at the call sites instead is what left the
+    operator's server covered on one of two.
+
+    Reported but not fatal, like the splits themselves: a frame whose panels cannot be
+    respawned is still a frame, and the harness pane's own `remain-on-exit` was armed
+    separately and earlier (`_remain_on_exit_argv`), so the exit code does not ride on
+    this.
     """
+    tmuxctl.run("keeping the frame's own dead panes long enough to bring them back",
+                _panel_remain_on_exit_argv(socket=socket, harness_pane=harness_pane),
+                env=env)
     panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=socket,
                                     harness_pane=harness_pane, env=pane_env)
     # Zipped with `slots`, not just iterated: `_resize_hook_argv` needs to know WHICH slot
@@ -1580,6 +1647,16 @@ def _arm_panel_respawn(socket: str, *, fid: str, panes: dict[str, str],
     the life of the frame, with no message, no respawn and no backoff. Both ends now build
     their argv through `tmuxctl.server_argv` and resolve liveness through `_frame_is_live`,
     so the same hook is correct on either server and there is nothing left here to refuse.
+
+    **An armed hook and a hook that can FIRE are two claims, and the first round of #408
+    only bought the first.** tmux runs `pane-died` for a pane that died and STAYED; a
+    pane on a server left at `remain-on-exit off` — an operator's own tmux — is destroyed
+    at death, taking its pane-scoped hook with it, and every argv here can be perfect
+    while nothing ever runs. What makes this reachable is `_panel_remain_on_exit_argv`,
+    armed on charter's own window before the first panel is split; the measurement is in
+    that function's docstring and the end-to-end test is
+    `WindowInsideAnOperatorsTmux.test_a_panels_respawn_hook_is_armed_against_this_server_and_fires`,
+    which runs against a server nothing has pre-armed.
 
     A pane charter will not arm (`_panel_died_hook_argv` returning ``None`` — see its own
     docstring for what fails that check) is NAMED rather than skipped in silence: the

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -155,14 +155,29 @@ def respawn_argv(*, socket: str, harness_pane: str, env: dict[str, str],
     set is an OVERLAY on whatever the pane would have inherited anyway.
 
     That matters twice. It means a caller may carry only the variables that must differ
-    (which `session_argv` and `panel_argvs` on charter's own server now do — see
+    (which `session_argv` and `panel_argvs` on charter's own server already did — see
     `commands_frame._frame_identity_env`, and note that a `-e` is argv and argv is
-    world-readable). And it means this call site's full-environment pass is a CHOICE
-    rather than a requirement: on the operator's server the base the overlay lands on is
-    THEIR tmux server's environment, which may predate this plane entirely, so charter
-    states everything rather than trusting it. That choice keeps the operator's whole
-    environment on a tmux command line, which is a real exposure with a real reason and
-    is not this issue's to change unmeasured.
+    world-readable). And it meant this call site's full-environment pass was a CHOICE
+    rather than a requirement.
+
+    **That choice is gone, and #446 is why.** This call carried `dict(os.environ, …)`
+    whole into `/proc/<pid>/cmdline`: measured on one real environment, 129 argv elements,
+    7,773 bytes, four live 1Password service-account tokens and an npm auth token. What it
+    was buying was "the base the overlay lands on is THEIR tmux server's environment, which
+    may predate this plane entirely". Two things were then measured against tmux 3.7c and
+    settle it (`commands_frame._guest_harness_env` carries the numbers):
+
+    * a pane's `$PATH` is the INVOKING CLIENT's, not the server's — charter's own, the
+      one `cmd_launch`'s `shutil.which` resolved the harness against. An explicit
+      `-e PATH=…` does not even survive: tmux overwrites it afterwards.
+    * everything else a harness reads it reads for itself, from a server environment that
+      belongs to the same operator on the same machine.
+
+    So only `commands_frame._guest_harness_env` travels here. The cost is stated in
+    `docs/frame.md` beside the other named costs of being a guest: the harness inherits
+    the operator's TMUX SERVER environment rather than their current shell's — exactly
+    what already happens on charter's own shared server, and never worth a credential on a
+    world-readable command line.
 
     Every `-e` lands before the `--` — they are `respawn-pane`'s own options, and must
     never be grafted onto the harness's own argv.
@@ -222,6 +237,29 @@ def session_argv(*, session: str, conf: str, socket: str, cols: int, rows: int,
                 "--", *harness_argv)
 
 
+#: Every environment variable name charter will ever put on a tmux command line, and the
+#: whole of it.
+#:
+#: **The list is the promise, and it lives HERE because this is the only place a `-e`
+#: is built.** #412 narrowed one call site (`session_argv`) and #446 was the other one
+#: (`respawn_argv`) still passing `dict(os.environ, …)` whole — the same defect, found a
+#: release apart, because the rule was enforced at the call sites rather than at the
+#: single funnel every call site goes through. :func:`_env_argv` refuses anything else
+#: outright, so the next call site cannot quietly leak the way that one did: a wide
+#: environment is a loud `ValueError` in the test that first builds it, not 7,773 bytes
+#: of `/proc/<pid>/cmdline` on somebody's laptop.
+#:
+#: Names, never a `CHARTER_` prefix glob, for `commands_frame._FRAME_IDENTITY`'s own
+#: reason: a prefix would keep the promise for a variable nobody has invented yet.
+#: `PATH` is the one non-charter name and `commands_frame._guest_harness_env` is where
+#: its measurement is written down. Nothing here is ever a credential — that is the
+#: property that makes an argv acceptable at all.
+CARRIABLE = frozenset({
+    "CHARTER_SESSION_ID", "CHARTER_HARNESS", "CHARTER_ROOT", "CHARTER_WORKSPACE",
+    "CHARTER_PERSONA", "PATH",
+})
+
+
 def _env_argv(env: dict[str, str] | None) -> list[str]:
     """`-e NAME=VALUE` per entry, sorted so the command is the same on every launch.
 
@@ -229,7 +267,19 @@ def _env_argv(env: dict[str, str] | None) -> list[str]:
     these are tmux's own options, not something to graft onto the program's argv. Empty
     for an empty (or absent) *env*, so a call that has nothing to carry produces exactly
     the command it always did.
+
+    **Every name must be in :data:`CARRIABLE`.** Raising is the point: the alternative —
+    dropping the extras quietly — would let a caller believe it had handed the harness a
+    variable that never arrived, and would make the leak this guard exists to stop
+    invisible rather than impossible. Only NAMES appear in the message; a value that does
+    not belong on a command line does not belong in a traceback either.
     """
+    unlisted = sorted(set(env or {}) - CARRIABLE)
+    if unlisted:
+        raise ValueError(
+            f"tmux `-e` may only carry {sorted(CARRIABLE)} — refusing "
+            f"{len(unlisted)} other name(s): {unlisted}. A `-e` is argv, and argv is "
+            "world-readable; see frame/layout.CARRIABLE")
     return [x for name in sorted(env or {}) for x in ("-e", f"{name}={env[name]}")]
 
 
@@ -282,13 +332,17 @@ def panel_argvs(*, slots: list[str], session: str, socket: str,
     correct that (an index would renumber under the very next split, same failure the
     module docstring already measures for the harness pane).
 
-    *env* is `-e`. On somebody else's server it carries the launcher's environment whole,
-    because a pane created there inherits THAT SERVER's — whatever their shell had when
-    they first ran `tmux`, possibly days ago and in another plane — and a panel resolves
-    the plane it draws (`config.STATE_DIR` among it) from its own.
+    *env* is `-e`, and it carries charter's identity and nothing else on EITHER server.
+    The sentence here used to say that on somebody else's server it "carries the
+    launcher's environment whole", and #446 is that sentence: a panel needs the plane it
+    draws stated (`$CHARTER_ROOT`, `$CHARTER_WORKSPACE` — it inherits that server's
+    otherwise, whatever their shell had when they first ran `tmux`), and it needs nothing
+    else. A panel starts no subprocess at all — `frame/gather.py`, `frame/slots.py` and
+    `frame/panel.py` are pure file and state reads — so it has no use for `$PATH` either,
+    and its own interpreter is already absolute (`panel_command`, #390).
 
-    **On charter's own server it carries charter's identity and nothing else, and the
-    sentence that used to be here was wrong.** It said the panels inherit the launcher's
+    **On charter's own server it carried charter's identity and nothing else already, and
+    the sentence that used to be here was wrong.** It said the panels inherit the launcher's
     environment "because `new-session` is what starts that server" — true of the launch
     that starts it and of no other (#411; see :func:`session_argv`). Every later frame's
     panels inherited the FIRST launcher's, and `$CHARTER_WORKSPACE` is the sharp one:

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -116,7 +116,12 @@ deaths in one frame's life is a broken panel, not a streak to start over. A pane
 been able to take the agent down with it; the hook is scoped to the panel's own pane, so it
 cannot reach the harness pane's hooks, which are what carry the agent's exit code. It works
 the same inside a tmux you already have — which it did not until recently: a panel that
-died there used to stay dead for the life of the frame.
+died there used to stay dead for the life of the frame. Making it work there needs one more
+thing than the hook, and it is the reason the first attempt at this changed nothing: tmux
+only runs a `pane-died` hook for a pane that died and *stayed*, and at tmux's default a pane
+whose program exits is destroyed along with its hook. Charter sets that one option on the
+**window it opened** and nowhere else, so panes in your own windows still close the way they
+always did.
 
 Charter never touches `~/.tmux.conf` — the frame's settings go into a private server of
 charter's own (`tmux -L charter`), one server shared by every frame on the machine, with
@@ -132,8 +137,11 @@ when the harness exits, charter closes the window, tmux puts you back where you 
 `charter claude` exits with the harness's own code.
 
 Charter is a guest there, and behaves like one — it writes **nothing** of yours. Not a
-server option, not a session option, not a key binding. That has costs, and they are the
-honest price of the sentence above:
+server option, not a session option, not a key binding. What it does write is scoped to the
+window it opened and the panes it created inside that window: those keep their dead panes so
+charter can read an exit code and bring a dead panel back. Your other windows are not
+touched by it, and the setting goes when the window does. That boundary has costs, and they
+are the honest price of the sentence above:
 
 - **Your scrollback limit and your mouse setting apply, not charter's.** `history-limit`
   and `mouse` are session options in tmux; setting them for the frame would set them for

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -114,7 +114,9 @@ that can help a failure like that, which is why it is the half that gets a retry
 The count is per slot, per frame, and is not reset by a respawn that appears to work: three
 deaths in one frame's life is a broken panel, not a streak to start over. A panel has never
 been able to take the agent down with it; the hook is scoped to the panel's own pane, so it
-cannot reach the harness pane's hooks, which are what carry the agent's exit code.
+cannot reach the harness pane's hooks, which are what carry the agent's exit code. It works
+the same inside a tmux you already have — which it did not until recently: a panel that
+died there used to stay dead for the life of the frame.
 
 Charter never touches `~/.tmux.conf` — the frame's settings go into a private server of
 charter's own (`tmux -L charter`), one server shared by every frame on the machine, with
@@ -143,6 +145,16 @@ honest price of the sentence above:
   entry is "Detach" and your own prefix key already does that better. The bottom panel
   drops its hotkey hint to match rather than advertising a key that does nothing.
 - **Your status bar stays.** The frame gets the window, not the screen.
+- **The harness inherits your tmux SERVER's environment, not your current shell's.**
+  Charter states its own five identity variables and `$PATH` on the pane it creates, and
+  nothing else. Anything you exported in the shell you typed `charter claude` in — a key
+  for this project, a `direnv` load, a `nvm use` — does not reach the harness; whatever
+  your environment held when you first started `tmux` does. It is the same thing that
+  already happens on charter's own server, and the reason is the same: a tmux `-e` is a
+  command line, and a command line is world-readable to every local user on Linux and
+  recorded permanently by process auditing. Charter will not put your environment there.
+  Export it in the pane the frame runs in, or start the harness from a shell inside the
+  frame, if the harness needs it.
 - **If `charter` itself is killed while the harness is running**, the harness keeps
   running and its window stays in your window list — close it with your own `prefix-&`.
   On charter's private server that same case is handled by a teardown hook; here a hook

--- a/docs/news/unreleased-a-panel-comes-back-in-your-own-tmux.md
+++ b/docs/news/unreleased-a-panel-comes-back-in-your-own-tmux.md
@@ -1,0 +1,40 @@
+---
+version: unreleased
+headline: A panel that dies inside the tmux you already have now comes back
+---
+
+Panels get their own `pane-died` hook and respawn with backoff — three attempts, then the
+dead pane and its message are left where you can read them. Inside your own tmux no hook
+was ever armed, so a panel that died there stayed dead for the life of the frame: no
+message, no respawn, no backoff. Only the frame drawn as a window in your server was
+affected; a plain terminal takes charter's private-server path, where this always worked.
+
+The reason it was not simply extended is worth recording, because it is the shape of bug
+that looks fixed in a diff. Both ends of the mechanism named charter's private server by
+hand — `tmux -L charter` — while your server is reached by socket **path**, `tmux -S …`.
+Arming the hook as written would have installed a `run-shell` pointing at a different tmux
+server: one that may not exist, or that may be another frame's. So it was backed out
+instead of guessed at.
+
+Both ends now ask the one function that already knows `-L` from `-S`, and `charter
+frame-respawn` resolves which server the frame is on from the frame's own record — asking
+about **windows** on your server and **sessions** on charter's, because a frame is a window
+in one and a session in the other. A server that does not answer at all is not treated as
+an empty one: charter declines to respawn rather than aim a command at a tmux it could not
+reach.
+
+The hook also carries what it needs on its own command line now — the interpreter and the
+frame id — rather than reading them back from tmux session variables. Those are set with
+`set-environment`, which charter does not write on a server it is a guest on, so there was
+no channel there at all (measured: a `run-shell` fired by a pane-scoped hook sees the
+session environment and not the pane's own).
+
+Which means charter's interpreter path is written into a string tmux later re-reads, and
+charter refuses to arm a hook whose path holds a character that would not survive that
+intact — saying so, rather than installing something that runs a command it did not mean. A
+path with a space, a `;` or an `&` is fine and was measured arriving byte for byte; one
+with `$( )` is not, and was measured executing. The first version of that check looked for
+quote characters and would have shipped: a hook action passes through **three** parsers,
+and the first is tmux's own `#{…}` format expansion — measured rewriting a literal
+`/opt/py#{pane_id}/x` into `/opt/py%1/x` before any shell saw it, with `#{pane_title}`
+expanding to text the program in that pane sets for itself. `#` is refused with the rest.

--- a/docs/news/unreleased-a-panel-comes-back-in-your-own-tmux.md
+++ b/docs/news/unreleased-a-panel-comes-back-in-your-own-tmux.md
@@ -23,6 +23,16 @@ in one and a session in the other. A server that does not answer at all is not t
 an empty one: charter declines to respawn rather than aim a command at a tmux it could not
 reach.
 
+An armed hook and a hook that can **fire** turned out to be two different claims, and the
+first round of this fix bought only the first. tmux runs `pane-died` for a pane that died
+and *stayed*; your tmux is at tmux's own default, where a pane whose program exits is
+destroyed on the spot and takes its own hook with it. So every argv was correct and nothing
+ever ran. Charter's private server never showed it, because that server has `remain-on-exit`
+set globally and every pane on it already stays. The frame's own window now keeps its dead
+panes — the window charter opened, and no other: your windows still close their panes the
+way they always did, and your server's setting is untouched. It is set once, before the
+first panel is split, so a panel that dies in its own first second is covered too.
+
 The hook also carries what it needs on its own command line now — the interpreter and the
 frame id — rather than reading them back from tmux session variables. Those are set with
 `set-environment`, which charter does not write on a server it is a guest on, so there was

--- a/docs/news/unreleased-a-panel-comes-back-in-your-own-tmux.md
+++ b/docs/news/unreleased-a-panel-comes-back-in-your-own-tmux.md
@@ -48,3 +48,15 @@ quote characters and would have shipped: a hook action passes through **three** 
 and the first is tmux's own `#{…}` format expansion — measured rewriting a literal
 `/opt/py#{pane_id}/x` into `/opt/py%1/x` before any shell saw it, with `#{pane_title}`
 expanding to text the program in that pane sets for itself. `#` is refused with the rest.
+
+The same treatment now covers the other three values that reach that text — the pane, the
+slot and the frame id — and each is checked against the shape tmux or charter actually
+mints rather than trusted for having come from a launch. What decides is the value, never
+where it came from: the second caller reads its pane ids and frame id back off **disk**,
+which is not tmux's own word for them any more.
+
+One neighbour is knowingly left for its own fix: the `window-resized` hook builds its
+action the same way and still trusts its caller for the pane ids in it, and on the
+density-change path one of those ids comes off disk unchecked
+([#475](https://github.com/diazoxide/charter/issues/475)). That is not new here — it
+predates this work and is unchanged by it.

--- a/docs/news/unreleased-your-environment-off-the-tmux-command-line.md
+++ b/docs/news/unreleased-your-environment-off-the-tmux-command-line.md
@@ -1,0 +1,45 @@
+---
+version: unreleased
+headline: Inside your own tmux, the frame no longer puts your whole environment on a tmux command line
+---
+
+To start the harness in a tmux server it does not own, charter uses `respawn-pane -e
+NAME=VALUE` — and it was passing **the whole environment**, one `-e` per variable.
+Measured on one real machine: 129 argv elements, 7,773 bytes, four live 1Password
+service-account tokens and an npm auth token. On Linux `/proc/<pid>/cmdline` is
+world-readable to every local user for as long as the tmux client runs, and exec-audit
+tooling records argv permanently. `charter claude` is the default command, so that was
+every launch from inside tmux.
+
+0.51.0 closed the same hole on charter's own private server and deliberately left this one
+open, for a stated reason: the environment this `-e` lands on belongs to a tmux server
+*you* started, possibly weeks ago, so charter stated everything rather than trust it.
+Measuring it is what settles it. Against tmux 3.7c:
+
+- A pane's `$PATH` is the one the tmux **client** that issued the command had — charter's,
+  the same `$PATH` charter resolved the harness binary against a moment earlier. An
+  explicit `-e PATH=…` does not even survive: tmux overwrites it after applying the `-e`
+  set.
+- Everything else a harness reads it reads for itself, out of a server environment that
+  belongs to the same person on the same machine.
+
+So the harness pane is now told six names — `CHARTER_SESSION_ID`, `CHARTER_HARNESS`,
+`CHARTER_ROOT`, `CHARTER_WORKSPACE`, `CHARTER_PERSONA` and `PATH` — and each panel pane the
+five identity ones. Named one at a time, never a `CHARTER_` prefix match, because the list
+is a promise about what appears in `/proc/<pid>/cmdline` and a prefix would keep that
+promise for a variable nobody has invented yet. `PATH` is on it as belt and braces: on this
+tmux the pane already has charter's, but no measurement says an older one does the same,
+and a harness that cannot be executed costs more than one argv pair that is never a
+credential.
+
+**The price, said plainly.** The harness inherits your tmux **server's** environment, not
+your current shell's. Something you exported in the pane you typed `charter claude` in — a
+key for this project, a `direnv` load, a `nvm use` — does not reach it. That was already
+true on charter's own server; it is now true on both. Export it inside the frame if the
+harness needs it. `docs/frame.md` lists it beside the other costs of charter being a guest
+in your tmux.
+
+The rule moved as well as the code. It used to live at each call site, which is exactly why
+one of the two was fixed a release ago and the other was not; it now lives in the single
+function that builds every `-e` charter emits, and an unlisted name is refused outright
+rather than carried.

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -1011,11 +1011,12 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         audit. Measured on a real environment, the full `_frame_env` came to 138 argv
         elements and 7,696 bytes carrying two live service-account tokens.
 
-        `_launch_in_operator_tmux` still passes the whole environment there, which is
-        #446 and out of scope — but new code may not reproduce it, and "out of scope"
-        is not a reason a keypress should start leaking an operator's tokens onto a
-        command line. Pinned with a sentinel that could only arrive by the whole
-        environment being handed over.
+        `_launch_in_operator_tmux` passed the whole environment there until #446 closed
+        it; `layout._env_argv` now refuses an unlisted name outright, so this cannot come
+        back at any call site. Pinned here as well with a sentinel that could only arrive
+        by the whole environment being handed over — the funnel's own guard is tested in
+        `tests/test_frame_layout.NothingUnnamedReachesACommandLine`, and this is the
+        keypress path actually reaching it.
 
         This is also what covers the launching pane's own identity: `TMUX`, `TMUX_PANE`,
         `COLUMNS` and `LINES` describe the pane `cmd_density` was FIRED in, and an equality
@@ -1054,15 +1055,24 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         self._run("full")
         self.assertTrue(menu.build(self.fid))
 
-    def test_a_new_pane_inside_an_operators_tmux_is_not_armed_for_respawn(self):
-        """`cmd_respawn` and `_panel_died_hook_argv` both assume `-L charter`, charter's
-        own server NAME. Arming a panel on the operator's server would install a hook
-        whose action targets the wrong tmux entirely — so it is refused there, and the
-        refusal now lives in `_arm_panel_respawn` rather than in where the loop happens to
-        sit, because a re-layout runs on either server."""
+    def test_a_new_pane_inside_an_operators_tmux_is_armed_against_that_server(self):
+        """#408. This used to assert the opposite — `_arm_panel_respawn` refused on the
+        operator's server, because `cmd_respawn` and `_panel_died_hook_argv` both spelled
+        `-L charter` by hand and would have aimed the hook at charter's private server.
+        Both build their argv through `tmuxctl.server_argv` now, so the pane IS armed and
+        the hook names the operator's socket by PATH.
+
+        The `-S` is what this asserts, not merely that some hook was installed: a hook
+        armed with `-L /private/tmp/…` would satisfy "a pane-died command was issued" and
+        still be the whole defect."""
         state.record_server(self.fid, "/private/tmp/tmux-502/default")
         _, fake = self._run("full")
-        self.assertFalse([c for c in fake.calls if "pane-died" in c], fake.calls)
+        armed = [c for c in fake.calls if "pane-died" in c and "-u" not in c]
+        self.assertEqual(len(armed), 2, fake.calls)
+        for cmd in armed:
+            self.assertEqual(cmd[:3],
+                             ["tmux", "-S", "/private/tmp/tmux-502/default"])
+            self.assertIn(f"--frame {self.fid}", cmd[-1])
 
     def test_a_new_pane_on_charters_own_server_is_armed_for_respawn(self):
         """The other direction, so the refusal above cannot be satisfied by never arming

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -450,42 +450,53 @@ class PanelRespawnHook(unittest.TestCase):
       into the harness pane and does not drop it into copy-mode even when the command
       it runs exits non-zero — the exact failure `conf_text`'s docstring records for
       the un-backgrounded form;
-    * the single-quoted inner command reaches `/bin/sh` with `$CHARTER_PY` unexpanded by
-      tmux, so the SHELL expands it, and `$CHARTER_SESSION_ID` is in that shell's
-      environment (`set-environment -t <session>`, already issued by `cmd_launch`);
+    * the single-quoted inner command reaches `/bin/sh` intact, and since #408 it carries
+      the interpreter and the frame id as TEXT rather than reading `$CHARTER_PY` and
+      `$CHARTER_SESSION_ID` back out of the environment — both of those are session
+      options, and `_launch_in_operator_tmux` writes none on a server it is a guest on
+      (measured: a `run-shell` fired by a pane-scoped hook sees the session environment
+      and does NOT see the pane's own `-e`);
     * the hook SURVIVES the `respawn-pane` it triggers, which is why an attempt count on
       disk is the only thing bounding the loop.
     """
+
+    def _argv(self, **kw):
+        """The real builder, with the arguments a launch would hand it."""
+        return commands_frame._panel_died_hook_argv(
+            **{"socket": "charter", "panel_pane": "%11", "slot": "top",
+               "fid": "demo-1234", **kw})
 
     def test_it_is_scoped_to_the_panel_pane_never_the_harness_pane(self):
         """`-p -t <panel pane>`: an unscoped (or session-scoped) `pane-died` hook fires
         for ANY pane, so it would respawn a panel every time the HARNESS died — and,
         worse, would be a second writer of the same option array the exit-code hooks
         live in."""
-        cmd = commands_frame._panel_died_hook_argv(socket="charter", panel_pane="%11",
-                                                   slot="top")
+        cmd = self._argv()
         self.assertIn("-p", cmd)
         self.assertEqual(cmd[cmd.index("-t") + 1], "%11")
         self.assertEqual(cmd[cmd.index("set-hook") + 1], "-p")
 
-    def test_the_action_names_the_slot_and_the_pane_it_must_bring_back(self):
-        action = commands_frame._panel_died_hook_argv(socket="charter", panel_pane="%11",
-                                                      slot="bottom")[-1]
+    def test_the_action_names_the_slot_the_pane_and_the_frame_it_must_bring_back(self):
+        action = self._argv(slot="bottom")[-1]
         self.assertIn("frame-respawn", action)
         self.assertIn("bottom", action)
         self.assertIn("%11", action)
+        self.assertIn("--frame demo-1234", action)
 
     def test_the_action_never_names_a_bare_charter_off_the_path(self):
         """The same trap `conf_text`'s own docstring measures for the hotkey bind: a
         bare `charter` resolves against the tmux SERVER's `$PATH`, which need not have
-        charter on it at all. The interpreter is carried out of band in
-        `$CHARTER_PY` (`_charter_py_env_argv`) and expanded by the shell this action
-        spawns — single-quoted, so tmux's own parsing leaves the `$` alone (verified
-        against 3.7c: `show-hooks` reads the action back with the dollar escaped and
-        the spawned shell receives the expanded path)."""
-        action = commands_frame._panel_died_hook_argv(socket="charter", panel_pane="%11",
-                                                      slot="top")[-1]
-        self.assertIn(f'"${tmuxctl.CHARTER_PY_ENV}" -m charter', action)
+        charter on it at all.
+
+        Since #408 the interpreter is written into the action rather than read back from
+        `$CHARTER_PY`: that variable is delivered by `set-environment -t <session>`, and
+        `_launch_in_operator_tmux` writes no session option at all, so on the operator's
+        own server the out-of-band channel does not exist. `util.self_relaunch_argv`'s
+        own bytes, `-P` and all, so a respawned panel cannot import a `charter/` package
+        that happens to sit in the pane's cwd (#390)."""
+        action = self._argv()[-1]
+        self.assertNotIn(f"${tmuxctl.CHARTER_PY_ENV}", action)
+        self.assertIn(f'"{sys.executable}" -P -m charter frame-respawn', action)
 
     def test_the_action_is_backgrounded_so_it_cannot_draw_in_the_harness_pane(self):
         """`run-shell -b`, not a bare `run-shell`. Un-backgrounded, tmux prints a
@@ -495,31 +506,108 @@ class PanelRespawnHook(unittest.TestCase):
         same failing command produced no output there at all (measured against 3.7c).
         This also matters because the command deliberately SLEEPS for its backoff: a
         blocking `run-shell` would stall tmux's command queue for seconds."""
-        action = commands_frame._panel_died_hook_argv(socket="charter", panel_pane="%11",
-                                                      slot="top")[-1]
+        action = self._argv()[-1]
         self.assertTrue(action.startswith("run-shell -b "), action)
 
     def test_it_is_a_clean_argv_list_naming_charters_own_socket(self):
-        cmd = commands_frame._panel_died_hook_argv(socket="charter", panel_pane="%11",
-                                                   slot="top")
+        cmd = self._argv()
         self.assertTrue(all(isinstance(a, str) for a in cmd))
         self.assertEqual(cmd[:4], ["tmux", "-L", "charter", "set-hook"])
 
+    def test_the_operators_socket_is_reached_by_path_and_never_by_name(self):
+        """#408's own defect, at the arming end. This function hand-built
+        `["tmux", "-L", socket, ...]`, so handed the operator's socket PATH it would have
+        aimed a `set-hook` at a SERVER NAMED by that path — one that does not exist, or
+        that tmux would start empty. `tmuxctl.server_argv` is the one place that knows
+        `-L` from `-S`, and asking it is what makes the two shapes impossible to disagree.
+        """
+        cmd = self._argv(socket="/private/tmp/tmux-502/default")
+        self.assertEqual(cmd[:4],
+                         ["tmux", "-S", "/private/tmp/tmux-502/default", "set-hook"])
+        self.assertNotIn("-L", cmd)
+
+    def test_an_interpreter_path_that_means_something_else_is_not_armed_at_all(self):
+        """The property, not a list of known-bad paths: the action is read by THREE
+        parsers before it is argv — tmux's format expansion, where `#{...}` is replaced;
+        tmux's command parser, where a single quote ends the action; and `/bin/sh`'s,
+        where `$`, backtick, backslash and `"` have meaning inside the `"..."` the
+        interpreter sits in — and a path carrying any of those says something else by the
+        end.
+
+        Measured against tmux 3.7c in every direction, which is what makes this a guard
+        rather than a formality: an interpreter under `.../plain $(touch CANARY) dir/py`
+        CREATED the canary, an action holding the literal `/opt/py#{pane_id}/x` reached
+        the shell as `/opt/py%1/x`, and one under
+        `.../a b;c&d(e)f*g-h,i=j+k@l:m[n]o{p}q!r%s^t~u/fake py` — every other ASCII
+        punctuation character plus a space — arrived byte for byte.
+
+        Written against the CONSTANT rather than a list of its own, and the `#` case is
+        why: a first version of this guard named itself after quotes, looked only for
+        quote characters, and let a whole parser through. A test carrying its own copy of
+        the set would have agreed with it.
+        """
+        safe = "/opt/a b;c&d(e)f*g-h,i=j+k@l:m[n]o{p}q!r%s^t~u/py"
+        with mock.patch("charter.commands_frame.util.self_relaunch_argv",
+                        side_effect=lambda *a: [safe, "-P", "-m", "charter", *a]):
+            self.assertIsNotNone(self._argv())
+        for meta in commands_frame._ACTION_METACHARACTERS + "\n\x7f":
+            hostile = f"/opt/py{meta}x/python3"
+            with mock.patch("charter.commands_frame.util.self_relaunch_argv",
+                            side_effect=lambda *a, h=hostile: [h, "-P", "-m", "charter", *a]):
+                self.assertIsNone(self._argv(),
+                                  f"an interpreter path holding {meta!r} was armed")
+
+    def test_the_format_parser_is_one_of_the_three_this_guards_against(self):
+        """Named on its own, because it is the parser a guard written from the word
+        "quote" does not think of — and the one with the sharpest edge.
+        `#{pane_title}` expands to text the program running in that pane sets for ITSELF
+        with an escape sequence, so a path reaching the action unfiltered would put a
+        value under somebody else's control into a command line charter then runs.
+
+        A bare `#` is refused, not only `#{`: `##` is tmux's own escape for a literal
+        `#`, so the sequences that matter are not one character wide, and charter has
+        nothing to gain from arming a path with a `#` in it."""
+        self.assertIn("#", commands_frame._ACTION_METACHARACTERS)
+        for hostile in ("/opt/py#{pane_title}/python3", "/opt/py##/python3",
+                        "/opt/py#/python3"):
+            with mock.patch("charter.commands_frame.util.self_relaunch_argv",
+                            side_effect=lambda *a, h=hostile: [h, "-P", "-m", "charter", *a]):
+                self.assertIsNone(self._argv(), hostile)
+
+    def test_a_pane_a_slot_or_a_frame_id_that_is_not_charters_own_is_not_armed(self):
+        """Every value that reaches the action text is checked HERE, not trusted for
+        having come from `cmd_launch`. `_arm_panel_respawn` has a second caller
+        (`_relayout`) whose pane ids and frame id are read back off DISK, which is not
+        tmux's own word for them any more."""
+        self.assertIsNone(self._argv(panel_pane="%11; kill-server"))
+        self.assertIsNone(self._argv(panel_pane="all"))
+        self.assertIsNone(self._argv(slot="top; kill-server"))
+        self.assertIsNone(self._argv(fid="demo-1234 ; kill-server"))
+        self.assertIsNone(self._argv(fid=""))
+
 
 class _RespawnTmux:
-    """A tmux that answers only what `cmd_respawn` asks: is the session still live, and
-    did the pane come back."""
+    """A tmux that answers only what `cmd_respawn` asks: is the frame still live, and
+    did the pane come back.
 
-    def __init__(self, *, live=("f-1",), respawn_rc=0):
+    Both liveness questions, because a frame is a SESSION on charter's own server and a
+    WINDOW on the operator's (#408) — and `list_rc` is how a test says "that server did
+    not answer at all", which `_live_windows` reports as ``None`` and `_frame_is_live`
+    must read as "do not respawn".
+    """
+
+    def __init__(self, *, live=("f-1",), respawn_rc=0, list_rc=0):
         self.live = list(live)
         self.respawn_rc = respawn_rc
+        self.list_rc = list_rc
         self.calls: list[list[str]] = []
 
     def __call__(self, cmd, **kwargs):
         self.calls.append(list(cmd))
-        if "list-sessions" in cmd:
-            return subprocess.CompletedProcess(cmd, 0, stdout="\n".join(self.live),
-                                               stderr="")
+        if "list-sessions" in cmd or "list-windows" in cmd:
+            return subprocess.CompletedProcess(
+                cmd, self.list_rc,
+                stdout="\n".join(self.live) if self.list_rc == 0 else "", stderr="")
         if "respawn-pane" in cmd:
             return subprocess.CompletedProcess(cmd, self.respawn_rc, stdout="",
                                                stderr="" if self.respawn_rc == 0
@@ -530,10 +618,18 @@ class _RespawnTmux:
     def respawns(self):
         return [c for c in self.calls if "respawn-pane" in c]
 
+    @property
+    def liveness(self):
+        return [c for c in self.calls
+                if "list-sessions" in c or "list-windows" in c]
 
-def _respawn(fake, *, slot="bottom", pane="%11", fid="f-1", slept=None):
-    args = SimpleNamespace(slot=slot, pane=pane)
-    env = {"CHARTER_SESSION_ID": fid} if fid is not None else {}
+
+def _respawn(fake, *, slot="bottom", pane="%11", fid="f-1", slept=None, on_argv=False):
+    """*on_argv* puts the frame id on `--frame` (the hook #408 installs) instead of in
+    `$CHARTER_SESSION_ID` (the hook a charter before it installed)."""
+    args = SimpleNamespace(slot=slot, pane=pane,
+                           frame=fid if on_argv else None)
+    env = {} if on_argv or fid is None else {"CHARTER_SESSION_ID": fid}
     with mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
          mock.patch.dict(os.environ, env, clear=True), \
          mock.patch("charter.commands_frame.time.sleep",
@@ -676,6 +772,66 @@ class Respawn(PersonaIso, unittest.TestCase):
         fake = _RespawnTmux()
         with mock.patch("charter.frame.state.respawn_attempt", return_value=None):
             rc = _respawn(fake)
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.respawns, [])
+
+    # -- #408: which server this is talking to ------------------------------------- #
+
+    def test_the_frame_id_may_arrive_on_the_argv_with_no_environment_at_all(self):
+        """The hook #408 installs passes `--frame`, because on the operator's own tmux
+        there is no `$CHARTER_SESSION_ID` to read: that variable is a session option
+        (`_session_id_env_argv`) and `_launch_in_operator_tmux` writes none there.
+        `clear=True` in `_respawn` is what makes this mean something — the environment
+        really is empty, so a fallback read could not accidentally supply it."""
+        fake = _RespawnTmux()
+        rc = _respawn(fake, on_argv=True)
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(fake.respawns), 1, fake.calls)
+
+    def test_a_frame_recorded_on_the_operators_socket_is_reached_by_path(self):
+        """#408's other half. `cmd_respawn` hardcoded `["tmux", "-L", SOCKET, …]` and
+        `_live_sessions(SOCKET)`, so a hook fired inside the operator's tmux asked
+        charter's PRIVATE server whether a session it never had was alive — always no —
+        and would have aimed the respawn at that server too. Both now come from
+        `state.frame_server`.
+
+        Asserts the SHAPE of both commands, not just that a respawn happened: `-L
+        /private/tmp/…` would still be a `respawn-pane` and would still be the bug."""
+        state.record_server("f-1", "/private/tmp/tmux-502/default")
+        fake = _RespawnTmux()
+        rc = _respawn(fake, on_argv=True)
+        self.assertEqual(rc, 0)
+        self.assertEqual([c[:3] for c in fake.liveness],
+                         [["tmux", "-S", "/private/tmp/tmux-502/default"]], fake.calls)
+        self.assertIn("list-windows", fake.liveness[0],
+                      "a frame in the operator's tmux is a WINDOW; `list-sessions` "
+                      "there asks about sessions that are all theirs")
+        self.assertEqual(len(fake.respawns), 1, fake.calls)
+        self.assertEqual(fake.respawns[0][:3],
+                         ["tmux", "-S", "/private/tmp/tmux-502/default"])
+
+    def test_a_frame_on_charters_own_server_is_still_reached_by_name(self):
+        """The other direction, so the test above cannot be satisfied by a `-S` for
+        everything: charter's own server is a NAME and `list-sessions` is the right
+        question there."""
+        fake = _RespawnTmux()
+        _respawn(fake, on_argv=True)
+        self.assertEqual(fake.liveness[0][:3], ["tmux", "-L", commands_frame.SOCKET])
+        self.assertIn("list-sessions", fake.liveness[0])
+        self.assertEqual(fake.respawns[0][:3], ["tmux", "-L", commands_frame.SOCKET])
+
+    def test_an_operators_server_that_does_not_answer_is_not_respawned_into(self):
+        """`_live_windows` answers `None` when the server did not answer at all, which
+        is a different fact from "it answered, and this frame is not on it" — `$TMUX`
+        outlives a killed server often enough that `_launch_in_operator_tmux` branches on
+        it. A respawn is the operation with a cost here, so no answer means no respawn.
+
+        Without this the empty stdout of a FAILED `list-windows` would read as "no
+        windows", which is the same shape as a torn-down frame and would look like it
+        passed for the wrong reason — hence `list_rc`, not an empty live list."""
+        state.record_server("f-1", "/private/tmp/tmux-502/default")
+        fake = _RespawnTmux(live=("f-1",), list_rc=1)
+        rc = _respawn(fake, on_argv=True)
         self.assertEqual(rc, 0)
         self.assertEqual(fake.respawns, [])
 
@@ -3395,11 +3551,97 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
         """`$TMUX`/`$TMUX_PANE` describe the pane charter was TYPED in, and tmux sets
         both itself for the pane it creates. Carrying the launcher's own values across
         would tell the harness it is running in a pane it is not — the identity
-        collision `_PANE_ID_VARS` and `WINDOWID` were argued about for."""
+        collision `_PANE_ID_VARS` and `WINDOWID` were argued about for.
+
+        Since #446 nothing unnamed reaches this argv at all, so these two could not
+        arrive whether or not `_frame_env` pops them. Kept as the statement of the
+        property rather than of the mechanism: the day a name is added to
+        `layout.CARRIABLE`, this is what says these two are still not it."""
         fake = _FakeOperatorTmux(exit_code=0)
         _launch_inside(fake)
         self.assertNotIn("TMUX", fake.respawn_env)
         self.assertNotIn("TMUX_PANE", fake.respawn_env)
+
+    def test_the_harness_pane_is_told_charters_path_and_no_other_name(self):
+        """#446. This argv carried `dict(os.environ, …)` whole — measured on one real
+        environment at 129 elements, 7,773 bytes, four live 1Password service-account
+        tokens and an npm auth token, into `/proc/<pid>/cmdline`.
+
+        `$PATH` is the one name beyond the frame's identity, and it is here for a reason
+        the private-server path does not have: `cmd_launch` resolved the harness binary
+        with `shutil.which` against charter's OWN `$PATH`, while the base this `-e`
+        overlays is a server the OPERATOR started, possibly weeks ago. (Measured against
+        tmux 3.7c, a pane's `$PATH` is the invoking client's regardless — so on that tmux
+        this is redundant rather than load-bearing. It is carried because no measurement
+        says an older tmux does the same, and a harness that cannot be executed costs
+        more than one argv pair that is never a credential.)
+
+        The sentinel is what makes this fail if the whole environment comes back: it is
+        a name nothing in `layout.CARRIABLE` matches, under a `CHARTER_` prefix so a glob
+        would carry it."""
+        fake = _FakeOperatorTmux(exit_code=0)
+        with mock.patch.dict(os.environ, {"CHARTER_BRIDGE_TOKEN": "SENTINEL-0xC0FFEE",
+                                          "PATH": "/charters/own/bin"}):
+            _launch_inside(fake)
+        self.assertEqual(fake.respawn_env.get("PATH"), "/charters/own/bin")
+        self.assertNotIn("CHARTER_BRIDGE_TOKEN", fake.respawn_env)
+        self.assertEqual(sorted(fake.respawn_env),
+                         sorted([*commands_frame._FRAME_IDENTITY, "PATH"]),
+                         "the harness pane was told a name charter did not choose")
+        # And nowhere else in the launch either — `-e` is the channel this was leaking
+        # through, but the assertion worth making is about the argv, not the channel.
+        # A filtered report: the whole of these calls is exactly what must not be printed.
+        leaked = [c[3] for c in fake.calls if "SENTINEL-0xC0FFEE" in " ".join(c)]
+        self.assertEqual(leaked, [],
+                         f"a decoy value reached the command line of: {leaked}")
+
+    def test_a_charter_with_no_path_states_none_rather_than_an_empty_one(self):
+        """`-e PATH=` would hand the pane an EMPTY `$PATH`, which is strictly worse than
+        letting it inherit the server's: nothing off a path would run at all. Charter
+        with no `$PATH` of its own has nothing to say here."""
+        fake = _FakeOperatorTmux(exit_code=0)
+        env = {k: v for k, v in os.environ.items() if k != "PATH"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            _launch_inside(fake)
+        self.assertNotIn("PATH", fake.respawn_env)
+
+    def test_a_panel_here_is_told_the_frames_identity_and_nothing_more(self):
+        """The other `-e` on this path, and it was the whole environment too. A panel
+        starts no subprocess (`frame/gather.py`, `frame/slots.py`, `frame/panel.py` are
+        file and state reads) and its own interpreter is absolute (#390), so unlike the
+        harness pane it has no use for `$PATH` either — which is why this asserts the
+        five identity names exactly, not the six the harness gets."""
+        fake = _FakeOperatorTmux(exit_code=0)
+        with mock.patch.dict(os.environ, {"CHARTER_BRIDGE_TOKEN": "SENTINEL-0xC0FFEE"}), \
+             mock.patch.dict(config.FRAME, {"slots": ["top"]}):
+            _launch_inside(fake)
+        splits = [c for c in fake.calls if "split-window" in c]
+        self.assertTrue(splits, fake.calls)
+        for cmd in splits:
+            carried = {cmd[i + 1].split("=", 1)[0]
+                       for i, a in enumerate(cmd) if a == "-e"}
+            self.assertEqual(sorted(carried), sorted(commands_frame._FRAME_IDENTITY),
+                             "a panel pane was told a name charter did not choose")
+
+    def test_a_panel_here_is_armed_to_come_back_if_it_dies(self):
+        """#408 — a panel that died inside the operator's own tmux stayed dead for the
+        life of the frame: `_arm_panel_respawn` refused there, because both ends of the
+        respawn mechanism spelled `-L charter` by hand.
+
+        Asserts the argv SHAPE, not merely that something was armed: a `set-hook` sent to
+        `-L /private/tmp/…` is still a `set-hook` and is the entire defect."""
+        fake = _FakeOperatorTmux(exit_code=0, panel_pane_ids={"top": "%9"})
+        with mock.patch.dict(config.FRAME, {"slots": ["top"]}):
+            _launch_inside(fake)
+        armed = [c for c in fake.calls
+                 if "set-hook" in c and any("frame-respawn" in a for a in c)]
+        # A filtered projection, never `fake.calls`: this path's argv now carries
+        # `$PATH`, and a failure message is not a place to print an environment.
+        self.assertEqual(len(armed), 1,
+                         [c[3] for c in fake.calls if len(c) > 3])
+        self.assertEqual(armed[0][:3], ["tmux", "-S", OPERATOR_SOCKET])
+        self.assertEqual(armed[0][armed[0].index("-t") + 1], "%9")
+        self.assertIn(f"--frame {_frame_id()}", armed[0][-1])
 
     def test_the_frames_state_is_reaped_against_the_operators_server(self):
         """A frame here is a window on their socket and appears in no `tmux -L charter
@@ -3545,13 +3787,17 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
                              "every split targets the harness pane's id — tmux "
                              "renumbers indices on each one")
 
-    def test_the_panels_get_charters_own_environment_too(self):
+    def test_the_panels_get_charters_own_identity_too(self):
         """Not only the harness. A panel resolves the plane it draws — `config.STATE_DIR`
         among it — from its own environment, and a pane on the operator's server inherits
         THEIR tmux server's, which may predate this plane entirely. Left unfixed, a panel
         inside their tmux drew a different plane's numbers from the harness beside it,
         and (measured by hand) `frame/slots.py` could not find this frame's own server
-        marker, so the bottom row went on advertising a hotkey charter had not bound."""
+        marker, so the bottom row went on advertising a hotkey charter had not bound.
+
+        "charter's own ENVIRONMENT" is what this said until #446, and it was the defect
+        rather than the fix: the whole of it travelled. Which names travel is asserted
+        next door; this is the one that says the values are the FRAME's."""
         fake = _FakeOperatorTmux(exit_code=0, panel_pane_ids={"top": "%8"})
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "stale-sentinel"}):
             _launch_inside(fake)

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1313,6 +1313,22 @@ class _FakeTmux:
         raise AssertionError(f"unexpected tmux command in test: {cmd}")
 
 
+def _arms_remain_on_exit(cmd: list[str], scope: str) -> bool:
+    """Is *cmd* an arming of `remain-on-exit` at *scope* (`-g`, `-w` or `-p`)?
+
+    Charter issues this option at three scopes for three different reasons — the whole
+    server (`_PLACEHOLDER_CONF`'s backstop), the frame's own window (`_split_panels`, so
+    a dead panel is still there for its hook to fire from) and the harness pane alone
+    (`_remain_on_exit_argv`) — and a test that matched the bare STRING would be answered
+    by whichever of the three happened to run. The scope is the fact each of those tests
+    is about, so it is what gets matched, and the value is checked too: `off` is also a
+    command with `remain-on-exit` in it.
+    """
+    return (scope in cmd and "remain-on-exit" in cmd
+            and cmd[cmd.index("remain-on-exit") + 1:cmd.index("remain-on-exit") + 2]
+            == ["on"])
+
+
 def _outside_tmux():
     """Say, explicitly, that this launch is NOT happening inside somebody's tmux.
 
@@ -1701,17 +1717,48 @@ class Launch(PersonaIso, unittest.TestCase):
         fake = _FakeTmux(exit_code=0, pre_existing_sessions=frozenset({"someone-elses"}))
         rc = _launch(fake)
         self.assertEqual(rc, 0)
-        self.assertTrue(any("remain-on-exit" in c for c in fake.calls),
+        self.assertTrue(any(_arms_remain_on_exit(c, "-g") for c in fake.calls),
                         "remain-on-exit was not armed directly ahead of a running server")
 
     def test_remain_on_exit_is_not_armed_a_second_way_on_a_fresh_server(self):
         """Companion: when nothing else is running, the placeholder `-f` is sufficient
-        (it IS what starts the server), so the direct arm command should not run —
+        (it IS what starts the server), so the direct SERVER-WIDE arm should not run —
         pinning that the condition is actually checked, not that running it twice would
-        itself be wrong."""
+        itself be wrong.
+
+        Scoped to `-g`, and that is the whole subject. `_split_panels` arms
+        `remain-on-exit` on the frame's own WINDOW on every launch on either server
+        (#408: a panel pane destroyed at death takes its respawn hook with it), which is
+        a different command answering a different question — the test below pins that it
+        runs here, so narrowing this one to `-g` gives nothing away."""
         fake = _FakeTmux(exit_code=0)  # pre_existing_sessions defaults to empty
         _launch(fake)
-        self.assertFalse(any("remain-on-exit" in c for c in fake.calls))
+        self.assertFalse(any(_arms_remain_on_exit(c, "-g") for c in fake.calls),
+                         "the server-wide arm ran on a server the placeholder started")
+
+    def test_the_frames_own_window_keeps_its_dead_panes_on_either_server(self):
+        """#408's second half, on charter's OWN server — where it is redundant and is
+        issued anyway.
+
+        `_PLACEHOLDER_CONF` already sets `remain-on-exit` server-globally here, so this
+        command changes nothing on this path. It is unconditional because the ALTERNATIVE
+        is the defect: a rule applied per call site is what left the operator's server
+        arming one of two panes' worth of state, twice now (#412 then #446 for `-e`, #408
+        for this). One funnel, one rule, on every server — and on this one it is also the
+        backstop for the case the launcher already knows about, where `-f` is silently
+        ignored because some other charter started the server first.
+
+        The pane it names is the harness pane the launcher read off `new-session`'s own
+        stdout, never a hardcoded `%0` — so a launcher that armed the wrong window would
+        show up here."""
+        fake = _FakeTmux(exit_code=0)
+        self.assertEqual(_launch(fake), 0)
+        armed = [c for c in fake.calls if _arms_remain_on_exit(c, "-w")]
+        self.assertEqual(len(armed), 1,
+                         f"expected exactly one window-scoped arm, got {len(armed)}")
+        self.assertEqual(armed[0][armed[0].index("-t") + 1], fake.pane_id,
+                         "the frame's window was named by something other than the pane "
+                         "id tmux reported for this launch")
 
     def test_a_still_live_session_after_attach_is_a_detach_not_a_silent_zero(self):
         """The spec's own words: "Detach is allowed and prints how to reattach...
@@ -3475,15 +3522,46 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
         self.assertEqual(respawn[respawn.index("--") + 1:], ["claude"])
 
     def test_the_pane_is_kept_askable_before_the_harness_can_exit(self):
+        """Matched on the PANE scope, not on the string: charter arms `remain-on-exit`
+        twice on this path now (`-p` on the harness pane here, `-w` on the frame's own
+        window when the panels are drawn — #408), and a `next(... if "remain-on-exit" in
+        c)` would silently start answering about whichever came first."""
         fake = _FakeOperatorTmux(exit_code=0)
         _launch_inside(fake)
-        arm = next(i for i, c in enumerate(fake.calls) if "remain-on-exit" in c)
+        arm = next(i for i, c in enumerate(fake.calls)
+                   if _arms_remain_on_exit(c, "-p"))
         respawn = next(i for i, c in enumerate(fake.calls) if "respawn-pane" in c)
         self.assertLess(arm, respawn,
                         f"remain-on-exit must be armed first: {fake.calls}")
         armed = fake.calls[arm]
-        self.assertIn("-p", armed, "pane-scoped, never the operator's own -g or session")
         self.assertEqual(armed[armed.index("-t") + 1], "%7")
+
+    def test_a_dead_panel_is_still_there_for_its_hook_to_fire_from(self):
+        """#408's second half on the guest path, at the launcher's own level: the
+        respawn hook is armed on each panel PANE, and tmux runs a `pane-died` hook only
+        for a pane that died and stayed. At the operator's default the pane is destroyed
+        and takes the hook with it, so an armed hook that never fires is what the first
+        round of this fix shipped.
+
+        Ordered BEFORE the first `split-window`, and that is the assertion rather than a
+        detail: a pane option cannot be set on a pane that does not exist yet, so a panel
+        that dies in its own first milliseconds is only covered if the WINDOW was armed
+        ahead of it."""
+        fake = _FakeOperatorTmux(exit_code=0)
+        _launch_inside(fake)
+        # Positions and the option's own argv only — never `fake.calls`, which carries a
+        # `respawn-pane -e PATH=…` holding the whole of this machine's `$PATH`.
+        armed = [i for i, c in enumerate(fake.calls) if _arms_remain_on_exit(c, "-w")]
+        self.assertEqual(len(armed), 1, "expected exactly one window-scoped arm, "
+                                        f"got {len(armed)}")
+        cmd = fake.calls[armed[0]]
+        self.assertEqual(cmd[cmd.index("-t") + 1], "%7",
+                         "the window was named through a pane that is not the harness's")
+        splits = [i for i, c in enumerate(fake.calls) if "split-window" in c]
+        self.assertTrue(splits, "no panel was drawn, so this test measured nothing")
+        self.assertLess(armed[0], splits[0],
+                        f"the first panel was split (call {splits[0]}) before its window "
+                        f"was armed to keep it (call {armed[0]})")
 
     def test_nothing_of_the_operators_is_written(self):
         """Their config untouched, in the spec's own words. Every one of these would

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -574,16 +574,94 @@ class PanelRespawnHook(unittest.TestCase):
                             side_effect=lambda *a, h=hostile: [h, "-P", "-m", "charter", *a]):
                 self.assertIsNone(self._argv(), hostile)
 
-    def test_a_pane_a_slot_or_a_frame_id_that_is_not_charters_own_is_not_armed(self):
-        """Every value that reaches the action text is checked HERE, not trusted for
-        having come from `cmd_launch`. `_arm_panel_respawn` has a second caller
-        (`_relayout`) whose pane ids and frame id are read back off DISK, which is not
-        tmux's own word for them any more."""
-        self.assertIsNone(self._argv(panel_pane="%11; kill-server"))
-        self.assertIsNone(self._argv(panel_pane="all"))
-        self.assertIsNone(self._argv(slot="top; kill-server"))
-        self.assertIsNone(self._argv(fid="demo-1234 ; kill-server"))
+    def _refused_by_the_guard_under_test(self, **kw):
+        """*kw* is not armed — and no OTHER clause of the guard could have been what
+        refused it.
+
+        Asserting the reason, not the status. `_panel_died_hook_argv` refuses on four
+        separate clauses, and a hostile value that trips several of them tests none of
+        them: delete the clause the case is named for and the case still passes, because
+        a different one caught it. So every value handed here is checked to be a single
+        bare word (nothing for the bare-word clause to refuse) that passes
+        :func:`_action_word_is_safe` (nothing for the metacharacter clause to refuse),
+        which leaves only the shape guard the case is about.
+        """
+        self.assertIsNone(self._argv(**kw), kw)
+        for value in kw.values():
+            self.assertEqual(value.split(), [value],
+                             f"{value!r} is not one bare word, so the bare-word clause "
+                             "would refuse it whichever guard this case is about")
+            self.assertTrue(commands_frame._action_word_is_safe(value),
+                            f"{value!r} holds an _ACTION_METACHARACTERS character, so "
+                            "that clause would refuse it whichever guard this is about")
+
+    def test_a_pane_that_is_not_tmuxs_own_word_for_a_pane_is_not_armed(self):
+        """`_arm_panel_respawn` has a second caller (`_relayout`) whose pane ids are read
+        back off DISK, which is not tmux's own `-P -F '#{pane_id}'` any more.
+
+        `%11;kill-server` is the whole point of the shape check: `;` is a tmux command
+        separator and is NOT in `_ACTION_METACHARACTERS`, which is the complete set of
+        characters that change what the text SAYS on the way to `/bin/sh` — a `;` inside
+        the single-quoted action is literal, so nothing else in this function objects to
+        it. Only "that is not a pane id" does.
+        """
+        for hostile in ("all", "%11;kill-server", "%11x", "11", "%"):
+            self._refused_by_the_guard_under_test(panel_pane=hostile)
+        self.assertIsNone(self._argv(panel_pane=""))
+
+    def test_a_pane_id_of_unicode_digits_is_not_tmuxs_own_and_is_not_armed(self):
+        """The property is "tmux's own `%<digits>`", and Python's `\\d` is not that:
+        `re.fullmatch(r"%\\d+", "%١٢")` matches, as does the fullwidth `%１１`. tmux has
+        never minted either. Neither is dangerous by itself — a Unicode digit means
+        nothing to any of the three parsers — which is exactly why the class was `\\d`
+        for as long as it was: nothing failed. Pinned so the next reader cannot widen it
+        back by writing the shorthand."""
+        for hostile in ("%١٢", "%１１", "%۵"):
+            self._refused_by_the_guard_under_test(panel_pane=hostile)
+
+    def test_a_slot_that_is_not_one_of_charters_own_is_not_armed(self):
+        """A key of `frame_slots.SLOTS`, checked rather than assumed: the slot is
+        interpolated into the action as a bare word, and `_relayout` reads it back off
+        disk."""
+        for hostile in ("top;kill-server", "middle", "TOP", "top."):
+            self._refused_by_the_guard_under_test(slot=hostile)
+        self.assertIsNone(self._argv(slot=""))
+
+    def test_a_frame_id_outside_the_alphabet_state_mints_is_not_armed(self):
+        """`_FRAME_ID_RE` is `frame.state._UNSAFE`'s complement, asked here rather than
+        assumed: the id reaching this function may have come from `$CHARTER_SESSION_ID`
+        or off disk rather than from `state.frame_id`, and `cmd_respawn` reads it back
+        off the argv this action carries.
+
+        Measured on a real tmux 3.7c with this guard widened to `re.compile(r".+")`, and
+        with a frame id holding NO whitespace at all so that no other clause could have
+        stood in for it: `fid='demo-1;>/…/CANARY'` armed the `pane-died` hook, the panel
+        pane died, and the canary FILE EXISTED — tmux keeps the `;` literal inside the
+        action's single quotes and hands the whole string to `/bin/sh`, which does not.
+        As shipped the same input is not armed at all and no canary appears. So this is
+        a guard and not a formality, and `;` is the shape of the attack even though
+        `_ACTION_METACHARACTERS` correctly does not list it."""
+        for hostile in ("demo-1;kill-server", "demo/1", "demo:1", "demo|1"):
+            self._refused_by_the_guard_under_test(fid=hostile)
         self.assertIsNone(self._argv(fid=""))
+
+    def test_a_word_after_the_interpreter_that_is_not_one_bare_word_is_not_armed(self):
+        """The fourth clause, and the only one no argument of this function can reach:
+        every word after `words[0]` goes into the action UNQUOTED, so a word carrying a
+        space is two words by the time tmux parses the command line. The three shape
+        guards above already forbid whitespace in the pane, slot and frame id, so this
+        one is reached only through `util.self_relaunch_argv` itself — which is where it
+        has to live, because `words[0]` is the ONE word allowed a space (it is inside
+        `"…"`) and the rule is different on either side of that boundary.
+
+        Mocked for that reason and not for convenience, with the positive control beside
+        it: the same argv without the space IS armed, so what this pins is the space and
+        not the mock."""
+        for argv1, armed in ((["-P", "-m", "charter x"], False),
+                             (["-P", "-m", "charter"], True)):
+            with mock.patch("charter.commands_frame.util.self_relaunch_argv",
+                            side_effect=lambda *a, w=argv1: [sys.executable, *w, *a]):
+                self.assertEqual(self._argv() is not None, armed, argv1)
 
 
 class _RespawnTmux:

--- a/tests/test_frame_layout.py
+++ b/tests/test_frame_layout.py
@@ -332,9 +332,11 @@ class WindowInTheOperatorsServer(unittest.TestCase):
         reach the harness, and would also hand every new shell they open a frame id
         that is not theirs.
 
-        Measured against tmux 3.7c: `respawn-pane -e` REPLACES the pane's environment
-        rather than adding to what `new-window -e` set, so everything the harness needs
-        has to be on this call, not the one that made the window."""
+        Re-measured against tmux 3.7c, correcting what this docstring used to claim:
+        `respawn-pane -e` does NOT replace the pane's environment, it OVERLAYS it — a
+        server holding `FOO`/`BAZ`, respawned with only `-e BAR=`, produced a pane with
+        all three. That is why this call may carry a named few rather than everything
+        (#446, `commands_frame._guest_harness_env`)."""
         cmd = layout.respawn_argv(socket="/s", harness_pane="%7", cwd="/work/repo",
                                   env={"CHARTER_SESSION_ID": "demo-1",
                                        "CHARTER_HARNESS": "claude-code"},
@@ -391,6 +393,92 @@ class ServerSelection(unittest.TestCase):
         cmds = layout.panel_argvs(slots=["top"], session="f", socket="/tmp/tmux-1/default",
                                   harness_pane="%3")
         self.assertEqual(cmds[0][:3], ["tmux", "-S", "/tmp/tmux-1/default"])
+
+
+class NothingUnnamedReachesACommandLine(unittest.TestCase):
+    """#446 — a tmux `-e` is argv, and argv is not private.
+
+    #412 narrowed `session_argv`'s `-e` to a named list and left `respawn_argv`'s
+    passing `dict(os.environ, …)` whole, because the rule lived at the CALL SITES. The
+    same defect, twice, a release apart. So the rule moved to the one funnel every `-e`
+    in charter goes through (`layout._env_argv`), and these are that funnel's tests:
+    a value that has no business on a command line cannot get onto one from ANY caller,
+    including one written next month.
+
+    Never a real credential in a fixture, and never an assertion that prints a whole
+    environment: the decoy below is a synthetic string and the failure messages name
+    only which builder leaked it.
+    """
+
+    #: A value no environment could produce by accident, so "it did not appear" is a
+    #: fact about the builder rather than about the string being unlikely.
+    DECOY = "decoy-value-9f2c1b-must-never-reach-argv"
+
+    def _hostile_env(self):
+        """One decoy under every spelling this guard could plausibly be written to miss.
+
+        `CHARTER_SOMETHING` is the sharp one: a `CHARTER_`-prefix glob — the shape the
+        allowlist deliberately is NOT — would carry it happily, and it is exactly how a
+        variable invented next release gets onto a command line nobody re-reviewed.
+        """
+        return {
+            "CHARTER_SESSION_ID": "demo-1",
+            "OP_SERVICE_ACCOUNT_TOKEN": self.DECOY,
+            "CHARTER_BRIDGE_TOKEN": self.DECOY,
+            "charter_session_id": self.DECOY,
+            "CHARTER_SESSION_ID_EXTRA": self.DECOY,
+            "SSH_AUTH_SOCK": self.DECOY,
+            "": self.DECOY,
+        }
+
+    def _builders(self, env):
+        return {
+            "respawn_argv": lambda: layout.respawn_argv(
+                socket="/tmp/tmux-1/default", harness_pane="%7", env=env, cwd="/w",
+                harness_argv=["claude"]),
+            "session_argv": lambda: layout.session_argv(
+                session="f", conf="/c", socket="charter", cols=80, rows=24,
+                harness_argv=["claude"], env=env),
+            "panel_argvs": lambda: layout.panel_argvs(
+                slots=["top"], session="f", socket="charter", harness_pane="%3",
+                env=env),
+        }
+
+    def test_no_builder_will_put_an_unlisted_name_on_a_command_line(self):
+        for name, build in self._builders(self._hostile_env()).items():
+            with self.subTest(builder=name):
+                with self.assertRaises(ValueError) as caught:
+                    build()
+                # The refusal must name what it refused and NOT what was in it.
+                self.assertNotIn(self.DECOY, str(caught.exception),
+                                 f"{name}'s own refusal printed the value it refused")
+
+    def test_the_refusal_is_loud_rather_than_a_silent_drop(self):
+        """Dropping the extras quietly would leave a caller believing it had handed the
+        harness a variable that never arrived, AND would make the next leak invisible
+        instead of impossible. The raise is the guard."""
+        with self.assertRaises(ValueError):
+            layout.respawn_argv(socket="charter", harness_pane="%7",
+                                env={"CHARTER_SESSION_ID": "d", "LANG": "en_US.UTF-8"},
+                                cwd="/w", harness_argv=["claude"])
+
+    def test_every_carriable_name_really_does_travel(self):
+        """The other direction, so the guard above cannot be satisfied by a builder that
+        carries nothing at all. Asserted against `CARRIABLE` itself rather than a second
+        copy of the list — a copy is a tautology when the constant is what changed."""
+        env = {name: f"v-{name}" for name in layout.CARRIABLE}
+        cmd = layout.respawn_argv(socket="charter", harness_pane="%7", env=env, cwd="/w",
+                                  harness_argv=["claude"])
+        carried = {cmd[i + 1].split("=", 1)[0] for i, a in enumerate(cmd) if a == "-e"}
+        self.assertEqual(carried, set(layout.CARRIABLE))
+
+    def test_nothing_carriable_is_a_credential_by_name(self):
+        """The property that makes putting any of these on an argv acceptable at all.
+        A name is not proof, but a name that ANNOUNCES a secret is proof of the
+        opposite, and this is the check that fires when the list grows."""
+        for name in layout.CARRIABLE:
+            for word in ("TOKEN", "SECRET", "PASSWORD", "KEY", "CREDENTIAL", "AUTH"):
+                self.assertNotIn(word, name.upper(), name)
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -120,13 +120,28 @@ def _importable_env(env: dict) -> dict:
                                  else str(_REPO_ROOT)))
 
 
+def _tmux_on(socket: str, *args: str,
+             env: dict | None = None) -> subprocess.CompletedProcess:
+    """`tmux -L <socket>`, for a test that has to say WHICH server it means.
+
+    There is more than one server in this module now: `SOCKET` is charter's own, set up
+    the way charter sets its own up, and `OP_SOCKET` stands in for a tmux the operator
+    already had open, left at tmux's own defaults. A helper hard-wired to one of them is
+    how the operator's server came to be charter's server under another name — see
+    `OP_SOCKET`'s own comment for what that cost.
+    """
+    return subprocess.run(["tmux", "-L", socket, *args], capture_output=True, text=True,
+                          timeout=10, env=env)
+
+
 def _tmux(*args: str, env: dict | None = None) -> subprocess.CompletedProcess:
-    """*env* is `None` by every existing call site (inherit this process's own
+    """`_tmux_on(SOCKET, …)` — charter's own server, the default for this module.
+
+    *env* is `None` by every existing call site (inherit this process's own
     environment, unchanged) — `PanelIntegration` is the one caller that needs a
     DIFFERENT environment for a `new-session` call, so tmux hands its spawned pane a
     throwaway plane's `$CHARTER_ROOT` rather than this test process's real one."""
-    return subprocess.run(["tmux", "-L", SOCKET, *args], capture_output=True, text=True,
-                          timeout=10, env=env)
+    return _tmux_on(SOCKET, *args, env=env)
 
 
 def _run(cmd: list[str]) -> subprocess.CompletedProcess:
@@ -431,6 +446,27 @@ class _TmuxServerFixture:
     class's own subclass listed `unittest.TestCase` here instead.
     """
 
+    #: Which server this class's tests stand up. `SOCKET` is charter's own; the class
+    #: that is about the tmux charter is a GUEST on overrides it, because a guest server
+    #: charter's own fixture has already configured is not a guest server (`OP_SOCKET`).
+    SOCKET_NAME = SOCKET
+
+    #: Whether `_new_pane` arms `remain-on-exit` server-globally, the way
+    #: `commands_frame._PLACEHOLDER_CONF` does on charter's own private server.
+    #:
+    #: **A class that is about somebody else's tmux must turn this OFF, and the whole of
+    #: #408's second half is why.** With it on, every pane on the server keeps its corpse
+    #: and therefore fires `pane-died` — including panes charter did nothing to. A test
+    #: for "charter makes a dying panel reachable" then passes on the FIXTURE's option
+    #: and cannot see charter failing to set one; measured, by deleting the production
+    #: call and watching the test stay green.
+    ARMS_REMAIN_ON_EXIT = True
+
+    def _srv(self, *args: str, env: dict | None = None) -> subprocess.CompletedProcess:
+        """`tmux` against THIS class's own server — never the module-level `_tmux`, which
+        is `SOCKET` and `SOCKET` only."""
+        return _tmux_on(self.SOCKET_NAME, *args, env=env)
+
     def setUp(self) -> None:
         # FIRST, and cooperatively: `PersonaIso.setUp` is what repoints `config`, and it
         # only runs if this method hands control up the MRO. A `setUp` that quietly
@@ -459,29 +495,34 @@ class _TmuxServerFixture:
         running", yet the file stays in `/tmp/tmux-<uid>/`. A cleanup that only killed
         the server would still leak one stale entry per test run — which is exactly how
         this module's own hand-verification sessions left 52 of them behind before this
-        fix. tmux computes this path itself from `-L SOCKET`; matched here rather than
+        fix. tmux computes this path itself from `-L <socket>`; matched here rather than
         asked of tmux because there is no query command for it, only observed behaviour
         (`/tmp/tmux-<getuid()>/<socket name>` on every platform this repo runs on)."""
-        _tmux("kill-server")
-        (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET).unlink(missing_ok=True)
+        self._srv("kill-server")
+        (Path("/tmp") / f"tmux-{os.getuid()}" / self.SOCKET_NAME).unlink(missing_ok=True)
 
     def _new_pane(self, dies_by: str = "exit 0") -> tuple[str, str, str]:
-        """A fresh session on `SOCKET`, `remain-on-exit` armed; its name, pane id and GATE.
+        """A fresh session on this class's server; its name, pane id and GATE.
 
         The pane runs a program that WAITS for its gate file and then dies by *dies_by* —
         the caller opens the gate (`_release`) when it wants the death. See `_gate_argv`
         for why the pane is never driven with `send-keys` instead, which is the shape this
         module used to use and the reason it failed roughly one CI run in ten.
+
+        `remain-on-exit` is armed globally here only when `ARMS_REMAIN_ON_EXIT` says so —
+        see that attribute for why a class about somebody else's tmux must not.
         """
         self._pane_counter += 1
         name = f"p{self._pane_counter}"
         gate = os.path.join(self._gate_dir, f"gate-{name}")
-        r = _tmux("new-session", "-d", "-s", name, "-x", "80", "-y", "24",
-                  "-P", "-F", "#{pane_id}", "--", *_gate_argv(gate, dies_by))
+        r = self._srv("new-session", "-d", "-s", name, "-x", "80", "-y", "24",
+                      "-P", "-F", "#{pane_id}", "--", *_gate_argv(gate, dies_by))
         self.assertEqual(r.returncode, 0, r.stderr)
-        # Global on this socket's server — cheap to repeat per pane, and every frame
-        # wants it regardless (see `commands_frame._PLACEHOLDER_CONF`'s own docstring).
-        _tmux("set", "-g", "remain-on-exit", "on")
+        if self.ARMS_REMAIN_ON_EXIT:
+            # Global on this socket's server — cheap to repeat per pane, and every frame
+            # on CHARTER'S OWN server wants it regardless (see
+            # `commands_frame._PLACEHOLDER_CONF`'s own docstring).
+            self._srv("set", "-g", "remain-on-exit", "on")
         return name, r.stdout.strip(), gate
 
     @staticmethod
@@ -489,13 +530,20 @@ class _TmuxServerFixture:
         """Open a pane's gate: its program stops waiting and dies the way it was built to."""
         Path(gate).touch()
 
-    def _hook_reaches_a_shim(self, *, socket, pane, gate, interpreter_dir):
+    def _hook_reaches_a_shim(self, *, socket, pane, gate, interpreter_dir,
+                             timeout=_DEADLINE):
         """Arm *pane*'s respawn hook with a shim as charter's interpreter, open the gate,
         and return whatever argv the shim recorded (``None`` if it never ran).
 
         The shim stands in for `sys.executable`, so the argv it records is what charter
         would REALLY have been invoked with — and *interpreter_dir* is how a caller
         chooses what shape of path that is.
+
+        *timeout* is the full `_DEADLINE` for a caller expecting the hook to fire — a
+        slow machine must come back slow, never wrong. A caller expecting NOTHING passes
+        a shorter one and earns the right to by establishing separately that the pane is
+        GONE: once tmux has destroyed a pane, `pane-died` for it can no longer fire at
+        any deadline, so waiting longer proves nothing that the pane's absence does not.
         """
         os.makedirs(interpreter_dir, exist_ok=True)
         marker = os.path.join(self._gate_dir, f"argv-{os.path.basename(pane)}")
@@ -509,7 +557,7 @@ class _TmuxServerFixture:
         self.assertIsNotNone(argv, f"charter refused to arm a hook for {shim!r}")
         self.assertEqual(_run(argv).returncode, 0)
         self._release(gate)
-        if not _await_file(marker):
+        if not _await_file(marker, timeout):
             return None
         return Path(marker).read_text().split()
 
@@ -529,14 +577,23 @@ class _TmuxServerFixture:
 
         Probed once per process (`_PANE_DIED_FIRES`) — the answer is a property of this
         tmux and this environment, not of any one test, and each probe costs a pane.
+
+        **The probe sets `remain-on-exit` itself rather than inheriting it from the
+        fixture**, which it used to do and which made it a probe of the fixture as much
+        as of tmux: on a class with `ARMS_REMAIN_ON_EXIT` off it would answer "does not
+        fire" everywhere and skip every test that asks. Window-scoped, because that is
+        the scope with no version floor under it — `set-option -p` is tmux 3.0+, and a
+        probe that reported a capability missing because the SCOPE was unsupported would
+        skip tests for the wrong reason.
         """
         if not _PANE_DIED_FIRES:
             _, pane, gate = self._new_pane("exit 7")
             tmp = tempfile.mkdtemp(prefix="charter-integ-probe-")
             self.addCleanup(shutil.rmtree, tmp, True)
             marker = os.path.join(tmp, "fired")
-            _tmux("set-hook", "-p", "-t", pane, "pane-died",
-                  f'run-shell "touch {marker}"')
+            self._srv("set-option", "-w", "-t", pane, "remain-on-exit", "on")
+            self._srv("set-hook", "-p", "-t", pane, "pane-died",
+                      f'run-shell "touch {marker}"')
             self._release(gate)
             _PANE_DIED_FIRES.append(_await_file(marker))
         if not _PANE_DIED_FIRES[0]:
@@ -2563,11 +2620,23 @@ class EarlyDeathIntegration(unittest.TestCase):
         self.assertIn(str(code), msg)
 
 
-#: The socket FILE tmux computes for `-L SOCKET` — the same path `_teardown_socket`
+#: A SECOND real server, standing in for the tmux the OPERATOR already had open.
+#:
+#: **Separate from `SOCKET`, and that separation is #408's second half.**
+#: `WindowInsideAnOperatorsTmux` used to run against `SOCKET` reached by PATH — the same
+#: server every other class here uses, under another name. `_TmuxServerFixture._new_pane`
+#: had already run `set -g remain-on-exit on` on it, so the "operator's" tmux arrived
+#: pre-configured the way only charter's own private server ever is, and a test asking
+#: whether charter makes a dead PANEL reachable was answered by the fixture. It stayed
+#: green with the production call deleted. This one is never configured by anything: what
+#: it does with a dying pane is tmux's own default, which is what an operator's tmux is.
+OP_SOCKET = f"charter-integration-operator-{os.getpid()}"
+
+#: The socket FILE tmux computes for `-L OP_SOCKET` — the same path `_teardown_socket`
 #: already has to know. Needed as a path (not a name) by `WindowInsideAnOperatorsTmux`,
 #: because the whole point of that class is exercising the `-S <socket path>` half of
 #: `tmuxctl.server_argv`, which is how charter reaches a server it did not start.
-SOCKET_PATH = str(Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET)
+OP_SOCKET_PATH = str(Path("/tmp") / f"tmux-{os.getuid()}" / OP_SOCKET)
 
 
 class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
@@ -2588,7 +2657,18 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
     real `cmd_launch`, which reaps and writes frame state under `config.STATE_DIR`. The
     tmux server this class stands up is a throwaway; without `PersonaIso` the PLANE it
     writes to would not be. See `_TmuxServerFixture`'s docstring for what that cost.
+
+    **The server is `OP_SOCKET`, not `SOCKET` reached by path, and nothing configures
+    it.** Those are the two halves of the same requirement and this class had neither
+    until #408's second round: it ran against the same server as every other class here,
+    which `_new_pane` had already given `set -g remain-on-exit on` — so a pane that
+    charter had done nothing to still kept its corpse and still fired `pane-died`, and
+    the test below could not tell charter arming a panel from the fixture having armed
+    the whole server. See `OP_SOCKET` and `ARMS_REMAIN_ON_EXIT` for the measurement.
     """
+
+    SOCKET_NAME = OP_SOCKET
+    ARMS_REMAIN_ON_EXIT = False
 
     def _operator_server(self, harness_dies_by="exit 0"):
         """A session standing in for one the operator already had open.
@@ -2597,15 +2677,31 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         harness will die by. The session's own pane runs a program that never exits on
         its own, so anything that quietly takes the operator's session down shows up as
         a missing session rather than as a race.
+
+        **The precondition is checked, not assumed, and that is the whole of #408's
+        second round.** "This is somebody else's tmux" is a claim about the SERVER'S
+        STATE, not about which constant names its socket — a separate socket that
+        something has already armed is charter's own server again, and a shared one that
+        nothing has armed is not. So the property is asserted here, on every test in the
+        class, against tmux's own answer: `remain-on-exit` is at the default an operator
+        would have. Every test below whose subject is a dying pane is measuring charter
+        only while this holds.
         """
         name, pane, gate = self._new_pane("exit 0")
-        sid = _tmux("display-message", "-p", "-t", pane, "#{session_id}").stdout.strip()
+        self.assertEqual(
+            self._srv("show-options", "-g", "remain-on-exit").stdout.strip(),
+            "remain-on-exit off",
+            "the server standing in for the operator's tmux is not at tmux's default — "
+            "something armed `remain-on-exit` on it before charter got there, and every "
+            "test in this class about a pane surviving its own death is now measuring "
+            "that instead of measuring charter (see `ARMS_REMAIN_ON_EXIT`)")
+        sid = self._srv("display-message", "-p", "-t", pane, "#{session_id}").stdout.strip()
         self.assertTrue(sid.startswith("$"), sid)
         return name, sid, pane, gate
 
     def _open_frame_window(self, sid, fid="charter-demo-1"):
         """`layout.window_argv`'s own bytes, run for real. Returns (window id, pane id)."""
-        r = _run(layout.window_argv(socket=SOCKET_PATH, session=sid, window=fid,
+        r = _run(layout.window_argv(socket=OP_SOCKET_PATH, session=sid, window=fid,
                                     cwd=self._gate_dir))
         self.assertEqual(r.returncode, 0, r.stderr)
         window_id, _, pane_id = r.stdout.strip().partition(" ")
@@ -2629,7 +2725,7 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         window (see `commands_frame._remain_on_exit_argv`). A tmux without pane options
         cannot do the thing these tests measure, so they skip naming that rather than
         failing with tmux's own argument-parsing text."""
-        r = _run(commands_frame._remain_on_exit_argv(socket=SOCKET_PATH,
+        r = _run(commands_frame._remain_on_exit_argv(socket=OP_SOCKET_PATH,
                                                      harness_pane=pane_id))
         if r.returncode != 0:
             self.skipTest("this tmux does not accept a pane-scoped `remain-on-exit` "
@@ -2645,17 +2741,17 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         window_id, pane_id = self._open_frame_window(sid)
         self._require_pane_options(pane_id)
         gate = os.path.join(self._gate_dir, "harness-gate")
-        r = _run(layout.respawn_argv(socket=SOCKET_PATH, harness_pane=pane_id, env={},
+        r = _run(layout.respawn_argv(socket=OP_SOCKET_PATH, harness_pane=pane_id, env={},
                                      cwd=self._gate_dir,
                                      harness_argv=_gate_argv(gate, "exit 33")))
         self.assertEqual(r.returncode, 0, r.stderr)
-        self.assertEqual(commands_frame._pane_state(SOCKET_PATH, pane_id),
+        self.assertEqual(commands_frame._pane_state(OP_SOCKET_PATH, pane_id),
                          (commands_frame._ALIVE, None))
         self._release(gate)
         self.assertTrue(self._wait_until(
-            lambda: commands_frame._pane_state(SOCKET_PATH, pane_id)[0]
+            lambda: commands_frame._pane_state(OP_SOCKET_PATH, pane_id)[0]
             == commands_frame._DEAD), "the pane never came back dead")
-        self.assertEqual(commands_frame._pane_state(SOCKET_PATH, pane_id),
+        self.assertEqual(commands_frame._pane_state(OP_SOCKET_PATH, pane_id),
                          (commands_frame._DEAD, 33))
         del window_id
 
@@ -2667,7 +2763,7 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         _, sid, _, _ = self._operator_server()
         _, pane_id = self._open_frame_window(sid)
         time.sleep(0.4)
-        self.assertEqual(commands_frame._pane_state(SOCKET_PATH, pane_id)[0],
+        self.assertEqual(commands_frame._pane_state(OP_SOCKET_PATH, pane_id)[0],
                          commands_frame._ALIVE,
                          "the placeholder exited on its own")
 
@@ -2678,12 +2774,12 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         `#{pane_dead}` being `1` would poll a window nobody can bring back, forever."""
         _, sid, _, _ = self._operator_server()
         window_id, pane_id = self._open_frame_window(sid)
-        raw = _run(tmuxctl.server_argv(SOCKET_PATH, "display-message", "-p", "-t",
+        raw = _run(tmuxctl.server_argv(OP_SOCKET_PATH, "display-message", "-p", "-t",
                                        pane_id, commands_frame._DEAD_FORMAT))
         self.assertEqual(raw.returncode, 0)
         self.assertEqual(raw.stdout.strip(), "0:")
-        _run(tmuxctl.server_argv(SOCKET_PATH, "kill-window", "-t", window_id))
-        gone = _run(tmuxctl.server_argv(SOCKET_PATH, "display-message", "-p", "-t",
+        _run(tmuxctl.server_argv(OP_SOCKET_PATH, "kill-window", "-t", window_id))
+        gone = _run(tmuxctl.server_argv(OP_SOCKET_PATH, "display-message", "-p", "-t",
                                         pane_id, commands_frame._DEAD_FORMAT))
         self.assertEqual(gone.returncode, 0,
                          "tmux is expected to answer, not to refuse")
@@ -2691,7 +2787,7 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
                          "both variables expand to nothing, and the format's own "
                          "literal `:` is all that is left — NOT an empty line, which "
                          "is what a guard written from memory assumed")
-        self.assertEqual(commands_frame._pane_state(SOCKET_PATH, pane_id),
+        self.assertEqual(commands_frame._pane_state(OP_SOCKET_PATH, pane_id),
                          (commands_frame._GONE, None))
 
     def test_closing_the_frames_window_leaves_the_operators_session_alone(self):
@@ -2699,14 +2795,14 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         up after itself and charter ending every window the operator had open."""
         name, sid, op_pane, _ = self._operator_server()
         window_id, _ = self._open_frame_window(sid)
-        before = _tmux("list-windows", "-a", "-F", "#{window_name}").stdout.split()
+        before = self._srv("list-windows", "-a", "-F", "#{window_name}").stdout.split()
         self.assertIn("charter-demo-1", before)
-        _run(tmuxctl.server_argv(SOCKET_PATH, "kill-window", "-t", window_id))
-        after = _tmux("list-windows", "-a", "-F", "#{window_name}").stdout.split()
+        _run(tmuxctl.server_argv(OP_SOCKET_PATH, "kill-window", "-t", window_id))
+        after = self._srv("list-windows", "-a", "-F", "#{window_name}").stdout.split()
         self.assertNotIn("charter-demo-1", after)
-        self.assertIn(name, _tmux("list-sessions", "-F", "#{session_name}").stdout.split(),
+        self.assertIn(name, self._srv("list-sessions", "-F", "#{session_name}").stdout.split(),
                       "the operator's own session went with charter's window")
-        self.assertEqual(_tmux("display-message", "-p", "-t", op_pane,
+        self.assertEqual(self._srv("display-message", "-p", "-t", op_pane,
                                "#{pane_dead}").stdout.strip(), "0",
                          "the operator's own pane died with it")
 
@@ -2723,7 +2819,7 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         env["CHARTER_HARNESS"] = "claude-code"
         env = commands_frame._guest_harness_env(env)
         r = _run(layout.respawn_argv(
-            socket=SOCKET_PATH, harness_pane=pane_id, env=env, cwd=self._gate_dir,
+            socket=OP_SOCKET_PATH, harness_pane=pane_id, env=env, cwd=self._gate_dir,
             harness_argv=["/bin/sh", "-c",
                           f'printf "%s\\n%s\\n%s\\n" "$CHARTER_SESSION_ID" '
                           f'"$CHARTER_HARNESS" "$TMUX_PANE" > "{out}"']))
@@ -2759,7 +2855,7 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         out = os.path.join(self._gate_dir, "harness-path")
         mine = os.environ.get("PATH", "")
         r = _run(layout.respawn_argv(
-            socket=SOCKET_PATH, harness_pane=pane_id,
+            socket=OP_SOCKET_PATH, harness_pane=pane_id,
             env={"PATH": "/charter/said/this", "CHARTER_SESSION_ID": "charter-demo-1"},
             cwd=self._gate_dir,
             harness_argv=[sys.executable, "-c",
@@ -2777,35 +2873,142 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
                             "`-e PATH=` now survives; the same note is stale the other "
                             "way, and charter could state a PATH deliberately")
 
+    def _panel_funnel(self, harness_pane, slots=()):
+        """Run charter's OWN panel funnel against this server — the whole of what a
+        launch (and every density change) does around a `split-window`.
+
+        `slots=()` by default because a pane these tests can use has to be able to DIE ON
+        COMMAND and `charter panel` cannot: what they need from the funnel is the state
+        it leaves charter's WINDOW in before any panel is split, which is the half that
+        was missing. It is a shape the launcher really passes, not one invented here —
+        `_drawable_slots` answers `[]` below its size floors and `cmd_launch` calls
+        straight through with it.
+        """
+        return commands_frame._split_panels(
+            OP_SOCKET_PATH, slots=list(slots), fid="charter-demo-1",
+            harness_pane=harness_pane, env=None, pane_env=None)
+
     def test_a_panels_respawn_hook_is_armed_against_this_server_and_fires(self):
         """#408, end to end on the path it was broken on. `_arm_panel_respawn` refused
         here outright, because `_panel_died_hook_argv` hand-built `["tmux", "-L", …]` and
         would have aimed a `run-shell` at charter's private server — or started an empty
         one named after a socket path.
 
-        Two things a mock cannot check: that `set-hook -p` is accepted on a pane charter
-        created inside somebody else's server at all, and that the action reaches a real
+        Three things a mock cannot check: that `set-hook -p` is accepted on a pane charter
+        created inside somebody else's server at all, that the action reaches a real
         shell with the frame id ON IT — there is no `set-environment` here to read
-        `$CHARTER_SESSION_ID` back out of, which is the reason `--frame` exists."""
+        `$CHARTER_SESSION_ID` back out of, which is the reason `--frame` exists — and
+        that the pane the hook is armed on is STILL THERE to fire it.
+
+        **The third is #408's second half, and this test could not see it.** tmux runs
+        `pane-died` only for a pane that died and STAYED; the panel used to be handed
+        `set-option -p … remain-on-exit on` BY THIS TEST — a command production issues
+        nowhere — on a server the fixture had already set the same option on globally. So
+        the assertion below was about the test's own arming. Nothing here arms anything
+        now: the server is left at tmux's default and the only thing run against it is
+        charter's own panel funnel (`_panel_funnel`).
+
+        The property, stated so the next reader tests the property and not this spelling:
+        a panel is not covered because some function was called with its slot in a list —
+        it is covered because it was BORN INTO A WINDOW THAT KEEPS CORPSES. The pane below
+        is split in after the funnel has run and belongs to no slot the funnel was given,
+        which is the same shape a density change (`_relayout`) and any future
+        panel-creating path have. What it does NOT cover is a panel that leaves that
+        window: the coverage is the window's, so `break-pane`/`join-pane` on a panel would
+        silently undo it — charter issues neither today, and that is the next spelling of
+        this defect."""
         self._require_pane_died_fires()
         _, sid, _, _ = self._operator_server()
         _, pane_id = self._open_frame_window(sid)
         self._require_pane_options(pane_id)
+        self._panel_funnel(pane_id)
         gate = os.path.join(self._gate_dir, "panel-gate")
         panel = _run(tmuxctl.server_argv(
-            SOCKET_PATH, "split-window", "-t", pane_id, "-v", "-l", "1",
+            OP_SOCKET_PATH, "split-window", "-t", pane_id, "-v", "-l", "1",
             "-P", "-F", "#{pane_id}", "--", *_gate_argv(gate, "exit 4"))).stdout.strip()
         self.assertTrue(panel.startswith("%"), panel)
-        _run(tmuxctl.server_argv(SOCKET_PATH, "set-option", "-p", "-t", panel,
-                                 "remain-on-exit", "on"))
         seen = self._hook_reaches_a_shim(
-            socket=SOCKET_PATH, pane=panel, gate=gate,
+            socket=OP_SOCKET_PATH, pane=panel, gate=gate,
             interpreter_dir=os.path.join(self._gate_dir, "op interp"))
         self.assertIsNotNone(
             seen, "a panel that died inside the operator's own tmux reached nothing — "
-                  f"hooks: {_run(tmuxctl.server_argv(SOCKET_PATH, 'show-hooks', '-p', '-t', panel)).stdout!r}")
+                  f"hooks: {_run(tmuxctl.server_argv(OP_SOCKET_PATH, 'show-hooks', '-p', '-t', panel)).stdout!r}")
         self.assertEqual(seen, ["-P", "-m", "charter", "frame-respawn", "top",
                                 "--pane", panel, "--frame", "demo-1"])
+
+    def test_a_panel_dying_here_is_destroyed_unless_charter_arms_the_window(self):
+        """The NEGATIVE control for the test above, and the measurement #408's first
+        round was missing.
+
+        Same server, same window, same pane-scoped `pane-died` hook, same death — and
+        charter's panel funnel simply not run. tmux destroys the pane, the hook goes with
+        it, and nothing reaches a shell. Without this, "the hook fires" above could be
+        true of any pane on any server and nobody would know which fact was carrying it;
+        putting `ARMS_REMAIN_ON_EXIT` back to `True` is caught here and nowhere else.
+
+        Asserted on the RECORDED ARGV rather than on any exit status: every command
+        involved succeeds either way, which is exactly why this defect survived a round —
+        `set-hook -p` on a doomed pane returns 0."""
+        self._require_pane_died_fires()
+        _, sid, _, _ = self._operator_server()
+        _, pane_id = self._open_frame_window(sid)
+        self._require_pane_options(pane_id)
+        gate = os.path.join(self._gate_dir, "unarmed-gate")
+        panel = _run(tmuxctl.server_argv(
+            OP_SOCKET_PATH, "split-window", "-t", pane_id, "-v", "-l", "1",
+            "-P", "-F", "#{pane_id}", "--", *_gate_argv(gate, "exit 4"))).stdout.strip()
+        self.assertTrue(panel.startswith("%"), panel)
+        seen = self._hook_reaches_a_shim(
+            socket=OP_SOCKET_PATH, pane=panel, gate=gate,
+            interpreter_dir=os.path.join(self._gate_dir, "bare interp"), timeout=5.0)
+        # The DETERMINISTIC half, asserted first: the pane is gone. After that no
+        # deadline can change the answer below — tmux cannot fire `pane-died` for a pane
+        # it has already destroyed — which is what makes the short wait above sound.
+        self.assertTrue(self._wait_until(
+            lambda: _run(tmuxctl.server_argv(
+                OP_SOCKET_PATH, "display-message", "-p", "-t", panel,
+                "#{pane_id}")).stdout.strip() != panel),
+            "the pane was still there, so this is not the state the control is about")
+        self.assertIsNone(
+            seen, "a pane on a server at tmux's own default kept its corpse and fired "
+                  "`pane-died` with nothing having armed `remain-on-exit` — if that is "
+                  "now tmux's behaviour, the test above is no longer measuring charter")
+
+    def test_arming_the_frames_window_leaves_the_operators_own_windows_alone(self):
+        """The blast radius of the one option `_panel_remain_on_exit_argv` writes, read
+        back out of tmux rather than argued from its flags.
+
+        `-w` is a scope this module's own docstrings refused on the ground that it reaches
+        past charter's own window. It does not, when the target is a pane charter created
+        in a window charter opened — measured here in three directions: charter's window
+        comes back `on`, the operator's own window is still exactly where it was, the
+        SERVER is still at its default, and a pane of theirs that dies is still destroyed
+        rather than left as a corpse in their window list. `-g` fails the last three,
+        which is why the harness pane's own `remain-on-exit` is `-p` and this one is
+        `-w`."""
+        _, sid, op_pane, _ = self._operator_server()
+        window_id, pane_id = self._open_frame_window(sid)
+        default = self._srv("show-options", "-w", "-t", op_pane,
+                            "remain-on-exit").stdout.strip()
+        self._panel_funnel(pane_id)
+        self.assertEqual(self._srv("show-options", "-w", "-t", window_id,
+                                   "remain-on-exit").stdout.strip(), "remain-on-exit on")
+        self.assertEqual(self._srv("show-options", "-w", "-t", op_pane,
+                                   "remain-on-exit").stdout.strip(), default,
+                         "charter changed how the operator's OWN window treats a death")
+        self.assertEqual(self._srv("show-options", "-g", "remain-on-exit").stdout.strip(),
+                         "remain-on-exit off",
+                         "charter reached the whole server, not just its own window")
+        # And the operator's own pane still dies the way it did before charter arrived.
+        gate = os.path.join(self._gate_dir, "their-gate")
+        theirs = self._srv("split-window", "-t", op_pane, "-v", "-l", "1", "-P", "-F",
+                           "#{pane_id}", "--", *_gate_argv(gate, "exit 0")).stdout.strip()
+        self.assertTrue(theirs.startswith("%"), theirs)
+        self._release(gate)
+        self.assertTrue(self._wait_until(
+            lambda: self._srv("display-message", "-p", "-t", theirs,
+                              "#{pane_id}").stdout.strip() != theirs),
+            "a pane of the operator's own was left behind as a corpse")
 
     def test_a_frame_here_is_live_by_its_window_never_by_a_session(self):
         """`cmd_respawn` asked `_live_sessions(SOCKET)` unconditionally, which on this
@@ -2817,15 +3020,15 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         always being the same one."""
         _, sid, _, _ = self._operator_server()
         self._open_frame_window(sid, fid="charter-demo-1")
-        self.assertTrue(commands_frame._frame_is_live(SOCKET_PATH, "charter-demo-1"))
-        self.assertFalse(commands_frame._frame_is_live(SOCKET_PATH, "a-frame-that-ended"))
+        self.assertTrue(commands_frame._frame_is_live(OP_SOCKET_PATH, "charter-demo-1"))
+        self.assertFalse(commands_frame._frame_is_live(OP_SOCKET_PATH, "a-frame-that-ended"))
         # And the operator's OWN session name is not a frame: a `list-sessions`-shaped
         # answer here would report it live and respawn a panel into a window charter
         # never opened.
-        sessions = _tmux("list-sessions", "-F", "#{session_name}").stdout.split()
+        sessions = self._srv("list-sessions", "-F", "#{session_name}").stdout.split()
         self.assertTrue(sessions, "the fixture server reported no sessions at all")
         for name in sessions:
-            self.assertFalse(commands_frame._frame_is_live(SOCKET_PATH, name), name)
+            self.assertFalse(commands_frame._frame_is_live(OP_SOCKET_PATH, name), name)
 
     def test_the_harness_starts_where_charter_was_typed(self):
         """A pane in a server charter did not start otherwise inherits the SESSION's
@@ -2835,7 +3038,7 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         self._require_pane_options(pane_id)
         out = os.path.join(self._gate_dir, "harness-cwd")
         r = _run(layout.respawn_argv(
-            socket=SOCKET_PATH, harness_pane=pane_id, env={}, cwd=self._gate_dir,
+            socket=OP_SOCKET_PATH, harness_pane=pane_id, env={}, cwd=self._gate_dir,
             harness_argv=["/bin/sh", "-c", f'pwd > "{out}"']))
         self.assertEqual(r.returncode, 0, r.stderr)
         self.assertTrue(_await_file(out), "the harness never ran")
@@ -2882,20 +3085,24 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
                         f"({self.tmp}), so it belongs to somebody real")
 
         def _snapshot():
-            return tuple(_tmux(*args).stdout for args in (
+            return tuple(self._srv(*args).stdout for args in (
                 ("show-options", "-g"),
                 ("show-options", "-t", name),
                 ("show-options", "-g", "-w"),
+                # The operator's OWN window, added with #408's second half: charter now
+                # writes a WINDOW option (`_panel_remain_on_exit_argv`), and a scope slip
+                # from charter's window to theirs would otherwise be invisible here.
+                ("show-options", "-w", "-t", op_pane),
                 ("list-keys",)))
 
         before = _snapshot()
-        server_pid = _tmux("display-message", "-p", "#{pid}").stdout.strip()
+        server_pid = self._srv("display-message", "-p", "#{pid}").stdout.strip()
         args = SimpleNamespace(harness="frame", rest=["--", *_gate_argv(gate, "exit 21")],
                                no_frame=False)
         rc: list[int] = []
 
         def _run_launch():
-            env = dict(os.environ, TMUX=f"{SOCKET_PATH},{server_pid},{sid[1:]}",
+            env = dict(os.environ, TMUX=f"{OP_SOCKET_PATH},{server_pid},{sid[1:]}",
                        TMUX_PANE=op_pane)
             with mock.patch.dict(os.environ, env, clear=True), \
                  mock.patch("sys.stdout.isatty", return_value=True), \
@@ -2906,7 +3113,7 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         worker = threading.Thread(target=_run_launch, daemon=True)
         worker.start()
         self.assertTrue(self._wait_until(
-            lambda: "demo-" in _tmux("list-windows", "-a", "-F",
+            lambda: "demo-" in self._srv("list-windows", "-a", "-F",
                                      "#{window_name}").stdout),
             "the frame's own window never appeared in the operator's server")
         during = _snapshot()
@@ -2917,8 +3124,8 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         self.assertEqual(before, during,
                          "charter wrote something on a server it is only a guest on")
         self.assertEqual(before, _snapshot())
-        self.assertIn(name, _tmux("list-sessions", "-F", "#{session_name}").stdout.split())
-        self.assertNotIn("demo-", _tmux("list-windows", "-a", "-F",
+        self.assertIn(name, self._srv("list-sessions", "-F", "#{session_name}").stdout.split())
+        self.assertNotIn("demo-", self._srv("list-windows", "-a", "-F",
                                         "#{window_name}").stdout,
                          "the frame's window was left behind")
         self.assertFalse(decoy.exists(),
@@ -2952,7 +3159,8 @@ class ASecondFrameOnTheSharedServer(_TmuxServerFixture, PersonaIso):
     _VAR = "CHARTER_INTEG_PROBE"
 
     def _session_reading_the_var(self, name: str, *, client_value: str,
-                                 carry: str | None = None) -> str:
+                                 carry: str | None = None,
+                                 carry_raw: str | None = None) -> str:
         """A session on `SOCKET` whose pane writes `$_VAR` out; returns what it wrote.
 
         *client_value* is what the tmux CLIENT process is started with — the thing a
@@ -2960,10 +3168,17 @@ class ASecondFrameOnTheSharedServer(_TmuxServerFixture, PersonaIso):
         passes none. The pane sleeps afterwards so the SERVER stays up for the next
         session: a server that empties shuts itself down, and a second `new-session`
         against a dead server would start a fresh one and quietly measure nothing.
+
+        *carry_raw* is the `-e` argument spelled by the CALLER rather than built from a
+        name and a value — the one way to ask tmux what it does with a spelling charter
+        never emits, which is the whole subject of
+        :meth:`test_a_bare_e_name_cannot_take_a_variable_away`.
         """
         out = os.path.join(self._gate_dir, f"env-{name}")
         args = ["new-session", "-d", "-s", name, "-x", "80", "-y", "24",
                 "-P", "-F", "#{pane_pid}"]
+        if carry_raw is not None:
+            args += ["-e", carry_raw]
         if carry is not None:
             args += ["-e", f"{self._VAR}={carry}"]
         args += ["--", "sh", "-c",
@@ -3016,6 +3231,38 @@ class ASecondFrameOnTheSharedServer(_TmuxServerFixture, PersonaIso):
         self.assertEqual(
             self._session_reading_the_var("second", client_value="two", carry="two"),
             "two", "`-e` did not reach the pane `new-session` itself creates")
+
+    def test_a_bare_e_name_cannot_take_a_variable_away(self):
+        """`-e NAME` with no `=` is not an unset, and tmux does not say so.
+
+        `commands_frame._frame_identity_env` emits `NAME=` for every name it has no value
+        for, and the obvious-looking alternative is to hand tmux the bare name and let it
+        REMOVE the inherited one. Measured here instead of assumed, because the two
+        failure modes are opposites and only one of them is visible: `-e` is purely
+        ADDITIVE — the bare form is accepted, returns 0, prints nothing, and leaves the
+        server's inherited value exactly where it was. A charter that reached for it would
+        have handed a second frame the first frame's workspace pin and had no error
+        anywhere to show for it.
+
+        Three sessions against one server, so the three answers can only differ by the
+        `-e`: the value the server was started with, the same value after a bare `-e`,
+        and the empty string after `-e NAME=` — which is the only spelling that shadows,
+        and the one charter emits.
+        """
+        self._require_new_session_env()
+        self.assertEqual(self._session_reading_the_var("first", client_value="one"),
+                         "one")
+        self.assertEqual(
+            self._session_reading_the_var("second", client_value="two",
+                                          carry_raw=self._VAR),
+            "one",
+            "`-e NAME` with no `=` removed an inherited variable — if tmux now supports "
+            "an unset, `_frame_identity_env` has a better option than shadowing with an "
+            "empty value and should be told about it")
+        self.assertEqual(
+            self._session_reading_the_var("third", client_value="three", carry=""),
+            "", "`-e NAME=` is the spelling charter relies on to shadow an inherited "
+                "value, and it did not")
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -284,7 +284,28 @@ def _refusal(fd: int) -> str:
     return out.decode("utf-8", "replace").strip()
 
 
-def _await_file(path: str, timeout: float = 5.0) -> bool:
+#: How long ANY one thing this module waits to happen gets to happen — #409.
+#:
+#: **One constant, because the flake was module-wide and the deadline was not.** Eleven
+#: separate waits carried 3, 5, 8 and 15 seconds apiece, each number picked where it was
+#: written and none of them re-examined after CI got slower; the signal-death test alone
+#: cost a re-run on five PRs, which is exactly the tax that teaches people to merge over
+#: red. A per-call number is a per-call judgement about a machine nobody who wrote it was
+#: running on.
+#:
+#: **Only POSITIVE waits use it** — "wait until X happens, then assert it did". A wait
+#: that exists to show something does NOT happen must keep its own short, deliberate
+#: number: raising one of those buys no reliability and spends the time on every single
+#: run. This one is spent only by a test that is already failing or skipping.
+#:
+#: Generous rather than tuned, for the reason `_ATTACH_TIMEOUT` gives: polling makes a
+#: slow machine slow instead of wrong, and every wait below returns the instant its
+#: condition holds, so the number is what a LOADED runner may take and never what a
+#: healthy one does.
+_DEADLINE = 20.0
+
+
+def _await_file(path: str, timeout: float = _DEADLINE) -> bool:
     """Wait for a hook-written file to appear, up to *timeout*.
 
     A fixed `time.sleep(1)` here was a guess about how long a `run-shell` takes to fork a
@@ -325,7 +346,7 @@ def _await_client(session: str, exclude: frozenset, pid: int) -> str:
     return ""
 
 
-def _await_dead(pane: str, timeout: float = 5.0) -> int | None:
+def _await_dead(pane: str, timeout: float = _DEADLINE) -> int | None:
     """Poll the launcher's OWN `_query_pane_dead_status` until *pane* is gone.
 
     Polled rather than slept for the same reason `_await_file` is: how long tmux takes to
@@ -467,6 +488,30 @@ class _TmuxServerFixture:
     def _release(gate: str) -> None:
         """Open a pane's gate: its program stops waiting and dies the way it was built to."""
         Path(gate).touch()
+
+    def _hook_reaches_a_shim(self, *, socket, pane, gate, interpreter_dir):
+        """Arm *pane*'s respawn hook with a shim as charter's interpreter, open the gate,
+        and return whatever argv the shim recorded (``None`` if it never ran).
+
+        The shim stands in for `sys.executable`, so the argv it records is what charter
+        would REALLY have been invoked with — and *interpreter_dir* is how a caller
+        chooses what shape of path that is.
+        """
+        os.makedirs(interpreter_dir, exist_ok=True)
+        marker = os.path.join(self._gate_dir, f"argv-{os.path.basename(pane)}")
+        shim = os.path.join(interpreter_dir, "fake charter py")
+        Path(shim).write_text(f'#!/bin/sh\nprintf "%s" "$*" > "{marker}"\n')
+        os.chmod(shim, 0o755)
+        with mock.patch("charter.commands_frame.util.self_relaunch_argv",
+                        side_effect=lambda *a: [shim, "-P", "-m", "charter", *a]):
+            argv = commands_frame._panel_died_hook_argv(
+                socket=socket, panel_pane=pane, slot="top", fid="demo-1")
+        self.assertIsNotNone(argv, f"charter refused to arm a hook for {shim!r}")
+        self.assertEqual(_run(argv).returncode, 0)
+        self._release(gate)
+        if not _await_file(marker):
+            return None
+        return Path(marker).read_text().split()
 
     def _require_pane_died_fires(self) -> None:
         """Skip unless a pane-scoped `pane-died` hook actually FIRES on this machine.
@@ -635,8 +680,12 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
                            *_gate_argv(os.path.join(self._gate_dir, "never"), "exit 0")
                            ).stdout.strip()
         self.assertTrue(panel_pane.startswith("%"), panel_pane)
-        armed = _run(commands_frame._panel_died_hook_argv(
-            socket=SOCKET, panel_pane=panel_pane, slot="bottom"))
+        argv = commands_frame._panel_died_hook_argv(
+            socket=SOCKET, panel_pane=panel_pane, slot="bottom", fid="demo-1")
+        self.assertIsNotNone(argv, "this machine's own interpreter path cannot be "
+                                   "written into a hook action — see "
+                                   "`_action_word_is_safe`")
+        armed = _run(argv)
         self.assertEqual(armed.returncode, 0, armed.stderr)
 
         after = _tmux("show-hooks", "-p", "-t", harness_pane).stdout
@@ -657,34 +706,149 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
         deliver the right argv?
 
         Four separate things have to hold at once and none of them can be checked by
-        reading the string: tmux must not eat the `$` before the shell sees it (the
-        failure `_pane_died_write_hook_argv`'s docstring measures for double quotes),
-        `$CHARTER_PY` must be resolvable from a `run-shell` spawned by a PANE-scoped
-        hook, `run-shell -b` must still run the command at all, and the slot and pane id
-        must arrive as separate argv words. `$CHARTER_PY` is pointed at a script that
-        records its own argv, so what is asserted is what charter would really have been
-        invoked with."""
+        reading the string: the interpreter path has to survive tmux's own parse of the
+        action (the failure `_pane_died_write_hook_argv`'s docstring measures for double
+        quotes, one layer over), `run-shell -b` must still run the command at all, the
+        slot and pane id must arrive as separate argv words, and — since #408 — the
+        frame id has to travel WITH them rather than out of band, because
+        `set-environment` is unavailable on the operator's own server.
+
+        The interpreter is a script that records its own argv, at a path holding a SPACE:
+        a bare interpolation would split it into two words and the shim would never run
+        at all."""
         self._require_pane_died_fires()
-        session, pane, gate = self._new_pane("exit 3")
-        tmp = tempfile.mkdtemp(prefix="charter-integ-respawn-")
-        self.addCleanup(shutil.rmtree, tmp, True)
-        marker = os.path.join(tmp, "argv")
-        fake_py = os.path.join(tmp, "fake-charter-py")
-        Path(fake_py).write_text(
-            f'#!/bin/sh\nprintf "%s" "$*" > {marker}\n')
-        os.chmod(fake_py, 0o755)
+        _, pane, gate = self._new_pane("exit 3")
+        seen = self._hook_reaches_a_shim(
+            socket=SOCKET, pane=pane, gate=gate,
+            interpreter_dir=os.path.join(self._gate_dir, "interp dir"))
+        self.assertIsNotNone(
+            seen, "the panel's own pane-died hook never reached a shell — "
+                  f"hooks: {_tmux('show-hooks', '-p', '-t', pane).stdout!r}")
+        self.assertEqual(seen, ["-P", "-m", "charter", "frame-respawn", "top",
+                                "--pane", pane, "--frame", "demo-1"])
+
+    def test_an_awkward_interpreter_path_arrives_byte_for_byte(self):
+        """The property `_ACTION_QUOTE_BREAKERS` is derived from, measured rather than
+        argued: every ASCII punctuation character EXCEPT the six that mean something to
+        one of the three parsers involved is literal on the way through, so an
+        interpreter living behind one is armed rather than refused — and the argv that
+        comes out the far side is the one charter meant.
+
+        Without this the guard could be tightened to a paranoid allowlist and nothing
+        would notice; with it, a tightening that costs a real path its respawn fails
+        here."""
+        self._require_pane_died_fires()
+        _, pane, gate = self._new_pane("exit 3")
+        awkward = "a b;c&d(e)f*g-h,i=j+k@l:m[n]o{p}q!r%s^t~u"
+        seen = self._hook_reaches_a_shim(
+            socket=SOCKET, pane=pane, gate=gate,
+            interpreter_dir=os.path.join(self._gate_dir, awkward))
+        self.assertEqual(seen, ["-P", "-m", "charter", "frame-respawn", "top",
+                                "--pane", pane, "--frame", "demo-1"])
+
+    def test_a_hook_action_really_is_format_expanded_before_any_shell_sees_it(self):
+        """The POSITIVE CONTROL for `_action_word_is_safe` refusing `#`, and the reason
+        that refusal exists at all rather than being tidiness about a harmless character.
+
+        tmux expands `#{…}` in a hook action before parsing it as a command — that is the
+        mechanism `_pane_died_write_hook_argv` relies on to get `#{pane_dead_status}` to a
+        shell, and it applies to every other character of the action equally. Measured
+        here in the shape an interpreter path would have: the literal text
+        `/opt/py#{pane_id}/x` reaches `/bin/sh` rewritten.
+
+        A first version of charter's guard looked only for quote characters and let this
+        through entirely. Without this control, tightening the guard would look like
+        caution rather than like the fix for a measured rewrite — and `#{pane_title}`
+        expands to text the program in that pane sets for itself."""
+        self._require_pane_died_fires()
+        _, pane, gate = self._new_pane("exit 3")
+        out = os.path.join(self._gate_dir, "expanded")
         self.assertEqual(
-            _run(commands_frame._charter_py_env_argv(socket=SOCKET, session=session)
-                 [:-1] + [fake_py]).returncode, 0)
-        self.assertEqual(
-            _run(commands_frame._panel_died_hook_argv(socket=SOCKET, panel_pane=pane,
-                                                      slot="top")).returncode, 0)
+            _tmux("set-hook", "-p", "-t", pane, "pane-died",
+                  f"""run-shell -b 'echo "/opt/py#{{pane_id}}/x" > "{out}"'""").returncode,
+            0)
         self._release(gate)
-        self.assertTrue(_await_file(marker),
-                        "the panel's own pane-died hook never reached a shell — "
-                        f"hooks: {_tmux('show-hooks', '-p', '-t', pane).stdout!r}")
-        self.assertEqual(Path(marker).read_text().split(),
-                         ["-m", "charter", "frame-respawn", "top", "--pane", pane])
+        self.assertTrue(_await_file(out), "the hook never reached a shell")
+        seen = Path(out).read_text().strip()
+        self.assertNotEqual(
+            seen, "/opt/py#{pane_id}/x",
+            "tmux no longer expands formats inside a hook action — if that is really "
+            "true, `_pane_died_write_hook_argv`'s `#{pane_dead_status}` has stopped "
+            "working too, which is a much larger thing than this test")
+        self.assertEqual(seen, f"/opt/py{pane}/x",
+                         "the text was rewritten, but not into the pane id — read what "
+                         "this tmux actually does before trusting the guard's reasoning")
+
+    #: How many deaths one exit-status test may spend before it gives up on this
+    #: machine — #409.
+    #:
+    #: **Not a retry for flakiness: a retry for a trial that measured nothing.** The
+    #: signal-death test was failing about one CI job in eight on tmux 3.4, and the
+    #: diagnosis in the ticket ("tmux marks the pane dead and THEN runs the hook; the
+    #: read lands in that window") predicts a longer wait would fix it. This module had
+    #: already measured otherwise, in `PanelIntegration`'s own docstring: pinned to one
+    #: cpu against four spin loops, 11 of 120 deaths on tmux 3.4 ended `#{pane_dead}` `1`
+    #: with an EMPTY status and the `pane-died` hook never firing — **permanently**,
+    #: polling a further 8 seconds never filled it in. tmux 3.4's `server_destroy_pane`
+    #: does not have the child's status when the pane's fd closes, and nothing arrives
+    #: later. So the deadline is not the knob for THIS one, and a bounded poll alone
+    #: would have re-shipped the same flake with a longer wait attached to it.
+    #:
+    #: What a death like that produces is not a wrong answer, it is no answer: the pane
+    #: is gone and tmux never ran charter's hook, so there is nothing for the test to be
+    #: about. :meth:`_a_death_the_hook_saw` detects exactly that — with a probe hook
+    #: beside charter's own, not by reading the empty status, which the healthy signal
+    #: death also has — and spends another pane on it.
+    _HOOK_TRIALS = 3
+
+    def _a_death_the_hook_saw(self, dies_by: str, status_path: str):
+        """One trial of "a pane dies, charter's write hook records its status".
+
+        Returns the status file's CONTENT, or ``None`` when tmux never ran this pane's
+        `pane-died` array at all — the tmux 3.4 window :data:`_HOOK_TRIALS` describes,
+        which is a trial that measured nothing rather than a result.
+
+        **The probe hook is what tells those apart, and it is a different question from
+        the one the test asks.** It is installed at `pane-died[1]` with a CONSTANT action
+        — `touch <marker>`, no `#{pane_dead_status}`, no `$CHARTER_FRAME_EXIT`, nothing
+        charter builds — so the only thing its marker can report is "tmux reached this
+        pane's hook array". tmux runs an array in index order, so the marker cannot
+        appear unless charter's own `[0]` was reached first. An INDEXED install beside an
+        existing `[0]` is safe: that is exactly what
+        `test_the_write_hook_must_be_installed_before_the_teardown_hook` measures, and it
+        is the same shape `cmd_launch` itself uses.
+
+        **A fired array with no file is a FAILURE, not a void trial**, and that is the
+        half that keeps this test able to fail. Delete the `${v:-N}` fallback and the
+        hook still fires and still writes — an empty line — so the file exists and its
+        content is asserted. Break the hook so nothing is written at all and the probe
+        still fires, so this says so rather than skipping.
+        """
+        session, pane, gate = self._new_pane(dies_by)
+        self.assertEqual(_run(commands_frame._exit_path_env_argv(
+            socket=SOCKET, session=session, status_path=status_path)).returncode, 0)
+        self.assertEqual(_run(commands_frame._pane_died_write_hook_argv(
+            socket=SOCKET, harness_pane=pane)).returncode, 0)
+        fired = os.path.join(self._gate_dir, f"array-ran-{pane.lstrip('%')}")
+        self.assertEqual(_tmux("set-hook", "-p", "-t", pane, "pane-died[1]",
+                               f'run-shell "touch {fired}"').returncode, 0)
+        self._release(gate)
+        if not _await_file(fired):
+            return None, pane
+        self.assertTrue(
+            _await_file(status_path),
+            "tmux ran this pane's `pane-died` array — a constant-action probe hook "
+            "beside charter's own fired — and charter's write hook produced no file at "
+            "all. That is charter, not the runner.")
+        return Path(status_path).read_text().strip(), pane
+
+    def _no_death_was_delivered(self):
+        self.skipTest(
+            f"none of {self._HOOK_TRIALS} deaths on this machine reached a `pane-died` "
+            "hook at all — tmux never had the child's status when the pane's fd closed "
+            "(measured on tmux 3.4 under load; see `_HOOK_TRIALS`). The capability this "
+            "test measures was not present to measure, and nothing here is widened to "
+            "pass without it.")
 
     # -- 2. Path delivery and injection ---------------------------------------------- #
 
@@ -693,9 +857,11 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
         exit-status path reaches the write hook's shell — verified here against a path
         containing a space, a literal `'`, and a `$(touch ...)` injection attempt all at
         once: the file at that exact path must hold the harness's real exit code, and
-        nothing embedded in the path may execute."""
+        nothing embedded in the path may execute.
+
+        Tried up to `_HOOK_TRIALS` times, for #409's reason and not for flakiness'
+        sake: a death tmux never ran a hook for measured nothing about this path."""
         self._require_pane_died_fires()
-        session, pane, gate = self._new_pane("exit 42")
         tmp = tempfile.mkdtemp(prefix="charter-integ-inj-")
         self.addCleanup(shutil.rmtree, tmp, True)
         canary = os.path.join(tmp, "canary")
@@ -703,21 +869,15 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
         os.makedirs(hostile_dir, exist_ok=True)
         status_path = os.path.join(hostile_dir, "exit")
 
-        env_cmd = commands_frame._exit_path_env_argv(socket=SOCKET, session=session,
-                                                      status_path=status_path)
-        self.assertEqual(_run(env_cmd).returncode, 0)
-        write_cmd = commands_frame._pane_died_write_hook_argv(socket=SOCKET, harness_pane=pane)
-        self.assertEqual(_run(write_cmd).returncode, 0)
-        teardown_cmd = commands_frame._pane_died_teardown_hook_argv(socket=SOCKET, harness_pane=pane)
-        self.assertEqual(_run(teardown_cmd).returncode, 0)
-
-        self._release(gate)
-        _await_file(status_path)
-
-        self.assertFalse(os.path.exists(canary),
-                         "the $(touch ...) inside the plane path must never execute")
-        with open(status_path) as f:
-            self.assertEqual(f.read().strip(), "42")
+        for _ in range(self._HOOK_TRIALS):
+            content, _pane = self._a_death_the_hook_saw("exit 42", status_path)
+            if content is None:
+                continue   # tmux never ran the array — see `_HOOK_TRIALS`
+            self.assertFalse(os.path.exists(canary),
+                             "the $(touch ...) inside the plane path must never execute")
+            self.assertEqual(content, "42")
+            return
+        self._no_death_was_delivered()
 
     # -- 3. Signal death -------------------------------------------------------------- #
 
@@ -732,36 +892,44 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
 
         The pane's own program signals ITSELF once its gate opens, rather than the test
         typing the same thing at an interactive shell — see `_gate_argv` for the 30-trial
-        measurement that made the difference between the two shapes."""
+        measurement that made the difference between the two shapes.
+
+        **#409, and what it is NOT.** This failed about one CI job in eight on tmux 3.4
+        and cost a re-run on five PRs. Two fixes were rejected on the way to this one.
+        Accepting an empty `#{pane_dead_status}` as a pass would make the assertion
+        unfailable — the sentinel is the whole subject. And a longer wait would not have
+        worked either: the ticket reads the failure as a race against the hook, but this
+        module had already measured the opposite (`PanelIntegration`'s docstring, 11 of
+        120 deaths on a one-cpu 3.4), that in that window the hook never fires AT ALL and
+        never will. So the fix is to notice a death that carried no measurement and spend
+        another pane, while asserting every delivered death exactly as strictly as before
+        — see :meth:`_a_death_the_hook_saw` and :data:`_HOOK_TRIALS`."""
         self._require_pane_died_fires()
-        session, pane, gate = self._new_pane("kill -9 $$")
         tmp = tempfile.mkdtemp(prefix="charter-integ-sig-")
         self.addCleanup(shutil.rmtree, tmp, True)
-        status_path = os.path.join(tmp, "exit")
 
-        env_cmd = commands_frame._exit_path_env_argv(socket=SOCKET, session=session,
-                                                      status_path=status_path)
-        self.assertEqual(_run(env_cmd).returncode, 0)
-        write_cmd = commands_frame._pane_died_write_hook_argv(socket=SOCKET, harness_pane=pane)
-        self.assertEqual(_run(write_cmd).returncode, 0)
+        for attempt in range(self._HOOK_TRIALS):
+            # A fresh path per trial, so a file left by an earlier trial can never be
+            # what a later one reads back.
+            status_path = os.path.join(tmp, f"exit-{attempt}")
+            content, pane = self._a_death_the_hook_saw("kill -9 $$", status_path)
+            if content is None:
+                continue   # tmux never ran the array — see `_HOOK_TRIALS`
 
-        self._release(gate)
-        _await_file(status_path)
-
-        dead, _, status = _tmux("display-message", "-p", "-t", pane,
-                                "#{pane_dead}:#{pane_dead_status}").stdout.strip().partition(":")
-        self.assertEqual(dead, "1", "the pane must be confirmed dead before this test "
-                                    "means anything")
-        self.assertEqual(status, "", "this pins that tmux itself still reports an EMPTY "
-                                     "status for a signal death, not a negative number "
-                                     "— the wrong premise an earlier version of this "
-                                     "suite assumed")
-
-        with open(status_path) as f:
-            content = f.read().strip()
-        self.assertEqual(content, str(commands_frame._UNKNOWN_DEATH_CODE),
-                         f"expected the sentinel, got {content!r} (an empty string here "
-                         f"is exactly the bug: state.exit_code cannot parse it)")
+            dead, _, status = _tmux(
+                "display-message", "-p", "-t", pane,
+                "#{pane_dead}:#{pane_dead_status}").stdout.strip().partition(":")
+            self.assertEqual(dead, "1", "the pane must be confirmed dead before this "
+                                        "test means anything")
+            self.assertEqual(status, "",
+                             "this pins that tmux itself still reports an EMPTY status "
+                             "for a signal death, not a negative number — the wrong "
+                             "premise an earlier version of this suite assumed")
+            self.assertEqual(content, str(commands_frame._UNKNOWN_DEATH_CODE),
+                             f"expected the sentinel, got {content!r} (an empty string "
+                             f"here is exactly the bug: state.exit_code cannot parse it)")
+            return
+        self._no_death_was_delivered()
 
     # -- 4. Resize redistribution ----------------------------------------------------- #
 
@@ -975,7 +1143,7 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
         r = _tmux("set", "-w", "-t", session, "remain-on-exit", "on")
         self.assertEqual(r.returncode, 0, r.stderr)
 
-    def _wait_for(self, target: str, needle: str, timeout: float = 8.0) -> str:
+    def _wait_for(self, target: str, needle: str, timeout: float = _DEADLINE) -> str:
         """Poll `capture-pane` until *needle* is on the visible screen, returning the
         last capture either way — the same "poll for content, never sleep a guess"
         shape `_await_file` uses, so a slow runner is slow rather than wrong."""
@@ -1105,7 +1273,7 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
         self._remain_on_exit("panel-oldshape")
         Path(gate).write_text("x")
 
-        deadline = time.monotonic() + 8
+        deadline = time.monotonic() + _DEADLINE
         while time.monotonic() < deadline and self._dead("panel-oldshape") != "1":
             time.sleep(0.1)
         self.assertEqual(self._dead("panel-oldshape"), "1",
@@ -1144,7 +1312,7 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
         todos.add("demo", "a fresh todo the live panel should pick up")
         state.bump(fid)
 
-        deadline = time.monotonic() + 3
+        deadline = time.monotonic() + _DEADLINE
         changed = False
         while time.monotonic() < deadline:
             if _tmux("capture-pane", "-p", "-t", "panel-live").stdout != first:
@@ -1191,7 +1359,7 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
             })
         self.assertIsNone(out, "posttooluse should emit nothing for a plain Read")
 
-        deadline = time.monotonic() + 3
+        deadline = time.monotonic() + _DEADLINE
         changed = False
         while time.monotonic() < deadline:
             if _tmux("capture-pane", "-p", "-t", "panel-hook-live").stdout != first:
@@ -1320,7 +1488,7 @@ class MenuIntegration(PersonaIso, unittest.TestCase):
         r = _tmux("run-shell", "-t", fid, action)
         self.assertEqual(r.returncode, 0, r.stderr)
 
-        deadline = time.monotonic() + 5
+        deadline = time.monotonic() + _DEADLINE
         while time.monotonic() < deadline and not os.path.exists(canary):
             time.sleep(0.2)
 
@@ -1531,7 +1699,7 @@ class MenuFormatIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
                          "rendered")
 
         os.write(fd, b"1")
-        deadline = time.monotonic() + 5
+        deadline = time.monotonic() + _DEADLINE
         while time.monotonic() < deadline and not os.path.exists(real_canary):
             time.sleep(0.2)
         self.assertTrue(os.path.exists(real_canary),
@@ -1770,7 +1938,7 @@ class MenuClientIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
                          "own hotkey opened — the menu did not open specifically on "
                          "A's screen (the exact regression this round fixes)")
         os.write(fdA, b"1")
-        deadline = time.monotonic() + 5
+        deadline = time.monotonic() + _DEADLINE
         while time.monotonic() < deadline and not os.path.exists(canary_a):
             time.sleep(0.2)
         self.assertTrue(os.path.exists(canary_a),
@@ -1789,7 +1957,7 @@ class MenuClientIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
                          "client A's own keystream selected an item in the menu B's "
                          "own hotkey opened")
         os.write(fdB, b"1")
-        deadline = time.monotonic() + 5
+        deadline = time.monotonic() + _DEADLINE
         while time.monotonic() < deadline and not os.path.exists(canary_b):
             time.sleep(0.2)
         self.assertTrue(os.path.exists(canary_b),
@@ -1965,7 +2133,7 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
     def _alive(self, pane: str) -> str:
         return _tmux("display-message", "-p", "-t", pane, "#{pane_dead}").stdout.strip()
 
-    def _wait_for(self, pane: str, needle: str, timeout: float = 5.0) -> str:
+    def _wait_for(self, pane: str, needle: str, timeout: float = _DEADLINE) -> str:
         """Poll `capture-pane` for *pane* until *needle* appears or *timeout*
         elapses, returning whatever was last captured either way.
 
@@ -2445,7 +2613,7 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         self.assertTrue(pane_id.startswith("%"), r.stdout)
         return window_id, pane_id
 
-    def _wait_until(self, predicate, timeout=5.0):
+    def _wait_until(self, predicate, timeout=_DEADLINE):
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             if predicate():
@@ -2553,6 +2721,7 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         out = os.path.join(self._gate_dir, "harness-env")
         env = commands_frame._frame_env("charter-demo-1", None)
         env["CHARTER_HARNESS"] = "claude-code"
+        env = commands_frame._guest_harness_env(env)
         r = _run(layout.respawn_argv(
             socket=SOCKET_PATH, harness_pane=pane_id, env=env, cwd=self._gate_dir,
             harness_argv=["/bin/sh", "-c",
@@ -2567,6 +2736,96 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         self.assertEqual(pane_seen, pane_id,
                          "the harness must see its OWN pane, not the launcher's")
         self.assertNotEqual(pane_seen, op_pane)
+
+    def test_a_pane_here_gets_the_invoking_clients_path_not_the_servers(self):
+        """The measurement `_guest_harness_env` rests on, pinned against a real server so
+        charter is TOLD if tmux ever changes it.
+
+        `cmd_launch` resolves the harness binary with `shutil.which` against charter's own
+        `$PATH`; the pane it then respawns into lives on a server the operator started.
+        Measured against tmux 3.7c: the pane's `$PATH` is the one the CLIENT that issued
+        `respawn-pane` had — charter's — and an explicit `-e PATH=…` does not even
+        survive, tmux overwrites it after applying the `-e` set. So on this tmux carrying
+        `PATH` is redundant; if that ever stops being true, `_guest_harness_env` becomes
+        the only thing standing between an operator and a harness that cannot be executed,
+        and this test is where the change shows up.
+
+        `python3` reads the value, not a shell, so no shell's own `$PATH` normalisation
+        can be what is being measured.
+        """
+        _, sid, _, _ = self._operator_server()
+        _, pane_id = self._open_frame_window(sid)
+        self._require_pane_options(pane_id)
+        out = os.path.join(self._gate_dir, "harness-path")
+        mine = os.environ.get("PATH", "")
+        r = _run(layout.respawn_argv(
+            socket=SOCKET_PATH, harness_pane=pane_id,
+            env={"PATH": "/charter/said/this", "CHARTER_SESSION_ID": "charter-demo-1"},
+            cwd=self._gate_dir,
+            harness_argv=[sys.executable, "-c",
+                          "import os,sys;open(sys.argv[1],'w')"
+                          ".write(os.environ.get('PATH',''))", out]))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertTrue(_await_file(out), "the harness never ran")
+        seen = Path(out).read_text()
+        self.assertNotEqual(seen, "", "the pane was handed no PATH at all")
+        self.assertEqual(seen, mine,
+                         "a pane on somebody else's server no longer gets the invoking "
+                         "client's PATH — `_guest_harness_env`'s `-e PATH` is now the "
+                         "only thing carrying it, and its 'redundant here' note is stale")
+        self.assertNotEqual(seen, "/charter/said/this",
+                            "`-e PATH=` now survives; the same note is stale the other "
+                            "way, and charter could state a PATH deliberately")
+
+    def test_a_panels_respawn_hook_is_armed_against_this_server_and_fires(self):
+        """#408, end to end on the path it was broken on. `_arm_panel_respawn` refused
+        here outright, because `_panel_died_hook_argv` hand-built `["tmux", "-L", …]` and
+        would have aimed a `run-shell` at charter's private server — or started an empty
+        one named after a socket path.
+
+        Two things a mock cannot check: that `set-hook -p` is accepted on a pane charter
+        created inside somebody else's server at all, and that the action reaches a real
+        shell with the frame id ON IT — there is no `set-environment` here to read
+        `$CHARTER_SESSION_ID` back out of, which is the reason `--frame` exists."""
+        self._require_pane_died_fires()
+        _, sid, _, _ = self._operator_server()
+        _, pane_id = self._open_frame_window(sid)
+        self._require_pane_options(pane_id)
+        gate = os.path.join(self._gate_dir, "panel-gate")
+        panel = _run(tmuxctl.server_argv(
+            SOCKET_PATH, "split-window", "-t", pane_id, "-v", "-l", "1",
+            "-P", "-F", "#{pane_id}", "--", *_gate_argv(gate, "exit 4"))).stdout.strip()
+        self.assertTrue(panel.startswith("%"), panel)
+        _run(tmuxctl.server_argv(SOCKET_PATH, "set-option", "-p", "-t", panel,
+                                 "remain-on-exit", "on"))
+        seen = self._hook_reaches_a_shim(
+            socket=SOCKET_PATH, pane=panel, gate=gate,
+            interpreter_dir=os.path.join(self._gate_dir, "op interp"))
+        self.assertIsNotNone(
+            seen, "a panel that died inside the operator's own tmux reached nothing — "
+                  f"hooks: {_run(tmuxctl.server_argv(SOCKET_PATH, 'show-hooks', '-p', '-t', panel)).stdout!r}")
+        self.assertEqual(seen, ["-P", "-m", "charter", "frame-respawn", "top",
+                                "--pane", panel, "--frame", "demo-1"])
+
+    def test_a_frame_here_is_live_by_its_window_never_by_a_session(self):
+        """`cmd_respawn` asked `_live_sessions(SOCKET)` unconditionally, which on this
+        server is a question about somebody else's sessions: it answers "gone" for a
+        frame that is on screen, so a panel could never have been brought back even once
+        the hook reached charter. `_frame_is_live` asks the right question per server.
+
+        Both directions against the same real server, so neither can pass by the answer
+        always being the same one."""
+        _, sid, _, _ = self._operator_server()
+        self._open_frame_window(sid, fid="charter-demo-1")
+        self.assertTrue(commands_frame._frame_is_live(SOCKET_PATH, "charter-demo-1"))
+        self.assertFalse(commands_frame._frame_is_live(SOCKET_PATH, "a-frame-that-ended"))
+        # And the operator's OWN session name is not a frame: a `list-sessions`-shaped
+        # answer here would report it live and respawn a panel into a window charter
+        # never opened.
+        sessions = _tmux("list-sessions", "-F", "#{session_name}").stdout.split()
+        self.assertTrue(sessions, "the fixture server reported no sessions at all")
+        for name in sessions:
+            self.assertFalse(commands_frame._frame_is_live(SOCKET_PATH, name), name)
 
     def test_the_harness_starts_where_charter_was_typed(self):
         """A pane in a server charter did not start otherwise inherits the SESSION's
@@ -2648,7 +2907,7 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         worker.start()
         self.assertTrue(self._wait_until(
             lambda: "demo-" in _tmux("list-windows", "-a", "-F",
-                                     "#{window_name}").stdout, timeout=15),
+                                     "#{window_name}").stdout),
             "the frame's own window never appeared in the operator's server")
         during = _snapshot()
         self._release(gate)


### PR DESCRIPTION
Three defects on the frame drawn as a window in a tmux charter does not own.

Closes #446
Closes #408
Closes #409

## #446 — the operator-tmux path stops putting the environment on a command line

`respawn-pane -e` carried `dict(os.environ, …)` whole. Measured on one real environment:
**129 argv elements, 7,773 bytes, four live 1Password service-account tokens and an npm
auth token**, into a `/proc/<pid>/cmdline` that is world-readable to every local user on
Linux and recorded permanently by exec-audit tooling. `charter claude` is the default
command, so that was every launch from inside tmux. #412 closed the same hole on charter's
own server and left this one, on the stated ground that the base the overlay lands on is a
server charter does not own.

**The measurement the issue asked for, against tmux 3.7c** (scripts and raw output were
run against a real server, not reasoned about):

| question | answer |
|---|---|
| Does a pane inherit the operator's SERVER environment? | Yes — a var set only on the server reached the pane; a var set only on the invoking client did not. |
| Is `$PATH` the exception? | **Yes.** Server `PATH=/server/bin`, client `PATH=/respawnclient/bin` → pane got `/respawnclient/bin`. |
| Does `-e PATH=…` override that? | **No.** `-e PATH=/explicit/bin` on the same command was discarded; tmux overwrites `PATH` *after* applying the `-e` set. (Read out of the pane by `python3`, not a shell, to rule out shell normalisation.) |
| Does `-e NAME` (no `=`) unset a variable? | No — the variable survived. |

So the harness pane is told `_FRAME_IDENTITY` + `PATH` (six names) and each panel pane the
five identity names — panels start no subprocess at all and their interpreter is already
absolute, so they have no use for `PATH`. `PATH` is belt and braces rather than the fix: on
this tmux the pane already has charter's, but nothing says an older tmux does the same, and
`cmd_launch` resolved the harness binary with `shutil.which` against charter's own `$PATH`
— a promise it would otherwise be unable to keep.

**The rule moved, not just the code.** It lived at the call sites, which is precisely why
one of the two was fixed a release ago and the other was not. It now lives in
`layout._env_argv`, the single funnel every `-e` charter emits passes through, and an
unlisted name is a `ValueError` rather than a leak. Mutating that guard away turns 29 tests
red across three files.

**Cost, stated in `docs/frame.md` and the news entry rather than left implicit:** the
harness inherits the operator's *tmux server's* environment, not their current shell's.
Already true on charter's own server; now true on both.

## #408 — a panel that dies inside the operator's tmux comes back

`_arm_panel_respawn` refused there, because `_panel_died_hook_argv` and `cmd_respawn` both
spelled `["tmux", "-L", SOCKET, …]` by hand while that server is reached by `-S <path>`.
Both now build argv through `tmuxctl.server_argv` — the one place that already knows the
difference — and `cmd_respawn` resolves its server from `state.frame_server(fid)` with
`_frame_is_live`, which asks about **windows** on the operator's server and **sessions** on
charter's. A server that does not answer at all is not respawned into.

**One thing the issue could not have known.** The hook's action needed `$CHARTER_PY` and
`$CHARTER_SESSION_ID`, both delivered by `set-environment -t <session>` — which this path
must not write. Measured: a `run-shell` fired by a pane-scoped hook sees the SESSION
environment (`$CHARTER_PY` set that way arrived intact) and does **not** see the pane's own
`-e` (a `CHARTER_PY` on `split-window -e` read back empty). There is no out-of-band channel
on that server, so both values travel in the action text and `cmd_respawn` grew `--frame`
(optional — a hook installed by an older charter still resolves from the environment).

That means charter's interpreter path is interpolated into a string tmux re-parses, so
`_action_word_is_safe` refuses to arm a hook whose path would not survive intact.

### The next spelling, found and closed

The first version of that guard named itself after quotes and checked only for quote
characters. A hook action passes through **three** parsers, and the first is tmux's own
`#{…}` format expansion — the very mechanism `_pane_died_write_hook_argv` uses to get
`#{pane_dead_status}` to a shell. Measured: an action holding the literal
`/opt/py#{pane_id}/x` reached `/bin/sh` as `/opt/py%1/x`. `#{pane_title}` expands to text
the program running in that pane sets for itself with an escape sequence. `#` is refused
with the rest, the constant is renamed for what it is, and there is a positive control in
the integration suite that fails if tmux ever stops expanding formats in an action.

Measured in both directions, so the guard is not a paranoid allowlist: an interpreter under
`…/a b;c&d(e)f*g-h,i=j+k@l:m[n]o{p}q!r%s^t~u/fake py` is armed and arrives byte for byte;
one under `…/plain $(touch CANARY) dir/py` created the canary and is refused.

## #409 — the flaky signal-death test, with the ticket's diagnosis refuted

The ticket reads the failure as a race ("tmux marks the pane dead and *then* runs the
hook") and predicts a bounded poll with a longer deadline fixes it. **This suite had
already measured otherwise.** `PanelIntegration`'s own docstring records: pinned to one cpu
against four spin loops on tmux 3.4, **11 of 120 deaths** ended `pane_dead=1` with an empty
status and the `pane-died` hook never firing — *permanently*, polling a further 8 seconds
never filled it in. tmux 3.4's `server_destroy_pane` does not have the child's status when
the pane's fd closes, and nothing arrives later. A longer wait would have re-shipped the
same flake with more seconds attached.

The assertion is unchanged and unwidened — the sentinel is the whole subject. Instead the
test detects a death that carried **no measurement** and spends another pane, up to three:

- the discriminator is a **constant-action probe hook at `pane-died[1]`** (`touch <marker>`
  — nothing charter builds), because the empty `pane_dead_status` looks identical in the
  healthy case and cannot tell them apart;
- tmux runs an array in index order, so the marker cannot appear unless charter's `[0]` was
  reached;
- **a fired array with no file is a FAILURE, not a void trial** — that is what keeps the
  test able to fail. Mutating the write hook to produce nothing at all turns it red rather
  than skipping it.

Both hook-written-file tests use it. The eleven separate deadlines this module carried (3,
5, 8 and 15 seconds apiece) are now one `_DEADLINE` constant, applied to positive waits
only — a wait that exists to show something does *not* happen keeps its own short number,
since raising those spends the time on every run.

## Mutation testing

Each applied, confirmed RED, restored, confirmed GREEN, `__pycache__` cleared between runs:

| mutation | result |
|---|---|
| `${v:-N}` fallback dropped from the write hook | RED (signal-death) |
| write hook writes nothing at all | RED (both exit-status tests) — proves the retry is not a skip |
| `_env_argv`'s allowlist never refuses | RED (4 layout tests) |
| `_guest_harness_env` returns the whole environment | RED (29 tests, 3 files) |
| hook builder hardcodes `-L` again | RED (4 tests: unit, density, launcher, integration) |
| `cmd_respawn` asks `_live_sessions(SOCKET)` | RED |
| a non-answering server counts as live | RED |
| `_action_word_is_safe` returns True | RED |
| interpreter left unquoted for the shell | RED (2 integration tests) |
| `#` dropped from the metacharacter set | RED |

## Verification

`python3 -m unittest discover -s tests` — **4549 tests, OK** on Python 3.14 and 3.12
(macOS, tmux 3.7c). No new dependency; stdlib only. No test makes a network call. Every
new test that touches plane state runs under `PersonaIso`. No fixture or assertion message
carries a real credential, and the new assertions compare filtered projections rather than
whole argvs — the launch argv now legitimately carries `$PATH`, which is not a thing to
print in a failure message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
