### PR TITLE
frame: switch workspace and persona by hotkey, and pick one before the harness starts (#517, #518)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -681,6 +681,21 @@ def _add_frame_parsers(sub) -> None:
         parser.add_argument("--probe", action="store_true",
                             help="Read-only: can a frame run here? Prints one line, "
                                  "starts nothing, never launches the harness.")
+        # #518. `--workspace` is the top rung of `workspace.resolve`'s own precedence,
+        # said on the command line — so it both aims the launch and skips the picker, in
+        # one flag, without a second rule for the second job. `--pick` is the other
+        # direction: ask even though something already answered.
+        #
+        # Both share `--no-frame`'s `_OWN_FLAGS`/`_OWN_VALUE_FLAGS` treatment below, so
+        # they reach `cmd_launch` as flags instead of being grafted onto the harness's own
+        # verbatim argv — and only in the leading position, which is the one unambiguous
+        # rule available once a harness's own flags are indistinguishable from ours by
+        # shape (see `_split_frame_argv`).
+        parser.add_argument("--workspace", dest="workspace", default=None,
+                            help="Run in this workspace (skips the picker).")
+        parser.add_argument("--pick", action="store_true",
+                            help="Choose the workspace before the harness starts, even "
+                                 "if one is already selected.")
         parser.set_defaults(harness=name, func=commands_frame.cmd_launch)
 
     # Snapshot, not a live read of `sub.choices` inside the loop — see this function's
@@ -706,7 +721,7 @@ def _add_frame_parsers(sub) -> None:
     # version (see `commands_frame.cmd_probe`'s own docstring).
     _core_commands = set(sub.choices) | {"frame", "panel", "frame-menu", "frame-action",
                                          "frame-probe", "frame-respawn", "frame-density",
-                                         "frame-resize", "frame-gather"}
+                                         "frame-resize", "frame-gather", "frame-switch"}
 
     # Which harness (by `.name`, never `.cli_name` — that's the dict key below) has
     # already claimed each word, so a SECOND harness wanting it is told who got there
@@ -770,13 +785,37 @@ def _add_frame_parsers(sub) -> None:
     # the bind's `run-shell` text before this process starts — never queried after the
     # fact (see `cmd_menu`'s own docstring for why: `list-clients` cannot tell WHO
     # pressed the key, only who is attached, and picking among several guessed wrong).
+    #
+    # `--group` opens a SUBMENU (#517). It arrives from a menu item's own command text,
+    # which charter wrote (`frame/menu.py`'s `menu_argv`) — and is validated in
+    # `cmd_menu` against `menu.GROUPS` rather than by `choices=` here, for the same
+    # reason `frame-density`'s `level` is not: a `choices=` mismatch exits 2 from inside a
+    # `run-shell`, where nothing prints the reason.
     mn = sub.add_parser("frame-menu")
     mn.add_argument("client")
+    mn.add_argument("--group", dest="group", default=None)
     mn.set_defaults(func=commands_frame.cmd_menu)
 
     act = sub.add_parser("frame-action")
     act.add_argument("action_id")
     act.set_defaults(func=commands_frame.cmd_action)
+
+    # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the
+    # ones above. Fired by a hotkey-SUBMENU selection (#517,
+    # `commands_frame._switch_entries`), whose stored argv is exactly
+    # `util.self_relaunch_argv("frame-switch", "--workspace"|"--persona", <name>)`. Also
+    # typeable by hand from inside a frame, which is why the name is a value and not a
+    # positional: `charter frame-switch --workspace foo` reads as what it does.
+    #
+    # The two are separate flags rather than one `--to` plus a noun, because a switch is
+    # not one operation with a parameter — `frame/switch.py` has different refusals, a
+    # different lock story and a different repaint cost for each, and a single flag would
+    # have to be dispatched on a second one anyway.
+    sw = sub.add_parser("frame-switch",
+                        help="Move this frame to another workspace or persona.")
+    sw.add_argument("--workspace", dest="workspace", default=None)
+    sw.add_argument("--persona", dest="persona", default=None)
+    sw.set_defaults(func=commands_frame.cmd_switch)
 
     # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the
     # two above. Fired by a PANEL pane's own `pane-died` hook (#382,
@@ -1335,7 +1374,17 @@ def _frame_command_names() -> set[str]:
 #: harness named `""`, bare `frame`) hands `["--probe"]` to `bypass`, which
 #: `os.execvp("--probe", ...)` turns into a `FileNotFoundError` — confirmed by running
 #: `charter frame --probe` with this entry left out before adding it.
-_OWN_FLAGS = ("--no-frame", "--probe", "-h", "--help")
+_OWN_FLAGS = ("--no-frame", "--probe", "--pick", "-h", "--help")
+
+#: The launcher's own flags that take a VALUE — `--workspace <name>` (#518). Kept apart
+#: from `_OWN_FLAGS` because the two are consumed differently and getting that wrong is
+#: silent in both directions: listed here but consumed as one token, and the name after it
+#: becomes `argv[0]` of the harness's own command; listed in `_OWN_FLAGS` and consumed as
+#: two, and a harness argument disappears.
+#:
+#: `--workspace=<name>` needs no entry — it is a single token, so the leading-run scan
+#: below matches it by prefix and `argparse` splits it.
+_OWN_VALUE_FLAGS = ("--workspace",)
 
 
 def _split_frame_argv(argv: list[str]) -> tuple[list[str], list[str] | None]:
@@ -1359,12 +1408,30 @@ def _split_frame_argv(argv: list[str]) -> tuple[list[str], list[str] | None]:
     or `--help` is just more of the harness's own verbatim argv, which is the one
     unambiguous rule available once the harness's own flags (`-p`, `--continue`,
     anything) are indistinguishable from ours by shape alone.
+
+    **A value-taking flag consumes two tokens, and that is why `_OWN_VALUE_FLAGS` is a
+    separate tuple.** `--workspace foo` in the leading run is charter's; scanning it as one
+    token would leave `foo` as the harness's `argv[0]`, which for `charter frame
+    --workspace foo -- true` would try to execute the workspace name. A trailing
+    `--workspace` with nothing after it stops the scan there and is handed to `argparse`,
+    which refuses it with its own "expected one argument" — the right message, from the
+    part that owns the flag.
     """
     if not argv or argv[0] not in _frame_command_names():
         return argv, None
     i = 1
-    while i < len(argv) and argv[i] in _OWN_FLAGS:
-        i += 1
+    while i < len(argv):
+        tok = argv[i]
+        if tok in _OWN_FLAGS or any(tok.startswith(f + "=") for f in _OWN_VALUE_FLAGS):
+            i += 1
+        elif tok in _OWN_VALUE_FLAGS:
+            # Two tokens, or one when the flag is last — that trailing case is handed to
+            # `argparse` on its own so its "expected one argument" is what the operator
+            # gets, rather than the flag disappearing into the harness's verbatim argv
+            # where nothing would ever mention it.
+            i += 2 if i + 1 < len(argv) else 1
+        else:
+            break
     return argv[:i], argv[i:]
 
 

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -132,8 +132,8 @@ import subprocess
 import sys
 import time
 
-from . import config, harness, util, workspace
-from .frame import gather, layout, menu, state, tmuxctl
+from . import config, contain, harness, tui, util, workspace
+from .frame import gather, layout, menu, picker, state, switch, tmuxctl
 # Aliased: `cmd_launch` already has a local variable named `slots` (the VISIBLE slot
 # list `layout.visible_slots` returns) — importing the renderer registry under its own
 # name would be shadowed by that local the moment it's assigned, and a `slots.SLOTS`
@@ -2097,6 +2097,113 @@ def early_death_message(argv: list[str], code: int, last_words: list[str]) -> st
     return "\n".join(lines)
 
 
+#: What `cmd_launch` returns when the operator cancelled the picker. 130 is the shell's
+#: own "ended by SIGINT" convention, which is what cancelling is — and it is deliberately
+#: not 0: a script that ran `charter claude` and got 0 back would take a frame that was
+#: never started for one that ran and exited cleanly.
+_PICKER_CANCELLED = 130
+
+
+def _picker_wanted(args, chosen: str | None) -> bool:
+    """Should this launch stop and ask? #518's whole gating rule, in one place.
+
+    **A non-interactive launch must never block, and that is a property here, not a
+    promise.** `charter claude` runs from scripts and from other agents; a prompt waiting
+    on a pipe is a hang, not a question. Two gates close that by construction:
+
+    * `cmd_launch` has already returned through `bypass` for `--no-frame` and for a
+      non-tty stdout, so nothing reaches here with its output redirected;
+    * stdin is checked HERE, because the two can differ — `charter claude < /dev/null` on
+      a real terminal has a tty for output and nothing to read from.
+
+    * **`--workspace` and `$CHARTER_WORKSPACE` skip it outright.** They are the top two
+      rungs of `workspace.resolve`'s precedence and they mean "this one, I have decided" —
+      putting a picker in front of an answer already given would be the same silence #518
+      complains about, wearing a prompt.
+
+    * **`--pick` forces it**, for the launch where an operator wants to move and has a
+      pointer saying otherwise.
+
+    * Otherwise the question is whether **anything chose**: `workspace.chosen` is
+      `resolve`'s ladder minus its built-in fallback, so ``None`` means every rung came
+      back empty and the launch was about to answer `default` — a name nobody picked.
+      That is the launch #518 is about, and it is a PROPERTY of the resolution rather than
+      a spelling of `workspace.source`'s human-facing label.
+    """
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return False
+    if getattr(args, "workspace", None) or os.environ.get("CHARTER_WORKSPACE"):
+        return False
+    if getattr(args, "pick", False):
+        return True
+    return chosen is None
+
+
+def _choose_workspace(args) -> tuple[str, int | None, bool]:
+    """``(workspace, exit code or None, whether the operator picked it)`` — #518.
+
+    The launch's workspace, either resolved exactly as it always was or chosen at a
+    prompt. A non-``None`` exit code means the launch is over and nothing was started.
+
+    **Creating happens here and nowhere else.** `frame/picker.py` renders and reads; it
+    returns a decision. That split is what makes "a cancelled picker creates nothing" a
+    fact about the code — there is no create call inside the picker to reach — and it is
+    why the confirmation (`[y/N]`, defaulting to no) can live next to the prompt while the
+    side effect lives next to the launch.
+
+    `workspace.ensure` is the validating creator (`charter workspace create` calls the
+    same one), so a name that got past the picker's own `valid_name` and still cannot be
+    made raises `ValueError` here and ends the launch with a message, rather than being
+    carried into a frame for a workspace that does not exist.
+
+    The clone count each row carries is `workspace.clones` — one directory listing per
+    workspace, paid once, before tmux starts. It is what makes the list worth reading
+    (#512: the repo table is empty until the first gather, so the count is the only thing
+    on screen at pick time that distinguishes them), and it is on no repaint path, so the
+    idle-cost property is untouched.
+    """
+    explicit = getattr(args, "workspace", None)
+    chosen = workspace.chosen(explicit)
+    if not _picker_wanted(args, chosen):
+        return workspace.resolve(explicit), None, False
+
+    current = chosen or config.DEFAULT_WORKSPACE
+
+    def _read() -> str | None:
+        # `EOFError` is a closed stdin and `KeyboardInterrupt` is the operator pressing
+        # ^C at the prompt: both are "no answer", which the picker reads as cancel. Caught
+        # at the seam rather than around the whole launch, so a ^C means "not this
+        # workspace" and never leaves a half-built frame behind — nothing has been created
+        # or started at this point in `cmd_launch`.
+        try:
+            return input()
+        except (EOFError, KeyboardInterrupt):
+            return None
+
+    def _write(text: str) -> None:
+        sys.stdout.write(text)
+        sys.stdout.flush()
+
+    got = picker.ask(
+        picker.rows(switch.workspaces(), lambda n: len(workspace.clones(n))),
+        current, read=_read, write=_write, name_ok=workspace.valid_name,
+        width=tui.term_width())
+
+    if got.action == picker.CANCEL:
+        util.info("charter: nothing started.")
+        return "", _PICKER_CANCELLED, False
+    if got.action == picker.CREATE:
+        try:
+            wd = workspace.ensure(got.name)
+        except ValueError as e:
+            util.err(str(e))
+            return "", 1, False
+        workspace.scaffold(got.name)
+        util.ok(f"Workspace '{contain.one_line(got.name)}' created → "
+                f"{wd.relative_to(config.ROOT)}/")
+    return got.name, None, True
+
+
 def cmd_launch(args) -> int:
     """One launcher, shared by every registered harness and by `charter frame --`."""
     if getattr(args, "probe", False):
@@ -2165,8 +2272,41 @@ def cmd_launch(args) -> int:
     # It is reported by `frame_ready` (`--probe`, `charter frame-probe`) and by
     # `doctor.check_frame` instead; see `frame_ready`'s own docstring.
 
-    ws = workspace.resolve()
+    ws, rc, picked = _choose_workspace(args)
+    if rc is not None:
+        return rc
     fid = state.frame_id(ws, os.getpid())
+    if picked:
+        # **Only when the operator actually picked.** A launch that resolved silently
+        # writes no pointer today and must keep writing none — starting to would move
+        # every framed session's workspace on a path nobody asked anything on.
+        #
+        # `session_id=fid`, so the per-session pointer lands under the FRAME's id: inside
+        # a frame the frame IS the charter session (ADR 0019), which is what makes the
+        # choice reach the panels and the agent's own shell alike (`state.workspace_for`
+        # rung 1). `set_active` also writes the pointer for the LAUNCHER's terminal, and
+        # that is the half that answers #518's "must not answer a prompt every launch":
+        # the next launch from this terminal finds `workspace.chosen` already answered
+        # and never asks.
+        #
+        # `force=True` because `fid` is minted from the workspace and this process's pid,
+        # so an earlier launcher with the same pid and the same workspace can have left a
+        # lock under this very id (`cmd_launch` reaps exactly that case a few lines down).
+        # Being refused by a dead frame's lock, on a name the operator just typed, is not
+        # a refusal worth having.
+        workspace.set_active(ws, session_id=fid, force=True)
+        # **Picking IS the confirmation that locks, and #518 asks that this be decided and
+        # SAID.** `set_active`'s contract is that confirming a workspace locks the session
+        # to it, and the picker is a confirmation — the alternative would be a launch that
+        # writes the pointer and leaves the lock off, which is a third behaviour for
+        # `charter workspace use` to disagree with. What makes it liveable is that the
+        # frame has its own way out: `F2 → workspace` overrides the lock and says so
+        # (`frame/switch.py`), so the operator is not sent back to the shell for a choice
+        # they just made at a prompt. Printed here rather than in the picker, because it
+        # describes what the LAUNCH did with the answer, not what the answer was.
+        util.info(f"Workspace '{contain.one_line(ws)}' — 🔒 locked for this frame's "
+                  f"session. F2 → workspace changes it; `charter workspace unlock` "
+                  f"releases it.")
 
     # Inside a tmux the operator already has, the frame is a WINDOW in THEIR server —
     # same layout, no second tmux, no second prefix key (ADR 0018 and the design spec
@@ -2522,9 +2662,24 @@ def _menu_entries(fid: str, socket: str, *, current: str) -> list[tuple[str, lis
     *current* is marked, not filtered out: an operator who selects the level they are
     already on gets a re-layout that produces the same frame, which is the harmless
     outcome, and a menu whose rows move around depending on state is a menu nobody learns.
+
+    **Workspaces and personas are SUBMENUS, not two more top-level binds (#517).** A tmux
+    key table is server-wide with no per-session form — the same measurement that put
+    density here — so two more `bind -n` keys would cost every frame on the socket two
+    more keys and still give an operator inside their own tmux nothing. The hotkey charter
+    already binds opens this menu; the two lists hang off it, which reuses the containment
+    (`menu._safe_label`), the action-id validation (`menu._ACTION_ID_RE`) and the repaint
+    path (`frame/switch.py` → `state.bump`) that already exist, instead of opening three
+    new doors.
+
+    Each list is capped at :data:`_MENU_LIST_MAX` with a last row saying how many were
+    left out — `slots._cap_personas`' own rule, one surface over. A `display-menu` is
+    drawn inside the terminal and tmux does not scroll it; a plane with forty workspaces
+    would otherwise build a menu taller than the window, and what tmux does then is not
+    something charter should be finding out at an operator's keypress.
     """
     from . import instance
-    entries: list[tuple[str, list[str]]] = [
+    entries: list = [
         # The spec's own words, "Detach is allowed and prints how to reattach". `-s fid`
         # (not `-t`): `detach-client`'s `-s` targets every client attached to a SESSION,
         # `-t` a single CLIENT — this frame normally has exactly one attached client, but
@@ -2536,7 +2691,64 @@ def _menu_entries(fid: str, socket: str, *, current: str) -> list[tuple[str, lis
         mark = on if level == current else off
         entries.append((f"{mark} density: {level}",
                         util.self_relaunch_argv("frame-density", level)))
+    entries += _switch_entries(fid)
     return entries
+
+
+#: How many workspaces (or personas) one submenu ever lists. `slots._MAX_PERSONA_LINES`
+#: bounds the sidebar for the same reason and this is the same trade — a bound that fits
+#: on a screen, with the overflow SAID rather than silently dropped.
+_MENU_LIST_MAX = 12
+
+
+def _switch_entries(fid: str) -> list:
+    """The two submenu openers and the rows they open — #517's whole menu surface.
+
+    `frame/switch.py` owns every name that appears here, already checked against
+    `workspace.valid_name`/`persona.valid_name`, and `contain.one_line` is applied to each
+    one BEFORE it is measured or padded — #472 was filed because a table sized its columns
+    from a raw name first, and a menu row is a table one column wide. `menu._safe_label`
+    then makes it inert against tmux's own format parser, which is a different property
+    from being one line and is applied at a different boundary (see `menu.py`).
+
+    The mark is `_DENSITY_MARK`'s, reused rather than re-chosen: it is already the answer
+    to "which one am I on" everywhere else in this menu, and `*` is unambiguously narrow
+    where `●`/`◆` are East-Asian *Ambiguous* and have broken this layout twice
+    (`statusline._persona_chips`).
+
+    An empty list still gets its opener, carrying the count — `personas 0` opening an
+    empty submenu would be a row that does nothing, so the openers say what they hold and
+    the empty submenu says so in a row of its own. `cmd_menu` refuses to draw a zero-row
+    menu outright (`display-menu` fails with `not enough arguments`), so that row is what
+    stands between an empty plane and a hotkey that silently does nothing.
+    """
+    from . import contain
+    out: list = []
+    for group, names, current, verb in (
+            (menu.WORKSPACES, switch.workspaces(), switch.current_workspace(fid),
+             "workspace"),
+            (menu.PERSONAS, switch.personas(), switch.current_persona(fid), "persona")):
+        shown = names[:_MENU_LIST_MAX]
+        out.append(menu.Entry(
+            label=f"{verb}: {contain.one_line(current) if current else '—'}  ▸",
+            opens=group))
+        on, off = _DENSITY_MARK
+        for n in shown:
+            out.append(menu.Entry(
+                label=f"{on if n == current else off} {contain.one_line(n)}",
+                argv=tuple(util.self_relaunch_argv("frame-switch", f"--{verb}", n)),
+                group=group))
+        if len(names) > len(shown):
+            # A row that names no workspace and runs nothing — the same sentence-not-an-
+            # item shape `slots._cap_personas` ends its column with. It is still a real
+            # menu row (tmux has no inert one that does not desynchronise the triples —
+            # see `menu.record`), so it resolves to an argv that does nothing observable.
+            out.append(menu.Entry(label=f"  …{len(names) - len(shown)} more — "
+                                        f"charter {verb} list",
+                                 argv=("true",), group=group))
+        elif not shown:
+            out.append(menu.Entry(label=f"  no {verb}s yet", argv=("true",), group=group))
+    return out
 
 
 def _pane_identity_env(env: dict[str, str], v: tuple[int, int]) -> dict[str, str] | None:
@@ -2987,15 +3199,116 @@ def cmd_menu(args) -> int:
     refuses an empty id — so a keypress arriving with no session id would otherwise
     have gone on to build a zero-item `display-menu` call and fail loudly for no
     reason the operator could see).
+
+    **`--group` is how a SUBMENU opens (#517), and it is the same command because it is
+    the same job**: resolve the frame, resolve the presser's client, draw one of this
+    frame's recorded menus. The group arrives from a menu item's own command text, which
+    charter wrote (`menu.menu_argv`) — so it is checked against `menu.GROUPS` here anyway,
+    at the point it becomes an argument, and an unknown one is the same quiet no-op as a
+    missing client rather than an argparse exit 2 from inside a `run-shell` where nothing
+    would print the reason. Deliberately NOT `choices=` in the parser, for exactly the
+    reason `frame-density`'s own `level` is not.
+
+    That membership test is a **floor, not the guard**, and is worth saying so rather than
+    testing as if it were: `menu.build(fid, <unknown>)` is empty for any group no row
+    claims, so the empty-menu refusal beside it already answers the same way. What the
+    test buys is that `menu_argv` is never called with a group charter did not choose, so
+    the `-T charter · <group>` title cannot carry a caller's string.
     """
     fid = os.environ.get("CHARTER_SESSION_ID", "")
-    if not args.client or not menu.build(fid):
+    group = getattr(args, "group", None) or menu.MAIN
+    if not args.client or group not in menu.GROUPS or not menu.build(fid, group):
         return 0
+    # Written before the menu is drawn, so a `frame-switch` fired from it has a screen to
+    # report a refusal on — see `state.record_menu_client` for why an action's own argv
+    # cannot carry one, and what this deliberately is not.
+    state.record_menu_client(fid, args.client)
     # `tmuxctl.interact`: `display-menu` draws on an attached client and does not return
     # until the operator chooses or dismisses it, so it belongs with `attach` on the
     # no-capture, no-timeout side of `tmuxctl` — time-boxing it would close a menu for
     # the crime of being read slowly.
-    return tmuxctl.interact(menu.menu_argv(fid, SOCKET, client=args.client)).returncode
+    return tmuxctl.interact(
+        menu.menu_argv(fid, SOCKET, client=args.client, group=group)).returncode
+
+
+def cmd_switch(args) -> int:
+    """`charter frame-switch --workspace <name>` / `--persona <name>` — move THIS frame.
+
+    Fired by a hotkey-submenu selection (`_switch_entries`), and typeable by hand from
+    inside a frame. The frame is resolved from `$CHARTER_SESSION_ID` exactly as
+    `cmd_density`, `cmd_menu` and `cmd_respawn` resolve theirs, and for the same reason:
+    one bind and one action template are shared by every frame on `SOCKET`, so the frame
+    a keypress acts on is resolved at the moment it fires, never baked into a menu action.
+
+    The switch itself is `frame/switch.py`'s — this function is the tmux half and nothing
+    else: which frame, and where the answer is shown.
+
+    **Every outcome is put on the operator's screen, and that is the point of the command
+    existing at all.** #517: "a menu that silently fails against a lock is worse than no
+    menu — if a switch is refused, the frame must say so." A refusal here has no other
+    surface: this runs as a `run-shell` child of a menu selection, whose stdout tmux
+    prints INTO THE HARNESS PANE and then drops that pane into copy-mode — charter drawing
+    in the one rectangle ADR 0018 says it never draws. So the message goes through
+    `display-message`, which draws on the client's own status area and disappears on its
+    own.
+
+    **Which screen.** This command's argv cannot carry `#{client_name}` — it is run by
+    `cmd_action` through `subprocess.run` as a LIST, which tmux never parses, so a format
+    in it would be four literal characters (see `state.record_menu_client`). The presser's
+    client comes from the menu that fired this instead, recorded by `cmd_menu` an instant
+    before it drew. It matters: measured against tmux 3.7c with two real ptys attached to
+    one session, `display-message -t <session>` drew on the most recently attached client
+    regardless of who pressed, and `-c` drew on exactly the named one.
+
+    **Always 0**, like `cmd_density` and `cmd_respawn`: nothing reads this status, and a
+    non-zero exit is what makes tmux print into the harness pane.
+    """
+    fid = os.environ.get("CHARTER_SESSION_ID", "")
+    if not fid:
+        return 0
+    ws = getattr(args, "workspace", None)
+    persona_name = getattr(args, "persona", None)
+    if ws:
+        out = switch.to_workspace(fid, ws)
+    elif persona_name:
+        out = switch.to_persona(fid, persona_name)
+    else:
+        return 0
+    _say_on_screen(fid, out, state.menu_client(fid))
+    return 0
+
+
+def _say_on_screen(fid: str, out, client: str | None = None) -> None:
+    """Put one `switch.Outcome` on the frame's own screen. Best effort, never raises.
+
+    **The message is a tmux FORMAT, exactly as a menu label is.** `display-message`'s own
+    docs say so, and `menu._safe_label`'s measurement — a `#(...)` in a label runs during
+    format evaluation whether or not the thing goes on to display — applies here word for
+    word. `out.message` already carries a contained workspace or persona name
+    (`contain.one_line`, in `switch.py`), which closes the newline half; `_safe_label`
+    closes the `#` half. Both, because they are different properties: one line, and inert.
+
+    A leading `-` would make tmux read the message as a flag of its own and refuse the
+    whole command — the same measured failure `_safe_label` guards a label against — so
+    the same guard is what runs here rather than a second one that "does the same thing".
+
+    `-d 4000`: long enough to read a sentence, short enough that it is gone before the
+    operator wants the screen back. tmux's own default comes from `display-time`, which is
+    an operator's setting for THEIR messages and typically 750ms — too short for a refusal
+    that names a workspace and says what to do about it.
+    """
+    socket = state.frame_server(fid) or SOCKET
+    argv = tmuxctl.server_argv(socket, "display-message", "-d", "4000")
+    if client:
+        argv += ["-c", client]
+    else:
+        argv += ["-t", fid]
+    # One prefix for both outcomes. Every refusal `switch.py` produces already reads as
+    # one ("cannot switch: …", "no workspace 'x' — have: …"), and a second word saying so
+    # only ate columns off a status line tmux truncates without saying it did — measured
+    # against a 100-column client: `charter: refused — cannot switch: …` ran off the end.
+    tmuxctl.run("reporting a switch on screen",
+                argv + [menu._safe_label("charter: " + out.message)])
 
 
 def cmd_respawn(args) -> int:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -3260,6 +3260,9 @@ def cmd_switch(args) -> int:
     one session, `display-message -t <session>` drew on the most recently attached client
     regardless of who pressed, and `-c` drew on exactly the named one.
 
+    **The menu is re-recorded** (`_rerecord_menu`) — it is a snapshot, and one taken
+    before the switch names the workspace the frame left.
+
     **Always 0**, like `cmd_density` and `cmd_respawn`: nothing reads this status, and a
     non-zero exit is what makes tmux print into the harness pane.
     """
@@ -3274,8 +3277,45 @@ def cmd_switch(args) -> int:
         out = switch.to_persona(fid, persona_name)
     else:
         return 0
+    _rerecord_menu(fid)
     _say_on_screen(fid, out, state.menu_client(fid))
     return 0
+
+
+def _rerecord_menu(fid: str) -> None:
+    """Rewrite *fid*'s menu table so the next keypress describes the frame as it now is.
+
+    `menu.record` writes a SNAPSHOT: `_menu_entries` resolves the current workspace and
+    persona once, and every row's label and action id is minted from that. So a switch
+    that does not re-record leaves the menu naming the workspace the frame LEFT —
+    measured on a real plane before this call existed: after `switch.to_workspace(fid,
+    "ws05")` with `state.workspace_for(fid) == "ws05"`, `menu.build(fid, MAIN)` still
+    returned `workspace: ws00  ▸` and the submenu still marked `* ws00`. The panels
+    repainted; the menu lied. The same staleness is why a workspace or persona created
+    after launch never appeared in the submenu at all.
+
+    This is `cmd_density`'s own rule, applied to the command #517 is about rather than
+    only to the one beside it — same call, same operator-socket refusal, and for the same
+    reason: charter binds no key inside an operator's tmux, so there is nothing there to
+    open a menu with, and the "Detach" row `_menu_entries` grows targets `detach-client
+    -s <fid>`, a SESSION name that does not exist on that server.
+
+    The density argument is `_current_density(fid)` rather than a level passed in: this
+    command does not change the density, so the mark has to be re-derived from the frame's
+    own record or it would be re-recorded as whatever this function guessed.
+
+    **On a refusal too, and that is not an oversight.** A refused switch left the frame
+    where it was, so no mark moves — but the OTHER half of the staleness is the plane, and
+    that half moved regardless of what this frame did. A pinned frame whose operator keeps
+    pressing the hotkey is exactly the frame that would otherwise never see a workspace
+    made since launch. Guarding on `out.ok` would buy nothing back — the labels a refusal
+    re-records are identical, and `menu.record` mints every action id from position, so
+    the ids come out the same — and would cost that refresh.
+    """
+    socket = state.frame_server(fid) or SOCKET
+    if tmuxctl.is_operator_socket(socket):
+        return
+    menu.record(fid=fid, entries=_menu_entries(fid, socket, current=_current_density(fid)))
 
 
 def _say_on_screen(fid: str, out, client: str | None = None) -> None:

--- a/charter/frame/menu.py
+++ b/charter/frame/menu.py
@@ -410,9 +410,25 @@ def _key(i: int) -> str:
 
     `display-menu`'s middle argument is a KEY NAME, not a label: `"10"` is not one. Before
     submenus the menu had four fixed rows and could never reach it; a workspace list can,
-    so rows past the ninth get ``-`` — tmux's own spelling for a row with no key bound,
-    still selectable with the arrow keys. Ten rows is also where the digits run out, not
-    an arbitrary cap: continuing into letters would shadow `display-menu`'s own `q`, and
-    a menu whose tenth row silently quits it is worse than one with no shortcut there.
+    so rows past the ninth get the **empty string**, which is tmux's own spelling for a row
+    with no key bound. Ten rows is also where the digits run out, not an arbitrary cap:
+    continuing into letters would shadow `display-menu`'s own `q`, and a menu whose tenth
+    row silently quits it is worse than one with no shortcut there.
+
+    **Not ``-``, which is a real key.** Measured against tmux 3.7c on an attached pty, a
+    four-row menu keyed ``1``, ``-``, ``-``, ``""``::
+
+        ┌─probe─────┐
+        │ row-a (1) │
+        │ row-b (-) │
+        │ row-c (-) │
+        │ row-d     │
+        └───────────┘
+
+    Pressing ``-`` RAN row-b's command and closed the menu — so a stray hyphen on a
+    workspace submenu would have performed a real switch to the tenth workspace, and
+    row-c, which advertises the same ``(-)``, was unreachable by that key. The empty-key
+    row is drawn with no ``(…)`` at all and is still arrow-selectable: from the same menu,
+    three Downs and Enter fired row-d.
     """
-    return str(i + 1) if i < 9 else "-"
+    return str(i + 1) if i < 9 else ""

--- a/charter/frame/menu.py
+++ b/charter/frame/menu.py
@@ -58,8 +58,28 @@ from __future__ import annotations
 import json
 import os
 import re
+from typing import NamedTuple
 
 from . import state, tmuxctl
+
+#: The top-level menu — what `F2` opens, and what every table written before groups
+#: existed is read as. Named rather than spelled `"main"` at four call sites.
+MAIN = "main"
+
+#: The two submenus (#517). Named rather than spelled at each call site, and indexed by
+#: name rather than by position in :data:`GROUPS` — a list a future group is appended to
+#: must not silently re-point the workspace menu at the persona one.
+WORKSPACES = "workspace"
+PERSONAS = "persona"
+
+#: The closed set of menu groups, and **the only thing between a group name and tmux's own
+#: parser**: a submenu opener's command is a template with the group interpolated into it
+#: (`menu_argv`), so a group is in exactly the position `_ACTION_ID_RE` guards an action id
+#: in. These are charter's own constants — no committed value ever becomes one — and the
+#: membership test below is the guard at the join, for `_ACTION_ID_RE`'s own stated reason:
+#: a hand-edited or otherwise corrupted `actions.json` is not bound by what `record` would
+#: have written.
+GROUPS = (MAIN, WORKSPACES, PERSONAS)
 
 #: The bound on one label's length, and the reason for it: a `display-menu` row is one
 #: line, and a label long enough to wrap would corrupt the menu's own layout rather than
@@ -77,6 +97,25 @@ _MAX_LABEL = 60
 _ACTION_ID_RE = re.compile(r"^a[0-9]+$")
 
 
+class Entry(NamedTuple):
+    """One row of one menu, in the shape `record` stores and `menu_argv` renders.
+
+    Constructible from a plain tuple of two, three or four values, so every caller that
+    only ever wanted a label and an argv (`("Detach", ["true"])`) keeps working unchanged
+    — `record` normalises through ``Entry(*e)``.
+
+    ``group`` says which menu the row belongs to; ``opens`` makes the row a **submenu
+    opener** — a row that draws another group instead of running an argv. The two are
+    mutually exclusive in practice: an opener has no argv, because opening a menu is a
+    tmux command and not something `cmd_action` could run through `subprocess.run`.
+    """
+
+    label: str
+    argv: tuple = ()
+    group: str = MAIN
+    opens: str | None = None
+
+
 def _table(fid: str, *, create: bool = False):
     """Path to *fid*'s menu table, or ``None`` when `state.frame_dir` refuses *fid*.
 
@@ -90,8 +129,15 @@ def _table(fid: str, *, create: bool = False):
     return None if d is None else d / "actions.json"
 
 
-def record(*, fid: str, entries: list[tuple[str, list[str]]]) -> None:
-    """Store this frame's menu as ``{id: {label, argv}}``. The only place ids are minted.
+def record(*, fid: str, entries) -> None:
+    """Store this frame's menus as ``{id: {label, argv, group, opens}}``. The only place
+    ids are minted.
+
+    **One table, one id space, several menus.** *entries* holds every row of every group
+    (:data:`GROUPS`) in one list, and an id is minted from position across the whole of
+    it — so `resolve` and `cmd_action` never have to know which menu a selection came
+    from, and a submenu costs no second file, no second id space and no second thing that
+    can go stale against the first. `build` filters by group at read time.
 
     Ids are ``a0``, ``a1``, … — insertion order, never re-derived from the label — so
     `resolve` can answer purely from the id with no dependency on what a label happens to
@@ -123,9 +169,18 @@ def record(*, fid: str, entries: list[tuple[str, list[str]]]) -> None:
     if path is None:
         return
     data = {}
-    for i, (label, argv) in enumerate(entries):
-        clean = label.replace("\n", " ")[:_MAX_LABEL] or "(untitled)"
-        data[f"a{i}"] = {"label": clean, "argv": list(argv)}
+    for i, raw in enumerate(entries):
+        e = raw if isinstance(raw, Entry) else Entry(*raw)
+        clean = e.label.replace("\n", " ")[:_MAX_LABEL] or "(untitled)"
+        row = {"label": clean, "argv": list(e.argv)}
+        # Only written when they say something — a table with no submenus in it stays
+        # byte-for-byte what it was before groups existed, so nothing has to migrate and
+        # a frame running across the upgrade keeps the menu it already has.
+        if e.group != MAIN:
+            row["group"] = e.group
+        if e.opens:
+            row["opens"] = e.opens
+        data[f"a{i}"] = row
     tmp = path.with_name(path.name + ".tmp")
     try:
         tmp.write_text(json.dumps(data))
@@ -137,8 +192,17 @@ def record(*, fid: str, entries: list[tuple[str, list[str]]]) -> None:
         return
 
 
-def build(fid: str) -> list[tuple[str, str]]:
-    """``(label, opaque id)`` for each entry, in the order `record` stored them.
+def build(fid: str, group: str = MAIN) -> list[tuple[str, str]]:
+    """``(label, opaque id)`` for each entry of *group*, in the order `record` stored them.
+
+    Thin over :func:`rows` — the same read, dropping the two fields a caller that only
+    wants to name the rows does not need. See :func:`rows` for what is checked and why.
+    """
+    return [(e.label, action_id) for e, action_id in rows(fid, group)]
+
+
+def rows(fid: str, group: str = MAIN) -> list[tuple[Entry, str]]:
+    """``(entry, opaque id)`` for every row of *group*, in the order `record` stored them.
 
     `json.loads` rebuilds the dict in the order its keys appeared in the text, which is
     the same order `record`'s own dict comprehension wrote them in — no `sorted()` here on
@@ -158,6 +222,23 @@ def build(fid: str) -> list[tuple[str, str]]:
     of defect `_ACTION_ID_RE` exists to close for the key, applied consistently to the
     value next to it, so a corrupted label degrades the one row it belongs to rather
     than crashing the hotkey for the whole menu.
+
+    **`opens` is checked against :data:`GROUPS` here, at the join**, for exactly
+    `_ACTION_ID_RE`'s reason and not because `record` might write something else: it is
+    interpolated into tmux command text by `menu_argv`, so a corrupted table holding
+    ``"opens": "x'; run-shell \\"...\\""`` would otherwise reach that f-string untouched.
+    An unknown `opens` costs the row only its submenu, degrading it to an ordinary row,
+    because that field is decoration on a row that is otherwise complete.
+
+    **`group` is NOT checked against `GROUPS`, deliberately.** It is a filter key and
+    nothing else — it reaches no parser, no argv and no screen — so a row claiming a
+    group this charter does not have is already unreachable by the `g != group`
+    comparison below, and adding a membership test next to it would be a guard no
+    mutation could turn red: this repo's own "a guard passing because a DIFFERENT guard
+    caught it". Confirmed by mutating it out and watching the covering test stay green.
+
+    A MISSING `group` is `main`: that is every table written before groups existed, and a
+    frame running across the upgrade keeps its menu.
     """
     path = _table(fid)
     if path is None:
@@ -172,8 +253,17 @@ def build(fid: str) -> list[tuple[str, str]]:
     for k, v in data.items():
         if not isinstance(v, dict) or not _ACTION_ID_RE.fullmatch(k):
             continue
+        g = v.get("group", MAIN)
+        if g != group:
+            continue
         label = v.get("label")
-        out.append((label if isinstance(label, str) and label else "(untitled)", k))
+        opens = v.get("opens")
+        argv = v.get("argv")
+        out.append((Entry(
+            label=label if isinstance(label, str) and label else "(untitled)",
+            argv=tuple(argv) if isinstance(argv, list) else (),
+            group=g,
+            opens=opens if opens in GROUPS else None), k))
     return out
 
 
@@ -238,8 +328,26 @@ def _safe_label(label: str) -> str:
     return label
 
 
-def menu_argv(fid: str, socket: str, client: str) -> list[str]:
-    """The `display-menu` invocation for this frame. Ids only — never a name.
+def menu_argv(fid: str, socket: str, client: str, group: str = MAIN) -> list[str]:
+    """The `display-menu` invocation for one of this frame's menus. Ids only — never a name.
+
+    **A submenu is a row whose command opens another `display-menu`, and the client it
+    opens on is carried by tmux itself.** An opener's command is a second fixed template,
+    ``run-shell '"$CHARTER_PY" -m charter frame-menu #{client_name} --group <g>'`` — the
+    same shape the `F2` bind already uses (`commands_frame.conf_text`), with `<g>` taken
+    from the closed set :data:`GROUPS` and nothing else varying. Measured against tmux
+    3.7c with **two real ptys attached to one session**: `#{client_name}` inside a menu
+    item's own command expands to the client the menu was drawn on (`-c`), never to
+    whichever client tmux would otherwise call current — pressing on client A ran the
+    item with A's name, pressing on B ran it with B's, in the same session. That is the
+    property `cmd_menu`'s docstring says was NOT available from `list-clients`, and it is
+    what lets a submenu reach the presser's screen without charter storing a client
+    anywhere or guessing at one.
+
+    The opener cannot go through `frame-action` like every other row: `cmd_action` runs a
+    stored argv through `subprocess.run`, which is a list and is never seen by tmux, so a
+    `#{client_name}` in it would be four literal characters. Opening a menu is a tmux
+    command; only text tmux parses can carry the format that names the screen.
 
     `-c client` is what selects WHICH ATTACHED TERMINAL the menu is drawn on —
     `display-menu`'s own docs: "Display a menu on target-client. target-pane gives the
@@ -281,9 +389,30 @@ def menu_argv(fid: str, socket: str, client: str) -> list[str]:
     instead would put an absolute path back inside a nested tmux-quote layer, the exact
     construction the `commands_frame` module docstring bans for `status_path`.
     """
-    cmd = ["tmux", "-L", socket, "display-menu", "-t", fid, "-c", client, "-T", "charter"]
-    for i, (label, action_id) in enumerate(build(fid)):
-        cmd += [_safe_label(label), str(i + 1),
-                f'run-shell \'"${tmuxctl.CHARTER_PY_ENV}" -m charter '
-                f'frame-action {action_id}\'']
+    title = "charter" if group == MAIN else f"charter · {group}"
+    cmd = ["tmux", "-L", socket, "display-menu", "-t", fid, "-c", client, "-T", title]
+    for i, (entry, action_id) in enumerate(rows(fid, group)):
+        if entry.opens:
+            # `entry.opens` is already confined to `GROUPS` by `rows`, at the read — the
+            # same discipline `_ACTION_ID_RE` gets, and for the same reason: this is an
+            # f-string into text tmux re-parses.
+            action = (f'run-shell \'"${tmuxctl.CHARTER_PY_ENV}" -m charter '
+                      f'frame-menu #{{client_name}} --group {entry.opens}\'')
+        else:
+            action = (f'run-shell \'"${tmuxctl.CHARTER_PY_ENV}" -m charter '
+                      f'frame-action {action_id}\'')
+        cmd += [_safe_label(entry.label), _key(i), action]
     return cmd
+
+
+def _key(i: int) -> str:
+    """The one-key shortcut for row *i*, or tmux's own "no shortcut".
+
+    `display-menu`'s middle argument is a KEY NAME, not a label: `"10"` is not one. Before
+    submenus the menu had four fixed rows and could never reach it; a workspace list can,
+    so rows past the ninth get ``-`` — tmux's own spelling for a row with no key bound,
+    still selectable with the arrow keys. Ten rows is also where the digits run out, not
+    an arbitrary cap: continuing into letters would shadow `display-menu`'s own `q`, and
+    a menu whose tenth row silently quits it is worse than one with no shortcut there.
+    """
+    return str(i + 1) if i < 9 else "-"

--- a/charter/frame/picker.py
+++ b/charter/frame/picker.py
@@ -1,0 +1,191 @@
+"""Choosing a workspace before the harness starts — #518.
+
+`charter <harness>` resolved one silently and went straight into the frame; choosing
+where to work meant quitting, running `charter workspace use <name>`, and launching
+again. This is the prompt that replaces that round trip.
+
+**Where it lives, and why it is not a tmux menu.** #518 offered two homes: the
+`layout.PLACEHOLDER` moment inside the frame, or a plain terminal prompt before tmux
+takes over. This is the second, for a reason the first cannot answer: a picker must be
+able to say *no*, and cancelling inside the frame means tearing down a session, a
+harness pane and every hook that was armed for it — a launch that half happened. Before
+tmux, cancelling is a `return`. The cost is the honest one #518 names: it looks like
+charter's CLI rather than like the frame. It is charter's CLI — nothing has been drawn
+yet.
+
+**Nothing here touches the plane.** This module renders and reads; it returns a
+:class:`Choice`, and `commands_frame.cmd_launch` is what creates, switches and launches.
+That split is what makes "a cancelled picker creates nothing" a property of the code
+rather than a promise: there is no create call in this file to reach.
+
+**Input and output are injected**, not `input()` and `print()`. A picker is exactly the
+shape of test this repo keeps getting wrong — one that reads the developer's machine
+instead of the repo — and a test that has to own a tty to check that `q` cancels would
+be testing tmux, pty allocation and the terminal, none of which is the property. `read`
+returns one line or ``None`` for end-of-input; `write` takes finished text.
+
+**Names are contained before they are measured.** A workspace name is a committed value
+(#472 was filed because a table sized its columns from a raw name), so `contain.one_line`
+runs first and `tui.width` — never `len` — does the arithmetic afterwards.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, NamedTuple
+
+from .. import contain, tui
+
+#: The three things the operator can decide. ``USE`` and ``CREATE`` carry a name that has
+#: already passed `workspace.valid_name`; ``CANCEL`` carries none and means the launch
+#: must stop having done nothing at all.
+USE, CREATE, CANCEL = "use", "create", "cancel"
+
+#: How many unusable answers in a row before the picker gives up and cancels. A tty
+#: reaches end-of-input and the loop ends on ``None``; this is for the stream that
+#: neither answers nor ends, where an unbounded loop would be a hang with no message —
+#: the failure #518 says a picker must never be.
+_MAX_TRIES = 20
+
+#: Marker for the workspace the launch would have resolved on its own. `_DENSITY_MARK`'s
+#: `*` for `_DENSITY_MARK`'s reason: `●`/`◆` are East-Asian *Ambiguous* and
+#: `statusline._persona_chips` records them breaking this layout twice.
+_MARK = ("*", " ")
+
+_R, _DIM, _BOLD = "\033[0m", "\033[2m", "\033[1m"
+
+
+class Choice(NamedTuple):
+    """What the operator decided. ``name`` is empty for :data:`CANCEL`."""
+
+    action: str
+    name: str = ""
+
+
+class Row(NamedTuple):
+    """One workspace as the picker shows it: its name, and how many clones it holds.
+
+    The count is what makes the list worth reading — #512's own note on #518 is that a
+    freshly picked workspace draws an empty repo table until the first gather, so the
+    number of clones is the only thing on screen at pick time that says which of these
+    is the one with the work in it. It is one `iterdir` per workspace, paid once, before
+    tmux starts — not on any repaint path, so the idle-cost property is untouched.
+    """
+
+    name: str
+    clones: int
+
+
+def rows(names: list[str], count: Callable[[str], int]) -> list[Row]:
+    """*names* with their clone counts. ``count`` is injected so the renderer can be
+    exercised without a plane under it."""
+    return [Row(n, count(n)) for n in names]
+
+
+def render(rows_: list[Row], current: str, width: int) -> str:
+    """The list, as the operator sees it.
+
+    Two columns, sized from the CONTAINED names (see the module docstring), with the
+    whole line truncated to *width* so a plane with a very long workspace name wraps
+    nothing. `tui.pad` and `tui.truncate` do the arithmetic; `len` appears nowhere.
+    """
+    on, off = _MARK
+    shown = [(contain.one_line(r.name), r) for r in rows_]
+    name_w = max([tui.width(n) for n, _ in shown] or [0])
+    out = [f"\n  {_BOLD}charter{_R}{_DIM} · which workspace?{_R}\n"]
+    for i, (name, r) in enumerate(shown, start=1):
+        mark = on if r.name == current else off
+        repos = "—" if not r.clones else f"{r.clones} repo" + ("s" if r.clones > 1 else "")
+        line = (f"    {_DIM}{i:>2}{_R}  {mark} {tui.pad(name, name_w)}  "
+                f"{_DIM}{repos}{_R}")
+        out.append(tui.truncate(line, width))
+    out.append(f"\n    {_DIM} n{_R}    create a new workspace")
+    out.append(f"    {_DIM} q{_R}    cancel — start nothing\n\n")
+    return "\n".join(out)
+
+
+def ask(rows_: list[Row], current: str, *, read: Callable[[], str | None],
+        write: Callable[[str], None], name_ok: Callable[[str], bool],
+        width: int = 80) -> Choice:
+    """Draw the list, read one decision, and answer with it. Creates nothing.
+
+    Refusals loop back to the list rather than ending the launch: a mistyped number is a
+    mistype, not a decision, and #518's whole complaint is about being given no choice.
+    End-of-input (`read` returning ``None``) is :data:`CANCEL` — that is what a closed
+    stdin means, and it is the one answer that can never be a hang.
+
+    An empty line takes *current*, which is the row already marked. That is the "just get
+    on with it" key, and it is the same answer the launch would have given with no picker
+    at all — so an operator who does not care pays one keystroke, not a decision.
+    """
+    write(render(rows_, current, width))
+    names = [r.name for r in rows_]
+    for _ in range(_MAX_TRIES):
+        write(f"  workspace {_DIM}[{contain.one_line(current)}]{_R}: ")
+        line = read()
+        if line is None:
+            write("\n")
+            return Choice(CANCEL)
+        s = line.strip()
+        if not s:
+            return Choice(USE, current)
+        if s in ("q", "Q"):
+            return Choice(CANCEL)
+        if s in ("n", "N"):
+            got = _ask_new(names, read=read, write=write, name_ok=name_ok)
+            if got is not None:
+                return got
+            write(render(rows_, current, width))
+            continue
+        if s.isdigit() and 1 <= int(s) <= len(names):
+            return Choice(USE, names[int(s) - 1])
+        # The name itself is accepted too — an operator who knows where they are going
+        # should not have to find its row number. Checked against the LIST, never against
+        # `name_ok` alone: a shape-valid name that is not there is a typo, and creating on
+        # a typo is exactly the litter #518 refuses.
+        if s in names:
+            return Choice(USE, s)
+        write(f"  {_DIM}not one of these — a number, a name, n to create, q to cancel{_R}\n")
+    return Choice(CANCEL)
+
+
+def _ask_new(names: list[str], *, read, write, name_ok) -> Choice | None:
+    """The create branch. ``None`` means "back to the list", having created nothing.
+
+    Three gates before a :data:`CREATE` ever comes back, which is #518's "creating is not
+    free" in code:
+
+    * **empty** — the operator changed their mind at the prompt. Back to the list.
+    * **the name must pass `workspace.valid_name`** (injected as *name_ok*, so this module
+      never has to import `workspace` and the one rule stays `instance.workspace_name_ok`).
+      A refusal names the alphabet rather than only saying no.
+    * **an existing name is a USE, not a CREATE** — asking to create something that is
+      already there is not an error and must not be a second `workspace.ensure`; it is
+      the operator naming a workspace the long way round.
+
+    Then an explicit `y`. Anything else — including a bare Enter — is back to the list.
+    A default of no is the whole point: the fat-fingered path has to be the one that
+    creates nothing.
+    """
+    write(f"  new workspace name {_DIM}(letters, digits, . _ -){_R}: ")
+    raw = read()
+    if raw is None:
+        write("\n")
+        return Choice(CANCEL)
+    name = raw.strip()
+    if not name:
+        return None
+    if not name_ok(name):
+        write(f"  {_DIM}'{contain.one_line(name)}' is not a workspace name — letters and "
+              f"digits, then . _ -{_R}\n")
+        return None
+    if name in names:
+        return Choice(USE, name)
+    write(f"  create {_BOLD}{contain.one_line(name)}{_R} and switch to it? "
+          f"{_DIM}[y/N]{_R}: ")
+    ans = read()
+    if ans is None:
+        write("\n")
+        return Choice(CANCEL)
+    if ans.strip().lower() not in ("y", "yes"):
+        return None
+    return Choice(CREATE, name)

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -368,6 +368,66 @@ def frame_server(fid: str) -> str | None:
         return None
 
 
+#: What tmux calls a client: the path of the pty it is attached on (`/dev/ttys042`), or
+#: an operator's own `-c`/`client_name`. Bounded on the way back off disk for
+#: `_PANE_ID_RE`'s reason — it arrives as text and goes straight into an argv element.
+_CLIENT_RE = re.compile(r"^[A-Za-z0-9._/-]{1,128}$")
+
+
+def record_menu_client(fid: str, client: str) -> None:
+    """Write down which client this frame's menu was last drawn for.
+
+    **Only a menu SELECTION needs this, and only to say something back.** A menu item's
+    own command is text tmux parses, so it can carry `#{client_name}` and reach the
+    presser's screen by construction (`frame/menu.py` measures that against two attached
+    clients). What it cannot carry is a client into a `frame-action` argv:
+    `commands_frame.cmd_action` runs a stored LIST through `subprocess.run`, which tmux
+    never sees, so a format in it would be four literal characters. That is fine for every
+    action that only *does* something — and not fine for one that has to *report*, which
+    is what `charter frame-switch` is (#517: a switch refused in silence is worse than no
+    switch at all).
+
+    So `cmd_menu`, which is handed the presser's own client, writes it here immediately
+    before drawing, and `cmd_switch` reads it back when it has something to say.
+
+    **What this is not:** it is not an answer to "who is attached", and it is not
+    consulted for anything but a message. With two clients each opening the menu, the
+    second write wins and a message can land on the other operator's screen — narrow (it
+    needs a second menu opened between this write and the selection), cosmetic, and
+    strictly better than the alternative, which is not a guess but a measured wrong
+    answer: `display-message -t <session>` with two clients attached was confirmed against
+    tmux 3.7c to draw on the most recently attached one regardless of who pressed.
+
+    Same atomic-write, never-raise shape as :func:`record_server`.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    tmp = d / "menu-client.tmp"
+    try:
+        tmp.write_text(f"{client}\n")
+        os.replace(tmp, d / "menu-client")
+    except OSError:
+        return
+
+
+def menu_client(fid: str) -> str | None:
+    """The client *fid*'s menu was last drawn for, or ``None``.
+
+    ``None`` is a frame whose menu has never been opened, a corrupt file, and a value
+    outside :data:`_CLIENT_RE` — answered the same way, because the caller's fallback for
+    all three is the same and is safe: send the message to the frame and let tmux pick.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        val = (d / "menu-client").read_text().strip()
+    except (OSError, ValueError):
+        return None
+    return val if _CLIENT_RE.fullmatch(val) else None
+
+
 def record_workspace(fid: str, name: str) -> None:
     """Write down which workspace this frame was LAUNCHED for.
 

--- a/charter/frame/switch.py
+++ b/charter/frame/switch.py
@@ -1,0 +1,262 @@
+"""Moving a running frame to another workspace or persona — #517, and the half of #518
+that happens once a name has been chosen.
+
+One mechanism, four steps, and every surface that switches goes through it: **list the
+names, contain them, perform the switch, repaint the panels.** The hotkey menu
+(`commands_frame._menu_entries` → `cmd_switch`) and the launch picker
+(`frame/picker.py` → `cmd_launch`) are two front doors onto the same rooms.
+
+**A switch is a write to the frame's OWN identity, never a pointer somebody might read.**
+#411 is the whole reason this file is not four lines: panels followed `charter ws use`
+only through the `$CHARTER_SESSION_ID` collision, and #412 made that identity explicit on
+tmux's `-e`. `state.workspace_for` is the one rule every frame surface asks, and its rungs
+are, in order: the `$CHARTER_WORKSPACE` pin, `workspace.for_session(fid)`,
+`state.frame_workspace(fid)`, a local resolve. So a workspace switch writes rungs 1 and 2
+— the per-session pointer under the FRAME's id, and the frame's recorded workspace — and
+refuses outright when rung 0 is occupied, because nothing this process can write outranks
+a variable already sitting in a live pane's environment.
+
+**Which is exactly why the pin is a refusal and not a best effort.** A panel pane was
+started with `-e CHARTER_WORKSPACE=<pin>` (`commands_frame._frame_identity_env`); that
+value is in the pane's process environment for as long as the pane lives, and no file
+charter writes can take it out. Reporting "switched" and drawing the old workspace is the
+failure mode #411 was filed for. Reporting "this frame is pinned" is the honest one.
+
+**The session lock is overridden, deliberately, and said out loud.** `workspace.set_active`
+locks the session to what it selected, so the switcher's own first write takes the lock and
+a second switch would be refused by the switcher's own doing — a switcher that works once
+is worse than none. The lock exists so a workspace cannot be swapped out from under a
+running task; an operator pressing a key and choosing a name off a menu is not that. So
+:func:`to_workspace` forces, and :data:`Outcome.message` names the workspace the lock was
+taken for, so nothing moves without the operator being told what moved.
+
+**And nothing here writes a TERMINAL pointer**, which is #411 arriving on this command.
+Both `workspace.set_active` and `persona.set_active` normally write one, keyed on
+`$TERM_SESSION_ID`/`$TMUX_PANE`/`$STY`/`$SSH_TTY` — and in a `run-shell` child of charter's
+private tmux server those names belong to whichever launcher STARTED that server, which is
+shared between every frame on the machine and may be days old. A switch inside frame B
+would have moved the workspace of the terminal that launched frame A. Both calls below
+pass `terminal_id=""`: this process genuinely has no terminal to speak for.
+
+**Nothing here creates anything.** `charter workspace create` is a real side effect on the
+plane (#518: "a picker that creates on a typo leaves litter"), so an unknown name is a
+refusal with the existing names beside it, never an implicit create. Creating is the
+launch picker's own explicitly-confirmed step, in `commands_frame`, on a name the operator
+typed.
+
+Every name that reaches a message goes through `contain.one_line` first — a workspace or
+persona name is a committed value, and a message is a line of charter's own output that a
+newline in a name could forge a second line of (`contain.py`, #453). The tmux side of the
+same rule lives in `frame/menu.py`, which contains a label again before it reaches tmux's
+own format parser.
+
+No tmux call is made from here at all. That keeps this module testable without a server —
+`commands_frame` owns the one `display-message` that puts a refusal on screen.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from .. import contain
+from . import state
+
+
+class Outcome(NamedTuple):
+    """What a switch did, and the one line the operator is shown for it.
+
+    ``ok`` is whether the frame moved. ``message`` is always set — a refusal that says
+    nothing is the failure #517 calls "worse than no menu" — and is already contained,
+    so a caller may put it straight into a line of its own output.
+    """
+
+    ok: bool
+    message: str
+
+
+def workspaces() -> list[str]:
+    """Every workspace a switcher may offer, name-checked on the way out.
+
+    `workspace.list_workspaces` reads directory names off the plane, so the check is the
+    same floor `state.frame_workspace` applies to its own read: these names go on to a
+    `workspace_dir()` join and onto a tmux menu, and #442 is what an unchecked one in that
+    position already cost. `config.DEFAULT_WORKSPACE` is folded in whether or not its
+    directory exists yet, matching `commands_workspace.cmd_workspace_use` — it is
+    documented as the always-present workspace and `workspace.ensure` makes it on demand,
+    and a fresh plane that has never made one would otherwise offer an empty list.
+    """
+    from .. import config, workspace as ws_mod
+    names = [n for n in ws_mod.list_workspaces() if ws_mod.valid_name(n)]
+    if config.DEFAULT_WORKSPACE not in names:
+        names.append(config.DEFAULT_WORKSPACE)
+    return sorted(names)
+
+
+def personas() -> list[str]:
+    """Every persona a switcher may offer, name-checked on the way out.
+
+    Same reasoning as :func:`workspaces`, one noun over — `persona.list_personas` globs
+    the plane's `personas/` directory, and `persona.valid_name` is the rule
+    `persona.dir_of`'s own join depends on. No fold-in here: there is no always-present
+    persona, and "no personas" is a real and ordinary answer for a plane that has none.
+    """
+    from .. import persona as p_mod
+    return sorted(n for n in p_mod.list_personas() if p_mod.valid_name(n))
+
+
+#: How many names an "I do not have that one, here is what I have" message lists. A
+#: refusal is drawn on a status line — one row, and tmux truncates what does not fit
+#: without saying it did — so the message is kept short BY CONSTRUCTION rather than left
+#: to be cut off mid-name. Rendered against a 100-column client and read back: the
+#: longest message this file can produce fits.
+_SOME = 5
+
+
+def _some(names: list[str]) -> str:
+    """*names*, contained, capped at :data:`_SOME`, saying how many were left out."""
+    shown = [contain.one_line(n) for n in names[:_SOME]]
+    if len(names) > len(shown):
+        shown.append(f"…{len(names) - len(shown)} more")
+    return ", ".join(shown) if shown else "none"
+
+
+def _pin(fid: str, name: str) -> str | None:
+    """The value *fid* was LAUNCHED with for environment variable *name*, if it is a
+    usable one — the rung nothing this module writes can outrank.
+
+    Read from `state.identity`, which the launcher wrote, never from `os.environ`: this
+    runs as a `run-shell` child of charter's private tmux server, which is shared between
+    every frame on the machine, so this process's own `$CHARTER_WORKSPACE` may be another
+    frame's (`state.record_identity` measures exactly that). Empty is what
+    `_frame_identity_env` emits for a name the launch did not have, and empty is what
+    every charter reader already treats as absent — so an empty value is not a pin.
+    """
+    val = state.identity(fid).get(name, "").strip()
+    return val or None
+
+
+def to_workspace(fid: str, name: str) -> Outcome:
+    """Move frame *fid* to workspace *name*, or say why it did not.
+
+    Refusals, in the order they are checked, and each of them is a thing the operator can
+    act on:
+
+    * **not a workspace name** — `workspace.valid_name`, the one rule
+      (`instance.workspace_name_ok`). A name off a menu charter built cannot fail this;
+      one typed at `charter frame-switch` can.
+    * **no such workspace** — an unknown name is a question, never an implicit create
+      (see the module docstring). The existing names go in the message, which is the same
+      shape `charter workspace use` already answers an unknown name with.
+    * **pinned** — `$CHARTER_WORKSPACE` was set at launch, so it is in every panel pane's
+      environment and outranks anything written here. See the module docstring.
+
+    On success: the per-session pointer under the frame's id
+    (`workspace.set_active(..., session_id=fid)`, rung 1 of `state.workspace_for`), the
+    frame's recorded workspace (`state.record_workspace`, rung 2 — so a panel respawned
+    later, and `commands_frame._relayout_pane_env`, agree with the panels that are up),
+    then the gather cache, then the bump.
+
+    **The cache is refreshed before the bump, not after** — `frame/notify.py` settles the
+    same ordering for the same reason: a panel's poll loop reads the version first and the
+    cache second, so bumping first opens a window where a panel repaints the new
+    workspace's name over the old workspace's repo table. This is a keypress, not a tick,
+    so it does not touch the idle-cost property
+    (`test_an_idle_tick_costs_exactly_one_stat_and_nothing_else`) — nothing here runs per
+    repaint.
+
+    `state.identity` is deliberately NOT rewritten. It records what the LAUNCH put on
+    tmux's `-e`, and `_relayout_pane_env` replays it onto panes split later; an empty
+    `CHARTER_WORKSPACE` there means "resolve locally", which lands on the pointer this
+    just wrote. Writing the new name into it would pin the frame — taking `charter
+    workspace use` away from the agent inside it, which `state.record_workspace`'s own
+    docstring rules out in as many words.
+    """
+    from .. import workspace as ws_mod
+    from . import gather
+    shown = contain.one_line(name)
+    if not ws_mod.valid_name(name):
+        return Outcome(False, f"'{shown}' cannot name a workspace")
+    known = workspaces()
+    if name not in known:
+        return Outcome(False, f"no workspace '{shown}' — have: {_some(known)}")
+    pinned = _pin(fid, "CHARTER_WORKSPACE")
+    if pinned:
+        return Outcome(False, "cannot switch: $CHARTER_WORKSPACE pins this frame to "
+                              f"'{contain.one_line(pinned)}'")
+    # `force=True`: see the module docstring. The lock is reported whether or not it was
+    # this switcher's own earlier write that took it, because the operator cannot tell
+    # those apart from the outside and the one that matters — an agent's `charter
+    # workspace use` mid-task — looks identical.
+    was = ws_mod.is_locked(fid)
+    ws_mod.set_active(name, session_id=fid, force=True, terminal_id="")
+    state.record_workspace(fid, name)
+    gather.refresh(fid, workspace=name)
+    state.bump(fid)
+    if was and was != name:
+        return Outcome(True, f"workspace → {shown}  "
+                             f"(lock moved from '{contain.one_line(was)}')")
+    return Outcome(True, f"workspace → {shown}")
+
+
+def to_persona(fid: str, name: str) -> Outcome:
+    """Adopt persona *name* in frame *fid*, or say why it did not.
+
+    The same three refusals as :func:`to_workspace`, one noun over — `persona.valid_name`,
+    an unknown name, and a `$CHARTER_PERSONA` pin carried from the launch. There is no
+    lock: personas have never had one (`persona.set_active` writes and returns a reach),
+    so nothing is forced and nothing is overridden.
+
+    `session_id=fid` is stated rather than inherited, for `_pin`'s reason: this runs as a
+    child of a tmux server shared between frames, and `session.current()` would answer
+    from an environment that is not reliably this frame's. It is what makes every panel
+    see the change — `statusline._persona_chip_cells` asks `persona.resolve_active`, whose
+    session rung is keyed on `$CHARTER_SESSION_ID`, which inside a frame is the frame's id
+    (ADR 0019).
+
+    No gather refresh: the gather cache holds repos, and a persona does not change which
+    repos a workspace has. The bump alone is what repaints.
+    """
+    from .. import persona as p_mod
+    shown = contain.one_line(name)
+    if not p_mod.valid_name(name):
+        return Outcome(False, f"'{shown}' cannot name a persona")
+    known = personas()
+    if name not in known:
+        return Outcome(False, f"no persona '{shown}' — have: {_some(known)}")
+    pinned = _pin(fid, "CHARTER_PERSONA")
+    if pinned:
+        return Outcome(False, "cannot switch: $CHARTER_PERSONA pins this frame to "
+                              f"'{contain.one_line(pinned)}'")
+    p_mod.set_active(name, session_id=fid, terminal_id="")
+    state.bump(fid)
+    return Outcome(True, f"persona → {shown}")
+
+
+def current_workspace(fid: str) -> str:
+    """What the frame is drawing right now — `state.workspace_for`, named here so a menu
+    and the switcher cannot come to disagree about which name gets the mark."""
+    return state.workspace_for(fid)
+
+
+def current_persona(fid: str) -> str | None:
+    """The persona the frame is drawing right now, or ``None``.
+
+    Asked with the frame's id rather than from the ambient environment, for `_pin`'s
+    reason — and through the frame's own recorded pin first, so a menu built by a
+    `run-shell` child marks the row the PANELS are showing rather than the row this
+    process would resolve for itself off a shared server's environment. `resolve_active`
+    is deliberately not called: its top rung is `$CHARTER_PERSONA` out of *this* process,
+    which is exactly the value that belongs to another frame.
+
+    The rungs are the ones a PANEL reaches, in a panel's order: the pin the launch carried
+    on `-e`, the per-session pointer under the frame's id, then the plane-wide defaults.
+    `config.ACTIVE_PERSONA_FILE` is skipped because `persona.set_active` writes it only
+    when there is neither a session id nor a pane id — inside a frame there is always a
+    session id (the frame's), so it is a rung a framed plane does not have.
+    """
+    from .. import persona as p_mod
+    pinned = _pin(fid, "CHARTER_PERSONA")
+    if pinned:
+        return pinned if p_mod.valid_name(pinned) else None
+    val = p_mod.for_session(fid) or p_mod.declared_default() or p_mod.default_persona()
+    return val if val and p_mod.valid_name(val) else None

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -757,7 +757,8 @@ def declared_default() -> str | None:
     return val if val and reference_ok(val) and def_path(val).exists() else None
 
 
-def _pointer_files() -> tuple[Path | None, Path | None]:
+def _pointer_files(session_id: str | None = None,
+                   terminal_id: str | None = None) -> tuple[Path | None, Path | None]:
     """``(session pointer, terminal pointer)`` for right now — either may be ``None``.
 
     Mirrors workspaces exactly (``.charter/sessions/<id>.workspace`` and
@@ -765,10 +766,23 @@ def _pointer_files() -> tuple[Path | None, Path | None]:
     one, one noun over: a single plane-wide file meant `charter persona use forge` in one
     pane changed the persona in every other pane and every future session, which is the
     opposite of what a fleet of parallel personas is for (#255).
+
+    ``session_id`` names *whose* session pointer, for the same reason
+    `workspace.set_active` takes one: the process writing is not always the session being
+    written for. A frame's persona switcher (`frame/switch.py`) is the case — it runs as a
+    `run-shell` child of the tmux server and must write under the FRAME's id, which it was
+    handed, rather than under whatever `$CHARTER_SESSION_ID` that child happens to have
+    inherited from a server shared with every other frame on the machine (#411).
+
+    ``terminal_id=""`` says the same thing about the TERMINAL pointer, and is the half
+    that matters more: `session.terminal()` reads `$TERM_SESSION_ID`/`$TMUX_PANE`/`$STY`/
+    `$SSH_TTY`, and in that same `run-shell` child those belong to whichever launcher
+    started the shared server. Writing a persona pointer for THAT terminal would change
+    the persona in a terminal nobody touched. See `workspace.set_active`'s own note.
     """
     from . import session as _session
-    sid = _session.current()
-    tid = _session.terminal()
+    sid = _session.current(session_id)
+    tid = _session.terminal() if terminal_id is None else terminal_id
     return (config.SESSIONS_DIR / f"{sid}.persona" if sid else None,
             config.TERMINALS_DIR / f"{tid}.persona" if tid else None)
 
@@ -780,6 +794,23 @@ def _read_pointer(f: Path | None) -> str | None:
         return f.read_text().strip() or None
     except OSError:
         return None
+
+
+def for_session(sid: str) -> str | None:
+    """The persona explicitly chosen FOR *sid*, or ``None`` if nobody chose one.
+
+    The per-session rung of :func:`_resolved`, asked about a session that is not
+    necessarily this process's — the exact counterpart of `workspace.for_session`, and
+    public for the same reason. A frame's menu (`frame/switch.py`) has to mark the persona
+    the PANELS are showing, and it runs as a `run-shell` child of a tmux server shared
+    between every frame on the machine, so reading the rung out of its own environment
+    would answer for whichever frame started that server (#411).
+
+    Name-checked on the way out, like `workspace.for_session`: the value ends up in
+    :func:`dir_of`'s join and on a panel's screen.
+    """
+    val = _read_pointer(config.SESSIONS_DIR / f"{sid}.persona") if sid else None
+    return val if val and valid_name(val) else None
 
 
 def _resolved(explicit: str | None = None) -> tuple[str | None, str]:
@@ -827,16 +858,22 @@ def source(explicit: str | None = None) -> str:
     return _resolved(explicit)[1]
 
 
-def set_active(name: str) -> str:
+def set_active(name: str, session_id: str | None = None,
+               terminal_id: str | None = None) -> str:
     """Select *name* for this session and this pane. Returns the reach of what was written
     (``session`` | ``terminal`` | ``plane``) so a caller can say how long it will last.
 
     The plane-wide file is written only when there is neither a session id nor a pane id —
     a bare shell with nothing to key on. That is the one case where it is still the right
     answer, and it is why the file is kept rather than removed.
+
+    ``session_id`` and ``terminal_id`` state which session and which terminal are being
+    selected for, rather than letting :func:`charter.session` read them out of the
+    environment — see :func:`_pointer_files` for the case that needs it. Ordinary callers
+    (`charter persona use`) leave both unset and get exactly today's behaviour.
     """
     config.private_mkdir(config.STATE_DIR)
-    sf, tf = _pointer_files()
+    sf, tf = _pointer_files(session_id, terminal_id)
     for f in (sf, tf):
         if f is not None:
             config.private_mkdir(f.parent)

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -299,6 +299,39 @@ def resolve(explicit: str | None = None, session_id: str | None = None,
     Code runs the hook and passes the session's directory in the payload, so a renderer
     reading ``os.getcwd()`` would answer for the hook. Callers that ARE the session — every
     CLI command — leave it unset and get the process cwd, which is the same fact.
+
+    The whole ladder lives in :func:`chosen`; this is that answer with the built-in
+    fallback underneath it. Two functions, one ladder — see :func:`chosen` for why the
+    difference between them is the question #518 is about.
+    """
+    return chosen(explicit, session_id, cwd) or config.DEFAULT_WORKSPACE
+
+
+def chosen(explicit: str | None = None, session_id: str | None = None,
+           cwd=None) -> str | None:
+    """The workspace something actually **chose**, or ``None`` when nothing did.
+
+    :func:`resolve`'s ladder, minus its last rung. ``None`` means every rung came back
+    empty and `resolve` is about to answer :data:`config.DEFAULT_WORKSPACE` — which is not
+    a decision anybody made, it is the name charter falls back to when there is nothing to
+    read. That difference is the whole of #518: `charter <harness>` "resolves a workspace
+    silently", and the launch worth interrupting with a picker is exactly the one where
+    nobody had chosen.
+
+    **One ladder, asked twice — not two ladders that agree today.** `resolve` used to walk
+    the rungs itself and this function would have been a second walker; that is the shape
+    this module already warns about in :func:`valid_name` (one rule, two copies, and the
+    reading site and the deciding site drift apart). A rung added here reaches `resolve`
+    for free, and a picker that fired on a launch `resolve` had an answer for would be a
+    prompt in front of a decision already made.
+
+    :func:`source` remains a third walker: it answers a different question (a human label
+    for a status line, including *why* nothing chose), and folding it in here would make
+    this return a sentence. Its rungs must mirror these — that was already true before
+    this split and is unchanged by it.
+
+    ``declared_default()`` counts as a choice: somebody nominated it (#193). The built-in
+    below it does not, and that is the one rung this function drops.
     """
     if explicit:
         return explicit
@@ -327,7 +360,7 @@ def resolve(explicit: str | None = None, session_id: str | None = None,
     declared = declared_default()
     if declared:
         return declared
-    return config.DEFAULT_WORKSPACE
+    return None
 
 
 def source(explicit: str | None = None, session_id: str | None = None,
@@ -414,7 +447,8 @@ def unlock(session_id: str | None = None) -> bool:
     return False
 
 
-def set_active(name: str, session_id: str | None = None, force: bool = False) -> str:
+def set_active(name: str, session_id: str | None = None, force: bool = False,
+               terminal_id: str | None = None) -> str:
     """Select ``name`` for THIS pane/session only, and **lock** the session to it.
 
     Writes a **per-terminal** pointer (keyed by a stable terminal id, so the pane
@@ -426,13 +460,24 @@ def set_active(name: str, session_id: str | None = None, force: bool = False) ->
     the switch is refused and ``"locked"`` is returned (nothing is written) — unless
     ``force=True``. Confirming a workspace locks the session to it, so the workspace
     can't be swapped out from under a running task. Returns the scope
-    (``session`` | ``terminal`` | ``none``) on success, or ``"locked"`` when refused."""
+    (``session`` | ``terminal`` | ``none``) on success, or ``"locked"`` when refused.
+
+    **``terminal_id=""`` writes no terminal pointer, and that is not a micro-option — it
+    closes #411 one caller over.** A frame's own switcher (`frame/switch.py`) runs as a
+    ``run-shell`` child of charter's private tmux server, and that server is SHARED: its
+    environment belongs to whichever launcher happened to start it, possibly days ago, in
+    another terminal. :func:`_terminal_id` reads `$TERM_SESSION_ID`/`$TMUX_PANE`/`$STY`/
+    `$SSH_TTY` out of that environment, so a switch inside frame B would otherwise write
+    the pointer for the terminal that launched frame A — moving a workspace in a terminal
+    nobody touched. Passing the empty string says "this process has no terminal to speak
+    for", which is the truth there. ``None`` (the default) keeps today's behaviour for
+    every ordinary caller: `charter workspace use` IS the terminal it is typed in."""
     locked = is_locked(session_id)
     if locked and locked != name and not force:
         _trace("workspace-refused", session_id, workspace=name, locked_to=locked)
         return "locked"
     config.private_mkdir(config.STATE_DIR)
-    tid = _terminal_id()
+    tid = _terminal_id() if terminal_id is None else terminal_id
     if tid:
         config.private_mkdir(config.TERMINALS_DIR)
         _terminal_file(tid).write_text(name + "\n")

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -14,10 +14,11 @@ for a command charter has no launcher for at all. That is not just naming: once 
 frame` is on the command line, everything after it is grafted onto the harness's own argv
 verbatim, before charter's own argument parser ever sees it, so `frame claude -p hi` would
 hand `claude -p hi` to the `frame --` mechanism rather than route anywhere. The same reason
-keeps `frame-menu`, `frame-action`, `frame-density`, `frame-resize` and `frame-probe` —
-the command tmux's hotkey calls back into, the one every menu action calls back into, the
-one the density entries run, the one the `window-resized` hook calls back into, and the
-read-only probe — as top-level names rather than nested under `frame` too.
+keeps `frame-menu`, `frame-action`, `frame-density`, `frame-switch`, `frame-resize` and
+`frame-probe` — the command tmux's hotkey calls back into, the one every menu action calls
+back into, the one the density entries run, the one the workspace and persona entries run,
+the one the `window-resized` hook calls back into, and the read-only probe — as top-level
+names rather than nested under `frame` too.
 
 ## What it needs
 
@@ -495,8 +496,81 @@ resolved settings charter's own code reads back use an underscore
 is silently not recognized — the hyphenated spelling above is the one that is read.
 
 The hotkey (`F2` by default) opens a small menu on whichever frame you are attached to —
-"Detach", and the three density levels. It exists only on charter's own server; inside a
-tmux you already have, charter binds no key at all (see above). However you detach — that
-entry, or tmux's own prefix key — charter notices the session is still running and prints
-how to get back in (`tmux -L charter attach -t <frame-id>`) rather than leaving you to
-remember the flags.
+"Detach", the three density levels, and two submenus: the plane's workspaces and its
+personas, each marking the one the frame is drawing. It exists only on charter's own
+server; inside a tmux you already have, charter binds no key at all (see above). However
+you detach — that entry, or tmux's own prefix key — charter notices the session is still
+running and prints how to get back in (`tmux -L charter attach -t <frame-id>`) rather than
+leaving you to remember the flags.
+
+```
+┌─charter───────────────────────────┐        ┌─charter · workspace───┐
+│ Detach                        (1) │        │   default         (1) │
+│   density: minimal            (2) │        │ * harness-wrapper (2) │
+│ * density: normal             (3) │   ▸    │   release-0-54    (3) │
+│   density: full               (4) │        │   user-reporting  (4) │
+│ workspace: harness-wrapper  ▸ (5) │        └───────────────────────┘
+│ persona: forge  ▸             (6) │
+└───────────────────────────────────┘
+```
+
+**Switching from the menu moves the frame, and says so.** Choosing a workspace writes the
+choice under the frame's own id — the same pointer `charter workspace use` writes from
+inside the frame, which is what makes the panels follow — records it as the frame's
+workspace, re-gathers the repo table for it, and bumps the frame so every panel repaints
+against the new plane. A persona switch is the same minus the gather. Either way a
+one-line message lands on your own screen saying what happened.
+
+**Two switches are refused, and both say why on that same line.** A frame launched with
+`$CHARTER_WORKSPACE` (or `$CHARTER_PERSONA`) set is *pinned*: that variable is in every
+panel pane's environment for as long as the pane lives, and nothing charter can write
+outranks it — so the menu says `cannot switch: $CHARTER_WORKSPACE pins this frame to
+'<name>'` rather than reporting a move that would not happen. A name that is not there is
+refused with the names that are; the menu never creates a workspace.
+
+**The session lock moves with you.** `charter workspace use` locks the session to what it
+selected so a workspace cannot be swapped out from under a running task — but a keypress
+on a menu *is* you, and the switcher's own first write would otherwise take a lock that
+its second write hit, leaving a switcher that worked exactly once. So the menu overrides
+the lock and names what it overrode: `workspace → beta  (lock moved from 'alpha')`.
+
+Long lists are cut to twelve rows with a last row saying how many were left out — a tmux
+menu is drawn inside your terminal and does not scroll. Rows past the ninth have no
+number key; the arrow keys still reach them.
+
+### Picking a workspace when the frame opens
+
+`charter <harness>` used to resolve a workspace silently and go straight in. If **nothing
+chose one** — no `--workspace`, no `$CHARTER_WORKSPACE`, not standing in a workspace tree,
+no per-session or per-terminal pointer, no declared default — it now asks first:
+
+```
+  charter · which workspace?
+
+     1  * default          —
+     2    harness-wrapper  7 repos
+     3    user-reporting   1 repo
+
+     n    create a new workspace
+     q    cancel — start nothing
+
+  workspace [default]:
+```
+
+A number, a name, or Enter for the marked one. `n` prompts for a name, checks it against
+the workspace alphabet, and asks `create <name> and switch to it? [y/N]` — anything but a
+`y` goes back to the list, and a cancelled picker creates nothing at all. `q`, Ctrl-C or a
+closed stdin end the launch having started nothing; the exit code is 130.
+
+**Picking is the confirmation that locks.** That is what selecting a workspace has always
+meant — `charter workspace use` locks the session to what it selected — and the launch
+says so on the line after your answer. The frame has its own way out: `F2 → workspace`
+overrides the lock and tells you it did, so a choice made at the prompt does not send you
+back to a shell to change it.
+
+**It never asks twice, and it never asks a script.** Your choice is written as the
+terminal's own pointer, so the next launch from that terminal has an answer and goes
+straight in. And the prompt is reached only on the interactive path: `--no-frame`, a
+redirected stdout and a stdin that is not a terminal each return before it — `charter
+claude` from a script or another agent cannot block on it. `--workspace <name>` names one
+outright and skips the picker; `--pick` asks even when something already chose.

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -535,8 +535,8 @@ its second write hit, leaving a switcher that worked exactly once. So the menu o
 the lock and names what it overrode: `workspace → beta  (lock moved from 'alpha')`.
 
 Long lists are cut to twelve rows with a last row saying how many were left out — a tmux
-menu is drawn inside your terminal and does not scroll. Rows past the ninth have no
-number key; the arrow keys still reach them.
+menu is drawn inside your terminal and does not scroll. Rows past the ninth are drawn with
+no key at all — the digits run out at nine — and the arrow keys still reach them.
 
 ### Picking a workspace when the frame opens
 

--- a/docs/news/unreleased-switch-and-pick-a-workspace.md
+++ b/docs/news/unreleased-switch-and-pick-a-workspace.md
@@ -1,0 +1,114 @@
+---
+version: unreleased
+headline: Switch workspace and persona from inside the frame, and pick one before it opens
+---
+
+Two round trips are gone. Changing workspace meant quitting the frame, running `charter
+workspace use <name>`, and launching again; choosing where to work at all meant knowing
+before you typed `charter claude`, because the launcher resolved a workspace silently and
+went straight in.
+
+**`F2` now lists them.** The menu the hotkey already opened — "Detach", and the three
+density levels — has two more rows, each opening a submenu:
+
+```
+┌─charter───────────────────────────┐        ┌─charter · workspace───┐
+│ Detach                        (1) │        │   default         (1) │
+│   density: minimal            (2) │        │ * harness-wrapper (2) │
+│ * density: normal             (3) │   ▸    │   release-0-54    (3) │
+│   density: full               (4) │        │   user-reporting  (4) │
+│ workspace: harness-wrapper  ▸ (5) │        └───────────────────────┘
+│ persona: forge  ▸             (6) │
+└───────────────────────────────────┘
+```
+
+Submenus rather than two more keys, deliberately: a tmux key table is server-wide with no
+per-session form, so a second and third `bind` would cost every frame on the machine two
+more keys and still give you nothing inside a tmux of your own, where charter binds no key
+at all. One hotkey, already paid for.
+
+**Choosing one moves the frame, not a file something might read.** A workspace switch
+writes the choice under the frame's own id — the same pointer `charter workspace use`
+writes from inside the frame, which is what has always made the panels follow — records it
+as the frame's workspace so a panel respawned later agrees with the ones already up,
+re-gathers the repo table for the new workspace, and *then* bumps the frame so every panel
+repaints. The gather happens before the bump on purpose: a panel reads the version first
+and the cache second, so bumping first would repaint the new workspace's name over the old
+workspace's repos. A persona switch is the same thing minus the gather.
+
+**Two switches are refused, and a refusal is put on your screen.** A frame launched with
+`$CHARTER_WORKSPACE` or `$CHARTER_PERSONA` set is *pinned*: the variable is in every panel
+pane's environment for as long as the pane lives, and no file charter writes outranks it.
+Reporting "switched" and then drawing the pin would be the worse outcome, so the menu says
+`cannot switch: $CHARTER_WORKSPACE pins this frame to '<name>'` instead. A name that is
+not there is refused with the ones that are — the menu never creates a workspace. Both
+land as a one-line tmux message on the screen of whoever pressed the key, which matters
+with two terminals attached to one frame: a message sent without naming a client was
+measured landing on the most recently attached one regardless of who asked.
+
+**The session lock moves with you rather than locking you out.** `charter workspace use`
+locks a session to what it selected so a workspace cannot be swapped out from under a
+running task. But a keypress on a menu *is* you — and the switcher's own first write would
+otherwise take a lock that its second write hit, leaving a switcher that worked exactly
+once. So the menu overrides the lock and names what it overrode:
+`workspace → beta  (lock moved from 'alpha')`. Nothing moves without you being told what
+moved.
+
+## And a picker at launch
+
+If **nothing chose a workspace** — no `--workspace`, no `$CHARTER_WORKSPACE`, not standing
+in a workspace tree, no per-session or per-terminal pointer, no declared default — the
+launch was about to answer `default`, a name nobody picked. It asks now:
+
+```
+  charter · which workspace?
+
+     1  * default          —
+     2    harness-wrapper  7 repos
+     3    user-reporting   1 repo
+
+     n    create a new workspace
+     q    cancel — start nothing
+
+  workspace [default]:
+```
+
+A number, a name, or Enter for the marked one. The clone count is there because the repo
+table is empty until the first gather lands, so at pick time it is the only thing on
+screen that tells two workspaces apart.
+
+`n` prompts for a name, checks it against the workspace alphabet, and asks
+`create <name> and switch to it? [y/N]`. Anything but a `y` goes back to the list. A typo
+creates nothing, a cancelled picker creates nothing, and naming a workspace that already
+exists selects it rather than making a second one — creating is a real side effect on your
+plane and the fat-fingered path had to be the one that does not take it.
+
+`q`, Ctrl-C, or a closed stdin end the launch having started nothing, with exit code 130.
+Not 0: a script that ran `charter claude` and got 0 back would read a frame that never
+started as one that ran and exited cleanly.
+
+**Picking is the confirmation that locks**, because that is what choosing a workspace has
+always meant — and the launch says so on the line after your answer rather than leaving
+you to find out at the next `charter workspace use`. What makes it liveable is that the
+frame has its own way out: `F2 → workspace` overrides the lock and tells you it did, so a
+choice you just made at a prompt does not send you back to a shell to change it.
+
+**It does not ask twice, and it cannot ask a script.** What you pick is written as your
+terminal's own pointer, so the next launch from that terminal has an answer and goes
+straight in — you answer once, not every launch. And the prompt sits below every
+non-interactive exit charter already had: `--no-frame`, a redirected stdout, and now a
+stdin that is not a terminal each return before it, so `charter claude` run from a script
+or by another agent cannot block on a question nobody is there to answer.
+
+## New flags
+
+`charter <harness> --workspace <name>` runs in that workspace and skips the picker — the
+top rung of charter's own precedence, said on the command line. `--pick` asks even when
+something already chose, for the launch where you want to move and a pointer says
+otherwise. A pin still outranks both: `$CHARTER_WORKSPACE` cannot be moved from inside the
+frame either, so offering a choice that could not take effect would be worse than not
+offering one.
+
+Nothing to adopt — upgrading is the whole of it. Inside a tmux you already have, charter
+still binds no key, so there is no menu there; `charter frame-switch --workspace <name>`
+and `--persona <name>` do the same job typed by hand from inside the frame.

--- a/docs/news/unreleased-switch-and-pick-a-workspace.md
+++ b/docs/news/unreleased-switch-and-pick-a-workspace.md
@@ -36,6 +36,18 @@ repaints. The gather happens before the bump on purpose: a panel reads the versi
 and the cache second, so bumping first would repaint the new workspace's name over the old
 workspace's repos. A persona switch is the same thing minus the gather.
 
+**And the menu follows.** It is rebuilt after every switch, so the next `F2` names the
+workspace you are in rather than the one you left, the `*` sits on the row you chose, and
+a workspace or persona made since the frame opened is in the list. The menu is rebuilt
+after a *refused* switch too — the frame did not move, but your plane may have, and a
+pinned frame is the one that would otherwise never see a new name.
+
+**Rows past the ninth are drawn with no shortcut**, and that is now literally true. They
+used to be given the key `-`, on the belief that tmux spells "no key" that way. It does
+not: `-` is a real key, and on a list long enough to reach the tenth row a stray hyphen
+performed a real workspace switch while every row under it advertised a `(-)` that did
+nothing. Ten rows is where the digits run out; the arrow keys reach the rest.
+
 **Two switches are refused, and a refusal is put on your screen.** A frame launched with
 `$CHARTER_WORKSPACE` or `$CHARTER_PERSONA` set is *pinned*: the variable is in every panel
 pane's environment for as long as the pane lives, and no file charter writes outranks it.

--- a/tests/test_frame_switch.py
+++ b/tests/test_frame_switch.py
@@ -321,7 +321,13 @@ class MenuGroups(PersonaIso, unittest.TestCase):
     def test_the_tenth_row_gets_no_key_rather_than_an_impossible_one(self):
         """`display-menu`'s middle argument is a KEY NAME: `"10"` is not one. Before
         submenus the menu had four fixed rows and could never reach it; a workspace list
-        can."""
+        can.
+
+        The no-key spelling is the EMPTY STRING and the constant is pinned here because
+        the obvious-looking `-` is a real tmux key: measured against 3.7c on an attached
+        pty, a row keyed `-` renders as `(-)` and pressing `-` ran its command. On a
+        workspace submenu that is a stray keystroke performing a real switch (see
+        `menu._key`)."""
         menu.record(fid=self.FID, entries=[(f"row {i}", ["true"]) for i in range(11)])
         argv = menu.menu_argv(self.FID, "charter", client="/dev/ttys0")
         # The triples begin after `tmux -L <sock> display-menu -t <fid> -c <client> -T
@@ -329,7 +335,8 @@ class MenuGroups(PersonaIso, unittest.TestCase):
         # word, since the socket and the title are both spelled "charter".
         keys = argv[10:][1::3]
         self.assertEqual(keys[:9], [str(i) for i in range(1, 10)])
-        self.assertEqual(keys[9:], ["-", "-"])
+        self.assertEqual(keys[9:], ["", ""])
+        self.assertNotIn("-", keys)
 
 
 class TheMenuOffersBothLists(PersonaIso, unittest.TestCase):
@@ -378,6 +385,98 @@ class TheMenuOffersBothLists(PersonaIso, unittest.TestCase):
                                return_value=["alpha", "line break"]):
             rows = self._labels("workspace")
         self.assertTrue(all(" " not in r for r in rows), rows)
+
+
+class TheMenuFollowsTheSwitch(PersonaIso, unittest.TestCase):
+    """`cmd_switch` re-records the menu, so the next keypress describes the frame as it
+    now is rather than as it was when it launched.
+
+    `menu.record` writes a snapshot — `_menu_entries` resolves the current workspace and
+    persona once, and every label is minted from that — so without this the F2 menu keeps
+    naming the workspace the frame LEFT, and a workspace made after launch never appears
+    in the submenu at all. It is `cmd_density`'s own rule ("re-recorded so the menu's own
+    mark moves with the frame"), applied to the command #517 is about.
+    """
+
+    FID = "f-menu-follows"
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID},
+                                          clear=True))
+        # No screen to report on in a test: `_say_on_screen` is the tmux half and is
+        # covered by its own cases. What is under test is what the menu table holds after.
+        self.said = self.enterContext(mock.patch.object(commands_frame, "_say_on_screen"))
+        _plane_workspaces("alpha", "beta")
+        _plane_personas("forge", "scribe")
+        state.frame_dir(self.FID, create=True)
+        state.record_identity(self.FID, {"CHARTER_SESSION_ID": self.FID,
+                                         "CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
+        state.record_workspace(self.FID, "alpha")
+        menu.record(fid=self.FID,
+                    entries=commands_frame._menu_entries(self.FID, "charter",
+                                                         current="normal"))
+
+    def _labels(self, group):
+        return [lbl for lbl, _ in menu.build(self.FID, group)]
+
+    def _switch(self, **kw):
+        return commands_frame.cmd_switch(mock.Mock(**{"workspace": None, "persona": None,
+                                                      **kw}))
+
+    def test_the_top_row_names_the_workspace_the_frame_moved_TO(self):
+        self.assertIn("workspace: alpha  ▸", self._labels(menu.MAIN))
+        self.assertEqual(self._switch(workspace="beta"), 0)
+        self.assertIn("workspace: beta  ▸", self._labels(menu.MAIN))
+
+    def test_the_submenu_mark_moves_with_the_frame(self):
+        # `default` is folded in whether or not its directory exists — `switch.workspaces`
+        # matches `commands_workspace.cmd_workspace_use` there.
+        self.assertEqual(self._labels("workspace"),
+                         ["* alpha", "  beta", "  default"])
+        self._switch(workspace="beta")
+        self.assertEqual(self._labels("workspace"),
+                         ["  alpha", "* beta", "  default"])
+
+    def test_a_persona_switch_moves_its_own_mark_too(self):
+        self.assertEqual(self._labels("persona"), ["  forge", "  scribe"])
+        self._switch(persona="scribe")
+        self.assertEqual(self._labels("persona"), ["  forge", "* scribe"])
+
+    def test_a_workspace_made_after_launch_reaches_the_submenu(self):
+        """The same staleness seen from the other side: the table is a snapshot, so a
+        plane that grew a workspace since launch had no row for it."""
+        _plane_workspaces("gamma")
+        self._switch(workspace="beta")
+        self.assertIn("  gamma", self._labels("workspace"))
+
+    def test_a_refusal_refreshes_the_list_without_moving_the_mark(self):
+        """A refused switch left the frame where it was — but the plane moved anyway, and
+        a pinned frame whose operator keeps pressing the hotkey is the one frame that
+        would otherwise never see a workspace made since launch. So the mark stays on the
+        pin and the new name still arrives."""
+        state.record_identity(self.FID, {"CHARTER_WORKSPACE": "alpha"})
+        _plane_workspaces("gamma")
+        self._switch(workspace="beta")
+        self.assertEqual(self._labels("workspace"),
+                         ["* alpha", "  beta", "  default", "  gamma"])
+
+    def test_nothing_is_recorded_on_a_tmux_charter_is_a_guest_on(self):
+        """`cmd_launch` and `cmd_density` both refuse to write a menu inside an operator's
+        own tmux: charter binds no key there, so there is nothing to open one with, and
+        the `Detach` row would target a session name that server does not have."""
+        state.record_server(self.FID, "/tmp/operator.sock")
+        self._switch(workspace="beta")
+        self.assertEqual(self._labels("workspace"),
+                         ["* alpha", "  beta", "  default"])
+
+    def test_the_density_mark_survives_a_switch(self):
+        """The re-record has to re-derive the density from the frame's own record: a
+        switch does not change it, and a guessed level would be written over the real
+        one."""
+        state.record_density(self.FID, "full")
+        self._switch(workspace="beta")
+        self.assertIn("* density: full", self._labels(menu.MAIN))
 
 
 class ThePickerDecidesNothingOnItsOwn(unittest.TestCase):

--- a/tests/test_frame_switch.py
+++ b/tests/test_frame_switch.py
@@ -1,0 +1,608 @@
+"""Switching a frame's workspace and persona, and picking one before it opens — #517/#518.
+
+Both features are one mechanism — list the names, contain them, perform the switch,
+repaint the panels — so they are tested against one set of properties:
+
+* a switch moves the frame's OWN identity, not a pointer some panels may or may not read
+  (#411/#412 are what "own identity" means here: `state.workspace_for`'s rungs);
+* a switch that cannot take effect is REFUSED and says so, never reported as done;
+* the switcher's own lock does not lock the switcher out of its second use;
+* nothing creates a workspace except the one confirmed step in `cmd_launch`;
+* a non-interactive launch never blocks;
+* no name — a committed value — reaches a tmux command slot or forges a line.
+
+`os.environ` is cleared in every case that resolves a workspace or a persona: both
+ladders read `$CHARTER_WORKSPACE`/`$CHARTER_PERSONA` and `$CHARTER_SESSION_ID`, so a
+developer running the suite inside a live frame would otherwise be supplying half of
+every fixture (#519/#521/#528).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import unittest
+from unittest import mock
+
+from charter import cli, commands_frame, config, persona, tui, workspace
+from charter.frame import menu, picker, state, switch
+
+from tests._isolation import PersonaIso
+
+
+def _plane_workspaces(*names: str) -> None:
+    for n in names:
+        (config.WORKSPACES_DIR / n).mkdir(parents=True, exist_ok=True)
+
+
+def _plane_personas(*names: str) -> None:
+    for n in names:
+        d = config.PERSONAS_DIR / n
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "persona.md").write_text("# p\n")
+
+
+class SwitchingWorkspace(PersonaIso, unittest.TestCase):
+    """`switch.to_workspace` — what moves, what refuses, and what is said either way."""
+
+    FID = "f-switch"
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        _plane_workspaces("alpha", "beta")
+        state.frame_dir(self.FID, create=True)
+        # What a launch that pinned NOTHING records: every name present and empty, which
+        # is `commands_frame._frame_identity_env`'s own shape.
+        state.record_identity(self.FID, {"CHARTER_SESSION_ID": self.FID,
+                                         "CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
+        state.record_workspace(self.FID, "alpha")
+
+    def test_a_switch_moves_what_every_frame_surface_asks(self):
+        """`state.workspace_for` is the one rule every panel, the gather and the status
+        line ask (#512's own docstring says so), so that — not the file the switch
+        happened to write — is what "the frame moved" has to mean. Asserting on the
+        pointer file instead would be this repo's "a test asserting one layer BELOW the
+        code that prints"."""
+        self.assertEqual(state.workspace_for(self.FID), "alpha")
+        out = switch.to_workspace(self.FID, "beta")
+        self.assertTrue(out.ok, out.message)
+        self.assertEqual(state.workspace_for(self.FID), "beta")
+
+    def test_a_switch_bumps_the_frame_so_panels_repaint(self):
+        """A panel repaints because the version moved (`frame/panel.py`'s contract).
+        Writing the pointer without bumping is exactly the "some panels may or may not
+        read it" failure #411 was filed for — the frame would keep drawing the old plane
+        until something else happened to bump."""
+        before = state.version(self.FID)
+        switch.to_workspace(self.FID, "beta")
+        self.assertNotEqual(state.version(self.FID), before)
+
+    def test_the_launch_record_moves_too_so_a_respawned_panel_agrees(self):
+        """Rung 1 (the pointer) is what live panels read; rung 2 (`record_workspace`) is
+        what `_relayout_pane_env` replays onto panes split LATER and what a panel resolves
+        if the pointer is ever gone. Moving only rung 1 leaves a frame whose next density
+        change draws the old workspace beside the new one."""
+        switch.to_workspace(self.FID, "beta")
+        self.assertEqual(state.frame_workspace(self.FID), "beta")
+
+    def test_switching_twice_is_not_refused_by_the_first_switchs_own_lock(self):
+        """`workspace.set_active` LOCKS the session to what it selected, so the switcher's
+        own first write takes a lock that its second write would hit. A switcher that
+        works exactly once is the "silently fails against a lock" failure #517 names,
+        arrived at by charter's own hand."""
+        self.assertTrue(switch.to_workspace(self.FID, "beta").ok)
+        second = switch.to_workspace(self.FID, "alpha")
+        self.assertTrue(second.ok, second.message)
+        self.assertEqual(state.workspace_for(self.FID), "alpha")
+
+    def test_overriding_a_lock_is_said_out_loud(self):
+        """An agent inside the frame locked it with `charter workspace use`; the operator
+        then picks another off the menu. The switch happens — they are at the keyboard —
+        but the message has to name what was overridden, or the agent's next command acts
+        on a workspace nobody was told about."""
+        workspace.set_active("alpha", session_id=self.FID)
+        out = switch.to_workspace(self.FID, "beta")
+        self.assertTrue(out.ok)
+        self.assertIn("alpha", out.message)
+        self.assertIn("lock", out.message)
+
+    def test_no_terminal_pointer_is_written_for_somebody_elses_terminal(self):
+        """#411, arriving on this command. A switch runs as a `run-shell` child of
+        charter's private tmux server — SHARED between every frame on the machine, and
+        holding the environment of whichever launcher started it, possibly days ago in
+        another terminal. `workspace.set_active` normally writes a per-terminal pointer
+        keyed on `$TERM_SESSION_ID`/`$TMUX_PANE`/`$STY`/`$SSH_TTY`, so without
+        `terminal_id=""` a switch inside frame B moves the workspace of the terminal that
+        launched frame A."""
+        os.environ["TERM_SESSION_ID"] = "someone-elses-terminal"
+        before = sorted(p.name for p in config.TERMINALS_DIR.iterdir()) \
+            if config.TERMINALS_DIR.exists() else []
+        self.assertTrue(switch.to_workspace(self.FID, "beta").ok)
+        after = sorted(p.name for p in config.TERMINALS_DIR.iterdir()) \
+            if config.TERMINALS_DIR.exists() else []
+        self.assertEqual(after, before)
+
+    def test_an_unknown_workspace_is_refused_and_creates_nothing(self):
+        before = sorted(p.name for p in config.WORKSPACES_DIR.iterdir())
+        out = switch.to_workspace(self.FID, "nope")
+        self.assertFalse(out.ok)
+        self.assertIn("nope", out.message)
+        self.assertEqual(sorted(p.name for p in config.WORKSPACES_DIR.iterdir()), before)
+        self.assertEqual(state.workspace_for(self.FID), "alpha")
+
+    def test_a_name_outside_the_alphabet_is_refused(self):
+        out = switch.to_workspace(self.FID, "../escape")
+        self.assertFalse(out.ok)
+        self.assertEqual(state.workspace_for(self.FID), "alpha")
+
+    def test_a_pinned_frame_is_refused_rather_than_told_it_moved(self):
+        """`$CHARTER_WORKSPACE` was set at launch, so every panel pane holds it in its own
+        process environment and no file charter writes can take it out — rung 0 of
+        `state.workspace_for` outranks rungs 1 and 2 both. Reporting "switched" and then
+        drawing the pin is the failure; reporting the pin is the honest answer."""
+        state.record_identity(self.FID, {"CHARTER_WORKSPACE": "alpha"})
+        out = switch.to_workspace(self.FID, "beta")
+        self.assertFalse(out.ok)
+        self.assertIn("alpha", out.message)
+        self.assertIn("CHARTER_WORKSPACE", out.message)
+        self.assertIsNone(workspace.for_session(self.FID))
+
+    def test_the_pin_is_read_from_the_frame_not_from_this_process(self):
+        """The switcher runs as a `run-shell` child of a tmux server shared between every
+        frame on the machine, so this process's `$CHARTER_WORKSPACE` may be ANOTHER
+        frame's (`state.record_identity` measures exactly that). Reading the pin from
+        `os.environ` would refuse a switch on a frame that was never pinned."""
+        os.environ["CHARTER_WORKSPACE"] = "someone-elses"
+        self.assertTrue(switch.to_workspace(self.FID, "beta").ok)
+
+    def test_an_empty_recorded_pin_is_not_a_pin(self):
+        """`_frame_identity_env` emits every name, present or not, so a frame that pinned
+        nothing records `CHARTER_WORKSPACE=""`. Treating presence rather than truth as the
+        pin would refuse every switch on every ordinary frame."""
+        self.assertEqual(state.identity(self.FID).get("CHARTER_WORKSPACE"), "")
+        self.assertTrue(switch.to_workspace(self.FID, "beta").ok)
+
+    def test_a_refusal_message_cannot_forge_a_second_line(self):
+        """A workspace name is a committed value and a message is a line of charter's own
+        output (`contain.py`, #453). The name here is refused for its alphabet anyway —
+        what is under test is that the name it ECHOES is contained, since the same echo
+        carries a plane-supplied name on the "no workspace named" path."""
+        out = switch.to_workspace(self.FID, "beta\nrefused — everything is fine")
+        self.assertFalse(out.ok)
+        self.assertNotIn("\n", out.message)
+
+
+class SwitchingPersona(PersonaIso, unittest.TestCase):
+    FID = "f-persona"
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        _plane_personas("forge", "scribe")
+        state.frame_dir(self.FID, create=True)
+        state.record_identity(self.FID, {"CHARTER_PERSONA": "", "CHARTER_WORKSPACE": ""})
+
+    def test_the_pointer_lands_under_the_frames_id_not_this_processs(self):
+        """Inside a frame the frame IS the charter session (ADR 0019), which is why a
+        panel sees the change at all: `persona.resolve_active`'s session rung is keyed on
+        `$CHARTER_SESSION_ID`, and in a panel that is the frame id. A switcher that let
+        `session.current()` read the id out of its own environment would write under a
+        server-inherited id — another frame's, or none."""
+        os.environ["CHARTER_SESSION_ID"] = "a-different-frame"
+        out = switch.to_persona(self.FID, "forge")
+        self.assertTrue(out.ok, out.message)
+        self.assertEqual(persona.for_session(self.FID), "forge")
+        self.assertIsNone(persona.for_session("a-different-frame"))
+
+    def test_a_switch_bumps_the_frame(self):
+        before = state.version(self.FID)
+        switch.to_persona(self.FID, "forge")
+        self.assertNotEqual(state.version(self.FID), before)
+
+    def test_no_terminal_pointer_is_written_for_somebody_elses_terminal(self):
+        """The persona half of the same #411 leak — see the workspace case."""
+        os.environ["TERM_SESSION_ID"] = "someone-elses-terminal"
+        self.assertTrue(switch.to_persona(self.FID, "forge").ok)
+        listed = (sorted(p.name for p in config.TERMINALS_DIR.iterdir())
+                  if config.TERMINALS_DIR.exists() else [])
+        self.assertEqual([n for n in listed if n.endswith(".persona")], [])
+
+    def test_an_unknown_persona_is_refused(self):
+        out = switch.to_persona(self.FID, "nobody")
+        self.assertFalse(out.ok)
+        self.assertIsNone(persona.for_session(self.FID))
+
+    def test_a_pinned_frame_is_refused(self):
+        state.record_identity(self.FID, {"CHARTER_PERSONA": "forge"})
+        out = switch.to_persona(self.FID, "scribe")
+        self.assertFalse(out.ok)
+        self.assertIn("CHARTER_PERSONA", out.message)
+        self.assertIsNone(persona.for_session(self.FID))
+
+    def test_the_marked_row_is_the_one_the_panels_are_showing(self):
+        """`switch.current_persona` must answer for the FRAME. `persona.resolve_active`
+        would answer for this process — whose `$CHARTER_PERSONA` belongs to whichever
+        launcher started the shared tmux server."""
+        os.environ["CHARTER_PERSONA"] = "someone-elses"
+        switch.to_persona(self.FID, "scribe")
+        self.assertEqual(switch.current_persona(self.FID), "scribe")
+
+
+class MenuGroups(PersonaIso, unittest.TestCase):
+    """A submenu is rows of the one table, filtered — and a group is a closed set."""
+
+    FID = "f-menu"
+
+    def test_a_submenu_row_never_reaches_a_command_slot(self):
+        """The property `menu.py` exists for, extended to the rows that carry a workspace
+        name: every item's COMMAND is one of two fixed templates, and the name appears
+        only in the label slot."""
+        hostile = 'x" ; run-shell "touch /tmp/pwned'
+        menu.record(fid=self.FID, entries=[
+            menu.Entry("workspace: alpha  ▸", opens="workspace"),
+            menu.Entry(f"* {hostile}", ("charter", "frame-switch", "--workspace",
+                                        hostile), "workspace"),
+        ])
+        argv = menu.menu_argv(self.FID, "charter", client="/dev/ttys0", group="workspace")
+        label, key, command = argv[-3:]
+        self.assertIn(hostile, label)
+        self.assertNotIn(hostile, command)
+        self.assertEqual(command,
+                         'run-shell \'"$CHARTER_PY" -m charter frame-action a1\'')
+
+    def test_an_opener_carries_the_client_format_and_the_group(self):
+        """Measured against tmux 3.7c with two attached ptys: `#{client_name}` inside a
+        menu item's own command expands to the client the menu was DRAWN on, so the
+        submenu reaches the presser's screen with nothing stored and nothing guessed."""
+        menu.record(fid=self.FID,
+                    entries=[menu.Entry("workspace: alpha  ▸", opens="workspace")])
+        command = menu.menu_argv(self.FID, "charter", client="/dev/ttys0")[-1]
+        self.assertEqual(
+            command,
+            'run-shell \'"$CHARTER_PY" -m charter frame-menu #{client_name} '
+            '--group workspace\'')
+
+    def test_rows_are_filtered_by_group(self):
+        menu.record(fid=self.FID, entries=[
+            ("Detach", ["true"]),
+            menu.Entry("* alpha", ("true",), "workspace"),
+            menu.Entry("* forge", ("true",), "persona"),
+        ])
+        self.assertEqual([lbl for lbl, _ in menu.build(self.FID)], ["Detach"])
+        self.assertEqual([lbl for lbl, _ in menu.build(self.FID, "workspace")],
+                         ["* alpha"])
+        self.assertEqual([lbl for lbl, _ in menu.build(self.FID, "persona")], ["* forge"])
+
+    def test_ids_are_one_space_across_every_group(self):
+        """One table, one id space — so `cmd_action`/`menu.resolve` never have to know
+        which menu a selection came from, and a submenu adds no second thing that can go
+        stale against the first."""
+        menu.record(fid=self.FID, entries=[
+            ("Detach", ["true"]),
+            menu.Entry("* alpha", ("charter", "alpha"), "workspace"),
+        ])
+        self.assertEqual(menu.resolve(self.FID, "a1"), ["charter", "alpha"])
+
+    def test_a_group_written_before_groups_existed_is_the_main_menu(self):
+        """A frame running across the upgrade keeps the menu it already has: a table with
+        no `group` key anywhere is the top-level menu, not an empty one."""
+        menu.record(fid=self.FID, entries=[("Detach", ["true"])])
+        raw = json.loads((state.frame_dir(self.FID) / "actions.json").read_text())
+        self.assertNotIn("group", raw["a0"])
+        self.assertEqual([lbl for lbl, _ in menu.build(self.FID)], ["Detach"])
+
+    def test_a_group_this_charter_does_not_have_is_in_no_menu(self):
+        """`build` reads whatever is on disk. A row claiming an unknown group belongs to
+        no menu charter can open — and that falls out of the `g != group` filter itself,
+        which is why there is no membership test beside it: one was written, mutated out,
+        and the covering test stayed green (`rows`' own docstring records this)."""
+        menu.record(fid=self.FID, entries=[("Detach", ["true"])])
+        path = state.frame_dir(self.FID) / "actions.json"
+        path.write_text(json.dumps({"a0": {"label": "sneak", "argv": ["true"],
+                                           "group": "elsewhere"}}))
+        for group in menu.GROUPS:
+            self.assertEqual(menu.build(self.FID, group), [], group)
+
+    def test_a_corrupt_opens_cannot_reach_tmux_command_text(self):
+        """`opens` is interpolated into text tmux re-parses, so it is checked at the join
+        for `_ACTION_ID_RE`'s stated reason — a hand-edited table is not bound by what
+        `record` would have written. The row degrades to an ordinary one."""
+        menu.record(fid=self.FID, entries=[("Detach", ["true"])])
+        path = state.frame_dir(self.FID) / "actions.json"
+        path.write_text(json.dumps({"a0": {"label": "x", "argv": ["true"],
+                                           "opens": "w\'; run-shell \'touch /tmp/pwned"}}))
+        command = menu.menu_argv(self.FID, "charter", client="/dev/ttys0")[-1]
+        self.assertNotIn("pwned", command)
+        self.assertEqual(command,
+                         'run-shell \'"$CHARTER_PY" -m charter frame-action a0\'')
+
+    def test_the_tenth_row_gets_no_key_rather_than_an_impossible_one(self):
+        """`display-menu`'s middle argument is a KEY NAME: `"10"` is not one. Before
+        submenus the menu had four fixed rows and could never reach it; a workspace list
+        can."""
+        menu.record(fid=self.FID, entries=[(f"row {i}", ["true"]) for i in range(11)])
+        argv = menu.menu_argv(self.FID, "charter", client="/dev/ttys0")
+        # The triples begin after `tmux -L <sock> display-menu -t <fid> -c <client> -T
+        # <title>` — ten fixed elements. Sliced by position rather than by searching for a
+        # word, since the socket and the title are both spelled "charter".
+        keys = argv[10:][1::3]
+        self.assertEqual(keys[:9], [str(i) for i in range(1, 10)])
+        self.assertEqual(keys[9:], ["-", "-"])
+
+
+class TheMenuOffersBothLists(PersonaIso, unittest.TestCase):
+    FID = "f-entries"
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        state.frame_dir(self.FID, create=True)
+        state.record_identity(self.FID, {"CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
+
+    def _labels(self, group):
+        entries = commands_frame._menu_entries(self.FID, "charter", current="normal")
+        menu.record(fid=self.FID, entries=entries)
+        return [lbl for lbl, _ in menu.build(self.FID, group)]
+
+    def test_the_top_level_grows_exactly_two_rows(self):
+        _plane_workspaces("alpha")
+        labels = self._labels(menu.MAIN)
+        self.assertEqual(labels[0], "Detach")
+        self.assertTrue(labels[-2].startswith("workspace: "), labels)
+        self.assertTrue(labels[-1].startswith("persona: "), labels)
+
+    def test_a_long_list_is_capped_and_says_so(self):
+        """`slots._cap_personas`' rule, one surface over: a `display-menu` is drawn inside
+        the terminal and tmux does not scroll it, so a plane with forty workspaces would
+        otherwise build a menu taller than the window."""
+        _plane_workspaces(*[f"ws{i:02d}" for i in range(30)])
+        rows = self._labels("workspace")
+        self.assertEqual(len(rows), commands_frame._MENU_LIST_MAX + 1)
+        self.assertIn("more", rows[-1])
+
+    def test_an_empty_list_still_draws_a_row(self):
+        """`cmd_menu` refuses a zero-row menu outright — `display-menu` fails with tmux's
+        own `not enough arguments` — so a submenu with nothing in it would be a hotkey
+        that silently does nothing."""
+        rows = self._labels("persona")
+        self.assertEqual(rows, ["  no personas yet"])
+
+    def test_a_name_is_contained_before_it_becomes_a_row(self):
+        """#472: a table sized its columns from a raw name first. `contain.one_line` runs
+        before any width arithmetic, and a name that could hold a newline cannot put one
+        in a menu row."""
+        (config.WORKSPACES_DIR / "alpha").mkdir(parents=True)
+        with mock.patch.object(switch, "workspaces",
+                               return_value=["alpha", "line break"]):
+            rows = self._labels("workspace")
+        self.assertTrue(all(" " not in r for r in rows), rows)
+
+
+class ThePickerDecidesNothingOnItsOwn(unittest.TestCase):
+    """`frame/picker.py` renders and reads. It creates nothing, and it cannot hang."""
+
+    ROWS = [picker.Row("alpha", 3), picker.Row("beta", 0)]
+
+    def _ask(self, answers, name_ok=lambda n: n.replace("-", "").isalnum()):
+        written: list[str] = []
+        it = iter(answers)
+
+        def read():
+            try:
+                return next(it)
+            except StopIteration:
+                return None
+
+        got = picker.ask(self.ROWS, "alpha", read=read, write=written.append,
+                         name_ok=name_ok)
+        return got, "".join(written)
+
+    def test_a_number_picks_that_row(self):
+        got, _ = self._ask(["2"])
+        self.assertEqual(got, picker.Choice(picker.USE, "beta"))
+
+    def test_empty_takes_the_marked_row(self):
+        got, _ = self._ask([""])
+        self.assertEqual(got, picker.Choice(picker.USE, "alpha"))
+
+    def test_a_name_can_be_typed_instead_of_a_number(self):
+        got, _ = self._ask(["beta"])
+        self.assertEqual(got, picker.Choice(picker.USE, "beta"))
+
+    def test_q_cancels(self):
+        got, _ = self._ask(["q"])
+        self.assertEqual(got, picker.Choice(picker.CANCEL, ""))
+
+    def test_end_of_input_cancels_rather_than_waiting(self):
+        """The one answer that can never be a hang. A closed stdin is not a workspace."""
+        got, _ = self._ask([])
+        self.assertEqual(got, picker.Choice(picker.CANCEL, ""))
+
+    def test_creating_needs_an_explicit_yes(self):
+        got, _ = self._ask(["n", "feature-x", ""])
+        self.assertNotEqual(got.action, picker.CREATE)
+
+    def test_creating_confirmed_returns_a_create(self):
+        got, _ = self._ask(["n", "feature-x", "y"])
+        self.assertEqual(got, picker.Choice(picker.CREATE, "feature-x"))
+
+    def test_a_name_that_already_exists_is_a_use_not_a_second_create(self):
+        got, _ = self._ask(["n", "beta"])
+        self.assertEqual(got, picker.Choice(picker.USE, "beta"))
+
+    def test_a_name_outside_the_alphabet_never_becomes_a_create(self):
+        got, _ = self._ask(["n", "../escape", "y", "q"])
+        self.assertEqual(got.action, picker.CANCEL)
+
+    def test_an_answer_that_never_arrives_ends_rather_than_spins(self):
+        """A tty ends on EOF; this is the stream that neither answers nor ends. An
+        unbounded loop there is a hang with no message — the failure #518 says a picker
+        must never be."""
+        written: list[str] = []
+        got = picker.ask(self.ROWS, "alpha", read=lambda: "?", write=written.append,
+                         name_ok=lambda n: True)
+        self.assertEqual(got.action, picker.CANCEL)
+
+    def test_two_names_that_differ_only_invisibly_are_drawn_differently(self):
+        """A workspace name is a committed value, contained BEFORE the column arithmetic
+        that lays the list out (#472).
+
+        The property is NOT "a newline cannot add a row" — `tui.pad` already closes that
+        by replacing every control character with a space, so a test asserting it would
+        be green with the containment deleted (measured). What `contain.one_line` adds is
+        that the replacement is VISIBLE: without it, `a b` and `a\\nb` are two different
+        workspaces drawn as the same row, and the operator picks one of them blind."""
+        rows = [picker.Row("a b", 1), picker.Row("a\nb", 1)]
+        text = "\n".join(tui.strip_ansi(ln)
+                         for ln in picker.render(rows, "a b", 80).splitlines())
+        self.assertIn("\\x0a", text)
+        listed = [ln for ln in text.splitlines() if ln.strip()[:1].isdigit()]
+        self.assertEqual(len(listed), 2, text)
+        self.assertNotEqual(listed[0][6:].strip(), listed[1][6:].strip())
+
+    def test_the_list_is_measured_with_display_width_not_length(self):
+        """`tui.width`, never `len` — the column would drift by one cell per wide
+        character otherwise, which `_persona_chips`' own comment says has broken this
+        layout twice."""
+        rows = [picker.Row("ws", 1), picker.Row("日本", 1)]
+        # Line by line: `tui.strip_ansi` runs `tui.sanitize`, which escapes every control
+        # character — a newline included — so stripping the whole block first would leave
+        # one line and `splitlines()` nothing to split.
+        text = "\n".join(tui.strip_ansi(ln)
+                         for ln in picker.render(rows, "ws", 80).splitlines())
+        # `tui.pad` clamps as well as pads, so a column sized with `len` does not drift —
+        # it EATS the name: `name_w` would be 2 for both, and `pad("日本", 2)` renders
+        # `"… "`. The name surviving intact is the property; the alignment underneath it
+        # is `tui.pad`'s and is true either way, which is why asserting on the columns
+        # would have been a guard no mutation could turn red.
+        self.assertIn("日本", text)
+        self.assertNotIn("…", text)
+        rows_shown = [ln for ln in text.splitlines() if ln.strip()[:1].isdigit()]
+        self.assertEqual(len(rows_shown), 2, text)
+        starts = {tui.width(ln[:ln.index("1 repo")]) for ln in rows_shown}
+        self.assertEqual(len(starts), 1, rows_shown)
+
+
+class ANonInteractiveLaunchNeverBlocks(PersonaIso, unittest.TestCase):
+    """#518's hard requirement: `charter <harness>` runs from scripts and other agents."""
+
+    def _args(self, **kw):
+        return mock.Mock(**{"workspace": None, "pick": False, **kw})
+
+    def test_a_pipe_is_never_asked(self):
+        with mock.patch.dict(os.environ, {}, clear=True), \
+             mock.patch("sys.stdin", io.StringIO("")), \
+             mock.patch("sys.stdout") as out:
+            out.isatty.return_value = True
+            self.assertFalse(commands_frame._picker_wanted(self._args(), None))
+
+    def test_a_redirected_stdout_is_never_asked(self):
+        with mock.patch.dict(os.environ, {}, clear=True), \
+             mock.patch("sys.stdin") as sin, mock.patch("sys.stdout") as out:
+            sin.isatty.return_value = True
+            out.isatty.return_value = False
+            self.assertFalse(commands_frame._picker_wanted(self._args(), None))
+
+    def _tty(self):
+        sin = self.enterContext(mock.patch("sys.stdin"))
+        out = self.enterContext(mock.patch("sys.stdout"))
+        sin.isatty.return_value = True
+        out.isatty.return_value = True
+
+    def test_an_env_pin_outranks_even_an_explicit_pick(self):
+        """`$CHARTER_WORKSPACE` is the top of `resolve`'s precedence and means "this one,
+        I have decided" — the documented way to aim an unattended agent.
+
+        Asserted WITH `--pick`, because that is the only case in which the check earns
+        its line: without it, the pin is also what `workspace.chosen` answers, so the
+        bottom rung refuses the picker anyway and a test asking without `--pick` would
+        pass with the check deleted. It is also the right answer on its own terms — a
+        pin cannot be moved from inside the frame either (`switch.to_workspace` refuses
+        it), so offering a choice that cannot take effect would be the worse outcome."""
+        self._tty()
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "pinned"}, clear=True):
+            self.assertFalse(
+                commands_frame._picker_wanted(self._args(pick=True), "pinned"))
+
+    def test_an_explicit_workspace_flag_outranks_even_an_explicit_pick(self):
+        self._tty()
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(commands_frame._picker_wanted(
+                self._args(workspace="alpha", pick=True), "alpha"))
+
+    def test_nothing_chosen_is_what_asks(self):
+        self._tty()
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(commands_frame._picker_wanted(self._args(), None))
+            self.assertFalse(commands_frame._picker_wanted(self._args(), "already"))
+
+    def test_pick_asks_even_when_something_chose(self):
+        self._tty()
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(
+                commands_frame._picker_wanted(self._args(pick=True), "already"))
+
+
+class WhatChoseAndWhatMerelyFellBack(PersonaIso, unittest.TestCase):
+    """`workspace.chosen` is `resolve`'s ladder minus its built-in — one ladder, two
+    questions, so a rung added to one reaches the other (#518)."""
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+
+    def test_nothing_chose_is_none_while_resolve_still_answers(self):
+        self.assertIsNone(workspace.chosen())
+        self.assertEqual(workspace.resolve(), config.DEFAULT_WORKSPACE)
+
+    def test_every_rung_that_answers_resolve_also_answers_chosen(self):
+        self.assertEqual(workspace.chosen("explicit"), "explicit")
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "env"}, clear=True):
+            self.assertEqual(workspace.chosen(), "env")
+        workspace.set_active("alpha", session_id="s-1")
+        self.assertEqual(workspace.chosen(session_id="s-1"), "alpha")
+
+    def test_a_declared_default_counts_as_a_choice(self):
+        """Somebody nominated it (#193) — unlike `config.DEFAULT_WORKSPACE`, which is the
+        name charter falls back to when there is nothing to read."""
+        workspace.set_declared_default("nominated")
+        self.assertEqual(workspace.chosen(), "nominated")
+
+
+class TheLauncherOwnsItsOwnFlags(unittest.TestCase):
+    """`--workspace <name>` is charter's, and it takes a value — #518's escape hatch."""
+
+    def test_a_value_flag_consumes_two_tokens(self):
+        """Scanning it as one would leave the workspace NAME as the harness's `argv[0]` —
+        `charter frame --workspace foo -- true` would try to execute `foo`."""
+        head, rest = cli._split_frame_argv(["frame", "--workspace", "foo", "--", "true"])
+        self.assertEqual(head, ["frame", "--workspace", "foo"])
+        self.assertEqual(rest, ["--", "true"])
+
+    def test_the_equals_form_is_one_token(self):
+        head, rest = cli._split_frame_argv(["claude", "--workspace=foo", "-p", "hi"])
+        self.assertEqual(head, ["claude", "--workspace=foo"])
+        self.assertEqual(rest, ["-p", "hi"])
+
+    def test_a_trailing_value_flag_is_left_for_argparse_to_refuse(self):
+        """argparse's own "expected one argument" is the right message, from the part
+        that owns the flag — better than silently consuming past the end."""
+        head, rest = cli._split_frame_argv(["claude", "--workspace"])
+        self.assertEqual(head, ["claude", "--workspace"])
+        self.assertEqual(rest, [])
+
+    def test_pick_is_a_leading_flag_and_nothing_after_it_is(self):
+        head, rest = cli._split_frame_argv(["claude", "--pick", "-p", "--pick"])
+        self.assertEqual(head, ["claude", "--pick"])
+        self.assertEqual(rest, ["-p", "--pick"])
+
+    def test_the_flags_reach_the_launcher(self):
+        args = cli.build_parser().parse_args(["claude", "--workspace", "alpha", "--pick"])
+        self.assertEqual(args.workspace, "alpha")
+        self.assertTrue(args.pick)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -2050,6 +2050,60 @@ class MenuFormatIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
         self.assertFalse(os.path.exists(format_canary),
                          "selecting the item must not retroactively execute the label")
 
+    def test_a_row_past_the_ninth_is_fired_by_no_keystroke_but_is_still_reachable(self):
+        """`menu._key`'s "no shortcut" has to be measured against tmux, not believed.
+
+        It used to be `-`, on the reading that tmux spells an unbound row that way. It
+        does not: `-` is an ordinary key name, and a menu of eleven rows gave the tenth
+        one a working `-` shortcut — a stray hyphen on the workspace submenu performing a
+        real switch, and the eleventh row advertising a `(-)` that could never fire.
+        `tests/test_frame_switch.py` pins the constant; only a rendered menu can say which
+        constant is right, which is the whole reason this class exists.
+
+        Both halves in one test, because an unbound key does NOT dismiss a tmux menu
+        (measured here): `-` is pressed first and must create nothing, then nine Downs and
+        Enter must reach the SAME row on the SAME still-open menu. A row with no shortcut
+        that the arrow keys could not reach either would be a row that does nothing at
+        all — which is the failure the `-` was reached for in the first place.
+        """
+        fid = f"menu-fmt-integ4-{os.getpid()}"
+        self._new_session(fid)
+        client, fd = self._attach_pty(fid)
+        self.assertEqual(_run(commands_frame._session_id_env_argv(
+            socket=SOCKET, session=fid)).returncode, 0)
+        self.assertEqual(_tmux("set-environment", "-t", fid, "CHARTER_PY",
+                               sys.executable).returncode, 0)
+
+        tmp = tempfile.mkdtemp(prefix="charter-integ-fmt4-")
+        self.addCleanup(shutil.rmtree, tmp, True)
+        canary = os.path.join(tmp, "TENTH_ROW")
+        # Eleven rows: nine that take the digits, then the two that do not. The canary
+        # hangs off the TENTH — the first row past the ninth, and the one that used to be
+        # keyed `-`.
+        entries = [(f"row {i}", ["true"]) for i in range(11)]
+        entries[9] = ("row 9", [sys.executable, "-c",
+                                f"open({canary!r}, 'w').close()"])
+        menu.record(fid=fid, entries=entries)
+        cmd = menu.menu_argv(fid, SOCKET, client=client)
+        self.assertEqual(cmd[10:][1::3][9:], ["", ""], cmd)
+        self._drive_menu(fd, cmd)
+
+        os.write(fd, b"-")
+        time.sleep(0.8)
+        self.assertFalse(os.path.exists(canary),
+                         "`-` fired the tenth row — it is a real tmux key, not tmux's "
+                         "spelling for 'no shortcut'")
+
+        # Nine Downs from the first row lands on the tenth: the menu opens with row 0
+        # selected, so the count is the index, not the position.
+        os.write(fd, b"\x1b[B" * 9 + b"\r")
+        deadline = time.monotonic() + _DEADLINE
+        while time.monotonic() < deadline and not os.path.exists(canary):
+            time.sleep(0.2)
+        self.assertTrue(os.path.exists(canary),
+                        "a row with no key must still be selectable with the arrow keys "
+                        "— and the unbound `-` must not have dismissed the menu")
+
 
 @unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
 class MenuClientIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase):

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -2308,6 +2308,64 @@ class MenuClientIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
         self.assertTrue(os.path.exists(canary_b),
                         "B's own hotkey press must open B's own, selectable menu")
 
+    def test_a_submenu_opens_on_the_presser_and_its_rows_are_selectable(self):
+        """#517's whole mechanism, proved through the real chain rather than asserted
+        from an argv.
+
+        A submenu row's own command is `run-shell '"$CHARTER_PY" -m charter frame-menu
+        #{client_name} --group workspace'` — a SECOND `display-menu`, opened by a
+        `run-shell` child of the FIRST one's selection, on a client named by a tmux
+        format expanded inside the item's own command text. Two things could be true
+        instead, and neither is checkable from `menu_argv`'s argv:
+
+        * `#{client_name}` could expand to whatever tmux calls the current client rather
+          than to the one the menu was drawn on — the exact defect
+          `test_each_presser_gets_their_own_menu_not_the_others` above exists for, one
+          layer deeper. B's keystream selecting A's submenu row is what that would look
+          like, so that is what is asserted.
+        * the nested `display-menu` could fail to wire itself to the client's key input
+          at all — this class's own docstring records `display-menu` behaving differently
+          when issued directly rather than from a bind, and a submenu is issued from
+          neither: it comes off another menu's selection. The canary firing on A's own
+          `1` is what rules that out.
+        """
+        fid = f"menu-sub-integ-{os.getpid()}"
+        self._new_session(fid)
+        clientA, fdA = self._attach_pty(fid)
+        clientB, fdB = self._attach_pty(fid, exclude=frozenset({clientA}))
+        self.assertNotEqual(clientA, clientB)
+        self.assertEqual(_run(commands_frame._session_id_env_argv(
+            socket=SOCKET, session=fid)).returncode, 0)
+        self.assertEqual(_tmux("set-environment", "-t", fid, "CHARTER_PY",
+                              str(self.shim)).returncode, 0)
+        self._install_real_bind(fid)
+
+        canary = self._short_canary("sub")
+        menu.record(fid=fid, entries=[
+            menu.Entry("workspace: demo  ▸", opens="workspace"),
+            menu.Entry("* demo",
+                       (sys.executable, "-c", f"open({canary!r}, 'w').close()"),
+                       "workspace"),
+        ])
+
+        os.write(fdA, b"\x1bOQ")   # F2 on A -> the top-level menu, on A
+        time.sleep(0.8)
+        os.write(fdA, b"1")        # its only row is the opener -> the submenu, on A
+        time.sleep(1.2)
+        os.write(fdB, b"1")        # B must not be able to select in A's submenu
+        time.sleep(0.8)
+        self.assertFalse(os.path.exists(canary),
+                         "client B's keystream selected a row in the SUBMENU that A's "
+                         "own press opened — `#{client_name}` inside a menu item's own "
+                         "command did not resolve to the client the menu was drawn on")
+        os.write(fdA, b"1")
+        deadline = time.monotonic() + _DEADLINE
+        while time.monotonic() < deadline and not os.path.exists(canary):
+            time.sleep(0.2)
+        self.assertTrue(os.path.exists(canary),
+                        "selecting a submenu opener must open a submenu on the "
+                        "presser's own client, with selectable rows")
+
 
 def _git(repo: Path, *args: str) -> None:
     subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)


### PR DESCRIPTION
Two features that share one mechanism — **list the names, contain them, perform the switch, repaint the panels** — built once in `charter/frame/switch.py`.

Closes #517
Closes #518

---

## #517 — switch from inside a running frame

The `F2` menu gains two submenu openers. Submenus, not two more `bind -n` keys: a tmux key table is server-wide with no per-session form, so two more binds would cost every frame on the socket two more keys and still give an operator inside their own tmux nothing.

```
┌─charter───────────────────────────┐        ┌─charter · workspace───┐
│ Detach                        (1) │        │   default         (1) │
│   density: minimal            (2) │        │ * harness-wrapper (2) │
│ * density: normal             (3) │   ▸    │   release-0-54    (3) │
│   density: full               (4) │        │   user-reporting  (4) │
│ workspace: harness-wrapper  ▸ (5) │        └───────────────────────┘
│ persona: forge  ▸             (6) │
└───────────────────────────────────┘
```

(Captured from a real tmux 3.7c client, not drawn by hand — see **Rendered** below.)

**A submenu is rows of the ONE action table**, filtered by a `group` field. Ids stay one space, so `menu.resolve` and `cmd_action` are untouched and a submenu adds no second file that can go stale against the first.

**The client is carried by tmux, not stored or guessed.** An opener's command is a second fixed template — `run-shell '"$CHARTER_PY" -m charter frame-menu #{client_name} --group workspace'`. Measured against tmux 3.7c **with two real ptys attached to one session**: a format inside a menu item's own command expands to the client the menu was drawn on (`-c`), never to whichever client tmux would otherwise call current. Pressing on A ran the item with A's name; on B, with B's. That is exactly the property `cmd_menu`'s docstring records as *not* available from `list-clients`.

**A switch moves the frame's OWN identity.** `state.workspace_for` is the one rule every frame surface asks. A workspace switch writes its rung 1 (the per-session pointer under the **frame's** id) and rung 2 (`state.record_workspace`), refreshes the gather cache, and *then* bumps — refresh before bump, `frame/notify.py`'s own ordering, so no panel repaints the new workspace's name over the old workspace's repo table. `state.identity` is deliberately not rewritten: that would pin the frame and take `charter workspace use` away from the agent inside it.

**A pin is refused, not best-effort.** `$CHARTER_WORKSPACE` is in every panel pane's environment for as long as the pane lives and nothing charter writes outranks it, so the menu says `cannot switch: $CHARTER_WORKSPACE pins this frame to '<name>'` rather than reporting a move that will not happen.

**Every outcome lands on the presser's screen** via `display-message -c`. Measured: `-t <session>` with two clients attached drew on the most recently attached one regardless of who pressed. `cmd_menu` records the client it drew for an instant before drawing; `state.record_menu_client`'s docstring says plainly what that is and is not.

**The lock moves with the operator.** `workspace.set_active` locks the session to what it selected — so the switcher's own first write would take a lock its second write hit, leaving a switcher that worked exactly once. It forces, and names what it overrode: `workspace → beta  (lock moved from 'alpha')`.

## #518 — pick or create a workspace when the harness opens

Shown when **nothing chose** — `workspace.chosen`, which is `resolve`'s ladder minus its built-in fallback, so one ladder answers both questions rather than two that agree today.

```
  charter · which workspace?

     1  * default          —
     2    harness-wrapper  7 repos
     3    user-reporting   1 repo

     n    create a new workspace
     q    cancel — start nothing

  workspace [default]: n
  new workspace name (letters, digits, . _ -): feature-x
  create feature-x and switch to it? [y/N]: y
✓ Workspace 'feature-x' created → workspaces/feature-x/
```

**A non-interactive launch cannot block.** `--no-frame` and a non-tty stdout already returned before this point; stdin is checked here, because the two can differ. `--workspace <name>` names one outright and skips the picker; `--pick` asks even when something chose; an env pin outranks both, since a pin cannot be moved from inside the frame either.

**Creating is confirmed, and a cancel creates nothing** — as a fact about the code, not a promise: `frame/picker.py` renders and reads and returns a decision, and `cmd_launch` is the only thing that calls `workspace.ensure`. A name that already exists is a *use*, not a second create.

**Picking is the confirmation that locks**, and the launch says so on the line after the answer. The frame's own `F2 → workspace` overrides that lock and tells you it did, so a choice made at a prompt does not send you back to a shell to change it.

**It does not ask twice**: the choice is written as the launching terminal's own pointer, so the next launch from that terminal has an answer.

`--workspace` takes a value, so `_split_frame_argv` grows `_OWN_VALUE_FLAGS` — consumed as two tokens in the leading position only, `--workspace=x` as one, and a trailing `--workspace` handed to argparse so its own "expected one argument" is what the operator sees.

## A #411 leak found while re-reading (fixed here)

Both `workspace.set_active` and `persona.set_active` write a per-terminal pointer keyed on `$TERM_SESSION_ID`/`$TMUX_PANE`/`$STY`/`$SSH_TTY`. In a `run-shell` child of charter's **shared** private tmux server those names belong to whichever launcher started it — possibly days ago, in another terminal. A switch inside frame B would have moved the workspace of the terminal that launched frame A. Both now take `terminal_id=""`; every ordinary caller is unchanged, and both directions are mutation-tested.

## Rendered

The menu screenshots above are `capture-pane` output from an outer tmux whose pane holds a real inner client, so the menu overlay is visible. A separate end-to-end drive (`display-menu` → `run-shell` → real `charter frame-menu`/`frame-switch`) confirms the whole chain:

```
=== 1. F2 opens the menu ===
┌─charter───────────────────────────┐
│ Detach                        (1) │
│   density: minimal            (2) │
│ * density: normal             (3) │
│   density: full               (4) │
│ workspace: harness-wrapper  ▸ (5) │
│ persona: forge  ▸             (6) │
└───────────────────────────────────┘

=== 2. picking `workspace ▸` opens the submenu on the SAME client ===
┌─charter · workspace───┐
│   default         (1) │
│ * harness-wrapper (2) │
│   user-reporting  (3) │
└───────────────────────┘

=== 3. picking `user-reporting` — the frame says what it did ===
charter: workspace → user-reporting

state.workspace_for(fid)   = user-reporting
workspace.for_session(fid) = user-reporting
state.frame_workspace(fid) = user-reporting
```

And the refusal, read off the same client's status line:

```
charter: cannot switch: $CHARTER_WORKSPACE pins this frame to 'harness-wrapper'
```

## Verification

- **Full suite green — 5583 tests, `OK`** — run from this worktree with `env -u CHARTER_SESSION_ID -u CLAUDE_CODE_SESSION_ID -u TMUX -u TMUX_PANE`. `test_plugin_freshness` (#529) passed here too.
- **22 mutation pairs, every one RED then GREEN on restore**, `__pycache__` cleared between runs — the pin check, the force, reading the pin from the frame rather than the process, both terminal-pointer leaks, the persona session id, `record_workspace`, the bump, `opens` containment, the tenth-row key, the menu-row containment, the stdin check, the env pin, the create confirmation, the existing-name branch, `tui.width` vs `len`, the raw-name render, the EOF cancel, the list cap, the unknown-name refusal, the argv split, and `workspace.chosen`.
- **Three guards were written, mutated, and found NOT to be guards** — and were removed or rewritten rather than left in: a `GROUPS` membership test in `menu.rows` that a sibling comparison already answered; a picker test asserting a newline cannot add a row, which `tui.pad` already closes; and an env-pin test that passed with the check deleted because a lower rung answered anyway. Each is recorded in the docstring or the test that replaced it.
- New tmux integration test in the existing `MenuClientIntegration` class proving a submenu opens on the presser's client with selectable rows, and that the *other* client's keystream cannot select in it.

## Notes for the reviewer

- `config.ROOT` in this worktree resolves to **`/Users/aharon/IdeaProjects/charter`** (the main tree) — printed before concluding anything, per the worktree warning. Every new test is `PersonaIso`-isolated; nothing was written to the live plane.
- `charter/frame/switch.py` makes no tmux call at all, which is what keeps it testable without a server; `commands_frame` owns the one `display-message`.
- Nothing versioned, stamped or tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9
