### PR TITLE
frame: a panel draws the workspace the launch resolved, and says "gathering" instead of "no repos" (#512)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -706,7 +706,7 @@ def _add_frame_parsers(sub) -> None:
     # version (see `commands_frame.cmd_probe`'s own docstring).
     _core_commands = set(sub.choices) | {"frame", "panel", "frame-menu", "frame-action",
                                          "frame-probe", "frame-respawn", "frame-density",
-                                         "frame-resize"}
+                                         "frame-resize", "frame-gather"}
 
     # Which harness (by `.name`, never `.cli_name` — that's the dict key below) has
     # already claimed each word, so a SECOND harness wanting it is told who got there
@@ -805,6 +805,22 @@ def _add_frame_parsers(sub) -> None:
     rz = sub.add_parser("frame-resize")
     rz.add_argument("--frame", dest="frame", default=None)
     rz.set_defaults(func=commands_frame.cmd_resize)
+
+    # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the
+    # ones above. Fired DETACHED by `commands_frame._spawn_gather` at launch (#512) —
+    # never typed by an operator, and never by tmux: this one has no `run-shell` behind
+    # it at all, it is `util.detach_self` out of the launcher's own process.
+    #
+    # BOTH arguments are required, and neither has a default that could be inferred. The
+    # child is deliberately as far from the operator's terminal as a panel is (a new
+    # session, no controlling tty), so `workspace.resolve`'s pointer rungs would answer
+    # for the CHILD rather than for the frame — which is exactly the defect #512 is. The
+    # launcher already knows both; stating them is what keeps the gather keyed to the
+    # frame it is for.
+    gt = sub.add_parser("frame-gather")
+    gt.add_argument("--session", dest="session", required=True)
+    gt.add_argument("--workspace", dest="workspace", required=True)
+    gt.set_defaults(func=commands_frame.cmd_gather)
 
     # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the
     # three above. Fired by a hotkey-menu selection (`commands_frame._menu_entries`), whose

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1067,6 +1067,61 @@ def _wait_for_harness(socket: str, harness_pane: str) -> int | None:
         time.sleep(_POLL_SECONDS)
 
 
+def _spawn_gather(fid: str, ws: str) -> None:
+    """Fill *fid*'s gather cache in a DETACHED child, and bump the frame when it lands.
+
+    **The launcher empties the cache and nothing used to refill it — #512.** `cmd_launch`
+    calls `gather.discard(fid)` before it draws anything (a recycled pid must not adopt a
+    dead frame's rows; see that function), and the only other caller of `gather.refresh`
+    in charter is `frame/notify.plane_changed`, reached from a `posttooluse*` hook. So a
+    frame's repo table was filled by the operator's FIRST TOOL CALL and by nothing else —
+    reported as "the repos appear after I resize", because a resize happens to coincide
+    with one.
+
+    **Detached rather than inline, and that is the whole design.** A cold `gather.scan()`
+    is ~35ms and three git invocations per repo; the launch path is a person waiting for a
+    harness to appear, and `charter claude` is the default way charter is started. So this
+    is the shape charter already uses twice for exactly this problem — `update.maybe_spawn`
+    and `glstate.maybe_spawn`: draw immediately with whatever is there, kick a child, let
+    the answer arrive a beat later. `slots._bottom` says "gathering" in the meantime rather
+    than drawing an empty table (`slots._unknown_lines`), so the window this opens is
+    visible and honest rather than a silent lie.
+
+    **`--workspace` is passed, not left to the child, for `glstate.maybe_spawn`'s own
+    reason**: the launcher resolves the workspace for the FRAME — from its own terminal,
+    its own cwd, its own pointers — while the child would resolve it for ITSELF, and a
+    detached process started with `start_new_session` is exactly as far from the
+    operator's terminal as a panel is (#512 again: `session.terminal()` would answer for
+    the child, not for the frame). A refresh keyed to a different workspace than the frame
+    it is refreshing is the defect, not a stale value.
+
+    **The child bumps, because a panel repaints on nothing else.** `panel.run` polls
+    `state.version`; a cache written with no bump behind it would sit on disk unread until
+    something unrelated moved the version — which on an idle session is the same "first
+    tool call" wait this function exists to end. `notify.plane_changed`'s order is kept
+    verbatim (refresh, THEN bump) and for its stated reason: a poller that saw the new
+    version must never then read the old cache.
+
+    **Inline as a last resort, never as the plan.** `util.detach_self` reports whether the
+    spawn happened; when it did not there is no other filler on this path, and a pane
+    saying "gathering" for the rest of the session would be a promise charter had already
+    broken. Paying ~35ms once, on a launch that has just failed to fork, is the cheaper
+    of the two — and it is the only path in this function that costs the operator anything.
+
+    Never raises: a frame must launch whether or not its rows can be gathered.
+    """
+    try:
+        if util.detach_self(["frame-gather", "--session", fid, "--workspace", ws]):
+            return
+    except Exception:
+        pass
+    try:
+        gather.refresh(fid, workspace=ws)
+        state.bump(fid)
+    except Exception:
+        return
+
+
 def _launch_sizes(fid: str, slots: list[str], *,
                   window_cols: int, window_rows: int) -> dict[str, int]:
     """How big each of *slots* is split, in a *window_cols* x *window_rows* window —
@@ -1435,8 +1490,8 @@ def _panel_remain_on_exit_argv(*, socket: str, harness_pane: str) -> list[str]:
                                "remain-on-exit", "on")
 
 
-def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, argv: list[str],
-                             h, v: tuple[int, int]) -> int | None:
+def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, ws: str,
+                             argv: list[str], h, v: tuple[int, int]) -> int | None:
     """Build the frame as a WINDOW in the tmux the operator is already in.
 
     The same layout as the private-server path — harness in the middle, charter's panels
@@ -1533,7 +1588,15 @@ def _launch_in_operator_tmux(socket: str, session: str, *, fid: str, argv: list[
     # Rewritten, not merely written: an adopted directory may name the OTHER server, and
     # a stale marker would make `reap` there skip a frame that is now genuinely ours.
     state.record_server(fid, socket)
+    # And the workspace this frame is FOR, for the same rewrite-don't-merge reason and a
+    # sharper one of its own: a panel process cannot resolve it (#512 — see
+    # `state.record_workspace`), so this launcher is the only thing that ever knows.
+    state.record_workspace(fid, ws)
     state.bump(fid)
+    # Kicked here, before a single tmux split — the child gathers while tmux is still
+    # carving panes, so on an ordinary launch the cache is already on disk by the time
+    # the first panel process paints. See `_spawn_gather`.
+    _spawn_gather(fid, ws)
 
     env = _frame_env(fid, h)
     # The launcher is the only process that knows this frame's own charter identity —
@@ -2115,7 +2178,8 @@ def cmd_launch(args) -> int:
     # exactly that, and the private-server path below is the right one after all.
     inside = tmuxctl.operator_server()
     if inside is not None:
-        rc = _launch_in_operator_tmux(inside[0], inside[1], fid=fid, argv=argv, h=h, v=v)
+        rc = _launch_in_operator_tmux(inside[0], inside[1], fid=fid, ws=ws, argv=argv,
+                                      h=h, v=v)
         if rc is not None:
             return rc
 
@@ -2177,8 +2241,15 @@ def cmd_launch(args) -> int:
     # may name the OTHER server, and a stale marker would make `reap` on this one skip
     # a frame that is now genuinely ours.
     state.record_server(fid, SOCKET)
+    # And the workspace this frame is FOR — rewritten for the same reason, and the one
+    # thing here no process inside the frame can work out for itself (#512; see
+    # `state.record_workspace`).
+    state.record_workspace(fid, ws)
     state.clear_respawn(fid)
     state.bump(fid)
+    # Kicked before tmux is asked for anything, so the gather runs alongside the session
+    # start rather than in front of it. See `_spawn_gather`.
+    _spawn_gather(fid, ws)
 
     try:
         cols, rows = os.get_terminal_size()
@@ -2757,6 +2828,47 @@ def cmd_resize(args) -> int:
     socket = state.frame_server(fid) or SOCKET
     cols, rows = _window_size(socket, harness_pane)
     _reassert_sizes(socket, fid=fid, panes=panes, window_cols=cols, window_rows=rows)
+    return 0
+
+
+def cmd_gather(args) -> int:
+    """`charter frame-gather --session <fid> --workspace <ws>` — gather one frame's repo
+    state into its cache and bump it. Internal: fired detached by `_spawn_gather` at
+    launch, never typed.
+
+    **Its own command rather than a thread in the launcher**, for the reason
+    `update.maybe_spawn` and `glstate.maybe_spawn` are both separate processes: the work
+    has to outlive the call that started it *and* not be on its stack. A launcher blocks
+    in `attach`/`_wait_for_harness` for the whole life of the frame on one path, and a
+    background thread there would be a git sweep running inside the process the operator's
+    terminal is currently handed to.
+
+    **`--workspace` is required and never inferred here.** A detached child started with
+    `start_new_session` has no terminal of the operator's, and `$CHARTER_SESSION_ID` names
+    the FRAME rather than any agent session — the two rungs `workspace.resolve` would
+    otherwise land on (#512). The launcher resolved this frame's workspace already; asking
+    a second process to guess at it is the whole bug.
+
+    **The order is `notify.plane_changed`'s, verbatim: refresh, then bump.** A panel's poll
+    reads `state.version` first and the cache second, so bumping first opens a window where
+    a poller sees the new version and still reads the old cache. Refreshing first closes it.
+
+    **Always 0, and every refusal is a quiet no-op** — the same posture `cmd_respawn` and
+    `cmd_resize` keep, for the same reason: nothing reads this process's status, and the
+    only screen it could complain to is the agent's own. `gather.refresh` and `state.bump`
+    each already promise not to raise; the `try` is here so that a future change to either
+    — or to anything this grows between them — cannot turn a background gather into a
+    traceback nobody will ever read.
+    """
+    fid = getattr(args, "session", None) or ""
+    ws = getattr(args, "workspace", None) or ""
+    if not fid or not ws:
+        return 0
+    try:
+        gather.refresh(fid, workspace=ws)
+        state.bump(fid)
+    except Exception:
+        return 0
     return 0
 
 

--- a/charter/frame/gather.py
+++ b/charter/frame/gather.py
@@ -347,10 +347,10 @@ def read(fid: str, *, workspace: str | None = None, cwd: str | None = None) -> d
     all fall through to a fresh :func:`scan`, the same one a caller would
     otherwise have no data to draw from. This never returns anything but a dict
     carrying ``repos``/``worktrees`` as lists — never the raw, untrusted value a
-    corrupt or stale cache file happened to contain. :func:`_cached` is where each of
+    corrupt or stale cache file happened to contain. :func:`cached` is where each of
     those degradations actually lives; this is that plus the fallback.
     """
-    data = _cached(fid)
+    data = cached(fid)
     if data is not None:
         return data
     try:
@@ -359,7 +359,7 @@ def read(fid: str, *, workspace: str | None = None, cwd: str | None = None) -> d
         return _empty(workspace)
 
 
-def _cached(fid: str) -> dict | None:
+def cached(fid: str) -> dict | None:
     """Whatever *fid*'s cache file holds, if it holds something a renderer can index
     into — ``None`` for every way that can fail.
 
@@ -404,17 +404,26 @@ def row_count(fid: str) -> int:
       uses, rather than a second way of counting repos that could disagree with the rows
       the panel then draws.
 
+    **The listing counts the FRAME's workspace, not the asking process's** (#512).
+    `state.workspace_for` is the one rule every frame surface asks — what was chosen inside
+    the frame, else what the launcher recorded, else a local resolve — so the pane is sized
+    from the same workspace `slots._bottom` then draws. The two callers make the difference
+    real: the launcher IS the process that resolved it and would agree either way, but
+    `cmd_resize` runs as a tmux `run-shell` child, whose environment is the SERVER's and
+    whose cwd and pane id are not the operator's — so it would size `bottom` for whatever
+    workspace it resolved for itself, which on the plane that reported #512 was a
+    `default` holding no clones at all.
+
     Zero for anything that fails, which is the floor `layout.bottom_rows` already
     handles: a frame whose repo count could not be established gets the one-row strip
     `bottom` always was, never a taller pane full of nothing.
     """
-    data = _cached(fid)
+    data = cached(fid)
     if data is not None:
         return len(data.get("repos") or []) + len(data.get("worktrees") or [])
     try:
         from .. import statusline as sl
-        from .. import workspace as ws_mod
-        active = ws_mod.resolve()
+        active = state.workspace_for(fid)
         dirs = sl._repo_trees(active)
         return len(dirs) + len(sl._detail_worktrees(active, dirs))
     except Exception:

--- a/charter/frame/notify.py
+++ b/charter/frame/notify.py
@@ -105,7 +105,16 @@ def plane_changed() -> None:
         _last["at"] = now
         try:
             from . import gather
-            gather.refresh(fid)
+            # The FRAME's workspace, not this hook process's own answer (#512). The cache
+            # belongs to the frame and a panel draws it whole, so a refresh keyed to a
+            # different workspace does not degrade the table, it REPLACES it — the launch
+            # gathers the workspace you launched for, and the first tool call swaps in
+            # another one's repos. The two answers can genuinely differ: this runs inside
+            # the harness, whose cwd and pane id are its own. `state.workspace_for` is the
+            # one rule every frame surface asks — an explicit `charter workspace use`
+            # inside the frame first, then the launcher's recorded answer, then a local
+            # resolve for a frame that predates the record.
+            gather.refresh(fid, workspace=state.workspace_for(fid))
         except Exception:
             pass
         state.bump(fid)

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -90,6 +90,30 @@ def verbosity(fid: str) -> str:
     return instance.verbosity_for(override or config.FRAME["density"])
 
 
+def _frame_workspace(fid: str) -> str:
+    """Which workspace THIS FRAME is drawing — `state.workspace_for`, which owns the rule.
+
+    **A panel that re-resolves the workspace gets a different answer, and #512 is what
+    that costs.** `state.record_workspace`'s docstring has the full walk through
+    `workspace.resolve`'s rungs and why a panel process reaches none of the ones that
+    ordinarily decide it; the short version is that a panel falls all the way to the
+    declared default while the launcher — one ordinary shell, one rung up — resolved
+    something else. On the plane that reported #512 that gap was the whole bug: `bottom`
+    drew `default`'s empty repo list into a pane the launcher had sized for
+    `harness-wrapper`'s three rows, and the rows only appeared once the first tool call's
+    hook refreshed the cache from inside the HARNESS, which resolves it correctly.
+
+    Kept as a named function here rather than inlined at the three call sites, because
+    what it means is a `slots` fact: every panel goes through it — `_top` names the
+    workspace, `_bottom` counts its todos and its alerts and draws its repo table — so the
+    things a frame says about "where am I" cannot disagree with each other. That is a
+    failure an operator reads immediately: a header saying `default` above a table listing
+    another workspace's repos.
+    """
+    from . import state
+    return state.workspace_for(fid)
+
+
 def _width() -> int:
     """The pane's own width in columns — measured, never read out of `$COLUMNS`.
 
@@ -222,7 +246,12 @@ def _top(fid: str) -> str:
     """
     from .. import __version__, statusline, workspace
     from . import state
-    ws = workspace.resolve()
+    # The FRAME's workspace, not this pane's own guess at one (#512) — see
+    # :func:`_frame_workspace`. `source()` is still asked locally and still only decides
+    # the PIN: `$CHARTER_WORKSPACE` is the one rung a panel does share with its launcher
+    # (`commands_frame._frame_identity_env` carries it, empty when the launcher had none),
+    # so "the operator pinned this by hand" is a question this process can still answer.
+    ws = _frame_workspace(fid)
     src = workspace.source()
     pin = "*" if src == "$CHARTER_WORKSPACE" else ""
     persona = statusline._persona_line() or ""
@@ -448,6 +477,40 @@ def _table_lines(data: dict, width: int, budget: int) -> list[str]:
                                 f"{emph}{sl._DIM}{p['name']}{sl._R}", p, width,
                                 branch_override="" if wb == p.get("name") else None))
     return lines[:budget]
+
+
+def _unknown_lines(width: int) -> list[str]:
+    """What the repo table draws when charter has not gathered this frame's repos YET —
+    which is a different claim from "this workspace has no repos", and #512 is the whole
+    cost of drawing them the same.
+
+    `cmd_launch` deletes the cache before it draws anything (`gather.discard`, so a
+    recycled pid cannot adopt a dead frame's rows) and a detached refresh fills it a beat
+    later (`commands_frame._spawn_gather`). Between the two there is a real window in
+    which the honest answer is "not known yet" — and an empty table is not that answer,
+    it is a confident `no repos` on a plane that may have fourteen. That is the same
+    false-clean reading `_table_lines` refuses for a starved pane ("too narrow for the
+    table is NO table, not a cut one") and the same one the `left` sidebar was retired
+    for in #488; this is it said out loud instead of implied by absence.
+
+    **A pane too narrow for the table says nothing here either**, which matters: a line
+    that appeared while the rows were unknown and vanished the moment they were known
+    would read as "the repos went away". That is not enforced HERE, though — the width
+    rule for this pane lives in :func:`_table_cap`, which answers 0 below
+    `statusline._LEFT_W`, and `_bottom` already refuses to compose anything on a budget of
+    0. A second copy of the rule in this function would be unreachable through the only
+    caller there is, and a guard no test can turn red is exactly the kind that passes
+    because a DIFFERENT guard caught it.
+
+    One line, always: there is exactly one thing to say and repeating it down a tall pane
+    would be padding. Bounded through `tui.truncate` like every other line in this module
+    — `⋯` and `…` are both East-Asian *Ambiguous*, the class `statusline._persona_chips`
+    records as having "broken this layout twice", so their width is measured rather than
+    counted.
+    """
+    from .. import statusline as sl
+
+    return [tui.truncate(f"  {sl._DIM}⋯ gathering this workspace's repos…{sl._R}", width)]
 
 
 def _table_cap(fid: str, width: int) -> int:
@@ -990,9 +1053,12 @@ def _bottom(fid: str) -> str:
     repaints a second. Everything the table draws comes out of the cache; see
     :func:`_table_row` for the one column that costs (presence) and is therefore absent.
     """
-    from .. import config, session as _session, statusline as sl, workspace
+    from .. import config, session as _session, statusline as sl
     from . import state, tmuxctl
-    ws = workspace.resolve()
+    # The FRAME's workspace (#512), for the todo count and the alerts as much as for the
+    # table: they are three statements about one workspace on one row, and a panel that
+    # resolved its own would count another workspace's todos beside this one's repos.
+    ws = _frame_workspace(fid)
     todos = sl._todo_count(ws)
     alerts = sl._alerts(ws)
     news = sl._session_news(_session.current(), inflight=False)
@@ -1042,7 +1108,30 @@ def _bottom(fid: str) -> str:
     budget = min(_height() - len(lines), _table_cap(fid, w))
     if budget > 0:
         from . import gather
-        lines.extend(_table_lines(gather.read(fid), w, budget))
+        # `gather.cached`, never `gather.read` (#512). The two differ by exactly one
+        # thing: `read` falls back to a live `scan()` when there is no cache, and a
+        # PANEL is the one caller that must not have that fallback. Two reasons, and
+        # both are rules this module already keeps:
+        #
+        # * **A panel does not sweep.** `_table_lines`' own docstring promises it never
+        #   reaches a repo directory, a `git status` or a `glstate.read_for`; #387 pinned
+        #   an idle tick at one `stat`, and `bottom` is the ONE animated slot, so a paint
+        #   that scans is five cold sweeps a second for as long as anything is in flight.
+        #   `cmd_launch` calls `gather.discard` before it draws, so a fresh frame reached
+        #   that fallback BY DESIGN, on the very repaints an operator is watching.
+        # * **An empty table is not the same claim as an unknown one.** `read`'s fallback
+        #   returns `repos: []` for "the scan found nothing" and for "the scan ran in the
+        #   wrong workspace" alike, and `_table_lines` draws both as no rows at all — a
+        #   pane that says "no repos" on a plane full of them. `None` here keeps the two
+        #   apart, and :func:`_unknown_lines` says which one this is.
+        #
+        # Nothing is left blank waiting: `commands_frame._spawn_gather` kicks a detached
+        # refresh at launch which writes this cache and bumps the version, the same shape
+        # `update.maybe_spawn`/`glstate.maybe_spawn` already use, and every
+        # `posttooluse*` hook refreshes it after that (`notify.plane_changed`).
+        data = gather.cached(fid)
+        lines.extend(_unknown_lines(w) if data is None
+                     else _table_lines(data, w, budget))
     return "\n".join(lines)
 
 

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -244,16 +244,23 @@ def _top(fid: str) -> str:
     degrade. The `dev` chip travels inside that one f-string, so it goes and comes back
     with the version and can never be left behind on its own.
     """
-    from .. import __version__, statusline, workspace
+    from .. import __version__, statusline
     from . import state
     # The FRAME's workspace, not this pane's own guess at one (#512) — see
-    # :func:`_frame_workspace`. `source()` is still asked locally and still only decides
-    # the PIN: `$CHARTER_WORKSPACE` is the one rung a panel does share with its launcher
-    # (`commands_frame._frame_identity_env` carries it, empty when the launcher had none),
-    # so "the operator pinned this by hand" is a question this process can still answer.
+    # :func:`_frame_workspace`. `$CHARTER_WORKSPACE` is the one rung a panel does share
+    # with its launcher (`commands_frame._frame_identity_env` carries it, empty when the
+    # launcher had none), so "the operator pinned this by hand" is a question this process
+    # can still answer.
+    #
+    # The variable is compared to the NAME DRAWN, not asked about through
+    # `workspace.source()`: the `*` claims the environment chose *this* name, and a marker
+    # that only knows the variable is set somewhere will say so over a name the variable
+    # did not name — which is what `state.workspace_for`'s rung 0 is about. Comparing the
+    # value keeps the two halves of the chip agreeing by construction rather than by both
+    # happening to consult the same rung, and it drops `source()`'s `from_path` walk and
+    # pointer reads off this slot.
     ws = _frame_workspace(fid)
-    src = workspace.source()
-    pin = "*" if src == "$CHARTER_WORKSPACE" else ""
+    pin = "*" if ws == os.environ.get("CHARTER_WORKSPACE", "").strip() else ""
     persona = statusline._persona_line() or ""
     # Two file reads on a slot that repaints only on a version bump (`top` is not in
     # `ANIMATED`), and nothing is read at all for a frame with no recorded session —

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -455,8 +455,16 @@ def frame_workspace(fid: str) -> str | None:
 def workspace_for(fid: str) -> str:
     """The workspace this frame is DRAWING — what every surface of the frame asks.
 
-    Three rungs, and the order is the whole of it:
+    Four rungs, and the order is the whole of it:
 
+    0. **The pin.** ``$CHARTER_WORKSPACE`` outranks everything, because that is what it
+       means everywhere else in charter: `workspace.resolve` puts it above every pointer,
+       `commands_workspace` warns that `ws use` will not stick while it is set, and `hooks`
+       tells an operator to "re-launch with CHARTER_WORKSPACE=<name> set" as the way to aim
+       a parallel or unattended agent. A frame is not exempt from it. Skip this rung and a
+       framed session that also typed `charter workspace use other` draws `other` while
+       every command it runs acts on the pinned name — a panel naming a workspace nothing
+       in the session touches, wearing `slots`' `*` that says the environment chose it.
     1. **What was chosen inside this frame.** `charter workspace use <name>` typed at the
        agent writes the per-session pointer under the FRAME's id, because inside a frame
        the frame is the charter session (`docs/frame.md`, ADR 0019) — and "it moves the
@@ -468,21 +476,33 @@ def workspace_for(fid: str) -> str:
        that predates the record and still running across the upgrade — today's behaviour,
        so this is never worse than what it replaces.
 
-    Rungs 1 and 2 are the only two that can ever disagree, and it is worth saying why the
-    others cannot. `$CHARTER_WORKSPACE` reaches a panel exactly when the launcher had it
-    (`commands_frame._frame_identity_env` carries it, empty when absent), and the launcher
-    resolves it first — so the record holds the same value. The cwd rung is the same story:
-    a panel's cwd is the launcher's, and the launcher asked `from_path` about it before
-    anything else. The per-terminal pointer and the declared default are the two rungs a
-    panel reaches that answer for the PANEL rather than for the frame, and those are
-    exactly the two the record is here to outrank.
+    Rungs 1 and 2 are the only two below the pin that can ever disagree, and it is worth
+    saying why the others cannot. `$CHARTER_WORKSPACE` reaches a panel exactly when the
+    launcher had it (`commands_frame._frame_identity_env` carries it, empty when absent),
+    and the launcher resolves it first — so the record holds the same value; rung 0 is
+    therefore invisible on an ordinary pinned launch and only shows itself when something
+    inside the frame tried to move off the pin. The cwd rung is the same story: a panel's
+    cwd is the launcher's, and the launcher asked `from_path` about it before anything
+    else. The per-terminal pointer and the declared default are the two rungs a panel
+    reaches that answer for the PANEL rather than for the frame, and those are exactly the
+    two the record is here to outrank.
+
+    **Name-checked, and `valid_name` alone with no `env and` in front of it** — the same
+    rule and the same reasoning as :func:`frame_workspace`, since this value ends up in
+    `workspace_dir()`'s join too, and `valid_name("")` is already False so a truthiness
+    test would be a second guard no mutation can turn red. A pin that cannot name a
+    workspace does not get drawn: it falls through, and `slots` withholds the `*` because
+    the name on screen is then not the one the environment named.
 
     Asked through `workspace.for_session` rather than by reading `workspace.source()`'s
     label: that function returns a sentence written for a status line, and matching the
     string ``"session"`` would be this repo's own recurring defect — a spelling standing in
-    for a property.
+    for a property. Rung 0 reads the variable itself for the same reason.
     """
     from .. import workspace as ws_mod
+    env = os.environ.get("CHARTER_WORKSPACE", "").strip()
+    if ws_mod.valid_name(env):
+        return env
     return ws_mod.for_session(fid) or frame_workspace(fid) or ws_mod.resolve()
 
 

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -368,6 +368,124 @@ def frame_server(fid: str) -> str | None:
         return None
 
 
+def record_workspace(fid: str, name: str) -> None:
+    """Write down which workspace this frame was LAUNCHED for.
+
+    **A panel cannot work this out for itself, and #512 is what that costs.**
+    `workspace.resolve`'s rungs are, in order: `--workspace`, `$CHARTER_WORKSPACE`, the
+    tree you are standing in, a per-SESSION pointer, a per-TERMINAL pointer, the declared
+    default. At LAUNCH — before anything inside the frame has chosen anything — a panel
+    process reaches none of the rungs that could speak for the frame:
+
+    * `$CHARTER_WORKSPACE` arrives as the empty string on every launch where the operator
+      did not pin one by hand — `commands_frame._frame_identity_env` emits every name in
+      `_FRAME_IDENTITY`, present or not, precisely so a frame cannot inherit a *stale*
+      pin from whichever launcher started the shared tmux server. Absent is absent.
+    * the cwd is the pane's, which is the plane root for anyone who typed `charter claude`
+      there — `workspace.from_path` answers `None` for it.
+    * the per-session pointer is keyed on `session.current()`, which inside a frame is the
+      FRAME id (`$CHARTER_SESSION_ID`), not the harness's own session id; and the
+      per-terminal pointer is keyed on `session.terminal()`, which is the panel's OWN tmux
+      pane. Both miss.
+
+    So a panel falls all the way to the declared default (`default`, ordinarily) while the
+    launcher — an ordinary shell, in the operator's own terminal, one rung up — resolved
+    something else entirely. Measured on the plane that reported #512: three terminal
+    pointers naming `harness-wrapper` and one naming `user-reporting`, a `default`
+    workspace holding no clones at all, and every panel drawing `default`'s empty repo
+    list beside a `bottom` pane the LAUNCHER had sized for the real workspace's rows.
+
+    The launcher is the one process that knows, so it writes it down — the same argument
+    :func:`record_identity` already makes for the rest of a frame's identity, and the same
+    atomic-write, never-raise, rewrite-on-every-launch shape as :func:`record_server` (an
+    adopted directory's value is another frame's answer, so it is overwritten rather than
+    merged).
+
+    This is deliberately NOT `$CHARTER_WORKSPACE`. Exporting the resolved name into the
+    frame's environment would fix the same reads and take `charter ws use` away from every
+    framed session on the way past — `workspace.resolve` ranks the variable above every
+    pointer, `commands_workspace` says so in as many words, and `hooks` skips its
+    session-start workspace nudge whenever it is set. A frame recording what it drew is
+    not the same thing as a session being pinned.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    tmp = d / "workspace.tmp"
+    try:
+        tmp.write_text(f"{name}\n")
+        os.replace(tmp, d / "workspace")
+    except OSError:
+        return
+
+
+def frame_workspace(fid: str) -> str | None:
+    """The workspace *fid* was launched for, or ``None`` when charter does not know.
+
+    ``None`` is the migration case (a frame launched by a charter that predates
+    :func:`record_workspace` and still running across the upgrade) and the corrupt one,
+    answered the same way and for :func:`identity`'s reason: the caller
+    (:func:`workspace_for`) decides what to do instead, which is to fall through to the
+    rung below — a local resolve, exactly today's behaviour and no worse than it.
+
+    **Name-checked on the way out**, like every other name charter reads off disk and
+    joins onto a path (`workspace.declared_default`, `persona.default_persona`). The value
+    is charter's own — written by a launcher, under `config.STATE_DIR` — not a committed
+    file a teammate can set, so this is a floor rather than the whole guard; but the read
+    ends up in `workspace_dir()`'s join and on a panel's screen, and #442 is what an
+    unchecked `../../` in that position already cost once.
+
+    `valid_name` alone, with no `val and` in front of it: `workspace.valid_name("")` is
+    already False, so the truthiness test would be a second guard that no mutation can
+    turn red — the shape this repo keeps shipping ("a guard passing because a DIFFERENT
+    guard caught it"). A truncated write is refused by the name check, on the name check's
+    own terms.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        val = (d / "workspace").read_text().strip()
+    except (OSError, ValueError):
+        return None
+    from .. import workspace as ws_mod
+    return val if ws_mod.valid_name(val) else None
+
+
+def workspace_for(fid: str) -> str:
+    """The workspace this frame is DRAWING — what every surface of the frame asks.
+
+    Three rungs, and the order is the whole of it:
+
+    1. **What was chosen inside this frame.** `charter workspace use <name>` typed at the
+       agent writes the per-session pointer under the FRAME's id, because inside a frame
+       the frame is the charter session (`docs/frame.md`, ADR 0019) — and "it moves the
+       panels too" is a documented promise, not an accident. An explicit choice made while
+       the frame runs outranks anything the launch decided.
+    2. **What the launcher resolved**, :func:`record_workspace`. The seed: the launch's own
+       answer to a question nothing inside the frame can ask (#512).
+    3. **Whatever this process resolves for itself**, for a frame launched by a charter
+       that predates the record and still running across the upgrade — today's behaviour,
+       so this is never worse than what it replaces.
+
+    Rungs 1 and 2 are the only two that can ever disagree, and it is worth saying why the
+    others cannot. `$CHARTER_WORKSPACE` reaches a panel exactly when the launcher had it
+    (`commands_frame._frame_identity_env` carries it, empty when absent), and the launcher
+    resolves it first — so the record holds the same value. The cwd rung is the same story:
+    a panel's cwd is the launcher's, and the launcher asked `from_path` about it before
+    anything else. The per-terminal pointer and the declared default are the two rungs a
+    panel reaches that answer for the PANEL rather than for the frame, and those are
+    exactly the two the record is here to outrank.
+
+    Asked through `workspace.for_session` rather than by reading `workspace.source()`'s
+    label: that function returns a sentence written for a status line, and matching the
+    string ``"session"`` would be this repo's own recurring defect — a spelling standing in
+    for a property.
+    """
+    from .. import workspace as ws_mod
+    return ws_mod.for_session(fid) or frame_workspace(fid) or ws_mod.resolve()
+
+
 def record_density(fid: str, level: str) -> None:
     """Write down the density THIS RUNNING FRAME is at, overriding `[frame] density`.
 

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -56,6 +56,31 @@ def _session_file(sid: str) -> Path:
     return config.SESSIONS_DIR / f"{sid}.workspace"
 
 
+def for_session(sid: str) -> str | None:
+    """The workspace explicitly chosen FOR *sid*, or ``None`` if nobody chose one.
+
+    The per-session pointer rung of :func:`resolve`, asked about a session that is not
+    necessarily this process's — which is the whole reason it is public. Inside a charter
+    frame the frame **is** the charter session (`docs/frame.md`, ADR 0019), so
+    `charter workspace use <name>` typed at the agent writes this file under the FRAME's
+    id, and that is the documented mechanism by which it "moves the panels too".
+
+    A panel needs to tell that choice apart from the frame's launch-time answer
+    (`frame/state.py`'s `record_workspace`, #512): the launcher's answer is a SEED, and an
+    operator choosing inside the running frame outranks it. Asking this directly is what
+    keeps that distinction a property rather than a spelling — the alternative was reading
+    :func:`source`'s human-facing label and matching the string ``"session"``, which is a
+    sentence written for a status line, not an API.
+
+    Name-checked like every other rung that hands a value to :func:`workspace_dir`'s join.
+    The ``val and`` in front of it is a None-guard rather than a second name check —
+    :func:`_read` answers ``None`` for a missing or empty file, and `valid_name` takes a
+    string.
+    """
+    val = _read(_session_file(sid)) if sid else None
+    return val if val and valid_name(val) else None
+
+
 def _terminal_id(explicit: str | None = None) -> str | None:
     """This terminal PANE's id, or ``None`` — see :func:`charter.session.terminal`,
     which owns it. Kept as a module-level name because it is the seam tests patch to

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -372,10 +372,18 @@ instead. Nothing is pinned into the environment to achieve it, deliberately: exp
 `$CHARTER_WORKSPACE` would rank above every pointer and take `charter workspace use` away
 from every framed session.
 
-So the order the panels read is: what you chose **inside** this frame, then what the
-launch resolved, then whatever the panel can resolve for itself (a frame launched by an
-older charter, still running across the upgrade). `charter workspace use <name>` at the
-agent still moves the panels, and still moves them for the same reason as before.
+So the order the panels read is: `$CHARTER_WORKSPACE` if you pinned one, then what you
+chose **inside** this frame, then what the launch resolved, then whatever the panel can
+resolve for itself (a frame launched by an older charter, still running across the
+upgrade). `charter workspace use <name>` at the agent still moves the panels, and still
+moves them for the same reason as before.
+
+The pin comes first because that is what it means everywhere else in charter: it ranks
+above every pointer in `charter`'s own resolution, and `charter workspace use` warns you
+that it will not stick while the variable is set. A frame is not an exception to that —
+if it were, a frame launched under a pin that then had `ws use` typed at it would draw a
+workspace no command in that session acts on. The `*` beside the name on `top` marks that
+name as the pinned one.
 
 **The repo table is gathered at launch, in the background.** A launch deletes the cached
 scan first — pids are recycled and a new frame must not adopt a dead one's rows — and a

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -363,6 +363,29 @@ Claude Code's own session id has not gone anywhere; it arrives in the status lin
 payload and keys what comes with it (the usage history, the session trace). Two ids, two
 jobs. See ADR 0019.
 
+**Which workspace the panels draw is decided once, at launch, by the launcher.** A panel
+cannot work it out for itself: the launcher is an ordinary shell in your own terminal and
+answers from your cwd or your terminal's pointer, while a panel's cwd is the pane's and
+its terminal id is its own tmux pane, so it would fall all the way through to `default` —
+and did (#512). The launcher writes the answer into the frame's own state directory
+instead. Nothing is pinned into the environment to achieve it, deliberately: exporting
+`$CHARTER_WORKSPACE` would rank above every pointer and take `charter workspace use` away
+from every framed session.
+
+So the order the panels read is: what you chose **inside** this frame, then what the
+launch resolved, then whatever the panel can resolve for itself (a frame launched by an
+older charter, still running across the upgrade). `charter workspace use <name>` at the
+agent still moves the panels, and still moves them for the same reason as before.
+
+**The repo table is gathered at launch, in the background.** A launch deletes the cached
+scan first — pids are recycled and a new frame must not adopt a dead one's rows — and a
+detached `charter frame-gather` fills it alongside the frame coming up, then bumps the
+frame so the panels repaint. Until it lands, `bottom` says `⋯ gathering this workspace's
+repos…` rather than drawing an empty table: a workspace with no clones and a workspace not
+yet looked at are different facts, and drawing them the same way is what made a frame read
+as "no repos" on a plane full of them. A panel never gathers on its own — it reads the
+cache or says it has none.
+
 ## Configuring it
 
 ```toml

--- a/docs/news/unreleased-the-frame-draws-your-workspace-not-default.md
+++ b/docs/news/unreleased-the-frame-draws-your-workspace-not-default.md
@@ -40,10 +40,19 @@ same thing as a session being pinned.
 workspace use <name>` typed at the agent still moves the panels, exactly as it always has
 and for the same reason — inside a frame the frame *is* the charter session, so the
 pointer is written under the frame's id and the panels read it back under the same one.
-The order is: what you chose inside this frame, then what the launch resolved, then
-whatever the panel can resolve for itself. A frame already running across the upgrade has
-no record and lands on that third rung, so it behaves exactly as it does today; relaunch
-it and it draws yours.
+The order is: `$CHARTER_WORKSPACE` if you pinned one, then what you chose inside this
+frame, then what the launch resolved, then whatever the panel can resolve for itself. A
+frame already running across the upgrade has no record and lands on that last rung, so it
+behaves exactly as it does today; relaunch it and it draws yours.
+
+**And a pin still outranks all of it**, because that is what `$CHARTER_WORKSPACE` means
+everywhere else — it ranks above every pointer when charter resolves a workspace, and
+`charter workspace use` tells you it will not stick while the variable is set. It is also
+how charter itself tells you to aim a parallel or unattended agent. So a frame launched
+under a pin keeps drawing the pinned workspace even if something inside it writes a
+pointer, and the `*` on the header marks that name as the pinned one. Without that rung
+the frame would draw a workspace no command in the session acts on — and wear the `*`
+over it, claiming an environment variable had chosen a name it never named.
 
 **And the table it draws was never being filled at launch.** A launch deliberately deletes
 the cached repo scan before it draws anything — a frame id is `<workspace>-<launcher pid>`,

--- a/docs/news/unreleased-the-frame-draws-your-workspace-not-default.md
+++ b/docs/news/unreleased-the-frame-draws-your-workspace-not-default.md
@@ -1,0 +1,83 @@
+---
+version: unreleased
+headline: The frame draws the workspace you launched it for, and says "gathering" instead of "no repos"
+---
+
+Open a session and the frame's repo table was empty. Resize the window and the repos
+appeared. The resize was a coincidence — it happened alongside a tool call, and a tool
+call is what refreshed the table.
+
+Two separate things were wrong, and both are fixed.
+
+**A panel could not tell which workspace it was drawing.** `charter` resolves the active
+workspace from, in order: `--workspace`, `$CHARTER_WORKSPACE`, the tree you are standing
+in, a per-session pointer, a per-terminal pointer, and the declared default. A panel is a
+long-lived tmux pane command, and at launch it reaches **none** of the rungs that could
+speak for the frame. `$CHARTER_WORKSPACE` is empty unless you pinned one by hand (a frame
+is given every identity variable explicitly, present or not, so that a second frame cannot
+inherit the first one's pin). Its working directory is the pane's, which is the plane root
+for anyone who typed `charter claude` there. The per-session pointer is keyed on the
+session id — which inside a frame names the *frame*, and nothing has written one yet at
+launch; the per-terminal pointer is keyed on the asking pane, which is the panel's own. So
+every panel fell all the way through to `default` — while the launcher, one ordinary shell
+in your own terminal, had answered correctly one rung up.
+
+On the plane this was reported from, that is the whole bug: three terminal pointers naming
+`harness-wrapper`, one naming `user-reporting`, and a `default` workspace with no clones in
+it at all. The launcher sized `bottom` for the real workspace's repos; the panel drew
+`default`'s empty list into it. The header said `default` too. The rows only appeared once
+a tool call's hook refreshed the cache from inside the harness, which resolves it the way
+you would expect.
+
+**The launcher writes the frame's workspace down now**, and every surface of the frame
+reads that one answer — the header, the todo count, the alerts, the repo table, and the
+height the pane is given. Nothing is pinned into your environment to achieve it: exporting
+`$CHARTER_WORKSPACE` would have fixed the same reads and taken `charter workspace use`
+away from every framed session on the way past. A frame recording what it drew is not the
+same thing as a session being pinned.
+
+**It is a seed, not an override**, which matters if you switch mid-session. `charter
+workspace use <name>` typed at the agent still moves the panels, exactly as it always has
+and for the same reason — inside a frame the frame *is* the charter session, so the
+pointer is written under the frame's id and the panels read it back under the same one.
+The order is: what you chose inside this frame, then what the launch resolved, then
+whatever the panel can resolve for itself. A frame already running across the upgrade has
+no record and lands on that third rung, so it behaves exactly as it does today; relaunch
+it and it draws yours.
+
+**And the table it draws was never being filled at launch.** A launch deliberately deletes
+the cached repo scan before it draws anything — a frame id is `<workspace>-<launcher pid>`,
+pids get recycled, and a new frame must not adopt a dead one's rows. Nothing refilled it.
+The only thing in charter that refreshed that cache was the hook on your tool calls, so the
+table was populated by your first tool call and by nothing else.
+
+It is filled at launch now, by a detached `charter frame-gather` — the same shape charter
+already uses for its version check and for forge state: the frame appears immediately, a
+child gathers alongside it, and the rows arrive a beat later when it bumps the frame.
+Nothing is added to the path you are waiting on; a cold scan is around 35ms and three git
+invocations per repo, and `charter claude` is the default way charter starts.
+
+**In the gap, the pane says what is true.** `⋯ gathering this workspace's repos…`, not an
+empty table. An empty table on a plane with fourteen repos reads as "no repos", which is
+the same confidently-wrong output the 22-column left sidebar was retired for. The line goes
+the moment the rows land, and a workspace that genuinely has no clones still draws exactly
+the one-row strip it always did — the two claims are kept apart rather than spelled the
+same way.
+
+**A panel is a pure cache reader again, which it was supposed to be already.** The cache
+reader it calls used to fall back to a live `git` sweep whenever there was nothing to
+read — and a fresh frame is exactly that state, by design, on the repaints you are
+watching. `bottom` is the one slot that animates, so that fallback was a full sweep five
+times a second for as long as anything was in flight. It no longer has one: the panel reads
+the cache or says it does not have one.
+
+Nothing to adopt — upgrading is the whole of it.
+
+One surface still re-derives it and is filed rather than fixed here: the **harness pane**
+itself (**#524**). Your agent session reaches the same dead rungs a panel did, so on a
+plane whose workspace came from a per-terminal pointer the frame can now draw
+`harness-wrapper` correctly while the session inside it resolves `default`. Reconciling
+those two is a design decision rather than a bug fix — pinning the session to the frame
+would take `charter ws use` away from every framed session — and it is the same question
+**#517** (switch workspace from inside the frame) and **#518** (pick one at launch) are
+approaching from the other end.

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1580,11 +1580,36 @@ def _carried_env(cmd: list[str]) -> dict[str, str]:
     return out
 
 
+def _no_real_detached_child(sink: list):
+    """Record what a launch would have spawned DETACHED, and spawn nothing.
+
+    `_spawn_gather` (#512) fires `charter frame-gather` through `util.detach_self`, which
+    is a real `subprocess.Popen` with `start_new_session=True` and `os.environ.copy()`.
+    That child is a separate PROCESS: `PersonaIso`'s `config.use()` cannot reach it and
+    `tests/_planeguard.py` says so in as many words ("What this cannot see: a
+    subprocess"), so an unpatched launch here would gather — and BUMP — against whatever
+    plane the developer's own environment resolves, exactly the #402 shape
+    `_refuse_the_real_plane` above exists for. It happened to be harmless on the machine
+    this was written on (a checkout, not an install: `-P` leaves `charter` unimportable,
+    so every child died at once) and would not have been on a machine with charter
+    installed — which is precisely the kind of "passes here" a tripwire is for.
+
+    Recorded rather than merely blocked: the launcher's own tests assert on this sink, so
+    the stub that keeps the suite off the real plane is also the thing that proves the
+    launch fires the gather at all. Returns True, like a spawn that worked, so
+    `_spawn_gather`'s inline last resort is not taken (that path runs a real `gather.scan`
+    on the launch, which every launcher test here would then pay for).
+    """
+    return mock.patch("charter.util.detach_self",
+                      side_effect=lambda args: (sink.append(list(args)), True)[1])
+
+
 def _launch(fake: _FakeTmux, *, cols=200, rows=50, version=(3, 7), harness="claude",
-           rest=(), which=None):
+           rest=(), which=None, detached=None):
     _refuse_the_real_plane()
     args = SimpleNamespace(harness=harness, rest=list(rest), no_frame=False)
     with _outside_tmux(), \
+         _no_real_detached_child(detached if detached is not None else []), \
          mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
          mock.patch("sys.stdout.isatty", return_value=True), \
          _harness_binary_installed(which), \
@@ -1914,6 +1939,7 @@ class Launch(PersonaIso, unittest.TestCase):
         fake_call = fake.__call__
         args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
         with _outside_tmux(), \
+             _no_real_detached_child([]), \
              mock.patch("charter.commands_frame.subprocess.run", side_effect=_peek), \
              mock.patch("sys.stdout.isatty", return_value=True), \
              _harness_binary_installed(), \
@@ -2396,6 +2422,7 @@ class Launch(PersonaIso, unittest.TestCase):
         fake = _FakeTmux(exit_code=0)
         args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
         with _outside_tmux(), \
+             _no_real_detached_child([]), \
              mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
              mock.patch("sys.stdout.isatty", return_value=True), \
              _harness_binary_installed(), \
@@ -3820,12 +3847,13 @@ def _frame_id():
 
 
 def _launch_inside(fake: _FakeOperatorTmux, *, version=(3, 7), harness="claude",
-                   rest=(), tmux_env=OPERATOR_TMUX, slots=None):
+                   rest=(), tmux_env=OPERATOR_TMUX, slots=None, detached=None):
     """Run `cmd_launch` as if the operator typed it inside their own tmux."""
     _refuse_the_real_plane()
     args = SimpleNamespace(harness=harness, rest=list(rest), no_frame=False)
     env = dict(os.environ, TMUX=tmux_env, TMUX_PANE="%0")
     ctx = [mock.patch.dict(os.environ, env, clear=True),
+           _no_real_detached_child(detached if detached is not None else []),
            mock.patch("charter.commands_frame.subprocess.run", side_effect=fake),
            mock.patch("charter.commands_frame.time.sleep"),
            mock.patch("sys.stdout.isatty", return_value=True),
@@ -4394,6 +4422,7 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
             return private(cmd, **kw)
 
         with mock.patch.dict(os.environ, dict(os.environ, TMUX=OPERATOR_TMUX)), \
+             _no_real_detached_child([]), \
              mock.patch("charter.commands_frame.subprocess.run", side_effect=_route), \
              mock.patch("charter.commands_frame.time.sleep"), \
              mock.patch("sys.stdout.isatty", return_value=True), \
@@ -4422,6 +4451,218 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
         rc = _launch_inside(fake)
         self.assertNotEqual(rc, 0)
         self.assertTrue(fake.window_killed, "the placeholder window was left behind")
+
+
+class ALaunchFillsTheCacheItJustEmptied(PersonaIso, unittest.TestCase):
+    """#512 — `gather.discard` had no counterpart.
+
+    `cmd_launch` empties the gather cache on both paths, deliberately (a recycled pid must
+    not adopt a dead frame's rows, #383) and **nothing refilled it**: the only other caller
+    of `gather.refresh` in charter is `frame/notify.plane_changed`, reached from a
+    `posttooluse*` hook. So a frame's repo table was filled by the operator's first tool
+    call and by nothing else. The fix is the shape charter already uses twice
+    (`update.maybe_spawn`, `glstate.maybe_spawn`): draw now, gather in a detached child,
+    let the rows arrive a beat later.
+
+    Both launch paths are asserted, separately, because they are two functions: the
+    private-server `cmd_launch` body and `_launch_in_operator_tmux`. Every property this
+    class pins was broken on both at once and could be fixed on one.
+    """
+
+    def _spawns_on(self, launch) -> list[list[str]]:
+        detached: list[list[str]] = []
+        launch(detached)
+        return [a for a in detached if a and a[0] == "frame-gather"]
+
+    def test_the_private_server_path_kicks_a_gather_for_the_frame_it_just_emptied(self):
+        spawns = self._spawns_on(
+            lambda d: _launch(_FakeTmux(exit_code=0), detached=d))
+        self.assertEqual(
+            spawns, [["frame-gather", "--session", _frame_id(), "--workspace", "demo"]],
+            "nothing refilled the cache `gather.discard` emptied — the repo table waits "
+            "for the session's first tool call, which is #512")
+
+    def test_the_operators_tmux_path_kicks_one_too(self):
+        spawns = self._spawns_on(
+            lambda d: _launch_inside(_FakeOperatorTmux(exit_code=0), detached=d))
+        self.assertEqual(
+            spawns, [["frame-gather", "--session", _frame_id(), "--workspace", "demo"]])
+
+    def test_the_workspace_is_stated_rather_than_left_to_the_child(self):
+        """`glstate.maybe_spawn`'s own rule, and #512's root cause. The launcher resolves
+        the workspace for the FRAME — its terminal, its cwd, its pointers — and a detached
+        child (`start_new_session`, no controlling terminal) is exactly as far from all
+        three as a panel is. A child left to resolve for itself gathers a different
+        workspace's repos into this frame's cache.
+
+        The launch fixture pins `workspace.resolve` to `demo`, so a spawn carrying
+        anything else — or nothing — is a child asking its own question."""
+        for name, launch in (("private", lambda d: _launch(_FakeTmux(exit_code=0),
+                                                           detached=d)),
+                             ("operator", lambda d: _launch_inside(
+                                 _FakeOperatorTmux(exit_code=0), detached=d))):
+            with self.subTest(path=name):
+                argv = self._spawns_on(launch)[0]
+                self.assertIn("--workspace", argv)
+                self.assertEqual(argv[argv.index("--workspace") + 1], "demo")
+
+    def test_the_gather_is_kicked_after_the_discard_that_empties_the_cache(self):
+        """Order, not merely presence — and this is the one that a future tidy-up breaks
+        silently. `gather.discard` deletes the cache file; a spawn ordered BEFORE it races
+        a child whose whole job is to write that same file, and the launch would then
+        delete the rows it had just asked for, intermittently, on a fast machine only.
+
+        Both paths, and both spied through the REAL functions so the assertion is about
+        `cmd_launch`'s sequence rather than about a stub's."""
+        for name, launch in (("private", _launch), ("operator", _launch_inside)):
+            with self.subTest(path=name):
+                order: list[str] = []
+                real_discard = gather.discard
+                with mock.patch("charter.commands_frame.gather.discard",
+                                side_effect=lambda fid: (order.append("discard"),
+                                                         real_discard(fid))[1]), \
+                     mock.patch("charter.commands_frame._spawn_gather",
+                                side_effect=lambda fid, ws: order.append("spawn")):
+                    launch(_FakeTmux(exit_code=0) if name == "private"
+                           else _FakeOperatorTmux(exit_code=0))
+                self.assertEqual(order, ["discard", "spawn"],
+                                 f"a launch that spawns before it discards can delete "
+                                 f"the rows it just asked for: {order}")
+
+    def test_the_frames_own_workspace_is_written_down_on_both_paths(self):
+        """The other half of #512: a panel cannot resolve the workspace itself, so the
+        launcher records it (`state.record_workspace`).
+
+        Asserted on the CALL rather than on the file, for `record_server`'s own reason in
+        this module: the last `reap` of a finished launch legitimately removes this
+        frame's whole directory, marker and all."""
+        for name, launch in (("private", _launch), ("operator", _launch_inside)):
+            with self.subTest(path=name):
+                marked: list[tuple[str, str]] = []
+                real = state.record_workspace
+                with mock.patch("charter.frame.state.record_workspace",
+                                side_effect=lambda fid, ws: (marked.append((fid, ws)),
+                                                             real(fid, ws))[1]):
+                    launch(_FakeTmux(exit_code=0) if name == "private"
+                           else _FakeOperatorTmux(exit_code=0))
+                self.assertEqual(marked, [(_frame_id(), "demo")])
+
+
+class SpawningTheGather(PersonaIso, unittest.TestCase):
+    """`_spawn_gather` on its own — the fallbacks a launch cannot exercise."""
+
+    def test_a_successful_spawn_does_no_gathering_on_the_launch_path(self):
+        """The whole reason this is detached. A cold `gather.scan()` is ~35ms and three
+        git invocations per repo, and the launch path is a person waiting for a harness to
+        appear. `charter claude` is the default way charter starts, so this is not a
+        micro-optimisation — it is the difference between the frame appearing and the
+        frame appearing after a git sweep."""
+        with mock.patch("charter.util.detach_self", return_value=True), \
+             mock.patch.object(gather, "refresh",
+                               side_effect=AssertionError("gathered on the launch path")):
+            commands_frame._spawn_gather("f-1", "demo")
+
+    def test_a_spawn_that_never_started_is_gathered_inline_instead(self):
+        """A pane saying "gathering …" for the rest of the session would be a promise
+        charter had already broken, and after a failed fork there is no other filler on
+        this path. Paying ~35ms once, on a launch that has just failed to fork, is the
+        cheaper of the two."""
+        seen: list[tuple] = []
+        with mock.patch("charter.util.detach_self", return_value=False), \
+             mock.patch.object(gather, "refresh",
+                               side_effect=lambda fid, workspace=None: seen.append(
+                                   (fid, workspace))):
+            commands_frame._spawn_gather("f-1", "demo")
+        self.assertEqual(seen, [("f-1", "demo")],
+                         "the spawn failed and nothing gathered — the frame's table "
+                         "would say `gathering` until the first tool call")
+
+    def test_the_inline_fallback_bumps_so_a_panel_ever_reads_what_it_wrote(self):
+        """A panel repaints on nothing but a `state.version` bump (`panel.run`), so a
+        cache written with no bump behind it sits on disk unread until something unrelated
+        moves the version — which on an idle session is the same "first tool call" wait
+        this whole fix exists to end."""
+        before = state.version("f-1")
+        with mock.patch("charter.util.detach_self", return_value=False), \
+             mock.patch.object(gather, "refresh", return_value={}):
+            commands_frame._spawn_gather("f-1", "demo")
+        self.assertNotEqual(state.version("f-1"), before)
+
+    def test_nothing_it_can_hit_reaches_the_launch(self):
+        """A frame must launch whether or not its rows can be gathered — the same posture
+        every other writer on this path keeps."""
+        with mock.patch("charter.util.detach_self", side_effect=OSError("no fork")), \
+             mock.patch.object(gather, "refresh", side_effect=RuntimeError("boom")):
+            commands_frame._spawn_gather("f-1", "demo")     # must not raise
+
+
+class TheGatherCommand(PersonaIso, unittest.TestCase):
+    """`charter frame-gather` — what the detached child actually runs."""
+
+    def _args(self, session="f-1", workspace="demo"):
+        return SimpleNamespace(session=session, workspace=workspace)
+
+    def test_it_refreshes_the_named_frame_for_the_named_workspace(self):
+        seen: list[tuple] = []
+        with mock.patch.object(gather, "refresh",
+                               side_effect=lambda fid, workspace=None: seen.append(
+                                   (fid, workspace))):
+            self.assertEqual(commands_frame.cmd_gather(self._args()), 0)
+        self.assertEqual(seen, [("f-1", "demo")])
+
+    def test_it_bumps_after_it_refreshes_never_before(self):
+        """`notify.plane_changed`'s order, verbatim, and for its stated reason: a panel's
+        poll reads `state.version` first and the cache second, so bumping first opens a
+        window in which a poller sees the new version and still reads the old cache."""
+        order: list[str] = []
+        with mock.patch.object(gather, "refresh",
+                               side_effect=lambda *a, **k: order.append("refresh")), \
+             mock.patch("charter.frame.state.bump",
+                        side_effect=lambda fid: order.append("bump")):
+            commands_frame.cmd_gather(self._args())
+        self.assertEqual(order, ["refresh", "bump"])
+
+    def test_it_really_writes_the_cache_a_panel_then_reads(self):
+        """Through the real `gather.refresh`, not a stub: the cache FILE is what a panel
+        reads, and a `refresh` that gathered without saving would satisfy every
+        call-spy above."""
+        commands_frame.cmd_gather(self._args(session="f-real"))
+        self.assertIsNotNone(gather.cached("f-real"),
+                             "the child gathered and left nothing on disk for a panel")
+
+    def test_it_gathers_the_workspace_it_was_told_about(self):
+        """The argument is the point of the command existing (#512). A child that
+        resolved its own would answer for a detached process with no terminal, which is
+        the defect."""
+        commands_frame.cmd_gather(self._args(session="f-real", workspace="named-by-hand"))
+        self.assertEqual((gather.cached("f-real") or {}).get("workspace"),
+                         "named-by-hand")
+
+    def test_a_call_missing_either_half_is_a_quiet_no_op(self):
+        """Nothing reads this process's status and the only screen it could complain to
+        is the agent's own — `cmd_respawn`/`cmd_resize`'s posture. Refusing rather than
+        guessing: a gather keyed to a workspace nobody named is the bug, not a degraded
+        version of the fix.
+
+        **Recorded, never raised from inside the mock.** This test was first written with
+        `side_effect=AssertionError(...)`, and `cmd_gather`'s own `except Exception` — the
+        never-raise promise every `frame-*` command keeps — swallowed it: mutation testing
+        turned `or` into `and` here and the test stayed green. A stub that raises into code
+        whose whole job is to catch is a stub that proves nothing; the call is counted
+        outside instead. Both halves are asserted separately, because `and` in place of
+        `or` still refuses when BOTH are missing."""
+        called: list[tuple] = []
+        with mock.patch.object(gather, "refresh",
+                               side_effect=lambda *a, **k: called.append((a, k))):
+            self.assertEqual(commands_frame.cmd_gather(self._args(session="")), 0)
+            self.assertEqual(called, [], "gathered for a frame nobody named")
+            self.assertEqual(commands_frame.cmd_gather(self._args(workspace="")), 0)
+            self.assertEqual(called, [], "gathered for a workspace nobody named — the "
+                                         "child guessing its own is #512 itself")
+
+    def test_a_failure_inside_it_is_still_a_zero(self):
+        with mock.patch.object(gather, "refresh", side_effect=RuntimeError("boom")):
+            self.assertEqual(commands_frame.cmd_gather(self._args()), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_liveness.py
+++ b/tests/test_frame_liveness.py
@@ -75,7 +75,10 @@ class Notify(PersonaIso, unittest.TestCase):
         frame and wrote that answer down. Without this, a launch gathers the workspace you
         launched for and the very first tool call swaps in another one's repos."""
         state.record_workspace("f-1", "the-frames-own")
-        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}), \
+        # Cleared rather than merely overwritten: rung 0 of `workspace_for` reads
+        # `$CHARTER_WORKSPACE`, so a developer's own ambient pin would otherwise survive
+        # into this environ and answer instead of the recorded name (#519, #521).
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}, clear=True), \
              mock.patch.object(gather, "refresh") as refresh:
             notify._last["at"] = 0.0
             notify.plane_changed()
@@ -87,7 +90,11 @@ class Notify(PersonaIso, unittest.TestCase):
         workspace this hook would have gathered on its own — never worse than before
         #512, and never a blank."""
         self.assertIsNone(state.frame_workspace("f-1"))
-        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}), \
+        # Cleared rather than merely overwritten (#519, #521): otherwise an ambient
+        # `$CHARTER_WORKSPACE` would answer `workspace.resolve()` too, and both sides of
+        # the assertion below would collapse to the pinned name whether or not the
+        # local-resolve fallback this test exists to pin actually ran.
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}, clear=True), \
              mock.patch.object(gather, "refresh") as refresh:
             notify._last["at"] = 0.0
             notify.plane_changed()

--- a/tests/test_frame_liveness.py
+++ b/tests/test_frame_liveness.py
@@ -11,7 +11,7 @@ import os
 import unittest
 from unittest import mock
 
-from charter import hooks
+from charter import hooks, workspace
 from charter.frame import gather, notify, state
 
 from tests._isolation import PersonaIso, run_hook
@@ -65,7 +65,33 @@ class Notify(PersonaIso, unittest.TestCase):
              mock.patch.object(gather, "refresh") as refresh:
             notify._last["at"] = 0.0
             notify.plane_changed()
-            refresh.assert_called_once_with("f-1")
+            refresh.assert_called_once()
+            self.assertEqual(refresh.call_args.args, ("f-1",))
+
+    def test_the_refresh_is_keyed_to_the_frames_workspace_not_this_hooks(self):
+        """#512. The cache belongs to the FRAME and a panel draws it whole, so a refresh
+        keyed to another workspace does not degrade the table — it replaces it. This runs
+        inside the harness, which resolves for the SESSION; the launcher resolved for the
+        frame and wrote that answer down. Without this, a launch gathers the workspace you
+        launched for and the very first tool call swaps in another one's repos."""
+        state.record_workspace("f-1", "the-frames-own")
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}), \
+             mock.patch.object(gather, "refresh") as refresh:
+            notify._last["at"] = 0.0
+            notify.plane_changed()
+            refresh.assert_called_once_with("f-1", workspace="the-frames-own")
+
+    def test_a_frame_with_no_recorded_workspace_refreshes_what_it_always_did(self):
+        """The migration case. `state.workspace_for`'s last rung is a local `resolve()`,
+        so a frame launched by a charter that predates the record gathers exactly the
+        workspace this hook would have gathered on its own — never worse than before
+        #512, and never a blank."""
+        self.assertIsNone(state.frame_workspace("f-1"))
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}), \
+             mock.patch.object(gather, "refresh") as refresh:
+            notify._last["at"] = 0.0
+            notify.plane_changed()
+            refresh.assert_called_once_with("f-1", workspace=workspace.resolve())
 
     def test_a_second_call_inside_the_debounce_window_skips_the_refresh_too(self):
         """The cache refresh rides the SAME debounce as the version bump (see the
@@ -99,7 +125,7 @@ class Notify(PersonaIso, unittest.TestCase):
         order = []
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}), \
              mock.patch.object(gather, "refresh",
-                                side_effect=lambda fid: order.append("refresh")), \
+                                side_effect=lambda fid, **kw: order.append("refresh")), \
              mock.patch.object(state, "bump",
                                 side_effect=lambda fid: order.append("bump")):
             notify._last["at"] = 0.0

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -448,6 +448,74 @@ class EveryPanelDrawsTheFramesOwnWorkspace(PersonaIso, unittest.TestCase):
         self.assertIn(config.DEFAULT_WORKSPACE, out)
 
 
+class TheChipAndItsStarNameTheSameWorkspace(PersonaIso, unittest.TestCase):
+    """`top`'s `⬢ <name>*` is one claim, not two, and the `*` is the half that says who
+    made it: "`$CHARTER_WORKSPACE` chose this".
+
+    The two halves used to be answered from different rungs — the name from
+    `state.workspace_for`, the star from `workspace.source()`, which only knows whether
+    the variable is set at all. A frame launched under the pin that then had `charter
+    workspace use other` typed at it drew `⬢ other*`: a name the environment did not
+    name, wearing the marker that says it did, while every command in that session went
+    on acting in the pinned workspace. Self-contradictory on its own line, and the
+    contradiction is the tell — an operator reading it has no way to know which half to
+    believe.
+
+    This is the case charter's own documentation steers people into: `hooks`' nudge tells
+    an operator to "re-launch with `CHARTER_WORKSPACE=<name>` set" to aim a parallel or
+    unattended agent, and `commands_workspace` warns that `ws use` will not stick while
+    it is. The frame has to survive somebody doing both.
+    """
+
+    def _top(self, fid="f-1", *, cols=200, rows=24) -> str:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, rows))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return tui.strip_ansi(slots.render("top", fid))
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+
+    def test_the_pinned_name_is_the_one_drawn_and_it_keeps_the_star(self):
+        """Through the real `workspace.set_active` with the frame's id in the
+        environment, because that is what `charter workspace use` does — a hand-written
+        pointer file would prove the reader reads a file, not that a real in-frame command
+        can no longer move the header off the pin."""
+        os.environ["CHARTER_WORKSPACE"] = "zeta"
+        state.record_workspace("f-1", "zeta")
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
+            workspace.set_active("other", force=True)
+        self.assertEqual(workspace.for_session("f-1"), "other",
+                         "the fixture never wrote the pointer this test is about")
+        out = self._top()
+        self.assertIn("⬢ zeta*", out)
+        self.assertNotIn("other", out,
+                         "the header named a workspace no command in the session acts on")
+        self.assertEqual(workspace.resolve(), "zeta",
+                         "the header and the session's own commands disagree")
+
+    def test_a_name_the_pin_did_not_choose_never_wears_the_star(self):
+        """The star's meaning, checked from the other side: a pin charter refuses to draw
+        (`workspace_dir()` would join it) leaves the panel on a name the variable did not
+        name, and the marker has to come off with it. A star sourced from "is the variable
+        set" would still be there."""
+        os.environ["CHARTER_WORKSPACE"] = "../../escaped"
+        state.record_workspace("f-1", "recorded-at-launch")
+        out = self._top()
+        self.assertIn("⬢ recorded-at-launch", out)
+        self.assertNotIn("escaped", out)
+        self.assertNotIn("*", out, "the star claimed the environment chose this name")
+
+    def test_no_pin_means_no_star(self):
+        """The ordinary frame, so neither test above can pass by the star never being
+        drawn at all."""
+        state.record_workspace("f-1", "recorded-at-launch")
+        out = self._top()
+        self.assertIn("⬢ recorded-at-launch", out)
+        self.assertNotIn("*", out)
+
+
 class TopDrawsTheRecordedGauge(PersonaIso, unittest.TestCase):
     """#413: `ctx NN%` / `cache NN%` on `top`, out of the history the suppressed status
     line records — the one capability a framed Claude Code session lost to #386 and the

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -20,7 +20,7 @@ import sys
 import unittest
 from unittest import mock
 
-from charter import config, instance, statusline, tui
+from charter import config, instance, statusline, todos, tui, workspace
 from charter.frame import gather, slots, state
 
 from tests._isolation import PersonaIso
@@ -330,6 +330,124 @@ class TopRenderer(PersonaIso, unittest.TestCase):
         self.assertEqual(statusline._context_gauge(None), [])
 
 
+class EveryPanelDrawsTheFramesOwnWorkspace(PersonaIso, unittest.TestCase):
+    """#512 — the reported bug, at the layer that showed it.
+
+    An operator opened a session and the frame's repo table was empty; the repos appeared
+    "after I resized the window". The resize was a coincidence (it happened alongside a
+    tool call, and a tool call's `posttooluse` hook refreshes the gather cache from inside
+    the HARNESS). What was actually wrong is that **a panel resolved a different workspace
+    than the launcher did**: measured on the reporting plane, three per-terminal pointers
+    naming `harness-wrapper`, one naming `user-reporting`, and a `default` workspace with
+    no clones in it at all. `workspace.resolve` from inside a panel pane cannot reach any
+    of the rungs that decided it (`state.record_workspace`'s docstring walks all six), so
+    every panel drew `default` — its empty repo list, its todo count, its alerts — into a
+    frame the launcher had built for another workspace entirely.
+
+    The fixture below is that situation exactly: the panel's OWN `workspace.resolve()`
+    answers `default`, and the frame was launched for `elsewhere`. Nothing here mocks a
+    renderer or a helper — `workspace.resolve` is left completely alone and answers
+    honestly for this process, which is the whole point: the defect was never that
+    `resolve` was wrong, it was that a panel asked it at all.
+    """
+
+    OTHER = "elsewhere"
+
+    def _render(self, slot, fid="f-1", *, cols=200, rows=24) -> str:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, rows))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return tui.strip_ansi(slots.render(slot, fid))
+
+    def setUp(self) -> None:
+        super().setUp()
+        # A panel process standing at the plane root, with no pin and no pointer it can
+        # read — `workspace.resolve()` genuinely answers the built-in default here, which
+        # is what a real panel gets.
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        self.assertEqual(workspace.resolve(), config.DEFAULT_WORKSPACE,
+                         "the fixture no longer reproduces a panel's own answer")
+
+    def test_top_names_the_workspace_the_frame_was_launched_for(self):
+        state.record_workspace("f-1", self.OTHER)
+        out = self._render("top")
+        self.assertIn(self.OTHER, out)
+        self.assertNotIn(config.DEFAULT_WORKSPACE, out,
+                         "the header named the panel's own guess, not the frame's")
+
+    def test_the_attention_row_counts_the_frames_workspaces_todos(self):
+        """The same defect one field over, and the reason `_bottom` goes through
+        `_frame_workspace` too rather than only the table: a row reading `0 todos` beside
+        a table of another workspace's repos is two answers to one question."""
+        todos.add(self.OTHER, "something the frame's workspace is carrying")
+        state.record_workspace("f-1", self.OTHER)
+        _seed("f-1")
+        self.assertIn("1 todo", self._render("bottom"))
+
+    def test_without_the_record_it_falls_back_to_resolving_locally(self):
+        """The migration case, and the failed-write case. `None` from
+        `state.frame_workspace` means "do not take it from here" — the fallback is exactly
+        what every panel did before #512, so this is never worse than what it replaces."""
+        self.assertIsNone(state.frame_workspace("f-1"))
+        self.assertIn(config.DEFAULT_WORKSPACE, self._render("top"))
+
+    def test_a_workspace_chosen_inside_the_frame_still_moves_the_panels(self):
+        """`docs/frame.md`'s own promise, and the regression #512's first cut shipped:
+        "`charter workspace use <name>` typed at the agent moves the panels too — the
+        pointer is written under the frame's id and the panels read it back under the same
+        one." The launcher's recorded answer is a SEED, not an override; a choice made
+        while the frame is running outranks it.
+
+        Through the real `workspace.set_active`, with the frame's id in the environment,
+        because that is exactly what `charter workspace use` does — a hand-written pointer
+        file would prove that `state.workspace_for` reads a file, not that the two ends of
+        this promise still meet."""
+        state.record_workspace("f-1", self.OTHER)
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
+            self.assertNotEqual(workspace.set_active("chosen-later"), "locked")
+        out = self._render("top")
+        self.assertIn("chosen-later", out)
+        self.assertNotIn(self.OTHER, out,
+                         "the panel ignored a workspace chosen inside the running frame")
+
+    def test_the_frames_repo_table_follows_that_choice_too(self):
+        """The same rung, on the surface #512 is actually about — a header that moved and
+        a table that did not would be the disagreement this class exists to prevent."""
+        clone = config.WORKSPACES_DIR / "chosen-later" / "arepo"
+        (clone / ".git").mkdir(parents=True)
+        state.record_workspace("f-1", self.OTHER)
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
+            workspace.set_active("chosen-later")
+        self.assertEqual(slots.bottom_rows_wanted("f-1", pane_cols=200), 2)
+
+    def test_the_pane_is_sized_from_the_frames_workspace_too(self):
+        """`gather.row_count`'s no-cache path is the third surface that used to resolve
+        for itself, and its caller makes it matter: `cmd_resize` runs as a tmux
+        `run-shell` child on every step of a terminal drag, with the SERVER's environment
+        and neither the operator's cwd nor their pane id. A pane sized from one workspace
+        while its panel draws another is #512 wearing a height instead of a row.
+
+        Two real workspaces on disk, one with a clone in it and one without, so the count
+        can only come from the right listing — and no cache, which is the state
+        `cmd_launch` guarantees by calling `gather.discard`."""
+        clone = config.WORKSPACES_DIR / self.OTHER / "arepo"
+        (clone / ".git").mkdir(parents=True)
+        self.assertEqual(slots.bottom_rows_wanted("f-1", pane_cols=200), 1,
+                         "the fixture already counted a repo before the record existed")
+        state.record_workspace("f-1", self.OTHER)
+        self.assertEqual(slots.bottom_rows_wanted("f-1", pane_cols=200), 2)
+
+    def test_a_corrupt_record_falls_back_rather_than_drawing_it(self):
+        """`frame_workspace` name-checks on read, so a `workspaces/` escape never reaches
+        `workspace_dir()`'s join or the operator's screen — and the panel degrades to its
+        own answer rather than to nothing at all."""
+        d = state.frame_dir("f-1", create=True)
+        (d / "workspace").write_text("../../escaped\n")
+        out = self._render("top")
+        self.assertNotIn("escaped", out)
+        self.assertIn(config.DEFAULT_WORKSPACE, out)
+
+
 class TopDrawsTheRecordedGauge(PersonaIso, unittest.TestCase):
     """#413: `ctx NN%` / `cache NN%` on `top`, out of the history the suppressed status
     line records — the one capability a framed Claude Code session lost to #386 and the
@@ -637,9 +755,68 @@ class BottomTable(PersonaIso, unittest.TestCase):
     def test_a_plane_with_no_repos_is_the_one_row_strip_it_always_was(self):
         """The floor `layout.bottom_rows` keeps, seen from the renderer's side. The
         reported "always empty sidebar" of #488 was this case being told the truth —
-        a workspace with 0 clones — so it must stay honest rather than grow furniture."""
+        a workspace with 0 clones — so it must stay honest rather than grow furniture.
+
+        `_seed` is what makes this the honest case rather than the unknown one below: a
+        cache exists and it says zero repos. Delete the seed and this is a DIFFERENT
+        claim, which is #512."""
         _seed("f-1")
         self.assertEqual(len(self._render().split("\n")), 1)
+
+    def test_a_frame_whose_repos_are_not_gathered_yet_says_so_rather_than_showing_none(self):
+        """#512, at the renderer. `cmd_launch` deletes the cache before it draws anything
+        and a detached child fills it a beat later, so there is a real window in which
+        charter does not KNOW this frame's repos — and drawing that as an empty table is
+        the same confidently-wrong output the `left` sidebar was retired for in #488.
+
+        The two cases are asserted against each other rather than in isolation, because
+        "says something" and "says nothing" are only meaningful as a pair: a renderer that
+        drew this line unconditionally would pass a membership check on its own and would
+        be a permanent lie on every plane with no clones."""
+        unknown = self._render("f-never-gathered")
+        _seed("f-known-empty")
+        empty = self._render("f-known-empty")
+        self.assertIn("gathering", unknown)
+        self.assertEqual(len(unknown.split("\n")), 2)
+        self.assertNotIn("gathering", empty)
+        self.assertEqual(len(empty.split("\n")), 1)
+
+    def test_the_gathering_line_goes_the_moment_the_rows_arrive(self):
+        """It is a statement about now, not furniture. Same frame id, one cache write
+        between the two renders — the sequence a real launch actually performs."""
+        self.assertIn("gathering", self._render("f-1"))
+        _seed("f-1", repos=[_row("demo")])
+        after = self._render("f-1")
+        self.assertNotIn("gathering", after)
+        self.assertIn("demo", after)
+
+    def test_a_pane_too_narrow_for_the_table_says_nothing_either(self):
+        """`_table_cap` answers 0 below `statusline._LEFT_W` and `bottom` composes nothing
+        on a budget of 0, so a "gathering" line cannot appear where a table never will:
+        one that did would show up while the rows were unknown and VANISH once they were
+        known — "the repos went away", which is worse than the silence it replaces.
+
+        Asserted through the whole renderer at both widths in one test, because what is
+        being pinned is that the two agree: the SAME frame, gathered or not, draws exactly
+        the attention row at 90 columns."""
+        self.assertEqual(len(self._render("f-never-gathered", cols=90).split("\n")), 1)
+        _seed("f-never-gathered", repos=[_row("demo")])
+        self.assertEqual(len(self._render("f-never-gathered", cols=90).split("\n")), 1)
+
+    def test_a_repaint_never_runs_a_gather_of_its_own(self):
+        """The rule `_table_lines`' own docstring states and #512 found broken: a panel
+        reads the cache and nothing else. `gather.read` falls back to a live `scan()`
+        when there is no cache — three git invocations and ~35ms — and `cmd_launch`
+        guarantees exactly that state at launch, so every repaint of a fresh frame was
+        paying for one, on the ONE animated slot (`slots.ANIMATED`), five times a second
+        for as long as anything was in flight.
+
+        Asserted on the unknown case specifically: with a cache present, a renderer that
+        called `scan` unconditionally would still be caught, but a renderer that called it
+        only when there is nothing to read — the actual defect — would not."""
+        with mock.patch.object(gather, "scan",
+                               side_effect=AssertionError("a repaint gathered")):
+            self.assertIn("gathering", self._render("f-never-gathered"))
 
     def test_a_dirty_repo_shows_the_dirty_marker(self):
         _seed("f-1", repos=[_row("demo", dirty=True)])
@@ -1015,9 +1192,16 @@ class BottomTable(PersonaIso, unittest.TestCase):
         pinned against a renderer that reaches into a real dependency.
 
         Rendered at a width the table is actually attempted at: below
-        `statusline._LEFT_W` there is no table, so `gather.read` is never reached and the
-        test would pass by never running the code it claims to bound."""
-        with mock.patch.object(gather, "read", side_effect=RuntimeError("boom")), \
+        `statusline._LEFT_W` there is no table, so the cache is never reached and the
+        test would pass by never running the code it claims to bound.
+
+        **`cached`, not `read` (#512).** `_bottom` stopped calling `gather.read` when a
+        panel stopped being allowed to fall back to a live `scan()`, and this test kept
+        passing against a mock nothing called any more — the exact "instrumenting one
+        function while claiming to bound a property" shape. It is pinned to whichever
+        function the renderer actually reaches, and `_seed` is deliberately NOT called
+        first: a cache on disk would make a raising reader unreachable a second way."""
+        with mock.patch.object(gather, "cached", side_effect=RuntimeError("boom")), \
              mock.patch("os.get_terminal_size",
                         return_value=os.terminal_size((200, 24))), \
              mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -638,5 +638,91 @@ class TheFramesOwnWorkspace(PersonaIso, unittest.TestCase):
                          "a read minted the frame directory it was only looking in")
 
 
+class ThePinOutranksTheFramesOwnRungs(PersonaIso, unittest.TestCase):
+    """`workspace_for`'s rung 0. `$CHARTER_WORKSPACE` beats every rung below it, because
+    that is what the variable means everywhere else charter reads it.
+
+    Nothing in the frame is allowed to draw a workspace the session's own commands will
+    not act on, and the pin is the one rung that decides for BOTH: `workspace.resolve`
+    puts it above every pointer, so a `charter ws` command run at the agent answers the
+    pinned name no matter what the frame recorded or what pointer the session wrote. A
+    panel that ranked the per-session pointer first drew `other` while every command in
+    that session worked in the pinned workspace.
+
+    That is also the mechanism charter itself tells operators to use for parallel and
+    unattended agents — `hooks`' own nudge says to "re-launch with `CHARTER_WORKSPACE`
+    set" — so it is precisely the case where nobody is watching the panel closely enough
+    to catch it lying.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Cleared rather than merely overwritten: `resolve`'s rungs below the pin read
+        # `$CHARTER_SESSION_ID` and `$TMUX_PANE` out of whatever terminal the suite is
+        # being run from, so a developer inside a live frame would otherwise be supplying
+        # half this fixture (#519, #521).
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+
+    def _pin(self, name: str) -> None:
+        os.environ["CHARTER_WORKSPACE"] = name
+
+    def test_the_pin_beats_a_workspace_chosen_inside_the_frame(self):
+        """The regression. Both rungs answer, they disagree, and the pin wins — the same
+        way `workspace.resolve` decides it for every command the session runs."""
+        from charter import workspace as ws
+        self._pin("zeta")
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
+            ws.set_active("other", force=True)
+        self.assertEqual(ws.for_session("f-1"), "other",
+                         "the fixture never wrote the pointer this test is about")
+        self.assertEqual(state.workspace_for("f-1"), "zeta")
+        self.assertEqual(ws.resolve(), "zeta",
+                         "the frame and the session's own commands must not disagree")
+
+    def test_the_pin_beats_what_the_launcher_recorded(self):
+        """The second rung, checked separately so the test above cannot pass merely
+        because the record happened to be missing."""
+        self._pin("zeta")
+        state.record_workspace("f-1", "recorded-at-launch")
+        self.assertEqual(state.workspace_for("f-1"), "zeta")
+
+    def test_with_no_pin_the_frames_own_rungs_decide(self):
+        """The ordinary case, and the guard against a rung 0 that answers when it should
+        not: an unset variable must leave the chain exactly as it was."""
+        state.record_workspace("f-1", "recorded-at-launch")
+        self.assertEqual(state.workspace_for("f-1"), "recorded-at-launch")
+
+    def test_a_pin_that_cannot_name_a_workspace_is_not_drawn(self):
+        """The value reaches `workspace_dir()`'s join and a panel's screen, so it is
+        name-checked here on the same terms as `frame_workspace` — #442 is what an
+        unchecked `../../` in that position cost once already. A pin charter cannot use
+        falls through rather than being rendered."""
+        self._pin("../../escaped")
+        state.record_workspace("f-1", "recorded-at-launch")
+        self.assertEqual(state.workspace_for("f-1"), "recorded-at-launch")
+
+    def test_the_pin_is_stripped_the_way_resolve_strips_it(self):
+        """`workspace.resolve` returns `env.strip()`, so a variable exported with padding
+        (a here-doc, a `.env` line, an `export CHARTER_WORKSPACE=$(…)` with a trailing
+        newline) names a real workspace to every command the session runs. A frame that
+        compared the raw value would find no such name, fall through, and draw something
+        else — the disagreement this whole rung exists to close, arriving through a space."""
+        from charter import workspace as ws
+        self._pin("  zeta\n")
+        state.record_workspace("f-1", "recorded-at-launch")
+        self.assertEqual(ws.resolve(), "zeta",
+                         "the fixture no longer matches what `resolve` does with padding")
+        self.assertEqual(state.workspace_for("f-1"), "zeta")
+
+    def test_an_empty_pin_is_no_pin(self):
+        """`CHARTER_WORKSPACE=` exported empty is how a shell clears one, and
+        `workspace.resolve` already treats it as absent. The name check answers this on
+        its own terms — `valid_name("")` is False — so there is no separate truthiness
+        guard here for a mutation to pass through."""
+        self._pin("   ")
+        state.record_workspace("f-1", "recorded-at-launch")
+        self.assertEqual(state.workspace_for("f-1"), "recorded-at-launch")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -570,5 +570,73 @@ class ReapAcrossServers(PersonaIso, unittest.TestCase):
         self.assertIsNone(state.frame_server("../escape"))
 
 
+class TheFramesOwnWorkspace(PersonaIso, unittest.TestCase):
+    """`record_workspace`/`frame_workspace` — #512.
+
+    A frame is launched FOR a workspace, and no process inside it can work out which one:
+    `workspace.resolve`'s deciding rungs are a `$CHARTER_WORKSPACE` the launcher usually
+    does not have, a cwd that is the plane root, a per-session pointer keyed on an id that
+    inside a frame names the FRAME, and a per-terminal pointer keyed on the asking pane.
+    The launcher is one ordinary shell in the operator's own terminal and answers all
+    three; a panel answers none of them, and falls to `default`. So the launcher writes
+    the answer down.
+    """
+
+    def test_the_recorded_workspace_reads_back(self):
+        state.record_workspace("f-1", "harness-wrapper")
+        self.assertEqual(state.frame_workspace("f-1"), "harness-wrapper")
+
+    def test_a_frame_nobody_recorded_one_for_says_it_does_not_know(self):
+        """`None`, never a guessed name. The migration case (a frame launched by a
+        charter that predates this and still running across the upgrade) and the failed
+        write are the same fact — "do not take this frame's workspace from here" — and
+        `slots._frame_workspace` is what decides what to do instead."""
+        state.bump("f-never-recorded")
+        self.assertIsNone(state.frame_workspace("f-never-recorded"))
+
+    def test_a_relaunch_on_the_same_id_overwrites_rather_than_keeps(self):
+        """The recycled-pid case #383 is about, on this file. A frame id is
+        `<workspace>-<launcher pid>` and `reap` keeps a directory while that pid is live —
+        which on a launch it is, because it is the launcher's own. An adopted `workspace`
+        is another frame's answer, so every launch rewrites it, exactly as `record_server`
+        does with its own marker."""
+        state.record_workspace("f-1", "an-older-frames-workspace")
+        state.record_workspace("f-1", "this-frames-workspace")
+        self.assertEqual(state.frame_workspace("f-1"), "this-frames-workspace")
+
+    def test_a_name_that_could_escape_the_workspaces_directory_is_refused_on_read(self):
+        """The value is joined onto `workspaces/` by `workspace_dir()` and drawn on a
+        panel's screen. #442 is what an unchecked `../../` in that position already cost
+        once, through `workspace.declared_default`; this keeps the same rule
+        (`workspace.valid_name`) on charter's own copy of the same kind of value.
+
+        Written past `record_workspace` deliberately — the writer is charter's own
+        launcher and never produces this, so a test that went through it would be pinning
+        the writer rather than the reader that has to survive a corrupt file."""
+        d = state.frame_dir("f-1", create=True)
+        (d / "workspace").write_text("../../escaped\n")
+        self.assertIsNone(state.frame_workspace("f-1"))
+
+    def test_an_empty_recorded_workspace_is_not_known_either(self):
+        """A truncated write is the shape that would otherwise pass the truthiness test
+        one layer up and hand `workspace_dir()` the `workspaces/` directory itself."""
+        d = state.frame_dir("f-1", create=True)
+        (d / "workspace").write_text("\n")
+        self.assertIsNone(state.frame_workspace("f-1"))
+
+    def test_recording_for_an_id_no_directory_can_be_made_for_is_a_no_op(self):
+        """The launch path's own promise, kept here too: an id `contain.child` refuses
+        degrades to "charter does not know" rather than taking the launch down."""
+        state.record_workspace("../escape", "demo")
+        self.assertIsNone(state.frame_workspace("../escape"))
+
+    def test_reading_never_creates_the_directory_it_looked_in(self):
+        """The rule the whole module keeps and `version`'s docstring states: a read must
+        not resurrect a directory `reap()` has just removed."""
+        self.assertIsNone(state.frame_workspace("f-never-existed"))
+        self.assertFalse(state.frame_dir("f-never-existed").exists(),
+                         "a read minted the frame directory it was only looking in")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -75,6 +75,13 @@ from charter.frame import slots as frame_slots
 from charter.frame import state, tmuxctl
 
 from tests._isolation import PersonaIso, run_hook
+# Imported rather than re-declared: a second copy of the stub that keeps a launch's
+# detached `frame-gather` child off the developer's real plane is a copy that can drift
+# out of step with the production call it stands in for, and `tests/_planeguard.py`
+# cannot see a subprocess to tell anyone it drifted. Cross-module test imports are this
+# suite's ordinary way of sharing a fixture (`tests.test_hooks.InAControlPlane` has four
+# importers).
+from tests.test_frame_launcher import _no_real_detached_child
 
 _HAS_TMUX = shutil.which("tmux") is not None
 
@@ -3589,7 +3596,21 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
         def _run_launch():
             env = dict(os.environ, TMUX=f"{OP_SOCKET_PATH},{server_pid},{sid[1:]}",
                        TMUX_PANE=op_pane)
+            # `_no_real_detached_child` because a launch now FORKS (#512): `_spawn_gather`
+            # sends `charter frame-gather` through `util.detach_self`, a real
+            # `subprocess.Popen` carrying `os.environ.copy()`. That child is a separate
+            # PROCESS, so neither `PersonaIso`'s in-process `config.use()` nor
+            # `tests/_planeguard.py` reaches it, and the environment being copied here is
+            # the DEVELOPER'S with no `$CHARTER_ROOT` in it — so on any machine where
+            # `sys.executable` can import charter the child resolves the plane from the
+            # checkout's cwd and gathers, bumps and git-sweeps the operator's live one.
+            # Measured on the machine this was written on: `detach_self` really fired,
+            # with `argv=['frame-gather', '--session', 'demo-<pid>', '--workspace',
+            # 'demo']` and `CHARTER_ROOT=''`. This test is about what a launch writes on
+            # somebody else's tmux SERVER; the gather child is not part of that question,
+            # and it is the one part of a launch that escapes the isolation.
             with mock.patch.dict(os.environ, env, clear=True), \
+                 _no_real_detached_child([]), \
                  mock.patch("sys.stdout.isatty", return_value=True), \
                  mock.patch("charter.workspace.resolve", return_value="demo"), \
                  mock.patch.dict(config.FRAME, {"slots": []}):

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -2519,6 +2519,32 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         # test can still inspect rather than one that simply vanishes.
         conf_path.write_text(commands_frame._PLACEHOLDER_CONF)
 
+        # The two things `cmd_launch` does to a frame's own state directory before it
+        # asks tmux for anything, and #512 is why they are here rather than left out with
+        # the hotkey menu and the exit-code hooks. A panel is a PURE CACHE READER since
+        # #512 (`slots._bottom` calls `gather.cached`, never `gather.read`), so a frame
+        # nobody gathered for shows "gathering …" forever — which is what this test
+        # observed the day the fallback went, and correctly: production fills that cache
+        # from the launcher, so a test that hand-builds a frame has to do the launcher's
+        # job or it is not testing a launch.
+        #
+        # Both are the REAL production functions, not a hand-rolled `gather.save`:
+        # `_spawn_gather` IS #512's fix, and running it here is what makes the repo-row
+        # assertions below a proof that the detached child really starts, really gathers
+        # the workspace it was told to, really writes the cache, and really bumps the
+        # frame — end to end, through a real `charter frame-gather` process, against a
+        # real git repo, read back out of a real tmux pane.
+        #
+        # `os.environ` is patched for exactly that call, and only for it: the child is a
+        # separate PROCESS, so `PersonaIso`'s in-process `config.use()` redirection cannot
+        # reach it — without this it would resolve the DEVELOPER'S OWN plane and gather
+        # (and bump) there. `self.env` is the same isolated environment every pane in this
+        # frame already runs under, so the child lands on the same throwaway plane the
+        # panels are reading.
+        state.record_workspace(fid, "demo")
+        with mock.patch.dict(os.environ, self.env, clear=True):
+            commands_frame._spawn_gather(fid, "demo")
+
         session_cmd = layout.session_argv(session=fid, conf=str(conf_path), socket=SOCKET,
                                           cols=120, rows=40, harness_argv=["sleep", "600"])
         r = self._run_env(session_cmd)

--- a/tests/test_workspace_scope_honesty.py
+++ b/tests/test_workspace_scope_honesty.py
@@ -84,6 +84,49 @@ class TestScopeNamesWhatWasWritten(ScopeBase):
         self.assertEqual(workspace.resolve(session_id=self.SID), "alpha")
 
 
+class TestAskingWhatOneSessionChose(ScopeBase):
+    """`workspace.for_session` — the per-session pointer rung, asked about a session that
+    is not this process's.
+
+    Public since #512, for one caller that genuinely has to distinguish it from the rest of
+    the chain: a frame panel. Inside a frame the frame IS the charter session, so `charter
+    workspace use` writes this pointer under the FRAME's id and `docs/frame.md` promises
+    that "moves the panels too". The panels also carry a launch-time answer the launcher
+    recorded for them, and an operator's live choice has to outrank it — which is only
+    askable if this rung can be asked ON ITS OWN. `resolve()` cannot answer it: it returns
+    a workspace whatever happened, and `source()`'s label is a sentence for a status line.
+    """
+
+    def test_it_names_the_workspace_that_session_chose(self):
+        with mock.patch.object(workspace, "_terminal_id", return_value=None):
+            workspace.set_active("alpha")
+        self.assertEqual(workspace.for_session(self.SID), "alpha")
+
+    def test_a_session_that_chose_nothing_answers_none_rather_than_a_default(self):
+        """The distinction the caller needs and `resolve()` cannot make: `resolve` would
+        answer `default` here, which is a workspace, not "nobody chose"."""
+        self.assertIsNone(workspace.for_session("a-session-that-never-chose"))
+        self.assertEqual(workspace.resolve(session_id="a-session-that-never-chose"),
+                         config.DEFAULT_WORKSPACE)
+
+    def test_it_answers_for_the_session_asked_about_not_this_process(self):
+        """The whole reason it takes an argument: a panel asks about the FRAME's id while
+        running as its own process."""
+        with mock.patch.object(workspace, "_terminal_id", return_value=None):
+            workspace.set_active("alpha")
+        self.assertIsNone(workspace.for_session("some-other-session"))
+
+    def test_a_name_that_could_escape_the_workspaces_directory_is_refused(self):
+        """It feeds `workspace_dir()`'s join like every other rung, and #442 is what an
+        unchecked `../../` in that position cost once already."""
+        config.SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+        workspace._session_file("hostile").write_text("../../escaped\n")
+        self.assertIsNone(workspace.for_session("hostile"))
+
+    def test_no_session_id_at_all_is_not_an_error(self):
+        self.assertIsNone(workspace.for_session(""))
+
+
 class TestTheMessageFollowsTheScope(ScopeBase):
     def test_terminal_scope_may_promise_a_restart(self):
         self.assertIn("reopening", _scope_note("terminal"))


### PR DESCRIPTION
Closes #512

## What the operator saw

A new session's frame showed no repos; after resizing the window, the table appeared.
The resize was a coincidence — it landed alongside a tool call, and a tool call's
`posttooluse` hook is what refreshed the table.

## What was actually wrong

**#512's stated root cause is half of it, and the half it names would not have produced
a blank table on its own.** The issue says `slots._bottom` "renders from `gather.read(fid)`
— which has nothing to read". `gather.read` has a documented fallback: with no cache it
runs a live `scan()`. So a panel with an empty cache still draws rows — *if it is scanning
the right workspace*.

It was not.

`workspace.resolve`'s rungs are `--workspace` → `$CHARTER_WORKSPACE` → the tree you are
standing in → a per-session pointer → a per-terminal pointer → the declared default. At
launch a panel pane reaches none of the rungs that could speak for the frame:

| rung | what a panel gets |
|---|---|
| `$CHARTER_WORKSPACE` | empty — `_frame_identity_env` states every identity name, present or not, so a second frame cannot inherit the first's pin (#411) |
| cwd | the pane's, which is the plane root for anyone who typed `charter claude` there |
| per-session pointer | keyed on `session.current()`, which inside a frame is the FRAME id — and nothing has written one yet at launch |
| per-terminal pointer | keyed on `session.terminal()`, which is the panel's own tmux pane |

So it fell to the declared default while the launcher — one ordinary shell in the
operator's terminal — had answered a rung up.

**Measured on the reporting plane** (read-only): `.charter/terminals/` holds three
pointers naming `harness-wrapper` and one naming `user-reporting`, and
`workspaces/default/` holds `memory refs todos workspace.md` — no clones at all. The
launcher sized `bottom` for the real workspace's repos and the panel drew `default`'s
empty list into it. `top` said `default` too.

**Reproduced end to end** on an isolated plane whose active workspace comes from a
terminal pointer, with a real `charter frame` in a real tmux and no tool call:

```
=== TOP ===
 ⬢ default    charter 0.53.0
=== BOTTOM ===
0 todos · ⚠ front door steward — no such persona · charter persona default <name>
                        <- three blank rows, in a pane sized for three repos
```

The second defect is the one #512 names, and it is real: nothing refilled the cache
`gather.discard` empties at launch, so a panel was live-scanning on every repaint of a
fresh frame — on `bottom`, the one animated slot.

## The fix

**1. The frame's workspace is decided once, by the launcher, and written down.**
`state.record_workspace` on both launch paths; `state.workspace_for` is the one rule
every frame surface asks — `_top`'s header, `_bottom`'s todo count and alerts and table,
`gather.row_count`'s pane sizing, and `notify.plane_changed`'s refresh.

Deliberately **not** `$CHARTER_WORKSPACE`: exporting the resolved name would fix the same
reads and rank above every pointer, taking `charter workspace use` away from every framed
session on the way past.

**It is a seed, not an override.** `docs/frame.md` promises that `charter workspace use`
typed at the agent "moves the panels too" — it writes the per-session pointer under the
frame's id. The first cut of this change broke that promise. `workspace.for_session` (new,
public) is asked first, the launcher's record second, a local resolve third. Asked as a
property rather than by matching `workspace.source()`'s human-facing `"session"` label.

**2. The cache is filled at launch, detached.** `_spawn_gather` kicks
`charter frame-gather --session <fid> --workspace <ws>` through `util.detach_self` — the
shape `update.maybe_spawn` and `glstate.maybe_spawn` already use — which refreshes and
then bumps the frame so panels repaint. `--workspace` is stated for `glstate.maybe_spawn`'s
own reason: a `start_new_session` child is as far from the operator's terminal as a panel
is. Kicked *after* `gather.discard` (ordering pinned by a test — a spawn before it races a
child whose whole job is to write the file the discard deletes) and *before* tmux is asked
for anything, so the gather runs alongside the splits. Inline only if the fork fails.

**3. The first paint does not lie, and a panel does not sweep.** `_bottom` reads
`gather.cached`, never `gather.read`. `None` means "not gathered yet" and draws
`⋯ gathering this workspace's repos…`; an empty table keeps meaning "this workspace has no
clones". No panel scan on paint, which is the rule `_table_lines`' own docstring already
stated.

## Rendered output

The fix, on the same real frame as the repro above:

```
=== TOP ===
 ⬢ zeta    charter 0.53.0
=== BOTTOM ===
0 todos · ⚠ front door steward — no such persona · charter persona default <name>
  ├─ alpha                             main
  ├─ beta                              main*
  └─ gamma                             main
```

The unknown state and its replacement, read out of a real tmux pane running a real
`charter panel bottom`:

```
=== no cache on disk (the launch window) ===
0 todos · ⚠ front door steward — no such persona · charter persona default <name> · F2 menu
  ⋯ gathering this workspace's repos…

=== after the detached child lands and bumps ===
0 todos · ⚠ front door steward — no such persona · charter persona default <name> · F2 menu
  ├─ alpha                             main
  ├─ beta                              main*
  └─ gamma                             main
```

`charter workspace use` inside a live frame, still moving the panels — header first, then
the table once the next hook refresh lands:

```
--- before ---
 ⬢ zeta ...            ├─ alpha / ├─ beta / └─ gamma
--- after `charter workspace use other` ---
 ⬢ other ...           ├─ alpha / ├─ beta / └─ gamma      (cache not yet refreshed)
--- after a posttooluse-style refresh ---
 ⬢ other ...           └─ solo
```

## Tests

`Ran 5454 tests ... OK` (stdlib `unittest`, full discovery). Four new classes and several
new cases; two existing tests corrected rather than deleted:

- `test_frame_slots.BottomTable.test_a_failing_gather_read_yields_a_line_rather_than_an_exception`
  patched `gather.read`, which `_bottom` no longer calls — it would have kept passing
  against a mock nothing reached.
- `FourEdgeIntegration._spawn_frame` now performs the launcher's two new steps, through
  the real production functions, with `os.environ` patched to the throwaway plane for the
  one call that forks. That makes the existing repo-row assertions a proof that the
  detached child really starts, gathers the workspace it was told, writes the cache and
  bumps the frame.

**23 mutations, each applied alone, each RED on a named test**, baseline GREEN before and
after, `__pycache__` cleared between every one. Two survived the first sweep and both were
real defects in the tests:

- a width guard inside `_unknown_lines` that `_table_cap` already enforced — an
  unreachable second guard, removed rather than tested;
- a `side_effect=AssertionError` stub raising into `cmd_gather`'s own `except Exception`,
  so the mutation `or` → `and` stayed green. Counted outside the mock now.

## A hazard this closes on the way past

`cmd_launch` now forks. Every launcher test would have forked a real `charter
frame-gather` with the test process's environment — which `PersonaIso` cannot reach, and
`tests/_planeguard.py` says in as many words that it cannot see a subprocess — gathering
and **bumping** in the developer's own plane. It was harmless on this machine only because
`-P` leaves `charter` unimportable from a checkout. Both launch helpers and the three
ad-hoc `cmd_launch` call sites now stub `util.detach_self` and assert on what it was
handed, so the thing that keeps the suite off the real plane is also the thing that proves
the launch fires the gather.

## Filed, not widened

**#524** — the HARNESS pane reaches the same dead rungs a panel did, so the agent session
inside a frame can still resolve a different workspace than the frame draws. Reconciling
those two is a design decision (pinning the session would take `charter workspace use`
away from it) and it is the same question **#517** and **#518** approach from the other
end.

No version bump, no stamping, no tag. News entry:
`docs/news/unreleased-the-frame-draws-your-workspace-not-default.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
