### PR TITLE
The state directory is charter's to choose, and a roster row is one row (#470 #471 #472)

### DIFF
--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -148,18 +148,41 @@ def cmd_persona_list(args) -> int:
     if not names:
         util.info('No personas yet. Create one: charter persona create <name> --role "<Role>"')
         return 0
-    print(f"Active persona: {active or '—'}  (via {persona.source()})\n")
-    roles = {n: ((persona.load(n) or {"meta": {}})["meta"].get("role") or "") for n in names}
-    vaults = {n: (persona.vault_of(n) or "—") for n in names}
+    # Every committed value in this table is rendered through `contain.one_line`, and the
+    # rendering happens BEFORE the widths are measured. A persona is a DIRECTORY under
+    # `personas/`, so its name is a committed value charter did not mint —
+    # `list_personas()` asks only for a leading underscore and a `persona.md`, and a
+    # filesystem forbids `/` and NUL and nothing else. A separator in one therefore wrote a
+    # second physical row wearing this table's own column layout (#472), which is #453's
+    # mechanism one surface over. `role` comes out of the same committed file, and the
+    # active pointer can come from committed `charter.toml`/`personas/.default`.
+    #
+    # Before the widths, not at the `print`: `one_line` GROWS a name (a separator becomes a
+    # four-character escape), so measuring the raw name and printing the rendered one
+    # leaves every column after PERSONA misaligned for every row in the table.
+    shown = {n: contain.one_line(n) for n in names}
+    print(f"Active persona: {contain.one_line(active) if active else '—'}  "
+          f"(via {contain.one_line(persona.source())})\n")
+    roles = {n: contain.one_line((persona.load(n) or {"meta": {}})["meta"].get("role") or "")
+             for n in names}
+    # The raw vault name stays the key `_vault_status` is asked about — a bound is a
+    # display transform, never a lookup key.
+    named = {n: (persona.vault_of(n) or "—") for n in names}
+    vaults = {n: contain.one_line(v) for n, v in named.items()}
     # dynamic column widths so long persona/role/vault names don't collide
-    nw = max([len("PERSONA")] + [len(n) for n in names]) + 2
+    nw = max([len("PERSONA")] + [len(s) for s in shown.values()]) + 2
     rw = min(38, max([len("ROLE")] + [len(r) for r in roles.values()])) + 2
     vw = max([len("VAULT")] + [len(v) for v in vaults.values()]) + 2
     fmt = f"{{}}{{:<{nw}}}{{:<{rw}}}{{:<{vw}}}{{}}"
     print(fmt.format("  ", "PERSONA", "ROLE", "VAULT", "VAULT STATUS"))
     for n in names:
+        # Identity, not display: `one_line` maps `evil\n` and a literal `evil\x0a` onto the same
+        # rendered string, so deciding the marker from the rendered form would mark every
+        # such twin active as soon as one of them is. The raw names are what charter
+        # resolves a dispatch against, so they are what this compares.
         mark = "* " if n == active else "  "
-        print(fmt.format(mark, n, roles[n][:rw - 2], vaults[n], _vault_status(vaults[n])))
+        print(fmt.format(mark, shown[n], roles[n][:rw - 2], vaults[n],
+                         contain.one_line(_vault_status(named[n]))))
     return 0
 
 
@@ -1169,7 +1192,11 @@ def cmd_persona_stats(args) -> int:
         elif not shared_row and n_disp == 0 and disp:
             status = "never dispatched"
             unused += 1
-        print(f"{r['persona']:<28}{r['count']:>5}{rec:>8}{v:>8}{d:>6}"
+        # Bounded where it is PRINTED, raw everywhere it is a key: `disp`, `is_draft` and
+        # `skilluse.drift` below all ask the filesystem and the committed dispatch log
+        # about this persona, and the answer for a name holding a separator is not the answer for its
+        # rendered spelling. See `cmd_persona_list` for why the name needs bounding at all.
+        print(f"{contain.one_line(r['persona']):<28}{r['count']:>5}{rec:>8}{v:>8}{d:>6}"
               f"{(n_disp if not shared_row else '—'):>6}  "
               f"{glyph.get(status, '⚑' if status == 'never dispatched' else '·')} {status}")
         dormant += r["status"] == "dormant"
@@ -1191,13 +1218,18 @@ def cmd_persona_stats(args) -> int:
     if drifted:
         print("SKILLS — declared vs actually invoked")
         for name, d in drifted:
+            # Same rule as the table: the persona name and the skill names are committed
+            # values landing in a report of one-line rows.
+            shown = contain.one_line(name)
             if d["unused"]:
                 # Not untidy: `skills:` preloads full text on EVERY dispatch, so an unused
                 # declaration is a standing context cost bought for nothing.
-                print(f"  {name:<26} unused: {', '.join(d['unused'])}"
+                print(f"  {shown:<26} unused: "
+                      f"{', '.join(contain.one_line(s) for s in d['unused'])}"
                       f"   (preloaded every dispatch)")
             if d["undeclared"]:
-                print(f"  {name:<26} used but not declared: {', '.join(d['undeclared'])}")
+                print(f"  {shown:<26} used but not declared: "
+                      f"{', '.join(contain.one_line(s) for s in d['undeclared'])}")
         print()
     util.info(f"RECENT = memories in the last {getattr(args, 'recent_days', 14)} days · "
               f"VERIFY = share carrying a verification marker (quality proxy) · DUP = share "

--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -181,8 +181,13 @@ def cmd_persona_list(args) -> int:
         # such twin active as soon as one of them is. The raw names are what charter
         # resolves a dispatch against, so they are what this compares.
         mark = "* " if n == active else "  "
+        # `PATH_DISPLAY_LIMIT`, not the display default: a vault's status line names PATHS
+        # (`listed by other accounts: .charter 755 (want 700 — chmod 700)`), and a remedy
+        # clipped at 160 characters is one the reader cannot act on. Still a fixed budget,
+        # for the reason `contain` gives: a budget the input can grow is no budget.
         print(fmt.format(mark, shown[n], roles[n][:rw - 2], vaults[n],
-                         contain.one_line(_vault_status(named[n]))))
+                         contain.one_line(_vault_status(named[n]),
+                                          contain.PATH_DISPLAY_LIMIT)))
     return 0
 
 

--- a/charter/commands_update.py
+++ b/charter/commands_update.py
@@ -113,7 +113,7 @@ def read_baseline() -> str | None:
 def _stamp_baseline(version: str) -> None:
     try:
         p = _baseline_file()
-        p.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(p.parent)
         p.write_text(version)
     except OSError:
         pass          # a missing baseline degrades the news RANGE, never the update

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -700,7 +700,7 @@ def cmd_workspace_autosave(args) -> int:
         if not _git(["status", "--porcelain", "--", *rel], cwd=config.ROOT).stdout.strip():
             return 0  # nothing pending
         marker = config.STATE_DIR / "ws-autosave" / name
-        marker.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(marker.parent)
         if marker.exists() and time.time() - marker.stat().st_mtime < 90:
             return 0  # debounce: at most once per ~90s per workspace
         # commit locally, scoped + secret-scanned (commit_push refuses a secret → rc 1)

--- a/charter/config.py
+++ b/charter/config.py
@@ -285,6 +285,72 @@ def _mkdir_0700(d: "Path") -> None:
         pass
 
 
+def under_state(p) -> bool:
+    """Is *p* the state directory, or a path inside it?
+
+    Asked of two spellings of both sides, and answered "yes" if **either** says so: the
+    lexical one (``..`` collapsed, no link followed — the only answer available for a path
+    that does not exist yet) and the resolved one (``/tmp`` → ``/private/tmp`` — the only
+    answer available when the caller resolved first, which on macOS is most of them).
+    A disagreement is resolved towards "yes" on purpose. The cost of that error is a
+    directory that came out 0700 when 0755 would have done; the cost of the other one is
+    the exposure the walk exists to close.
+    """
+    p, state = Path(p), Path(STATE_DIR)
+    for a in {os.path.normpath(os.path.abspath(p)), str(_resolved(p))}:
+        for b in {os.path.normpath(os.path.abspath(state)), str(_resolved(state))}:
+            if a == b or a.startswith(b.rstrip(os.sep) + os.sep):
+                return True
+    return False
+
+
+def _resolved(p: "Path") -> "Path":
+    """*p* with links followed, falling back to the lexical form when it cannot be.
+
+    ``(OSError, RuntimeError)`` for the same reason :func:`worktrees_root_for` catches
+    both: a symlink loop is `RuntimeError` on some versions and `OSError` on others, and
+    this runs on the path of every state write.
+    """
+    try:
+        return p.resolve()
+    except (OSError, RuntimeError):
+        return Path(os.path.normpath(os.path.abspath(p)))
+
+
+def mkdir_for(p, parents: bool = True) -> None:
+    """Create *p* — **privately when it is charter's own state, ordinarily when it is
+    not** — for the writer that is *handed* its directory rather than deriving one.
+
+    `private_mkdir` closes the writers that name a state path themselves, and
+    `tests/_statedirscan.py` reads the package to prove none is left. Neither can see a
+    path that arrives as a **parameter**: `memstore.write(mem_dir, …)` is handed the
+    committed ``personas/<n>/memory`` on one call and the gitignored
+    ``PERSONA_STATE_DIR/ephemeral/<session>/<n>`` on the next, and which one it is a
+    question only the caller can answer. So the callee asks it at runtime, here (#470).
+
+    That mattered more than "a level below `.charter/` came out loose": on a fresh clone
+    ``.charter/`` is gitignored and absent, so ``charter persona remember … --ephemeral``
+    is what *creates the state directory itself* — at ``0o777 & ~umask``, i.e. 0755 for
+    everyone and 0777 under ``umask 000``. Every later file written straight into
+    ``.charter/`` — ``vaults.json``, ``guard-seen.json``, ``fingerprint.key`` — then sat
+    in a directory any account on the machine could list.
+
+    **The property is "the umask does not decide the mode of charter's state", not "this
+    call site is private".** Routing this one caller would leave the next writer handed a
+    state path exactly as exposed; the dispatch is on where the path *is*.
+
+    A path outside the state directory is created with a plain ``mkdir(exist_ok=True)``
+    and NOT tightened — committed directories are the operator's to mode, and charter
+    tightening one it merely wrote into is the same overreach as chmod-ing a pre-existing
+    ``.charter/`` (#331).
+    """
+    p = Path(p)
+    if under_state(p):
+        private_mkdir(p, parents=parents)
+        return
+    p.mkdir(parents=parents, exist_ok=True)
+
+
 def derive(root: Path, start: Path | None = None) -> dict:
     """Every setting that follows from *root*, as ``{NAME: value}``.
 

--- a/charter/config.py
+++ b/charter/config.py
@@ -192,6 +192,99 @@ def _repoint_vault_registry(legacy_dir: Path, new_dir: Path) -> None:
               file=sys.stderr)
 
 
+def private_mkdir(p, parents: bool = True) -> None:
+    """Create directory *p*, and **every level of it charter has to create**, at 0700.
+
+    The one way charter makes a directory under its own state directory, and it lives
+    here — in `config`, which every state writer already imports — because the writers
+    that create ``.charter/`` are spread across the registry, the persona and workspace
+    pointers, the caches, the session markers and the frame (#470). A helper any of them
+    has to reach into `charter.secrets` for is a helper most of them will not call.
+
+    **The umask must not decide the mode of the plane's state directory.** It did:
+    ``mkdir(parents=True, exist_ok=True)`` creates at ``0o777 & ~umask``, so on the
+    default ``umask 022`` every level came out 0755 and any account on the machine could
+    list ``.charter/`` — the vault registry's own directory, and the one holding
+    ``fingerprint.key``. Whichever command got there first decided it, so the mode
+    depended on the order somebody happened to run things in.
+
+    ``Path.mkdir(parents=True, mode=0o700)`` is **not** this, which is what the first cut
+    of #437 assumed: CPython's ``pathlib`` applies *mode* to the leaf only and creates the
+    missing parents with a bare recursive ``mkdir``, i.e. at the umask default again. Each
+    missing level is therefore created individually here and chmod-ed explicitly — mkdir's
+    *mode* argument is itself masked by the umask, so a process under a permissive umask is
+    not guaranteed the bits it asked for. The chmod names 0700 outright and so cannot widen
+    anything: there is no window in which the directory is looser than it ends up.
+
+    **A directory that already exists is left exactly as it is.** Not an oversight: charter
+    tightens what it creates and *reports* what it did not. A ``.charter/`` that predates
+    this, or one made by ``mkdir -p`` under ``umask 022``, keeps its 0755 — tightening a
+    directory charter did not create is how it would come to chmod a home directory or a
+    shared team directory unprompted (#331), and ``$CHARTER_HOME`` can point the state
+    directory anywhere on the machine. `charter vault list` and `charter doctor` both name
+    a loose one and print the ``chmod`` to run (#471).
+
+    **The leaf is attempted FIRST, and the parents only after it answers "no such file or
+    directory".** That is `pathlib`'s own order, and copying it is not cosmetic: a leaf
+    that cannot exist for a reason of its own — a name longer than ``NAME_MAX``, which is
+    exactly what a frame id built out of a hostile workspace name can be — fails with
+    ``ENAMETOOLONG``, and a walk that created the parents on the way down would leave the
+    frame root standing where the caller had just checked it was gone. `frame.state` pins
+    that as "does not raise **or create**", and it is the shape of a directory being
+    resurrected under somebody who had reaped it.
+
+    *parents* is the same argument `Path.mkdir` takes, for the same reason: a caller that
+    must not create the levels above the leaf — counting a respawn against a frame
+    directory `reap` may already have deleted — passes ``parents=False`` and gets the
+    ``FileNotFoundError`` as its answer.
+
+    :func:`charter.secrets.base.make_private_dir` is this function under the name the vault
+    writers already call it by; one implementation, so a fix to the walk cannot land on
+    only one of the two.
+    """
+    p = Path(p)
+    try:
+        _mkdir_0700(p)
+        return
+    except FileNotFoundError:
+        if not parents:
+            raise
+    missing = []
+    cur = p.parent
+    while not cur.exists():
+        missing.append(cur)
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    for d in [*reversed(missing), p]:
+        _mkdir_0700(d)
+
+
+def _mkdir_0700(d: "Path") -> None:
+    """One level, created at 0700 and chmod-ed to it; an existing directory is untouched.
+
+    The chmod is not redundant with ``os.mkdir``'s *mode*: mkdir's argument is masked by
+    the umask, so a process under a permissive-in-the-wrong-direction umask is not
+    guaranteed the bits it asked for. It names 0700 outright, so it cannot widen anything
+    and there is no window in which the directory is looser than it ends up.
+
+    ``FileExistsError`` on a **directory** is the concurrent case — someone else got there
+    between the walk and here, so it is now a directory charter did not create and keeps
+    its mode. On a non-directory it is re-raised, which is what ``mkdir(exist_ok=True)``
+    does and what callers that write into the path afterwards depend on.
+    """
+    try:
+        d.mkdir(mode=0o700)
+    except FileExistsError:
+        if not d.is_dir():
+            raise
+        return
+    try:
+        os.chmod(d, 0o700)
+    except OSError:
+        pass
+
+
 def derive(root: Path, start: Path | None = None) -> dict:
     """Every setting that follows from *root*, as ``{NAME: value}``.
 

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1348,6 +1348,14 @@ def check_vaults() -> Result:
     if not vs:
         return Result("vaults", OK, detail="none configured")
     bad, no_identity, timed_out = [], [], []
+    # The loose-directory report, collected as (path, mode) rather than scraped out of
+    # `health()`'s sentence (#471). `_loose_dir_note` deliberately does not set `healthy`
+    # False — a directory another account can list is not an unreachable vault, and this
+    # check runs from the SessionStart hook where it must not hold up a session — so the
+    # only way it reaches an operator through `doctor` is a note on the green line. Keyed
+    # by resolved path: several vaults normally share `.charter/`, and one directory is one
+    # `chmod`, not one per vault.
+    loose: dict = {}
     for name in vs:
         try:
             prov = registry.provider_for(name)
@@ -1357,7 +1365,9 @@ def check_vaults() -> Result:
             # vault rather than as a missing credential. Separated from `bad` because
             # the fix is `export`, not anything about the vault.
             prov.env_overlay()
-            healthy, _ = prov.health()
+            healthy, _detail = prov.health()
+            for d, mode in prov.loose_dirs():
+                loose[str(d)] = (d, mode)
         except util.ProcTimeout:
             # `op` reaching a desktop app that is waiting on a biometric prompt looks
             # exactly like a hang. Naming it beats inheriting the caller's whole budget.
@@ -1370,8 +1380,19 @@ def check_vaults() -> Result:
             healthy = False
         if not healthy:
             bad.append(name)
+    # Deepest first, matching the order `charter vault list` prints, and on EVERY return
+    # below rather than only the green one: a vault that times out or has no identity is a
+    # different problem, and a loose state directory does not stop being one while it is
+    # being fixed. Dropping the note on those paths is how it would come back to being
+    # reported only in conditions nobody is in.
+    loose_note = base.loose_dir_note(
+        sorted(loose.values(), key=lambda pm: len(Path(pm[0]).parts), reverse=True))
+
+    def _with_note(*parts: str) -> str:
+        return "; ".join([p for p in parts if p])
+
     if timed_out:
-        return Result("vaults", WARN, detail=f"{len(vs)} configured",
+        return Result("vaults", WARN, detail=_with_note(f"{len(vs)} configured", loose_note),
                       hint=f"timed out reading: {', '.join(timed_out)} — the provider CLI "
                            f"did not answer within {CHECK_TIMEOUT:g}s (1Password waiting on "
                            f"a biometric prompt looks exactly like this).")
@@ -1379,13 +1400,13 @@ def check_vaults() -> Result:
         srcs = []
         for n in no_identity:
             srcs += [f"${s}" for s in (vs[n].get("config", {}).get("env") or {}).values()]
-        return Result("vaults", WARN, detail=f"{len(vs)} configured",
+        return Result("vaults", WARN, detail=_with_note(f"{len(vs)} configured", loose_note),
                       hint=f"identity variable unset for: {', '.join(no_identity)} — "
                            f"export {', '.join(sorted(set(srcs)))} (charter will not fall "
                            f"back to an ambient token; that would read the vault as "
                            f"someone else)")
     if bad:
-        return Result("vaults", WARN, detail=f"{len(vs)} configured",
+        return Result("vaults", WARN, detail=_with_note(f"{len(vs)} configured", loose_note),
                       hint="not reachable: " + ", ".join(bad))
     # Says what was actually checked, and nothing more. This line used to read "all
     # healthy", which is a claim about resolution that nothing here tests: `health()`
@@ -1405,7 +1426,7 @@ def check_vaults() -> Result:
     # a SUPPORTED configuration that `commands_secrets` recommends by name, so warning
     # about it every session start would be a check crying wolf at a working plane, which
     # this file has already paid for twice (#171, #55). State it; do not resolve it.
-    notes = []
+    notes = [loose_note] if loose_note else []
     outside = registry.shared_files_outside_plane()
     if outside:
         notes.append(f"vaults.json points outside the plane: {', '.join(outside)}")

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -96,7 +96,7 @@ def frame_dir(fid: str, *, create: bool = False) -> Path | None:
         return None
     if create:
         try:
-            d.mkdir(parents=True, exist_ok=True)
+            config.private_mkdir(d)
         except OSError:
             # Shaped correctly (no traversal, no separators) but unusable anyway —
             # ENAMETOOLONG is the case this exists for, but any mkdir failure here
@@ -572,7 +572,9 @@ def respawn_attempt(fid: str, slot: str) -> int | None:
         return None
     root = d / _RESPAWN_DIR
     try:
-        root.mkdir(exist_ok=True)
+        # `parents=False`: counting an attempt must not recreate a frame directory
+        # `reap` has already deleted — the hazard this whole function is careful about.
+        config.private_mkdir(root, parents=False)
     except OSError:
         return None
     # One file per slot under a directory of their own, rather than a `respawn-<slot>`

--- a/charter/glstate.py
+++ b/charter/glstate.py
@@ -85,7 +85,7 @@ def _write_lock(pid: int | None) -> None:
     either way. Never raises — every caller is on a path that must not fail."""
     try:
         lock = _lock_file()
-        lock.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(lock.parent)
         lock.write_text(str(pid) if pid else "")
     except Exception:
         pass
@@ -147,7 +147,7 @@ def load() -> dict:
 def _save(cache: dict) -> None:
     f = _cache_file()
     try:
-        f.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(f.parent)
         f.write_text(json.dumps(cache))
     except Exception:
         pass

--- a/charter/guardseen.py
+++ b/charter/guardseen.py
@@ -79,7 +79,7 @@ def mark(harness: str | None = None, when: datetime | None = None,
     src = source or _source()
     p = path()
     try:
-        p.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(p.parent)
         p.write_text(json.dumps({"ts": when.isoformat(timespec="seconds"),
                                  "harness": harness, "source": src},
                                 sort_keys=True) + "\n")

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -280,7 +280,7 @@ def _ask_mark_set(sid, tuid, kind) -> None:
     if f is None:
         return
     try:
-        f.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(f.parent)
         f.touch()
     except OSError:
         pass
@@ -4088,7 +4088,7 @@ def _ws_edit_first_this_session(session, ws) -> bool:
         return True
     try:
         d = config.STATE_DIR / "ws-edit-nudge"
-        d.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(d)
         key = re.sub(r"[^A-Za-z0-9._-]", "", f"{session}-{ws}")
         marker = d / key
         if marker.exists():
@@ -4125,7 +4125,7 @@ def _memnudge_get(sid: str) -> int:
 def _memnudge_set(sid: str, n: int) -> None:
     try:
         f = _memnudge_file(sid)
-        f.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(f.parent)
         f.write_text(str(n))
     except OSError:
         pass
@@ -4300,7 +4300,7 @@ def _configver_file(sid: str) -> Path:
 
 def _write_configver(f: Path, sha: str) -> None:
     try:
-        f.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(f.parent)
         f.write_text(sha + "\n")
     except OSError:
         pass
@@ -4496,7 +4496,7 @@ def _agent_map_file() -> Path:
 def _agent_map_remember(agent_id: str, persona_name: str) -> None:
     try:
         f = _agent_map_file()
-        f.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(f.parent)
         try:
             data = json.loads(f.read_text())
         except (OSError, ValueError):
@@ -4605,7 +4605,7 @@ def _commit_dispatch(path, agent: str) -> None:
         return
     lock = _cfg.STATE_DIR / "dispatch-commit.lock"
     try:
-        lock.parent.mkdir(parents=True, exist_ok=True)
+        _cfg.private_mkdir(lock.parent)
         with open(lock, "w") as fh:
             fcntl.flock(fh, fcntl.LOCK_EX)
             try:
@@ -4715,7 +4715,7 @@ def _commit_gate_due(sid: str | None) -> bool:
         return True
     try:
         d = config.STATE_DIR / "commit-gate"
-        d.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(d)
         f = d / re.sub(r"[^A-Za-z0-9._-]", "", sid)
         n = int(f.read_text().strip()) if f.exists() else 0
         if n > 0:
@@ -4759,7 +4759,7 @@ def _route_mark_set(sid: str | None, names: list[str]) -> None:
     if f is None:
         return
     try:
-        f.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(f.parent)
         # The roster's NAMES, so the ask can list them without re-deriving the roster from
         # a persona that may have changed mid-turn. Names only — the same counts-and-names
         # discipline the tally keeps; no prompt text goes anywhere near this file.

--- a/charter/inflight.py
+++ b/charter/inflight.py
@@ -148,8 +148,10 @@ def start(agent: str) -> str | None:
     if not agent:
         return None
     try:
+        from . import config
+
         d = _dir()
-        d.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(d)
         # mkstemp, not a timestamped name: two dispatches starting in the same
         # millisecond would collide and the second would overwrite the first —
         # losing exactly the overlap this exists to observe. The agent name stays

--- a/charter/mcpseen.py
+++ b/charter/mcpseen.py
@@ -237,7 +237,7 @@ def approve(persona_name: str, fingerprints) -> None:
     doc = _read()
     doc[persona_name] = sorted({f for f in fingerprints if f})
     p = path()
-    p.parent.mkdir(parents=True, exist_ok=True)
+    config.private_mkdir(p.parent)
     p.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
 
 

--- a/charter/memstore.py
+++ b/charter/memstore.py
@@ -18,7 +18,7 @@ import datetime
 import re
 from pathlib import Path
 
-from . import contain
+from . import config, contain
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 
@@ -44,6 +44,15 @@ def _now() -> datetime.datetime:
 #: check entirely (#349).
 writable = contain.writable
 
+#: **The one gate on the MODE side**, for the same reason and at the same three writes.
+#: This module is handed its directory: ``personas/<n>/memory`` (committed, the operator's
+#: to mode) on one call and ``PERSONA_STATE_DIR/ephemeral/<sid>/<n>`` (charter's own state,
+#: which must be 0700 whatever the umask says) on the next. A bare
+#: ``mkdir(parents=True, exist_ok=True)`` here is what created ``.charter/`` at 0755 on a
+#: fresh clone, and no reader of this file could have told — only the caller knows which
+#: quadrant it is. `config.mkdir_for` asks at runtime (#470).
+mkdir_for = config.mkdir_for
+
 
 def ensure_index(mem_dir: Path, header: str) -> Path:
     """Create the dir + MEMORY.md (with *header*) if missing; return the index path."""
@@ -51,7 +60,7 @@ def ensure_index(mem_dir: Path, header: str) -> Path:
     # directory outside the plane, and would then create that directory's missing parents
     # for the attacker on the way past.
     idx = writable(index_path(mem_dir))
-    mem_dir.mkdir(parents=True, exist_ok=True)
+    mkdir_for(mem_dir)
     if not idx.exists():
         idx.write_text(header if header.endswith("\n") else header + "\n")
     return idx
@@ -73,7 +82,7 @@ def write(mem_dir: Path, text: str, title: str | None = None, *, timestamped: bo
     refusal = contain.dir_refusal(mem_dir, "write")
     if refusal:
         raise contain.Refused(refusal)
-    mem_dir.mkdir(parents=True, exist_ok=True)
+    mkdir_for(mem_dir)
     now = stamp or _now()
     prefix = now.strftime("%Y%m%d-%H%M%S-") if timestamped else ""
     base = slug(title)
@@ -96,7 +105,7 @@ def write(mem_dir: Path, text: str, title: str | None = None, *, timestamped: bo
 def index_append(idx: Path, filename: str, title: str) -> None:
     idx = writable(idx)
     if not idx.exists():
-        idx.parent.mkdir(parents=True, exist_ok=True)
+        mkdir_for(idx.parent)
         idx.write_text("# Memory Index\n\n")
     with idx.open("a") as f:
         f.write(f"- [{title}]({filename})\n")
@@ -413,7 +422,7 @@ def archive(mem_dir: Path, ident: str) -> Path | None:
     # batch.
     if contain.dir_refusal(dest_dir, "write"):
         return None
-    dest_dir.mkdir(parents=True, exist_ok=True)
+    mkdir_for(dest_dir)
     dest = dest_dir / p.name
     i = 2
     while dest.exists():

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -835,11 +835,11 @@ def set_active(name: str) -> str:
     a bare shell with nothing to key on. That is the one case where it is still the right
     answer, and it is why the file is kept rather than removed.
     """
-    config.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    config.private_mkdir(config.STATE_DIR)
     sf, tf = _pointer_files()
     for f in (sf, tf):
         if f is not None:
-            f.parent.mkdir(parents=True, exist_ok=True)
+            config.private_mkdir(f.parent)
             f.write_text((name or "") + "\n")
     if sf is None and tf is None:
         config.ACTIVE_PERSONA_FILE.write_text((name or "") + "\n")

--- a/charter/planegit.py
+++ b/charter/planegit.py
@@ -245,7 +245,7 @@ def record_push(res: PushResult, head: str = "") -> PushResult:
         if res.outcome == PUSHED:
             p.unlink(missing_ok=True)
             return res
-        p.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(p.parent)
         p.write_text(json.dumps({
             "outcome": res.outcome, "branch": res.branch, "landed": res.landed,
             "url": res.url, "detail": res.detail, "head": head, "at": time.time(),

--- a/charter/report.py
+++ b/charter/report.py
@@ -297,7 +297,7 @@ def all_reports() -> list[dict]:
 
 
 def _write(rec: dict) -> str:
-    config.REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    config.private_mkdir(config.REPORTS_DIR)
     _path(rec["id"]).write_text(json.dumps(rec, indent=2))
     return rec["id"]
 

--- a/charter/secrets/base.py
+++ b/charter/secrets/base.py
@@ -89,29 +89,17 @@ def make_private_dir(p) -> None:
     watching — the #331 defect with a fresh coat of paint. charter tightens what it
     creates and **reports** what it did not; :meth:`PlainFileProvider.health` is where the
     report comes out.
-    """
-    import os
-    from pathlib import Path
 
-    p = Path(p)
-    missing = []
-    cur = p
-    while not cur.exists():
-        missing.append(cur)
-        if cur.parent == cur:
-            break
-        cur = cur.parent
-    for d in reversed(missing):
-        try:
-            d.mkdir(mode=0o700)
-        except FileExistsError:
-            # Someone else created it between the walk and here. It is now a directory
-            # charter did NOT create, and the rule above applies to it: leave its mode.
-            continue
-        try:
-            os.chmod(d, 0o700)
-        except OSError:
-            pass
+    **One implementation, two names.** The walk lives in :func:`charter.config.private_mkdir`
+    now, because the writers that create ``.charter/`` are not only the vault writers —
+    the registry, the persona and workspace pointers, the caches and the session markers
+    all get there first on some flow, and each of them needs this without importing
+    `charter.secrets` (#470). This name stays: it is what the three secrets writers call,
+    and what `tests/test_vault_dir_mode.py` measures.
+    """
+    from .. import config as _config
+
+    _config.private_mkdir(p)
 
 
 def loose_dirs(leaf, stop) -> list:
@@ -179,6 +167,42 @@ def _same(p, resolved) -> bool:
         return Path(p).resolve() == resolved
     except OSError:
         return False
+
+
+def short_path(p) -> str:
+    """A path as it should be SHOWN — relative to the plane when it lives inside it.
+
+    `charter vault list` printed the absolute path in its STATUS column, which is noise
+    and leaks one developer's local layout into terminal output other people see (issue
+    #21's aside). Inside the plane the relative form is both shorter and the same string
+    everyone else would see.
+    """
+    from pathlib import Path
+
+    from .. import config as _config
+    try:
+        return str(Path(p).resolve().relative_to(Path(_config.ROOT).resolve()))
+    except (ValueError, OSError):
+        return str(p)
+
+
+def loose_dir_note(loose) -> str:
+    """``listed by other accounts: .charter 755 (want 700 — chmod 700)``, or ``""``.
+
+    **One wording, two commands.** `charter vault list` prints it as its STATUS column and
+    `charter doctor` puts it on the vaults line (#471); if each rendered its own sentence,
+    the day somebody rewords one is the day an operator can no longer grep for the thing
+    they were told to look for. It is also the sentence tests assert on, and two of them
+    means one gets updated.
+
+    Terse on purpose: it lands in a table row, and *why* charter will not fix the
+    directory itself is a paragraph that belongs in `docs/secrets.md`. The row carries what
+    is wrong and what to type.
+    """
+    if not loose:
+        return ""
+    named = ", ".join(f"{short_path(d)} {oct(m)[-3:]}" for d, m in loose)
+    return f"listed by other accounts: {named} (want 700 — chmod 700)"
 
 
 class VaultProvider(ABC):
@@ -313,6 +337,24 @@ class VaultProvider(ABC):
         Must never include a secret value in ``detail``.
         """
         return True, "ok"
+
+    def loose_dirs(self) -> list:
+        """``(path, mode)`` for each directory this vault is reached through that another
+        account on the machine can reach. Empty for a provider that keeps nothing on disk.
+
+        **The structured answer, so two commands cannot disagree about it.** The note used
+        to exist only inside the string :meth:`health` returns, which is why `doctor` — who
+        keeps the boolean and drops the string — could not report it however much its docs
+        said it did (#471). Substring-matching `health`'s prose from `doctor` would have
+        "fixed" it in the way this codebase keeps being bitten by: the report would go
+        silent the day somebody rewords the sentence, and nothing would fail. Both surfaces
+        now ask this, and :func:`loose_dir_note` renders it for both.
+
+        A provider that stores its data somewhere else entirely (1Password, Vault) has no
+        directory of charter's to report, so the honest answer is an empty list rather than
+        a guess about a backend charter does not own.
+        """
+        return []
 
 
 def redact(text: str, secrets: list[str]) -> str:

--- a/charter/secrets/plain_file.py
+++ b/charter/secrets/plain_file.py
@@ -13,22 +13,8 @@ import os
 import stat
 from pathlib import Path
 
-from .base import SecretNotFound, VaultError, VaultProvider, loose_dirs, make_private_dir
-
-
-def _short(p: Path) -> str:
-    """A path as it should be SHOWN — relative to the plane when it lives inside it.
-
-    `charter vault list` printed the absolute path in its STATUS column, which is noise
-    and leaks one developer's local layout into terminal output other people see (issue
-    #21's aside). Inside the plane the relative form is both shorter and the same string
-    everyone else would see.
-    """
-    from .. import config as _config
-    try:
-        return str(Path(p).resolve().relative_to(Path(_config.ROOT).resolve()))
-    except (ValueError, OSError):
-        return str(p)
+from .base import (SecretNotFound, VaultError, VaultProvider, loose_dir_note,
+                   loose_dirs as _dirs_up_to, make_private_dir, short_path as _short)
 
 
 class PlainFileProvider(VaultProvider):
@@ -213,58 +199,55 @@ class PlainFileProvider(VaultProvider):
         if not self.config.get("file"):
             return False, "no 'file' configured"
         pp = self.file_path
+        note = loose_dir_note(self.loose_dirs())
         if not pp.exists():
-            return True, f"not created yet ({_short(pp)})"
+            # The note belongs here too: what another account can list is the DIRECTORY,
+            # and it is just as listable before this vault's file exists as after. Leaving
+            # it off this branch would also make `vault list` and `doctor` disagree about
+            # a vault that has been added and not yet written to.
+            return True, f"not created yet ({_short(pp)})" + (f", {note}" if note else "")
         try:
             count = len(self._load())
         except VaultError as e:
             return False, str(e)
         mode = stat.S_IMODE(pp.stat().st_mode)
         perms = "" if mode == 0o600 else f", perms {oct(mode)[-3:]} (want 600)"
-        return True, f"{count} secret(s){perms}{self._loose_dir_note(pp)}"
+        return True, f"{count} secret(s){perms}" + (f", {note}" if note else "")
 
-    @staticmethod
-    def _loose_dir_note(pp: Path) -> str:
+    def loose_dirs(self) -> list:
         """The other-readable directories holding this vault, named — never chmod-ed.
 
-        A directory *this writer* creates is 0700 (:func:`base.make_private_dir`) — a
-        narrower statement than "a directory charter creates", and the narrowing is the
-        point: `.charter/` itself is normally made by the registry write inside `charter
-        vault add`, at the umask default, and so lands here as a directory to report
-        rather than one already fixed (#470).
+        Every directory charter creates on the way here is 0700: the vault writers walk
+        each level (:func:`base.make_private_dir`), and since #470 so does whatever creates
+        ``.charter/`` first, which on the ``charter vault add`` flow is the registry write
+        rather than any vault writer.
 
         A directory that was already there when charter arrived keeps whatever mode it
-        has, and the common case is exactly the one that matters: a ``.charter/vaults/``
-        created before 0.51.x, or by ``mkdir -p`` at the umask default, sits at 0755 and
-        lists every vault name on the plane to every account on the machine. `set` does
-        not fix it, because a vault's ``file`` can name any path on this machine and
-        charter chmod-ing a directory it did not create — a home directory, a shared team
-        directory — is the #331 defect over again.
+        has, and that is the case this exists for: a ``.charter/vaults/`` created before
+        0.51.x, or by ``mkdir -p`` at the umask default, sits at 0755 and lists every vault
+        name on the plane to every account on the machine. `set` does not fix it, because a
+        vault's ``file`` can name any path on this machine and charter chmod-ing a
+        directory it did not create — a home directory, a shared team directory — is the
+        #331 defect over again.
 
-        So it is REPORTED — on the string `health` returns, which `charter vault list`
-        prints as its STATUS column. `charter doctor` keeps only the boolean from
-        `health()` and drops this string, so the note does not reach it (#471).
+        So it is REPORTED, and reported as a *list* rather than as prose inside `health`'s
+        string: `charter vault list` renders it into its STATUS column and `charter doctor`
+        puts it on the vaults line, both through :func:`base.loose_dir_note` (#471).
 
-        This is the same posture the file mode above already takes on the read-only
-        paths: `health`, `keys` and `ages` name a loose mode rather than
-        silently fixing it, because a health check that writes is the defect regardless of
-        what it writes.
+        This is the same posture the file mode already takes on the read-only paths:
+        `health`, `keys` and `ages` name a loose mode rather than silently fixing it,
+        because a health check that writes is the defect regardless of what it writes.
 
-        Never raises: a health line that can throw is a `doctor` that cannot run. The
-        catch is `Exception`, not `BaseException`, deliberately — `tests/_planeguard.py`
-        signals a test reaching the real ``.charter/`` with a `BaseException` precisely so
-        that fallbacks like this one cannot turn it into a quiet empty string.
+        Never raises: a health line that can throw is a `doctor` that cannot run. The catch
+        is `Exception`, not `BaseException`, deliberately — `tests/_planeguard.py` signals
+        a test reaching the real ``.charter/`` with a `BaseException` precisely so that
+        fallbacks like this one cannot turn it into a quiet empty answer.
         """
         from .. import config
 
         try:
-            loose = loose_dirs(pp.parent, config.STATE_DIR)
+            if not self.config.get("file"):
+                return []
+            return _dirs_up_to(self.file_path.parent, config.STATE_DIR)
         except Exception:
-            return ""
-        if not loose:
-            return ""
-        # Terse on purpose: this lands in a `charter vault list` table row, and the reason
-        # charter does not fix it itself is a paragraph, which belongs in `docs/secrets.md`
-        # and not in a column. The row carries what is wrong and what to type.
-        named = ", ".join(f"{_short(d)} {oct(m)[-3:]}" for d, m in loose)
-        return f", listed by other accounts: {named} (want 700 — chmod 700)"
+            return []

--- a/charter/secrets/registry.py
+++ b/charter/secrets/registry.py
@@ -184,7 +184,7 @@ def _write(path, doc: dict, mode: int) -> None:
     and environment variable NAMES — never a value — which is what makes the weaker
     posture the right one rather than an oversight.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
+    config.private_mkdir(path.parent)
     fd = os.open(str(path), os.O_WRONLY | os.O_CREAT, mode)
     try:
         try:

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -211,7 +211,7 @@ def _record_turn(sid: str, hit: int, read: int, write: int) -> list[int]:
     rows.append(stamp)
     rows = rows[-_TREND_KEEP:]
     try:
-        f.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(f.parent)
         f.write_text("\n".join(rows) + "\n")
     except OSError:
         pass
@@ -474,7 +474,7 @@ def _repo_states(dirs: list[Path]) -> dict:
             changed = True
     if changed:
         try:
-            cache_file.parent.mkdir(parents=True, exist_ok=True)
+            config.private_mkdir(cache_file.parent)
             cache_file.write_text(json.dumps(cache))
         except Exception:
             pass
@@ -1058,7 +1058,7 @@ def _vault_health(vault: str) -> tuple[bool, str]:
     ok, detail = registry.provider_for(vault).health()
     cache[vault] = {"ok": bool(ok), "detail": detail or "", "ts": now}
     try:
-        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(cache_file.parent)
         cache_file.write_text(json.dumps(cache))
     except Exception:
         pass

--- a/charter/toolgate.py
+++ b/charter/toolgate.py
@@ -790,8 +790,10 @@ def snapshot(session_id: str | None = None) -> dict:
     except Exception:
         return {}
     try:
+        from . import config
+
         f = _ceiling_file(sid)
-        f.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(f.parent)
         _marker_file(sid).touch()   # before the ceiling: see `_marker_file`
         tmp = f.with_name(f.name + ".tmp")
         tmp.write_text(json.dumps(data, sort_keys=True))

--- a/charter/trace.py
+++ b/charter/trace.py
@@ -80,7 +80,7 @@ def record(event: str, session: str | None = None, **fields) -> None:
     """
     try:
         f = _file(session)
-        f.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(f.parent)
         rec = {"ts": datetime.datetime.now().isoformat(timespec="seconds"), "event": event}
         rec.update({k: v for k, v in fields.items() if v is not None})
         with f.open("a") as fh:

--- a/charter/update.py
+++ b/charter/update.py
@@ -266,7 +266,7 @@ def fetch_and_store() -> str | None:
         record["ts"] = time.time()
     try:
         p = _cache_file()
-        p.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(p.parent)
         p.write_text(json.dumps(record))
     except OSError:
         return None
@@ -290,7 +290,7 @@ def maybe_spawn() -> None:
     except Exception:
         return
     try:
-        lock.parent.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(lock.parent)
         lock.touch()          # touch FIRST: a spawn storm is worse than a missed check
         # -P (util.self_relaunch_argv, #390): this ALSO runs on the status line's own
         # render path (see the module docstring's mirror of glstate) — without it, a

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -406,14 +406,14 @@ def set_active(name: str, session_id: str | None = None, force: bool = False) ->
     if locked and locked != name and not force:
         _trace("workspace-refused", session_id, workspace=name, locked_to=locked)
         return "locked"
-    config.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    config.private_mkdir(config.STATE_DIR)
     tid = _terminal_id()
     if tid:
-        config.TERMINALS_DIR.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(config.TERMINALS_DIR)
         _terminal_file(tid).write_text(name + "\n")
     sid = _session_id(session_id)
     if sid:
-        config.SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(config.SESSIONS_DIR)
         _session_file(sid).write_text(name + "\n")
         _lock_file(sid).write_text(name + "\n")  # confirming = locking for the session
     _prune()
@@ -441,7 +441,7 @@ def reconcile(session_id: str | None = None, terminal_id: str | None = None) -> 
     tid = _terminal_id(terminal_id)
     val = _read(_terminal_file(tid)) if tid else None
     if val:
-        config.SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+        config.private_mkdir(config.SESSIONS_DIR)
         _session_file(sid).write_text(val + "\n")
         # The one pointer write nobody typed. If any write is ever going to look as though
         # it came from nowhere, it is this one — so it says where it came from.

--- a/docs/news/0.52.0-a-vault-charter-cannot-make-private.md
+++ b/docs/news/0.52.0-a-vault-charter-cannot-make-private.md
@@ -40,16 +40,19 @@ on a plane where charter created every level itself, for a vault at
 the one holding the vault names — was world-listable. Each level is now created and
 chmod-ed individually.
 
-**Known remaining case: `.charter/` itself, when something else creates it first.** The
-0700 walk lives in the secrets writers, and on the default flow they are not what creates
-the state directory — `charter vault add` writes the local registry first, and that write
-makes `.charter/` with no mode of its own. So under `umask 022` the state directory is
-0755 and under `umask 077` it is 0700: the umask decides that one level, and the fix above
-decides every level below it. `.charter/vaults/`, the directory that lists vault names, is
-0700 either way, and `charter vault list` names the loose `.charter` on the health line
-like any other. Filed as [#470](https://github.com/diazoxide/charter/issues/470) rather
-than fixed here, because moving state-directory creation onto this walk touches the
-registry, persona and workspace writers and none of those are this entry's subject.
+**Known remaining case in this release: `.charter/` itself, when something else creates it
+first.** The 0700 walk lives in the secrets writers, and on the default flow they are not
+what creates the state directory — `charter vault add` writes the local registry first, and
+that write makes `.charter/` with no mode of its own. So on 0.52.0, under `umask 022` the
+state directory is 0755 and under `umask 077` it is 0700: the umask decides that one level,
+and the fix above decides every level below it. `.charter/vaults/`, the directory that
+lists vault names, is 0700 either way, and `charter vault list` names the loose `.charter`
+on the health line like any other. Filed as
+[#470](https://github.com/diazoxide/charter/issues/470) rather than fixed here, because
+moving state-directory creation onto this walk touches the registry, persona and workspace
+writers and none of those are this entry's subject. **It is fixed in the next release** —
+see *The state directory is charter's to choose*, which routes all of them through the same
+walk.
 
 **A directory that was already there keeps its mode, and charter says so instead of
 fixing it.** A `.charter/vaults/` that predates this, or one made by `mkdir -p` at the
@@ -61,11 +64,11 @@ on the vault's health line — which is the `STATUS` column of `charter vault li
 `listed by other accounts: .charter/vaults 755 (want 700)`. The remedy is one `chmod 700`,
 run by you.
 
-That line reaches `charter vault list` and nothing else. `charter doctor` asks each vault
-whether it is *reachable* and drops the rest of the health detail, so a loose directory
-appears in neither `doctor` nor `doctor --json`. Getting it onto doctor's green line is
-[#471](https://github.com/diazoxide/charter/issues/471); this entry no longer claims it is
-already there.
+On this release that line reaches `charter vault list` and nothing else: `charter doctor`
+asks each vault whether it is *reachable* and drops the rest of the health detail, so a
+loose directory appears in neither `doctor` nor `doctor --json`. Getting it onto doctor's
+green line was [#471](https://github.com/diazoxide/charter/issues/471), and it landed in
+the next release — see *The state directory is charter's to choose*.
 
 The rotation sidecar goes through the same writer.
 

--- a/docs/news/unreleased-one-row-per-persona-in-the-roster-reports.md
+++ b/docs/news/unreleased-one-row-per-persona-in-the-roster-reports.md
@@ -26,12 +26,19 @@ Nothing is executed off the back of a table row, so this is not a privilege boun
 a forged row can do is name a persona that does not exist, or hide one that does, in the
 report a steward prunes the roster from.
 
-Both renderers now map the roster through `contain.one_line` **before** they measure their
-column widths, and print from that. The order matters: both size their columns from the
-names, and `one_line` grows a name (a separator becomes a four-character escape), so
-bounding at the `print` alone would leave every column after PERSONA misaligned for every
-persona in the table. The role, the vault name, the vault status and the skills block get
-the same treatment — all of them come out of committed files.
+Both renderers now map every committed value through `contain.one_line`, and print from
+that. The role, the vault name, the vault status and the skills block get the same
+treatment — all of them come out of committed files.
+
+Where the bound goes differs, because only one of the two measures anything. `persona
+list` sizes its PERSONA column from the names it is about to print, so it has to bound
+them **before** it measures: `one_line` grows a name — a separator becomes a
+four-character escape — and bounding at the `print` alone would leave every column after
+PERSONA misaligned for every persona in the table. `persona stats` measures nothing; it
+prints into a fixed 28-wide column, so it is bounded at the `print`. A name longer than 28
+characters still pushes that row's later columns to the right there, exactly as it did
+before — `one_line` bounds line STRUCTURE, which is what forged the extra row, not width
+(#508).
 
 The active marker still compares the **raw** names. Bounding is a display transform and two
 different names can share one rendered form, so deciding the marker from the rendering would

--- a/docs/news/unreleased-one-row-per-persona-in-the-roster-reports.md
+++ b/docs/news/unreleased-one-row-per-persona-in-the-roster-reports.md
@@ -1,0 +1,40 @@
+---
+version: unreleased
+headline: a committed persona directory name could write its own row into `persona list` and `persona stats`
+---
+
+A persona is a directory under `personas/`, and that name is committed — it arrives from
+whoever last pushed to the repo. `persona.list_personas()` globs `personas/*/`, asks only
+for a leading underscore and a `persona.md`, and never asks `valid_name`; a filesystem
+forbids `/` and NUL and nothing else. So a commit could add a directory whose name holds a
+line separator, and `charter persona list` printed **two** table rows for it — the second
+one entirely attacker-chosen and wearing charter's own column layout:
+
+```
+  PERSONA                             ROLE  VAULT  VAULT STATUS
+  evil
+  fake     Fake role   vault2        —      no vault
+  good                                Good  v      not set up (local)
+```
+
+Two personas on disk, three rows in the report. `charter persona stats` did the same. It
+works for `\n`, `\r`, U+2028, U+2029, U+0085 and every other separator `str.splitlines`
+honours — which is the same mechanism as the `mcp.json` server-name hole 0.52.0 closed: a
+committed value crossing into a format that has structure, without being escaped for it.
+
+Nothing is executed off the back of a table row, so this is not a privilege boundary. What
+a forged row can do is name a persona that does not exist, or hide one that does, in the
+report a steward prunes the roster from.
+
+Both renderers now map the roster through `contain.one_line` **before** they measure their
+column widths, and print from that. The order matters: both size their columns from the
+names, and `one_line` grows a name (a separator becomes a four-character escape), so
+bounding at the `print` alone would leave every column after PERSONA misaligned for every
+persona in the table. The role, the vault name, the vault status and the skills block get
+the same treatment — all of them come out of committed files.
+
+The active marker still compares the **raw** names. Bounding is a display transform and two
+different names can share one rendered form, so deciding the marker from the rendering would
+mark every twin active as soon as one of them is — a report lying about which persona a
+dispatch will actually use. Same rule for the dispatch tally, the draft check and the skills
+lookup: the bound is what gets printed, never what gets looked up.

--- a/docs/news/unreleased-the-state-directory-is-charters-to-choose.md
+++ b/docs/news/unreleased-the-state-directory-is-charters-to-choose.md
@@ -22,10 +22,33 @@ the trace and the reports. Each missing level is created individually and chmod-
 because `mkdir(parents=True, mode=0o700)` applies the mode to the leaf only and `mkdir`'s
 mode argument is masked by the umask anyway.
 
+**The fourth writer, and the one no reader of the package could have named.**
+`charter persona remember <persona> "…" --ephemeral` writes under
+`.charter/persona-state/ephemeral/`, and on a fresh clone — where `.charter/` is gitignored
+and absent — that write is what creates the state directory itself. It went through none of
+the above, and the static scan that was supposed to notice reported a clean package,
+because the directory does not reach the writer as anything the scan could read: it reaches
+`memstore.write(mem_dir, …)` as a **parameter**, and the same function is handed the
+committed `personas/<n>/memory` on the very next call. Only the caller knows which.
+
+So the question is now asked at runtime, by `config.mkdir_for`: a path under the state
+directory is created through the private walk, and a path outside it is created with a
+plain `mkdir` and left at the operator's umask. It is a dispatch, not a privatiser —
+committed persona directories keep their 0755, and a version of this that made everything
+private would have passed every mode test above while quietly tightening the plane's
+committed tree.
+
+The scan changed with it. It used to match a *spelling* — `.STATE_DIR` appearing in the
+path expression at the `mkdir` line — and now asks reachability: a call that passes a state
+path into a package function taints that parameter, transitively across modules, and a
+`mkdir` on a tainted parameter is a violation exactly as `config.STATE_DIR / "x"` is. Put
+`memstore`'s bare `mkdir` back and the scan names the file and line.
+
 `umask 000`, `umask 022`, `umask 077`: `.charter` comes out 0700 in all three, on `vault
-add`, on the SessionStart hook and on the PreToolUse hook. The property being tested is
-that the umask does not decide it — a fix that only held under the umask it was written for
-would satisfy "the mode is 0700" and nothing else.
+add`, on the SessionStart hook, on the PreToolUse hook and on `persona remember
+--ephemeral`. The property being tested is that the umask does not decide it — a fix that
+only held under the umask it was written for would satisfy "the mode is 0700" and nothing
+else.
 
 **A directory that was already there keeps its mode, and is still reported.**
 A `.charter/` that predates this, or one made by `mkdir -p` at the umask default, is 0755
@@ -57,6 +80,15 @@ but if that directory predates charter, neither `vault list` nor `doctor` says s
 plane whose only vaults are references. The base provider's honest answer is an empty list
 rather than a guess about a backend charter does not own; teaching the reference provider to
 answer properly is [#491](https://github.com/diazoxide/charter/issues/491).
+
+**Known remaining case: the files inside `.charter/` are still written at your umask.**
+Charter's own state directory is 0700, so nothing it creates is exposed. But charter
+deliberately leaves a `.charter/` it did not create exactly as it is, and on such a plane
+`guard-seen.json`, the trace log and the ephemeral persona store are all 0644 —
+`vaults.json` is 0600 only because the registry chmods it outright. That is the same
+property one surface over (the umask does not decide the mode of charter's own state), and
+answering it for files is [#505](https://github.com/diazoxide/charter/issues/505) rather
+than a wider version of this change.
 
 Two things this does not do. It does not read ACLs: on macOS `chmod +a` and on Linux
 `setfacl` grant another account access while `st_mode` still reads 0700, and a POSIX mode

--- a/docs/news/unreleased-the-state-directory-is-charters-to-choose.md
+++ b/docs/news/unreleased-the-state-directory-is-charters-to-choose.md
@@ -44,6 +44,17 @@ path into a package function taints that parameter, transitively across modules,
 `mkdir` on a tainted parameter is a violation exactly as `config.STATE_DIR / "x"` is. Put
 `memstore`'s bare `mkdir` back and the scan names the file and line.
 
+It also stopped guessing *where in a call the path is*, which was the same mistake one
+level down. `p.mkdir(…)` keeps its path in the receiver and `os.makedirs(p)` in the first
+argument, and both are attribute calls — so reading the receiver of every attribute call,
+which is what the scan did, saw `os.makedirs(config.STATE_DIR / "x")` as the expression
+`os` and never flagged it. Keying on the name instead (`makedirs` takes an argument,
+`mkdir` a receiver) only swaps one spelling for another and still lets `os.mkdir(p)`
+through. So the shape is no longer decided at all: every position that could hold the path
+is scanned — receiver, first argument, and the `path=`/`name=` keywords — and a state path
+in any of them is a violation. Nothing in `charter/` uses those spellings today; the scan
+now enforces the coverage its title always claimed.
+
 `umask 000`, `umask 022`, `umask 077`: `.charter` comes out 0700 in all three, on `vault
 add`, on the SessionStart hook, on the PreToolUse hook and on `persona remember
 --ephemeral`. The property being tested is that the umask does not decide it — a fix that

--- a/docs/news/unreleased-the-state-directory-is-charters-to-choose.md
+++ b/docs/news/unreleased-the-state-directory-is-charters-to-choose.md
@@ -1,0 +1,65 @@
+---
+version: unreleased
+headline: `.charter/` is 0700 because charter says so, not because of your umask
+---
+
+`.charter/` holds the vault registry, `fingerprint.key`, and every plain-file vault this
+plane keeps. Until now the mode of that directory was decided by whoever created it, at
+`0o777 & ~umask` — 0755 on the default `umask 022`. The vault writers walked every level of
+a vault path at 0700, but on the flow `charter vault add` prints as its own first step they
+are not what creates the state directory: the local registry write is, through a bare
+`mkdir(parents=True, exist_ok=True)`. So did the first SessionStart hook in a freshly cloned
+plane (`.charter/` is gitignored, so a teammate's clone has none), and so did the PreToolUse
+hook, and so did the status line's cache. Whichever you happened to run first decided
+whether every account on the machine could list the plane's state directory
+([#470](https://github.com/diazoxide/charter/issues/470)).
+
+The walk now lives in `config.private_mkdir` — `secrets.base.make_private_dir` is the same
+function under the name the vault writers already used — and **every writer that creates a
+directory under `.charter/` goes through it**: the registry, the persona and workspace
+pointers, the session and terminal markers, the caches, the dispatch tracker, the frame,
+the trace and the reports. Each missing level is created individually and chmod-ed to 0700,
+because `mkdir(parents=True, mode=0o700)` applies the mode to the leaf only and `mkdir`'s
+mode argument is masked by the umask anyway.
+
+`umask 000`, `umask 022`, `umask 077`: `.charter` comes out 0700 in all three, on `vault
+add`, on the SessionStart hook and on the PreToolUse hook. The property being tested is
+that the umask does not decide it — a fix that only held under the umask it was written for
+would satisfy "the mode is 0700" and nothing else.
+
+**A directory that was already there keeps its mode, and is still reported.**
+A `.charter/` that predates this, or one made by `mkdir -p` at the umask default, is 0755
+before and 0755 after. Charter tightens what it creates and names what it did not: a
+vault's `file` may point anywhere on this machine and `$CHARTER_HOME` may move the state
+directory anywhere, so "chmod whatever we land in" is how charter would come to tighten a
+home directory or a shared team directory unprompted.
+
+**That report now reaches `charter doctor`**
+([#471](https://github.com/diazoxide/charter/issues/471)). It used to exist only inside the string
+`health()` returns — which `charter vault list` prints as its STATUS column and `doctor`
+threw away, keeping just the reachable/not-reachable boolean. `doctor` now asks the
+provider for the directories themselves and renders them with the same function `vault
+list` uses, so the two cannot drift apart:
+
+```
+  ✓  vaults           1 reachable (references not resolved); listed by other accounts: .charter 755 (want 700 — chmod 700)
+```
+
+Green, not a warning, and on the JSON too. Charter will not fix this one for you, so saying
+it *is* the remedy — and a warning at every session start about a directory you have decided
+to leave alone is a check people learn to skip, which takes the rest of the report with it.
+It also rides the warning paths: a vault that times out or has no identity is a different
+problem, and the loose directory does not stop being one while that is being fixed.
+
+**Known remaining case: a `reference` vault reports no directory.** It writes its file
+under `.charter/vaults/` through the same private walk, so nothing it creates is loose —
+but if that directory predates charter, neither `vault list` nor `doctor` says so for a
+plane whose only vaults are references. The base provider's honest answer is an empty list
+rather than a guess about a backend charter does not own; teaching the reference provider to
+answer properly is [#491](https://github.com/diazoxide/charter/issues/491).
+
+Two things this does not do. It does not read ACLs: on macOS `chmod +a` and on Linux
+`setfacl` grant another account access while `st_mode` still reads 0700, and a POSIX mode
+is all charter looks at. And it does not encrypt anything — a plain-file vault stores values
+in the clear, which is documented in four places and remains the trade-off for the provider
+whose entire job is "a JSON file you can also edit by hand".

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -15,14 +15,21 @@ you, can read the file directly. `charter` does not pretend otherwise: the vault
 registry and every vault file live under `.charter/` (gitignored — never committed, never
 synced anywhere by `charter` itself).
 
-Every directory **the vault writers create** on the way to a vault file is 0700, each
-level of it and not just the last, so the directory listing your vault *names* is not
-readable by other accounts either. A directory that **already existed** keeps the mode it
-has — a `.charter/vaults/` made by hand or by an older charter is 0755 before `secret set`
-and 0755 after. charter will not chmod a directory it did not create (a vault's `--file`
-can name any path on this machine, and silently tightening someone's home or a shared team
-directory is worse than the thing it fixes), so it reports it instead, on the vault's
-health line — which is the `STATUS` column of `charter vault list`:
+Every directory **charter creates** on the way to a vault file is 0700, each level of it
+and not just the last, so the directory listing your vault *names* is not readable by
+other accounts either. That now includes `.charter/` itself, whichever command makes it:
+on the default flow it is not a vault writer at all — `charter vault add` writes the local
+registry first, a fresh clone's first hook writes a session pointer — and every one of
+those goes through the same walk, so the umask no longer decides the mode of your state
+directory ([#470](https://github.com/diazoxide/charter/issues/470)).
+
+**The limit, measured rather than assumed.** A directory that **already existed** keeps the
+mode it has — a `.charter/` or `.charter/vaults/` made by hand, or by a charter older than
+0.52.1, is 0755 before `secret set` and 0755 after. charter will not chmod a directory it
+did not create (a vault's `--file` can name any path on this machine, and silently
+tightening someone's home or a shared team directory is worse than the thing it fixes), so
+it reports it instead, on the vault's health line — which is the `STATUS` column of
+`charter vault list`:
 
 ```
 devops: 3 secret(s), listed by other accounts: .charter/vaults 755 (want 700 — chmod 700)
@@ -30,20 +37,11 @@ devops: 3 secret(s), listed by other accounts: .charter/vaults 755 (want 700 —
 
 One `chmod 700 .charter/vaults` clears it.
 
-**Two limits on that sentence, both measured rather than assumed.**
-
-`.charter/` itself is usually *not* one of the directories the vault writers create. On
-the default flow, `charter vault add` writes the local registry before any vault file
-exists, and that write creates `.charter/` with no mode of its own — so under `umask 022`
-the state directory comes out 0755 and stays there, and under `umask 077` it comes out
-0700. The umask decides that one level; charter decides every level below it. The report
-above still names it (`listed by other accounts: .charter 755`) and one `chmod 700
-.charter` clears it — but the paragraph above is a claim about the vault writers, and the
-state directory is not theirs to create — [#470](https://github.com/diazoxide/charter/issues/470).
-
-And the report reaches `charter vault list` only. `charter doctor` asks each vault
-whether it is *reachable* and discards the rest of the health line, so a loose directory
-shows up in neither `doctor` nor `doctor --json` — [#471](https://github.com/diazoxide/charter/issues/471).
+The same note is on `charter doctor`'s vaults line, and in `charter doctor --json`
+([#471](https://github.com/diazoxide/charter/issues/471)) — one line naming each loose
+directory and the `chmod` to run. It stays a **green** line rather than a warning: charter
+will not fix this one for you, so saying it is the remedy, and a warning at every session
+start about a directory you have decided to leave alone is a check nobody reads twice.
 
 If you want encryption at rest, use your **OS keychain** (macOS Keychain, a real
 password manager, or a proper secrets backend) to hold the credential, and treat

--- a/tests/_statedirscan.py
+++ b/tests/_statedirscan.py
@@ -1,0 +1,163 @@
+"""Which ``mkdir`` calls in `charter/` can create a directory under the state directory.
+
+Static, and deliberately so: the question is *coverage* — has every writer that can make
+``.charter/`` been routed through `config.private_mkdir` — and coverage is a question about
+code that was not executed. The behavioural half lives in
+`test_the_state_directory_is_charters_to_choose.py`, which runs real commands and measures
+the mode that comes out; this half is what notices the writer nobody ran.
+
+Not a ``test_*`` module, so discovery skips it. Its own accuracy is tested there, against
+sources built for the purpose.
+
+**How a path is judged to be state-derived, and why it is derived rather than listed.**
+The names that live under ``STATE_DIR`` are asked of `config` itself — every entry of
+`config.DERIVED` whose value is a path under the state directory — so a setting added to
+`config.derive` is covered the day it is added rather than the day somebody remembers this
+file. Matching is on the ATTRIBUTE name (``.STATE_DIR``), never on the module alias in
+front of it: `hooks` reaches it as ``_cfg.STATE_DIR`` and `frame.state` as
+``config.STATE_DIR``, and a scan keyed to one spelling would silently skip the other.
+
+One level of indirection is followed, transitively: a module-level function whose returns
+mention a state name is itself a state path source (``_cache_file()``, ``_route_mark(sid)``,
+``frame.state._root()``), and so is one that returns a call to such a function. Local
+assignments inside the calling function are substituted before the test, so
+``f = _cache_file()`` … ``f.parent.mkdir(…)`` is seen for what it is.
+
+**What it cannot see, said out loud.** A path that reaches a writer as a *parameter* —
+`memstore.write(mem_dir, …)` is handed either a committed persona directory or an
+ephemeral one under ``PERSONA_STATE_DIR`` — is invisible to a static reader, because the
+answer depends on the caller. A path assembled from a string (``Path(str(config.ROOT) +
+"/.charter")``) is invisible too. Those are the next spellings, and neither is closed here:
+what closes the exposure they would open is that ``.charter/`` itself is 0700, so a
+directory created under it at the umask default is still reachable by nobody but its owner.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+#: The package under test, as a directory.
+PACKAGE = Path(__file__).resolve().parent.parent / "charter"
+
+
+def state_attribute_names() -> set[str]:
+    """Every ``config`` attribute whose value is the state directory or lives under it.
+
+    Asked of `config.derive`, not written down: `derive` is the single definition of what
+    follows from the plane root, and this is a question about its output.
+    """
+    from charter import config
+
+    values = config.derive(Path("/nonexistent-plane-root"))
+    state = Path(values["STATE_DIR"])
+    out = set()
+    for name, val in values.items():
+        if not isinstance(val, Path):
+            continue
+        try:
+            val.relative_to(state)
+        except ValueError:
+            continue
+        out.add(name)
+    return out
+
+
+def _returns(fn: ast.AST) -> list[str]:
+    return [ast.unparse(n.value) for n in ast.walk(fn)
+            if isinstance(n, ast.Return) and n.value is not None]
+
+
+def _mentions_state(text: str, state_names: set[str]) -> bool:
+    """Keyed to the ATTRIBUTE — ``.STATE_DIR`` — so `hooks`'s ``_cfg.STATE_DIR`` and
+    `frame.state`'s ``config.STATE_DIR`` are one question, not two."""
+    return any(re.search(rf"\.{n}\b", text) for n in state_names)
+
+
+def _calls(text: str, names) -> bool:
+    """Does *text* call one of *names*? Word-anchored: ``consent_path()`` is not a call to
+    ``_path()``, and a substring test says it is."""
+    return any(re.search(rf"(?<![\w.]){re.escape(n)}\s*\(", text) for n in names)
+
+
+def state_path_functions(tree: ast.AST, state_names: set[str]) -> set[str]:
+    """Module-level function names whose return value is a path under the state directory.
+
+    A fixpoint, so ``path_for()`` returning ``_dir() / …`` counts when ``_dir()`` does.
+    """
+    funcs = {n.name: n for n in tree.body
+             if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
+    found: set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        for name, fn in funcs.items():
+            if name in found:
+                continue
+            texts = _returns(fn)
+            hit = any(_mentions_state(t, state_names) for t in texts) or \
+                any(_calls(t, found) for t in texts)
+            if hit:
+                found.add(name)
+                changed = True
+    return found
+
+
+def _expand(expr: str, assigns: dict[str, str], rounds: int = 4) -> str:
+    """*expr* with local names replaced by what they were assigned, a few rounds deep."""
+    text = expr
+    for _ in range(rounds):
+        before = text
+        for name, value in assigns.items():
+            if name in text:
+                text = text.replace(name, f"({value})")
+        if text == before:
+            return text
+    return text
+
+
+def violations(source: str, state_names: set[str]) -> list[tuple[int, str]]:
+    """``(line, path expression)`` for every ``mkdir``/``makedirs`` in *source* whose path
+    is state-derived — i.e. every one that should be `config.private_mkdir` and is not."""
+    tree = ast.parse(source)
+    state_funcs = state_path_functions(tree, state_names)
+    scopes = [(n.lineno, n.end_lineno, n) for n in ast.walk(tree)
+              if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]
+    out = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        name = getattr(fn, "attr", None) or getattr(fn, "id", None)
+        if name not in ("mkdir", "makedirs"):
+            continue
+        if isinstance(fn, ast.Attribute):
+            expr = ast.unparse(fn.value)
+        elif node.args:
+            expr = ast.unparse(node.args[0])
+        else:
+            continue
+        enclosing = sorted((s for s in scopes if s[0] <= node.lineno <= s[1]),
+                           key=lambda s: s[1] - s[0])
+        assigns = {}
+        if enclosing:
+            for n2 in ast.walk(enclosing[0][2]):
+                if isinstance(n2, ast.Assign) and len(n2.targets) == 1 \
+                        and isinstance(n2.targets[0], ast.Name):
+                    assigns.setdefault(n2.targets[0].id, ast.unparse(n2.value))
+        full = _expand(expr, assigns)
+        if _mentions_state(full, state_names) or _calls(full, state_funcs):
+            out.append((node.lineno, expr))
+    return out
+
+
+def scan_package() -> dict[str, list[tuple[int, str]]]:
+    """``{relative path: violations}`` over the whole package, empty entries dropped."""
+    names = state_attribute_names()
+    found = {}
+    for f in sorted(PACKAGE.rglob("*.py")):
+        hits = violations(f.read_text(), names)
+        if hits:
+            found[str(f.relative_to(PACKAGE.parent))] = hits
+    return found

--- a/tests/_statedirscan.py
+++ b/tests/_statedirscan.py
@@ -1,13 +1,22 @@
 """Which ``mkdir`` calls in `charter/` can create a directory under the state directory.
 
 Static, and deliberately so: the question is *coverage* — has every writer that can make
-``.charter/`` been routed through `config.private_mkdir` — and coverage is a question about
-code that was not executed. The behavioural half lives in
+``.charter/`` been routed through `config.private_mkdir` / `config.mkdir_for` — and
+coverage is a question about code that was not executed. The behavioural half lives in
 `test_the_state_directory_is_charters_to_choose.py`, which runs real commands and measures
 the mode that comes out; this half is what notices the writer nobody ran.
 
 Not a ``test_*`` module, so discovery skips it. Its own accuracy is tested there, against
 sources built for the purpose.
+
+**The property is "a mkdir that can be reached with a state path", not "a mkdir whose own
+line spells one".** Those are different questions, and the first cut asked only the
+second: it matched the *spelling* ``.STATE_DIR`` in the path expression at the call site.
+`memstore.write(mem_dir, …)` spells nothing — it is *handed* the committed
+``personas/<n>/memory`` on one call and the gitignored
+``PERSONA_STATE_DIR/ephemeral/<session>/<n>`` on the next — so the scan reported a clean
+package while ``charter persona remember … --ephemeral`` created ``.charter/`` itself at
+the umask default (#470). Two halves now, and the second is the one that class needs.
 
 **How a path is judged to be state-derived, and why it is derived rather than listed.**
 The names that live under ``STATE_DIR`` are asked of `config` itself — every entry of
@@ -19,17 +28,28 @@ front of it: `hooks` reaches it as ``_cfg.STATE_DIR`` and `frame.state` as
 
 One level of indirection is followed, transitively: a module-level function whose returns
 mention a state name is itself a state path source (``_cache_file()``, ``_route_mark(sid)``,
-``frame.state._root()``), and so is one that returns a call to such a function. Local
-assignments inside the calling function are substituted before the test, so
+``persona.ephemeral_dir()``), and so is one that returns a call to such a function. That
+fixpoint is now **cross-module** — a caller reaching `persona.ephemeral_dir` through the
+alias it imported it under is the same question as one calling a helper in its own file.
+Local assignments inside the calling function are substituted before the test, so
 ``f = _cache_file()`` … ``f.parent.mkdir(…)`` is seen for what it is.
 
-**What it cannot see, said out loud.** A path that reaches a writer as a *parameter* —
-`memstore.write(mem_dir, …)` is handed either a committed persona directory or an
-ephemeral one under ``PERSONA_STATE_DIR`` — is invisible to a static reader, because the
-answer depends on the caller. A path assembled from a string (``Path(str(config.ROOT) +
-"/.charter")``) is invisible too. Those are the next spellings, and neither is closed here:
-what closes the exposure they would open is that ``.charter/`` itself is 0700, so a
-directory created under it at the umask default is still reachable by nobody but its owner.
+**The handed half.** :func:`handed_violations` propagates *arguments*: a call that passes
+a state path (or a parameter already known to carry one) into a package function taints
+that function's parameter, transitively, and a ``mkdir`` on a tainted parameter is a
+violation exactly as a ``mkdir`` on ``config.STATE_DIR / …`` is. This is what makes the
+scan match reachability rather than a spelling, and what closes the gap the docstring
+above it used to describe and excuse.
+
+**What it still cannot see, said out loud.** A path assembled from a string
+(``Path(str(config.ROOT) + "/.charter")``) is invisible: no attribute is named and no
+call is made. A path arriving from outside the package — read out of JSON, taken from
+``argv`` — is invisible for the same reason. Neither is closed here, and the honest reason
+they are not an exposure is no longer "``.charter/`` is 0700 so a loose directory under it
+does not matter" — that was false on the exact flow above, where the loose directory *was*
+``.charter/``. It is that `config.mkdir_for` decides at **runtime**, on where the path
+actually is, so a writer routed through it is right about a path this reader cannot name.
+The scan's job is to prove every writer is routed; the guard is `config`.
 """
 
 from __future__ import annotations
@@ -40,6 +60,18 @@ from pathlib import Path
 
 #: The package under test, as a directory.
 PACKAGE = Path(__file__).resolve().parent.parent / "charter"
+
+#: The two routed spellings. A ``mkdir`` is never one of these — they are functions, not
+#: methods named ``mkdir`` — so this is documentation of what "routed" means rather than a
+#: filter, and is asserted against `config` so a rename cannot leave it stale.
+ROUTED = ("private_mkdir", "mkdir_for")
+
+#: `config`'s own walk, exempt because it **is** the routing. ``_mkdir_0700`` is the
+#: private mkdir itself; ``mkdir_for``'s bare one is the branch it takes having just
+#: decided at runtime that the path is not state. Flagging these would be asking the guard
+#: to route through itself. Named in full — ``module.function`` — so an unrelated
+#: ``_mkdir_0700`` appearing elsewhere would still be scanned.
+THE_WALK = ("config.private_mkdir", "config._mkdir_0700", "config.mkdir_for")
 
 
 def state_attribute_names() -> set[str]:
@@ -69,10 +101,25 @@ def _returns(fn: ast.AST) -> list[str]:
             if isinstance(n, ast.Return) and n.value is not None]
 
 
+#: One compiled alternation per set of state names, because the package-wide scan asks
+#: this question tens of thousands of times and a regex per name per ask is the difference
+#: between a test and a coffee break.
+_STATE_RE: dict[frozenset, "re.Pattern"] = {}
+
+
+def _state_re(state_names) -> "re.Pattern":
+    key = frozenset(state_names)
+    r = _STATE_RE.get(key)
+    if r is None:
+        r = _STATE_RE[key] = re.compile(
+            r"\.(?:" + "|".join(sorted(map(re.escape, key))) + r")\b")
+    return r
+
+
 def _mentions_state(text: str, state_names: set[str]) -> bool:
     """Keyed to the ATTRIBUTE — ``.STATE_DIR`` — so `hooks`'s ``_cfg.STATE_DIR`` and
     `frame.state`'s ``config.STATE_DIR`` are one question, not two."""
-    return any(re.search(rf"\.{n}\b", text) for n in state_names)
+    return bool(state_names) and bool(_state_re(state_names).search(text))
 
 
 def _calls(text: str, names) -> bool:
@@ -81,10 +128,23 @@ def _calls(text: str, names) -> bool:
     return any(re.search(rf"(?<![\w.]){re.escape(n)}\s*\(", text) for n in names)
 
 
+def _names(text: str, names) -> bool:
+    """Does *text* mention one of *names* as a name (not as somebody's attribute)?"""
+    if not names:
+        return False
+    return bool(re.search(r"(?<![\w.])(?:" + "|".join(sorted(map(re.escape, names)))
+                          + r")\b", text))
+
+
+#: ``foo(``/``a.b(`` — every callable named in an expression, in one pass.
+_CALLED_RE = re.compile(r"(?<![\w.])([\w.]+)\s*\(")
+
+
 def state_path_functions(tree: ast.AST, state_names: set[str]) -> set[str]:
     """Module-level function names whose return value is a path under the state directory.
 
     A fixpoint, so ``path_for()`` returning ``_dir() / …`` counts when ``_dir()`` does.
+    Single-module; :func:`package_state_functions` is the same question across the package.
     """
     funcs = {n.name: n for n in tree.body
              if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
@@ -104,14 +164,26 @@ def state_path_functions(tree: ast.AST, state_names: set[str]) -> set[str]:
     return found
 
 
-def _expand(expr: str, assigns: dict[str, str], rounds: int = 4) -> str:
-    """*expr* with local names replaced by what they were assigned, a few rounds deep."""
+def _expand(expr: str, assigns: dict[str, str], rounds: int = 4,
+            limit: int = 4000) -> str:
+    """*expr* with local names replaced by what they were assigned, a few rounds deep.
+
+    Substituted on a WORD boundary, and never after a dot: a local named ``d`` must not
+    rewrite the middle of ``mem_dir``, and ``f.parent`` is not an assignment to ``parent``.
+    A plain ``str.replace`` did both.
+
+    *limit* stops the substitution once the text has grown past anything a path expression
+    plausibly is. Expansion is quadratic in a long function with many locals — and this now
+    runs on every call site in the package, not only the ``mkdir`` ones — while a 4000-character
+    expression that has not yet named a state path is not about to start.
+    """
     text = expr
     for _ in range(rounds):
         before = text
         for name, value in assigns.items():
-            if name in text:
-                text = text.replace(name, f"({value})")
+            if len(text) > limit:
+                return text
+            text = re.sub(rf"(?<![\w.]){re.escape(name)}\b", lambda _m: f"({value})", text)
         if text == before:
             return text
     return text
@@ -119,12 +191,47 @@ def _expand(expr: str, assigns: dict[str, str], rounds: int = 4) -> str:
 
 def violations(source: str, state_names: set[str]) -> list[tuple[int, str]]:
     """``(line, path expression)`` for every ``mkdir``/``makedirs`` in *source* whose path
-    is state-derived — i.e. every one that should be `config.private_mkdir` and is not."""
+    is state-derived **by its own spelling** — the named half. The handed half, where the
+    path arrives as a parameter, is :func:`handed_violations`."""
     tree = ast.parse(source)
     state_funcs = state_path_functions(tree, state_names)
-    scopes = [(n.lineno, n.end_lineno, n) for n in ast.walk(tree)
-              if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]
     out = []
+    for node, expr, enclosing in _mkdir_sites(tree):
+        full = _expand(expr, _local_assigns(enclosing))
+        if _mentions_state(full, state_names) or _calls(full, state_funcs):
+            out.append((node.lineno, expr))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# shared AST plumbing                                                          #
+# --------------------------------------------------------------------------- #
+def _scopes(tree: ast.AST):
+    return [(n.lineno, n.end_lineno, n) for n in ast.walk(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]
+
+
+def _enclosing(scopes, lineno):
+    """The innermost function containing *lineno*, or None at module level."""
+    hits = sorted((s for s in scopes if s[0] <= lineno <= s[1]), key=lambda s: s[1] - s[0])
+    return hits[0][2] if hits else None
+
+
+def _local_assigns(fn) -> dict[str, str]:
+    """``{name: source of what it was assigned}`` for simple local assignments in *fn*."""
+    assigns: dict[str, str] = {}
+    if fn is None:
+        return assigns
+    for n in ast.walk(fn):
+        if isinstance(n, ast.Assign) and len(n.targets) == 1 \
+                and isinstance(n.targets[0], ast.Name):
+            assigns.setdefault(n.targets[0].id, ast.unparse(n.value))
+    return assigns
+
+
+def _mkdir_sites(tree: ast.AST):
+    """``(call node, path expression, enclosing function)`` for every ``mkdir``/``makedirs``."""
+    scopes = _scopes(tree)
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
@@ -138,26 +245,242 @@ def violations(source: str, state_names: set[str]) -> list[tuple[int, str]]:
             expr = ast.unparse(node.args[0])
         else:
             continue
-        enclosing = sorted((s for s in scopes if s[0] <= node.lineno <= s[1]),
-                           key=lambda s: s[1] - s[0])
-        assigns = {}
-        if enclosing:
-            for n2 in ast.walk(enclosing[0][2]):
-                if isinstance(n2, ast.Assign) and len(n2.targets) == 1 \
-                        and isinstance(n2.targets[0], ast.Name):
-                    assigns.setdefault(n2.targets[0].id, ast.unparse(n2.value))
-        full = _expand(expr, assigns)
-        if _mentions_state(full, state_names) or _calls(full, state_funcs):
-            out.append((node.lineno, expr))
+        yield node, expr, _enclosing(scopes, node.lineno)
+
+
+def _params(fn) -> list[str]:
+    """Positional parameter names of *fn*, in call order, ``self`` dropped."""
+    a = fn.args
+    out = [p.arg for p in (*a.posonlyargs, *a.args)]
+    return out[1:] if out[:1] == ["self"] else out
+
+
+def _kwparams(fn) -> set[str]:
+    return {p.arg for p in (*fn.args.args, *fn.args.posonlyargs, *fn.args.kwonlyargs)}
+
+
+# --------------------------------------------------------------------------- #
+# the package as one graph                                                     #
+# --------------------------------------------------------------------------- #
+def load_package() -> dict[str, tuple[Path, ast.Module]]:
+    """``{module name: (path, tree)}`` for every module in the package.
+
+    Module names are dotted and relative to the package (``memstore``, ``frame.state``),
+    which is how the import aliases below resolve.
+    """
+    out = {}
+    for f in sorted(PACKAGE.rglob("*.py")):
+        rel = f.relative_to(PACKAGE).with_suffix("")
+        parts = list(rel.parts)
+        if parts[-1] == "__init__":
+            parts.pop()
+        out[".".join(parts) or "__init__"] = (f, ast.parse(f.read_text()))
     return out
 
 
+def modules_from(sources: dict[str, str]) -> dict[str, tuple[Path, ast.Module]]:
+    """A package built out of *sources* — ``{module name: source}`` — for testing the scan.
+
+    The handed half is a question about calls *between* modules, so its accuracy cannot be
+    checked against one string the way :func:`violations` can. This gives the tests the
+    same shape :func:`load_package` produces, without a package on disk.
+    """
+    return {name: (PACKAGE / (name.replace(".", "/") + ".py"), ast.parse(src))
+            for name, src in sources.items()}
+
+
+def _aliases(tree: ast.Module, module: str) -> dict[str, str]:
+    """``{local name: module it refers to}`` for the package-relative imports in *tree*.
+
+    ``from . import memstore`` and ``from . import config as _cfg`` and
+    ``from .frame import state`` — the three shapes this package uses. An absolute import
+    of something outside the package resolves to nothing and is dropped, so a third-party
+    ``state.mkdir`` cannot be mistaken for `charter.frame.state`.
+    """
+    here = module.rsplit(".", 1)[0] if "." in module else ""
+    out = {}
+    for n in ast.walk(tree):
+        if not isinstance(n, ast.ImportFrom) or n.level == 0:
+            continue
+        base = here if n.level == 1 else ".".join(here.split(".")[:-(n.level - 1)] or [])
+        if n.module:
+            base = f"{base}.{n.module}" if base else n.module
+        for a in n.names:
+            target = f"{base}.{a.name}" if base else a.name
+            out[a.asname or a.name] = target
+    return out
+
+
+def package_state_functions(mods, state_names: set[str]) -> set[str]:
+    """``{"module.func"}`` for every package function returning a path under the state dir.
+
+    The cross-module fixpoint: `commands_persona` calling ``persona.ephemeral_dir()`` is
+    the same question as `persona` calling its own ``_dir()``, and a per-file scan answers
+    only the second.
+    """
+    funcs = {}   # "mod.name" -> (module, return expressions)
+    for module, (_p, tree) in mods.items():
+        for n in ast.walk(tree):
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                funcs.setdefault(f"{module}.{n.name}", (module, _returns(n)))
+    aliases = {m: _aliases(t, m) for m, (_p, t) in mods.items()}
+    found: set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        for qual, (module, texts) in funcs.items():
+            if qual in found:
+                continue
+            if any(_mentions_state(t, state_names) for t in texts) or \
+                    any(_is_state_call(t, module, aliases[module], found) for t in texts):
+                found.add(qual)
+                changed = True
+    return found
+
+
+def _is_state_call(text: str, module: str, aliases: dict, state_funcs: set[str]) -> bool:
+    """Does *text*, read from inside *module*, call one of the qualified *state_funcs*?
+
+    Every callable named in *text* is pulled out in one pass and then RESOLVED through the
+    caller's own import aliases — rather than each state function being searched for by
+    bare name. Not only faster: ``_dir()`` exists in more than one module here and only
+    some of them are state, so a bare-name match would flag `dispatch`'s (which returns a
+    committed ``personas/`` path) on the strength of somebody else's.
+    """
+    for cand in _CALLED_RE.findall(text):
+        if "." in cand:
+            head, _, attr = cand.rpartition(".")
+            head = head.split(".")[0]
+            target = aliases.get(head)
+            if target is None:
+                continue
+            if f"{target}.{attr}" in state_funcs or target in state_funcs:
+                return True
+        elif f"{module}.{cand}" in state_funcs:
+            return True
+        elif aliases.get(cand) in state_funcs:
+            return True
+    return False
+
+
+def _resolve_callee(call: ast.Call, module: str, mods, aliases) -> str | None:
+    """``"module.func"`` for a call to a package function, else None."""
+    fn = call.func
+    if isinstance(fn, ast.Name):
+        return f"{module}.{fn.id}"
+    if isinstance(fn, ast.Attribute) and isinstance(fn.value, ast.Name):
+        target = aliases.get(fn.value.id)
+        if target is None:
+            return None
+        if target in mods:
+            return f"{target}.{fn.attr}"
+        return f"{target}.{fn.attr}"  # ``from . import x`` of a name, then ``x.attr``
+    return None
+
+
+def tainted_params(mods, state_names: set[str], state_funcs: set[str]) -> set[str]:
+    """``{"module.func.param"}`` — every package parameter a state path can reach.
+
+    Seeded by call sites that pass one (``memstore.write(ephemeral_dir(…), …)``) and
+    closed under passing a tainted parameter on to the next function, so the depth of the
+    call chain is not a way to fall out of the scan.
+    """
+    sig = {}     # "mod.func" -> (positional names, keyword names)
+    for module, (_p, tree) in mods.items():
+        for n in ast.walk(tree):
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                sig.setdefault(f"{module}.{n.name}", (_params(n), _kwparams(n)))
+
+    # Every call that could taint something, flattened once: unparsing and expanding
+    # arguments is the expensive part and none of it changes between rounds.
+    sites = []   # (module, aliases, enclosing name, callee, [(param, expanded arg text)])
+    for module, (_p, tree) in mods.items():
+        aliases = _aliases(tree, module)
+        scopes = _scopes(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            callee = _resolve_callee(node, module, mods, aliases)
+            if callee is None or callee not in sig:
+                continue
+            positional, kw = sig[callee]
+            here = _enclosing(scopes, node.lineno)
+            assigns = _local_assigns(here)
+            args = [(positional[i], _expand(ast.unparse(a), assigns))
+                    for i, a in enumerate(node.args) if i < len(positional)]
+            args += [(k.arg, _expand(ast.unparse(k.value), assigns))
+                     for k in node.keywords if k.arg in kw]
+            if args:
+                sites.append((module, aliases, here.name if here else None, callee, args))
+
+    tainted: set[str] = set()
+    # Seed: an argument that names a state path outright, independent of any other round.
+    seeds = []
+    for module, aliases, hname, callee, args in sites:
+        rest = []
+        for param, text in args:
+            if _mentions_state(text, state_names) or \
+                    _is_state_call(text, module, aliases, state_funcs):
+                tainted.add(f"{callee}.{param}")
+            elif hname is not None:
+                rest.append((f"{module}.{hname}.", callee, param, text))
+        seeds.extend(rest)
+
+    # Close under passing one on: depth of the call chain is not a way out of the scan.
+    changed = True
+    while changed:
+        changed = False
+        for prefix, callee, param, text in seeds:
+            q = f"{callee}.{param}"
+            if q in tainted:
+                continue
+            mine = [t.rpartition(".")[2] for t in tainted if t.startswith(prefix)]
+            if mine and _names(text, mine):
+                tainted.add(q)
+                changed = True
+    return tainted
+
+
+def handed_violations(mods, state_names: set[str]) -> dict[str, list[tuple[int, str]]]:
+    """``{relative path: [(line, expr)]}`` for every ``mkdir`` on a **handed** state path.
+
+    The half the named scan cannot see, and the one `memstore` fell through.
+    """
+    state_funcs = package_state_functions(mods, state_names)
+    tainted = tainted_params(mods, state_names, state_funcs)
+    found: dict[str, list[tuple[int, str]]] = {}
+    for module, (path, tree) in mods.items():
+        scopes = _scopes(tree)
+        for node, expr, here in _mkdir_sites(tree):
+            if here is None or f"{module}.{here.name}" in THE_WALK:
+                continue
+            mine = [q.rpartition(".")[2] for q in tainted
+                    if q.startswith(f"{module}.{here.name}.")]
+            if not mine:
+                continue
+            full = _expand(expr, _local_assigns(here))
+            if _names(full, mine):
+                found.setdefault(str(path.relative_to(PACKAGE.parent)), []).append(
+                    (node.lineno, expr))
+    for hits in found.values():
+        hits.sort()
+    return found
+
+
 def scan_package() -> dict[str, list[tuple[int, str]]]:
-    """``{relative path: violations}`` over the whole package, empty entries dropped."""
+    """``{relative path: violations}`` over the whole package — both halves, merged.
+
+    Named and handed are one answer because they are one property: a ``mkdir`` that can
+    run on a path under ``.charter/`` without going through `config`.
+    """
     names = state_attribute_names()
-    found = {}
-    for f in sorted(PACKAGE.rglob("*.py")):
-        hits = violations(f.read_text(), names)
+    mods = load_package()
+    found: dict[str, list[tuple[int, str]]] = {}
+    for module, (path, tree) in mods.items():
+        hits = violations(path.read_text(), names)
         if hits:
-            found[str(f.relative_to(PACKAGE.parent))] = hits
+            found[str(path.relative_to(PACKAGE.parent))] = hits
+    for f, hits in handed_violations(mods, names).items():
+        merged = sorted(set(found.get(f, [])) | set(hits))
+        found[f] = merged
     return found

--- a/tests/_statedirscan.py
+++ b/tests/_statedirscan.py
@@ -41,7 +41,19 @@ violation exactly as a ``mkdir`` on ``config.STATE_DIR / …`` is. This is what 
 scan match reachability rather than a spelling, and what closes the gap the docstring
 above it used to describe and excuse.
 
-**What it still cannot see, said out loud.** A path assembled from a string
+**Which subexpression is the path is a property, not a spelling.** ``p.mkdir(…)`` keeps its
+path in the RECEIVER and ``os.makedirs(p)`` in the first ARGUMENT, and both are attribute
+calls — so the first cut, which read the receiver of every attribute call, scanned
+``os.makedirs(config.STATE_DIR / 'x')`` as the expression ``os`` and the advertised
+``makedirs`` coverage was dead for the only spelling anyone writes. The shape is no longer
+decided: `_mkdir_sites` yields every position that could hold the path — receiver, first
+argument, and the ``path=``/``name=`` keywords the stdlib signatures use — and a state path
+in any of them is a violation. A wrong guess now costs a false positive, which is loud and
+in the safe direction, rather than a silence.
+
+**What it still cannot see, said out loud.** A directory maker reached through a local
+rebinding (``mk = os.makedirs`` … ``mk(p)``) is not recognised as one: the aliased *import*
+is followed, an assignment is not. A path assembled from a string
 (``Path(str(config.ROOT) + "/.charter")``) is invisible: no attribute is named and no
 call is made. A path arriving from outside the package — read out of JSON, taken from
 ``argv`` — is invisible for the same reason. Neither is closed here, and the honest reason
@@ -196,10 +208,13 @@ def violations(source: str, state_names: set[str]) -> list[tuple[int, str]]:
     tree = ast.parse(source)
     state_funcs = state_path_functions(tree, state_names)
     out = []
-    for node, expr, enclosing in _mkdir_sites(tree):
-        full = _expand(expr, _local_assigns(enclosing))
-        if _mentions_state(full, state_names) or _calls(full, state_funcs):
-            out.append((node.lineno, expr))
+    for node, exprs, enclosing in _mkdir_sites(tree):
+        assigns = _local_assigns(enclosing)
+        for expr in exprs:
+            full = _expand(expr, assigns)
+            if _mentions_state(full, state_names) or _calls(full, state_funcs):
+                out.append((node.lineno, expr))
+                break
     return out
 
 
@@ -229,23 +244,56 @@ def _local_assigns(fn) -> dict[str, str]:
     return assigns
 
 
+#: The keywords the stdlib gives the path of a directory-making call: ``os.mkdir(path=…)``
+#: and ``os.makedirs(name=…)``. Read from the signatures, not invented.
+_PATH_KWARGS = ("path", "name")
+
+
+def _maker_aliases(tree: ast.AST) -> set[str]:
+    """Local names bound to ``os.mkdir`` / ``os.makedirs`` by an *aliased* import.
+
+    ``from os import makedirs`` already lands under the bare name; ``from os import
+    makedirs as md`` renames the call site, and a filter reading the local spelling would
+    let the alias walk out of the scan.
+    """
+    out = set()
+    for n in ast.walk(tree):
+        if not isinstance(n, ast.ImportFrom) or n.level != 0 or n.module != "os":
+            continue
+        out |= {a.asname for a in n.names if a.name in ("mkdir", "makedirs") and a.asname}
+    return out
+
+
 def _mkdir_sites(tree: ast.AST):
-    """``(call node, path expression, enclosing function)`` for every ``mkdir``/``makedirs``."""
+    """``(call node, candidate path expressions, enclosing function)`` per ``mkdir``.
+
+    **Which subexpression is the path is a property of the call shape, and the first cut
+    matched a spelling instead.** ``p.mkdir(…)`` is a bound method and the path is the
+    RECEIVER; ``os.mkdir(p)`` / ``os.makedirs(p)`` are module functions and the path is the
+    first ARGUMENT. Both are attribute calls, and reading the receiver of every attribute
+    call — which is what this did — scanned ``os.makedirs(config.STATE_DIR / 'x')`` as the
+    expression ``os``, so the advertised ``makedirs`` coverage was dead for the only
+    spelling anyone writes. Keying instead on the name (``makedirs`` takes an argument,
+    ``mkdir`` a receiver) trades one spelling for another and still misses ``os.mkdir(p)``.
+
+    So the shape is not decided at all: every position that COULD hold the path is
+    yielded, and a state path in any of them is a violation. A wrong guess costs a false
+    positive — loud, and in the safe direction — where a wrong shape costs silence.
+    """
     scopes = _scopes(tree)
+    aliases = _maker_aliases(tree)
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         fn = node.func
         name = getattr(fn, "attr", None) or getattr(fn, "id", None)
-        if name not in ("mkdir", "makedirs"):
+        if name not in ("mkdir", "makedirs") and name not in aliases:
             continue
-        if isinstance(fn, ast.Attribute):
-            expr = ast.unparse(fn.value)
-        elif node.args:
-            expr = ast.unparse(node.args[0])
-        else:
-            continue
-        yield node, expr, _enclosing(scopes, node.lineno)
+        exprs = [ast.unparse(fn.value)] if isinstance(fn, ast.Attribute) else []
+        exprs += [ast.unparse(a) for a in node.args[:1]]
+        exprs += [ast.unparse(k.value) for k in node.keywords if k.arg in _PATH_KWARGS]
+        if exprs:
+            yield node, tuple(exprs), _enclosing(scopes, node.lineno)
 
 
 def _params(fn) -> list[str]:
@@ -451,17 +499,19 @@ def handed_violations(mods, state_names: set[str]) -> dict[str, list[tuple[int, 
     found: dict[str, list[tuple[int, str]]] = {}
     for module, (path, tree) in mods.items():
         scopes = _scopes(tree)
-        for node, expr, here in _mkdir_sites(tree):
+        for node, exprs, here in _mkdir_sites(tree):
             if here is None or f"{module}.{here.name}" in THE_WALK:
                 continue
             mine = [q.rpartition(".")[2] for q in tainted
                     if q.startswith(f"{module}.{here.name}.")]
             if not mine:
                 continue
-            full = _expand(expr, _local_assigns(here))
-            if _names(full, mine):
-                found.setdefault(str(path.relative_to(PACKAGE.parent)), []).append(
-                    (node.lineno, expr))
+            assigns = _local_assigns(here)
+            for expr in exprs:
+                if _names(_expand(expr, assigns), mine):
+                    found.setdefault(str(path.relative_to(PACKAGE.parent)), []).append(
+                        (node.lineno, expr))
+                    break
     for hits in found.values():
         hits.sort()
     return found

--- a/tests/test_docs_claims_carry_their_residual.py
+++ b/tests/test_docs_claims_carry_their_residual.py
@@ -88,8 +88,12 @@ CLAIM_DOCS = (
 
 #: Where the directory-mode claims are made — "every level is 0700" and "and charter
 #: reports the ones it did not create". Both overreached in round two: the first swallowed
-#: `.charter/` itself (#470), the second put the report in `doctor` (#471).
-DIR_CLAIM_ENTRIES = entries("a-vault-charter-cannot-make-private")
+#: `.charter/` itself (#470), the second put the report in `doctor` (#471). Both are closed
+#: now, and the entry that closes them makes the same two claims, so it is held to the same
+#: residual: charter still does not touch a directory it did not create, and still has to
+#: say so where it cannot fix it.
+DIR_CLAIM_ENTRIES = (*entries("a-vault-charter-cannot-make-private"),
+                     *entries("the-state-directory-is-charters-to-choose"))
 DIR_CLAIM_DOCS = ("docs/secrets.md", *DIR_CLAIM_ENTRIES)
 
 #: The claim: some form of "this line cannot be checked against a guessed value".
@@ -154,61 +158,56 @@ class EveryAssuranceCarriesItsResidual(unittest.TestCase):
                     "listed by other accounts", text,
                     "and must name the report that replaces the fix it cannot make")
 
-    def test_the_directory_claim_does_not_swallow_the_state_directory(self) -> None:
-        """"Every directory charter creates" is false one level up, and was shipped anyway.
+    def test_the_directory_claim_names_the_level_it_did_not_used_to_cover(self) -> None:
+        """"Every directory charter creates" was false one level up, and shipped anyway.
 
-        `make_private_dir` is reached from the three secrets writers and from nowhere
-        else. On the default flow `charter vault add` writes the local registry first,
-        which creates `.charter/` through a bare `mkdir(parents=True, exist_ok=True)`, so
-        the state directory is the umask's to decide and not charter's (#470). Both
-        documents said "every directory charter creates", and `.charter` is one of the
-        three levels the news entry's own before-measurement lists as broken.
+        `make_private_dir` was reached from the three secrets writers and from nowhere
+        else, so on the default flow `.charter/` was the umask's to decide (#470). It is
+        charter's now — every state writer goes through the same walk — and these
+        documents have to say which of the two they are describing, because a reader on
+        0.52.0 and a reader on the next release are looking at different behaviour.
 
-        The behaviour is pinned in `test_vault_dir_mode.TheOrderTheCliActuallyUses`, which
-        drives `registry.add_vault` and measures the result under two umasks. This case
-        only stops the sentence from drifting back off it.
+        The behaviour is pinned in `test_vault_dir_mode.TheOrderTheCliActuallyUses` and in
+        `test_the_state_directory_is_charters_to_choose.py`. This case only stops the
+        sentence from drifting off it.
         """
         for rel in DIR_CLAIM_DOCS:
             with self.subTest(doc=rel):
                 text = flat(rel)
-                # `assertNotRegex` renders the whole flattened document into the failure
-                # message, which buries the sentence at fault under twelve screens of the
-                # ones that are fine. These files are long enough that the search has to
-                # be run by hand and only the match reported.
-                hit = re.search(r"[Ee]very directory charter \*{0,2}creates", text)
-                self.assertIsNone(
-                    hit,
-                    f"{rel} says {hit.group(0)!r}: every directory charter creates on the "
-                    f"way to a vault file is 0700. `.charter/` is not one of them on the "
-                    f"default flow — scope the sentence to the vault writers (#470)"
-                    if hit else "")
                 self.assertIsNotNone(
                     re.search(r"issues/470", text),
-                    f"{rel} must name the level the walk does not cover, and where it is "
-                    f"tracked, rather than leaving the reader to measure it")
+                    f"{rel} must name the level the walk did not used to cover, and where "
+                    f"that was tracked, rather than leaving the reader to measure it")
+                self.assertRegex(
+                    text, r"`?\.charter/?`?",
+                    f"{rel} makes a claim about directory modes without naming the "
+                    f"directory the claim is about")
 
-    def test_no_document_claims_the_loose_directory_note_reaches_doctor(self) -> None:
-        """`check_vaults` does ``healthy, _ = prov.health()``. The detail is dropped.
+    def test_every_document_says_which_surfaces_carry_the_note(self) -> None:
+        """The note is the whole remedy for a directory charter will not chmod, so where it
+        appears is not a detail — it is the sentence the reader acts on.
 
-        `_loose_dir_note` also never sets ``healthy`` False — on purpose, since the check
-        runs from the SessionStart hook — so there is no path at all by which the note
-        reaches `doctor` or `doctor --json`, and two documents said there was (#471).
-        Pinned behaviourally by `test_vault_dir_mode.TheOrderTheCliActuallyUses.
-        test_doctor_is_not_where_it_appears`.
+        It reached `charter vault list` and nothing else, while two documents said
+        otherwise (#471). Both surfaces carry it now, from one rendering of one structured
+        answer, and the documents name both. Pinned behaviourally by
+        `test_doctor_names_a_loose_state_directory.py`.
         """
         for rel in DIR_CLAIM_DOCS:
             with self.subTest(doc=rel):
                 text = flat(rel)
-                hit = re.search(r"and (?:so |therefore )?in `?(?:charter )?doctor`?", text)
-                self.assertIsNone(
-                    hit,
-                    f"{rel} says {hit.group(0)!r} — the loose-directory note does not "
-                    f"appear in `doctor`: `check_vaults` keeps only the healthy flag "
-                    f"and drops the detail (#471)" if hit else "")
                 self.assertIsNotNone(
                     re.search(r"issues/471", text),
-                    f"{rel} must say where the note actually appears and where the gap "
-                    f"is tracked")
+                    f"{rel} must say where the note appears and where the gap that kept "
+                    f"it off `doctor` was tracked")
+                self.assertRegex(
+                    text, r"vault list",
+                    f"{rel} names the loose-directory note without naming the command "
+                    f"whose STATUS column prints it")
+                self.assertRegex(
+                    text, r"doctor",
+                    f"{rel} names the loose-directory note without saying anything about "
+                    f"`charter doctor`, which is the command an operator runs to find "
+                    f"exactly this class of thing")
 
 
 class TheResidualIsRealAndStillOpen(PersonaIso):

--- a/tests/test_doctor_names_a_loose_state_directory.py
+++ b/tests/test_doctor_names_a_loose_state_directory.py
@@ -1,0 +1,207 @@
+"""The loose-directory note reaches `charter doctor`, not only `charter vault list` (#471).
+
+`PlainFileProvider.health()` returns ``(healthy, detail)`` and put the note in *detail*::
+
+    1 secret(s), listed by other accounts: .charter 755 (want 700 — chmod 700)
+
+`charter vault list` prints that detail as its STATUS column. `check_vaults` did
+``healthy, _ = prov.health()`` and dropped it — and `_loose_dir_note` deliberately never
+sets ``healthy`` False, because a directory another account can list is not an unreachable
+vault and this check runs from the SessionStart hook, where it must not hold up a session.
+So there was no path at all by which the note reached the command whose entire job is
+surfacing exactly this class of thing.
+
+**The fix is a structured question, not a substring.** `doctor` asks
+`VaultProvider.loose_dirs()` for ``(path, mode)`` pairs and renders them through
+`base.loose_dir_note`, which is also what `health()` renders. Scraping `health()`'s
+sentence from `doctor` would have been the bypass this codebase keeps paying for: the
+report would go silent the day somebody rewords the sentence, and nothing would fail. The
+cases below assert the two surfaces carry **the same rendering of the same list**, rather
+than asserting the prose twice.
+
+**It stays a green line.** Charter will not chmod a directory it did not create — a
+vault's ``file`` may name any path on this machine, and ``$CHARTER_HOME`` may move the
+state directory anywhere — so reporting *is* the remedy, and a WARN at every session start
+about a directory the operator has decided to leave alone is a check crying wolf. The note
+is on the ✓ line, in the same posture as the "points outside the plane" note beside it.
+
+The next spelling: a provider whose data lives in a directory charter creates and whose
+`loose_dirs()` still answers ``[]``. `reference` is exactly that today — it writes a file
+under ``.charter/vaults/`` through the same private walk, and reports nothing about a
+directory that predates it, on either surface. That is a real gap and it is not this
+file's: it is filed upstream, and the base class's default is the honest ``[]`` rather than
+a guess.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import stat
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from charter import config, doctor
+from charter.commands_secrets import cmd_vault_list
+from charter.secrets import base, registry
+from charter.secrets.plain_file import PlainFileProvider
+
+from tests._isolation import PersonaIso
+
+#: More than 0755, for the reason `test_vault_dir_mode` lists them: 0705 and 0701 grant
+#: other without group, 0711 traverse without read, 0730 a group write. A report written
+#: against a literal list of bad modes is the failure this suite keeps finding.
+LOOSE_MODES = (0o755, 0o750, 0o705, 0o701, 0o711, 0o730, 0o707)
+
+
+class LooseStateDir(PersonaIso):
+    """A plane whose `.charter/` predates the fix: made by hand, at the umask default.
+
+    Not `charter`'s own doing — since #470 charter creates it 0700 — which is exactly why
+    this is the case that has to be REPORTED rather than fixed.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.sd = Path(config.STATE_DIR)
+        self.sd.mkdir(parents=True, exist_ok=True)
+        os.chmod(self.sd, 0o755)
+        self.vf = self.sd / "vaults" / "devops.json"
+        registry.add_vault("devops", "plain-file", {"file": str(self.vf)})
+        PlainFileProvider("devops", {"file": str(self.vf)}).set("K", "value-one")
+        self.assertEqual(stat.S_IMODE(self.sd.stat().st_mode), 0o755,
+                         "precondition: there is something to report")
+
+    def vault_list(self) -> str:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cmd_vault_list(argparse.Namespace())
+        return buf.getvalue()
+
+
+class TheNoteReachesDoctor(LooseStateDir):
+    def test_the_green_vaults_line_names_the_directory_and_the_chmod(self) -> None:
+        res = doctor.check_vaults()
+        rendered = res.render()
+        self.assertIn("listed by other accounts", rendered)
+        self.assertIn(".charter 755", rendered,
+                      f"the line must name the level that is loose, not merely that one "
+                      f"is: {rendered!r}")
+        self.assertIn("chmod 700", rendered, "and what to type about it")
+
+    def test_it_is_not_a_warn(self) -> None:
+        """A loose directory is an operator's decision, not an unreachable vault — and
+        this check runs from the SessionStart hook."""
+        self.assertEqual(doctor.check_vaults().status, doctor.OK)
+
+    def test_it_reaches_the_json(self) -> None:
+        """`doctor --json` is what a script reads, and the note is worth as much there.
+
+        `cmd_doctor` builds each object out of ``r.detail`` (name/status/detail/hint), so
+        the note has to be in the DETAIL and not only in the rendered line — a fix that put
+        it in `render()` alone would leave `doctor --json` exactly as silent as before.
+        """
+        res = doctor.check_vaults()
+        payload = json.dumps({"name": res.name, "status": res.status,
+                              "detail": res.detail, "hint": res.hint})
+        self.assertIn("listed by other accounts", payload)
+
+    def test_both_surfaces_render_the_same_list(self) -> None:
+        """The property, rather than the prose: `vault list` and `doctor` say the same
+        thing because they render the same structured answer, not because two sentences
+        were kept in step by hand."""
+        note = base.loose_dir_note(registry.provider_for("devops").loose_dirs())
+        self.assertTrue(note, "precondition: the provider reports the directory")
+        self.assertIn(note, self.vault_list())
+        self.assertIn(note, doctor.check_vaults().render())
+
+    def test_every_loose_mode_is_reported_not_just_0755(self) -> None:
+        for mode in LOOSE_MODES:
+            with self.subTest(mode=oct(mode)):
+                os.chmod(self.sd, mode)
+                self.assertIn("listed by other accounts", doctor.check_vaults().render(),
+                              f"{oct(mode)[-3:]} lets another account in and was not named")
+
+    def test_a_private_state_directory_says_nothing(self) -> None:
+        """The complaint has to be caused by the mode. A note that is always there is a
+        line people learn to skip, and it takes the rest of the report with it."""
+        os.chmod(self.sd, 0o700)
+        rendered = doctor.check_vaults().render()
+        self.assertNotIn("listed by other accounts", rendered)
+        self.assertEqual(doctor.check_vaults().status, doctor.OK)
+
+    def test_one_directory_is_named_once_however_many_vaults_share_it(self) -> None:
+        """Several vaults normally sit in one `.charter/`. One directory is one `chmod`,
+        and a doctor line that repeats it per vault is the same fact three times."""
+        for name in ("second", "third"):
+            vf = self.sd / "vaults" / f"{name}.json"
+            registry.add_vault(name, "plain-file", {"file": str(vf)})
+            PlainFileProvider(name, {"file": str(vf)}).set("K", "v")
+        rendered = doctor.check_vaults().render()
+        self.assertEqual(rendered.count("listed by other accounts"), 1, rendered)
+        self.assertEqual(rendered.count(".charter 755"), 1, rendered)
+
+
+class TheNoteSurvivesTheOtherPaths(LooseStateDir):
+    """`check_vaults` returns from five places. A note that only rides the green one is
+    reported in exactly the conditions where nothing else is wrong."""
+
+    def test_an_unreachable_vault_does_not_take_the_note_with_it(self) -> None:
+        broken = self.sd / "vaults" / "broken.json"
+        registry.add_vault("broken", "plain-file", {"file": str(broken)})
+        broken.parent.mkdir(parents=True, exist_ok=True)
+        broken.write_text("{ not json")
+        res = doctor.check_vaults()
+        self.assertEqual(res.status, doctor.WARN, "precondition: a vault must be broken")
+        self.assertIn("not reachable", res.render())
+        self.assertIn("listed by other accounts", res.render(),
+                      "the loose directory did not stop being loose because a different "
+                      "vault is also broken")
+
+
+class ADirectoryCharterMadeIsNotReported(PersonaIso):
+    """The pair to the case above, and the one that says #470 landed: on a plane charter
+    builds from nothing there is nothing for this note to say."""
+
+    def test_a_plane_charter_built_itself_has_no_note(self) -> None:
+        old = os.umask(0o022)
+        self.addCleanup(os.umask, old)
+        sd = Path(config.STATE_DIR)
+        self.assertFalse(sd.exists(), "precondition: charter creates every level here")
+        vf = sd / "vaults" / "devops.json"
+        registry.add_vault("devops", "plain-file", {"file": str(vf)})
+        PlainFileProvider("devops", {"file": str(vf)}).set("K", "value-one")
+        self.assertEqual(stat.S_IMODE(sd.stat().st_mode), 0o700,
+                         "precondition: #470 — charter chose this mode, not the umask")
+        self.assertNotIn("listed by other accounts", doctor.check_vaults().render())
+
+
+class ProvidersWithoutADirectoryOfCharterS(PersonaIso):
+    """A provider that keeps nothing on disk has no directory of charter's to report, and
+    the honest answer is an empty list rather than a guess about somebody's backend."""
+
+    def test_the_base_default_is_empty(self) -> None:
+        class Nowhere(base.VaultProvider):
+            id = "nowhere"
+
+            def get(self, key):  # pragma: no cover - never called
+                raise base.SecretNotFound(key)
+
+            def set(self, key, value):  # pragma: no cover - never called
+                raise base.VaultError("read-only")
+
+            def delete(self, key):  # pragma: no cover - never called
+                raise base.VaultError("read-only")
+
+            def keys(self):
+                return []
+
+        self.assertEqual(Nowhere("v", {}).loose_dirs(), [])
+        self.assertEqual(base.loose_dir_note([]), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_doctor_vault_registry_malformed.py
+++ b/tests/test_doctor_vault_registry_malformed.py
@@ -143,6 +143,9 @@ class TestTheTwoVaultLinesNoLongerContradict(MalformedEntryCase):
         prov = mock.Mock()
         prov.env_overlay.return_value = None
         prov.health.return_value = (True, 1)
+        # `check_vaults` iterates this (#471). A bare Mock returns a Mock, which is not
+        # iterable — and a vault stubbed as reachable has no loose directory to report.
+        prov.loose_dirs.return_value = []
         return mock.patch.object(registry, "provider_for", return_value=prov)
 
     def test_ignored_and_counted_agree(self):

--- a/tests/test_the_roster_report_is_one_row_per_persona.py
+++ b/tests/test_the_roster_report_is_one_row_per_persona.py
@@ -1,0 +1,322 @@
+"""A persona DIRECTORY name is a committed value, and the roster reports print it (#472).
+
+`persona.list_personas()` globs ``personas/*/``, asks only for a leading underscore and a
+``persona.md``, and never asks `valid_name`. A filesystem forbids ``/`` and NUL and
+nothing else, so a commit can add a directory whose name holds a line separator —
+``evil\\u2028  fake     Fake role   vault2`` — and `charter persona list` then prints two
+table rows for one persona on disk, the second one entirely attacker-chosen and wearing
+charter's own column layout. `charter persona stats` does the same one command over.
+
+This is #453's mechanism (a committed value crossing into a format that has structure,
+without being escaped for it) on the two surfaces that report the roster. It is not a
+privilege boundary — nothing is executed off the back of a table row — but a forged row
+can name a persona that does not exist, or hide one that does, in the report a steward
+prunes from.
+
+**The property is "one physical line per persona", and it is measured, not counted into
+this file.** Every case renders the same roster twice — once with a separator in the name,
+once with a benign name of the same shape — and compares the two reports. A hard-coded row
+count would also be satisfied by a report that printed nothing at all.
+
+**The second property is that the columns still line up**, and it is the half a bound at
+the `print` alone does not give you. Both renderers size their columns from the names
+(`nw = max(len(n) for n in names) + 2`), so a bound applied only where the row is printed
+measures a string longer than the one it prints — every column after PERSONA shifts, for
+every persona in the table, whenever one committed name holds a separator. `one_line`
+*grows* a name (a separator becomes a four-character escape), so this is not hypothetical:
+it is what the fix does if the bound lands on the wrong side of the arithmetic. The
+alignment case below asserts the last column of each data row begins where the header's
+does — the last one because its offset is the sum of every width the renderer computed, so
+one probe catches a mis-measure in any of them.
+
+**The active marker compares identity, and the rows render a bound.** Those are different
+questions and this file pins them apart: two personas whose names differ only in
+characters `one_line` escapes must not both come out marked active, and the marked one
+must be the one that is actually selected.
+
+The next spelling: a roster surface this file does not drive. `list` and `stats` are the
+two named in #472; `lint` was bounded with #453 and is pinned in
+`test_a_server_name_cannot_declare_a_server.py`. Anything else that turns
+`list_personas()` into a table — a future `persona tree`, a JSON emitter — needs the same
+treatment, and `SEPARATORS` here is deliberately not the bound: the bound is
+`contain.one_line`, whose codespace-wide sweep lives in that same module.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import re
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from unittest import mock
+
+from charter import commands_persona, config, contain, persona
+from tests._isolation import PersonaIso
+
+#: Every spelling of "this line ends here" that `str.splitlines` honours, beyond the
+#: `\r`/`\n` pair everyone thinks of. Written as escapes, never as the literal character:
+#: a raw U+2028 in a fixture is invisible in the editor of whoever reads this next. NOT the
+#: bound — `contain.one_line` is, and it is asked of the whole codespace elsewhere. This
+#: exists so a failure names which spelling failed.
+SEPARATORS = {
+    "LF": "\n",
+    "CR": "\r",
+    "CRLF": "\r\n",
+    "U+2028 LINE SEPARATOR": "\u2028",
+    "U+2029 PARAGRAPH SEPARATOR": "\u2029",
+    "U+0085 NEL": "\x85",
+    "U+000B VERTICAL TAB": "\v",
+    "U+000C FORM FEED": "\f",
+    "U+001C FILE SEPARATOR": "\x1c",
+}
+
+#: The row the payload forges: charter's own column layout, a persona that does not exist,
+#: and a vault it does not have.
+FORGED_ROW = "  fake     Fake role   vault2"
+
+
+class Args:
+    """`cmd_persona_list` and `cmd_persona_stats` read attributes off argparse's namespace
+    with `getattr(..., default)`; this is the shape they both accept."""
+
+    name = None
+    recent_days = 14
+
+
+class RosterBase(PersonaIso):
+    def _roster(self, *names: str) -> None:
+        """Replace the roster with exactly *names*, each an ordinary loadable persona.
+
+        Ordinary on purpose: a persona that fails to load takes a different path through
+        both commands, and the defect here is on the path where everything is fine.
+        """
+        import shutil
+
+        for sub in config.PERSONAS_DIR.iterdir():
+            shutil.rmtree(sub) if sub.is_dir() else sub.unlink()
+        for i, n in enumerate(names):
+            self.make_persona(n, role=f"Role{i}")
+
+    @staticmethod
+    def _run(fn) -> list[str]:
+        """The physical lines *fn* writes to stdout."""
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            fn(Args())
+        return out.getvalue().splitlines()
+
+    def _list(self) -> list[str]:
+        return self._run(commands_persona.cmd_persona_list)
+
+    def _stats(self) -> list[str]:
+        return self._run(commands_persona.cmd_persona_stats)
+
+    def _skip_unless_nameable(self, name: str) -> None:
+        """Some filesystems refuse some of these names. Say so rather than passing."""
+        try:
+            (config.PERSONAS_DIR / name).mkdir()
+        except OSError:
+            self.skipTest(f"filesystem refuses the name {name!r}")
+        (config.PERSONAS_DIR / name).rmdir()
+
+
+class TestPersonaListGetsOneRowPerPersona(RosterBase):
+    def test_a_separator_in_a_directory_name_adds_no_row(self):
+        self._roster("good", f"evil{FORGED_ROW}")
+        benign = self._list()
+        for label, sep in SEPARATORS.items():
+            with self.subTest(separator=label):
+                name = f"evil{sep}{FORGED_ROW}"
+                self._skip_unless_nameable(name)
+                self._roster("good", name)
+                rows = self._list()
+                self.assertEqual(
+                    len(rows), len(benign),
+                    f"{label} in a committed directory name added a physical line to "
+                    f"`charter persona list`:\n" + "\n".join(rows))
+
+    def test_the_row_still_names_the_persona_in_its_bounded_spelling(self):
+        """Suppressing the name would satisfy the row count and tell the steward nothing.
+        Asserting the *bounded* spelling is also what says the count held because the name
+        was bounded, rather than because some other guard dropped the persona."""
+        for label, sep in SEPARATORS.items():
+            with self.subTest(separator=label):
+                name = f"evil{sep}{FORGED_ROW}"
+                self._skip_unless_nameable(name)
+                self._roster("good", name)
+                rows = self._list()
+                self.assertTrue(
+                    any(contain.one_line(name) in r for r in rows),
+                    f"the persona is not named in its bounded spelling:\n"
+                    + "\n".join(rows))
+
+    def test_the_columns_line_up_for_every_persona(self):
+        """The half a bound at the `print` alone does not give you: the widths are measured
+        from the names, so they have to be measured from the *bounded* names."""
+        for label, sep in SEPARATORS.items():
+            with self.subTest(separator=label):
+                name = f"evil{sep}{FORGED_ROW}"
+                self._skip_unless_nameable(name)
+                self._roster("good", name)
+                rows = self._list()
+                header = next(r for r in rows if "PERSONA" in r and "VAULT STATUS" in r)
+                at = header.index("VAULT STATUS")
+                # The last column, so its offset is the sum of every width this renderer
+                # computed — one probe that catches a mis-measure in any of them. Both
+                # personas carry no vault, so both rows end in the same word.
+                data = [r for r in rows if "no vault" in r]
+                self.assertEqual(len(data), 2, rows)
+                for r in data:
+                    self.assertEqual(
+                        r.index("no vault"), at,
+                        f"the VAULT STATUS column of this row starts at "
+                        f"{r.index('no vault')}, the header's at {at} — the widths were "
+                        f"measured from a string other than the one printed:\n"
+                        + "\n".join(rows))
+
+    def test_the_committed_rung_of_the_active_pointer_refuses_a_separator(self):
+        """Where the committed half of `resolve_active()` actually stands, asserted rather
+        than assumed: `personas/.default` and `charter.toml`'s `[persona] default` both go
+        through `persona.reference_ok`, which is `valid_name` — so neither can carry a
+        separator into the line above the table. Written down here because the next reader
+        of this file will otherwise reach for the same fixture I did."""
+        name = "evil\u2028  and another line"
+        self._skip_unless_nameable(name)
+        self._roster("good", name)
+        (config.PERSONAS_DIR / ".default").write_text(name)
+        self.assertIsNone(persona.resolve_active(),
+                          "the committed default rung stopped refusing a hostile name")
+
+    def test_the_active_line_stays_one_line(self):
+        """The rungs that are NOT gated — `$CHARTER_PERSONA`, `--persona`, the local
+        pointer — are the operator's own, so this is depth rather than a boundary. It is
+        one line above a table of one-line rows, and it costs a `one_line` call to keep it
+        that way."""
+        for label, sep in SEPARATORS.items():
+            with self.subTest(separator=label):
+                name = f"evil{sep}  and another line"
+                self._roster("good")
+                with mock.patch.dict(os.environ, {"CHARTER_PERSONA": name}):
+                    rows = self._list()
+                head = [r for r in rows if r.startswith("Active persona:")]
+                self.assertEqual(len(head), 1, rows)
+                self.assertIn(contain.one_line(name), head[0])
+                self.assertEqual([r for r in rows if "and another line" in r], head, rows)
+
+
+class TestTheActiveMarkerIsIdentityNotDisplay(RosterBase):
+    """Bounding is a display transform: two different names can share one bounded form.
+
+    `one_line` maps ``evil\\n`` and ``evil\\u2028`` — and ``evil\\x0a`` typed literally —
+    onto the same rendered string. Deciding the marker from that rendered string marks
+    every one of them active as soon as one of them is, which is a report that lies about
+    which persona a dispatch will use. The marker asks the raw names.
+    """
+
+    #: Two DIFFERENT directory names with ONE rendered form: `one_line` escapes the
+    #: separator in the first to the literal characters that spell the second. Written this
+    #: way rather than as two separator-bearing names \u2014 those render to *different*
+    #: escapes, so a roster of them would be marked correctly by a rendered-form comparison
+    #: too, and the case would pass under the mutation it exists to catch.
+    TWINS = ("evil\n", r"evil\x0a")
+
+    def test_only_the_selected_persona_is_marked(self):
+        for n in self.TWINS:
+            self._skip_unless_nameable(n)
+        self.assertEqual(len({contain.one_line(n) for n in self.TWINS}), 1,
+                         "fixture: these must share one rendered form or the case is "
+                         "asserting nothing about display-versus-identity")
+        self._roster(*self.TWINS)
+        persona.set_active(self.TWINS[1])
+        self.assertEqual(persona.resolve_active(), self.TWINS[1],
+                         "fixture: exactly one of the two is selected")
+        rows = [r for r in self._list() if r.startswith("* ")]
+        self.assertEqual(
+            len(rows), 1,
+            "both twins are marked active, so the marker is comparing what is DISPLAYED. "
+            "One of these two is what a dispatch resolves to and the other is not:\n"
+            + "\n".join(self._list()))
+        self.assertIn(contain.one_line(self.TWINS[1]), rows[0])
+
+    def test_the_marked_row_is_the_one_that_is_selected(self):
+        """And it is the persona charter would actually resolve, not merely *a* row."""
+        self._roster("evil\u2028fake", "evil")
+        persona.set_active("evil\u2028fake")
+        self.assertEqual(persona.resolve_active(), "evil\u2028fake")
+        rows = [r for r in self._list() if r.startswith("* ")]
+        self.assertEqual(len(rows), 1, rows)
+        self.assertIn(contain.one_line("evil\u2028fake"), rows[0])
+
+
+class TestPersonaStatsGetsOneRowPerPersona(RosterBase):
+    def test_a_separator_in_a_directory_name_adds_no_row(self):
+        self._roster("good", f"evil{FORGED_ROW}")
+        benign = self._stats()
+        for label, sep in SEPARATORS.items():
+            with self.subTest(separator=label):
+                name = f"evil{sep}{FORGED_ROW}"
+                self._skip_unless_nameable(name)
+                self._roster("good", name)
+                rows = self._stats()
+                self.assertEqual(
+                    len(rows), len(benign),
+                    f"{label} in a committed directory name added a physical line to "
+                    f"`charter persona stats`:\n" + "\n".join(rows))
+
+    def test_the_row_still_names_the_persona_in_its_bounded_spelling(self):
+        for label, sep in SEPARATORS.items():
+            with self.subTest(separator=label):
+                name = f"evil{sep}{FORGED_ROW}"
+                self._skip_unless_nameable(name)
+                self._roster("good", name)
+                rows = self._stats()
+                self.assertTrue(
+                    any(contain.one_line(name) in r for r in rows),
+                    f"the persona is not named in its bounded spelling:\n"
+                    + "\n".join(rows))
+
+    def test_the_columns_of_the_hostile_row_come_from_the_real_name(self):
+        """A bound is a display transform and must not become the lookup key.
+
+        The DISP column is `disp.get(r["persona"])` against the committed dispatch log,
+        keyed by the name as it is on disk. Bounding the roster once at the top \u2014 the
+        obvious over-correction \u2014 makes every such lookup miss, and the row then reports 0
+        dispatches for a persona that has been dispatched, plus the "never dispatched"
+        status charter retires personas on. A row-count-only test lets that straight
+        through, which is why the count is not the only thing asserted here.
+        """
+        name = "evil\u2028fake"
+        self._skip_unless_nameable(name)
+        self._roster("good", name)
+        from charter import dispatch
+
+        self.assertIsNotNone(dispatch.record(name), "fixture: the dispatch was not recorded")
+        self.assertEqual(dispatch.tally().get(name), 1, "fixture: the tally must see it")
+        rows = [r for r in self._stats() if contain.one_line(name) in r]
+        self.assertEqual(len(rows), 1, rows)
+        self.assertNotIn("never dispatched", rows[0])
+        # DISP is the last number before the status glyph.
+        m = re.search(r"(\d+)\s+[●○✗⚑⬡◇·]\s", rows[0])
+        self.assertIsNotNone(m, rows[0])
+        self.assertEqual(m.group(1), "1",
+                         f"the DISP column lost the dispatch this persona actually "
+                         f"had:\n{rows[0]}")
+
+
+class TestABenignRosterIsUnchanged(RosterBase):
+    """A bound that mangles an ordinary roster gets turned off by the first person it
+    annoys — and both reports are read by a human every day."""
+
+    def test_ordinary_names_are_printed_verbatim(self):
+        self._roster("steward", "release-manager", "db-admin")
+        rows = self._list()
+        for n in ("steward", "release-manager", "db-admin"):
+            self.assertEqual(len([r for r in rows if n in r]), 1, rows)
+        stats = self._stats()
+        for n in ("steward", "release-manager", "db-admin"):
+            self.assertEqual(len([r for r in stats if r.startswith(n)]), 1, stats)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_the_state_directory_is_charters_to_choose.py
+++ b/tests/test_the_state_directory_is_charters_to_choose.py
@@ -21,22 +21,44 @@ everybody pictures, while 0705, 0711, 0730 and 0701 list or traverse just as wel
 
 *Behaviour* is the CLI, in a subprocess, in a plane that has no ``.charter/`` yet — a fresh
 clone of a control plane, which is the ordinary case rather than an exotic one, since
-``.charter/`` is gitignored. Three different writers get the first move, because the defect
+``.charter/`` is gitignored. Four different writers get the first move, because the defect
 was never in one of them: it was in every writer that reached the state directory without
-going through the walk.
+going through the walk — and the fourth, ``persona remember --ephemeral``, is the one no
+reader of the package could have named (see below).
 
 *Coverage* is `tests/_statedirscan.py`, which reads the package and asks whether any
 ``mkdir`` left in it can still create a directory under the state directory without going
-through `config.private_mkdir`. A behavioural sweep can only ever cover the writers
-somebody thought to run; this is what notices the fourth one. Its own accuracy is tested
-here against sources built for the purpose, so a scanner that has quietly stopped seeing
-anything cannot report a clean package.
+through `config.private_mkdir` or `config.mkdir_for`. A behavioural sweep can only ever
+cover the writers somebody thought to run; this is what notices the fourth one. Its own
+accuracy is tested here against sources built for the purpose, so a scanner that has
+quietly stopped seeing anything cannot report a clean package.
 
-**The next spelling.** A path that reaches a writer as a parameter, or one assembled from
-a string, is invisible to the scanner — it says so itself. What keeps that from being an
-exposure is that the level those paths hang off, ``.charter/`` itself, is 0700: a
-directory created under it at the umask default is still reachable by nobody but its
-owner. The scan is about keeping the walk honest, not about being the guard.
+**The spelling this file used to excuse, and the property that replaced it.** The first
+cut of the paragraph above said a path reaching a writer as a *parameter* was invisible to
+the scan, and that this was safe "because the level those paths hang off, ``.charter/``
+itself, is 0700". That reasoning was wrong on the exact flow that exercises it. On a fresh
+clone ``.charter/`` is gitignored and absent, so ``charter persona remember <p> "…"
+--ephemeral`` — whose directory reaches `memstore.write` as a parameter — is what *creates
+the state directory itself*, at 0755 under ``umask 022`` and 0777 under ``umask 000``.
+There was no 0700 level above it to hang off. Two things changed together, and either
+alone would have been half a fix:
+
+- `config.mkdir_for` decides at **runtime**, on where the path actually is, so a writer
+  that is handed its directory is right about a path no reader could have named. It is a
+  dispatch, not a privatiser: a committed directory passed to it keeps the operator's
+  umask, which `TheDispatchOnWhereThePathIs` and the committed CLI case both pin.
+- the scan stopped matching the spelling ``.STATE_DIR`` at the call site and started
+  asking **reachability** — a call that passes a state path into a package function taints
+  that parameter, transitively, and a ``mkdir`` on a tainted parameter is a violation
+  exactly as a ``mkdir`` on ``config.STATE_DIR / …`` is. Put `memstore`'s bare mkdir back
+  and the scan names it.
+
+**The next spelling after this one.** A path assembled from a string
+(``Path(str(config.ROOT) + "/.charter")``), or arriving from outside the package — read
+out of JSON, taken from ``argv`` — names no attribute and makes no call, so the reader
+cannot see it and this time the scan says so without an excuse attached. What answers it
+is `config.mkdir_for`, at runtime. The scan's job is to prove every writer is routed; the
+guard is `config`.
 
 `charter statusline` is deliberately NOT one of the commands swept: it forks a detached
 ``charter _version-check``, and no test in this suite makes a network call, directly or by
@@ -105,6 +127,13 @@ class TheCliDecidesIt(unittest.TestCase):
             stdin=subprocess.DEVNULL)
         if r.returncode != 0:
             raise AssertionError(f"could not build the fixture plane:\n{r.stdout}\n{r.stderr}")
+        # A persona, written as plain files rather than by `charter persona create`, so
+        # the template still cannot smuggle a `.charter/` into every case. The ephemeral
+        # sweep below needs one to exist; nothing else here reads it.
+        d = cls.template / "personas" / "steward"
+        d.mkdir(parents=True)
+        (d / "persona.md").write_text(
+            "---\nname: steward\nrole: Steward\n---\n\n# Steward\n\ncharter body\n")
         if (cls.template / ".charter").exists():
             raise AssertionError(
                 "`charter init` now creates `.charter/` itself. That is not wrong, but it "
@@ -146,7 +175,16 @@ class TheCliDecidesIt(unittest.TestCase):
             "the mode of a directory nobody made. Pick a command that does.")
         return stat.S_IMODE(sd.stat().st_mode)
 
-    def _sweep(self, label: str, args: tuple, stdin: str = "") -> None:
+    def _sweep(self, label: str, args: tuple, stdin: str = "",
+               wrote: str | None = None) -> None:
+        """Run *args* under each umask in a fresh plane and assert one private mode.
+
+        *wrote* is a glob the command must have left behind. Without it a case passes as
+        long as `.charter/` came out private — including when the command it names failed
+        outright and some *other* writer in the same process (a trace line, a session
+        marker) made the directory. That is the shape where a fixture goes wrong silently
+        and the sweep keeps saying OK.
+        """
         seen = {}
         for um in UMASKS:
             with self.subTest(umask=oct(um)):
@@ -159,6 +197,12 @@ class TheCliDecidesIt(unittest.TestCase):
                 self.assertNotIn("Traceback (most recent call last):",
                                  (proc.stdout or "") + (proc.stderr or ""),
                                  f"the command crashed:\n{proc.stdout}\n{proc.stderr}")
+                if wrote is not None:
+                    self.assertTrue(
+                        list(plane.glob(wrote)),
+                        f"`charter {' '.join(args)}` left nothing at {wrote}, so whatever "
+                        f"made `.charter/` here was not the writer this case names:\n"
+                        f"{proc.stdout}\n{proc.stderr}")
                 mode = self.state_mode(plane)
                 seen[um] = mode
                 self.assertEqual(
@@ -189,6 +233,47 @@ class TheCliDecidesIt(unittest.TestCase):
         payload = json.dumps({"session_id": "sess-470", "cwd": ".",
                               "tool_name": "Bash", "tool_input": {"command": "ls"}})
         self._sweep("pretooluse", ("hook", "pretooluse"), stdin=payload)
+
+    def test_ephemeral_memory_gets_there_first(self) -> None:
+        """The fourth writer — and the one the scan could not see.
+
+        `persona remember … --ephemeral` writes under ``PERSONA_STATE_DIR``, and the path
+        reaches the writer as a **parameter**: `memstore.write(mem_dir, …)` is handed the
+        committed ``personas/<n>/memory`` on one call and this gitignored one on the next.
+        No line in `memstore` spells a state name, so a scan matching the spelling saw a
+        clean package while this command created `.charter/` itself at the umask default
+        (#470). `config.mkdir_for` asks the question the caller alone could answer.
+        """
+        self._sweep("ephem", ("persona", "remember", "steward",
+                              "an ordinary scratch note", "--ephemeral"),
+                    wrote=".charter/persona-state/ephemeral/*/steward/*.md")
+
+    def test_the_committed_quadrant_is_not_tightened(self) -> None:
+        """The other half of the same dispatch, and not a footnote: a `mkdir_for` that
+        made everything private would pass the sweep above and quietly turn committed
+        persona directories 0700 — the same overreach as chmod-ing a `.charter/` charter
+        did not create (#331). Measured against a control directory made by a plain
+        `mkdir` in this process under the same umask, so the assertion is "whatever the
+        operator's umask says", not a mode written down here.
+        """
+        plane = self.plane("committed")
+        old = os.umask(0o022)
+        try:
+            control = plane / "control-dir"
+            control.mkdir()
+            proc = self.charter(plane, "persona", "remember", "steward", "a committed fact")
+        finally:
+            os.umask(old)
+        self.assertEqual(proc.returncode, 0, f"{proc.stdout}\n{proc.stderr}")
+        mem = plane / "personas" / "steward" / "memory"
+        self.assertTrue(mem.is_dir(), "the committed memory directory was not created, so "
+                                      "this case measures nothing")
+        self.assertEqual(
+            stat.S_IMODE(mem.stat().st_mode), stat.S_IMODE(control.stat().st_mode),
+            "charter tightened a committed directory the operator's umask had modes for")
+        self.assertNotEqual(stat.S_IMODE(mem.stat().st_mode) & 0o077, 0,
+                            "under umask 022 a plain mkdir is 0755 — a 0700 here means "
+                            "`mkdir_for` stopped dispatching and is privatising everything")
 
     def test_an_existing_loose_state_directory_is_left_exactly_as_it_is(self) -> None:
         """The other half, and it is not a compromise: charter tightens what it creates and
@@ -273,6 +358,116 @@ class ThePrivateWalkItself(PersonaIso):
         self.assertEqual(calls, [Path(self.tmp) / "via-secrets"])
 
 
+class TheDispatchOnWhereThePathIs(PersonaIso):
+    """`config.mkdir_for` — the walk for a writer that is **handed** its directory.
+
+    `private_mkdir` closes the writers that name a state path themselves. It cannot close
+    the ones that do not: `memstore.write(mem_dir, …)` is handed
+    ``personas/<n>/memory`` on one call and ``PERSONA_STATE_DIR/ephemeral/<sid>/<n>`` on
+    the next, and only the caller knows which. Routing that one caller would have left the
+    next handed writer exactly as exposed, so the dispatch is on **where the path is**, at
+    runtime, and both directions of it are pinned here — a `mkdir_for` that privatised
+    everything would pass the sweep above while turning committed persona directories 0700.
+    """
+
+    def test_a_handed_state_path_is_private_under_every_umask(self) -> None:
+        for um in UMASKS:
+            with self.subTest(umask=oct(um)):
+                # Removed between rounds so each umask CREATES `.charter/` itself, which is
+                # the flow from the issue — a fresh clone has none.
+                shutil.rmtree(config.STATE_DIR, ignore_errors=True)
+                leaf = config.STATE_DIR / f"handed-{um:03o}" / "a" / "b"
+                old = os.umask(um)
+                try:
+                    config.mkdir_for(leaf)
+                finally:
+                    os.umask(old)
+                chain = modes_up_to(leaf, config.STATE_DIR)
+                self.assertGreaterEqual(len(chain), 4, "a short chain makes this vacuous")
+                for p, mode in chain.items():
+                    self.assertEqual(mode & 0o077, 0, f"{p} came out {oct(mode)[-3:]}")
+
+    def test_a_handed_path_outside_it_keeps_the_umask_and_is_not_tightened(self) -> None:
+        """Measured against a control directory made by a plain `mkdir` in this process
+        under the same umask — so the assertion is "whatever the operator's umask says",
+        not a mode written down here that a changed default would quietly falsify."""
+        old = os.umask(0o022)
+        try:
+            control = Path(self.tmp) / "control"
+            control.mkdir()
+            d = config.PERSONAS_DIR / "steward" / "memory"
+            config.mkdir_for(d)
+        finally:
+            os.umask(old)
+        self.assertEqual(stat.S_IMODE(d.stat().st_mode),
+                         stat.S_IMODE(control.stat().st_mode),
+                         "charter tightened a committed directory it merely wrote into")
+        self.assertNotEqual(stat.S_IMODE(d.stat().st_mode) & 0o077, 0,
+                            "0700 here means the dispatch stopped dispatching")
+
+    def test_the_state_directory_itself_counts_as_under_it(self) -> None:
+        self.assertTrue(config.under_state(config.STATE_DIR))
+        self.assertTrue(config.under_state(config.STATE_DIR / "vaults"))
+
+    def test_a_sibling_sharing_its_name_as_a_prefix_does_not(self) -> None:
+        """The classic prefix bug: ``.charter-backup`` starts with ``.charter`` and is a
+        different directory. A ``startswith`` on the bare string says otherwise."""
+        self.assertFalse(config.under_state(
+            config.STATE_DIR.parent / f"{config.STATE_DIR.name}-backup"))
+
+    def test_a_traversal_back_out_of_it_does_not(self) -> None:
+        self.assertFalse(config.under_state(config.STATE_DIR / ".." / "personas" / "x"))
+
+    def test_a_path_reaching_it_through_a_symlink_still_does(self) -> None:
+        """The two spellings disagree here, and the answer is "yes".
+
+        Lexically ``<tmp>/link/cache`` is nowhere near the state directory; resolved it is
+        inside it. Built here rather than relying on the platform's own (``/tmp`` →
+        ``/private/tmp`` on macOS) so the case is a case on every platform.
+        """
+        config.private_mkdir(config.STATE_DIR)
+        link = Path(self.tmp) / "link-to-state"
+        link.symlink_to(config.STATE_DIR)
+        self.assertFalse(str(link / "cache").startswith(str(config.STATE_DIR)),
+                         "precondition: the lexical spelling must NOT match, or this "
+                         "case is not about resolution at all")
+        self.assertTrue(config.under_state(link / "cache"))
+
+
+class TheHandedWriterAsksWhereItIs(PersonaIso):
+    """`memstore`, the writer the whole class of defect ran through, at handler level.
+
+    One flow, two quadrants, one umask: `persona.remember` picks the directory and
+    `memstore.write` creates it, and the mode has to come out different for the two.
+    """
+
+    def test_ephemeral_memory_is_private_and_committed_memory_is_left_alone(self) -> None:
+        from charter import persona
+
+        self.make_persona("steward")
+        old = os.umask(0o022)
+        try:
+            control = Path(self.tmp) / "control"
+            control.mkdir()
+            # `make_persona` scaffolded the committed store already; remove it so the
+            # committed half measures a directory THIS call creates, not that one.
+            shutil.rmtree(persona.memory_dir("steward"), ignore_errors=True)
+            eph = persona.remember("steward", "an ordinary scratch note", ephemeral=True)
+            com = persona.remember("steward", "a fact worth committing")
+        finally:
+            os.umask(old)
+
+        chain = modes_up_to(eph.parent, config.STATE_DIR)
+        self.assertGreaterEqual(len(chain), 4, "a short chain makes this vacuous")
+        for p, mode in chain.items():
+            self.assertEqual(mode & 0o077, 0,
+                             f"{p} came out {oct(mode)[-3:]} — the ephemeral quadrant is "
+                             f"under `.charter/` and the umask decided its mode")
+        self.assertEqual(stat.S_IMODE(com.parent.stat().st_mode),
+                         stat.S_IMODE(control.stat().st_mode),
+                         "the committed quadrant was tightened; it is the operator's")
+
+
 class TheScanSeesWhatItClaims(unittest.TestCase):
     """The coverage scanner's own accuracy, against sources written for the purpose.
 
@@ -318,6 +513,129 @@ class TheScanSeesWhatItClaims(unittest.TestCase):
     def test_the_routed_call_is_not_flagged(self) -> None:
         src = ("def f():\n    config.private_mkdir(config.STATE_DIR / 'cache')\n")
         self.assertEqual(scan.violations(src, self.names), [])
+
+
+class TheHandedScanSeesWhatItClaims(unittest.TestCase):
+    """The second half of the scanner's accuracy, against a package built for the purpose.
+
+    This half is the one that was missing, so it gets the same treatment the first got: a
+    scan that has quietly stopped propagating arguments reports a clean package, and a
+    scan that propagates everything reports a package that cannot be cleaned. Both
+    failures are checked here, because only one of them is loud in production.
+    """
+
+    def setUp(self) -> None:
+        self.names = scan.state_attribute_names()
+
+    def hits(self, **sources) -> dict:
+        return scan.handed_violations(scan.modules_from(sources), self.names)
+
+    #: The callee every case below hands a directory to — `memstore.write`'s shape.
+    STORE = "def write(mem_dir, text):\n    mem_dir.mkdir(parents=True, exist_ok=True)\n"
+
+    def test_a_state_path_passed_as_an_argument_taints_the_parameter(self) -> None:
+        """The defect, in eight lines: nothing in `store` spells a state name."""
+        self.assertEqual(
+            self.hits(store=self.STORE,
+                      caller="from . import store\n\n"
+                             "def go():\n    store.write(config.STATE_DIR / 'x', 'y')\n"),
+            {"charter/store.py": [(2, "mem_dir")]})
+
+    def test_a_committed_path_passed_the_same_way_is_not(self) -> None:
+        """A scan that flagged every parameter would flag this one, and would be "fixed"
+        by making committed directories private — which is the other defect."""
+        self.assertEqual(
+            self.hits(store=self.STORE,
+                      caller="from . import store\n\n"
+                             "def go():\n    store.write(config.PERSONAS_DIR / 'x', 'y')\n"),
+            {})
+
+    def test_the_routed_call_clears_it(self) -> None:
+        """`config.mkdir_for` is not a method named ``mkdir``, so the taint stays and the
+        violation goes — which is what "routed" has to mean for the handed half."""
+        self.assertEqual(
+            self.hits(store="def write(mem_dir, text):\n    config.mkdir_for(mem_dir)\n",
+                      caller="from . import store\n\n"
+                             "def go():\n    store.write(config.STATE_DIR / 'x', 'y')\n"),
+            {})
+
+    def test_a_state_path_helper_taints_it_too(self) -> None:
+        """The real caller's shape: `persona.remember` passes ``ephemeral_dir(name)``,
+        not ``config.PERSONA_STATE_DIR`` spelled out at the call site."""
+        self.assertEqual(
+            self.hits(store=self.STORE,
+                      persona="def ephemeral_dir(n):\n    return config.STATE_DIR / 'e' / n\n",
+                      caller="from . import persona, store\n\n"
+                             "def go(n):\n    store.write(persona.ephemeral_dir(n), 'y')\n"),
+            {"charter/store.py": [(2, "mem_dir")]})
+
+    def test_the_taint_survives_another_hop(self) -> None:
+        """Depth of the call chain is not a way out of the scan."""
+        self.assertEqual(
+            self.hits(store=self.STORE,
+                      middle="from . import store\n\n"
+                             "def save(d, t):\n    store.write(d, t)\n",
+                      caller="from . import middle\n\n"
+                             "def go():\n    middle.save(config.STATE_DIR / 'x', 'y')\n"),
+            {"charter/store.py": [(2, "mem_dir")]})
+
+    def test_a_keyword_argument_is_the_same_question(self) -> None:
+        self.assertEqual(
+            self.hits(store=self.STORE,
+                      caller="from . import store\n\n"
+                             "def go():\n"
+                             "    store.write(text='y', mem_dir=config.STATE_DIR / 'x')\n"),
+            {"charter/store.py": [(2, "mem_dir")]})
+
+    def test_a_local_assignment_does_not_hide_the_argument(self) -> None:
+        self.assertEqual(
+            self.hits(store=self.STORE,
+                      caller="from . import store\n\n"
+                             "def go():\n    d = config.STATE_DIR / 'x'\n"
+                             "    store.write(d, 'y')\n"),
+            {"charter/store.py": [(2, "mem_dir")]})
+
+    def test_a_helper_of_the_same_name_in_another_module_does_not_taint_it(self) -> None:
+        """The spelling trap this scan is built to avoid, and the one a bare-name match
+        walks straight into: ``_dir()`` exists in more than one module here, and only some
+        of them return state. `dispatch._dir()` returns a committed ``personas/`` path —
+        matched by name against `frame`'s, it would be flagged forever, and the only way to
+        clear it would be to route a committed directory through the private walk.
+        """
+        self.assertEqual(
+            self.hits(store=self.STORE,
+                      framey="def _dir():\n    return config.STATE_DIR / 'f'\n",
+                      dispatch="def _dir():\n    return config.PERSONAS_DIR / 'd'\n\n"
+                               "def go():\n    pass\n",
+                      caller="from . import dispatch, store\n\n"
+                             "def go():\n    store.write(dispatch._dir(), 'y')\n"),
+            {})
+
+    def test_an_untainted_parameter_is_left_alone(self) -> None:
+        """No caller passes state at all — the whole package is clean, and a scan that
+        cannot say so is a scan nobody can act on."""
+        self.assertEqual(self.hits(store=self.STORE), {})
+
+    def test_config_own_walk_is_exempt_and_named_in_full(self) -> None:
+        """`config`'s own ``mkdir`` calls ARE the routing — flagging them would be asking
+        the guard to route through itself. Exempted by ``module.function``, so the same
+        function name in another module is still scanned."""
+        for qual in scan.THE_WALK:
+            module, _, fn = qual.rpartition(".")
+            self.assertTrue(hasattr(config, fn), f"{qual} no longer exists in `config`; "
+                                                 "the exemption list is stale")
+        self.assertEqual(
+            self.hits(config="def mkdir_for(p):\n    p.mkdir(parents=True, exist_ok=True)\n",
+                      caller="from . import config as c\n\n"
+                             "def go():\n    c.mkdir_for(config.STATE_DIR / 'x')\n"),
+            {})
+        self.assertEqual(
+            self.hits(other="def mkdir_for(p):\n    p.mkdir(parents=True, exist_ok=True)\n",
+                      caller="from . import other\n\n"
+                             "def go():\n    other.mkdir_for(config.STATE_DIR / 'x')\n"),
+            {"charter/other.py": [(2, "p")]},
+            "the exemption is keyed to the bare function name, so any module can opt out "
+            "of the scan by naming a function `mkdir_for`")
 
 
 class EveryStateWriterGoesThroughTheWalk(unittest.TestCase):

--- a/tests/test_the_state_directory_is_charters_to_choose.py
+++ b/tests/test_the_state_directory_is_charters_to_choose.py
@@ -514,6 +514,69 @@ class TheScanSeesWhatItClaims(unittest.TestCase):
         src = ("def f():\n    config.private_mkdir(config.STATE_DIR / 'cache')\n")
         self.assertEqual(scan.violations(src, self.names), [])
 
+    #: Every spelling of "make a directory here" the stdlib offers, and where each one
+    #: keeps its path. The scan advertised ``makedirs`` coverage while reading the
+    #: RECEIVER of every attribute call — which is where ``p.mkdir()`` keeps its path and
+    #: not where ``os.makedirs(p)`` does, so ``os.makedirs`` was scanned as the expression
+    #: ``os`` and never flagged. Keying on the NAME instead (``makedirs`` takes an
+    #: argument, ``mkdir`` a receiver) swaps one spelling for another and still lets
+    #: ``os.mkdir(p)`` through, so the table is the test: each of these creates a
+    #: directory at a state path, and the scan owes the same answer to all of them.
+    MAKERS = {
+        "bound method, path is the receiver":
+            "def f():\n    (config.STATE_DIR / 'x').mkdir(parents=True, exist_ok=True)\n",
+        "module function, path is argument 0":
+            "import os\ndef f():\n    os.makedirs(config.STATE_DIR / 'x', exist_ok=True)\n",
+        "os.mkdir — the one a `makedirs` name-match still misses":
+            "import os\ndef f():\n    os.mkdir(config.STATE_DIR / 'x')\n",
+        "the path arrives by keyword":
+            "import os\ndef f():\n    os.makedirs(name=config.STATE_DIR / 'x')\n",
+        "imported bare":
+            "from os import makedirs\ndef f():\n    makedirs(config.STATE_DIR / 'x')\n",
+        "imported under another name":
+            "from os import makedirs as md\ndef f():\n    md(config.STATE_DIR / 'x')\n",
+        "unbound, path is argument 0 of an attribute call":
+            "from pathlib import Path\ndef f():\n    Path.mkdir(config.STATE_DIR / 'x')\n",
+    }
+
+    def test_every_spelling_of_making_a_directory_is_scanned(self) -> None:
+        """The scan's own title claims ``mkdir``/``makedirs``. This is that claim."""
+        for label, src in self.MAKERS.items():
+            with self.subTest(label):
+                hits = scan.violations(src, self.names)
+                self.assertEqual([e for _ln, e in hits], ["config.STATE_DIR / 'x'"],
+                                 f"{label}: a state directory made here went unseen")
+
+    def test_the_same_spellings_on_a_committed_path_are_left_alone(self) -> None:
+        """The other half of the claim, and the one a scan that flagged every argument
+        would fail: widening where the path is looked for must not widen WHAT counts as
+        one, or the fix is to route committed directories through the private walk."""
+        for label, src in self.MAKERS.items():
+            with self.subTest(label):
+                self.assertEqual(
+                    scan.violations(src.replace("STATE_DIR", "PERSONAS_DIR"), self.names),
+                    [], f"{label}: a committed directory was flagged as state")
+
+    def test_a_mode_argument_is_not_mistaken_for_a_path(self) -> None:
+        """`Path.mkdir`'s first positional argument is the MODE. Scanning every position
+        that could hold a path means scanning that one too, and it must not hit."""
+        src = "def f():\n    (config.PERSONAS_DIR / 'x').mkdir(0o700, exist_ok=True)\n"
+        self.assertEqual(scan.violations(src, self.names), [])
+
+    def test_the_handed_half_sees_the_module_function_spellings_too(self) -> None:
+        """The handed scan reads the path out of the same place the named one does, so
+        the blind spot was shared. `memstore` is the module that fell through once."""
+        caller = ("from . import store\n\n"
+                  "def go():\n    store.write(config.STATE_DIR / 'x', 'y')\n")
+        for label, body in (("os.makedirs", "    os.makedirs(mem_dir, exist_ok=True)\n"),
+                            ("os.mkdir", "    os.mkdir(mem_dir)\n")):
+            with self.subTest(label):
+                mods = scan.modules_from({
+                    "store": "import os\n\ndef write(mem_dir, text):\n" + body,
+                    "caller": caller})
+                self.assertEqual(scan.handed_violations(mods, self.names),
+                                 {"charter/store.py": [(4, "mem_dir")]})
+
 
 class TheHandedScanSeesWhatItClaims(unittest.TestCase):
     """The second half of the scanner's accuracy, against a package built for the purpose.

--- a/tests/test_the_state_directory_is_charters_to_choose.py
+++ b/tests/test_the_state_directory_is_charters_to_choose.py
@@ -1,0 +1,336 @@
+"""``.charter/`` is 0700 because charter says so, not because of the operator's umask.
+
+`base.make_private_dir` created every level of a **vault** path at 0700, and the state
+directory is not one of those levels on any flow that reaches it first. `charter vault
+add` writes the local registry through a bare ``mkdir(parents=True, exist_ok=True)`; the
+SessionStart hook writes a workspace pointer; the PreToolUse hook writes ``guard-seen.json``;
+the status line writes a cache. Whichever ran first decided the mode, at ``0o777 & ~umask``
+— 0755 on the default ``umask 022``. So every account on the machine could list the plane's
+state directory, and *which* command you happened to run first decided whether it could
+(#470).
+
+**The property is "the umask does not decide it", not "the mode is 0700".** Those come
+apart: a fix that hardcoded 0755 would satisfy "the mode is a constant" and be no fix at
+all, and one that only works under `umask 022` satisfies nothing. Every case below runs the
+same flow under three umasks — ``000`` (0777 by default), ``022`` (the default) and ``077``
+(already private) — and asserts the same private mode came out of all three. Modes are
+tested through ``mode & 0o077``, never against a list of known-bad values: 0755 is the one
+everybody pictures, while 0705, 0711, 0730 and 0701 list or traverse just as well.
+
+**Two halves, because either alone is a fix that looks whole.**
+
+*Behaviour* is the CLI, in a subprocess, in a plane that has no ``.charter/`` yet — a fresh
+clone of a control plane, which is the ordinary case rather than an exotic one, since
+``.charter/`` is gitignored. Three different writers get the first move, because the defect
+was never in one of them: it was in every writer that reached the state directory without
+going through the walk.
+
+*Coverage* is `tests/_statedirscan.py`, which reads the package and asks whether any
+``mkdir`` left in it can still create a directory under the state directory without going
+through `config.private_mkdir`. A behavioural sweep can only ever cover the writers
+somebody thought to run; this is what notices the fourth one. Its own accuracy is tested
+here against sources built for the purpose, so a scanner that has quietly stopped seeing
+anything cannot report a clean package.
+
+**The next spelling.** A path that reaches a writer as a parameter, or one assembled from
+a string, is invisible to the scanner — it says so itself. What keeps that from being an
+exposure is that the level those paths hang off, ``.charter/`` itself, is 0700: a
+directory created under it at the umask default is still reachable by nobody but its
+owner. The scan is about keeping the walk honest, not about being the guard.
+
+`charter statusline` is deliberately NOT one of the commands swept: it forks a detached
+``charter _version-check``, and no test in this suite makes a network call, directly or by
+proxy. It reaches the state directory through `update.maybe_spawn`'s lock file, which the
+scan covers.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from charter import config
+
+from tests import _statedirscan as scan
+from tests._isolation import PersonaIso
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: ``000`` makes a bare mkdir 0777, ``022`` is the default that shipped the defect, ``077``
+#: is the one under which the old code was accidentally right. A fix has to produce the
+#: same private mode under all three — the property is the independence, not the value.
+UMASKS = (0o000, 0o022, 0o077)
+
+
+def modes_up_to(leaf, stop) -> dict:
+    """``{path: mode}`` for every directory from *leaf* up to and including *stop*."""
+    out, cur, stop_rp = {}, Path(leaf), Path(stop).resolve()
+    while True:
+        out[cur] = stat.S_IMODE(cur.stat().st_mode)
+        if cur.resolve() == stop_rp or cur.parent == cur:
+            return out
+        cur = cur.parent
+
+
+class TheCliDecidesIt(unittest.TestCase):
+    """The real binary, in a real plane, with no ``.charter/`` in it yet.
+
+    A subprocess rather than a handler call, because the umask is a property of the
+    process and because the defect was in the *order commands run in* — which is a thing
+    only the CLI actually has.
+    """
+
+    #: One plane, built once by `charter init` and copied per case. Building it per case
+    #: costs a second each; copying is free, and `init` creates no `.charter/`, so the
+    #: template cannot smuggle a mode into a case.
+    template: Path
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._root = Path(tempfile.mkdtemp(prefix="charter-statedir-"))
+        cls.template = cls._root / "template"
+        cls.template.mkdir()
+        env = cls.child_env()
+        r = subprocess.run(
+            [sys.executable, "-m", "charter", "init", "--forge", "github",
+             "--owner", "acme", "--no-front-door"],
+            cwd=cls.template, env=env, text=True, capture_output=True, timeout=120,
+            stdin=subprocess.DEVNULL)
+        if r.returncode != 0:
+            raise AssertionError(f"could not build the fixture plane:\n{r.stdout}\n{r.stderr}")
+        if (cls.template / ".charter").exists():
+            raise AssertionError(
+                "`charter init` now creates `.charter/` itself. That is not wrong, but it "
+                "makes every case below start from a state directory the template chose — "
+                "copy the plane WITHOUT it, or these tests stop measuring anything.")
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        shutil.rmtree(cls._root, ignore_errors=True)
+
+    @staticmethod
+    def child_env() -> dict:
+        """The child's environment: this checkout on the path, and every charter variable
+        that could redirect the state directory removed, so the plane under test is the
+        temp one and nothing reaches the developer's own."""
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(REPO_ROOT)
+        for var in ("CHARTER_HOME", "CHARTER_PERSONA", "CHARTER_WORKSPACE",
+                    "CHARTER_WORKTREES", "CHARTER_CONFIG_HOME"):
+            env.pop(var, None)
+        return env
+
+    def plane(self, tag: str) -> Path:
+        d = self._root / tag
+        shutil.copytree(self.template, d)
+        self.assertFalse((d / ".charter").exists(), "precondition: charter creates it")
+        return d
+
+    def charter(self, plane: Path, *args: str, stdin: str = "") -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, "-m", "charter", *args], cwd=plane, env=self.child_env(),
+            input=stdin, text=True, capture_output=True, timeout=120)
+
+    def state_mode(self, plane: Path) -> int:
+        sd = plane / ".charter"
+        self.assertTrue(
+            sd.is_dir(),
+            "this command no longer creates `.charter/`, so the case proves nothing about "
+            "the mode of a directory nobody made. Pick a command that does.")
+        return stat.S_IMODE(sd.stat().st_mode)
+
+    def _sweep(self, label: str, args: tuple, stdin: str = "") -> None:
+        seen = {}
+        for um in UMASKS:
+            with self.subTest(umask=oct(um)):
+                plane = self.plane(f"{label}-{um:03o}")
+                old = os.umask(um)
+                try:
+                    proc = self.charter(plane, *args, stdin=stdin)
+                finally:
+                    os.umask(old)
+                self.assertNotIn("Traceback (most recent call last):",
+                                 (proc.stdout or "") + (proc.stderr or ""),
+                                 f"the command crashed:\n{proc.stdout}\n{proc.stderr}")
+                mode = self.state_mode(plane)
+                seen[um] = mode
+                self.assertEqual(
+                    mode & 0o077, 0,
+                    f"under umask {oct(um)}, `charter {' '.join(args)}` left `.charter` at "
+                    f"{oct(mode)[-3:]} — another account on this machine can reach the "
+                    f"plane's state directory")
+        self.assertEqual(
+            len(set(seen.values())), 1,
+            f"the umask still decides it: {[(oct(u), oct(m)[-3:]) for u, m in seen.items()]}")
+
+    def test_vault_add_is_the_flow_from_the_issue(self) -> None:
+        """`charter vault add` writes the local registry first, and that write is what
+        created `.charter/` at the umask default on the flow the issue reproduces."""
+        self._sweep("vaultadd", ("vault", "add", "devops", "--provider", "plain-file"))
+
+    def test_the_session_start_hook_gets_there_first_on_a_fresh_clone(self) -> None:
+        """The ordinary case: `.charter/` is gitignored, so a teammate who clones the
+        plane has none, and the first thing that runs is a hook — which writes a workspace
+        pointer under `.charter/sessions/`, not through any vault writer."""
+        payload = json.dumps({"session_id": "sess-470", "cwd": "."})
+        self._sweep("sessionstart", ("hook", "sessionstart"), stdin=payload)
+
+    def test_the_pretooluse_hook_gets_there_first(self) -> None:
+        """A third writer, and a third file: `guard-seen.json` sits directly in
+        `.charter/`. Three independent paths, because the defect was never in one writer —
+        it was in every writer that reached the state directory without the walk."""
+        payload = json.dumps({"session_id": "sess-470", "cwd": ".",
+                              "tool_name": "Bash", "tool_input": {"command": "ls"}})
+        self._sweep("pretooluse", ("hook", "pretooluse"), stdin=payload)
+
+    def test_an_existing_loose_state_directory_is_left_exactly_as_it_is(self) -> None:
+        """The other half, and it is not a compromise: charter tightens what it creates and
+        reports what it did not. `$CHARTER_HOME` can point the state directory at any path
+        on the machine, so "chmod whatever we land in" is how charter would come to tighten
+        a home or a shared team directory unprompted (#331)."""
+        plane = self.plane("preexisting")
+        sd = plane / ".charter"
+        sd.mkdir()
+        os.chmod(sd, 0o755)
+        self.charter(plane, "vault", "add", "devops", "--provider", "plain-file")
+        self.assertEqual(stat.S_IMODE(sd.stat().st_mode), 0o755,
+                         "charter chmod-ed a directory it did not create")
+
+
+class ThePrivateWalkItself(PersonaIso):
+    """`config.private_mkdir`, at the level the CLI sweep cannot reach."""
+
+    def test_every_level_it_creates_is_private(self) -> None:
+        """The defect the first cut of #437 shipped: ``mkdir(parents=True, mode=0o700)``
+        applies *mode* to the leaf only and creates the parents at the umask default."""
+        for um in UMASKS:
+            with self.subTest(umask=oct(um)):
+                old = os.umask(um)
+                self.addCleanup(os.umask, old)
+                root = Path(self.tmp) / f"walk-{um:03o}"
+                leaf = root / "a" / "b" / "c"
+                config.private_mkdir(leaf)
+                chain = modes_up_to(leaf, root)
+                self.assertGreaterEqual(len(chain), 3, "a short chain makes this vacuous")
+                for p, mode in chain.items():
+                    self.assertEqual(mode & 0o077, 0, f"{p} came out {oct(mode)[-3:]}")
+
+    def test_an_existing_directory_keeps_its_mode(self) -> None:
+        d = Path(self.tmp) / "pre"
+        d.mkdir()
+        os.chmod(d, 0o755)
+        config.private_mkdir(d)
+        self.assertEqual(stat.S_IMODE(d.stat().st_mode), 0o755)
+
+    def test_the_leaf_is_attempted_before_the_parents(self) -> None:
+        """A leaf that cannot exist must not leave its parents standing behind it.
+
+        `frame.state` counts a respawn against a directory `reap` may have deleted, and
+        pins "does not raise **or create**". A walk that made the parents on the way down
+        would resurrect a frame root under whoever had just reaped it — so the order is
+        `pathlib`'s: leaf first, parents only on ``FileNotFoundError``.
+        """
+        root = Path(self.tmp) / "leaffirst"
+        overlong = root / "missing" / ("x" * 5000)
+        with self.assertRaises(OSError):
+            config.private_mkdir(overlong)
+        self.assertFalse(root.exists(),
+                         "the parents were created for a leaf that could never exist")
+
+    def test_parents_false_refuses_to_build_the_path(self) -> None:
+        root = Path(self.tmp) / "noparents"
+        with self.assertRaises(FileNotFoundError):
+            config.private_mkdir(root / "a" / "b", parents=False)
+        self.assertFalse(root.exists())
+
+    def test_a_file_in_the_way_is_still_an_error(self) -> None:
+        """``mkdir(exist_ok=True)`` raises when the path exists and is not a directory, and
+        every caller here writes into the path afterwards. Swallowing it would turn a
+        `FileExistsError` into a confusing failure one line later."""
+        f = Path(self.tmp) / "not-a-dir"
+        f.write_text("x")
+        with self.assertRaises(FileExistsError):
+            config.private_mkdir(f)
+
+    def test_the_vault_writers_call_the_same_walk(self) -> None:
+        """One implementation, two names — so a fix to one cannot miss the other."""
+        from charter.secrets import base
+
+        calls = []
+        original = config.private_mkdir
+        config.private_mkdir = lambda p, *a, **kw: calls.append(Path(p))
+        try:
+            base.make_private_dir(Path(self.tmp) / "via-secrets")
+        finally:
+            config.private_mkdir = original
+        self.assertEqual(calls, [Path(self.tmp) / "via-secrets"])
+
+
+class TheScanSeesWhatItClaims(unittest.TestCase):
+    """The coverage scanner's own accuracy, against sources written for the purpose.
+
+    A scan that has quietly stopped seeing anything reports a clean package, which is the
+    most comfortable way for this whole file to become decorative.
+    """
+
+    def setUp(self) -> None:
+        self.names = scan.state_attribute_names()
+
+    def test_the_state_names_are_asked_of_config(self) -> None:
+        """Derived from `config.derive`, not listed here: a setting added under the state
+        directory is covered the day it is added."""
+        self.assertIn("STATE_DIR", self.names)
+        self.assertIn("SESSIONS_DIR", self.names)
+        self.assertNotIn("PERSONAS_DIR", self.names, "personas/ is committed, not state")
+        self.assertNotIn("ROOT", self.names)
+
+    def test_a_bare_mkdir_on_the_state_directory_is_caught(self) -> None:
+        src = "def f():\n    (config.STATE_DIR / 'x').mkdir(parents=True, exist_ok=True)\n"
+        self.assertEqual([ln for ln, _ in scan.violations(src, self.names)], [2])
+
+    def test_the_module_alias_does_not_hide_it(self) -> None:
+        """`hooks` reaches config as `_cfg`. A scan keyed to the alias would skip it."""
+        src = "def f():\n    (_cfg.STATE_DIR / 'x').mkdir(parents=True)\n"
+        self.assertEqual([ln for ln, _ in scan.violations(src, self.names)], [2])
+
+    def test_one_hop_of_indirection_does_not_hide_it(self) -> None:
+        """The shape most of the writers actually have: a module-level path helper, then
+        ``f.parent.mkdir(...)`` in the function that writes."""
+        src = ("def _cache_file():\n    return config.STATE_DIR / 'cache' / 'x.json'\n\n"
+               "def save():\n    f = _cache_file()\n"
+               "    f.parent.mkdir(parents=True, exist_ok=True)\n")
+        self.assertEqual([ln for ln, _ in scan.violations(src, self.names)], [6])
+
+    def test_a_directory_outside_the_state_tree_is_not_flagged(self) -> None:
+        """A scan that flagged everything would be as useless as one that flagged
+        nothing — and would be "fixed" by making committed directories private."""
+        src = ("def _p():\n    return config.PERSONAS_DIR / 'x'\n\n"
+               "def f():\n    _p().mkdir(parents=True, exist_ok=True)\n")
+        self.assertEqual(scan.violations(src, self.names), [])
+
+    def test_the_routed_call_is_not_flagged(self) -> None:
+        src = ("def f():\n    config.private_mkdir(config.STATE_DIR / 'cache')\n")
+        self.assertEqual(scan.violations(src, self.names), [])
+
+
+class EveryStateWriterGoesThroughTheWalk(unittest.TestCase):
+    def test_no_mkdir_in_the_package_can_make_a_loose_state_directory(self) -> None:
+        found = scan.scan_package()
+        self.assertEqual(
+            found, {},
+            "these create a directory under `.charter/` without `config.private_mkdir`, "
+            "so whichever of them runs first in a fresh plane hands the umask the mode of "
+            "the state directory (#470):\n"
+            + "\n".join(f"  {f}:{ln}  {expr}.mkdir(…)"
+                        for f, hits in found.items() for ln, expr in hits))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vault_dir_mode.py
+++ b/tests/test_vault_dir_mode.py
@@ -29,16 +29,20 @@ covers two levels and not three goes RED. Modes are tested through that mask and
 against a list of known-bad values: 0755 is the one everybody pictures, while 0705, 0711,
 0730 and 0701 list or traverse just as well and appear on no such list.
 
-**"The vault writers", not "charter", and the qualifier is load-bearing.** The 0700 walk
-lives in :func:`base.make_private_dir`, which only the three secrets writers call. On the
-default CLI flow they are not what creates ``.charter/``: ``charter vault add`` writes the
-local registry first, through a bare ``path.parent.mkdir(parents=True, exist_ok=True)``,
-so the state directory is already there — at the umask default — before any vault file is
+**"The vault writers", and who else gets there first.** The 0700 walk is
+:func:`base.make_private_dir`, which the three secrets writers call — and it is
+:func:`config.private_mkdir` under another name, which is what every other state writer
+calls since #470. That distinction used to matter: on the default CLI flow the vault
+writers are not what creates ``.charter/`` (``charter vault add`` writes the local
+registry first, through a bare ``path.parent.mkdir(parents=True, exist_ok=True)``), so the
+state directory was already there, at the umask default, before any vault file was
 written. Every class below except :class:`TheOrderTheCliActuallyUses` gives the vault
 writer the first move, which is the order a direct ``PlainFileProvider(...).set()``
-produces and not the order the CLI produces, and under that fixture the writer creates
-``.charter/`` too. That class exists so the difference is pinned rather than hidden: it
-reproduces the registry-first ordering and asserts what is true under it (#470).
+produces and not the order the CLI produces. That class exists so the difference is pinned
+rather than hidden: it reproduces the registry-first ordering and asserts that the state
+directory comes out 0700 under it too. The whole-CLI sweep — real binary, real plane,
+three umasks, three different first writers — is
+`tests/test_the_state_directory_is_charters_to_choose.py`.
 
 The second property is the honest half, and it is asserted rather than merely documented:
 
@@ -487,15 +491,16 @@ class TheOrderTheCliActuallyUses(PersonaIso):
     So this class drives ``registry.add_vault`` first, which is the real call, and pins
     all three halves of what the documents now say:
 
-    * the levels the vault writers create are 0700 whatever the umask is — unchanged, and
-      that is the fix;
-    * ``.charter/`` itself is whatever the umask left it — the residual, open as #470;
-    * it is *reported* rather than silently fine, on the health line ``charter vault list``
-      prints.
+    * the levels the vault writers create are 0700 whatever the umask is;
+    * ``.charter/`` itself is 0700 too, whatever the umask is — the registry write goes
+      through the same walk since #470, so the mode no longer depends on which command
+      somebody happened to run first;
+    * a directory charter did **not** create keeps its mode and is *reported* — on the
+      health line ``charter vault list`` prints, and on ``charter doctor``'s vaults line
+      (#471).
 
-    The middle one is a defect pinned on purpose. If it goes RED because #470 landed, that
-    is good news and the thing to fix is `docs/secrets.md` and the news entry, which
-    currently tell the reader it is open.
+    The middle one used to be a defect pinned on purpose, with the residual written into
+    `docs/secrets.md` and the news entry. Both now describe the fix.
     """
 
     def _fresh_plane(self, tag: str, um: int):
@@ -555,30 +560,27 @@ class TheOrderTheCliActuallyUses(PersonaIso):
                         f"registry going first must not cost the levels below it")
                 self.assertEqual(stat.S_IMODE(vf.stat().st_mode), 0o600, "and the file")
 
-    def test_the_state_directory_itself_is_decided_by_the_umask(self):
-        """The residual, executed. `.charter/` is the registry's to create, not the walk's.
+    def test_the_state_directory_is_charters_to_choose(self):
+        """The residual, closed (#470). `.charter/` is the registry's to create — and the
+        registry creates it through the same walk now.
 
-        Asserted as *the umask decides it* — two umasks, two different modes — and not
-        merely as "0755 under 022". A regression that hardcoded 0755 would satisfy the
-        second and not the first, and the property is the dependence, not the value.
+        Asserted as *the umask does not decide it* — three umasks, one mode — and not
+        merely as "0700 under 022". The property is the independence; a fix that only held
+        under the umask it was written for would satisfy the weaker reading. The CLI-level
+        sweep, in a plane built by `charter init` and driven through the real binary, is
+        `tests/test_the_state_directory_is_charters_to_choose.py`; this case is the
+        in-process pin on the ordering `charter vault add` produces.
         """
         seen = {}
-        for um in (0o022, 0o077):
+        for um in (0o000, 0o022, 0o077):
             self._fresh_plane(f"s{um:03o}", um)
             self._add_vault("devops", "vaults/team/prod.json")
             seen[um] = stat.S_IMODE(Path(config.STATE_DIR).stat().st_mode)
 
-        self.assertNotEqual(
-            seen[0o022], seen[0o077],
-            f"`.charter/` came out {oct(seen[0o022])[-3:]} under both umasks. If charter "
-            f"now chooses this mode itself, #470 is fixed — good news, and docs/secrets.md "
-            f"and the `a-vault-charter-cannot-make-private` news entry both still tell the "
-            f"reader it is open. Update them and delete this case.")
-        self.assertEqual(seen[0o077], 0o700, "umask 077 masks the group and other bits")
         self.assertEqual(
-            seen[0o022] & 0o077, 0o055,
-            f"the measurement in #470: umask 022 leaves `.charter` at "
-            f"{oct(seen[0o022])[-3:]}, other-readable and other-traversable")
+            set(seen.values()), {0o700},
+            f"the umask still decides `.charter/`: "
+            f"{[(oct(u), oct(m)[-3:]) for u, m in seen.items()]}")
 
     def test_the_loose_state_directory_is_named_where_the_docs_say_it_is(self):
         """Reported, not silently accepted — and reported in `charter vault list`.
@@ -594,10 +596,15 @@ class TheOrderTheCliActuallyUses(PersonaIso):
         from charter.secrets import registry
 
         self._fresh_plane("report", 0o022)
+        # Made by hand, before charter gets there: since #470 a `.charter/` charter creates
+        # is 0700, so the directory that has to be REPORTED is the one that predates it —
+        # an older charter's, or a `mkdir -p` at the umask default.
+        sd = Path(config.STATE_DIR)
+        sd.mkdir(parents=True)
+        os.chmod(sd, 0o755)
         vf = self._add_vault("devops", "vaults/team/prod.json")
         PlainFileProvider("devops", {"file": str(vf)}).set("K", "value-one")
 
-        sd = Path(config.STATE_DIR)
         self.assertEqual(stat.S_IMODE(sd.stat().st_mode) & 0o077, 0o055,
                          "precondition: there is something to report")
 
@@ -615,33 +622,25 @@ class TheOrderTheCliActuallyUses(PersonaIso):
                       "`charter vault list`'s STATUS column is where docs/secrets.md now "
                       "says this appears, so that is where it has to appear")
 
-    def test_doctor_is_not_where_it_appears(self):
-        """The other narrowed sentence, pinned as the limit it is (#471).
+    def test_the_note_is_where_the_docs_say_it_is_in_doctor_too(self):
+        """#471, closed: `check_vaults` asks `loose_dirs()` and renders the same note.
 
-        `check_vaults` does ``healthy, _ = prov.health()`` and drops the detail, and
-        `_loose_dir_note` never sets ``healthy`` False — deliberately, since this check
-        runs from the SessionStart hook. So no path carries the note into `doctor`, and
-        the docs no longer say one does.
+        Kept here as the pair to the case above — the two surfaces are one claim, and a
+        test file that pins only one of them is how they came apart in the first place.
+        The rest of doctor's behaviour around it (the JSON, the WARN paths, one line per
+        directory) is `tests/test_doctor_names_a_loose_state_directory.py`.
         """
         from charter import doctor
-        from charter.secrets import registry
 
         self._fresh_plane("doctor", 0o022)
+        sd = Path(config.STATE_DIR)
+        sd.mkdir(parents=True)
+        os.chmod(sd, 0o755)
         vf = self._add_vault("devops", "vaults/team/prod.json")
         PlainFileProvider("devops", {"file": str(vf)}).set("K", "value-one")
 
-        self.assertIn("listed by other accounts",
-                      registry.provider_for("devops").health()[1],
-                      "precondition: the health line carries the note, so doctor had "
-                      "something to drop")
-
         res = doctor.check_vaults()
-        rendered = res.render()
-        self.assertNotIn(
-            "listed by other accounts", rendered,
-            f"doctor now carries the loose-directory note. #471 is fixed — good news, and "
-            f"docs/secrets.md and the news entry both still say it does not. Update them "
-            f"and delete this case. Got: {rendered!r}")
+        self.assertIn("listed by other accounts: .charter 755", res.render())
         self.assertEqual(res.status, doctor.OK,
                          "and it stays a green line: a loose directory is an operator's "
                          "decision, not an unreachable vault")

--- a/tests/test_vault_verify.py
+++ b/tests/test_vault_verify.py
@@ -53,6 +53,12 @@ class _Ref:
         # variable is unset is broken in a way health() cannot see.
         return {}
 
+    def loose_dirs(self):
+        # Part of the provider contract since #471: `doctor` asks every vault which of the
+        # directories it is reached through another account can list. A reference vault
+        # here keeps nothing this test put on disk, so the answer is the base class's.
+        return []
+
     def get(self, key):
         if key in self._fails:
             raise base.VaultError(f"resolving '{key}' via op failed (exit 1)")


### PR DESCRIPTION
Closes #470
Closes #471
Closes #472

#473 is **not** closed here — see the last section.

## #470 — `.charter/` was created at the umask default

Reproduced first, on the flow the issue names and on three more:

| first writer | before | after |
| --- | --- | --- |
| `charter vault add` (registry `_write`) | `drwxr-xr-x` | `drwx------` |
| `charter hook sessionstart` (workspace pointer) | `drwxr-xr-x` | `drwx------` |
| `charter hook pretooluse` (`guard-seen.json`) | `drwxr-xr-x` | `drwx------` |
| `charter statusline` (update-check lock) | `drwxr-xr-x` | `drwx------` |

The issue suggests routing `registry._write` and the persona/workspace writers. That is the
flow it reproduces, and it is not the property: a plane is cloned without `.charter/`
(gitignored), so on an ordinary teammate's first session it is a *hook* that creates the
state directory, not any of those three. **Every writer that creates a directory under the
state directory is routed**, through one implementation:

- the walk moves to `config.private_mkdir` (in `config`, which every state writer already
  imports — a helper they must reach into `charter.secrets` for is a helper most of them
  will not call). `secrets.base.make_private_dir` is that function under the name the vault
  writers already use, so a fix to the walk cannot land on only one of the two.
- the leaf is attempted **before** the parents, which is `pathlib`'s order and load-bearing:
  a leaf that cannot exist (`ENAMETOOLONG` on a frame id built from a hostile workspace
  name) must not leave its parents standing where the caller has just checked they were
  gone. `frame.state` pins that as "does not raise **or create**", and the first cut of this
  branch turned four of its cases red. `private_mkdir(p, parents=False)` is there for the
  one caller that must not build the path at all.
- a directory that already exists is still left exactly as it is. `$CHARTER_HOME` may point
  the state directory at any path on the machine, so "chmod whatever we land in" is #331
  with a fresh coat of paint.

**Coverage, not just behaviour.** A behavioural sweep covers the writers somebody thought to
run. `tests/_statedirscan.py` reads the package and asks whether any `mkdir` left in it can
still create a directory under the state directory without the walk — state paths derived
from `config.derive` rather than listed, matched on the *attribute* (`.STATE_DIR`) rather
than the module alias in front of it, one transitive hop through module-level path helpers.
Its own accuracy is tested against sources written for the purpose, so a scanner that has
quietly stopped seeing anything cannot report a clean package.

*What it cannot see, said out loud in the module:* a path that arrives as a parameter
(`memstore.write(mem_dir, …)` takes either a committed persona directory or an ephemeral
one) or one assembled from a string. What keeps that from being an exposure is that the
level they hang off is 0700 — a directory created under it at the umask default is still
reachable by nobody but its owner. **That is the next spelling**, and it is the one to check
first if this ever regresses.

## #471 — `doctor` dropped the vault health detail

`check_vaults` did `healthy, _ = prov.health()`. The fix is a **structured question**, not a
substring: `VaultProvider.loose_dirs()` answers `(path, mode)` pairs, and `vault list` and
`doctor` both render them through `base.loose_dir_note`. Scraping `health()`'s sentence from
`doctor` would have gone silent the day somebody reworded it, with nothing failing.

```
  ✓  vaults           1 reachable (references not resolved); listed by other accounts: .charter 755 (want 700 — chmod 700)
```

Green, in `--json` (the note is in `detail`, which is what `cmd_doctor` serialises), one line
per directory however many vaults share it, and on the WARN paths too — a loose directory
does not stop being one because a different vault is also unreachable.

## #472 — a committed directory name could write its own table row

Reproduced for `\n`, `\r`, `\r\n`, U+2028, U+2029, U+0085, VT, FF and FS, on both commands.
The bound lands **before** the width arithmetic (`one_line` *grows* a name, so bounding at
the `print` alone misaligns every column after PERSONA for every row), and the roster is
mapped once and used throughout.

The active marker still compares the **raw** names, and that is the half worth reading
twice: `one_line` maps `evil\n` and a literal `evil\x0a` onto one rendered string, so a
marker decided from the rendering marks both active as soon as either is — a report lying
about which persona a dispatch resolves to. Same rule for the dispatch tally, the draft
check and the skills lookup: the bound is what gets printed, never what gets looked up.

## Mutation testing

Fifteen applied, each RED then restored GREEN, `__pycache__` cleared between:

`private_mkdir` creating at the umask · the workspace writer back to a bare `mkdir` · the
registry writer back to a bare `mkdir` · parents created before the leaf · an existing
directory chmod-ed too · `make_private_dir` keeping its own copy of the walk · `doctor`
dropping the detail again · the note on the green line only · the provider reporting no
directories · the directory named once per vault · the scanner seeing no state paths at all
· `persona list` printing the raw name · widths measured from the raw names · the marker
comparing rendered names · the stats tally looked up by the rendered name.

Two of those were caught only after the fixture was fixed: the marker case first used two
*separator-bearing* twins, which render to **different** escapes — so it passed under the
mutation it exists to catch until the twins became `evil\n` and a literal `evil\x0a`, which
share one rendered form. The stats case first used a draft persona, and `resolve()` returns
`None` for a separator-bearing name, so the fixture could not make the condition it claimed
to observe.

## Not in this PR

- **#473 stays open, and it is a decision rather than a defect.** Option (1) — state the
  boundary — is already merged: `tests/test_workflows.py` says the property is "every
  reference charter *writes*". The gap it names is live and concrete today, and worth
  recording: charter's `publish` job (`id-token: write`) uses
  `pypa/gh-action-pypi-publish@dc37677…`, which at that pinned SHA is a **composite** action
  that generates a Docker action at run time from its own `Dockerfile` — and that Dockerfile
  reads `FROM python:3.13-slim`, a tag its publisher rewrites. It also `uses:
  actions/setup-python@a309ff8b…` (SHA-pinned, so that hop is fine). Closing it needs the
  network on a schedule or a vendored copy, and both are standing costs someone has to own —
  a scheduled audit that reports a floating base image nobody triages is the check-crying-
  wolf failure this repo has already paid for twice. Evidence is on the issue.
- **A `reference` vault reports no directory at all** — #491, filed with a reproduction and
  referenced from the news entry as the known remaining case.

## Docs

`docs/secrets.md` and the 0.52.0 news entry both said these two were open; both now say what
is true, and the 0.52.0 entry keeps its measurement of what shipped in *that* release and
points forward. Two staged entries, no version bump, no stamping.

Full suite green: `Ran 4928 tests … OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
