### PR TITLE
The frame calls a persona a persona, not an agent (#513)

### DIFF
--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1185,11 +1185,18 @@ def _persona_line() -> str | None:
             # applying "the same" rule: this renderer is the fallback, so a divergence
             # here would only ever be seen on the day the layout is already broken.
             seg += f"{_DIM} · vault {_R}{vault}{_vault_dot(vault)}"
-        # The other personas, on the same line — each dispatchable as a sub-agent.
+        # The other personas, on the same line. The label names the CONCEPT — a persona —
+        # and not the mechanism one harness happens to dispatch it with (#513). Under
+        # Claude Code each of these is also reachable as a sub-agent, which is how this
+        # line came to read `◇ agents`; but this row is drawn identically on codex and
+        # opencode, neither of which has a sub-agent at all, so on two of the three
+        # harnesses charter supports that label named nothing the operator could act on.
+        # `personas` is the word `charter persona`, `personas/`, the ADRs and the
+        # no-active branch above all already use.
         others = [n for n in names if n != active]
         if others:
             chips = f"{_DIM} · {_R}".join(f"{_DIM}{n}{_R}" for n in others)
-            seg += f"{_DIM} · ◇ agents {_R}{chips}"
+            seg += f"{_DIM} · ◇ personas {_R}{chips}"
         return seg
     except Exception:
         return None

--- a/docs/news/unreleased-the-frame-calls-a-persona-a-persona.md
+++ b/docs/news/unreleased-the-frame-calls-a-persona-a-persona.md
@@ -1,0 +1,59 @@
+---
+version: unreleased
+headline: The frame calls a persona a persona, not an agent
+---
+
+The frame's identity row listed the personas you were not currently being under the label
+`◇ agents`:
+
+```
+ ⬢ default  ◆ steward · ◇ agents devops · qa  charter 0.53.0
+```
+
+The operator's question was the whole bug report: *"why we have agents in top bar? Agents
+are not our concept — we have personas concept."* Three lines above that label, in the
+same function, the code's own comment called them personas. Everywhere else charter
+does too — `charter persona`, `personas/`, `docs/personas.md`, the ADRs, the skill, and
+the very next branch of that same renderer, which draws `◆ persona none` on a plane with
+nothing adopted.
+
+It now reads:
+
+```
+ ⬢ default  ◆ steward · ◇ personas devops · qa  charter 0.53.0
+```
+
+**This is not only a word.** "Sub-agent" is how *Claude Code* dispatches a persona — one
+harness's API, the `Task`/`Agent` tool and `.claude/agents/`. The frame is drawn
+identically under codex and opencode, and neither has a sub-agent at all. So on two of the
+three harnesses charter supports, that label named a mechanism that does not exist there,
+attached to three names that are personas on all three.
+
+Nothing else was renamed, and the line between the two vocabularies is worth stating
+because getting it backwards would be the same mistake pointing the other way.
+`.claude/agents/`, `charter persona sync-agents`, the `Task`/`Agent` tool names the guards
+match on, and every "dispatched as a sub-agent" sentence in the docs are Claude Code's own
+surface being named correctly — they stay. What changed is a label charter draws for a
+charter concept. A sweep of every user-facing string in `charter/`, `docs/` and `skills/`
+found exactly one that had crossed that line, and this was it.
+
+The guard is the property rather than the spelling: the frame's `top` row, both branches
+of the roster renderer and the status line's persona chips are rendered with personas
+whose own names carry no such word, and asserted to contain none of Claude Code's dispatch
+vocabulary. A future label reaching for `sub-agent` fails the same test, in the same
+place, whichever of the two surfaces it is added to.
+
+`personas` is two columns wider than `agents`. The row is bounded with `tui.truncate`
+against the pane it is drawn in, measured in display cells, so the two columns come out of
+the tail of the row and never out of the pane — pinned from 24 columns up.
+
+One thing found while verifying this and deliberately left out of it: the suite fails 16
+tests when it is run *inside a charter frame*, because nothing isolates a test from the
+operator's own `CHARTER_SESSION_ID`, `CLAUDE_CODE_SESSION_ID` or `TMUX` — a session
+identity from the surrounding shell wins over the one the fixture set. It reproduces on
+`main` without any of this branch, and it is **#519**, with the four variables, the 16
+tests and what a fix has to settle. Worth knowing today because it is 16 false REDs; worth
+fixing because the same hole passes a test the day the environment happens to supply the
+answer the assertion wanted.
+
+Nothing to adopt: upgrading is the whole of it.

--- a/tests/test_frame_vocabulary_is_charters_own.py
+++ b/tests/test_frame_vocabulary_is_charters_own.py
@@ -1,0 +1,151 @@
+"""#513: the frame names charter's own concepts, in charter's own words.
+
+The operator asked "why we have agents in top bar? Agents are not our concept — we have
+personas concept", and they were right: `statusline._persona_line` labelled the roster of
+other personas `◇ agents`, three lines under a comment that called them personas.
+
+**The property is not the spelling `agents`.** It is that a label the frame draws for a
+charter concept must name the concept and not the mechanism ONE harness happens to reach
+it with. A persona is charter's — `charter persona`, `personas/`, `docs/personas.md`, the
+ADRs, and the no-active branch of this very renderer all say so. A *sub-agent* is Claude
+Code's dispatch API. The two are not synonyms, and the frame is drawn identically under
+codex and opencode, neither of which has a sub-agent at all: on two of the three harnesses
+charter supports, `◇ agents` named a thing that does not exist there.
+
+So the tests below render the surfaces an operator actually reads — `slots.render("top",
+…)`, the panel row, and the two `statusline` renderers that feed the roster — and assert
+that no word from Claude Code's dispatch vocabulary appears on them. Every persona,
+workspace and vault name in the fixtures is chosen to carry none of those words itself, so
+a hit can only have come from a label charter wrote.
+
+What this deliberately does NOT assert: that the word "agent" is absent from charter's
+source or docs. `.claude/agents/`, `charter persona sync-agents`, the `Task`/`Agent` tool
+names in `hooks.py` and every "dispatched as a sub-agent" sentence are Claude Code's own
+API surface being named correctly, and renaming those would be the same mistake pointing
+the other way. The bound here is the frame's own labels.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+from charter import persona, statusline, tui
+from charter.frame import slots
+
+from tests._isolation import PersonaIso
+
+#: Claude Code's dispatch vocabulary. A frame label containing any of these is naming a
+#: mechanism, and a mechanism only one of charter's three harnesses has.
+_HARNESS_DISPATCH_WORDS = ("agent", "agents", "sub-agent", "sub agent", "subagent")
+
+#: Fixture names chosen so none of them contains a dispatch word — otherwise a hit below
+#: could come from the operator's own data rather than from a label charter wrote, and
+#: the test would be observing the fixture instead of the code.
+_PERSONAS = ("steward", "devops", "qa")
+
+
+def _offending(text: str) -> list[str]:
+    low = text.lower()
+    return [w for w in _HARNESS_DISPATCH_WORDS if w in low]
+
+
+class RosterLabelNamesTheConcept(PersonaIso):
+    """The roster label on the identity row."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        for n in _PERSONAS:
+            self.make_persona(n, role=f"{n} role")
+        for w in _PERSONAS:
+            self.assertEqual([], _offending(w),
+                             "precondition: a fixture persona name carries a dispatch "
+                             "word, so any hit below would be the fixture's, not a label's")
+
+    def _top(self) -> str:
+        """The panel row an operator reads, through the real slot renderer."""
+        with mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+             mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((200, 3))):
+            return tui.strip_ansi(slots.render("top", "vocab-frame"))
+
+    def test_the_roster_label_says_personas(self):
+        """The positive half: the label is present and it is charter's word. Asserted on
+        the rendered row, not on the module constant that produces it — a test comparing
+        the label to itself would survive any rename."""
+        persona.set_active("steward")
+        line = tui.strip_ansi(statusline._persona_line() or "")
+        self.assertIn("◇ personas ", line)
+        self.assertIn("devops", line)
+        self.assertIn("qa", line)
+
+    def test_the_identity_row_carries_no_harness_dispatch_word(self):
+        """The property. With an active persona and two others, the row that names them
+        must not reach for Claude Code's word for how one of them gets dispatched."""
+        persona.set_active("steward")
+        line = tui.strip_ansi(statusline._persona_line() or "")
+        self.assertEqual([], _offending(line),
+                         f"the persona roster line names a harness mechanism: {line!r}")
+
+    def test_the_rendered_panel_row_carries_no_harness_dispatch_word(self):
+        """One layer up, at the surface that actually prints. `_persona_line` is only the
+        status line's *fallback* path; `slots._top` is what a framed operator sees on
+        every repaint, and a label fixed one layer below the printer is not fixed."""
+        persona.set_active("steward")
+        row = self._top()
+        self.assertIn("steward", row)
+        self.assertEqual([], _offending(row),
+                         f"the frame's `top` row names a harness mechanism: {row!r}")
+
+    def test_no_active_persona_still_names_only_personas(self):
+        """The other branch of the same renderer. It already said `persona none`; this
+        pins that the branch charter falls into on a fresh plane cannot drift either."""
+        persona.clear_active()
+        line = tui.strip_ansi(statusline._persona_line() or "")
+        self.assertIn("persona", line)
+        self.assertEqual([], _offending(line),
+                         f"the no-active persona line names a harness mechanism: {line!r}")
+
+    def test_the_sidebar_chips_carry_no_harness_dispatch_word_either(self):
+        """The roster's OTHER renderer. `_persona_chips` draws the same personas down the
+        status line's right column, and a vocabulary fixed in one of the two places would
+        just move the operator's question to the other surface. This asserts the word is
+        absent — not what the chips return — so it constrains nothing about their shape."""
+        persona.set_active("steward")
+        chips = [tui.strip_ansi(c) for c in statusline._persona_chips()]
+        self.assertTrue(chips, "precondition: three personas exist, so chips are drawn")
+        joined = "\n".join(chips)
+        self.assertEqual([], _offending(joined),
+                         f"a persona chip names a harness mechanism: {joined!r}")
+
+
+class TheLabelIsMeasuredNotCounted(PersonaIso):
+    """`personas` is two columns wider than `agents`, and the row it sits on is shared
+    with the workspace, the vault, the context gauge and the version. The row is bounded
+    by `tui.truncate` against the pane, so the two columns cost the tail of the row and
+    never an overflow — pinned here because the failure mode of getting this wrong is a
+    wrapped panel, which no assertion about the label's text would catch."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        for n in _PERSONAS:
+            self.make_persona(n, role=f"{n} role")
+        persona.set_active("steward")
+
+    def test_the_row_still_fits_a_narrow_pane(self):
+        for cols in (24, 40, 60, 80, 120):
+            with self.subTest(cols=cols):
+                with mock.patch.object(sys.stdout, "fileno", return_value=1,
+                                       create=True), \
+                     mock.patch("os.get_terminal_size",
+                                return_value=os.terminal_size((cols, 3))):
+                    row = slots.render("top", "vocab-frame")
+                for ln in row.split("\n"):
+                    self.assertLessEqual(tui.width(tui.strip_ansi(ln)), cols,
+                                         f"`top` overflowed a {cols}-column pane: {ln!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #513

The operator's question was the whole report: *"why we have agents in top bar? Agents are
not our concept — we have personas concept."*

## Before / after — the real rendered row

```
[120 cols] | ⬢ default  ◆ steward · ◇ agents devops · keycloak-master · qa  charter 0.53.0 |
```
```
[120 cols] | ⬢ default  ◆ steward · ◇ personas devops · keycloak-master · qa  charter 0.53.0 |
```

Both branches of the renderer, and the chips column it shares the roster with:

```
=== statusline._persona_line(), both branches ===
  active   : ◆ steward · ◇ personas devops · keycloak-master · qa
  no active: ◆ persona none · devops · keycloak-master · qa · steward · charter persona use <name>

=== statusline._persona_chips() (the right column — untouched) ===
    ▸ steward
    ▫ devops
    ▫ keycloak-master
    ▫ qa
```

The `no active` branch already said `persona`. That is the point: the two branches of one
function disagreed with each other about what charter calls its own concept.

## The property, not the spelling

A label the frame draws for a charter concept must name the **concept**, not the mechanism
one harness happens to reach it with. A persona is charter's — `charter persona`,
`personas/`, `docs/personas.md`, the ADRs, the skill. A *sub-agent* is Claude Code's
dispatch API. The frame is drawn identically under codex and opencode, and neither has a
sub-agent at all, so on two of the three harnesses charter supports that label named a
mechanism that does not exist there, attached to three names that are personas on all
three.

## The distinction drawn, for review

A sweep of every user-facing string in `charter/`, `docs/` and `skills/` found exactly one
that had crossed the line. **Unchanged, deliberately** — these are Claude Code's own API
surface being named correctly, and renaming them would be the same mistake pointing the
other way:

| Left alone | Why |
| --- | --- |
| `Task` / `Agent` in `hooks.py:4366`, `:4563`, `dispatch.py:353` | Claude Code's tool names; the guards match on them |
| `.claude/agents/`, `charter persona sync-agents` | a real directory and a real command name |
| "dispatched as a sub-agent" throughout `docs/personas.md`, `skills/persona/SKILL.md` | describing Claude Code's dispatch, accurately |
| `render.py`'s "generic agent" in the routing report | the persona-vs-`general-purpose` ratio — the generic thing really is an agent |
| `dispatch.py`'s `"agent"` JSONL field | on-disk record format, not a label |

## Test

`tests/test_frame_vocabulary_is_charters_own.py` renders the surfaces an operator actually
reads and asserts none of Claude Code's dispatch vocabulary appears on them:

- `slots.render("top", …)` — **the layer that prints.** `_persona_line` is only the status
  line's *fallback* path (`statusline.py:2263`, inside an `except`); the panel row is what
  a framed operator sees on every repaint, and a label fixed one layer below the printer
  is not fixed.
- both branches of `_persona_line`.
- `_persona_chips`, the roster's other renderer — asserting the **absence of a word**, not
  a return shape, so it constrains nothing the sidebar group is changing there.

Every fixture persona, workspace and vault name is asserted in `setUp` to contain no
dispatch word itself, so a hit can only have come from a label charter wrote — the test is
not observing its own fixture.

## Width

`personas` is two columns wider than `agents`, on a row shared with the workspace, the
vault, the context gauge and the version. The row is bounded by `tui.truncate` in display
cells, so the two columns come out of the tail and never out of the pane. Pinned from 24
columns up, and measured:

```
[120 cols] width=81   [100 cols] width=81   [80 cols] width=80
[ 60 cols] width=60   [ 40 cols] width=40   [24 cols] width=24
```

## Mutation test

| Mutation | Result |
| --- | --- |
| restore `◇ agents` | RED — 3 of 6 fail (`['agent', 'agents']` on the `top` row) |
| append `(sub-agent)` to an idle chip in `_persona_chips` | RED — the chips guard fails |
| both restored, `__pycache__` cleared | GREEN — 6/6 |

## Suite

```
Ran 5420 tests in 205.429s
OK
```

...with `CHARTER_SESSION_ID`, `CLAUDE_CODE_SESSION_ID`, `TMUX` and `TMUX_PANE` unset.

**In the operator's own environment it fails 16 tests** — and does so on `origin/main`
content with this branch stashed, so it is not from here. Nothing isolates a test from the
ambient session environment; `session.current()` reads `CHARTER_SESSION_ID` /
`CLAUDE_CODE_SESSION_ID` straight out of `os.environ` and wins over what the fixture set.
Filed as **#519** with the reproduction, the 16 tests and what a fix has to settle, and
referenced from the news entry. Not widened into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BLdgKv6vYBfDxRfasyWRrJ
