### PR TITLE
frame: charter owns its own pane-border chrome (#514)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1321,6 +1321,87 @@ def _remain_on_exit_argv(*, socket: str, harness_pane: str) -> list[str]:
                                "remain-on-exit", "on")
 
 
+#: The style every rule in the frame is drawn in — both borders, on both servers.
+#:
+#: `dim` over the terminal's own default foreground, which is `statusline._boxed`'s own
+#: `\033[2m` said in tmux's style language: charter's chrome is one shade of the
+#: operator's own palette everywhere it is drawn, never a colour charter picked out of
+#: the 256 and imposed on a theme it cannot see. A terminal too old to honour SGR 2
+#: renders both borders in the plain default instead, which is still ONE colour — the
+#: property here is sameness, and it survives the attribute being dropped.
+_CHROME_STYLE = "fg=default,dim"
+
+#: Every window option tmux consults to draw a pane border, pinned to charter's own
+#: answer. #514: the frame's rules came out in two colours, and neither of them was
+#: charter's choice — tmux's own `pane-active-border-style` default is `fg=green` while
+#: `pane-border-style` is `default`, so a rule running past the active pane's corner
+#: changed colour mid-line (measured on 3.7c: `\033[32m` for the 77 cells over the
+#: harness, `\033[39m` for the 22 over the sidebar, in one horizontal rule).
+#:
+#: **Both styles, and that is the whole first half of the fix**: setting one leaves the
+#: other at tmux's default, which is how the two came to disagree in the first place.
+#:
+#: The other three are the same defect wearing different options, and they bite on the
+#: OPERATOR'S server where their own `.tmux.conf` is what charter would otherwise
+#: inherit (measured, with a hostile config on a real 3.7c): `pane-border-indicators
+#: arrows` puts `↑`/`←` glyphs on the active pane's borders and no others, so one rule
+#: carries a glyph its neighbour does not; `pane-border-lines double`/`heavy`/`number`
+#: redraws every rule in a different weight (`number` writes pane NUMBERS into them);
+#: and `pane-border-status top` is the worst of the three — it turns every border into a
+#: title bar carrying `#{pane_title}` (the machine's hostname, by default) AND adds a
+#: border row above the topmost pane, a row `layout._BORDER_ROWS` never budgeted for.
+#:
+#: `pane-border-format` is deliberately NOT here: it is inert while `pane-border-status`
+#: is `off`, and pinning a format nothing renders would be pinning a spelling rather than
+#: the property.
+_CHROME: tuple[tuple[str, str], ...] = (
+    ("pane-border-style", _CHROME_STYLE),
+    ("pane-active-border-style", _CHROME_STYLE),
+    ("pane-border-indicators", "off"),
+    ("pane-border-lines", "single"),
+    ("pane-border-status", "off"),
+)
+
+
+def _chrome_argvs(*, socket: str, harness_pane: str) -> list[list[str]]:
+    """`set-option -w`: charter's own answer for every option tmux draws a border from.
+
+    **Charter owns the frame's chrome, and tmux draws all of it.** #514 named two
+    candidate causes — tmux's own two-colour default, and a panel drawing its own box
+    inside a pane tmux is already bordering. Only the first is real: no frame renderer
+    draws a box, because `statusline._boxed` is the only thing in charter that does and
+    `statusline.a_frame_owns_this_surface` suppresses the whole status line inside a
+    frame (ADR 0019). So the fix is not to make a second drawer stop; it is to stop
+    tmux drawing charter's chrome from an answer charter never gave.
+
+    **WINDOW-scoped, targeting the harness pane, exactly as `_panel_remain_on_exit_argv`
+    is** — `-w -t <a pane id>` resolves to that pane's window, which is charter's own on
+    either server. Measured on 3.7c with a hostile global config in place: after this
+    runs, charter's window reads its own five values back and the operator's own windows
+    still resolve to theirs. Every one of these is a window option, so there is no
+    session- or server-scoped form that could reach past charter's window even by
+    mistake, and `-g` never appears here for the reason `_remain_on_exit_argv`'s
+    docstring gives.
+
+    **One place, both servers, and that is the point rather than a convenience.** The
+    defect this closes is chrome styled in two places that could never agree; a fix that
+    put the private server's answer in `conf_text` (which `_launch_in_operator_tmux` must
+    never `source-file`) and the operator server's answer here would rebuild exactly that
+    shape one layer down. `_split_panels` is the one funnel every panel pane charter
+    creates comes out of — both launch paths and every density change — which is why
+    `remain-on-exit` is already armed there, and it is where these go too.
+
+    Five `set-option` calls rather than one config file, and the cost is measured: 22.2ms
+    per launch on this machine (ten runs against a real 3.7c), alongside the roughly
+    fifteen tmux calls a launch already makes. Nothing here runs on a panel's repaint —
+    the idle tick this must not touch is `panel.py`'s one `stat`, and these are issued at
+    launch and at a density change, never per paint.
+    """
+    return [tmuxctl.server_argv(socket, "set-option", "-w", "-t", harness_pane, name,
+                                value)
+            for name, value in _CHROME]
+
+
 def _panel_remain_on_exit_argv(*, socket: str, harness_pane: str) -> list[str]:
     """`set-option -w`: keep dead panes in CHARTER'S OWN WINDOW, and in no other.
 
@@ -1387,15 +1468,25 @@ def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, argv: list[
     every window on their server to reach a redundant menu is a worse trade than no key
     — `frame/slots.py` drops the hotkey hint from the bottom panel to match.
 
-    Three things that ARE written are charter's own and reach nothing of theirs, because
+    Four things that ARE written are charter's own and reach nothing of theirs, because
     every one of them is scoped to a pane charter created or to the window charter
     created: `remain-on-exit` on the harness pane (`_remain_on_exit_argv`, PANE-scoped);
     `remain-on-exit` on the frame's own window, so a dead PANEL stays long enough for its
     hook to run (`_panel_remain_on_exit_argv`, WINDOW-scoped — measured to leave the
-    operator's own windows at their own default); and each panel pane's own `pane-died`
+    operator's own windows at their own default); each panel pane's own `pane-died`
     respawn hook (`_arm_panel_respawn`, PANE-scoped, #408 — it refused here until the
     hook could name this server rather than charter's, and then never fired here until
-    the window kept the corpse it has to fire from).
+    the window kept the corpse it has to fire from); and the frame's own pane-border
+    chrome (`_chrome_argvs`, WINDOW-scoped, #514).
+
+    **That fourth one is here BECAUSE this is somebody else's server, not in spite of
+    it.** On charter's private server the borders came out in tmux's own two default
+    colours; here they come out in whatever the operator's `.tmux.conf` says, which
+    measurably includes a `pane-border-status top` that writes their hostname into every
+    rule and costs the frame a row. Charter's window is charter's to draw, and pinning
+    five window options on it is the same WINDOW-scoped move `_panel_remain_on_exit_argv`
+    already makes — measured the same way, and leaving their own windows at their own
+    values.
 
     **The harness's exit code travels without hooks here, and that is a real
     difference.** The private-server path needs `pane-died[0]`/`pane-died[1]` because it
@@ -1632,6 +1723,12 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     reach panels through this function; arming at the call sites instead is what left the
     operator's server covered on one of two.
 
+    **The frame's own chrome is armed at the same point, for that same reason** (#514,
+    `_chrome_argvs`). A pane border belongs to the window, not to the pane that was just
+    split off, so every rule in the frame is drawn from one set of window options — and
+    the only way for the two servers to agree about them is for one call site to set them
+    on both.
+
     Reported but not fatal, like the splits themselves: a frame whose panels cannot be
     respawned is still a frame, and the harness pane's own `remain-on-exit` was armed
     separately and earlier (`_remain_on_exit_argv`), so the exit code does not ride on
@@ -1640,6 +1737,14 @@ def _split_panels(socket: str, *, slots: list[str], fid: str, harness_pane: str,
     tmuxctl.run("keeping the frame's own dead panes long enough to bring them back",
                 _panel_remain_on_exit_argv(socket=socket, harness_pane=harness_pane),
                 env=env)
+    # And the chrome those panes will be bordered with, armed at the same moment and for
+    # the same reason: this is the one funnel both launch paths and every density change
+    # reach panels through, so a rule cannot come out styled one way on charter's own
+    # server and another way on the operator's (#514, `_chrome_argvs`). Reported but not
+    # fatal, like the splits themselves — a frame whose borders kept tmux's own colours
+    # is a frame that looks wrong, not one that fails.
+    for chrome in _chrome_argvs(socket=socket, harness_pane=harness_pane):
+        tmuxctl.run("styling the frame's own rules", chrome, env=env)
     panel_cmds = layout.panel_argvs(slots=slots, session=fid, socket=socket,
                                     harness_pane=harness_pane, env=pane_env,
                                     sizes=sizes)

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -148,9 +148,10 @@ when the harness exits, charter closes the window, tmux puts you back where you 
 Charter is a guest there, and behaves like one — it writes **nothing** of yours. Not a
 server option, not a session option, not a key binding. What it does write is scoped to the
 window it opened and the panes it created inside that window: those keep their dead panes so
-charter can read an exit code and bring a dead panel back. Your other windows are not
-touched by it, and the setting goes when the window does. That boundary has costs, and they
-are the honest price of the sentence above:
+charter can read an exit code and bring a dead panel back, and that window draws its pane
+borders charter's way rather than yours. Your other windows are not touched by it, and the
+settings go when the window does. That boundary has costs, and they are the honest price of
+the sentence above:
 
 - **Your scrollback limit and your mouse setting apply, not charter's.** `history-limit`
   and `mouse` are session options in tmux; setting them for the frame would set them for
@@ -162,6 +163,16 @@ are the honest price of the sentence above:
   entry is "Detach" and your own prefix key already does that better. The bottom panel
   drops its hotkey hint to match rather than advertising a key that does nothing.
 - **Your status bar stays.** The frame gets the window, not the screen.
+- **Your pane-border styling does not apply inside the frame's window.** Charter pins all
+  five of the options tmux draws a border from — both border styles, plus
+  `pane-border-lines`, `pane-border-indicators` and `pane-border-status` — so every rule in
+  the frame is one colour and the frame looks the same in your tmux as in charter's own.
+  This is the one place charter overrides a preference of yours rather than deferring to
+  it, and the reason is that two of those options make one rule differ from its neighbour:
+  the active-pane colour and the arrow indicators mark some borders and not others, and
+  `pane-border-status top` writes your hostname into every rule and takes a row the
+  frame's height arithmetic never budgeted for. Window-scoped, so your own windows keep
+  your own values.
 - **The harness inherits your tmux SERVER's environment, not your current shell's.**
   Charter states its own five identity variables and `$PATH` on the pane it creates, and
   nothing else. Anything you exported in the shell you typed `charter claude` in — a key

--- a/docs/news/unreleased-the-frame-draws-its-own-chrome.md
+++ b/docs/news/unreleased-the-frame-draws-its-own-chrome.md
@@ -1,0 +1,59 @@
+---
+version: unreleased
+headline: The frame's rules are one colour, and charter picks it
+---
+
+The frame's borders came out in two colours — the outer rules one shade, the separator
+under them another. Nothing in charter chose either: tmux ships
+`pane-active-border-style` as **green** and `pane-border-style` as the terminal default,
+and it picks between them **per border cell**. So a single horizontal rule running past
+the active pane's corner changed colour halfway along it. Measured on tmux 3.7c in a
+100-column frame: `\033[32m` for the 77 cells over the agent session, `\033[39m` for the
+22 over the persona strip beside it, in one line.
+
+Charter now sets both, to the same thing: the terminal's own foreground, dimmed — the
+same `\033[2m` the status line's own box has always used. No hue is imposed on your
+theme; a rule is one shade of whatever your palette already is, and a terminal too old to
+honour dim draws both in the plain default, which is still one colour.
+
+**Three more settings came with it, and they matter most in the tmux you already have.**
+On charter's private server the borders were tmux's defaults; inside your own server they
+are whatever your `.tmux.conf` says, and charter was inheriting all of it. Measured
+against a real config:
+
+- `pane-border-indicators arrows` marks the **active** pane's borders with `←`/`↓` and
+  leaves its neighbours plain — one rule carrying a glyph the next one does not.
+- `pane-border-lines double` (or `heavy`, or `number`) redraws every rule in a different
+  weight; `number` writes pane numbers into them.
+- `pane-border-status top` is the loud one: it turns every border into a title bar
+  carrying `#{pane_title}` — your machine's hostname, by default — **and** adds a border
+  row above the topmost pane, a row the frame's own height arithmetic never budgeted for.
+
+All five are pinned on charter's own window and nowhere else. They are window options, so
+the scope is exactly the window charter opened: a window you already had still resolves to
+your own values, and your server's globals are untouched. Verified on a real 3.7c with a
+hostile config in place, and pinned by a test that renders the frame through a nested tmux
+client and reads the border cells' colours back off the screen.
+
+**One place sets them, for both servers.** The defect was chrome decided in two places
+that could never agree; a fix that put charter's private server's answer in its config file
+and your server's answer somewhere else would have rebuilt that shape one layer down. The
+settings are issued from the single funnel every panel pane charter creates comes out of —
+both launch paths, and every density change.
+
+The other candidate cause was checked and is not real: no panel draws its own box. The
+only thing in charter that draws one is the status line's frame, and inside a frame the
+status line is suppressed outright. There is now a test holding that line — a panel's
+output may never be a line enclosed at both edges, which is what a box is and what the
+repo table's `├─` tree markers are not.
+
+Nothing to adopt: upgrading is the whole of it, and it applies to frames you launch after
+upgrading rather than to one already running.
+
+One neighbour was found on the way and is left for its own fix: sixteen tests fail when
+the suite is run from a shell that is itself inside a charter frame, and pass with
+`$CHARTER_SESSION_ID` and `$TMUX` cleared. They read the developer's own terminal instead
+of stating what they assume about it — the same ambient-environment shape the frame suite
+already isolates against in one place and not the others. That is
+[#521](https://github.com/diazoxide/charter/issues/521); it predates this work and is
+unchanged by it.

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -342,6 +342,116 @@ class Conf(unittest.TestCase):
         self.assertIn("bind -n M-m run-shell", text)
 
 
+class Chrome(unittest.TestCase):
+    """The frame's own pane-border settings (#514) — the builder alone; the launch paths
+    that issue them are pinned in `Launch` and `LaunchInsideTmux` below, and what tmux
+    actually DRAWS from them is in `tests/test_frame_tmux_integration.py`.
+
+    The defect these close is not "the border was the wrong colour" — it is that charter
+    never gave tmux an answer, so tmux used two of its own: `pane-active-border-style`
+    ships `fg=green` and `pane-border-style` ships `default`, and a rule that runs past
+    the active pane's corner changes colour in the middle of the line. Every assertion
+    here is therefore about SAMENESS and SCOPE, never about which shade charter picked.
+    """
+
+    def _argvs(self, **kw):
+        """The real builder, with the arguments a launch would hand it."""
+        return commands_frame._chrome_argvs(
+            **{"socket": "charter", "harness_pane": "%7", **kw})
+
+    def test_both_border_styles_are_given_the_same_answer(self):
+        """#514 itself. Setting one and leaving the other is what makes a rule change
+        colour halfway along it — so the property is that the two AGREE, which is a
+        different (and stronger) statement than either of them equalling a constant this
+        test could just as easily read out of the module it is testing."""
+        styles = {cmd[-2]: cmd[-1] for cmd in self._argvs()
+                  if cmd[-2].endswith("border-style")}
+        self.assertEqual(set(styles), {"pane-border-style", "pane-active-border-style"},
+                         f"one of the two border styles is not set at all: {styles}")
+        self.assertEqual(len(set(styles.values())), 1,
+                         f"the active and inactive borders disagree: {styles}")
+
+    def test_the_active_border_is_not_left_at_tmuxs_own_green(self):
+        """The companion the test above cannot make on its own: two styles that agree
+        would still satisfy it if both were set to tmux's own `fg=green` default, which
+        is the colour the operator's screenshot is OF. Charter's chrome is one shade of
+        the terminal's own palette, never a hue charter imposes."""
+        styles = [cmd[-1] for cmd in self._argvs()
+                  if cmd[-2].endswith("border-style")]
+        for style in styles:
+            self.assertNotIn("green", style, f"tmux's own default colour: {style}")
+            self.assertIn("fg=default", style,
+                          f"the border names a colour rather than the terminal's: {style}")
+
+    def test_every_setting_is_window_scoped_to_charters_own_window(self):
+        """`-w -t <a pane id>` resolves to that pane's window — charter's own on either
+        server. The scope IS the boundary on the operator's server: a pane border is a
+        window option, so `-g` here would restyle every window they have open, and the
+        operator's own `.tmux.conf` would be overwritten by charter's taste in chrome."""
+        for cmd in self._argvs():
+            self.assertIn("-w", cmd, cmd)
+            self.assertEqual(cmd[cmd.index("-t") + 1], "%7", cmd)
+            self.assertEqual(cmd[cmd.index("set-option") + 1], "-w", cmd)
+            for scope in ("-g", "-s", "-p"):
+                self.assertNotIn(scope, cmd, f"{scope} reaches past charter's window: {cmd}")
+
+    def test_the_harness_pane_is_named_rather_than_a_hardcoded_index(self):
+        """The same rule `layout.py`'s docstring measures for every split: tmux renumbers
+        pane INDICES on every split, so a `session:0.0` here would name whichever pane
+        happened to land at that index. The pane id the launcher read off tmux's own
+        stdout is what gets named."""
+        for cmd in self._argvs(harness_pane="%42"):
+            self.assertEqual(cmd[cmd.index("-t") + 1], "%42", cmd)
+            self.assertNotIn("0.0", " ".join(cmd))
+
+    def test_the_operators_socket_is_reached_by_path_and_never_by_name(self):
+        """`tmuxctl.server_argv` is the one place that knows `-L` from `-S`. Hand-built
+        `["tmux", "-L", socket, ...]` was #408's own defect at the arming end: handed the
+        operator's socket PATH it aims at a server NAMED by that path, which does not
+        exist — and a chrome setting that lands on a server nobody is looking at is the
+        quietest possible way for this fix to do nothing."""
+        for cmd in self._argvs(socket="/private/tmp/tmux-502/default"):
+            self.assertEqual(cmd[:3], ["tmux", "-S", "/private/tmp/tmux-502/default"])
+            self.assertNotIn("-L", cmd)
+        for cmd in self._argvs(socket="charter"):
+            self.assertEqual(cmd[:3], ["tmux", "-L", "charter"])
+
+    def test_each_setting_is_a_clean_argv_never_a_joined_string(self):
+        """`layout.py`'s never-join-argv rule, which this module is a second citizen of:
+        one option, one value, each its own element, nothing tmux re-parses."""
+        for cmd in self._argvs():
+            self.assertTrue(all(isinstance(a, str) for a in cmd), cmd)
+            self.assertEqual(cmd[3:7], ["set-option", "-w", "-t", "%7"], cmd)
+            self.assertEqual(len(cmd), 9,
+                             f"not `tmux -L X set-option -w -t %7 <opt> <val>`: {cmd}")
+            for a in cmd:
+                self.assertNotIn(";", a, cmd)
+                self.assertNotIn(" ", a, cmd)
+
+    def test_no_option_is_set_twice_with_two_different_answers(self):
+        """Last write wins in tmux, so a duplicated name with a different value would
+        make the frame's chrome depend on the order this list happens to be in."""
+        names = [cmd[-2] for cmd in self._argvs()]
+        self.assertEqual(len(names), len(set(names)), f"an option is set twice: {names}")
+
+    def test_the_three_inherited_border_settings_are_pinned_too(self):
+        """Colour is not the only thing an operator's own `.tmux.conf` hands charter's
+        window. Measured on a real 3.7c with a hostile config: `pane-border-indicators
+        arrows` marks the ACTIVE pane's borders and no others (one rule with a glyph, its
+        neighbour without); `pane-border-lines double` redraws every rule in a different
+        weight, and `number` writes pane numbers into them; and `pane-border-status top`
+        turns every border into a title bar carrying the machine's hostname AND adds a
+        border row above the topmost pane — a row `layout._BORDER_ROWS` never budgeted.
+
+        Named here, and derived from tmux's own option table in
+        `tests/test_frame_tmux_integration.py`, so a border option tmux grows later is
+        caught by the second even though this one names today's."""
+        pinned = {cmd[-2]: cmd[-1] for cmd in self._argvs()}
+        self.assertEqual(pinned.get("pane-border-indicators"), "off")
+        self.assertEqual(pinned.get("pane-border-lines"), "single")
+        self.assertEqual(pinned.get("pane-border-status"), "off")
+
+
 class PaneDiedHooks(unittest.TestCase):
     """The exit-status hook is now TWO separate tmux commands, not one — see
     `commands_frame.py`'s module docstring ("Teardown is its own hook") for why a
@@ -1275,7 +1385,7 @@ class _FakeTmux:
                 panel_pane_ids=None, pane_capture="",
                 session_rc=0, source_rc=0, env_set_rc=0, write_hook_rc=0,
                 teardown_hook_rc=0, panel_rc=0, select_rc=0, attach_rc=0, dm_rc=0,
-                kill_rc=0, arm_rc=0, resize_hook_rc=0, capture_rc=0,
+                kill_rc=0, arm_rc=0, chrome_rc=0, resize_hook_rc=0, capture_rc=0,
                 respawn_hook_rc=0,
                 resize_hook_stderr="bad resize hook target"):
         self.pane_id = pane_id
@@ -1301,6 +1411,7 @@ class _FakeTmux:
         self.dm_rc = dm_rc
         self.kill_rc = kill_rc
         self.arm_rc = arm_rc
+        self.chrome_rc = chrome_rc
         self.resize_hook_rc = resize_hook_rc
         self.capture_rc = capture_rc
         self.respawn_hook_rc = respawn_hook_rc
@@ -1333,6 +1444,10 @@ class _FakeTmux:
             # file, never as a bare tmux argv command).
             return subprocess.CompletedProcess(cmd, self.arm_rc, stdout="",
                                                stderr="" if self.arm_rc == 0 else "cannot set")
+        if _is_chrome(cmd):
+            return subprocess.CompletedProcess(cmd, self.chrome_rc, stdout="",
+                                               stderr="" if self.chrome_rc == 0
+                                               else "invalid option")
         if "set-environment" in cmd:
             return subprocess.CompletedProcess(cmd, self.env_set_rc, stdout="",
                                                stderr="" if self.env_set_rc == 0 else "bad session")
@@ -1390,6 +1505,29 @@ class _FakeTmux:
                 live = {self.fid} if self.still_live else set()
             return subprocess.CompletedProcess(cmd, 0, stdout="\n".join(live), stderr="")
         raise AssertionError(f"unexpected tmux command in test: {cmd}")
+
+
+def _is_chrome(cmd: list[str]) -> bool:
+    """Is *cmd* one of the frame's own pane-border settings (#514)?
+
+    Matched by what tmux itself calls the family — a `set-option` naming an option whose
+    name begins `pane-border`/`pane-active-border` — rather than by the exact five names
+    `commands_frame._CHROME` happens to hold today, so a sixth border option added there
+    tomorrow is answered by these fakes instead of raising "unexpected tmux command" in
+    forty unrelated tests. The tests that are ABOUT the chrome read the real constant.
+    """
+    return "set-option" in cmd and any(
+        a.startswith(("pane-border", "pane-active-border")) for a in cmd)
+
+
+def _chrome_values(calls: list[list[str]]) -> dict[str, str]:
+    """`{option: value}` for every chrome setting in *calls* — last write wins, exactly
+    as tmux itself resolves them."""
+    out: dict[str, str] = {}
+    for cmd in calls:
+        if _is_chrome(cmd):
+            out[cmd[-2]] = cmd[-1]
+    return out
 
 
 def _arms_remain_on_exit(cmd: list[str], scope: str) -> bool:
@@ -1838,6 +1976,33 @@ class Launch(PersonaIso, unittest.TestCase):
         self.assertEqual(armed[0][armed[0].index("-t") + 1], fake.pane_id,
                          "the frame's window was named by something other than the pane "
                          "id tmux reported for this launch")
+
+    def test_the_frame_styles_its_own_rules_on_charters_private_server(self):
+        """#514, on the path that reproduced it. Charter's private server runs at tmux's
+        own defaults — `pane-active-border-style fg=green` beside `pane-border-style
+        default` — so a frame that sets neither draws a rule that changes colour at the
+        active pane's corner. Every setting `_CHROME` names must actually reach tmux,
+        and must name the pane id THIS launch read off `new-session`.
+
+        Asserted against the whole of `commands_frame._CHROME` rather than a copy of it:
+        the risk this guards is an option being added to the constant and never issued,
+        which a hand-written list here would not notice."""
+        fake = _FakeTmux(exit_code=0)
+        self.assertEqual(_launch(fake), 0)
+        self.assertEqual(_chrome_values(fake.calls), dict(commands_frame._CHROME))
+        for cmd in [c for c in fake.calls if _is_chrome(c)]:
+            self.assertEqual(cmd[cmd.index("-t") + 1], fake.pane_id, cmd)
+            self.assertNotIn("-g", cmd, cmd)
+
+    def test_a_chrome_setting_tmux_refuses_is_reported_but_not_fatal(self):
+        """A frame whose borders kept tmux's own colours is a frame that looks wrong, not
+        one that failed — the same rule the splits themselves follow. An old tmux that
+        does not know one of these option names must not cost the operator their
+        session."""
+        fake = _FakeTmux(exit_code=0, chrome_rc=1)
+        with mock.patch("charter.util.err") as err:
+            self.assertEqual(_launch(fake), 0)
+        self.assertTrue(err.called, "a refused chrome setting was swallowed silently")
 
     def test_a_still_live_session_after_attach_is_a_detach_not_a_silent_zero(self):
         """The spec's own words: "Detach is allowed and prints how to reattach...
@@ -3536,7 +3701,7 @@ class _FakeOperatorTmux:
     def __init__(self, *, window_id="@3", pane_id="%7", polls_alive=1, exit_code=0,
                  pane_vanishes=False, window_size=(200, 50),
                  pre_existing_windows=("zsh",), list_windows_rc=0,
-                 new_window_rc=0, arm_rc=0, respawn_rc=0, panel_rc=0,
+                 new_window_rc=0, arm_rc=0, chrome_rc=0, respawn_rc=0, panel_rc=0,
                  panel_pane_ids=None, resize_hook_rc=0, select_rc=0, kill_rc=0,
                  pane_capture="", capture_rc=0):
         self.window_id = window_id
@@ -3555,6 +3720,7 @@ class _FakeOperatorTmux:
         self.list_windows_rc = list_windows_rc
         self.new_window_rc = new_window_rc
         self.arm_rc = arm_rc
+        self.chrome_rc = chrome_rc
         self.respawn_rc = respawn_rc
         self.panel_rc = panel_rc
         self.panel_pane_ids = panel_pane_ids or {}
@@ -3588,6 +3754,10 @@ class _FakeOperatorTmux:
         if "remain-on-exit" in cmd:
             return subprocess.CompletedProcess(cmd, self.arm_rc, stdout="",
                                                stderr="" if self.arm_rc == 0 else "cannot set")
+        if _is_chrome(cmd):
+            return subprocess.CompletedProcess(cmd, self.chrome_rc, stdout="",
+                                               stderr="" if self.chrome_rc == 0
+                                               else "invalid option")
         if "respawn-pane" in cmd:
             self.respawn_env = {a.split("=", 1)[0]: a.split("=", 1)[1]
                                 for i, a in enumerate(cmd)
@@ -3758,6 +3928,39 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
         self.assertLess(armed[0], splits[0],
                         f"the first panel was split (call {splits[0]}) before its window "
                         f"was armed to keep it (call {armed[0]})")
+
+    def test_the_frame_styles_its_own_rules_on_the_operators_server_too(self):
+        """#514's second half, and the half the issue says charter's assumptions do not
+        reach: here the borders are drawn from the OPERATOR'S `.tmux.conf`, not from
+        tmux's defaults, so charter inherits whatever they chose — a `pane-border-status
+        top` that writes their hostname into every rule, a `pane-border-lines double`,
+        an active-border colour that has nothing to do with the frame.
+
+        The same settings as the private-server path, from the same constant, through
+        the same `_split_panels` funnel — which is the fix. Two call sites with two
+        answers is the shape that produced a two-coloured rule in the first place."""
+        fake = _FakeOperatorTmux(exit_code=0)
+        self.assertEqual(_launch_inside(fake), 0)
+        self.assertEqual(_chrome_values(fake.calls), dict(commands_frame._CHROME))
+
+    def test_the_chrome_here_is_window_scoped_and_reaches_no_window_of_theirs(self):
+        """The boundary, stated where it costs something. Every option in `_CHROME` is a
+        WINDOW option, so `-g` would restyle every window the operator has open — and a
+        pane-scoped `-p` would style nothing at all, because a border belongs to the
+        window rather than to a pane. `-w -t <the harness pane>` resolves to charter's
+        own window and no other (measured on 3.7c; see `_chrome_argvs`)."""
+        fake = _FakeOperatorTmux(exit_code=0)
+        _launch_inside(fake)
+        chrome = [c for c in fake.calls if _is_chrome(c)]
+        self.assertTrue(chrome, "no chrome was set at all, so this test measured nothing")
+        for cmd in chrome:
+            self.assertEqual(cmd[:3], ["tmux", "-S", OPERATOR_SOCKET], cmd)
+            self.assertEqual(cmd[cmd.index("set-option") + 1], "-w", cmd)
+            self.assertEqual(cmd[cmd.index("-t") + 1], "%7",
+                             "the window was named through a pane that is not the "
+                             f"harness's: {cmd}")
+            self.assertNotIn("-g", cmd, cmd)
+            self.assertNotIn("-p", cmd, cmd)
 
     def test_nothing_of_the_operators_is_written(self):
         """Their config untouched, in the spec's own words. Every one of these would

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -123,6 +123,65 @@ class Render(PersonaIso, unittest.TestCase):
         self.assertIn("sideways", out)
 
 
+class NoPanelDrawsItsOwnChrome(PersonaIso, unittest.TestCase):
+    """tmux borders the pane; the panel fills it. #514's second candidate cause.
+
+    A panel that drew its own box inside a pane tmux is already bordering gives a DOUBLE
+    line by construction, and the two can never agree on colour — one comes from
+    `commands_frame._CHROME`, the other from whatever the renderer chose. `statusline
+    ._boxed` is the one thing in charter that draws such a box (`┌─┐│└┘` around its whole
+    output), and inside a frame the status line it belongs to is suppressed outright
+    (`statusline.a_frame_owns_this_surface`, ADR 0019) — so the frame is clean today, and
+    this is what keeps it clean when a renderer next reaches for a helper.
+
+    **Asked as "is this line ENCLOSED", never as "does it contain a box character".**
+    Panels legitimately draw box-drawing glyphs: `statusline._TREE_MID`/`_TREE_END`/
+    `_TREE_WT` are `├─ `, `└─ ` and `╰─ `, and the repo table is made of them. What
+    `_boxed` does and a tree marker never does is put a glyph hard against BOTH edges of
+    the same line. That is the property; the glyph is only a spelling.
+    """
+
+    #: `_boxed`'s own left and right edges — the top/bottom/rule rows (`┌ ┐`, `└ ┘`,
+    #: `├ ┤`) and the body rows (`│ … │`) it wraps every line in.
+    _LEFT = "┌│└├"
+    _RIGHT = "┐│┘┤"
+
+    def test_no_slot_returns_a_line_boxed_at_both_edges(self):
+        for slot in slots.SLOTS:
+            out = slots.render(slot, "f-1")
+            for line in out.splitlines():
+                bare = tui.strip_ansi(line).rstrip()
+                if not bare:
+                    continue
+                with self.subTest(slot=slot, line=bare[:40]):
+                    self.assertFalse(
+                        bare[0] in self._LEFT and bare[-1] in self._RIGHT,
+                        f"{slot} drew its own box inside a pane tmux already "
+                        f"borders — a double rule, in two colours: {bare!r}")
+
+    def test_the_check_would_catch_the_box_the_status_line_draws(self):
+        """The control this file cannot do without: every assertion above is a NEGATIVE,
+        and a negative passes just as well when the check is broken as when the code is
+        right. `statusline._boxed` is the exact thing being excluded, so it is what the
+        check is proved against — using the real function, not a hand-typed imitation of
+        its output."""
+        boxed = statusline._boxed("hello\nworld", 40).splitlines()
+        self.assertTrue(boxed, "`_boxed` drew nothing to check against")
+        for line in boxed:
+            bare = tui.strip_ansi(line).rstrip()
+            self.assertTrue(bare[0] in self._LEFT and bare[-1] in self._RIGHT,
+                            f"the enclosure check does not recognise `_boxed`: {bare!r}")
+
+    def test_a_tree_marker_is_not_mistaken_for_a_box(self):
+        """The other control. `├─ ` opens a repo row and `╰─ ` opens a worktree's, so a
+        check that merely looked for box characters would condemn the repo table — which
+        is the panel's whole content."""
+        for marker in (statusline._TREE_MID, statusline._TREE_END, statusline._TREE_WT):
+            bare = f"{marker}charter".rstrip()
+            self.assertFalse(bare[0] in self._LEFT and bare[-1] in self._RIGHT,
+                             f"a tree row reads as a box: {bare!r}")
+
+
 class Unimplemented(unittest.TestCase):
     """Which configured slots charter sizes but cannot draw — asked in one place because
     three callers need the same answer and must not drift: `cmd_launch` (to skip

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -55,8 +55,10 @@ from __future__ import annotations
 
 import os
 import pty
+import re
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -3720,6 +3722,367 @@ class ASecondFrameOnTheSharedServer(_TmuxServerFixture, PersonaIso):
             self._session_reading_the_var("third", client_value="three", carry=""),
             "", "`-e NAME=` is the spelling charter relies on to shadow an inherited "
                 "value, and it did not")
+
+# --- The frame's own chrome (#514) ------------------------------------------------- #
+
+#: Every code point tmux can draw a pane border with — the whole Box Drawing block, so a
+#: rule is recognised whatever `pane-border-lines` is set to (`single`, `double`, `heavy`
+#: and `number` all draw from it, and charter pins `single`).
+#:
+#: A GLYPH set rather than a coordinate calculation, deliberately: charter has no
+#: business re-deriving tmux's own pane geometry inside a test, and every pane in these
+#: tests runs `cat`, which draws nothing — so every box-drawing cell on the screen is a
+#: cell tmux drew as chrome.
+#:
+#: **`pane-border-lines simple`'s own `+`/`-`/`|` are deliberately NOT here.** They are
+#: ordinary ASCII, indistinguishable from text, and including them made this set match
+#: the hyphens in the HOST tmux's status line — which is that server's chrome, drawn in
+#: its own colours, and counted as a second rule colour in a frame that had exactly one.
+#: `_screenshot` turns that status line off as well; a match that cannot happen for two
+#: independent reasons is the right number of reasons for this one.
+_RULE_GLYPHS = frozenset(chr(c) for c in range(0x2500, 0x2580))
+
+_SGR_RE = re.compile("\x1b\\[([0-9;]*)m")
+
+
+def _sgr_runs(text: str) -> list[tuple[frozenset, str]]:
+    """`(appearance, character)` for every printable cell of *text*.
+
+    The appearance is NORMALISED, not the raw escape bytes, because two spellings of one
+    look must not read as two colours: `\\x1b[39m` and a line that never issued an escape
+    at all are both "the terminal's own foreground", and a test comparing escape STRINGS
+    would call those different — then pass on a frame that looks perfectly uniform. That
+    is the spelling-versus-property trap this repo keeps paying for, so the property
+    (what a cell LOOKS like) is what gets compared.
+
+    Line-scoped: `capture-pane -e` re-states a line's attributes at its start, and a run
+    carried across a newline would attribute one row's colour to the next.
+    """
+    out: list[tuple[frozenset, str]] = []
+    for line in text.split("\n"):
+        fg: object = "default"
+        bg: object = "default"
+        attrs: set[int] = set()
+        i = 0
+        while i < len(line):
+            m = _SGR_RE.match(line, i)
+            if m:
+                params = [int(p or 0) for p in m.group(1).split(";")]
+                j = 0
+                while j < len(params):
+                    p = params[j]
+                    if p == 0:
+                        fg, bg, attrs = "default", "default", set()
+                    elif p in (38, 48):
+                        # 38;5;N or 38;2;R;G;B — consume the whole colour, whichever form
+                        take = 3 if j + 1 < len(params) and params[j + 1] == 5 else 5
+                        value = tuple(params[j:j + take])
+                        if p == 38:
+                            fg = value
+                        else:
+                            bg = value
+                        j += take
+                        continue
+                    elif 30 <= p <= 37 or 90 <= p <= 97:
+                        fg = p
+                    elif p == 39:
+                        fg = "default"
+                    elif 40 <= p <= 47 or 100 <= p <= 107:
+                        bg = p
+                    elif p == 49:
+                        bg = "default"
+                    elif p in (1, 2, 3, 4, 5, 7, 9):
+                        attrs.add(p)
+                    elif p == 22:
+                        attrs -= {1, 2}
+                    elif p in (23, 24, 25, 27, 29):
+                        attrs.discard(p - 20)
+                    j += 1
+                i = m.end()
+                continue
+            out.append((frozenset({("fg", fg), ("bg", bg),
+                                   *(("attr", a) for a in sorted(attrs))}), line[i]))
+            i += 1
+    return out
+
+
+def _rule_states(text: str) -> set:
+    """The distinct appearances every pane-border cell in *text* is drawn with.
+
+    One entry means every rule in the frame looks the same, which IS #514's property.
+    """
+    return {state for state, ch in _sgr_runs(text) if ch in _RULE_GLYPHS}
+
+
+def _rule_glyphs(text: str) -> set:
+    """Which border characters *text* is drawn with — `─│┬┴` for `pane-border-lines
+    single`, `═║╦╩` for `double`, and so on. What a rule is made OF, beside
+    `_rule_states`' what it looks like."""
+    return {ch for ch in text if ch in _RULE_GLYPHS}
+
+
+#: What `pane-border-indicators arrows` marks the ACTIVE pane's borders with, and only
+#: the active pane's — so an inherited `arrows` puts a glyph on one rule that its
+#: neighbour does not carry. Outside the Box Drawing block, which is why `_rule_glyphs`
+#: cannot see them and they are asked about by name.
+_INDICATOR_GLYPHS = frozenset("←→↑↓")
+
+
+class ChromeIsOneColour(_TmuxServerFixture, PersonaIso, unittest.TestCase):
+    """#514, asked of the SCREEN: charter's own frame must draw every rule the same.
+
+    **The only tests in this suite that look at what an operator looks at.** A pane
+    border belongs to no pane, so `capture-pane` cannot see one — it captures a pane's
+    CONTENT, and the chrome lives in the gaps between panes. So the frame is rendered
+    inside a second tmux: an OUTER server holds one pane whose program is a client
+    attached to the frame's own (inner) server, which makes that pane's content the
+    frame's entire screen, borders and all. `capture-pane -e` on the outer pane then
+    hands the rules back with their colour escapes still attached — as close to the
+    operator's own screenshot as a test gets without a camera.
+
+    **Every test here renders the defect first, as a control.** Not decoration: without
+    it, "every rule is one colour" is equally satisfied by a machine that rendered no
+    rules at all, or by a capture this parser happened to read as one long run — and a
+    harness that cannot see the two-coloured frame cannot testify about the one-coloured
+    one. The control is a live render on this machine at this moment, never a baseline
+    read out of another branch. A machine whose control comes back uniform SKIPS, naming
+    what it could not measure.
+    """
+
+    #: The frame's own shape, in the order the shipped `slots` produces it: a one-row
+    #: `top`, a `bottom`, and a `right` column beside the harness — every split off the
+    #: harness pane, exactly as `layout.panel_argvs` does it.
+    #:
+    #: Three panels rather than one, because the defect needs a rule that runs PAST the
+    #: active pane's corner: with the harness and a single neighbour, every border cell
+    #: touches the active pane and the frame comes out uniform by accident.
+    _SPLITS = (("-v", "-b", "1"), ("-v", "", "3"), ("-h", "", "22"))
+
+    def _outer(self, *args: str) -> subprocess.CompletedProcess:
+        return _tmux_on(self._outer_socket, *args)
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._outer_socket = f"{self.SOCKET_NAME}-host"
+        self.addCleanup(self._teardown_outer)
+
+    def _teardown_outer(self) -> None:
+        """The same two-step `_teardown_socket` does, for the second server these tests
+        need — `kill-server` ends it, and the socket FILE it leaves behind is removed by
+        hand because tmux does not."""
+        self._outer("kill-server")
+        (Path("/tmp") / f"tmux-{os.getuid()}" / self._outer_socket).unlink(missing_ok=True)
+
+    def _hostile(self) -> None:
+        """Somebody else's `.tmux.conf`, applied the way theirs is: `-wg`, reaching every
+        window on the server charter is a guest on."""
+        for name, value in (("pane-border-style", "fg=blue"),
+                            ("pane-active-border-style", "fg=red,bold"),
+                            ("pane-border-indicators", "arrows"),
+                            ("pane-border-lines", "double"),
+                            ("pane-border-status", "top")):
+            self.assertEqual(self._srv("set", "-wg", name, value).returncode, 0)
+
+    def _screenshot(self, *, arm: bool, hostile: bool = False) -> str:
+        """Build the frame on the inner server, show it through the outer one, and return
+        what the outer pane holds — the frame's whole screen, escapes and all."""
+        session = f"f{int(arm)}{int(hostile)}-{self._pane_counter}"
+        self._pane_counter += 1
+        r = self._srv("new-session", "-d", "-s", session, "-x", "100", "-y", "24",
+                      "-P", "-F", "#{pane_id}", "--", "cat")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness = r.stdout.strip()
+        # `conf_text`'s own first line, so this screenshot is of a real frame rather than
+        # of a bare tmux session. It is also load-bearing for the hostname assertion in
+        # `test_the_frame_draws_every_rule_the_same_inside_the_operators_own_tmux`: tmux's
+        # DEFAULT `status-right` carries `#{=21:pane_title}`, which is this machine's
+        # hostname truncated to 21 cells — so on a machine whose hostname is 21
+        # characters or shorter that assertion would fail on the status line and never
+        # reach the borders it is about, and on this developer's 24-character hostname it
+        # would have passed by truncation. Neither is a measurement.
+        self.assertEqual(self._srv("set", "-t", session, "status", "off").returncode, 0)
+        if hostile:
+            self._hostile()
+        if arm:
+            # The production argv, never a hand-retyped `set-option` — see `_run`.
+            for cmd in commands_frame._chrome_argvs(socket=self.SOCKET_NAME,
+                                                    harness_pane=harness):
+                self.assertEqual(_run(cmd).returncode, 0, cmd)
+        for direction, before, size in self._SPLITS:
+            args = ["split-window", "-t", harness, direction]
+            if before:
+                args.append(before)
+            args += ["-l", size, "--", "cat"]
+            self.assertEqual(self._srv(*args).returncode, 0, args)
+        self.assertEqual(self._srv("select-pane", "-t", harness).returncode, 0)
+        host = f"host-{session}"
+        r = self._outer("new-session", "-d", "-s", host, "-x", "100", "-y", "24",
+                        "--", "tmux", "-L", self.SOCKET_NAME, "attach", "-t", session)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        # The HOST's own status line is not part of the frame, and leaving it on puts a
+        # second server's chrome — its own colours, and this machine's hostname — into
+        # the bottom row of every screenshot. Off, so the capture is the frame and
+        # nothing else. (`charter` turns its own off the same way, in `conf_text`.)
+        self._outer("set", "-t", host, "status", "off")
+        # Polled rather than slept: the inner client has to connect, resize and paint
+        # before there is anything to read, and how long that takes is the machine's
+        # business. Gives up quietly — `_control` is what turns "nothing rendered" into a
+        # skip that says so.
+        deadline = time.time() + 10
+        shot = ""
+        while time.time() < deadline:
+            got = self._outer("capture-pane", "-p", "-e", "-t", host)
+            if got.returncode == 0:
+                shot = got.stdout
+            if _rule_states(shot):
+                break
+            time.sleep(0.1)
+        self._outer("kill-session", "-t", host)
+        self._srv("kill-session", "-t", session)
+        return shot
+
+    def _control(self, **kw) -> str:
+        """The frame as it renders UNFIXED — and the proof these tests can see the defect
+        at all. Skips (never fails, and never passes quietly) on a machine whose render
+        this harness cannot read."""
+        shot = self._screenshot(arm=False, **kw)
+        states = _rule_states(shot)
+        if not states:
+            raise unittest.SkipTest(
+                "this machine rendered no pane borders through a nested tmux client at "
+                "all, so there is nothing here to measure the colour of")
+        if len(states) == 1:
+            raise unittest.SkipTest(
+                "the unfixed frame already renders every rule identically on this tmux "
+                f"({states}) — the two-colour defect #514 is about does not reproduce "
+                "here, so a fixed frame rendering uniformly would prove nothing")
+        return shot
+
+    def test_the_unfixed_frame_really_does_draw_its_rules_in_two_colours(self):
+        """The defect itself, named rather than only used as a control. tmux ships
+        `pane-active-border-style fg=green` beside `pane-border-style default` and picks
+        per BORDER CELL — so one horizontal rule is green for the cells above the active
+        pane and the terminal's own default for the cells above its neighbour."""
+        states = _rule_states(self._control())
+        self.assertGreater(len({dict(s)["fg"] for s in states}), 1,
+                           f"the rules differ, but not in colour: {states}")
+
+    def test_the_frame_draws_every_rule_the_same_on_charters_own_server(self):
+        self._control()
+        states = _rule_states(self._screenshot(arm=True))
+        self.assertTrue(states, "the armed frame rendered no rules at all")
+        self.assertEqual(len(states), 1,
+                         f"charter's own frame still draws its rules two ways: {states}")
+
+    def test_the_frame_draws_every_rule_the_same_inside_the_operators_own_tmux(self):
+        """The second server path, where charter's assumptions do not hold: the borders
+        are not tmux's defaults here, they are the operator's own config, which charter
+        would otherwise inherit whole. All five settings, because colour is only the most
+        visible of them — their `pane-border-status top` writes this machine's hostname
+        into every rule and takes a row the frame's own arithmetic never budgeted for."""
+        self._control(hostile=True)
+        shot = self._screenshot(arm=True, hostile=True)
+        states = _rule_states(shot)
+        self.assertTrue(states, "the armed frame rendered no rules at all")
+        self.assertEqual(len(states), 1,
+                         "the operator's own border styling still reaches charter's "
+                         f"window: {states}")
+        self.assertNotIn(socket.gethostname().split(".")[0], shot,
+                         "`pane-border-status` is still on, so the frame's rules are "
+                         "carrying this machine's hostname")
+        self.assertEqual(set(shot) & _INDICATOR_GLYPHS, set(),
+                         "`pane-border-indicators` is still theirs, so charter's frame "
+                         "marks its active pane's borders and not its others")
+        # The whole property in one line: the frame drawn inside their tmux is the same
+        # frame, cell for cell of chrome, as the one drawn on charter's own server.
+        # Colour alone would not catch a `pane-border-lines double` — every rule would
+        # still be one colour, and the frame would still not be charter's.
+        own = self._screenshot(arm=True)
+        self.assertEqual((_rule_glyphs(shot), states),
+                         (_rule_glyphs(own), _rule_states(own)),
+                         "charter's frame is drawn differently on the operator's server "
+                         "than on charter's own")
+
+    def test_charters_chrome_reaches_charters_own_window_and_no_other(self):
+        """The boundary the `-w` scope is for, measured on a real server rather than
+        argued from the flag: after charter styles its own window, a window the operator
+        already had still resolves to the value THEIR config set."""
+        theirs = self._srv("new-session", "-d", "-s", "theirs", "-x", "80", "-y", "24",
+                           "--", "cat")
+        self.assertEqual(theirs.returncode, 0, theirs.stderr)
+        self.assertEqual(self._srv("set", "-wg", "pane-border-style",
+                                   "fg=blue").returncode, 0)
+        ours = self._srv("new-session", "-d", "-s", "ours", "-x", "80", "-y", "24",
+                         "-P", "-F", "#{pane_id}", "--", "cat")
+        self.assertEqual(ours.returncode, 0, ours.stderr)
+        for cmd in commands_frame._chrome_argvs(socket=self.SOCKET_NAME,
+                                                harness_pane=ours.stdout.strip()):
+            self.assertEqual(_run(cmd).returncode, 0, cmd)
+        # `-A` so tmux reports the value the window RESOLVES to (inherited included), not
+        # only what was set on it locally — the second would answer "nothing" for their
+        # window whether charter had reached it or not.
+        resolved = self._srv("show-options", "-w", "-A", "-v", "-t", "theirs:0",
+                             "pane-border-style")
+        self.assertEqual(resolved.stdout.strip(), "fg=blue",
+                         "charter restyled a window that is not its own")
+        mine = self._srv("show-options", "-w", "-A", "-v", "-t", "ours:0",
+                         "pane-border-style")
+        self.assertEqual(mine.stdout.strip(),
+                         dict(commands_frame._CHROME)["pane-border-style"],
+                         "charter's own window did not take charter's own style")
+
+
+class EveryBorderOptionThisTmuxHasIsPinned(_TmuxServerFixture, PersonaIso,
+                                           unittest.TestCase):
+    """Asked of tmux's own option table, never of a list somebody remembered to update.
+
+    #514 was one option charter never set. The CLASS of defect is "tmux decides part of
+    charter's chrome and charter never gave an answer", and a hand-written list of five
+    names cannot see the sixth option a later tmux adds. `show-options -wg` is tmux
+    itself saying what it draws a border from.
+    """
+
+    def _window_options(self) -> dict[str, str]:
+        # A server has to exist for `show-options -g` to answer; `_new_pane` starts one
+        # the way every other class here does.
+        self._new_pane()
+        r = self._srv("show-options", "-wg")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        out = {}
+        for line in r.stdout.splitlines():
+            name, _, value = line.partition(" ")
+            out[name] = value
+        return out
+
+    def test_no_pane_border_option_is_left_for_the_operators_config_to_decide(self):
+        """Every `pane-*border*` window option this tmux has, pinned by `_CHROME`.
+
+        `pane-border-format` is the one exclusion, and it is CONDITIONAL rather than
+        permanent: it decides what `pane-border-status` draws, and charter pins that to
+        `off`, so nothing renders it. The first assertion re-establishes that condition
+        instead of trusting it — turn the status on and this test starts demanding the
+        format be pinned too.
+        """
+        pinned = dict(commands_frame._CHROME)
+        self.assertEqual(pinned.get("pane-border-status"), "off",
+                         "`pane-border-status` is no longer off, so `pane-border-format` "
+                         "renders and must be pinned as well")
+        inert = {"pane-border-format"}
+        theirs = {name for name in self._window_options()
+                  if name.startswith("pane-") and "border" in name} - inert
+        self.assertTrue(theirs, "this tmux reported no pane-border options at all")
+        self.assertEqual(theirs - set(pinned), set(),
+                         "this tmux draws pane borders from an option charter never "
+                         "answers, so the operator's own config decides part of the "
+                         "frame's chrome")
+
+    def test_every_option_charter_pins_is_one_this_tmux_actually_has(self):
+        """The other direction. A misspelt option name is refused by `set-option`, and a
+        launch treats that refusal as non-fatal — so the typo would leave the real option
+        inherited and the frame wrong, with nothing but a warning to show for it."""
+        theirs = self._window_options()
+        for name in dict(commands_frame._CHROME):
+            self.assertIn(name, theirs, f"{name} is not a window option on this tmux")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The frame's rules came out in two colours and **neither of them was charter's choice**.
tmux ships `pane-active-border-style` as `fg=green` and `pane-border-style` as the
terminal default, and it picks between them **per border cell** — so one horizontal rule
running past the active pane's corner changes colour halfway along it.

## The defect, rendered

A pane border belongs to no pane, so `capture-pane` cannot see one. These are real
screenshots: an outer tmux server holds one pane whose program is a client attached to the
frame's own server, which makes that pane's content the frame's **whole screen**, borders
included; `capture-pane -e` then hands the rules back with their colour escapes attached.
Colours below are the normalised SGR state of each border cell.

**Before — charter's own private server, tmux's defaults:**

```
  1 | [green]─x78 [terminal-default]─x22      <- ONE rule, two colours
  2 | [green]│x1
 ... | [green]│x1
 15 | [green]─x78 [terminal-default]─x22
```

**After:**

```
  1 | [terminal-default+dim]─x100
  2 | [terminal-default+dim]│x1
 ... | [terminal-default+dim]│x1
 15 | [terminal-default+dim]─x100
```

**Before — inside the operator's own tmux, where their `.tmux.conf` applies** (this is the
half #514 says charter's assumptions do not reach):

```
  0 | [blue]'╦╦0 "EasyDMARCs-MacBook-'
  1 | [red+bold]'╩↓' [red+bold]'1' [red+bold]'"EasyDMARCs-MacBook-Pro-' [blue]'╩╩2 "EasyDMARCs-MacBoo'
  2 | [red+bold]║x1
  3 | [red+bold]'←'
 ... | [red+bold]║x1
 15 | [blue]'══3 "EasyDMARCs-MacBook-'
```

Their config put the machine's hostname into every rule, arrows on the active pane's
borders and no others, double-weight lines, and **an extra border row above the topmost
pane** — a row `layout._BORDER_ROWS` never budgeted for.

**After — same server, same hostile config:**

```
  1 | [terminal-default+dim]─x100
  2 | [terminal-default+dim]│x1
 ... | [terminal-default+dim]│x1
 15 | [terminal-default+dim]─x100
```

Byte for byte the same frame as on charter's own server.

## The fix

`_CHROME` pins every window option tmux draws a border from:

| option | charter's answer | what it costs unpinned |
| --- | --- | --- |
| `pane-border-style` | `fg=default,dim` | tmux's `default`, beside a green active border |
| `pane-active-border-style` | `fg=default,dim` | tmux's `fg=green` — the reported defect |
| `pane-border-indicators` | `off` | `arrows` marks the active pane's borders and no others |
| `pane-border-lines` | `single` | `double`/`heavy` change the weight; `number` writes pane numbers into the rules |
| `pane-border-status` | `off` | `top` turns every border into a title bar and takes a row |

`fg=default,dim` is `statusline._boxed`'s own `\033[2m` said in tmux's style language:
charter's chrome is one shade of the operator's own palette everywhere it is drawn, never
a colour charter picked out of the 256 and imposed on a theme it cannot see. A terminal
too old to honour SGR 2 draws both borders in the plain default — still **one** colour,
because the property is sameness.

`pane-border-format` is deliberately not pinned: it is inert while `pane-border-status` is
`off`, and pinning a format nothing renders would be pinning a spelling rather than the
property. The test that checks coverage re-establishes that condition rather than trusting
it — turn the status on and it starts demanding the format too.

**Window-scoped through the harness pane**, exactly as `_panel_remain_on_exit_argv` is:
`-w -t <a pane id>` resolves to that pane's window, which is charter's own on either
server. Measured with a hostile global config in place — charter's window reads its own
five values back, the operator's own windows still resolve to theirs.

**One place, both servers, and that is the point rather than a convenience.** Issued from
`_split_panels`, the one funnel every panel pane charter creates comes out of (both launch
paths, every density change) — which is why `remain-on-exit` is already armed there. A fix
that put the private server's answer in `conf_text` (which `_launch_in_operator_tmux` must
never `source-file`) and the operator server's answer at a call site would have rebuilt
the exact shape being closed: chrome decided in two places that can never agree.

Cost: 22.2ms per launch (five `set-option` calls, ten runs against a real 3.7c), alongside
the ~15 tmux calls a launch already makes. Nothing here runs on a repaint — the idle tick
stays one `stat`.

## #514's second candidate cause is refuted

No frame renderer draws its own box. `statusline._boxed` is the only thing in charter that
draws one, and `statusline.a_frame_owns_this_surface` suppresses the whole status line
inside a frame (ADR 0019). So the fix is not to make a second drawer stop; it is to stop
tmux drawing charter's chrome from an answer charter never gave.

`NoPanelDrawsItsOwnChrome` holds that as a **property**, not a glyph ban: a panel's output
may never be a line **enclosed at both edges**, which is what a box is and what
`statusline._TREE_MID`/`_TREE_END`/`_TREE_WT` (`├─ `, `└─ `, `╰─ `) are not — a glyph ban
would condemn the repo table, which is made of them. Two controls come with it: the check
is proved against `statusline._boxed`'s real output (every line of it must read as boxed)
and against a real tree marker (which must not), so the negative assertion cannot pass by
being broken.

## Tests

- `test_frame_launcher.Chrome` — the builder. Both styles carry the **same** answer (a
  sameness assertion, not an equality-with-the-constant tautology); neither is left at
  tmux's green; every setting is `-w`-scoped to the pane tmux reported and never `-g`,
  `-s` or `-p`; the socket is reached by path or name through `tmuxctl.server_argv`.
- `test_frame_launcher.Launch` / `LaunchInsideTmux` — the whole of `_CHROME` actually
  reaches tmux on **both** launch paths, asserted against the constant rather than a
  hand-copied list, and a refusal is reported without being fatal.
- `test_frame_tmux_integration.ChromeIsOneColour` — the screenshots above, as assertions.
  Every one runs the **defect first as a live control** on the same machine at the same
  moment; a machine whose control comes back uniform (or renders no borders at all) skips
  and says which, rather than passing vacuously. Colours are compared as **normalised
  appearances**, never as escape strings, so `\x1b[39m` and a line that issued no escape
  read as the one colour they are. The hostile test also asserts the frame drawn in their
  tmux is cell-for-cell the frame drawn on charter's own.
- `test_frame_tmux_integration.EveryBorderOptionThisTmuxHasIsPinned` — coverage derived
  from `show-options -wg`, tmux's own table, so a border option a later tmux adds fails
  the suite instead of being silently inherited; and the reverse direction, that every
  name charter pins is one this tmux actually has (a typo is non-fatal at launch and would
  leave the real option inherited, silently).

**Two test-only traps found and closed while writing them**, both of the shapes this repo
keeps paying for:

1. `pane-border-lines simple`'s ASCII `+`/`-`/`|` matched the **host** tmux's own
   status-line hyphens, counting that server's chrome as a second rule colour in a frame
   that had exactly one.
2. tmux's default `status-right` carries `#{=21:pane_title}` — this machine's hostname
   truncated to 21 cells. The "no hostname in the rules" assertion passed **only because
   this developer's hostname is 24 characters**; on a machine with a shorter one it would
   have failed on the status line and never reached the borders it is about. Both servers'
   status lines are off in the screenshot now, which is also what a real frame does
   (`conf_text`'s own first line).

**Mutation-tested.** Eight mutations, each applied to the production source, suite run,
source restored, `__pycache__` cleared on both sides:

| mutation | result |
| --- | --- |
| drop `pane-active-border-style` | RED (4) |
| make the two styles disagree (active back to green) | RED (4) |
| drop `pane-border-status` | RED (3) |
| drop `pane-border-indicators` | RED (3) |
| drop `pane-border-lines` | RED (3) |
| never issue the chrome at all | RED (4) |
| `-g` instead of `-w` | RED (7) |
| a pane index instead of the reported pane id | RED (5) |
| *(restored)* | GREEN |

Every one is caught by the **rendered** test as well as by a builder test.

Full suite: `Ran 5435 tests ... OK`.

## Adjacent, filed not fixed

Sixteen tests fail when the suite is run from a shell that is itself inside a live charter
frame, and pass with `$CHARTER_SESSION_ID`/`$TMUX` cleared — they read the developer's own
terminal instead of stating what they assume about it. Reproduced on `origin/main` at
d85da08 before any change here. Filed as #521 and referenced from the news entry.

Closes #514
