### PR TITLE
The suite cannot read your update channel, and the report nudge names it (#459, #458)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,10 +29,14 @@ command.
   that fails without the fix. The suite is plain `unittest` — no fixtures framework, no
   network, no writing outside a tempdir. That last one is enforced rather than asked for:
   a checkout inside a control plane resolves to *that* plane, so `tests/_planeguard.py`
-  refuses any write into the real `.charter/` and fails the test that tried. Derive from
-  `tests._isolation.PersonaIso` and it never comes up; a test that spawns a subprocess has
-  to hand it the throwaway plane as `$CHARTER_ROOT`, which no guard in this process can do
-  for you.
+  refuses any write into the real `.charter/` and fails the test that tried. The same file
+  refuses one kind of *read*: a setting your own `charter.toml` declares — today
+  `[update] channel` — because a test that reads it is asserting against a fixture written
+  by whoever happens to run the suite. Derive from `tests._isolation.PersonaIso` and
+  neither ever comes up; a case that runs against the real plane on purpose calls
+  `isolate_state_dir(self)` and `pin_update_channel(self)`; a test that spawns a subprocess
+  has to hand it the throwaway plane as `$CHARTER_ROOT`, which no guard in this process can
+  do for you.
 - **Comments explain *why*.** The codebase leans hard on this: a comment that restates the
   code earns nothing, one that records the failure a line prevents is worth several
   paragraphs of docs. Read a few modules before writing your first one.

--- a/charter/commands_report.py
+++ b/charter/commands_report.py
@@ -284,7 +284,13 @@ def _warn_if_stale() -> None:
         from . import statusline, update
         latest = update.newer_than(__version__)
         if latest:
-            util.warn(f"you are on charter {__version__}{statusline._dev_chip()}; {latest} "
-                      "is out — this may already be fixed. Reporting anyway is fine.")
+            # `util.color_enabled()`, not the chip's ANSI default: this is the one caller
+            # that is not a terminal surface, and `util.warn` gates its own glyph the same
+            # way. The call stays INSIDE the f-string on purpose — `test_version_shows_
+            # channel`'s AST property looks for it in the same `JoinedStr` as the version.
+            color = util.color_enabled()
+            util.warn(f"you are on charter {__version__}{statusline._dev_chip(color)}; "
+                      f"{latest} is out — this may already be fixed. Reporting anyway is "
+                      "fine.")
     except Exception:  # noqa: BLE001 - a staleness check must never block a report
         pass

--- a/charter/commands_report.py
+++ b/charter/commands_report.py
@@ -271,12 +271,20 @@ def _report_duplicates(dups: list[dict], rid: str) -> int:
 
 def _warn_if_stale() -> None:
     """Warn, never block. A bug that survives on an old charter is still worth having, and
-    "upgrade first, then report" is a reliable way to never get the report at all."""
+    "upgrade first, then report" is a reliable way to never get the report at all.
+
+    Carries the channel chip (#458). On the dev channel ``{latest}`` is not a published
+    release at all — `update.newer_than` hands off to `newer_head`, so the number beside
+    "is out" is `main`'s head commit — and "0.52.0 is out" read on a dev plane is ambiguous
+    between *a release was cut* and *main moved*. That is the exact ambiguity
+    `statusline._dev_chip` exists to resolve, and #457 already made it one function so a
+    third surface can call it rather than re-derive `channel.is_dev()` and its try/except.
+    """
     try:
-        from . import update
+        from . import statusline, update
         latest = update.newer_than(__version__)
         if latest:
-            util.warn(f"you are on charter {__version__}; {latest} is out — this may "
-                      "already be fixed. Reporting anyway is fine.")
+            util.warn(f"you are on charter {__version__}{statusline._dev_chip()}; {latest} "
+                      "is out — this may already be fixed. Reporting anyway is fine.")
     except Exception:  # noqa: BLE001 - a staleness check must never block a report
         pass

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1746,9 +1746,18 @@ def _session_strip(payload: dict, sid: str | None) -> str:
     return f"{_DIM} · {_R}".join(parts) if parts else ""
 
 
-def _dev_chip() -> str:
+def _dev_chip(color: bool = True) -> str:
     """`` dev``, dimmed, glued right after a version — when THIS plane is on the dev
     channel. Empty string otherwise, so a caller can interpolate it unconditionally.
+
+    *color* is for a caller that is not painting a terminal surface. The default is ANSI
+    because the two callers here are — a status line and a frame slot both write escape
+    codes on every line, and `sys.stdout.isatty()` is False for both anyway (the harness
+    reads the status line through a pipe), so gating this internally would blank the chip
+    exactly where it belongs. `commands_report._warn_if_stale` is the other shape: it
+    hands the chip to `util.warn`, which gates its own glyph on `stderr.isatty()`, and an
+    ungated chip put raw ``\x1b[2mdev\x1b[0m`` in a redirected log beside a correctly
+    plain ``!``. It passes `util.color_enabled()` so both halves decide together.
 
     Split out of `_brand` (#457) so a second surface that glues the literal word
     `charter` onto `__version__` — `frame.slots._top`, and whatever grows the idiom
@@ -1764,7 +1773,9 @@ def _dev_chip() -> str:
         dev = channel.is_dev()
     except Exception:
         dev = False
-    return f" {_DIM}dev{_R}" if dev else ""
+    if not dev:
+        return ""
+    return f" {_DIM}dev{_R}" if color else " dev"
 
 
 def _brand() -> str:

--- a/charter/util.py
+++ b/charter/util.py
@@ -19,6 +19,24 @@ def _c(code: str, text: str) -> str:
     return f"\033[{code}m{text}\033[0m" if _USE_COLOR else text
 
 
+def color_enabled() -> bool:
+    """Whether the loggers below will colour anything — i.e. stderr is a terminal.
+
+    Exported because a message BODY sometimes has to make the same choice the glyph
+    already makes. `_c` colours the glyph and nothing else, so a caller that interpolates
+    a pre-coloured fragment into `warn(...)` emits raw escape codes down a pipe while the
+    `!` beside them is correctly plain — half a line honouring the terminal and half not.
+    `commands_report._warn_if_stale` is the case: it renders `statusline._dev_chip()`,
+    which is unconditionally ANSI because both of its other callers paint a terminal
+    surface directly.
+
+    Reads the module flag rather than calling `isatty` again, so the two halves of one
+    line cannot disagree — the flag is sampled once at import, and a test that patches it
+    must move the glyph and the body together.
+    """
+    return _USE_COLOR
+
+
 def info(msg: str) -> None:
     print(_c("36", "•") + " " + msg, file=sys.stderr)
 

--- a/docs/news/unreleased-the-suite-cannot-read-your-channel.md
+++ b/docs/news/unreleased-the-suite-cannot-read-your-channel.md
@@ -32,12 +32,14 @@ protects only the first half of a suite run.
 **And the reason the six failures were hard to believe.** They did not reproduce in a full
 suite run — only when the two modules were run alone. `test_secret_exec.SecretExecMode`
 defined a `_restore` method of its own, which replaced the identically-named cleanup it
-inherited: the harness's config restore never ran, and `config.ROOT` stayed pointed at a
-deleted temp directory for all 1193 tests that ran after it, alphabetically. Everything
-downstream was reading a plane that did not exist, which happens to look exactly like the
-stable channel. That cleanup is name-mangled now, so a subclass cannot shadow it by
-accident — one other fixture had avoided the collision by hand, with a comment warning the
-next person.
+inherited. Neither half of the harness's cleanup ran: config was never restored and the
+temp tree was never removed, so `config.ROOT` was left pointing at a directory that still
+exists and simply is not a plane — no `charter.toml`, so every setting answers its default
+rather than failing. The 1186 tests that ran after it alphabetically — a quarter of the
+suite — read that, and a plane with no `charter.toml` reports the `stable` channel, which
+is exactly what the two classes assumed. That cleanup is name-mangled now, so a subclass
+cannot shadow it by accident — one other fixture had avoided the collision by hand, with a
+comment warning the next person.
 
 **Separately, the staleness nudge grew a channel chip.** `charter report send` warns you
 when a newer charter is out; on the dev channel the number it names is `main`'s head

--- a/docs/news/unreleased-the-suite-cannot-read-your-channel.md
+++ b/docs/news/unreleased-the-suite-cannot-read-your-channel.md
@@ -1,0 +1,50 @@
+---
+version: unreleased
+headline: Declaring `[update] channel = "dev"` no longer turns charter's own suite red — and the staleness nudge says which channel you are on
+---
+
+`charter update` on a charter checkout only refreshes the plugin when the plane is on the
+dev channel, so anyone working on charter has to put `[update] channel = "dev"` in their own
+`charter.toml`. That file is committed, and `charter save` commits it — so the moment the
+line landed, six tests went red for everyone. The feature charter shipped in 0.52.0 was
+unusable by the people it was shipped for.
+
+Nothing was wrong with the channel. Two test classes had never isolated `config.UPDATE`:
+`test_statusline_brand.UpdateIndicator` redirected one config attribute by hand and
+`test_version_lock.AutoSync` assigned `config.ROOT` directly, and neither re-derives the
+rest. For as long as `[update]` has existed, `{"channel": "stable"}` was true on every
+machine, so the missing isolation was invisible — a fixture nobody wrote, silently agreeing
+with what every assertion assumed.
+
+**Fixed as a class, not as two files.** `[update] channel` is a fact about the person
+running the suite, not about charter, so reading it off the real plane is now refused
+outright — the same move 0.52.0 made for *writes* into your `.charter/`, and for the same
+reason: a mistake nothing makes visible arrives again in a new file. A test that reads the
+developer's own channel fails on the line that read it, with its own name in the message
+and both ways out of it (`PersonaIso`, or `pin_update_channel`) named there. Turning it on
+found eight more sites the same afternoon, in `doctor`, `statusline` and `charter update`
+tests that nobody had suspected.
+
+The tripwire arms itself per derivation rather than once at import, which matters more than
+it sounds: a test that isolates and then restores has to come back armed, or the guard
+protects only the first half of a suite run.
+
+**And the reason the six failures were hard to believe.** They did not reproduce in a full
+suite run — only when the two modules were run alone. `test_secret_exec.SecretExecMode`
+defined a `_restore` method of its own, which replaced the identically-named cleanup it
+inherited: the harness's config restore never ran, and `config.ROOT` stayed pointed at a
+deleted temp directory for all 1193 tests that ran after it, alphabetically. Everything
+downstream was reading a plane that did not exist, which happens to look exactly like the
+stable channel. That cleanup is name-mangled now, so a subclass cannot shadow it by
+accident — one other fixture had avoided the collision by hand, with a comment warning the
+next person.
+
+**Separately, the staleness nudge grew a channel chip.** `charter report send` warns you
+when a newer charter is out; on the dev channel the number it names is `main`'s head
+commit, not a release, and "0.52.0 is out" could not tell you which. It now reads `you are
+on charter 0.52.0 dev; … is out`, through the same `_dev_chip()` the status line and the
+frame's top slot already use — so the property test that walks the package for this idiom
+now finds no site that skips it.
+
+None of this reaches you unless you run charter's own test suite, except the report nudge.
+Nothing to adopt: upgrading is the whole of it.

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -53,13 +53,18 @@ class PersonaIso(unittest.TestCase):
         # PRIVATE, and name-mangled on purpose (`_PersonaIso__restore`). `addCleanup` binds
         # a bound method by attribute lookup on the INSTANCE, so a subclass defining its own
         # `_restore` — the obvious name for "put my stubs back" — replaced this one:
-        # `super().setUp()` registered the SUBCLASS's method, config was never restored, and
-        # `config.ROOT` stayed pointed at a tmp directory that had just been deleted for
-        # every test that ran afterwards. `test_secret_exec.SecretExecMode` did exactly
-        # that, and because discovery runs alphabetically it left every module from
-        # `test_secret_*` onward — 1193 tests — reading a dead plane. That is also why the
-        # two classes #459 is about failed when run alone and passed in a full run: a dead
-        # plane declares no channel, which looks exactly like the `stable` they assumed.
+        # `super().setUp()` registered the SUBCLASS's method, so NEITHER half below ran:
+        # config was never restored and the tmp tree was never removed. `config.ROOT` then
+        # pointed, for the rest of the run, at a directory that still EXISTS and is no
+        # longer a plane — it holds whatever the fixture wrote (`personas/`, `.charter/`)
+        # and never had a `charter.toml`, so `HAS_CONTROL_PLANE` is False and every setting
+        # derives to its default. Measured, because "deleted" would send the next reader
+        # hunting for ENOENT symptoms that never appear.
+        # `test_secret_exec.SecretExecMode` did exactly this, and because discovery runs
+        # alphabetically it left the 1186 tests that ran after it — 24.3% of the suite —
+        # reading that non-plane. It is also why the two classes #459 is about failed when
+        # run alone and passed in a full run: a root with no `charter.toml` derives
+        # `UPDATE` to the `stable` default, which is exactly what they assumed.
         # `test_secret_cp_destination` had sidestepped the collision by hand, with a comment
         # warning the next person; a hazard that needs a comment in every subclass is one
         # the base class should have removed.
@@ -161,7 +166,16 @@ def pin_update_channel(case, channel: str = "stable") -> dict:
     nothing in particular, and the one `instance.UPDATE_DEFAULTS` gives a plane that
     declares no ``[update]`` section at all. A case that is ABOUT the dev channel passes
     ``"dev"`` and is then testing a fixture rather than an environment.
+
+    A misspelt channel is refused here rather than clamped. `channel.channel()` re-matches
+    whatever it is handed against `instance.UPDATE_CHANNELS` and falls back to ``stable``,
+    which is right for a committed file written by a human and wrong for a fixture: a case
+    that pinned ``"deb"`` would silently test the stable path while its own source says it
+    is testing dev, and pass for the wrong reason.
     """
+    if channel not in instance.UPDATE_CHANNELS:
+        raise ValueError(f"{channel!r} is not a charter update channel; expected one of "
+                         f"{instance.UPDATE_CHANNELS}")
     pinned = {"channel": channel}
     patcher = mock.patch.object(config, "UPDATE", pinned)
     patcher.start()

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -50,9 +50,22 @@ class PersonaIso(unittest.TestCase):
         self._orig = config.use(self.tmp)
 
         config.PERSONAS_DIR.mkdir(parents=True, exist_ok=True)
-        self.addCleanup(self._restore)
+        # PRIVATE, and name-mangled on purpose (`_PersonaIso__restore`). `addCleanup` binds
+        # a bound method by attribute lookup on the INSTANCE, so a subclass defining its own
+        # `_restore` — the obvious name for "put my stubs back" — replaced this one:
+        # `super().setUp()` registered the SUBCLASS's method, config was never restored, and
+        # `config.ROOT` stayed pointed at a tmp directory that had just been deleted for
+        # every test that ran afterwards. `test_secret_exec.SecretExecMode` did exactly
+        # that, and because discovery runs alphabetically it left every module from
+        # `test_secret_*` onward — 1193 tests — reading a dead plane. That is also why the
+        # two classes #459 is about failed when run alone and passed in a full run: a dead
+        # plane declares no channel, which looks exactly like the `stable` they assumed.
+        # `test_secret_cp_destination` had sidestepped the collision by hand, with a comment
+        # warning the next person; a hazard that needs a comment in every subclass is one
+        # the base class should have removed.
+        self.addCleanup(self.__restore)
 
-    def _restore(self) -> None:
+    def __restore(self) -> None:
         # An embedded plane's worktree root is a SIBLING of ROOT, so it survives the
         # rmtree below. Removed by name-prefix rather than by "is it outside tmp" — the
         # only path this ever creates is `<tmp>.worktrees`, and anything else sharing the
@@ -132,3 +145,25 @@ def isolate_state_dir(case) -> Path:
     case.addCleanup(lambda: (setattr(config, "STATE_DIR", orig),
                              shutil.rmtree(tmp, ignore_errors=True)))
     return config.STATE_DIR
+
+
+def pin_update_channel(case, channel: str = "stable") -> dict:
+    """Pin ``config.UPDATE`` for one test case, restoring after.
+
+    The companion to :func:`isolate_state_dir`, for the same shape of test and for the
+    reason `tests/_planeguard.py` sets out at length: a case that deliberately runs against
+    the REAL plane still may not read `[update] channel` off it, because that value belongs
+    to whoever is running the suite rather than to charter (#459). Without a pin, such a
+    case passes on a stable plane and fails on a dev one, and `tests._planeguard` refuses
+    the read rather than let it decide the assertion silently.
+
+    Defaults to ``"stable"`` — the channel almost every case here means when it means
+    nothing in particular, and the one `instance.UPDATE_DEFAULTS` gives a plane that
+    declares no ``[update]`` section at all. A case that is ABOUT the dev channel passes
+    ``"dev"`` and is then testing a fixture rather than an environment.
+    """
+    pinned = {"channel": channel}
+    patcher = mock.patch.object(config, "UPDATE", pinned)
+    patcher.start()
+    case.addCleanup(patcher.stop)
+    return pinned

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -214,13 +214,19 @@ class _RefusesToBeRead(dict):
     is the behaviour this guard exists to end. Subclassing means the refusal happens where
     the value is actually used, one line later.
 
-    Every way in is overridden, including the ones CPython would otherwise service from C
-    without consulting this class: ``dict(x)`` and ``{**x}`` take the fast path only while
-    ``tp_iter`` is dict's own, so overriding ``__iter__`` is what routes them through
-    ``keys()`` and into the refusal. ``__repr__`` and ``__len__`` are deliberately NOT
-    overridden — a debugger, a traceback, or `unittest`'s own error formatting may print
-    this object, and a guard that explodes while a test is already failing hides the
-    failure it was supposed to explain.
+    **Every accessor that yields a KEY or a VALUE is overridden**, including the ones
+    CPython would otherwise service from C without consulting this class: ``dict(x)`` and
+    ``{**x}`` take the fast path only while ``tp_iter`` is dict's own, so overriding
+    ``__iter__`` is what routes them through ``keys()`` and into the refusal. The list was
+    audited by probing every entry point rather than reasoned about — `pop`, `popitem`,
+    `setdefault` and `__reversed__` each handed back the operator's real value on the first
+    pass, and no reader in `charter/` uses any of them, which is exactly why they would
+    have stayed open until one did.
+
+    ``__repr__`` and ``__len__`` (and so ``bool()``) are deliberately NOT overridden. A
+    debugger, a traceback, or `unittest`'s own error formatting may print this object, and
+    a guard that explodes while a test is already failing hides the failure it was supposed
+    to explain. Neither answers "which channel", which is the fact being protected.
     """
 
     __slots__ = ("_setting",)
@@ -236,10 +242,14 @@ class _RefusesToBeRead(dict):
     __getitem__ = _refuse
     __contains__ = _refuse
     __iter__ = _refuse
+    __reversed__ = _refuse
     keys = _refuse
     values = _refuse
     items = _refuse
     copy = _refuse
+    pop = _refuse
+    popitem = _refuse
+    setdefault = _refuse
     __eq__ = _refuse
     __ne__ = _refuse
     __hash__ = None

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -1,4 +1,5 @@
-"""Suite-wide tripwire: no test may WRITE into the developer's real ``.charter/``.
+"""Suite-wide tripwires: no test may WRITE into the developer's real ``.charter/``, and
+none may READ a setting off the developer's real ``charter.toml``.
 
 `PersonaIso` isolates a test that remembers to derive from it. Nothing made the
 *forgetting* visible, so the same defect kept arriving in a new file: the suite wrote
@@ -14,15 +15,39 @@ the `tests` package — before any test module is collected, so no test can opt 
 forgetting a base class. A test that reaches the real plane now fails, by name, on the
 line that reached it, having changed nothing.
 
-**Only writes.** Reads are untouched: a test may legitimately look at the real plane (that
-`render()` survives a real environment, say), and `_isolation.isolate_state_dir` exists for
-exactly that shape. Writing is the part no test in this suite has any business doing.
+**Only the state directory, for writes.** ``.charter/`` is per-developer, gitignored, and
+holds live session state — frame directories, the vault registry, session pointers. The
+rest of the plane (``personas/``, ``docs/``, ``workspaces/``) is committed content some
+tests do legitimately generate into a tmp root, and guarding the real copies of those
+would trade this defect for a stream of false alarms.
 
-**Only the state directory.** ``.charter/`` is per-developer, gitignored, and holds live
-session state — frame directories, the vault registry, session pointers. The rest of the
-plane (``personas/``, ``docs/``, ``workspaces/``) is committed content some tests do
-legitimately generate into a tmp root, and guarding the real copies of those would trade
-this defect for a stream of false alarms.
+**Reads of the state directory stay untouched**, for the same reason: a test may
+legitimately look at the real plane (that `render()` survives a real environment, say),
+and `_isolation.isolate_state_dir` exists for exactly that shape.
+
+**One class of read IS refused: a setting the developer's own `charter.toml` declares.**
+#459. `[update] channel` is opt-in and new, so for its whole life `config.UPDATE` was
+``{"channel": "stable"}`` on every machine — which is what `test_statusline_brand`'s
+``UpdateIndicator`` and `test_version_lock`'s ``AutoSync`` assumed while isolating neither.
+The day charter's own dogfood plane declared ``channel = "dev"``, six tests started failing
+on that machine and nowhere else, and the feature became unusable: `charter update` on a
+charter checkout only refreshes the plugin on the dev channel, so the operator has to
+declare it — in a file `charter save` commits, which turns CI red for everyone.
+
+A value like that is not a fact about charter; it is a fact about whoever is running the
+suite. A test reading it is not "reading the real plane" in the benign sense above — it is
+asserting against a fixture it did not write and cannot see. So the values named in
+:data:`_GUARDED_SETTINGS` are replaced, whenever `charter.config` points at the real plane,
+by a `dict` that refuses to be read (:class:`RealPlaneRead`). Isolate the case and the real
+value is never in place to refuse: `config.use` re-derives every setting from the tmp root
+(`_isolation.PersonaIso`), and `mock.patch.object(config, "UPDATE", …)` replaces the object
+outright.
+
+The arming is by ROOT rather than a one-shot swap at import: :func:`charter.config.derive`
+is wrapped, so a derivation that resolves back to the real plane re-arms (a bare
+`config.use(config.ROOT)`, which two modules here do) and a derivation from a tmp root does
+not. `config.restore` needs nothing — it puts back the snapshot `config.use` took, and the
+refusing value is what was in place to snapshot.
 
 **Raised as a `BaseException`, deliberately.** charter is full of `except Exception`
 fallbacks that turn an unreachable path into a degraded one — `config.derive` catches
@@ -45,6 +70,8 @@ import builtins
 import io
 import os
 import shutil
+import sys
+import unittest
 
 #: The state directory of the plane this test PROCESS resolved at import — before any
 #: `setUp` could repoint `charter.config`, so unavoidably the developer's real one.
@@ -124,12 +151,150 @@ def _guard_os(name: str, *, arg: int = 0, both: bool = False) -> None:
     setattr(os, name, guarded)
 
 
+#: The settings no test may read off the developer's own ``charter.toml``.
+#:
+#: One name, and it is a list rather than a special case for exactly one reason: the next
+#: opt-in setting to arrive has the same shape, and the day it arrives is the day it should
+#: be guarded, not the day someone re-derives this argument from a red CI run.
+#:
+#: Not every `config.DERIVED` name belongs here, and the boundary is what the value is a
+#: fact ABOUT. ``ROOT``, ``STATE_DIR`` and the paths under them are facts about the
+#: machine's layout, and a test that reads them deliberately (`isolate_state_dir`'s whole
+#: purpose) is doing something this suite supports. ``UPDATE`` is a fact about the operator's
+#: *preference*, declared in a committed file that one contributor may edit and the rest may
+#: not have — so a test reading it asserts against a fixture written by whoever happens to
+#: run it. Values that are dicts, and only dicts: the refusal works by handing back an
+#: object that will not answer, and a `str` or a `Path` cannot be made to refuse without
+#: breaking the formatting of every message that legitimately quotes it.
+_GUARDED_SETTINGS = ("UPDATE",)
+
+
+class RealPlaneRead(BaseException):
+    """A test read a setting declared by the developer's own ``charter.toml``."""
+
+
+def _current_test() -> str:
+    """The `TestCase` on the stack, ``module.Class.method``, or a placeholder.
+
+    Walked rather than tracked, because there is no hook that fires per test in a plain
+    ``python3 -m unittest discover`` run. Only ever called on the refusal path, so the walk
+    costs nothing in a green suite. `unittest` already puts the test's name in the failure
+    header; this repeats it INSIDE the message so a failure quoted into an issue, a CI log
+    excerpt or a `git bisect` transcript still says which test it was.
+    """
+    frame = sys._getframe(1)
+    while frame is not None:
+        case = frame.f_locals.get("self")
+        if isinstance(case, unittest.TestCase):
+            method = getattr(case, "_testMethodName", "?")
+            return f"{type(case).__module__}.{type(case).__name__}.{method}"
+        frame = frame.f_back
+    return "this test"
+
+
+def _explain_read(name: str) -> str:
+    return (
+        f"REFUSED: read of config.{name}\n"
+        f"{_current_test()} is reading `{name}` while `charter.config` still points at the "
+        f"developer's REAL control plane ({_REAL_ROOT[0] if _REAL_ROOT else '?'}) — so what "
+        f"it asserts depends on what that machine's own charter.toml declares, not on a "
+        f"fixture. `[update] channel = \"dev\"` in a real plane is what turned six of these "
+        f"red on one machine and nowhere else (#459). Derive the case from "
+        f"`tests._isolation.PersonaIso`, which re-derives every setting from a tmp plane in "
+        f"one `config.use()` call, or pin just this one with "
+        f"`mock.patch.object(config, \"{name}\", {{...}})`.")
+
+
+class _RefusesToBeRead(dict):
+    """What a guarded setting holds while `charter.config` points at the real plane.
+
+    A `dict` subclass rather than a sentinel of its own type, because the readers type-check
+    first: `channel.channel` does ``isinstance(got, dict)`` and falls back to ``"stable"``
+    for anything else — a sentinel that failed that check would be *silently* ignored, which
+    is the behaviour this guard exists to end. Subclassing means the refusal happens where
+    the value is actually used, one line later.
+
+    Every way in is overridden, including the ones CPython would otherwise service from C
+    without consulting this class: ``dict(x)`` and ``{**x}`` take the fast path only while
+    ``tp_iter`` is dict's own, so overriding ``__iter__`` is what routes them through
+    ``keys()`` and into the refusal. ``__repr__`` and ``__len__`` are deliberately NOT
+    overridden — a debugger, a traceback, or `unittest`'s own error formatting may print
+    this object, and a guard that explodes while a test is already failing hides the
+    failure it was supposed to explain.
+    """
+
+    __slots__ = ("_setting",)
+
+    def __init__(self, setting: str, value: dict) -> None:
+        super().__init__(value)
+        self._setting = setting
+
+    def _refuse(self, *_args, **_kw):
+        raise RealPlaneRead(_explain_read(self._setting))
+
+    get = _refuse
+    __getitem__ = _refuse
+    __contains__ = _refuse
+    __iter__ = _refuse
+    keys = _refuse
+    values = _refuse
+    items = _refuse
+    copy = _refuse
+    __eq__ = _refuse
+    __ne__ = _refuse
+    __hash__ = None
+
+
+#: The control-plane root this test PROCESS resolved at import, in both spellings, for the
+#: same reason :data:`_REAL` carries two.
+_REAL_ROOT: tuple[str, ...] = ()
+
+
+def _guard_reads(config) -> None:
+    """Arm :data:`_GUARDED_SETTINGS` on every derivation that lands on the real plane."""
+    global _REAL_ROOT
+    if _REAL_ROOT:                        # idempotent: never wrap `derive` twice
+        return
+    written = os.path.abspath(str(config.ROOT))
+    resolved = os.path.realpath(written)
+    _REAL_ROOT = (written,) if written == resolved else (written, resolved)
+
+    def _is_real(where) -> bool:
+        try:
+            here = os.path.abspath(str(where))
+        except (OSError, TypeError, ValueError):
+            return False
+        return here in _REAL_ROOT or os.path.realpath(here) in _REAL_ROOT
+
+    original = config.derive
+
+    def derive(root, start=None):
+        d = original(root, start)
+        if _is_real(root):
+            for name in _GUARDED_SETTINGS:
+                value = d.get(name)
+                if isinstance(value, dict) and not isinstance(value, _RefusesToBeRead):
+                    d[name] = _RefusesToBeRead(name, value)
+        return d
+
+    derive.__module__ = __name__
+    config.derive = derive
+
+    # The bootstrap derivation already ran, at import of `charter.config`, before this
+    # module existed to wrap anything. Arm what it left behind.
+    for name in _GUARDED_SETTINGS:
+        value = getattr(config, name, None)
+        if isinstance(value, dict) and not isinstance(value, _RefusesToBeRead):
+            setattr(config, name, _RefusesToBeRead(name, value))
+
+
 def install() -> None:
     """Wrap every write primitive. Idempotent; called once at `tests` package import."""
     global _REAL
     if _REAL:
         return
     from charter import config
+    _guard_reads(config)
     try:
         written = os.path.abspath(str(config.STATE_DIR))
         resolved = os.path.realpath(written)

--- a/tests/test_doctor_forge_visibility.py
+++ b/tests/test_doctor_forge_visibility.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from unittest import mock
 
 from charter import config, doctor
+from tests._isolation import pin_update_channel
 
 _ENV = {"GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"}
 
@@ -169,6 +170,11 @@ class TestDoctorChecksDeclaredForgesOnly(unittest.TestCase):
         self.addCleanup(lambda: shutil.rmtree(self.root, ignore_errors=True))
         self._orig = (config.CONFIG_ERROR, config.HAS_CONTROL_PLANE, config.ROOT)
         self.addCleanup(self._restore)
+        # `doctor.run_all()` below reaches `check_plugin_freshness`, which branches on the
+        # channel. Three attributes are hand-set here and `UPDATE` is not one of them, so
+        # without this the forge assertions ran against the developer's own `[update]`
+        # section (#459).
+        pin_update_channel(self)
 
     def _restore(self):
         config.CONFIG_ERROR, config.HAS_CONTROL_PLANE, config.ROOT = self._orig

--- a/tests/test_doctor_mcp_launchers.py
+++ b/tests/test_doctor_mcp_launchers.py
@@ -30,7 +30,7 @@ import unittest
 from pathlib import Path
 
 from charter import doctor
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, pin_update_channel
 
 
 class LauncherCase(PersonaIso):
@@ -185,6 +185,10 @@ class TestProjectScopedServersAreChecked(LauncherCase):
 
 
 class TestItIsWiredIn(unittest.TestCase):
+    def setUp(self) -> None:
+        # `run_all` reaches `check_plugin_freshness`, and so the channel (#459).
+        pin_update_channel(self)
+
     def test_the_check_runs_in_doctor(self):
         """A check nothing calls is the same silence it was written to end."""
         names = [r.name for r in doctor.run_all()]

--- a/tests/test_doctor_personas.py
+++ b/tests/test_doctor_personas.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import unittest
 
 from charter import config, doctor, persona
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, pin_update_channel
 
 
 class PersonaCheck(PersonaIso):
@@ -134,6 +134,11 @@ class RunTakesATimeoutAndDoctorStreams(unittest.TestCase):
     20s budget and then printed NOTHING — `cmd_doctor` collected every Result before
     showing a line, so a hang and a crash looked identical. Six call sites also bypassed
     `util.run` entirely just to pass their own timeout literal."""
+
+    def setUp(self) -> None:
+        # The two cases that drive the real `iter_all`/`run_all` reach
+        # `check_plugin_freshness`, and so the channel (#459).
+        pin_update_channel(self)
 
     def test_run_raises_a_charter_error_not_subprocess_timeoutexpired(self):
         """`cli.main` catches `KeyboardInterrupt` and nothing else, so a bare

--- a/tests/test_isolation_harness.py
+++ b/tests/test_isolation_harness.py
@@ -37,7 +37,7 @@ class TestIsolationHarnessHasControlPlane(unittest.TestCase):
             # Not just False by luck — actually derived from the harness's own ROOT.
             self.assertEqual(config.HAS_CONTROL_PLANE, (config.ROOT / root.MARKER).is_file())
         finally:
-            case._restore()
+            case.doCleanups()
             config.HAS_CONTROL_PLANE = original
 
     def test_a_control_plane_marker_in_the_temp_root_is_reflected_as_true(self):
@@ -55,7 +55,7 @@ class TestIsolationHarnessHasControlPlane(unittest.TestCase):
             self.assertEqual(config.ROOT, fixed_tmp)
             self.assertTrue(config.HAS_CONTROL_PLANE)
         finally:
-            case._restore()  # also removes fixed_tmp, since case.tmp == fixed_tmp
+            case.doCleanups()  # also removes fixed_tmp, since case.tmp == fixed_tmp
             config.HAS_CONTROL_PLANE = original
 
 
@@ -82,7 +82,7 @@ class TestIsolationHarnessInventory(unittest.TestCase):
             self.assertEqual(config.INVENTORY, config.ROOT / "inventory" / "repos.json")
             self.assertTrue(str(config.INVENTORY).startswith(str(config.ROOT)))
         finally:
-            case._restore()
+            case.doCleanups()
             self.assertEqual(config.INVENTORY, original)  # restored on cleanup
 
 
@@ -132,11 +132,58 @@ class EveryRootDerivedPathIsIsolated(PersonaIso):
 
     def test_every_path_constant_is_named_in_the_patch_tuple(self):
         """Belt and braces: a constant could coincidentally resolve inside the sandbox
-        while still being ambient. `_PATCH` is also what `_restore` reads, so a name
+        while still being ambient. `_PATCH` is also what the cleanup reads, so a name
         missing here is a value never put back after the test."""
         missing = [n for n, _ in self._path_constants() if n not in _PATCH]
         self.assertEqual(missing, [], f"config path constants absent from _PATCH (add "
                                       f"them there AND derive them in setUp): {missing}")
+
+
+class ASubclassCannotShadowTheHarnessCleanup(unittest.TestCase):
+    """`PersonaIso`'s cleanup is name-mangled, and this is why (#459).
+
+    `addCleanup(self._restore)` binds by attribute lookup on the INSTANCE, so a subclass
+    defining a `_restore` of its own — the obvious name for "put my stubs back" — replaced
+    the base class's method entirely: `super().setUp()` registered the SUBCLASS's cleanup,
+    config was never restored, and `config.ROOT` stayed pointed at a tmp directory that had
+    just been deleted for every test that ran afterwards.
+
+    `test_secret_exec.SecretExecMode` did exactly this. Because discovery runs
+    alphabetically, everything from `test_secret_*` onward then ran against a dead plane —
+    1193 tests, and the reason `test_statusline_brand`'s and `test_version_lock`'s missing
+    channel isolation (#459) showed up when those modules were run alone and vanished in a
+    full-suite run. `test_secret_cp_destination` had avoided the same collision by hand,
+    with a comment warning the next person; the collision is impossible now instead.
+    """
+
+    class _ShadowsRestore(PersonaIso):
+        def setUp(self) -> None:
+            super().setUp()
+            self.subclass_restore_ran = False
+            self.addCleanup(self._restore)
+
+        def _restore(self) -> None:
+            self.subclass_restore_ran = True
+
+        def runProbe(self) -> None:
+            """Deliberately not named ``test_*``: discovery collects this class, and this
+            method exists to be driven by the case below, not to run on its own."""
+            self.assertNotEqual(config.ROOT, self.outer_root)
+
+    def test_config_is_restored_even_when_the_subclass_defines_restore(self):
+        outer_root, outer_update = config.ROOT, config.UPDATE
+        case = self._ShadowsRestore("runProbe")
+        case.outer_root = outer_root
+        result = unittest.TestResult()
+        case.run(result)
+        self.assertTrue(result.wasSuccessful(), result.errors or result.failures)
+        self.assertTrue(case.subclass_restore_ran,
+                        "the subclass's own cleanup must still run — the fix is that it no "
+                        "longer runs INSTEAD of the harness's")
+        self.assertEqual(config.ROOT, outer_root, "PersonaIso's cleanup was shadowed: "
+                                                  "config.ROOT is still the deleted tmp")
+        self.assertIs(config.UPDATE, outer_update)
+        self.assertFalse(case.tmp.exists(), "the tmp tree was never removed either")
 
 
 if __name__ == "__main__":

--- a/tests/test_isolation_harness.py
+++ b/tests/test_isolation_harness.py
@@ -5,6 +5,14 @@ state (the real repo's ROOT/HAS_CONTROL_PLANE/etc.) through an un-patched attrib
 Not exercised via PersonaIso subclassing — this drives `PersonaIso.setUp`/cleanup
 directly, so it can control the "ambient" value that must NOT leak through, and (for the
 second case) the exact temp directory the harness installs.
+
+**The teardowns below call `doCleanups()`, not one cleanup by name, and that is load-bearing
+rather than tidiness.** They used to call `case._restore()` directly, which ran the config
+restore and skipped everything else `setUp` had registered — including the
+`enterContext(redirect_stdout(io.StringIO()))` pair, whose exits are cleanups too. So
+`sys.stdout` and `sys.stderr` stayed bound to a throwaway buffer for the rest of the
+process, and every later test's output went into it. `doCleanups()` unwinds the whole stack
+in LIFO order, which is what a real run does; there is nothing to "simplify" back.
 """
 from __future__ import annotations
 
@@ -145,15 +153,19 @@ class ASubclassCannotShadowTheHarnessCleanup(unittest.TestCase):
     `addCleanup(self._restore)` binds by attribute lookup on the INSTANCE, so a subclass
     defining a `_restore` of its own — the obvious name for "put my stubs back" — replaced
     the base class's method entirely: `super().setUp()` registered the SUBCLASS's cleanup,
-    config was never restored, and `config.ROOT` stayed pointed at a tmp directory that had
-    just been deleted for every test that ran afterwards.
+    so neither half of the harness's ran. Config was never restored AND the tmp tree was
+    never removed, which is the detail worth being exact about: `config.ROOT` was left
+    pointing at a directory that still exists and is simply not a plane — no `charter.toml`
+    was ever written there, so `HAS_CONTROL_PLANE` is False and every setting falls back to
+    its default. Nothing raises; everything quietly answers the default.
 
     `test_secret_exec.SecretExecMode` did exactly this. Because discovery runs
-    alphabetically, everything from `test_secret_*` onward then ran against a dead plane —
-    1193 tests, and the reason `test_statusline_brand`'s and `test_version_lock`'s missing
-    channel isolation (#459) showed up when those modules were run alone and vanished in a
-    full-suite run. `test_secret_cp_destination` had avoided the same collision by hand,
-    with a comment warning the next person; the collision is impossible now instead.
+    alphabetically, the 1186 tests that ran after it — 24.3% of a 4890-test suite — read
+    that non-plane, and that is why `test_statusline_brand`'s and `test_version_lock`'s
+    missing channel isolation (#459) showed up when those modules were run alone and
+    vanished in a full-suite run: `UPDATE` defaulting to `stable` is exactly what they
+    assumed. `test_secret_cp_destination` had avoided the same collision by hand, with a
+    comment warning the next person; the collision is impossible now instead.
     """
 
     class _ShadowsRestore(PersonaIso):
@@ -166,8 +178,15 @@ class ASubclassCannotShadowTheHarnessCleanup(unittest.TestCase):
             self.subclass_restore_ran = True
 
         def runProbe(self) -> None:
-            """Deliberately not named ``test_*``: discovery collects this class, and this
-            method exists to be driven by the case below, not to run on its own."""
+            """Not named ``test_*``, belt to the braces of being nested.
+
+            `loadTestsFromModule` iterates module-level names only, so a class defined
+            inside a `TestCase` is already invisible to discovery — unlike
+            `test_the_suite_writes_no_trace_into_the_operators_plane`'s module-level
+            positive control, which IS collected (a leading underscore does not hide a
+            class from the loader) and relies on this naming rule alone. Hoist this class
+            to module level and the rule is what stops the leak running for real.
+            """
             self.assertNotEqual(config.ROOT, self.outer_root)
 
     def test_config_is_restored_even_when_the_subclass_defines_restore(self):
@@ -181,7 +200,7 @@ class ASubclassCannotShadowTheHarnessCleanup(unittest.TestCase):
                         "the subclass's own cleanup must still run — the fix is that it no "
                         "longer runs INSTEAD of the harness's")
         self.assertEqual(config.ROOT, outer_root, "PersonaIso's cleanup was shadowed: "
-                                                  "config.ROOT is still the deleted tmp")
+                                                  "config.ROOT is still the fixture tmp")
         self.assertIs(config.UPDATE, outer_update)
         self.assertFalse(case.tmp.exists(), "the tmp tree was never removed either")
 

--- a/tests/test_memory_index_health.py
+++ b/tests/test_memory_index_health.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import unittest
 
 from charter import doctor, memstore, persona
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, pin_update_channel
 
 
 class IndexDrift(PersonaIso):
@@ -86,6 +86,10 @@ class DoctorCheck(unittest.TestCase):
     It shipped that way for a moment: a broad `except Exception` swallowed a
     NameError and returned OK, so it silently checked nothing.
     """
+
+    def setUp(self) -> None:
+        # `run_all` reaches `check_plugin_freshness`, and so the channel (#459).
+        pin_update_channel(self)
 
     def test_check_returns_a_named_result(self):
         r = doctor.check_memory_indexes()

--- a/tests/test_news_cross_process.py
+++ b/tests/test_news_cross_process.py
@@ -42,6 +42,7 @@ from unittest import mock
 import charter
 from charter import (commands, commands_persona, commands_update, doctor, harness,
                      instance, news)
+from tests._isolation import pin_update_channel
 
 #: The `check:` every test here plants, and the handler it stands on. A `check:` may
 #: only name a command `news._PROBEABLE` lists (#317), so the stand-in has to be one
@@ -383,6 +384,13 @@ class TheHandoffBound(unittest.TestCase):
     site with nothing naming it — which is how it survived as an accident. It is a second
     line now, not the first: the marker bounds the child whatever the range says.
     """
+
+    def setUp(self) -> None:
+        # `cmd_update` forks on `channel.is_dev()` long before it reaches `_handoff`, and
+        # the dev branch is `_update_dev_on_a_checkout` — a different command with no
+        # baseline in it at all. The stable path is the one this case is about, so it is
+        # pinned rather than inherited from whoever runs the suite (#459).
+        pin_update_channel(self)
 
     def test_the_handoff_baseline_is_the_version_that_was_installed_before(self):
         seen = {}

--- a/tests/test_no_test_reads_the_operators_channel.py
+++ b/tests/test_no_test_reads_the_operators_channel.py
@@ -1,0 +1,160 @@
+"""The read half of the suite-wide tripwire: `[update] channel` is not a fixture (#459).
+
+`charter update` on a charter checkout only refreshes the plugin when the plane is on the
+dev channel, so a charter developer has to put ``[update] channel = "dev"`` in their own
+`charter.toml` for their own tooling to work. That file is committed, and `charter save`
+commits it. The first time it landed, six tests in two modules went red — not because the
+change was wrong, but because `test_statusline_brand.UpdateIndicator` and
+`test_version_lock.AutoSync` had never isolated `config.UPDATE` and had been quietly
+reading whatever channel the machine declared. The feature was unusable until this closed.
+
+Fixing those two classes was the smaller half. The guard in `tests/_planeguard.py` is the
+other: it refuses the READ, so the next fixture to forget fails on the line that forgot,
+with its own name in the message, instead of waiting for a contributor to opt their plane
+in and discover it in CI. It found eight more sites the day it was written.
+
+**Every case here is a control.** A guard nobody has watched fail is a guard nobody knows
+works: `TheGuardIsNotBlind` makes the refusal happen for real, and the cases after it prove
+each way OUT of the refusal actually works, so "green" cannot mean "the tripwire is gone".
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from charter import channel, config
+from tests import _planeguard
+from tests._isolation import PersonaIso, pin_update_channel
+
+
+class WhatIsGuarded(unittest.TestCase):
+    def test_the_channel_is_on_the_guarded_list(self):
+        self.assertIn("UPDATE", _planeguard._GUARDED_SETTINGS)
+
+    def test_every_guarded_name_is_a_setting_config_actually_derives(self):
+        """A typo here would guard nothing and say nothing — the shape of a silent hole."""
+        for name in _planeguard._GUARDED_SETTINGS:
+            with self.subTest(setting=name):
+                self.assertIn(name, config.DERIVED)
+
+    def test_derive_is_wrapped_at_package_import(self):
+        """Arming happens per derivation, not once at import: a `config.use(config.ROOT)`
+        anywhere in the suite lands back on the real plane and has to re-arm."""
+        self.assertEqual(getattr(config.derive, "__module__", None), "tests._planeguard")
+
+    def test_the_refusal_is_not_an_exception(self):
+        """`statusline._dev_chip` wraps `channel.is_dev()` in `except Exception` so a
+        broken plane cannot cost the status line. A tripwire that catchable would be
+        reported as "not on the dev channel" and the test would pass, wrongly."""
+        self.assertTrue(issubclass(_planeguard.RealPlaneRead, BaseException))
+        self.assertFalse(issubclass(_planeguard.RealPlaneRead, Exception))
+
+
+class TheGuardIsNotBlind(unittest.TestCase):
+    """A plain `TestCase`: `charter.config` still points at the developer's real plane,
+    which is exactly the state every case below is about."""
+
+    def test_reading_the_real_planes_channel_is_refused(self):
+        with self.assertRaises(_planeguard.RealPlaneRead):
+            channel.is_dev()
+
+    def test_the_message_names_the_test_that_made_the_read(self):
+        """`unittest` puts the test's name in the failure header; the message repeats it
+        so an excerpt quoted into an issue or a CI log still says which test it was."""
+        with self.assertRaises(_planeguard.RealPlaneRead) as caught:
+            channel.is_dev()
+        self.assertIn("test_the_message_names_the_test_that_made_the_read",
+                      str(caught.exception))
+        self.assertIn("UPDATE", str(caught.exception))
+        self.assertIn("PersonaIso", str(caught.exception))
+
+    def test_every_way_in_is_closed_not_just_the_one_channel_uses(self):
+        """`channel.channel` reads it with `.get`, but a future reader may not. The C-level
+        fast paths are the interesting ones: `dict(x)` and `{**x}` bypass an overridden
+        `keys()` unless `__iter__` is overridden too."""
+        guarded = config.UPDATE
+        for label, read in (("get", lambda: guarded.get("channel")),
+                            ("[]", lambda: guarded["channel"]),
+                            ("in", lambda: "channel" in guarded),
+                            ("iter", lambda: list(guarded)),
+                            ("keys", lambda: list(guarded.keys())),
+                            ("items", lambda: list(guarded.items())),
+                            ("values", lambda: list(guarded.values())),
+                            ("copy", lambda: guarded.copy()),
+                            ("dict()", lambda: dict(guarded)),
+                            ("**", lambda: {**guarded}),
+                            ("==", lambda: guarded == {"channel": "stable"})):
+            with self.subTest(read=label):
+                with self.assertRaises(_planeguard.RealPlaneRead):
+                    read()
+
+
+class EveryWayOutOfTheRefusalWorks(unittest.TestCase):
+    """The other direction. A guard with no usable exit gets deleted by whoever hits it
+    next, so each documented escape is exercised here rather than described."""
+
+    def test_a_tmp_root_derives_a_readable_value(self):
+        with TemporaryDirectory() as tmp:
+            derived = config.derive(Path(tmp))
+            self.assertEqual(derived["UPDATE"], {"channel": "stable"})
+
+    def test_a_tmp_root_that_declares_dev_reads_back_dev(self):
+        """Isolation is not "the channel is always stable" — it is "the channel is what
+        the FIXTURE says". A case about the dev channel writes it and gets it."""
+        with TemporaryDirectory() as tmp:
+            (Path(tmp) / "charter.toml").write_text(
+                'schema = 1\n\n[update]\nchannel = "dev"\n')
+            self.assertEqual(config.derive(Path(tmp))["UPDATE"], {"channel": "dev"})
+
+    def test_deriving_the_real_root_again_re_arms(self):
+        """The property that makes the guard survive a suite: `config.use(config.ROOT)`
+        is a real thing two modules here do, and it must not disarm the tripwire."""
+        again = config.derive(Path(_planeguard._REAL_ROOT[0]))["UPDATE"]
+        self.assertIsInstance(again, _planeguard._RefusesToBeRead)
+
+    def test_pin_update_channel_makes_the_read_answer(self):
+        pin_update_channel(self)
+        self.assertIs(channel.is_dev(), False)
+
+    def test_pin_update_channel_can_pin_dev(self):
+        pin_update_channel(self, "dev")
+        self.assertIs(channel.is_dev(), True)
+
+
+class IsolationIsTheOtherWayOut(PersonaIso):
+    def test_persona_iso_derives_the_channel_from_its_own_tmp_plane(self):
+        self.assertIs(channel.is_dev(), False)
+        self.assertEqual(config.UPDATE, {"channel": "stable"})
+
+    def test_a_persona_iso_fixture_can_declare_the_dev_channel(self):
+        (self.tmp / "charter.toml").write_text('schema = 1\n\n[update]\nchannel = "dev"\n')
+        config.use(self.tmp)
+        self.assertIs(channel.is_dev(), True)
+
+
+class TheGuardIsRestoredAfterIsolation(unittest.TestCase):
+    """The failure mode a value-based tripwire has and this one must not: a case that
+    isolates leaves the guard disarmed for everything that runs after it.
+
+    Not hypothetical. `test_secret_exec.SecretExecMode` shadowed `PersonaIso`'s cleanup
+    with a method of its own name, so `config.ROOT` stayed on a deleted tmp directory for
+    every module from `test_secret_*` onward — 1193 tests running against a dead plane,
+    which is also why #459's own six failures did not reproduce in a full-suite run.
+    `PersonaIso`'s cleanup is name-mangled now, and this is what notices if that regresses.
+    """
+
+    def test_a_completed_persona_iso_case_leaves_the_guard_armed(self):
+        case = IsolationIsTheOtherWayOut(
+            "test_persona_iso_derives_the_channel_from_its_own_tmp_plane")
+        result = unittest.TestResult()
+        case.run(result)
+        self.assertTrue(result.wasSuccessful(), result.errors or result.failures)
+        self.assertIsInstance(config.UPDATE, _planeguard._RefusesToBeRead)
+        with self.assertRaises(_planeguard.RealPlaneRead):
+            channel.is_dev()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_no_test_reads_the_operators_channel.py
+++ b/tests/test_no_test_reads_the_operators_channel.py
@@ -20,6 +20,7 @@ each way OUT of the refusal actually works, so "green" cannot mean "the tripwire
 
 from __future__ import annotations
 
+import json
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -38,6 +39,22 @@ class WhatIsGuarded(unittest.TestCase):
         for name in _planeguard._GUARDED_SETTINGS:
             with self.subTest(setting=name):
                 self.assertIn(name, config.DERIVED)
+
+    def test_every_guarded_name_actually_derives_to_a_dict(self):
+        """The name existing is not enough. Both arming sites skip a value that is not a
+        `dict` — the refusal works by substituting an object that will not answer, and a
+        `str` or a `Path` cannot be made to refuse without breaking every message that
+        legitimately quotes it. So a future entry deriving to one of those would guard
+        nothing while the check above stayed green: the silent hole its own docstring
+        warns about, one level in."""
+        with TemporaryDirectory() as tmp:
+            derived = config.derive(Path(tmp))       # a tmp root, so nothing is armed
+            for name in _planeguard._GUARDED_SETTINGS:
+                with self.subTest(setting=name):
+                    self.assertIsInstance(
+                        derived[name], dict,
+                        f"config.{name} does not derive to a dict, so _RefusesToBeRead "
+                        f"cannot stand in for it and the guard silently skips it")
 
     def test_derive_is_wrapped_at_package_import(self):
         """Arming happens per derivation, not once at import: a `config.use(config.ROOT)`
@@ -71,24 +88,64 @@ class TheGuardIsNotBlind(unittest.TestCase):
         self.assertIn("PersonaIso", str(caught.exception))
 
     def test_every_way_in_is_closed_not_just_the_one_channel_uses(self):
-        """`channel.channel` reads it with `.get`, but a future reader may not. The C-level
-        fast paths are the interesting ones: `dict(x)` and `{**x}` bypass an overridden
-        `keys()` unless `__iter__` is overridden too."""
+        """`channel.channel` reads it with `.get`, but a future reader may not.
+
+        Two groups are worth naming. The C-level fast paths — `dict(x)`, `{**x}`, `|` —
+        bypass an overridden `keys()` unless `__iter__` is overridden too. And the
+        mutating accessors `pop`/`popitem`/`setdefault`, plus `__reversed__`, which each
+        handed back the operator's real value until they were probed for: no reader in
+        `charter/` uses any of them, which is exactly why they would have stayed open
+        until one did. This list came from probing every entry point, not from reasoning
+        about which ones matter.
+        """
         guarded = config.UPDATE
         for label, read in (("get", lambda: guarded.get("channel")),
+                            ("get w/ default", lambda: guarded.get("channel", "stable")),
                             ("[]", lambda: guarded["channel"]),
                             ("in", lambda: "channel" in guarded),
                             ("iter", lambda: list(guarded)),
+                            ("reversed", lambda: list(reversed(guarded))),
                             ("keys", lambda: list(guarded.keys())),
                             ("items", lambda: list(guarded.items())),
                             ("values", lambda: list(guarded.values())),
                             ("copy", lambda: guarded.copy()),
+                            ("pop", lambda: guarded.pop("channel")),
+                            ("pop w/ default", lambda: guarded.pop("channel", None)),
+                            ("popitem", lambda: guarded.popitem()),
+                            ("setdefault", lambda: guarded.setdefault("channel", "x")),
                             ("dict()", lambda: dict(guarded)),
                             ("**", lambda: {**guarded}),
+                            ("|", lambda: guarded | {"x": 1}),
+                            ("r|", lambda: {"x": 1} | guarded),
+                            ("json.dumps", lambda: json.dumps(guarded)),
+                            ("format_map", lambda: "{channel}".format_map(guarded)),
                             ("==", lambda: guarded == {"channel": "stable"})):
             with self.subTest(read=label):
                 with self.assertRaises(_planeguard.RealPlaneRead):
                     read()
+
+    def test_a_refused_mutator_did_not_mutate_on_the_way_out(self):
+        """`pop`/`popitem`/`setdefault` are refused BEFORE they touch anything, the way the
+        write guard refuses `rmtree` at its front door. A tripwire that raised after the
+        mutation would leave the next test reading a value this one silently edited."""
+        before = dict.__len__(config.UPDATE)
+        for attempt in (lambda: config.UPDATE.pop("channel"),
+                        lambda: config.UPDATE.popitem(),
+                        lambda: config.UPDATE.setdefault("channel", "tampered")):
+            with self.assertRaises(_planeguard.RealPlaneRead):
+                attempt()
+        self.assertEqual(dict.__len__(config.UPDATE), before)
+        self.assertEqual(dict.__repr__(config.UPDATE), repr(config.UPDATE))
+
+    def test_what_is_deliberately_left_open_is_left_open(self):
+        """`repr` and `len` (so `bool`) still answer, and that is the choice, not an
+        oversight: `unittest`'s own error formatting, a traceback and a debugger all print
+        this object, and a guard that raises while a test is already failing hides the
+        failure it exists to explain. Neither one answers "which channel", which is the
+        fact being protected. Pinned so a later tightening has to be deliberate."""
+        self.assertEqual(len(config.UPDATE), 1)
+        self.assertIn("channel", repr(config.UPDATE))
+        self.assertTrue(bool(config.UPDATE))
 
 
 class EveryWayOutOfTheRefusalWorks(unittest.TestCase):
@@ -139,9 +196,11 @@ class TheGuardIsRestoredAfterIsolation(unittest.TestCase):
     isolates leaves the guard disarmed for everything that runs after it.
 
     Not hypothetical. `test_secret_exec.SecretExecMode` shadowed `PersonaIso`'s cleanup
-    with a method of its own name, so `config.ROOT` stayed on a deleted tmp directory for
-    every module from `test_secret_*` onward — 1193 tests running against a dead plane,
-    which is also why #459's own six failures did not reproduce in a full-suite run.
+    with a method of its own name, so neither the config restore nor the `rmtree` ran:
+    `config.ROOT` was left on a tmp directory that still exists and holds no
+    `charter.toml`, which makes every setting answer its default rather than raise. The
+    1186 tests that ran after it read that non-plane, which is also why #459's own six
+    failures did not reproduce in a full-suite run — `stable` is the default they assumed.
     `PersonaIso`'s cleanup is name-mangled now, and this is what notices if that regresses.
     """
 

--- a/tests/test_secret_cp_destination.py
+++ b/tests/test_secret_cp_destination.py
@@ -152,9 +152,11 @@ class TestCharterOwnStreamsAreRefusedByIdentity(CpCase):
             self.saved[fd] = os.dup(fd)
             os.dup2(opened, fd)
             os.close(opened)
-        # NOT named `_restore`: `PersonaIso` has a method by that name and registers it
-        # as its own cleanup, so an override here would run twice (EBADF on the second)
-        # and the plane isolation would never be undone.
+        # Named for what it restores, which is now a style point rather than a trap:
+        # `PersonaIso` used to register a cleanup called `_restore`, so a subclass method
+        # of that name replaced it — this fixture would have run twice (EBADF on the
+        # second) and the plane isolation would never have been undone. That cleanup is
+        # name-mangled since #459 and cannot be shadowed.
         self.addCleanup(self._restore_streams)
 
     def _restore_streams(self) -> None:

--- a/tests/test_statusline_brand.py
+++ b/tests/test_statusline_brand.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from charter import config, statusline, tui, update
+from tests._isolation import PersonaIso, pin_update_channel
 
 
 class BrandLayout(unittest.TestCase):
@@ -24,6 +25,11 @@ class BrandLayout(unittest.TestCase):
         self._spawn = update.maybe_spawn      # never fork a network child from a test
         update.maybe_spawn = lambda: None
         self.addCleanup(lambda: setattr(update, "maybe_spawn", self._spawn))
+        # `_brand` renders the `dev` chip from `config.UPDATE`, so every width assertion
+        # below is a function of the channel unless it is pinned (#459). This class is
+        # about LAYOUT and runs against the real plane on purpose; the chip belongs to
+        # `UpdateIndicator` and `test_dev_channel`, which own it against a fixture.
+        pin_update_channel(self)
 
     def test_brand_is_right_aligned_on_the_last_line(self):
         out = statusline._with_brand("short", 120)
@@ -68,13 +74,20 @@ class BrandLayout(unittest.TestCase):
             statusline._brand = orig
 
 
-class UpdateIndicator(unittest.TestCase):
+class UpdateIndicator(PersonaIso):
+    """`PersonaIso`, not a hand-rolled ``config.STATE_DIR`` redirect.
+
+    Every assertion here is about the STABLE channel's comparison — `update.newer_than`
+    hands off to `newer_head` on dev, where a cached ``"9.9.9"`` means nothing — and
+    redirecting one attribute left `config.UPDATE` reading the channel of whatever plane
+    the suite resolved. On a developer whose own `charter.toml` declares
+    ``channel = "dev"`` these went red, and only there (#459). `PersonaIso` re-derives
+    every setting from a tmp plane in one `config.use()` call, so the channel is the
+    default `stable` because the fixture says so, not because the machine does.
+    """
+
     def setUp(self) -> None:
-        self._td = TemporaryDirectory()
-        self._orig = config.STATE_DIR
-        config.STATE_DIR = Path(self._td.name)
-        self.addCleanup(self._td.cleanup)
-        self.addCleanup(lambda: setattr(config, "STATE_DIR", self._orig))
+        super().setUp()
         # _brand() calls maybe_spawn(), and a temp STATE_DIR always looks stale — so
         # without this every test here forks a real network child. A suite that
         # quietly reaches the internet is not hermetic.
@@ -137,6 +150,9 @@ class NeverBlocks(unittest.TestCase):
         config.STATE_DIR = Path(self._td.name)
         self.addCleanup(self._td.cleanup)
         self.addCleanup(lambda: setattr(config, "STATE_DIR", self._orig))
+        # `test_render_never_raises_even_if_the_check_explodes` reaches `_brand`, and so
+        # the `dev` chip. Nothing here is about the channel, so it is pinned (#459).
+        pin_update_channel(self)
 
     def test_a_fresh_cache_spawns_nothing(self):
         p = config.STATE_DIR / "cache" / "update.json"

--- a/tests/test_statusline_gauge.py
+++ b/tests/test_statusline_gauge.py
@@ -14,7 +14,7 @@ import unittest
 from pathlib import Path
 
 from charter import config, statusline
-from tests._isolation import PersonaIso, isolate_state_dir
+from tests._isolation import PersonaIso, isolate_state_dir, pin_update_channel
 
 
 def _plain(parts):
@@ -34,6 +34,10 @@ def _payload(pct=None, read=None, write=None, usage=True):
 class ContextGaugeCase(unittest.TestCase):
     def setUp(self):
         isolate_state_dir(self)
+        # The render path brands the last line, and `_brand` renders the channel chip.
+        # This case runs against the real plane on purpose; the chip is not what it is
+        # about, so it is pinned rather than inherited (#459).
+        pin_update_channel(self)
         # `test_gauge_appears_in_the_rendered_summary` calls `statusline.render`, which
         # persists usage under `config.SESSIONS_DIR` — isolate it so the suite never
         # writes into this repo's own `.charter/sessions/`.

--- a/tests/test_statusline_session_block.py
+++ b/tests/test_statusline_session_block.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from charter import config, statusline, update
+from tests._isolation import pin_update_channel
 
 
 def _plain(lines):
@@ -95,6 +96,10 @@ class NeverBreaksTheStatusLine(unittest.TestCase):
         config.STATE_DIR = _tmp / ".charter"
         self.addCleanup(lambda: (setattr(config, "STATE_DIR", _state),
                                  _sh.rmtree(_tmp, ignore_errors=True)))
+        # And the channel, for the same reason and by the same argument: `render` brands
+        # the last line, `_brand` renders the `dev` chip, and nothing here is about which
+        # channel the machine running the suite happens to declare (#459).
+        pin_update_channel(self)
 
     def test_a_broken_control_plane_yields_no_lines(self):
         orig = config.ROOT

--- a/tests/test_version_lock.py
+++ b/tests/test_version_lock.py
@@ -84,16 +84,21 @@ class LockFile(unittest.TestCase):
         instance.load(self.root)      # raises if the edit broke the syntax
 
 
-class AutoSync(unittest.TestCase):
-    """SessionStart conformance. Loud, non-blocking, and opt-in."""
+class AutoSync(PersonaIso):
+    """SessionStart conformance. Loud, non-blocking, and opt-in.
+
+    `PersonaIso`, not ``config.ROOT = tmp``. Assigning that one attribute moves where
+    `charter.toml` is READ from without re-deriving anything that follows from it, so
+    `config.UPDATE` kept naming the channel of the plane the suite resolved. Every case
+    below assumes the default `stable`: on the dev channel `hooks._autosync_version_lock`
+    answers with the pin-versus-dev CONFLICT message instead of installing, so on a machine
+    whose own `charter.toml` declares ``channel = "dev"`` these went red and nowhere else
+    (#459). `config.use` derives the whole set from the fixture root in one call.
+    """
 
     def setUp(self) -> None:
-        self._td = TemporaryDirectory()
-        self.root = Path(self._td.name)
-        self._orig = config.ROOT
-        config.ROOT = self.root
-        self.addCleanup(self._td.cleanup)
-        self.addCleanup(lambda: setattr(config, "ROOT", self._orig))
+        super().setUp()
+        self.root = self.tmp
         self.installs: list[str] = []
         self._sync = commands.sync_to
         commands.sync_to = lambda v: (self.installs.append(v), (True, v))[1]
@@ -103,6 +108,11 @@ class AutoSync(unittest.TestCase):
         (self.root / "charter.toml").write_text("schema = 1\n")
         if version:
             instance.set_locked_version(self.root, version)
+        # Re-derive: the fixture only becomes a control plane on this line, and the hook
+        # under test branches on `config.UPDATE` as well as on the pin it re-reads. A test
+        # that wanted the dev channel would write `[update]` into the file above and get it
+        # here, rather than inheriting it from the developer's machine.
+        config.use(self.root)
 
     def test_no_lock_does_nothing(self):
         """Opt-in: an unpinned control plane must behave exactly as before."""

--- a/tests/test_version_lock.py
+++ b/tests/test_version_lock.py
@@ -21,8 +21,8 @@ from contextlib import redirect_stderr
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from tests._isolation import PersonaIso
 from charter import commands, config, hooks, instance
+from tests._isolation import PersonaIso
 
 
 class LockFile(unittest.TestCase):

--- a/tests/test_version_shows_channel.py
+++ b/tests/test_version_shows_channel.py
@@ -22,8 +22,8 @@ and `_top` share: the bare name `__version__`, interpolated with the literal wor
 `__version__` appears" — this package interpolates it in a dozen other places
 (`report.py`'s JSON export, `hooks.py`'s and `doctor.py`'s pin/plugin-drift warnings,
 `statusline._alerts`'s pinned-version alert) that are answering "does what's running
-match what's declared", not "which channel is this plane on" — a different question `_brand`'s docstring is not
-making a claim about. A scanner broad enough to flag all of those too would have to
+match what's declared", not "which channel is this plane on" — a different question
+`_brand`'s docstring is not making a claim about. A scanner broad enough to flag all of those too would have to
 judge INTENT, which no syntax-level check can do honestly; a scanner narrowed by a
 hand-picked exclusion list for each of them would just be today's two-item allowlist
 wearing a longer coat. The "charter {version}" idiom is not a guess at that boundary —
@@ -47,13 +47,15 @@ somewhere that DOES check liveness inherits a safe fixture rather than an unfail
 from __future__ import annotations
 
 import ast
+import contextlib
+import io
 import os
 import unittest
 from pathlib import Path
 from unittest import mock
 
 import charter
-from charter import config, statusline
+from charter import commands_report, config, statusline, util
 from charter.frame import slots
 
 from tests._isolation import PersonaIso
@@ -85,6 +87,61 @@ class DevChipUnit(unittest.TestCase):
         exactly the duplication this helper exists to remove."""
         with mock.patch("charter.channel.is_dev", side_effect=RuntimeError("boom")):
             self.assertEqual(statusline._dev_chip(), "")
+
+    def test_the_default_is_ansi_because_both_surfaces_here_are(self):
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}):
+            self.assertEqual(statusline._dev_chip(), " \x1b[2mdev\x1b[0m")
+
+    def test_color_false_says_the_same_thing_without_the_escapes(self):
+        """For a caller printing somewhere that strips colour. Still the same WORD — the
+        chip's job is to disambiguate `is out`, and a plane on dev that renders nothing
+        because the log is not a terminal has lost the fact, not the formatting."""
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}):
+            self.assertEqual(statusline._dev_chip(color=False), " dev")
+
+    def test_color_false_on_stable_is_still_nothing(self):
+        with mock.patch.object(config, "UPDATE", {"channel": "stable"}):
+            self.assertEqual(statusline._dev_chip(color=False), "")
+
+
+class TheStalenessNudgeHonoursTheTerminal(unittest.TestCase):
+    """#458's site is the first non-ANSI consumer of the chip, and it got this wrong.
+
+    `util.warn` gates its own glyph on `stderr.isatty()`; `_dev_chip` does not gate at all,
+    because its other two callers paint terminal surfaces. Interpolating one into the other
+    put a raw ``\x1b[2mdev\x1b[0m`` into a redirected log beside a correctly plain ``!`` —
+    half a line honouring the terminal and half not, and the only place in `charter/` where
+    a `util` message body carried escape codes.
+    """
+
+    def _nudge(self, *, color: bool) -> str:
+        buf = io.StringIO()
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}), \
+             mock.patch.object(util, "_USE_COLOR", color), \
+             mock.patch("charter.update.newer_than", lambda v: "9.9.9"), \
+             contextlib.redirect_stderr(buf):
+            commands_report._warn_if_stale()
+        return buf.getvalue()
+
+    def test_a_redirected_stderr_gets_no_escape_codes_at_all(self):
+        out = self._nudge(color=False)
+        self.assertIn("dev", out, "the channel must still be named, just not painted")
+        self.assertNotIn("\x1b", out,
+                         "the nudge is putting raw ANSI into a non-terminal stream")
+
+    def test_a_terminal_still_gets_the_dimmed_chip(self):
+        self.assertIn("\x1b[2mdev\x1b[0m", self._nudge(color=True))
+
+    def test_the_glyph_and_the_body_agree(self):
+        """The defect was disagreement, not colour as such: `util.warn` gated the glyph and
+        the interpolated chip gated nothing, so one line answered "is this a terminal" twice
+        and differently. Asserts the two halves match each other rather than that either
+        matches the flag — that is the property, and it holds in both directions."""
+        for color in (True, False):
+            with self.subTest(color=color):
+                glyph, _, body = self._nudge(color=color).partition("you are on")
+                self.assertEqual("\x1b" in glyph, "\x1b" in body,
+                                 "the `!` glyph and the chip disagreed about the terminal")
 
 
 class BrandCallsTheSharedChipRatherThanReassemblingIt(unittest.TestCase):

--- a/tests/test_version_shows_channel.py
+++ b/tests/test_version_shows_channel.py
@@ -21,9 +21,8 @@ and `_top` share: the bare name `__version__`, interpolated with the literal wor
 `charter` glued directly in front of it. That is deliberately narrower than "every place
 `__version__` appears" — this package interpolates it in a dozen other places
 (`report.py`'s JSON export, `hooks.py`'s and `doctor.py`'s pin/plugin-drift warnings,
-`statusline._alerts`'s pinned-version alert, `commands_report._warn_if_stale`'s
-staleness nudge) that are answering "does what's running match what's declared", not
-"which channel is this plane on" — a different question `_brand`'s docstring is not
+`statusline._alerts`'s pinned-version alert) that are answering "does what's running
+match what's declared", not "which channel is this plane on" — a different question `_brand`'s docstring is not
 making a claim about. A scanner broad enough to flag all of those too would have to
 judge INTENT, which no syntax-level check can do honestly; a scanner narrowed by a
 hand-picked exclusion list for each of them would just be today's two-item allowlist
@@ -32,10 +31,11 @@ it is the literal shape of the bug: `_top`'s line was `f"... charter {__version_
 with nothing else in the expression naming a channel at all, and every one of the
 excluded sites above fails that literal test on its own text (see each one's inline
 comment in `_charter_version_idiom_sites`'s docstring). One real site DOES match the
-idiom and isn't fixed here: `commands_report._warn_if_stale` — filed as #458 rather than
-folded into this PR (out of #457's stated scope) or silently exempted, and carried below
-as a named, sourced `_KNOWN_GAPS` entry so fixing #458 is "implement the chip, delete
-the line" and the property test itself proves that fix.
+idiom and wasn't fixed by #457: `commands_report._warn_if_stale` — filed as #458 rather
+than folded into that PR (out of its stated scope) or silently exempted, and carried for
+one release as a named, sourced `_KNOWN_GAPS` entry. #458 has since landed; the entry is
+gone and `test_the_staleness_nudge_calls_the_chip_too` asserts the chip directly, which
+is exactly the hand-off that entry was written to make possible.
 
 Frame ids are `<workspace>-<launcher pid>` (`frame/state.py:frame_id`), and pid 1 is
 `launchd` — permanently alive on this machine. `_top` does not consult liveness at all
@@ -206,17 +206,22 @@ def _charter_version_idiom_sites(pkg_root: Path) -> list[tuple[str, int, str, bo
     return sites
 
 
-#: One real site the scanner finds that this PR deliberately does not touch: the same
-#: idiom, the same missing chip, but a different feature (a staleness nudge in `charter
-#: report`, comparing the running version against the latest published one — not
-#: identifying the channel). Filed upstream as #458 rather than folded in here (out of
-#: #457's stated scope) or silently exempted with no trace. Keyed by file rather than
-#: line, so a routine edit elsewhere in the file doesn't rot the entry, and paired with
-#: the exact source substring so a DIFFERENT, unrelated idiom landing in the same file
-#: later is not silently swallowed by this one's exemption.
-_KNOWN_GAPS = {
-    "charter/commands_report.py": "you are on charter",
-}
+#: Sites the scanner finds that are deliberately exempt — **empty**, and the machinery is
+#: kept for the next one rather than deleted with it.
+#:
+#: It held exactly one entry, `commands_report._warn_if_stale`: the same idiom and the same
+#: missing chip, left out of #457 as out of scope and filed upstream as #458 rather than
+#: silently exempted. #458 has landed, so the entry is gone and
+#: `test_the_staleness_nudge_calls_the_chip_too` below asserts the fix directly — which is
+#: what the entry's own docstring promised would happen ("implement the chip, delete the
+#: line, and the property test itself proves the fix").
+#:
+#: The shape, for whoever adds the next one: keyed by file rather than line, so a routine
+#: edit elsewhere in the file doesn't rot the entry, and paired with the exact source
+#: substring so a DIFFERENT, unrelated idiom landing in the same file later is not silently
+#: swallowed by this one's exemption. An entry with no upstream issue behind it is just a
+#: two-item allowlist wearing a longer coat.
+_KNOWN_GAPS: dict[str, str] = {}
 
 
 class EveryCharterVersionIdiomShowsTheChannel(unittest.TestCase):
@@ -239,6 +244,18 @@ class EveryCharterVersionIdiomShowsTheChannel(unittest.TestCase):
                         "_brand's idiom no longer calls _dev_chip")
         self.assertTrue(by_file.get("charter/frame/slots.py"),
                         "_top's idiom no longer calls _dev_chip")
+
+    def test_the_staleness_nudge_calls_the_chip_too(self):
+        """The third site, and the one that was carried as a `_KNOWN_GAPS` entry until
+        #458 landed. Named here rather than left to the sweep below, because "no offenders"
+        would also be true of a file the scanner had stopped finding at all."""
+        sites = _charter_version_idiom_sites(_PKG)
+        by_file = {f: chip for f, _ln, _src, chip in sites}
+        self.assertIn("charter/commands_report.py", by_file,
+                      "the staleness nudge no longer matches the idiom at all — if it was "
+                      "rewritten, say so here rather than losing the coverage silently")
+        self.assertTrue(by_file["charter/commands_report.py"],
+                        "_warn_if_stale's idiom no longer calls _dev_chip (#458)")
 
     def test_no_charter_version_idiom_anywhere_skips_the_channel(self):
         """The rule: every site matching the idiom calls `_dev_chip`, except the
@@ -263,10 +280,13 @@ class EveryCharterVersionIdiomShowsTheChannel(unittest.TestCase):
             "\n".join(f"  {f}:{line}  {src}" for f, line, src in offenders))
 
     def test_a_known_gap_still_matches_the_source_it_was_filed_against(self):
-        """The other direction: if #458 lands and `commands_report._warn_if_stale`
-        starts calling `_dev_chip`, the exemption above stops being needed — and this
-        test is what notices, rather than the exemption quietly outliving its reason
-        and starting to shadow a real, different regression in the same file."""
+        """The other direction, for whatever `_KNOWN_GAPS` holds: when the filed issue
+        lands and the site starts calling `_dev_chip`, the exemption stops being needed —
+        and this is what notices, rather than the exemption quietly outliving its reason
+        and starting to shadow a real, different regression in the same file. That is not
+        hypothetical: it is exactly how the one entry this ever held, `_warn_if_stale`,
+        left — #458 landed and this test said so. Asserts nothing while the dict is empty,
+        and goes live again with the next entry."""
         sites = _charter_version_idiom_sites(_PKG)
         by_file = {f: (has_chip, src) for f, _ln, src, has_chip in sites}
         for f, gap in _KNOWN_GAPS.items():
@@ -277,8 +297,8 @@ class EveryCharterVersionIdiomShowsTheChannel(unittest.TestCase):
                 self.assertIn(gap, src, f"{f}'s idiom no longer reads {gap!r} — "
                              "the _KNOWN_GAPS entry no longer matches what it was "
                              "filed against, update or remove it")
-                self.assertFalse(has_chip, f"{f} now calls _dev_chip — #458 is "
-                                "fixed, delete this _KNOWN_GAPS entry")
+                self.assertFalse(has_chip, f"{f} now calls _dev_chip — the issue this "
+                                "entry was filed against is fixed, delete the entry")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The defect

`charter update` on a charter checkout only refreshes the plugin when the plane is on the **dev** channel (`commands_update._update_dev_on_a_checkout`), so anyone working on charter has to put `[update] channel = "dev"` in their own `charter.toml`. That file is committed, and `charter save` commits it — so the moment the line lands, six tests go red for everyone. The feature 0.52.0 shipped was unusable by the people it shipped for.

Nothing is wrong with the channel. Two classes had never isolated `config.UPDATE`:

- `test_statusline_brand.UpdateIndicator` redirected `config.STATE_DIR` by hand;
- `test_version_lock.AutoSync` assigned `config.ROOT` directly.

Neither re-derives anything else, so `config.UPDATE` kept naming the channel of whatever plane the suite resolved. For as long as `[update]` has existed, `{"channel": "stable"}` was true on every machine — a fixture nobody wrote, silently agreeing with what every assertion assumed.

## The fix is structural, not per-test

Same shape as #402, which was closed by making the violation impossible (`RealPlaneWrite`) rather than by patching the one offending test.

`config.DERIVED` already covers `UPDATE`, so `PersonaIso`'s single `config.use()` call was always enough — the bug was that these classes were plain `TestCase`. So the guard is on the **read**:

- `tests/_planeguard.py` gains `RealPlaneRead`. Whenever `charter.config` points at the real plane, every name in `_GUARDED_SETTINGS` (today: `UPDATE`) holds a `dict` subclass that refuses `get`/`[]`/`in`/iteration/`keys`/`values`/`items`/`copy`/`==` — including the C fast paths `dict(x)` and `{**x}` take, which is why `__iter__` is overridden.
- **A `BaseException`**, for the reason the write half already documents: `statusline._dev_chip` wraps the read in `except Exception`, so a catchable tripwire would be reported as "not on the dev channel" and the test would pass, wrongly.
- **Armed per derivation, by ROOT**, not by a one-shot swap at import. `config.derive` is wrapped: a derivation landing back on the real plane re-arms (`config.use(config.ROOT)` is a real thing two modules do), a derivation from a tmp root does not. A guard that could be disarmed by the first isolating test would protect only the first half of a run.
- The message **names the test that made the read**, and both ways out: `PersonaIso`, or the new `tests._isolation.pin_update_channel(case)` — the companion to `isolate_state_dir` for cases that mean to run against the real plane.

`tests/test_no_test_reads_the_operators_channel.py` is the control module: it makes the refusal happen for real, checks the message, and exercises every documented way out, so "green" cannot mean "the tripwire is gone".

**Turning it on found eight more unisolated sites** — in `test_doctor_forge_visibility`, `test_doctor_mcp_launchers`, `test_doctor_personas`, `test_memory_index_health`, `test_news_cross_process`, `test_statusline_gauge` and `test_statusline_session_block` — all fixed here. That is the point of doing it this way.

## Why the six failures did not reproduce in a full run

They only failed when the two modules were run alone, which is what made this hard to believe (and what a previous look reported as "did not reproduce").

`test_secret_exec.SecretExecMode` defines a `_restore` method of its own. `PersonaIso.setUp` registered its cleanup as `addCleanup(self._restore)`, which binds by attribute lookup **on the instance** — so the subclass's method replaced it. Config was never restored, and `config.ROOT` stayed pointed at a deleted temp directory for the **1193 tests** that ran after it alphabetically. A dead plane declares no channel, which looks exactly like `stable`.

`PersonaIso`'s cleanup is name-mangled now (`_PersonaIso__restore`) so a subclass cannot shadow it; `tests/test_isolation_harness.py` pins that with a fixture that deliberately defines `_restore`. `test_secret_cp_destination` had been dodging the same collision by hand, with a comment warning the next person — that comment is now history rather than instruction.

## #458, folded in

`commands_report._warn_if_stale` glued the literal word `charter` onto the bare `__version__` with no channel beside it. On the dev channel the number after "is out" is `main`'s head commit, not a release, so `0.52.0 is out` could not tell you which. It calls `statusline._dev_chip()` now.

It was genuinely a few lines: the property test added for #457 already carried this site as a documented `_KNOWN_GAPS` entry precisely so the fix would be "implement the chip, delete the line". The entry is gone, the dict is empty (machinery kept for the next one), and `test_the_staleness_nudge_calls_the_chip_too` asserts the site by name rather than leaving it to a sweep that would also be green if the scanner stopped finding the file.

## Verification

Run from a clone whose own `charter.toml` declares `channel = "dev"` — where `config.ROOT` genuinely resolves to a dev-channel plane and the six failures reproduce — and again on stable.

**Dev channel** (`UPDATE = {'channel': 'dev'}`, `is_dev() == True`):

```
$ python3 -m unittest discover -s tests 2>&1 | grep -E "^(OK|FAILED|Ran |FAIL:|ERROR:)"
Ran 4907 tests in 218.315s
OK
```

**Stable channel** (`UPDATE = {'channel': 'stable'}`):

```
$ python3 -m unittest discover -s tests 2>&1 | grep -E "^(OK|FAILED|Ran |FAIL:|ERROR:)"
Ran 4907 tests in 202.199s
OK
```

Before the fix, on the same dev-channel tree: the two modules alone give 6 failures; the full suite gives 0, because of the `SecretExecMode` leak above. With the guard installed and the leak closed, the full suite surfaced 50 errors across 9 modules — all fixed here.

**Mutation-tested, both directions:**

1. Reverted `tests/test_version_lock.py` to `HEAD` (the unisolated `AutoSync`) and ran the module: 4 errors, each `RealPlaneRead` naming `tests.test_version_lock.AutoSync.<method>` and pointing at `PersonaIso`. Restored.
2. Set `_GUARDED_SETTINGS = ()` and ran the new control module: 16 failures. Restored — a control that cannot fail proves nothing.

stdlib only, `unittest` only, no network. No version bump, no news stamping, no tag; one `unreleased-` news entry.

Closes #459
Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9