### PR TITLE
The plugin classification asks the index, not the developer's filesystem (#529)

### DIFF
--- a/docs/news/unreleased-the-plugin-classification-reads-the-index.md
+++ b/docs/news/unreleased-the-plugin-classification-reads-the-index.md
@@ -1,0 +1,50 @@
+---
+version: unreleased
+headline: charter's suite no longer fails because you have actually used charter — the plugin classification reads the index, not your filesystem
+---
+
+`tests.test_plugin_freshness.TheHashCoversWhatThePluginLoads` holds a classification: every
+top-level directory in this repository is either something a Claude Code plugin **loads**
+(`plugincache.PLUGIN_SURFACE`) or something it does not (`_NOT_PLUGIN_SURFACE`), and adding a
+third kind fails the test until a person decides which it is. That decision is the only thing
+the check exists to force, and it is a good one to force: the surface constant is a whitelist,
+so a plugin directory missing from it is a whole category of staleness `doctor` would report
+as clean.
+
+It enumerated `REPO.iterdir()` — the working directory. So on a plane that has actually been
+used it failed, naming the plane's own gitignored `.charter/` (state) and `.superpowers/` (SDD
+workspaces) as unclassified directories:
+
+```
+AssertionError: Items in the first set but not the second:
+'.superpowers'
+'.charter' : new top-level directories ['.charter', '.superpowers']:
+             does a Claude Code plugin LOAD it? Add it to plugincache.PLUGIN_SURFACE,
+             or to _NOT_PLUGIN_SURFACE in this file.
+```
+
+Neither is repo content, neither ships, and neither is an answer to "does a plugin load it".
+It passed in CI, in a `git archive` extraction and in a linked worktree — every tree that has
+never been worked in. **The only place it failed was a machine charter is used from.**
+
+That is the third layer of the same mistake this suite keeps making: a test reading the
+developer's environment (#519/#521/#528), the developer's plane (#402/#492), and now the
+developer's filesystem.
+
+**Fixed by asking the index, not the disk.** `git ls-files` is already the seam
+`tests/test_workflows.py` uses to decide which files move only with a commit, for exactly this
+reason: a denylist of local artefacts is a guess at where untracked content lives, and the
+index is the answer. A directory that is gitignored cannot reach the classification; a
+directory that is genuinely committed still fails the test on the PR that commits it, which is
+the property the check was strengthened for.
+
+**The cheap fix is now refused mechanically.** Writing `.charter` and `.superpowers` into
+`_NOT_PLUGIN_SURFACE` would have gone green on one machine and left the test reading the
+filesystem — and the list would then grow by one name per developer (`.venv`, `.idea`,
+`.pytest_cache`, a scratch directory) while the check quietly stopped classifying anything. A
+second test now holds every name in that constant to being a directory this repository
+actually tracks, so a local artefact parked there fails by name. `.git` and `dist` were listed
+and are gone with it; they were never repo content either.
+
+This only ever reached you if you run charter's own test suite. Nothing to adopt: upgrading is
+the whole of it.

--- a/tests/test_plugin_freshness.py
+++ b/tests/test_plugin_freshness.py
@@ -26,6 +26,8 @@ own plugin installation.
 
 from __future__ import annotations
 
+import os
+import subprocess
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -44,6 +46,32 @@ def tree(root: Path, files: dict[str, str]) -> Path:
     return root
 
 
+def tracked_top_level_directories(repo: Path = REPO) -> set[str]:
+    """Every top-level directory this repository TRACKS — read from the index, not the disk.
+
+    The question the classification below asks is about the repository: what does charter
+    ship, and does a plugin load it. A directory that is not in the index is not shipped, so
+    it cannot be an answer to that question — it is an artefact of whoever is running the
+    suite. `git ls-files` is the same seam `tests/test_workflows.tracked` uses, and for the
+    same reason: a denylist of local artefacts (`.venv`, `dist`, `.pytest_cache`) is a guess
+    at where untracked content lives, and the index is the answer.
+
+    `check=True` on purpose. If the index cannot be read this test has nothing to say, and
+    saying nothing quietly — an empty set, which classifies vacuously — is the shape of guard
+    that reports green forever.
+
+    **What this does not see**, stated because a guard that overclaims is the defect twice
+    over: a top-level *submodule*. `git ls-files` prints a gitlink as a bare path with no
+    slash, indistinguishable here from a tracked top-level file, so one would be classified
+    as neither. charter has no submodules and `dependencies = []`; adding one at the top
+    level would need `ls-files -s` and a mode-160000 check here.
+    """
+    out = subprocess.run(
+        ["git", "-C", str(repo), "ls-files", "-z"],
+        capture_output=True, check=True, text=True)
+    return {p.split("/", 1)[0] for p in out.stdout.split("\0") if p and "/" in p}
+
+
 #: Top-level directories this repo ships that a Claude Code plugin does NOT load.
 #:
 #: The other half of the classification `test_every_top_level_directory_is_classified`
@@ -51,9 +79,14 @@ def tree(root: Path, files: dict[str, str]) -> Path:
 #: live in `<plugin>/agents/`, and this repo's `.claude/agents/` is its OWN project
 #: configuration, which travels into the cache because the marketplace entry is
 #: `"source": "./"` and is not loaded as plugin content.
+#:
+#: **Every name here must be a tracked directory**, and a test holds it to that. `.git` and
+#: `dist` used to be listed, back when the classification enumerated the filesystem; they
+#: are not repo content, and keeping untracked names here is how the list would grow one
+#: developer's machine at a time — `.charter`, `.superpowers`, `.venv`, `.idea` — until it
+#: classified nothing.
 _NOT_PLUGIN_SURFACE = {
-    ".git", ".github", ".claude", "charter", "docs", "tests", "personas", "workspaces",
-    "dist",
+    ".github", ".claude", "charter", "docs", "tests", "personas", "workspaces",
 }
 
 PLUGIN = {
@@ -129,25 +162,89 @@ class TheHashCoversWhatThePluginLoads(PersonaIso):
         """The constant is a whitelist, so a plugin directory missing from it is a whole
         category of drift this module reports as clean.
 
-        **Enumerated from the filesystem, and classified exhaustively.** The first version
-        of this test built its `shipped` set from a hardcoded literal identical to
+        **Enumerated from the index, and classified exhaustively.** The first version of
+        this test built its `shipped` set from a hardcoded literal identical to
         `PLUGIN_SURFACE` and then asserted one was a subset of the other — true by
         construction. It caught a *removal* from the constant and could not catch the
         *addition* its own docstring claimed it caught.
 
-        This asks the repository what directories it has and requires every one of them to
-        be in exactly one of two lists. Add `mcp/` or `commands/` to charter tomorrow and
-        this fails until somebody decides which it is — which is the decision the check
-        needs made, and the only thing a test can usefully force.
+        The second version enumerated `REPO.iterdir()`, which is the developer's filesystem
+        rather than the repository. It passed in CI, in a `git archive` extraction and in a
+        linked worktree, and failed on the one machine charter is actually used from: a real
+        plane has a gitignored `.charter/` (its state) and a gitignored `.superpowers/` (SDD
+        workspaces), and neither is an answer to "does a plugin load it" — they are not
+        shipped at all.
+
+        So this asks the *index* what directories the repository has, and requires every one
+        of them to be in exactly one of two lists. Add `mcp/` or `commands/` to charter
+        tomorrow and this fails on the PR that commits it, until somebody decides which it
+        is — which is the decision the check needs made, and the only thing a test can
+        usefully force. A directory that exists only on one machine is not that decision.
         """
-        tops = {p.name for p in REPO.iterdir()
-                if p.is_dir() and not p.name.startswith("__")}
+        tops = tracked_top_level_directories()
         unclassified = tops - set(plugincache.PLUGIN_SURFACE) - _NOT_PLUGIN_SURFACE
         self.assertEqual(
             unclassified, set(),
             f"new top-level director{'y' if len(unclassified) == 1 else 'ies'} "
             f"{sorted(unclassified)}: does a Claude Code plugin LOAD it? Add it to "
             f"plugincache.PLUGIN_SURFACE, or to _NOT_PLUGIN_SURFACE in this file.")
+
+    def test_the_classification_reads_the_index_and_not_the_working_directory(self):
+        """The property #529 is about, held directly rather than left to CI's clean tree.
+
+        An untracked directory — `.charter/`, `.superpowers/`, `.venv/`, a scratch dir — must
+        not reach the classification, and a tracked one must. Both halves against a real
+        throwaway git repository, because the seam being tested *is* git: asserting against a
+        faked `subprocess.run` would only prove the parsing, and the parsing was never the
+        defect.
+        """
+        repo = self.tmp / "planeish"
+        (repo / "skills").mkdir(parents=True)
+        (repo / "skills" / "SKILL.md").write_text("# x\n")
+        for local in (".charter", ".superpowers", ".venv"):
+            (repo / local).mkdir()
+            (repo / local / "junk.json").write_text("{}\n")
+        # A throwaway index, not the developer's: every GIT_* the ambient environment
+        # carries is dropped, and both config files are pointed at nothing.
+        env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+        env.update(GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_SYSTEM=os.devnull,
+                   HOME=str(self.tmp))
+
+        def run(*args):
+            subprocess.run(["git", "-C", str(repo), *args], check=True,
+                           capture_output=True, text=True, env=env)
+
+        run("init", "-q")
+        run("add", "skills/SKILL.md")
+
+        self.assertEqual(tracked_top_level_directories(repo), {"skills"},
+                         "an untracked directory reached the classification")
+
+        (repo / "commands").mkdir()
+        (repo / "commands" / "go.md").write_text("# go\n")
+        run("add", "commands/go.md")
+        self.assertEqual(tracked_top_level_directories(repo), {"skills", "commands"},
+                         "a committed directory did NOT reach the classification")
+
+    def test_nothing_untracked_can_be_parked_in_the_not_plugin_surface_list(self):
+        """The workaround #529 forbids, refused mechanically.
+
+        The cheap fix for "`.charter/` fails the classification" is to write `.charter` into
+        `_NOT_PLUGIN_SURFACE` — green on that machine, and the list then grows by one name
+        per developer while the check quietly stops classifying anything. Every name in that
+        constant is a directory this repository *ships*, so every name must be in the index.
+
+        `PLUGIN_SURFACE` is deliberately not held to this: it names what a plugin loads *if
+        present*, and `commands/` and `agents/` are two Claude Code surfaces charter does not
+        use yet.
+        """
+        tracked = tracked_top_level_directories()
+        stale = _NOT_PLUGIN_SURFACE - tracked
+        self.assertEqual(
+            stale, set(),
+            f"_NOT_PLUGIN_SURFACE names {sorted(stale)}, which this repository does not "
+            f"track. This list classifies directories charter SHIPS; a local artefact "
+            f"belongs in .gitignore, not here (see #529).")
 
     def test_the_three_directories_the_plugin_loads_today_are_covered(self):
         """The removal half, named concretely so the pair covers both directions."""


### PR DESCRIPTION
Closes #529

## The defect

`TheHashCoversWhatThePluginLoads.test_every_top_level_directory_is_classified_one_way_or_the_other`
enumerated `REPO.iterdir()`. The question it asks is about the **repository** — does a Claude
Code plugin load this directory — and a gitignored directory cannot be an answer to it, because
it is not shipped at all.

It passed in CI, in a `git archive` extraction, and in a linked worktree — every tree nobody has
worked in. The only place it failed was a plane charter is actually used from, where `.charter/`
(state) and `.superpowers/` (SDD workspaces) exist and are gitignored. Third layer of the same
mistake: the developer's environment (#519/#521/#528), their plane (#402/#492), now their
filesystem.

## The fix

`git ls-files` — already the seam `tests/test_workflows.tracked` uses, for the same stated
reason: a denylist of local artefacts is a guess at where untracked content lives, and the index
is the answer.

`.charter` and `.superpowers` are **not** added to `_NOT_PLUGIN_SURFACE`. Two entries that were
already there and are not repo content — `.git` and `dist` — are removed with the filesystem
walk, and a second test now holds every remaining name to being tracked. The cheap fix now fails
by name rather than going green on one machine while the list grows one developer at a time.

`PLUGIN_SURFACE` is deliberately exempt from that guard, and the docstring says so: it names what
a plugin loads *if present*, and `commands/` and `agents/` are two Claude Code surfaces charter
does not use yet.

## Verified the way the defect appears

A tree carrying `.charter/`, `.superpowers/`, `.venv/` and `.pytest_cache/` — the pre-fix
enumeration and the post-fix one, side by side against that same tree:

```
$ find . -maxdepth 1 -type d -not -name . | sort
./.charter
./.claude
./.claude-plugin
./.github
./.pytest_cache
./.superpowers
./.venv
./charter
./docs
./hooks
./personas
./skills
./tests
./workspaces

OLD (REPO.iterdir) unclassified: ['.charter', '.pytest_cache', '.superpowers', '.venv']
NEW (git ls-files)  unclassified: []
```

Green in that tree:

```
$ python3 -m unittest tests.test_plugin_freshness.TheHashCoversWhatThePluginLoads.test_every_top_level_directory_is_classified_one_way_or_the_other
Ran 1 test in 0.308s
OK
```

And separately, a **genuinely tracked** new top-level directory still turns it red — the property
#510's `M34` work strengthened this test for:

```
$ mkdir mcp && echo '{"servers": {}}' > mcp/servers.json && git add mcp/servers.json
$ python3 -m unittest tests.test_plugin_freshness.TheHashCoversWhatThePluginLoads.test_every_top_level_directory_is_classified_one_way_or_the_other
AssertionError: Items in the first set but not the second:
'mcp' : new top-level directory ['mcp']: does a Claude Code plugin LOAD it? Add it to
        plugincache.PLUGIN_SURFACE, or to _NOT_PLUGIN_SURFACE in this file.
FAILED (failures=1)
```

Nothing here renders, so there is no frame output to paste; the only user-facing surface is the
assertion message above.

## Mutation tests

Each applied, run RED, restored, run GREEN, with `__pycache__` cleared between.

**M1 — park the untracked names in the list** (the workaround #529 forbids):
`_NOT_PLUGIN_SURFACE` += `".charter", ".superpowers"` →

```
FAIL: test_nothing_untracked_can_be_parked_in_the_not_plugin_surface_list
AssertionError: Items in the first set but not the second:
'.charter'
'.superpowers' : _NOT_PLUGIN_SURFACE names ['.charter', '.superpowers'], which this
                 repository does not track. This list classifies directories charter SHIPS;
                 a local artefact belongs in .gitignore, not here (see #529).
```

**M2 — the helper reads the filesystem again** (the pre-fix behaviour, restored inside
`tracked_top_level_directories`) → **two** failures, the new property test and the
classification itself:

```
FAIL: test_the_classification_reads_the_index_and_not_the_working_directory
AssertionError: Items in the first set but not the second:
'.superpowers'
'.charter'
'.venv'
'.git' : an untracked directory reached the classification
FAILED (failures=2)
```

**M3 — drop the directory filter** (`if p` instead of `if p and "/" in p`, so tracked top-level
*files* count as directories) →

```
FAIL: test_every_top_level_directory_is_classified_one_way_or_the_other
FAILED (failures=1)
```

Restored: `Ran 53 tests in 2.251s / OK`.

One mutation is honestly **not** caught: flipping `check=True` to `check=False` on the
`git ls-files` call changes nothing while git succeeds, so no test distinguishes it. It is a
robustness choice rather than a property, and the docstring says why it is there — a helper that
returns an empty set when it cannot read the index classifies vacuously, which is a guard that
reports green forever.

## Suite

Ambient variables cleared, outside a live frame, in a tree that had `.charter/`,
`.superpowers/`, `.venv/` and `.pytest_cache/` present:

```
$ env -u CHARTER_SESSION_ID -u CLAUDE_CODE_SESSION_ID -u TMUX -u TMUX_PANE \
    python3 -m unittest discover -s tests
Ran 5528 tests in 227.864s
OK
```

`config.ROOT` resolved to `/Users/aharon/IdeaProjects/charter` — the worktree's own
`charter.toml` redirects to the main tree via `root._plane_of`, as the brief warns. It does not
affect this change: the module's `REPO` comes from `Path(__file__).resolve().parents[1]`, so the
index read is the worktree's own.

## Filed, not widened

Two adjacent surfaces found while here, filed rather than folded in:

* **#532** — `TestShippedSkillsStayInSync` reads `skills/` off the filesystem, so a locally
  drafted `skills/<name>/SKILL.md` turns the suite red. Same shape one level down.
* **#531** — 26 test modules define classes *after* their `if __name__ == "__main__"` trailer, so
  `python3 tests/test_doctor_shadowed.py` runs 8 tests and says `OK` while
  `python3 -m unittest tests.test_doctor_shadowed` runs 14. The six that disappear are the
  `PersonaIso` ones that exercise the real seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
