### PR TITLE
A release leads with the entry that matters, not the one named earliest (#486)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
             echo "::error::tag v$tag does not match pyproject.toml version $pkg — refusing to publish"
             exit 1
           fi
-      - name: Refuse to publish a version that ships no news entry
+      - name: Refuse to publish a version whose news entries cannot be rendered
         run: |
           # The version comes from pyproject, not the tag: it is defined on BOTH trigger
           # paths (a workflow_dispatch retry has no tag to read), and the step above has
@@ -65,9 +65,15 @@ jobs:
           # same call that renders the Release body below. Globbing would be a second
           # answer to one question, free to say yes on a release whose notes come out
           # empty. `charter news --for` exits non-zero when there is nothing to render.
+          #
+          # It exits non-zero for MORE than that now (#486): an ordering field charter
+          # cannot read, or two entries both claiming `lead: true`. So the annotation
+          # names both causes and defers to the command's own stderr — which `>/dev/null`
+          # keeps, since it drops only stdout — rather than prescribing `news stamp` for
+          # a failure stamping cannot fix.
           version=$(python -c 'import tomllib;print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
           if ! python -m charter news --for "$version" >/dev/null; then
-            echo "::error::no docs/news/$version-<slug>.md — every published version ships an entry, including a patch. Run: charter news stamp $version"
+            echo "::error::cannot render the release notes for $version: either no docs/news/$version-<slug>.md (every published version ships an entry, including a patch — run: charter news stamp $version), or an ordering those entries declare that charter cannot honour. See the error above for which."
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,15 @@ command.
   `charter news stamp <version>` to move it onto the version that ships it. Entries travel
   inside the wheel, so `charter news` works offline on any harness.
 
+  Two optional ordering fields, both `true`/`false` and both off by default. `security:
+  true` says this entry is a security fix: it sorts above the ordinary entries of its
+  version and renders as `security: <headline>`, in the Release body and in `charter news`
+  alike. Any number of entries may say it. `lead: true` says this entry goes first, and
+  only one entry per version may — a second is refused at the release gate rather than
+  resolved by a coin toss. Say `security:` if you know what your entry *is*; leave `lead:`
+  to the release, which is the only vantage point from which "first" means anything.
+  Without either, entries sort by filename as they always have.
+
   Write it in the PR that builds the thing: you are the only person who knows why it
   matters and what would prove somebody has taken it up, and reconstructing that from
   commit titles at release time is how notes become a changelog nobody reads. Nothing in CI

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -2425,8 +2425,10 @@ def _news_line(e, status: str) -> str:
     this text is the only thing an agent on another harness has — a machine surface would
     become the parsed one, and this the unchecked one.
     """
+    from . import news
+
     how = f"adopt: charter {e.adopt}" if e.adopt else "adopt: manual (see the entry)"
-    return f"  {e.slug} · {e.headline}\n      {how}"
+    return f"  {e.slug} · {news.marker(e)}{e.headline}\n      {how}"
 
 
 #: Said once, where a probe would otherwise be run against nothing.
@@ -2447,6 +2449,18 @@ def cmd_news(args) -> int:
 
     version = getattr(args, "for_version", None)
     if version:
+        # THE release gate. `release.yml`'s pre-publish check runs this and refuses to tag
+        # on a non-zero exit, and its `announce` job pipes this same stdout into
+        # `gh release create --notes-file`. So an ordering charter cannot honour is caught
+        # before a Release exists to be wrong, rather than after — which is the position
+        # #486 was filed from, with the notes already published.
+        problems = news.ordering_errors(news.for_version(version))
+        if problems:
+            util.err(f"the news entries for {version} declare an ordering charter cannot "
+                     f"honour:")
+            for why in problems:
+                util.info(f"  {why}")
+            return 1
         body = news.render_body(version)
         if not body:
             util.err(f"no news entry for {version}.")
@@ -2497,9 +2511,15 @@ def cmd_news(args) -> int:
         return 0
     if planeless:
         util.warn(_NO_PLANE)
+    # Warned, not refused. This view is a reader catching up, and withholding the range
+    # over a malformed `security:` line would lose them the other nineteen entries to
+    # protect them from one being in the wrong place. `--for` is where refusing belongs,
+    # because that is the call that becomes a published Release.
+    for why in news.ordering_errors(entries):
+        util.warn(why)
     for e in entries:
         status, _ = (news.INFORMATIONAL, "") if planeless else news.probe(e)
-        print(f"{e.version}  {e.headline}")
+        print(f"{e.version}  {news.marker(e)}{e.headline}")
         # Only an entry with something to DO gets the action line. An informational entry
         # — a patch note, usually — exists to say there is nothing to take up, so printing
         # "adopt: manual" beneath it invents a chore out of the line that denies one.

--- a/charter/news.py
+++ b/charter/news.py
@@ -4,7 +4,16 @@ A *news entry* is a shipped, per-item note that a version introduced something, 
 an optional probe for whether this plane has adopted it. Not a changelog: an entry exists
 to be **acted on**, and one with nothing to adopt is one line.
 
-Four properties are load-bearing.
+Five properties are load-bearing.
+
+**One entry, two consumers, one answer.** The GitHub Release body and the offline `charter
+news` suggestion are the same entries rendered twice — `release.yml`'s announce job pipes
+`charter news --for <version>` straight into `gh release create --notes-file`. So anything
+that decides how an entry is presented has to be decided once, where both reach it, and
+never at a call site. It was not, and #486 is what that cost: ORDER was left to
+`sorted(glob("*.md"))`, which for a stamped release is alphabetical by slug, so 0.52.0's
+vault-spending fix rendered eighth, under a docs correction. :func:`all` now applies the
+declared order and :func:`marker` the label, and both views come through them.
 
 **It ships in the wheel.** Entries travel with the code that implements them, resolved the
 way :mod:`charter.docsrc` resolves documentation — packaged copy first, the repo's
@@ -76,7 +85,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import NamedTuple
 
-from . import persona, update
+from . import contain, persona, update
 
 #: The version a staged entry carries until a release stamps it. A feature PR cannot know
 #: which version will ship it — the next release may be a patch, or the PR may sit through
@@ -131,6 +140,22 @@ _refused: str | None = None
 _ENV = "CHARTER_NEWS_PROBE"
 
 
+#: The two opt-in ordering fields, and the only two. `security:` is a CLASS — a version
+#: may ship any number of security entries, and they sort above everything else. `lead:`
+#: is a POSITION, so at most one entry per version may claim it; a second is a
+#: contradiction :func:`ordering_errors` reports rather than resolving.
+#:
+#: Split rather than collapsed into one `rank: <int>`, because the two answer different
+#: questions and only one of them can be answered by an author working alone. "Is this a
+#: security fix?" is a fact about the entry, knowable while writing it and true forever.
+#: "Does this go first?" is a fact about the RELEASE, which the author cannot know — 24
+#: entries were staged for 0.52.0 and none of their authors could see the other 23. A
+#: numeric rank would make every author guess at that, and guess wrong quietly; these two
+#: let an author state only what they actually know.
+LEAD, SECURITY = "lead", "security"
+_ORDERING_FIELDS = (LEAD, SECURITY)
+
+
 class Entry(NamedTuple):
     version: str
     slug: str
@@ -139,6 +164,17 @@ class Entry(NamedTuple):
     adopt: str
     body: str
     path: Path
+    #: Declared position and class. Both default False — 24 entries do not each need a
+    #: number, and an entry that says nothing sorts exactly where it always did.
+    lead: bool = False
+    security: bool = False
+    #: ``(field, raw)`` for every ordering field whose value was not understood. Carried
+    #: rather than raised, and rather than silently read as false, because false is the
+    #: answer that SINKS the entry — an author who wrote `security: yes` and got the
+    #: bottom of the release notes would have been failed by the field that was supposed
+    #: to help them. :func:`ordering_errors` turns these into sentences, and
+    #: `charter news --for` — which is the release workflow's own gate — refuses on them.
+    bad: tuple[tuple[str, str], ...] = ()
 
 
 def _is_checkout(d: Path) -> bool:
@@ -184,20 +220,175 @@ def _read(p: Path) -> Entry | None:
     # The slug is the filename's, the version is the frontmatter's. Two sources for one
     # fact would drift the moment `news stamp` renamed a file and missed the field.
     slug = p.stem.split("-", 1)[1] if "-" in p.stem else p.stem
+    flags: dict[str, bool] = {}
+    bad: list[tuple[str, str]] = []
+    for field in _ORDERING_FIELDS:
+        # `field in meta`, not `meta.get(field) or ""`: absent and present-but-empty are
+        # different facts, and `.get(…) or ""` is the line that made them one. See
+        # :func:`_flag` — a `security:` whose value went onto the continuation line is a
+        # declaration charter could not read, not a declaration that was never made.
+        raw = meta[field].strip() if field in meta else None
+        value = _flag(raw)
+        if value is None:
+            bad.append((field, raw or ""))
+        flags[field] = bool(value)
     return Entry(version=version, slug=slug,
                  headline=(meta.get("headline") or "").strip(),
                  check=(meta.get("check") or "").strip(),
                  adopt=(meta.get("adopt") or "").strip(),
-                 body=body, path=p)
+                 body=body, path=p,
+                 lead=flags[LEAD], security=flags[SECURITY], bad=tuple(bad))
+
+
+def _flag(raw: str | None) -> bool | None:
+    """An ordering field's declared value: True, False, or ``None`` for "not understood".
+
+    ``raw is None`` means **the key is not in the frontmatter at all**, and that is False —
+    the whole of what opt-in means, and why 24 entries needed no edit when this landed.
+    Absence is not a value, so it is spelled as the absence of one; every ``str`` reaching
+    here, ``""`` included, is something an author typed.
+
+    **Empty is a declaration charter could not read, not a declaration never made**, and
+    reading the two as one is how #486 came back through the field added to prevent it.
+    charter's frontmatter is flat ``key: value`` — `persona.parse` drops any line without a
+    colon — so the YAML habit of putting the value on the continuation line::
+
+        security:
+          true
+
+    leaves ``security`` present with nothing after it, and so does ``security:`` typed with
+    the value forgotten or with a trailing space. Folded into "absent", that entry declares
+    a security fix, renders below the ordinary ones, and `charter news --for` exits 0 with
+    an empty stderr: the exact silence #486 is about, from an author who did opt in. The
+    first cut of this function did fold them, by way of ``(meta.get(field) or "").strip()``
+    at the one call site — a spelling of "missing" that a present key also matches, which
+    is the failure this module's docstring names six times over.
+
+    Present-but-unrecognised is **None**, not False, and that distinction is the point of
+    this function. The obvious spelling of "is this true?" is a truthy set —
+    ``{"true", "yes", "1", "on"}`` — and it fails the way every other guard in this
+    codebase has failed: it matches a spelling. The next author writes ``security: Y``,
+    or ``yes  # per the security charter``, or a full-width ``ｔｒｕｅ``, and the set does
+    not hold it, so the entry reads as false and sinks to the bottom of the release notes
+    — silently, in exactly the position the field was added to prevent. Widening the set
+    only moves that edge somewhere less obvious.
+
+    So the property is not "which words mean yes" but **"was this value understood?"**.
+    Two literals are recognised, case-folded; every other string an author typed is
+    reported by :func:`ordering_errors` naming the value it could not read. An author who
+    writes something outside the pair is told so at the release gate rather than being
+    quietly overruled by it.
+
+    **The next spelling** is not in this function: it is the KEY. `persona.parse` matches
+    exactly and case-sensitively, so ``Security: true`` never arrives as ``security`` and
+    is genuinely absent here (#503); and it keeps the LAST of two lines with the same key,
+    so an entry declaring ``security:`` twice has one of them dropped without a word
+    (#509). Both are reached through the dict this function is handed, not through the
+    value it reads, and both change how every caller of `persona.parse` reads its result.
+    """
+    if raw is None:
+        return False
+    folded = raw.strip().casefold()
+    return folded == "true" if folded in ("true", "false") else None
+
+
+def rank(e: Entry) -> int:
+    """Where *e* sits among its own version's entries: 0 leads, 1 is a security fix, 2 is
+    everything else. Lower first."""
+    return 0 if e.lead else 1 if e.security else 2
+
+
+def marker(e: Entry) -> str:
+    """The word that precedes a security entry's headline, everywhere a headline is
+    rendered — ``""`` for an ordinary entry.
+
+    One function rather than a literal at each call site, for the same reason `_dev_chip`
+    is one function: the Release body and the offline `charter news` view are deliberately
+    the same answer printed twice (that is #486's whole premise), and two copies of the
+    label is how they start disagreeing. `lead:` gets no marker — it is a position, not a
+    kind, and "this was listed first" is already visible from being listed first.
+
+    ASCII, and a word rather than a glyph. It renders into a GitHub Release body, into a
+    `TERM=dumb` CI log, and into a terminal charter does not control.
+    """
+    return "security: " if e.security else ""
+
+
+def ordering_errors(entries: list[Entry]) -> list[str]:
+    """Why the declared ordering of *entries* cannot be honoured, as sentences.
+
+    Empty is the ordinary answer. Two failures are reported, and neither is resolved
+    quietly, because a quiet resolution is what #486 was about:
+
+    * an ordering field whose value was not understood (see :func:`_flag`), named with the
+      value, so an author who wrote ``security: yes`` learns which word charter reads —
+      and, when the field was declared with nothing after the colon, naming the shape
+      instead of the empty value, because the author who wrote it almost certainly put
+      the value on the next line and needs to be told that line is not read;
+    * two entries in one version both declaring ``lead: true``. One of them is not going
+      to be first, and picking silently would hand back the accident #486 already
+      diagnosed — a position decided by something other than a person deciding it.
+
+    Callers rather than this function decide the consequence: `charter news --for`, which
+    IS the release workflow's publish gate, refuses; the range view warns and prints on.
+    """
+    out: list[str] = []
+    for e in sorted(entries, key=lambda e: e.path.name):
+        for field, raw in e.bad:
+            if raw == "":
+                # Distinct from the sentence below, because the fix is different: there
+                # is no value to correct, and quoting one back ("`security: `") would
+                # read like a rendering bug. Name the shape that produces it instead —
+                # the value on the continuation line is the way this gets typed.
+                out.append(
+                    f"{e.path.name}: `{field}:` is declared with no value on that line "
+                    f"— a news ordering field is `true` or `false`, written after the "
+                    f"colon. charter's frontmatter is flat `key: value` and drops a line "
+                    f"without a colon, so a value indented onto the NEXT line never "
+                    f"reaches charter. Left unread, this entry sorts as though it never "
+                    f"declared anything.")
+                continue
+            out.append(
+                f"{e.path.name}: `{field}: {contain.one_line(raw)}` is not a value "
+                f"charter reads — a news ordering field is `true` or `false`. Left "
+                f"unread, this entry sorts as though it never declared anything.")
+    leads: dict[str, list[Entry]] = {}
+    for e in entries:
+        if e.lead:
+            leads.setdefault(e.version, []).append(e)
+    for version, claimants in sorted(leads.items()):
+        if len(claimants) > 1:
+            names = ", ".join(sorted(c.path.name for c in claimants))
+            out.append(
+                f"{version}: {len(claimants)} entries declare `lead: true` ({names}) — "
+                f"only one entry can be the one a reader sees first. Leave `lead:` off "
+                f"all but one; a security fix that need not be first can say "
+                f"`security: true` instead, which any number of entries may.")
+    return out
 
 
 def all() -> list[Entry]:
-    """Every entry that parses, oldest version first; staged entries last."""
+    """Every entry that parses, oldest version first; staged entries last, and within one
+    version: the entry that declared `lead:`, then security fixes, then the rest.
+
+    **This sort is the whole of #486.** Both public views of an entry come through here —
+    `render_body` (the GitHub Release body, via :func:`for_version`) and `charter news`
+    (via :func:`released`/:func:`between`) — so an ordering honoured by one is honoured by
+    the other by construction, rather than by two call sites agreeing to sort the same
+    way. The release engineer's charter says the shipped entry is the single source for
+    both and that hand-editing a Release forks them; a fix that taught only the Release
+    body to lead with a security note would be that same fork wearing a commit.
+
+    Within a rank the order is still the filename's, and `sorted` is stable, so an entry
+    that declares nothing lands exactly where it landed before this existed.
+    """
     d = _dir()
     if d is None:
         return []
     found = [e for e in (_read(p) for p in sorted(d.glob("*.md"))) if e is not None]
-    return sorted(found, key=lambda e: (e.version == UNRELEASED, update._parse(e.version)))
+    return sorted(found,
+                  key=lambda e: (e.version == UNRELEASED, update._parse(e.version),
+                                 rank(e)))
 
 
 def released() -> list[Entry]:
@@ -225,10 +416,13 @@ def render_body(version: str) -> str:
 
     The shipped entry is the single source for both the offline suggestion and the public
     notes, so the two cannot drift: one is printed from the other.
+
+    Order comes from :func:`all`, not from this function — see its docstring, and #486.
+    The label comes from :func:`marker`, which the offline view calls too.
     """
     parts = []
     for e in for_version(version):
-        parts.append(f"### {e.headline}\n\n{e.body}".rstrip())
+        parts.append(f"### {marker(e)}{e.headline}\n\n{e.body}".rstrip())
     return "\n\n".join(parts)
 
 

--- a/docs/news/0.52.0-a-server-name-cannot-declare-a-server.md
+++ b/docs/news/0.52.0-a-server-name-cannot-declare-a-server.md
@@ -1,6 +1,7 @@
 ---
 version: 0.52.0
 headline: a committed MCP server name could declare a second server and spend any vault on the machine
+lead: true
 ---
 
 `personas/<name>/mcp.json` is committed. It arrives from whoever last pushed to the repo, and

--- a/docs/news/unreleased-a-release-can-lead-with-what-matters.md
+++ b/docs/news/unreleased-a-release-can-lead-with-what-matters.md
@@ -1,0 +1,115 @@
+---
+version: unreleased
+headline: A release leads with the entry that matters, instead of the one named earliest in the alphabet
+---
+
+`charter news --for <version>` rendered a version's entries in `sorted(glob("*.md"))`
+order, which for a stamped release is alphabetical by slug. `release.yml`'s announce job
+pipes that straight into `gh release create --notes-file`, so slug order **was** the
+published order — and a slug is a name an author picked while thinking about something
+else entirely.
+
+0.52.0 shipped 24 entries. The one that mattered most — a committed MCP server name
+interpolated raw into a generated sub-agent's YAML, which could hand any vault on the
+machine to an attacker-chosen command — rendered *eighth*, below a 1Password docs
+correction. Someone who opened the Release, read two screens and closed it never learned
+they needed to upgrade.
+
+The ordering was not a decision. It was whatever the filenames sorted to.
+
+## Two fields, both opt-in
+
+```
+---
+version: unreleased
+headline: …
+security: true
+lead: true
+---
+```
+
+The bare word, on the same line as the key, and nothing after it: charter's frontmatter is
+flat `key: value` with **no comment syntax**, so a trailing `# …` is part of the value; a
+line without a colon is dropped entirely, so the YAML habit of
+
+```
+security:
+  true
+```
+
+never reaches charter at all. A value charter cannot read is reported rather than guessed
+at, and so is a field declared with nothing after the colon — writing the key is opting
+in, and charter will not quietly decide the author meant "no".
+
+`security: true` says what the entry **is**. It sorts above the ordinary entries of its
+version and renders as `security: <headline>` — in the GitHub Release body and in
+`charter news` alike, which is the half slug order could never give the offline view. Any
+number of a version's entries may declare it.
+
+`lead: true` says where the entry **goes**, and only one entry per version may say it. It
+is deliberately not the author's field: 24 entries were staged for 0.52.0 and none of
+their authors could see the other 23. "First" is a claim that needs the whole release in
+view, so it belongs to the release engineer at `charter news stamp` time.
+
+Declare neither and nothing changes — entries sort by filename exactly as they always
+have. That is why 24 shipped entries needed no edit.
+
+## Both views, one answer
+
+The sort lives in `news.all()`, which the Release body and `charter news` both read
+through. That is the point rather than an implementation detail: the shipped entry is
+deliberately the single source for both, and a fix that taught only the Release body to
+lead with a security note would have forked them just as surely as hand-editing the
+Release would have.
+
+## A contradiction stops the tag, not the reader
+
+Two entries in one version both claiming `lead: true` is not a tie to be broken quietly —
+that is the same "decided by an accident" this exists to end. `charter news --for` refuses
+such a version, and since that call *is* the release workflow's pre-publish guard, the
+release stops before there is a Release body to be wrong.
+
+An ordering field charter cannot read stops it too. The fields take `true` or `false`,
+and anything else — `yes`, `1`, a full-width `ｔｒｕｅ` — is reported by name rather than
+read as false.
+The obvious implementation is a set of words meaning yes, and it fails the way this
+codebase has been failed six times before: an author writes the seventh spelling, charter
+reads it as "no", and the entry sinks to the bottom of the notes in silence — the exact
+defect the field was added to prevent. So the question asked is not *which word is this*
+but *was this value understood*.
+
+**Declaring the field and leaving the value off is that same failure, and it very nearly
+shipped inside the fix.** `security:` with the value indented onto the next line — the
+YAML habit — leaves charter holding the key with an empty value, and the first cut read
+"empty" and "never written" as one thing, because the code asked for the value and treated
+a blank one as a missing key. So an author who *did* declare a security fix got the
+bottom of the notes, exit 0, and not one word about it: #486 restored through the field
+added to prevent it. Declaring a field is now a fact charter reads separately from the
+value in it, and an empty one is refused with a sentence naming the line the value went
+onto.
+
+`charter news`'s range view warns instead of refusing. A reader catching up should not
+lose nineteen entries because a twentieth has a typo in its frontmatter.
+
+## Three limits, filed rather than folded in
+
+Write the field's **name** in any other case — `Security: true` — and none of the above
+happens. charter's frontmatter is looked up by an exact key, so the entry declares nothing
+as far as the sort is concerned, `charter news --for` is satisfied, and the entry sinks
+exactly as #486 described. That is the value half's failure reached through the key half,
+and fixing it means changing how `persona.parse`'s dict is read by every caller of it, so
+it is **#503**. Write the field **twice** in one entry and charter keeps the last line
+without saying so, so `security: true` followed by a stray `security: false` reads as
+false — the same collapse one row over, and **#509**.
+
+And the messages above name the entry by filename, which is committed text, contained for
+its value but not for its name — a `.md` whose name holds a newline forges a line of
+charter's own report. Two of the four sites predate this change, in `news stamp`, so all
+four move together in **#502**.
+
+## What to do about it
+
+Nothing. If you write news entries, `security: true` is now available and worth using
+when it is true. 0.52.0's entry for the MCP server-name fix has been marked `lead: true`,
+so `charter news --for 0.52.0` now shows it first — the published Release body for that
+version was rendered before any of this existed and is unchanged.

--- a/personas/release/persona.md
+++ b/personas/release/persona.md
@@ -90,7 +90,20 @@ A successful publish is followed by one more job, which creates the **GitHub Rel
 `gh release create v<X.Y.Z>` and a body generated from `charter news --for <X.Y.Z>`. Do not
 write release notes by hand: the shipped entry is the single source for both the public
 notes and the offline `charter news` suggestion, and hand-editing forks them. To change what
-a Release says, change the entry and the text follows. That job carries `contents: write`
+a Release says, change the entry and the text follows.
+
+**Including the order.** Entries sorted by filename until #486, so 0.52.0's security fix
+rendered eighth, under a docs correction — an ordering nobody chose. Two frontmatter
+fields now decide it, and they are entry text like everything else, so changing them is
+changing the source rather than forking it. `security: true` is the author's to write and
+sorts that entry above the ordinary ones. `lead: true` is **yours**, at stamp time: it is
+the only claim that needs the whole release in view, and only one entry per version may
+make it — `charter news --for` refuses a version where two do, which is the same call the
+pre-publish guard runs, so a contradiction stops the tag rather than the reader. After
+stamping, read `charter news --for <X.Y.Z>` and check the first entry is the one you would
+want a reader to see if they stopped after two screens.
+
+That job carries `contents: write`
 alone — the workflow's top-level grant stays `contents: read` — and it leaves an existing
 Release untouched, so a `workflow_dispatch` retry after a partial failure is safe to run.
 

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -37,8 +37,12 @@ that is all it did; on stable, and whenever `--to` names a version, it refuses o
 charter news --pending
 ```
 
-Each line is one entry: its slug, what it gives you, and how to take it up. Work them **one
-at a time**, and ask before each:
+Each line is one entry: its slug, what it gives you, and how to take it up. An entry
+prefixed `security:` is a security fix, and within its own version it is listed above the
+ordinary entries — take those up first rather than in list order, and say so when you
+offer them.
+
+Work them **one at a time**, and ask before each:
 
 1. Say what it is and why it matters — `charter news --for <version>` prints the entry.
 2. `adopt: charter <command>` → run it once they say yes.

--- a/tests/test_news_ordering.py
+++ b/tests/test_news_ordering.py
@@ -1,0 +1,662 @@
+"""#486: a release leads with the entry that matters, and both consumers agree on which.
+
+`charter news --for <version>` rendered entries in `sorted(d.glob("*.md"))` order, which
+for a stamped release is alphabetical by **slug** — a name an author picked for a reason
+that had nothing to do with importance. `release.yml`'s announce job pipes that straight
+into `gh release create --notes-file`, so slug order *was* the published order: 0.52.0's
+vault-spending fix (#453) rendered eighth, under a 1Password docs correction.
+
+**The property is not "security sorts first".** It is that *ordering is declared in the
+entry and honoured by every consumer of it*. That distinction is the whole test module.
+The obvious fix — teach `render_body` to sort — would pass a test asserting the Release
+body leads correctly while `charter news` kept printing slug order, and the two are
+deliberately the same answer printed twice (the release charter: "the shipped entry is
+the single source for both … hand-editing forks them"). So the assertions below compare
+the two consumers' orders **to each other**, from one fixture, rather than each to a
+hand-written expectation that could be satisfied by two independently-sorted lists.
+
+The sort therefore lives in `news.all()`, which both reach through, and these tests would
+still fail if someone re-sorted at either call site — because the fixture's declared order
+disagrees with its filename order in both directions.
+
+Two fields, and they are not two spellings of one:
+
+* `security: true` is a **class**, knowable by the author alone, and any number of a
+  version's entries may carry it.
+* `lead: true` is a **position**, which no author can know — 24 entries were staged for
+  0.52.0 and none of their authors could see the other 23 — so it belongs to the release
+  and only one entry per version may claim it.
+
+Fixture slugs below are chosen so filename order and declared order **disagree**: the
+entry that should lead is named `z-…` and the ordinary one `a-…`. A fixture where the
+right answer is also the alphabetical one is a fixture that cannot fail.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands, news, persona
+
+_V = "0.60.0"
+
+
+def _entry(version: str, headline: str, **fields) -> str:
+    lines = [f"version: {version}", f"headline: {headline}"]
+    lines += [f"{k}: {v}" for k, v in fields.items()]
+    return "---\n" + "\n".join(lines) + "\n---\n\nbody text\n"
+
+
+class NewsDir(unittest.TestCase):
+    """Entries read from a throwaway directory, so a test never depends on what shipped —
+    the same isolation `tests/test_news.py` establishes, for the same reason."""
+
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        patch = mock.patch.object(news, "_PACKAGED", self.dir)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def write(self, name: str, text: str) -> None:
+        (self.dir / name).write_text(text)
+
+    def three(self, **decls: dict) -> None:
+        """Three entries in one version whose filename order is a-, m-, z-. Any declared
+        field is passed through, so a caller states only what it is testing."""
+        for slug, headline in (("a-ordinary", "ordinary"),
+                               ("m-middle", "middle"),
+                               ("z-important", "important")):
+            self.write(f"{_V}-{slug}.md",
+                       _entry(_V, headline, **decls.get(slug, {})))
+
+    # -- the two consumers, each reduced to the sequence of headlines it shows -- #
+    def release_body_order(self) -> list[str]:
+        """What GitHub publishes: the `### ` headings of `charter news --for`, in order.
+        Read off the rendered text rather than off `for_version()`, so a sort applied
+        after the entries are fetched would still be caught."""
+        return [ln[4:] for ln in news.render_body(_V).splitlines()
+                if ln.startswith("### ")]
+
+    def offline_order(self) -> list[str]:
+        """What `charter news` shows a reader with no network: the range view's own
+        stdout, parsed back. Again the printed text, not the list behind it."""
+        out = io.StringIO()
+        args = SimpleNamespace(for_version=None, pending=False,
+                               since="0.59.0", until=_V)
+        with mock.patch.object(news, "probe",
+                               return_value=(news.INFORMATIONAL, "")), \
+             redirect_stdout(out), redirect_stderr(io.StringIO()):
+            self.assertEqual(commands.cmd_news(args), 0)
+        return [ln.split("  ", 1)[1] for ln in out.getvalue().splitlines()
+                if ln.startswith(_V + "  ")]
+
+
+class DeclaringNothingChangesNothing(NewsDir):
+    """Opt-in, and that is what let 24 shipped entries stay untouched."""
+
+    def test_entries_that_declare_no_order_still_sort_by_filename(self):
+        self.three()
+        self.assertEqual(self.release_body_order(), ["ordinary", "middle", "important"])
+
+    def test_and_the_offline_view_agrees_with_it(self):
+        self.three()
+        self.assertEqual(self.offline_order(), self.release_body_order())
+
+    def test_an_undeclared_entry_carries_neither_flag_and_no_complaint(self):
+        self.three()
+        for e in news.for_version(_V):
+            self.assertFalse(e.lead)
+            self.assertFalse(e.security)
+            self.assertEqual(e.bad, ())
+        self.assertEqual(news.ordering_errors(news.for_version(_V)), [])
+
+
+class ADeclaredOrderBeatsTheFilename(NewsDir):
+    def test_lead_puts_an_entry_first_however_its_file_is_named(self):
+        self.three(**{"z-important": {"lead": "true"}})
+        self.assertEqual(self.release_body_order(),
+                         ["important", "ordinary", "middle"])
+
+    def test_security_sorts_above_the_ordinary_entries(self):
+        self.three(**{"z-important": {"security": "true"}})
+        self.assertEqual(self.release_body_order(),
+                         ["security: important", "ordinary", "middle"])
+
+    def test_lead_outranks_security_because_a_position_beats_a_class(self):
+        """Both declared, on different entries. `security:` says what an entry IS and any
+        number may say it; `lead:` says where it GOES and one may. So the one claiming the
+        position gets it, and the security entry keeps its place above the rest."""
+        self.three(**{"z-important": {"security": "true"},
+                      "m-middle": {"lead": "true"}})
+        self.assertEqual(self.release_body_order(),
+                         ["middle", "security: important", "ordinary"])
+
+    def test_several_security_entries_all_rise_and_keep_filename_order_among_themselves(self):
+        """A class may have many members. Within a rank nothing is re-decided, so the
+        order is the one it always was — `sorted` is stable and the key ends at the rank."""
+        self.three(**{"z-important": {"security": "true"},
+                      "a-ordinary": {"security": "true"}})
+        self.assertEqual(self.release_body_order(),
+                         ["security: ordinary", "security: important", "middle"])
+
+
+class BothConsumersHonourIt(NewsDir):
+    """The anti-fork property, and the reason #486 was not fixed by editing one Release.
+
+    Compared to EACH OTHER rather than to a written-out expectation: a fix that sorted
+    inside `render_body` would satisfy a hand-written list for the Release body and leave
+    `charter news` printing slug order, which is precisely the fork the release charter
+    forbids. Two lists that must be equal cannot both be satisfied by one of them being
+    right.
+    """
+
+    def test_the_release_body_and_the_offline_view_render_one_order(self):
+        self.three(**{"z-important": {"lead": "true"},
+                      "m-middle": {"security": "true"}})
+        body = self.release_body_order()
+        self.assertEqual(body,
+                         ["important", "security: middle", "ordinary"])  # not vacuous
+        self.assertEqual(self.offline_order(), body)
+
+    def test_and_they_render_one_label(self):
+        """`security:` is visible offline too — the half of #486 slug order could never
+        give `charter news`, which has no colours, no badges and no rendered markdown."""
+        self.three(**{"m-middle": {"security": "true"}})
+        self.assertIn("security: middle", news.render_body(_V))
+        self.assertIn("security: middle", self.offline_order())
+
+    def test_an_ordinary_entry_is_not_labelled(self):
+        self.three(**{"m-middle": {"security": "true"}})
+        self.assertNotIn("security: ordinary", news.render_body(_V))
+
+    def test_lead_alone_adds_no_label(self):
+        """A position is not a kind. "This was listed first" is already legible from
+        being listed first, and a `lead:` badge would let an entry that is not a security
+        fix wear a word suggesting it is."""
+        self.three(**{"z-important": {"lead": "true"}})
+        self.assertEqual(news.marker(news.for_version(_V)[0]), "")
+        self.assertIn("### important", news.render_body(_V))
+
+
+class AValueCharterCannotReadIsSaid(NewsDir):
+    """The failure `_flag` exists to refuse: a value the author meant as yes, read as no,
+    and the entry sinking to the bottom in silence — #486's own defect, restored by the
+    field added to prevent it."""
+
+    def test_true_and_false_are_the_two_values(self):
+        self.three(**{"z-important": {"security": "true"},
+                      "m-middle": {"security": "false"}})
+        self.assertEqual(news.ordering_errors(news.for_version(_V)), [])
+        self.assertEqual(self.release_body_order(),
+                         ["security: important", "ordinary", "middle"])
+
+    def test_case_is_not_a_spelling_difference(self):
+        self.three(**{"z-important": {"security": "TRUE"}})
+        self.assertEqual(news.ordering_errors(news.for_version(_V)), [])
+        self.assertEqual(self.release_body_order()[0], "security: important")
+
+    def test_a_value_outside_the_pair_is_reported_rather_than_read_as_false(self):
+        """`yes` is the obvious next thing an author types. A truthy-set implementation
+        would accept it and be walked past by the one after that; the property here is
+        not which words mean yes but whether the value was UNDERSTOOD."""
+        self.three(**{"z-important": {"security": "yes"}})
+        why, = news.ordering_errors(news.for_version(_V))
+        self.assertIn("z-important", why)
+        self.assertIn("yes", why)
+        self.assertIn("`true` or `false`", why)
+
+    def test_a_lookalike_true_is_reported_too(self):
+        """Full-width `ｔｒｕｅ` case-folds to itself — it is not `true`, and charter says
+        so rather than deciding for the author. This is the codepoint that walks past
+        every membership test written against a list of words."""
+        self.three(**{"z-important": {"security": "ｔｒｕｅ"}})
+        self.assertTrue(news.ordering_errors(news.for_version(_V)))
+
+    def test_the_unreadable_value_cannot_forge_a_second_line_of_output(self):
+        """A news entry is a committed file, so its frontmatter is untrusted input, and
+        this message is a line of charter's own report. `contain.one_line` is what stops a
+        newline in the value writing a second one (#453's mechanism, one surface over)."""
+        self.three(**{"z-important": {"security": "yes"}})
+        # A newline cannot reach the value through flat frontmatter, so plant it directly
+        # at the layer the message is built from — the guard has to hold on the argument
+        # it is given, not on the parser upstream of it.
+        e = news.for_version(_V)[0]._replace(bad=(("security", "yes\nEVIL: line"),))
+        why, = news.ordering_errors([e])
+        self.assertNotIn("\n", why)
+        self.assertIn("EVIL", why)  # shown, escaped — not dropped
+
+    def test_the_entry_still_ships_rather_than_vanishing(self):
+        """Refusing to parse it would be worse than mis-sorting it: `stamped()` reads
+        filenames, so the release guard would still pass while the notes lost an entry
+        entirely. The entry renders; the ordering claim is what gets reported."""
+        self.three(**{"z-important": {"security": "yes"}})
+        self.assertIn("important", self.release_body_order())
+
+
+class ADeclaredFieldWithNoValueIsUnreadRatherThanUnmade(NewsDir):
+    """The first cut of this feature reintroduced #486 through the field added to prevent
+    it, and by the same mechanism every bypass in this codebase has used: it matched a
+    SPELLING of "missing" instead of asking the property.
+
+    `_read` asked ``(meta.get(field) or "").strip()``. That expression is true of a key
+    that is absent AND of a key that is present with nothing after the colon, so the two
+    arrived at `_flag` as the same ``""`` and took the "absent is False" path. The
+    property is not "is the value empty" but **"was the field declared, and if so was its
+    value understood?"** — two facts, and `.get(…) or ""` is exactly the line that makes
+    them one. The declaration lives in the dict's KEYS; only the value lives in its values.
+
+    The authoring shape is not exotic, which is what makes it the dangerous one: it is
+    the YAML habit of putting the value on the continuation line. `persona.parse` is flat
+    ``key: value`` and drops any line without a colon, so the ``  true`` never arrives.
+    An author who did opt in got an entry that sorted as though they had not, a release
+    that published it eighth, and `charter news --for` exiting 0 with an empty stderr.
+
+    **The next spelling is the KEY, not the value.** ``Security: true`` is a different
+    dict key and is genuinely absent here (#503), and two ``security:`` lines in one
+    entry silently keep the last (#509). Both are reached through `persona.parse`'s dict
+    rather than through `_flag`, and both are filed rather than folded in, because fixing
+    either changes how every caller of that parser reads its result.
+    """
+
+    #: The value on the continuation line, as an author would actually type it. Written
+    #: as raw text rather than through `_entry`, because the helper joins `key: value`
+    #: pairs and cannot express the shape under test.
+    _CONTINUATION = ("---\n"
+                     f"version: {_V}\n"
+                     "headline: important\n"
+                     "security:\n"
+                     "  true\n"
+                     "---\n\nbody text\n")
+
+    def _important(self, text: str) -> None:
+        """Three entries, with `z-important` replaced by *text*. `z-` sorts last, so an
+        entry that fails to be recognised as a security fix stays where the filename put
+        it — the fixture cannot pass by coincidence."""
+        self.three()
+        self.write(f"{_V}-z-important.md", text)
+
+    def test_the_continuation_line_really_does_leave_the_key_present_and_empty(self):
+        """The premise, asserted rather than assumed. If `persona.parse` ever grew
+        multi-line values this class would be testing a shape that no longer exists, and
+        it should say so here rather than keep passing on the rest."""
+        meta, _body = persona.parse(self._CONTINUATION)
+        self.assertIn("security", meta)
+        self.assertEqual(meta["security"], "")
+
+    def test_a_value_on_the_continuation_line_is_reported_not_read_as_false(self):
+        self._important(self._CONTINUATION)
+        why, = news.ordering_errors(news.for_version(_V))
+        self.assertIn("z-important", why)
+        self.assertIn("security", why)
+
+    def test_and_the_release_gate_refuses_rather_than_publishing_it_eighth(self):
+        """The whole point. Before the fix this rendered `ordinary`, `middle`,
+        `important` and exited 0 — #486's published order, from an entry that declared
+        otherwise."""
+        self._important(self._CONTINUATION)
+        out, err = io.StringIO(), io.StringIO()
+        args = SimpleNamespace(for_version=_V, pending=False, since=None, until=None)
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = commands.cmd_news(args)
+        self.assertEqual(rc, 1)
+        self.assertIn("z-important", err.getvalue())
+        self.assertEqual(out.getvalue(), "")
+
+    def test_a_declaration_with_nothing_after_the_colon_is_the_same_answer(self):
+        """`security:` typed and the value forgotten, and `security: ` with a trailing
+        space, reach `_read` as the same empty string the continuation line does. One
+        answer for all three, because they are one fact: the field was declared."""
+        for text in (f"---\nversion: {_V}\nheadline: important\nsecurity:\n---\n\nb\n",
+                     f"---\nversion: {_V}\nheadline: important\nsecurity: \n---\n\nb\n"):
+            with self.subTest(text=text):
+                self._important(text)
+                self.assertTrue(news.ordering_errors(news.for_version(_V)))
+
+    def test_lead_declared_empty_is_reported_too(self):
+        """Both ordering fields, not just the one the repro used. `_ORDERING_FIELDS` is
+        walked in one loop, so a fix applied to `security` alone would be a fix nobody
+        wrote — but a test that only ever names `security` would not know."""
+        self._important(f"---\nversion: {_V}\nheadline: important\nlead:\n  true\n"
+                        f"---\n\nb\n")
+        why, = news.ordering_errors(news.for_version(_V))
+        self.assertIn("lead", why)
+
+    def test_the_message_names_the_shape_instead_of_quoting_an_empty_value(self):
+        """There is no value to correct here, so echoing one back — "`security: `" with
+        nothing after it — reads as a rendering bug and tells the author nothing. The
+        sentence has to name the line the value went onto, because that is the edit."""
+        self._important(self._CONTINUATION)
+        why, = news.ordering_errors(news.for_version(_V))
+        self.assertNotIn("`security: `", why)
+        self.assertIn("`true` or `false`", why)
+        self.assertIn("next line", why.casefold())
+
+    def test_declaring_nothing_at_all_is_still_silent_and_still_false(self):
+        """The counterfactual, and it is not decorative: "every field is unreadable"
+        passes every assertion above while refusing all 24 shipped entries and breaking
+        opt-in outright. Absence is the one input that must stay False."""
+        self.three()
+        for e in news.for_version(_V):
+            self.assertFalse(e.security)
+            self.assertFalse(e.lead)
+            self.assertEqual(e.bad, ())
+        self.assertEqual(news.ordering_errors(news.for_version(_V)), [])
+        self.assertEqual(self.release_body_order(),
+                         ["ordinary", "middle", "important"])
+
+    def test_absent_and_empty_are_two_different_calls_to_the_reader(self):
+        """`_flag`'s contract, at the layer the docs test also reaches it through: absence
+        is spelled as the absence of a value, and every string — `""` included — is
+        something an author typed. Collapsing them at the call site is the defect; a
+        reader that cannot tell them apart is where it would come back."""
+        self.assertIs(news._flag(None), False)
+        self.assertIsNone(news._flag(""))
+        self.assertIsNone(news._flag("   "))
+        self.assertIs(news._flag("true"), True)
+        self.assertIs(news._flag("false"), False)
+
+
+class TheReleaseGateRefusesAContradiction(NewsDir):
+    """`charter news --for <version>` is not just a view — `release.yml` runs it as the
+    pre-publish guard and pipes it into `gh release create --notes-file`. So this is where
+    an ordering charter cannot honour has to stop, before there is a Release to be wrong.
+    """
+
+    def _for(self, version: str = _V) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        args = SimpleNamespace(for_version=version, pending=False, since=None, until=None)
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = commands.cmd_news(args)
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_two_entries_claiming_the_lead_stop_the_release(self):
+        self.three(**{"z-important": {"lead": "true"}, "a-ordinary": {"lead": "true"}})
+        rc, out, err = self._for()
+        self.assertEqual(rc, 1)
+        self.assertIn("lead", err)
+        self.assertIn("z-important", err)
+        self.assertIn("a-ordinary", err)
+
+    def test_and_publishes_no_partial_body_while_refusing(self):
+        """The announce job redirects this stdout into the notes file. A refusal that
+        still printed the entries would put un-ordered notes on the Release anyway."""
+        self.three(**{"z-important": {"lead": "true"}, "a-ordinary": {"lead": "true"}})
+        _rc, out, _err = self._for()
+        self.assertEqual(out, "")
+
+    def test_a_value_it_cannot_read_stops_the_release_too(self):
+        self.three(**{"z-important": {"security": "yes"}})
+        rc, _out, err = self._for()
+        self.assertEqual(rc, 1)
+        self.assertIn("z-important", err)
+
+    def test_one_lead_and_many_security_entries_publish_normally(self):
+        """The counterfactual: the gate must not refuse the ordering it exists to allow.
+        Without this the three tests above pass on a `--for` that always returns 1."""
+        self.three(**{"z-important": {"lead": "true"},
+                      "m-middle": {"security": "true"},
+                      "a-ordinary": {"security": "true"}})
+        rc, out, _err = self._for()
+        self.assertEqual(rc, 0)
+        self.assertIn("### important", out)
+
+    def test_leads_in_DIFFERENT_versions_are_not_a_contradiction(self):
+        """One entry per version, not one entry ever. `released()` spans every version
+        charter has shipped, so a check written over the whole list rather than per
+        version would refuse the second release that ever used the field."""
+        self.write(f"{_V}-only.md", _entry(_V, "this one", lead="true"))
+        self.write("0.61.0-only.md", _entry("0.61.0", "that one", lead="true"))
+        self.assertEqual(news.ordering_errors(news.all()), [])
+        self.assertEqual(self._for(_V)[0], 0)
+        self.assertEqual(self._for("0.61.0")[0], 0)
+
+
+class TheRangeViewWarnsRatherThanWithholding(NewsDir):
+    """A reader catching up is not a release. Losing them nineteen entries because a
+    twentieth has a malformed `security:` line would be the wrong trade — `--for` is the
+    call that becomes something permanent, and it is the one that refuses."""
+
+    def test_it_still_prints_every_entry(self):
+        self.three(**{"z-important": {"security": "yes"}})
+        self.assertEqual(len(self.offline_order()), 3)
+
+    def test_and_says_what_it_could_not_read(self):
+        self.three(**{"z-important": {"security": "yes"}})
+        out, err = io.StringIO(), io.StringIO()
+        args = SimpleNamespace(for_version=None, pending=False, since="0.59.0", until=_V)
+        with mock.patch.object(news, "probe", return_value=(news.INFORMATIONAL, "")), \
+             redirect_stdout(out), redirect_stderr(err):
+            self.assertEqual(commands.cmd_news(args), 0)
+        self.assertIn("z-important", err.getvalue())
+
+
+class WhatShippedStillParses(unittest.TestCase):
+    """Over the real `docs/news`, not a fixture: every entry in the tree reads cleanly,
+    and no version has two leads. This is what would have caught a hand-edit to a shipped
+    entry's frontmatter, and it is the check `release.yml` runs per version, asked once
+    across all of them."""
+
+    def test_no_shipped_entry_declares_an_order_charter_cannot_honour(self):
+        entries = news.all()
+        self.assertTrue(entries, "no news entries found — this test proves nothing")
+        self.assertEqual(news.ordering_errors(entries), [])
+
+    def test_the_0_52_0_release_leads_with_its_security_fix(self):
+        """#486's own case, on real data. 0.52.0 shipped 24 entries and the vault-spending
+        fix rendered eighth, below a docs correction; the entry now declares the lead, so
+        the offline view of that release is right even though its published Release body
+        was rendered before this existed."""
+        first, *rest = news.for_version("0.52.0")
+        self.assertTrue(rest, "0.52.0 should have many entries")
+        self.assertIn("server name", first.headline)
+        self.assertTrue(first.lead)
+
+
+class ADocumentedExampleIsParsedTheWayCharterParsesIt(unittest.TestCase):
+    """Every frontmatter block the docs print as copyable must survive `persona.parse`.
+
+    The first draft of this feature's own news entry taught the failure it exists to
+    prevent. It showed::
+
+        security: true      # this entry is a security fix
+
+    and `persona.parse` has **no comment syntax** — it is `key, _, value =
+    line.partition(":")` and keeps the rest verbatim — so a reader who copied that block
+    got the value ``true      # this entry is a security fix``, which `_flag` cannot read.
+    Loud rather than silent, and the release gate catches it; but the example still taught
+    a syntax charter does not have, and the reader who was taught it is the one with no
+    other source.
+
+    The property is not "no `#` in the docs". It is that a block presented as frontmatter
+    is run through the real parser and the real field reader — so the test cannot be
+    satisfied by an example that merely avoids the one character this draft used. A
+    trailing `# …`, an inline YAML `{}`, a quoted `"true"`, a value indented onto the next
+    line: each yields something `_flag` does not understand, and each fails here.
+
+    **The fourth of those was a claim this test could not make until `_flag` learned to
+    tell absent from empty.** An indented continuation leaves the key present with ``""``,
+    and `_flag` used to read that as False — understood, and false — so a doc teaching the
+    multi-line spelling passed the test written to stop exactly it, and the reader who
+    copied it shipped an entry that sank in silence. The gate above (`if field not in
+    meta: continue`) was always structured to catch it; the reader it called was not. That
+    is why this class asserts `assertIsNotNone` rather than a value: the question is
+    whether charter UNDERSTOOD the block, and "absent" is the only understanding a doc
+    example must not reach by accident.
+
+    **The next spelling** is a comment on a key that is *not* typed — `headline: x  # y`
+    parses to a headline ending in `# y`, which no reader of this test would learn about
+    because free text has no wrong value to detect. It is also the harmless half: a
+    mangled headline is visible in the first line of the notes, where a mangled
+    `security:` is visible only as an entry sitting lower than it should. If a third typed
+    field is ever added, it belongs in `news._ORDERING_FIELDS` and this test picks it up
+    with no edit.
+    """
+
+    _ROOT = Path(__file__).resolve().parent.parent
+    _FENCE = re.compile(r"```[a-z]*\n(.*?)```", re.S)
+
+    def _blocks(self):
+        roots = ["docs", "skills", "personas"]
+        files = [p for r in roots for p in (self._ROOT / r).rglob("*.md")]
+        files += [self._ROOT / "CONTRIBUTING.md", self._ROOT / "README.md"]
+        for path in sorted(p for p in files if p.is_file()):
+            for m in self._FENCE.finditer(path.read_text()):
+                block = m.group(1)
+                if block.lstrip().startswith("---") and "version:" in block:
+                    yield path, block
+
+    def test_every_documented_news_frontmatter_declares_a_value_charter_reads(self):
+        found = list(self._blocks())
+        self.assertTrue(found, "no documented frontmatter examples found — vacuous")
+        seen_typed = False
+        for path, block in found:
+            meta, _body = persona.parse(block.lstrip())
+            for field in news._ORDERING_FIELDS:
+                if field not in meta:
+                    continue
+                seen_typed = True
+                raw = meta[field]
+                with self.subTest(path=path.name, field=field):
+                    shown = (f"`{field}:` with nothing after it" if raw.strip() == ""
+                             else f"`{field}: {raw}`")
+                    self.assertIsNotNone(
+                        news._flag(raw),
+                        f"{path.relative_to(self._ROOT)} shows {shown} in a "
+                        f"frontmatter example, and charter reads that as a value it does "
+                        f"not understand. The frontmatter parser is flat `key: value` "
+                        f"with no comment syntax and no quoting — whatever follows the "
+                        f"colon IS the value, and a line without a colon is dropped, so "
+                        f"a value on the next line never arrives. Anyone who copies this "
+                        f"block gets a refused release.")
+        self.assertTrue(seen_typed,
+                        "no example declares an ordering field, so this test proves "
+                        "nothing about them")
+
+
+class TheGateAnnotationNamesWhatTheGateNowCatches(NewsDir):
+    """The CI sentence a release engineer reads at 2am, with the run and nothing else.
+
+    `release.yml`'s pre-publish guard *is* `charter news --for $version`, and until #486
+    that call had exactly one way to exit 1 — no entry — so its `::error::` could state
+    that as fact and prescribe `charter news stamp $version`. #486 gave it two more: an
+    ordering value charter cannot read, and two entries both claiming `lead: true`.
+    Against either, an annotation naming only the missing entry names a cause that is not
+    the cause and prescribes a command that changes nothing — and stamping a version that
+    is already stamped is a no-op, so the operator's next move produces no new
+    information either.
+
+    Three properties, in ascending order of teeth.
+
+    1. The annotation names both causes rather than one, and defers to the command's own
+       output for which.
+    2. The words it defers with are words the command actually prints. A reader who
+       greps the run for the annotation's vocabulary has to land on the line that
+       explains it, so the two texts are asserted against each other rather than each
+       against a hand-written expectation.
+    3. **The stream it points at survives the redirect.** `>/dev/null` drops stdout
+       alone, deliberately — that stdout is the announce job's notes file. `2>&1` or
+       `&>` would drop the half the sentence points at, turning "see the error above"
+       into a lie that nothing else in the run would notice.
+
+    And the recurring failure here is a *fourth* exit-1 path added to `--for` without
+    anyone remembering this annotation exists. `test_a_new_refusal_is_a_new_sentence`
+    below counts them at the source, so adding one goes red on the PR that adds it.
+    """
+
+    _WORKFLOW = Path(__file__).resolve().parent.parent / ".github/workflows/release.yml"
+
+    def setUp(self):
+        super().setUp()
+        text = self._WORKFLOW.read_text()
+        self.assertIn("news --for", text, "the guard no longer runs `charter news --for`")
+        self.gate = next(ln for ln in text.splitlines() if "news --for" in ln
+                         and "python" in ln)
+        self.annotation = next(ln for ln in text.splitlines() if "::error::" in ln
+                               and "news" in ln)
+
+    def _stderr_of(self, version: str) -> str:
+        err = io.StringIO()
+        args = SimpleNamespace(for_version=version, pending=False, since=None, until=None)
+        with redirect_stdout(io.StringIO()), redirect_stderr(err):
+            self.assertEqual(commands.cmd_news(args), 1,
+                             f"--for {version} was expected to refuse")
+        return err.getvalue()
+
+    def test_the_annotation_names_the_ordering_cause_as_well_as_the_missing_entry(self):
+        self.assertIn("docs/news/", self.annotation)
+        self.assertIn("ordering", self.annotation)
+
+    def test_and_defers_to_the_command_for_which_of_them_it_was(self):
+        """Rather than diagnosing. Two causes named in one line is only an improvement if
+        the line also says where the answer is."""
+        self.assertIn("the error above", self.annotation.casefold())
+
+    def test_a_missing_entry_prints_the_words_the_annotation_sends_a_reader_to_find(self):
+        self.assertIn("news entry", self._stderr_of("9.9.9"))
+
+    def test_an_unhonourable_ordering_prints_them_too(self):
+        """The coupling that makes property 1 more than a word in a YAML file: reword
+        `cmd_news`'s ordering refusal to drop "ordering" and this goes red, because the
+        annotation is still sending the reader to look for it.
+
+        Every ordering shape that refuses, not one of them. The sentence the annotation
+        sends the reader to find is `cmd_news`'s wrapper line, and a refusal added later
+        that printed only its own per-entry sentence would leave that reader grepping the
+        log for a word the run never says.
+        """
+        shapes = {
+            "two entries claim the lead":
+                lambda: self.three(**{"z-important": {"lead": "true"},
+                                      "a-ordinary": {"lead": "true"}}),
+            "a value charter cannot read":
+                lambda: self.three(**{"z-important": {"security": "yes"}}),
+            "a field declared with no value":
+                lambda: (self.three(),
+                         self.write(f"{_V}-z-important.md",
+                                    f"---\nversion: {_V}\nheadline: important\n"
+                                    f"security:\n  true\n---\n\nb\n")),
+        }
+        for name, stage in shapes.items():
+            with self.subTest(shape=name):
+                stage()
+                self.assertIn("ordering", self._stderr_of(_V))
+
+    def test_the_gate_drops_only_the_stream_the_annotation_does_not_point_at(self):
+        """stdout is discarded on purpose — it is the Release body, and the guard wants
+        the exit code, not the notes. stderr is the whole of what the annotation promises
+        is "above", so a redirect that swallowed it would break the sentence silently."""
+        self.assertIn(">/dev/null", self.gate)
+        for swallow in ("2>&1", "2>/dev/null", "&>"):
+            self.assertNotIn(swallow, self.gate,
+                             f"the guard's `{swallow}` discards the stderr its own "
+                             f"annotation tells the operator to read")
+
+    def test_a_new_refusal_is_a_new_sentence(self):
+        """The next spelling, made checkable.
+
+        Nothing about adding a third `return 1` to this branch would have told its author
+        that a workflow annotation two directories away enumerates them. So the count is
+        pinned here: raise it and this test names the file to update, in the same PR that
+        creates the obligation.
+        """
+        import inspect
+
+        src = inspect.getsource(commands.cmd_news)
+        branch = src.split("if version:", 1)[1].split("if getattr(args, \"pending\"", 1)[0]
+        self.assertEqual(
+            branch.count("return 1"), 2,
+            "`charter news --for` has a number of ways to refuse that this test no "
+            "longer expects. That call is release.yml's pre-publish guard, and its "
+            "`::error::` annotation enumerates the causes for an operator who has only "
+            "the CI log — update `.github/workflows/release.yml` and this count together.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
One surface. Rebased onto current `main`, narrowed to #486.

Closes #486

**#458 is gone from this PR.** #492 landed it while this branch was open, and landed it
better: it passes `util.color_enabled()` into `statusline._dev_chip(color=...)` rather
than stripping escapes inside `_warn_if_stale`. `sys.stdout.isatty()` is False for both
of `_dev_chip`'s other callers — the harness reads the status line through a pipe — so
gating inside the chip would have blanked it exactly where it belongs. This branch's
duplicate fix and its news entry are dropped. `_warn_if_stale` was re-checked after the
rebase: with stderr redirected it emits no escape byte, which is the property #492 added.

**#452 stays closed as refuted**, with evidence on the issue; the half that survives is
#489.

---

## #486 — a release can lead with the entry that matters

`charter news --for <version>` rendered `sorted(glob("*.md"))` order, which for a stamped
release is alphabetical by slug. `release.yml`'s announce job pipes that straight into
`gh release create --notes-file`, so a slug an author picked while thinking about
something else decided the published order. 0.52.0's vault-spending fix (#453) rendered
**eighth**, below a 1Password docs correction.

Two opt-in frontmatter fields, and they are not two spellings of one:

| field | is a | who knows it | how many per version |
|---|---|---|---|
| `security: true` | **class** — what the entry is | the author, while writing it | any number |
| `lead: true` | **position** — where it goes | only the release, with all entries in view | at most one |

A single numeric `rank:` was the tempting collapse, and it would have made every author
guess at a fact none of them can see — 24 entries were staged for 0.52.0 and no author
could see the other 23. These two let an author state only what they actually know.

`security:` also renders as `security: <headline>`, which is the half slug order could
never give the offline view: `charter news` has no colours, no badges and no rendered
markdown.

Declare neither and nothing changes. That is why 24 shipped entries needed no edit, and
`DeclaringNothingChangesNothing` pins it.

**The sort lives in `news.all()`, not at either call site.** That is the fix rather than
an implementation detail. The Release body and offline `charter news` are deliberately the
same answer printed twice — the release charter says so, and says hand-editing forks them
— so a fix that taught only `render_body` to sort would have been that same fork wearing a
commit. The tests compare the two consumers' orders **to each other** from one fixture,
which no half-fix satisfies. Fixture slugs are chosen so filename order and declared order
disagree (the entry that should lead is named `z-…`, the ordinary one `a-…`); a fixture
where the right answer is also the alphabetical one cannot fail.

**Checked, not resolved quietly.** Two entries claiming `lead:` in one version is a
contradiction, and picking one silently would hand back the accident #486 diagnosed.
`charter news --for` refuses such a version — and that call *is* the workflow's pre-publish
guard, so the tag stops before there is a Release body to be wrong. It also prints nothing
to stdout while refusing, because the announce job redirects that stdout into the notes
file.

**The property is "was this value understood?", not "which words mean yes".** The obvious
implementation of a boolean field is a truthy set — `{"true","yes","1","on"}` — and it
fails the way this codebase has failed six times: the next author writes the seventh
spelling, the set does not hold it, the entry reads as *false* and sinks to the bottom of
the notes in silence. That is the exact defect the field was added to prevent, restored by
the fix. So `_flag` returns `True`, `False`, or **`None` for "not understood"**, and `None`
is reported by name rather than read as false. `yes`, `1` and a full-width `ｔｒｕｅ` are all
reported.

The malformed entry still ships — refusing to parse it would be worse, since `stamped()`
reads filenames and the release guard would pass while the notes silently lost an entry.
And the reported value goes through `contain.one_line`, because a news entry is committed
input and that message is a line of charter's own report (#453's mechanism, one surface
over).

`charter news`'s range view warns instead of refusing: a reader catching up should not lose
nineteen entries because a twentieth has a typo.

0.52.0's #453 entry now declares `lead: true`, so `charter news --for 0.52.0` shows it
first. The published Release body for that version was rendered before any of this existed
and is untouched.

## Round two — the gate's own sentence, and the example that taught a syntax charter lacks

**The pre-publish annotation named a cause that was not the cause.** `release.yml:58-78` is
the guard this PR repurposes. Until now `charter news --for` had exactly one way to exit 1,
so the annotation could state it as fact — `::error::no docs/news/$version-<slug>.md … Run:
charter news stamp $version`. It has three now, and against an unreadable ordering value or
two `lead: true` claims, that sentence diagnosed the wrong thing and prescribed a no-op:
stamping a version that is already stamped changes nothing, so the operator's next move
produces no new information either. It now names both causes and defers to the command's
own stderr for which — and the step's `>/dev/null` keeps stderr, because it drops only the
stdout that becomes the notes file.

`TheGateAnnotationNamesWhatTheGateNowCatches` pins three properties, in ascending order of
teeth:

1. the annotation names both causes and says where the answer is;
2. the words it defers with are words `cmd_news` actually prints — asserted against the
   command's real stderr in both failure modes, so rewording the refusal breaks the test
   rather than quietly breaking the sentence;
3. the redirect never grows a `2>&1`, `2>/dev/null` or `&>`, any of which would drop the
   stream the annotation promises is "above" and turn it into a lie nothing else notices.

And **the recurring failure, made checkable**: a *fourth* `return 1` added to `--for` would
outrun the annotation with nothing to say so. `test_a_new_refusal_is_a_new_sentence` counts
the branch's refusals at the source and names `.github/workflows/release.yml` when the
count moves, on the PR that creates the obligation.

**A documented example is now parsed the way charter parses it.** The example frontmatter
in this PR's own news entry showed:

```
security: true      # this entry is a security fix
```

`persona.parse` has **no comment syntax** — it is `key, _, value = line.partition(":")` and
keeps the rest verbatim — so a reader who copied that block got the value `true      # this
entry is a security fix`, which `_flag` refuses. Loud rather than silent, and the gate
catches it, but the example still taught a syntax charter does not have, to the one reader
with no other source. The comments are gone.

`ADocumentedExampleIsParsedTheWayCharterParsesIt` makes it a property rather than an edit:
every fenced frontmatter block in `docs/`, `skills/`, `personas/`, `CONTRIBUTING.md` and
`README.md` is run through the **real** parser and the **real** field reader. That cannot
be satisfied by an example that merely avoids `#` — a quoted `"true"`, an inline `{}`, an
indented continuation each fail it too. It reads `news._ORDERING_FIELDS`, so a third typed
field is covered with no edit.

## Filed, not folded in

* **#502** — these report lines contain the ordering **value** but interpolate the
  committed **filename** raw, so a `.md` whose name holds a newline forges an extra line of
  charter's own report. Four sites; two are pre-existing in `news stamp` (`news.py:899`,
  `:904`), which is what makes it adjacent rather than a regression.
* **#503** — the fields are matched by an exact, **case-sensitive** key, so `Security: true`
  parses as absent, `ordering_errors` returns `[]`, and the entry sinks — the value half's
  failure reached through the key half, which is the outcome `_flag`'s docstring argues
  against. The fix is in how `persona.parse`'s dict is read by every caller of it, and has
  to say what `{"Security": ..., "security": ...}` means.

Both are referenced from the news entry.

## Verification

Full suite on the rebased branch: `Ran 5194 tests ... OK` (stdlib `unittest`, no pytest, no
new imports).

Mutation-tested, each applied then restored with `__pycache__` cleared:

| mutation | result |
|---|---|
| sort key drops `rank(e)` | RED (8) |
| unknown flag value read as `False` | RED (4) |
| duplicate-`lead` check disabled | RED (3) |
| `--for` ordering gate removed | RED (4) |
| marker dropped everywhere | RED (7) |
| `contain.one_line` dropped from the error | RED (1) |
| range view stops warning | RED (1) |
| annotation loses its ordering clause | RED (2) |
| annotation loses "see the error above" | RED (1) |
| gate grows `2>&1` | RED (1) |
| a third `return 1` added to `--for` | RED (1) |
| ordering refusal reworded off the annotation's vocabulary | RED (1) |
| the frontmatter example's `#` comments put back | RED (2) |

Restored green after every one.


## Round three — the field added to prevent #486 was reintroducing it

A review of this branch reproduced #486's own mechanism on a **new spelling of the field
itself**, end to end, and it is fixed here.

`_read` asked `(meta.get(field) or "").strip()`. That expression is true of a key that is
**absent** and of a key that is **present with nothing after the colon**, so both reached
`_flag` as `""` and took the "absent is False" path. The authoring shape is not exotic —
it is the YAML habit:

```
---
version: 0.60.0
headline: important
security:
  true
---
```

`persona.parse` is flat `key: value` and drops any line without a colon, so the `  true`
never arrives. Before the fix, that entry plus one ordinary `a-…` entry rendered:

```
rank 2  security False  bad ()   0.60.0-a-ordinary.md
rank 2  security False  bad ()   0.60.0-z-important.md
ordering_errors: []
cmd_news(--for 0.60.0) -> rc 0, stderr empty
body: "### ordinary" first, "### important" second
```

An author who *did* declare a security fix got the bottom of the notes, exit 0, and not
one word — which is exactly what `_flag`'s docstring said was impossible. `security:`
with the value forgotten and `security: ` with a trailing space are the same input.
`WhatShippedStillParses` was no net either: `ordering_errors` returned `[]`.

### The property, and the next spelling

Not "is the value empty" but **was the field DECLARED, and if so was its value
UNDERSTOOD** — two facts, and `.get(…) or ""` is the line that made them one. The
declaration lives in the dict's KEYS; only the value lives in its values.

* `_flag` now takes `str | None`. `None` is the key's absence, and that alone is False.
  Every `str` reaching it — `""` included — is something an author typed, and is either
  `true`, `false`, or reported.
* `_read` asks `field in meta` instead of leaning on a falsy value.
* `ordering_errors` gives the empty case its own sentence. Echoing an empty value back
  ("`security: `") reads like a rendering bug and names no edit; the line the value went
  onto **is** the edit, so the message names that.

**The next spelling is the KEY, not the value.** `Security: true` is a different dict key
and genuinely absent — #503, already filed. And two `security:` lines in one entry
silently keep the last: **#509**, filed tonight. It is not confined to news —
`persona.parse` reads every persona definition, skill and entry in the tree, so the same
silence covers a `vault:` or `extends:` written twice. Both need `persona.parse` to carry
information it currently discards, which lands on every caller at once, so neither is
folded in here.

### The docstring that claimed it was caught (settled in the same commit)

`ADocumentedExampleIsParsedTheWayCharterParsesIt`'s class docstring listed four shapes
that "each fails here". Three did. The fourth — a value indented onto the next line — did
not, because `_flag("")` was False and the assertion is `assertIsNotNone`, so a doc
teaching the multi-line spelling would have passed the test written to stop exactly that.

**Proved by probe, not by inference.** A `docs/news-example-probe.md` carrying that exact
block passes the test on the previous head and fails it now, with the failure naming
`docs/news-example-probe.md` — so the walker demonstrably reached the file rather than the
run merely being red for some other reason. The gate (`if field not in meta: continue`)
was always structured to catch this; the reader it called was not. Closing the `_read` gap
makes the sentence true, so it is strengthened rather than narrowed, and the test's
failure message now distinguishes the empty case.

### Mutation, round three

| mutation | result |
| --- | --- |
| the `_read` collapse restored (`(meta.get(field) or "").strip() or None`) | RED (6) |
| `_flag` reading empty as False | RED (7) |
| the empty-case sentence dropped, falling through to the generic one | RED (1) |
| the fix applied to `security` but not `lead` | RED (1) |
| `docs/news-example-probe.md` added with the continuation shape | RED (1) |

Restored green after every one, `__pycache__` cleared between. Full suite **5249 OK**,
eight more than the 5241 this branch ran on the same `origin/main` before the change.

### Not weaker than main

Every line added this round is a refusal, in code that exists only on this branch. The
one input whose answer must not change is a field **not declared at all**, and
`test_declaring_nothing_at_all_is_still_silent_and_still_false` pins it — without that
counterfactual, "every field is unreadable" would satisfy every other assertion in the new
class while refusing all 24 shipped entries and breaking opt-in outright.

Rebased onto `origin/main` at #495/#497/#499.

## The next spelling

For the annotation, it was **a fourth refusal path**, and that one is now counted rather
than trusted. For the documented example, it is a comment on a key that is *not* typed —
`headline: x  # y` parses to a headline ending in `# y`, and free text has no wrong value
to detect. That is also the harmless half: a mangled headline is the first line of the
notes, where a mangled `security:` is visible only as an entry sitting lower than it should.

For the fields themselves it is the **key**, not the value, and that is #503: `Securiy:`,
`leads:`, `security-fix:` all parse cleanly into `meta`, are never looked up, and sink the
entry with an empty `ordering_errors`. The fix worth having there is probably not
case-folding but its complement — report a frontmatter key `news` does not recognise, the
way an unrecognised value is reported — which makes case stop being a special case of
anything.

For #486's own property it remains **a third consumer**: the sort lives where both current
consumers reach it, and nothing structurally stops a fourth view from fetching entries and
re-sorting. Today they all go through `all()`. Filed only if a fourth appears — there is no
defect to reproduce yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9

