### PR TITLE
frame: the sidebar gets headings, a badge column and this workspace's todos (#516)

### DIFF
--- a/charter/frame/gather.py
+++ b/charter/frame/gather.py
@@ -66,6 +66,21 @@ from . import state
 #: name; a caller asks :func:`save`/:func:`read` instead of the path.
 _CACHE_NAME = "gather.json"
 
+#: How many of the workspace's open todos :func:`scan` writes into the cache.
+#:
+#: **A bound on the cache file, not a rendering choice.** ``frame/slots.py``'s ``_right``
+#: draws at most a handful of rows and says how many it hid, so nothing on screen wants
+#: more than this; what this number actually stops is a workspace with four hundred open
+#: todos turning a file every panel re-reads into a four-hundred-entry JSON document. It
+#: is deliberately far above what any pane can draw, so the renderer's own budget — not
+#: this — is what decides how many rows appear.
+#:
+#: The COUNT is stored separately (``todo_count``) and is never clipped, so the
+#: ``…(+N more)`` line stays honest past this bound: clipping the list and then deriving
+#: the total from its length would tell an operator with four hundred todos they have
+#: twenty.
+_MAX_TODOS = 20
+
 
 def _cache_file(fid: str, *, create: bool) -> Path | None:
     """The cache file's path for *fid*, or ``None`` when ``state.frame_dir``
@@ -93,6 +108,8 @@ def _empty(workspace: str | None) -> dict:
         "current_repo": None,
         "repos": [],
         "worktrees": [],
+        "todos": [],
+        "todo_count": 0,
     }
 
 
@@ -239,12 +256,40 @@ def scan(workspace: str | None = None, cwd: str | None = None) -> dict:
     except Exception:
         repos, worktrees = [], []
 
+    # This workspace's own open todos, gathered here for exactly the reason every other
+    # field is: ``frame/slots.py``'s ``_right`` lists them in the sidebar, and a panel
+    # repaints without asking anybody's permission. ``todos.open_todos`` opens and parses
+    # one file per todo — affordable once per plane-state bump, and a per-repaint cost the
+    # frame is not allowed to have (``panel.py``: an idle tick is one ``stat``). The
+    # renderer therefore reads this and never ``todos`` directly.
+    #
+    # Only what a row needs — the title. Neither the body nor the age is carried, and the
+    # rule is the same for both: a cache every panel re-reads is the wrong place to keep
+    # text nothing draws. A sidebar row is one line in a 22-column pane, ``charter ws
+    # todo`` is what shows the rest, and a field added here "in case a renderer wants it"
+    # is a field nothing is measuring the cost of.
+    #
+    # Open todos only, which is the whole of what ``open_todos`` returns and is stated
+    # here because it is a choice: a done todo is not something the frame is asking you to
+    # look at, and a sidebar listing them would be a list you read past rather than act on.
+    todo_items: list = []
+    todo_count = 0
+    try:
+        from .. import todos as todos_mod
+        open_todos = todos_mod.open_todos(active)
+        todo_count = len(open_todos)
+        todo_items = [{"title": t.get("title") or ""} for t in open_todos[:_MAX_TODOS]]
+    except Exception:
+        todo_items, todo_count = [], 0
+
     return {
         "gathered_at": time.time(),
         "workspace": active,
         "current_repo": cur_repo,
         "repos": repos,
         "worktrees": worktrees,
+        "todos": todo_items,
+        "todo_count": todo_count,
     }
 
 

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -201,6 +201,24 @@ def _top(fid: str) -> str:
     about the version, not a fourth thing on this row, so it goes exactly where the
     version goes — including out, at `terse`, since a density that meant to buy back a
     whole line does not mean to keep half of it.
+
+    **The version sits at the row's RIGHT-HAND END (#516), and everything else stays
+    where it was.** The split is what the operator asked for and it is also the reading
+    the row already had: the left of this bar answers *where am I and who am I being* —
+    the workspace, the gauge, the persona — and the version answers *which build is
+    saying so*, which is not part of that sentence. Pushed to the far edge it stops
+    reading as a fourth field of the identity and starts reading as the bar's own
+    signature, which is what it is.
+
+    **Right-aligned by PADDING, never by truncating the identity into it.** `tui.pad`
+    on the left half is what places the version, so a wide row simply has spaces in
+    between; and when the two halves genuinely do not both fit, the VERSION is dropped
+    whole rather than the workspace being cut to make room for it. That is the same
+    "shown whole or dropped whole" discipline `_fit_fields` keeps one slot over, and it
+    is the same field `terse` already drops — so a starved row and a terse row lose the
+    same thing, rather than a narrow terminal inventing a third way for this bar to
+    degrade. The `dev` chip travels inside that one f-string, so it goes and comes back
+    with the version and can never be left behind on its own.
     """
     from .. import __version__, statusline, workspace
     from . import state
@@ -214,10 +232,17 @@ def _top(fid: str) -> str:
     gauge = " ".join(statusline.recorded_context_gauge(
         state.harness_session(fid) or ""))
     left = f" ⬢ {ws}{pin}"
-    tail = (persona if verbosity(fid) == "terse"
-            else f"{persona}  charter {__version__}{statusline._dev_chip()} ")
-    right = f"{gauge}  {tail}" if gauge else tail
-    return tui.truncate(f"{left}  {right}", _width())
+    identity = f"{left}  {gauge}  {persona}" if gauge else f"{left}  {persona}"
+    if verbosity(fid) == "terse":
+        return tui.truncate(identity, _width())
+    build = f"charter {__version__}{statusline._dev_chip()} "
+    w = _width()
+    # `+ 1` is the one column that must separate them; without it a full-width identity
+    # would butt straight up against the version and read as one word.
+    if tui.width(identity) + tui.width(build) + 1 > w:
+        return tui.truncate(identity, w)
+    return tui.Row(tui.Cell(identity, w - tui.width(build)),
+                   tui.Cell(build, tui.width(build)), gap="").render(w)[0]
 
 
 class _RowKey:
@@ -514,50 +539,277 @@ def bottom_rows_wanted(fid: str, *, pane_cols: int) -> int:
     return 1 + (min(gather.row_count(fid), cap) if cap > 0 else 0)
 
 
+#: Columns the persona NAME cell is never squeezed below once the badges have a column
+#: of their own — the two-cell marker plus enough of a name to tell two personas apart.
+#:
+#: The badge column is sized from the WIDEST badge on screen, so without a floor one
+#: persona holding three dispatches (`⚡3 2h?` — eleven columns) would take that width off
+#: every name in a 22-column sidebar and leave `▸ ste…` down the whole list. Past this
+#: point the BADGE column is what gives way, and a badge that no longer fits is cut by its
+#: own cell rather than by pushing a name out of the pane.
+_NAME_MIN_W = 12
+
+#: The most rows the sidebar's todo section may occupy — its heading, its items and its
+#: `…(+N more)` line together.
+#:
+#: A cap on top of the pane's own height, because the two answer different questions: the
+#: pane says how many rows there ARE, and this says how many of them a todo list has any
+#: business taking. `right` is the persona column first — that is what the slot is for
+#: everywhere else charter names it — so on a forty-row terminal the todos get a section
+#: and the rest of the pane stays quiet, rather than the list running to the bottom of the
+#: screen. `charter ws todo` is where the whole list lives; this is the frame's reminder
+#: that it does, not a replacement for it.
+_MAX_TODO_LINES = 8
+
+
+def _sidebar_head(label: str, count: int, width: int) -> str:
+    """One section heading for the `right` sidebar — ``▪ personas 6``.
+
+    Composed from `statusline.py`'s OWN header constants (`_HEAD_PAD`, which carries
+    `_MARK_HEAD`, and `_DIM`) rather than a string of this module's, so the frame's
+    sidebar and the status line's persona column cannot come to disagree about what a
+    column header looks like — the same delegation this module already practises with
+    `_markers`, `_ci_part` and the table's column widths.
+
+    Lower case, and a bare word with no glyph of its own. The frame's chrome is lower case
+    wherever it speaks (`no personas`, `3 todos`, `F2 menu`), and `_HEAD_PAD`'s own
+    comment in `statusline.py` records that a decorative glyph on a header shipped broken
+    twice: a header is the one row with no sibling beneath it to reveal that a font drew
+    it wider than the Unicode tables claim.
+    """
+    from .. import statusline as sl
+    return tui.truncate(f"{sl._DIM}{sl._HEAD_PAD}{label}{sl._R} {count}", width)
+
+
+def _persona_total(cells) -> int:
+    """How many personas *cells* stands for: the rows that name one, plus the personas a
+    `…(+N more)` row admits it is standing in for.
+
+    Added up from `PersonaChip.hidden` rather than read back out of the rendered note,
+    which would tie a heading's number to the wording of a sentence — the same reason
+    `statusline._persona_chip_cells` records a flagged persona in a set instead of looking
+    for its glyph afterwards.
+    """
+    return sum(1 for c in cells if c.name is not None) + sum(c.hidden for c in cells)
+
+
+def _cap_personas(cells: list, keep: int) -> list:
+    """*cells* trimmed to at most *keep* rows, the last of them saying how many personas
+    it dropped.
+
+    **One trimmer for both reasons the sidebar shows fewer personas than exist** — a
+    `terse` density asking for less, and a pane too short to hold the list. "Which
+    personas survive" is one question, and answering it in two places is how the two
+    answers come to disagree; a short pane at `terse` asks it once here.
+
+    `_persona_chip_cells` is already ordered (the active persona first, then anything
+    carrying a health mark), so what survives is the top of an order rather than an
+    arbitrary handful, and a row that was ALREADY standing for hidden personas folds its
+    count into the new row rather than losing it.
+    """
+    from .. import statusline as sl
+    if keep <= 0 or len(cells) <= keep:
+        return cells
+    shown = cells[:max(0, keep - 1)]
+    hidden = _persona_total(cells[len(shown):])
+    return [*shown,
+            sl.PersonaChip(None, f"{sl._DIM}  …(+{hidden} more){sl._R}", "", hidden)]
+
+
+def _persona_rows(cells: list, width: int) -> list[str]:
+    """The persona chips drawn as a TABLE: names down the left, badges in a right-hand
+    column of their own (#516).
+
+    The badges used to start wherever a name happened to end, so the column was ragged
+    and one long name pushed its own badge past every other. The column's width is the
+    widest badge ON SCREEN — measured with `tui.width`, never `len`, because `✎ ◌ ⚑ ✗ ⚡`
+    and the vault dot are exactly the glyphs `_persona_chip_cells`' own comment says have
+    broken this layout twice — bounded by :data:`_NAME_MIN_W` so a persona with three
+    dispatches in flight cannot take a 22-column sidebar's names away from it.
+
+    **The name is contained BEFORE the arithmetic, not after** (#472). Neither number
+    here is derived from a persona name: the badge column comes from the badges, the name
+    column is the pane's remainder, and `tui.Cell`'s own `pad`/`truncate` is what fits the
+    name into the column it was given — sanitising it on the way, which is the containment.
+    A row whose name is too long loses its own tail to a `…` and moves nothing else.
+
+    Badges keep the leading separator `_mem_badge`/`_health_mark`/`_inflight_badge` each
+    put on themselves, so the cells are joined with no gap and `head + badges` is still
+    byte-for-byte what `statusline._persona_chips` renders.
+    """
+    badge_w = min(max((tui.width(c.badges) for c in cells), default=0),
+                  max(0, width - _NAME_MIN_W))
+    rows: list[str] = []
+    for c in cells:
+        if badge_w <= 0 or c.name is None:
+            # A `…(+N more)` row names no persona and carries no badge — it is a sentence
+            # about the list, so it spans the pane rather than being padded into a name
+            # cell whose column it has no business lining up with.
+            rows.append(tui.truncate(c.head + c.badges, width))
+        else:
+            rows.append(tui.Row(tui.Cell(c.head, width - badge_w),
+                                tui.Cell(c.badges, badge_w), gap="").render(width)[0])
+    return rows
+
+
+def _todo_rows(data: dict, width: int, budget: int) -> list[str]:
+    """This workspace's open todos, heading included, in at most *budget* lines.
+
+    **Read from the gather cache, never from the todo directory** — *data* is
+    `gather.read(fid)`'s, and `gather.scan` is what opened and parsed those files, once,
+    on a plane-state bump. `todos.open_todos` is one file read per todo; a panel repaints
+    on every version bump and `bottom` repaints five times a second while work is in
+    flight, so a renderer that called it would be the per-row filesystem work #387 pinned
+    a panel's idle tick against. Same rule, same cache, same reason as the repo table.
+
+    **Which ones, and how many.** `open_todos` is oldest-first and that ordering is the
+    point of it — what surfaces is what is being avoided, rather than what you already
+    have in mind — so the rows are its own top, not a sample. The section spends
+    *budget* in the same priority order `_table_lines` spends its own: the heading, then
+    items, then the `…(+N more)` line that admits what was dropped, which is RESERVED out
+    of the budget rather than appended and trimmed off the end. A budget of exactly two
+    therefore says the count and how much is hidden, because "there is more here than
+    fits" outranks "here is an arbitrary one of them".
+
+    **Nothing at all when there is nothing open**, unlike `_bottom`'s `0 todos`. That row
+    is one row on a strip that is never blank anyway; this is a heading plus an empty
+    space in a column, which is furniture within a day — and then a real todo appearing in
+    it draws no more attention than the zero did. `_bottom` keeps its unconditional count,
+    so the frame still says `0 todos` somewhere: the two surfaces are not saying the same
+    thing twice, they are saying it at two different costs.
+
+    **Done todos never appear**, which is the whole of what `open_todos` returns: a closed
+    todo is not something the frame is asking you to look at, and a list you have to read
+    past is not a list you act on.
+
+    A todo's title is a COMMITTED value — someone else's machine wrote it into this
+    plane's repo — so `contain.one_line` bounds it BEFORE any width arithmetic touches it,
+    which is the ordering #472 was filed for. The width maths here does not read the title
+    at all (`tui.truncate` fits the finished row to the pane), so the bound cannot be
+    walked around by a title long enough to matter.
+    """
+    from .. import contain, statusline as sl
+    items = [t for t in (data.get("todos") or []) if isinstance(t, dict)]
+    if not items or budget < 2:
+        return []
+    # `todo_count` is the UNCLIPPED total (`gather._MAX_TODOS` bounds only the list), so a
+    # cache written by an older charter — which has the items and no count — falls back to
+    # what it can actually see rather than reporting zero hidden todos it cannot name.
+    raw = data.get("todo_count")
+    total = raw if isinstance(raw, int) and raw >= len(items) else len(items)
+    room = budget - 1                       # the heading is not negotiable
+    shown = items[:room]
+    if total > len(shown):
+        shown = items[:max(0, room - 1)]    # reserve the line that says how many are left
+    rows = [_sidebar_head("todos", total, width)]
+    for t in shown:
+        title = contain.one_line(t.get("title") or "")
+        # An ASCII `-`, and the bullet every eye reaches for first (`·`, `•`) is exactly
+        # the one this column may not have: both are East-Asian *Ambiguous*, so a terminal
+        # may draw either two cells wide and shift every todo title one column right of
+        # the persona names above them — the drift `_persona_chip_cells`' own comment says
+        # has broken this layout twice. `-` is Narrow everywhere, which is
+        # `_inflight_badge`'s own reason for spelling presumed-dead as `?`.
+        #
+        # Two columns of marker, so a title begins in the same column as a persona name
+        # and as both headings — `_HEAD_PAD` exists to make that one column, and a section
+        # whose rows started somewhere else would undo it.
+        rows.append(tui.truncate(f"{sl._DIM}-{sl._R} {title}", width))
+    hidden = total - len(shown)
+    if hidden > 0:
+        # The count alone, with no command beside it — unlike `_persona_chip_cells`'
+        # `…(+N more · charter persona list)`, which is written for a status line 36
+        # columns wide at its narrowest. This pane is 22 (`layout.SLOT_SIZE`), and
+        # `…(+4 more · charter ws todo)` is 28: the command would be cut off on every
+        # frame charter actually draws, and half a command name is worse than none —
+        # it is a thing to type that does not work.
+        rows.append(tui.truncate(f"{sl._DIM}  …(+{hidden} more){sl._R}", width))
+    return rows
+
+
 def _right(fid: str) -> str:
-    """Persona chips — memory badges, in-flight badges and vault dots included,
-    because `statusline._persona_chips` already builds one chip as all four
-    combined (`◆ name` + vault dot + memory badge + health mark + in-flight
-    badge) and this calls it rather than reassembling the same facts out of
+    """The plane's personas, and this workspace's open todos underneath them.
+
+    Persona chips carry memory badges, in-flight badges and vault dots because
+    `statusline._persona_chip_cells` already builds them all, and this calls it
+    rather than reassembling the same facts out of
     `_mem_badge`/`_inflight_badge`/`_inflight_by_persona`/`_vault_dot`/
     `_mem_count` itself. A fix to any one of those five lands here the moment it
     lands in the status line's right column — nothing in this module could drift
     from it, because nothing in this module repeats what it does.
 
+    **#516 asked for the badges in a column, and that is why the parts exist.**
+    `_persona_chips` returns one flat string per persona, with the name, the vault dot
+    and all three badges already concatenated — nothing left to put in a column. The
+    honest fix was upstream: `statusline` grew `PersonaChip`, `_persona_chips` became
+    ``head + badges`` over it, and this reads the same parts the status line composes.
+    Recomposing the chip HERE out of the five helpers would have satisfied the same
+    screenshot while reintroducing exactly the drift the paragraph above rules out.
+
     No per-turn session id to hand it: unlike `statusline.render`, a frame panel
     never receives Claude Code's JSON payload on stdin (see `gather.py`'s own
     module docstring for the identical point about the gather side).
-    `_persona_chips()`'s own default (`session=None`) is exactly right here —
+    `_persona_chip_cells()`'s own default (`session=None`) is exactly right here —
     its ephemeral-memory count falls back through `charter.session.current`,
     which reads `$CHARTER_SESSION_ID`/`$CLAUDE_CODE_SESSION_ID` out of the
     environment a launched panel process inherits whole from the harness (the
     same env var `notify.plane_changed` already depends on being set there).
 
-    No guard of its own around the call: `_persona_chips` already swallows
+    No guard of its own around the call: `_persona_chip_cells` already swallows
     every failure internally and answers `[]` (its own docstring's "never
     breaks the status line"), and `render`'s caller-side `try/except` covers
     whatever gets past that — the same trust `_top`/`_bottom` already place in
     it rather than each re-wrapping their own calls into `statusline.py`.
 
-    **At `terse` this keeps :data:`_TERSE_ROWS` chips and says so.** A slice, not a
-    narrower chip: `_persona_chips` builds one chip as `◆ name` plus its vault dot,
-    memory badge, health mark and in-flight badge all together, and dropping any of
-    those parts would mean reassembling the chip here out of the five helpers this
-    function exists specifically not to duplicate. So the panel drops whole personas
-    and adds `_left`'s own `…(+N more)` line, which is the honest way to show fewer of
-    a list — `_persona_chips` is already ordered, so what survives is the top of an
-    order rather than an arbitrary handful.
+    **Two headings, because a bare column of names told a newcomer nothing** (#516) —
+    `_sidebar_head` is where their register is argued, and it is `statusline.py`'s own.
+    The personas heading counts every persona this plane has, not the rows that fit:
+    `_persona_total` adds the hidden ones back from `PersonaChip.hidden`, so the heading
+    and the `…(+N more)` line beneath it can never contradict each other.
+
+    **The pane is measured, and the personas are served first.** `_cap_personas` bounds
+    the list by `_height()` — a `terse` density and a short pane reach it through the same
+    call — and the todos take what is left, capped by :data:`_MAX_TODO_LINES`. That
+    ordering is deliberate rather than incidental: `right` is the persona column
+    everywhere else charter names it, so a pane too short for both loses the section that
+    is duplicated elsewhere (`charter ws todo`, and `bottom`'s own count) rather than the
+    one that is not. How SHORT is too short is `_todo_rows`' own rule and is asked there
+    once — this function only decides whether there is any room at all to be worth
+    opening the cache for, which is a question about a file read rather than about a row.
     """
     from .. import statusline as sl
+    from . import gather
 
-    w = _width()
-    chips = sl._persona_chips()
-    if not chips:
-        return tui.truncate(f"{sl._DIM}no personas{sl._R}", w)
-    if verbosity(fid) == "terse" and len(chips) > _TERSE_ROWS:
-        hidden = len(chips) - (_TERSE_ROWS - 1)
-        chips = [*chips[:_TERSE_ROWS - 1], f"{sl._DIM}…(+{hidden} more){sl._R}"]
-    return "\n".join(tui.truncate(c, w) for c in chips)
+    w, h = _width(), _height()
+    terse = verbosity(fid) == "terse"
+    cells = sl._persona_chip_cells()
+    if cells:
+        keep = h - 1                        # the heading takes a row off the list
+        if terse:
+            keep = min(keep, _TERSE_ROWS)
+        cells = _cap_personas(cells, keep)
+        lines = [_sidebar_head("personas", _persona_total(cells), w),
+                 *_persona_rows(cells, w)]
+    else:
+        lines = [tui.truncate(f"{sl._DIM}no personas{sl._R}", w)]
+
+    # The blank row between the two sections is counted OUT of the todo budget rather
+    # than added on top of it, so the section can never be the row that overflows the
+    # pane — the same reservation `_table_lines` makes for its own overflow line.
+    #
+    # `> 0` and NOT the two-row floor, which is `_todo_rows`' to keep: this test is only
+    # "is there any room at all", asked so a pane with none does not open a cache file it
+    # is about to discard (`bottom_rows_wanted` orders its own two questions the same way,
+    # and for the same reason). Repeating the floor here would put one rule in two places,
+    # where the outer copy silently decides the case and the inner one can be broken
+    # without anything noticing — which is exactly what a mutation of the inner guard
+    # proved while both existed.
+    budget = min(h - len(lines) - 1, _TERSE_ROWS if terse else _MAX_TODO_LINES)
+    if budget > 0:
+        rows = _todo_rows(gather.read(fid), w, budget)
+        if rows:
+            lines.extend(["", *rows])
+    return "\n".join(lines)
 
 
 def _inflight_field() -> str:

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -543,10 +543,11 @@ def bottom_rows_wanted(fid: str, *, pane_cols: int) -> int:
 #: of their own — the two-cell marker plus enough of a name to tell two personas apart.
 #:
 #: The badge column is sized from the WIDEST badge on screen, so without a floor one
-#: persona holding three dispatches (`⚡3 2h?` — eleven columns) would take that width off
-#: every name in a 22-column sidebar and leave `▸ ste…` down the whole list. Past this
-#: point the BADGE column is what gives way, and a badge that no longer fits is cut by its
-#: own cell rather than by pushing a name out of the pane.
+#: persona holding three dispatches — ` ✎47 ⚡3 2h?`, twelve columns once `⚡`'s two cells
+#: are counted — would take all twelve off every NAME in a 22-column sidebar, leaving ten
+#: for the marker and the name together (`▫ reddit-o…`). Past this point the BADGE column
+#: is what gives way, and a badge that no longer fits is cut by its own cell rather than
+#: by pushing a name out of the pane.
 _NAME_MIN_W = 12
 
 #: The most rows the sidebar's todo section may occupy — its heading, its items and its

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -51,6 +51,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import NamedTuple
 
 from . import config, tui
 
@@ -1434,10 +1435,63 @@ def _inflight_badge(entry: tuple[int, float, bool] | None) -> str:
         return ""
 
 
+class PersonaChip(NamedTuple):
+    """One row of the persona column, split where a table COLUMN can be drawn through it.
+
+    :func:`_persona_chips` is exactly ``head + badges`` per row, so a surface that draws
+    the two halves as separate columns and a surface that draws one flat string cannot
+    come to disagree about what a chip says. That is the whole reason this type exists:
+    `frame/slots.py`'s `_right` wants the badges in a column of their own, and the only
+    other way to get them there is to recompose the chip out of `_vault_dot`,
+    `_mem_badge`, `_health_mark` and `_inflight_badge` — which is precisely the drift
+    `_right`'s own docstring says it delegates in order to avoid.
+
+    *head* is everything that must start in the same screen column on every row: the
+    two-cell marker, the name, and the vault dot. *badges* is everything that trails it —
+    the memory badge, the health mark and the in-flight badge, each of which already
+    carries its own leading separator, so ``head + badges`` needs nothing between them and
+    a caller padding *badges* into a fixed cell gets the separator for free.
+
+    **The vault dot belongs to the head**, and it is the one genuinely arguable placement
+    here. `_vault_dot` speaks only when a vault cannot be USED, so it is absent on almost
+    every row; in a right-hand badge column its width would therefore be paid by every
+    persona for a fact about one of them, and the whole column would shift on the day
+    somebody registers a vault. In the head it trails the name, where nothing after it has
+    to line up — which is exactly where the flat chip already put it.
+
+    *name* is ``None`` on the ``…(+N more)`` row, which is not a persona: it names none,
+    carries no badges, and a caller drawing columns must let it span the row rather than
+    pad it into a name cell. *hidden* is how many personas that row stands for, carried as
+    DATA rather than left to be read back out of the rendered text — a caller that wants
+    the true total (a column heading, say) adds it to the rows that do name a persona,
+    instead of parsing a sentence whose wording is a rendering choice.
+    """
+
+    name: str | None
+    head: str
+    badges: str
+    hidden: int = 0
+
+
 def _persona_chips(session: str | None = None) -> list[str]:
     """One chip per persona (active first) for the status-line right column, each
     tagged with its memory counts (``✎`` persistent + ``◌`` ephemeral). Every
-    persona is also dispatchable as a sub-agent."""
+    persona is also dispatchable as a sub-agent.
+
+    Composed from :func:`_persona_chip_cells` rather than built alongside it — one
+    builder, two shapes. See :class:`PersonaChip`.
+    """
+    return [c.head + c.badges for c in _persona_chip_cells(session)]
+
+
+def _persona_chip_cells(session: str | None = None) -> list[PersonaChip]:
+    """:func:`_persona_chips`, with each chip still in the parts it is made of.
+
+    Everything :func:`_persona_chips` promises is decided here — which personas, in what
+    order, capped at :data:`_MAX_PERSONA_LINES` with a row that says how many were
+    dropped, and never raising. See :class:`PersonaChip` for where the split falls and
+    why the vault dot sits on the name's side of it.
+    """
     try:
         from . import persona
         names = sorted(persona.list_personas())
@@ -1471,10 +1525,9 @@ def _persona_chips(session: str | None = None) -> list[str]:
             # move. `⚡` is East-Asian *Wide* — two cells, unambiguously, unlike the
             # Ambiguous glyphs that have broken this layout twice — and it is trailing,
             # so its width never reaches a name.
-            if n == active:
-                chips.append(f"{_MAGENTA}{_MARK_ACTIVE} {_BOLD}{n}{_R}{dot}{badge}{health}{flight}")
-            else:
-                chips.append(f"{_DIM}{_MARK_IDLE} {n}{_R}{dot}{badge}{health}{flight}")
+            head = (f"{_MAGENTA}{_MARK_ACTIVE} {_BOLD}{n}{_R}{dot}" if n == active
+                    else f"{_DIM}{_MARK_IDLE} {n}{_R}{dot}")
+            chips.append(PersonaChip(n, head, f"{badge}{health}{flight}"))
         if len(chips) > _MAX_PERSONA_LINES:
             # Which ones survive matters more than how many. Keeping the first N
             # alphabetically would drop exactly the personas worth seeing, so the order is
@@ -1484,14 +1537,16 @@ def _persona_chips(session: str | None = None) -> list[str]:
             # contract `_repo_rows` keeps with its own "(+N more)".
             keep = _MAX_PERSONA_LINES - 1          # one row spent saying what was dropped
             by_name = dict(zip(order, chips))
-            head = [n for n in order[:1] if n == active]
-            rest = [n for n in order if n not in head]
-            ordered = head + [n for n in rest if n in flagged_names] \
+            lead = [n for n in order[:1] if n == active]
+            rest = [n for n in order if n not in lead]
+            ordered = lead + [n for n in rest if n in flagged_names] \
                            + [n for n in rest if n not in flagged_names]
             shown = ordered[:keep]
             hidden = len(order) - len(shown)
             chips = [by_name[n] for n in shown]
-            chips.append(f"{_DIM}  …(+{hidden} more · charter persona list){_R}")
+            chips.append(PersonaChip(
+                None, f"{_DIM}  …(+{hidden} more · charter persona list){_R}", "",
+                hidden))
         return chips
     except Exception:
         return []

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -408,8 +408,8 @@ those four rows instead of all of them, which is the point of the level: `minima
 your session the rows back rather than blanking them. How many rows that is depends on how
 many clones you have — a fourteen-repo workspace gets ten back, an eight-repo one gets
 four, and a workspace with four or fewer gets none, because there was never a fifth row to
-give. If you have kept
-`right` by writing `slots` yourself, `minimal` shows four chips in it and says the same.
+give. `right` shows four persona chips at `minimal` and says how many it hid, and its
+todo list shrinks to four rows the same way.
 
 **The hotkey changes the density of the running frame, and nothing else.** `F2` opens the
 menu, which now lists all three levels with a `•` on the one in effect; choosing one
@@ -432,10 +432,17 @@ cannot make sense of it. That check is not cosmetic: this value is interpolated 
 configuration that `source-file` *executes*, and `charter.toml` is a committed, shared
 file that arrives from someone else's machine.
 
-Every edge is on by default. `top` is a one-line strip; `bottom` is the attention row
-plus the repo table under it, as many rows tall as the plane and the terminal allow (see
-above); `right` (persona chips) is a 22-column sidebar that drops itself on a terminal too
-small for it. The **order** is the order the panes are split in, and therefore the
+Every edge is on by default. `top` is a one-line strip — the workspace and the persona on
+the left, the charter version (and the `dev` chip, if you are on that channel) at the
+far right, so identity and build are not read as one sentence; `bottom` is the attention
+row plus the repo table under it, as many rows tall as the plane and the terminal allow
+(see above); `right` is a 22-column sidebar carrying two headed sections — `personas`,
+one row each with the memory, health and in-flight badges lined up in a column of their
+own, and `todos`, this workspace's open todos beneath them. The todo list is what
+`charter ws todo` shows, oldest first, cut to what the pane has room for with a
+`…(+N more)` line saying how many it hid; a workspace with nothing open gets no todo
+section at all rather than a heading over an empty space. The sidebar drops itself on a
+terminal too small for it. The **order** is the order the panes are split in, and therefore the
 geometry: with `bottom` before the sidebar its rows span the whole frame, while listing it
 last leaves it only the width the sidebar did not take — 23 columns fewer, which means a
 118-column terminal before the table is drawn at all. `bottom` is where an alert, the

--- a/docs/news/unreleased-the-sidebar-gets-headings-and-your-todos.md
+++ b/docs/news/unreleased-the-sidebar-gets-headings-and-your-todos.md
@@ -79,7 +79,7 @@ charter's own output as the first.
 **And the charter version moved to the top bar's right-hand end.**
 
 ```
- ⬢ demo*  ◆ steward · ◇ agents forge · reddit · release           charter 0.53.0
+ ⬢ demo*  ◆ steward · ◇ personas forge · reddit · release        charter 0.53.0
 ```
 
 The left of that bar answers *where am I and who am I being*; the version answers *which
@@ -92,6 +92,7 @@ row to degrade.
 
 Nothing to adopt. Upgrading is the whole of it.
 
-One thing to know if you are watching a frame come up: the gather cache is not populated at
-launch, so the todo list — like the repo table beside it — is empty on the very first paint
-and fills in on the first plane-state bump. That is **#512**, and it is not fixed here.
+One thing to know if you are watching a frame come up: a launch deliberately starts with no
+gather cache — a recycled pid must not inherit another frame's repos — and the sidebar's
+first paint falls through to a live gather rather than drawing an empty list. The cache is
+what makes every repaint *after* that one free; it is not what fills the first one.

--- a/docs/news/unreleased-the-sidebar-gets-headings-and-your-todos.md
+++ b/docs/news/unreleased-the-sidebar-gets-headings-and-your-todos.md
@@ -1,0 +1,97 @@
+---
+version: unreleased
+headline: The frame's sidebar gets headings, a badge column, and this workspace's todos
+---
+
+The right sidebar was a bare column of names with glyphs trailing them. Nothing said what
+the column was, the badges started wherever each name happened to end, and the todos you
+had actually written down were visible nowhere in the frame — `bottom` printed `3 todos`
+and that was the whole of it.
+
+**Two headed sections now.** `personas`, then `todos` beneath it:
+
+```
+▪ personas 6
+▸ steward          ✎47
+▫ forge ◦          ✎9
+▫ reddit           ✎7
+▫ release          ✎38
+▫ statusline       ✎14
+▫ 測試員測試員     ✎3
+
+▪ todos 10
+- wire the sidebar heading into the frame
+- decide what a done todo looks like
+- chase the flaky tmux integration module
+  …(+7 more)
+```
+
+The headings are the status line's own — same marker, same indent, same lower-case word —
+so the two surfaces cannot drift into two different ideas of what a column header looks
+like. The persona count is every persona this plane has, not the number of rows that fit:
+it and the `…(+N more)` line under it come from the same number, so they cannot contradict
+each other.
+
+**The badges are a column now, not a tail.** They used to start wherever the name ended, so
+a longer name pushed its own badge past every other and the column read as ragged. The
+column's width is the widest badge on screen, measured in terminal cells rather than
+characters — `⚡` is two cells wide and `✎ ◌ ⚑ ✗` are the ambiguous kind a font gets a vote
+on, which is what had broken this layout twice before. A name too long for what is left
+loses its own tail to a `…` and moves nothing else.
+
+The vault dot stays with the name rather than joining the badges, and that is a choice
+worth stating: it appears only when a vault *cannot be used*, so it is absent on almost
+every row. In the badge column its width would be paid by every persona for a fact about
+one of them, and the whole column would shift the day somebody registers a vault.
+
+There is a floor under the name: one persona holding three dispatches (`⚡3 2h?`) will not
+take twelve columns off every name in a 22-column sidebar. Past that point the badge
+column is what gives way.
+
+**The todos come from the workspace, and never from a per-repaint read.** `charter ws todo`
+is still where the whole list lives; this is the frame's reminder that it does. Open todos
+only — oldest first, which is `charter ws todo`'s own ordering and the point of it: what
+surfaces is what is being avoided, not what you already have in mind. Done todos never
+appear, because a list you read past is not a list you act on. A workspace with nothing
+open gets **no section at all** rather than a `todos 0` heading over an empty space; the
+attention row at the bottom of the frame keeps its unconditional count, so the number is
+still somewhere.
+
+How many rows you get is what the pane has. The personas are served first — `right` is the
+persona column everywhere else charter names it — and the todos take what is left, capped
+at eight rows so a forty-row terminal does not turn into a todo list. A pane with room for
+only one row draws no section: a heading with nothing under it claims this workspace has no
+todos, which is exactly the false-clean reading the frame refuses everywhere else. At
+`minimal` density the section shrinks to four rows, the same as the persona list.
+
+**It costs nothing at idle, and that was a constraint rather than a hope.** Reading todos
+means opening and parsing one file per todo, and a panel repaints whenever the plane's
+state moves. So the todos are gathered once, into the same cache the repo table already
+draws from, and the sidebar reads that — the panel never touches the todo directory. The
+cache carries at most twenty titles and the true count beside them, unclipped, so a
+workspace with four hundred open todos is told it has four hundred rather than twenty.
+
+A todo's title is a committed value — someone else's machine wrote it into this plane's
+repo — so it is bounded before any column arithmetic touches it. A newline in a title
+shows as `\x0a` on one row instead of writing a second row that looks exactly as much like
+charter's own output as the first.
+
+**And the charter version moved to the top bar's right-hand end.**
+
+```
+ ⬢ demo*  ◆ steward · ◇ agents forge · reddit · release           charter 0.53.0
+```
+
+The left of that bar answers *where am I and who am I being*; the version answers *which
+build is saying so*, which is not part of the same sentence. At the far edge it reads as
+the bar's signature rather than as a fourth field of your identity. The `dev` chip travels
+with it, as it always has. Nothing is cut to make room: on a bar too narrow for both, the
+version is dropped whole — the same field `minimal` already drops, so a starved bar and a
+terse bar lose the same thing rather than a narrow terminal inventing a third way for the
+row to degrade.
+
+Nothing to adopt. Upgrading is the whole of it.
+
+One thing to know if you are watching a frame come up: the gather cache is not populated at
+launch, so the todo list — like the repo table beside it — is empty on the very first paint
+and fills in on the first plane-state bump. That is **#512**, and it is not fixed here.

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -433,13 +433,18 @@ class TerseSaysLess(PersonaIso, unittest.TestCase):
         self.assertIn("solo", terse, "the repo keeps its row whatever its pieces lose")
 
     def test_right_shows_fewer_personas_and_says_how_many_it_hid(self):
-        chips = [f"◆ p{i}" for i in range(9)]
-        with mock.patch("charter.statusline._persona_chips", return_value=chips):
+        """`+ 1` on both counts is the `personas` heading #516 added — it is chrome the
+        density does not buy back, because a column of names with no title is what the
+        heading exists to fix and one row is not what `minimal` is short of."""
+        cells = [statusline.PersonaChip(f"p{i}", f"▫ p{i}", "") for i in range(9)]
+        with mock.patch("charter.statusline._persona_chip_cells", return_value=cells):
             normal = self._render("right", "normal")
             terse = self._render("right", "minimal")
-        self.assertEqual(len(normal.split("\n")), 9)
-        self.assertEqual(len(terse.split("\n")), slots._TERSE_ROWS)
+        self.assertEqual(len(normal.split("\n")), 9 + 1)
+        self.assertEqual(len(terse.split("\n")), slots._TERSE_ROWS + 1)
         self.assertIn("more", terse)
+        self.assertIn("personas 9", tui.strip_ansi(terse),
+                      "the heading must count the personas, not the rows that fit")
 
 
 class TheSpinnerRunsOnlyWhileWorkDoes(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_gather.py
+++ b/tests/test_frame_gather.py
@@ -252,6 +252,74 @@ class ScanWithNoRepos(PersonaIso, unittest.TestCase):
         self.assertEqual(data["worktrees"], [])
 
 
+class TheWorkspacesTodosAreGatheredToo(PersonaIso, unittest.TestCase):
+    """#516: the sidebar lists this workspace's open todos, and `todos.open_todos` opens
+    and parses one file per todo.
+
+    That cost belongs HERE, once per plane-state bump, for exactly the reason every other
+    field is here: a panel repaints without asking anybody's permission, and `panel.py`
+    pins an idle tick at one `stat`. A renderer reading the todo directory would be the
+    per-row filesystem work #488's table was explicitly not allowed to add either.
+    """
+
+    def _add(self, *titles: str) -> None:
+        from charter import todos
+        for t in titles:
+            todos.add(config.DEFAULT_WORKSPACE, t)
+
+    def test_an_open_todo_lands_in_the_cache(self):
+        self._add("ship the sidebar")
+        data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.tmp))
+        self.assertEqual([t["title"] for t in data["todos"]], ["ship the sidebar"])
+        self.assertEqual(data["todo_count"], 1)
+
+    def test_a_workspace_with_nothing_open_carries_an_empty_list_not_a_missing_key(self):
+        """A renderer must never need a `None`-check before indexing — `_empty`'s own
+        contract, and the reason it grew the two keys at the same time this did."""
+        data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.tmp))
+        self.assertEqual(data["todos"], [])
+        self.assertEqual(data["todo_count"], 0)
+        self.assertEqual(gather._empty("w")["todos"], [])
+        self.assertEqual(gather._empty("w")["todo_count"], 0)
+
+    def test_only_the_title_is_carried(self):
+        """Not the body, and not the age. A cache every panel re-reads on every version
+        bump is the wrong place to keep text nothing draws."""
+        self._add("a todo with a body")
+        data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.tmp))
+        self.assertEqual(list(data["todos"][0]), ["title"])
+
+    def test_the_list_is_bounded_but_the_count_is_not(self):
+        """`_MAX_TODOS` bounds the FILE. Deriving the total from the clipped list would
+        tell an operator with far more open todos that they have exactly the cap — and
+        the sidebar's "…(+N more)" line is computed from that number."""
+        self._add(*[f"todo number {i}" for i in range(gather._MAX_TODOS + 5)])
+        data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.tmp))
+        self.assertEqual(len(data["todos"]), gather._MAX_TODOS)
+        self.assertEqual(data["todo_count"], gather._MAX_TODOS + 5)
+
+    def test_a_broken_todo_read_degrades_to_no_todos_rather_than_losing_the_scan(self):
+        """Individually wrapped like every other step — one bad field must not cost the
+        repo rows gathered beside it."""
+        with mock.patch("charter.todos.open_todos", side_effect=RuntimeError("boom")):
+            data = gather.scan(workspace=config.DEFAULT_WORKSPACE, cwd=str(self.tmp))
+        self.assertEqual(data["todos"], [])
+        self.assertEqual(data["todo_count"], 0)
+        self.assertIn("repos", data)
+
+    def test_a_cache_written_before_todos_existed_is_still_read_as_a_scan(self):
+        """`_shaped_like_a_scan` is deliberately loose about fields a FUTURE scan adds,
+        and this is that case arriving: a cache file surviving an upgrade must still
+        render rather than be thrown away as corrupt."""
+        old = {"gathered_at": 0.0, "workspace": "w", "current_repo": None,
+               "repos": [], "worktrees": []}
+        self.assertTrue(gather._shaped_like_a_scan(old))
+        gather.save("f-todo-1", old)
+        with mock.patch.object(gather, "scan",
+                               side_effect=AssertionError("re-gathered a good cache")):
+            self.assertEqual(gather.read("f-todo-1"), old)
+
+
 class ScanNeverRaises(PersonaIso, unittest.TestCase):
     """Every step in `scan()` is wrapped individually — Task 2 calls this from a
     hook, where "a hook may cost a session its briefing, never its turn"."""

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -41,6 +41,19 @@ def _row(name, *, branch="main", dirty=False, tracked_dirty=False, ahead=0, behi
     return d
 
 
+def _plain_lines(out: str) -> list[str]:
+    """*out* as the plain rows a terminal would show, split BEFORE the colour is stripped.
+
+    The order is load-bearing and the obvious spelling is wrong: `tui.strip_ansi` runs
+    `tui.sanitize` first, which turns a newline into a SPACE (it must — a wrapped line
+    shears every column below it). So `strip_ansi(out).split("\\n")` returns ONE row
+    however many the renderer emitted, and a test written that way cannot tell "the
+    heading is the first line" from "the heading is somewhere in the pane" — which is
+    exactly the difference every assertion about a multi-section sidebar is making.
+    """
+    return [tui.strip_ansi(ln) for ln in out.split("\n")]
+
+
 def _seed(fid: str, **overrides) -> dict:
     data = {"gathered_at": 0.0, "workspace": "w", "current_repo": None,
            "repos": [], "worktrees": []}
@@ -1091,7 +1104,7 @@ class BottomRowsWanted(PersonaIso, unittest.TestCase):
 
 
 class RightRenderer(PersonaIso, unittest.TestCase):
-    """`right`: `statusline._persona_chips` called, not reassembled — each chip
+    """`right`: `statusline._persona_chip_cells` called, not reassembled — each chip
     already carries its own memory badge, in-flight badge and vault dot."""
 
     def test_lists_a_persona_chip(self):
@@ -1106,12 +1119,19 @@ class RightRenderer(PersonaIso, unittest.TestCase):
     def test_calls_persona_chips_rather_than_reassembling_it(self):
         """A fix to a chip (its vault dot, its memory badge, its in-flight badge)
         must land here the moment it lands in the status line — pinned by handing
-        `_persona_chips` a value nothing in `_right` could have produced on its
-        own, and requiring it survive to the pane byte-for-byte."""
-        with mock.patch("charter.statusline._persona_chips",
-                        return_value=["SENTINEL-CHIP-0xF00D"]):
+        `_persona_chip_cells` values nothing in `_right` could have produced on its
+        own, and requiring BOTH halves survive to the pane byte-for-byte.
+
+        Both halves, because #516 is exactly the change that could have lost one: the
+        badges now go into a column of their own, and a `_right` that recomposed them
+        out of `_mem_badge`/`_health_mark`/`_inflight_badge` itself would still print a
+        persona's name."""
+        with mock.patch("charter.statusline._persona_chip_cells",
+                        return_value=[statusline.PersonaChip(
+                            "alice", "SENTINEL-HEAD-0xF00D", "SENTINEL-BADGE-0xBEEF")]):
             out = slots.render("right", "f-1")
-        self.assertIn("SENTINEL-CHIP-0xF00D", out)
+        self.assertIn("SENTINEL-HEAD-0xF00D", out)
+        self.assertIn("SENTINEL-BADGE-0xBEEF", out)
 
     def test_never_exceeds_the_pane_width(self):
         self.make_persona("a-persona-with-quite-a-long-descriptive-name")
@@ -1132,14 +1152,275 @@ class RightRenderer(PersonaIso, unittest.TestCase):
             self.assertLessEqual(tui.width(line), 20)
 
     def test_a_failing_persona_chips_call_yields_a_line_rather_than_an_exception(self):
-        """`_right` carries no guard of its own around the call (`_persona_chips`
-        already swallows its own failures) — this pins `render`'s own outer
-        `try/except` as the thing that actually catches whatever gets past that,
-        the same generic promise `Render.test_a_failing_renderer_yields_a_line...`
-        pins for an arbitrary slot, exercised here through a real dependency."""
-        with mock.patch("charter.statusline._persona_chips",
+        """`_right` carries no guard of its own around the call
+        (`_persona_chip_cells` already swallows its own failures) — this pins
+        `render`'s own outer `try/except` as the thing that actually catches whatever
+        gets past that, the same generic promise
+        `Render.test_a_failing_renderer_yields_a_line...` pins for an arbitrary slot,
+        exercised here through a real dependency."""
+        with mock.patch("charter.statusline._persona_chip_cells",
                         side_effect=RuntimeError("boom")):
             self.assertIn("charter", slots.render("right", "f-1"))
+
+
+class TheSidebarHasHeadings(PersonaIso, unittest.TestCase):
+    """#516's first ask: a bare column of names told a newcomer nothing about what it was.
+
+    The headings are `statusline.py`'s own (`_HEAD_PAD`, which carries `_MARK_HEAD`), so
+    the frame's chrome and the status line's persona column cannot drift apart — asserted
+    against that constant rather than against the literal `▪ `, which would pass a change
+    that moved only one of the two surfaces.
+    """
+
+    def _render(self, *, cols=22, rows=26, fid="f-1") -> str:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, rows))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return slots.render("right", fid)
+
+    def test_the_persona_list_is_headed(self):
+        self.make_persona("alice")
+        self.assertEqual(_plain_lines(self._render())[0],
+                         f"{statusline._HEAD_PAD}personas 1")
+
+    def test_the_heading_counts_every_persona_not_only_the_rows_that_fit(self):
+        """The number and the `…(+N more)` line beneath it come from the same data
+        (`PersonaChip.hidden`), so a truncated column cannot end up headed with the
+        count of what survived truncation — which is the number a reader would take
+        for "how many personas does this plane have"."""
+        for i in range(9):
+            self.make_persona(f"p{i:02d}")
+        lines = _plain_lines(self._render(rows=6))
+        self.assertEqual(lines[0], f"{statusline._HEAD_PAD}personas 9")
+        self.assertTrue(any("…(+" in ln for ln in lines),
+                        "it hid personas without a heading that says so")
+
+    def test_a_plane_with_no_personas_still_says_so_rather_than_heading_nothing(self):
+        lines = _plain_lines(self._render())
+        self.assertIn("no personas", lines[0])
+        self.assertFalse(any("personas 0" in ln for ln in lines), lines)
+
+
+class TheSidebarBadgesFormAColumn(PersonaIso, unittest.TestCase):
+    """#516's comment: the badges start wherever a name ends, so the column is ragged
+    and a longer name pushes its badge past every other.
+
+    The property is the SCREEN COLUMN the badge starts in, measured with `tui.width` on
+    the plain text — not the character offset, which is what `len()` would give and what
+    a wide glyph makes wrong. A test asserting the rendered string would pass on a row
+    that merely happened to line up.
+    """
+
+    def _rows(self, cells, width=22):
+        return slots._persona_rows(cells, width)
+
+    def _badge_col(self, line: str, badge: str) -> int:
+        plain = tui.strip_ansi(line)
+        return tui.width(plain[:plain.index(badge)])
+
+    def test_two_names_of_different_lengths_put_their_badges_in_one_column(self):
+        cells = [statusline.PersonaChip("steward", "▸ steward", " A"),
+                 statusline.PersonaChip("statusline", "▫ statusline", " B")]
+        a, b = self._rows(cells)
+        self.assertEqual(self._badge_col(a, "A"), self._badge_col(b, "B"))
+
+    def test_a_row_with_no_badge_at_all_leaves_the_column_where_it_was(self):
+        """The vault dot is present on some rows and absent on others, and so is every
+        badge — a column sized per row would move under the rows that have one."""
+        cells = [statusline.PersonaChip("steward", "▸ steward", " A"),
+                 statusline.PersonaChip("quiet", "▫ quiet", ""),
+                 statusline.PersonaChip("forge", "▫ forge ◦", " B")]
+        a, _quiet, b = self._rows(cells)
+        self.assertEqual(self._badge_col(a, "A"), self._badge_col(b, "B"))
+
+    def test_the_vault_dot_stays_on_the_names_side_of_the_column(self):
+        """`_vault_dot` speaks only when a vault cannot be used, so it is absent on
+        almost every row: in the badge column its width would be paid by every persona
+        for a fact about one of them."""
+        cells = [statusline.PersonaChip("forge", "▫ forge ◦", " A"),
+                 statusline.PersonaChip("reddit", "▫ reddit", " B")]
+        a, b = self._rows(cells)
+        self.assertEqual(self._badge_col(a, "A"), self._badge_col(b, "B"))
+        self.assertIn("◦", tui.strip_ansi(a).split("A")[0])
+
+    def test_a_wide_glyph_in_a_badge_is_measured_in_cells_not_characters(self):
+        """`⚡` is East-Asian Wide — two cells, one character — so `len()` under-counts
+        the widest badge and the column comes out a cell too narrow. The tell is not
+        misalignment (every row is padded to the same wrong number, so they still line
+        up) but SILENT LOSS: the badge that is actually the widest gets truncated inside
+        its own cell, and `⚡2 4m` becomes `⚡2 4…`. That is the drift
+        `_persona_chip_cells`' own comment says has broken this layout twice."""
+        cells = [statusline.PersonaChip("a", "▫ a", " ⚡2 4m"),
+                 statusline.PersonaChip("b", "▫ b", " ✎7")]
+        a, b = self._rows(cells)
+        self.assertEqual(self._badge_col(a, "⚡"), self._badge_col(b, "✎"))
+        self.assertIn("⚡2 4m", tui.strip_ansi(a),
+                      "the widest badge was cut by a column sized in characters")
+
+    def test_a_name_too_long_for_its_cell_loses_its_own_tail_and_moves_nothing(self):
+        """The whole defect, stated as a property: a longer name must cost ITS OWN row
+        columns, never the column every other row's badge sits in."""
+        cells = [statusline.PersonaChip("short", "▫ short", " A"),
+                 statusline.PersonaChip("l" * 60, "▫ " + "l" * 60, " B")]
+        a, b = self._rows(cells)
+        self.assertEqual(self._badge_col(a, "A"), self._badge_col(b, "B"))
+        self.assertLessEqual(tui.width(b), 22)
+
+    def test_the_more_row_spans_the_pane_rather_than_being_padded_into_a_name_cell(self):
+        """It names no persona and carries no badge — it is a sentence about the list,
+        so lining it up with a column it has no entry in would only indent it."""
+        cells = [statusline.PersonaChip("a", "▫ a", " ✎40"),
+                 statusline.PersonaChip(None, "  …(+7 more)", "", 7)]
+        _, note = self._rows(cells)
+        self.assertEqual(tui.strip_ansi(note), "  …(+7 more)")
+
+    def test_a_badge_column_never_squeezes_the_names_below_the_floor(self):
+        """One persona holding three dispatches (`⚡3 2h?`) must not take twelve columns
+        off every NAME in a 22-column sidebar — past `_NAME_MIN_W` the badge column is
+        what gives way, not the names.
+
+        The fixture is a LITERAL ten-character name rather than one built from
+        `_NAME_MIN_W`, and that is deliberate: a fixture derived from the constant under
+        test moves with it, so setting the floor to zero would shorten the name to
+        nothing and the test would pass having asserted that the empty string survives.
+        A concrete name that a real 22-column sidebar has to hold is what actually
+        exercises the floor."""
+        cells = [statusline.PersonaChip("reddit-ops", "▫ reddit-ops", " ✎47 ⚡3 2h?"),
+                 statusline.PersonaChip("reddit", "▫ reddit", " ✎7")]
+        rows = self._rows(cells)
+        self.assertIn("reddit-ops", tui.strip_ansi(rows[0]),
+                      "a wide badge took the name's own columns")
+        self.assertIn("reddit", tui.strip_ansi(rows[1]))
+
+
+class TheSidebarListsTheWorkspacesTodos(PersonaIso, unittest.TestCase):
+    """#516's second ask. `_bottom` renders a COUNT; the items were visible nowhere in
+    the frame.
+
+    Every test renders through the real `slots.render("right", …)` rather than calling
+    `_todo_rows`, for the reason `BottomTable` gives for the same choice: a helper
+    returning perfect rows that `_right` never asks for satisfies a unit test of the
+    helper and none of the promise.
+    """
+
+    def _render(self, *, cols=22, rows=26, fid="f-1") -> str:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, rows))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return slots.render("right", fid)
+
+    def _seed_todos(self, titles, *, total=None, fid="f-1"):
+        _seed(fid, todos=[{"title": t} for t in titles],
+              todo_count=len(titles) if total is None else total)
+
+    def test_a_todo_reaches_the_pane(self):
+        self._seed_todos(["ship the sidebar"])
+        self.assertIn("- ship the sidebar", _plain_lines(self._render(cols=40)))
+
+    def test_the_todos_sit_beneath_the_personas(self):
+        """The order is the ask, and a membership check would pass with them on top."""
+        self.make_persona("alice")
+        self._seed_todos(["ship the sidebar"])
+        lines = _plain_lines(self._render(cols=40))
+        self.assertLess([i for i, ln in enumerate(lines) if "alice" in ln][0],
+                        [i for i, ln in enumerate(lines) if "ship the sidebar" in ln][0])
+
+    def test_they_are_headed_with_the_open_count(self):
+        self._seed_todos(["one", "two"])
+        self.assertIn(f"{statusline._HEAD_PAD}todos 2", _plain_lines(self._render(cols=40)))
+
+    def test_a_workspace_with_nothing_open_draws_no_section_at_all(self):
+        """Not `todos 0`. A heading over an empty space is furniture within a day, and
+        then a real todo appearing under it draws no more attention than the zero did.
+        `_bottom` keeps its unconditional count; this is the column, not the strip."""
+        self.make_persona("alice")
+        self._seed_todos([])
+        self.assertNotIn("todos", "\n".join(_plain_lines(self._render(cols=40))))
+
+    def test_more_todos_than_fit_are_counted_rather_than_silently_dropped(self):
+        self._seed_todos([f"todo number {i}" for i in range(30)], total=30)
+        lines = _plain_lines(self._render(cols=40))
+        shown = sum(1 for ln in lines if ln.startswith("- todo number"))
+        self.assertGreater(shown, 0, lines)
+        self.assertIn(f"  …(+{30 - shown} more)", lines)
+
+    def test_the_hidden_count_is_the_true_total_not_the_cached_slice(self):
+        """`gather._MAX_TODOS` bounds what the cache holds; `todo_count` is unclipped.
+        Deriving the total from the list's length would tell an operator with four
+        hundred open todos that they have twenty."""
+        self._seed_todos([f"todo {i}" for i in range(20)], total=400)
+        lines = _plain_lines(self._render(cols=40))
+        shown = sum(1 for ln in lines if ln.startswith("- todo "))
+        self.assertIn(f"{statusline._HEAD_PAD}todos 400", lines)
+        self.assertIn(f"  …(+{400 - shown} more)", lines)
+
+    def test_a_cache_written_before_the_count_existed_still_lists_what_it_has(self):
+        """`_shaped_like_a_scan` is deliberately loose so a cache file surviving an
+        upgrade still renders. A `todos` list with no `todo_count` beside it is exactly
+        that file, and it must not report a negative or zero total."""
+        _seed("f-1", todos=[{"title": "an older cache"}])
+        lines = _plain_lines(self._render(cols=40))
+        self.assertIn(f"{statusline._HEAD_PAD}todos 1", lines)
+        self.assertIn("- an older cache", lines)
+        self.assertFalse(any("…(+" in ln for ln in lines), lines)
+
+    def test_a_short_pane_keeps_the_personas_and_gives_up_the_todos(self):
+        """`right` is the persona column everywhere else charter names it, so a pane too
+        short for both loses the section that is duplicated elsewhere (`charter ws todo`,
+        and `bottom`'s own count) rather than the one that is not."""
+        for i in range(6):
+            self.make_persona(f"p{i}")
+        self._seed_todos(["a todo nobody will see"])
+        out = "\n".join(_plain_lines(self._render(rows=7, cols=40)))
+        self.assertIn("p0", out)
+        self.assertNotIn("a todo nobody will see", out)
+
+    def test_a_pane_with_room_for_one_row_draws_no_section_at_all(self):
+        """A heading with nothing under it claims this workspace has no todos, which is
+        the false-clean reading the module refuses everywhere else. Two rows is the
+        floor, and two rows is spent on the count and how much is hidden — the honest
+        half of the pair, exactly as `_table_lines` spends a one-row budget."""
+        for i in range(4):
+            self.make_persona(f"p{i}")
+        self._seed_todos(["one", "two"])
+        # 4 persona rows + the heading is 5, and the blank separator takes a sixth.
+        one_row = "\n".join(_plain_lines(self._render(rows=7, cols=40)))
+        self.assertNotIn("todos", one_row)
+        two_rows = _plain_lines(self._render(rows=8, cols=40))
+        self.assertIn(f"{statusline._HEAD_PAD}todos 2", two_rows)
+        self.assertIn("  …(+2 more)", two_rows)
+
+    def test_a_todo_title_is_contained_before_it_reaches_a_row(self):
+        """A todo is a COMMITTED value — someone else's machine wrote it into this
+        plane's repo. A newline in one writes a second line that looks exactly as much
+        like charter's own output as the first (#472's class), and the bound has to come
+        before the width arithmetic, not after."""
+        self._seed_todos(["first line\nSECOND ROW FORGED"])
+        lines = _plain_lines(self._render(cols=60))
+        # ONE row, with the newline shown as its own escape — not two rows, the second
+        # of which looks exactly as much like charter's own output as the first.
+        self.assertIn("- first line\\x0aSECOND ROW FORGED", lines)
+        self.assertEqual(sum(1 for ln in lines if "SECOND ROW FORGED" in ln), 1, lines)
+
+    def test_an_escape_in_a_todo_title_never_reaches_the_pane(self):
+        self._seed_todos(["\x1b[2Jcleared your screen"])
+        self.assertNotIn("\x1b[2J", self._render(cols=60))
+
+    def test_a_cjk_todo_title_does_not_push_the_row_past_the_pane(self):
+        self._seed_todos(["測" * 40])
+        for line in self._render(cols=22).split("\n"):
+            self.assertLessEqual(tui.width(line), 22)
+
+    def test_the_rows_come_from_the_cache_and_never_from_the_todo_directory(self):
+        """The idle-cost rule, one slot over from `bottom`'s table: `todos.open_todos`
+        opens and parses one file per todo, and a panel repaints on every version bump.
+        Pinned by making the live reader raise — a renderer that reaches it is red,
+        rather than merely slow in a way no test can see."""
+        self._seed_todos(["from the cache"])
+        with mock.patch("charter.todos.open_todos",
+                        side_effect=AssertionError("read the workspace, and must not")):
+            lines = _plain_lines(self._render(cols=40))
+        self.assertIn("- from the cache", lines)
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -1422,6 +1422,40 @@ class TheSidebarListsTheWorkspacesTodos(PersonaIso, unittest.TestCase):
             lines = _plain_lines(self._render(cols=40))
         self.assertIn("- from the cache", lines)
 
+    def test_a_frames_first_paint_lists_the_todos_rather_than_an_empty_column(self):
+        """**The cache makes every repaint after the first one free; it is not what
+        makes the first one right.**
+
+        A launch DISCARDS the gather cache on purpose (`gather.discard` — a recycled pid
+        must not adopt a dead frame's repos), so the very first paint of a new frame
+        reaches this section with no cache file at all. `gather.read` falls through to a
+        live `scan()` exactly there, which is the path that `discard`'s own docstring
+        says deleting the file restores — so the first frame an operator sees carries
+        their todos.
+
+        Written because the round-1 news entry claimed the opposite, and the claim was
+        never executed. It is also the guard against the cheap-looking simplification of
+        `read` — answering `_empty()` on a cold cache rather than scanning — which would
+        make a new frame's first impression a confident "this workspace has no todos".
+        The seeded sibling above pins the other half: with a cache present, the todo
+        directory is never touched at all.
+
+        WHICH workspace that live gather is for is a separate question and a real one —
+        `gather.scan` resolves it from the panel process, which #512 showed reaches none
+        of the rungs that speak for the frame. Filed as **#526** rather than fixed here:
+        the mechanism it wants (`state.workspace_for`) arrives with #525.
+        """
+        from charter import todos, workspace
+        todos.add(workspace.resolve(), "written before the frame ever launched")
+        gather.discard("f-cold")            # what `cmd_launch` runs before it draws
+        with mock.patch.object(gather, "scan", wraps=gather.scan) as scanned:
+            lines = _plain_lines(self._render(cols=50, fid="f-cold"))
+        self.assertIn(f"{statusline._HEAD_PAD}todos 1", lines)
+        self.assertIn("- written before the frame ever launched", lines)
+        # And the cache really was cold: the rows came from the live fallback, not from
+        # a file some earlier assertion had quietly left behind.
+        self.assertTrue(scanned.called)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_statusline_persona_cap.py
+++ b/tests/test_statusline_persona_cap.py
@@ -101,6 +101,49 @@ class TestTheRightChipsSurvive(ColumnCase):
         self.assertLess(len(shown), len(names))
 
 
+class TestTheFlatChipIsItsOwnPartsJoined(ColumnCase):
+    """#516 split a chip into `PersonaChip(name, head, badges)` so `frame/slots.py` can
+    give the badges a column of their own. The split is only safe while the two shapes
+    are ONE builder: the moment `_persona_chips` composes anything of its own, a fix to a
+    vault dot or a memory badge can land on one surface and not the other — which is the
+    drift `_right`'s docstring says it delegates in order to avoid.
+
+    Asserted as an identity over real personas rather than by reading the source, because
+    the property is what the two functions RETURN, not how they are written.
+    """
+
+    def test_every_chip_is_exactly_its_head_and_its_badges(self):
+        self.make_many(6)
+        persona.set_active("p03")
+        cells = statusline._persona_chip_cells(None)
+        self.assertEqual(self.chips(), [c.head + c.badges for c in cells])
+        self.assertTrue(cells, "the roster produced no cells to compare")
+
+    def test_the_split_survives_the_truncation_notice(self):
+        """The `…(+N more)` row is not a persona: it names none and carries no badges,
+        and a caller drawing columns has to be able to tell. Its hidden COUNT rides with
+        it as data, so a heading can add it back without parsing the sentence."""
+        self.make_many(30)
+        cells = statusline._persona_chip_cells(None)
+        note = cells[-1]
+        self.assertIsNone(note.name)
+        self.assertEqual(note.badges, "")
+        self.assertGreater(note.hidden, 0)
+        named = sum(1 for c in cells if c.name is not None)
+        self.assertEqual(named + note.hidden, 30)
+
+    def test_the_vault_dot_travels_with_the_name_and_not_with_the_badges(self):
+        """It is absent on almost every row, so in a badge column its width would be
+        paid by every persona for a fact about one of them."""
+        self.make_persona("vaulted", role="R", vault="nowhere-registered")
+        cells = statusline._persona_chip_cells(None)
+        cell = next(c for c in cells if c.name == "vaulted")
+        dot = statusline._vault_dot("nowhere-registered").strip()
+        self.assertTrue(dot, "the fixture produced no vault dot to place")
+        self.assertIn(dot, cell.head)
+        self.assertNotIn(dot, cell.badges)
+
+
 class TestItNeverBreaksTheRender(ColumnCase):
     def test_a_broken_roster_still_returns_a_list(self):
         """`_persona_chips` runs on every turn and its own contract is to degrade to an
@@ -109,6 +152,14 @@ class TestItNeverBreaksTheRender(ColumnCase):
         persona.list_personas = lambda: (_ for _ in ()).throw(OSError("nope"))
         self.addCleanup(setattr, persona, "list_personas", real)
         self.assertEqual(self.chips(), [])
+
+    def test_the_parts_degrade_the_same_way_the_flat_chips_do(self):
+        """Both shapes answer empty, because both are the same function — a `_right`
+        that got `None` here would need a guard its docstring says it does not have."""
+        real = persona.list_personas
+        persona.list_personas = lambda: (_ for _ in ()).throw(OSError("nope"))
+        self.addCleanup(setattr, persona, "list_personas", real)
+        self.assertEqual(statusline._persona_chip_cells(None), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_version_shows_channel.py
+++ b/tests/test_version_shows_channel.py
@@ -50,12 +50,13 @@ import ast
 import contextlib
 import io
 import os
+import sys
 import unittest
 from pathlib import Path
 from unittest import mock
 
 import charter
-from charter import commands_report, config, statusline, util
+from charter import commands_report, config, statusline, tui, util
 from charter.frame import slots
 
 from tests._isolation import PersonaIso
@@ -194,6 +195,33 @@ class TopRendersTheChannelBesideTheVersion(PersonaIso, unittest.TestCase):
         with mock.patch("charter.channel.is_dev", side_effect=RuntimeError("boom")):
             out = slots.render("top", self.fid)
         self.assertIn("charter", out)
+
+    def test_the_chip_moves_to_the_right_hand_end_with_the_version(self):
+        """#516 right-aligned the version. The chip is a fact ABOUT the version, not a
+        fourth thing on the row, so it has to travel — pinned by asserting they are
+        still adjacent at the row's end rather than that both merely appear."""
+        from charter import __version__
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}), \
+             mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((110, 1))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            out = tui.strip_ansi(slots.render("top", self.fid))
+        self.assertTrue(out.rstrip().endswith(f"charter {__version__} dev"), out)
+        self.assertGreater(out.index("charter "), len(out) // 2,
+                           "the version is still sitting beside the identity")
+
+    def test_a_row_with_no_room_for_both_drops_the_version_and_its_chip_together(self):
+        """Half of a dropped field is worse than the field: a bare `dev` with no version
+        beside it names a channel and nothing to act on. They go out together the way
+        `terse` already takes them out together."""
+        from charter import __version__
+        with mock.patch.object(config, "UPDATE", {"channel": "dev"}), \
+             mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((26, 1))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            out = tui.strip_ansi(slots.render("top", self.fid))
+        self.assertNotIn(__version__, out)
+        self.assertNotIn("dev", out)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Four changes to the right sidebar and the top bar. `Closes #516`.

## What it looks like

Rendered into a synthetic plane at the sidebar's real width (22 columns, `layout.SLOT_SIZE`), pane borders drawn so the column edges are visible.

```
┌──────────────────────┐
│▪ personas 6          │
│▸ steward          ✎47│
│▫ forge ◦          ✎9 │
│▫ reddit           ✎7 │
│▫ release          ✎38│
│▫ statusline       ✎14│
│▫ 測試員測試員     ✎3 │
│                      │
│▪ todos 10            │
│- wire the sidebar he…│
│- decide what a done …│
│- chase the flaky tmu…│
│- measure the badge c…│
│- answer the operator…│
│- retire the left sid…│
│  …(+4 more)          │
└──────────────────────┘
```

Three dispatches out on `forge` — the badge column widens, the names give up columns down to the floor, and the badge that no longer fits is cut by its own cell rather than pushing a name out:

```
┌──────────────────────┐
│▪ personas 6          │
│▸ steward    ✎47      │
│▫ forge ◦    ✎9 ⚡3 1…│
│▫ reddit     ✎7 ⚡ 2m │
│▫ release    ✎38      │
│▫ statusline ✎14      │
│▫ 測試員測…  ✎3       │
└──────────────────────┘
```

`minimal` density — four persona rows and four todo rows, each saying how many it hid:

```
┌──────────────────────┐
│▪ personas 6          │
│▸ steward          ✎47│
│▫ forge ◦          ✎9 │
│▫ reddit           ✎7 │
│  …(+3 more)          │
│                      │
│▪ todos 10            │
│- wire the sidebar he…│
│- decide what a done …│
│  …(+8 more)          │
└──────────────────────┘
```

A seven-row pane — the personas keep it and the todo section is not drawn:

```
┌──────────────────────┐
│▪ personas 6          │
│▸ steward          ✎47│
│▫ forge ◦          ✎9 │
│▫ reddit           ✎7 │
│▫ release          ✎38│
│▫ statusline       ✎14│
│▫ 測試員測試員     ✎3 │
└──────────────────────┘
```

A workspace with nothing open gets the persona section and no `todos 0` heading.

The top bar, at 110 columns, `minimal`, and 34 columns:

```
│ ⬢ demo*  ◆ steward · ◇ agents forge · reddit · release · statusline · 測試員測試員            charter 0.53.0 │
│ ⬢ demo*  ◆ steward · ◇ agents forge · reddit · release · statusline · 測試員測試員                           │
│ ⬢ demo*  ◆ steward · ◇ agents fo…│
```

## The one with depth: the badges

`statusline._persona_chips` returned one flat string per persona — name, vault dot, memory badge, health mark and in-flight badge already concatenated — so `_right` had nothing to put in a column.

The fix went upstream rather than into `_right`. `statusline` grew `PersonaChip(name, head, badges, hidden)` and `_persona_chips` became `head + badges` over it: one builder, two shapes. `_right`'s docstring says it delegates precisely so "a fix to any one of those five lands here the moment it lands in the status line's right column"; reassembling the chip in `_right` would have satisfied the same screenshot and thrown that away. A test asserts the identity `_persona_chips() == [c.head + c.badges for c in _persona_chip_cells()]` over a real roster, so the two shapes cannot come apart.

- The column is sized from the widest badge, measured with `tui.width` and never `len()`. The tell for `len()` is not misalignment — every row is padded to the same wrong number — but silent loss: the widest badge gets cut inside its own cell, `⚡2 4m` → `⚡2 4…`. That is what the test asserts.
- **The vault dot stays on the name's side.** It speaks only when a vault cannot be *used*, so it is absent on almost every row; in the badge column its width would be paid by every persona for a fact about one of them, and the whole column would shift the day somebody registers a vault.
- A `_NAME_MIN_W` floor keeps one persona's `⚡3 2h?` from taking twelve columns off every name in a 22-column sidebar. Past that point the badge column gives way.

## The todos

Read from the gather cache. `scan()` now gathers them next to the repo rows, because `todos.open_todos` opens and parses one file per todo and a panel repaints whenever the plane's state moves — the same rule the repo table is held to. A test makes `todos.open_todos` raise and requires the sidebar still render from the cache.

The cache carries at most twenty titles (`gather._MAX_TODOS`, a bound on the file) and the **unclipped** count beside them, so a workspace with four hundred open todos is told it has four hundred rather than twenty.

What the issue asked to settle:

- **How many rows** — the personas first (`right` is the persona column everywhere else charter names it), the todos take what is left, capped at eight rows and four at `terse`.
- **More than fits** — a `…(+N more)` line, reserved *out* of the budget rather than appended and trimmed off the end. A pane with room for one row draws no section: a heading with nothing under it claims this workspace has no todos.
- **Done items** — never shown; `open_todos` returns open ones, and a list you read past is not a list you act on.

A todo title is a committed value, so `contain.one_line` bounds it **before** any width arithmetic — #472's ordering. A newline in a title renders as `\x0a` on one row rather than writing a second row that looks like charter's own output.

## The version

Right-aligned by padding the identity, not by cutting it. `terse` still drops it; the `dev` chip travels inside the same f-string (which `test_version_shows_channel`'s AST property also requires); and a bar too narrow for both drops the version **whole** rather than cutting the workspace to fit it — the same field `terse` drops, so a starved bar and a terse bar lose the same thing.

## Mutation testing

Seventeen mutations, applied one at a time, `__pycache__` cleared, suite restored green after each. All seventeen RED:

`len()` for `tui.width()` · the name floor removed · per-row badge padding · the vault dot moved into the badges · the flat chip composed separately from its parts · the heading counting rows-that-fit · no heading at all · the todo list read live instead of from the cache · the title left uncontained · the hidden count derived from the clipped list · a one-row budget spent on a bare heading · the overflow line appended rather than reserved · the cache list left unbounded · the todos drawn above the personas · the version left beside the identity · a starved bar cutting the identity · the dev chip left behind.

**Two survived the first round**, and both are recorded in the commit because they are the shapes this repo keeps hitting:

- The one-row-budget guard was **masked by a duplicate of itself** in `_right`. The outer test now asks only "is there any room at all" — a question about whether to open a file — and the two-row floor is `_todo_rows`' alone.
- The name-floor test built its fixture **from the constant under test**, so setting `_NAME_MIN_W` to zero shortened the fixture name to the empty string and the test passed having asserted that nothing survives. It uses a literal name now.

## Suite

`Ran 5449 tests … OK`, full `unittest discover`.

Worth knowing if you run it yourself: sixteen unrelated tests fail on this machine with `CHARTER_SESSION_ID` exported into the shell (`test_session_identity`, `test_piece_claim`, `test_trace`, …). They pass with it unset, and none of them touch this diff.

## Adjacent, filed rather than widened

The cache is empty at launch, so the todo list — like the repo table beside it — is blank on the very first paint. That is **#512**, being fixed in parallel; this reads the cache and adds no refresh of its own. The news entry says so.

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
