### PR TITLE
frame: the repo table moves to a variable-height bottom, and three limits the frame carried are closed (#488, #475, #420, #413)

### DIFF
--- a/charter.toml
+++ b/charter.toml
@@ -11,7 +11,12 @@ share = "local"
 default = "steward"
 
 [frame]
-# All four slots: repos down the left, persona chips down the right, the wide repo
-# table across the bottom. `left`/`right` need a terminal at least `min-cols` wide —
-# below that `layout.visible_slots` drops them rather than cramping the harness.
-slots = ["top", "left", "right", "bottom"]
+# Every slot: identity across the top, the wide repo table across the bottom, persona
+# chips down the right. `right` needs a terminal at least `min-cols` wide — below that
+# `layout.visible_slots` drops it rather than cramping the harness.
+#
+# The ORDER is the geometry (#488): `bottom` is split before `right`, so its table gets
+# the full window width. Listed after it, the same table would be inset to 177 columns
+# and start losing its own right-hand columns. There is no `left` any more — it drew a
+# 22-column copy of the table `bottom` now draws properly.
+slots = ["top", "bottom", "right"]

--- a/charter.toml
+++ b/charter.toml
@@ -16,7 +16,9 @@ default = "steward"
 # `layout.visible_slots` drops it rather than cramping the harness.
 #
 # The ORDER is the geometry (#488): `bottom` is split before `right`, so its table gets
-# the full window width. Listed after it, the same table would be inset to 177 columns
-# and start losing its own right-hand columns. There is no `left` any more — it drew a
-# 22-column copy of the table `bottom` now draws properly.
+# the full window width. Listed after it, `bottom` is split off a harness the sidebar has
+# already narrowed — 23 columns short of the window, so the table needs a 118-column
+# terminal before it is drawn at all, and below that the pane is the attention row alone
+# (#500). There is no `left` any more — it drew a 22-column copy of the table `bottom`
+# now draws properly.
 slots = ["top", "bottom", "right"]

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -705,7 +705,8 @@ def _add_frame_parsers(sub) -> None:
     # naming `frame-probe` silently launching a harness instead of reading tmux's own
     # version (see `commands_frame.cmd_probe`'s own docstring).
     _core_commands = set(sub.choices) | {"frame", "panel", "frame-menu", "frame-action",
-                                         "frame-probe", "frame-respawn", "frame-density"}
+                                         "frame-probe", "frame-respawn", "frame-density",
+                                         "frame-resize"}
 
     # Which harness (by `.name`, never `.cli_name` — that's the dict key below) has
     # already claimed each word, so a SECOND harness wanting it is told who got there
@@ -791,6 +792,19 @@ def _add_frame_parsers(sub) -> None:
     rs.add_argument("--pane", dest="pane", required=True)
     rs.add_argument("--frame", dest="frame", default=None)
     rs.set_defaults(func=commands_frame.cmd_respawn)
+
+    # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the
+    # ones above. Fired by the frame window's own `window-resized` hook (#488,
+    # `commands_frame._resize_hook_argv`) — never typed by an operator. The hook used to
+    # carry the sizes as literal text; `bottom` is content-sized now, so the sizes have
+    # to be RECOMPUTED against the window that just changed, and only charter can do
+    # that. `--frame` travels on the argv for `frame-respawn`'s reason: on the operator's
+    # own server there is no `$CHARTER_SESSION_ID` for a `run-shell` child to read.
+    # Optional, not required, so a hook installed by an older charter and still sitting
+    # in a running frame's window options resolves its frame from the environment.
+    rz = sub.add_parser("frame-resize")
+    rz.add_argument("--frame", dest="frame", default=None)
+    rz.set_defaults(func=commands_frame.cmd_resize)
 
     # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the
     # three above. Fired by a hotkey-menu selection (`commands_frame._menu_entries`), whose

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -422,8 +422,25 @@ def _clone_one(r: dict, wd) -> dict:
     which is the whole point), `registry.for_repo` builds a fresh backend per call, and
     `gitpolicy.apply` writes only inside this clone's own `.git/config`. Nothing here is
     shared between repos.
+
+    **The network half is recorded as in flight (#420).** #387 promised the frame a
+    spinner while "a dispatch, clone or `gl-refresh`" runs and only dispatches animated,
+    because `inflight.start` had one caller. This is one of the two that were missing. The
+    record is per REPO rather than per command, so eight parallel clones read as eight —
+    `inflight`'s own `mkstemp` naming exists for exactly that concurrency, and this
+    function is already the per-repo, thread-local unit.
+
+    `kind=inflight.CLONE`, which is what keeps the dispatch-overlap nudge out of it: that
+    nudge reads names back to an operator as a sentence, and `inflight.still_running`
+    answers dispatches unless asked otherwise (see that module's docstring).
+
+    Recorded only around the parts that take time — after the destination and the URL are
+    settled, so a refusal never leaves a record, and released in a `finally`, so a `git`
+    that raises does not either. A process KILLED mid-clone still leaves one, and that is
+    the case `PRESUMED_DEAD_SECONDS`/`PRUNE_SECONDS` already exist for: the frame draws
+    such a record statically (`⋯`), never spinning.
     """
-    from . import gitpolicy
+    from . import gitpolicy, inflight
     from .forge import registry
 
     # #325: the destination is a name out of `inventory/repos.json`, a TRACKED file, and
@@ -446,15 +463,19 @@ def _clone_one(r: dict, wd) -> dict:
                 "reason": "its inventory record carries no HTTPS clone URL, and the "
                           "`ssh_url` it does carry is not a form this forge recognises — "
                           "charter will not hand git a string it did not build"}
-    proc = _git([*_cred_flag(forge), "clone", "--branch", r["default_branch"],
-                 "--", url, str(dest)])
-    if proc.returncode != 0:
-        return {"repo": r, "dest": dest, "status": "failed", "forge": forge,
-                "stderr": (proc.stderr or "").strip()}
-    # Golden rule 0: every git op from this clone uses ITS FORGE's token over HTTPS —
-    # credential helper + signing off + SSH→HTTPS rewrites (see charter/gitpolicy.py).
-    gitpolicy.apply(dest)
-    return {"repo": r, "dest": dest, "status": "ok", "forge": forge}
+    inflight.start(dest.name, kind=inflight.CLONE)
+    try:
+        proc = _git([*_cred_flag(forge), "clone", "--branch", r["default_branch"],
+                     "--", url, str(dest)])
+        if proc.returncode != 0:
+            return {"repo": r, "dest": dest, "status": "failed", "forge": forge,
+                    "stderr": (proc.stderr or "").strip()}
+        # Golden rule 0: every git op from this clone uses ITS FORGE's token over HTTPS —
+        # credential helper + signing off + SSH→HTTPS rewrites (see charter/gitpolicy.py).
+        gitpolicy.apply(dest)
+        return {"repo": r, "dest": dest, "status": "ok", "forge": forge}
+    finally:
+        inflight.finish(dest.name, kind=inflight.CLONE)
 
 
 def cmd_save(args) -> int:
@@ -614,7 +635,23 @@ def cmd_gl_refresh(args) -> int:
     if not dirs:
         util.info(f"No repos in workspace '{ws}'.")
         return 0
-    cache = glstate.refresh(dirs)
+    # In flight while the fetch runs (#420) — the second of the two callers #387's
+    # spinner was promised and never got. Recorded HERE, in the process that does the
+    # work, never in the `--detach` branch above: that branch returns immediately, and a
+    # record taken there would clear before the child it started had begun. `glstate
+    # .maybe_spawn` starts that child on the status line's own render path, so an
+    # operator sees the frame move while their forge state is being fetched rather than
+    # wondering why a column changed by itself.
+    #
+    # The WORKSPACE is the agent name, not a repo: one refresh covers every tree in it,
+    # and naming one of them would be a claim about which. `kind=inflight.REFRESH` keeps
+    # it out of the dispatch nudge and the persona chips.
+    from . import inflight
+    inflight.start(ws, kind=inflight.REFRESH)
+    try:
+        cache = glstate.refresh(dirs)
+    finally:
+        inflight.finish(ws, kind=inflight.REFRESH)
     util.ok(f"Refreshed forge state for {len(dirs)} tree(s) in '{ws}'.")
     for d in dirs:
         ent = cache.get(str(d), {})

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1067,9 +1067,9 @@ def _wait_for_harness(socket: str, harness_pane: str) -> int | None:
         time.sleep(_POLL_SECONDS)
 
 
-def _launch_sizes(fid: str, slots: list[str], rows: int) -> dict[str, int]:
-    """How big each of *slots* is split, in a *rows*-row window — the launch-time half of
-    `layout.slot_sizes`, shared by both launch paths so they cannot disagree.
+def _launch_sizes(fid: str, slots: list[str], cols: int, rows: int) -> dict[str, int]:
+    """How big each of *slots* is split, in a *cols* x *rows* window — the launch-time
+    half of `layout.slot_sizes`, shared by both launch paths so they cannot disagree.
 
     `bottom` is the only slot whose answer is not a constant (#488): it is sized to the
     repo table it is about to draw, floored at the one row it always was and capped so
@@ -1078,13 +1078,21 @@ def _launch_sizes(fid: str, slots: list[str], rows: int) -> dict[str, int]:
     coming up with a pane taller than its content or a table cut off with nothing saying
     so.
 
+    **`cols` is not decoration (#500).** The renderer draws NO table below
+    `statusline._LEFT_W` (95) and at most `slots._TERSE_ROWS` of one at a `terse`
+    density, and neither is a rare shape: `layout.visible_slots` keeps `bottom` down to
+    `min_cols // 2`, so an 80-column terminal is one, and `minimal` is a level the F2
+    menu offers. Sizing from the repo count alone gave both of them a pane sized for a
+    table the panel then refused to draw — up to fourteen blank rows taken off the
+    harness. `bottom` is split BEFORE `right`, so the window's width IS the pane's.
+
     Affordable at launch by construction, and that is not incidental: `cmd_launch` calls
     `gather.discard(fid)` before it draws anything, so this reaches `gather.row_count`
     with no cache and gets the directory-listing answer — an `iterdir`, never the git
     sweep `gather.scan` would run. See `gather.row_count`'s own docstring for both paths.
     """
     return layout.slot_sizes(slots, window_rows=rows,
-                             content_rows=frame_slots.bottom_rows_wanted(fid))
+                             content_rows=frame_slots.bottom_rows_wanted(fid, cols=cols))
 
 
 def _drawable_slots(cols: int, rows: int, configured: list[str] | None = None) -> list[str]:
@@ -1501,7 +1509,7 @@ def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, argv: list[
     # the whole environment here (#446): see `_guest_harness_env`.
     panes = _draw_panels(socket, slots=slots, fid=fid, harness_pane=harness_pane,
                          env=None, v=v, pane_env=_pane_identity_env(env, v),
-                         sizes=_launch_sizes(fid, slots, rows))
+                         sizes=_launch_sizes(fid, slots, cols, rows))
     _arm_panel_respawn(socket, fid=fid, panes=panes, env=None)
     tmuxctl.run("focusing the harness pane",
                 tmuxctl.server_argv(socket, "select-pane", "-t", harness_pane))
@@ -2221,7 +2229,7 @@ def cmd_launch(args) -> int:
             panes = _draw_panels(
                 SOCKET, slots=slots, fid=fid, harness_pane=harness_pane, env=env, v=v,
                 pane_env=_pane_identity_env(env, v),
-                sizes=_launch_sizes(fid, slots, rows))
+                sizes=_launch_sizes(fid, slots, cols, rows))
             _arm_panel_respawn(SOCKET, fid=fid, panes=panes, env=env)
 
             # `split-window` makes the newly created pane the ACTIVE one by default, so
@@ -2407,7 +2415,7 @@ def _relayout_pane_env(fid: str, v: tuple[int, int]) -> dict[str, str] | None:
 
 def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str],
               want: list[str], v: tuple[int, int],
-              window_rows: int) -> dict[str, str]:
+              window_cols: int, window_rows: int) -> dict[str, str]:
     """Make the running frame's panes match *want*, and return the map that resulted.
 
     Kill what is no longer wanted, split what is newly wanted, re-arm the hooks, re-assert
@@ -2426,8 +2434,11 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
       engine the `window-resized` hook exists to correct after a window resize. The panes
       that merely SURVIVED a density change are the ones that get stretched by it, so
       they are exactly the ones a `-l` on the new pane cannot fix. :func:`_reassert_sizes`
-      does it, and *window_rows* is why it takes a measurement rather than a constant:
-      `bottom`'s height depends on the window it is in (#488).
+      does it, and *window_cols*/*window_rows* are why it takes a measurement rather
+      than a constant: `bottom`'s height depends on the window it is in — on its rows
+      (#488) and, since #500, on its columns and this frame's density too, because a
+      panel narrower than `statusline._LEFT_W` draws no table and `terse` draws at most
+      `slots._TERSE_ROWS` of one.
 
     Slots whose `split-window` fails are simply absent from the returned map, as at launch:
     a decorative panel that could not be drawn must not take down a frame that is running.
@@ -2475,14 +2486,16 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
         keep.update(_split_panels(
             socket, slots=missing, fid=fid, harness_pane=harness_pane, env=None,
             pane_env=pane_env,
-            sizes=layout.slot_sizes(want, window_rows=window_rows,
-                                    content_rows=frame_slots.bottom_rows_wanted(fid))))
+            sizes=layout.slot_sizes(
+                want, window_rows=window_rows,
+                content_rows=frame_slots.bottom_rows_wanted(fid, cols=window_cols))))
         _arm_panel_respawn(socket, fid=fid,
                            panes={s: keep[s] for s in missing if s in keep}, env=None)
 
     _install_resize_hook(socket, harness_pane=harness_pane, panes=keep, v=v,
                          env=None, fid=fid, replacing=True)
-    _reassert_sizes(socket, fid=fid, panes=keep, window_rows=window_rows)
+    _reassert_sizes(socket, fid=fid, panes=keep,
+                    window_cols=window_cols, window_rows=window_rows)
     # `split-window` makes each new pane the ACTIVE one, so without this the operator is
     # left typing into a panel. The same correction `cmd_launch` makes after its own
     # splits, for the same reason.
@@ -2492,9 +2505,9 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
 
 
 def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str],
-                    window_rows: int) -> None:
+                    window_cols: int, window_rows: int) -> None:
     """Re-apply every pane in *panes* the size `layout.slot_sizes` says it should have in
-    a *window_rows*-row window.
+    a *window_cols* x *window_rows* window.
 
     The one place a pane is told its size after it exists, shared by the two callers that
     need it and for two different reasons: :func:`_relayout`, because a `split-window -l`
@@ -2509,6 +2522,13 @@ def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str],
     on tmux 3.7c, asserting `-y 40` in a 20-row window leaves the harness 1 row.
     *window_rows* is therefore a measurement the CALLER just took, not a remembered one.
 
+    **And *window_cols* alongside it (#500), for the same reason and a sharper one.** A
+    resize changes the window's WIDTH too, and how tall `bottom` should be depends on it:
+    below `statusline._LEFT_W` the panel draws no table, so it wants one row. Dropping the
+    width here — `cmd_resize` measured it and threw it away as `_cols` — is what made a
+    narrowed terminal keep a table-sized pane it could no longer draw a table in, on every
+    step of the drag rather than only at launch.
+
     Every pane id is checked before it is used, even though both callers already checked
     theirs. `_panel_died_hook_argv`'s own rule ("every value that reaches the text is
     what decides, never where it came from") applies to a `-t` argument too, and #475 was
@@ -2519,8 +2539,9 @@ def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str],
     between the map being read and this running) makes `resize-pane` fail, and that is
     not an integration failure worth printing over the agent's own screen.
     """
-    sizes = layout.slot_sizes(list(panes), window_rows=window_rows,
-                              content_rows=frame_slots.bottom_rows_wanted(fid))
+    sizes = layout.slot_sizes(
+        list(panes), window_rows=window_rows,
+        content_rows=frame_slots.bottom_rows_wanted(fid, cols=window_cols))
     for slot, pane_id in panes.items():
         if slot not in _RESIZE_FLAG or slot not in sizes:
             continue
@@ -2560,13 +2581,22 @@ def cmd_resize(args) -> int:
     `cmd_respawn`: on the operator's own server there IS no `$CHARTER_SESSION_ID` to
     read, because that variable is a session option charter does not write there.
 
+    **Both dimensions are used, not just the rows (#500).** The window's WIDTH decides
+    whether `bottom` can draw its table at all (`statusline._LEFT_W`), so narrowing a
+    terminal below 95 columns has to shrink the pane to the one-row strip it can actually
+    fill. This measured the width and discarded it as `_cols`, which left a narrowed
+    frame re-asserting a table-sized pane it drew one line into — on every step of the
+    drag, so the harness stayed pinned at `layout.HARNESS_MIN_ROWS` for as long as the
+    terminal stayed narrow.
+
     **This is the hot path of the whole feature.** A terminal drag fires `window-resized`
     once per size change, so this runs repeatedly and in the background while the
     operator is still dragging. Everything it reads is cheap by construction:
     `state.harness_pane`/`state.panes` are two small files, `_window_size` is one
     `display-message`, and `frame_slots.bottom_rows_wanted` goes through
     `gather.row_count`, which answers from the frame's cache and never runs a git sweep
-    (see its own docstring).
+    (see its own docstring) — and at a width below `_LEFT_W` it does not even ask, since
+    the answer is one row whatever the count is.
     """
     fid = getattr(args, "frame", None) or os.environ.get("CHARTER_SESSION_ID", "")
     if not fid:
@@ -2578,8 +2608,8 @@ def cmd_resize(args) -> int:
     if not panes:
         return 0
     socket = state.frame_server(fid) or SOCKET
-    _cols, rows = _window_size(socket, harness_pane)
-    _reassert_sizes(socket, fid=fid, panes=panes, window_rows=rows)
+    cols, rows = _window_size(socket, harness_pane)
+    _reassert_sizes(socket, fid=fid, panes=panes, window_cols=cols, window_rows=rows)
     return 0
 
 
@@ -2641,7 +2671,7 @@ def cmd_density(args) -> int:
     cols, rows = _window_size(socket, harness_pane)
     want = _drawable_slots(cols, rows, instance.density_slots(level))
     panes = _relayout(socket, fid=fid, harness_pane=harness_pane, panels=panels,
-                      want=want, v=v, window_rows=rows)
+                      want=want, v=v, window_cols=cols, window_rows=rows)
     state.record_panes(fid, panels=panes)
     # Re-recorded so the menu's own mark moves with the frame. `menu.record` rewrites the
     # table whole, and every action id is minted from position, so the ids the operator's

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -841,6 +841,19 @@ def _resize_hook_argv(*, socket: str, harness_pane: str, fid: str) -> list[str] 
     which is charter drawing in the one rectangle ADR 0018 says it never draws in; and a
     blocking `run-shell` in a hook stalls tmux's own command queue.
 
+    **What a charter per resize event costs, measured rather than assumed.** One
+    `charter frame-resize` child: median **20ms** (5 runs, refused before any tmux call, so
+    the interpreter and charter's import graph and nothing else). `window-resized` fires
+    once per size change, so a drag of thirty of them is ~0.6 CPU-seconds spread across the
+    drag, backgrounded, with tmux's own queue never waiting on it — the same order as the
+    `pane-died` respawn hook this construction was copied from. Nothing here is free, and
+    the old literal-text action was; that is the price of a size that has to be recomputed.
+
+    **Known remaining case: #501.** Nothing serialises those children and `-b` gives no
+    completion ordering, so during a drag one that measured a taller window can apply after
+    one that measured the final, shorter one — a pane sized for a window that is already
+    gone, until the next resize corrects it.
+
     **It also removes #475 rather than patching it.** The old action interpolated a pane
     id read back off DISK (`state.panes`, via `_relayout`'s `keep` map, which skipped the
     `_PANE_ID_RE` check for every slot it kept) into text tmux re-parses as a command

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -773,11 +773,12 @@ def _panel_died_hook_argv(*, socket: str, panel_pane: str, slot: str,
                                action)
 
 
-#: Which `resize-pane` flag re-asserts a slot's fixed dimension: `-y` (rows) for the
-#: horizontal strips, `-x` (columns) for the side columns — the same axis `layout.py`'s
-#: own `-v`/`-h` split direction already encodes for the same slots, read here rather
-#: than re-derived a third way.
-_RESIZE_FLAG = {"top": "-y", "bottom": "-y", "left": "-x", "right": "-x"}
+#: Which `resize-pane` flag re-asserts a slot's dimension: `-y` (rows) for the horizontal
+#: strips, `-x` (columns) for the side column — the same axis `layout.py`'s own `-v`/`-h`
+#: split direction already encodes for the same slots, read here rather than re-derived a
+#: third way. The SIZE that goes with it is `layout.slot_sizes`', not `SLOT_SIZE`'s, since
+#: `bottom`'s is a function of its content and of the window (#488).
+_RESIZE_FLAG = {"top": "-y", "bottom": "-y", "right": "-x"}
 
 #: Every real pane id tmux's own `-P -F '#{pane_id}'` has ever reported (`%<digits>`,
 #: confirmed against tmux 3.7c and never observed otherwise). Checked before a value
@@ -813,39 +814,65 @@ _PANE_ID_RE = re.compile(r"%[0-9]+")
 _INVALID_HOOK_NAME = "invalid option"
 
 
-def _resize_hook_argv(*, socket: str, harness_pane: str, panes: dict[str, str]) -> list[str]:
-    """`window-resized`: re-asserts every fixed-size panel's dimension after a resize.
+def _resize_hook_argv(*, socket: str, harness_pane: str, fid: str) -> list[str] | None:
+    """`window-resized`: ask charter to re-size this frame's panes, whatever the new
+    window turns out to be.
 
     Measured against tmux 3.7c (see `layout.panel_argvs`'s own docstring): tmux's layout
     engine redistributes EVERY pane proportionally whenever the window's size changes,
     `-l size` notwithstanding — a 120x30 frame grown to 200x50 stretched two one-row
     panels to 8 and 7 rows apiece, and only snapped back to 1 row because that particular
-    shrink happened to be an exact round trip of the same grow. `resize-pane -t <pane>
-    -y/-x <size>` re-applies the intended size directly and was verified by hand to hold
-    across repeated grows AND shrinks to arbitrary sizes, not just a round trip.
+    shrink happened to be an exact round trip of the same grow. So something has to
+    re-apply the intended sizes after every resize.
+
+    **This used to be the sizes themselves, as literal text, and #488 is why it cannot
+    be.** The action was `resize-pane -t %1 -y 1 ; resize-pane -t %2 -x 22` — a constant,
+    computed once when the frame was laid out. `bottom`'s height is no longer a constant:
+    it is `min(content, cap)` where the cap is what the window can spare
+    (`layout.bottom_rows`), so a stale number is not merely imprecise, it is destructive.
+    Measured on 3.7c: a window shrunk from 50 rows to 20 with a hook still asserting
+    `-y 40` left the harness pane **1 row tall**. tmux does not refuse an over-large
+    height — it grants it out of the neighbour. The hook therefore has to RECOMPUTE, and
+    the only thing that can recompute is charter.
+
+    **`run-shell -b`, and both halves matter** — the same construction, for the same two
+    measured reasons, as `_panel_died_hook_argv`: un-backgrounded, tmux prints a non-zero
+    command's own `'…' returned N` INTO THE HARNESS PANE and drops it into copy-mode,
+    which is charter drawing in the one rectangle ADR 0018 says it never draws in; and a
+    blocking `run-shell` in a hook stalls tmux's own command queue.
+
+    **It also removes #475 rather than patching it.** The old action interpolated a pane
+    id read back off DISK (`state.panes`, via `_relayout`'s `keep` map, which skipped the
+    `_PANE_ID_RE` check for every slot it kept) into text tmux re-parses as a command
+    line — so a `%1;kill-server` written into the frame's own state directory armed
+    `kill-server` on every resize for the life of the window. No pane id reaches this
+    text at all now. `cmd_resize` reads them on the other side and checks each one before
+    it becomes a `resize-pane -t` **argv element**, where a `;` is a character in a
+    filename rather than a command separator.
 
     Installed as a WINDOW hook (`-w`, scoped via *harness_pane* — tmux resolves its
     containing window from the pane), not a session or global one, so a sibling frame's
     own window is left untouched. Fires on EVERY resize for the life of the window, not
     only the first, since an operator's terminal can be grown and shrunk any number of
-    times.
-
-    *panes* maps each slot that was actually split to the pane id tmux reported for it —
-    never a slot whose `split-window` itself failed, since there is nothing there to
-    resize. Pane ids are tmux's own (`%<digits>`), never operator- or plane-derived, so
-    this action is safe to build directly: there is no hostile string here for a nested
-    tmux-quote layer to mangle, unlike `status_path` (see `_EXIT_PATH_ENV`'s own
-    docstring).
-
-    A SINGLE `set-hook` call, not one per slot: nothing else in this codebase installs a
+    times. A SINGLE `set-hook` call: nothing else in this codebase installs a
     `window-resized` hook, so there is no existing index to collide with — contrast
-    `pane-died`, which needed two INDEXED hooks specifically because two independent
-    actions shared one event (see `_pane_died_teardown_hook_argv`'s own docstring). One
-    action string chaining every slot's `resize-pane` with `;` covers all of them.
+    `pane-died`, which needed two INDEXED hooks because two independent actions shared
+    one event (see `_pane_died_teardown_hook_argv`).
+
+    ``None`` back means charter will not arm the hook, and — exactly as in
+    `_panel_died_hook_argv` — every value that reaches the text is what decides, never
+    where it came from: *fid* must be a `state.frame_id` (`_FRAME_ID_RE`) and every word
+    including the interpreter path must pass :func:`_action_word_is_safe`. A frame whose
+    id could not survive all three parses gets no resize recovery, which costs it
+    panels that drift out of shape; arming it anyway would cost it whatever the id
+    actually said.
     """
-    action = " ; ".join(
-        f"resize-pane -t {pane} {_RESIZE_FLAG[slot]} {layout.SLOT_SIZE[slot]}"
-        for slot, pane in panes.items())
+    words = util.self_relaunch_argv("frame-resize", "--frame", fid)
+    if (not _FRAME_ID_RE.fullmatch(fid)
+            or not all(_action_word_is_safe(w) for w in words)
+            or any(w.split() != [w] for w in words[1:])):
+        return None
+    action = f"""run-shell -b '"{words[0]}" {" ".join(words[1:])}'"""
     return tmuxctl.server_argv(socket, "set-hook", "-w", "-t", harness_pane,
                                "window-resized", action)
 
@@ -1027,6 +1054,26 @@ def _wait_for_harness(socket: str, harness_pane: str) -> int | None:
         time.sleep(_POLL_SECONDS)
 
 
+def _launch_sizes(fid: str, slots: list[str], rows: int) -> dict[str, int]:
+    """How big each of *slots* is split, in a *rows*-row window — the launch-time half of
+    `layout.slot_sizes`, shared by both launch paths so they cannot disagree.
+
+    `bottom` is the only slot whose answer is not a constant (#488): it is sized to the
+    repo table it is about to draw, floored at the one row it always was and capped so
+    the harness keeps `layout.HARNESS_MIN_ROWS`. `frame_slots.bottom_rows_wanted` is the
+    same function the RENDERER's own budget comes from, which is what stops a frame
+    coming up with a pane taller than its content or a table cut off with nothing saying
+    so.
+
+    Affordable at launch by construction, and that is not incidental: `cmd_launch` calls
+    `gather.discard(fid)` before it draws anything, so this reaches `gather.row_count`
+    with no cache and gets the directory-listing answer — an `iterdir`, never the git
+    sweep `gather.scan` would run. See `gather.row_count`'s own docstring for both paths.
+    """
+    return layout.slot_sizes(slots, window_rows=rows,
+                             content_rows=frame_slots.bottom_rows_wanted(fid))
+
+
 def _drawable_slots(cols: int, rows: int, configured: list[str] | None = None) -> list[str]:
     """Which configured slots this frame will actually draw, at *cols* x *rows*.
 
@@ -1039,7 +1086,8 @@ def _drawable_slots(cols: int, rows: int, configured: list[str] | None = None) -
 
     `[frame] slots` can accept a slot (`instance.FRAME_SLOTS`, sized by
     `layout.SLOT_SIZE`) that `frame.slots.SLOTS` — the RENDERER registry — has no
-    renderer for (as `left`/`right` were until Task 3 (#385) gave them one). Left
+    renderer for (as `left`/`right` were until Task 3 (#385) gave them one, and as the
+    next slot this frame grows will be on its first day). Left
     unfiltered, `panel_argvs` would still split a real pane for it; `panel.run`
     correctly refuses or exits 2 (Task 7's own "no empty pane" rule), but with
     `remain-on-exit on` keeping that pane alive, the operator is left with a permanently
@@ -1439,7 +1487,8 @@ def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, argv: list[
     # private-server path carries, for `_pane_identity_env`'s own reason. It used to be
     # the whole environment here (#446): see `_guest_harness_env`.
     panes = _draw_panels(socket, slots=slots, fid=fid, harness_pane=harness_pane,
-                         env=None, v=v, pane_env=_pane_identity_env(env, v))
+                         env=None, v=v, pane_env=_pane_identity_env(env, v),
+                         sizes=_launch_sizes(fid, slots, rows))
     _arm_panel_respawn(socket, fid=fid, panes=panes, env=None)
     tmuxctl.run("focusing the harness pane",
                 tmuxctl.server_argv(socket, "select-pane", "-t", harness_pane))
@@ -1501,7 +1550,8 @@ def _window_size(socket: str, harness_pane: str) -> tuple[int, int]:
 
 def _draw_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
                  env: dict | None, v: tuple[int, int],
-                 pane_env: dict[str, str] | None = None) -> dict[str, str]:
+                 pane_env: dict[str, str] | None = None,
+                 sizes: dict[str, int] | None = None) -> dict[str, str]:
     """Split one pane per slot off *harness_pane*, then install the resize hook.
 
     Shared by both paths: a panel is a panel wherever the frame is, the splits target
@@ -1518,8 +1568,9 @@ def _draw_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     inside an operator's tmux the cwd is the same cwd, so the hole is the same hole.
     """
     panes = _split_panels(socket, slots=slots, fid=fid, harness_pane=harness_pane,
-                          env=env, pane_env=pane_env)
-    _install_resize_hook(socket, harness_pane=harness_pane, panes=panes, v=v, env=env)
+                          env=env, pane_env=pane_env, sizes=sizes)
+    _install_resize_hook(socket, harness_pane=harness_pane, panes=panes, v=v, env=env,
+                         fid=fid)
     # Written down, because a frame's shape can now be CHANGED while it runs (the density
     # menu — `cmd_density`), and nothing else afterwards can say which tmux pane charter
     # meant as which slot. Slots only: `state.record_harness_pane` already owns the
@@ -1529,7 +1580,8 @@ def _draw_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
 
 
 def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
-                  env: dict | None, pane_env: dict[str, str] | None) -> dict[str, str]:
+                  env: dict | None, pane_env: dict[str, str] | None,
+                  sizes: dict[str, int] | None = None) -> dict[str, str]:
     """One `split-window` per slot, and the `{slot: pane id}` map that came back.
 
     The splitting half of :func:`_draw_panels`, separated from the hook-and-record half so
@@ -1552,7 +1604,8 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
                 _panel_remain_on_exit_argv(socket=socket, harness_pane=harness_pane),
                 env=env)
     panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=socket,
-                                    harness_pane=harness_pane, env=pane_env)
+                                    harness_pane=harness_pane, env=pane_env,
+                                    sizes=sizes)
     # Zipped with `slots`, not just iterated: `_resize_hook_argv` needs to know WHICH slot
     # each successfully-created pane belongs to (for its size and its resize-pane flag),
     # and `panel_argvs` returns exactly one command per slot, in the same order (see its
@@ -1572,19 +1625,21 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
 
 
 def _install_resize_hook(socket: str, *, harness_pane: str, panes: dict[str, str],
-                         v: tuple[int, int], env: dict | None,
+                         v: tuple[int, int], env: dict | None, fid: str,
                          replacing: bool = False) -> None:
-    """Arm (or re-arm) the `window-resized` hook for exactly *panes*.
+    """Arm (or re-arm) the `window-resized` hook, or remove it when nothing is left to
+    resize.
 
     Split out of :func:`_draw_panels` because a live re-layout (`cmd_density`) changes
-    which panes exist without going through a whole launch, and the hook's action names
-    every pane it resizes — one stale entry there is a `resize-pane` aimed at a pane that
-    no longer exists, on every resize, for the life of the window. One `set-hook` replaces
-    the whole hook, so re-arming from the new map covers every case but one: an EMPTY map
-    replaces nothing. *replacing* is what tells the two apart — a launch with no panels has
-    nothing armed to remove and issues no command at all, while a re-layout that dropped
-    every slot must actively `set-hook -u`. It is reachable rather than theoretical:
-    `_drawable_slots` answers `[]` below half the size floors.
+    which panes exist without going through a whole launch. *panes* no longer reaches the
+    hook's TEXT — since #488 the action names only the frame, and `cmd_resize` reads the
+    pane map off disk when it fires — so a stale entry can no longer be armed at all.
+    What *panes* still decides here is whether there is anything to arm: an empty map
+    means every panel is gone, and one `set-hook` replaces a hook only when there is
+    something to replace it with. *replacing* tells the two empty cases apart — a launch
+    with no panels has nothing armed to remove and issues no command at all, while a
+    re-layout that dropped every slot must actively `set-hook -u`. It is reachable rather
+    than theoretical: `_drawable_slots` answers `[]` below half the size floors.
 
     **Nothing is printed here any more, and that is #387's half of it.** This function
     used to `util.warn` when the tmux was below `RESIZE_HOOK_FLOOR` — a STANDING fact about
@@ -1626,7 +1681,16 @@ def _install_resize_hook(socket: str, *, harness_pane: str, panes: dict[str, str
                                         harness_pane, "window-resized"),
                     env=env, report=False)
         return
-    resize_cmd = _resize_hook_argv(socket=socket, harness_pane=harness_pane, panes=panes)
+    resize_cmd = _resize_hook_argv(socket=socket, harness_pane=harness_pane, fid=fid)
+    if resize_cmd is None:
+        # A frame id that could not survive the three parses a hook action passes
+        # through (`_resize_hook_argv`). Warned rather than silent, and for the same
+        # reason a failed install below is: the consequence is visible — panels drift out
+        # of shape on every resize — and an operator told why beats a frame that quietly
+        # stopped correcting itself. Nothing was armed, so there is nothing to remove.
+        util.warn("charter frame: this frame's id cannot be named safely in a tmux "
+                  "hook — panels may drift out of shape if this terminal is resized")
+        return
     # `report=False`: this is the one call site that reads a failure's own stderr
     # before deciding whether it IS one — an unrecognised hook name here is a
     # capability ceiling to note quietly, not an integration to report loudly, and
@@ -2143,7 +2207,8 @@ def cmd_launch(args) -> int:
             # below `PANE_ENV_FLOOR`, where `split-window` cannot parse the flag.
             panes = _draw_panels(
                 SOCKET, slots=slots, fid=fid, harness_pane=harness_pane, env=env, v=v,
-                pane_env=_pane_identity_env(env, v))
+                pane_env=_pane_identity_env(env, v),
+                sizes=_launch_sizes(fid, slots, rows))
             _arm_panel_respawn(SOCKET, fid=fid, panes=panes, env=env)
 
             # `split-window` makes the newly created pane the ACTIVE one by default, so
@@ -2328,7 +2393,8 @@ def _relayout_pane_env(fid: str, v: tuple[int, int]) -> dict[str, str] | None:
 
 
 def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str],
-              want: list[str], v: tuple[int, int]) -> dict[str, str]:
+              want: list[str], v: tuple[int, int],
+              window_rows: int) -> dict[str, str]:
     """Make the running frame's panes match *want*, and return the map that resulted.
 
     Kill what is no longer wanted, split what is newly wanted, re-arm the hooks, re-assert
@@ -2344,9 +2410,11 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
       exists at all.
     * **Re-assert every size afterwards, not only the new panes'.** A `split-window -l` or
       a `kill-pane` makes tmux redistribute the remaining panes proportionally — the same
-      engine `_resize_hook_argv` exists to correct after a window resize. The panes that
-      merely SURVIVED a density change are the ones that get stretched by it, so they are
-      exactly the ones a `-l` on the new pane cannot fix.
+      engine the `window-resized` hook exists to correct after a window resize. The panes
+      that merely SURVIVED a density change are the ones that get stretched by it, so
+      they are exactly the ones a `-l` on the new pane cannot fix. :func:`_reassert_sizes`
+      does it, and *window_rows* is why it takes a measurement rather than a constant:
+      `bottom`'s height depends on the window it is in (#488).
 
     Slots whose `split-window` fails are simply absent from the returned map, as at launch:
     a decorative panel that could not be drawn must not take down a frame that is running.
@@ -2367,13 +2435,19 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
     pane_env = _relayout_pane_env(fid, v)
     keep: dict[str, str] = {}
     for slot, pane_id in panels.items():
+        # Checked ABOVE the `want` branch, not inside the kill branch — #475. `panels` is
+        # `state.panes(fid)`, read back out of the frame's directory on disk, so it is
+        # not tmux's own word for a pane any more whichever branch it takes. The guard
+        # used to sit below the `continue`, which meant every slot the new density KEPT
+        # went into `keep` unexamined and straight on to a `resize-pane -t` and a hook —
+        # a `%1;kill-server` in that file armed `kill-server` on every window resize for
+        # the life of the window. The property is that nothing off disk is used as a pane
+        # id until it has tmux's own shape, and a guard on one branch of a loop is a
+        # guard on the wrong thing.
+        if not _PANE_ID_RE.fullmatch(pane_id):
+            continue
         if slot in want:
             keep[slot] = pane_id
-            continue
-        if not _PANE_ID_RE.fullmatch(pane_id):
-            # Read back off disk, so it is not tmux's own word for it any more. Same
-            # treatment `_draw_panels` gives an id on the way in, for the same reason:
-            # this one is about to be interpolated into a hook action and a kill.
             continue
         _disarm_panel_respawn(socket, pane_id=pane_id)
         tmuxctl.run(f"closing the {slot} panel",
@@ -2385,25 +2459,115 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
         # `instance.FRAME_DENSITY` for why that order is geometry rather than reading
         # order. Every split targets the harness pane, so a slot added to a frame that
         # already has the others lands exactly where a launch would have put it.
-        keep.update(_split_panels(socket, slots=missing, fid=fid,
-                                  harness_pane=harness_pane, env=None,
-                                  pane_env=pane_env))
+        keep.update(_split_panels(
+            socket, slots=missing, fid=fid, harness_pane=harness_pane, env=None,
+            pane_env=pane_env,
+            sizes=layout.slot_sizes(want, window_rows=window_rows,
+                                    content_rows=frame_slots.bottom_rows_wanted(fid))))
         _arm_panel_respawn(socket, fid=fid,
                            panes={s: keep[s] for s in missing if s in keep}, env=None)
 
     _install_resize_hook(socket, harness_pane=harness_pane, panes=keep, v=v,
-                         env=None, replacing=True)
-    for slot, pane_id in keep.items():
-        tmuxctl.run(f"restoring the {slot} panel's size",
-                    tmuxctl.server_argv(socket, "resize-pane", "-t", pane_id,
-                                        _RESIZE_FLAG[slot], str(layout.SLOT_SIZE[slot])),
-                    report=False)
+                         env=None, fid=fid, replacing=True)
+    _reassert_sizes(socket, fid=fid, panes=keep, window_rows=window_rows)
     # `split-window` makes each new pane the ACTIVE one, so without this the operator is
     # left typing into a panel. The same correction `cmd_launch` makes after its own
     # splits, for the same reason.
     tmuxctl.run("focusing the harness pane",
                 tmuxctl.server_argv(socket, "select-pane", "-t", harness_pane))
     return keep
+
+
+def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str],
+                    window_rows: int) -> None:
+    """Re-apply every pane in *panes* the size `layout.slot_sizes` says it should have in
+    a *window_rows*-row window.
+
+    The one place a pane is told its size after it exists, shared by the two callers that
+    need it and for two different reasons: :func:`_relayout`, because a `split-window -l`
+    or a `kill-pane` makes tmux redistribute the SURVIVING panes proportionally (so the
+    panes a density change merely kept are exactly the ones a `-l` on the new pane cannot
+    fix); and :func:`cmd_resize`, because the whole window just changed size under all of
+    them.
+
+    **The sizes are recomputed here, never carried in.** `bottom`'s height depends on the
+    window it is in (`layout.bottom_rows`), so a caller passing a launch-time number
+    would re-assert a height that was right for a window that no longer exists — measured
+    on tmux 3.7c, asserting `-y 40` in a 20-row window leaves the harness 1 row.
+    *window_rows* is therefore a measurement the CALLER just took, not a remembered one.
+
+    Every pane id is checked before it is used, even though both callers already checked
+    theirs. `_panel_died_hook_argv`'s own rule ("every value that reaches the text is
+    what decides, never where it came from") applies to a `-t` argument too, and #475 was
+    exactly a builder that documented "safe because my caller checked" growing a second
+    caller.
+
+    `report=False`: a pane that has since died (the operator closed it, a panel crashed
+    between the map being read and this running) makes `resize-pane` fail, and that is
+    not an integration failure worth printing over the agent's own screen.
+    """
+    sizes = layout.slot_sizes(list(panes), window_rows=window_rows,
+                              content_rows=frame_slots.bottom_rows_wanted(fid))
+    for slot, pane_id in panes.items():
+        if slot not in _RESIZE_FLAG or slot not in sizes:
+            continue
+        if not _PANE_ID_RE.fullmatch(pane_id):
+            continue
+        tmuxctl.run(f"restoring the {slot} panel's size",
+                    tmuxctl.server_argv(socket, "resize-pane", "-t", pane_id,
+                                        _RESIZE_FLAG[slot], str(sizes[slot])),
+                    report=False)
+
+
+def cmd_resize(args) -> int:
+    """`charter frame-resize --frame <fid>` — re-apply this frame's pane sizes for the
+    window's CURRENT size. Fired by the `window-resized` hook, never typed.
+
+    **Why this is a command and not a string in a hook.** tmux's layout engine
+    redistributes every pane proportionally on a resize, so the intended sizes have to be
+    re-applied afterwards; until #488 the hook carried them as literal text, computed once
+    at layout time. `bottom`'s height is content-and-window dependent now
+    (`layout.bottom_rows`), and a literal is not merely stale then — measured on tmux
+    3.7c, a hook still asserting `-y 40` after the window shrank to 20 rows left the
+    harness pane **1 row tall**. Recomputing needs charter, so the hook calls charter.
+
+    **Always 0, and every refusal is a quiet no-op** — `cmd_respawn`'s reason exactly:
+    this is a `run-shell -b` child, nothing reads its status, and a non-zero exit is what
+    makes tmux print into the harness pane on the un-backgrounded path. There is no
+    screen left to report on that is not the agent's own.
+
+    Refusals, in order:
+
+    * no frame on the argv and no `$CHARTER_SESSION_ID` — not fired by a frame at all;
+    * a harness pane that is not tmux's own `%<digits>` — it arrives off disk, and
+      `_window_size` is about to target it;
+    * no panes recorded — a frame whose panels all failed to draw has nothing to resize.
+
+    The frame comes off the argv first and the environment only as a fallback, matching
+    `cmd_respawn`: on the operator's own server there IS no `$CHARTER_SESSION_ID` to
+    read, because that variable is a session option charter does not write there.
+
+    **This is the hot path of the whole feature.** A terminal drag fires `window-resized`
+    once per size change, so this runs repeatedly and in the background while the
+    operator is still dragging. Everything it reads is cheap by construction:
+    `state.harness_pane`/`state.panes` are two small files, `_window_size` is one
+    `display-message`, and `frame_slots.bottom_rows_wanted` goes through
+    `gather.row_count`, which answers from the frame's cache and never runs a git sweep
+    (see its own docstring).
+    """
+    fid = getattr(args, "frame", None) or os.environ.get("CHARTER_SESSION_ID", "")
+    if not fid:
+        return 0
+    harness_pane = state.harness_pane(fid) or ""
+    if not _PANE_ID_RE.fullmatch(harness_pane):
+        return 0
+    panes = state.panes(fid)
+    if not panes:
+        return 0
+    socket = state.frame_server(fid) or SOCKET
+    _cols, rows = _window_size(socket, harness_pane)
+    _reassert_sizes(socket, fid=fid, panes=panes, window_rows=rows)
+    return 0
 
 
 def cmd_density(args) -> int:
@@ -2464,7 +2628,7 @@ def cmd_density(args) -> int:
     cols, rows = _window_size(socket, harness_pane)
     want = _drawable_slots(cols, rows, instance.density_slots(level))
     panes = _relayout(socket, fid=fid, harness_pane=harness_pane, panels=panels,
-                      want=want, v=v)
+                      want=want, v=v, window_rows=rows)
     state.record_panes(fid, panels=panes)
     # Re-recorded so the menu's own mark moves with the frame. `menu.record` rewrites the
     # table whole, and every action id is minted from position, so the ids the operator's

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1067,9 +1067,11 @@ def _wait_for_harness(socket: str, harness_pane: str) -> int | None:
         time.sleep(_POLL_SECONDS)
 
 
-def _launch_sizes(fid: str, slots: list[str], cols: int, rows: int) -> dict[str, int]:
-    """How big each of *slots* is split, in a *cols* x *rows* window — the launch-time
-    half of `layout.slot_sizes`, shared by both launch paths so they cannot disagree.
+def _launch_sizes(fid: str, slots: list[str], *,
+                  window_cols: int, window_rows: int) -> dict[str, int]:
+    """How big each of *slots* is split, in a *window_cols* x *window_rows* window —
+    the launch-time half of `layout.slot_sizes`, shared by both launch paths so they
+    cannot disagree.
 
     `bottom` is the only slot whose answer is not a constant (#488): it is sized to the
     repo table it is about to draw, floored at the one row it always was and capped so
@@ -1078,21 +1080,34 @@ def _launch_sizes(fid: str, slots: list[str], cols: int, rows: int) -> dict[str,
     coming up with a pane taller than its content or a table cut off with nothing saying
     so.
 
-    **`cols` is not decoration (#500).** The renderer draws NO table below
+    **The width is not decoration (#500).** The renderer draws NO table below
     `statusline._LEFT_W` (95) and at most `slots._TERSE_ROWS` of one at a `terse`
     density, and neither is a rare shape: `layout.visible_slots` keeps `bottom` down to
     `min_cols // 2`, so an 80-column terminal is one, and `minimal` is a level the F2
     menu offers. Sizing from the repo count alone gave both of them a pane sized for a
     table the panel then refused to draw — up to fourteen blank rows taken off the
-    harness. `bottom` is split BEFORE `right`, so the window's width IS the pane's.
+    harness.
+
+    **And it is the PANE's columns, which are not always the window's.** *slots* is the
+    split order and the split order is the geometry (`instance.frame_of` keeps an
+    operator's own `[frame] slots` verbatim), so a `right` split before `bottom` has
+    already taken 23 columns off the pane `bottom` is carved from — 87 in a 110-column
+    window, measured on tmux 3.7c. `layout.bottom_cols` is that arithmetic; handing
+    `bottom_rows_wanted` *window_cols* straight through was #500's own second half, and
+    it put six blank rows into exactly the frame this function exists to size. Both
+    measurements are keyword-only and named for the WINDOW here for that reason: this
+    function's whole job is turning a window into panes, and the two names that reach it
+    must not be mistakable for either a row count or a pane's own width.
 
     Affordable at launch by construction, and that is not incidental: `cmd_launch` calls
     `gather.discard(fid)` before it draws anything, so this reaches `gather.row_count`
     with no cache and gets the directory-listing answer — an `iterdir`, never the git
     sweep `gather.scan` would run. See `gather.row_count`'s own docstring for both paths.
     """
-    return layout.slot_sizes(slots, window_rows=rows,
-                             content_rows=frame_slots.bottom_rows_wanted(fid, cols=cols))
+    return layout.slot_sizes(
+        slots, window_rows=window_rows,
+        content_rows=frame_slots.bottom_rows_wanted(
+            fid, pane_cols=layout.bottom_cols(slots, window_cols=window_cols)))
 
 
 def _drawable_slots(cols: int, rows: int, configured: list[str] | None = None) -> list[str]:
@@ -1509,7 +1524,8 @@ def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, argv: list[
     # the whole environment here (#446): see `_guest_harness_env`.
     panes = _draw_panels(socket, slots=slots, fid=fid, harness_pane=harness_pane,
                          env=None, v=v, pane_env=_pane_identity_env(env, v),
-                         sizes=_launch_sizes(fid, slots, cols, rows))
+                         sizes=_launch_sizes(fid, slots, window_cols=cols,
+                                             window_rows=rows))
     _arm_panel_respawn(socket, fid=fid, panes=panes, env=None)
     tmuxctl.run("focusing the harness pane",
                 tmuxctl.server_argv(socket, "select-pane", "-t", harness_pane))
@@ -2229,7 +2245,8 @@ def cmd_launch(args) -> int:
             panes = _draw_panels(
                 SOCKET, slots=slots, fid=fid, harness_pane=harness_pane, env=env, v=v,
                 pane_env=_pane_identity_env(env, v),
-                sizes=_launch_sizes(fid, slots, cols, rows))
+                sizes=_launch_sizes(fid, slots, window_cols=cols,
+                                    window_rows=rows))
             _arm_panel_respawn(SOCKET, fid=fid, panes=panes, env=env)
 
             # `split-window` makes the newly created pane the ACTIVE one by default, so
@@ -2483,12 +2500,23 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
         # `instance.FRAME_DENSITY` for why that order is geometry rather than reading
         # order. Every split targets the harness pane, so a slot added to a frame that
         # already has the others lands exactly where a launch would have put it.
+        #
+        # `list(keep) + missing` and NOT `want`, for `bottom`'s width (#500): the panes
+        # that survived this re-layout are wherever their own launch put them, and the
+        # new ones are split after all of them. That concatenation is the order the panes
+        # are actually in — which is what `layout.bottom_cols` needs, and what `want`'s
+        # order is not. A frame launched with `["right", "top", "bottom"]` and then sent
+        # to the `full` density keeps its inset 87-column `bottom`, because nothing was
+        # killed or re-split; sizing it from `want`'s `["top", "bottom", "right"]` would
+        # say 110 and hand it the seven-row pane this fix exists to stop.
         keep.update(_split_panels(
             socket, slots=missing, fid=fid, harness_pane=harness_pane, env=None,
             pane_env=pane_env,
             sizes=layout.slot_sizes(
                 want, window_rows=window_rows,
-                content_rows=frame_slots.bottom_rows_wanted(fid, cols=window_cols))))
+                content_rows=frame_slots.bottom_rows_wanted(
+                    fid, pane_cols=layout.bottom_cols(list(keep) + missing,
+                                                      window_cols=window_cols)))))
         _arm_panel_respawn(socket, fid=fid,
                            panes={s: keep[s] for s in missing if s in keep}, env=None)
 
@@ -2529,6 +2557,12 @@ def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str],
     narrowed terminal keep a table-sized pane it could no longer draw a table in, on every
     step of the drag rather than only at launch.
 
+    **And the window's width is not the PANE's.** `layout.bottom_cols` turns one into the
+    other from the order *panes* is in, which is the order those panes were split in. A
+    frame whose `[frame] slots` names `right` before `bottom` has an 87-column `bottom`
+    in a 110-column window, and this is the site that re-applied the wrong height for it
+    on every step of a drag — the launch-time defect's longer-lived half.
+
     Every pane id is checked before it is used, even though both callers already checked
     theirs. `_panel_died_hook_argv`'s own rule ("every value that reaches the text is
     what decides, never where it came from") applies to a `-t` argument too, and #475 was
@@ -2539,9 +2573,17 @@ def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str],
     between the map being read and this running) makes `resize-pane` fail, and that is
     not an integration failure worth printing over the agent's own screen.
     """
+    # `list(panes)` twice, and it is the same list for two different questions:
+    # `slot_sizes` needs to know which OTHER horizontal strips are charging `bottom`
+    # rows, and `bottom_cols` needs the order they were split in to know how wide
+    # `bottom` is. Both callers hand a map whose insertion order is that split order —
+    # `_draw_panels` records a launch in split order, `_relayout` keeps survivors ahead
+    # of new splits, and `state.panes` is JSON, which round-trips a dict's order.
+    order = list(panes)
     sizes = layout.slot_sizes(
-        list(panes), window_rows=window_rows,
-        content_rows=frame_slots.bottom_rows_wanted(fid, cols=window_cols))
+        order, window_rows=window_rows,
+        content_rows=frame_slots.bottom_rows_wanted(
+            fid, pane_cols=layout.bottom_cols(order, window_cols=window_cols)))
     for slot, pane_id in panes.items():
         if slot not in _RESIZE_FLAG or slot not in sizes:
             continue

--- a/charter/frame/gather.py
+++ b/charter/frame/gather.py
@@ -302,20 +302,78 @@ def read(fid: str, *, workspace: str | None = None, cwd: str | None = None) -> d
     all fall through to a fresh :func:`scan`, the same one a caller would
     otherwise have no data to draw from. This never returns anything but a dict
     carrying ``repos``/``worktrees`` as lists — never the raw, untrusted value a
-    corrupt or stale cache file happened to contain.
+    corrupt or stale cache file happened to contain. :func:`_cached` is where each of
+    those degradations actually lives; this is that plus the fallback.
     """
-    f = _cache_file(fid, create=False)
-    if f is not None:
-        try:
-            data = json.loads(f.read_text())
-        except (OSError, ValueError):
-            data = None
-        if _shaped_like_a_scan(data):
-            return data
+    data = _cached(fid)
+    if data is not None:
+        return data
     try:
         return scan(workspace=workspace, cwd=cwd)
     except Exception:
         return _empty(workspace)
+
+
+def _cached(fid: str) -> dict | None:
+    """Whatever *fid*'s cache file holds, if it holds something a renderer can index
+    into — ``None`` for every way that can fail.
+
+    The half of :func:`read` that does NOT fall back to a live :func:`scan`, split out
+    because :func:`row_count` needs exactly this and must not pay for the other half.
+    Degrades rather than raising at every stage: a hostile or never-bumped *fid* (no
+    directory at all — the ordinary cold-start case, not an error), a directory with no
+    cache file yet, a file that is not valid JSON (``json.JSONDecodeError``, a
+    ``ValueError`` subclass), and — because ``json.loads`` succeeding says nothing about
+    what it produced — one that parses to something not :func:`_shaped_like_a_scan`.
+    """
+    f = _cache_file(fid, create=False)
+    if f is None:
+        return None
+    try:
+        data = json.loads(f.read_text())
+    except (OSError, ValueError):
+        return None
+    return data if _shaped_like_a_scan(data) else None
+
+
+def row_count(fid: str) -> int:
+    """How many table rows this frame's repos and pieces would fill — **never a git
+    sweep**, on either path.
+
+    #488 made the `bottom` pane's HEIGHT a function of its content, which means somebody
+    outside a panel has to know how much content there is: the launcher, before any panel
+    exists, and `commands_frame.cmd_resize`, every time the window changes size. Both are
+    on paths where cost is felt directly — a launch the operator is waiting on, and a
+    hook that fires on every step of a terminal drag — so neither may call :func:`scan`.
+
+    Two sources, and the order is the point:
+
+    * **The cache, when there is one.** `notify.plane_changed` keeps it current, so a
+      running frame's count is exactly the count its panels are drawing from.
+    * **A directory listing, when there is not.** `cmd_launch` calls :func:`discard`
+      before it draws anything (a recycled pid must not adopt another frame's repos —
+      see that function), so the launch path reaches here with no cache BY DESIGN.
+      `statusline._repo_trees` and `_detail_worktrees` are the same two calls `scan`
+      itself starts with and both are filesystem-only — no subprocess, no network, no
+      `git status` — so this costs an `iterdir`, not a sweep. It is the SAME pair `scan`
+      uses, rather than a second way of counting repos that could disagree with the rows
+      the panel then draws.
+
+    Zero for anything that fails, which is the floor `layout.bottom_rows` already
+    handles: a frame whose repo count could not be established gets the one-row strip
+    `bottom` always was, never a taller pane full of nothing.
+    """
+    data = _cached(fid)
+    if data is not None:
+        return len(data.get("repos") or []) + len(data.get("worktrees") or [])
+    try:
+        from .. import statusline as sl
+        from .. import workspace as ws_mod
+        active = ws_mod.resolve()
+        dirs = sl._repo_trees(active)
+        return len(dirs) + len(sl._detail_worktrees(active, dirs))
+    except Exception:
+        return 0
 
 
 def discard(fid: str) -> None:

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -81,6 +81,62 @@ HARNESS_MIN_ROWS = 12
 #: says what it is doing.
 _BORDER_ROWS = 1
 
+#: One column per pane border, the vertical counterpart of :data:`_BORDER_ROWS` and
+#: measured the same way — on tmux 3.7c, a 110-column window split `-h -l 22` reads back
+#: as an 87-column harness and a 22-column sidebar, which is 109.
+_BORDER_COLS = 1
+
+#: Slots that take COLUMNS off the pane they are split from rather than rows — the `-h`
+#: half of :func:`panel_argvs`' `direction`. Kept as a name rather than an inline
+#: ``== "right"`` because :func:`bottom_cols` and `panel_argvs` are two places that have
+#: to agree about which splits cost columns, and the next side slot must not have to be
+#: remembered in both.
+_COLUMN_SLOTS = ("right",)
+
+
+def bottom_cols(slots: list[str] | tuple[str, ...], *, window_cols: int) -> int:
+    """How wide the `bottom` pane actually is, in a *window_cols*-column window whose
+    slots were split in *slots*' order — **not the window's own width** (#500).
+
+    `panel_argvs` splits every slot off the HARNESS pane in list order, so a side slot
+    split before `bottom` has already narrowed the pane `bottom` is then carved out of.
+    Measured on tmux 3.7c, window 110x40, `-l 22` for `right` and `-l 7` for `bottom`:
+
+    * ``["top", "bottom", "right"]`` (the shipped order) — `bottom` reads back **110**
+      wide; `right` is split off the harness afterwards and sits beside the harness only.
+    * ``["right", "top", "bottom"]`` and ``["top", "right", "bottom"]`` — `bottom` reads
+      back **87**, which is ``110 - 22 - 1``.
+
+    That difference is a promise, not an accident: `instance.frame_of` keeps an
+    operator's `[frame] slots` order verbatim and
+    `tests/test_frame_config.py::test_the_operators_own_slot_order_is_kept_exactly`
+    pins it, precisely because the order IS the geometry. What #500 got wrong was not the
+    order — it was handing `slots.bottom_rows_wanted` the window's width regardless, so a
+    `bottom` that had been inset beside the sidebar was sized for a table its own pane
+    was too narrow to draw. Below `statusline._LEFT_W` (95) the renderer draws no table
+    at all, so a 110-column frame with `right` first got a seven-row pane and one line in
+    it, six rows taken off the harness and left blank.
+
+    Order in, order out — this reads *slots* rather than a set, and stops at `bottom`.
+    A slot split AFTER `bottom` costs it nothing (measured above), and killing one gives
+    the columns back (`kill-pane` on `right` widened the same `bottom` from 87 to 110),
+    which is why the list a caller passes has to be the order its panes were actually
+    split in: at launch that is the drawable slot list, and for a running frame it is the
+    recorded pane map's own order, survivors first and later splits appended.
+
+    With no `bottom` in *slots* this answers the width one WOULD be split to. Nothing
+    asks in that state today — `slot_sizes` only sizes the slots it was given — and an
+    answer that is right the moment the slot appears is better than a zero that is right
+    for nothing.
+    """
+    out = window_cols
+    for slot in slots:
+        if slot == "bottom":
+            break
+        if slot in _COLUMN_SLOTS:
+            out -= SLOT_SIZE[slot] + _BORDER_COLS
+    return max(0, out)
+
 
 def visible_slots(slots: list[str], cols: int, rows: int,
                   min_cols: int, min_rows: int) -> list[str]:
@@ -457,7 +513,10 @@ def panel_argvs(*, slots: list[str], session: str, socket: str,
     cmds: list[list[str]] = []
     for slot in slots:
         size = (sizes or SLOT_SIZE).get(slot, SLOT_SIZE[slot])
-        direction = "-v" if slot in ("top", "bottom") else "-h"
+        # :data:`_COLUMN_SLOTS` rather than a second list of names: which splits take
+        # COLUMNS is exactly what :func:`bottom_cols` has to know to answer how wide
+        # `bottom` ends up, and two copies of that fact are two things to keep in step.
+        direction = "-h" if slot in _COLUMN_SLOTS else "-v"
         before = ["-b"] if slot == "top" else []
         cmds.append(_tmux(socket, "split-window", "-t", harness_pane,
                           direction, *before, "-l", str(size),

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -41,14 +41,45 @@ from __future__ import annotations
 from . import tmuxctl
 from .. import util
 
-#: The order slots are dropped in as the terminal shrinks. Sides first — a side panel
+#: The order slots are dropped in as the terminal shrinks. The side first — a side panel
 #: costs the harness columns, so it goes as soon as space is tight in EITHER dimension,
 #: not only when columns themselves are the short one — then the top, whose row is worth
-#: less than the bottom's alerts, and which only goes when rows are the tight dimension.
-_DROP_ORDER = ("left", "right", "top", "bottom")
+#: less than the bottom's alerts and repo table, and which only goes when rows are the
+#: tight dimension.
+#:
+#: **`left` is not here any more, and #488 is why.** It drew repo rows recomposed for a
+#: 22-column pane; `bottom` now draws the same rows as the full-width table the status
+#: line draws, so the sidebar's only remaining job was a lesser copy of its neighbour's.
+#: Retiring it hands those 22 columns back to the harness at every density.
+_DROP_ORDER = ("right", "top", "bottom")
 
 #: Rows a horizontal panel occupies, and columns a vertical one does.
-SLOT_SIZE = {"top": 1, "bottom": 1, "left": 22, "right": 22}
+#:
+#: **`bottom`'s entry is a FLOOR now, not its size** (#488). Every other slot is fixed:
+#: `top` says one row's worth of identity, `right` is a column of persona chips. `bottom`
+#: carries the repo table, which is as many rows as there are repos — so its real height
+#: is :func:`bottom_rows`, and this is what it never goes below (and what it is, on a
+#: plane with no repos at all). Callers ask :func:`slot_sizes` rather than indexing this
+#: directly, so nothing has to remember which of the two questions it is asking.
+SLOT_SIZE = {"top": 1, "bottom": 1, "right": 22}
+
+#: Rows the harness keeps whatever the repo table would like. The frame exists to show
+#: the plane's state around an agent session, and a session squeezed into three rows is
+#: not one anybody can read — so the table gives up rows before the harness does.
+#:
+#: Not hypothetical, and this number is what stands between the operator and it: measured
+#: against tmux 3.7c, `resize-pane -t <bottom> -y 40` in a 20-row window left the harness
+#: pane **1 row tall**. tmux clamps to what the window has and takes the remainder from
+#: its neighbour without complaint, so an over-large height is not refused — it is
+#: granted, out of the one pane that matters.
+HARNESS_MIN_ROWS = 12
+
+#: One row per pane border. tmux charges a horizontal split one row for the divider on
+#: top of the pane's own height — measured on 3.7c: a 50-row window split `-l 8` reads
+#: back as a 41-row harness and an 8-row panel, which is 49. Counted explicitly rather
+#: than folded into :data:`HARNESS_MIN_ROWS` so the arithmetic in :func:`bottom_rows`
+#: says what it is doing.
+_BORDER_ROWS = 1
 
 
 def visible_slots(slots: list[str], cols: int, rows: int,
@@ -57,18 +88,78 @@ def visible_slots(slots: list[str], cols: int, rows: int,
 
     Degradation, not refusal: below the floor the harness simply gets the whole terminal,
     which is the same choice `statusline.render` makes when it runs out of width. Follows
-    `_DROP_ORDER`: `left`/`right` are the first to go, on ANY shortage — a terminal that is
-    short on rows cannot spare a side panel's own divider any more than a narrow one can
-    spare its columns — then `top`, only when rows specifically are the tight dimension.
+    `_DROP_ORDER`: `right` is the first to go, on ANY shortage — a terminal that is short
+    on rows cannot spare a side panel's own divider any more than a narrow one can spare
+    its columns — then `top`, only when rows specifically are the tight dimension.
+
+    `bottom` never goes here, and it does not need to: it is the slot that SHRINKS
+    instead (:func:`bottom_rows` floors it at one row, the height it always had), so a
+    terminal too small for a table still gets the alert line the frame is really for.
     """
     keep = list(slots)
     if cols < min_cols or rows < min_rows:
-        keep = [s for s in keep if s not in ("left", "right")]
+        keep = [s for s in keep if s != "right"]
     if rows < min_rows:
         keep = [s for s in keep if s != "top"]
     if cols < min_cols // 2 or rows < min_rows // 2:
         keep = []
     return [s for s in slots if s in keep]
+
+
+def bottom_rows(*, content_rows: int, window_rows: int,
+                slots: list[str] | tuple[str, ...] = ()) -> int:
+    """How many rows the `bottom` pane gets: what its content wants, floored and capped.
+
+    Pure arithmetic, deliberately — this is the whole of #488's "how tall is `bottom`?"
+    and it is decided here, with no tmux and no filesystem, so both callers that need an
+    answer (a launch, and the `window-resized` hook's own recompute) necessarily get the
+    same one.
+
+    * **The floor is `SLOT_SIZE["bottom"]`.** A plane with no clones still has an alert
+      row, a todo count and this session's news to draw, which is the row `bottom` always
+      was. Never zero: a zero-row pane is one tmux refuses to split at all.
+    * **The cap leaves the harness :data:`HARNESS_MIN_ROWS`.** *window_rows* is the whole
+      window, *slots* is what else is being drawn in it, and every horizontal strip costs
+      its own height plus :data:`_BORDER_ROWS`. `right` costs columns, not rows, so it is
+      not counted here — asking for the whole slot list rather than a pre-computed number
+      is what keeps that decision in one place instead of at each call site.
+    * **Between the two, the content wins.** *content_rows* is what `slots._bottom` would
+      actually fill (`slots.bottom_rows_wanted`), so a two-repo plane gets a three-row
+      strip rather than a fourteen-row one padded with blanks.
+
+    The cap can come out below the floor — a 14-row window has no rows to spare at all —
+    and the floor wins then, because the alternative is a frame with no alert row in
+    exactly the terminal where an alert is most likely to be the reason it is there.
+    """
+    floor = SLOT_SIZE["bottom"]
+    other = sum(SLOT_SIZE[s] + _BORDER_ROWS
+                for s in slots if s in ("top",))
+    cap = window_rows - other - _BORDER_ROWS - HARNESS_MIN_ROWS
+    return max(floor, min(content_rows, cap))
+
+
+def slot_sizes(slots: list[str], *, window_rows: int, content_rows: int) -> dict[str, int]:
+    """Every slot in *slots* mapped to the size it should be given — rows for the
+    horizontal strips, columns for the side.
+
+    The one place `bottom`'s variable height and the other slots' fixed sizes are
+    answered together, so a caller never has to know which kind a slot is. `panel_argvs`
+    splits with it, `commands_frame._reassert_sizes` re-applies it, and the
+    `window-resized` recompute calls it again with the window's NEW row count — which is
+    the whole reason it takes *window_rows* rather than closing over a launch-time value.
+
+    Unknown slot names are dropped rather than raised on, matching `visible_slots`'
+    filter-don't-refuse discipline: `[frame] slots` is committed, untrusted input, and by
+    the time a list reaches here it has already been through `instance.FRAME_SLOTS`.
+    """
+    out: dict[str, int] = {}
+    for slot in slots:
+        if slot == "bottom":
+            out[slot] = bottom_rows(content_rows=content_rows,
+                                    window_rows=window_rows, slots=slots)
+        elif slot in SLOT_SIZE:
+            out[slot] = SLOT_SIZE[slot]
+    return out
 
 
 #: What a frame's window runs while charter is still setting it up, before the harness
@@ -312,7 +403,8 @@ def panel_command(*, slot: str, session: str) -> list[str]:
 
 def panel_argvs(*, slots: list[str], session: str, socket: str,
                 harness_pane: str,
-                env: dict[str, str] | None = None) -> list[list[str]]:
+                env: dict[str, str] | None = None,
+                sizes: dict[str, int] | None = None) -> list[list[str]]:
     """One `split-window` per slot in *slots*, each carving its rectangle off *harness_pane*.
 
     *harness_pane* is the id `session_argv`'s caller read off tmux's stdout, and every
@@ -354,12 +446,19 @@ def panel_argvs(*, slots: list[str], session: str, socket: str,
 
     Only `commands_frame._FRAME_IDENTITY` travels, never the whole environment: a `-e` is
     argv, and argv is world-readable. See `commands_frame._frame_identity_env`.
+
+    *sizes* is :func:`slot_sizes`' answer for this window, and it exists because `bottom`
+    is no longer a fixed height (#488). ``None`` falls back to :data:`SLOT_SIZE`, which
+    is `bottom`'s FLOOR — right for a caller that has no window to measure (a test, a
+    `--probe`), wrong for a launch, which is why both launch paths pass one. Read with a
+    per-slot fallback rather than replaced wholesale, so a *sizes* missing an entry
+    degrades to the fixed size instead of a `KeyError` inside a launch.
     """
     cmds: list[list[str]] = []
     for slot in slots:
-        size = SLOT_SIZE[slot]
+        size = (sizes or SLOT_SIZE).get(slot, SLOT_SIZE[slot])
         direction = "-v" if slot in ("top", "bottom") else "-h"
-        before = ["-b"] if slot in ("top", "left") else []
+        before = ["-b"] if slot == "top" else []
         cmds.append(_tmux(socket, "split-window", "-t", harness_pane,
                           direction, *before, "-l", str(size),
                           *_env_argv(env),

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -66,9 +66,9 @@ the reason to stderr does not fix that, and the measurement is why (real tmux 3.
 `remain-on-exit on`): tmux writes its own `Pane is dead (status N, <date>)` message by
 moving to the pane's LAST row and issuing a linefeed first, which scrolls the pane up by
 exactly one line — in a six-row pane the first of three stderr lines is lost and the
-rest survive, but `top` and `bottom` are ONE row (`layout.SLOT_SIZE`), so that one
-scrolled line is the whole pane and `Pane is dead (status 2)` is provably all that is
-left. It cost a real debugging session, whose only way through was running the panel's
+rest survive, but `top` is ONE row (`layout.SLOT_SIZE`) and `bottom` is one whenever the
+workspace holds no clones (its own floor, since #488), so that one scrolled line is the
+whole pane and `Pane is dead (status 2)` is provably all that is left. It cost a real debugging session, whose only way through was running the panel's
 argv by hand outside tmux. A pane whose process is still ALIVE keeps what it painted
 (measured the same way), so `_hold` paints the reason and then simply does not return.
 
@@ -163,8 +163,9 @@ def _hold(reason: str, *, once: bool, rc: int) -> int:
     The whole of this module's answer to a panel that cannot run: **returning is the
     bug**. A panel process that exits hands its pane to `remain-on-exit`, and tmux then
     scrolls the pane by exactly one line to write `Pane is dead (status N, <date>)` over
-    it — which in the one-row `top`/`bottom` panes is the entire pane (measured against
-    real tmux 3.7c; see the module docstring). So the reason is painted and the process
+    it — which in a one-row pane, which `top` always is and `bottom` is on a plane with
+    no clones, is the entire pane (measured against real tmux 3.7c; see the module
+    docstring). So the reason is painted and the process
     simply does not leave, which is the only state in which a pane keeps what was
     written to it.
 

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -208,7 +208,7 @@ def _new_inflight_cache() -> dict:
 
 
 def _running(cache: dict) -> int:
-    """How many dispatches are in flight right now — one `stat` when nothing has changed.
+    """How much work is in flight right now — one `stat` when nothing has changed.
 
     The idle cost of the whole animation, and the reason it can be on by default. The
     expensive answer (`inflight.live_records()`: open the directory, read every entry,
@@ -221,8 +221,9 @@ def _running(cache: dict) -> int:
       consulted while something is actually running, so an idle panel never computes a
       deadline, never stores one, and never compares against one.
 
-    Counts RUNNING records only, presumed-dead ones excluded, and that is what stops a
-    killed dispatch from spinning a panel for the rest of the day: `inflight` keeps such a
+    Counts RUNNING records of EVERY kind — a clone and a `gl-refresh` move the spinner
+    exactly as a dispatch does (#420) — presumed-dead ones excluded, and that is what
+    stops a killed dispatch from spinning a panel for the rest of the day: `inflight` keeps such a
     record for `PRUNE_SECONDS` (24 hours) precisely so it stays visible, and
     `slots._inflight_field` does still draw it — statically, with `⋯`. Animating it would
     claim progress that stopped hours ago, on an otherwise idle machine.
@@ -238,7 +239,11 @@ def _running(cache: dict) -> int:
         stale = cache["running"] and time.time() >= cache["recheck"]
         if stamp == cache["stamp"] and not stale:
             return cache["running"]
-        records = inflight.live_records()
+        # `kind=None`: the gate has to agree with what `slots._inflight_field` will
+        # DRAW, or a clone would leave the row showing a spinner frame frozen at whatever
+        # instant the last version bump happened to be (#420). The nudge's dispatch-only
+        # view is a different question, asked elsewhere — see `inflight`'s own docstring.
+        records = inflight.live_records(kind=None)
         cache["stamp"] = stamp
         cache["running"] = sum(1 for _a, _t, dead in records if not dead)
         cache["recheck"] = min((t for _a, t, dead in records if not dead),

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -21,17 +21,21 @@ module docstring for the full measurement. Duplicating that logic here would jus
 second place to get it wrong; `_paint` below calls `slots.render` and trusts its output
 is already clamped to the pane's width.
 
-**Height is this module's job.** `render()`'s contract is a single string, so nothing
-downstream of it knows how many ROWS the pane it is about to overwrite actually has. A
-`top`/`bottom` panel is one row today (`layout.SLOT_SIZE`), but `left`/`right` are
-full-height panes the layout module already supports — assuming "one line" here would
-silently clip a future multi-line renderer to its first row, or (the opposite failure)
-let it emit more lines than the pane holds and scroll THAT PANEL'S OWN rows — measured
-against real tmux: each pane keeps its own scroll region, so an over-height paint pushes
-only its own top line out of view and leaves every sibling pane untouched, not the whole
-frame. `_rows` measures the pane the same way `slots._width` measures it, and `_paint`
-clamps the LINE COUNT to that measurement the way `tui.truncate` already clamps each
-line's WIDTH.
+**Clamping the height is this module's job; MEASURING it is not, any more.**
+`render()`'s contract is a single string, so nothing downstream of it knows how many ROWS
+the pane it is about to overwrite actually has. Assuming "one line" here would silently
+clip a multi-line renderer to its first row, or (the opposite failure) let it emit more
+lines than the pane holds and scroll THAT PANEL'S OWN rows — measured against real tmux:
+each pane keeps its own scroll region, so an over-height paint pushes only its own top
+line out of view and leaves every sibling pane untouched, not the whole frame. `_paint`
+clamps the LINE COUNT the way `tui.truncate` already clamps each line's WIDTH.
+
+The measurement itself moved to `slots._height` with #488, beside `slots._width` and for
+the same reason width already lived there: a renderer needs it now. `bottom` is sized to
+its content and draws as much of the repo table as its pane holds, choosing which rows to
+spend on through `statusline._pick_rows` — a clamp applied after the fact would cut the
+table at whatever came last, which is the unranked slice that ranking exists to prevent.
+So the renderer measures first and this clamp goes back to being a safety net.
 
 **Animation is scoped to work that is actually in flight, and idle stays one `stat`.**
 A panel repaints on a version bump, and a dispatch STARTING does not bump anything — the
@@ -77,9 +81,9 @@ failing to start, a SIGKILL), which is the only kind respawning could ever help.
 **Holding rather than exiting into that hook is a decision, so here is the argument.**
 Exiting would let a crashed panel be retried three times, which sounds strictly better
 until you ask what can actually reach the handler: `slots.render` catches everything a
-renderer raises, `state.version` catches everything a read raises, and `_rows` catches
-its own `OSError` — so what is left is a genuine bug in charter, or a pane whose fd has
-gone away. Neither is transient, so all a retry buys is three more identical crashes,
+renderer raises, `state.version` catches everything a read raises, and `_rows` (through
+`slots._height`) catches its own `OSError` — so what is left is a genuine bug in charter,
+or a pane whose fd has gone away. Neither is transient, so all a retry buys is three more identical crashes,
 and the cost is certain: three deaths, and then tmux's own message scrolling the reason
 out of a one-row pane — the exact failure this whole section exists to end. The pane
 that HAS gone away needs no special case either; `_hold`'s own write raises in turn, the
@@ -88,7 +92,6 @@ process dies for real, and the respawn hook takes it from there.
 
 from __future__ import annotations
 
-import os
 import signal
 import sys
 import time
@@ -107,20 +110,26 @@ TICK = 0.2
 #: hand for debugging, or a test). Matches `commands_frame._FALLBACK_SIZE`'s own row
 #: count: the same "traditional default screen" charter already falls back to elsewhere
 #: when a terminal's real size is unknowable.
-_DEFAULT_ROWS = 24
+#:
+#: Re-exported from `slots` rather than declared here, because #488 gave a RENDERER a
+#: reason to ask the same question (`bottom` chooses which repo rows to spend its pane
+#: on, so it has to know how many it has) and two copies of a fallback are two answers
+#: to "how tall is a pane nobody can measure" — one of which would eventually move.
+_DEFAULT_ROWS = slots._DEFAULT_ROWS
 
 
 def _rows() -> int:
-    """This pane's own height, measured the way `slots._width` measures its own width:
-    `os.get_terminal_size(sys.stdout.fileno())` asks the file descriptor this process is
-    actually writing to, which for a panel launched as a tmux pane command IS the pane —
-    not a pipe, not the launching terminal. Only when that raises (no tty behind the fd
-    at all) does this fall back to `_DEFAULT_ROWS`.
+    """This pane's own height — `slots._height()`, the same one the renderer measures
+    with, for exactly the reason this module already asks `slots` for the WIDTH.
+
+    It was implemented here first, and correctly, back when height was purely this
+    module's clamp. #488 made it a renderer's question too (`slots._bottom` decides how
+    many repo rows to draw), and a second `os.get_terminal_size` with its own `OSError`
+    fallback beside the first is how the two come to disagree about a pane neither can
+    measure. Kept as a named function rather than inlined: `_write` reads better for it,
+    and this is where the module docstring's "Height is this module's job" section points.
     """
-    try:
-        return os.get_terminal_size(sys.stdout.fileno()).lines
-    except OSError:
-        return _DEFAULT_ROWS
+    return slots._height()
 
 
 def _write(text: str) -> None:

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -347,14 +347,16 @@ def _table_lines(data: dict, width: int, budget: int) -> list[str]:
     # `charter  main`. Refusing to draw says "no room to say" where a trimmed row says
     # "nothing to say".
     #
-    # **Ordinary, not exotic — an 80-column terminal lands here.** `bottom` is split
-    # BEFORE `right` (the slot order IS the geometry — `instance.FRAME_FIELDS`), so its
-    # width is the whole WINDOW's; and `[frame] min-cols` (100) gates `right` and `top`
-    # only — `layout.visible_slots` keeps `bottom` all the way down to `min_cols // 2`.
-    # So every frame between 50 and `_LEFT_W - 1` (94) columns draws the attention row
-    # and no table, which is why :func:`_table_cap` — not this function — is what the
-    # LAUNCHER asks, and why it asks with the same width. The attention row above is
-    # unaffected either way; it does its own per-field budgeting (`_fit_fields`).
+    # **Ordinary, not exotic — an 80-column terminal lands here.** `[frame] min-cols`
+    # (100) gates `right` and `top` only; `layout.visible_slots` keeps `bottom` all the
+    # way down to `min_cols // 2`, so every frame between 50 and `_LEFT_W - 1` (94)
+    # columns draws the attention row and no table. And the PANE can be narrower than the
+    # window on top of that: the slot order is the geometry, so a `[frame] slots` that
+    # names `right` before `bottom` insets this pane by `right`'s columns and its border
+    # (`layout.bottom_cols`). Which is why :func:`_table_cap` — not this function — is
+    # what the LAUNCHER asks, and why it asks with the width of the PANE rather than of
+    # the window. The attention row above is unaffected either way; it does its own
+    # per-field budgeting (`_fit_fields`).
     if width < sl._LEFT_W:
         return []
 
@@ -443,7 +445,7 @@ def _table_cap(fid: str, width: int) -> int:
       table under its attention row rather than forty.
 
     **Both sides of "how tall is `bottom`?" call this, and that is the whole point.**
-    :func:`bottom_rows_wanted` asks it with the WINDOW's width to size the pane;
+    :func:`bottom_rows_wanted` asks it to size the pane before it exists;
     :func:`_bottom` asks it with the pane's own measured width to bound what it draws
     into it. A cap applied on one side only is exactly the defect #500 fixes: the sizer
     used to answer from the repo count alone, so an 80-column frame with six repos got a
@@ -452,9 +454,12 @@ def _table_cap(fid: str, width: int) -> int:
     re-taken by `cmd_resize` on every subsequent resize.
 
     Takes *width* rather than measuring it: the renderer has a pane to measure and the
-    launcher has only the window it is about to split. Same number by construction —
-    `bottom` is split BEFORE `right` (`instance.FRAME_FIELDS`' order is the geometry), so
-    the pane's width IS the window's.
+    launcher has only a window it has not split yet. **Both must be the PANE's width, and
+    that is not always the window's** — `layout.bottom_cols` is where the launcher's side
+    of it is computed, because a `[frame] slots` naming `right` before `bottom` insets
+    this pane by 23 columns (measured on tmux 3.7c: 87 in a 110-column window). Sizing
+    from the window's width there is the second half of the same defect, and it is what
+    round 2 of #500 shipped.
     """
     from .. import statusline as sl
     if width < sl._LEFT_W:
@@ -465,8 +470,8 @@ def _table_cap(fid: str, width: int) -> int:
     return cap
 
 
-def bottom_rows_wanted(fid: str, *, cols: int) -> int:
-    """How many rows `_bottom` would fill for this frame in a *cols*-column window.
+def bottom_rows_wanted(fid: str, *, pane_cols: int) -> int:
+    """How many rows `_bottom` would fill for this frame in a *pane_cols*-column PANE.
 
     **One answer to "how tall is `bottom`", read by both sides of the question.** The
     renderer spends the pane it was given (:func:`_table_lines`' *budget*); the LAUNCHER
@@ -479,10 +484,20 @@ def bottom_rows_wanted(fid: str, *, cols: int) -> int:
     renders `_bottom` into a pane of exactly this height, at exactly this width and at
     every density, and counts the lines that come back.
 
-    *cols* is required, and keyword-only so no caller can pass a row count by mistake.
-    A frame narrower than `statusline._LEFT_W` draws no table at all, so it wants the
-    one-row strip `bottom` always was — see :func:`_table_cap`, which is where every
+    *pane_cols* is required, and keyword-only so no caller can pass a row count by
+    mistake. A pane narrower than `statusline._LEFT_W` draws no table at all, so it wants
+    the one-row strip `bottom` always was — see :func:`_table_cap`, which is where every
     reason the renderer draws fewer rows than there is content now lives.
+
+    **The PANE's columns, not the window's, and the name is the guard.** Round 2 of #500
+    called this argument `cols` and every caller handed it the window's width, which is
+    only `bottom`'s width when nothing took columns off it first: with a `[frame]
+    slots` of `["right", "top", "bottom"]` a 110-column window gives an 87-column
+    `bottom` (measured, tmux 3.7c), so a six-repo plane was split seven rows tall for a
+    table the panel then refused to draw. The number is `layout.bottom_cols`' answer, and
+    the rename is what makes the old, wrong call a `TypeError` at the call site rather
+    than a frame with six blank rows in it — the same discipline `window_cols=` already
+    applies one level up.
 
     `+ 1` is the attention row — the alert, the spinner, this session's news, the todo
     count and the hotkey hint — which `_bottom` always draws and which #488 is explicit
@@ -495,7 +510,7 @@ def bottom_rows_wanted(fid: str, *, cols: int) -> int:
     about to discard.
     """
     from . import gather
-    cap = _table_cap(fid, cols)
+    cap = _table_cap(fid, pane_cols)
     return 1 + (min(gather.row_count(fid), cap) if cap > 0 else 0)
 
 
@@ -706,10 +721,13 @@ def _bottom(fid: str) -> str:
 
     **The pane is measured, not assumed.** :func:`_height` reads this pane's own tty the
     way :func:`_width` reads its width; :func:`bottom_rows_wanted` is what told the
-    LAUNCHER how tall to make it, and both go through :func:`_table_cap` with the same
-    width and the same density — so on an untouched frame the two agree exactly and no
-    row is either blank or cut, at every width the frame is drawn at and at every level
-    the density menu offers. A pane that is shorter anyway — a transient mid-resize
+    LAUNCHER how tall to make it, and both go through :func:`_table_cap` at the same
+    density and at THIS PANE's width — measured here, predicted there by
+    `layout.bottom_cols`, which is the only reason the launcher's number can match a pane
+    the sidebar has narrowed. So on an untouched frame the two agree exactly and no row
+    is either blank or cut, at every width the frame is drawn at, at every level the
+    density menu offers, and in whatever order the operator's `[frame] slots` puts the
+    edges in. A pane that is shorter anyway — a transient mid-resize
     size, or a window with no rows to spare — costs the table its lowest-priority rows
     through `_pick_rows`' ranking, never the attention row.
 

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -347,13 +347,14 @@ def _table_lines(data: dict, width: int, budget: int) -> list[str]:
     # `charter  main`. Refusing to draw says "no room to say" where a trimmed row says
     # "nothing to say".
     #
-    # Reachable but not ordinary: `bottom` is split BEFORE `right` (the slot order IS
-    # the geometry — `instance.FRAME_FIELDS`), so its width is the whole WINDOW's, and
-    # `_LEFT_W` (95) is below the shipped `[frame] min-cols` (100) — every frame at or
-    # above its own floor draws the full table. What lands here is a frame on a
-    # hand-lowered `min-cols`, or the transient mid-resize starvation `layout.py`'s
-    # module docstring measures. The attention row above is unaffected either way; it
-    # does its own per-field budgeting (`_fit_fields`).
+    # **Ordinary, not exotic — an 80-column terminal lands here.** `bottom` is split
+    # BEFORE `right` (the slot order IS the geometry — `instance.FRAME_FIELDS`), so its
+    # width is the whole WINDOW's; and `[frame] min-cols` (100) gates `right` and `top`
+    # only — `layout.visible_slots` keeps `bottom` all the way down to `min_cols // 2`.
+    # So every frame between 50 and `_LEFT_W - 1` (94) columns draws the attention row
+    # and no table, which is why :func:`_table_cap` — not this function — is what the
+    # LAUNCHER asks, and why it asks with the same width. The attention row above is
+    # unaffected either way; it does its own per-field budgeting (`_fit_fields`).
     if width < sl._LEFT_W:
         return []
 
@@ -422,34 +423,80 @@ def _table_lines(data: dict, width: int, budget: int) -> list[str]:
     return lines[:budget]
 
 
-def bottom_rows_wanted(fid: str) -> int:
-    """How many rows `_bottom` would fill for this frame, given room for all of them.
+def _table_cap(fid: str, width: int) -> int:
+    """The most rows of repo table `_bottom` will draw in a *width*-column pane —
+    **every reason the renderer draws fewer rows than there is content**, in one place.
+
+    Three of them, and until #500 only the first was written down where the LAUNCHER
+    could read it:
+
+    * **Too narrow is no table at all.** Below `statusline._LEFT_W` (95)
+      :func:`_table_lines` refuses outright rather than trimming a row into a false-clean
+      `charter  main`, and that is not an exotic width: `layout.visible_slots` keeps
+      `bottom` down to `min_cols // 2` (50), so every ordinary 80-column terminal is here.
+    * **`terse` keeps :data:`_TERSE_ROWS`.** A density that buys the harness back its
+      rows has to buy them from the slot that has rows to give, so `minimal` asks for a
+      SHORTER pane, not the same pane with more of it blank.
+    * **`statusline._MAX_REPO_LINES` bounds the rest**, the same total-row budget the
+      wide table keeps (repo rows plus the `…(+N more)` line, not repo COUNT — see that
+      constant's own comment), so a workspace with forty clones gets fourteen rows of
+      table under its attention row rather than forty.
+
+    **Both sides of "how tall is `bottom`?" call this, and that is the whole point.**
+    :func:`bottom_rows_wanted` asks it with the WINDOW's width to size the pane;
+    :func:`_bottom` asks it with the pane's own measured width to bound what it draws
+    into it. A cap applied on one side only is exactly the defect #500 fixes: the sizer
+    used to answer from the repo count alone, so an 80-column frame with six repos got a
+    seven-row pane to draw one line in, and `minimal` on a wide terminal got an
+    eleven-row pane to draw five — rows taken from the harness and left blank, and
+    re-taken by `cmd_resize` on every subsequent resize.
+
+    Takes *width* rather than measuring it: the renderer has a pane to measure and the
+    launcher has only the window it is about to split. Same number by construction —
+    `bottom` is split BEFORE `right` (`instance.FRAME_FIELDS`' order is the geometry), so
+    the pane's width IS the window's.
+    """
+    from .. import statusline as sl
+    if width < sl._LEFT_W:
+        return 0
+    cap = sl._MAX_REPO_LINES
+    if verbosity(fid) == "terse":
+        cap = min(cap, _TERSE_ROWS)
+    return cap
+
+
+def bottom_rows_wanted(fid: str, *, cols: int) -> int:
+    """How many rows `_bottom` would fill for this frame in a *cols*-column window.
 
     **One answer to "how tall is `bottom`", read by both sides of the question.** The
     renderer spends the pane it was given (:func:`_table_lines`' *budget*); the LAUNCHER
     has to decide how tall to make that pane before any panel exists, and the
     `window-resized` recompute has to decide again with the window's new size. If those
     two disagreed, a frame would come up with a pane taller than its content (blank rows
-    the harness could have had) or shorter (a table cut off with nothing saying so).
-    Pinned by a test that renders `_bottom` into a pane of exactly this height and counts
-    the lines that come back.
+    the harness could have had) or shorter (a table cut off with nothing saying so) —
+    and both were shipped by #488, because this asked the repo count and nothing else
+    while the renderer also asked the width and the density. Pinned by a test that
+    renders `_bottom` into a pane of exactly this height, at exactly this width and at
+    every density, and counts the lines that come back.
+
+    *cols* is required, and keyword-only so no caller can pass a row count by mistake.
+    A frame narrower than `statusline._LEFT_W` draws no table at all, so it wants the
+    one-row strip `bottom` always was — see :func:`_table_cap`, which is where every
+    reason the renderer draws fewer rows than there is content now lives.
 
     `+ 1` is the attention row — the alert, the spinner, this session's news, the todo
     count and the hotkey hint — which `_bottom` always draws and which #488 is explicit
     that the table joins rather than evicts.
 
-    Capped at `statusline._MAX_REPO_LINES`, the same total-row budget the wide table
-    itself keeps (repo rows plus the `…(+N more)` line, not repo COUNT — see that
-    constant's own comment), so a workspace with forty clones asks for a fifteen-row
-    strip rather than a forty-one-row one.
-
     `gather.row_count` is what makes this affordable at launch: it answers from the
     frame's cache when there is one and from a plain directory listing when there is not,
-    and never runs a git sweep. See its own docstring.
+    and never runs a git sweep. See its own docstring. It is asked SECOND, after the
+    width test that can answer zero, so a narrow frame does not pay for a count it is
+    about to discard.
     """
-    from .. import statusline as sl
     from . import gather
-    return 1 + min(gather.row_count(fid), sl._MAX_REPO_LINES)
+    cap = _table_cap(fid, cols)
+    return 1 + (min(gather.row_count(fid), cap) if cap > 0 else 0)
 
 
 def _right(fid: str) -> str:
@@ -659,8 +706,10 @@ def _bottom(fid: str) -> str:
 
     **The pane is measured, not assumed.** :func:`_height` reads this pane's own tty the
     way :func:`_width` reads its width; :func:`bottom_rows_wanted` is what told the
-    LAUNCHER how tall to make it, so on an untouched frame the two agree exactly and no
-    row is either blank or cut. A pane that is shorter anyway — a transient mid-resize
+    LAUNCHER how tall to make it, and both go through :func:`_table_cap` with the same
+    width and the same density — so on an untouched frame the two agree exactly and no
+    row is either blank or cut, at every width the frame is drawn at and at every level
+    the density menu offers. A pane that is shorter anyway — a transient mid-resize
     size, or a window with no rows to spare — costs the table its lowest-priority rows
     through `_pick_rows`' ranking, never the attention row.
 
@@ -712,14 +761,14 @@ def _bottom(fid: str) -> str:
              if n in keep]
     lines = [tui.truncate(" · ".join(parts), w)]
 
-    # The table gets what is left of the pane below the attention row. At `terse` it is
-    # asked for fewer ROWS rather than sliced afterwards, so what survives is still
-    # `_pick_rows`' ranked subset (the repo you are standing in, the ones with something
-    # on them) rather than whichever happened to come first — the same discipline the
-    # `terse` chip list in `_right` keeps.
-    budget = _height() - len(lines)
-    if verbosity(fid) == "terse":
-        budget = min(budget, _TERSE_ROWS)
+    # The table gets what is left of the pane below the attention row, bounded by
+    # `_table_cap` — the SAME call `bottom_rows_wanted` made to size this pane, with this
+    # pane's own measured width instead of the window's. Asked for fewer ROWS rather than
+    # sliced afterwards, so what survives at `terse` is still `_pick_rows`' ranked subset
+    # (the repo you are standing in, the ones with something on them) rather than
+    # whichever happened to come first — the same discipline the `terse` chip list in
+    # `_right` keeps.
+    budget = min(_height() - len(lines), _table_cap(fid, w))
     if budget > 0:
         from . import gather
         lines.extend(_table_lines(gather.read(fid), w, budget))

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -468,7 +468,7 @@ def _inflight_field() -> str:
     """`⠙ 2 running`, or nothing at all when nothing is.
 
     **The one moving thing in the frame, and it moves only while work is genuinely in
-    flight.** `inflight` records a dispatch when it STARTS and clears it when it ends (see
+    flight.** `inflight` records work when it STARTS and clears it when it ends (see
     that module's docstring — the completion tally cannot answer this), so "is anything
     running right now" is a question about files on disk rather than about anything
     charter has to keep in memory or poll for. `panel._running` is what decides whether the
@@ -476,6 +476,15 @@ def _inflight_field() -> str:
     the row says, and it says nothing when there is nothing to say. Empty means the field
     is dropped whole by `_fit_fields`, which is what makes idle completely still: no
     spinner, no zero, no furniture.
+
+    **`kind=None` — every kind of work, and #420 is the whole of it.** #387 promised a
+    spinner for "a dispatch, clone or `gl-refresh`" and delivered dispatches, because
+    `inflight.start` had one caller. It now has three, and this is the one reader that
+    asks for all of them: the row counts records and never names them, so a clone and a
+    dispatch are both simply "running" here. The readers that NAME what is running —
+    the dispatch-overlap nudge, the per-persona chips — keep `inflight`'s dispatch-only
+    default, which is what stopped this from being a one-line change (see that module's
+    own docstring for the sentence a `clone` record would otherwise have produced).
 
     Presumed-dead records get their own, DELIBERATELY STATIC piece. A record past
     `inflight.PRESUMED_DEAD_SECONDS` is one nobody should still be expecting (its process
@@ -491,7 +500,7 @@ def _inflight_field() -> str:
     both on the same row saying it twice.
     """
     from .. import inflight, statusline as sl
-    records = inflight.live_records()
+    records = inflight.live_records(kind=None)
     if not records:
         return ""
     running = sum(1 for _agent, _started, dead in records if not dead)

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -39,9 +39,13 @@ from .. import tui
 SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 SPINNER_PERIOD = 0.2
 
-#: How many rows a full-height panel (`left`, `right`) draws at `terse`. The horizontal
-#: strips have no equivalent — `top` and `bottom` are one row at every density
-#: (`layout.SLOT_SIZE`), so what "less" means for them is FIELDS, not rows.
+#: How many rows the full-height `right` panel draws at `terse`, and how many rows of
+#: repo table `bottom` keeps there. `top` has no equivalent — it is one row at every
+#: density (`layout.SLOT_SIZE`), so what "less" means for it is FIELDS, not rows.
+#:
+#: `bottom` is BOTH now (#488): at `terse` its attention row keeps one field and its
+#: table keeps this many rows, because a density that buys back rows has to buy them
+#: from the slot that actually has rows to give.
 _TERSE_ROWS = 4
 
 
@@ -103,6 +107,31 @@ def _width() -> int:
         return os.get_terminal_size(sys.stdout.fileno()).columns
     except OSError:
         return tui.term_width(default=80, floor=20)
+
+
+#: Rows a renderer assumes when this pane's own tty cannot be measured at all — the same
+#: number, and the same case, as `panel._DEFAULT_ROWS`: stdout piped somewhere with no
+#: tty behind it (a test, or `charter panel bottom --session x > /tmp/log` run by hand).
+_DEFAULT_ROWS = 24
+
+
+def _height() -> int:
+    """The pane's own height in rows — measured, exactly the way :func:`_width` measures
+    its width, and for the same reason `panel._rows` measures it there.
+
+    **A renderer needs this now, and #488 is why.** Until `bottom` grew the repo table,
+    every renderer emitted whatever it had and `panel._paint` clamped the LINE COUNT
+    afterwards — right for a one-row strip, wrong the moment a renderer has to CHOOSE
+    which rows to spend its pane on. Clamping after the fact would cut the table off at
+    whatever came last, which is the unranked slice `statusline._pick_rows` exists to
+    prevent (its own docstring: thirteen clean repos shown and the dirty one hidden).
+    So the budget is measured before anything is composed, and `panel._paint`'s clamp
+    goes back to being the safety net it is elsewhere rather than the mechanism.
+    """
+    try:
+        return os.get_terminal_size(sys.stdout.fileno()).lines
+    except OSError:
+        return _DEFAULT_ROWS
 
 
 def _top(fid: str) -> str:
@@ -172,7 +201,7 @@ class _RowKey:
     """A directory-shaped key for one cache row: `_pick_rows` wants something with
     a `.name` it can compare against `cur_repo` and use as a `states`/`gl` dict
     key (ordinarily a `Path`) — this is that, minus the filesystem, since nothing
-    in :func:`_left` touches one. Identity-hashed on purpose (no `__eq__`
+    in :func:`_table_lines` touches one. Identity-hashed on purpose (no `__eq__`
     override): two repos can share a name only if the cache itself is
     inconsistent, and identity keeps every row distinct even then, the same
     guarantee a real `Path` object would not actually make either (two `Path`s
@@ -188,238 +217,205 @@ def _needs_attention(r: dict) -> bool:
     """True when a repo/piece row has something on it worth a look — the same
     four facts `_repo_rows`' own "…(+N more)" line checks before it dares say
     "all clean": dirty, unpushed/behind, a failing or running pipeline, an open
-    change. Shared by :func:`_left`'s own overflow line so the two claims (which
-    repos are hidden, and whether that is safe to say) cannot drift apart."""
+    change. Shared by :func:`_table_lines`' own overflow line so the two claims
+    (which repos are hidden, and whether that is safe to say) cannot drift
+    apart."""
     return bool(r.get("dirty") or r.get("ahead") or r.get("behind")
                or r.get("ci") in ("failed", "running") or r.get("change"))
 
 
-def _row(lead: str, name_markup: str, r: dict, width: int, badge_n: int = 0) -> str:
-    """One row — *lead* glyphs, a name, then branch+markers, CI, an open
-    change, and (last, lowest priority) a `⑂N` piece-count badge — each field
-    sized against its OWN budget rather than the assembled line trimmed once
-    from the right at the end.
+def _table_row(lead: str, name_markup: str, r: dict, width: int,
+               branch_override: str | None = None) -> str:
+    """One row of the WIDE repo table — the same four columns
+    `statusline._tree_cells` draws, at the same declared widths, so a row in the
+    frame's `bottom` pane and a row in the status line's own table line up
+    character for character.
 
-    **Fix round 1, finding 1.** The first version of this function built the
-    whole line (`f"{name} {branch}{marks} {ci} {change}"`) and let a single
-    `tui.truncate` at the call site cut whatever didn't fit off the end. On
-    this project's own branches — `worktree-recall-since`,
-    `browser-session-scope`, `global-shim-refresh`: 21-28 characters is the
-    NORM here, not an edge case — `name + " " + branch` alone already fills a
-    22-column pane, so the cut always landed on the markers, the CI glyph and
-    the change sigil. A dirty, CI-failing, unpushed repo rendered as
-    `"charter worktree-reca…"` — a FALSE CLEAN reading, worse than not having
-    the panel at all for a panel that exists to surface exactly that.
+    **Composed here rather than by calling `_tree_cells` itself, and the reason is
+    the idle-cost rule, not style.** That function ends in `_presence_for_dir(d)`,
+    which is a `worktree.locate`/`workspace.clone_of` pair — a filesystem walk PER
+    ROW, on every repaint. `bottom` is the one animated slot (:data:`ANIMATED`), so
+    at `panel.TICK` a fourteen-row table would be seventy directory walks a second
+    while any dispatch is in flight. #387 pinned a panel's idle tick at exactly one
+    `stat` and #488 must not spend that back: everything below comes out of
+    `gather.read(fid)`'s cache and touches no repo directory at all.
 
-    `statusline._branch_cell_for` already keeps the right rule for the wide
-    table (`_BRANCH_W - width(marks)`, so the branch shrinks and the markers
-    never do) — this generalises it to a whole LINE's budget rather than one
-    fixed-width cell, and extends the same "shrink the least important field
-    first" idea to CI and an open change: they are appended whole or not at
-    all (never character-truncated — half a glyph reads as broken, an absent
-    one reads honestly as "no room to say"), in priority order behind the
-    markers, and the branch — read last on this line, and the one field
-    genuinely fine to abbreviate — is what actually gives up its columns.
+    The cost is stated rather than hidden: the frame's table has no presence column
+    ("who else is standing in this tree"). It is the one field of `_tree_cells` that
+    cannot be answered from the gather, and `_branch_cell_for` already treats it as
+    the field that loses its columns first — so the frame draws the cell exactly as
+    the status line draws it on a pane too narrow for presence.
 
-    `_markers` and `_CI_MARK` are `statusline.py`'s own — called, not
-    reimplemented, so a fix to what a marker or a CI glyph means lands here
-    the moment it lands in the wide table.
+    Everything else IS `statusline.py`'s own — `_markers`, `_branch_cell_for`,
+    `_ci_part`, `_CI_MARK`, the four column widths, `_GAP` — called, not
+    reimplemented, so a fix to what a marker or a CI glyph means lands in both
+    surfaces at once.
+
+    *branch_override* is `_tree_cells`' own `branch=` parameter under a clearer name:
+    ``""`` prints the markers alone, which is what a piece whose branch merely
+    restates its own name gets (see :func:`_table_lines`).
     """
     from .. import statusline as sl
 
-    _plain, marks, _dirty = sl._markers(r)
-    marks_w = tui.width(marks)
-
-    ci = r.get("ci")
-    ci_text = ""
-    if ci:
-        c, glyph, _label = sl._CI_MARK.get(ci, (sl._DIM, "?", ci))
-        ci_text = f" {c}{glyph}{sl._R}"
-    ci_w = tui.width(ci_text)
+    marks_plain, marks_col, is_dirty = sl._markers(r)
+    text = r.get("branch") or "?" if branch_override is None else branch_override
+    branch_cell = sl._branch_cell_for(text, "", marks_plain, marks_col, is_dirty)
 
     change = r.get("change")
-    change_text = ""
-    if change:
-        sigil = r.get("sigil") or "!"
-        change_text = f" {sl._GREEN}{sigil}{change}{sl._R}"
-    change_w = tui.width(change_text)
+    sigil = r.get("sigil") or "!"
+    mr = f"{sl._GREEN}{sigil}{change}{sl._R}" if change else ""
 
-    badge_text = f" {sl._DIM}⑂{badge_n}{sl._R}" if badge_n else ""
-    badge_w = tui.width(badge_text)
-
-    branch = r.get("branch") or "?"
-    lead_w = tui.width(lead)
-
-    budget = max(0, width - lead_w)
-    name_w = min(tui.width(name_markup), max(1, budget // 2))
-    name_shown = tui.truncate(name_markup, name_w)
-    budget -= tui.width(name_shown)
-
-    sep = " " if budget > 0 else ""
-    budget -= tui.width(sep)
-
-    # What's left for the branch, once the markers glued to it are reserved.
-    remaining = budget - marks_w
-    # CI, an open change, and the piece badge are included only while there is
-    # still at least 1 column left over for the branch itself after they are —
-    # dropped whole, priority order, rather than let any of them crowd the
-    # branch out entirely.
-    show_ci = bool(ci_text) and (remaining - ci_w) >= 1
-    tail_w = ci_w if show_ci else 0
-    show_change = bool(change_text) and (remaining - tail_w - change_w) >= 1
-    if show_change:
-        tail_w += change_w
-    show_badge = bool(badge_text) and (remaining - tail_w - badge_w) >= 1
-    if show_badge:
-        tail_w += badge_w
-
-    branch_w = max(1, remaining - tail_w)
-    branch_shown = tui.truncate(f"{sl._DIM}{branch}{sl._R}", branch_w)
-
-    line = f"{lead}{name_shown}{sep}{branch_shown}{marks}"
-    if show_ci:
-        line += ci_text
-    if show_change:
-        line += change_text
-    if show_badge:
-        line += badge_text
-    # Safety net, not the fix: correct budgeting above should already leave
-    # this a no-op (`tui.truncate`'s own fast path returns unchanged input
-    # unmodified) — kept only so a rounding slip degrades to a trimmed line
-    # rather than an over-width one, the same belt-and-braces `panel.py`
-    # already keeps around its own measurements.
-    return tui.truncate(line, width)
+    row = tui.Row(tui.Cell(f"{lead}{name_markup}", 2 + 3 + sl._NAME_W),
+                  tui.Cell(branch_cell, sl._BRANCH_W),
+                  tui.Cell(sl._ci_part(r.get("ci")), sl._CI_W),
+                  tui.Cell(mr, sl._MR_W),
+                  gap=sl._GAP)
+    return row.render(width)[0]
 
 
-def _repo_line(r: dict, color: str, width: int, badge_n: int = 0) -> str:
-    """One repo, one line: name (bold+underline if it is where you are
-    standing, coloured by the same per-position palette `_repo_rows` cycles),
-    then :func:`_row`'s shared branch/markers/CI/change/badge composition.
+def _table_lines(data: dict, width: int, budget: int) -> list[str]:
+    """The repo table `bottom` draws under its attention row, at most *budget* lines.
 
-    *badge_n* is the repo's `⑂N` — the pieces NOT already shown as their own
-    rows below it (see :func:`_left`'s own docstring: `0` when every piece
-    already has a row, or when the repo has none)."""
-    from .. import statusline as sl
-    emph = f"{sl._BOLD}{sl._UNDER}" if r.get("current") else ""
-    name_markup = f"{emph}{color}{r['name']}{sl._R}"
-    return _row("", name_markup, r, width, badge_n=badge_n)
+    **This is #488's actual answer**: the frame used to show LESS of the plane's repo
+    state than the status line it suppresses (#386), because the only slot drawing repos
+    was a 22-column sidebar whose own docstring conceded that `_NAME_W` (32) and
+    `_BRANCH_W` (34) alone exceed the whole pane. `bottom` is the frame's full-width
+    slot, so the table goes here and is drawn at the widths it was designed for.
 
+    Reads ONLY *data* — one `gather.read(fid)` in the caller — and never a repo
+    directory, a `git status` or a `glstate.read_for` of its own. Every field a row needs
+    (`name`, `branch`, `dirty`, `tracked_dirty`, `ahead`, `behind`, `ci`, `change`,
+    `sigil`, `current`, `worktree_count`) is already in that one gather.
 
-def _piece_line(p: dict, width: int) -> str:
-    """One piece (worktree), indented under its repo — same composition as
-    :func:`_repo_line` minus the palette colour and the bold/underline
-    emphasis, which belong to a REPO's row, not one of its pieces."""
-    from .. import statusline as sl
-    lead = f"{sl._DIM}{sl._TREE_WT}{sl._R}"
-    return _row(lead, p["name"], p, width)
+    `statusline._pick_rows` is called rather than reinvented, for the reason its own
+    docstring records in production: an unranked slice of 18 clones showed thirteen clean
+    repos on `main` and hid the one dirty repo you were standing in. It wants
+    directory-shaped keys (`.name`, hashable), so each cache row is wrapped in a bare
+    :class:`_RowKey` — nothing here touches a filesystem, and a `Path` would imply one
+    exists to touch.
 
+    *budget* is the pane's real height minus the attention row, measured by
+    :func:`_height` before anything is composed. The budget is spent in priority order —
+    repo rows first, then the `…(+N more)` line that admits what was dropped, then piece
+    rows — so a short pane loses DETAIL rather than losing a repo. That ordering is
+    `statusline._repo_rows`' own (`wt_budget` there), kept because the two tables are
+    meant to read alike.
 
-def _left(fid: str) -> str:
-    """Repo rows, narrow: the same per-tree facts `_tree_cells` draws in the wide
-    status-line table (name, branch, dirty/ahead/behind markers, CI, open
-    change), recomposed for a 22-column pane rather than reusing the `tui.Node`s
-    built for the wide one — `_NAME_W` (32) and `_BRANCH_W` (34) alone already
-    exceed this whole pane's width, which is exactly why "share the gather, not
-    the composition" is this plan's own rule.
-
-    Reads ONLY `gather.read(fid)` — the cache Task 1 built and Task 2 keeps
-    refreshed — never a repo directory listing, a `git status`, or a
-    `glstate.read_for` of its own; every field a row needs (`name`, `branch`,
-    `dirty`, `tracked_dirty`, `ahead`, `behind`, `ci`, `change`, `sigil`,
-    `current`, `worktree_count`) is already sitting in that one gather.
-    `_pick_rows` is called rather than reinvented for the same reason: it
-    already carries the lesson `statusline.py` paid for in production (an
-    unranked slice of 18 clones showed thirteen clean repos on `main` and hid
-    the one dirty repo you were actually standing in) — `_pick_rows` wants
-    directory-shaped keys (`.name`, hashable), so each cache row is wrapped in
-    a bare `_RowKey` rather than a `Path`: nothing here touches a filesystem,
-    and a `Path` would imply one exists to touch (and, unlike a `Path`, two
-    `_RowKey`s never compare equal just because their names happen to match —
-    see its own docstring).
-
-    `left` is a full-height pane with rows to fill, unlike `top`/`bottom`'s fixed
-    single row — but nothing in this module measures how many it actually has
-    (`_width` measures COLUMNS; there is no equivalent asked for here). The
-    budget handed to `_pick_rows` is `_MAX_REPO_LINES`, the same cap the wide
-    table itself uses, reused rather than invented fresh; `panel.py`'s own
-    height clamp (`_rows()` there — see its "Height is this module's job"
-    section) is what actually protects a short pane from an overflow.
-
-    Piece rows come from `data["worktrees"]`, which `gather.scan` populates
-    ONLY when the workspace resolves to exactly one repo — it mirrors
-    `statusline._detail_worktrees`'s own single-repo rule verbatim (see that
-    function's docstring: spending rows on piece detail is only a good trade
-    when there is exactly one repo to spend them on). Every OTHER repo's
-    pieces — the ones never turned into rows of their own — still get a `⑂N`
-    badge on their repo's own line, from `worktree_count` (fix round 1,
-    finding 2, #385: this used to be missing from the cache entirely for a
-    multi-repo workspace; `gather.py`'s own module docstring records the
-    fix). `_repo_line` is handed `0` whenever every one of a repo's pieces
-    already has its own row — the badge means "there is more you cannot see
-    here," not "this repo has pieces."
-
-    **At `terse` the budget drops to :data:`_TERSE_ROWS` and piece rows go.** `_pick_rows`
-    is asked for fewer rows rather than the result being sliced afterwards, so the rows
-    that survive are still the ones worth keeping (the repo you are standing in, the ones
-    with something on them) rather than whichever happened to come first — the exact
-    lesson `statusline.py` paid for and this function already borrows. The `…(+N more)`
-    line and its "all clean" claim come along unchanged, so a terse panel still says how
-    much it is not showing, which is what makes showing less honest rather than
-    misleading. Pieces are dropped whole: they are DETAIL under a repo that still has its
-    own row, so losing them costs no repo its line.
+    Piece rows come from ``data["worktrees"]``, which `gather.scan` populates only when
+    the workspace resolves to exactly one repo — `statusline._detail_worktrees`' rule
+    verbatim. Every OTHER repo's pieces get a `⑂N` badge on the repo's own row instead,
+    from `worktree_count`; the badge means "there is more you cannot see here", so it is
+    dropped whenever every piece already has its own row.
     """
     from .. import statusline as sl
-    from . import gather
 
-    data = gather.read(fid)
     repos = data.get("repos") or []
-    w = _width()
-    if not repos:
-        return tui.truncate(f"{sl._DIM}no repos{sl._R}", w)
+    if not repos or budget <= 0:
+        return []
+    # **Too narrow for the table is NO table, not a cut one**, and the alternative is
+    # the exact failure this plan's Global Constraints name. Every column after the
+    # branch — the CI glyph, an open change — sits at a fixed offset past
+    # `_NAME_W + _BRANCH_W`, so a pane narrower than the row simply loses them off the
+    # right-hand end, and a dirty, CI-failing, unpushed repo renders as a clean-looking
+    # `charter  main`. Refusing to draw says "no room to say" where a trimmed row says
+    # "nothing to say".
+    #
+    # Reachable but not ordinary: `bottom` is split BEFORE `right` (the slot order IS
+    # the geometry — `instance.FRAME_FIELDS`), so its width is the whole WINDOW's, and
+    # `_LEFT_W` (95) is below the shipped `[frame] min-cols` (100) — every frame at or
+    # above its own floor draws the full table. What lands here is a frame on a
+    # hand-lowered `min-cols`, or the transient mid-resize starvation `layout.py`'s
+    # module docstring measures. The attention row above is unaffected either way; it
+    # does its own per-field budgeting (`_fit_fields`).
+    if width < sl._LEFT_W:
+        return []
 
-    color_by_name = {r["name"]: sl._PALETTE[i % len(sl._PALETTE)]
-                     for i, r in enumerate(repos)}
     keys = [_RowKey(r["name"]) for r in repos]
     by_key = dict(zip(keys, repos))
     cur_repo = data.get("current_repo")
+    palette = {r["name"]: sl._PALETTE[i % len(sl._PALETTE)] for i, r in enumerate(repos)}
 
-    # How many of a repo's pieces already have their own row below it
-    # (`data["worktrees"]`, single-repo-only — see the docstring above), so
-    # the badge can say "there is more" rather than double-count what is
-    # already on screen.
+    capped = len(keys) > budget
+    show = (sl._pick_rows(keys, max(1, budget - 1), cur_repo, by_key, by_key)
+            if capped else keys)
+
+    pieces = list(data.get("worktrees") or [])
     shown_pieces: dict = {}
-    for p in (data.get("worktrees") or []):
+    for p in pieces:
         shown_pieces[p.get("repo")] = shown_pieces.get(p.get("repo"), 0) + 1
 
-    def _badge_for(r: dict) -> int:
+    # Rows left for piece detail once every repo has its own row and, if capped, the
+    # overflow line has been reserved. `statusline._repo_rows` spends its budget in
+    # exactly this order and for exactly this reason: a repo must never lose its row to
+    # another repo's pieces.
+    room = budget - len(show) - (1 if capped else 0)
+    kids = pieces[:max(0, room)] if len(show) == 1 else []
+
+    lines: list[str] = []
+    for i, k in enumerate(show):
+        r = by_key[k]
         total = r.get("worktree_count") or 0
-        return total if shown_pieces.get(r["name"], 0) < total else 0
-
-    terse = verbosity(fid) == "terse"
-    budget = _TERSE_ROWS if terse else sl._MAX_REPO_LINES
-    capped = len(keys) > budget
-    show = sl._pick_rows(keys, (budget - 1) if capped else budget,
-                         cur_repo, by_key, by_key) if capped else keys
-
-    lines = [_repo_line(by_key[k], color_by_name[by_key[k]["name"]], w,
-                        badge_n=_badge_for(by_key[k]))
-             for k in show]
+        badge = (f"{sl._DIM} ⑂{total}{sl._R}"
+                 if total and shown_pieces.get(r["name"], 0) < total else "")
+        emph = f"{sl._BOLD}{sl._UNDER}" if r.get("current") else ""
+        # A repo with rows nested beneath it is not where the tree ends, so it keeps
+        # `├─` — `statusline._repo_rows`' own rule, and the reason `_TREE_WT` exists.
+        is_last = (not capped) and i == len(show) - 1 and not kids
+        tree = sl._TREE_END if is_last else sl._TREE_MID
+        lines.append(_table_row(f"  {sl._DIM}{tree}{sl._R}",
+                                f"{emph}{palette[r['name']]}{r['name']}{sl._R}{badge}",
+                                r, width))
 
     if capped:
-        shown = set(show)
-        hidden = [k for k in keys if k not in shown]
+        hidden = [k for k in keys if k not in set(show)]
         quiet = not any(_needs_attention(by_key[k]) for k in hidden)
-        # Same wording as `_repo_rows`' own overflow line (`statusline.py`) —
-        # this used to say bare ", clean", a needless divergence between the
-        # two surfaces for the exact same claim.
         note = ", all clean" if quiet else ""
-        lines.append(tui.truncate(f"{sl._DIM}…(+{len(hidden)} more{note}){sl._R}", w))
+        lines.append(tui.truncate(
+            f"  {sl._DIM}…(+{len(hidden)} more{note}){sl._R}", width))
 
-    if not terse:
-        for p in (data.get("worktrees") or []):
-            lines.append(_piece_line(p, w))
+    for j, p in enumerate(kids):
+        mark = sl._TREE_WT if j == len(kids) - 1 else sl._TREE_MID
+        emph = f"{sl._BOLD}{sl._UNDER}" if p.get("current") else ""
+        # `charter worktree add <repo> <piece>` names the branch after the piece, so by
+        # default these two columns print the same word twice — empty the branch cell
+        # when they agree, exactly as `statusline._repo_rows` does, so the column comes
+        # to mean "this piece is NOT on the branch you would assume". The markers still
+        # render: dirty and ahead/behind are true of the tree whatever its branch.
+        wb = p.get("branch") or "?"
+        lines.append(_table_row(f"  {sl._DIM}{sl._TREE_PIPE}{mark}{sl._R}",
+                                f"{emph}{sl._DIM}{p['name']}{sl._R}", p, width,
+                                branch_override="" if wb == p.get("name") else None))
+    return lines[:budget]
 
-    return "\n".join(lines)
+
+def bottom_rows_wanted(fid: str) -> int:
+    """How many rows `_bottom` would fill for this frame, given room for all of them.
+
+    **One answer to "how tall is `bottom`", read by both sides of the question.** The
+    renderer spends the pane it was given (:func:`_table_lines`' *budget*); the LAUNCHER
+    has to decide how tall to make that pane before any panel exists, and the
+    `window-resized` recompute has to decide again with the window's new size. If those
+    two disagreed, a frame would come up with a pane taller than its content (blank rows
+    the harness could have had) or shorter (a table cut off with nothing saying so).
+    Pinned by a test that renders `_bottom` into a pane of exactly this height and counts
+    the lines that come back.
+
+    `+ 1` is the attention row — the alert, the spinner, this session's news, the todo
+    count and the hotkey hint — which `_bottom` always draws and which #488 is explicit
+    that the table joins rather than evicts.
+
+    Capped at `statusline._MAX_REPO_LINES`, the same total-row budget the wide table
+    itself keeps (repo rows plus the `…(+N more)` line, not repo COUNT — see that
+    constant's own comment), so a workspace with forty clones asks for a fifteen-row
+    strip rather than a forty-one-row one.
+
+    `gather.row_count` is what makes this affordable at launch: it answers from the
+    frame's cache when there is one and from a plain directory listing when there is not,
+    and never runs a git sweep. See its own docstring.
+    """
+    from .. import statusline as sl
+    from . import gather
+    return 1 + min(gather.row_count(fid), sl._MAX_REPO_LINES)
 
 
 def _right(fid: str) -> str:
@@ -565,14 +561,13 @@ def _bottom(fid: str) -> str:
     `$CHARTER_SESSION_ID`/`$CLAUDE_CODE_SESSION_ID` a launched panel inherits whole from
     the harness (`_right`'s docstring makes the identical point for `_persona_chips`).
 
-    **Four candidate fields now, not three, each shown WHOLE or dropped WHOLE — never
-    one assembled string cut once from the right.** `bottom` is one fixed row
-    (`layout.SLOT_SIZE["bottom"] == 1`) but its WIDTH is the frame's own, not a narrow
-    side panel's, so ordinarily every field fits comfortably and this never has to choose.
-    But `layout.py`'s own module docstring records a REAL tmux 3.7c resize that
-    transiently starves a fixed-size pane before the corrective hook snaps it back — not
-    hypothetical, reachable by an ordinary window resize at any moment (Task 3's fix
-    round 2 pinned the identical shape for `left`). A naive single `tui.truncate` over the
+    **Four candidate fields on that row, each shown WHOLE or dropped WHOLE — never one
+    assembled string cut once from the right.** The attention row is one row whatever
+    this pane's height is, and its WIDTH is the frame's own, not a narrow side panel's,
+    so ordinarily every field fits comfortably and this never has to choose. But
+    `layout.py`'s own module docstring records a REAL tmux 3.7c resize that transiently
+    starves a pane before the corrective hook snaps it back — not hypothetical, reachable
+    by an ordinary window resize at any moment. A naive single `tui.truncate` over the
     joined line would risk Task 3's own Critical on perfectly ordinary data: an alert
     exists specifically to carry the command that fixes it, and slicing into that command
     mid-word reads as "no problem here" — the exact false-clean failure this plan's
@@ -606,6 +601,31 @@ def _bottom(fid: str) -> str:
     every operator the wrong key, on every repaint, forever. `config.FRAME` is the
     resolved value `commands_frame.conf_text` binds, so there is one source for what the
     panel says and what the frame actually does.
+
+    **Under it, the wide repo table — #488.** The frame suppresses the status line
+    (#386) and until now showed LESS of the plane's repo state than the line it replaced:
+    the only slot drawing repos was a 22-column `left` sidebar recomposing a table
+    designed for 66. `bottom` is the frame's full-width slot, so the table lives here
+    now, at `statusline.py`'s own column widths, and `left` is retired rather than left
+    drawing a lesser copy of its neighbour.
+
+    **The attention row is not evicted by it — it is the first line, always.** The alert
+    and the command that fixes it outrank any repo row; the table gets what is left of
+    the pane after it (`_table_lines`' own *budget*). On a plane with no clones there is
+    no table at all and this is exactly the one-row strip it always was.
+
+    **The pane is measured, not assumed.** :func:`_height` reads this pane's own tty the
+    way :func:`_width` reads its width; :func:`bottom_rows_wanted` is what told the
+    LAUNCHER how tall to make it, so on an untouched frame the two agree exactly and no
+    row is either blank or cut. A pane that is shorter anyway — a transient mid-resize
+    size, or a window with no rows to spare — costs the table its lowest-priority rows
+    through `_pick_rows`' ranking, never the attention row.
+
+    **One `gather.read`, and no repo directory touched.** #387 pinned a panel's idle tick
+    at exactly one `stat` and `bottom` is the ONE animated slot (:data:`ANIMATED`), so a
+    table that walked a directory per row would pay that back fourteen times over at five
+    repaints a second. Everything the table draws comes out of the cache; see
+    :func:`_table_row` for the one column that costs (presence) and is therefore absent.
     """
     from .. import config, session as _session, statusline as sl, workspace
     from . import state, tmuxctl
@@ -647,12 +667,25 @@ def _bottom(fid: str) -> str:
               "todo": todo_text, "hotkey": hotkey_text}
     parts = [fields[n] for n in ("todo", "alert", "inflight", "news", "hotkey")
              if n in keep]
-    return tui.truncate(" · ".join(parts), w)
+    lines = [tui.truncate(" · ".join(parts), w)]
+
+    # The table gets what is left of the pane below the attention row. At `terse` it is
+    # asked for fewer ROWS rather than sliced afterwards, so what survives is still
+    # `_pick_rows`' ranked subset (the repo you are standing in, the ones with something
+    # on them) rather than whichever happened to come first — the same discipline the
+    # `terse` chip list in `_right` keeps.
+    budget = _height() - len(lines)
+    if verbosity(fid) == "terse":
+        budget = min(budget, _TERSE_ROWS)
+    if budget > 0:
+        from . import gather
+        lines.extend(_table_lines(gather.read(fid), w, budget))
+    return "\n".join(lines)
 
 
 #: Every slot charter can draw. `panel.run` refuses a name that is not in here rather
 #: than painting an empty pane, because an empty pane reads as a broken frame.
-SLOTS = {"top": _top, "bottom": _bottom, "left": _left, "right": _right}
+SLOTS = {"top": _top, "bottom": _bottom, "right": _right}
 
 
 #: Which slots draw something that CHANGES ON ITS OWN, with no version bump and no
@@ -660,8 +693,8 @@ SLOTS = {"top": _top, "bottom": _bottom, "left": _left, "right": _right}
 #: is `_bottom` and only `_bottom` (through :func:`_inflight_field`).
 #:
 #: **This is what scopes the animation's cost to the pane that needs it.** `panel._watch`
-#: runs one process per slot, so an unscoped "is work in flight" would repaint all four at
-#: `panel.TICK` for the whole length of a dispatch — three of them redrawing byte-identical
+#: runs one process per slot, so an unscoped "is work in flight" would repaint every one of
+#: them at `panel.TICK` for the whole length of a dispatch — the rest redrawing byte-identical
 #: output. That is not free: measured on this project (8 personas, 6 repos), one
 #: `render("right")` costs 4 816µs, because `statusline._persona_chips` asks
 #: `persona.is_draft`, `structural_errors`, `_mem_count` twice and `_vault_dot` per
@@ -680,11 +713,13 @@ ANIMATED = frozenset({"bottom"})
 def unimplemented(configured) -> list[str]:
     """Which of *configured* charter sizes and accepts but has no renderer for.
 
-    Answers empty as of Task 3: `left`/`right` landed beside `top`/`bottom` in
-    :data:`SLOTS`, so every slot `instance.FRAME_SLOTS` accepts and
-    `layout.SLOT_SIZE` sizes now has a renderer. Kept rather than deleted —
+    Answers empty: every slot `instance.FRAME_SLOTS` accepts and `layout.SLOT_SIZE`
+    sizes has a renderer in :data:`SLOTS`. It stayed non-empty for a whole release
+    while `left`/`right` were sized but not drawn, and #488 closed the question from
+    the other end — `left` is retired from both registries at once rather than left
+    half-present in one. Kept rather than deleted —
     the next slot this frame grows will pass through here on day one exactly
-    the way `left`/`right` did until this task, and three callers need exactly
+    the way `left`/`right` did, and three callers need exactly
     this list and must agree — `commands_frame.cmd_launch` (to skip splitting a
     pane that would be permanently dead under `remain-on-exit on`),
     `commands_frame.frame_ready` (`--probe`) and `doctor.check_frame` (both to

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -162,19 +162,35 @@ def _top(fid: str) -> str:
     Composing `_session_strip(payload, sid)` instead would not help: it is exactly
     `[*_context_gauge(payload), *_session_news(sid)]`, so with the gauge half structurally
     dead the call would only ever surface `_session_news`'s half — which is `bottom`'s
-    own, explicit assignment (see `_bottom`'s docstring), not `top`'s. Calling it here
-    too would either duplicate `bottom` byte-for-byte or (worse, since a panel's `sid` may
-    differ in nothing from `bottom`'s) read as two different panes agreeing by
-    coincidence. Per the task brief: "a gauge that silently reads zero is worse than no
-    gauge" — so this is left out, not stubbed in, until #386 (which owns the suppression
-    and recording question this finding feeds) decides a panel should have its own
-    persisted usage snapshot to read. Pinned by `tests.test_frame_slots.TopRenderer`.
+    own, explicit assignment (see `_bottom`'s docstring), not `top`'s.
+
+    **That argument stopped applying, and #413 is where it stopped.** Every word of it is
+    still true of `_context_gauge`, which is why this function still does not call it —
+    but its conclusion ("so the frame cannot have a gauge") rested on a premise that is no
+    longer the whole picture: a panel now has a FILE to read. The suppressing
+    `statusline.main` is the one process that sees both Claude Code's session id and this
+    frame's, so it writes the mapping down (`state.record_harness_session`), and
+    `record_usage` writes the numbers themselves — including, since #413, the context
+    percentage, which is the one figure nothing can re-derive. `statusline
+    .recorded_context_gauge` composes exactly what `_context_gauge` composes, from the
+    recorded history instead of a live payload, so the two surfaces cannot disagree about
+    a threshold or a label.
+
+    **What has NOT changed is the rule the old argument was built on**: a gauge that
+    silently reads zero is worse than no gauge. Every way of not knowing — a frame with no
+    recorded session (a harness that is not Claude Code is never handed a usage payload at
+    all), a session with no turns recorded yet, a history written entirely by a charter
+    that predates the fourth field — answers `[]` and draws nothing, rather than a
+    confident `ctx 0%`. Pinned by `tests.test_frame_slots.TopRenderer`.
 
     **At `terse` the version goes, and nothing else does.** `top` answers "where am I and
-    who am I being", and of the three things on it the charter version is the only one
-    that reads the same on every frame on this machine all day — it is a fact about the
+    who am I being", and of the things on it the charter version is the only one that
+    reads the same on every frame on this machine all day — it is a fact about the
     install, not about where you are standing. The workspace and the persona ARE the
-    answer, so a density that dropped either would leave a row not earning its line.
+    answer, so a density that dropped either would leave a row not earning its line. The
+    gauge stays for the opposite reason: it is the one field on this row that is different
+    every turn, and a density that buys back columns should not spend them on the field
+    that had something new to say.
 
     **The version carries the dev-channel chip, `statusline._dev_chip()` (#457).** #386
     made a frame suppress the status line entirely, and `_brand` is the only OTHER place
@@ -187,13 +203,20 @@ def _top(fid: str) -> str:
     whole line does not mean to keep half of it.
     """
     from .. import __version__, statusline, workspace
+    from . import state
     ws = workspace.resolve()
     src = workspace.source()
     pin = "*" if src == "$CHARTER_WORKSPACE" else ""
     persona = statusline._persona_line() or ""
+    # Two file reads on a slot that repaints only on a version bump (`top` is not in
+    # `ANIMATED`), and nothing is read at all for a frame with no recorded session —
+    # which is every frame whose harness is not Claude Code.
+    gauge = " ".join(statusline.recorded_context_gauge(
+        state.harness_session(fid) or ""))
     left = f" ⬢ {ws}{pin}"
-    right = (persona if verbosity(fid) == "terse"
-             else f"{persona}  charter {__version__}{statusline._dev_chip()} ")
+    tail = (persona if verbosity(fid) == "terse"
+            else f"{persona}  charter {__version__}{statusline._dev_chip()} ")
+    right = f"{gauge}  {tail}" if gauge else tail
     return tui.truncate(f"{left}  {right}", _width())
 
 

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -281,7 +281,11 @@ def _table_row(lead: str, name_markup: str, r: dict, width: int,
     from .. import statusline as sl
 
     marks_plain, marks_col, is_dirty = sl._markers(r)
-    text = r.get("branch") or "?" if branch_override is None else branch_override
+    # Parenthesised, though Python's precedence already reads it this way: the `or "?"`
+    # is the DEFAULT for a missing branch, not an alternative to the override — and an
+    # override of `""` (a piece whose branch restates its own name) must stay empty
+    # rather than turn into `?`.
+    text = (r.get("branch") or "?") if branch_override is None else branch_override
     branch_cell = sl._branch_cell_for(text, "", marks_plain, marks_col, is_dirty)
 
     change = r.get("change")

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -359,7 +359,14 @@ def _table_lines(data: dict, width: int, budget: int) -> list[str]:
     palette = {r["name"]: sl._PALETTE[i % len(sl._PALETTE)] for i, r in enumerate(repos)}
 
     capped = len(keys) > budget
-    show = (sl._pick_rows(keys, max(1, budget - 1), cur_repo, by_key, by_key)
+    # `budget - 1` and no `max(1, …)` underneath it: the overflow line is reserved OUT of
+    # the budget rather than appended on top of it and trimmed off at the end. With a
+    # one-row budget the trimmed version showed a single repo row and dropped the
+    # `…(+N more)` line — a pane claiming that one clean repo is the whole plane, which is
+    # the false-clean reading this module refuses everywhere else. A budget of exactly one
+    # therefore spends it on the note, which is the honest half of the pair: "there is
+    # more here than fits" outranks "here is an arbitrary one of them".
+    show = (sl._pick_rows(keys, budget - 1, cur_repo, by_key, by_key)
             if capped else keys)
 
     pieces = list(data.get("worktrees") or [])

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -262,6 +262,69 @@ def harness_pane(fid: str) -> str | None:
         return None
 
 
+def record_harness_session(fid: str, sid: str) -> bool:
+    """Write down the HARNESS's own session id for this frame. ``True`` when the recorded
+    value actually changed.
+
+    **The mapping #413 is about, and there is exactly one process that can write it.**
+    Claude Code's per-turn token usage is keyed by ITS session id, and a panel never sees
+    that id — a panel only ever knows ``$CHARTER_SESSION_ID``, which the frame launcher
+    sets to the FRAME's id. The one moment both ids are in the same process is the
+    suppressing `statusline.main`: it has the frame id in its environment and Claude
+    Code's id in the JSON payload on its stdin. So it writes this, and a panel reads it.
+
+    **In the frame's own directory, and that placement is the answer to "must not leak
+    between planes".** `frame_dir` sits under `config.STATE_DIR`, which is per-plane; the
+    file goes with the frame and `reap` deletes it with the rest of the directory when
+    the launcher's pid dies. Nothing is committed, nothing is shared, and nothing outlives
+    the frame it describes.
+
+    Returns whether it CHANGED, because the caller runs on the status line's own render
+    path — several times per turn — and uses the answer to decide whether the frame's
+    panels have anything new to repaint for. Reading before writing is also what keeps
+    this to one `stat`-shaped read on the overwhelmingly common no-op path.
+
+    Same atomic-write, never-raise shape as :func:`record_harness_pane`, and for the same
+    reason: a frame whose harness session could not be recorded simply draws no gauge,
+    which is the safe direction — no gauge rather than a wrong one.
+    """
+    sid = (sid or "").strip()
+    if not sid or harness_session(fid) == sid:
+        return False
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return False
+    tmp = d / "session.tmp"
+    try:
+        tmp.write_text(f"{sid}\n")
+        os.replace(tmp, d / "session")
+    except OSError:
+        return False
+    return True
+
+
+def harness_session(fid: str) -> str | None:
+    """The harness's own session id for *fid*, or ``None`` when charter does not know.
+
+    ``None`` for a frame whose harness is not Claude Code (nothing else is handed a
+    per-turn usage payload, so nothing else writes here), for a frame launched by a
+    charter that predates :func:`record_harness_session`, for a directory that is not a
+    frame's, and for a file that cannot be read.
+
+    Four reasons, deliberately one answer, because every caller does the same thing with
+    it: **draw no gauge.** `frame/slots.py`'s own rule — a gauge that silently reads zero
+    is worse than no gauge — makes "charter does not know" and "charter knows there is
+    nothing" the same picture on purpose.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        return (d / "session").read_text().strip() or None
+    except (OSError, ValueError):
+        return None
+
+
 def record_server(fid: str, server: str) -> None:
     """Write down which tmux server this frame's session (or window) lives on.
 
@@ -350,8 +413,8 @@ def density(fid: str) -> str | None:
 
 
 def clear_shape(fid: str) -> None:
-    """Forget the density and the pane map recorded under *fid*, because a NEW frame is
-    claiming the id.
+    """Forget the density, the pane map and the harness session recorded under *fid*,
+    because a NEW frame is claiming the id.
 
     The fourth and fifth lines on :func:`clear_exit`'s bill, and the same recycled pid
     underneath them (#383). A frame id is ``<workspace>-<launcher pid>``; :func:`reap`
@@ -370,13 +433,20 @@ def clear_shape(fid: str) -> None:
       it as it draws, so this only matters when a launch dies before that — but then the
       map survives pointing at nothing, and the next density change on the next frame to
       claim the id would `kill-pane` ids that mean whatever tmux has since reused.
+    * ``session`` names ANOTHER agent session's token usage (#413). This one is the
+      sharpest of the three, because the failure is not an empty panel but a confident
+      wrong number: the new frame's `top` row would draw the previous session's `ctx 78%`
+      as its own, and go on doing it until that session's own harness happened to write a
+      new one — which it never will, because it is over. `slots.py`'s rule is that a gauge
+      reading zero is worse than no gauge; a gauge reading somebody else's 78% is worse
+      than either.
 
     Never raises, and never creates, like everything else here.
     """
     d = frame_dir(fid)
     if d is None:
         return
-    for name in ("density", "panes"):
+    for name in ("density", "panes", "session"):
         try:
             (d / name).unlink(missing_ok=True)
         except OSError:

--- a/charter/inflight.py
+++ b/charter/inflight.py
@@ -1,4 +1,4 @@
-"""In-flight dispatch tracking — the signal the completion tally cannot give.
+"""In-flight work tracking — the signal the completion tally cannot give.
 
 ``personas/_dispatch/`` records a dispatch when it **finishes**, so two dispatches
 five minutes apart sequentially are indistinguishable from two that overlapped.
@@ -6,12 +6,30 @@ That makes it useless for the one failure it would be worth catching: two
 code-writing personas editing the same working tree at once, which fails quietly
 — no error, just interleaved edits and whichever commit lands last.
 
-This records a dispatch when it **starts** and clears it when it ends, so overlap
-is actually observable.
+This records work when it **starts** and clears it when it ends, so overlap is
+actually observable.
+
+**Every record carries a KIND, and #420 is why.** #387 promised the frame "a
+spinner while a dispatch, clone or `gl-refresh` runs"; only dispatches animated,
+because :func:`start` had exactly one caller. Wiring the other two in was not a
+one-liner: the SAME records feed the dispatch-overlap nudge through
+:func:`still_running`, and a record named ``clone`` would have made that nudge
+tell an operator *"`x` writes code and `clone` are already running"* — wrong, and
+wrong in the confident, human-readable way that is worse than silence.
+
+So a record says what it is, and every reader says which kinds it means. The
+default everywhere is :data:`DISPATCH`, deliberately: the readers that must not
+see a clone (the nudge, the per-persona chips, the session's own ``⚡ N``) get
+that by NOT asking, so the next kind somebody invents cannot leak into them by
+being forgotten. The frame's spinner is the one caller that opts into "anything
+live" (``kind=None``), which is exactly what it is for.
+
+A record written by a charter that predates the field reads as a
+:data:`DISPATCH`, which is what it was.
 
 Local and ephemeral: it lives under the state dir, is never committed, and holds
-only an agent name and a timestamp — the same discipline as the committed tally,
-which deliberately stores counts and dates, never prompt text.
+only an agent name, a kind and a timestamp — the same discipline as the committed
+tally, which deliberately stores counts and dates, never prompt text.
 
 Everything here is best-effort. A tracker that breaks a turn is worse than one
 that misses an overlap.
@@ -43,9 +61,33 @@ PRESUMED_DEAD_SECONDS = 30 * 60
 PRUNE_SECONDS = 24 * 60 * 60
 
 
+#: A sub-agent handed work by the `Task`/`Agent` tool. What this tracker held for its
+#: whole life before #420, and still what every reader means unless it says otherwise —
+#: including a record written before the field existed (:func:`_kind_of`).
+DISPATCH = "dispatch"
+
+#: One repo being cloned into a workspace (`commands.cmd_clone`, one per repo, so eight
+#: parallel clones read as eight).
+CLONE = "clone"
+
+#: A forge-state refresh (`commands.cmd_gl_refresh`) — the detached child
+#: `glstate.maybe_spawn` starts, not the parent that spawned it.
+REFRESH = "gl-refresh"
+
+
 def _dir() -> Path:
     from . import config
     return config.STATE_DIR / "dispatch-inflight"
+
+
+def _kind_of(rec: dict) -> str:
+    """What kind of work *rec* describes — :data:`DISPATCH` for anything that does not
+    say, which is every record this tracker held before #420 and every one written by an
+    older charter still sitting on disk. A non-string is treated the same way rather than
+    passed through: the value is compared against a caller's filter, and a filter that
+    can never match would silently hide a live record from the nudge that needs it."""
+    kind = rec.get("kind")
+    return kind if isinstance(kind, str) and kind else DISPATCH
 
 
 def _safe_name(agent: str) -> str:
@@ -79,8 +121,19 @@ def stamp() -> int | None:
         return None
 
 
-def live_records(exclude_token: str | None = None) -> list[tuple[str, float, bool]]:
+def live_records(exclude_token: str | None = None, *,
+                 kind: str | None = DISPATCH) -> list[tuple[str, float, bool]]:
     """``(agent, started_at, presumed_dead)`` per record, duplicates preserved.
+
+    *kind* selects which records answer: one of :data:`DISPATCH`/:data:`CLONE`/
+    :data:`REFRESH`, or ``None`` for every kind. **It defaults to `DISPATCH`, and that
+    default is the guard** — see the module docstring. The frame's spinner is the one
+    caller that wants everything; every other reader means dispatches and gets them
+    without having to remember to say so.
+
+    The kind is not in the returned tuple. Nothing that filters also needs to display it,
+    and a fourth element would have to be threaded through `panel._running`'s cache and
+    every test that builds a record by hand for no reader's benefit.
 
     The start time is what separates "two agents are out" from "two agents have been
     out for forty minutes", and only the second is worth interrupting for. It is read
@@ -112,6 +165,8 @@ def live_records(exclude_token: str | None = None) -> list[tuple[str, float, boo
             if exclude_token and p.stem == exclude_token:
                 continue
             rec = json.loads(p.read_text())
+            if kind is not None and _kind_of(rec) != kind:
+                continue
             ts = rec.get("ts")
             started = float(ts) if isinstance(ts, (int, float)) else mtime
             out.append((rec.get("agent") or p.stem, started,
@@ -121,29 +176,42 @@ def live_records(exclude_token: str | None = None) -> list[tuple[str, float, boo
     return out
 
 
-def live(exclude_token: str | None = None) -> list[str]:
+def live(exclude_token: str | None = None, *,
+         kind: str | None = DISPATCH) -> list[str]:
     """Agent names the tracker holds — presumed-dead ones included, since the aggregate
     this feeds counts records and the distinction is drawn per chip.
 
     ``exclude_token`` drops one specific record — the caller's own, so a dispatch
-    never reports itself as a concurrent peer.
+    never reports itself as a concurrent peer. *kind* is :func:`live_records`'.
     """
-    return sorted(name for name, _, _ in live_records(exclude_token))
+    return sorted(name for name, _, _ in live_records(exclude_token, kind=kind))
 
 
-def still_running(exclude_token: str | None = None) -> list[str]:
+def still_running(exclude_token: str | None = None, *,
+                  kind: str | None = DISPATCH) -> list[str]:
     """Agent names charter can still claim are *running* — presumed-dead ones dropped.
 
     For the callers that assert liveness rather than display it. The dispatch nudge says
     a peer "is already running", which stops being true at the presumed-dead threshold;
     keeping the record so a stuck dispatch stays visible must not turn that nudge into a
     nag that outlives the process by a day.
+
+    **Its *kind* default is load-bearing rather than tidy.** This is the function whose
+    output is read back to an operator as a sentence naming each peer, so a `clone`
+    record reaching it produces *"`x` writes code and `clone` are already running"* —
+    the wrong-and-confident failure #420 declined to ship. The nudge asks for nothing,
+    and therefore gets dispatches.
     """
-    return sorted(name for name, _, dead in live_records(exclude_token) if not dead)
+    return sorted(name for name, _, dead in live_records(exclude_token, kind=kind)
+                  if not dead)
 
 
-def start(agent: str) -> str | None:
-    """Mark *agent* as in flight; returns an opaque token, or None on any failure."""
+def start(agent: str, *, kind: str = DISPATCH) -> str | None:
+    """Mark *agent* as in flight; returns an opaque token, or None on any failure.
+
+    *kind* is what a reader filters on — :data:`DISPATCH` unless the caller says
+    otherwise, which keeps every pre-#420 call site meaning exactly what it meant.
+    """
     agent = (agent or "").strip()
     if not agent:
         return None
@@ -156,15 +224,16 @@ def start(agent: str) -> str | None:
         # in the prefix so `finish` can still find its own records.
         fd, path = tempfile.mkstemp(prefix=f"{_safe_name(agent)}.", suffix=".json", dir=d)
         with os.fdopen(fd, "w") as fh:
-            json.dump({"agent": agent, "ts": time.time()}, fh)
+            json.dump({"agent": agent, "kind": kind, "ts": time.time()}, fh)
         return Path(path).stem
     except OSError:
         return None
 
 
-def finish(agent: str) -> None:
-    """Clear one in-flight record for *agent* — the oldest **still-running** one, since a
-    repeat dispatch of the same persona should retire the run that started first.
+def finish(agent: str, *, kind: str = DISPATCH) -> None:
+    """Clear one in-flight record for *agent* of *kind* — the oldest **still-running**
+    one, since a repeat dispatch of the same persona should retire the run that started
+    first.
 
     "Still running" is the qualification records surviving past the presumed-dead
     threshold made necessary. Oldest-first alone would hand a finishing dispatch the
@@ -172,17 +241,38 @@ def finish(agent: str) -> None:
     to keep, and leaving a false live one in its place. Presumed-dead records are still
     eligible when there is nothing else, because a genuinely long dispatch does finish
     eventually and its record has to go when it does.
+
+    **The kind is matched, not merely written.** The file NAME carries only the agent, so
+    a clone of a repo called ``steward`` and a dispatch to a persona called ``steward``
+    glob identically — and whichever finished first would retire the other's record,
+    leaving a false live one behind and clearing a true one. Deciding it by reading each
+    candidate rather than by renaming the files keeps the on-disk shape unchanged in both
+    directions, so a record written by an older charter is still findable and one written
+    by this charter is still findable by an older one.
     """
     agent = (agent or "").strip()
     if not agent:
         return
     try:
         now = time.time()
-        matches = sorted(_dir().glob(f"{_safe_name(agent)}.*.json"),
-                         key=lambda p: p.stat().st_mtime)
+        matches = [p for p in sorted(_dir().glob(f"{_safe_name(agent)}.*.json"),
+                                     key=lambda p: p.stat().st_mtime)
+                   if _matches_kind(p, kind)]
         running = [p for p in matches
                    if now - p.stat().st_mtime <= PRESUMED_DEAD_SECONDS]
         for p in (running or matches)[:1]:
             p.unlink(missing_ok=True)
     except OSError:
         return
+
+
+def _matches_kind(p: Path, kind: str) -> bool:
+    """Is the record at *p* of *kind*? A file that cannot be read or parsed answers
+    **False** — :func:`finish` deletes what this admits, and deleting a record charter
+    could not read is deleting something it cannot claim is the caller's own. The
+    unreadable file is pruned on its own schedule (:data:`PRUNE_SECONDS`, in
+    :func:`live_records`), which is where a stray belongs."""
+    try:
+        return _kind_of(json.loads(p.read_text())) == kind
+    except (OSError, TypeError, ValueError):
+        return False

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -405,10 +405,17 @@ FRAME_SLOTS = ("top", "bottom", "right")
 #: EDGES there are — the two that keep `bottom` differ in how many of its rows the table
 #: is allowed (`slots._TERSE_ROWS` at `terse`), and `full` is now "every edge charter
 #: has" with `left` retired out of it rather than "all four".
+#:
+#: **And the PANE is that many rows, not just the table (#500).** `slots._table_cap` is
+#: read by the launcher and the resize hook as well as by the renderer, so `terse` makes
+#: `bottom` genuinely shorter and hands the difference to the harness. As #488 shipped it
+#: only the renderer knew: `minimal` cost the harness exactly the rows `normal` did and
+#: drew fewer of them, which is the opposite of what the level is for.
 FRAME_DENSITY = {
     #: Top and bottom, each saying only the most important thing it has: one field on the
-    #: attention row, and at most `slots._TERSE_ROWS` rows of repo table under it. For a
-    #: terminal where the harness's own rows are what you came for.
+    #: attention row, and at most `slots._TERSE_ROWS` rows of repo table under it — so the
+    #: pane is that much shorter and the harness keeps the rest. For a terminal where the
+    #: harness's own rows are what you came for.
     "minimal": {"slots": ["top", "bottom"], "verbosity": "terse"},
     #: The same two edges, saying everything they have — the whole repo table, as tall as
     #: the window can spare it (`layout.HARNESS_MIN_ROWS` is what it may not take).

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -364,7 +364,14 @@ def drift(root: Path) -> list[str]:
 
 #: The edges a frame may occupy. A slot outside this set is a typo, and a typo must not
 #: reach a tmux argv — so an unknown one is dropped rather than passed through.
-FRAME_SLOTS = ("top", "bottom", "left", "right")
+#:
+#: **`left` is gone as of #488**, and that filter is what makes retiring it safe: a
+#: committed `charter.toml` still carrying `slots = ["top", "bottom", "left", "right"]`
+#: — from a plane that upgraded, or from a teammate's checkout — has the dead name
+#: dropped here and gets the other three, rather than a `KeyError` in a launcher or a
+#: pane split for a slot with no renderer. It drew repo rows recomposed for 22 columns;
+#: `bottom` now draws the same rows at the width the table was designed for.
+FRAME_SLOTS = ("top", "bottom", "right")
 
 #: How much frame there is, as a PRESET over :data:`FRAME_SLOTS` — never a second
 #: configuration system sitting beside `slots`.
@@ -385,22 +392,29 @@ FRAME_SLOTS = ("top", "bottom", "left", "right")
 #:
 #: **Every ``slots`` list here is in GEOMETRY order, not reading order — do not sort
 #: them.** `layout.panel_argvs` splits each slot off the harness pane in list order, so a
-#: slot listed after `left`/`right` gets only the width they left behind. Measured
-#: against tmux 3.7c in a 200x50 window (#386): `["top", "bottom", "left", "right"]`
-#: gives a **200-column** `bottom` with 46-row side panels between the two strips, while
-#: `["top", "left", "right", "bottom"]` gives a `bottom` of **154 columns**, inset
-#: between them. `bottom` is the row carrying the one alert and the command that fixes
-#: it, and `slots._bottom` drops whole fields when it runs out of width — so those 46
-#: columns belong to it rather than to two side panels already truncating their own 22.
-#: The shipped ``slots`` default above is in the same order for the same reason.
+#: slot listed after `right` gets only the width it left behind. Measured against tmux
+#: 3.7c in a 200x50 window (#386): `["top", "bottom", "right"]` gives a **200-column**
+#: `bottom`, while `["top", "right", "bottom"]` gives a `bottom` of **177 columns**,
+#: inset beside the side panel. `bottom` carries the one alert, the command that fixes
+#: it, and (since #488) the repo table whose four columns want 95 of them — and
+#: `slots._bottom` drops whole fields when it runs out of width — so they belong to it
+#: rather than to a side panel already truncating its own 22.
+#:
+#: **#488 re-derived these, it did not patch them.** `bottom` is no longer one row
+#: (`layout.bottom_rows`), so what separates the three levels is no longer only how many
+#: EDGES there are — the two that keep `bottom` differ in how many of its rows the table
+#: is allowed (`slots._TERSE_ROWS` at `terse`), and `full` is now "every edge charter
+#: has" with `left` retired out of it rather than "all four".
 FRAME_DENSITY = {
-    #: One-line top and bottom, each saying only the most important thing it has. For a
+    #: Top and bottom, each saying only the most important thing it has: one field on the
+    #: attention row, and at most `slots._TERSE_ROWS` rows of repo table under it. For a
     #: terminal where the harness's own rows are what you came for.
     "minimal": {"slots": ["top", "bottom"], "verbosity": "terse"},
-    #: The same two edges, saying everything they have.
+    #: The same two edges, saying everything they have — the whole repo table, as tall as
+    #: the window can spare it (`layout.HARNESS_MIN_ROWS` is what it may not take).
     "normal": {"slots": ["top", "bottom"], "verbosity": "normal"},
-    #: All four edges — the shipped frame since #386, and the same order it ships in.
-    "full": {"slots": ["top", "bottom", "left", "right"], "verbosity": "normal"},
+    #: Every edge charter draws, and the same order it ships in.
+    "full": {"slots": ["top", "bottom", "right"], "verbosity": "normal"},
 }
 
 #: What a panel falls back to for any level charter does not know — see
@@ -458,26 +472,29 @@ def verbosity_for(level) -> str:
 #: impossible by construction rather than merely unlikely. Only the ``toml_key`` spelling
 #: is ever honoured — the underscore form is not accepted as a second, undocumented alias.
 FRAME_FIELDS = {
-    #: All four edges, because the frame now OWNS the surface (ADR 0019): inside a frame
-    #: `charter statusline` draws nothing, so whatever the frame does not show is not
-    #: shown anywhere. Two one-line strips are not a frame — they are the status line
-    #: again, in a worse shape — and that is exactly how the first release of this was
-    #: reported: *"only top and bottom single lines added, no left right sidebar."*
-    #: `slots.SLOTS` has had `left` (repo rows) and `right` (persona chips) since #385;
-    #: they were built, tested and switched off. `layout.visible_slots` drops the two
-    #: side panels first on any shortage against `min_cols`/`min_rows`, so a narrow
-    #: terminal degrades to exactly the frame this default used to be.
+    #: Every edge charter draws, because the frame now OWNS the surface (ADR 0019):
+    #: inside a frame `charter statusline` draws nothing, so whatever the frame does not
+    #: show is not shown anywhere. Two one-line strips were not a frame — they were the
+    #: status line again, in a worse shape — and that is exactly how the first release of
+    #: this was reported: *"only top and bottom single lines added, no left right
+    #: sidebar."*
+    #:
+    #: **`left` is not on this list any more, and that is #488 rather than a retreat.**
+    #: The sidebar drew repo rows recomposed for 22 columns, which its own docstring
+    #: conceded was less than the status line it replaced. `bottom` is variable-height
+    #: now and draws the FULL table, so the sidebar's only remaining job was a lesser
+    #: copy of its neighbour's, at the cost of 22 columns of harness.
+    #: `layout.visible_slots` still drops `right` first on any shortage against
+    #: `min_cols`/`min_rows`, so a narrow terminal degrades to two strips as before.
     #:
     #: **The ORDER is the geometry, not a reading order.** `layout.panel_argvs` splits
-    #: each slot off the harness pane in list order, so a slot listed after `left`/`right`
-    #: gets only the width they left behind. Measured against tmux 3.7c in a 200x50
-    #: window: this order gives a 200-column `bottom`, with the side panels 46 rows tall
-    #: between the two strips; `["top", "left", "right", "bottom"]` instead gives 48-row
-    #: side panels and a `bottom` of **154 columns**, inset between them. `bottom` is the
-    #: row that carries the one alert and the command that fixes it, and `slots._bottom`
-    #: drops whole fields when it runs out of width — so the 46 columns belong to it and
-    #: not to two side panels that are already truncating their own 22.
-    "slots": (["top", "bottom", "left", "right"], "slots"),
+    #: each slot off the harness pane in list order, so a slot listed after `right` gets
+    #: only the width it left behind. Measured against tmux 3.7c in a 200x50 window: this
+    #: order gives a 200-column `bottom`; `["top", "right", "bottom"]` instead gives a
+    #: `bottom` of **177 columns**, inset beside the side panel. `bottom` carries the one
+    #: alert, the command that fixes it, and the repo table — so those columns belong to
+    #: it and not to a side panel already truncating its own 22.
+    "slots": (["top", "bottom", "right"], "slots"),
     #: A PRESET over the line above, not a rival to it (see :data:`FRAME_DENSITY`). The
     #: shipped value is the level that expands to EXACTLY the shipped `slots` above —
     #: same edges, same ORDER, and saying as much as a panel has — and that is not a

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -192,12 +192,34 @@ def _usage_file(sid: str) -> Path:
     return config.SESSIONS_DIR / f"{sid}.usage"
 
 
-def _record_turn(sid: str, hit: int, read: int, write: int) -> list[int]:
+def _record_turn(sid: str, hit: int, read: int, write: int,
+                 ctx: int | None = None) -> list[int]:
     """Append this turn's cache-hit % to the session's trend and return the recent history.
 
     The status line can render several times per turn, so a sample is only appended when the
     underlying API numbers CHANGE — the payload reflects the most recent API response, so an
-    identical (read, write) pair is the same turn re-rendered, not a new one."""
+    identical (read, write) pair is the same turn re-rendered, not a new one.
+
+    **The row grew a fourth field with #413, and it is the one number a panel cannot
+    derive.** ``ctx`` is ``context_window.used_percentage``, which lives only in Claude
+    Code's per-turn payload — the cache ratio and the rebuild history are both computable
+    from ``read``/``write``, and this is not. Inside a frame the status line draws nothing
+    and a panel draws instead, out of this file, so a percentage that was never written
+    down is a percentage the frame can never show. ``None`` writes an empty field rather
+    than a zero: early in a session, and right after ``/compact``, there is no percentage,
+    and ``ctx 0%`` is a claim rather than a gap.
+
+    **The de-duplication compares ``read``/``write`` only**, which is what the paragraph
+    above has always claimed the rule is. It used to compare the whole assembled row —
+    equivalent while every other field was derived from those two, and no longer, since
+    ``ctx`` is not. A row differing only in the percentage is still the same API response
+    re-rendered, and appending it would spend a slot of the ring buffer on a duplicate
+    turn and shift the rebuild history by one.
+
+    Reading a 3-field row back still works and a 3-field row is still readable by an older
+    charter, so an upgrade mid-session neither loses the history nor corrupts it: see
+    :func:`_history` and :func:`_last_ctx`.
+    """
     if not sid:
         return []
     f = _usage_file(sid)
@@ -205,9 +227,11 @@ def _record_turn(sid: str, hit: int, read: int, write: int) -> list[int]:
         rows = [ln for ln in f.read_text().splitlines() if ln.strip()]
     except OSError:
         rows = []
-    stamp = f"{read},{write},{hit}"
-    if rows and rows[-1] == stamp:            # same API response → same turn, don't double-count
-        return [int(r.rsplit(",", 1)[1]) for r in rows]
+    stamp = f"{read},{write},{hit},{'' if ctx is None else int(ctx)}"
+    # Same API response → same turn, don't double-count. Compared on the two fields the
+    # API actually reports, never on the whole row: see the docstring above.
+    if rows and rows[-1].split(",")[:2] == [str(read), str(write)]:
+        return _hits(rows)
     rows.append(stamp)
     rows = rows[-_TREND_KEEP:]
     try:
@@ -215,20 +239,82 @@ def _record_turn(sid: str, hit: int, read: int, write: int) -> list[int]:
         f.write_text("\n".join(rows) + "\n")
     except OSError:
         pass
-    return [int(r.rsplit(",", 1)[1]) for r in rows]
+    return _hits(rows)
+
+
+def _hits(rows: list[str]) -> list[int]:
+    """The cache-hit percentages out of raw rows, skipping any that cannot be read.
+
+    Positional (``rows[2]``), not "the last field", which is what this was when a row had
+    exactly three of them. With ``ctx`` appended, "the last field" is the percentage of
+    the CONTEXT WINDOW — a plausible number in the same range, so the trend would have
+    gone on rendering and quietly meant something else. A row too short to hold a hit is
+    skipped rather than guessed at.
+    """
+    out = []
+    for r in rows:
+        p = r.split(",")
+        if len(p) >= 3:
+            try:
+                out.append(int(p[2]))
+            except ValueError:
+                continue
+    return out
 
 
 def _history(sid: str) -> list[tuple[int, int]]:
-    """The session's recorded (cache_read, cache_write) pairs."""
+    """The session's recorded (cache_read, cache_write) pairs.
+
+    ``len(p) >= 3``, not ``== 3``: #413 appended a fourth field, and an exact-length check
+    would have silently dropped every row this charter writes — leaving `_rebuilds` with
+    an empty history and the `↻N` counter permanently absent, which reads as "no rebuilds
+    have happened" rather than as "charter stopped reading its own file".
+    """
     try:
         out = []
         for ln in _usage_file(sid).read_text().splitlines():
             p = ln.split(",")
-            if len(p) == 3:
+            if len(p) >= 3:
                 out.append((int(p[0]), int(p[1])))
         return out
     except (OSError, ValueError):
         return []
+
+
+def _last_ctx(sid: str) -> int | None:
+    """The most recent recorded ``context_window.used_percentage``, or ``None``.
+
+    ``None`` for every way there is nothing to say: no session id, no file, a file whose
+    rows are all pre-#413 three-field ones (an older charter's, or this session's own
+    turns from before an upgrade), or a last row whose ctx field is empty because that
+    turn had no percentage. Each of those is "charter does not know", and the caller draws
+    nothing — `frame/slots.py`'s rule that a gauge reading zero is worse than no gauge.
+
+    The LAST row that has one, not the last row: a turn early in a session carries usage
+    without a percentage, and falling back to the most recent one charter actually saw
+    beats blanking a gauge that was correct a moment ago. It cannot drift far — the ring
+    buffer is `_TREND_KEEP` turns deep.
+    """
+    if not sid:
+        return None
+    try:
+        rows = _usage_file(sid).read_text().splitlines()
+    except OSError:
+        return None
+    for ln in reversed(rows):
+        p = ln.split(",")
+        if len(p) < 4:
+            continue
+        try:
+            return int(p[3])
+        except ValueError:
+            # An EMPTY field is the ordinary case, not a corrupt one: a turn with usage
+            # but no percentage writes `900,100,90,` deliberately, because `ctx 0%` would
+            # be a claim where there is none. `int("")` raising is what skips it, and the
+            # same clause covers a genuinely corrupt value for free — a hand-edited file
+            # is one this reader must degrade past, not one it may guess at.
+            continue
+    return None
 
 
 # A cache REBUILD is the expensive event, and it is invisible in the hit *ratio*: in steady
@@ -280,6 +366,46 @@ def _cache_hint(streak: int) -> str | None:
             f"churns the prefix; prefer {_R}{_BOLD}/rewind{_R}{_DIM} over /compact{_R}")
 
 
+def _ctx_percentage(payload: dict) -> int | None:
+    """``context_window.used_percentage`` as a whole number, or ``None``.
+
+    Split out because two surfaces need the same answer from two different places: the
+    status line reads it live off the payload, and a frame panel reads it back out of the
+    recorded history (:func:`_last_ctx`) because it never sees a payload at all. Both then
+    hand it to :func:`_ctx_part`, so the two surfaces cannot come to draw the same number
+    with different thresholds or a different label.
+    """
+    pct = ((payload or {}).get("context_window") or {}).get("used_percentage")
+    return int(pct) if isinstance(pct, (int, float)) else None
+
+
+def _ctx_part(pct: int | None) -> str:
+    """``ctx NN%``, coloured by how full the window is — or ``''`` for "not known".
+
+    The thresholds live here rather than at each call site for #413's own reason: the
+    frame's `top` row and Claude Code's footer draw this same number from two different
+    sources, and a green 60% on one surface beside a yellow 60% on the other is the kind
+    of disagreement nobody can debug from what is on screen.
+    """
+    if pct is None:
+        return ""
+    col = _GREEN if pct < 50 else (_YELLOW if pct < 80 else _RED)
+    return f"{_DIM}ctx{_R} {col}{int(pct)}%{_R}"
+
+
+def _cache_part(hit: int | None) -> str:
+    """``cache NN%`` — the share of this turn's input served from cache — or ``''``.
+
+    <50% sustained means the prefix is churning, which is the expensive failure mode.
+    Dim label, coloured number: the exact shape :func:`_ctx_part` uses, so the two session
+    gauges read as a pair rather than as a word and a symbol.
+    """
+    if hit is None:
+        return ""
+    col = _GREEN if hit >= 80 else (_YELLOW if hit >= 50 else _RED)
+    return f"{_DIM}cache{_R} {col}{hit}%{_R}"
+
+
 def _usage_numbers(payload: dict) -> tuple[str, int, int, int] | None:
     """``(session_id, cache_read, cache_write, hit%)`` out of a status-line payload, or
     ``None`` when this turn carries no live numbers.
@@ -327,7 +453,7 @@ def record_usage(payload: dict) -> list[int]:
     if nums is None:
         return []
     sid, read, write, hit = nums
-    return _record_turn(sid, hit, read, write)
+    return _record_turn(sid, hit, read, write, _ctx_percentage(payload))
 
 
 def _context_gauge(payload: dict) -> list[str]:
@@ -349,20 +475,14 @@ def _context_gauge(payload: dict) -> list[str]:
     two bolts apart only by a ``%``. The bolt went to the fact that has two rendering sites and
     needs them to read as one thing; the gauge took a word, which is what its sibling ``ctx``
     already had and what a rate nobody can guess from a symbol always wanted."""
-    cw = (payload or {}).get("context_window") or {}
     out: list[str] = []
-    pct = cw.get("used_percentage")
-    if isinstance(pct, (int, float)):
-        col = _GREEN if pct < 50 else (_YELLOW if pct < 80 else _RED)
-        out.append(f"{_DIM}ctx{_R} {col}{int(pct)}%{_R}")
+    ctx = _ctx_part(_ctx_percentage(payload))
+    if ctx:
+        out.append(ctx)
     nums = _usage_numbers(payload)
     if nums is not None:
         sid, _read, _write, hit = nums
-        # <50% sustained = the prefix is churning; that's the expensive failure mode.
-        col = _GREEN if hit >= 80 else (_YELLOW if hit >= 50 else _RED)
-        # Dim label, coloured number — the exact shape `ctx NN%` above uses, so the two
-        # session gauges read as a pair rather than as a word and a symbol.
-        out.append(f"{_DIM}cache{_R} {col}{hit}%{_R}")
+        out.append(_cache_part(hit))
         try:
             trend = record_usage(payload)
             # Rebuilds are the dominant cost and are invisible in the ratio — surface them
@@ -381,6 +501,50 @@ def _context_gauge(payload: dict) -> list[str]:
         except Exception:
             pass          # diagnostics must never break the footer
     return out
+
+
+def recorded_context_gauge(sid: str) -> list[str]:
+    """The same ``ctx NN%`` / ``cache NN%`` / ``↻N`` gauge, for a reader with no payload.
+
+    **#413, and it exists because a panel is exactly that reader.** `_context_gauge` is
+    gated on a live payload at every branch, and there is one source for that payload —
+    `statusline.main`'s stdin, sent only to the process Claude Code invokes as its
+    `statusLine` command. A frame panel is started once as a long-lived tmux pane command
+    and is never handed it, so inside a frame those two numbers had nowhere to come from
+    and the frame showed nothing at all (its own known limit, recorded in 0.52.0's news).
+
+    This closes it from the other side: everything drawn here comes out of the history
+    `record_usage` already writes, and #413's own change to that file is what makes `ctx`
+    answerable at all (:func:`_record_turn`). *sid* is Claude Code's session id, which a
+    panel gets from `frame.state.harness_session` — the mapping the suppressing
+    `statusline.main` writes, being the one process that sees both ids.
+
+    **``[]`` for anything not actually known**, and that is the rule rather than a
+    fallback: `frame/slots.py`'s `_top` already argues that a gauge silently reading zero
+    is worse than no gauge, and every "unknown" here — no sid, no file, a file with no
+    percentage recorded yet, a session whose turns all predate the fourth field — comes
+    back empty rather than as a confident 0%.
+
+    Never raises: this is drawn by a panel, where an exception is a hole in the frame.
+    """
+    try:
+        if not sid:
+            return []
+        out: list[str] = []
+        ctx = _ctx_part(_last_ctx(sid))
+        if ctx:
+            out.append(ctx)
+        hits = _hits([ln for ln in _usage_file(sid).read_text().splitlines()
+                      if ln.strip()])
+        if hits:
+            out.append(_cache_part(hits[-1]))
+        n, cost = _rebuilds(_history(sid))
+        if n:
+            col = _RED if cost >= _REBUILD_LOUD else _YELLOW
+            out.append(f"{col}↻{n} {_fmt_tok(cost)}{_R}")
+        return out
+    except Exception:
+        return []
 
 
 def _stale_structure(ws: str) -> bool:
@@ -2231,6 +2395,88 @@ def a_frame_owns_this_surface() -> bool:
         return False
 
 
+def _usage_stamp(sid: str) -> tuple[int, int] | None:
+    """``(mtime_ns, size)`` of the usage file, or ``None`` when there is no file (or no
+    session).
+
+    Read on both sides of :func:`record_usage` by :func:`_record_and_wake_the_frame`, and
+    that is the only thing it is for: `_record_turn` writes only when it actually appends
+    a row — a re-render of the same turn returns without touching the file — so a moved
+    stamp IS "a new turn was recorded", asked with one `stat` instead of by re-reading and
+    diffing what was just written.
+
+    **Both fields, because mtime alone is a filesystem's promise rather than a fact.**
+    macOS/APFS keeps nanoseconds, but a filesystem with coarse timestamps (some ext4
+    configurations report whole seconds) can record two genuinely different turns inside
+    one tick, and the panels would then not be woken for the second. The size moves
+    whenever the appended row differs in length from the one it displaced, which covers
+    most of that. What is left — two turns in one coarse tick whose rows are the same
+    length — costs one stale repaint, corrected by the next turn, and never a wrong
+    number: the panel is reading the same file either way.
+    """
+    if not sid:
+        return None
+    try:
+        st = _usage_file(sid).stat()
+        return (st.st_mtime_ns, st.st_size)
+    except OSError:
+        return None
+
+
+def _record_and_wake_the_frame(payload: dict) -> None:
+    """Record this turn, write the frame-id → Claude-Code-session-id mapping, and wake
+    the frame's panels when either is new.
+
+    **This process is the only one that can write that mapping, and #413 is the whole of
+    that.** The usage history is keyed by Claude Code's session id, which arrives here in
+    the payload; a panel knows only ``$CHARTER_SESSION_ID``, which the frame launcher sets
+    to the FRAME's id. This is the one moment both are in the same process — which is
+    exactly why #386's implementer declined to invent the mapping as a side effect of a
+    bugfix and filed it instead.
+
+    Reached only from the suppressed branch, deliberately. `a_frame_owns_this_surface`
+    has already established that this invocation IS the harness of a live frame of this
+    plane (its own rungs, `$TMUX_PANE` included), so no separate check is made here: a
+    second, weaker one is how the two would come to disagree about what being inside a
+    frame means.
+
+    **The bump is conditional, and that is the difference between a gauge and a lie.** A
+    panel repaints on a version bump and on nothing else, and `record_usage` bumps
+    nothing — so without a bump, `top`'s gauge would sit on whatever it last drew until
+    some unrelated hook happened to fire, which on a turn that calls no tools is never.
+    Bumping unconditionally would be the opposite mistake: Claude Code re-renders this
+    command several times per turn, and each bump repaints every panel in the frame
+    (`slots.ANIMATED`'s own note measures one `render("right")` at 4.8ms).
+
+    **So "did anything change" is asked of the file, not of a cache.** Every invocation is
+    a whole process — an in-process memo would be empty on all of them and would bump
+    every single time, which is the unconditional version wearing a cache. `_record_turn`
+    writes only when it appends, so the usage file's mtime moving across the call is
+    exactly "a new turn"; the recorded session id changing is the other reason, and it
+    matters on its own because the panel is about to read a different session's history.
+
+    Never raises. Everything here is bookkeeping for a gauge; a footer is not worth a
+    crash, and neither is a panel's refresh — a frame that is not woken redraws on the
+    next hook like it always did.
+    """
+    sid = (payload or {}).get("session_id") or ""
+    before = _usage_stamp(sid)
+    try:
+        record_usage(payload)
+    except Exception:
+        pass          # the record is best-effort; a footer is not worth a crash
+    try:
+        fid = os.environ.get("CHARTER_SESSION_ID", "")
+        if not fid or not sid:
+            return
+        from .frame import state as frame_state
+        moved = _usage_stamp(sid) != before
+        if frame_state.record_harness_session(fid, sid) or moved:
+            frame_state.bump(fid)
+    except Exception:
+        return
+
+
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(prog="charter statusline", add_help=True)
     ap.add_argument("--watch", action="store_true",
@@ -2259,10 +2505,11 @@ def main(argv=None) -> int:
         # ADR 0019 says this in prose; this comment says it where the deletion would
         # happen. `print()` and not `return 0` alone: Claude Code reads a line from this
         # command, and an empty one is how it is told there is nothing to show.
-        try:
-            record_usage(payload)
-        except Exception:
-            pass          # the record is best-effort; a footer is not worth a crash
+        #
+        # `_record_and_wake_the_frame` is that recording plus #413's own half: this is
+        # also the one process that sees BOTH this frame's id and Claude Code's session
+        # id, so it writes the mapping a panel needs to find these numbers again.
+        _record_and_wake_the_frame(payload)
         print()
         return 0
     # Defense in depth (FINDING M9): `render()` itself is guarded end-to-end, but this

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -262,22 +262,35 @@ def _hits(rows: list[str]) -> list[int]:
     return out
 
 
-def _history(sid: str) -> list[tuple[int, int]]:
-    """The session's recorded (cache_read, cache_write) pairs.
+def _pairs(rows: list[str]) -> list[tuple[int, int]]:
+    """The ``(cache_read, cache_write)`` pairs out of raw rows.
 
     ``len(p) >= 3``, not ``== 3``: #413 appended a fourth field, and an exact-length check
     would have silently dropped every row this charter writes — leaving `_rebuilds` with
     an empty history and the `↻N` counter permanently absent, which reads as "no rebuilds
     have happened" rather than as "charter stopped reading its own file".
     """
+    out = []
+    for ln in rows:
+        p = ln.split(",")
+        if len(p) >= 3:
+            out.append((int(p[0]), int(p[1])))
+    return out
+
+
+def _usage_rows(sid: str) -> list[str]:
+    """The session's recorded rows, or ``[]`` for every way there are none."""
     try:
-        out = []
-        for ln in _usage_file(sid).read_text().splitlines():
-            p = ln.split(",")
-            if len(p) >= 3:
-                out.append((int(p[0]), int(p[1])))
-        return out
-    except (OSError, ValueError):
+        return [ln for ln in _usage_file(sid).read_text().splitlines() if ln.strip()]
+    except OSError:
+        return []
+
+
+def _history(sid: str) -> list[tuple[int, int]]:
+    """The session's recorded (cache_read, cache_write) pairs."""
+    try:
+        return _pairs(_usage_rows(sid))
+    except ValueError:
         return []
 
 
@@ -295,12 +308,11 @@ def _last_ctx(sid: str) -> int | None:
     beats blanking a gauge that was correct a moment ago. It cannot drift far — the ring
     buffer is `_TREND_KEEP` turns deep.
     """
-    if not sid:
-        return None
-    try:
-        rows = _usage_file(sid).read_text().splitlines()
-    except OSError:
-        return None
+    return _last_ctx_of(_usage_rows(sid)) if sid else None
+
+
+def _last_ctx_of(rows: list[str]) -> int | None:
+    """:func:`_last_ctx`, over rows a caller has already read."""
     for ln in reversed(rows):
         p = ln.split(",")
         if len(p) < 4:
@@ -530,15 +542,19 @@ def recorded_context_gauge(sid: str) -> list[str]:
     try:
         if not sid:
             return []
+        # ONE read, three answers. `_last_ctx`/`_history` each open the file themselves
+        # for callers that have nothing else to do with it; this one draws three fields
+        # off the same history, and a panel repainting is not the place to open the same
+        # file three times.
+        rows = _usage_rows(sid)
         out: list[str] = []
-        ctx = _ctx_part(_last_ctx(sid))
+        ctx = _ctx_part(_last_ctx_of(rows))
         if ctx:
             out.append(ctx)
-        hits = _hits([ln for ln in _usage_file(sid).read_text().splitlines()
-                      if ln.strip()])
+        hits = _hits(rows)
         if hits:
             out.append(_cache_part(hits[-1]))
-        n, cost = _rebuilds(_history(sid))
+        n, cost = _rebuilds(_pairs(rows))
         if n:
             col = _RED if cost >= _REBUILD_LOUD else _YELLOW
             out.append(f"{col}↻{n} {_fmt_tok(cost)}{_R}")

--- a/docs/adr/0019-the-frame-owns-the-surface.md
+++ b/docs/adr/0019-the-frame-owns-the-surface.md
@@ -200,9 +200,23 @@ not pretend to have made it.
   sees both ids at once, so it is the one place that could write the mapping. That is a
   surface decision with a width budget attached, and it belongs to the release that draws
   it, not to this one.
+
+  **Closed by #413, and closed the way this bullet said it would have to be.** The
+  suppressing `statusline.main` writes the mapping (`frame.state.record_harness_session`),
+  because it remains the one process that sees both ids; `record_usage` grew a fourth
+  field for the context percentage, which is the one figure nothing can re-derive from
+  `read`/`write`; and `slots._top` draws `statusline.recorded_context_gauge` — a sibling
+  of `_context_gauge` composed from the recorded history rather than a live payload, so
+  the two surfaces share their thresholds and their labels. `_context_gauge` itself is
+  still not called from a panel, and every word above about why remains true. What did NOT
+  change is the rule this bullet's own reasoning rested on: every way of not knowing
+  answers empty, because a gauge silently reading zero is worse than no gauge.
 * **codex and opencode get no context gauge either, and for a harder reason: nothing feeds
   them one.** Neither invokes `charter statusline` with a per-turn payload, so there is no
-  usage recorded to draw from at all. Their frames show everything else.
+  usage recorded to draw from at all — which #413 does not change and cannot: it made a
+  recorded history readable by a panel, and there is no history to read for a harness
+  nobody hands the numbers to. Their frames show everything else, and their `top` row
+  simply has no gauge on it.
 * **A human can still ask.** `charter statusline` at a terminal, and `charter statusline
   --watch`, render exactly as before, frame or no frame.
 * **Nothing outside a frame changes.** No renderer was modified, no test of `render`

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -264,9 +264,13 @@ attention row, capped so the harness always keeps at least 12 rows and floored a
 row `bottom` has always been. A workspace with no clones gets exactly that one row — and
 so does a frame narrower than the table's own 95 columns, or one at `minimal`, because
 "its content" means *what the panel will actually draw*, not how many clones there are:
-the launcher and the resize hook ask the same function the panel asks, with the same width
-and the same density. Narrow your terminal below 95 columns and `bottom` gives its rows
-back rather than keeping them blank. The
+the launcher and the resize hook ask the same function the panel asks, at the same density
+and — the part that is easy to get wrong — at the width of the **pane**, not of the
+window. Those are the same number for the shipped `slots`, where `bottom` spans the whole
+window. They are not the same if you have written a `slots` list that puts `right` before
+`bottom`: the sidebar is split off first, so `bottom` comes out 23 columns narrower, and
+it is that width the pane is sized for. Narrow your terminal below 95 columns and `bottom`
+gives its rows back rather than keeping them blank. The
 cap is recomputed on every terminal resize, not remembered from the launch — tmux does not
 refuse an over-large pane height, it takes the difference out of the neighbouring pane,
 and the neighbour is your agent session. Recomputing means charter runs for a moment on
@@ -280,9 +284,11 @@ drawn rather than drawn with its right-hand columns cut off: a row trimmed past 
 loses the CI glyph and the open-change count, and a dirty, failing repo then reads as a
 clean one. That is an ordinary width, not an exotic one — `min-cols` gates `right` and
 `top`, never `bottom` — so an 80-column frame is the attention row and nothing under it,
-and the pane is one row tall to match. The attention row itself is unaffected — it drops
-whole fields instead, in priority order. (The status line outside a frame still crops
-instead of refusing; that is #506.)
+and the pane is one row tall to match. A `slots` list naming `right` before `bottom` moves
+that threshold up by the sidebar's 23 columns: such a frame needs 118 columns of terminal
+before the table appears, and between 100 and 117 it is the attention row alone. The
+attention row itself is unaffected — it drops whole fields instead, in priority order.
+(The status line outside a frame still crops instead of refusing; that is #506.)
 
 If a future `[frame] slots` ever names an edge charter sizes but has no renderer for, that
 slot is skipped rather than drawn as a dead pane — the harness keeps the space — and
@@ -366,7 +372,7 @@ There are three levels:
 
 | level | edges | each panel says |
 |---|---|---|
-| `minimal` | `top` and `bottom` | one field on the attention row, four rows of repo table — and a `bottom` pane that is four rows tall, so the difference goes to your session |
+| `minimal` | `top` and `bottom` | one field on the attention row, at most four rows of repo table — and a `bottom` pane at most five rows tall (that row plus those four), so the difference goes to your session |
 | `normal` | `top` and `bottom` | everything they have, table as tall as the window can spare |
 | `full` | every edge | everything they have |
 
@@ -386,9 +392,12 @@ persona are what it exists to tell you), and `bottom` keeps only its highest-pri
 attention field (an alert if there is one, the spinner if work is running, otherwise the
 todo count, so the row is never blank) and at most four rows of repo table under it. The
 four that survive are the ones worth keeping — the repo you are standing in, and the ones
-with something on them — and the table still says how many it hid. The pane is four rows
-shorter to match, which is the point of the level: `minimal` gives your session the rows
-back rather than blanking them. If you have kept
+with something on them — and the table still says how many it hid. The pane is sized for
+those four rows instead of all of them, which is the point of the level: `minimal` gives
+your session the rows back rather than blanking them. How many rows that is depends on how
+many clones you have — a fourteen-repo workspace gets ten back, an eight-repo one gets
+four, and a workspace with four or fewer gets none, because there was never a fifth row to
+give. If you have kept
 `right` by writing `slots` yourself, `minimal` shows four chips in it and says the same.
 
 **The hotkey changes the density of the running frame, and nothing else.** `F2` opens the
@@ -417,7 +426,8 @@ plus the repo table under it, as many rows tall as the plane and the terminal al
 above); `right` (persona chips) is a 22-column sidebar that drops itself on a terminal too
 small for it. The **order** is the order the panes are split in, and therefore the
 geometry: with `bottom` before the sidebar its rows span the whole frame, while listing it
-last leaves it only the width the sidebar did not take. `bottom` is where an alert, the
+last leaves it only the width the sidebar did not take — 23 columns fewer, which means a
+118-column terminal before the table is drawn at all. `bottom` is where an alert, the
 command that fixes it, and the repo table all appear, so the shipped order gives it the
 full width.
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -303,9 +303,21 @@ context**, which no panel can do, because a panel draws to a pane the model neve
 codex is unaffected in either direction — `charter statusline --watch` never consults any
 of this.
 
-The honest cost: `ctx NN%` and `cache NN%` lived on the status line, and no panel draws
-them yet, so a framed Claude Code session does not show them. codex and opencode never
-showed them at all — nothing feeds either one a per-turn usage payload to draw from.
+`ctx NN%` and `cache NN%` lived on the status line, and for one release a framed Claude
+Code session did not show them anywhere. It does now: the `top` row draws them, out of the
+history the suppressed status line goes on recording. The suppressed command is also what
+makes that possible at all — it is the one process that sees both this frame's id and
+Claude Code's session id, so it writes the mapping down; a panel reads it back and finds
+the numbers.
+
+The panel's gauge is not a second implementation: both surfaces share the colours and the
+labels, so a green 60% in a frame and a green 60% in a footer mean the same thing. What a
+panel cannot do is invent a figure it was never given — a frame whose harness has recorded
+no turns yet, or whose harness is not Claude Code at all, simply has no gauge on its top
+row rather than a `ctx 0%`.
+
+codex and opencode still show nothing, and for a harder reason that has not changed:
+nothing feeds either one a per-turn usage payload, so there is no history to read.
 (opencode's `/charter` is not a way around that: it renders the same status line, which
 has no numbers to show without a payload.)
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -72,28 +72,37 @@ changed.
 shell's environment whole, so trusting `$COLUMNS` there would lay a panel out at the outer
 terminal's width and wrap inside its own much narrower one.
 
-**The frame animates only while a dispatch is in flight.** A dispatch that is still
-running puts a spinner and a count on the bottom row — `⠙ 2 running` — and the panel
-repaints often enough for it to turn. Only the bottom row moves; the other three panels
-repaint when something changes and not otherwise.
+**The frame animates only while work is in flight.** Work that is still running puts a
+spinner and a count on the bottom row — `⠙ 2 running` — and the panel repaints often
+enough for it to turn. Only the bottom row moves; the other panels repaint when something
+changes and not otherwise.
 
-**Dispatches, and nothing else.** A long `charter clone` or `gl-refresh` does *not* spin
-it: charter records a dispatch when it starts, which is what makes overlapping agents
-visible, and keeps no equivalent record for its own long commands. Covering them needs a
-second kind of record — putting a clone in the dispatch tracker would make the overlap
-nudge announce it as a peer agent — and that is filed as #420. The moment the last dispatch finishes, the frame goes completely
-still again and the panel goes back to waiting for a version bump. Nothing is polled to
-find this out: charter already records a dispatch when it *starts* (that is what makes
-overlapping agents visible at all), so the panel asks one question per tick — a single
-`stat` of that tracker's own directory — and reads the records themselves only when that
-answer moves. Measured on macOS/APFS: about 5µs per tick added to the ~26µs a panel
-already spends checking the version file, five times a second, or roughly 0.003% of one
-core while idle.
+**A dispatch, a `charter clone`, or a `gl-refresh`** — all three, since #420. Eight
+parallel clones read as eight, because each repo takes its own record. The row counts what
+is running and never names it, so the three are one number there.
 
-A dispatch charter has stopped believing in — no result after thirty minutes, so the
-process was probably killed — is still reported, and deliberately *not* animated: `⋯ 1
-stalled`. Charter keeps such a record for a day so a stuck dispatch stays visible, and a
-spinner turning next to it would be claiming progress that stopped half an hour ago.
+What they are is not lost, though: every record says which kind it is, and the surfaces
+that read a name back to you — the dispatch-overlap nudge, the `⚡` badge on a persona's
+chip, this session's own `⚡ N` — ask for dispatches and get only those. That was the whole
+reason the spinner shipped narrower than promised: put a clone in the same tracker without
+a kind on it, and the overlap nudge tells you *"`x` writes code and `clone` are already
+running"*. Every reader now says which kinds it means, and the default is dispatches, so
+the next kind of work charter learns to record cannot leak into a sentence by being
+forgotten at one call site.
+
+The moment the last of it finishes, the frame goes completely still again and the panel
+goes back to waiting for a version bump. Nothing is polled to find this out: charter
+records work when it *starts* (that is also what makes overlapping agents visible at all),
+so the panel asks one question per tick — a single `stat` of that tracker's own directory
+— and reads the records themselves only when that answer moves. Measured on macOS/APFS:
+about 5µs per tick added to the ~26µs a panel already spends checking the version file,
+five times a second, or roughly 0.003% of one core while idle.
+
+Work charter has stopped believing in — no result after thirty minutes, so the process was
+probably killed — is still reported, and deliberately *not* animated: `⋯ 1 stalled`.
+Charter keeps such a record for a day so a stuck dispatch (or a clone that was killed
+mid-fetch) stays visible, and a spinner turning next to it would be claiming progress that
+stopped half an hour ago.
 
 **A panel that fails says so in its own pane.** Anything charter's own code can see — an
 unknown slot, a renderer that raises, a crash in the panel's poll — is painted into the

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -261,7 +261,12 @@ split.
 `bottom` is never dropped by those floors — it **shrinks** instead. Its height is its
 content's: one row per repo (and per worktree, in a single-repo workspace), plus the
 attention row, capped so the harness always keeps at least 12 rows and floored at the one
-row `bottom` has always been. A workspace with no clones gets exactly that one row. The
+row `bottom` has always been. A workspace with no clones gets exactly that one row — and
+so does a frame narrower than the table's own 95 columns, or one at `minimal`, because
+"its content" means *what the panel will actually draw*, not how many clones there are:
+the launcher and the resize hook ask the same function the panel asks, with the same width
+and the same density. Narrow your terminal below 95 columns and `bottom` gives its rows
+back rather than keeping them blank. The
 cap is recomputed on every terminal resize, not remembered from the launch — tmux does not
 refuse an over-large pane height, it takes the difference out of the neighbouring pane,
 and the neighbour is your agent session. Recomputing means charter runs for a moment on
@@ -273,8 +278,11 @@ properly.
 If the frame ends up narrower than the repo table's own columns (95), the table is not
 drawn rather than drawn with its right-hand columns cut off: a row trimmed past the branch
 loses the CI glyph and the open-change count, and a dirty, failing repo then reads as a
-clean one. The attention row above it is unaffected — it drops whole fields instead, in
-priority order.
+clean one. That is an ordinary width, not an exotic one — `min-cols` gates `right` and
+`top`, never `bottom` — so an 80-column frame is the attention row and nothing under it,
+and the pane is one row tall to match. The attention row itself is unaffected — it drops
+whole fields instead, in priority order. (The status line outside a frame still crops
+instead of refusing; that is #506.)
 
 If a future `[frame] slots` ever names an edge charter sizes but has no renderer for, that
 slot is skipped rather than drawn as a dead pane — the harness keeps the space — and
@@ -358,7 +366,7 @@ There are three levels:
 
 | level | edges | each panel says |
 |---|---|---|
-| `minimal` | `top` and `bottom` | one field on the attention row, four rows of repo table |
+| `minimal` | `top` and `bottom` | one field on the attention row, four rows of repo table — and a `bottom` pane that is four rows tall, so the difference goes to your session |
 | `normal` | `top` and `bottom` | everything they have, table as tall as the window can spare |
 | `full` | every edge | everything they have |
 
@@ -378,7 +386,9 @@ persona are what it exists to tell you), and `bottom` keeps only its highest-pri
 attention field (an alert if there is one, the spinner if work is running, otherwise the
 todo count, so the row is never blank) and at most four rows of repo table under it. The
 four that survive are the ones worth keeping — the repo you are standing in, and the ones
-with something on them — and the table still says how many it hid. If you have kept
+with something on them — and the table still says how many it hid. The pane is four rows
+shorter to match, which is the point of the level: `minimal` gives your session the rows
+back rather than blanking them. If you have kept
 `right` by writing `slots` yourself, `minimal` shows four chips in it and says the same.
 
 **The hotkey changes the density of the running frame, and nothing else.** `F2` opens the

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -14,10 +14,10 @@ for a command charter has no launcher for at all. That is not just naming: once 
 frame` is on the command line, everything after it is grafted onto the harness's own argv
 verbatim, before charter's own argument parser ever sees it, so `frame claude -p hi` would
 hand `claude -p hi` to the `frame --` mechanism rather than route anywhere. The same reason
-keeps `frame-menu`, `frame-action`, `frame-density` and `frame-probe` — the command tmux's
-hotkey calls back into, the one every menu action calls back into, the one the density
-entries run, and the read-only probe — as top-level names rather than nested under `frame`
-too.
+keeps `frame-menu`, `frame-action`, `frame-density`, `frame-resize` and `frame-probe` —
+the command tmux's hotkey calls back into, the one every menu action calls back into, the
+one the density entries run, the one the `window-resized` hook calls back into, and the
+read-only probe — as top-level names rather than nested under `frame` too.
 
 ## What it needs
 
@@ -29,7 +29,7 @@ the harness's exit code back out. Below 3.2 `charter <harness>` still starts and
 is switched off: the hotkey stays bound but may open nothing, and if the exit-code hooks
 fail to install charter says so and declines to attach rather than risk a session nothing
 can end. The resize-recovery hook needs a further 3.3; below that a resize still works,
-panels can just drift out of their fixed size until the next one.
+panels can just drift out of shape until the frame is relaunched.
 
 `charter <harness> --probe` (or the standalone `charter frame-probe`) answers "can a frame
 run here, and what will it not be able to do" without starting anything: exit 0 if a frame
@@ -240,14 +240,28 @@ The size those floors are measured against is the terminal — or, inside a tmux
 already have, the tmux WINDOW the frame gets, which is what charter asks tmux for rather
 than measuring the pane it was typed in.
 
-Below `[frame]`'s `min-cols`/`min-rows`, the side panels (`left`/`right`) are the first to
-drop — any shortage costs them, since neither can spare its own divider. A further shortage
-in rows drops `top` too. Below half of either floor, every panel drops and the harness
-simply gets the whole terminal, the same choice `charter`'s own status line makes when it
-runs out of width. So a narrow terminal degrades to the two strips on its own; nothing has
-to be configured for it. A density change goes through the same floors, so choosing `full`
-in a terminal with no room for side panels gives you the edges that fit rather than a
-failed split.
+Below `[frame]`'s `min-cols`/`min-rows`, the side panel (`right`) is the first to drop —
+any shortage costs it, since it cannot spare its own divider. A further shortage in rows
+drops `top` too. Below half of either floor, every panel drops and the harness simply gets
+the whole terminal, the same choice `charter`'s own status line makes when it runs out of
+width. So a narrow terminal degrades to the two strips on its own; nothing has to be
+configured for it. A density change goes through the same floors, so choosing `full` in a
+terminal with no room for a side panel gives you the edges that fit rather than a failed
+split.
+
+`bottom` is never dropped by those floors — it **shrinks** instead. Its height is its
+content's: one row per repo (and per worktree, in a single-repo workspace), plus the
+attention row, capped so the harness always keeps at least 12 rows and floored at the one
+row `bottom` has always been. A workspace with no clones gets exactly that one row. The
+cap is recomputed on every terminal resize, not remembered from the launch — tmux does not
+refuse an over-large pane height, it takes the difference out of the neighbouring pane,
+and the neighbour is your agent session.
+
+If the frame ends up narrower than the repo table's own columns (95), the table is not
+drawn rather than drawn with its right-hand columns cut off: a row trimmed past the branch
+loses the CI glyph and the open-change count, and a dirty, failing repo then reads as a
+clean one. The attention row above it is unaffected — it drops whole fields instead, in
+priority order.
 
 If a future `[frame] slots` ever names an edge charter sizes but has no renderer for, that
 slot is skipped rather than drawn as a dead pane — the harness keeps the space — and
@@ -303,7 +317,7 @@ jobs. See ADR 0019.
 
 ```toml
 [frame]
-slots = ["top", "bottom", "left", "right"]
+slots = ["top", "bottom", "right"]
 density = "full"
 mouse = false
 hotkey = "F2"
@@ -319,9 +333,9 @@ There are three levels:
 
 | level | edges | each panel says |
 |---|---|---|
-| `minimal` | one-line `top` and `bottom` | only its most important field |
-| `normal` | `top` and `bottom` | everything it has |
-| `full` | all four edges | everything it has |
+| `minimal` | `top` and `bottom` | one field on the attention row, four rows of repo table |
+| `normal` | `top` and `bottom` | everything they have, table as tall as the window can spare |
+| `full` | every edge | everything they have |
 
 `full` is the shipped frame, so writing nothing at all and writing `density = "full"`
 give you the same thing — and that is enforced rather than trusted: charter's own test
@@ -336,9 +350,11 @@ primitive, and if you wrote a list you meant that list.
 `minimal` and `normal` are how you ask for less. Both drop to the two strips; `minimal`
 also makes each panel terser — `top` drops the charter version (the workspace and the
 persona are what it exists to tell you), and `bottom` keeps only its highest-priority
-field: an alert if there is one, the spinner if work is running, otherwise the todo
-count, so the row is never blank. If you have kept the sidebars by writing `slots`
-yourself, `minimal` shows four rows in each and says how many it hid.
+attention field (an alert if there is one, the spinner if work is running, otherwise the
+todo count, so the row is never blank) and at most four rows of repo table under it. The
+four that survive are the ones worth keeping — the repo you are standing in, and the ones
+with something on them — and the table still says how many it hid. If you have kept
+`right` by writing `slots` yourself, `minimal` shows four chips in it and says the same.
 
 **The hotkey changes the density of the running frame, and nothing else.** `F2` opens the
 menu, which now lists all three levels with a `•` on the one in effect; choosing one
@@ -361,13 +377,21 @@ cannot make sense of it. That check is not cosmetic: this value is interpolated 
 configuration that `source-file` *executes*, and `charter.toml` is a committed, shared
 file that arrives from someone else's machine.
 
-All four edges are on by default. `top` and `bottom` are one-line strips; `left` (repo
-rows) and `right` (persona chips) are 22-column sidebars, and both drop themselves on a
-terminal too small for them (see above). The **order** is the order the panes are split
-in, and therefore the geometry: with `bottom` before the sidebars its row spans the whole
-frame and the sidebars sit between the two strips, while listing it last leaves it only
-the width the sidebars did not take. The bottom row is where an alert and the command that
-fixes it appear, so the shipped order gives it the full width.
+Every edge is on by default. `top` is a one-line strip; `bottom` is the attention row
+plus the repo table under it, as many rows tall as the plane and the terminal allow (see
+above); `right` (persona chips) is a 22-column sidebar that drops itself on a terminal too
+small for it. The **order** is the order the panes are split in, and therefore the
+geometry: with `bottom` before the sidebar its rows span the whole frame, while listing it
+last leaves it only the width the sidebar did not take. `bottom` is where an alert, the
+command that fixes it, and the repo table all appear, so the shipped order gives it the
+full width.
+
+**There used to be a `left` sidebar, and it is gone.** It drew repo rows recomposed for 22
+columns — narrower than the name and branch columns of the table it was standing in for,
+so a real branch name was always elided and a dirty, CI-failing repo could render looking
+clean. `bottom` draws that table properly now, and the 22 columns go back to your agent
+session. A `charter.toml` still naming `left` in `slots` is not an error: the name is
+dropped the way any unknown slot is, and you get the rest of your list.
 
 `slots`/`density`/`mouse`/`hotkey` are spelled the same on both sides. `history-limit`,
 `min-cols` and `min-rows` are the three that are not: charter.toml spells them with a

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -264,7 +264,11 @@ attention row, capped so the harness always keeps at least 12 rows and floored a
 row `bottom` has always been. A workspace with no clones gets exactly that one row. The
 cap is recomputed on every terminal resize, not remembered from the launch — tmux does not
 refuse an over-large pane height, it takes the difference out of the neighbouring pane,
-and the neighbour is your agent session.
+and the neighbour is your agent session. Recomputing means charter runs for a moment on
+each resize (median 20ms, in the background, so nothing waits on it). During a fast drag
+those runs can finish out of order and leave `bottom` sized for a window you have already
+resized past; it corrects itself the next time you resize, and #501 tracks closing it
+properly.
 
 If the frame ends up narrower than the repo table's own columns (95), the table is not
 drawn rather than drawn with its right-hand columns cut off: a row trimmed past the branch

--- a/docs/news/unreleased-the-frame-gets-its-context-gauge-back.md
+++ b/docs/news/unreleased-the-frame-gets-its-context-gauge-back.md
@@ -1,0 +1,53 @@
+---
+version: unreleased
+headline: A framed Claude Code session shows ctx and cache again, on the top row
+---
+
+0.52.0's own news entry named this as the one thing the frame genuinely lost: `ctx NN%`
+and `cache NN%` lived on the status line, the frame blanked the status line, and no panel
+drew them. The recording was deliberately kept alive so a panel could be given one. This is
+that panel.
+
+**Why it took a release, in one sentence:** the usage history is keyed by *Claude Code's*
+session id, and a panel only ever knows the *frame's* id — the one set in its environment
+by the launcher. There is exactly one process that sees both at the same moment: the
+suppressed `charter statusline`, which has the frame id in its environment and Claude
+Code's in the JSON payload on its stdin. Inventing that mapping as a side effect of the
+suppression bugfix would have been a design decision smuggled in under a fix, so it was
+reported instead. It now writes the mapping into the frame's own state directory, and
+`top` reads it back.
+
+**One number had to start being written down.** The cache ratio and the rebuild counter
+are both computable from the token counts already in the history; the context percentage
+is not — it exists only in Claude Code's per-turn payload. So each recorded turn carries it
+now, as a fourth field. Rows written by an older charter still read fine, and rows written
+by this one are still readable by an older charter, so an upgrade mid-session neither loses
+the history nor corrupts it.
+
+**The two surfaces are one implementation.** A panel's gauge and Claude Code's footer draw
+the same numbers from two different sources, so they go through the same formatting and the
+same colour thresholds. A green 60% in a frame and a green 60% in a footer mean the same
+thing, and there is no second set of numbers to keep in step.
+
+**Not knowing shows nothing, and that is the rule rather than a fallback.** A frame whose
+harness has recorded no turns yet, one whose harness is not Claude Code at all (nothing
+else is handed a usage payload), one whose history predates the fourth field, one whose id
+was recycled from a dead frame — each of those draws no gauge rather than a confident
+`ctx 0%`. A gauge silently reading zero is worse than no gauge; a gauge reading somebody
+else's 78% is worse than either.
+
+**The panels are woken once per turn, not once per render.** A panel repaints on a version
+bump and on nothing else, and recording usage bumps nothing — so a gauge left to the next
+unrelated hook would sit stale through any turn that called no tools. Claude Code re-renders
+the status line several times per turn, though, and each bump repaints every panel, so the
+frame is woken only when a turn was actually recorded or when the session id on file
+changed.
+
+`ctx` also survives `density = "minimal"`, where the charter version does not: the version
+is a standing fact about the install, and the gauge is the one field on that row with
+something new to say every turn.
+
+codex and opencode still show no gauge, and for the harder reason that has not moved:
+nothing hands either of them a per-turn usage payload, so there is no history to read.
+
+Nothing to adopt — upgrading is the whole of it.

--- a/docs/news/unreleased-the-repo-table-moves-to-the-bottom.md
+++ b/docs/news/unreleased-the-repo-table-moves-to-the-bottom.md
@@ -58,14 +58,18 @@ draws". `minimal` and `normal` still expand to the same two strips, but what sep
 them is no longer only how much each panel *says* — `minimal` also keeps at most four rows
 of table, and the four that survive are ranked (the repo you are standing in, the ones
 with something on them), with the `…(+N more)` line still saying how many it hid. The pane
-is four rows shorter to match, so `minimal` actually gives your session the rows back
-rather than blanking them.
+is sized for those four rows instead of all of them — at most five rows tall, the
+attention row included — so `minimal` actually gives your session the rows back rather
+than blanking them. How many rows that is is however many the table was over four: ten on
+a fourteen-repo workspace, none at all on a workspace with four clones or fewer.
 
 **The panel's idle cost is unchanged, and that was a constraint rather than a hope.** A
-panel's idle tick is still exactly one `stat`. `bottom` is the one slot that animates, so a
-table that walked a directory per row would have paid that back fourteen times over, five
-times a second, for the length of every dispatch. Every row comes out of the gather cache;
-nothing here opens a repo directory. The one column that cannot be answered that way —
+panel's idle tick is still one filesystem touch — a read of the frame's own version file —
+whether the pane is one row or fifteen, and a repaint costs the same either way (measured:
+13 calls for a 2-line paint and the same 13 for a 15-line one). `bottom` is the one slot
+that animates, so a table that walked a directory per row would have paid that back
+fourteen times over, five times a second, for the length of every dispatch. Every row
+comes out of the gather cache; nothing here opens a repo directory. The one column that cannot be answered that way —
 presence, "who else is standing in this tree" — is absent rather than faked, exactly as
 the status line drops it on a pane too narrow to hold it.
 
@@ -84,15 +88,24 @@ question on the surface you see when you are *not* in a frame, and it is not fix
 
 **And the pane is sized for that, at every width and every density.** The launcher, the
 `window-resized` recompute and the panel itself all ask one function how many table rows
-there are room for, and they ask it with the same width and the same density. Narrow your
-terminal below 95 columns and `bottom` shrinks back to its one row; switch to `minimal`
-and it shrinks to the four rows that level draws. Both used to be sized from the repo
-count alone, so a six-repo plane on an 80-column terminal got a seven-row pane to draw one
-line in, and `minimal` on a wide one got an eleven-row pane to draw five — up to fourteen
-blank rows taken off your agent session, and re-taken on every subsequent resize.
+there are room for, at the same density and at the width of the **pane** — which is the
+window's only when `bottom` spans it. Narrow your terminal below 95 columns and `bottom`
+shrinks back to its one row; switch to `minimal` and it shrinks to the four rows that
+level draws. Both used to be sized from the repo count alone, so a six-repo plane on an
+80-column terminal got a seven-row pane to draw one line in, and `minimal` on a wide one
+got an eleven-row pane to draw five — up to fourteen blank rows taken off your agent
+session, and re-taken on every subsequent resize.
 
 Nothing to adopt: upgrading is the whole of it. A `charter.toml` still naming `left` in
 `[frame] slots` is not an error — the name is dropped the way any unknown slot always was,
-and you get the rest of your list. If yours pins the order, check it: `bottom` listed
-after `right` is inset to 177 columns instead of the window's full width, and the table
-starts giving up its right-hand columns.
+and you get the rest of your list. **If yours pins the order, this is the line to read.**
+`bottom` listed after `right` is split off a harness pane the sidebar has already
+narrowed, so it is 23 columns short of the window — 87 in a 110-column terminal, which is
+under the table's own 95, so that frame is the attention row alone until the terminal
+reaches 118 columns. That is the geometry your order asks for and charter keeps it; what
+changed is that the pane is now sized for it, one row rather than seven. Put `bottom`
+before `right` and it spans the window again.
+
+Charter works that width out from the order your panes were split in rather than asking
+tmux for the pane's own; that is right for every frame charter itself lays out, and
+**#510** is whether the running frame should measure instead of derive.

--- a/docs/news/unreleased-the-repo-table-moves-to-the-bottom.md
+++ b/docs/news/unreleased-the-repo-table-moves-to-the-bottom.md
@@ -57,7 +57,9 @@ resizes refuses a bad id itself rather than trusting its caller.
 draws". `minimal` and `normal` still expand to the same two strips, but what separates
 them is no longer only how much each panel *says* — `minimal` also keeps at most four rows
 of table, and the four that survive are ranked (the repo you are standing in, the ones
-with something on them), with the `…(+N more)` line still saying how many it hid.
+with something on them), with the `…(+N more)` line still saying how many it hid. The pane
+is four rows shorter to match, so `minimal` actually gives your session the rows back
+rather than blanking them.
 
 **The panel's idle cost is unchanged, and that was a constraint rather than a hope.** A
 panel's idle tick is still exactly one `stat`. `bottom` is the one slot that animates, so a
@@ -70,8 +72,24 @@ the status line drops it on a pane too narrow to hold it.
 If the frame ends up narrower than the table's own 95 columns, the table is not drawn
 rather than drawn cut off. A row trimmed past the branch loses the CI glyph and the open
 change, and a failing repo then reads as a clean one — "no room to say" beats "nothing to
-say". The shipped `min-cols` is 100, so this only comes up on a hand-lowered floor or
-during a resize.
+say". **This is an ordinary width, not an exotic one**: the shipped `min-cols` of 100
+gates the `right` and `top` strips, never `bottom`, which is kept down to half of it — so
+any terminal from 50 to 94 columns wide, an 80-column one included, is a frame with the
+attention row and no table under it.
+
+The status line itself still takes the other choice at those widths — it composes a row for
+95 columns and crops it, so the CI mark and the open change go off the right-hand end and a
+failing repo reads as merely dirty. That is **#506**, with the measurement; it is the same
+question on the surface you see when you are *not* in a frame, and it is not fixed here.
+
+**And the pane is sized for that, at every width and every density.** The launcher, the
+`window-resized` recompute and the panel itself all ask one function how many table rows
+there are room for, and they ask it with the same width and the same density. Narrow your
+terminal below 95 columns and `bottom` shrinks back to its one row; switch to `minimal`
+and it shrinks to the four rows that level draws. Both used to be sized from the repo
+count alone, so a six-repo plane on an 80-column terminal got a seven-row pane to draw one
+line in, and `minimal` on a wide one got an eleven-row pane to draw five — up to fourteen
+blank rows taken off your agent session, and re-taken on every subsequent resize.
 
 Nothing to adopt: upgrading is the whole of it. A `charter.toml` still naming `left` in
 `[frame] slots` is not an error — the name is dropped the way any unknown slot always was,

--- a/docs/news/unreleased-the-repo-table-moves-to-the-bottom.md
+++ b/docs/news/unreleased-the-repo-table-moves-to-the-bottom.md
@@ -1,0 +1,73 @@
+---
+version: unreleased
+headline: The repo table moves to the bottom of the frame, and the left sidebar is retired
+---
+
+The frame's whole claim is that it shows the plane's live state better than the single
+status line it suppresses. In one place it showed *less*: the only slot drawing repos was
+a 22-column `left` sidebar, and the wide table it was standing in for wants 32 columns for
+the repo name and 34 for the branch before anything else. Its own docstring conceded the
+point. So a real branch name was always elided, and on this project's own branches —
+`worktree-recall-since`, `browser-session-scope`: 21-28 characters is the norm — a dirty,
+CI-failing, unpushed repo could render as `charter worktree-reca…`, which reads as clean.
+
+**`bottom` draws the full table now, at the widths it was designed for**, and `left` is
+gone. The shipped `[frame] slots` is `["top", "bottom", "right"]`, and the 22 columns the
+sidebar was taking go back to your agent session.
+
+**`bottom` is variable-height, and that is the mechanism rather than a detail.** It was
+one row. It is now the attention row it always was — the alert and the command that fixes
+it, this session's news, the todo count, the spinner — plus one row per repo (and per
+worktree, in a single-repo workspace) underneath. The table joins that row; it never
+evicts it. A workspace with no clones gets exactly the one row it used to have, which is
+also what the "always empty sidebar" report turned out to be: the `default` workspace has
+zero clones and the panel was telling the truth.
+
+Two bounds decide the height, and both are worth knowing:
+
+- **A floor of one row.** The alert line is the thing a cramped terminal most needs.
+- **A cap that leaves your agent session at least 12 rows.** Measured against tmux 3.7c,
+  `resize-pane -y 40` in a 20-row window is not refused — tmux grants it and takes the
+  difference out of the neighbouring pane, and the neighbour is the harness. It left the
+  harness **one row tall**.
+
+**Which means the `window-resized` hook had to stop carrying a number.** It used to hold
+literal `resize-pane -t %1 -y 1` text, computed once when the frame was laid out. A height
+that depends on the window cannot be a constant, so the hook now calls charter back —
+`charter frame-resize` — and the sizes are recomputed against the window that actually
+exists. That costs a short charter process per resize event, backgrounded, the same shape
+the panel-respawn hook has had since 0.51.
+
+It also closes a hole nobody had to reach for. The old action interpolated pane ids read
+back off **disk** into a string tmux re-parses as a command line, and the shape check on
+those ids guarded only the slot being closed — every slot a density change *kept* went
+through unexamined. A `%1;kill-server` written into a frame's own state directory would
+have armed `kill-server` on every resize for the life of the window. No pane id reaches
+that text at all now; the check is hoisted above both branches, and the builder that
+resizes refuses a bad id itself rather than trusting its caller.
+
+**The density presets are re-derived, not patched.** `full` now means "every edge charter
+draws". `minimal` and `normal` still expand to the same two strips, but what separates
+them is no longer only how much each panel *says* — `minimal` also keeps at most four rows
+of table, and the four that survive are ranked (the repo you are standing in, the ones
+with something on them), with the `…(+N more)` line still saying how many it hid.
+
+**The panel's idle cost is unchanged, and that was a constraint rather than a hope.** A
+panel's idle tick is still exactly one `stat`. `bottom` is the one slot that animates, so a
+table that walked a directory per row would have paid that back fourteen times over, five
+times a second, for the length of every dispatch. Every row comes out of the gather cache;
+nothing here opens a repo directory. The one column that cannot be answered that way —
+presence, "who else is standing in this tree" — is absent rather than faked, exactly as
+the status line drops it on a pane too narrow to hold it.
+
+If the frame ends up narrower than the table's own 95 columns, the table is not drawn
+rather than drawn cut off. A row trimmed past the branch loses the CI glyph and the open
+change, and a failing repo then reads as a clean one — "no room to say" beats "nothing to
+say". The shipped `min-cols` is 100, so this only comes up on a hand-lowered floor or
+during a resize.
+
+Nothing to adopt: upgrading is the whole of it. A `charter.toml` still naming `left` in
+`[frame] slots` is not an error — the name is dropped the way any unknown slot always was,
+and you get the rest of your list. If yours pins the order, check it: `bottom` listed
+after `right` is inset to 177 columns instead of the window's full width, and the table
+starts giving up its right-hand columns.

--- a/docs/news/unreleased-the-repo-table-moves-to-the-bottom.md
+++ b/docs/news/unreleased-the-repo-table-moves-to-the-bottom.md
@@ -35,8 +35,15 @@ Two bounds decide the height, and both are worth knowing:
 literal `resize-pane -t %1 -y 1` text, computed once when the frame was laid out. A height
 that depends on the window cannot be a constant, so the hook now calls charter back —
 `charter frame-resize` — and the sizes are recomputed against the window that actually
-exists. That costs a short charter process per resize event, backgrounded, the same shape
-the panel-respawn hook has had since 0.51.
+exists. That costs a short charter process per resize event: median 20ms, backgrounded,
+with tmux's own command queue never waiting on it — the same shape the panel-respawn hook
+has had since 0.51. A drag of thirty size changes is about 0.6 CPU-seconds spread across
+the drag.
+
+One case is left open and worth knowing about: nothing serialises those children, so during
+a fast drag one that measured a taller window can apply *after* the one that measured the
+window you stopped at, leaving `bottom` sized for a window that is already gone until you
+resize again. Filed as **#501** with the measurement and what a fix has to settle.
 
 It also closes a hole nobody had to reach for. The old action interpolated pane ids read
 back off **disk** into a string tmux re-parses as a command line, and the shape check on

--- a/docs/news/unreleased-the-spinner-follows-every-kind-of-work.md
+++ b/docs/news/unreleased-the-spinner-follows-every-kind-of-work.md
@@ -1,0 +1,43 @@
+---
+version: unreleased
+headline: A clone and a gl-refresh move the frame's spinner too, because records now say what they are
+---
+
+The frame's one moving thing was promised for "a dispatch, clone or `gl-refresh`" and
+delivered dispatches. Not an oversight: `inflight.start` had exactly one caller, and the
+reason nobody added the other two is worth reading, because it is the whole of this
+change.
+
+The same records feed the **dispatch-overlap nudge** — the one that tells you a peer
+persona is already editing the tree you are about to hand to another one. That nudge reads
+its answer back as a sentence. A record named `clone` dropped into the same tracker would
+have produced *"`x` writes code and `clone` are already running"*: wrong, and wrong in the
+confident, human-readable way that is worse than saying nothing.
+
+**So every record now carries a kind, and every reader says which kinds it means.** A
+`charter clone` records one per repo (eight parallel clones read as eight); a `gl-refresh`
+records one for the workspace it is fetching, in the detached child that does the work
+rather than the parent that starts it. The frame's bottom row counts records and never
+names them, so all three are simply `⠙ 3 running` there.
+
+**The default is dispatches, and the default is the guard.** The readers that put a name
+in front of you — the overlap nudge, the `⚡` badge on a persona's chip, this session's own
+`⚡ N` — get dispatches by *not asking*. The frame's spinner is the single caller that opts
+into "anything live". That way the next kind of work charter learns to record cannot leak
+into a sentence by being forgotten at one call site; it would have to be let in
+deliberately.
+
+Two smaller things fell out of it, both about records that outlive the charter that wrote
+them — the tracker keeps one for a day, so an upgrade mid-dispatch is ordinary rather than
+exotic:
+
+- A record with no kind reads as a dispatch, which is what it was. Anything else would
+  drop a genuinely running peer out of the nudge that exists to catch it.
+- `finish` matches on the kind as well as the name. The file name carries only the agent,
+  so a clone of a repo called `steward` and a dispatch to a persona called `steward` were
+  indistinguishable — whichever ended first would have retired the other's record, clearing
+  a true one and leaving a false live one behind.
+
+Nothing to adopt, and nothing to clean up: records already on disk keep working in both
+directions — this charter can still find one an older charter wrote, and an older charter
+can still find one this charter writes.

--- a/tests/test_frame_config.py
+++ b/tests/test_frame_config.py
@@ -4,10 +4,11 @@ Defaults are the shipped behaviour, so they are asserted rather than assumed: `m
 off because `set -g mouse on` takes over drag-select, and breaking the operator's copy to
 enable a feature v1 does not ship is a bad trade.
 
-`slots` is all four edges since #386, and the reason is the same kind of trade read the
-other way: inside a frame `charter statusline` draws nothing (ADR 0019), so an edge the
-frame does not fill is information nobody sees at all. The order is asserted too, because
-it is the split order and therefore the geometry — see `instance.FRAME_FIELDS`.
+`slots` is every edge charter draws (#386, narrowed to three by #488's retirement of
+`left`), and the reason is the same kind of trade read the other way: inside a frame
+`charter statusline` draws nothing (ADR 0019), so an edge the frame does not fill is
+information nobody sees at all. The order is asserted too, because it is the split order
+and therefore the geometry — see `instance.FRAME_FIELDS`.
 """
 
 from __future__ import annotations
@@ -21,7 +22,7 @@ from charter import instance
 class FrameDefaults(unittest.TestCase):
     def test_an_absent_section_yields_the_shipped_defaults(self):
         f = instance.frame_of({})
-        self.assertEqual(f["slots"], ["top", "bottom", "left", "right"])
+        self.assertEqual(f["slots"], ["top", "bottom", "right"])
         self.assertIs(f["mouse"], False)
         self.assertEqual(f["hotkey"], "F2")
         self.assertEqual(f["history_limit"], 50000)
@@ -32,7 +33,7 @@ class FrameDefaults(unittest.TestCase):
         f = instance.frame_of({"frame": {"mouse": True, "hotkey": "F5"}})
         self.assertIs(f["mouse"], True)
         self.assertEqual(f["hotkey"], "F5")
-        self.assertEqual(f["slots"], ["top", "bottom", "left", "right"])
+        self.assertEqual(f["slots"], ["top", "bottom", "right"])
 
     def test_an_unknown_slot_is_dropped_rather_than_carried(self):
         """A typo must not reach a tmux argv. Dropping is louder than it looks: the slot
@@ -41,7 +42,7 @@ class FrameDefaults(unittest.TestCase):
         Until #386 this could not tell "filtered" from "ignored" on its own: the default
         was `["top", "bottom"]`, so `["top", "sideways", "bottom"]` filtered to something
         byte-identical to it and a stub that always returned the default passed too. The
-        shipped default is all four edges now, so the two answers differ and this test
+        shipped default carries `right` as well, so the two answers differ and this test
         distinguishes them by itself; `test_a_valid_slots_override_actually_takes_effect`
         below stays, because that is a property worth pinning on purpose rather than by
         the luck of what the default happens to be this release.
@@ -51,31 +52,37 @@ class FrameDefaults(unittest.TestCase):
 
     def test_a_valid_slots_override_actually_takes_effect(self):
         """Companion to the test above: a *different* valid override must actually be
-        honoured, not just filtered. Every slot name is in the shipped default now, so
-        "shares no element with it" is no longer available to anything; what rules a
-        default-returning stub out here is the length.
-
-        `["right", "left"]` and not `["left", "right"]`, and that is the whole point of
-        the pair below it: the first draft of this claimed to check an order "the default
-        does not have them in" while using the order the default DOES have them in."""
-        f = instance.frame_of({"frame": {"slots": ["left", "right"]}})
-        self.assertEqual(f["slots"], ["left", "right"])
+        honoured, not just filtered. Every slot name is in the shipped default, so
+        "shares no element with it" is not available to anything; what rules a
+        default-returning stub out here is the length."""
+        f = instance.frame_of({"frame": {"slots": ["bottom", "right"]}})
+        self.assertEqual(f["slots"], ["bottom", "right"])
 
     def test_the_operators_own_slot_order_is_kept_exactly(self):
         """**Order is geometry, so order is a promise.** `layout.panel_argvs` splits each
-        slot off the harness pane in list order, so `["top", "left", "right", "bottom"]`
-        and `["top", "bottom", "left", "right"]` are two different frames from the same
-        four names — measured on tmux 3.7c at 200x50, a 154-column bottom row inset
-        between the sidebars versus a full-width 200-column one (see
-        `instance.FRAME_FIELDS`).
+        slot off the harness pane in list order, so `["top", "right", "bottom"]` and
+        `["top", "bottom", "right"]` are two different frames from the same three names
+        — measured on tmux 3.7c at 200x50, a 177-column bottom row inset beside the
+        sidebar versus a full-width 200-column one (see `instance.FRAME_FIELDS`).
 
         Nothing pinned that. A `frame_of` that re-sorted an operator's `slots` into the
         shipped order — silently handing them a frame they did not ask for — passed the
         entire suite, including the test above, because every list it was ever given was
-        already in the default's relative order. `["right", "left"]` is the shortest list
+        already in the default's relative order. `["right", "top"]` is the shortest list
         that is not."""
-        f = instance.frame_of({"frame": {"slots": ["right", "left"]}})
-        self.assertEqual(f["slots"], ["right", "left"])
+        f = instance.frame_of({"frame": {"slots": ["right", "top"]}})
+        self.assertEqual(f["slots"], ["right", "top"])
+
+    def test_a_retired_slot_name_is_dropped_the_way_a_typo_is(self):
+        """#488 retired `left`, and a committed `charter.toml` outlives a charter
+        upgrade: a plane (or a teammate's checkout) still carrying the four-slot list is
+        the ORDINARY case for a release or two, not an edge one. `instance.FRAME_SLOTS`
+        is what makes it safe — the dead name is filtered here, so nothing downstream
+        splits a pane no renderer will ever draw in. Asserted with the exact list that
+        shipped as the default one release ago."""
+        f = instance.frame_of(
+            {"frame": {"slots": ["top", "bottom", "left", "right"]}})
+        self.assertEqual(f["slots"], ["top", "bottom", "right"])
 
     def test_a_malformed_section_falls_back_instead_of_raising(self):
         """`config` is imported by every command including `charter --version`, so a bad
@@ -88,7 +95,7 @@ class FrameDefaults(unittest.TestCase):
         final `isinstance(value, type(default))` type check is deleted: without it, the
         string `"lots"` would be assigned straight into `history_limit`."""
         f = instance.frame_of({"frame": {"slots": "top", "history-limit": "lots"}})
-        self.assertEqual(f["slots"], ["top", "bottom", "left", "right"])
+        self.assertEqual(f["slots"], ["top", "bottom", "right"])
         self.assertEqual(f["history_limit"], 50000)
 
     def test_a_bool_does_not_satisfy_a_non_bool_default(self):

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -33,7 +33,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-from charter import commands_frame, config, inflight, instance, tui, util
+from charter import (commands_frame, config, inflight, instance, statusline, tui,
+                     util)
 from charter.frame import gather, layout, menu, panel, slots, state
 
 from tests._isolation import PersonaIso
@@ -845,6 +846,38 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         self.assertEqual(state.panes(self.fid),
                          {"top": "%1", "bottom": "%2", "right": "%7"})
 
+    def _bottom_split_size(self, size):
+        """The `-l` a re-layout hands `split-window` for a `bottom` it has to create.
+
+        A density change can ADD `bottom` — a frame whose panel died and was reaped, or
+        one grown from a level that had none — and that split's own `-l` comes from
+        `layout.slot_sizes`, not from the `_reassert_sizes` that follows it. So it is a
+        second place the window's width has to reach, and the correction after it is
+        `report=False` best-effort rather than a guarantee.
+        """
+        state.record_panes(self.fid, panels={"top": "%1"})
+        rows = [{"name": f"repo{i}", "branch": "main", "dirty": False,
+                 "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": None,
+                 "change": None, "sigil": "", "current": False, "worktree_count": 0}
+                for i in range(6)]
+        gather.save(self.fid, {"gathered_at": 0.0, "workspace": "w",
+                               "current_repo": None, "repos": rows, "worktrees": []})
+        rc, fake = self._run("normal", _Tmux(size=size))
+        self.assertEqual(rc, 0)
+        split = next(c for c in fake.calls
+                     if "split-window" in c and "bottom" in c)
+        return int(split[split.index("-l") + 1])
+
+    def test_a_relayout_splits_bottom_for_the_table_a_wide_window_can_draw(self):
+        self.assertEqual(self._bottom_split_size("200:50"), 1 + 6)
+
+    def test_a_relayout_splits_bottom_for_one_row_on_a_narrow_window(self):
+        """#500's other call site. `_reassert_sizes` runs immediately after and would
+        correct it, but it is `report=False` best-effort against a pane that may already
+        be gone — the split has to ask for the right size in the first place, and a `-l`
+        that over-asks is granted by tmux out of the harness rather than refused."""
+        self.assertEqual(self._bottom_split_size("80:50"), 1)
+
     def test_shrinking_kills_the_panes_it_no_longer_wants(self):
         state.record_panes(self.fid, panels={"top": "%1", "right": "%3", "bottom": "%2"})
         rc, fake = self._run("minimal")
@@ -946,7 +979,8 @@ class LiveOverride(PersonaIso, unittest.TestCase):
                         side_effect=lambda a, argv, **k: calls.append(list(argv))):
             commands_frame._reassert_sizes(
                 "charter", fid=self.fid,
-                panes={"top": "%1", "bottom": "%2;kill-server"}, window_rows=50)
+                panes={"top": "%1", "bottom": "%2;kill-server"},
+                window_cols=200, window_rows=50)
         targets = [c[c.index("-t") + 1] for c in calls if "resize-pane" in c]
         self.assertEqual(targets, ["%1"], calls)
 
@@ -1223,6 +1257,67 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         rc, fake = self._run("full")
         self.assertEqual(rc, 0)
         self.assertEqual(fake.calls, [])
+
+
+class ResizeRecomputesForBothDimensions(PersonaIso, unittest.TestCase):
+    """#500: `charter frame-resize` re-applies a height that matches what the panel will
+    draw in the window it just measured — at that window's WIDTH and this frame's
+    DENSITY, not from the repo count alone.
+
+    This is the surface the operator actually hits, and it is not launch-only: the
+    `window-resized` hook fires on every step of a terminal drag, so a `bottom` sized for
+    a table it can no longer draw is re-asserted continuously for as long as the terminal
+    stays narrow — with the harness pinned at `layout.HARNESS_MIN_ROWS` the whole time
+    (measured on tmux 3.7c: a 26-row, 80-column window with 14 repos gave `bottom` 11
+    rows to draw one line in).
+
+    Driven through `cmd_resize` itself rather than through `_reassert_sizes`, because
+    what shipped broken was the call site: it measured the width into `_cols` and threw
+    it away.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.fid = f"rsz-{_a_dead_pid()}"
+        state.record_harness_pane(self.fid, "%0")
+        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2"})
+        rows = [{"name": f"repo{i}", "branch": "main", "dirty": False,
+                 "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": None,
+                 "change": None, "sigil": "", "current": False, "worktree_count": 0}
+                for i in range(6)]
+        gather.save(self.fid, {"gathered_at": 0.0, "workspace": "w",
+                               "current_repo": None, "repos": rows, "worktrees": []})
+
+    def _bottom_height(self, size):
+        fake = _Tmux(size=size)
+        with mock.patch("charter.frame.tmuxctl.run", side_effect=fake):
+            rc = commands_frame.cmd_resize(SimpleNamespace(frame=self.fid))
+        self.assertEqual(rc, 0)
+        sized = [c for c in fake.calls if "resize-pane" in c and "%2" in c]
+        self.assertEqual(len(sized), 1, fake.calls)
+        return int(sized[0][sized[0].index("-y") + 1])
+
+    def test_a_wide_window_keeps_the_table_sized_pane(self):
+        """The control. Without it the narrow assertion below would pass against a
+        function that always answered one."""
+        self.assertEqual(self._bottom_height("200:50"), 1 + 6)
+
+    def test_narrowing_the_terminal_shrinks_the_pane_back_to_its_one_row(self):
+        """The panel draws no table below `statusline._LEFT_W`, so every row past the
+        first was blank — and came out of the harness."""
+        for cols in (60, 80, statusline._LEFT_W - 1):
+            with self.subTest(cols=cols):
+                self.assertEqual(self._bottom_height(f"{cols}:50"), 1)
+
+    def test_the_density_the_operator_chose_is_read_here_too(self):
+        """`cmd_density` and `cmd_resize` are different processes minutes apart, so the
+        level has to come off the frame's own state directory on this path rather than
+        being remembered. A `minimal` frame that then gets resized must not be handed the
+        `normal` height back."""
+        state.record_density(self.fid, "minimal")
+        self.assertEqual(self._bottom_height("200:50"), 1 + slots._TERSE_ROWS)
+        state.record_density(self.fid, "normal")
+        self.assertEqual(self._bottom_height("200:50"), 1 + 6)
 
 
 class DensityIsWiredIntoTheCli(unittest.TestCase):

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -878,6 +878,41 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         that over-asks is granted by tmux out of the harness rather than refused."""
         self.assertEqual(self._bottom_split_size("80:50"), 1)
 
+    def test_a_bottom_split_in_beside_a_surviving_sidebar_gets_the_inset_width(self):
+        """Round 3, and the case that says why the order used here is the PANE order and
+        not *want*'s. A frame launched with `[frame] slots = ["right", "top"]` already
+        has a 22-column sidebar; growing it to `full` splits `bottom` off a harness pane
+        that is therefore already 23 columns narrower than the window — 87 in a
+        110-column window, measured on tmux 3.7c, which draws no table.
+
+        `want` at `full` is `["top", "bottom", "right"]`, whose order says `bottom` comes
+        first and is full width. That is the order a fresh launch would produce, not the
+        order THIS frame's panes are in: `right` is already there and is not re-split.
+        Sizing from `want` here answers 110 and hands back the seven-row pane — so the
+        list handed to `layout.bottom_cols` is the surviving panes in their recorded
+        order followed by what is about to be split, which is what actually happens.
+
+        The control is the same re-layout with no sidebar surviving, so a fix that simply
+        stopped sizing `bottom` for its content is red.
+        """
+        rows = [{"name": f"repo{i}", "branch": "main", "dirty": False,
+                 "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": None,
+                 "change": None, "sigil": "", "current": False, "worktree_count": 0}
+                for i in range(6)]
+        gather.save(self.fid, {"gathered_at": 0.0, "workspace": "w",
+                               "current_repo": None, "repos": rows, "worktrees": []})
+
+        def _split_l(panels):
+            state.record_panes(self.fid, panels=panels)
+            rc, fake = self._run("full", _Tmux(size="110:50"))
+            self.assertEqual(rc, 0)
+            cmd = next(c for c in fake.calls
+                       if "split-window" in c and "bottom" in c)
+            return int(cmd[cmd.index("-l") + 1])
+
+        self.assertEqual(_split_l({"right": "%3", "top": "%1"}), 1)
+        self.assertEqual(_split_l({"top": "%1"}), 1 + 6)
+
     def test_shrinking_kills_the_panes_it_no_longer_wants(self):
         state.record_panes(self.fid, panels={"top": "%1", "right": "%3", "bottom": "%2"})
         rc, fake = self._run("minimal")
@@ -1288,7 +1323,9 @@ class ResizeRecomputesForBothDimensions(PersonaIso, unittest.TestCase):
         gather.save(self.fid, {"gathered_at": 0.0, "workspace": "w",
                                "current_repo": None, "repos": rows, "worktrees": []})
 
-    def _bottom_height(self, size):
+    def _bottom_height(self, size, *, panels=None):
+        if panels is not None:
+            state.record_panes(self.fid, panels=panels)
         fake = _Tmux(size=size)
         with mock.patch("charter.frame.tmuxctl.run", side_effect=fake):
             rc = commands_frame.cmd_resize(SimpleNamespace(frame=self.fid))
@@ -1318,6 +1355,31 @@ class ResizeRecomputesForBothDimensions(PersonaIso, unittest.TestCase):
         self.assertEqual(self._bottom_height("200:50"), 1 + slots._TERSE_ROWS)
         state.record_density(self.fid, "normal")
         self.assertEqual(self._bottom_height("200:50"), 1 + 6)
+
+    def test_a_pane_inset_beside_the_sidebar_is_resized_for_its_own_width(self):
+        """Round 3. The window's width is not the PANE's when the frame's `[frame] slots`
+        put `right` before `bottom`: `panel_argvs` splits both off the harness pane in
+        list order, so `bottom` comes off a harness that is already 23 columns narrower —
+        measured on tmux 3.7c, 87 columns in a 110-column window, which is below
+        `statusline._LEFT_W` and draws no table at all.
+
+        `cmd_resize` never consults a slot list, so this was the longer-lived half of the
+        defect: it re-applied the over-tall pane on every step of a terminal drag. What it
+        does have is the recorded pane map, whose insertion order IS the order those panes
+        were split in — `_split_panels` writes it that way and JSON round-trips it — so
+        `layout.bottom_cols` can turn the window's width into the pane's.
+
+        The control is the same window and the same map with the shipped order, so a fix
+        that stopped sizing `bottom` for its content at all is red rather than green.
+        """
+        self.assertEqual(
+            self._bottom_height("110:50",
+                                panels={"right": "%3", "top": "%1", "bottom": "%2"}),
+            1)
+        self.assertEqual(
+            self._bottom_height("110:50",
+                                panels={"top": "%1", "bottom": "%2", "right": "%3"}),
+            1 + 6)
 
 
 class DensityIsWiredIntoTheCli(unittest.TestCase):

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -123,31 +123,45 @@ class ShippedDefaultsAgree(unittest.TestCase):
         self.assertEqual(
             instance.verbosity_for(instance.FRAME_DEFAULTS["density"]), "normal")
 
-    def test_full_is_all_four_edges(self):
-        """#387's own words. Pinned separately from the invariant above so that a change
-        making `full` mean something narrower cannot satisfy the agreement test by
-        shrinking `full` to match a smaller `slots` default."""
+    def test_full_is_every_edge_charter_draws(self):
+        """#387's own words, re-derived by #488 rather than restated: `full` means every
+        edge there IS, so retiring `left` had to move both this table and `FRAME_SLOTS`
+        together or one of them would have been lying. Pinned separately from the
+        invariant above so that a change making `full` mean something narrower cannot
+        satisfy the agreement test by shrinking `full` to match a smaller `slots`
+        default."""
         self.assertEqual(sorted(instance.FRAME_DENSITY["full"]["slots"]),
                          sorted(instance.FRAME_SLOTS))
 
-    def test_full_puts_the_strips_before_the_side_panels(self):
+    def test_full_puts_the_strips_before_the_side_panel(self):
         """The ORDER is geometry, not a reading order, and a sorted list would silently
         narrow the row that matters most. `layout.panel_argvs` splits in list order off
-        the harness pane, so a `bottom` listed after `left`/`right` gets only the width
-        they left behind — measured against tmux 3.7c at 200x50 (#386): 200 columns this
-        way, **154** with the side panels first. `bottom` carries the one alert and the
-        command that fixes it, and `_bottom` drops whole fields when it runs out of width.
+        the harness pane, so a `bottom` listed after `right` gets only the width it left
+        behind — measured against tmux 3.7c at 200x50 (#386): 200 columns this way,
+        **177** with the side panel first. `bottom` carries the one alert, the command
+        that fixes it, and (since #488) the repo table whose four columns want 95 of
+        them, and `_bottom` drops whole fields when it runs out of width.
 
         Asserted as index comparisons rather than as the literal list, so it says what is
         load-bearing (strips before sides) rather than freezing a list that may gain a
-        fifth slot."""
+        fourth slot."""
         order = instance.FRAME_DENSITY["full"]["slots"]
         for strip in ("top", "bottom"):
-            for side in ("left", "right"):
+            for side in ("right",):
                 with self.subTest(strip=strip, side=side):
                     self.assertLess(order.index(strip), order.index(side),
                                     f"{strip!r} must be split before {side!r} — see "
                                     f"this test's docstring for the measurement")
+
+    def test_no_level_names_the_retired_sidebar(self):
+        """#488's other half. `FRAME_SLOTS` filtering `left` out of an operator's own
+        list is not enough on its own — a preset is charter's own constant and reaches
+        `_drawable_slots` without passing that filter, so a `full` still naming `left`
+        would split a 22-column pane for a slot with no renderer on every launch. Both
+        registries have to move together, and this is what makes that mechanical."""
+        for level, spec in instance.FRAME_DENSITY.items():
+            with self.subTest(level=level):
+                self.assertNotIn("left", spec["slots"])
 
     def test_every_level_agrees_with_the_shipped_slots_about_order(self):
         """The shipped `slots` list and any level that names the same edges must split
@@ -159,12 +173,19 @@ class ShippedDefaultsAgree(unittest.TestCase):
                 common = [s for s in shipped if s in spec["slots"]]
                 self.assertEqual([s for s in spec["slots"] if s in shipped], common)
 
-    def test_minimal_is_one_line_top_and_bottom(self):
-        """#387's own words again. `top` and `bottom` are the two slots
-        `layout.SLOT_SIZE` gives one row each, which is what "one-line" names."""
+    def test_minimal_is_the_two_strips_saying_as_little_as_they_can(self):
+        """#387's own words, re-derived by #488. It used to be "one-line top and bottom",
+        and half of that stopped being true: `bottom` is variable-height now, so what
+        makes `minimal` minimal is the VERBOSITY — one field on the attention row and at
+        most `slots._TERSE_ROWS` rows of table under it — not a row count in
+        `SLOT_SIZE`. `top` is still literally one row, and `bottom`'s entry is still the
+        floor it never goes below, so both halves are asserted for what they now mean."""
         self.assertEqual(instance.FRAME_DENSITY["minimal"]["slots"], ["top", "bottom"])
-        for slot in instance.FRAME_DENSITY["minimal"]["slots"]:
-            self.assertEqual(layout.SLOT_SIZE[slot], 1)
+        self.assertEqual(instance.FRAME_DENSITY["minimal"]["verbosity"], "terse")
+        self.assertEqual(layout.SLOT_SIZE["top"], 1)
+        self.assertEqual(
+            layout.bottom_rows(content_rows=1, window_rows=50, slots=["top", "bottom"]),
+            1, "a plane with nothing to table must still get the one-row strip")
 
     def test_every_level_expands_to_slots_charter_actually_accepts(self):
         """A level naming a slot outside `FRAME_SLOTS` would be filtered out of an
@@ -351,32 +372,64 @@ class TerseSaysLess(PersonaIso, unittest.TestCase):
             terse = self._render("bottom", "minimal")
         self.assertIn("todo", terse)
 
-    def test_left_shows_fewer_repos_and_says_how_many_it_hid(self):
+    def test_bottoms_table_shows_fewer_repos_and_says_how_many_it_hid(self):
+        """#488 moved the repo table from the retired `left` sidebar to `bottom`, and
+        `terse` had to come with it: `bottom` is the slot with rows to give now, so
+        "less" means fewer of them. Asserted as line COUNTS against the same panel at
+        `normal`, so a renderer that merely broke cannot pass by drawing less of
+        nothing. `+ 1` is the attention row, which is not the table's to spend."""
         rows = [{"name": f"repo{i}", "branch": "main", "dirty": False,
                  "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": None,
                  "change": None, "sigil": "", "current": False, "worktree_count": 0}
                 for i in range(9)]
         gather.save(self.fid, {"gathered_at": 0.0, "workspace": "w",
                                "current_repo": None, "repos": rows, "worktrees": []})
-        normal = self._render("left", "normal")
-        terse = self._render("left", "minimal")
-        self.assertEqual(len(normal.split("\n")), 9)
-        self.assertEqual(len(terse.split("\n")), slots._TERSE_ROWS)
+        normal = self._render("bottom", "normal")
+        terse = self._render("bottom", "minimal")
+        self.assertEqual(len(normal.split("\n")), 1 + 9)
+        self.assertEqual(len(terse.split("\n")), 1 + slots._TERSE_ROWS)
         self.assertIn("more", terse, "a panel showing less must say how much less")
 
-    def test_left_drops_piece_rows(self):
+    def test_the_terse_table_still_keeps_the_repo_that_needs_attention(self):
+        """The rows that survive are `_pick_rows`' ranked subset, not the first four —
+        the exact lesson `statusline.py` paid for in production (an unranked slice of 18
+        clones showed thirteen clean repos and hid the dirty one you were standing in).
+        The dirty repo is placed LAST in the cache so position cannot be what saved it."""
+        rows = [{"name": f"repo{i}", "branch": "main", "dirty": False,
+                 "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": None,
+                 "change": None, "sigil": "", "current": False, "worktree_count": 0}
+                for i in range(9)]
+        rows[-1] = dict(rows[-1], name="the-dirty-one", dirty=True, tracked_dirty=True)
+        gather.save(self.fid, {"gathered_at": 0.0, "workspace": "w",
+                               "current_repo": None, "repos": rows, "worktrees": []})
+        terse = self._render("bottom", "minimal")
+        self.assertIn("the-dirty-one", terse)
+        # `_pick_rows` re-sorts the CHOSEN set back into cache order, so the two clean
+        # repos that share the last rows are still `repo0`/`repo1` — what distinguishes
+        # ranked from unranked is `repo2`, which a plain head-of-list slice would have
+        # kept in place of the dirty one.
+        self.assertNotIn("repo2", terse, "an unranked slice would have kept repo2")
+
+    def test_the_terse_table_drops_piece_rows_before_repo_rows(self):
+        """Pieces are DETAIL under a repo that still has its own row, so losing them
+        costs no repo its line — the trade `_table_lines` makes when the budget is
+        short, and the same one the wide table's own `wt_budget` makes."""
         gather.save(self.fid, {
             "gathered_at": 0.0, "workspace": "w", "current_repo": None,
             "repos": [{"name": "solo", "branch": "main", "dirty": False,
                        "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": None,
                        "change": None, "sigil": "", "current": True,
-                       "worktree_count": 1}],
-            "worktrees": [{"name": "a-piece", "repo": "solo", "branch": "wip",
+                       "worktree_count": 6}],
+            "worktrees": [{"name": f"piece-{i}", "repo": "solo", "branch": "wip",
                            "dirty": False, "tracked_dirty": False, "ahead": 0,
                            "behind": 0, "ci": None, "change": None, "sigil": "",
-                           "current": False, "worktree_count": 0}]})
-        self.assertIn("a-piece", self._render("left", "normal"))
-        self.assertNotIn("a-piece", self._render("left", "minimal"))
+                           "current": False, "worktree_count": 0}
+                          for i in range(6)]})
+        normal = self._render("bottom", "normal")
+        terse = self._render("bottom", "minimal")
+        self.assertIn("piece-5", normal)
+        self.assertNotIn("piece-5", terse)
+        self.assertIn("solo", terse, "the repo keeps its row whatever its pieces lose")
 
     def test_right_shows_fewer_personas_and_says_how_many_it_hid(self):
         chips = [f"◆ p{i}" for i in range(9)]
@@ -788,12 +841,12 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         self.assertEqual(rc, 0)
         split_slots = [c[c.index("panel") + 1] for c in fake.calls
                        if "split-window" in c and "panel" in c]
-        self.assertEqual(sorted(split_slots), ["left", "right"])
+        self.assertEqual(sorted(split_slots), ["right"])
         self.assertEqual(state.panes(self.fid),
-                         {"top": "%1", "bottom": "%2", "left": "%7", "right": "%8"})
+                         {"top": "%1", "bottom": "%2", "right": "%7"})
 
     def test_shrinking_kills_the_panes_it_no_longer_wants(self):
-        state.record_panes(self.fid, panels={"top": "%1", "left": "%3", "bottom": "%2"})
+        state.record_panes(self.fid, panels={"top": "%1", "right": "%3", "bottom": "%2"})
         rc, fake = self._run("minimal")
         self.assertEqual(rc, 0)
         killed = [c for c in fake.calls if "kill-pane" in c]
@@ -806,7 +859,7 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         `pane-died` hook, `cmd_respawn` waits out its backoff, finds the session still
         perfectly alive — only the layout changed — and puts the panel the operator just
         dismissed straight back, one respawn life poorer."""
-        state.record_panes(self.fid, panels={"top": "%1", "left": "%3", "bottom": "%2"})
+        state.record_panes(self.fid, panels={"top": "%1", "right": "%3", "bottom": "%2"})
         _, fake = self._run("minimal")
         disarm = fake.where("set-hook", "-u", "%3")
         kill = fake.where("kill-pane", "%3")
@@ -815,18 +868,22 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         self.assertLess(disarm[0], kill[0],
                         "the hook must be gone before the pane is")
 
-    def test_the_resize_hook_is_rebuilt_from_the_new_pane_set(self):
-        """One `set-hook` replaces the whole hook, and its action names every pane it
-        resizes — a stale entry is a `resize-pane` aimed at a killed pane on every
-        terminal resize for the life of the window."""
-        state.record_panes(self.fid, panels={"top": "%1", "left": "%3", "bottom": "%2"})
+    def test_the_resize_hook_names_the_frame_and_never_a_pane_id(self):
+        """#488 turned the `window-resized` action from literal `resize-pane` text into a
+        `run-shell` that calls charter back, because `bottom`'s height depends on the
+        window and a constant is destructive once the window shrinks. This pins the
+        consequence for #475 as well: NO pane id reaches the action text any more, so a
+        pane id read back off disk cannot be interpolated into a command line tmux
+        re-parses — not the killed one, and not the kept ones either."""
+        state.record_panes(self.fid, panels={"top": "%1", "right": "%3", "bottom": "%2"})
         _, fake = self._run("minimal")
         hooks = [c for c in fake.calls if "window-resized" in c]
         self.assertEqual(len(hooks), 1, fake.calls)
         action = hooks[0][-1]
-        self.assertIn("%1", action)
-        self.assertIn("%2", action)
-        self.assertNotIn("%3", action)
+        self.assertIn("frame-resize", action)
+        self.assertIn(self.fid, action)
+        for pane in ("%1", "%2", "%3"):
+            self.assertNotIn(pane, action, action)
 
     def test_dropping_every_slot_removes_the_resize_hook(self):
         """Reachable, not hypothetical: `_drawable_slots` answers `[]` below half of
@@ -836,10 +893,10 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         early return, the hook survives firing `resize-pane -t %1` at dead panes on every
         resize for the life of the window."""
         state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2",
-                                             "left": "%3", "right": "%4"})
+                                             "right": "%4"})
         rc, fake = self._run("minimal", fake=_Tmux(size="40:8"))
         self.assertEqual(rc, 0)
-        self.assertEqual(len([c for c in fake.calls if "kill-pane" in c]), 4, fake.calls)
+        self.assertEqual(len([c for c in fake.calls if "kill-pane" in c]), 3, fake.calls)
         unset = [c for c in fake.calls if "window-resized" in c and "-u" in c]
         self.assertEqual(len(unset), 1, fake.calls)
         self.assertEqual(state.panes(self.fid), {})
@@ -852,6 +909,46 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         resized = {c[c.index("-t") + 1] for c in fake.calls if "resize-pane" in c}
         self.assertIn("%1", resized)
         self.assertIn("%2", resized)
+
+    def test_a_kept_slots_pane_id_off_disk_is_shape_checked_before_it_is_carried(self):
+        """#475, and the guard it is actually about. `state.panes` is a file under the
+        frame's own directory, so whoever can write there decides what these strings say
+        — and `_relayout`'s shape check used to sit BELOW the `want` branch, guarding
+        only the slot being killed. Every slot the new density KEPT went into `keep`
+        unexamined, and `keep` is what gets resized, re-recorded, and (before #488) named
+        in a hook action.
+
+        **Asserted on the RECORDED MAP, not on the tmux argv, and that is what makes it
+        falsifiable on its own.** `_reassert_sizes` checks every id it is handed too, so
+        an argv assertion passes with this guard deleted — a guard passing because a
+        DIFFERENT guard caught it. Nothing downstream re-writes `state.panes`, so what
+        lands there can only have come from this branch: a refused id means the slot is
+        absent from `keep`, is re-split fresh (`%7`, from the fake), and the bad string
+        never reaches disk to be read again by the next keypress."""
+        state.record_panes(self.fid,
+                           panels={"top": "%1", "bottom": "%2;kill-server"})
+        self._run("normal")
+        recorded = state.panes(self.fid)
+        self.assertEqual(recorded, {"top": "%1", "bottom": "%7"}, recorded)
+
+    def test_reassert_sizes_refuses_a_pane_id_of_the_wrong_shape_itself(self):
+        """The second half of the same rule, pinned where the builder lives rather than
+        where its callers do. `_panel_died_hook_argv`'s own docstring states it — "every
+        value that reaches the text is what decides, never where it came from" — and #475
+        was exactly a helper documented as "safe because my caller checked" growing a
+        second caller. `cmd_resize` IS that second caller: it reads `state.panes` off
+        disk and hands it straight here, with no `_relayout` in between.
+
+        Called directly, with a hostile id its callers would have filtered, so the
+        assertion cannot be satisfied by somebody else's guard."""
+        calls = []
+        with mock.patch("charter.frame.tmuxctl.run",
+                        side_effect=lambda a, argv, **k: calls.append(list(argv))):
+            commands_frame._reassert_sizes(
+                "charter", fid=self.fid,
+                panes={"top": "%1", "bottom": "%2;kill-server"}, window_rows=50)
+        targets = [c[c.index("-t") + 1] for c in calls if "resize-pane" in c]
+        self.assertEqual(targets, ["%1"], calls)
 
     def test_the_harness_pane_gets_focus_back(self):
         """`split-window` makes each new pane ACTIVE — without this the operator is left
@@ -887,7 +984,7 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         self.assertEqual([lb for lb in labels if lb.startswith(on)],
                          [f"{on} density: full"], labels)
 
-    def test_a_terminal_too_small_for_the_level_still_drops_the_side_panels(self):
+    def test_a_terminal_too_small_for_the_level_still_drops_the_side_panel(self):
         """A density change goes through the SAME size floors a launch does — asking for
         `full` in an 80-column terminal must not split a pane the frame has no room for.
         `_drawable_slots` is what enforces it, and it is asked here rather than
@@ -1068,7 +1165,7 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         state.record_server(self.fid, "/private/tmp/tmux-502/default")
         _, fake = self._run("full")
         armed = [c for c in fake.calls if "pane-died" in c and "-u" not in c]
-        self.assertEqual(len(armed), 2, fake.calls)
+        self.assertEqual(len(armed), 1, fake.calls)
         for cmd in armed:
             self.assertEqual(cmd[:3],
                              ["tmux", "-S", "/private/tmp/tmux-502/default"])
@@ -1079,7 +1176,7 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         anything anywhere."""
         _, fake = self._run("full")
         armed = [c for c in fake.calls if "pane-died" in c and "-u" not in c]
-        self.assertEqual(len(armed), 2, fake.calls)
+        self.assertEqual(len(armed), 1, fake.calls)
 
     def test_no_session_id_is_a_quiet_no_op(self):
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": ""}):
@@ -1116,7 +1213,7 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         self.assertEqual(rc, 0)
         split_slots = sorted(c[c.index("panel") + 1] for c in fake.calls
                              if "split-window" in c and "panel" in c)
-        self.assertEqual(split_slots, ["bottom", "left", "right", "top"], fake.calls)
+        self.assertEqual(split_slots, ["bottom", "right", "top"], fake.calls)
 
     def test_a_harness_pane_that_is_not_tmuxs_own_shape_is_refused(self):
         """The id comes back off disk, not off `split-window`'s stdout, so it gets the

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -2653,9 +2653,14 @@ class BottomIsSplitForWhatItCanDraw(PersonaIso, unittest.TestCase):
     `_launch_sizes` and `layout.bottom_rows` run for real.
     """
 
-    def _bottom_split_size(self, *, cols, rows=50, repos=6):
-        fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11", "bottom": "%12"})
-        with mock.patch("charter.frame.gather.row_count", return_value=repos):
+    def _bottom_split_size(self, *, cols, rows=50, repos=6, slots=None):
+        fake = _FakeTmux(exit_code=0,
+                         panel_pane_ids={"top": "%11", "bottom": "%12", "right": "%13"})
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(
+                mock.patch("charter.frame.gather.row_count", return_value=repos))
+            if slots is not None:
+                stack.enter_context(mock.patch.dict(config.FRAME, {"slots": slots}))
             rc = _launch(fake, cols=cols, rows=rows)
         self.assertEqual(rc, 0)
         split = next(c for c in fake.calls
@@ -2680,6 +2685,42 @@ class BottomIsSplitForWhatItCanDraw(PersonaIso, unittest.TestCase):
         the test above happens to use."""
         self.assertEqual(self._bottom_split_size(cols=statusline._LEFT_W), 1 + 6)
         self.assertEqual(self._bottom_split_size(cols=statusline._LEFT_W - 1), 1)
+
+    def test_a_sidebar_split_first_makes_the_pane_narrower_than_the_window(self):
+        """Round 3, and the half two rounds of review passed over: the width that decides
+        is the PANE's, and only the shipped slot order makes that the window's.
+
+        `instance.frame_of` keeps an operator's `[frame] slots` verbatim and
+        `tests/test_frame_config.py::test_the_operators_own_slot_order_is_kept_exactly`
+        calls that a promise, so `["right", "top", "bottom"]` is a frame charter offers.
+        `panel_argvs` splits every slot off the HARNESS pane in list order, so `right`
+        going first leaves `bottom` 23 columns narrower than the window — measured on
+        tmux 3.7c with real `charter panel` processes: window 110x40, the bottom pane
+        reads back **87x7**, and the panel draws ONE line with six rows blank.
+
+        110 is not an arbitrary width. Below `[frame] min-cols` (100) `visible_slots`
+        drops `right` and `bottom` is full width again; at 118 the inset pane is still
+        `_LEFT_W` or wider and the table draws. 100..117 is the whole break band, and
+        this asserts inside it.
+
+        The control below is the same window and the same repo count with the shipped
+        order — without it, a fix that simply stopped sizing `bottom` for its content
+        would pass.
+        """
+        inset = ["right", "top", "bottom"]
+        self.assertEqual(self._bottom_split_size(cols=110, slots=inset), 1)
+        self.assertEqual(
+            self._bottom_split_size(cols=110, slots=["top", "bottom", "right"]), 1 + 6)
+
+    def test_the_inset_pane_still_gets_its_table_once_the_window_can_spare_it(self):
+        """Degradation, not refusal — the fix must not turn "sidebar first" into "never
+        a table". At 118 columns the inset pane is 95, which is `_LEFT_W` exactly, and
+        the table is drawn and therefore split for. Pinned from both sides of that
+        boundary so an off-by-one in the border column is red rather than absorbed."""
+        inset = ["right", "top", "bottom"]
+        edge = statusline._LEFT_W + layout.SLOT_SIZE["right"] + layout._BORDER_COLS
+        self.assertEqual(self._bottom_split_size(cols=edge, slots=inset), 1 + 6)
+        self.assertEqual(self._bottom_split_size(cols=edge - 1, slots=inset), 1)
 
 
 class EarlyDeathIsLegible(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -39,7 +39,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from tests._isolation import PersonaIso
-from charter import commands_frame, config, instance, util
+from charter import commands_frame, config, instance, statusline, util
 from charter.frame import gather, layout, menu, slots, state, tmuxctl
 
 #: The plane this test PROCESS was started in, captured at IMPORT — before any `setUp`
@@ -2635,6 +2635,51 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertEqual(state.respawn_attempt(fake.fid, "top"), 1,
                          "this frame's first panel death was charged to a dead frame's "
                          "budget and would never be respawned")
+
+
+class BottomIsSplitForWhatItCanDraw(PersonaIso, unittest.TestCase):
+    """#500: the `-l` the launcher hands `split-window` for `bottom` is the number of
+    rows the PANEL will fill, not the number of repos there are.
+
+    `bottom`'s renderer draws no table below `statusline._LEFT_W` (95) and at most
+    `slots._TERSE_ROWS` of one at a `terse` density. #488 sized the pane from the repo
+    count alone, so both shapes came up with a pane taller than anything that would be
+    drawn into it — and `layout.HARNESS_MIN_ROWS` means those rows come straight off the
+    agent session. Asserted at the LAUNCHER rather than at `bottom_rows_wanted`, because
+    the defect was a call site that had the width and did not pass it.
+
+    `gather.row_count` is stubbed so the count is the same on every pass and the only
+    thing varying is what the test says varies. What is NOT stubbed is the arithmetic:
+    `_launch_sizes` and `layout.bottom_rows` run for real.
+    """
+
+    def _bottom_split_size(self, *, cols, rows=50, repos=6):
+        fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11", "bottom": "%12"})
+        with mock.patch("charter.frame.gather.row_count", return_value=repos):
+            rc = _launch(fake, cols=cols, rows=rows)
+        self.assertEqual(rc, 0)
+        split = next(c for c in fake.calls
+                     if "split-window" in c and "bottom" in c)
+        return int(split[split.index("-l") + 1])
+
+    def test_a_wide_window_is_split_for_the_whole_table(self):
+        """The control, and it has to hold or the narrow assertion below is vacuous."""
+        self.assertEqual(self._bottom_split_size(cols=200), 1 + 6)
+
+    def test_a_window_too_narrow_for_the_table_is_split_for_one_row(self):
+        """`[frame] min-cols` (100) gates `right` and `top`; `layout.visible_slots` keeps
+        `bottom` down to `min_cols // 2`, so an 80-column terminal draws the attention
+        row and nothing else. It used to be split seven rows tall for it."""
+        for cols in (80, statusline._LEFT_W - 1):
+            with self.subTest(cols=cols):
+                self.assertEqual(self._bottom_split_size(cols=cols), 1)
+
+    def test_the_boundary_is_the_tables_own_width(self):
+        """Pinned from both sides at `_LEFT_W` itself, so an off-by-one in either
+        direction is red rather than absorbed by the two-column gap between the values
+        the test above happens to use."""
+        self.assertEqual(self._bottom_split_size(cols=statusline._LEFT_W), 1 + 6)
+        self.assertEqual(self._bottom_split_size(cols=statusline._LEFT_W - 1), 1)
 
 
 class EarlyDeathIsLegible(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -998,22 +998,23 @@ class Probe(unittest.TestCase):
         the harness pane silently keeps that space. Read from `config.FRAME` with
         nothing started — the probe's own read-only promise.
 
-        `left`/`right` shipped renderers in Task 3 (#385) — both are removed from the
-        registry here (restored after, via `mock.patch.dict`) to simulate the one
-        still-standing case the same way, rather than asserting against a pair that
-        no longer names it."""
+        Every slot charter accepts has a renderer today, so the case is SIMULATED:
+        `bottom` and `right` are removed from the registry here (restored after, via
+        `mock.patch.dict`) rather than asserting against names `FRAME_SLOTS` would have
+        filtered out one stage earlier. Two of them, so the probe is shown naming a SET
+        rather than happening to print one word."""
         with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
-             mock.patch.dict(config.FRAME, {"slots": ["top", "left", "right"]}), \
+             mock.patch.dict(config.FRAME, {"slots": ["top", "bottom", "right"]}), \
              mock.patch.dict(slots.SLOTS), \
              mock.patch("charter.commands_frame.subprocess.run") as run, \
              mock.patch("builtins.print") as p:
-            del slots.SLOTS["left"]
+            del slots.SLOTS["bottom"]
             del slots.SLOTS["right"]
             rc = commands_frame.cmd_probe()
         self.assertEqual(rc, 0, "an unimplemented slot is a ceiling, not a failure")
         run.assert_not_called()
         printed = " ".join(str(c) for c in p.call_args_list)
-        self.assertIn("left", printed)
+        self.assertIn("bottom", printed)
         self.assertIn("right", printed)
 
     def test_a_tmux_without_the_resize_hook_is_a_ceiling_the_probe_names(self):
@@ -2027,14 +2028,21 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertTrue(any("respawn" in m for m in buf), buf)
         self.assertTrue(any("attach" in c for c in fake.calls))
 
-    def test_a_resize_hook_is_installed_reasserting_every_drawn_panels_size(self):
+    def test_a_resize_hook_is_installed_that_asks_charter_to_recompute(self):
         """Cross-task fix round, item 3: tmux's own layout engine redistributes EVERY
         pane proportionally on any resize, `-l size` notwithstanding — verified by hand
         against real tmux 3.7c (`commands_frame._resize_hook_argv`'s own docstring): a
-        120x30 frame grown to 200x50 stretched two one-row panels to 8 and 7 rows.
-        `cmd_launch` must install a `window-resized` hook re-asserting each DRAWN
-        panel's fixed dimension, targeting the REAL pane id tmux reported for it — a
-        slot name alone is not a valid `resize-pane` target."""
+        120x30 frame grown to 200x50 stretched two one-row panels to 8 and 7 rows. So
+        `cmd_launch` must install a `window-resized` hook, scoped to the harness pane's
+        own window.
+
+        **What the action says changed with #488.** It used to carry the sizes as
+        literal `resize-pane -t %11 -y 1` text, computed once at launch. `bottom` is
+        content-and-window sized now, so a literal is destructive rather than merely
+        stale — measured on 3.7c, a hook still asserting `-y 40` after the window shrank
+        to 20 rows left the harness pane 1 row tall. The action calls charter back
+        instead, naming the FRAME, and `cmd_resize` recomputes from the window it finds.
+        """
         fake = _FakeTmux(exit_code=0, panel_pane_ids={"top": "%11", "bottom": "%12"})
         rc = _launch(fake)
         self.assertEqual(rc, 0)
@@ -2042,9 +2050,9 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertEqual(resize_cmd[resize_cmd.index("-t") + 1], fake.pane_id,
                          "the hook must be scoped to the harness pane's own window")
         action = resize_cmd[-1]
-        self.assertIn("%11", action)
-        self.assertIn("%12", action)
-        self.assertIn("-y 1", action)
+        self.assertIn("frame-resize", action)
+        self.assertIn("--frame", action)
+        self.assertTrue(action.startswith("run-shell -b "), action)
 
     def test_no_resize_hook_is_installed_when_no_panel_pane_id_was_learned(self):
         """Companion: every OTHER test in this class leaves `split-window` reporting no
@@ -2055,15 +2063,19 @@ class Launch(PersonaIso, unittest.TestCase):
         _launch(fake)
         self.assertFalse(any("window-resized" in c for c in fake.calls))
 
-    def test_a_pane_id_of_the_wrong_shape_is_never_interpolated_into_the_resize_hook(self):
-        """Fix round 2, item 3: `_resize_hook_argv` interpolates the pane id directly
-        into a hook ACTION STRING tmux later re-parses as a command line — the exact
-        construction the module docstring's "constant string" section bans for
-        `status_path`, for the same reason: something interpolated into an action must
-        be safe BY CONSTRUCTION, not merely safe because tmux happens to always report
-        `%<digits>` today. A value of any other shape must be treated the same as no id
-        at all — that one slot gets no resize-hook entry, and every OTHER (validly
-        shaped) slot still does."""
+    def test_no_pane_id_of_any_shape_reaches_the_resize_hooks_action(self):
+        """Fix round 2, item 3 — and #475 read forward. A hook ACTION is a string tmux
+        re-parses as a command line, so anything interpolated into one has to be safe BY
+        CONSTRUCTION rather than because the program that currently produces it happens
+        to be well-behaved. That used to mean checking each pane id against
+        `_PANE_ID_RE`, and #475 was the branch of `_relayout` that skipped the check for
+        every slot it KEPT, so `%1;kill-server` off disk armed `kill-server` on every
+        resize for the life of the window.
+
+        #488 removes the class rather than the instance: no pane id reaches the text at
+        all. Asserted on BOTH a well-shaped id and a malformed one, so the property
+        being pinned is "no pane ids here", not "no bad pane ids here" — a fix that
+        merely filtered would leave `%12` in the action and pass a one-sided check."""
         fake = _FakeTmux(exit_code=0,
                          panel_pane_ids={"top": "not-a-pane-id", "bottom": "%12"})
         rc = _launch(fake)
@@ -2071,7 +2083,25 @@ class Launch(PersonaIso, unittest.TestCase):
         resize_cmd = next(c for c in fake.calls if "window-resized" in c)
         action = resize_cmd[-1]
         self.assertNotIn("not-a-pane-id", action)
-        self.assertIn("%12", action)
+        self.assertNotIn("%12", action)
+        self.assertNotIn("resize-pane", action)
+
+    def test_a_frame_id_that_cannot_be_named_safely_arms_no_hook(self):
+        """The other side of the same rule: the ONE value that does reach the action
+        text now is the frame id, so it gets exactly the treatment
+        `_panel_died_hook_argv` gives its own — every value that reaches the text is
+        what decides, never where it came from. `#{pane_title}` is the sharp case
+        `_ACTION_METACHARACTERS` records: tmux expands `#{…}` formats inside a hook
+        action before any shell sees it, and a pane's title is text the program running
+        in that pane sets for itself.
+
+        Called directly rather than through a launch, because `state.frame_id` cannot
+        mint an id like this — which is the point of checking the VALUE rather than
+        trusting the mint."""
+        self.assertIsNone(commands_frame._resize_hook_argv(
+            socket="charter", harness_pane="%0", fid="demo-1#{pane_title}"))
+        self.assertIsNotNone(commands_frame._resize_hook_argv(
+            socket="charter", harness_pane="%0", fid="demo-1"))
 
     def test_a_failed_resize_hook_install_is_reported_but_not_fatal(self):
         """Same "report, don't kill an already-running pane" treatment every other
@@ -2384,18 +2414,20 @@ class Launch(PersonaIso, unittest.TestCase):
         frame actually comes up). This pins that no such pane is even attempted, one
         warning names it, and the implemented slots still draw.
 
-        `left` shipped a renderer in Task 3 (#385) — removed from the registry here
-        (restored after, via `mock.patch.dict`) to keep simulating the one
-        still-standing case, rather than asserting against a slot that now draws."""
+        Every slot charter accepts has a renderer today, so the case is SIMULATED:
+        `right`'s renderer is removed from the registry here (restored after, via
+        `mock.patch.dict`) rather than asserting against a name that is not in
+        `FRAME_SLOTS` at all — a config value filtered out one stage earlier would never
+        reach the filter this test is about."""
         fake = _FakeTmux(exit_code=0)
         buf = []
-        with mock.patch.dict(config.FRAME, {"slots": ["top", "bottom", "left"]}), \
+        with mock.patch.dict(config.FRAME, {"slots": ["top", "bottom", "right"]}), \
              mock.patch.dict(slots.SLOTS), \
              mock.patch("charter.util.warn", side_effect=lambda m: buf.append(m)):
-            del slots.SLOTS["left"]
+            del slots.SLOTS["right"]
             rc = _launch(fake)
         self.assertEqual(rc, 0)
-        self.assertFalse(any("panel" in c and "left" in c for c in fake.calls),
+        self.assertFalse(any("panel" in c and "right" in c for c in fake.calls),
                          "no pane may be spawned for a slot with no renderer")
         self.assertTrue(any("panel" in c and "bottom" in c for c in fake.calls),
                         "an IMPLEMENTED slot must still be drawn")
@@ -3920,7 +3952,7 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
         them had a test."""
         fake = _FakeOperatorTmux(exit_code=0, pane_id="%7",
                                  panel_pane_ids={"top": "%8", "bottom": "%9",
-                                                 "left": "%10", "right": "%11"})
+                                                 "right": "%11"})
         _launch_inside(fake)
         fid = state.frame_id("demo", os.getpid())
         self.assertEqual(state.harness_pane(fid), "%7")
@@ -3932,12 +3964,12 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
         four edges on) for a reason that has nothing to do with what it checks."""
         fake = _FakeOperatorTmux(exit_code=0,
                                  panel_pane_ids={"top": "%8", "bottom": "%9",
-                                                 "left": "%10", "right": "%11"})
+                                                 "right": "%11"})
         with mock.patch.dict(config.FRAME,
-                             {"slots": ["top", "bottom", "left", "right"]}):
+                             {"slots": ["top", "bottom", "right"]}):
             _launch_inside(fake)
         splits = [c for c in fake.calls if "split-window" in c]
-        self.assertEqual(len(splits), 4, f"one per configured slot: {splits}")
+        self.assertEqual(len(splits), 3, f"one per configured slot: {splits}")
         for cmd in splits:
             self.assertEqual(cmd[cmd.index("-t") + 1], "%7",
                              "every split targets the harness pane's id — tmux "

--- a/tests/test_frame_layout.py
+++ b/tests/test_frame_layout.py
@@ -40,18 +40,33 @@ def _size(cmd: list[str]) -> str:
 class VisibleSlots(unittest.TestCase):
     def test_a_wide_tall_terminal_keeps_every_slot(self):
         self.assertEqual(
-            layout.visible_slots(["top", "bottom", "left", "right"], 200, 50, 100, 20),
-            ["top", "bottom", "left", "right"])
+            layout.visible_slots(["top", "bottom", "right"], 200, 50, 100, 20),
+            ["top", "bottom", "right"])
 
-    def test_side_panels_go_first_when_the_terminal_is_narrow(self):
+    def test_the_side_panel_goes_first_when_the_terminal_is_narrow(self):
         self.assertEqual(
-            layout.visible_slots(["top", "bottom", "left", "right"], 80, 50, 100, 20),
+            layout.visible_slots(["top", "bottom", "right"], 80, 50, 100, 20),
             ["top", "bottom"])
 
     def test_the_top_goes_next_when_the_terminal_is_short(self):
         self.assertEqual(
-            layout.visible_slots(["top", "bottom", "left", "right"], 200, 12, 100, 20),
+            layout.visible_slots(["top", "bottom", "right"], 200, 12, 100, 20),
             ["bottom"])
+
+    def test_the_bottom_is_never_dropped_it_shrinks_instead(self):
+        """#488's own rule, and the reason `bottom` is absent from the two filters above.
+        Every other slot is a fixed size, so the only thing a short window can do with it
+        is drop it; `bottom` is variable-height (`layout.bottom_rows`), so it gives up
+        ROWS and keeps the alert line that is the whole reason a cramped terminal wants a
+        frame at all. Asserted across all three shortages the two filters answer —
+        narrow, short, and neither — so a `bottom` added to either filter is red whichever
+        one it was added to. The last clause (below HALF the floors) is a different rule
+        and still empties the list outright; `test_a_tiny_terminal_keeps_nothing` owns
+        that one."""
+        for cols, rows in ((80, 50), (200, 12), (100, 20)):
+            with self.subTest(cols=cols, rows=rows):
+                self.assertIn("bottom", layout.visible_slots(
+                    ["top", "bottom", "right"], cols, rows, 100, 20))
 
     def test_a_tiny_terminal_keeps_nothing(self):
         """Below the floor the harness gets the whole terminal. Degrading to a bare
@@ -140,7 +155,7 @@ class PanelArgvs(unittest.TestCase):
         which eventually fails outright once that panel is one row tall. Fails if any
         split falls back to a `session:0.0`-style target instead of the pane id it was
         given."""
-        cmds = layout.panel_argvs(slots=["top", "bottom", "left", "right"], **PANELS)
+        cmds = layout.panel_argvs(slots=["top", "bottom", "right"], **PANELS)
         for cmd in cmds:
             self.assertEqual(cmd[cmd.index("-t") + 1], "%0")
             self.assertNotIn(f"{PANELS['session']}:0.0", cmd)
@@ -151,7 +166,7 @@ class PanelArgvs(unittest.TestCase):
         target derived from loop position (e.g. incrementing an index, or chaining off
         the pane an earlier split in this same list would have created). Every split must
         name the one id `panel_argvs` was handed, regardless of its position in *slots*."""
-        cmds = layout.panel_argvs(slots=["top", "bottom", "left", "right"], **PANELS)
+        cmds = layout.panel_argvs(slots=["top", "bottom", "right"], **PANELS)
         targets = {cmd[cmd.index("-t") + 1] for cmd in cmds}
         self.assertEqual(targets, {"%0"})
 
@@ -212,7 +227,7 @@ class PanelGeometry(unittest.TestCase):
     def test_horizontal_edges_split_vertically_and_top_goes_before_the_harness(self):
         """`top` and `bottom` are full-width, one-row strips, so both are cut with a
         VERTICAL split (`-v` divides the terminal along its rows — the axis that makes a
-        one-row strip; `-h`, used by `left`/`right` below, divides it into side-by-side
+        one-row strip; `-h`, used by `right` below, divides it into side-by-side
         columns instead, which is the wrong shape for either of these). `top` is placed
         BEFORE the harness pane (`-b`); `bottom`, asserted right alongside it for
         contrast, goes after (no `-b`) — that contrast is what makes this one test with
@@ -236,27 +251,144 @@ class PanelGeometry(unittest.TestCase):
         self.assertEqual(_size(top), "1")
         self.assertEqual(_size(bottom), "1")
 
-    def test_vertical_edges_split_horizontally_and_left_goes_before_the_harness(self):
-        """Mirror of the test above, for the other axis. `left` and `right` are the side
-        columns, so both are cut with a HORIZONTAL split (`-h` — the axis that makes a
-        column; `-v`, used by `top`/`bottom` above, would instead slice off a row).
-        `left` goes BEFORE the harness (`-b`); `right`, alongside it for the same
-        contrast, goes after (no `-b`). Both are `SLOT_SIZE["left"] == SLOT_SIZE["right"]
-        == 22` columns, again the literal `"22"` rather than read back through
-        `layout.SLOT_SIZE`, for the reason given above.
+    def test_the_side_edge_splits_horizontally_and_goes_after_the_harness(self):
+        """Mirror of the test above, for the other axis. `right` is the side column, so
+        it is cut with a HORIZONTAL split (`-h` — the axis that makes a column; `-v`,
+        used by `top`/`bottom` above, would instead slice off a row), and it goes AFTER
+        the harness (no `-b`), unlike `top`. `SLOT_SIZE["right"] == 22` columns, again
+        the literal `"22"` rather than read back through `layout.SLOT_SIZE`, for the
+        reason given above.
 
-        Catches: mutation 1 on `left` (direction flips to `-v`, `-b` disappears — both
-        asserted here) and, together with the test above, rules out a fix that inverts
-        direction correctly on one axis but not the other. Catches mutation 2 via the
-        literal `"22"`.
+        `left` used to be asserted here beside it, as the `-b` half of the contrast;
+        #488 retired the slot, and the `-b`/no-`-b` contrast is now carried by
+        `top`/`bottom` in the test above, which still has both halves.
+
+        Catches: a direction inverted on this axis and not the other (the test above
+        rules out the converse), a stray `-b`, and `SLOT_SIZE`'s rows/cols swapped.
         """
-        left, right = layout.panel_argvs(slots=["left", "right"], **PANELS)
-        self.assertEqual(_direction(left), "-h")
+        right, = layout.panel_argvs(slots=["right"], **PANELS)
         self.assertEqual(_direction(right), "-h")
-        self.assertIn("-b", left)
         self.assertNotIn("-b", right)
-        self.assertEqual(_size(left), "22")
         self.assertEqual(_size(right), "22")
+
+    def test_left_is_not_a_slot_this_module_will_size_or_split(self):
+        """#488 retired the sidebar, and this pins BOTH halves of that rather than only
+        the registry: `SLOT_SIZE` no longer carries it, and `slot_sizes` — the one thing
+        callers ask for a size now — drops it rather than inventing one. A `left` left
+        in either place would be a pane charter splits and nothing draws in, which is
+        exactly the permanently-dead pane `_drawable_slots`' unimplemented filter exists
+        to prevent."""
+        self.assertNotIn("left", layout.SLOT_SIZE)
+        self.assertNotIn("left", layout._DROP_ORDER)
+        self.assertEqual(
+            layout.slot_sizes(["top", "left", "bottom"], window_rows=50, content_rows=3),
+            {"top": 1, "bottom": 3})
+
+
+class BottomIsSizedToItsContent(unittest.TestCase):
+    """#488: `bottom` is the one variable-height slot, and `bottom_rows` is the whole of
+    how tall it gets. Pure arithmetic, so it is pinned here with no tmux and no cache.
+
+    The property is `floor <= rows <= what the window can spare`, and each of the three
+    clauses is asserted where the OTHER two cannot be what produced the answer — a single
+    "it returns a plausible number" test would pass with any two of them deleted.
+    """
+
+    def test_a_small_plane_gets_exactly_the_rows_its_content_wants(self):
+        """Neither bound is binding here: 4 rows of content in a 50-row window is well
+        above the floor and well under the cap, so the answer can only have come from the
+        content itself. Deleting the `min` or the `max` leaves this green — which is why
+        the two tests below exist as well."""
+        self.assertEqual(
+            layout.bottom_rows(content_rows=4, window_rows=50, slots=["top", "bottom"]),
+            4)
+
+    def test_it_never_goes_below_the_one_row_it_has_always_been(self):
+        """A plane with no clones has no table, and `slots.bottom_rows_wanted` answers 1
+        — the attention row. Zero would be a pane tmux refuses to split at all, and the
+        alert line is the one thing the frame exists for."""
+        for content in (0, 1):
+            with self.subTest(content=content):
+                self.assertEqual(
+                    layout.bottom_rows(content_rows=content, window_rows=50,
+                                       slots=["top", "bottom"]),
+                    layout.SLOT_SIZE["bottom"])
+
+    def test_the_harness_keeps_its_floor_however_much_the_table_wants(self):
+        """The measured failure this cap exists for (tmux 3.7c): `resize-pane -y 40` in a
+        20-row window is not refused — tmux grants it out of the neighbour and leaves the
+        harness pane 1 row tall. Asserted as the HARNESS's remaining rows rather than as
+        a literal height, so the arithmetic is checked rather than restated: whatever
+        `bottom` takes, plus the strips and their borders, must leave at least
+        `HARNESS_MIN_ROWS`."""
+        slots = ["top", "bottom"]
+        rows = 20
+        got = layout.bottom_rows(content_rows=99, window_rows=rows, slots=slots)
+        # top(1) + its border(1) + bottom's own border(1)
+        harness = rows - got - layout.SLOT_SIZE["top"] - 2 * layout._BORDER_ROWS
+        self.assertGreaterEqual(harness, layout.HARNESS_MIN_ROWS)
+        self.assertLess(got, 99, "the cap did not bind at all")
+
+    def test_the_top_strips_own_rows_are_counted_against_the_cap(self):
+        """The cap is what the window can spare, and `top` is part of what it has already
+        spent. A frame drawing `top` must therefore give `bottom` strictly fewer rows
+        than one that is not, at the same window size — the arithmetic that a cap
+        ignoring *slots* would get wrong in exactly the direction that starves the
+        harness."""
+        with_top = layout.bottom_rows(content_rows=99, window_rows=24,
+                                      slots=["top", "bottom"])
+        without = layout.bottom_rows(content_rows=99, window_rows=24, slots=["bottom"])
+        self.assertLess(with_top, without)
+
+    def test_the_side_column_costs_columns_not_rows(self):
+        """`right` is a `-h` split: it takes width from the harness and no rows at all.
+        Counting it here would shorten the table for no reason on every wide terminal."""
+        self.assertEqual(
+            layout.bottom_rows(content_rows=99, window_rows=50,
+                               slots=["top", "bottom", "right"]),
+            layout.bottom_rows(content_rows=99, window_rows=50, slots=["top", "bottom"]))
+
+    def test_the_floor_wins_over_a_cap_that_has_gone_negative(self):
+        """A window with no rows to spare at all. The alternative — returning the cap —
+        is a zero or negative `-l`, which is a split tmux refuses outright, so the frame
+        would come up with no bottom pane in exactly the terminal most likely to have an
+        alert worth reading."""
+        self.assertEqual(
+            layout.bottom_rows(content_rows=9, window_rows=6, slots=["top", "bottom"]),
+            layout.SLOT_SIZE["bottom"])
+
+
+class SlotSizesAnswersEverySlotAtOnce(unittest.TestCase):
+    def test_the_fixed_slots_keep_their_declared_size(self):
+        got = layout.slot_sizes(["top", "bottom", "right"], window_rows=50,
+                                content_rows=5)
+        self.assertEqual(got["top"], layout.SLOT_SIZE["top"])
+        self.assertEqual(got["right"], layout.SLOT_SIZE["right"])
+
+    def test_only_the_bottom_moves_with_the_window(self):
+        """The one slot whose answer depends on the window it is in — which is why
+        `_reassert_sizes` recomputes on every resize instead of re-applying a constant."""
+        tall = layout.slot_sizes(["top", "bottom", "right"], window_rows=50,
+                                 content_rows=99)
+        short = layout.slot_sizes(["top", "bottom", "right"], window_rows=22,
+                                  content_rows=99)
+        self.assertEqual(tall["top"], short["top"])
+        self.assertEqual(tall["right"], short["right"])
+        self.assertGreater(tall["bottom"], short["bottom"])
+
+    def test_a_size_map_is_what_panel_argvs_splits_with(self):
+        """The seam that makes any of this reach tmux: `panel_argvs` takes the map and
+        emits it as `-l`. Asserted as the literal string tmux would see, so a map that is
+        built correctly and then ignored is red."""
+        sizes = layout.slot_sizes(["bottom"], window_rows=50, content_rows=7)
+        cmd, = layout.panel_argvs(slots=["bottom"], sizes=sizes, **PANELS)
+        self.assertEqual(_size(cmd), "7")
+
+    def test_a_missing_entry_degrades_to_the_fixed_size_rather_than_raising(self):
+        """`panel_argvs` reads *sizes* with a per-slot fallback. A `KeyError` here would
+        be raised from inside a launch, where the whole frame is lost over one slot."""
+        cmd, = layout.panel_argvs(slots=["bottom"], sizes={"top": 4}, **PANELS)
+        self.assertEqual(_size(cmd), str(layout.SLOT_SIZE["bottom"]))
 
 
 class WindowInTheOperatorsServer(unittest.TestCase):

--- a/tests/test_frame_layout.py
+++ b/tests/test_frame_layout.py
@@ -358,6 +358,92 @@ class BottomIsSizedToItsContent(unittest.TestCase):
             layout.SLOT_SIZE["bottom"])
 
 
+class BottomsWidthIsWhateverTheSplitOrderLeftIt(unittest.TestCase):
+    """#500, round 3: `layout.bottom_cols` — how wide the `bottom` PANE actually is.
+
+    The property, stated once: **a slot that takes columns and is split before `bottom`
+    has already narrowed the pane `bottom` is carved out of.** Not "the window's width",
+    which is what every caller was passing, and not "the width when `slots` happens to be
+    the shipped list", which is the coincidence that let it through two rounds of review.
+
+    Every number below was measured against real tmux 3.7c on a private socket, window
+    110x40, splitting exactly as `panel_argvs` does (`-h -l 22` for `right`, `-v -b -l 1`
+    for `top`, `-v -l 7` for `bottom`, every split targeting the harness pane):
+
+        ["top", "bottom", "right"]  ->  bottom 110x7   harness 87x30
+        ["right", "top", "bottom"]  ->  bottom  87x7   harness 87x30
+        ["top", "right", "bottom"]  ->  bottom  87x7   harness 87x30
+        ["bottom", "right"]         ->  bottom 110x7   harness 87x32
+
+    and, for the re-layout case, killing `right` on the second of those widened the same
+    `bottom` pane from 87 back to 110, while re-splitting `right` off the harness
+    afterwards left it at 110.
+    """
+
+    def test_the_shipped_order_leaves_bottom_the_whole_window(self):
+        """The control. `right` is split off the harness AFTER `bottom` and lands beside
+        the harness only, so it costs `bottom` nothing — without this the assertions
+        below could be satisfied by subtracting `right` unconditionally."""
+        self.assertEqual(
+            layout.bottom_cols(["top", "bottom", "right"], window_cols=110), 110)
+
+    def test_a_side_slot_split_first_insets_bottom_by_its_columns_and_its_border(self):
+        """The defect. `instance.frame_of` keeps an operator's `[frame] slots` order
+        verbatim — `tests/test_frame_config.py` calls that a promise — so this is a frame
+        charter ships the ability to ask for, not a corner. Both orders that put `right`
+        first are asserted, because "before `bottom`" is the property and "first in the
+        list" is only one spelling of it."""
+        for order in (["right", "top", "bottom"], ["top", "right", "bottom"]):
+            with self.subTest(order=order):
+                self.assertEqual(layout.bottom_cols(order, window_cols=110), 87)
+
+    def test_the_inset_is_the_slots_own_size_and_not_a_literal(self):
+        """87 is `110 - SLOT_SIZE["right"] - _BORDER_COLS`, asserted as that arithmetic
+        rather than restated, so a change to the sidebar's width moves this answer
+        instead of leaving a stale constant that is right for one release."""
+        self.assertEqual(
+            layout.bottom_cols(["right", "bottom"], window_cols=110),
+            110 - layout.SLOT_SIZE["right"] - layout._BORDER_COLS)
+
+    def test_two_side_slots_before_bottom_are_both_charged(self):
+        """The arithmetic accumulates rather than answering "was there a sidebar". No
+        second side slot exists today; the next one this frame grows is the reason the
+        loop subtracts per slot instead of testing for `right`."""
+        self.assertEqual(
+            layout.bottom_cols(["right", "right", "bottom"], window_cols=200),
+            200 - 2 * (layout.SLOT_SIZE["right"] + layout._BORDER_COLS))
+
+    def test_a_horizontal_strip_before_bottom_costs_it_no_columns(self):
+        """`top` is a `-v` split: it takes rows off the harness and spans its full width.
+        Charging it here would shrink the table on every frame that draws a `top`."""
+        self.assertEqual(layout.bottom_cols(["top", "bottom"], window_cols=110), 110)
+
+    def test_it_never_answers_a_negative_width(self):
+        """A terminal narrower than the sidebar. `visible_slots` drops `right` long
+        before this, so it is unreachable through the launcher — but the answer feeds a
+        `<` against `statusline._LEFT_W`, and a negative there would merely be right by
+        accident. Zero says "no columns" and means it."""
+        self.assertEqual(layout.bottom_cols(["right", "bottom"], window_cols=10), 0)
+
+    def test_which_splits_take_columns_is_one_fact_panel_argvs_shares(self):
+        """The two places that must agree: this function decides how much width a slot
+        costs `bottom`, and `panel_argvs` decides whether tmux is asked for a `-h` at
+        all. Two lists of names would drift the day a side slot is added — the frame
+        would split it with `-h` and `bottom` would be sized as if it had not.
+
+        Asserted across every slot `instance.FRAME_SLOTS` admits, so a new slot is
+        covered the moment it is declared rather than when someone remembers this test.
+        """
+        from charter import instance
+        for slot in instance.FRAME_SLOTS:
+            with self.subTest(slot=slot):
+                cmd, = layout.panel_argvs(slots=[slot], **PANELS)
+                self.assertEqual(
+                    _direction(cmd),
+                    "-h" if slot in layout._COLUMN_SLOTS else "-v",
+                    "panel_argvs and bottom_cols disagree about this slot's direction")
+
+
 class SlotSizesAnswersEverySlotAtOnce(unittest.TestCase):
     def test_the_fixed_slots_keep_their_declared_size(self):
         got = layout.slot_sizes(["top", "bottom", "right"], window_rows=50,

--- a/tests/test_frame_owns_the_surface.py
+++ b/tests/test_frame_owns_the_surface.py
@@ -137,6 +137,74 @@ class FrameOwnsTheSurface(PersonaIso, unittest.TestCase):
         self._run(fid=self._a_live_frame(), payload={"session_id": "cc-session-1"})
         self.assertEqual(statusline._history("cc-session-1"), [])
 
+    # -- and telling the frame whose session this is (#413) ----------------------- #
+
+    def test_the_frame_learns_the_harnesss_own_session_id(self):
+        """#413's mapping, and the reason it is written HERE and nowhere else: the usage
+        history is keyed by Claude Code's session id, a panel knows only the FRAME's id,
+        and this process is the one place both are in scope at the same moment — the
+        frame id in its environment, Claude Code's in the payload on its stdin.
+
+        Without it a framed session has no `ctx`/`cache` gauge at all, which 0.52.0's own
+        news entry named as the one capability the frame genuinely lost."""
+        fid = self._a_live_frame()
+        self._run(fid=fid)
+        self.assertEqual(state.harness_session(fid), "cc-session-1")
+
+    def test_a_session_that_changed_under_the_frame_is_rewritten(self):
+        """One frame outlives several agent sessions — `/clear`, or a resume — and each
+        gets a new id. The mapping is rewritten every turn rather than written once, so a
+        panel's gauge follows the session actually running rather than the first one the
+        frame ever saw."""
+        fid = self._a_live_frame()
+        self._run(fid=fid)
+        self._run(fid=fid, payload={"session_id": "cc-session-2",
+                                    "context_window": {"used_percentage": 10}})
+        self.assertEqual(state.harness_session(fid), "cc-session-2")
+
+    def test_the_panels_are_woken_when_a_turn_is_recorded(self):
+        """A panel repaints on a version bump and on nothing else, and `record_usage`
+        bumps nothing — so without this, `top`'s gauge would sit on whatever it last drew
+        until some unrelated hook happened to fire, which on a turn that calls no tools is
+        never. A gauge showing last hour's number is worse than no gauge, which is the
+        rule this whole feature is built around."""
+        fid = self._a_live_frame()
+        before = state.version(fid)
+        self._run(fid=fid)
+        self.assertNotEqual(state.version(fid), before)
+
+    def test_a_rerender_of_the_same_turn_wakes_nobody(self):
+        """The other half, and the one that keeps this affordable: the status line renders
+        several times per turn, and each bump repaints every panel — `slots.ANIMATED`'s
+        own note measures one `render("right")` at 4.8ms. So the frame is woken only when
+        something it could draw actually changed. Asserted through TWO calls with the
+        identical payload, which is exactly what a re-render is."""
+        fid = self._a_live_frame()
+        self._run(fid=fid)
+        after_first = state.version(fid)
+        self._run(fid=fid)
+        self.assertEqual(state.version(fid), after_first)
+
+    def test_a_new_session_id_alone_is_enough_to_wake_them(self):
+        """The mapping changing is its own reason to repaint even when no new turn was
+        recorded: the panel is about to read a different session's history, so what it is
+        drawing is stale the moment the file changes. The second payload carries no usage
+        numbers at all, so the recorded turn cannot be what moved the version."""
+        fid = self._a_live_frame()
+        self._run(fid=fid)
+        after_first = state.version(fid)
+        self._run(fid=fid, payload={"session_id": "cc-session-2"})
+        self.assertNotEqual(state.version(fid), after_first)
+
+    def test_nothing_is_recorded_for_a_session_line_that_was_not_suppressed(self):
+        """The mapping is written on the suppressed branch alone. Outside a frame there is
+        no frame to tell, and `a_frame_owns_this_surface` has already settled the question
+        — a second, weaker check here is how the two would come to disagree about what
+        counts as being inside one."""
+        fid = self._a_live_frame()
+        self._run(fid=fid, tty=True)
+        self.assertIsNone(state.harness_session(fid))
+
     # -- and drawing everywhere else --------------------------------------------- #
 
     def test_a_human_asking_at_a_terminal_still_gets_the_line(self):

--- a/tests/test_frame_panel.py
+++ b/tests/test_frame_panel.py
@@ -134,7 +134,8 @@ class FailureIsVisibleInThePane(PersonaIso, unittest.TestCase):
 class Height(unittest.TestCase):
     """Mirrors `test_frame_slots.py`'s own `Width` class: `_rows` must measure the
     pane's own tty, not assume one — `left`/`right` panels are full height while
-    `top`/`bottom` are one row (`layout.SLOT_SIZE`), and this is the one function that
+    `top` is one row (`layout.SLOT_SIZE`) and `bottom` is one on a plane with no clones
+    (its floor, since #488), and this is the one function that
     has to be right for both."""
 
     def test_rows_measures_the_panes_own_tty(self):

--- a/tests/test_frame_panel.py
+++ b/tests/test_frame_panel.py
@@ -251,6 +251,88 @@ class Tick(PersonaIso, unittest.TestCase):
         self.assertNotEqual(result, state.version(fid))
 
 
+class IdleCostsTheSameWhateverTheBottomPaneIsTallEnoughToDraw(PersonaIso,
+                                                              unittest.TestCase):
+    """The budget this module's own docstring states, checked against the thing #488 and
+    #500 changed underneath it: `bottom` is no longer a one-row strip, so "the frame
+    costs nothing at idle" is a claim about a pane that can now be fifteen rows tall.
+
+    An idle tick is the steady state a panel sits in between bumps — the version has not
+    moved, the pane has not resized, nothing is in flight — and it must cost the same
+    there whether the pane is one row or `statusline._MAX_REPO_LINES + 1`, because the
+    loop runs `1 / panel.TICK` times a second for the life of the frame.
+
+    Counted DIFFERENTIALLY and at every spelling a filesystem touch arrives by, for
+    `tests/test_frame_slots.py::BottomTable`' own reasons: an absolute number would have
+    to be revised whenever the version record changes shape, and a revised number is not
+    a budget. `os.stat` alone would miss it — `state.version` is a `read_text`, which is
+    `io.open` and not `builtins.open`; a directory walk is `os.scandir`; a git call is
+    `subprocess.Popen` under `run`. Each of those is the next spelling this would
+    otherwise miss.
+
+    Sibling to `BottomTable.test_a_taller_pane_costs_the_same_syscalls_as_a_one_row_one`,
+    which bounds a REPAINT. This bounds the tick that decides not to repaint at all —
+    the one that actually runs five times a second when nothing is happening.
+    """
+
+    _WATCHED = (("os", ("stat", "lstat", "scandir", "listdir")),
+                ("io", ("open",)), ("builtins", ("open",)),
+                ("subprocess", ("run", "Popen")))
+
+    def _idle_tick_calls(self, fid: str, repos: int) -> list[str]:
+        import builtins
+        import contextlib
+        import io as _io
+        import subprocess as _sp
+        from charter.frame import gather
+        mods = {"os": os, "io": _io, "builtins": builtins, "subprocess": _sp}
+        gather.save(fid, {"gathered_at": 0.0, "workspace": "w", "current_repo": None,
+                          "repos": [{"name": f"r{i}", "branch": "main", "dirty": False,
+                                     "tracked_dirty": False, "ahead": 0, "behind": 0,
+                                     "ci": None, "change": None, "sigil": "",
+                                     "current": False, "worktree_count": 0}
+                                    for i in range(repos)],
+                          "worktrees": []})
+        state.bump(fid)
+        version = state.version(fid)
+        rows = 1 + repos
+        seen: list[str] = []
+        size = mock.patch("os.get_terminal_size",
+                          return_value=os.terminal_size((200, rows)))
+        out = mock.patch.object(sys.stdout, "fileno", return_value=1, create=True)
+        with size, out, redirect_stdout(io.StringIO()):
+            # Primed first: the resolvers this reaches memoise, so an unprimed tick
+            # would be measuring the priming rather than the steady state.
+            panel._tick({"flag": False}, version, "bottom", fid)
+            with contextlib.ExitStack() as stack:
+                for mod_name, fns in self._WATCHED:
+                    for fn in fns:
+                        real = getattr(mods[mod_name], fn)
+                        tag = f"{mod_name}.{fn}"
+                        stack.enter_context(mock.patch(
+                            tag,
+                            (lambda r, t: lambda *a, **k:
+                                (seen.append(t), r(*a, **k))[1])(real, tag)))
+                painted = panel._tick({"flag": False}, version, "bottom", fid)
+        self.assertEqual(painted, version,
+                         "this tick repainted — it is not the idle one being budgeted")
+        return seen
+
+    def test_an_idle_tick_does_not_grow_with_the_panes_height(self):
+        from charter import statusline
+        short = self._idle_tick_calls("idle-short", 0)
+        tall = self._idle_tick_calls("idle-tall", statusline._MAX_REPO_LINES)
+        self.assertTrue(short, "nothing was counted at all — the budget is vacuous")
+        self.assertEqual(
+            sorted(tall), sorted(short),
+            f"a tall pane's idle tick cost {len(tall)} filesystem calls where a one-row "
+            f"pane's cost {len(short)} — the loop is doing per-row work when it is not "
+            f"even repainting")
+        self.assertEqual(len(short), 1,
+                         f"an idle tick cost {len(short)} filesystem calls, not the one "
+                         f"read of the frame's version this module's budget is: {short}")
+
+
 class Sigwinch(unittest.TestCase):
     """A resize does not bump the frame's version — only charter's own hooks call
     `state.bump` — so without this handler a pane would sit painted at the OLD size

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -19,7 +19,7 @@ import sys
 import unittest
 from unittest import mock
 
-from charter import config, statusline, tui
+from charter import config, instance, statusline, tui
 from charter.frame import gather, slots, state
 
 from tests._isolation import PersonaIso
@@ -128,23 +128,33 @@ class Unimplemented(unittest.TestCase):
     splitting a pane that would be permanently dead under `remain-on-exit on`),
     `frame_ready` (`--probe`) and `doctor.check_frame`."""
 
-    def test_all_four_slots_now_have_a_renderer(self):
-        """Task 3 landed `left`/`right` beside `top`/`bottom`: every slot
-        `instance.FRAME_SLOTS` accepts now has a renderer, so a fully-configured
-        frame names nothing missing."""
-        self.assertEqual(slots.unimplemented(["top", "left", "bottom", "right"]), [])
+    def test_every_slot_charter_accepts_has_a_renderer(self):
+        """The two registries have to agree: a slot `instance.FRAME_SLOTS` accepts and
+        `slots.SLOTS` cannot draw is a pane charter splits and then leaves permanently
+        dead. Asked of `FRAME_SLOTS` itself rather than a hand-written list, so retiring
+        a slot from one registry and not the other (#488 retired `left` from both) is red
+        rather than a frame with a hole in it."""
+        self.assertEqual(slots.unimplemented(list(instance.FRAME_SLOTS)), [])
+
+    def test_the_retired_sidebar_is_gone_from_the_registry_too(self):
+        """#488. `left` is not a slot charter accepts any more, so it cannot reach here
+        from config — but a preset or a hand-typed `charter panel left` still could, and
+        this is the answer they get: named as unimplemented, which is what makes
+        `_drawable_slots` skip it and `--probe`/`doctor` say so."""
+        self.assertNotIn("left", slots.SLOTS)
+        self.assertEqual(slots.unimplemented(["top", "left"]), ["left"])
 
     def test_an_all_implemented_configuration_names_nothing(self):
         self.assertEqual(slots.unimplemented(["top", "bottom"]), [])
 
-    def test_the_answer_comes_from_the_registry_not_a_hardcoded_pair(self):
-        """`left`/`right` having renderers today is not the rule this function follows
-        — the registry is. Proved here from the other direction now that both are
-        implemented: temporarily REMOVE one from the registry and the answer must
-        follow, exactly as it would the day a real slot's renderer regresses."""
+    def test_the_answer_comes_from_the_registry_not_a_hardcoded_name(self):
+        """Which slots have renderers TODAY is not the rule this function follows — the
+        registry is. Proved from the other direction: temporarily REMOVE one from the
+        registry and the answer must follow, exactly as it would the day a real slot's
+        renderer regresses."""
         with mock.patch.dict(slots.SLOTS):
             del slots.SLOTS["right"]
-            self.assertEqual(slots.unimplemented(["top", "left", "right"]), ["right"])
+            self.assertEqual(slots.unimplemented(["top", "right"]), ["right"])
 
 
 class Width(unittest.TestCase):
@@ -394,232 +404,308 @@ class FitFields(unittest.TestCase):
                          {"alert", "news"})
 
 
-class LeftRenderer(PersonaIso, unittest.TestCase):
-    """`left`: repo rows composed narrow straight from `gather`'s cache — never a
-    `git` call, never `glstate`, never `_repo_rows`' `tui.Node`s (built for a wide
-    boxed frame; `_NAME_W`=32 alone exceeds this whole pane)."""
+class BottomTable(PersonaIso, unittest.TestCase):
+    """#488: the repo table `bottom` draws under its attention row.
+
+    The rows are `statusline.py`'s OWN wide table — same four columns, same declared
+    widths, same markers and CI glyphs — composed straight from `gather`'s cache: never a
+    `git` call, never `glstate`, and never a repo directory (see `_table_row`'s docstring
+    for the one column that costs a filesystem walk per row and is therefore absent).
+
+    Every test here renders through the real `slots.render("bottom", …)` rather than
+    calling `_table_lines` directly, because what #488 actually promises is that a
+    PANEL shows this — a helper returning perfect rows that `_bottom` never asks for
+    would satisfy a unit test of the helper and none of the promise.
+    """
+
+    def _render(self, fid="f-1", *, cols=200, rows=24) -> str:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, rows))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return slots.render("bottom", fid)
 
     def test_lists_a_repo_from_the_cache(self):
         _seed("f-1", repos=[_row("demo")])
-        self.assertIn("demo", slots.render("left", "f-1"))
+        self.assertIn("demo", self._render())
 
-    def test_degrades_to_a_readable_line_with_an_empty_cache(self):
+    def test_the_attention_row_is_still_the_first_line(self):
+        """#488's non-negotiable: the table JOINS the alert, the news, the todo count and
+        the plane-root warning — it does not evict them. Asserted as line 0 specifically,
+        because a table drawn above the row it is meant to sit under would still contain
+        both strings and satisfy a membership check."""
+        _seed("f-1", repos=[_row("demo")])
+        out = self._render()
+        self.assertIn("todo", tui.strip_ansi(out.split("\n")[0]))
+        self.assertIn("demo", out)
+
+    def test_a_plane_with_no_repos_is_the_one_row_strip_it_always_was(self):
+        """The floor `layout.bottom_rows` keeps, seen from the renderer's side. The
+        reported "always empty sidebar" of #488 was this case being told the truth —
+        a workspace with 0 clones — so it must stay honest rather than grow furniture."""
         _seed("f-1")
-        out = slots.render("left", "f-1")
-        self.assertTrue(out.strip())
-        self.assertIn("no repos", tui.strip_ansi(out))
+        self.assertEqual(len(self._render().split("\n")), 1)
 
     def test_a_dirty_repo_shows_the_dirty_marker(self):
         _seed("f-1", repos=[_row("demo", dirty=True)])
-        self.assertIn("*", tui.strip_ansi(slots.render("left", "f-1")))
+        self.assertIn("*", tui.strip_ansi(self._render()))
 
     def test_a_clean_repo_shows_no_dirty_marker(self):
         _seed("f-1", repos=[_row("demo", dirty=False)])
-        self.assertNotIn("*", tui.strip_ansi(slots.render("left", "f-1")))
+        self.assertNotIn("*", tui.strip_ansi(self._render()))
 
     def test_an_open_change_shows_its_sigil_and_number(self):
         _seed("f-1", repos=[_row("demo", change=42, sigil="!")])
-        self.assertIn("!42", tui.strip_ansi(slots.render("left", "f-1")))
+        self.assertIn("!42", tui.strip_ansi(self._render()))
 
     def test_a_failing_ci_status_shows_its_glyph(self):
         _seed("f-1", repos=[_row("demo", ci="failed")])
-        self.assertIn("✗", tui.strip_ansi(slots.render("left", "f-1")))
+        self.assertIn("✗", tui.strip_ansi(self._render()))
+
+    def test_the_wide_tables_own_ci_label_survives_now_there_is_room_for_it(self):
+        """The gain #488 is actually for. `left` had 22 columns and could show only the
+        glyph; the wide table has `_CI_W` and shows `✗ failed` — the same
+        `statusline._ci_part` the status line calls, which is why this reads identically
+        in both surfaces. A frame drawing the glyph alone would still pass the test above
+        and would still be the downgrade the issue is about."""
+        _seed("f-1", repos=[_row("demo", ci="failed")])
+        self.assertIn("failed", tui.strip_ansi(self._render()))
+
+    def test_the_branch_gets_the_wide_tables_own_column_not_a_22_column_squeeze(self):
+        """`left`'s own docstring conceded it could not do this: `_NAME_W` (32) and
+        `_BRANCH_W` (34) alone exceed a 22-column pane, so a real branch name was always
+        elided. This is the reviewer's own repro fixture from #385's fix round 1, which
+        rendered as `charter worktree-reca…` there and must render whole here."""
+        _seed("f-1", repos=[_row("charter", branch="worktree-recall-since",
+                                 dirty=True, ahead=1, ci="failed")])
+        out = tui.strip_ansi(self._render())
+        self.assertIn("worktree-recall-since", out)
+        self.assertIn("*", out, "the dirty marker must survive")
+        self.assertIn("✗", out, "the CI glyph must survive")
 
     def test_a_piece_from_the_worktrees_cache_field_is_shown(self):
         _seed("f-1", repos=[_row("demo")],
-             worktrees=[_row("piece-one", repo="demo")])
-        self.assertIn("piece-one", tui.strip_ansi(slots.render("left", "f-1")))
+              worktrees=[_row("piece-one", repo="demo")])
+        self.assertIn("piece-one", tui.strip_ansi(self._render()))
+
+    def test_a_pieces_branch_column_is_emptied_when_it_restates_its_own_name(self):
+        """`charter worktree add <repo> <piece>` names the branch after the piece, so by
+        default those two columns print the same word twice — `statusline._repo_rows`
+        empties the branch cell when they agree, and this table does the same rather than
+        spending 34 columns restating the name beside it. The markers still render: dirty
+        is true of the tree whatever its branch is called."""
+        _seed("f-1", repos=[_row("demo", worktree_count=1)],
+              worktrees=[_row("same-name", repo="demo", branch="same-name",
+                              dirty=True)])
+        piece = tui.strip_ansi(self._render().split("\n")[-1])
+        self.assertEqual(piece.count("same-name"), 1, piece)
+        self.assertIn("*", piece, "the dirty marker survives an emptied branch cell")
 
     def test_a_multi_repo_workspaces_piece_count_shows_as_a_badge(self):
-        """Fix round 1, finding 2: `worktree_count` did not exist in the cache at
-        all for a multi-repo workspace before this round — `data["worktrees"]`
-        is `[]` here (as it always is with two repos; `gather._detail_worktrees`'
-        own single-repo rule), so the badge is the ONLY way either repo's pieces
-        are visible at all."""
+        """`data["worktrees"]` is `[]` here (as it always is with two repos —
+        `gather._detail_worktrees`' own single-repo rule), so the badge is the ONLY way
+        either repo's pieces are visible at all."""
         _seed("f-1", repos=[_row("demo", worktree_count=3),
                             _row("second", worktree_count=0)],
-             worktrees=[])
-        out = tui.strip_ansi(slots.render("left", "f-1"))
-        self.assertIn("⑂3", out)
+              worktrees=[])
+        self.assertIn("⑂3", tui.strip_ansi(self._render()))
 
     def test_a_repo_whose_pieces_are_all_shown_as_rows_carries_no_badge(self):
-        """The single-repo case: every piece already has its own row
-        (`data["worktrees"]`), so the badge — "there is more you cannot see" —
-        would be actively misleading if it appeared anyway."""
+        """The single-repo case: every piece already has its own row, so the badge —
+        "there is more you cannot see" — would be actively misleading if it appeared."""
         _seed("f-1", repos=[_row("demo", worktree_count=1)],
-             worktrees=[_row("piece-one", repo="demo")])
-        out = tui.strip_ansi(slots.render("left", "f-1"))
-        self.assertNotIn("⑂", out)
+              worktrees=[_row("piece-one", repo="demo")])
+        self.assertNotIn("⑂", tui.strip_ansi(self._render()))
 
     def test_picks_the_dirty_repo_over_clean_ones_when_over_budget(self):
-        """`_pick_rows` is CALLED here, not reinvented — the same ranking
-        `statusline.py`'s own regression (an unranked slice of 18 clones showed
-        thirteen clean repos and hid the one dirty one) was filed against. A plain
-        `dirs[:budget]` slice would keep `clean-0..clean-N` (they sort first) and
-        drop `zzz-dirty` off the end."""
+        """`statusline._pick_rows` is CALLED here, not reinvented — the same ranking
+        `statusline.py`'s own production regression (an unranked slice of 18 clones
+        showed thirteen clean repos and hid the one dirty one) was filed against."""
         clean = [_row(f"clean-{i}") for i in range(statusline._MAX_REPO_LINES)]
         dirty = _row("zzz-dirty-one-past-the-cap", dirty=True)
         _seed("f-1", repos=clean + [dirty])
-        self.assertIn("zzz-dirty-one-past-the-cap",
-                      tui.strip_ansi(slots.render("left", "f-1")))
+        self.assertIn("zzz-dirty-one-past-the-cap", tui.strip_ansi(self._render()))
 
     def test_the_overflow_note_matches_the_wide_tables_own_wording(self):
-        """Fix round 1, finding 3: this line used to say `", clean"` where
-        `_repo_rows`' own overflow line (`statusline.py`) says `", all clean"` —
-        the same claim, worded two different ways on the two surfaces."""
+        """One claim, one wording. `_repo_rows`' own overflow line says `, all clean`,
+        and a second surface saying `, clean` for the same claim is a divergence a reader
+        has to reconcile."""
         clean = [_row(f"clean-{i}") for i in range(statusline._MAX_REPO_LINES + 1)]
         _seed("f-1", repos=clean)
-        out = tui.strip_ansi(slots.render("left", "f-1"))
+        out = tui.strip_ansi(self._render(rows=8))
         self.assertIn(", all clean)", out)
         self.assertNotIn("more, clean)", out)
 
-    def test_never_exceeds_the_pane_width(self):
+    def test_the_overflow_note_refuses_to_say_all_clean_when_it_is_hiding_trouble(self):
+        """The half that matters. `_needs_attention` is what stands between the operator
+        and a panel that hides a failing pipeline behind the words "all clean" — the
+        false-clean reading this whole surface is built to avoid.
+
+        MORE repos need attention than the pane has rows, so `_pick_rows` ranking them
+        all to the front cannot empty the hidden set of them: two rows of table for five
+        failing repos means at least three failing ones are hidden, whatever the ranking
+        does. A single one would be ranked in and the note would then be telling the
+        truth — which is why the sibling test above asserts the `, all clean` wording and
+        this one asserts its absence."""
+        rows = [_row(f"failing-{i}", ci="failed") for i in range(5)]
+        rows += [_row(f"clean-{i}") for i in range(5)]
+        _seed("f-1", repos=rows)
+        out = tui.strip_ansi(self._render(rows=4))
+        self.assertIn("more)", out)
+        self.assertNotIn("all clean", out)
+
+    def test_the_table_is_bounded_by_the_panes_own_measured_height(self):
+        """The renderer must spend the pane it HAS, not the one the launcher intended:
+        a resize changes the pane under a running panel and nothing bumps the frame's
+        version for it. Asserted at two heights against the same cache, so a renderer
+        ignoring the measurement and emitting everything is red at the short one."""
+        _seed("f-1", repos=[_row(f"repo{i}") for i in range(10)])
+        self.assertEqual(len(self._render(rows=6).split("\n")), 6)
+        self.assertEqual(len(self._render(rows=20).split("\n")), 1 + 10)
+
+    def test_the_height_the_launcher_asks_for_is_the_height_the_renderer_fills(self):
+        """The seam #488 turns on. `slots.bottom_rows_wanted` is what tells
+        `layout.slot_sizes` how tall to split the pane; `_bottom` is what fills it. If
+        the two disagreed, every frame would come up either padded with blank rows the
+        harness could have had, or with a table cut off and nothing saying so — and
+        neither is visible from either side alone. Rendered into a pane of EXACTLY the
+        height the sizer asked for, and counted."""
+        for n in (0, 1, 4, 9):
+            with self.subTest(repos=n):
+                fid = f"wanted-{n}"
+                _seed(fid, repos=[_row(f"repo{i}") for i in range(n)])
+                want = slots.bottom_rows_wanted(fid)
+                out = self._render(fid, rows=want)
+                self.assertEqual(len(out.split("\n")), want, out)
+
+    def test_a_pane_too_narrow_for_the_table_draws_no_table_rather_than_a_cut_one(self):
+        """Every column after the branch sits at a fixed offset past
+        `_NAME_W + _BRANCH_W`, so a narrow pane loses the CI glyph and the open change
+        off the right-hand end — and a dirty, CI-failing repo then renders as a clean
+        `charter  main`. Refusing to draw says "no room to say"; a trimmed row says
+        "nothing to say", which is the false-clean failure the plan's Global Constraints
+        name. The attention row is unaffected — it budgets its own fields."""
+        _seed("f-1", repos=[_row("demo", dirty=True, ci="failed")])
+        out = self._render(cols=statusline._LEFT_W - 1)
+        self.assertEqual(len(out.split("\n")), 1, out)
+        self.assertIn("todo", tui.strip_ansi(out))
+        # ...and one column wider, it draws.
+        self.assertIn("demo", self._render(cols=statusline._LEFT_W))
+
+    def test_no_line_ever_exceeds_the_panes_width(self):
         _seed("f-1", repos=[_row("a-repo-with-quite-a-long-descriptive-name",
-                                change=999999, ci="failed", ahead=12, behind=34)])
-        with mock.patch("os.get_terminal_size", return_value=os.terminal_size((22, 24))), \
-             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
-            out = slots.render("left", "f-1")
-        for line in out.splitlines():
+                                 branch="a-very-long-branch-name-that-keeps-going",
+                                 change=999999, ci="failed", ahead=12, behind=34)],
+              worktrees=[])
+        for cols in (statusline._LEFT_W, 120, 200):
+            out = self._render(cols=cols)
+            for line in out.split("\n"):
+                with self.subTest(cols=cols, line=line):
+                    self.assertLessEqual(tui.width(line), cols)
+
+    def test_a_cjk_heavy_repo_name_does_not_push_the_table_past_the_pane(self):
+        """`tui.Cell` pads and truncates in display CELLS, not characters — a name of 30
+        CJK characters is 60 cells and would blow a 37-column name column out by 23 if
+        anything here counted characters."""
+        cjk = "測" * 30
+        _seed("f-1", repos=[_row(cjk, dirty=True, ci="failed")])
+        out = self._render(cols=statusline._LEFT_W)
+        for line in out.split("\n"):
             with self.subTest(line=line):
-                self.assertLessEqual(tui.width(line), 22)
+                self.assertLessEqual(tui.width(line), statusline._LEFT_W)
+        self.assertIn("✗", tui.strip_ansi(out), "the CI cell keeps its own column")
 
-    def test_never_exceeds_the_pane_width_even_when_narrower_than_the_markers(self):
-        """`_row`'s own per-field budgeting can still ask for more than a truly
-        tiny pane has (each field's floor is `max(1, ...)`, and those floors can
-        sum past `width` once the pane is narrower than the markers themselves)
-        — `_row`'s trailing `tui.truncate(line, width)` is the backstop for
-        exactly that. Confirmed load-bearing by mutation: dropping it lets a
-        5-repo-state line overflow a 3-column pane to 8 display cells."""
-        _seed("f-1", repos=[_row("abcdef", dirty=True, ahead=3, behind=2,
-                                ci="failed", change=5, sigil="!")])
-        with mock.patch("os.get_terminal_size", return_value=os.terminal_size((3, 24))), \
-             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
-            out = slots.render("left", "f-1")
-        for line in out.splitlines():
-            with self.subTest(line=line):
-                self.assertLessEqual(tui.width(line), 3)
+    def test_it_never_reaches_the_wide_tables_own_filesystem_walking_composer(self):
+        """#387 pinned a panel's idle tick at exactly one `stat`, and `bottom` is the ONE
+        animated slot — at `panel.TICK` a table that walked a directory per row would pay
+        that back fourteen times over, five times a second, for the length of every
+        dispatch.
 
-    def test_a_realistic_long_branch_does_not_crowd_out_the_dirty_marker_or_ci_glyph(self):
-        """Fix round 1, finding 1: a single `tui.truncate` over the whole assembled
-        line cut from the right, and this project's own branches
-        (`worktree-recall-since`, `browser-session-scope`, `global-shim-refresh`:
-        21-28 characters, the norm here) are long enough that `name + " " +
-        branch` alone fills a 22-column pane before the dirty marker, the CI
-        glyph or an open change is ever reached — a FALSE CLEAN reading on a
-        dirty, CI-failing, unpushed repo. `test_a_dirty_repo_shows_the_dirty_marker`
-        and `test_a_failing_ci_status_shows_its_glyph` above use `branch="main"`
-        (no truncation pressure) and would not have caught this; this fixture
-        matches the reviewer's own repro exactly."""
-        _seed("f-1", repos=[_row("charter", branch="worktree-recall-since",
-                                dirty=True, ahead=1, ci="failed")])
-        with mock.patch("os.get_terminal_size", return_value=os.terminal_size((22, 24))), \
-             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
-            out = tui.strip_ansi(slots.render("left", "f-1"))
-        self.assertIn("*", out, "the dirty marker must survive truncation")
-        self.assertIn("✗", out, "the CI glyph must survive truncation")
+        `statusline._tree_cells` is the composer this table deliberately does NOT call:
+        it ends in `_presence_for_dir`, a `worktree.locate`/`workspace.clone_of` pair,
+        per row. `worktree.dirs_for` is the other one — `_repo_rows` calls it per repo
+        for its `⑂N` badge, and the frame reads `worktree_count` out of the cache
+        instead. All three are made to raise, so a call is a loud failure rather than a
+        slow success.
 
-    def test_a_long_branch_with_a_change_still_surfaces_marker_ci_and_change(self):
-        """The three-field version of the test above, at the ACTUAL production
-        pane width (`layout.SLOT_SIZE["left"] == 22`) — pins that reserving room
-        for CI does not itself starve a trailing open change (`_row`'s priority
-        order includes it last), the case a narrower, artificial width would
-        have to invent rather than measure."""
-        _seed("f-1", repos=[_row("charter", branch="worktree-recall-since",
-                                dirty=True, ahead=1, ci="failed",
-                                change=12, sigil="!")])
-        with mock.patch("os.get_terminal_size", return_value=os.terminal_size((22, 24))), \
-             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
-            line = slots.render("left", "f-1").splitlines()[0]
-        out = tui.strip_ansi(line)
-        self.assertLessEqual(tui.width(line), 22)
-        self.assertIn("*", out, "the dirty marker must survive")
-        self.assertIn("✗", out, "the CI glyph must survive")
-        self.assertIn("!12", out, "the open change must survive")
+        Scoped to the three helpers rather than to "any filesystem call": `_bottom`'s
+        attention row legitimately resolves the workspace (which reaches
+        `worktree.locate` on its own), and the sibling test below is what bounds the
+        table's own syscalls."""
+        _seed("f-1", repos=[_row("demo", dirty=True, ci="failed", change=3, sigil="!",
+                                 worktree_count=2)],
+              worktrees=[_row("piece", repo="demo")])
+        boom = AssertionError("the table used the wide table's own row composer")
+        with mock.patch("charter.statusline._tree_cells", side_effect=boom), \
+             mock.patch("charter.statusline._presence_for_dir", side_effect=boom), \
+             mock.patch("charter.worktree.dirs_for", side_effect=boom):
+            out = tui.strip_ansi(self._render())
+        self.assertIn("demo", out)
+        self.assertIn("piece", out)
+        self.assertIn("⑂2", out, "the badge came from the cache, not a directory walk")
 
-    def test_a_cjk_heavy_repo_name_still_fits_a_narrow_pane(self):
-        """Fix round 2, finding 1: pins the width invariant end-to-end through
-        `_left`/`_repo_line` for a real CJK repo name — it does NOT by itself
-        pin that `_row`'s name truncation is cell-aware rather than
-        char-aware. A repo's `name_markup` carries an ANSI colour prefix
-        (`_PALETTE`), and naive `name_markup[:name_w]` character-slicing
-        spends several of the budgeted characters on the escape bytes rather
-        than the CJK text — which happens to *under*-consume the intended
-        cell budget for this fixture, so this test stays green under that
-        mutation (verified: reverting `_row`'s `tui.truncate(name_markup,
-        name_w)` to `name_markup[:name_w]` does not red this test, with or
-        without the trailing safety-net truncate). `_piece_line`'s CJK test
-        below is the one that actually pins cell-awareness — a piece name
-        carries no ANSI prefix to accidentally absorb the mistake."""
-        cjk = "測" * 30  # 30 characters, 60 display cells
-        _seed("f-1", repos=[_row(cjk)])
-        with mock.patch("os.get_terminal_size", return_value=os.terminal_size((20, 24))), \
-             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
-            out = slots.render("left", "f-1")
-        for line in out.splitlines():
-            self.assertLessEqual(tui.width(line), 20)
-
-    def test_a_cjk_heavy_piece_name_does_not_crowd_out_its_branch_or_markers(self):
-        """Fix round 2, finding 1: the genuinely fragile field. A piece's name
-        (`_piece_line`, `p["name"]`) carries no ANSI prefix, so nothing
-        absorbs a char-vs-cell counting mistake the way the repo-name test
-        above happens to. With `tui.truncate` doing the real truncation, the
-        branch and its markers survive alongside a correctly-shrunk CJK name
-        (`'╰─ 測測測… main* ✗'`); under naive `name_markup[:name_w]` slicing
-        the name alone consumes 2x its intended cell budget (each CJK
-        character sliced in COUNT costs 2 cells), so the branch, the dirty
-        marker and the CI glyph are all pushed out entirely by the trailing
-        safety-net truncate — the SAME false-clean failure mode fix round 1
-        closed for the branch field, reopened here through the name field."""
-        cjk = "測" * 30  # 30 characters, 60 display cells
-        _seed("f-1", repos=[_row("demo", worktree_count=1)],
-             worktrees=[_row(cjk, repo="demo", branch="main",
-                             dirty=True, ci="failed")])
-        with mock.patch("os.get_terminal_size", return_value=os.terminal_size((20, 24))), \
-             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
-            out = slots.render("left", "f-1")
-        for line in out.splitlines():
-            with self.subTest(line=line):
-                self.assertLessEqual(tui.width(line), 20)
-        piece_line = tui.strip_ansi(out.splitlines()[-1])
-        self.assertIn("main", piece_line, "the branch must survive")
-        self.assertIn("*", piece_line, "the dirty marker must survive")
-        self.assertIn("✗", piece_line, "the CI glyph must survive")
-
-    def test_a_starved_pane_drops_lowest_priority_fields_first(self):
-        """Fix round 2, finding 2: reachable in production despite the
-        22-column DEFAULT — `layout.py`'s own module docstring measures real
-        tmux 3.7c redistributing every pane proportionally on a resize, `-l
-        size` notwithstanding ("growing a 120x30 frame to 200x50 stretched two
-        one-row panels to 8 and 7 rows" before a corrective `window-resized`
-        hook snapped them back): an ORDINARY window resize, not a future
-        configurability feature. `_width()` measures the real pane rather
-        than trusting `layout.SLOT_SIZE` for exactly this reason.
-
-        Pins `_row`'s priority order (CI drops before the dirty marker, which
-        `_left`'s own overflow-quiet logic and `_tree_cells`' wide-table
-        counterpart both treat as the higher-priority fact) rather than
-        merely the total width bound `test_never_exceeds_the_pane_width_...`
-        above already covers."""
-        _seed("f-1", repos=[_row("ab", branch="main", dirty=True, ci="failed")])
-        # (width, marker expected, CI glyph expected) — matches this fixture
-        # measured directly: 'ab main* ✗' / 'ab m…* ✗' / 'ab m…*' / 'ab …'.
-        cases = [(10, True, True), (8, True, True), (6, True, False), (4, False, False)]
-        for width, want_marker, want_ci in cases:
-            with mock.patch("os.get_terminal_size", return_value=os.terminal_size((width, 24))), \
-                 mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
-                line = tui.strip_ansi(slots.render("left", "f-1").splitlines()[0])
-            with self.subTest(width=width):
-                self.assertLessEqual(tui.width(line), width)
-                self.assertEqual("*" in line, want_marker)
-                self.assertEqual("✗" in line, want_ci)
+    def test_composing_the_table_opens_no_file_and_starts_no_process(self):
+        """The syscall half of the same property, counted rather than timed (a wall-clock
+        assertion on a shared CI box measures the box) and counted at the BOTTOM —
+        `os.stat`, `builtins.open`, `subprocess.run` — which is where every higher-level
+        spelling (`Path.stat`, `Path.exists`, `read_text`, `glob`) must eventually
+        arrive. `_table_lines` is handed the cache it would otherwise read, so what is
+        left to count is composition alone: fourteen rows of it must cost nothing."""
+        import builtins
+        import subprocess as _sp
+        data = {"gathered_at": 0.0, "workspace": "w", "current_repo": "r0",
+                "repos": [_row(f"r{i}", dirty=True, ci="failed", change=i, sigil="!",
+                               worktree_count=2) for i in range(14)],
+                "worktrees": []}
+        real_stat, real_open, real_run = os.stat, builtins.open, _sp.run
+        stats, opens, runs = [], [], []
+        with mock.patch("os.stat", lambda *a, **k: (stats.append(a),
+                                                    real_stat(*a, **k))[1]), \
+             mock.patch("builtins.open", lambda *a, **k: (opens.append(a),
+                                                          real_open(*a, **k))[1]), \
+             mock.patch("subprocess.run", lambda *a, **k: (runs.append(a),
+                                                           real_run(*a, **k))[1]):
+            lines = slots._table_lines(data, 200, 14)
+        self.assertEqual(len(lines), 14)
+        self.assertEqual(stats, [], "composing the table stat'ed something")
+        self.assertEqual(opens, [], "composing the table opened a file")
+        self.assertEqual(runs, [], "composing the table started a process")
 
     def test_a_failing_gather_read_yields_a_line_rather_than_an_exception(self):
-        """A panel that raises leaves a hole in the frame — `slots.render`'s own
-        promise, pinned here against a renderer that actually reaches into a real
-        dependency (`gather.read`) rather than the generic lambda `Render`'s own
-        `test_a_failing_renderer...` uses."""
+        """A panel that raises leaves a hole in the frame — `slots.render`'s own promise,
+        pinned against a renderer that reaches into a real dependency."""
         with mock.patch.object(gather, "read", side_effect=RuntimeError("boom")):
-            self.assertIn("charter", slots.render("left", "f-1"))
+            self.assertIn("charter", slots.render("bottom", "f-1"))
+
+
+class BottomRowsWanted(PersonaIso, unittest.TestCase):
+    """`slots.bottom_rows_wanted` — the number the LAUNCHER sizes the pane from."""
+
+    def test_a_plane_with_no_repos_wants_exactly_the_attention_row(self):
+        _seed("f-1")
+        self.assertEqual(slots.bottom_rows_wanted("f-1"), 1)
+
+    def test_it_grows_with_the_repos_and_the_pieces_alike(self):
+        _seed("f-1", repos=[_row("a"), _row("b")],
+              worktrees=[_row("p", repo="a")])
+        self.assertEqual(slots.bottom_rows_wanted("f-1"), 1 + 3)
+
+    def test_it_is_capped_at_the_wide_tables_own_row_budget(self):
+        """A workspace with forty clones must ask for a fifteen-row strip, not a
+        forty-one-row one — `_MAX_REPO_LINES` is the same total-row budget the wide table
+        keeps, reused rather than invented fresh."""
+        _seed("f-1", repos=[_row(f"r{i}") for i in range(40)])
+        self.assertEqual(slots.bottom_rows_wanted("f-1"),
+                         1 + statusline._MAX_REPO_LINES)
+
+    def test_it_never_runs_a_git_sweep(self):
+        """It is called on a launch the operator is waiting on, and again on every step
+        of a terminal drag. `gather.row_count` answers from the cache when there is one
+        and from a directory listing when there is not; a `scan()` on either path would
+        put a `git status` per repo inside a `window-resized` hook."""
+        _seed("f-1", repos=[_row("a")])
+        with mock.patch("charter.frame.gather.scan",
+                        side_effect=AssertionError("row_count ran a scan")):
+            self.assertEqual(slots.bottom_rows_wanted("f-1"), 2)
 
 
 class RightRenderer(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -676,6 +676,25 @@ class BottomTable(PersonaIso, unittest.TestCase):
         self.assertIn("more)", out)
         self.assertNotIn("all clean", out)
 
+    def test_a_one_row_budget_spends_it_on_saying_how_much_is_hidden(self):
+        """The narrowest overflow case, and a false-clean one until it was closed. The
+        note used to be appended on top of the budget and trimmed off at the end, so a
+        pane with room for exactly one table row showed one repo — clean, on main — and
+        nothing saying the other nine existed. A pane claiming one clean repo IS the plane
+        is the reading this module refuses everywhere else, so the row is spent on the
+        note instead: "there is more here than fits" outranks an arbitrary one of them."""
+        rows = [_row(f"repo{i}") for i in range(10)]
+        rows[3] = _row("the-dirty-one", dirty=True)
+        _seed("f-1", repos=rows)
+        # Split BEFORE stripping: `tui.strip_ansi` runs `tui.sanitize`, which replaces a
+        # newline like any other control character, so stripping the whole render first
+        # would fold every row onto one line and make a line-count assertion meaningless.
+        lines = [tui.strip_ansi(ln) for ln in self._render(rows=2).split("\n")]
+        self.assertEqual(len(lines), 2, lines)
+        self.assertIn("+10 more", lines[1])
+        self.assertNotIn("all clean", lines[1],
+                         "it is hiding a dirty repo and must not claim otherwise")
+
     def test_the_table_is_bounded_by_the_panes_own_measured_height(self):
         """The renderer must spend the pane it HAS, not the one the launcher intended:
         a resize changes the pane under a running panel and nothing bumps the frame's

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -735,7 +735,7 @@ class BottomTable(PersonaIso, unittest.TestCase):
                         _seed(fid, repos=[_row(f"repo{i}") for i in range(n)])
                         if level is not None:
                             state.record_density(fid, level)
-                        want = slots.bottom_rows_wanted(fid, cols=cols)
+                        want = slots.bottom_rows_wanted(fid, pane_cols=cols)
                         out = self._render(fid, cols=cols, rows=want)
                         self.assertEqual(len(out.split("\n")), want, out)
 
@@ -754,9 +754,9 @@ class BottomTable(PersonaIso, unittest.TestCase):
         _seed("narrow", repos=[_row(f"repo{i}") for i in range(6)])
         for cols in (50, 80, statusline._LEFT_W - 1):
             with self.subTest(cols=cols):
-                self.assertEqual(slots.bottom_rows_wanted("narrow", cols=cols), 1)
+                self.assertEqual(slots.bottom_rows_wanted("narrow", pane_cols=cols), 1)
         self.assertEqual(slots.bottom_rows_wanted("narrow",
-                                                  cols=statusline._LEFT_W), 1 + 6)
+                                                  pane_cols=statusline._LEFT_W), 1 + 6)
 
     def test_a_terse_density_asks_for_a_shorter_pane_not_a_blanker_one(self):
         """`minimal` exists to give the harness its rows back — `instance.FRAME_DENSITY`
@@ -769,9 +769,9 @@ class BottomTable(PersonaIso, unittest.TestCase):
         between the two numbers is the one the level is for."""
         _seed("dense", repos=[_row(f"repo{i}") for i in range(10)])
         state.record_density("dense", "normal")
-        wide = slots.bottom_rows_wanted("dense", cols=200)
+        wide = slots.bottom_rows_wanted("dense", pane_cols=200)
         state.record_density("dense", "minimal")
-        terse = slots.bottom_rows_wanted("dense", cols=200)
+        terse = slots.bottom_rows_wanted("dense", pane_cols=200)
         self.assertEqual(wide, 1 + 10)
         self.assertEqual(terse, 1 + slots._TERSE_ROWS)
         self.assertLess(terse, wide)
@@ -957,19 +957,19 @@ class BottomRowsWanted(PersonaIso, unittest.TestCase):
 
     def test_a_plane_with_no_repos_wants_exactly_the_attention_row(self):
         _seed("f-1")
-        self.assertEqual(slots.bottom_rows_wanted("f-1", cols=200), 1)
+        self.assertEqual(slots.bottom_rows_wanted("f-1", pane_cols=200), 1)
 
     def test_it_grows_with_the_repos_and_the_pieces_alike(self):
         _seed("f-1", repos=[_row("a"), _row("b")],
               worktrees=[_row("p", repo="a")])
-        self.assertEqual(slots.bottom_rows_wanted("f-1", cols=200), 1 + 3)
+        self.assertEqual(slots.bottom_rows_wanted("f-1", pane_cols=200), 1 + 3)
 
     def test_it_is_capped_at_the_wide_tables_own_row_budget(self):
         """A workspace with forty clones must ask for a fifteen-row strip, not a
         forty-one-row one — `_MAX_REPO_LINES` is the same total-row budget the wide table
         keeps, reused rather than invented fresh."""
         _seed("f-1", repos=[_row(f"r{i}") for i in range(40)])
-        self.assertEqual(slots.bottom_rows_wanted("f-1", cols=200),
+        self.assertEqual(slots.bottom_rows_wanted("f-1", pane_cols=200),
                          1 + statusline._MAX_REPO_LINES)
 
     def test_the_width_is_required_and_cannot_be_confused_with_the_row_count(self):
@@ -984,6 +984,28 @@ class BottomRowsWanted(PersonaIso, unittest.TestCase):
         with self.assertRaises(TypeError):
             slots.bottom_rows_wanted("f-1", 200)
 
+    def test_the_width_asked_for_is_the_panes_and_a_window_width_will_not_fit(self):
+        """The rename is the guard, and this is what pins it. Round 2 of #500 spelled this
+        argument `cols` and every caller handed it the WINDOW's width — right only when
+        nothing vertical was split before `bottom`. `pane_cols` is not a nicer name for
+        the same number: it is the name that makes the old call a `TypeError` here rather
+        than six blank rows in a frame nobody thought to re-measure.
+
+        Asserted on the signature rather than only on a failing keyword, so a future
+        `**kwargs` (or a `cols` alias added back for compatibility) is red too — an alias
+        would restore exactly the confusion this closes. The next spelling to refuse is
+        `width`, which is what `_table_cap` calls its own parameter: it takes the pane's
+        width because the RENDERER measures a pane, and a caller that copies that name up
+        here would be naming the thing correctly by luck rather than by contract."""
+        import inspect
+        sig = inspect.signature(slots.bottom_rows_wanted)
+        self.assertEqual([p.name for p in sig.parameters.values()], ["fid", "pane_cols"])
+        self.assertEqual(sig.parameters["pane_cols"].kind,
+                         inspect.Parameter.KEYWORD_ONLY)
+        _seed("f-1", repos=[_row("a")])
+        with self.assertRaises(TypeError):
+            slots.bottom_rows_wanted("f-1", cols=200)
+
     def test_it_never_runs_a_git_sweep(self):
         """It is called on a launch the operator is waiting on, and again on every step
         of a terminal drag. `gather.row_count` answers from the cache when there is one
@@ -992,7 +1014,7 @@ class BottomRowsWanted(PersonaIso, unittest.TestCase):
         _seed("f-1", repos=[_row("a")])
         with mock.patch("charter.frame.gather.scan",
                         side_effect=AssertionError("row_count ran a scan")):
-            self.assertEqual(slots.bottom_rows_wanted("f-1", cols=200), 2)
+            self.assertEqual(slots.bottom_rows_wanted("f-1", pane_cols=200), 2)
 
     def test_a_narrow_frame_does_not_even_ask_how_many_repos_there_are(self):
         """The launch path reaches `gather.row_count` with no cache by design
@@ -1006,7 +1028,7 @@ class BottomRowsWanted(PersonaIso, unittest.TestCase):
         _seed("f-1", repos=[_row(f"r{i}") for i in range(6)])
         with mock.patch("charter.frame.gather.row_count",
                         side_effect=AssertionError("counted rows it had no room for")):
-            self.assertEqual(slots.bottom_rows_wanted("f-1", cols=80), 1)
+            self.assertEqual(slots.bottom_rows_wanted("f-1", pane_cols=80), 1)
 
 
 class RightRenderer(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -229,7 +229,14 @@ class TopRenderer(PersonaIso, unittest.TestCase):
     argument. These tests pin that finding as a regression rather than a one-time
     observation: a future edit that wires either call back into `_top` "because it
     compiles" must turn one of these red, since the call would return `[]` forever and
-    add nothing but a docstring gone stale."""
+    add nothing but a docstring gone stale.
+
+    **#413 gave `top` a gauge anyway, and none of that changed.** What changed is that a
+    panel now has a FILE to read (`statusline.recorded_context_gauge`), so the gauge is
+    composed from the recorded history rather than from a payload nobody hands it. The two
+    "never called" tests below are exactly as load-bearing as before: reaching for the
+    payload-gated helpers would still return `[]` forever, and now it would do it beside a
+    working gauge, which is harder to notice rather than easier."""
 
     def test_the_context_gauge_is_never_called_by_top(self):
         with mock.patch("charter.statusline._context_gauge") as gauge:
@@ -242,12 +249,128 @@ class TopRenderer(PersonaIso, unittest.TestCase):
         strip.assert_not_called()
 
     def test_context_gauge_confirmed_empty_with_no_payload_the_premise_top_relies_on(self):
-        """The load-bearing fact behind leaving the gauge out: with no live per-turn
-        payload — exactly what a panel process always has — `_context_gauge` produces
-        nothing, not a misleading zero. `tests/test_statusline_gauge.py` already pins
-        this generically (`test_silent_before_first_api_call`); repeated here because
+        """The load-bearing fact behind not reaching for the payload-gated helper: with no
+        live per-turn payload — exactly what a panel process always has — `_context_gauge`
+        produces nothing, not a misleading zero. `tests/test_statusline_gauge.py` already
+        pins this generically (`test_silent_before_first_api_call`); repeated here because
         it is the premise `_top`'s design decision rests on."""
         self.assertEqual(statusline._context_gauge(None), [])
+
+
+class TopDrawsTheRecordedGauge(PersonaIso, unittest.TestCase):
+    """#413: `ctx NN%` / `cache NN%` on `top`, out of the history the suppressed status
+    line records — the one capability a framed Claude Code session lost to #386 and the
+    thing 0.52.0's own news entry named as "genuinely lost".
+
+    Every test renders through the real `slots.render("top", …)`, because what #413
+    promises is that a PANEL shows this. And every "does not know" case is asserted to
+    draw NOTHING rather than a zero: that rule (`_top`'s own docstring, and the task
+    brief's) is what the whole design is built around, so it is pinned case by case
+    rather than once.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.fid = "gauge-frame"
+        self.sid = "cc-session-1"
+
+    def _usage(self, *rows: str) -> None:
+        f = statusline._usage_file(self.sid)
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("\n".join(rows) + "\n")
+
+    def _render(self) -> str:
+        with mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+             mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((200, 3))):
+            return tui.strip_ansi(slots.render("top", self.fid))
+
+    def test_a_recorded_session_puts_the_gauge_on_the_row(self):
+        state.record_harness_session(self.fid, self.sid)
+        self._usage("900,100,90,42")
+        out = self._render()
+        self.assertIn("ctx 42%", out)
+        self.assertIn("cache 90%", out)
+
+    def test_the_workspace_and_the_persona_are_not_pushed_off_by_it(self):
+        """The gauge JOINS `top`'s identity row; it does not replace it. `top` answers
+        "where am I and who am I being" first, and a session number that evicted either
+        would leave the row not earning its line."""
+        state.record_harness_session(self.fid, self.sid)
+        self._usage("900,100,90,42")
+        self.assertIn("⬢", self._render())
+
+    def test_a_frame_with_no_recorded_session_draws_no_gauge(self):
+        """Every frame whose harness is not Claude Code, and every frame launched by a
+        charter that predates the mapping. Nothing is handed a usage payload there, so
+        there is nothing to draw — and `ctx 0%` would be a claim about a session charter
+        has never seen a single number from."""
+        self._usage("900,100,90,42")
+        out = self._render()
+        self.assertNotIn("ctx", out)
+        self.assertNotIn("cache", out)
+
+    def test_a_recorded_session_with_no_turns_yet_draws_no_gauge(self):
+        """Early in a session, and right after `/compact`: the mapping is written on the
+        first render, the numbers only once the API has answered."""
+        state.record_harness_session(self.fid, self.sid)
+        out = self._render()
+        self.assertNotIn("ctx", out)
+        self.assertNotIn("cache", out)
+
+    def test_a_history_written_before_the_ctx_field_existed_draws_no_ctx(self):
+        """An upgrade mid-session is the ordinary case: three-field rows are what every
+        charter before #413 wrote. The cache half is still fully derivable from them and
+        is drawn; the context percentage was never recorded and is not guessed at."""
+        state.record_harness_session(self.fid, self.sid)
+        self._usage("900,100,90")
+        out = self._render()
+        self.assertNotIn("ctx", out)
+        self.assertIn("cache 90%", out)
+
+    def test_a_turn_recorded_without_a_percentage_falls_back_to_the_last_one_seen(self):
+        """A turn early in a session carries usage but no percentage, so its ctx field is
+        empty. Blanking a gauge that was correct one turn ago is worse than showing the
+        most recent figure charter actually saw — and the ring buffer is only
+        `_TREND_KEEP` turns deep, so it cannot drift far."""
+        state.record_harness_session(self.fid, self.sid)
+        self._usage("800,200,80,37", "900,100,90,")
+        self.assertIn("ctx 37%", self._render())
+
+    def test_the_gauge_survives_a_terse_density(self):
+        """`terse` buys back columns by dropping the charter version — a standing fact
+        about the install. The gauge is the opposite: the one field on this row that is
+        different every turn."""
+        state.record_harness_session(self.fid, self.sid)
+        self._usage("900,100,90,42")
+        state.record_density(self.fid, "minimal")
+        self.assertIn("ctx 42%", self._render())
+
+    def test_it_reads_the_session_the_frame_recorded_and_not_some_other(self):
+        """The mapping is the whole mechanism, so this pins that it is actually followed
+        rather than the panel finding a usage file some other way: two sessions with
+        different numbers on disk, and the row must show the one this frame is mapped
+        to."""
+        other = statusline._usage_file("cc-session-2")
+        other.parent.mkdir(parents=True, exist_ok=True)
+        other.write_text("100,900,10,99\n")
+        state.record_harness_session(self.fid, self.sid)
+        self._usage("900,100,90,42")
+        out = self._render()
+        self.assertIn("ctx 42%", out)
+        self.assertNotIn("99%", out)
+
+    def test_a_new_frame_claiming_a_recycled_pid_does_not_inherit_the_gauge(self):
+        """#383's recycled-pid adoption, applied to the sharpest of the three files it
+        clears. A frame id is `<workspace>-<launcher pid>`, and a launcher landing on a
+        pid an earlier launcher used adopts that frame's whole directory — so without
+        `clear_shape` taking `session` with it, a brand-new session's `top` row would
+        draw the PREVIOUS session's `ctx 42%` as its own, confidently, and forever: the
+        session that would correct it is over."""
+        state.record_harness_session(self.fid, self.sid)
+        self._usage("900,100,90,42")
+        state.clear_shape(self.fid)
+        self.assertNotIn("ctx", self._render())
         self.assertEqual(statusline._context_gauge({}), [])
 
 

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -14,6 +14,7 @@ environment. `Width` below pins that a panel lays out against its own tty instea
 
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 import unittest
@@ -705,19 +706,75 @@ class BottomTable(PersonaIso, unittest.TestCase):
         self.assertEqual(len(self._render(rows=20).split("\n")), 1 + 10)
 
     def test_the_height_the_launcher_asks_for_is_the_height_the_renderer_fills(self):
-        """The seam #488 turns on. `slots.bottom_rows_wanted` is what tells
-        `layout.slot_sizes` how tall to split the pane; `_bottom` is what fills it. If
-        the two disagreed, every frame would come up either padded with blank rows the
-        harness could have had, or with a table cut off and nothing saying so — and
-        neither is visible from either side alone. Rendered into a pane of EXACTLY the
-        height the sizer asked for, and counted."""
-        for n in (0, 1, 4, 9):
-            with self.subTest(repos=n):
-                fid = f"wanted-{n}"
-                _seed(fid, repos=[_row(f"repo{i}") for i in range(n)])
-                want = slots.bottom_rows_wanted(fid)
-                out = self._render(fid, rows=want)
-                self.assertEqual(len(out.split("\n")), want, out)
+        """The seam #488 turns on, over every input that changes either side's answer.
+
+        `slots.bottom_rows_wanted` is what tells `layout.slot_sizes` how tall to split the
+        pane; `_bottom` is what fills it. If the two disagreed, every frame would come up
+        either padded with blank rows the harness could have had, or with a table cut off
+        and nothing saying so — and neither is visible from either side alone.
+
+        **The PROPERTY is "the pane the launcher asks for is the pane the panel fills",
+        not "the row count matches".** #488 shipped a sizer that read the repo count and
+        a renderer that also read the WIDTH (no table below `statusline._LEFT_W`) and the
+        DENSITY (`_TERSE_ROWS` at `terse`), so the seam held only at the one shape the
+        original test used — wide, `normal`. Every input either side consults is varied
+        here: repo count across the cap, width across `_LEFT_W` and down to the smallest
+        `layout.visible_slots` still draws `bottom` at, and every level in
+        `instance.FRAME_DENSITY`. The next input to appear — a fourth density, a
+        `bottom`-specific `min-cols` — has to be added to this loop, and until it is, its
+        own dimension is unpinned rather than silently wrong.
+
+        Rendered into a pane of EXACTLY the height the sizer asked for, at EXACTLY the
+        width the sizer was asked about, and counted.
+        """
+        for level in (None, *sorted(instance.FRAME_DENSITY)):
+            for n in (0, 1, 4, 9, statusline._MAX_REPO_LINES + 3):
+                for cols in (50, 80, statusline._LEFT_W - 1, statusline._LEFT_W, 200):
+                    with self.subTest(density=level, repos=n, cols=cols):
+                        fid = f"wanted-{level}-{n}-{cols}"
+                        _seed(fid, repos=[_row(f"repo{i}") for i in range(n)])
+                        if level is not None:
+                            state.record_density(fid, level)
+                        want = slots.bottom_rows_wanted(fid, cols=cols)
+                        out = self._render(fid, cols=cols, rows=want)
+                        self.assertEqual(len(out.split("\n")), want, out)
+
+    def test_a_frame_too_narrow_for_the_table_is_sized_for_the_row_it_can_draw(self):
+        """The width half of the seam, stated as the number the LAUNCHER hands tmux.
+
+        `[frame] min-cols` (100) gates `right` and `top`; `layout.visible_slots` keeps
+        `bottom` down to `min_cols // 2`, so an 80-column terminal draws the attention row
+        and no table at all. Sized from the repo count alone it was given a pane for the
+        table anyway — six repos meant a seven-row pane holding one line, and the other
+        six rows came off the harness.
+
+        Asserted against a repo count large enough that the two answers cannot coincide,
+        and at `_LEFT_W` itself so the boundary is pinned from both sides rather than
+        only from the narrow one."""
+        _seed("narrow", repos=[_row(f"repo{i}") for i in range(6)])
+        for cols in (50, 80, statusline._LEFT_W - 1):
+            with self.subTest(cols=cols):
+                self.assertEqual(slots.bottom_rows_wanted("narrow", cols=cols), 1)
+        self.assertEqual(slots.bottom_rows_wanted("narrow",
+                                                  cols=statusline._LEFT_W), 1 + 6)
+
+    def test_a_terse_density_asks_for_a_shorter_pane_not_a_blanker_one(self):
+        """`minimal` exists to give the harness its rows back — `instance.FRAME_DENSITY`
+        says so in as many words. It shipped costing the harness exactly what `normal`
+        cost and drawing less in it: the renderer capped the TABLE at `_TERSE_ROWS`, the
+        sizer never read the density at all, so ten repos meant an eleven-row pane with
+        five lines in it and six blank.
+
+        Both levels asked for the same frame and the same width, so the only difference
+        between the two numbers is the one the level is for."""
+        _seed("dense", repos=[_row(f"repo{i}") for i in range(10)])
+        state.record_density("dense", "normal")
+        wide = slots.bottom_rows_wanted("dense", cols=200)
+        state.record_density("dense", "minimal")
+        terse = slots.bottom_rows_wanted("dense", cols=200)
+        self.assertEqual(wide, 1 + 10)
+        self.assertEqual(terse, 1 + slots._TERSE_ROWS)
+        self.assertLess(terse, wide)
 
     def test_a_pane_too_narrow_for_the_table_draws_no_table_rather_than_a_cut_one(self):
         """Every column after the branch sits at a fixed offset past
@@ -812,10 +869,86 @@ class BottomTable(PersonaIso, unittest.TestCase):
         self.assertEqual(opens, [], "composing the table opened a file")
         self.assertEqual(runs, [], "composing the table started a process")
 
+    def test_a_taller_pane_costs_the_same_syscalls_as_a_one_row_one(self):
+        """#387 pinned a panel's idle tick at exactly one `stat`, and #488 made `bottom`
+        the tall slot AND the one animated slot — so the question that budget does not
+        answer on its own is whether a REPAINT scales with the pane's height. At
+        `panel.TICK` a repaint that cost a syscall per row would pay fourteen times over,
+        five times a second, for the length of every dispatch.
+
+        The sibling test above bounds `_table_lines` in isolation, handed a dict; this
+        one bounds the whole `slots.render("bottom", …)` a panel actually calls — the
+        gather read, the workspace resolve, the alerts and the todo count included — and
+        it bounds it DIFFERENTIALLY. An absolute number would have to be revised every
+        time the attention row learns a new field, and a revised number is not a budget.
+        The claim is that the count does not depend on how many rows are drawn, so the
+        same count at one repo and at `_MAX_REPO_LINES` is exactly the claim.
+
+        Primed first: `workspace.resolve` and friends memoise, so the first render of the
+        process pays for caches every later one reuses, and comparing an unprimed render
+        against a primed one would measure the priming.
+
+        **Counted at every spelling a walk could arrive by, not at `os.stat` alone.** The
+        thing being kept out is "touch the filesystem once per row", and a directory walk
+        does not spell itself `stat`: `Path.iterdir` is `os.scandir`, `Path.resolve` is
+        `os.lstat`, `Path.read_text` is `io.open` and not `builtins.open`, and a `git`
+        call is `subprocess.Popen` under `run`. Each of those is the next spelling this
+        budget would otherwise miss, so each is counted.
+
+        Measured on this branch: 45 calls for a 2-line repaint and the same 45, in the
+        same order, for a 15-line one."""
+        import builtins
+        import io
+        import subprocess as _sp
+        watched = {"os": (os, ("stat", "lstat", "scandir", "listdir")),
+                   "io": (io, ("open",)), "builtins": (builtins, ("open",)),
+                   "subprocess": (_sp, ("run", "Popen"))}
+
+        def _count(fid, n):
+            _seed(fid, current_repo="r0",
+                  repos=[_row(f"r{i}", dirty=True, ci="failed", change=i, sigil="!",
+                              worktree_count=2) for i in range(n)])
+            self._render(fid, cols=200, rows=1 + n)          # prime
+            seen: list[str] = []
+            patches = []
+            for mod_name, (mod, fns) in watched.items():
+                for fn in fns:
+                    real = getattr(mod, fn)
+                    tag = f"{mod_name}.{fn}"
+                    patches.append(mock.patch(
+                        tag,
+                        (lambda r, t: lambda *a, **k: (seen.append(t), r(*a, **k))[1])(
+                            real, tag)))
+            with contextlib.ExitStack() as stack:
+                for p in patches:
+                    stack.enter_context(p)
+                out = self._render(fid, cols=200, rows=1 + n)
+            return len(out.split("\n")), seen
+
+        short_lines, short = _count("cost-1", 1)
+        tall_lines, tall = _count("cost-many", statusline._MAX_REPO_LINES)
+        self.assertEqual(short_lines, 2)
+        self.assertEqual(tall_lines, 1 + statusline._MAX_REPO_LINES,
+                         "the tall render drew no more rows — this proves nothing")
+        self.assertTrue(short, "nothing was counted at all — the budget is vacuous")
+        self.assertEqual(sorted(tall), sorted(short),
+                         f"a {tall_lines}-row repaint cost {len(tall)} filesystem calls "
+                         f"where a {short_lines}-row one cost {len(short)} — the table "
+                         f"is doing per-row filesystem work")
+        self.assertNotIn("subprocess.run", tall, "a repaint started a process")
+        self.assertNotIn("subprocess.Popen", tall, "a repaint started a process")
+
     def test_a_failing_gather_read_yields_a_line_rather_than_an_exception(self):
         """A panel that raises leaves a hole in the frame — `slots.render`'s own promise,
-        pinned against a renderer that reaches into a real dependency."""
-        with mock.patch.object(gather, "read", side_effect=RuntimeError("boom")):
+        pinned against a renderer that reaches into a real dependency.
+
+        Rendered at a width the table is actually attempted at: below
+        `statusline._LEFT_W` there is no table, so `gather.read` is never reached and the
+        test would pass by never running the code it claims to bound."""
+        with mock.patch.object(gather, "read", side_effect=RuntimeError("boom")), \
+             mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((200, 24))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
             self.assertIn("charter", slots.render("bottom", "f-1"))
 
 
@@ -824,20 +957,32 @@ class BottomRowsWanted(PersonaIso, unittest.TestCase):
 
     def test_a_plane_with_no_repos_wants_exactly_the_attention_row(self):
         _seed("f-1")
-        self.assertEqual(slots.bottom_rows_wanted("f-1"), 1)
+        self.assertEqual(slots.bottom_rows_wanted("f-1", cols=200), 1)
 
     def test_it_grows_with_the_repos_and_the_pieces_alike(self):
         _seed("f-1", repos=[_row("a"), _row("b")],
               worktrees=[_row("p", repo="a")])
-        self.assertEqual(slots.bottom_rows_wanted("f-1"), 1 + 3)
+        self.assertEqual(slots.bottom_rows_wanted("f-1", cols=200), 1 + 3)
 
     def test_it_is_capped_at_the_wide_tables_own_row_budget(self):
         """A workspace with forty clones must ask for a fifteen-row strip, not a
         forty-one-row one — `_MAX_REPO_LINES` is the same total-row budget the wide table
         keeps, reused rather than invented fresh."""
         _seed("f-1", repos=[_row(f"r{i}") for i in range(40)])
-        self.assertEqual(slots.bottom_rows_wanted("f-1"),
+        self.assertEqual(slots.bottom_rows_wanted("f-1", cols=200),
                          1 + statusline._MAX_REPO_LINES)
+
+    def test_the_width_is_required_and_cannot_be_confused_with_the_row_count(self):
+        """Keyword-only, so the launcher cannot hand it a window HEIGHT and get a
+        plausible-looking number back. #500's defect was a caller that had the width and
+        did not pass it (`cmd_resize` measured it into `_cols`); a positional parameter
+        would have turned that into the next one silently passing the wrong measurement.
+        A missing width is a `TypeError` at the call site, not a default of "wide"."""
+        _seed("f-1", repos=[_row("a")])
+        with self.assertRaises(TypeError):
+            slots.bottom_rows_wanted("f-1")
+        with self.assertRaises(TypeError):
+            slots.bottom_rows_wanted("f-1", 200)
 
     def test_it_never_runs_a_git_sweep(self):
         """It is called on a launch the operator is waiting on, and again on every step
@@ -847,7 +992,21 @@ class BottomRowsWanted(PersonaIso, unittest.TestCase):
         _seed("f-1", repos=[_row("a")])
         with mock.patch("charter.frame.gather.scan",
                         side_effect=AssertionError("row_count ran a scan")):
-            self.assertEqual(slots.bottom_rows_wanted("f-1"), 2)
+            self.assertEqual(slots.bottom_rows_wanted("f-1", cols=200), 2)
+
+    def test_a_narrow_frame_does_not_even_ask_how_many_repos_there_are(self):
+        """The launch path reaches `gather.row_count` with no cache by design
+        (`cmd_launch` calls `gather.discard` first), where it costs a directory listing.
+        Below `statusline._LEFT_W` the answer is one row whatever the count is, so the
+        listing is work with no reader — and `cmd_resize` would pay it again on every
+        step of a drag that is narrowing the terminal.
+
+        `row_count` itself is made to raise, so an implementation that asks and then
+        discards is a loud failure rather than a slow success."""
+        _seed("f-1", repos=[_row(f"r{i}") for i in range(6)])
+        with mock.patch("charter.frame.gather.row_count",
+                        side_effect=AssertionError("counted rows it had no room for")):
+            self.assertEqual(slots.bottom_rows_wanted("f-1", cols=80), 1)
 
 
 class RightRenderer(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -2838,6 +2838,75 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
                              f"the {slot!r} panel died sometime after repainting")
 
 
+class BottomsWidthIsWhatTmuxActuallyGivesIt(_TmuxServerFixture, PersonaIso):
+    """#500 round 3: `layout.bottom_cols` says how wide the `bottom` pane comes out.
+    tmux is the only authority on that, so this asks tmux.
+
+    The unit tests in `tests/test_frame_layout.py` pin the arithmetic against a number
+    written down by a human who once ran tmux. That is exactly the shape of assertion
+    this repo has been burned by — a constant that was right the day it was measured and
+    is never re-checked. What is actually being claimed is that a `right` split off the
+    harness pane BEFORE `bottom` costs `bottom` the sidebar's columns plus one border
+    column, and the only thing that can confirm it is `#{pane_width}` off a real server.
+
+    **The splits are `layout.panel_argvs`' own commands, not hand-retyped ones** — the
+    direction (`-h`/`-v`), the `-b`, and the `-l` are the production values, because
+    those flags ARE the geometry under test. Only the program after `--` is swapped for
+    a `sleep`, so this class needs no importable plane, no `charter panel` process and
+    no repaint: it is about rectangles, and `FourEdgeIntegration` above is where real
+    panels are proven.
+    """
+
+    def _bottom_width(self, order: list[str], cols: int) -> int:
+        session = f"bw{self._pane_counter}"
+        self._pane_counter += 1
+        r = self._srv("new-session", "-d", "-s", session,
+                      "-x", str(cols), "-y", "40", "-P", "-F", "#{pane_id}",
+                      "--", "sleep", "600")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness_pane = r.stdout.strip()
+        self.addCleanup(self._srv, "kill-session", "-t", session)
+
+        sizes = layout.slot_sizes(order, window_rows=40, content_rows=7)
+        cmds = layout.panel_argvs(slots=order, session=session,
+                                  socket=self.SOCKET_NAME,
+                                  harness_pane=harness_pane, sizes=sizes)
+        widths: dict[str, int] = {}
+        for slot, cmd in zip(order, cmds):
+            argv = cmd[:cmd.index("--") + 1] + ["sleep", "600"]
+            p = subprocess.run(argv, capture_output=True, text=True, timeout=10)
+            self.assertEqual(p.returncode, 0, f"splitting {slot!r}: {p.stderr}")
+            pane = p.stdout.strip()
+            self.addCleanup(_kill_pid, self._pane_pid_on(pane))
+            widths[slot] = pane
+        got = self._srv("display-message", "-p", "-t", widths["bottom"],
+                        "#{pane_width}").stdout.strip()
+        return int(got)
+
+    def _pane_pid_on(self, pane: str) -> str:
+        return self._srv("display-message", "-p", "-t", pane,
+                         "#{pane_pid}").stdout.strip()
+
+    def test_tmux_agrees_with_the_arithmetic_in_both_slot_orders(self):
+        """Both orders in one test, because the claim is a DIFFERENCE: the shipped order
+        leaves `bottom` the whole window and an operator's `right`-first order does not.
+        Asserted against `layout.bottom_cols`' own answer rather than against 110 and 87,
+        so this is tmux checking charter's arithmetic rather than two literals agreeing
+        with each other — and the second assertion is what stops "always the window's
+        width" from passing.
+        """
+        for order in (["top", "bottom", "right"], ["right", "top", "bottom"],
+                      ["top", "right", "bottom"], ["bottom", "right"]):
+            with self.subTest(order=order):
+                self.assertEqual(self._bottom_width(order, 110),
+                                 layout.bottom_cols(order, window_cols=110),
+                                 f"tmux disagrees with layout.bottom_cols for {order}")
+        self.assertNotEqual(
+            layout.bottom_cols(["top", "bottom", "right"], window_cols=110),
+            layout.bottom_cols(["right", "top", "bottom"], window_cols=110),
+            "the two orders answered the same width — the loop above proved nothing")
+
+
 @unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
 class EarlyDeathIntegration(unittest.TestCase):
     """#384: what a command that dies before the frame is drawn actually leaves behind.

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -68,7 +68,9 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands_frame, config, hooks, instance, todos
-from charter.frame import gather, layout, menu, notify, state, tmuxctl
+from charter.frame import gather, layout, menu, notify
+from charter.frame import slots as frame_slots
+from charter.frame import state, tmuxctl
 
 from tests._isolation import PersonaIso, run_hook
 
@@ -1202,16 +1204,30 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
 
     # -- 4. Resize redistribution ----------------------------------------------------- #
 
-    def test_a_fixed_size_panels_dimension_survives_a_real_window_resize(self):
+    def test_recomputed_sizes_really_hold_across_real_window_resizes(self):
         """Cross-task fix round, item 3: tmux's own layout engine redistributes EVERY
         pane proportionally on ANY resize, `-l size` notwithstanding — hand-verified
         against this exact tmux binary during development: a 120x30 frame grown to
         200x50 stretched a one-row panel to 8 rows, and only snapped back to 1 row on
         the way down because that particular shrink happened to be an exact round trip
-        of the same grow. This drives `commands_frame._resize_hook_argv` — the real
-        function, not a hand-retyped `resize-pane` — through three resizes (grow,
-        shrink smaller than the original, grow past the first grow) to rule out "only
-        works for a round trip" as the actual fix."""
+        of the same grow. Three resizes here (grow, shrink smaller than the original,
+        grow past the first grow) rule out "only works for a round trip".
+
+        **What is driven changed with #488.** The `window-resized` hook used to carry
+        `resize-pane -t %N -y 1` as literal text and this test installed it. `bottom` is
+        content-and-window sized now, so the correction has to be RECOMPUTED against the
+        window that just changed — `commands_frame._reassert_sizes`, the real function
+        the hook's `charter frame-resize` child calls, is driven here instead. That the
+        hook actually fires and actually reaches that child is proven end to end against
+        a real frame by `FourEdgeIntegration.
+        test_the_resize_hook_really_fires_and_charter_really_recomputes`.
+
+        The measured failure the CAP exists for is asserted here too, on the 90x25 pass:
+        a `bottom` that wanted more rows than the window can spare must not be granted
+        them, because tmux does not refuse an over-large `-y` — it takes the difference
+        out of the neighbour, and the neighbour is the harness (measured on 3.7c:
+        `resize-pane -y 40` in a 20-row window left the harness pane 1 row tall)."""
+        fid = state.frame_id("rsz", os.getpid())
         r = _tmux("new-session", "-d", "-s", "rsz", "-x", "120", "-y", "30",
                   "-P", "-F", "#{pane_id}")
         self.assertEqual(r.returncode, 0, r.stderr)
@@ -1220,20 +1236,41 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
                    "-P", "-F", "#{pane_id}", "--", "sleep", "600")
         self.assertEqual(top.returncode, 0, top.stderr)
         top_pane = top.stdout.strip()
+        bot = _tmux("split-window", "-t", harness_pane, "-v", "-l", "6",
+                    "-P", "-F", "#{pane_id}", "--", "sleep", "600")
+        self.assertEqual(bot.returncode, 0, bot.stderr)
+        bottom_pane = bot.stdout.strip()
+        panes = {"top": top_pane, "bottom": bottom_pane}
 
-        hook_cmd = commands_frame._resize_hook_argv(socket=SOCKET, harness_pane=harness_pane,
-                                                    panes={"top": top_pane})
-        self.assertEqual(_run(hook_cmd).returncode, 0, "installing the resize hook failed")
-
-        for cols, rows in ((200, 50), (90, 25), (300, 100)):
+        # The last size is the one the CAP binds at: at 20 rows the window can spare
+        # only `20 - top(1) - 2 borders - HARNESS_MIN_ROWS` = 5, fewer than the 6 the
+        # content wants — so `bottom` must come out a different number there than at the
+        # other three, and a `bottom_rows` that ignored *window_rows* entirely would
+        # still pass the first three.
+        for cols, rows in ((200, 50), (90, 25), (300, 100), (120, 20)):
             r = _tmux("resize-window", "-t", "rsz", "-x", str(cols), "-y", str(rows))
             self.assertEqual(r.returncode, 0, r.stderr)
-            time.sleep(0.3)
-            height = _tmux("display-message", "-p", "-t", top_pane,
-                           "#{pane_height}").stdout.strip()
-            self.assertEqual(height, "1",
-                             f"the panel drifted to {height} rows after resizing to "
-                             f"{cols}x{rows} — the hook did not hold")
+            with mock.patch("charter.frame.slots.bottom_rows_wanted", return_value=6):
+                commands_frame._reassert_sizes(SOCKET, fid=fid, panes=panes,
+                                               window_rows=rows)
+            want = layout.slot_sizes(["top", "bottom"], window_rows=rows,
+                                     content_rows=6)
+            if rows == 20:
+                self.assertLess(want["bottom"], 6,
+                                "the cap never bound — this loop's last pass is the "
+                                "only one that exercises it")
+            for slot, pane in panes.items():
+                height = _tmux("display-message", "-p", "-t", pane,
+                               "#{pane_height}").stdout.strip()
+                self.assertEqual(height, str(want[slot]),
+                                 f"the {slot} panel is {height} rows after resizing to "
+                                 f"{cols}x{rows}, not the {want[slot]} it was told")
+            harness = _tmux("display-message", "-p", "-t", harness_pane,
+                            "#{pane_height}").stdout.strip()
+            self.assertGreaterEqual(
+                int(harness), layout.HARNESS_MIN_ROWS,
+                f"the harness kept only {harness} rows at {cols}x{rows} — tmux grants "
+                f"an over-large -y out of the neighbour rather than refusing it")
 
     # -- 5. Session-scoped id delivery for the hotkey menu --------------------------- #
 
@@ -1379,8 +1416,10 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
     #: What that refusal writes to stderr, byte for byte (`frame/panel.py`'s `run`).
     #: Shared by the two tests below so the control below fails for the same REASON, and
     #: differs only in what the process does after printing it.
+    #: Read from the registry rather than spelled out, so retiring a slot (#488 retired
+    #: `left`) does not turn this control into a test that fails for the wrong reason.
     _BAD_SLOT_STDERR = (f"charter panel: unknown slot '{_BAD_SLOT}' "
-                        f"(known: bottom, left, right, top)")
+                        f"(known: {', '.join(sorted(frame_slots.SLOTS))})")
 
     #: A pane program that waits for a gate file, prints *stderr text* and exits 2 — the
     #: pre-#382 panel, reduced to the only two things about it that mattered. The gate
@@ -2268,7 +2307,7 @@ def _init_repo(path: Path, branch: str) -> Path:
     `tests/test_frame_gather.py`'s own `_init_repo` uses, duplicated here (rather
     than imported across test modules) so this module stays as self-contained as
     every other fixture in it already is. `FourEdgeIntegration` below is the only
-    caller: it needs a repo a real `charter panel left --session <fid>` subprocess
+    caller: it needs a repo a real `charter panel bottom --session <fid>` subprocess
     can gather for itself, through `gather.scan`, exactly the way an operator's own
     clone would be gathered."""
     path.mkdir(parents=True, exist_ok=True)
@@ -2287,7 +2326,7 @@ def _init_repo(path: Path, branch: str) -> Path:
 @unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
 class FourEdgeIntegration(PersonaIso, unittest.TestCase):
     """Task 5 (#385), the closing proof for this whole plan: a frame configured with
-    ALL FOUR slots comes up with all four panes alive and drawing REAL content, and
+    EVERY slot comes up with every pane alive and drawing REAL content, and
     repaints after a real `state.bump`. Tasks 1-4 were each unit-tested — a mocked
     `scan()`, an in-process cache read, a renderer called directly against a fixed
     `width`. Nothing before this class has ever run `gather.scan`,
@@ -2298,7 +2337,7 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
 
     `PanelIntegration` above already proves ONE panel end to end (`bottom`, driven
     by a direct `charter panel bottom --session <fid>` new-session). This class
-    proves the COMPOSITION `layout.panel_argvs` exists for instead: four real
+    proves the COMPOSITION `layout.panel_argvs` exists for instead: three real
     splits off the SAME harness pane id, in the same launch — the exact multi-split
     scenario `layout.py`'s own module docstring names as the index-churn hazard
     pane ids were built to close (tmux renumbers pane INDICES on every split;
@@ -2311,23 +2350,26 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
     `MenuIntegration`/`MenuFormatIntegration`/`MenuClientIntegration` above, and
     duplicating them here would only be a second, weaker copy.
 
-    **Only `left` is asserted through content that could only have come from the
-    cache Tasks 1/2 built.** `top` (workspace/persona/version), `right` (persona
-    chips) and `bottom` (todo count/alerts) all read live at render time —
-    `slots.py`'s own docstrings for `_top`/`_right`/`_bottom` each say so — real
-    subprocess, real data, but none of it through `gather.py`'s cache. `left` is
-    the one slot `slots._left` reads EXCLUSIVELY from `gather.read(fid)` (see that
-    function's own docstring: "never a repo directory listing, a `git status`, or a
+    **Only the repo TABLE is asserted through content that could only have come
+    from the cache Tasks 1/2 built.** `top` (workspace/persona/version), `right`
+    (persona chips) and `bottom`'s own attention row (todo count/alerts) all read
+    live at render time — `slots.py`'s own docstrings for `_top`/`_right`/`_bottom`
+    each say so — real subprocess, real data, but none of it through `gather.py`'s
+    cache. The table under that row (`slots._table_lines`, #488 — it was `left`
+    until then) is the one thing drawn EXCLUSIVELY from `gather.read(fid)` (see its
+    own docstring: "never a repo directory listing, a `git status`, or a
     `glstate.read_for` of its own"), so a real repo's real branch name showing up
-    in a captured `left` pane is the one assertion in this whole file that proves
+    in a captured `bottom` pane is the one assertion in this whole file that proves
     the actual thing this plan is for: a real `git` sweep, gathered ONCE, cached to
     disk by a hook, and read back by a panel process that never itself calls git —
     a panel showing "no repos" would be ALIVE and would tell you nothing about
     whether any of that chain actually works (see this module's own task brief).
+    That the two halves now share one pane is itself worth the assertion: #488's
+    own rule is that the table JOINS the attention row rather than evicting it.
 
     **Fix round 1 closed three links this proof left unproven, all the same shape
     (green even with the actual mechanism disabled):** a real, uncommitted file in
-    the fixture repo (mutation testing found `left`'s row shows a clean repo as
+    the fixture repo (mutation testing found the repo row shows a clean repo as
     clean whether or not `gather.scan`'s own `_repo_states` sweep — the real `git
     status --porcelain --branch` half — ever ran at all, since name/branch alone
     come from `_repo_trees`/`_branch`, neither of which touches it); a direct read
@@ -2481,9 +2523,17 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         self.assertTrue(harness_pane, "tmux did not report the harness pane's id")
         self.addCleanup(_kill_pid, self._pane_pid(harness_pane))
 
-        slots = ["top", "bottom", "left", "right"]
-        panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=SOCKET,
-                                        harness_pane=harness_pane)
+        slots = ["top", "bottom", "right"]
+        # `bottom` is content-sized since #488, and the sizer is asked for the size here
+        # rather than left to `SLOT_SIZE`'s floor — a one-row `bottom` would have no room
+        # for the repo table these tests read back, which is the whole point of the slot.
+        # *content_rows* is stated rather than taken from `slots.bottom_rows_wanted`: that
+        # helper resolves the workspace from THIS process's environment, and every panel
+        # below resolves it from the tmux session's instead, so a mismatch would size the
+        # pane for a different plane than the one the panels draw.
+        panel_cmds = layout.panel_argvs(
+            slots=slots, session=fid, socket=SOCKET, harness_pane=harness_pane,
+            sizes=layout.slot_sizes(slots, window_rows=40, content_rows=8))
         panes: dict[str, str] = {}
         for slot, cmd in zip(slots, panel_cmds):
             p = self._run_env(cmd)
@@ -2503,17 +2553,16 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         self._run_env(["tmux", "-L", SOCKET, "select-pane", "-t", harness_pane])
         return harness_pane, panes
 
-    def test_all_four_panels_come_up_alive_with_real_content_and_the_harness_keeps_focus(self):
-        """Launch composition, proven end to end: a frame with `top`/`left`/`right`/
-        `bottom` all configured comes up with all four panes alive, each showing
-        real content a broken renderer (or an empty, never-gathered cache) could
-        not have produced, and the harness pane — not the last panel
-        `split-window` happened to draw — holds keyboard focus once the launch
-        finishes.
+    def test_every_panel_comes_up_alive_with_real_content_and_the_harness_keeps_focus(self):
+        """Launch composition, proven end to end: a frame with `top`/`bottom`/`right`
+        all configured comes up with every pane alive, each showing real content a
+        broken renderer (or an empty, never-gathered cache) could not have produced, and
+        the harness pane — not the last panel `split-window` happened to draw — holds
+        keyboard focus once the launch finishes.
 
         **Fix round 1: the repo is made DIRTY before the frame ever launches, not
         left pristine.** `_init_repo`'s own repo has nothing uncommitted, so
-        without this, `left`'s row shows no marker regardless of whether
+        without this, the repo row shows no marker regardless of whether
         `gather.scan`'s `_repo_states` half (a real `git status --porcelain
         --branch` subprocess) ran at all — a mutation that replaced that whole
         sweep with `{}` left every assertion in this test green, because
@@ -2521,7 +2570,12 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         `_repo_trees`/`_branch` alone, neither of which touches `_repo_states`.
         The `*` dirty marker asserted below is the one thing in this test that
         can only come from that sweep actually running and actually landing in
-        the cache `left` reads back.
+        the cache the table reads back.
+
+        **#488 moved the repo table from `left` to `bottom`**, so the cache-proving
+        assertions moved with it: the same pane now carries the live todo count AND the
+        cached repo row, which is itself worth asserting together — the attention row
+        must survive the table joining it, not be evicted by it.
         """
         repo_name = f"cnry{os.getpid() % 10000}"
         branch = f"br{os.getpid() % 10000}a"
@@ -2533,7 +2587,7 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
 
         fid = state.frame_id("four-edge-alive", os.getpid())
         harness_pane, panes = self._spawn_frame(fid)
-        self.assertEqual(set(panes), {"top", "bottom", "left", "right"})
+        self.assertEqual(set(panes), {"top", "bottom", "right"})
 
         # Poll for real content (`_wait_for`'s own docstring — fix round 1:
         # replaces a fixed `time.sleep(1.5)` that guessed at how long four cold
@@ -2543,9 +2597,8 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         # `_wait_for` spends its own timeout before falling through to the alive
         # check below, same as a deliberate wait would have.
         top = self._wait_for(panes["top"], "demo")
-        left = self._wait_for(panes["left"], repo_name)
         right = self._wait_for(panes["right"], persona_name)
-        bottom = self._wait_for(panes["bottom"], "1 todo")
+        bottom = self._wait_for(panes["bottom"], repo_name)
 
         for slot, pane in panes.items():
             self.assertEqual(self._alive(pane), "0",
@@ -2556,19 +2609,22 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
 
         self.assertIn("demo", top, f"top never showed the real workspace name:\n{top!r}")
 
-        self.assertIn(repo_name, left, f"left never showed the real repo:\n{left!r}")
-        self.assertIn(branch, left, f"left never showed the real branch:\n{left!r}")
-        self.assertIn("*", left,
-                      f"left never showed the dirty marker for a real uncommitted "
+        self.assertIn(repo_name, bottom,
+                      f"bottom never showed the real repo:\n{bottom!r}")
+        self.assertIn(branch, bottom,
+                      f"bottom never showed the real branch:\n{bottom!r}")
+        self.assertIn("*", bottom,
+                      f"bottom never showed the dirty marker for a real uncommitted "
                       f"file — either gather.scan's own git-status sweep never "
                       f"ran, or nothing carried its result into the cached "
-                      f"row:\n{left!r}")
+                      f"row:\n{bottom!r}")
 
         self.assertIn(persona_name, right,
                       f"right never showed the real persona:\n{right!r}")
 
         self.assertIn("1 todo", bottom,
-                      f"bottom never showed the real todo count:\n{bottom!r}")
+                      f"the attention row was evicted by the table it is supposed to "
+                      f"sit above:\n{bottom!r}")
 
         focus = _tmux("display-message", "-p", "-t", harness_pane,
                       "#{pane_active}").stdout.strip()
@@ -2577,18 +2633,81 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
                          "operator's harness must be able to receive a keystroke "
                          "the instant the frame comes up")
 
-    def test_a_state_bump_through_the_real_hook_repaints_left_and_bottom_with_new_facts(self):
+    def test_the_resize_hook_really_fires_and_charter_really_recomputes(self):
+        """The one link `_reassert_sizes`' own integration test (`TmuxIntegration.
+        test_recomputed_sizes_really_hold_across_real_window_resizes`) cannot reach: that
+        one CALLS the recompute, and proves the sizes hold. This proves tmux actually
+        runs the hook charter installed, and that the `run-shell` child actually finds
+        this frame and resizes its panes — the whole of #488's answer to "a content-sized
+        pane must recompute its HEIGHT on `window-resized`, not just its width".
+
+        A real `set-hook` built by `commands_frame._resize_hook_argv`, a real
+        `resize-window`, and a real `charter frame-resize` subprocess started by tmux
+        against this class's own throwaway plane (the frame's harness pane, pane map and
+        server are recorded first, because that child reads all three off disk — which is
+        exactly why no pane id needs to travel in the hook's text, closing #475).
+
+        **Asserted on a GROW, and that is what makes it a test rather than a
+        coincidence.** On a shrink tmux's own proportional redistribution already makes
+        `bottom` smaller all by itself, so "it got smaller" would pass with no hook
+        installed at all — the fixture-coincidence shape this suite keeps paying for.
+        Growing the window is the one direction the two mechanisms disagree about: tmux
+        stretches every pane proportionally (measured on 3.7c: a one-row panel became 8
+        rows on a 120x30 -> 200x50 grow), while charter's recompute sizes `bottom` to its
+        CONTENT, and this frame's plane has no clones to table — so a pane that came out
+        SMALLER after the window grew can only be charter's answer.
+        """
+        fid = state.frame_id("four-edge-resize", os.getpid())
+        harness_pane, panes = self._spawn_frame(fid)
+        state.record_harness_pane(fid, harness_pane)
+        state.record_panes(fid, panels=panes)
+        state.record_server(fid, SOCKET)
+
+        hook = commands_frame._resize_hook_argv(socket=SOCKET,
+                                                harness_pane=harness_pane, fid=fid)
+        self.assertIsNotNone(hook, "the frame's own id was refused by the hook builder")
+        self.assertEqual(self._run_env(hook).returncode, 0,
+                         "installing the resize hook failed")
+        # The `run-shell` child is a `charter` of its own: it must find THIS plane, not
+        # the developer's. `_spawn_frame`'s session already carries `$CHARTER_ROOT` (see
+        # `setUp`), and the hook fires in that session's own environment.
+        before = int(_tmux("display-message", "-p", "-t", panes["bottom"],
+                           "#{pane_height}").stdout.strip())
+        self.assertGreater(before, 1, "the fixture never gave bottom a tall pane")
+
+        r = _tmux("resize-window", "-t", fid, "-x", "160", "-y", "80")
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+        deadline = time.monotonic() + _DEADLINE
+        height = before
+        while time.monotonic() < deadline:
+            height = int(_tmux("display-message", "-p", "-t", panes["bottom"],
+                               "#{pane_height}").stdout.strip() or before)
+            if height < before:
+                break
+            time.sleep(0.1)
+        self.assertLess(height, before,
+                        f"bottom is {height} rows after the window GREW from 40 to 80 — "
+                        f"tmux's own redistribution only ever stretches on a grow, so "
+                        f"this is what charter's recompute would have had to undo. The "
+                        f"hook never fired, or its child never reached this frame")
+        harness = int(_tmux("display-message", "-p", "-t", harness_pane,
+                            "#{pane_height}").stdout.strip())
+        self.assertGreaterEqual(harness, layout.HARNESS_MIN_ROWS, harness)
+
+    def test_a_state_bump_through_the_real_hook_repaints_the_table_and_the_alert_row(self):
         """Closes the gap `PanelIntegration`'s own hook test
         (`test_a_real_hook_call_repaints_a_live_panel_without_a_direct_state_bump`)
         leaves open for THIS plan: that test drives `hooks.posttooluse` against
         `bottom` alone, which never touches `gather.py` at all. This drives the
         SAME real hook — never a direct `state.bump` or `gather.refresh` call — and
-        watches `left` repaint with a NEW branch name that only exists because
+        watches `bottom`'s repo table repaint with a NEW branch name that only
+        exists because
         `notify.plane_changed` ran `gather.refresh` BEFORE `state.bump` (Task 2's
         own contract, and its own docstring's reason: refresh-then-bump closes the
         window where a poller sees the new version and still reads the stale
         cache). A version bump into a stale or never-refreshed cache would leave
-        `left` showing the OLD branch forever — this is the one test in the file
+        the table showing the OLD branch forever — this is the one test in the file
         that would catch that. `bottom` is watched in the same pass, from the SAME
         single hook call, to pin that one refresh/bump serves every slot that asks,
         not only the one `PanelIntegration` already covers.
@@ -2596,10 +2715,10 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         **The cache is warmed with one direct `gather.refresh` call before any
         assertion runs — this is load-bearing, not incidental.** Caught by
         mutation: with no cache file on disk yet, `gather.read`'s OWN fallback
-        (`_left` calls it, this file's `left` panel does not) recomputes a FRESH
+        (`_table_lines`' caller calls it) recomputes a FRESH
         scan on every call regardless of whether the cache was ever written — so
         with `notify.plane_changed`'s `gather.refresh` call deleted outright (a
-        real mutation tried while writing this test), `left` still showed the new
+        real mutation tried while writing this test), the table still showed the new
         branch every time, because it was never reading a cache at all, only ever
         falling through to a live scan. That passed for the wrong reason and would
         have shipped a vacuous proof of Task 2's whole contract. Priming the cache
@@ -2628,7 +2747,7 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         gather.refresh(fid, workspace="demo")
 
         # Fix round 1: prove the CACHE FILE itself exists and holds *branch_a* —
-        # not only that `left` shows the right text, which `gather.read`'s own
+        # not only that the table shows the right text, which `gather.read`'s own
         # missing-cache fallback (a fresh, live scan) can produce with `gather.
         # save` neutered outright and no cache ever written at all. This is the
         # direct check that `gather.refresh` did the WRITE half of its job, not
@@ -2642,10 +2761,9 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
                       f"the primed cache file exists but does not hold the "
                       f"starting branch:\n{cache.read_text()!r}")
 
-        left_before = self._wait_for(panes["left"], branch_a)
-        bottom_before = self._wait_for(panes["bottom"], "1 todo")
-        self.assertIn(branch_a, left_before,
-                      f"left never showed the starting branch:\n{left_before!r}")
+        bottom_before = self._wait_for(panes["bottom"], branch_a)
+        self.assertIn(branch_a, bottom_before,
+                      f"the table never showed the starting branch:\n{bottom_before!r}")
         self.assertIn("1 todo", bottom_before,
                       f"bottom never showed the starting todo count:\n{bottom_before!r}")
 
@@ -2669,7 +2787,7 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         # this throwaway plane's own `DEFAULT_WORKSPACE` instead (this process's
         # cwd is the checkout root, not inside `demo`'s own tree, so the cwd rung
         # cannot rescue it either) — `gather.refresh` would then cache a scan of
-        # the WRONG, repo-less workspace, and `left` would repaint to "no repos"
+        # the WRONG, repo-less workspace, and the table would repaint to "no repos"
         # rather than the new branch, for a reason that has nothing to do with
         # whether the refresh/bump wiring itself works.
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": fid,
@@ -2685,17 +2803,23 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         # paint (fix round 1) — waits for the specific new fact each panel is
         # expected to show, rather than a fixed sleep or an undifferentiated
         # "content changed" check.
-        left_after = self._wait_for(panes["left"], branch_b)
+        self._wait_for(panes["bottom"], branch_b)
+        # Both new facts land on the SAME pane now, and the two halves of the repaint
+        # arrive together — but poll for the second needle as well rather than assuming
+        # it, so a capture taken between the two is a retry rather than a failure.
         bottom_after = self._wait_for(panes["bottom"], "2 todos")
 
-        self.assertNotEqual(left_after, left_before,
-                            f"left never repainted after a real hooks.posttooluse() "
-                            f"call; still showing:\n{left_before!r}")
-        self.assertIn(branch_b, left_after,
-                      f"left repainted but not with the NEW branch:\n{left_after!r}")
-        self.assertNotIn(branch_a, left_after,
-                         f"left kept showing the OLD branch after the switch — a "
-                         f"stale cache surviving its own refresh:\n{left_after!r}")
+        self.assertNotEqual(bottom_after, bottom_before,
+                            f"bottom never repainted after a real hooks.posttooluse() "
+                            f"call; still showing:\n{bottom_before!r}")
+        self.assertIn(branch_b, bottom_after,
+                      f"bottom repainted but not with the NEW branch:\n{bottom_after!r}")
+        self.assertNotIn(branch_a, bottom_after,
+                         f"the table kept showing the OLD branch after the switch — a "
+                         f"stale cache surviving its own refresh:\n{bottom_after!r}")
+        self.assertIn("2 todos", bottom_after,
+                      f"the live half of the same pane never repainted:"
+                      f"\n{bottom_after!r}")
 
         # Fix round 1: the cache FILE on disk, not only the pane's own capture,
         # now holds the new branch — proving the hook's `gather.refresh` call did
@@ -2703,15 +2827,9 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         # direct check made against `branch_a` above, repeated here against the
         # value only a SECOND, successful refresh could have produced.
         self.assertIn(branch_b, cache.read_text(),
-                      f"left repainted (or the panel's own live fallback masked "
+                      f"bottom repainted (or the panel's own live fallback masked "
                       f"a broken refresh) but the cache file itself was never "
                       f"updated with the new branch:\n{cache.read_text()!r}")
-
-        self.assertNotEqual(bottom_after, bottom_before,
-                            f"bottom never repainted after the same real hook call; "
-                            f"still showing:\n{bottom_before!r}")
-        self.assertIn("2 todos", bottom_after,
-                      f"bottom repainted but not with the NEW todo count:\n{bottom_after!r}")
 
         for slot, pane in panes.items():
             self.assertEqual(self._alive(pane), "0",

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -1252,7 +1252,7 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
             self.assertEqual(r.returncode, 0, r.stderr)
             with mock.patch("charter.frame.slots.bottom_rows_wanted", return_value=6):
                 commands_frame._reassert_sizes(SOCKET, fid=fid, panes=panes,
-                                               window_rows=rows)
+                                               window_cols=cols, window_rows=rows)
             want = layout.slot_sizes(["top", "bottom"], window_rows=rows,
                                      content_rows=6)
             if rows == 20:

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -1480,7 +1480,8 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
         proves nothing at all about what an operator sees: the failure being fixed is
         specifically that the reason DID reach the pane and was then scrolled out of it
         by tmux's own dead-pane message. So this spawns the real `charter panel` argv
-        into a real ONE-ROW pane (`layout.SLOT_SIZE["bottom"]`) with `remain-on-exit`
+        into a real ONE-ROW pane (`layout.SLOT_SIZE["bottom"]` — `bottom`'s floor since
+        #488, and still the height a plane with no clones gets) with `remain-on-exit`
         armed exactly as a real frame arms it, and asserts on `capture-pane` — what is
         on the screen — not on a return code.
 
@@ -1560,7 +1561,8 @@ class PanelIntegration(PersonaIso, unittest.TestCase):
         to write a message about yet: this 74-column reason, `print`ed to a 40-column
         ONE-row pane, leaves the visible screen ALREADY blank — the wrap and the print's
         own trailing newline each scroll the pane's only row into history. So at the
-        size `top` and `bottom` actually are (`layout.SLOT_SIZE`: 1) the operator's
+        size `top` always is, and `bottom` is at its floor (`layout.SLOT_SIZE`: 1), the
+        operator's
         nothing does not wait for the death, and does not depend on which tmux is
         running: the dead-pane message, where a tmux writes one, lands on a row that was
         already empty. It is also why `panel._write` — the one path `_hold` paints

--- a/tests/test_inflight_dispatch.py
+++ b/tests/test_inflight_dispatch.py
@@ -24,7 +24,13 @@ from contextlib import redirect_stdout
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from charter import config, hooks, inflight
+import sys
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import config, hooks, inflight, tui
+
+from tests._isolation import PersonaIso
 
 
 def _age(path: Path, seconds: float) -> Path:
@@ -298,3 +304,254 @@ class ManifestWiring(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class RecordsSayWhatKindOfWorkTheyAre(unittest.TestCase):
+    """#420. #387 promised the frame "a spinner while a dispatch, clone or `gl-refresh`
+    runs" and shipped dispatches only, because `inflight.start` had exactly one caller.
+
+    Wiring the other two in was blocked on this: the SAME records feed the
+    dispatch-overlap nudge through `still_running`, which reads its answer back to an
+    operator as a sentence — so a record named `clone` would have produced *"`x` writes
+    code and `clone` are already running"*. Every test here is about which reader sees
+    which kind, because that is the whole of the design.
+    """
+
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self._orig = config.STATE_DIR
+        config.STATE_DIR = Path(self._td.name)
+        self.addCleanup(self._td.cleanup)
+        self.addCleanup(lambda: setattr(config, "STATE_DIR", self._orig))
+
+    def test_a_clone_is_invisible_to_every_reader_that_names_what_is_running(self):
+        """The three that would put the word in front of an operator: the nudge's own
+        `still_running`, the aggregate `live` behind the status line's `⚡ N`, and
+        `live_records`, which `statusline._inflight_by_persona` groups BY PERSONA — a
+        clone landing there would invent a persona named after a repo."""
+        inflight.start("iam-service", kind=inflight.CLONE)
+        self.assertEqual(inflight.still_running(), [])
+        self.assertEqual(inflight.live(), [])
+        self.assertEqual(inflight.live_records(), [])
+
+    def test_a_dispatch_is_still_visible_to_all_three(self):
+        """The other direction, so the test above cannot be satisfied by a filter that
+        hides everything."""
+        inflight.start("coder")
+        self.assertEqual(inflight.still_running(), ["coder"])
+        self.assertEqual(inflight.live(), ["coder"])
+        self.assertEqual([n for n, _, _ in inflight.live_records()], ["coder"])
+
+    def test_asking_for_no_kind_at_all_sees_every_kind(self):
+        """`kind=None` is what the frame's spinner asks for — it counts records and never
+        names them, so a clone and a dispatch are both simply "running" there."""
+        inflight.start("coder")
+        inflight.start("iam-service", kind=inflight.CLONE)
+        inflight.start("demo", kind=inflight.REFRESH)
+        self.assertEqual(sorted(n for n, _, _ in inflight.live_records(kind=None)),
+                         ["coder", "demo", "iam-service"])
+
+    def test_the_default_is_dispatch_rather_than_everything(self):
+        """**The default is the guard, not a convenience.** A reader that must not see a
+        clone gets that by NOT asking, so the next kind somebody invents cannot leak into
+        the nudge by being forgotten at one call site. Asserted as a property of the
+        signature — every one of the three readers, unasked — rather than of one of them,
+        because a fix that changed only the one under test is exactly the shape that
+        would pass a single-reader check."""
+        inflight.start("iam-service", kind=inflight.CLONE)
+        for fn in (inflight.live, inflight.still_running, inflight.live_records):
+            with self.subTest(fn=fn.__name__):
+                self.assertEqual(list(fn()), [], f"{fn.__name__} defaulted to every kind")
+
+    def test_a_record_written_before_the_field_existed_reads_as_a_dispatch(self):
+        """A record on disk outlives the charter that wrote it — the tracker keeps one
+        for `PRUNE_SECONDS` (a day), so an upgrade mid-dispatch is the ORDINARY case, not
+        an edge one. A pre-#420 record has no `kind`, and it was a dispatch: reading it as
+        anything else would drop a genuinely running peer out of the overlap nudge, which
+        is the one thing that nudge exists to catch."""
+        inflight.start("coder")
+        p = _only_record()
+        rec = json.loads(p.read_text())
+        del rec["kind"]
+        p.write_text(json.dumps(rec))
+        self.assertEqual(inflight.still_running(), ["coder"])
+
+    def test_a_kind_that_is_not_a_string_reads_as_a_dispatch_too(self):
+        """Same reasoning, one step further: the file is on disk, so a truncated write or
+        a hand edit can put anything there. A value that can never match a filter would
+        hide a live record from every reader — including the nudge — which is a silent
+        failure in the direction that matters. Degrading to `dispatch` shows it to the
+        reader that would rather have a false positive than a miss."""
+        inflight.start("coder")
+        p = _only_record()
+        p.write_text(json.dumps({"agent": "coder", "kind": 7, "ts": time.time()}))
+        self.assertEqual(inflight.still_running(), ["coder"])
+
+    def test_finish_retires_only_its_own_kind(self):
+        """The file NAME carries the agent and not the kind, so a clone of a repo called
+        `steward` and a dispatch to a persona called `steward` glob identically. Without
+        a kind check inside `finish`, whichever finished first would retire the other's
+        record — clearing a true one and leaving a false live one behind, which is
+        exactly the state #308 built this tracker to make impossible."""
+        inflight.start("steward")
+        inflight.start("steward", kind=inflight.CLONE)
+        inflight.finish("steward", kind=inflight.CLONE)
+        self.assertEqual(inflight.still_running(), ["steward"])
+        self.assertEqual([n for n, _, _ in inflight.live_records(kind=inflight.CLONE)],
+                         [])
+
+    def test_an_unreadable_record_is_never_the_one_finish_deletes(self):
+        """`finish` deletes what the kind check admits, and a file charter cannot read is
+        one it cannot claim belongs to this caller. Left alone here; `live_records`
+        prunes it on its own horizon, which is where a stray belongs."""
+        inflight.start("coder")
+        p = _only_record()
+        p.write_text("{not json")
+        inflight.finish("coder")
+        self.assertTrue(p.exists(), "finish deleted a record it could not identify")
+
+
+class TheSpinnerFollowsEveryKindOfWork(PersonaIso, unittest.TestCase):
+    """#420's actual deliverable: a clone or a `gl-refresh` moves the frame's spinner,
+    and neither reaches the surfaces that would name it."""
+
+    def _field(self) -> str:
+        from charter.frame import slots
+        with mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+             mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((200, 24))):
+            return tui.strip_ansi(slots._inflight_field())
+
+    def test_a_clone_in_flight_moves_the_spinner(self):
+        inflight.start("iam-service", kind=inflight.CLONE)
+        self.assertIn("1 running", self._field())
+
+    def test_a_gl_refresh_in_flight_moves_the_spinner(self):
+        inflight.start("demo", kind=inflight.REFRESH)
+        self.assertIn("1 running", self._field())
+
+    def test_a_clone_and_a_dispatch_are_counted_together(self):
+        """One count, not two fields: the row says how much work is in flight, and
+        splitting it by kind would put a taxonomy on a status row nobody asked for."""
+        inflight.start("coder")
+        inflight.start("iam-service", kind=inflight.CLONE)
+        self.assertIn("2 running", self._field())
+
+    def test_the_panels_own_gate_agrees_with_what_the_row_will_draw(self):
+        """`panel._running` decides whether the panel repaints often enough for the
+        spinner to MOVE; `_inflight_field` decides what it says. If the gate stayed
+        dispatch-only, a clone would leave the row showing a spinner frame frozen at
+        whichever instant the last version bump happened to be — a still picture of an
+        arbitrary frame, which is the exact thing `slots.SPINNER`'s own docstring says
+        the clock-driven design exists to avoid."""
+        from charter.frame import panel
+        inflight.start("iam-service", kind=inflight.CLONE)
+        self.assertEqual(panel._running(panel._new_inflight_cache()), 1)
+
+    def test_nothing_in_flight_is_still_perfect_stillness(self):
+        """The property #387 bought the whole gate for, re-asserted now that the gate
+        admits more: widening WHAT animates must not widen WHEN."""
+        from charter.frame import panel
+        self.assertEqual(self._field(), "")
+        self.assertEqual(panel._running(panel._new_inflight_cache()), 0)
+
+
+class CloneAndRefreshActuallyRecordThemselves(PersonaIso, unittest.TestCase):
+    """The wiring, not the mechanism: `inflight.start` having a second and third caller
+    is the entire content of #420, and a `kind` field nothing ever writes would be a
+    feature with no user."""
+
+    def test_a_clone_holds_a_record_for_as_long_as_git_runs(self):
+        """Observed from INSIDE the `git clone` call, which is the only moment it is
+        observable — and the only moment it matters, since that is when an operator is
+        looking at a frame wondering whether anything is happening. Asserted through the
+        real `_clone_one`, with only `git` itself stubbed."""
+        from charter import commands
+        seen = []
+
+        def fake_git(argv, **kw):
+            seen.append(inflight.live_records(kind=inflight.CLONE))
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        wd = config.WORKSPACES_DIR / "demo"
+        wd.mkdir(parents=True, exist_ok=True)
+        repo = {"name": "iam-service", "default_branch": "main",
+                "http_url": "https://example.invalid/x/iam-service.git"}
+        with mock.patch.object(commands, "_git", side_effect=fake_git), \
+             mock.patch.object(commands, "_https_url",
+                               return_value="https://example.invalid/x.git"), \
+             mock.patch("charter.gitpolicy.apply"):
+            res = commands._clone_one(repo, wd)
+        self.assertEqual(res["status"], "ok")
+        self.assertEqual([n for n, _, _ in seen[0]], ["iam-service"], seen)
+
+    def test_the_clones_record_is_released_when_git_returns(self):
+        from charter import commands
+        wd = config.WORKSPACES_DIR / "demo"
+        wd.mkdir(parents=True, exist_ok=True)
+        repo = {"name": "iam-service", "default_branch": "main"}
+        with mock.patch.object(commands, "_git",
+                               return_value=SimpleNamespace(returncode=0, stdout="",
+                                                            stderr="")), \
+             mock.patch.object(commands, "_https_url",
+                               return_value="https://example.invalid/x.git"), \
+             mock.patch("charter.gitpolicy.apply"):
+            commands._clone_one(repo, wd)
+        self.assertEqual(inflight.live_records(kind=None), [])
+
+    def test_a_clone_that_raises_still_releases_its_record(self):
+        """`finally`, not a trailing call: a record left behind by an exception would
+        spin an idle operator's frame until the presumed-dead threshold half an hour
+        later, and `git` shelling out is exactly where an unexpected `OSError` lives."""
+        from charter import commands
+        wd = config.WORKSPACES_DIR / "demo"
+        wd.mkdir(parents=True, exist_ok=True)
+        repo = {"name": "iam-service", "default_branch": "main"}
+        with mock.patch.object(commands, "_git", side_effect=OSError("no git")), \
+             mock.patch.object(commands, "_https_url",
+                               return_value="https://example.invalid/x.git"):
+            with self.assertRaises(OSError):
+                commands._clone_one(repo, wd)
+        self.assertEqual(inflight.live_records(kind=None), [])
+
+    def test_a_refused_clone_never_takes_a_record_at_all(self):
+        """The record is taken after the destination and the URL are settled, so a repo
+        charter refuses to clone leaves nothing behind to animate a frame over."""
+        from charter import commands
+        wd = config.WORKSPACES_DIR / "demo"
+        wd.mkdir(parents=True, exist_ok=True)
+        res = commands._clone_one({"name": "../escape", "default_branch": "main"}, wd)
+        self.assertEqual(res["status"], "refused")
+        self.assertEqual(inflight.live_records(kind=None), [])
+
+    def test_gl_refresh_holds_a_record_while_it_fetches(self):
+        """Observed from inside `glstate.refresh`, the call that actually goes to the
+        forge. The workspace is the name, not a repo: one refresh covers every tree in
+        it, and naming one of them would be a claim about which."""
+        from charter import commands
+        seen = []
+
+        def fake_refresh(dirs):
+            seen.append(inflight.live_records(kind=inflight.REFRESH))
+            return {}
+
+        with mock.patch("charter.workspace.repo_trees",
+                        return_value=[config.WORKSPACES_DIR / "demo" / "r"]), \
+             mock.patch("charter.worktree.dirs_for", return_value=[]), \
+             mock.patch("charter.glstate.refresh", side_effect=fake_refresh):
+            rc = commands.cmd_gl_refresh(SimpleNamespace(detach=False, workspace="demo"))
+        self.assertEqual(rc, 0)
+        self.assertEqual([n for n, _, _ in seen[0]], ["demo"], seen)
+        self.assertEqual(inflight.live_records(kind=None), [],
+                         "the refresh's record outlived the fetch")
+
+    def test_the_detach_branch_records_nothing(self):
+        """`--detach` returns before any work happens, in order to let the CHILD do it. A
+        record taken there would clear before the child had begun, and the frame would
+        blink rather than spin."""
+        from charter import commands
+        with mock.patch("charter.util.detach_self") as detach:
+            rc = commands.cmd_gl_refresh(SimpleNamespace(detach=True, workspace="demo"))
+        self.assertEqual(rc, 0)
+        detach.assert_called_once()
+        self.assertEqual(inflight.live_records(kind=None), [])

--- a/tests/test_statusline_gauge.py
+++ b/tests/test_statusline_gauge.py
@@ -13,6 +13,8 @@ import re
 import unittest
 from pathlib import Path
 
+from unittest import mock
+
 from charter import config, statusline
 from tests._isolation import PersonaIso, isolate_state_dir, pin_update_channel
 
@@ -342,3 +344,160 @@ class VaultHealthIsCachedOffTheRenderPath(PersonaIso):
         f.write_text(_json.dumps(doc))
         statusline._vault_health("v1")
         self.assertEqual(self.calls, ["v1", "v1"])
+
+
+class TheRecordedRowCarriesTheContextPercentage(unittest.TestCase):
+    """#413. `ctx NN%` is the one figure in the gauge that cannot be re-derived from
+    anything: the cache ratio and the rebuild history both come out of `read`/`write`,
+    and the percentage lives only in Claude Code's per-turn payload. Inside a frame the
+    status line draws nothing and a panel draws instead, out of this file — so a
+    percentage that was never written down is one the frame can never show.
+    """
+
+    def setUp(self):
+        isolate_state_dir(self)
+        import shutil
+        import tempfile
+        d = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, d, True)
+        self._orig_sessions = config.SESSIONS_DIR
+        config.SESSIONS_DIR = Path(d)
+        self.addCleanup(lambda: setattr(config, "SESSIONS_DIR", self._orig_sessions))
+
+    def _rows(self, sid="s1"):
+        return [ln for ln in statusline._usage_file(sid).read_text().splitlines()
+                if ln.strip()]
+
+    def test_the_percentage_is_written_as_a_fourth_field(self):
+        statusline.record_usage(dict(_payload(pct=42, read=900, write=100),
+                                     session_id="s1"))
+        self.assertEqual(self._rows(), ["900,100,90,42"])
+
+    def test_a_turn_with_no_percentage_writes_an_empty_field_not_a_zero(self):
+        """Early in a session, and right after `/compact`. `ctx 0%` would be a claim; an
+        empty field is the absence of one, and `_last_ctx` skips it."""
+        statusline.record_usage(dict(_payload(read=900, write=100), session_id="s1"))
+        self.assertEqual(self._rows(), ["900,100,90,"])
+        self.assertIsNone(statusline._last_ctx("s1"))
+
+    def test_a_rerender_of_one_turn_is_still_one_row(self):
+        """The de-duplication rule this file has always claimed — an identical
+        `(read, write)` pair is the same API response re-rendered — asserted against a
+        payload whose PERCENTAGE moved. Comparing the whole assembled row (what the code
+        did while every field was derived from those two) would append a second row for
+        the same turn, spending a slot of the ring buffer and shifting the rebuild
+        history by one."""
+        statusline.record_usage(dict(_payload(pct=42, read=900, write=100),
+                                     session_id="s1"))
+        statusline.record_usage(dict(_payload(pct=43, read=900, write=100),
+                                     session_id="s1"))
+        self.assertEqual(len(self._rows()), 1)
+
+    def test_a_real_new_turn_still_appends(self):
+        """The other direction, so the test above cannot be satisfied by a de-duplication
+        that never appends anything."""
+        statusline.record_usage(dict(_payload(pct=42, read=900, write=100),
+                                     session_id="s1"))
+        statusline.record_usage(dict(_payload(pct=44, read=1800, write=100),
+                                     session_id="s1"))
+        self.assertEqual(len(self._rows()), 2)
+
+    def test_the_hit_percentage_is_read_positionally_not_as_the_last_field(self):
+        """The trap the fourth field sets. `_hits` used to take the last field, which was
+        the hit rate; it is now the CONTEXT percentage — a plausible number in the same
+        0-100 range, so a trend reading it would have gone on rendering and quietly meant
+        something else entirely. The fixture makes the two differ so the mistake cannot
+        hide behind a coincidence."""
+        statusline._record_turn("s1", 90, 900, 100, 42)
+        self.assertEqual(statusline._hits(self._rows()), [90])
+
+    def test_a_three_field_row_from_an_older_charter_still_reads(self):
+        """The tracker keeps a session's history for its whole life, so an upgrade
+        mid-session is ordinary. A row written before #413 has no fourth field: its hit
+        rate and its `(read, write)` pair must both still be readable, or the rebuild
+        counter would silently report "no rebuilds" where it means "charter stopped
+        reading its own file"."""
+        f = statusline._usage_file("s1")
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("900,100,90\n1000,90000,1\n")
+        self.assertEqual(statusline._hits(self._rows()), [90, 1])
+        self.assertEqual(statusline._history("s1"), [(900, 100), (1000, 90000)])
+        self.assertIsNone(statusline._last_ctx("s1"))
+
+    def test_the_last_recorded_percentage_wins_over_an_empty_later_one(self):
+        f = statusline._usage_file("s1")
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("800,200,80,37\n900,100,90,\n")
+        self.assertEqual(statusline._last_ctx("s1"), 37)
+
+
+class ThePanelsGaugeReadsTheSameAsTheFooters(unittest.TestCase):
+    """#413's own correctness condition. `top` inside a frame and Claude Code's footer
+    outside one draw the same two numbers from two different sources — a live payload and
+    a recorded history. If the thresholds or the labels drifted apart, a green 60% on one
+    surface beside a yellow 60% on the other would be undebuggable from what is on screen.
+    Both go through `_ctx_part`/`_cache_part`, and these tests are what keeps that true.
+    """
+
+    def setUp(self):
+        isolate_state_dir(self)
+        import shutil
+        import tempfile
+        d = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, d, True)
+        self._orig_sessions = config.SESSIONS_DIR
+        config.SESSIONS_DIR = Path(d)
+        self.addCleanup(lambda: setattr(config, "SESSIONS_DIR", self._orig_sessions))
+
+    def test_the_context_thresholds_are_the_ones_the_colours_are_chosen_from(self):
+        """Agreement between the two surfaces (below) cannot see a threshold that moved on
+        BOTH of them, since both go through one helper — so the thresholds themselves are
+        pinned here, at the boundaries rather than in the middle of each band. The colour
+        IS the fact: it is what turns a number into "this is fine" or "start a new
+        session", and it is the half of the gauge nobody reads consciously."""
+        cases = [(0, statusline._GREEN), (49, statusline._GREEN),
+                 (50, statusline._YELLOW), (79, statusline._YELLOW),
+                 (80, statusline._RED), (100, statusline._RED)]
+        for pct, want in cases:
+            with self.subTest(pct=pct):
+                self.assertIn(want, statusline._ctx_part(pct))
+
+    def test_the_cache_thresholds_are_pinned_the_same_way(self):
+        """<50% sustained means the prefix is churning, which is the expensive failure
+        mode this gauge was built to surface at all."""
+        cases = [(0, statusline._RED), (49, statusline._RED),
+                 (50, statusline._YELLOW), (79, statusline._YELLOW),
+                 (80, statusline._GREEN), (100, statusline._GREEN)]
+        for hit, want in cases:
+            with self.subTest(hit=hit):
+                self.assertIn(want, statusline._cache_part(hit))
+
+    def test_the_two_surfaces_produce_byte_identical_markup(self):
+        """Compared with the ANSI kept, not stripped: the colour IS the fact here — the
+        thresholds are what turn a number into "this is fine" or "this is expensive"."""
+        payload = dict(_payload(pct=85, read=400, write=600), session_id="s1")
+        live = statusline._context_gauge(payload)[:2]
+        panel = statusline.recorded_context_gauge("s1")[:2]
+        self.assertEqual(panel, live)
+
+    def test_the_rebuild_badge_reaches_the_panel_too(self):
+        """`↻N <tokens>` is the number the ratio cannot show — one measured rebuild cost
+        696k tokens and reads as a single dipped turn. It is computed from the recorded
+        history on both surfaces, so a panel has no excuse for missing it."""
+        f = statusline._usage_file("s1")
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("900000,1000,99,40\n1000,600000,0,55\n")
+        out = _plain(statusline.recorded_context_gauge("s1"))
+        self.assertIn("↻1", out)
+
+    def test_an_unknown_session_draws_nothing_rather_than_zeros(self):
+        for sid in ("", "never-seen"):
+            with self.subTest(sid=sid):
+                self.assertEqual(statusline.recorded_context_gauge(sid), [])
+
+    def test_an_unreadable_history_draws_nothing_rather_than_raising(self):
+        """This is composed by a PANEL, where an exception is a hole in the frame rather
+        than a traceback anybody sees."""
+        with mock.patch("charter.statusline._usage_file",
+                        side_effect=RuntimeError("boom")):
+            self.assertEqual(statusline.recorded_context_gauge("s1"), [])


### PR DESCRIPTION
The frame's claim is that it shows the plane's live state better than the single status
line it suppresses. In one place it showed *less*, and the operator said so:

> move repos to bottom line like now our status-line, to show full repos experience that
> now we have.

Four issues, one surface.

## #488 — the repo table moves to a variable-height `bottom`, and `left` is retired

**Not a bug first, a measurement.** `slots._left` rendered correctly — probed against a
workspace holding a clone it returned `charter main ↓9 ✓` plus worktree rows. The reported
empty sidebar was the `default` workspace, which has **0 cloned repos**: the panel was
telling the truth. What was broken is that 22 columns cannot show a table whose name and
branch columns alone want 66, which `_left`'s own docstring already conceded.

`bottom` is variable-height now and draws that table at `statusline.py`'s own widths —
same four columns, same markers, same CI glyphs, same `…(+N more)` wording:

```
0 todos · ⚠ reinit: charter ws reinit needed · F2 menu
  ├─ charter ⑂3                        main↓9                              ✓ passed
  ├─ iam-service                       feat/rotate-signing-keys*↑2         ✗ failed      #412
  └─ billing-gateway ⑂1                main                                ● running
```

**How tall** (`layout.bottom_rows`, pure arithmetic): what its content wants, floored at
the one row it always was, capped so the harness keeps `HARNESS_MIN_ROWS`. The cap is not
theoretical — measured against tmux 3.7c, `resize-pane -y 40` in a 20-row window is *not
refused*: tmux grants it out of the neighbour, and the neighbour is the agent session. It
left the harness pane **1 row tall**.

**`left`'s fate: dropped**, from `FRAME_SLOTS`, `SLOT_SIZE`, `SLOTS`, `_DROP_ORDER` and
`full`. It was drawing a lesser copy of what `bottom` now draws; the 22 columns go back to
the harness. A committed `charter.toml` still naming it is filtered like any unknown slot,
which is pinned with the exact list that shipped as the default one release ago.

**The constraints held:**

- The attention row survives — alert, `_session_news`, todo count, plane-root warning — as
  line 0, always. The table joins it.
- Presets re-derived: `full` means "every edge charter draws", and `minimal`/`normal` now
  differ in how many of `bottom`'s ROWS the table gets (`_TERSE_ROWS`), because `bottom`
  is no longer one row and "one-line top and bottom" had stopped being true.
- Idle cost unchanged: a panel's idle tick is still exactly one `stat`. `bottom` is the one
  animated slot, so a table walking a directory per row would pay that back fourteen times
  over at five repaints a second — `statusline._tree_cells` is deliberately *not* called
  (it ends in a `worktree.locate`/`clone_of` pair per row), and the cost is stated: the
  frame's table has no presence column. `gather.row_count` answers the sizer from the cache
  when there is one and a directory listing when there is not, never a git sweep.
- Resize recomputes the HEIGHT — see below.

A pane narrower than the table's 95 columns draws **no** table rather than a cut one: a row
trimmed past the branch loses its CI glyph and open change, and a failing repo then reads
as clean. The shipped `min-cols` is 100.

## #475 — collapsed rather than patched

The `window-resized` hook used to carry the sizes as literal `resize-pane -t %1 -y 1` text.
A content-and-window-sized `bottom` cannot be a constant there, so the action now calls
charter back (`charter frame-resize`, `run-shell -b`, the same construction #408 hardened
for `pane-died`) and the sizes are recomputed against the window that exists.

That removes #475's class, not its instance: **no pane id reaches that text at all**. On
top of it, the two guards it was actually about:

- `_relayout`'s `_PANE_ID_RE` check is hoisted **above** the `want` branch. It guarded only
  the slot being killed, so every slot the new density KEPT went into `keep` unexamined —
  a `%1;kill-server` in the frame's own state directory armed `kill-server` on every resize
  for the life of the window.
- `_reassert_sizes` refuses a bad id itself rather than documenting "safe because my caller
  checked". #475 *was* such a builder growing a second caller; `cmd_resize` is that second
  caller, reading `state.panes` straight off disk.

Each is pinned by a test the *other* guard cannot satisfy (the first asserts the recorded
pane map, not the argv), because the first draft of both passed with either one deleted.

## #420 — records say what kind of work they are

#387 promised a spinner for "a dispatch, clone or `gl-refresh`" and shipped dispatches,
because `inflight.start` had one caller. The blocker was real: the same records feed the
dispatch-overlap nudge, which reads its answer back as a sentence — a record named `clone`
would have produced *"`x` writes code and `clone` are already running"*.

Every record carries a `kind` now, every reader says which kinds it means, **and the
default is `DISPATCH`**: the readers that put a name in front of an operator get that by
*not asking*, so the next kind cannot leak into a sentence by being forgotten at one call
site. The frame's spinner is the single caller that opts into `kind=None`.

`finish` matches on kind as well as name — the filename carries only the agent, so a clone
of a repo called `steward` and a dispatch to a persona called `steward` globbed identically
and whichever ended first retired the other's record.

## #413 — `top` gets the context gauge back

0.52.0's news named this as the one thing the frame genuinely lost. The blocker was that
the usage history is keyed by *Claude Code's* session id and a panel knows only the
*frame's*; the one process that sees both is the suppressing `statusline.main`. It writes
the mapping (`state.record_harness_session`, in the frame's own directory — per-plane,
reaped with the frame), and `slots._top` reads it back.

One figure had to start being written down: `context_window.used_percentage` exists only in
the payload, while the cache ratio and rebuild count are derivable from the token counts.
Rows grew a fourth field, readable both directions across an upgrade. Both surfaces share
`_ctx_part`/`_cache_part`, so a green 60% in a frame and in a footer mean the same thing.

**Every way of not knowing draws nothing** — no mapping, no turns yet, a history predating
the field, a recycled frame id (`clear_shape` takes the mapping with it) — because a gauge
silently reading zero is worse than no gauge, and one reading somebody else's 78% is worse
than either.

The panels are woken once per turn, not once per render: "did anything change" is asked of
the usage file's `(mtime, size)` across the record call — `_record_turn` writes only when
it appends — never of an in-process memo, which would be empty on every invocation since
each one is a whole process.

ADR 0019's consequence bullet is **amended in place**, not rewritten: it predicted exactly
this shape and stays as the record of why the decision was deferred.

## The property, and the next spelling of it

The recurring failure here is matching a spelling instead of the property, and #475 is the
seventh: the guard checked the *branch* an id took rather than the *value*. The fix names
the property twice over — the check is hoisted so it covers both branches, and the class is
removed by not putting a disk-read value into re-parsed text at all.

**The next spelling to watch for:** `layout.slot_sizes` interpolates an `int` into a
`resize-pane` argv, which is safe by type — but `cmd_resize` now reads `state.panes`'s
**keys** as well as its values, and a slot name reaches `_RESIZE_FLAG[slot]`. That is a
keyed lookup today (a bad slot raises rather than interpolates) and it is guarded by
`slot not in _RESIZE_FLAG: continue`. A future action that put a slot NAME into hook text —
a per-slot `pane-died` message, say — would need `_action_word_is_safe` on it, and nothing
would force that. The other one: `_resize_hook_argv` now trusts the frame id in action
text, so anything that widens `_FRAME_ID_RE` widens that surface with it.

## Verification

- Full suite green: `Ran 4967 tests … OK` (stdlib `unittest`, no pytest, no network).
- The real tmux integration proves both halves of the resize path against tmux 3.7c:
  `_reassert_sizes` holding sizes across four real resizes including one where the cap
  binds, and — separately — the installed hook actually firing and its `charter frame-resize`
  child actually recomputing. That one asserts on a **grow**, because on a shrink tmux's own
  redistribution makes `bottom` smaller by itself and "it got smaller" would pass with no
  hook at all.
- **41 mutations applied, all RED**, each restored with `__pycache__` cleared. Two came back
  GREEN on the first pass and both were fixed rather than explained: the #475 tests passed
  because a *different* guard caught the input, and one redundant condition turned out not to
  be a guard at all (its `try/except` already was, so the code was simplified and the
  exception mutated instead). The per-issue lists are in the commit messages.

Closes #488
Closes #475
Closes #420
Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
