### PR TITLE
guards: follow what a git command does and where a search goes (#467, #474, #476, #477, #483)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -112,9 +112,10 @@ user, and the shape of that limit is worth knowing rather than guessing at:
     supported on Windows, which is why the guard is not made to answer differently there.
     If that changes, this fold has to change with it (#476).
 - A **second predicate** covers the operand that *contains* the vault directory without
-  naming it (#474). `grep -r TOKEN .` from the plane root reads every vault file as
-  collateral and names none of them, so a guard that only reads the operand's text cannot
-  see it. Both routes now also ask whether the walk would **reach** charter's own state:
+  naming it (#474). `grep -r TOKEN .` from the plane root reads the vault directory as
+  collateral while its operand is the single character `.`, which leaves a guard that reads
+  only operand text with nothing to match on. Both routes now also ask whether the walk
+  would **reach** charter's own state:
   the operand is resolved against the shell's directory and compared by ancestry, and the
   entries it is compared against are read off the filesystem, so `.`, `..`, an absolute
   path and a symlinked parent are one question rather than four spellings. It fires only
@@ -128,9 +129,13 @@ user, and the shape of that limit is worth knowing rather than guessing at:
   handed the command line before `sh` runs and never sees what `sh` turns it into, so every
   expansion reaches the file unguarded: a glob (`cat .charter/vault?/db.json`,
   `head .charter/vault*/db.json`, `cat .cha*ter/vaults/db.json`), a variable
-  (`V=.charter/vaults/db.json; cat $V`), a command substitution, brace or tilde expansion,
-  and a changed working directory (`cd .charter/vaults && cat db.json`). Each is `cat` on
-  the same inode as the denied form, one keystroke away from it, and allowed. This is not a
+  (`V=.charter/vaults/db.json; cat $V`), a quoted command substitution, brace or tilde
+  expansion. Each is `cat` on the same inode as the denied form, one keystroke away from it,
+  and allowed. A changed working directory (`cd .charter/vaults && cat db.json`) used to be
+  named here as one of them and is **not** one: the guard walks the segments and carries the
+  relocation, however it is spelled (`cd`, `pushd`, `env -C`, `sudo --chdir`), so those are
+  denied — this page said otherwise while `docs/secrets.md` said the opposite on the same
+  day. This is not a
   list of tricks to close one by one — it is one fact with many spellings, and closing them
   means putting a shell inside the guard, which leaves a hole shaped like whichever
   construct that shell got wrong. The glob case has an exact edge worth knowing: the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -96,23 +96,34 @@ user, and the shape of that limit is worth knowing rather than guessing at:
 - It matches the **text of the operand as written**, normalised first. Redundant `/`
   separators, `.`/`..` segments and letter case are all collapsed, so
   `.charter//vaults/db.json`, `.charter/./vaults/db.json` and `.CHARTER/vaults/db.json` get
-  the same answer as `.charter/vaults/db.json` — the last of those matters because macOS and
-  Windows fold case in the filesystem, and it is the same file there. The directory itself
-  counts, with or without a trailing slash, because `grep -r TOKEN .charter/vaults` walks
-  every vault file in it. Three things it does **not** know, and they are limits rather than
-  bugs:
-  - An operand that *contains* the vault directory without naming it. `grep -r TOKEN .`
-    from the plane root reads every vault file as collateral and names none of them.
-    Denying every broad search is untenable, so both guards check the path you actually
-    named — the same limit, stated the same way, on both routes. `charter init` gitignores
-    the whole of `/.charter/`, which is what actually keeps a vault out of a commit.
+  the same answer as `.charter/vaults/db.json` — the last of those matters because macOS
+  folds case in the filesystem by default, and it is the same file there. The directory
+  itself counts, with or without a trailing slash, because `grep -r TOKEN .charter/vaults`
+  walks every vault file in it. Two things it does **not** know, and they are limits rather
+  than bugs:
   - A *different* path holding the same bytes: a vault registered outside `.charter/` (which
     is what `charter vault add --file` offers when the default location would be committed),
     a file `charter secret cp` wrote somewhere you named, or a symlink you planted. Resolving
     those would mean a `stat` on every operand of every command.
   - A separator that is not `/`. Normalisation is POSIX; a Windows-style
     `.charter\vaults\db.json` is a different path on POSIX, where a backslash is an
-    ordinary filename character, so folding it here would deny real filenames.
+    ordinary filename character, so folding it here would deny real filenames. **charter's
+    harness targets POSIX** — macOS and Linux, with tmux — and is neither tested nor
+    supported on Windows, which is why the guard is not made to answer differently there.
+    If that changes, this fold has to change with it (#476).
+- A **second predicate** covers the operand that *contains* the vault directory without
+  naming it (#474). `grep -r TOKEN .` from the plane root reads every vault file as
+  collateral and names none of them, so a guard that only reads the operand's text cannot
+  see it. Both routes now also ask whether the walk would **reach** charter's own state:
+  the operand is resolved against the shell's directory and compared by ancestry, and the
+  entries it is compared against are read off the filesystem, so `.`, `..`, an absolute
+  path and a symlinked parent are one question rather than four spellings. It fires only
+  when those entries exist and hold something, and the denial names the exclusion that
+  fixes it (`--exclude-dir=.charter`, `rg --glob '!.charter'`). What it still does not
+  cover is the same ceiling as above: **a program charter does not know walks directories**
+  — `find … -exec cat`, `tar`, an interpreter — reaches the same files unguarded. And
+  `charter init` gitignores the whole of `/.charter/`, which is what actually keeps a vault
+  out of a commit.
 - **Anything a shell does to that text, it does after the guard has answered.** The hook is
   handed the command line before `sh` runs and never sees what `sh` turns it into, so every
   expansion reaches the file unguarded: a glob (`cat .charter/vault?/db.json`,

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -435,14 +435,21 @@ _READERS = frozenset("cat less more head tail bat nl tac xxd od strings grep rg 
 #: the tool gate's surface on such a plane without being named there.
 #:
 #: `IGNORECASE` because the answer must not depend on which filesystem the guard happens to
-#: be running on. macOS/APFS and Windows fold case by default, so `.CHARTER/vaults/db.json`
-#: and `.charter/VAULTS/db.json` are the SAME INODE as the denied form there — and this
-#: pattern, being case-sensitive, allowed both. The flag closes every case spelling at once
-#: rather than a list of them; on a case-sensitive filesystem it costs a denial of a
-#: differently-cased directory that is not charter's, which is the fail-closed direction
-#: this guard already takes elsewhere (see `_names_a_vault_path`'s raw arm). The reader-name
-#: check has always `.lower()`ed for the same reason; the path check was the half that did
-#: not.
+#: be running on. macOS/APFS folds case by default, so `.CHARTER/vaults/db.json` and
+#: `.charter/VAULTS/db.json` are the SAME INODE as the denied form on half the machines
+#: charter runs on — and this pattern, being case-sensitive, allowed both. The flag closes
+#: every case spelling at once rather than a list of them; on a case-sensitive filesystem it
+#: costs a denial of a differently-cased directory that is not charter's, which is the
+#: fail-closed direction this guard already takes elsewhere (see `_names_a_vault_path`'s raw
+#: arm). The reader-name check has always `.lower()`ed for the same reason; the path check
+#: was the half that did not.
+#:
+#: This comment used to cite Windows alongside macOS, and the SEPARATOR is where that got
+#: expensive: the same argument reads as a reason to fold `\` too (#476). It is not, because
+#: charter's harness does not run on Windows — it builds and drives a tmux session and
+#: writes vaults at `0o600` — so folding a backslash would buy nothing on any supported host
+#: and would deny POSIX filenames that legitimately contain one. macOS carries the case
+#: argument on its own; nothing here answers for a platform charter does not support.
 _VAULT_PATH_RE = re.compile(
     r"\.(?:charter|edm)(?:/(?:vaults(?:/|$)|browser|active-|fingerprint)|/?$)",
     re.IGNORECASE)
@@ -497,6 +504,224 @@ def _names_a_vault_path(operand: str) -> bool:
     """
     norm = os.path.normpath(operand)
     return bool(_VAULT_PATH_RE.search(operand) or _VAULT_PATH_RE.search(norm))
+
+
+# --------------------------------------------------------------------------- #
+# The other half of the same guard: an operand that CONTAINS the vault          #
+# directory without naming it (#474).                                          #
+# --------------------------------------------------------------------------- #
+#: The names under `config.STATE_DIR` whose CONTENT is the secret — the same four things
+#: `_VAULT_PATH_RE` spells as text, listed here as directory entries because this half of
+#: the guard is about a walk that never spells them at all.
+#:
+#: Split into an EXACT name and three prefixes for the reason `_VAULT_PATH_RE` anchors
+#: `vaults` to a path segment: `.charter/vaults.json` is the REGISTRY — provider config and
+#: file paths, never a value — and an ordinary read that a wider match denies. A single
+#: `startswith` tuple here matched it, and the differential against `origin/main` caught
+#: `ag TOKEN .charter/vaults.json` newly refused, which is #443's false positive coming back
+#: through the other predicate. The other three are prefixes in `_VAULT_PATH_RE` too
+#: (`browser…`, `active-…`, `fingerprint…`), so they stay prefixes here.
+_GUARDED_STATE_EXACT = ("vaults",)
+_GUARDED_STATE_PREFIXES = ("browser", "active-", "fingerprint")
+
+
+def _guarded_state_entries() -> list[Path]:
+    """The state entries a directory WALK would read — asked of the filesystem.
+
+    Derived from `config.STATE_DIR` rather than from the literal `.charter/`, for the reason
+    `toolgate._control_roots` gives: `$CHARTER_HOME` puts this directory somewhere no
+    pattern can spell, and the legacy `.edm/` puts it somewhere else again.
+
+    An EMPTY guarded directory is left out on purpose. A fresh plane has `vaults/` and
+    nothing in it, and a guard that refuses `grep -r TODO .` there is refusing an ordinary
+    search to protect nothing — the fastest way to teach people that this denial is noise.
+    """
+    from . import config as _cfg
+    out: list[Path] = []
+    try:
+        entries = list(os.scandir(Path(_cfg.STATE_DIR)))
+    except OSError:
+        return out
+    for entry in entries:
+        if entry.name not in _GUARDED_STATE_EXACT and \
+                not entry.name.startswith(_GUARDED_STATE_PREFIXES):
+            continue
+        try:
+            if entry.is_dir() and next(os.scandir(entry.path), None) is None:
+                continue                    # an empty directory has nothing to leak
+        except OSError:
+            continue
+        out.append(Path(entry.path))
+    return out
+
+
+#: Readers that DESCEND INTO DIRECTORIES, and the options that tell them to. ``None`` means
+#: the program walks the tree with no option at all — `rg` and `ag` search everything below
+#: their operand, and below the cwd when given none.
+#:
+#: This is a subset of `_READERS` and inherits its ceiling exactly: a name missing from here
+#: is a walk this guard does not see, the same way a name missing from `_READERS` is a read
+#: it does not see. That ceiling is stated in `SECURITY.md` and is not raised by adding
+#: names — it is why the sentence there says *mistakes*.
+_TREE_WALKERS: dict[str, frozenset[str] | None] = {
+    "grep": frozenset({"-r", "-R", "--recursive", "--dereference-recursive"}),
+    "rg": None,
+    "ag": None,
+}
+
+#: Letters that swallow the rest of their token as a value, per walker. Without this a
+#: cluster scan reads the `R` in `grep -eR foo` — which is the PATTERN — as `-R`.
+_CLUSTER_STOPS = {"grep": frozenset("efmABCd")}
+
+#: Options whose value EXCLUDES a directory from the walk. Read so that the fix the denial
+#: prints actually runs: a guard that refuses the command it recommends is one people learn
+#: to route around, which is the lesson `_plane_root_branch_reason` records for the plane
+#: root's remedy.
+#:
+#: Deliberately permissive, and NOT a security boundary: it takes any of these values as a
+#: real exclusion without checking that the program would honour it there. This whole guard
+#: is about the accident of searching a plane from its top — an attacker with shell access
+#: has `sh -c`, which charter does not re-parse at all.
+_EXCLUDE_OPTS = ("--exclude-dir", "--exclude", "--ignore-dir", "-g", "--glob", "--iglob")
+
+
+def _excluded_names(prog: str, args: list[str]) -> list[str]:
+    """The directory-name patterns an invocation asks its walker to skip."""
+    out: list[str] = []
+    argv = args[1:] if args and args[0] == prog else args
+    take_next = False
+    for a in argv:
+        if take_next:
+            take_next = False
+            out.append(a)
+            continue
+        name, sep, val = a.partition("=")
+        if name in _EXCLUDE_OPTS:
+            if sep:
+                out.append(val)
+            else:
+                take_next = True
+    # `!x` is `rg`'s spelling of "exclude x"; `*/x/*` and `**/x/**` are how the same thing
+    # is spelled to a glob that matches whole paths. Strip the punctuation, keep the name.
+    return [p.lstrip("!").strip("/").removeprefix("**/").removeprefix("*/")
+             .removesuffix("/**").removesuffix("/*") for p in out if p]
+
+
+def _walks_directories(prog: str, args: list[str]) -> bool:
+    """True when *prog* would descend into subdirectories of the operands it is given."""
+    base = os.path.basename(prog).lower()
+    if base not in _TREE_WALKERS:
+        return False
+    flags = _TREE_WALKERS[base]
+    if flags is None:
+        return True                         # walks the tree with no option at all
+    argv = args[1:] if args and args[0] == prog else args
+    stops = _CLUSTER_STOPS.get(base, frozenset())
+    for i, a in enumerate(argv):
+        if not a.startswith("-") or a in ("-", "--"):
+            continue
+        name, sep, attached = a.partition("=")
+        if name in flags:
+            return True
+        # `grep -d recurse` / `--directories=recurse` is the long way to spell `-r`.
+        if name in ("-d", "--directories"):
+            val = attached if sep else (argv[i + 1] if i + 1 < len(argv) else "")
+            if val == "recurse":
+                return True
+            continue
+        if a.startswith("--"):
+            continue
+        for ch in a[1:]:
+            if f"-{ch}" in flags:
+                return True
+            if ch in stops:
+                break                       # this letter takes the rest as its value
+    return False
+
+
+def _walk_into_guarded_state(cwd: str, operands: list[str], excluded: list[str]) -> Path | None:
+    """The guarded state entry a walk rooted at one of *operands* would descend into.
+
+    **The property, named: does the walk REACH the directory** — not how the operand is
+    spelled and not how the recursion is requested. `.`, `..`, `$PWD` typed out, an absolute
+    path and a path through a symlinked parent are five spellings of one ancestor, and the
+    six bypasses this guard family has had were all a literal set of spellings. So the
+    operand is resolved against the shell's directory and compared by ANCESTRY, and the
+    thing it is compared against is asked of the filesystem (:func:`_guarded_state_entries`)
+    rather than matched as text.
+
+    `resolve()` costs a `stat` walk, which is why nothing above calls it: this runs only
+    after a reader that walks trees has already been identified, which is rare on the Bash
+    hot path and never true of the `cat`/`head`/`sed` case the guard usually answers.
+    """
+    import fnmatch
+    targets = _guarded_state_entries()
+    if not targets:
+        return None
+    base_dir = Path(cwd or ".")
+    for operand in operands:
+        try:
+            base = (Path(operand) if os.path.isabs(operand) else base_dir / operand).resolve()
+        except OSError:
+            continue
+        for target in targets:
+            try:
+                resolved = target.resolve()
+            except OSError:
+                continue
+            if resolved != base and base not in resolved.parents:
+                continue
+            # Everything between the operand and the entry is a directory the walk has to
+            # enter; excluding any one of them keeps it out. `fnmatch` because
+            # `--exclude-dir` takes a GLOB, and `.charter*` is how people write it.
+            try:
+                parts = resolved.relative_to(base).parts if resolved != base else ()
+            except ValueError:              # pragma: no cover — ancestry was just proved
+                parts = ()
+            hop = tuple(parts) + (resolved.name,)
+            if any(fnmatch.fnmatch(part, pat) for part in hop for pat in excluded):
+                continue
+            return resolved
+    return None
+
+
+def _glob_selects_inside(entry: Path, pattern: str, limit: int = 512) -> bool:
+    """True when *pattern* selects at least one file that is really inside *entry*.
+
+    A filesystem question rather than a reading of the glob: `*.py` over a directory holding
+    only `.json` vaults selects nothing, and refusing that search would be a false denial on
+    the commonest narrowed search an agent makes. Bounded, and the bound FAILS CLOSED — an
+    entry too large to answer cheaply is treated as selected.
+    """
+    import fnmatch
+    pat = pattern.rsplit("/", 1)[-1]
+    if entry.is_file():
+        return fnmatch.fnmatch(entry.name, pat)
+    seen = 0
+    for _base, _dirs, files in os.walk(entry):
+        for name in files:
+            seen += 1
+            if seen > limit or fnmatch.fnmatch(name, pat):
+                return True
+    return False
+
+
+def _walks_into_guarded_state(prog: str, args: list[str], cwd: str) -> Path | None:
+    """`_walk_into_guarded_state` for one invocation, or ``None`` if it walks nothing."""
+    if not _walks_directories(prog, args):
+        return None
+    operands = _file_operands(prog, args)
+    # A walker with no operand searches the CWD — `grep -r PATTERN` and `rg PATTERN` both
+    # do, verified — so "no path was named" is a path, and it is the one an agent standing
+    # in the plane root types most often.
+    return _walk_into_guarded_state(cwd, operands or ["."], _excluded_names(prog, args))
+
+
+#: What to do about it, in both spellings, so the refusal is one edit away from running.
+_WALK_FIX = (
+    "Exclude it — `grep -rn --exclude-dir=.charter …`, `rg --glob '!.charter' …` — or "
+    "search the path you actually mean. `charter … secret exec --env NAME=<key> -- <cmd>` "
+    "is how a command gets a value without anyone reading one.")
 
 
 #: `edm` is charter's pre-rename name. Kept because this is a security guard and the cost
@@ -816,6 +1041,21 @@ def _leak_reason(cmd: str, cwd: str = "") -> str | None:
             hit = _opens(_spliced_operands(_file_operands(prog, args)))
             if hit:
                 return hit
+        # …and the operand that contains the vault directory without naming it (#474). The
+        # two arms above decide on the TEXT of the operand, so `grep -rn TOKEN .` from the
+        # plane root printed every vault file while naming none of them. This one decides
+        # on where the walk GOES.
+        # `where`, not `cwd`: main's segment walk already tracks a `cd` across segments
+        # and a wrapper's own `-C`, and the walk's operand has to resolve against the
+        # directory the program will really run in — `cd sub && grep -r x .` searches
+        # `sub`, not the plane root, in BOTH directions.
+        hit = _walks_into_guarded_state(
+            prog, args,
+            where if os.path.isabs(where) else posixpath.join(cwd, where))
+        if hit is not None:
+            return (f"walks a directory tree that contains the plane's own `{hit.name}` — "
+                    f"every file in it would be printed into the transcript, and none of "
+                    f"them is named on this command line. " + _WALK_FIX)
     return None
 
 
@@ -1841,47 +2081,149 @@ _RESET_TREE_MODES = ("--hard", "--merge", "--keep")
 #: stands aside, and a refusal is one flag wide. Not hypothetical: this repo's own commit
 #: convention is `git -c commit.gpgsign=false commit`, so `git -c …` is a form agents type
 #: already.
-_GIT_VALUE_OPTS = ("-c", "--config-env", "--git-dir", "--work-tree", "--namespace")
+#:
+#: `-C` is here for the same reason and was NOT, because `_git_target` used to lift its
+#: value out of the argv before anything counted options — so `git -C <plane> checkout
+#: feature` presented `<plane>` as its subcommand the moment that lifting moved (#483). The
+#: two readings of a token belong in one table; keeping them apart is what made a directory
+#: and a subcommand indistinguishable in the first place.
+_GIT_VALUE_OPTS = ("-c", "-C", "--config-env", "--git-dir", "--work-tree", "--namespace",
+                   "--super-prefix")
+
+#: The env spellings of the two global options that NAME A REPOSITORY. git reads these
+#: whether or not the command line mentions them, and `GIT_DIR=<plane>/.git git checkout
+#: feature` moves the plane root's HEAD from anywhere — verified against git 2.50.
+_GIT_DIR_ENV = {"GIT_DIR": "git_dir", "GIT_WORK_TREE": "work_tree"}
 
 
-def _git_target(cwd: str, args: list[str]) -> tuple[Path, list[str]]:
-    """Which repo a git invocation acts on, and its argv with ``-C <path>`` removed.
+def _git_globals(args: list[str]) -> tuple[list[str], list[str]]:
+    """Split a git argv into ``(git's OWN options, the subcommand and everything after)``.
 
-    `git -C <path>` is how a session standing in a workspace reaches the shared tree, so a
-    guard that only looked at the cwd would leave the door open from every clone.
+    **The split is the fix for #483, and the reason it is a function.** git stops reading
+    its own globals at the first non-option token, and every option after that belongs to
+    the SUBCOMMAND — so `-C` means "change directory" in `git -C <dir> switch neu` and
+    means `--force-create` in `git switch -C neu`. `_git_target` used to strip `-C <value>`
+    from anywhere in the argv, which read the second as the first: `target` became
+    `<plane root>/neu`, a directory that is not the root, and the guard stood aside while
+    git answered *"Switched to a new branch 'neu'"*. The ATTACHED form `-Cneu` was refused
+    the whole time, which is what a spelling-shaped guard looks like from the inside.
 
-    **A `-C` is resolved against the SHELL's directory**, which is what *cwd* carries. It
-    used to be `Path(args[i + 1])`, so a relative one resolved against whatever directory
-    the hook process happened to be started in — a directory the command being judged has
-    nothing to do with. `git -C ../../.. checkout feature` from a workspace clone moves the
-    PLANE ROOT's HEAD (verified end to end against git 2.50: *"Switched to branch
-    'feature'"*, and the root's `symbolic-ref` follows), and the guard was reading it as a
-    command against a path three levels above the hook's cwd, found something that was not
-    the plane root, and stood aside. `git -C . checkout feature` typed in the root itself
-    landed the same way, and so did `cd .. && git -C <root-name> checkout feature`.
+    Nothing here knows which options are `switch`'s; it knows only WHERE git stops looking,
+    which is the property, and it costs no list that can go stale.
 
-    Joining onto the running *target* rather than onto *cwd* is also what git itself does
-    when a command carries several: *"each subsequent non-absolute `-C <path>` is
-    interpreted relative to the preceding one"* — verified, `git -C ../.. -C .` from a
-    subdirectory answers the top level.
-
-    *args* is `_invocation`'s argv, which INCLUDES the program — dropping it here is what
-    lets the caller take "the first non-flag token" as the subcommand rather than as `git`.
+    *args* is `_invocation`'s argv, which INCLUDES the program — dropped here, so the
+    caller can take ``rest[0]`` as the subcommand rather than as `git`.
     """
-    target = Path(cwd or ".")
-    rest: list[str] = []
-    i = 1 if args else 0
-    while i < len(args):
-        # Only the separated form: git rejects the attached one outright ("unknown option:
-        # -C.", verified), so reading `-C.` as a directory would be inventing a command.
-        if args[i] == "-C" and i + 1 < len(args):
-            val = args[i + 1]
-            target = Path(val) if os.path.isabs(val) else target / val
+    argv = args[1:] if args else []
+    i = 0
+    while i < len(argv) and argv[i].startswith("-"):
+        i += 2 if argv[i] in _GIT_VALUE_OPTS else 1
+    return argv[:i], argv[i:]
+
+
+def _git_target(cwd: str, pre: list[str], env: list[str] = ()) -> list[Path]:
+    """Every directory a git invocation's GLOBAL options aim it at — the subjects a
+    plane-root guard has to compare against the root.
+
+    Three global options name a repository, and the guard used to read exactly one of them:
+
+    * `git -C <path>` is how a session standing in a workspace reaches the shared tree, so a
+      guard that only looked at the cwd would leave the door open from every clone.
+    * `--work-tree <path>` names the working tree directly.
+    * `--git-dir <path>` names the refs that move. With no `--work-tree` beside it the
+      **cwd becomes the work tree**, so such an invocation has two subjects — the repository
+      the git dir belongs to, and the directory the files land in — and both are returned.
+
+    All three were already in `_GIT_VALUE_OPTS`, where they were skipped as option values so
+    they could not be misread as a subcommand, and then never looked at again. That is
+    #477: `git --git-dir <plane>/.git checkout feature`, run from a clone, moved the plane
+    root's HEAD and was allowed, because `_git_target` answered "the shell's cwd".
+    `GIT_DIR` / `GIT_WORK_TREE` are the same two options spelled as environment, and
+    `_split_env` was already holding them.
+
+    **A list, not a single path, because more than one directory can be the subject.** A
+    caller denies when ANY of them is the plane root, which is the fail-closed direction:
+    the cost is refusing `git --git-dir=<elsewhere>/.git checkout feature` typed IN the
+    plane root — a command that really does overwrite the root's working tree with another
+    repository's branch — and the benefit is that no single-path answer has to choose which
+    of two real subjects to report.
+
+    **Relative paths resolve against the SHELL's directory**, which is what *cwd* carries.
+    A `-C` used to be `Path(args[i + 1])`, so a relative one resolved against whatever
+    directory the hook process happened to be started in — a directory the command being
+    judged has nothing to do with. `git -C ../../.. checkout feature` from a workspace clone
+    moves the PLANE ROOT's HEAD (verified end to end against git 2.50: *"Switched to branch
+    'feature'"*), and the guard read it as a command against a path three levels above the
+    hook's cwd, found something that was not the plane root, and stood aside.
+
+    Joining onto the running target rather than onto *cwd* is also what git itself does when
+    a command carries several `-C`: *"each subsequent non-absolute `-C <path>` is
+    interpreted relative to the preceding one"* — verified, `git -C ../.. -C .` from a
+    subdirectory answers the top level. `--git-dir` and `--work-tree` are resolved against
+    the directory the `-C`s ended at, which is git's own documented rule for them.
+
+    *pre* is `_git_globals`' first half — git's own options ONLY. Passing the whole argv
+    here is what let `git switch -C neu` be read as a change of directory (#483).
+
+    **What it still does not follow**, because none of it is in the argv this holds: an
+    `export GIT_DIR=…` in an earlier segment of the same command line (the `cd` tracking in
+    `_plane_root_git` is the one shell effect charter models), a `GIT_DIR` already in the
+    session's environment, and `--git-dir` pointing at a linked worktree's git dir, whose
+    HEAD is that worktree's and not the root's.
+    """
+    here = Path(cwd or ".")
+    git_dir = work_tree = None
+    # Environment first, command line second: an option on the line overrides the env.
+    for assign in env:
+        name, _, val = assign.partition("=")
+        which = _GIT_DIR_ENV.get(name)
+        if which == "git_dir":
+            git_dir = val
+        elif which == "work_tree":
+            work_tree = val
+    i = 0
+    while i < len(pre):
+        tok = pre[i]
+        name, sep, attached = tok.partition("=")
+        # Only the separated form of `-C`: git rejects the attached one outright ("unknown
+        # option: -C.", verified), so reading `-C.` as a directory would invent a command.
+        if tok == "-C" and i + 1 < len(pre):
+            val = pre[i + 1]
+            if val:                     # `-C ""` leaves the directory unchanged (git docs)
+                here = Path(val) if os.path.isabs(val) else here / val
             i += 2
             continue
-        rest.append(args[i])
-        i += 1
-    return target, rest
+        if name in ("--git-dir", "--work-tree"):
+            if sep:
+                val, step = attached, 1
+            else:
+                val, step = (pre[i + 1] if i + 1 < len(pre) else ""), 2
+            if val:
+                if name == "--git-dir":
+                    git_dir = val
+                else:
+                    work_tree = val
+            i += step
+            continue
+        i += 2 if tok in _GIT_VALUE_OPTS else 1
+
+    def _at(p: str) -> Path:
+        return Path(p) if os.path.isabs(p) else here / p
+
+    out: list[Path] = []
+    if work_tree is None:
+        # No work tree named: the cwd is where the files land, and it is a subject whether
+        # or not a `--git-dir` moved the refs somewhere else.
+        out.append(here)
+    else:
+        out.append(_at(work_tree))
+    if git_dir is not None:
+        # The repository a git dir belongs to is its PARENT for the ordinary `<repo>/.git`
+        # layout, and the git dir itself when it is bare. Both are offered rather than
+        # guessed at: the caller only asks whether one of them is the plane root.
+        gd = _at(git_dir)
+        out.extend((gd, gd.parent))
+    return out
 
 
 def _plane_root_git(cmd: str, cwd: str, root: Path):
@@ -1891,10 +2233,11 @@ def _plane_root_git(cmd: str, cwd: str, root: Path):
     Factored out rather than copied when the reset guard arrived (#401). Everything in here
     is a trap one of the two guards already fell into once, and a second hand-written copy
     of it would fall into them again on its own schedule: the `cd` tracking is #183's fix,
-    the `-C` handling is what stops the guard being scoped to the cwd, and `_GIT_VALUE_OPTS`
-    is what stops `git -c x=y <sub>` reading as a subcommand nobody guards. A guard's blind
-    spot is invisible — it looks exactly like the guard being present and never firing — so
-    the two of them share one pair of eyes.
+    `_git_target` is what stops the guard being scoped to the cwd, and `_git_globals` is
+    what stops `git -c x=y <sub>` reading as a subcommand nobody guards — and, since #483,
+    what stops `git switch -C neu` reading as a change of directory. A guard's blind spot is
+    invisible — it looks exactly like the guard being present and never firing — so the two
+    of them share one pair of eyes.
 
     Yields ``(subcommand, args-after-it, git's-own-options-before-it)``. The subcommand is
     yielded raw; deciding which ones matter is each guard's own business. The leading
@@ -1907,13 +2250,17 @@ def _plane_root_git(cmd: str, cwd: str, root: Path):
     without quoting — and these are the guards whose failure mode is annoyance, not a leaked
     credential. A phantom `git checkout` conjured out of a broken quote must not stop a
     turn. The leak and one-credential guards, which may not miss, keep scanning it.
+
+    **Any** subject the invocation names being the plane root is enough, because a git
+    invocation can have more than one: `git --git-dir <plane>/.git checkout feature` moves
+    the root's refs while its files land in the cwd. See :func:`_git_target`.
     """
     segments, parsed = _segment_argv_parsed(cmd)
     if not parsed:
         return
     here = cwd
     for _toks in segments:
-        prog, _env, args = _split_env(_toks)
+        prog, env, args = _split_env(_toks)
         base = os.path.basename(prog or "")
         # A `cd` earlier in the SAME command moves where the later segments run. Without
         # this the guard refused `cd workspaces/<ws>/<repo> && git checkout -b x` — which is
@@ -1926,18 +2273,15 @@ def _plane_root_git(cmd: str, cwd: str, root: Path):
             continue
         if base != "git":
             continue
-        target, rest = _git_target(here, args)
-        i = 0
-        while i < len(rest) and rest[i].startswith("-"):
-            i += 2 if rest[i] in _GIT_VALUE_OPTS else 1
-        if i >= len(rest):
+        pre, rest = _git_globals(args)
+        if not rest:
             continue                        # global options only: no subcommand to judge
         try:
-            if target.resolve() != root:
+            if not any(t.resolve() == root for t in _git_target(here, pre, env)):
                 continue
         except OSError:
             continue
-        yield rest[i], rest[i + 1:], rest[:i]
+        yield rest[0], rest[1:], pre
 
 
 def _checkout_operand_kind(root: Path, op: str) -> str:
@@ -2450,10 +2794,16 @@ def _plane_root_reset_reason(cmd: str, cwd: str) -> str | None:
     case still exits on a string comparison.
     """
     # This is the SECOND guard on the plane root, and it runs on every Bash call the first
-    # one let through, so it does not pay for a shell parse it cannot use. Sound rather than
-    # heuristic: the only thing below that can deny is a subcommand token equal to `reset`,
-    # and a token cannot be in the argv without its characters being in the string.
-    if "reset" not in cmd:
+    # one let through, so it does not pay for a shell parse it cannot use. The test used to
+    # be `"reset" not in cmd`, which was sound while the guard read the subcommand as
+    # written — and stopped being sound the moment it started following ALIASES below: with
+    # `wipe = reset --hard` in the repo's config, `git wipe origin/main` destroys unpushed
+    # commits in the plane root and does not contain the word (#467).
+    #
+    # `git` is the sound version of the same shortcut: `_plane_root_git` yields only for a
+    # program whose basename is `git`, so those three characters have to be in the string
+    # before anything below can deny, however the subcommand is spelled.
+    if "git" not in cmd:
         return None
     from . import config as _cfg
     try:
@@ -2461,9 +2811,16 @@ def _plane_root_reset_reason(cmd: str, cwd: str) -> str | None:
     except OSError:
         return None
 
-    for sub, post, _pre in _plane_root_git(cmd, cwd, root):
+    for sub, post, pre in _plane_root_git(cmd, cwd, root):
         if sub != "reset":
-            continue
+            # …yet. The branch guard has followed aliases since #461's round two, and this
+            # one did not, so `git -c alias.z='reset --hard origin/main' z` destroyed the
+            # commits the branch guard would have refused a checkout for (#467). One guard
+            # resolving what a command will really do and its sibling matching the spelling
+            # is the split that let the alias route survive a fix aimed at it.
+            sub, post = _resolve_git_alias(root, sub, post, pre)
+            if sub != "reset":
+                continue
         if not any(a in _RESET_TREE_MODES for a in post):
             continue
         # Same reading of `--` the branch guard settled on: what FOLLOWS the separator is
@@ -2834,9 +3191,18 @@ def pretooluse_read() -> int:
     the next paragraph said it would. Any future widening belongs in the shared predicate,
     never in one caller.
 
-    Known limit, shared with the Bash guard and stated rather than papered over: a `Grep`
-    rooted at the repo top searches vault files as collateral. Denying every broad search is
-    untenable, so this checks the path the caller actually named.
+    **And the same second half, on the same route** (#474). `Grep` recurses — that is what
+    it is — so `Grep(path=".")` in the plane root read every vault file as collateral and
+    named none of them, exactly as `grep -rn TOKEN .` did on the Bash route. It is the same
+    defect, so it gets the same answer from the same pair of functions
+    (:func:`_walk_into_guarded_state`, :func:`_guarded_state_entries`): where the first
+    predicate reads the operand's TEXT, this one resolves it and asks whether the walk
+    REACHES a state entry that exists and holds bytes. `Read` is exempt because it takes a
+    file and does not walk.
+
+    Two routes, two predicates, one implementation of each. #462's lesson is the reason: the
+    day one route carried a private half of the answer, the vault DIRECTORY was refused here
+    and allowed on Bash.
 
     **The `except` covers the READING of the payload and nothing else** (#438). It used to
     wrap the whole body, `_deny` included, so any exception out of the refusal itself
@@ -2861,11 +3227,28 @@ def pretooluse_read() -> int:
         # directory operand for both routes, so this route no longer needs a private half of
         # the answer, and a repaired hole cannot be repaired in one caller again.
         hit = any(_names_a_vault_path(t) for t in targets)
+        # `Grep` walks; `Read` opens one file. So only `Grep` can reach a vault it did not
+        # name, and a `Grep` with no `path` at all searches the session's directory — the
+        # commonest spelling of the search that read every vault (#474).
+        walked = None
+        if not hit and (data.get("tool_name") or "") == "Grep":
+            walked = _walk_into_guarded_state(data.get("cwd") or "", targets or ["."], [])
+            # `Grep` has no exclude, so its own narrowing is what stands in for one — and it
+            # is answered by looking, not by reading the glob: a search for `*.py` over a
+            # directory of `.json` vaults prints nothing, and refusing it would be a false
+            # denial on the commonest narrowed search there is.
+            glob = str(ti.get("glob") or "")
+            if walked is not None and glob and not _glob_selects_inside(walked, glob):
+                walked = None
     except Exception:
         return 0
-    if not hit:
+    if not hit and walked is None:
         return 0
     reason = _READ_REASON
+    if walked is not None:
+        reason = (f"walks a directory tree that contains the plane's own `{walked.name}` — "
+                  f"every file in it would be printed into the transcript, and none of "
+                  f"them is named on this call. " + _WALK_FIX)
     rc = _deny("PreToolUse", reason)
     _trace("deny", data.get("session_id"), reason=reason[:70],
            cmd=(data.get("tool_name") or "")[:40])

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -538,8 +538,12 @@ def _guarded_state_entries() -> list[Path]:
     """
     from . import config as _cfg
     out: list[Path] = []
+    # Both scans are closed explicitly. This runs on the Bash hot path, so a leaked
+    # `ScandirIterator` per invocation is a leaked file descriptor per invocation — the
+    # suite printed one `ResourceWarning` per call before the `with`.
     try:
-        entries = list(os.scandir(Path(_cfg.STATE_DIR)))
+        with os.scandir(Path(_cfg.STATE_DIR)) as it:
+            entries = list(it)
     except OSError:
         return out
     for entry in entries:
@@ -547,8 +551,10 @@ def _guarded_state_entries() -> list[Path]:
                 not entry.name.startswith(_GUARDED_STATE_PREFIXES):
             continue
         try:
-            if entry.is_dir() and next(os.scandir(entry.path), None) is None:
-                continue                    # an empty directory has nothing to leak
+            if entry.is_dir():
+                with os.scandir(entry.path) as inner:
+                    if next(inner, None) is None:
+                        continue            # an empty directory has nothing to leak
         except OSError:
             continue
         out.append(Path(entry.path))
@@ -2148,6 +2154,17 @@ def _git_target(cwd: str, pre: list[str], env: list[str] = ()) -> list[Path]:
     repository's branch — and the benefit is that no single-path answer has to choose which
     of two real subjects to report.
 
+    **It is a SUPERSET of the cwd, not an enumeration of everything git will touch.** The
+    list is exactly: the cwd, always; the `--work-tree`/`GIT_WORK_TREE` if one is named; and
+    the `--git-dir`/`GIT_DIR` with its parent if one is named. That is the guarantee — every
+    directory it names is a place this invocation can act on, and it never answers with less
+    than the cwd — and it is deliberately NOT a claim that everything git touches appears
+    here. A submodule's own git dir, a `--namespace`, an `includeIf` that redirects a
+    worktree, and a `--git-dir` pointing at a LINKED worktree's git dir (whose HEAD is that
+    worktree's, not the root's) are all subjects this returns nothing for. Round one's
+    docstring said it "returns every subject an invocation names", which is a larger sentence
+    than the code keeps.
+
     **Relative paths resolve against the SHELL's directory**, which is what *cwd* carries.
     A `-C` used to be `Path(args[i + 1])`, so a relative one resolved against whatever
     directory the hook process happened to be started in — a directory the command being
@@ -2210,19 +2227,45 @@ def _git_target(cwd: str, pre: list[str], env: list[str] = ()) -> list[Path]:
     def _at(p: str) -> Path:
         return Path(p) if os.path.isabs(p) else here / p
 
-    out: list[Path] = []
-    if work_tree is None:
-        # No work tree named: the cwd is where the files land, and it is a subject whether
-        # or not a `--git-dir` moved the refs somewhere else.
-        out.append(here)
-    else:
+    # **The cwd is UNCONDITIONALLY a subject, and that is the invariant this list has.** It
+    # used to be dropped when a `--work-tree` was named, on the reading that the files land
+    # in the named tree so the cwd is out of it. That reading is wrong twice over:
+    #
+    #  * With a `--work-tree` and NO `--git-dir`, git still DISCOVERS the repository from
+    #    the cwd, so the refs that move are the CWD's. `git --work-tree=<elsewhere> reset
+    #    --hard origin/main`, typed in the plane root, destroyed two unpushed commits there
+    #    against git 2.50.1 with no refusal — a hole this function opened, since the guard
+    #    scoped to the cwd alone refused it.
+    #  * With both named the cwd really is untouched, and it is kept anyway. Dropping it is
+    #    the only way this list could answer with LESS than the cwd every earlier version of
+    #    the guard returned, and a subject list that gets SMALLER as the command line gets
+    #    longer is a flag-shaped bypass by construction. The invariant is the property worth
+    #    having; the cost is refusing a `--git-dir=<elsewhere>/.git --work-tree=<elsewhere>`
+    #    pair that happens to be typed while standing in the plane root, which is the same
+    #    fail-closed trade the paragraph above records.
+    #
+    # So: `_git_target` only ever ADDS subjects. `test_the_subject_list_only_ever_grows`
+    # states it over the whole option cross-product rather than over these two branches.
+    out: list[Path] = [here]
+    if work_tree is not None:
         out.append(_at(work_tree))
     if git_dir is not None:
         # The repository a git dir belongs to is its PARENT for the ordinary `<repo>/.git`
         # layout, and the git dir itself when it is bare. Both are offered rather than
         # guessed at: the caller only asks whether one of them is the plane root.
+        #
+        # `gd / ".."` and not `gd.parent`: `Path.parent` is LEXICAL, so it takes the last
+        # component off the string without looking at what it means. For `<plane>/.git` that
+        # is `<plane>` and the guard fired; for `<plane>/.git/refs/..` — the same directory,
+        # one dot-segment away — it is `<plane>/.git/refs`, which is not the plane root, and
+        # `git --git-dir=<plane>/.git/refs/.. reset --hard origin/main` destroyed two
+        # unpushed commits in the plane root against git 2.50.1 with the guard silent
+        # (#477, still open after round one closed the plain spelling). Appending the `..`
+        # instead hands the collapsing to the caller's `resolve()`, which asks the
+        # filesystem — so `.git`, `.git/./`, `.git/refs/..` and a symlinked route are one
+        # question rather than a list of spellings.
         gd = _at(git_dir)
-        out.extend((gd, gd.parent))
+        out.extend((gd, gd / ".."))
     return out
 
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -100,13 +100,22 @@ rule while one who reads a bare refusal files an issue.
   feature` the same branch move — including chains, aliases carrying their own options,
   `!git checkout`, and `git -c alias.co=checkout co …`. A `!`-alias that is not a plain
   `git …` is not read (refusing every shell alias here would refuse `s = !git status`), and
-  neither is `--config-env`. The **route** does not change the verdict either: the cwd, a
-  `cd` earlier in the same command, `git -C <path>` — absolute or relative, and relative
-  means *relative to the shell*, which is the fix for `git -C ../../.. checkout <branch>`
-  reaching the root from a clone — and the three options that name a repository without
-  naming a directory to stand in: `--git-dir`, `--work-tree` and their `GIT_DIR` /
-  `GIT_WORK_TREE` environment spellings, attached or separated, composing with `-C`
-  ([#477](https://github.com/diazoxide/charter/issues/477)). A `-C` counts as git's
+  neither is `--config-env`. **These routes all reach the same verdict** — the list is what
+  is covered, not a claim that every route is: the cwd, a `cd` earlier in the same command,
+  `git -C <path>` — absolute or relative, and relative means *relative to the shell*, which
+  is the fix for `git -C ../../.. checkout <branch>` reaching the root from a clone — and
+  the three options that name a repository without naming a directory to stand in:
+  `--git-dir`, `--work-tree` and their `GIT_DIR` / `GIT_WORK_TREE` environment spellings,
+  attached or separated, composing with `-C`
+  ([#477](https://github.com/diazoxide/charter/issues/477)). The cwd is a subject of every
+  git command, including one that names a `--work-tree` elsewhere: with no `--git-dir`, git
+  discovers the repository from the cwd, so the refs that move are the cwd's. And *which
+  repository a `--git-dir` belongs to* is asked of the filesystem rather than of the string,
+  so `<plane>/.git`, `<plane>/.git/./` and `<plane>/.git/refs/..` are one question — a
+  lexical parent made the last of those a live bypass for a round. What it still does not
+  place is a `--git-dir` pointing at a **linked worktree's** git dir, whose HEAD is that
+  worktree's and not the root's; that one is a missed denial, never a wrong one. A `-C`
+  counts as git's
   change-directory global only **before the subcommand**, which is the only position git
   reads one in — so `git switch -C <branch>`, where `-C` is `switch`'s own `--force-create`,
   is the branch creation it is rather than a directory called `<branch>`

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -101,22 +101,32 @@ rule while one who reads a bare refusal files an issue.
   `!git checkout`, and `git -c alias.co=checkout co …`. A `!`-alias that is not a plain
   `git …` is not read (refusing every shell alias here would refuse `s = !git status`), and
   neither is `--config-env`. The **route** does not change the verdict either: the cwd, a
-  `cd` earlier in the same command, and `git -C <path>` — absolute or relative, and relative
-  now means *relative to the shell*, which is the fix for `git -C ../../.. checkout <branch>`
-  reaching the root from a clone. `git --git-dir=<plane>/.git` is a route this guard does
-  **not** yet follow ([#477](https://github.com/diazoxide/charter/issues/477)), and
-  `git switch -C <branch>` — where `-C` is `switch`'s own `--force-create` and not git's
-  change-directory global — is read as a directory and missed
-  ([#483](https://github.com/diazoxide/charter/issues/483)); the attached spelling
-  `-C<branch>` is refused. Both are pinned as `ALLOW` rows in the guard's corpus
-  (`tests/test_plane_root_checkout_is_two_commands.py`), so closing either turns a row red
-  rather than passing unnoticed.
+  `cd` earlier in the same command, `git -C <path>` — absolute or relative, and relative
+  means *relative to the shell*, which is the fix for `git -C ../../.. checkout <branch>`
+  reaching the root from a clone — and the three options that name a repository without
+  naming a directory to stand in: `--git-dir`, `--work-tree` and their `GIT_DIR` /
+  `GIT_WORK_TREE` environment spellings, attached or separated, composing with `-C`
+  ([#477](https://github.com/diazoxide/charter/issues/477)). A `-C` counts as git's
+  change-directory global only **before the subcommand**, which is the only position git
+  reads one in — so `git switch -C <branch>`, where `-C` is `switch`'s own `--force-create`,
+  is the branch creation it is rather than a directory called `<branch>`
+  ([#483](https://github.com/diazoxide/charter/issues/483)). Every one of those is a row in
+  the guard's corpus (`tests/test_plane_root_checkout_is_two_commands.py`), crossed with the
+  commands rather than listed beside them. What the walk still does not carry across
+  segments is an environment assignment: `export GIT_DIR=<plane>/.git && git checkout
+  <branch>` reaches the root and is allowed
+  ([#496](https://github.com/diazoxide/charter/issues/496)), pinned as an `ALLOW` row so
+  closing it turns the row red rather than passing unnoticed.
 - **Plane-root history wipe.** A `git reset --hard` (or `--merge`/`--keep`) in the plane root
   that would take commits off the branch which no remote has a copy of — the command that
   destroyed eleven memory commits in one session. Only that: the unstage
   (`git reset HEAD -- <path>`), `--soft`/`--mixed`, a reset with no ref, and any reset over
   commits that are already pushed all run untouched. It clears itself — `charter save` lands
-  the commits and the same command is allowed.
+  the commits and the same command is allowed. It follows **aliases** exactly as the branch
+  guard does — `wipe = reset --hard` makes `git wipe origin/main` the same command, and so
+  does `git -c alias.z='reset --hard origin/main' z`
+  ([#467](https://github.com/diazoxide/charter/issues/467)) — and shares every route above,
+  so `git --git-dir=<plane>/.git reset --hard <ref>` from a clone is refused too.
 - **One credential.** SSH to a forge, `GIT_SSH_COMMAND`, `-S`/`--gpg-sign`, and the
   `core.sshCommand` family that reaches the same transport by another road (`-c`,
   `--config-env`, `GIT_CONFIG_KEY_n`, and a `git config` write of it). This one *is*

--- a/docs/news/unreleased-the-guards-follow-the-command.md
+++ b/docs/news/unreleased-the-guards-follow-the-command.md
@@ -1,0 +1,102 @@
+---
+version: unreleased
+headline: The plane-root and vault guards follow what a command does, not how it is spelled
+---
+
+Four holes, one shape. Each of the guards below already knew about the thing that walked
+past it — `--git-dir` was in the guard's own table of git options, `-C` was in its own list
+of branch-creating flags, the alias resolver was two hundred lines up the same file — and
+each read that thing in one role and never in the other. That is not a missing feature; it
+is a guard matching a **spelling** where the property was available to it.
+
+**`git switch -C <branch>` created a branch in the plane root and nothing said anything**
+([#483](https://github.com/diazoxide/charter/issues/483)). `-C` is git's own
+change-directory global *and* `switch`'s `--force-create`, and the guard stripped the first
+reading from anywhere in the argv — so `git switch -C neu` was read as a command aimed at a
+directory called `neu`, which is not the plane root, and both plane-root guards stood aside
+without printing a word. git answered *"Switched to a new branch 'neu'"*. The attached
+spelling `-C<branch>` was refused the whole time, which is what a spelling-shaped guard
+looks like from the inside: one keystroke decided whether the guard could see the command.
+
+The fix is a split, not a list. A `-C` counts as git's global only **before the
+subcommand** — the only position git itself reads one in — so nothing here has to know
+which options belong to `switch`, and the next subcommand option that collides with a git
+global is already covered.
+
+**`git --git-dir=<plane>/.git checkout <branch>` moved the plane root's HEAD from a
+workspace clone** ([#477](https://github.com/diazoxide/charter/issues/477)). `--git-dir`,
+`--work-tree` and their `GIT_DIR` / `GIT_WORK_TREE` environment spellings all name a
+repository without naming a directory to stand in. All of them were already in the guard's
+table of git options — where they were skipped as option *values* so they could not be
+misread as a subcommand, and then never looked at again. The guard now asks which
+repository an invocation names rather than "the cwd unless `-C` says otherwise", and answers
+with every subject the command has: a `--git-dir` with no `--work-tree` beside it moves the
+named repository's refs while its files land in the cwd, so both count. Attached and
+separated forms, composed with `-C` (git applies `-C` first, and a relative `--git-dir` is
+read against where it landed), and the environment spellings — all of them are now rows in
+the guard's corpus, crossed with the commands rather than listed beside them.
+
+**A `git reset --hard` hiding behind an alias destroyed unpushed commits in the plane
+root** ([#467](https://github.com/diazoxide/charter/issues/467)). The branch guard has
+followed aliases since 0.51 — `co = checkout` is on a large share of developer machines —
+and the history-wipe guard, the one that exists because eleven memory commits were lost in
+one session, was still comparing the subcommand to the string `reset`. So
+`git -c alias.z='reset --hard origin/main' z` went through, and so did `git wipe
+origin/main` with `wipe = reset --hard` in the repo's config. Both guards now resolve the
+alias before deciding. The cheap early exit went with it: testing for the word `reset` in
+the command line is sound only while the subcommand is read as written, and those five
+characters live in the config for a config alias. It tests for `git` instead, which is
+sound whatever the subcommand is called, because nothing below it can deny without a `git`
+invocation.
+
+**`grep -rn TOKEN .` from the plane root printed every vault file**
+([#474](https://github.com/diazoxide/charter/issues/474)). Both vault guards decided on the
+text of the operand, so an operand that *contains* the vault directory without naming it
+walked past them — on the Bash route and on `Grep(path=".")` alike. This was a documented
+trade rather than an oversight, and the trade is revisited on purpose: denying every broad
+search is untenable, but denying the ones that really would walk into charter's own state
+is not the same thing.
+
+The new predicate asks whether the walk **reaches** that directory. The operand is resolved
+against the shell's directory and compared by ancestry, and the entries it is compared
+against are read off the filesystem — so `.`, `..`, `../..`, an absolute path and a path
+through a symlinked parent are one question rather than five spellings, and a plane whose
+`$CHARTER_HOME` puts its vaults somewhere no pattern can spell is covered by the same code.
+It fires only when those entries exist and hold something, so a fresh plane never sees it.
+And the denial names the exclusion that fixes it — `grep -rn --exclude-dir=.charter …`,
+`rg --glob '!.charter' …` — which the guard reads, and which the tests execute, because a
+guard that refuses the command it recommends is one people learn to route around.
+
+**One route this deliberately did not chase**, filed instead:
+[#496](https://github.com/diazoxide/charter/issues/496). `GIT_DIR=<plane>/.git git checkout
+feature` is refused now; `export GIT_DIR=<plane>/.git && git checkout feature` is not,
+because the shared walk models exactly one shell effect that crosses segments — a `cd` —
+and env assignments are read only where they sit on the invocation itself. "Track the
+environment across segments" is a larger claim than "track the working directory across
+segments", and it belongs with its own evidence rather than inside this one. It is a row in
+the guard's corpus, named after the issue, so closing it turns the row red.
+
+**What still walks past, said plainly.** The new predicate knows which programs walk
+directories, and that list is shorter than the list of programs that walk: `find . -type f
+-exec cat {} +` and `tar cf - .` read the same files and are allowed, exactly as
+`base64 .charter/vaults/db.json` always has been. An interpreter's argument is still text
+charter does not re-parse, and `_leak_reason` still does not follow a `cd` earlier in the
+same command. Each is pinned as behaviour in `tests/test_vault_path_spellings.py`, so a
+later doc that claims otherwise fails the suite.
+
+**And one issue closed by deciding rather than by coding.**
+[#476](https://github.com/diazoxide/charter/issues/476) asked whether the vault guards
+should fold a Windows-style `.charter\vaults\db.json`. They should not, on the prerequisite
+the issue itself named: charter's harness does not run on Windows. It builds and drives a
+tmux session and writes vaults at `0o600`; there is no Windows CI and no Windows install
+path. Folding `\` would buy nothing on a supported host and would deny POSIX filenames that
+legitimately contain a backslash, and a platform-*conditional* fold would make the guard's
+answer depend on the host — the exact property `re.IGNORECASE` was added to remove. So
+`SECURITY.md` and `docs/secrets.md` now say charter's harness targets POSIX where they used
+to name Windows as a reason, the package's `Operating System :: OS Independent` classifier
+(which was never true) is now `POSIX`, and the decision is recorded next to the test rather
+than left as an open question.
+
+Nothing here changes what is allowed in a workspace clone, which is where branch work and
+destructive git belong. `git checkout <path>`, `git restore <path>`, the unstage, `--soft`
+and a narrowed search all run in the plane root exactly as before.

--- a/docs/news/unreleased-the-guards-follow-the-command.md
+++ b/docs/news/unreleased-the-guards-follow-the-command.md
@@ -30,11 +30,39 @@ repository without naming a directory to stand in. All of them were already in t
 table of git options — where they were skipped as option *values* so they could not be
 misread as a subcommand, and then never looked at again. The guard now asks which
 repository an invocation names rather than "the cwd unless `-C` says otherwise", and answers
-with every subject the command has: a `--git-dir` with no `--work-tree` beside it moves the
-named repository's refs while its files land in the cwd, so both count. Attached and
-separated forms, composed with `-C` (git applies `-C` first, and a relative `--git-dir` is
-read against where it landed), and the environment spellings — all of them are now rows in
-the guard's corpus, crossed with the commands rather than listed beside them.
+with a LIST of subjects rather than one path: the cwd, always; the work tree if one is
+named; and the git dir with the directory it belongs to. A `--git-dir` with no `--work-tree`
+beside it moves the named repository's refs while its files land in the cwd, so both count.
+The cwd stays on that list even when a `--work-tree` names somewhere else, and that is not
+belt-and-braces: with no `--git-dir`, git *discovers* the repository from the cwd, so
+`git --work-tree=<elsewhere> reset --hard origin/main` typed in the plane root destroys the
+root's unpushed commits. An earlier cut of this change dropped the cwd there and reopened
+exactly that. The list only ever grows now — a guard whose subjects SHRINK as the command
+line gets longer has a flag-shaped bypass in it by construction — and the invariant is
+asserted over the option cross-product, not over the spellings anyone happened to try.
+
+Which directory a git dir belongs to is asked of the **filesystem**, not of the string.
+`Path.parent` is lexical, so `<plane>/.git` resolved to the plane root and
+`<plane>/.git/refs/..` — the same directory, one segment away, same inode — resolved to
+`<plane>/.git/refs`, and `git --git-dir=<plane>/.git/hooks/.. reset --hard origin/main`
+destroyed both unpushed commits in the plane root with the guard silent. Attached and
+separated forms, dot segments in either direction, composed with `-C` (git applies `-C`
+first, and a relative `--git-dir` is read against where it landed), and the environment
+spellings — all of them are now rows in the guard's corpus, crossed with the commands rather
+than listed beside them.
+
+What this still does not place, said plainly rather than left to be found. A `--git-dir`
+pointing at a **linked worktree's** git dir (`<plane>/.git/worktrees/<name>`), whose HEAD
+belongs to that worktree and not to the root — a denial the guard does not make, never one
+it makes wrongly. And git's THIRD spelling of the work tree, the `core.worktree` key in a
+repository's own config: a clone carrying it has the plane root as its working tree for
+every command, with nothing on the command line to say so, and `git checkout <branch>` typed
+inside that clone overwrites the root's tree unrefused. Filed as
+[#504](https://github.com/diazoxide/charter/issues/504) with the reproduction rather than
+chased here, because following it means reading the cwd repository's config on every Bash
+tool call — a real cost on a path whose common case currently exits on a string comparison.
+The `-c core.worktree=…` form, which is the one an agent would type, was checked and does
+*not* reach the plane root on git 2.50.1; only the key written in the config does.
 
 **A `git reset --hard` hiding behind an alias destroyed unpushed commits in the plane
 root** ([#467](https://github.com/diazoxide/charter/issues/467)). The branch guard has
@@ -80,9 +108,14 @@ the guard's corpus, named after the issue, so closing it turns the row red.
 directories, and that list is shorter than the list of programs that walk: `find . -type f
 -exec cat {} +` and `tar cf - .` read the same files and are allowed, exactly as
 `base64 .charter/vaults/db.json` always has been. An interpreter's argument is still text
-charter does not re-parse, and `_leak_reason` still does not follow a `cd` earlier in the
-same command. Each is pinned as behaviour in `tests/test_vault_path_spellings.py`, so a
-later doc that claims otherwise fails the suite.
+charter does not re-parse. A `cd` earlier in the same command used to be on this list and is
+not any more: `_leak_reason` got the same segment walk the git guards have, and the walk
+predicate resolves its operand against the composed directory rather than the raw cwd — so
+`cd <plane> && grep -rn TOKEN .` from outside is refused, and `cd sub && grep -r x .` in the
+plane root is answered against `sub` rather than against the root. That row is still in
+`tests/test_vault_path_spellings.py` with its verdict flipped rather than deleted, which is
+how a closed limit should read. The rest are pinned there as behaviour, so a later doc that
+claims otherwise fails the suite.
 
 **And one issue closed by deciding rather than by coding.**
 [#476](https://github.com/diazoxide/charter/issues/476) asked whether the vault guards

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -164,9 +164,10 @@ shell history**, while still letting an agent *use* the credential:
   the hook, is the control.
 
   `Glob` is not denied — it returns file *names*, and that a vault exists is not the secret.
-  Neither is a search rooted far above `.charter/`, which reads vault files as collateral;
-  denying every broad search is untenable, so both guards check the path you actually named.
-  What the two routes do **not** differ on is any spelling of a guarded path: they call one
+  A **recursive search rooted above the vault directory is** — `grep -rn TOKEN .` from the
+  plane root reads every vault file as collateral, and since #474 both routes refuse it and
+  name the exclusion that fixes it. What the two routes do **not** differ on is any spelling
+  of a guarded path: they call one
   predicate on the operand as written and neither adds a step of its own, which is asserted
   in both directions rather than assumed — the one round where the read route carried an
   extra step, the Bash route allowed `grep -rn TOKEN .charter/vaults` while `Grep` on the
@@ -197,16 +198,25 @@ shell history**, while still letting an agent *use* the credential:
   an ordinary file to every guard charter has. And a separator that is not `/`:
   normalisation is POSIX, so a Windows-style `.charter\vaults\db.json` is not folded,
   because on POSIX a backslash is an ordinary filename character and folding it would deny
-  real filenames.
+  real filenames. charter's harness targets POSIX — macOS and Linux, with tmux — and is
+  neither tested nor supported on Windows, which is why the guard is not made to answer
+  differently there (#476).
 
-  *The path you actually named.* An operand that **contains** the vault directory without
-  naming it is not a vault path: `grep -rn TOKEN .` from the plane root reads every vault
-  file as collateral, names none of them, and is allowed. This is the one that ends up
-  mattering most in practice, and it is deliberate on both routes — denying every broad
-  search is untenable, so both the Bash guard and the `Read`/`Grep` guard check the path in
-  the operand rather than the files a recursive walk would reach. It is also the reason
-  `charter init` gitignores the whole of `/.charter/` rather than relying on the guard to
-  keep a vault out of a commit.
+  *The path you actually named — and, since #474, the path the walk reaches.* An operand
+  that **contains** the vault directory without naming it used to be allowed: `grep -rn
+  TOKEN .` from the plane root reads every vault file as collateral and names none of them.
+  A second predicate now covers it on both routes. It asks whether the walk would **reach**
+  charter's state directory rather than how the operand is spelled — the operand is resolved
+  against the shell's directory and compared by ancestry, so `.`, `..`, `../..`, an absolute
+  path and a symlinked parent are one question — and it fires only when the guarded entries
+  exist and hold something, so a plane with no file-backed vault never sees it. The denial
+  names the fix: `grep -rn --exclude-dir=.charter …`, `rg --glob '!.charter' …`, and both
+  are asserted to run in `tests/test_vault_path_spellings.py`.
+
+  The ceiling on *that* predicate is the same one the reader list has: it knows which
+  programs walk directories, so `find . -type f -exec cat {} +`, `tar cf - .` and an
+  interpreter all reach the same files unguarded. `charter init` gitignores the whole of
+  `/.charter/`, which is what actually keeps a vault out of a commit.
 
   *Before any shell runs.* This is the one people discover the hard way. The hook is handed
   the command line and never sees what the shell makes of it, so every expansion is a read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,13 @@ classifiers = [
   "Environment :: Console",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
-  "Operating System :: OS Independent",
+  # POSIX, not "OS Independent", which is what this said and was not true: the harness
+  # builds and drives a tmux session and writes its vaults at 0o600. Neither exists on
+  # Windows, there is no Windows CI, and a vault guard was being asked to answer for a
+  # platform charter does not run on (#476).
+  "Operating System :: POSIX",
+  "Operating System :: MacOS :: MacOS X",
+  "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -116,17 +116,19 @@ vaults' own lines — never a line from a value you supplied.
   - anything a shell rewrites for you: a glob (`cat .charter/vault?/db.json`), a variable
     (`V=…; cat $V`), a quoted command substitution, or brace expansion — the shell does
     all of that after the guard has already answered, on text the guard never sees;
-  - **a search rooted above the vault directory.** `grep -rn TOKEN .` reads every vault file
-    and is allowed, because the operand you named is `.` and not a vault path. Naming the
-    directory — `grep -rn TOKEN .charter/vaults`, with or without a trailing slash — is
-    denied. The difference is what you typed, not what the command reads.
+  - **a directory walk by a program it does not know.** `find . -type f -exec cat {} +`
+    and `tar cf - .` read every vault file and are allowed. A recursive `grep`/`rg`/`ag`
+    rooted above the vault directory *is* denied now (#474), and the denial names the
+    exclusion — but that covers the walkers charter knows, which is a shorter list than the
+    programs that walk.
 
   Each of those reaches the exact bytes the guard refuses when you spell the path plainly.
   **Never read a vault file, by any name, spelling, program, or recursive walk that happens
   to include it.** A denial is charter noticing a mistake, not charter's permission system —
   do not go looking for a form of the command it does not notice, and do not treat an
-  allowed command as cleared. If you need to search the plane, exclude the vault directory
-  (`grep -rn TOKEN . --exclude-dir=vaults`) rather than relying on the guard to stop you.
+  allowed command as cleared. If you need to search the plane, exclude charter's state
+  directory (`grep -rn TOKEN . --exclude-dir=.charter`) rather than relying on the guard to
+  stop you.
 - Never echo a secret, write it into a tracked file, or pass it as a literal argument.
 - **Never store a value in order to compare its fingerprint against another vault's.**
   That confirms a guess, which is the one thing masking exists to stop, and it is the

--- a/tests/test_plane_root_checkout_is_two_commands.py
+++ b/tests/test_plane_root_checkout_is_two_commands.py
@@ -63,6 +63,7 @@ from __future__ import annotations
 
 import itertools
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -95,7 +96,12 @@ _SUBS = ("checkout", "switch")
 #: option charter cannot place — in each spelling git's parser accepts: long, short, and a
 #: cluster in BOTH orders, since a cluster is read left to right and `-qd` meets a different
 #: letter first than `-dq`.
-_OPTS = ("", "-q", "--ours", "--detach", "-d", "-qd", "-dq", "-b", "--orphan")
+#:
+#: `-B` and `-C` are here since #483, and they are the axis that issue is really about: a
+#: short option whose LETTER is also the name of one of git's own globals. Crossing them
+#: with the operands is what produces `git switch -C feature` without anyone deciding to
+#: type it.
+_OPTS = ("", "-q", "--ours", "--detach", "-d", "-qd", "-dq", "-b", "-B", "-C", "--orphan")
 
 #: One witness per operand CLASS: the plane's DEFAULT BRANCH — the remedy's name, and the
 #: one the carve-out used to hand a free pass to whatever stood beside it — another branch,
@@ -561,6 +567,11 @@ class TestGitItselfIsTheOracle(CheckoutCase):
         "git checkout -f feature", "git checkout -q feature", "git checkout -fq feature",
         "git checkout --guess feature", "git checkout -m feature",
         "git switch feature", "git switch -c neu", "git switch -cneu",
+        # Round five's bypass, and the reason it was one: `-C` is git's change-directory
+        # global AND `switch`'s `--force-create`, and `_git_target` stripped the first
+        # reading from anywhere in the argv, so the SEPARATED form retargeted the guard at a
+        # directory called `neu` and the attached `-Cneu` was refused the whole time (#483).
+        "git switch -C neu", "git switch -Cneu", "git switch -C feature",
         "git switch --orphan neu", "git switch --orphan=neu",
         "git switch --detach feature", "git switch -d feature",
         # Restores and no-ops: nothing here may move HEAD, and the guard's verdict on them
@@ -602,7 +613,8 @@ class TestGitItselfIsTheOracle(CheckoutCase):
         for must in ("git checkout --orphan README", "git checkout -bREADME",
                      "git switch -cneu", "git checkout -d feature",
                      "git checkout --detach main", "git switch -d main",
-                     "git switch -- feature", "git switch -q -- ambig"):
+                     "git switch -- feature", "git switch -q -- ambig",
+                     "git switch -C neu"):
             self.assertIn(must, movers)
 
     def test_no_promised_restore_moves_head_and_every_one_is_allowed(self):
@@ -635,6 +647,17 @@ class TestEveryRouteToThePlaneRootIsTheSameRoute(CheckoutCase):
     So the routes are an axis too, crossed with commands whose effect **git decides** — the
     same oracle as above, run on the bare command once, because a route cannot change what a
     command does to HEAD.
+
+    **Round five added the routes that name a repository without naming a directory to stand
+    in** (#477). `--git-dir`, `--work-tree` and their `GIT_DIR` / `GIT_WORK_TREE` env
+    spellings were all already known to this guard — they sat in `_GIT_VALUE_OPTS`, where
+    they were skipped as option VALUES so they could not be misread as a subcommand, and
+    then never looked at again. Verified end to end against git 2.50 from a workspace clone:
+    `git --git-dir <plane>/.git checkout feature` answers *"Switched to branch 'feature'"*
+    and the plane root's `symbolic-ref` follows, and the guard printed nothing. That is the
+    shape this class exists for — a route the guard has heard of and does not follow — and
+    it survived three rounds of route work because the routes were a list rather than an
+    axis crossed with the commands.
     """
 
     #: `(subcommand, rest)`, kept split so the alias route can put the subcommand inside
@@ -643,6 +666,11 @@ class TestEveryRouteToThePlaneRootIsTheSameRoute(CheckoutCase):
         ("checkout", "feature"), ("switch", "feature"), ("checkout", "-b chore/x"),
         ("checkout", "--detach main"), ("switch", "-d main"), ("checkout", "--orphan README"),
         ("switch", "-- feature"), ("checkout", "ambig"),
+        # #483's command, carried through every route on purpose: the `-C` that means
+        # `--force-create` here has to survive being crossed with the routes that spell
+        # themselves `-C`, and `git -C <root> switch -C neu` is where the two readings meet
+        # in one argv.
+        ("switch", "-C neu"),
         # Not movers — carried through the same loop so the routes are exercised on the
         # allowed half too, and a route that started refusing every restore fails here.
         ("checkout", "README"), ("restore", "README"), ("checkout", "main"),
@@ -670,6 +698,27 @@ class TestEveryRouteToThePlaneRootIsTheSameRoute(CheckoutCase):
                f"cd .. && git -C {self.root.name} {tail}")
         yield ("an alias, from the clone", self.clone,
                f"git -C {self.up} -c alias.zz={sub} zz {rest}".strip())
+        # #477: the two globals that name a repository WITHOUT naming a directory to stand
+        # in. Both were already in `_GIT_VALUE_OPTS`, where they were skipped as option
+        # values so they could not be misread as a subcommand — and then never looked at
+        # again, so `git --git-dir <plane>/.git checkout feature` from a clone moved the
+        # root's HEAD and the guard said nothing. Verified end to end against git 2.50.
+        yield "--git-dir, separated", self.clone, f"git --git-dir {self.root}/.git {tail}"
+        yield "--git-dir=, attached", self.clone, f"git --git-dir={self.root}/.git {tail}"
+        yield ("--work-tree and --git-dir", self.clone,
+               f"git --work-tree={self.root} --git-dir={self.root}/.git {tail}")
+        yield ("--work-tree alone", self.clone,
+               f"git --work-tree {self.root} --git-dir {self.root}/.git {tail}")
+        # A relative `--git-dir` is interpreted against the directory the `-C`s ended at,
+        # which is git's own documented rule for it — so the two compose.
+        yield ("--git-dir relative to a -C", self.clone,
+               f"git -C {self.up} --git-dir=.git {tail}")
+        # The same two options spelled as environment. `_split_env` was already holding
+        # them; nothing read them.
+        yield ("GIT_DIR in the environment", self.clone,
+               f"GIT_DIR={self.root}/.git git {tail}")
+        yield ("GIT_WORK_TREE in the environment", self.clone,
+               f"GIT_WORK_TREE={self.root} GIT_DIR={self.root}/.git git {tail}")
 
     def test_a_head_move_is_denied_by_every_route(self):
         movers = []
@@ -684,8 +733,16 @@ class TestEveryRouteToThePlaneRootIsTheSameRoute(CheckoutCase):
                     self.assertEqual(_decision(r), "deny", f"{label}: {cmd}")
                     self.assertIn("PLANE ROOT", _reason(r), cmd)
         # Non-vacuity: if git stopped moving HEAD for these — a fixture with no second
-        # branch, say — the loop above would assert nothing and still pass.
-        self.assertGreaterEqual(len(movers), 7, movers)
+        # branch, say — the loop above would assert nothing and still pass. And the ROUTES
+        # are counted too: a `routes()` that quietly stopped yielding the `--git-dir` half
+        # would leave every remaining assertion green while covering less than it did.
+        self.assertGreaterEqual(len(movers), 8, movers)
+        labels = {label for label, _cwd, _cmd in self.routes("checkout", "feature")}
+        self.assertGreaterEqual(len(labels), 15, sorted(labels))
+        for must in ("--git-dir, separated", "--git-dir=, attached",
+                     "--work-tree and --git-dir", "--git-dir relative to a -C",
+                     "GIT_DIR in the environment", "GIT_WORK_TREE in the environment"):
+            self.assertIn(must, labels)
 
     def test_a_restore_is_allowed_by_every_route(self):
         """The routes do not become a way to refuse what charter permits. Widening the
@@ -789,7 +846,20 @@ PINNED: tuple[tuple[str, str, str, str], ...] = (
     ("DENY", "root", "git switch -", "the previous branch, again"),
     ("DENY", "root", "git switch -c neu", ""),
     ("DENY", "root", "git switch -cneu", "attached"),
-    ("DENY", "root", "git switch -Cneu", "the ATTACHED spelling of the one #483 misses"),
+    ("DENY", "root", "git switch -Cneu", "the ATTACHED spelling, refused all along"),
+    # Was the LIMIT #483 row until this commit, and the flip is the point of pinning it:
+    # `-C` is git's change-directory global AND `switch`'s `--force-create`, and
+    # `_git_target` stripped the first reading from ANYWHERE in the argv — so this
+    # retargeted the guard at a directory called `neu`, which is not the plane root, and
+    # both plane-root guards stood aside without printing anything. git: "Switched to a new
+    # branch 'neu'". `_git_globals` now splits the argv at the subcommand first, which is
+    # the only position git itself reads a global `-C` in.
+    ("DENY", "root", "git switch -C neu", "#483: the SEPARATED short form on `switch`"),
+    ("DENY", "root", "git switch -C feature", "the same, force-creating over a branch that exists"),
+    ("DENY", "root", "git switch -q -C neu", "and with a restore-shaped option beside it"),
+    ("DENY", "root", "git -C . switch -C neu",
+     "both readings of `-C` in one argv: the global retargets, the option creates"),
+    ("DENY", "clone", "git -C {up} switch -C neu", "the same from a clone, relative"),
     ("DENY", "root", "git switch --create neu", ""),
     ("DENY", "root", "git switch --force-create neu", ""),
     ("DENY", "root", "git switch --orphan neu", ""),
@@ -830,6 +900,35 @@ PINNED: tuple[tuple[str, str, str, str], ...] = (
     ("DENY", "clone", "git -C {up} -C . checkout feature", "two `-C`, each relative to the one before"),
     ("DENY", "clone", "git -C {up} switch -c neu", "a create by that route"),
     ("DENY", "clone", "git -C {up} -c alias.zz=checkout zz feature", "an alias by that route"),
+    # Was the three LIMIT #477 rows until this commit. `--git-dir` and `--work-tree` name a
+    # repository without naming a directory to stand in, and both were in `_GIT_VALUE_OPTS`
+    # — skipped as option VALUES so they could not be misread as a subcommand, and then
+    # never looked at again. Verified against git 2.50: from a clone, each of these answers
+    # "Switched to branch 'feature'" and the plane root's `symbolic-ref` follows.
+    ("DENY", "clone", "git --git-dir={root}/.git checkout feature", "#477: --git-dir, attached"),
+    ("DENY", "clone", "git --git-dir {root}/.git checkout feature", "#477: the separated form"),
+    ("DENY", "clone", "git --work-tree={root} --git-dir={root}/.git checkout feature",
+     "#477: --work-tree names the tree directly"),
+    ("DENY", "clone", "git --git-dir={root}/.git switch -c neu", "#477, creating a branch"),
+    ("DENY", "clone", "git -C {up} --git-dir=.git checkout feature",
+     "#477: a relative --git-dir is read against the directory the -C landed in"),
+    ("DENY", "clone", "GIT_DIR={root}/.git git checkout feature", "#477: the env spelling"),
+    ("DENY", "clone", "GIT_WORK_TREE={root} GIT_DIR={root}/.git git switch feature",
+     "#477: both env spellings together"),
+    ("DENY", "clone", "git --git-dir={root}/.git switch -C neu",
+     "#477 and #483 in one argv: the route the guard could not follow, carrying the option "
+     "it could not read"),
+    ("DENY", "clone", "git --git-dir={root}/.git checkout --orphan README",
+     "#477 carrying round one's bypass"),
+    ("DENY", "clone", "git --git-dir={root}/.git --work-tree={root} checkout --detach main",
+     "#477 with the options the other way round, carrying round three's"),
+    ("DENY", "above", "git --git-dir={name}/.git checkout feature",
+     "#477 with a RELATIVE git dir, resolved against the shell like a `-C`"),
+    ("DENY", "clone", "GIT_DIR={root}/.git git -c alias.zz=switch zz -d main",
+     "#477's route carrying #467's alias"),
+    ("DENY", "clone", "git --work-tree {root} checkout feature",
+     "git itself refuses --work-tree without a git dir; charter refuses AHEAD of git, "
+     "deliberately, rather than depending on git continuing to"),
     ("DENY", "above", "cd {name} && git checkout feature", "a `cd` earlier in the SAME command"),
     ("DENY", "above", "cd {name} && git switch feature", ""),
     ("DENY", "root", "cd .. && git -C {name} checkout feature", "out and back in again"),
@@ -872,19 +971,22 @@ PINNED: tuple[tuple[str, str, str, str], ...] = (
     ("ALLOW", "clone", "git -C . checkout -b feature/x", "the reach is not 'anything with a -C in it'"),
     ("ALLOW", "clone", "git -C {clone} checkout -b feature/x", ""),
     ("ALLOW", "clone", "cd .. && git -C svc checkout -b feature/x", ""),
+    ("ALLOW", "clone", "git switch -C neu", "#483's option, in the repo where branch work belongs"),
+    ("ALLOW", "clone", "git --git-dir=.git switch -c feature/x",
+     "#477's option pointed at the clone's OWN git dir: the reach is the repository it names"),
+    ("ALLOW", "clone", "git --work-tree={clone} --git-dir={clone}/.git checkout -b feature/x", ""),
+    ("ALLOW", "clone", "GIT_DIR={clone}/.git git switch -c feature/x", "the env spelling of the same"),
+    ("ALLOW", "clone", "git --git-dir={root}/.git checkout README",
+     "#477 widened the REACH, not what is refused: a restore is still a restore there"),
 
     # --- ALLOW, and every row a KNOWN LIMIT: a command that DOES move the plane root's
     #     HEAD and is not refused. Pinned as facts rather than left as silent gaps, each
     #     naming the issue that tracks it. Closing one turns its row RED, which is the
     #     point: a limit should not disappear without somebody noticing and saying so.
-    ("ALLOW", "root", "git switch -C neu",
-     "LIMIT #483: `-C` is _git_target's change-directory global AND switch's --force-create; "
-     "the separated form is eaten as a directory. git: Switched to a new branch 'neu'"),
-    ("ALLOW", "clone", "git --git-dir={root}/.git checkout feature",
-     "LIMIT #477: --git-dir names the repository and _git_target does not read it"),
-    ("ALLOW", "clone", "git --git-dir {root}/.git checkout feature", "LIMIT #477: the separated form"),
-    ("ALLOW", "clone", "git --work-tree={root} --git-dir={root}/.git checkout feature",
-     "LIMIT #477: --work-tree names the tree directly"),
+    ("ALLOW", "clone", "export GIT_DIR={root}/.git && git checkout feature",
+     "LIMIT #496: the shared walk carries a `cd` across segments and not an env assignment, "
+     "so the ATTACHED spelling `GIT_DIR=… git …` is refused (#477) and this one is not. "
+     "git: Switched to branch 'feature', and the root's symbolic-ref follows"),
     # #430 CLOSED. These six rows were recorded as limits — `prog` came from token 0, so a
     # wrapper word or a shell keyword standing in front of `git` hid it from every guard in
     # the module. `_split_env_chdir` strips the wrapper run before naming the program and
@@ -993,13 +1095,13 @@ class TestThePinnedCorpusIsTheBaseline(CheckoutCase):
         denies = [r for r in PINNED if r[0] == "DENY"]
         allows = [r for r in PINNED if r[0] == "ALLOW"]
         limits = [r for r in PINNED if _LIMIT in r[3]]
-        self.assertGreaterEqual(len(denies), 70, len(denies))
-        self.assertGreaterEqual(len(allows) - len(limits), 30, len(allows) - len(limits))
-        # Was 12. Six of those rows were the #430 wrapper-prefix family, and they are not
-        # gone — they are still in the table, flipped to DENY and annotated with the issue
-        # that closed them. A floor over the count alone cannot tell "closed" from
-        # "deleted", so the closed six are named below and this number is what remains.
-        self.assertGreaterEqual(len(limits), 6, len(limits))
+        self.assertGreaterEqual(len(denies), 85, len(denies))
+        self.assertGreaterEqual(len(allows) - len(limits), 35, len(allows) - len(limits))
+        # There is deliberately NO floor on `len(limits)`. A count cannot tell "closed" from
+        # "deleted" in either direction: #430's six rows are still here, flipped to DENY and
+        # annotated, and #483/#477's four are gone because they were closed. What holds the
+        # limits honest is `LIMIT_ISSUES` below — the exact SET of issues cited, which fails
+        # when one is closed without saying so AND when one is added without saying so.
         self.assertEqual(sorted({r[0] for r in PINNED}), ["ALLOW", "DENY"])
 
     def test_a_closed_limit_stays_in_the_table_as_a_denial(self):
@@ -1024,15 +1126,30 @@ class TestThePinnedCorpusIsTheBaseline(CheckoutCase):
             self.assertNotIn(key, seen, f"{cmd!r} in {where} appears twice")
             seen[key] = verdict
 
+    #: The issues the remaining `LIMIT` rows track — the WHOLE set, not a floor.
+    #:
+    #: A count was the wrong shape and this commit is why. Round five closed #483 and #477,
+    #: which took the corpus from twelve limits to eight; a `>= 12` assertion turns closing
+    #: a hole into a red test with no name on it, and the only way to read that failure is
+    #: to lower the number, which is indistinguishable from a limit quietly reappearing. An
+    #: exact set fails in BOTH directions and says which issue moved: closing one leaves an
+    #: issue listed here with no row, and adding one leaves a row citing an issue not here.
+    LIMIT_ISSUES = {"#430", "#496"}
+
     def test_every_known_limit_names_the_issue_that_tracks_it(self):
         """A limit with no issue behind it is a gap somebody decided to live with and then
         forgot. The `#nnn` is what makes the row a decision rather than an omission — and
         what a reader follows when the row goes red because the limit was closed."""
         limits = [r for r in PINNED if _LIMIT in r[3]]
+        self.assertTrue(limits)
         for verdict, _where, cmd, note in limits:
             with self.subTest(cmd=cmd):
                 self.assertEqual(verdict, "ALLOW", "a LIMIT row records what is NOT refused")
                 self.assertRegex(note, r"LIMIT #\d+", cmd)
+        cited = {m for _v, _w, _c, note in limits
+                 for m in re.findall(r"LIMIT (#\d+)", note)}
+        self.assertEqual(cited, self.LIMIT_ISSUES,
+                         "a limit was closed or added without saying so here")
 
     def test_the_axes_the_recent_work_established_all_have_rows(self):
         """The spellings this guard was taught over four rounds, asserted to be PRESENT.
@@ -1043,10 +1160,13 @@ class TestThePinnedCorpusIsTheBaseline(CheckoutCase):
         """
         commands = " || ".join(f"{w} {c}" for _v, w, c, _n in PINNED)
         for axis in ("checkout -b", "checkout -B", "--detach", "--orphan", "git switch ",
-                     "switch -c", "switch -C", "switch -d", "checkout -d",
+                     "switch -c", "switch -C neu", "switch -d", "checkout -d",
                      "-qbREADME", "-qd", "-dq", "checkout -- ", "git restore ",
                      "git -C .", "git -C {root}", "git -C {up}", "cd {name} &&",
-                     "alias", "ambig", "notes/a.md", "$(echo"):
+                     "alias", "ambig", "notes/a.md", "$(echo",
+                     # Round five's axes: #483's separated short `-C`, and #477's three
+                     # spellings of "the repository is over there".
+                     "--git-dir=", "--git-dir ", "--work-tree", "GIT_DIR=", "GIT_WORK_TREE="):
             with self.subTest(axis=axis):
                 self.assertIn(axis, commands, f"no row covers {axis!r} any more")
 

--- a/tests/test_plane_root_checkout_is_two_commands.py
+++ b/tests/test_plane_root_checkout_is_two_commands.py
@@ -707,8 +707,24 @@ class TestEveryRouteToThePlaneRootIsTheSameRoute(CheckoutCase):
         yield "--git-dir=, attached", self.clone, f"git --git-dir={self.root}/.git {tail}"
         yield ("--work-tree and --git-dir", self.clone,
                f"git --work-tree={self.root} --git-dir={self.root}/.git {tail}")
-        yield ("--work-tree alone", self.clone,
+        yield ("--work-tree and --git-dir, separated", self.clone,
                f"git --work-tree {self.root} --git-dir {self.root}/.git {tail}")
+        # This label used to sit on the line above, which passes BOTH options — so "work
+        # tree alone" was never actually a route, and the pinned note beside it asserted
+        # that git refuses the form. git 2.50.1 does not: with no `--git-dir` it DISCOVERS
+        # the repository from the cwd and writes into the named tree. Both real directions
+        # are routes now.
+        yield "--work-tree alone", self.clone, f"git --work-tree {self.root} {tail}"
+        yield ("--work-tree elsewhere, from the ROOT", self.root,
+               f"git --work-tree {self.clone} {tail}")
+        yield ("GIT_WORK_TREE elsewhere, from the ROOT", self.root,
+               f"GIT_WORK_TREE={self.clone} git {tail}")
+        # A git dir reached through a dot segment. `Path.parent` is lexical, so this is the
+        # same directory as `{root}/.git` and used to answer `{root}/.git/refs`.
+        yield ("--git-dir through a .. segment", self.clone,
+               f"git --git-dir={self.root}/.git/refs/.. {tail}")
+        yield ("GIT_DIR through a .. segment", self.clone,
+               f"GIT_DIR={self.root}/.git/hooks/.. git {tail}")
         # A relative `--git-dir` is interpreted against the directory the `-C`s ended at,
         # which is git's own documented rule for it — so the two compose.
         yield ("--git-dir relative to a -C", self.clone,
@@ -738,10 +754,16 @@ class TestEveryRouteToThePlaneRootIsTheSameRoute(CheckoutCase):
         # would leave every remaining assertion green while covering less than it did.
         self.assertGreaterEqual(len(movers), 8, movers)
         labels = {label for label, _cwd, _cmd in self.routes("checkout", "feature")}
-        self.assertGreaterEqual(len(labels), 15, sorted(labels))
+        self.assertGreaterEqual(len(labels), 20, sorted(labels))
         for must in ("--git-dir, separated", "--git-dir=, attached",
                      "--work-tree and --git-dir", "--git-dir relative to a -C",
-                     "GIT_DIR in the environment", "GIT_WORK_TREE in the environment"):
+                     "GIT_DIR in the environment", "GIT_WORK_TREE in the environment",
+                     # Round two's two families. Named individually because the count above
+                     # cannot tell "a route was dropped" from "a route was renamed", and
+                     # both of these were live bypasses that a generous floor would hide.
+                     "--work-tree alone", "--work-tree elsewhere, from the ROOT",
+                     "GIT_WORK_TREE elsewhere, from the ROOT",
+                     "--git-dir through a .. segment", "GIT_DIR through a .. segment"):
             self.assertIn(must, labels)
 
     def test_a_restore_is_allowed_by_every_route(self):
@@ -754,6 +776,35 @@ class TestEveryRouteToThePlaneRootIsTheSameRoute(CheckoutCase):
             for label, cwd, cmd in self.routes(sub, rest):
                 with self.subTest(route=label, cmd=cmd):
                     self.assertIsNone(_decision(self.run_cmd(cmd, cwd=cwd)), f"{label}: {cmd}")
+
+    def test_core_worktree_in_a_repos_config_is_a_route_this_guard_does_not_follow(self):
+        """**A LIMIT, pinned with its issue (#504).**
+
+        `core.worktree` is git's THIRD spelling of the work tree, after `--work-tree` and
+        `GIT_WORK_TREE`, and the only one that is a property of a repository on disk rather
+        than a token on the command line. A clone carrying it has the plane root as its
+        working tree for every command it runs, and `_git_target` — which reads argv and
+        environment — sees a plain `git checkout <branch>` in a clone.
+
+        Asserted the way a limit has to be: git is asked whether the route really reaches
+        the root, so the row cannot pass because the fixture stopped working. If it ever
+        starts being denied this fails, and #504 is where the decision is written down.
+
+        Not the same as `-c core.worktree=<plane>` on the command line: git 2.50.1 does not
+        honour that one — verified, `--show-toplevel` still answers the clone — so the
+        spelling an agent would actually type is already harmless.
+        """
+        clone = config.WORKSPACES_DIR / "ws" / "cfg"
+        clone.mkdir(parents=True, exist_ok=True)
+        self._git("init", "-q", "-b", "main", str(clone))
+        self._in(clone, "config", "core.worktree", str(self.root))
+        top = subprocess.run(["git", "-C", str(clone), "rev-parse", "--show-toplevel"],
+                             capture_output=True, text=True).stdout.strip()
+        self.assertEqual(Path(top).resolve(), self.root.resolve(),
+                         "the fixture stopped reaching the root, so the row below proves "
+                         "nothing about the guard")
+        self.assertIsNone(_decision(self.run_cmd("git checkout feature", cwd=clone)),
+                          "LIMIT #504 closed — say so in the news entry and flip this row")
 
     def test_a_route_that_does_not_reach_the_root_is_still_not_the_root(self):
         """The reach is not "anything with a `-C` in it". A relative `-C` that lands in the
@@ -926,9 +977,50 @@ PINNED: tuple[tuple[str, str, str, str], ...] = (
      "#477 with a RELATIVE git dir, resolved against the shell like a `-C`"),
     ("DENY", "clone", "GIT_DIR={root}/.git git -c alias.zz=switch zz -d main",
      "#477's route carrying #467's alias"),
+    # `--work-tree` WITHOUT a `--git-dir` — its own family, because round one's note here
+    # said "git itself refuses --work-tree without a git dir" and that is simply false.
+    # Asked of git 2.50.1 from the clone: `git --work-tree=<plane> rev-parse --git-dir`
+    # answers `.git` (the CLONE's, DISCOVERED from the cwd) and `--show-toplevel` answers
+    # `<plane>`. It runs, and it writes the clone's branch content into the plane root's
+    # working tree. That false belief is not an inert wrong note: it is exactly the reading
+    # that made `_git_target` DROP the cwd whenever a work tree was named, which reopened
+    # `git --work-tree=<elsewhere> reset --hard origin/main` in the plane root — 2 unpushed
+    # commits destroyed, verified, on a spelling `origin/main` refuses. Both directions are
+    # pinned below: the named tree is a subject, and so is the cwd.
     ("DENY", "clone", "git --work-tree {root} checkout feature",
-     "git itself refuses --work-tree without a git dir; charter refuses AHEAD of git, "
-     "deliberately, rather than depending on git continuing to"),
+     "--work-tree alone: git DISCOVERS the git dir from the cwd and writes into the named "
+     "tree, so the plane root is the tree that gets overwritten"),
+    ("DENY", "clone", "git --work-tree={root} switch -c neu", "the attached form, creating"),
+    ("DENY", "root", "git --work-tree={clone} checkout feature",
+     "the OTHER direction, and the (B) regression this closes: the tree is elsewhere, but "
+     "with no --git-dir git discovers the repo from the cwd, so the refs that move are the "
+     "PLANE ROOT's. Verified: this destroyed two unpushed commits with the guard silent"),
+    ("DENY", "root", "GIT_WORK_TREE={clone} git switch -c neu", "and by environment"),
+    ("DENY", "root", "GIT_WORK_TREE={clone} git checkout --detach main", "…and detaching"),
+    ("DENY", "root", "git --work-tree={clone} --git-dir={clone}/.git checkout feature",
+     "both named and neither is the root — kept a DENY on purpose. `_git_target` never "
+     "answers with less than the cwd, because a subject list that SHRINKS as the command "
+     "line grows is a flag-shaped bypass; the cost is this false positive"),
+    # `--git-dir` reached through a dot segment. `Path.parent` is lexical, so `.git/refs/..`
+    # — the same directory as `.git`, one segment away, same inode — had a parent of
+    # `.git/refs`, which is not the plane root, and #477 went on reproducing after round one
+    # closed the plain spelling. Verified against git 2.50.1: the reset form destroyed two
+    # unpushed commits in the plane root. Now `gd / ".."` and the caller's `resolve()` asks
+    # the filesystem, so these are not four more spellings on a list — they are the same
+    # question the plain form asks.
+    ("DENY", "clone", "git --git-dir={root}/.git/refs/.. checkout feature",
+     "#477 round two: a dot segment used to defeat the lexical parent"),
+    ("DENY", "clone", "git --git-dir {root}/.git/hooks/.. checkout feature",
+     "#477 round two, separated — the `reset --hard` spelling of this route is what really "
+     "destroyed commits, and it is pinned in tests/test_plane_root_reset_guard.py where the "
+     "fixture has an upstream for the reset guard to measure against"),
+    ("DENY", "clone", "git --git-dir={root}/.git/objects/.. switch -c neu", "#477 round two"),
+    ("DENY", "clone", "git --git-dir={root}/.git/refs/../objects/.. checkout feature",
+     "two hops back out: collapsing is the filesystem's job, not a pattern's"),
+    ("DENY", "clone", "GIT_DIR={root}/.git/refs/.. git checkout feature",
+     "#477 round two by environment"),
+    ("DENY", "clone", "git --git-dir={root}/.git/./ checkout feature",
+     "the `.` segment, which pathlib DID collapse — pinned so the pair reads as one rule"),
     ("DENY", "above", "cd {name} && git checkout feature", "a `cd` earlier in the SAME command"),
     ("DENY", "above", "cd {name} && git switch feature", ""),
     ("DENY", "root", "cd .. && git -C {name} checkout feature", "out and back in again"),

--- a/tests/test_plane_root_reset_guard.py
+++ b/tests/test_plane_root_reset_guard.py
@@ -21,6 +21,7 @@ being true and the command refused, or that fact being false and the same comman
 
 from __future__ import annotations
 
+import itertools
 import os
 import subprocess
 import unittest
@@ -285,6 +286,92 @@ class TestEveryRouteToTheRootReachesThisGuardToo(PlaneRootAheadCase):
     def test_a_git_dir_relative_to_a_dash_C(self):
         up = os.path.relpath(self.root, self.clone)
         self._denied(f"git -C {up} --git-dir=.git reset --hard origin/main")
+
+    # --- #477, round two: the same route through a DOT SEGMENT ---------------------------
+    # `_git_target` offered `gd.parent` for the ordinary `<repo>/.git` layout, and
+    # `Path.parent` is LEXICAL — it takes the last component off the string without asking
+    # what it means. `<plane>/.git` gave `<plane>` and the guard fired; `<plane>/.git/refs/..`
+    # is the SAME DIRECTORY, one segment away, same inode, and gave `<plane>/.git/refs`,
+    # which is not the plane root. Verified against git 2.50.1 from a clone: the first of
+    # these destroyed both unpushed commits in the plane root with the guard silent.
+    #
+    # The property, named: *the directory a git dir belongs to* is a question for the
+    # filesystem, not for a string. `gd / ".."` hands the collapsing to the caller's
+    # `resolve()`, so these are not four more entries on a list of spellings — they are the
+    # plain spelling asked properly. **The next spelling** is one `resolve()` cannot answer
+    # from the path alone: a `--git-dir` pointing at a LINKED WORKTREE's git dir
+    # (`<plane>/.git/worktrees/<name>`), whose `..`-parent is `<plane>/.git` and whose HEAD
+    # belongs to that worktree rather than to the root. That one is stated in
+    # `_git_target`'s docstring as not followed, and it fails OPEN — it is a missed denial,
+    # never a wrong one.
+
+    def test_a_git_dir_reached_through_a_dot_dot_segment(self):
+        self._denied(f"git --git-dir={self.root}/.git/refs/.. reset --hard origin/main")
+
+    def test_the_separated_form_of_the_same(self):
+        self._denied(f"git --git-dir {self.root}/.git/hooks/.. reset --hard origin/main")
+
+    def test_two_hops_back_out(self):
+        self._denied(f"git --git-dir={self.root}/.git/refs/../objects/.. "
+                     f"reset --hard origin/main")
+
+    def test_the_environment_spelling_of_the_dot_dot_route(self):
+        self._denied(f"GIT_DIR={self.root}/.git/objects/.. git reset --hard origin/main")
+
+    def test_a_single_dot_segment_too(self):
+        """`.` and a trailing slash, which pathlib DID collapse. Pinned beside the `..`
+        rows so the pair reads as one rule rather than as one fix and one coincidence."""
+        self._denied(f"git --git-dir={self.root}/.git/./ reset --hard origin/main")
+
+    # --- the (B) regression: a --work-tree with NO --git-dir -----------------------------
+
+    def test_a_work_tree_elsewhere_does_not_move_the_refs_elsewhere(self):
+        """Typed IN the plane root. With no `--git-dir`, git DISCOVERS the repository from
+        the cwd — asked of git 2.50.1, `git --work-tree=<elsewhere> rev-parse --git-dir`
+        from a repo answers that repo's own `.git` — so the refs that move are the plane
+        root's and the commits die there. `_git_target` dropped the cwd from its answer the
+        moment a work tree was named, which allowed this while `origin/main` refused it.
+
+        Run from the ROOT, which is the direction the other class in this file never takes.
+        """
+        r = self.run_cmd(f"git --work-tree={self.clone} reset --hard origin/main",
+                         cwd=self.root)
+        self.assertEqual(_decision(r), "deny")
+        self.assertIn("2 commits", _reason(r))
+
+    def test_the_environment_spelling_of_a_work_tree_elsewhere(self):
+        r = self.run_cmd(f"GIT_WORK_TREE={self.clone} git reset --hard origin/main",
+                         cwd=self.root)
+        self.assertEqual(_decision(r), "deny")
+
+    def test_a_relative_work_tree_elsewhere(self):
+        r = self.run_cmd("git --work-tree=.. reset --hard origin/main", cwd=self.root)
+        self.assertEqual(_decision(r), "deny")
+
+    def test_the_subject_list_only_ever_grows(self):
+        """The invariant behind all four rows above, stated over the option cross-product
+        instead of over the four spellings that happened to be tried.
+
+        `_git_target` may add subjects for the options an invocation carries; it may never
+        answer with LESS than the cwd. A list that gets SMALLER as the command line gets
+        longer is a flag-shaped bypass by construction — which is exactly what dropping the
+        cwd for a `--work-tree` was — and this fails for any option combination that
+        reintroduces one, including combinations nobody wrote a row for.
+        """
+        here = str(self.clone)
+        base = {p.resolve() for p in hooks._git_target(here, [])}
+        self.assertEqual(base, {self.clone.resolve()})
+        opts = ("--git-dir=" + str(self.root) + "/.git", "--work-tree=" + str(self.root),
+                "--namespace=n", "-c", "x=y")
+        for n in range(1, len(opts) + 1):
+            for combo in itertools.combinations(opts, n):
+                for env in ([], ["GIT_DIR=" + str(self.root) + "/.git"],
+                            ["GIT_WORK_TREE=" + str(self.root)]):
+                    with self.subTest(pre=combo, env=env):
+                        got = {p.resolve()
+                               for p in hooks._git_target(here, list(combo), env)}
+                        self.assertLessEqual(base, got,
+                                             "adding a global option REMOVED a subject")
 
     def test_the_clones_own_git_dir_is_not_the_root(self):
         """The reach is the repository the option NAMES, not "any command with a --git-dir

--- a/tests/test_plane_root_reset_guard.py
+++ b/tests/test_plane_root_reset_guard.py
@@ -21,6 +21,7 @@ being true and the command refused, or that fact being false and the same comman
 
 from __future__ import annotations
 
+import os
 import subprocess
 import unittest
 from pathlib import Path
@@ -248,6 +249,147 @@ class TestItDoesNotOverreach(PlaneRootAheadCase):
         the same command moves where the later segments run."""
         self.assertIsNone(_decision(
             self.run_cmd(f"cd {self.clone} && git reset --hard HEAD~1")))
+
+
+class TestEveryRouteToTheRootReachesThisGuardToo(PlaneRootAheadCase):
+    """The routes are shared with the branch guard, and so are their holes (#477).
+
+    `_plane_root_git` is one pair of eyes for both plane-root guards, precisely so a route
+    taught to one is a route both can see. #477 was the case where that paid a debt in the
+    other direction: `--git-dir`, `--work-tree` and their env spellings name a repository
+    without naming a directory to stand in, and `_git_target` read only the cwd and `-C` —
+    so `git --git-dir <plane>/.git reset --hard <ref>` destroyed unpushed commits in the
+    plane root from a clone, with no refusal, exactly as the branch half did.
+
+    Run from the CLONE, so the shell's own directory is never the answer.
+    """
+
+    def _denied(self, cmd: str) -> None:
+        r = self.run_cmd(cmd, cwd=self.clone)
+        self.assertEqual(_decision(r), "deny", cmd)
+        self.assertIn("2 commits", _reason(r), cmd)
+
+    def test_git_dir_attached(self):
+        self._denied(f"git --git-dir={self.root}/.git reset --hard origin/main")
+
+    def test_git_dir_separated(self):
+        self._denied(f"git --git-dir {self.root}/.git reset --hard origin/main")
+
+    def test_work_tree_and_git_dir(self):
+        self._denied(f"git --work-tree={self.root} --git-dir={self.root}/.git "
+                     f"reset --hard origin/main")
+
+    def test_the_environment_spelling(self):
+        self._denied(f"GIT_DIR={self.root}/.git git reset --hard origin/main")
+
+    def test_a_git_dir_relative_to_a_dash_C(self):
+        up = os.path.relpath(self.root, self.clone)
+        self._denied(f"git -C {up} --git-dir=.git reset --hard origin/main")
+
+    def test_the_clones_own_git_dir_is_not_the_root(self):
+        """The reach is the repository the option NAMES, not "any command with a --git-dir
+        in it". Asserted through the BRANCH guard, which needs no upstream to speak: a reset
+        in this clone is silent whatever the route, because nothing here is unpushed, so it
+        could not tell a working route from a broken one."""
+        self.assertIsNone(_decision(
+            self.run_cmd(f"git --git-dir={self.clone}/.git switch -c feature/x",
+                         cwd=self.clone)))
+
+
+class TestAnAliasIsAnotherSpellingOfReset(PlaneRootAheadCase):
+    """`git reset` is not the only way to spell `git reset` (#467).
+
+    The branch guard has followed aliases since #461's round two, for a reason its docstring
+    states plainly: `co = checkout` is on a large share of developer machines, and `git co
+    feature` moves the plane root's HEAD exactly as far. This guard — the one that exists
+    because eleven memory commits were destroyed — kept comparing the subcommand token to
+    the string `"reset"`, so the SAME alias route walked past it while its sibling refused a
+    branch switch through it. One guard resolving what a command will really do and its twin
+    matching the spelling is the split that let a fixed route stay open one guard over.
+
+    Every command below is a real `git reset --hard` wearing another name, and each is run
+    against the fixture that has two commits no remote holds — so the denial it must produce
+    is the measured one, not a guess about a shape.
+    """
+
+    def _denied_as_the_reset_guard(self, cmd: str) -> str:
+        """Assert the REASON, not the status. `git wipe origin/main` would be refused by the
+        branch guard too if the alias resolved to `checkout`, and a test that only read the
+        decision could not tell which guard spoke — the failure mode this file's siblings
+        record as "a guard passing because a DIFFERENT guard caught it"."""
+        r = self.run_cmd(cmd)
+        self.assertEqual(_decision(r), "deny", cmd)
+        reason = _reason(r)
+        self.assertIn("PLANE ROOT", reason, cmd)
+        self.assertIn("2 commits", reason, cmd)
+        self.assertIn("charter save", reason, cmd)
+        return reason
+
+    def test_a_command_line_alias_that_carries_the_whole_command(self):
+        """#467's own spelling: the definition and the use are in one command line, and no
+        `reset` token survives as the subcommand. git 2.50 runs it."""
+        self._denied_as_the_reset_guard("git -c alias.z='reset --hard origin/main' z")
+
+    def test_a_command_line_alias_that_carries_only_the_subcommand(self):
+        """The caller's own arguments are appended to the expansion, exactly as git appends
+        them — so the mode and the ref arrive from the other half of the argv."""
+        self._denied_as_the_reset_guard("git -c alias.zz=reset zz --hard origin/main")
+
+    def test_a_repo_config_alias(self):
+        """The spelling the early exit could not see. `_plane_root_reset_reason` used to
+        return on `"reset" not in cmd`, which is sound for a subcommand read as written and
+        false the moment aliases are followed: these five characters are in the config, not
+        in the command."""
+        self._in(self.root, "config", "alias.wipe", "reset --hard")
+        self._denied_as_the_reset_guard("git wipe origin/main")
+
+    def test_an_alias_that_carries_the_mode_and_takes_the_ref(self):
+        self._in(self.root, "config", "alias.nuke", "reset --hard origin/main")
+        self._denied_as_the_reset_guard("git nuke")
+
+    def test_an_alias_to_an_alias(self):
+        """git follows the chain, so a guard that stopped at one hop would be one alias
+        short of the same hole."""
+        self._in(self.root, "config", "alias.wipe", "reset --hard")
+        self._in(self.root, "config", "alias.w2", "wipe")
+        self._denied_as_the_reset_guard("git w2 origin/main")
+
+    def test_a_bang_alias_that_is_a_plain_git_command(self):
+        """`!git reset --hard` is a git command wearing a shell alias's clothes."""
+        self._in(self.root, "config", "alias.bang", "!git reset --hard")
+        self._denied_as_the_reset_guard("git bang origin/main")
+
+    def test_the_alias_route_reaches_the_root_from_a_clone(self):
+        self._in(self.root, "config", "alias.wipe", "reset --hard")
+        r = self.run_cmd(f"git -C {self.root} wipe origin/main", cwd=self.clone)
+        self.assertEqual(_decision(r), "deny")
+        self.assertIn("2 commits", _reason(r))
+
+    def test_the_same_alias_inside_a_clone_is_untouched(self):
+        """The widening is about WHAT the command is, not about where charter will refuse
+        it. Branch and reset work in a clone is the workflow both denials recommend."""
+        self._in(self.clone, "config", "alias.wipe", "reset --hard")
+        self.assertIsNone(_decision(self.run_cmd("git wipe HEAD~1", cwd=self.clone)))
+
+    def test_an_alias_that_is_not_a_reset_is_not_refused(self):
+        """The resolution has to be able to answer "no", or it is not resolution."""
+        self._in(self.root, "config", "alias.st", "status --short")
+        self._in(self.root, "config", "alias.lg", "log --oneline")
+        for cmd in ("git st", "git lg", "git -c alias.z='status --short' z"):
+            self.assertIsNone(_decision(self.run_cmd(cmd)), cmd)
+
+    def test_an_alias_to_a_soft_reset_is_not_refused(self):
+        """Following the alias does not widen what `reset` means: `--soft` leaves every byte
+        on disk for the next `charter save`, and is allowed spelled either way."""
+        self._in(self.root, "config", "alias.amend", "reset --soft HEAD~1")
+        self.assertIsNone(_decision(self.run_cmd("git amend")))
+
+    def test_a_shell_alias_charter_cannot_read_is_not_pretended_about(self):
+        """`s = !sh -c '…'` runs a shell charter does not parse. It stands aside rather than
+        refusing every shell alias in the plane root — the documented limit, pinned so a
+        later claim of completeness fails here."""
+        self._in(self.root, "config", "alias.sh1", "!sh -c 'git reset --hard origin/main'")
+        self.assertIsNone(_decision(self.run_cmd("git sh1")))
 
 
 class TestItIsScopedToAPlane(PlaneRootAheadCase):

--- a/tests/test_vault_path_spellings.py
+++ b/tests/test_vault_path_spellings.py
@@ -35,8 +35,11 @@ that reaches no vault, and the exclusion the denial recommends, both still run.
 
 **What is deliberately NOT closed, pinned as behaviour rather than left to be rediscovered.**
 `TestWhatStillWalksPastBothGuards` — a program charter does not know walks directories
-(`find … -exec cat`, `tar`), an interpreter's argument, and a `cd` earlier in the same
-command. `TestSeparatorMeansTheForwardSlash` — a Windows-style backslash spelling (#476),
+(`find … -exec cat`, `tar`) and an interpreter's argument. A `cd` earlier in the same command
+used to be a third: it is followed now, because #499 gave `_leak_reason` the segment walk the
+git guards already had and the walk predicate resolves against the composed directory rather
+than the raw cwd. Its row is still in that class, with the verdict flipped.
+`TestSeparatorMeansTheForwardSlash` — a Windows-style backslash spelling (#476),
 which stays unfolded because charter's harness targets POSIX and is not supported on
 Windows. All are stated as limits in `SECURITY.md`, `docs/secrets.md` and
 `skills/secrets/SKILL.md`, and if any ever starts being denied these tests fail next to the
@@ -606,10 +609,14 @@ class TestTheWalkGuardDoesNotOverreach(WalkCase):
 class TestWhatStillWalksPastBothGuards(WalkCase):
     """The limits round five did NOT close, pinned so the docs cannot quietly outgrow them.
 
-    Closing #474 moved the boundary; it did not remove it. Each of these really does read a
-    vault file, and each is allowed. They are the `_READERS` ceiling and the shell residual
-    in a new shape, and both are stated in `SECURITY.md` and `docs/secrets.md` — if one ever
-    starts being denied, this test fails next to the paragraph that has to change with it.
+    Closing #474 moved the boundary; it did not remove it. The first two here really do read
+    a vault file and are allowed: they are the `_READERS` ceiling and the shell residual in a
+    new shape, both stated in `SECURITY.md` and `docs/secrets.md` — if one ever starts being
+    denied, this test fails next to the paragraph that has to change with it.
+
+    The third was a limit and is a DENIAL now, kept in this class with its verdict flipped
+    rather than moved or deleted, because a limit that closes should be readable as a row
+    that changed and not as a row that disappeared.
     """
 
     def test_a_reader_charter_does_not_know_walks_unguarded(self):
@@ -624,12 +631,36 @@ class TestWhatStillWalksPastBothGuards(WalkCase):
     def test_an_interpreters_argument_is_text_and_is_not_re_parsed(self):
         self.assertIsNone(self.bash("sh -c 'grep -rn TOKEN .'"))
 
-    def test_a_cd_earlier_in_the_command_is_not_followed_by_this_guard(self):
-        """`_plane_root_git` follows a `cd`; `_leak_reason` does not, and that difference is
-        older than this change. Recorded here rather than half-fixed on the hot path."""
+    def test_a_cd_earlier_in_the_command_IS_followed_now(self):
+        """**This row was a LIMIT and is now a denial** — flipped deliberately and visibly.
+
+        Round five recorded that `_plane_root_git` followed a `cd` and `_leak_reason` did
+        not. #499 gave `_leak_reason` the same segment walk, and the walk predicate is
+        handed the composed directory rather than the raw `cwd`, so `cd <plane> && grep -rn
+        TOKEN .` from outside is refused. The row stays in this class rather than being
+        deleted: what changed is readable from a row that changed verdict, and invisible
+        from a row that vanished.
+
+        It is more accurate in BOTH directions, which is the point of composing rather than
+        of adding a `cd` case: `cd sub && grep -r x .` in the plane root now resolves `.`
+        against `sub`, so a search that cannot reach the vault directory is no longer
+        answered as if it were rooted at the plane root.
+        """
         outside = self.tmp / "elsewhere"
         outside.mkdir()
-        self.assertIsNone(self.bash(f"cd {self.root} && grep -rn TOKEN .", cwd=outside))
+        hit = self.bash(f"cd {self.root} && grep -rn TOKEN .", cwd=outside)
+        self.assertIsNotNone(hit, "a `cd` into the plane root is followed now")
+        self.assertIn("vaults", hit)
+
+    def test_a_cd_AWAY_from_the_vault_directory_is_followed_too(self):
+        """The other direction of the same composition, and the reason it is not just a
+        second denial: a walk that a `cd` moves OUT of range is allowed. Without this the
+        test above would pass for a guard that had simply started ignoring `cd` in the
+        fail-closed direction."""
+        sub = self.root / "notes"
+        sub.mkdir(exist_ok=True)
+        (sub / "a.md").write_text("hi\n")
+        self.assertIsNone(self.bash("cd notes && grep -rn TOKEN .", cwd=self.root))
 
 
 class TestSeparatorMeansTheForwardSlash(unittest.TestCase):

--- a/tests/test_vault_path_spellings.py
+++ b/tests/test_vault_path_spellings.py
@@ -25,12 +25,22 @@ file and `tests/test_vault_read_guard.py` were green throughout. `TestTheTwoGuar
 is the answer to that shape: one corpus, both routes, fails in either direction, so a repair
 made in one caller reddens it instead of hiding in it.
 
+**And the operand that CONTAINS the vault directory without naming it** — `grep -rn TOKEN .`
+from the plane root, which reads every vault file and names none of them. That was pinned
+here as a limit for two rounds and is closed in round five (#474) by a SECOND predicate
+rather than by widening this one: text about a path cannot answer a question about a walk.
+`TestAnOperandThatContainsTheVaultDirectoryIsRefused` holds the property, and
+`TestTheWalkGuardDoesNotOverreach` holds the half that makes it liveable — a broad search
+that reaches no vault, and the exclusion the denial recommends, both still run.
+
 **What is deliberately NOT closed, pinned as behaviour rather than left to be rediscovered.**
-`TestWhatStillWalksPastBothGuards` — an operand that merely CONTAINS the vault directory,
-e.g. `grep -rn TOKEN .` (#474). `TestSeparatorMeansTheForwardSlash` — a Windows-style
-backslash spelling (#476). Both are stated as limits in `SECURITY.md`, `docs/secrets.md` and
-`skills/secrets/SKILL.md`, and if either ever starts being denied these tests fail next to
-the paragraph that has to move with it.
+`TestWhatStillWalksPastBothGuards` — a program charter does not know walks directories
+(`find … -exec cat`, `tar`), an interpreter's argument, and a `cd` earlier in the same
+command. `TestSeparatorMeansTheForwardSlash` — a Windows-style backslash spelling (#476),
+which stays unfolded because charter's harness targets POSIX and is not supported on
+Windows. All are stated as limits in `SECURITY.md`, `docs/secrets.md` and
+`skills/secrets/SKILL.md`, and if any ever starts being denied these tests fail next to the
+paragraph that has to move with it.
 
 **What this file does NOT claim, because the first version of this docstring did and it was
 false.** It said the decision "depends on the path an operand names, not on how it is
@@ -388,24 +398,238 @@ class TestTheTwoGuardsCannotDisagree(PersonaIso):
                 self.assertFalse(self._read_denies(spelling), spelling)
 
 
-class TestWhatStillWalksPastBothGuards(unittest.TestCase):
-    """The limit this round did NOT close, pinned so the docs cannot quietly outgrow it.
+class WalkCase(PersonaIso):
+    """An isolated plane whose vault directory HOLDS SOMETHING.
 
-    Anchoring `vaults` to a segment closes every spelling of an operand that NAMES the vault
-    directory. It does nothing for an operand that merely CONTAINS it: `grep -r TOKEN .`
-    walks every vault file and names none of them. That is the same limit `pretooluse_read`'s
-    docstring already states for `Grep` — denying every broad search is untenable — and
-    `docs/secrets.md` now states it for the Bash route in the same words, where the
-    completeness claim is made.
+    `PersonaIso` is not optional here and the class it replaced went without it. The old
+    `TestWhatStillWalksPastBothGuards` was a bare `TestCase` asserting that
+    `grep -rn TOKEN .` is allowed — an assertion that reached `config.STATE_DIR` for the
+    REAL plane, and in a linked worktree `root.find_root()` redirects that to the operator's
+    main tree. It passed because the answer was "allowed" everywhere; the moment the answer
+    depends on what is on disk, a test without isolation is a test that reads someone's
+    actual `.charter/`.
 
-    Pinned as BEHAVIOUR, not as a wish: if someone later denies these, this test fails next
-    to the paragraph that has to change with it."""
+    The fabricated file matters too: `_guarded_state_entries` deliberately ignores an EMPTY
+    guarded directory, because a fresh plane has one and refusing every broad search there
+    protects nothing. So a fixture that only `mkdir`-ed would make every denial below
+    unreachable and every allowance below unfalsifiable.
+    """
 
-    def test_a_search_rooted_above_the_plane_is_allowed_on_both_routes(self):
-        for operand in (".", "..", "./", "/", "~", "$PWD"):
+    def setUp(self) -> None:
+        super().setUp()
+        from charter import config
+        self.state = config.STATE_DIR
+        self.vaults = self.state / "vaults"
+        self.vaults.mkdir(parents=True, exist_ok=True)
+        # A fabricated name and a fabricated value; nothing here is a credential.
+        (self.vaults / "db.json").write_text('{"password": "FABRICATED-not-real-9f3a"}\n')
+        self.root = config.ROOT
+
+    def bash(self, cmd: str, cwd=None) -> str | None:
+        return hooks._leak_reason(cmd, str(cwd if cwd is not None else self.root))
+
+    def grep_tool(self, cwd=None, **ti) -> str | None:
+        r = run_hook(hooks.pretooluse_read,
+                     {"tool_name": "Grep", "tool_input": ti, "session_id": "s",
+                      "cwd": str(cwd if cwd is not None else self.root)})
+        return (r or {}).get("hookSpecificOutput", {}).get("permissionDecisionReason")
+
+
+class TestAnOperandThatContainsTheVaultDirectoryIsRefused(WalkCase):
+    """The limit round three pinned and round five closed (#474).
+
+    Anchoring `vaults` to a path segment closed every spelling of an operand that NAMES the
+    vault directory. It did nothing for an operand that merely CONTAINS it: `grep -rn TOKEN
+    .` from the plane root printed every vault file and named none of them, and both guards
+    stood aside because both decided on the TEXT of the operand.
+
+    **The property is "the walk reaches the directory", and that is what is tested.** Not a
+    list of spellings of "here" — `.`, `..`, an absolute path, a path through a symlinked
+    parent and a path with dot segments in it are all the same ancestor, and the six
+    bypasses this guard family has had were every one of them a literal set. The operand is
+    resolved against the shell's directory and compared by ancestry, and the thing it is
+    compared against is asked of the filesystem rather than matched as text — so a plane
+    whose `$CHARTER_HOME` puts the vaults somewhere no pattern can spell is covered by the
+    same code.
+
+    What it costs, deliberately: a broad search from the plane root is now refused, with the
+    exclusion that fixes it in the message. `SECURITY.md` used to call that untenable. The
+    trade is revisited on purpose here — the denial is scoped to a plane that has vault
+    FILES, it is one flag away from running, and the thing it prevents is plaintext in a
+    transcript.
+    """
+
+    def test_the_reported_command(self):
+        """The exact reproduction in #474: a recursive grep of the plane root."""
+        reason = self.bash("grep -rn TOKEN .")
+        self.assertIsNotNone(reason)
+        self.assertIn("vaults", reason)
+        self.assertIn("--exclude-dir", reason)
+
+    def test_every_spelling_of_the_same_ancestor(self):
+        """One property, so the spellings are varied and the answer must not."""
+        for operand in (".", "./", "..", "./.", ".//", "x/..", str(self.root),
+                        str(self.root) + "/", str(self.root) + "/./"):
             with self.subTest(operand=operand):
-                self.assertIsNone(hooks._leak_reason(f"grep -rn TOKEN {operand}"))
-                self.assertFalse(hooks._names_a_vault_path(operand))
+                self.assertIsNotNone(self.bash(f"grep -rn TOKEN {operand}"), operand)
+
+    def test_a_symlinked_route_to_the_same_directory(self):
+        """`resolve()` is what makes this a question about the directory rather than about
+        the string, and a symlink is the cheapest proof that the two differ."""
+        link = self.tmp / "link-to-plane"
+        link.symlink_to(self.root)
+        self.assertIsNotNone(self.bash(f"grep -rn TOKEN {link}"))
+
+    def test_a_walker_that_needs_no_flag_at_all(self):
+        """`rg` and `ag` recurse by default, so gating on `-r` would have been a guard
+        against one program's spelling of a property two programs have."""
+        for cmd in ("rg TOKEN", "rg TOKEN .", "ag TOKEN", "ag TOKEN ."):
+            with self.subTest(cmd=cmd):
+                self.assertIsNotNone(self.bash(cmd), cmd)
+
+    def test_every_spelling_of_grep_recursion(self):
+        for cmd in ("grep -r TOKEN .", "grep -R TOKEN .", "grep --recursive TOKEN .",
+                    "grep --dereference-recursive TOKEN .", "grep -rn TOKEN .",
+                    "grep -nr TOKEN .", "grep -d recurse TOKEN .",
+                    "grep --directories=recurse TOKEN ."):
+            with self.subTest(cmd=cmd):
+                self.assertIsNotNone(self.bash(cmd), cmd)
+
+    def test_a_recursive_grep_with_no_operand_searches_here(self):
+        """`grep -r PATTERN` and `rg PATTERN` both default to the cwd, so "no path was
+        named" is a path — and it is the one an agent standing in the plane root types."""
+        self.assertIsNotNone(self.bash("grep -r TOKEN"))
+        self.assertIsNotNone(self.bash("rg TOKEN"))
+
+    def test_it_follows_the_shell_and_not_the_hook_process(self):
+        """A relative operand belongs to the SHELL's directory. Judged from a workspace
+        clone, `../..` is the plane root — the same class of defect `_git_target` had."""
+        clone = self.root / "workspaces" / "ws" / "svc"
+        clone.mkdir(parents=True, exist_ok=True)
+        import os as _os
+        up = _os.path.relpath(self.root, clone)
+        self.assertIsNotNone(self.bash(f"grep -rn TOKEN {up}", cwd=clone))
+        self.assertIsNone(self.bash("grep -rn TOKEN .", cwd=clone),
+                          "a search of the clone reaches no vault and must stay allowed")
+
+    def test_the_grep_tool_route_answers_the_same_way(self):
+        """#462's lesson: one operand, one answer, whichever route it arrives on."""
+        self.assertIsNotNone(self.grep_tool(pattern="TOKEN", path="."))
+        self.assertIsNotNone(self.grep_tool(pattern="TOKEN"), "no path means the cwd")
+        self.assertIsNotNone(self.grep_tool(pattern="TOKEN", path=str(self.root)))
+
+
+class TestTheWalkGuardDoesNotOverreach(WalkCase):
+    """The other half, and the reason the guard is scoped the way it is. Every denial that
+    is not needed is a denial that gets the guard switched off."""
+
+    def test_a_non_recursive_read_of_the_same_directory_is_untouched(self):
+        """`grep -n TOKEN .` without recursion reads the directory and no file in it — GNU
+        grep answers "Is a directory". Nothing leaks, so nothing is refused."""
+        self.assertIsNone(self.bash("grep -n TOKEN ."))
+        self.assertIsNone(self.bash("cat ."))
+
+    def test_a_search_of_a_sibling_directory_is_untouched(self):
+        (self.root / "docs").mkdir(exist_ok=True)
+        for cmd in ("grep -rn TOKEN docs", "grep -rn TOKEN ./docs", "rg TOKEN docs"):
+            with self.subTest(cmd=cmd):
+                self.assertIsNone(self.bash(cmd), cmd)
+
+    def test_a_search_outside_the_plane_is_untouched(self):
+        outside = self.tmp / "elsewhere"
+        outside.mkdir()
+        self.assertIsNone(self.bash(f"grep -rn TOKEN {outside}", cwd=outside))
+
+    def test_the_exclusion_the_denial_recommends_actually_runs(self):
+        """A guard that refuses the command it recommends teaches people to route around
+        it — the lesson the plane-root guard's remedy carve-out records. So the fix in the
+        message is executed here, in every spelling the message offers."""
+        for cmd in ("grep -rn --exclude-dir=.charter TOKEN .",
+                    "grep -rn --exclude-dir .charter TOKEN .",
+                    "grep -rn --exclude-dir=vaults TOKEN .",
+                    "grep -rn --exclude-dir='.charter*' TOKEN .",
+                    "rg --glob '!.charter' TOKEN .",
+                    "rg -g '!.charter/**' TOKEN ."):
+            with self.subTest(cmd=cmd):
+                self.assertIsNone(self.bash(cmd), cmd)
+
+    def test_an_empty_vault_directory_is_not_worth_a_denial(self):
+        """A fresh plane has `vaults/` and nothing in it. Refusing every broad search there
+        protects nothing and spends the guard's credibility."""
+        (self.vaults / "db.json").unlink()
+        self.assertIsNone(self.bash("grep -rn TOKEN ."))
+
+    def test_a_narrowed_grep_tool_call_is_answered_by_looking(self):
+        """`Grep` has no exclude, so its own narrowing stands in for one — and whether a
+        glob reaches a vault is decided by looking inside the directory, not by reading the
+        pattern. `*.json` does select the fixture; `*.py` does not."""
+        self.assertIsNone(self.grep_tool(pattern="TOKEN", path=".", glob="*.py"))
+        self.assertIsNotNone(self.grep_tool(pattern="TOKEN", path=".", glob="*.json"))
+
+    def test_the_registry_is_the_boundary_control_for_the_WALK_predicate_too(self):
+        """#443's false positive, one predicate over.
+
+        `.charter/vaults.json` is the registry — provider config and file paths, never a
+        value — and `_VAULT_PATH_RE` anchors `vaults` to a path SEGMENT so that it stays an
+        ordinary read. The walk predicate has its own copy of that question ("which entries
+        under the state directory are guarded?"), and its first cut asked
+        `name.startswith(("vaults", …))`, which matched the registry and started refusing
+        `ag TOKEN .charter/vaults.json` — a command `origin/main` allows.
+
+        The sibling test one class up asserts this through `cat`, which does not walk, so it
+        could not have caught it. This one uses a walker on purpose.
+        """
+        registry = self.state / ("vaul" + "ts.json")
+        registry.write_text("{}\n")
+        for cmd in (f"ag TOKEN {registry}", f"rg TOKEN {registry}",
+                    f"grep -rn TOKEN {registry}"):
+            with self.subTest(cmd=cmd):
+                self.assertIsNone(self.bash(cmd), cmd)
+        self.assertIsNone(self.grep_tool(pattern="TOKEN", path=str(registry)))
+
+    def test_an_exclusion_naming_the_vault_directory_still_lets_the_search_run(self):
+        """The same bug had a second face: with the registry counted as a guarded entry,
+        `--exclude-dir=vaults` excluded one target and not the other, so the remedy stopped
+        working while the denial kept recommending it."""
+        (self.state / ("vaul" + "ts.json")).write_text("{}\n")
+        self.assertIsNone(self.bash("grep -rn --exclude-dir=vaults TOKEN ."))
+
+    def test_read_does_not_walk(self):
+        """`Read` opens one file. It cannot reach a vault it did not name, and the named
+        case is the other predicate's."""
+        r = run_hook(hooks.pretooluse_read,
+                     {"tool_name": "Read", "tool_input": {"file_path": "README.md"},
+                      "session_id": "s", "cwd": str(self.root)})
+        self.assertIsNone(_decision(r))
+
+
+class TestWhatStillWalksPastBothGuards(WalkCase):
+    """The limits round five did NOT close, pinned so the docs cannot quietly outgrow them.
+
+    Closing #474 moved the boundary; it did not remove it. Each of these really does read a
+    vault file, and each is allowed. They are the `_READERS` ceiling and the shell residual
+    in a new shape, and both are stated in `SECURITY.md` and `docs/secrets.md` — if one ever
+    starts being denied, this test fails next to the paragraph that has to change with it.
+    """
+
+    def test_a_reader_charter_does_not_know_walks_unguarded(self):
+        """The ceiling `_READERS` already has: `_TREE_WALKERS` is a subset of it, and a name
+        missing from either is a read the guard does not see. Widening the list does not fix
+        this — the next name is always the missing one."""
+        for cmd in ("find . -type f -exec cat {} +", "tar cf - .",
+                    "python3 -c \"import pathlib;print(pathlib.Path('.').rglob('*'))\""):
+            with self.subTest(cmd=cmd):
+                self.assertIsNone(self.bash(cmd), cmd)
+
+    def test_an_interpreters_argument_is_text_and_is_not_re_parsed(self):
+        self.assertIsNone(self.bash("sh -c 'grep -rn TOKEN .'"))
+
+    def test_a_cd_earlier_in_the_command_is_not_followed_by_this_guard(self):
+        """`_plane_root_git` follows a `cd`; `_leak_reason` does not, and that difference is
+        older than this change. Recorded here rather than half-fixed on the hot path."""
+        outside = self.tmp / "elsewhere"
+        outside.mkdir()
+        self.assertIsNone(self.bash(f"cd {self.root} && grep -rn TOKEN .", cwd=outside))
 
 
 class TestSeparatorMeansTheForwardSlash(unittest.TestCase):
@@ -414,8 +638,23 @@ class TestSeparatorMeansTheForwardSlash(unittest.TestCase):
     `_VAULT_PATH_RE` and `os.path.normpath` are both POSIX `/`. A Windows-style
     `.charter\\vaults\\db.json` names the same file on a Windows filesystem and a
     DIFFERENT one on POSIX, where a backslash is an ordinary filename character. Charter
-    does not fold it, and the docs say `/` rather than "separators" for that reason. Filed
-    separately rather than closed here: folding `\\` on POSIX would deny real filenames.
+    does not fold it, and the docs say `/` rather than "separators" for that reason.
+
+    **#476 asked whether that should change, and the answer is no, on the prerequisite the
+    issue itself named: charter's harness does not run on Windows.** It is a tmux program —
+    `charter claude` builds and drives a tmux session, the frame repaints panes, and the
+    suite is run on macOS and Ubuntu — and it writes its vaults at `0o600`, a mode Windows
+    does not have. There is no Windows CI and no Windows install path. Folding `\\` would
+    therefore buy nothing on any host charter supports, and would cost a real denial on
+    POSIX filenames that legitimately contain a backslash; a platform-CONDITIONAL fold
+    would buy the same nothing at the price of making the guard's answer depend on the host,
+    which is the exact property `re.IGNORECASE` was added to remove. `toolgate._norm` made
+    the same call for the same reason in #443, where an unconditional fold INVENTED a
+    spelling and matched nothing.
+
+    So this is pinned as a decision, not as a gap, and `SECURITY.md` and `docs/secrets.md`
+    now say "charter's harness targets POSIX" where they used to name Windows as a reason.
+    The day a Windows harness exists, this test is where the change starts.
     """
 
     def test_a_backslash_spelling_is_not_folded(self):


### PR DESCRIPTION
Four holes of one shape, plus one issue closed by deciding rather than by coding. In every
case the guard already held the thing that walked past it and read it in one role only.

| Issue | Reproduced | Outcome |
|---|---|---|
| **#483** `git switch -C neu` | yes — git: *"Switched to a new branch 'neu'"*, both guards silent | fixed |
| **#477** `--git-dir` / `--work-tree` / `GIT_DIR` / `GIT_WORK_TREE` | yes — plane root's HEAD moved from a clone | fixed |
| **#467** alias → `reset --hard` | **half refuted, half real**: the branch guard already resolved aliases (#466 shipped it); the *reset* guard did not | fixed |
| **#474** `grep -rn TOKEN .` from the plane root | yes — every vault file printed, both routes | fixed |
| **#476** backslash separators | reproduced at the predicate | closed as a decision + docs; charter's harness is POSIX-only |

## #483 — a separated `-C` is `switch`'s option, not git's global

`_git_target` stripped `-C <value>` from **anywhere** in the argv, so `switch`'s own
`--force-create` was read as git's change-directory global: the guard was aimed at a
directory called `neu`, which is not the plane root, and stood aside without printing
anything. The attached `-Cneu` was refused the whole time — one keystroke decided whether
the guard could see the command.

`_git_globals` now splits the argv at the subcommand, which is the only position git itself
reads a global `-C` in. Nothing knows which options belong to `switch`; the next subcommand
option that collides with a git global is covered by construction.

## #477 — the options that name a repository without naming a directory

`--git-dir`, `--work-tree` and their env spellings were all already in `_GIT_VALUE_OPTS`,
where they were skipped as option *values* so they could not be misread as a subcommand,
and then never looked at again. `_git_target` returns **every** subject an invocation names
now: a `--git-dir` with no `--work-tree` beside it moves the named repository's refs while
its files land in the cwd, so both count, and a caller denies when any of them is the root.
Attached and separated forms, composed with `-C` (git applies `-C` first, and a relative
`--git-dir` is read against where it landed), and the environment spellings.

Added as a **route axis**, crossed with every command whose effect real git decides — not as
rows beside the commands, which is how this survived three rounds of route work.

## #467 — partly refuted, and the real half is the reset guard

The branch guard has resolved aliases since #466 (`_inline_aliases` / `_resolve_git_alias`),
so `git -c alias.z='checkout feature' z` is already denied on `origin/main` and there is a
`DENY` row for it in the corpus. The issue's *other* sentence was live: the history-wipe
guard still compared the subcommand to the string `reset`, so both

```
git -c alias.z='reset --hard origin/main' z      # allowed on main
git wipe origin/main   (wipe = reset --hard)     # allowed on main
```

destroyed unpushed commits in the plane root unrefused. Both guards resolve now. The
`"reset" not in cmd` early exit went with it — sound only while the subcommand is read as
written, and false the moment aliases are followed — and is `"git" not in cmd`, which is
sound whatever the alias is called because `_plane_root_git` only yields for a program whose
basename is `git`.

## #474 — the operand that *contains* the vault directory

Both vault guards decided on the operand's TEXT, so `grep -rn TOKEN .` (and
`Grep(path=".")`) read every vault file and named none of them. A **second predicate** asks
whether the walk *reaches* charter's state — the operand is resolved against the shell's
directory and compared by ancestry, and the entries it is compared against are read off the
filesystem, so `.`, `..`, `../..`, an absolute path and a symlinked parent are one question
rather than five spellings, and a `$CHARTER_HOME` plane is covered by the same code.

The half that makes it liveable, all tested:

* it fires only when the guarded entries **exist and hold bytes** — a fresh plane's empty
  `vaults/` never triggers it;
* it honours the exclusion its own denial recommends (`--exclude-dir=.charter`,
  `rg --glob '!.charter'`), and the tests **execute** those commands;
* a narrowed `Grep` glob is answered by looking inside the directory, not by reading the
  pattern — `*.py` over a directory of `.json` vaults is allowed;
* `Read` is exempt; it does not walk. A non-recursive `grep -n TOKEN .` is untouched.

## #476 — closed as a decision

The issue named its own prerequisite: *"Worth confirming first whether charter's hook
harness is supported on Windows at all."* It is not. Charter builds and drives a tmux
session and writes vaults at `0o600`; CI is Ubuntu and dev is macOS; there is no Windows
install path. Folding `\` would buy nothing on a supported host and would deny POSIX
filenames that legitimately contain one, and a platform-*conditional* fold would make the
guard's answer depend on the host — the exact property `re.IGNORECASE` was added to remove.
`toolgate._norm` made the same call in #443, where an unconditional fold *invented* a
spelling and matched nothing.

So `SECURITY.md` and `docs/secrets.md` now say charter's harness targets POSIX where they
named Windows as a reason, the package's `Operating System :: OS Independent` classifier
(never true) is now `POSIX`, and the reasoning sits in
`TestSeparatorMeansTheForwardSlash`'s docstring next to the assertion.

## The corpus, flipped deliberately

The four `LIMIT` rows for #483 and #477 are now `DENY` rows citing their issues. The
`assertGreaterEqual(len(limits), 12)` check is **replaced by the exact set of issues the
remaining rows cite** — a count turns closing a hole into a red test with no name on it, and
the only way to read that failure is to lower the number, which is indistinguishable from a
limit quietly reappearing. The set fails in both directions and says which issue moved.

## Evidence

**Differential against `origin/main`** — both checkouts run over one byte-identical fixture
plane (real git repo, real upstream, two unpushed commits, a fabricated vault file, a
workspace clone), 7533 decisions each:

* **0 inputs where `origin/main` denies and this branch allows.**
* 1040 newly denied: the four families above plus the walk guard. No `cat`/`head`/`sed`/`awk`
  row changed.

That run **caught a false positive this branch had introduced**: the walk predicate's
guarded-entry names were one `startswith` tuple, which matched the registry
`.charter/vaults.json` and newly refused `ag TOKEN .charter/vaults.json` — #443's false
positive coming back through the other predicate. Fixed with an exact/prefix split, plus a
test that uses a *walker*, because the existing registry test uses `cat` and could not have
caught it.

**Mutation testing** — 16 mutations, each applied, run, restored, `__pycache__` cleared:

| mutation | result |
|---|---|
| `_git_globals` reads a `-C` from anywhere in the argv again | RED (36) |
| `_git_target` stops reading `--git-dir` / `--work-tree` | RED (58) |
| `_git_target` stops reading `GIT_DIR` / `GIT_WORK_TREE` | RED (26) |
| a git dir's parent is no longer offered as the repository | RED (47) |
| the reset guard stops following aliases | RED (7) |
| the early exit goes back to `"reset" not in cmd` | RED (5) |
| the Bash walk arm never fires | RED (25) |
| grep's recursion flags stop counting | RED (19) |
| `rg`/`ag` stop counting as walkers | RED (5) |
| the operand is compared as text instead of by ancestry | RED (27) |
| a walker with no operand no longer defaults to the cwd | RED (3) |
| an empty guarded directory starts being denied | RED (1) |
| the recommended exclusion stops being honoured | RED (7) |
| the `Grep` route's walk arm never fires | RED (2) |
| guarded-entry names go back to one `startswith` tuple | RED (5) |
| a `Grep` glob is read instead of looked at | RED (1) |

Restored: GREEN. Full suite: `Ran 4926 tests … OK`.

## Filed, not chased

**#496** — `export GIT_DIR=<plane>/.git && git checkout feature` reaches the root and is
allowed, while the attached `GIT_DIR=… git …` is refused as of this PR. The shared walk
models one shell effect across segments — a `cd` — and "track the environment across
segments" is a larger claim than "track the working directory across segments". Reproduced
end to end, pinned as an `ALLOW` row naming the issue, and named in `docs/hooks.md` and the
news entry.

## The next spelling

For the git guards: an option that git *adds* which names a repository, or one that means
something different before and after the subcommand. The split is positional now rather than
a list, so the second class is covered structurally; the first is not, and the corpus's
route axis is where it would be caught.

For the walk guard: **a program that walks directories and is not in `_TREE_WALKERS`** —
`find . -exec cat {} +` and `tar cf - .` are the ones tested today. That is the same ceiling
`_READERS` has, it is not raised by adding names, and it is stated in `SECURITY.md`,
`docs/secrets.md` and `skills/secrets/SKILL.md` and pinned in
`TestWhatStillWalksPastBothGuards`.

Closes #467
Closes #474
Closes #476
Closes #477
Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
