### PR TITLE
frame: the repo table becomes its own panel and the attention row is the last line (#515)

### DIFF
--- a/charter.toml
+++ b/charter.toml
@@ -11,14 +11,22 @@ share = "local"
 default = "steward"
 
 [frame]
-# Every slot: identity across the top, the wide repo table across the bottom, persona
-# chips down the right. `right` needs a terminal at least `min-cols` wide — below that
-# `layout.visible_slots` drops it rather than cramping the harness.
+# Every slot: identity across the top, the one-row attention strip under it, the wide
+# repo table below that, persona chips down the right. `right` needs a terminal at least
+# `min-cols` wide — below that `layout.visible_slots` drops it rather than cramping the
+# harness. `repos` is dropped the same way once its own pane would be narrower than the
+# 95 columns the table needs, because a `repos` pane too narrow to draw one is a bordered
+# rectangle that reads as "this workspace has no repos" (#515).
 #
-# The ORDER is the geometry (#488): `bottom` is split before `right`, so its table gets
-# the full window width. Listed after it, `bottom` is split off a harness the sidebar has
-# already narrowed — 23 columns short of the window, so the table needs a 118-column
-# terminal before it is drawn at all, and below that the pane is the attention row alone
-# (#500). There is no `left` any more — it drew a 22-column copy of the table `bottom`
-# now draws properly.
-slots = ["top", "bottom", "right"]
+# `repos` carries the table as of #515; before that `bottom` carried the attention row
+# and the table stacked in one pane. This line has to NAME it: `slots` is the primitive
+# and an explicit list wins over the default outright, so a list without `repos` launches
+# fine and simply draws no table.
+#
+# The ORDER is the geometry (#488): `repos` is split before `right`, so its table gets
+# the full window width — measured drawn at 95 columns and up. Listed after it, `repos`
+# is split off a harness the sidebar has already narrowed — 23 columns short of the
+# window, so the table needs a 118-column terminal before it is drawn at all, and below
+# that the slot is dropped and the harness keeps the rows (#500). There is no `left` any
+# more — it drew a 22-column copy of the rows `repos` now draws at full width.
+slots = ["top", "bottom", "repos", "right"]

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -796,7 +796,7 @@ def _add_frame_parsers(sub) -> None:
     # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the
     # ones above. Fired by the frame window's own `window-resized` hook (#488,
     # `commands_frame._resize_hook_argv`) — never typed by an operator. The hook used to
-    # carry the sizes as literal text; `bottom` is content-sized now, so the sizes have
+    # carry the sizes as literal text; `repos` is content-sized now, so the sizes have
     # to be RECOMPUTED against the window that just changed, and only charter can do
     # that. `--frame` travels on the argv for `frame-respawn`'s reason: on the operator's
     # own server there is no `$CHARTER_SESSION_ID` for a `run-shell` child to read.

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -773,11 +773,30 @@ def _panel_died_hook_argv(*, socket: str, panel_pane: str, slot: str,
                                action)
 
 
-#: Which `resize-pane` flag re-asserts a slot's dimension: `-y` (rows) for the horizontal
-#: strips, `-x` (columns) for the side column — the same axis `layout.py`'s own `-v`/`-h`
-#: split direction already encodes for the same slots, read here rather than re-derived a
-#: third way. The SIZE that goes with it is `layout.slot_sizes`', not `SLOT_SIZE`'s, since
-#: `bottom`'s is a function of its content and of the window (#488).
+#: Which `resize-pane` flag re-asserts a slot's dimension, **for every slot
+#: :func:`_reassert_sizes` asserts one for**: `-y` (rows) for the horizontal strips, `-x`
+#: (columns) for the side column — the same axis `layout.py`'s own `-v`/`-h` split
+#: direction already encodes for the same slots, read here rather than re-derived a third
+#: way. The SIZE that goes with it is `layout.slot_sizes`', not `SLOT_SIZE`'s, since
+#: `repos`' is a function of its content and of the window (#488).
+#:
+#: **`repos` is deliberately absent, and #515 is the whole of it.** The issue asked for
+#: the second bottom pane to be in this map and that would be wrong — not because its
+#: axis is in doubt (it is rows; its width is whatever the harness column leaves it, and
+#: no `resize-pane -x` ever set that), but because tmux's `resize-pane` moves exactly ONE
+#: boundary. In a vertical stack of N panes only N-1 heights can be asserted; assert them
+#: all and the outcome depends on the order they are asserted in. Measured on tmux 3.7c
+#: at 200x50, asserting `top`, `bottom` and `repos` in split order: the table came back
+#: **1** row tall and the attention strip **6** — the two sizes swapped panes, and the
+#: harness kept whatever tmux's own proportional redistribution had left it.
+#:
+#: So the pane left out is the one whose height is already a function of all the others
+#: (`layout.VARIABLE_ROW_SLOTS`), the HARNESS is told its height explicitly
+#: (`layout.harness_rows`), and the table lands on exactly `layout.repos_rows`' answer
+#: without anything naming it. Putting `repos` back in this map is a mutation
+#: `tests/test_frame_density.py::ResizeRecomputesForBothDimensions
+#: ::test_the_fixed_strips_are_re_asserted_at_their_own_constant_height` turns red — it
+#: asserts the whole set of `-y`s issued, not merely that each one present is right.
 _RESIZE_FLAG = {"top": "-y", "bottom": "-y", "right": "-x"}
 
 #: Every real pane id tmux's own `-P -F '#{pane_id}'` has ever reported (`%<digits>`,
@@ -827,9 +846,9 @@ def _resize_hook_argv(*, socket: str, harness_pane: str, fid: str) -> list[str] 
 
     **This used to be the sizes themselves, as literal text, and #488 is why it cannot
     be.** The action was `resize-pane -t %1 -y 1 ; resize-pane -t %2 -x 22` — a constant,
-    computed once when the frame was laid out. `bottom`'s height is no longer a constant:
+    computed once when the frame was laid out. The table pane's height is not a constant:
     it is `min(content, cap)` where the cap is what the window can spare
-    (`layout.bottom_rows`), so a stale number is not merely imprecise, it is destructive.
+    (`layout.repos_rows`), so a stale number is not merely imprecise, it is destructive.
     Measured on 3.7c: a window shrunk from 50 rows to 20 with a hook still asserting
     `-y 40` left the harness pane **1 row tall**. tmux does not refuse an over-large
     height — it grants it out of the neighbour. The hook therefore has to RECOMPUTE, and
@@ -1083,7 +1102,7 @@ def _spawn_gather(fid: str, ws: str) -> None:
     harness to appear, and `charter claude` is the default way charter is started. So this
     is the shape charter already uses twice for exactly this problem — `update.maybe_spawn`
     and `glstate.maybe_spawn`: draw immediately with whatever is there, kick a child, let
-    the answer arrive a beat later. `slots._bottom` says "gathering" in the meantime rather
+    the answer arrive a beat later. `slots._repos` says "gathering" in the meantime rather
     than drawing an empty table (`slots._unknown_lines`), so the window this opens is
     visible and honest rather than a silent lie.
 
@@ -1128,27 +1147,27 @@ def _launch_sizes(fid: str, slots: list[str], *,
     the launch-time half of `layout.slot_sizes`, shared by both launch paths so they
     cannot disagree.
 
-    `bottom` is the only slot whose answer is not a constant (#488): it is sized to the
-    repo table it is about to draw, floored at the one row it always was and capped so
-    the harness keeps `layout.HARNESS_MIN_ROWS`. `frame_slots.bottom_rows_wanted` is the
-    same function the RENDERER's own budget comes from, which is what stops a frame
-    coming up with a pane taller than its content or a table cut off with nothing saying
-    so.
+    `repos` is the only slot whose answer is not a constant (#488, moved off `bottom` by
+    #515): it is sized to the repo table it is about to draw, floored at one row and
+    capped so the harness keeps `layout.HARNESS_MIN_ROWS`.
+    `frame_slots.repos_rows_wanted` is the same function the RENDERER's own budget comes
+    from, which is what stops a frame coming up with a pane taller than its content or a
+    table cut off with nothing saying so.
 
     **The width is not decoration (#500).** The renderer draws NO table below
     `statusline._LEFT_W` (95) and at most `slots._TERSE_ROWS` of one at a `terse`
-    density, and neither is a rare shape: `layout.visible_slots` keeps `bottom` down to
-    `min_cols // 2`, so an 80-column terminal is one, and `minimal` is a level the F2
-    menu offers. Sizing from the repo count alone gave both of them a pane sized for a
-    table the panel then refused to draw — up to fourteen blank rows taken off the
-    harness.
+    density, and `minimal` is a level the F2 menu offers. Sizing from the repo count
+    alone gave both of them a pane sized for a table the panel then refused to draw — up
+    to fourteen blank rows taken off the harness. (Since #515 `layout.visible_slots`
+    drops `repos` outright below `statusline._LEFT_W` rather than splitting a pane its
+    renderer will not draw in, so the narrow case now costs no rows at all.)
 
     **And it is the PANE's columns, which are not always the window's.** *slots* is the
     split order and the split order is the geometry (`instance.frame_of` keeps an
-    operator's own `[frame] slots` verbatim), so a `right` split before `bottom` has
-    already taken 23 columns off the pane `bottom` is carved from — 87 in a 110-column
-    window, measured on tmux 3.7c. `layout.bottom_cols` is that arithmetic; handing
-    `bottom_rows_wanted` *window_cols* straight through was #500's own second half, and
+    operator's own `[frame] slots` verbatim), so a `right` split before `repos` has
+    already taken 23 columns off the pane `repos` is carved from — 97 in a 120-column
+    window, measured on tmux 3.7c. `layout.repos_cols` is that arithmetic; handing
+    `repos_rows_wanted` *window_cols* straight through was #500's own second half, and
     it put six blank rows into exactly the frame this function exists to size. Both
     measurements are keyword-only and named for the WINDOW here for that reason: this
     function's whole job is turning a window into panes, and the two names that reach it
@@ -1161,8 +1180,8 @@ def _launch_sizes(fid: str, slots: list[str], *,
     """
     return layout.slot_sizes(
         slots, window_rows=window_rows,
-        content_rows=frame_slots.bottom_rows_wanted(
-            fid, pane_cols=layout.bottom_cols(slots, window_cols=window_cols)))
+        content_rows=frame_slots.repos_rows_wanted(
+            fid, pane_cols=layout.repos_cols(slots, window_cols=window_cols)))
 
 
 def _drawable_slots(cols: int, rows: int, configured: list[str] | None = None) -> list[str]:
@@ -2628,7 +2647,7 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
       that merely SURVIVED a density change are the ones that get stretched by it, so
       they are exactly the ones a `-l` on the new pane cannot fix. :func:`_reassert_sizes`
       does it, and *window_cols*/*window_rows* are why it takes a measurement rather
-      than a constant: `bottom`'s height depends on the window it is in — on its rows
+      than a constant: `repos`' height depends on the window it is in — on its rows
       (#488) and, since #500, on its columns and this frame's density too, because a
       panel narrower than `statusline._LEFT_W` draws no table and `terse` draws at most
       `slots._TERSE_ROWS` of one.
@@ -2671,34 +2690,44 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
                     tmuxctl.server_argv(socket, "kill-pane", "-t", pane_id))
 
     missing = [s for s in want if s not in keep]
+    # The table pane's width is not the window's, and a re-layout is where the two come
+    # apart (#500 round 3, #515). `want` is the LEVEL's slot list, which is the order a
+    # fresh launch would split in; the panes this frame actually has are `keep`'s, and a
+    # `right` already sitting beside the harness insets anything split off it afterwards.
+    # `_drawable_slots` filtered `want` against the level's order and so believed the
+    # table fits; asked with the order the panes are really in, it may not — and a pane
+    # split too narrow for its table is the bordered rectangle #515 exists to stop.
+    if "repos" in missing and not layout.repos_fits(list(keep) + missing,
+                                                    window_cols=window_cols):
+        missing = [s for s in missing if s != "repos"]
     if missing:
         # Split in `want`'s order, which is the density level's own — see
         # `instance.FRAME_DENSITY` for why that order is geometry rather than reading
         # order. Every split targets the harness pane, so a slot added to a frame that
         # already has the others lands exactly where a launch would have put it.
         #
-        # `list(keep) + missing` and NOT `want`, for `bottom`'s width (#500): the panes
+        # `list(keep) + missing` and NOT `want`, for `repos`' width (#500): the panes
         # that survived this re-layout are wherever their own launch put them, and the
         # new ones are split after all of them. That concatenation is the order the panes
-        # are actually in — which is what `layout.bottom_cols` needs, and what `want`'s
-        # order is not. A frame launched with `["right", "top", "bottom"]` and then sent
-        # to the `full` density keeps its inset 87-column `bottom`, because nothing was
-        # killed or re-split; sizing it from `want`'s `["top", "bottom", "right"]` would
-        # say 110 and hand it the seven-row pane this fix exists to stop.
+        # are actually in — which is what `layout.repos_cols` needs, and what `want`'s
+        # order is not. A frame launched with `["right", "top", "bottom", "repos"]` and
+        # then sent to the `full` density keeps its inset 97-column table pane, because
+        # nothing was killed or re-split; sizing it from `want`'s own order would say 120
+        # and hand it the seven-row pane this fix exists to stop.
         keep.update(_split_panels(
             socket, slots=missing, fid=fid, harness_pane=harness_pane, env=None,
             pane_env=pane_env,
             sizes=layout.slot_sizes(
                 want, window_rows=window_rows,
-                content_rows=frame_slots.bottom_rows_wanted(
-                    fid, pane_cols=layout.bottom_cols(list(keep) + missing,
+                content_rows=frame_slots.repos_rows_wanted(
+                    fid, pane_cols=layout.repos_cols(list(keep) + missing,
                                                       window_cols=window_cols)))))
         _arm_panel_respawn(socket, fid=fid,
                            panes={s: keep[s] for s in missing if s in keep}, env=None)
 
     _install_resize_hook(socket, harness_pane=harness_pane, panes=keep, v=v,
                          env=None, fid=fid, replacing=True)
-    _reassert_sizes(socket, fid=fid, panes=keep,
+    _reassert_sizes(socket, fid=fid, panes=keep, harness_pane=harness_pane,
                     window_cols=window_cols, window_rows=window_rows)
     # `split-window` makes each new pane the ACTIVE one, so without this the operator is
     # left typing into a panel. The same correction `cmd_launch` makes after its own
@@ -2708,7 +2737,7 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
     return keep
 
 
-def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str],
+def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str], harness_pane: str,
                     window_cols: int, window_rows: int) -> None:
     """Re-apply every pane in *panes* the size `layout.slot_sizes` says it should have in
     a *window_cols* x *window_rows* window.
@@ -2720,23 +2749,23 @@ def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str],
     fix); and :func:`cmd_resize`, because the whole window just changed size under all of
     them.
 
-    **The sizes are recomputed here, never carried in.** `bottom`'s height depends on the
-    window it is in (`layout.bottom_rows`), so a caller passing a launch-time number
+    **The sizes are recomputed here, never carried in.** `repos`' height depends on the
+    window it is in (`layout.repos_rows`), so a caller passing a launch-time number
     would re-assert a height that was right for a window that no longer exists — measured
     on tmux 3.7c, asserting `-y 40` in a 20-row window leaves the harness 1 row.
     *window_rows* is therefore a measurement the CALLER just took, not a remembered one.
 
     **And *window_cols* alongside it (#500), for the same reason and a sharper one.** A
-    resize changes the window's WIDTH too, and how tall `bottom` should be depends on it:
+    resize changes the window's WIDTH too, and how tall `repos` should be depends on it:
     below `statusline._LEFT_W` the panel draws no table, so it wants one row. Dropping the
     width here — `cmd_resize` measured it and threw it away as `_cols` — is what made a
     narrowed terminal keep a table-sized pane it could no longer draw a table in, on every
     step of the drag rather than only at launch.
 
-    **And the window's width is not the PANE's.** `layout.bottom_cols` turns one into the
+    **And the window's width is not the PANE's.** `layout.repos_cols` turns one into the
     other from the order *panes* is in, which is the order those panes were split in. A
-    frame whose `[frame] slots` names `right` before `bottom` has an 87-column `bottom`
-    in a 110-column window, and this is the site that re-applied the wrong height for it
+    frame whose `[frame] slots` names `right` before `repos` has a 97-column table pane
+    in a 120-column window, and this is the site that re-applied the wrong height for it
     on every step of a drag — the launch-time defect's longer-lived half.
 
     Every pane id is checked before it is used, even though both callers already checked
@@ -2745,22 +2774,45 @@ def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str],
     exactly a builder that documented "safe because my caller checked" growing a second
     caller.
 
+    **The HARNESS is told its height too, and the variable slot is left as the remainder
+    — #515.** tmux's `resize-pane -y` moves exactly ONE boundary: the one below the pane,
+    or the one above it when the pane is last in its stack. With two strips that always
+    traded with the harness, so asserting both was enough and the harness never had to be
+    named. Three strips have two of them BELOW the harness, and those two trade with each
+    other: measured on tmux 3.7c at 200x50, asserting `top`, `bottom` and `repos` in split
+    order left the table 1 row tall and the attention strip 6 — the two sizes swapped
+    panes, and the harness kept whatever tmux's own redistribution had given it.
+
+    So this asserts every slot :data:`_RESIZE_FLAG` names — which is every slot whose size
+    is a CONSTANT, and deliberately not `layout.VARIABLE_ROW_SLOTS` — plus
+    `layout.harness_rows` on the harness itself. The table's size is already a function of
+    all the others, so it lands on exactly `repos_rows`' answer without being asserted. In
+    a stack of N panes only N-1 heights are free; asserting all N is what made the result
+    depend on the order.
+
+    *harness_pane* is checked like every other id here and for the same reason: it is read
+    off disk (`state.harness_pane`) by `cmd_resize`, which is exactly the shape #475 was.
+
     `report=False`: a pane that has since died (the operator closed it, a panel crashed
     between the map being read and this running) makes `resize-pane` fail, and that is
     not an integration failure worth printing over the agent's own screen.
     """
     # `list(panes)` twice, and it is the same list for two different questions:
-    # `slot_sizes` needs to know which OTHER horizontal strips are charging `bottom`
-    # rows, and `bottom_cols` needs the order they were split in to know how wide
-    # `bottom` is. Both callers hand a map whose insertion order is that split order —
+    # `slot_sizes` needs to know which OTHER horizontal strips are charging `repos`
+    # rows, and `repos_cols` needs the order they were split in to know how wide
+    # `repos` is. Both callers hand a map whose insertion order is that split order —
     # `_draw_panels` records a launch in split order, `_relayout` keeps survivors ahead
     # of new splits, and `state.panes` is JSON, which round-trips a dict's order.
     order = list(panes)
     sizes = layout.slot_sizes(
         order, window_rows=window_rows,
-        content_rows=frame_slots.bottom_rows_wanted(
-            fid, pane_cols=layout.bottom_cols(order, window_cols=window_cols)))
+        content_rows=frame_slots.repos_rows_wanted(
+            fid, pane_cols=layout.repos_cols(order, window_cols=window_cols)))
     for slot, pane_id in panes.items():
+        # `layout.VARIABLE_ROW_SLOTS` is not in `_RESIZE_FLAG` at all, which is what
+        # leaves the table pane as the stack's dependent one — see that constant's own
+        # comment for the tmux measurement, and note that a second check for it here
+        # would be a guard no mutation could turn red, because this one already caught it.
         if slot not in _RESIZE_FLAG or slot not in sizes:
             continue
         if not _PANE_ID_RE.fullmatch(pane_id):
@@ -2768,6 +2820,12 @@ def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str],
         tmuxctl.run(f"restoring the {slot} panel's size",
                     tmuxctl.server_argv(socket, "resize-pane", "-t", pane_id,
                                         _RESIZE_FLAG[slot], str(sizes[slot])),
+                    report=False)
+    if _PANE_ID_RE.fullmatch(harness_pane or ""):
+        tmuxctl.run("restoring the harness pane's height",
+                    tmuxctl.server_argv(
+                        socket, "resize-pane", "-t", harness_pane, "-y",
+                        str(layout.harness_rows(sizes, window_rows=window_rows))),
                     report=False)
 
 
@@ -2778,8 +2836,8 @@ def cmd_resize(args) -> int:
     **Why this is a command and not a string in a hook.** tmux's layout engine
     redistributes every pane proportionally on a resize, so the intended sizes have to be
     re-applied afterwards; until #488 the hook carried them as literal text, computed once
-    at layout time. `bottom`'s height is content-and-window dependent now
-    (`layout.bottom_rows`), and a literal is not merely stale then — measured on tmux
+    at layout time. The table pane's height is content-and-window dependent now
+    (`layout.repos_rows`), and a literal is not merely stale then — measured on tmux
     3.7c, a hook still asserting `-y 40` after the window shrank to 20 rows left the
     harness pane **1 row tall**. Recomputing needs charter, so the hook calls charter.
 
@@ -2800,7 +2858,7 @@ def cmd_resize(args) -> int:
     read, because that variable is a session option charter does not write there.
 
     **Both dimensions are used, not just the rows (#500).** The window's WIDTH decides
-    whether `bottom` can draw its table at all (`statusline._LEFT_W`), so narrowing a
+    whether `repos` can draw its table at all (`statusline._LEFT_W`), so narrowing a
     terminal below 95 columns has to shrink the pane to the one-row strip it can actually
     fill. This measured the width and discarded it as `_cols`, which left a narrowed
     frame re-asserting a table-sized pane it drew one line into — on every step of the
@@ -2811,7 +2869,7 @@ def cmd_resize(args) -> int:
     once per size change, so this runs repeatedly and in the background while the
     operator is still dragging. Everything it reads is cheap by construction:
     `state.harness_pane`/`state.panes` are two small files, `_window_size` is one
-    `display-message`, and `frame_slots.bottom_rows_wanted` goes through
+    `display-message`, and `frame_slots.repos_rows_wanted` goes through
     `gather.row_count`, which answers from the frame's cache and never runs a git sweep
     (see its own docstring) — and at a width below `_LEFT_W` it does not even ask, since
     the answer is one row whatever the count is.
@@ -2827,7 +2885,8 @@ def cmd_resize(args) -> int:
         return 0
     socket = state.frame_server(fid) or SOCKET
     cols, rows = _window_size(socket, harness_pane)
-    _reassert_sizes(socket, fid=fid, panes=panes, window_cols=cols, window_rows=rows)
+    _reassert_sizes(socket, fid=fid, panes=panes, harness_pane=harness_pane,
+                    window_cols=cols, window_rows=rows)
     return 0
 
 

--- a/charter/frame/gather.py
+++ b/charter/frame/gather.py
@@ -3,7 +3,7 @@
 ``statusline.render`` performs an expensive gather before it lays anything out:
 ``_repo_trees``, ``_repo_states`` (one ``git status --porcelain --branch`` per
 repo), ``_branch`` per tree, and ``glstate.read_for``. The frame has up to four
-panels (``top``/``left``/``right``/``bottom``); if each gathered independently
+panels (``top``/``repos``/``right``/``bottom``); if each gathered independently
 that would be four identical git sweeps per repaint, which destroys the property
 the frame was built for — see ``charter/frame/panel.py``'s own docstring: a panel
 repaints only on a ``state.version`` bump, so watching a frame must cost a
@@ -385,7 +385,7 @@ def row_count(fid: str) -> int:
     """How many table rows this frame's repos and pieces would fill — **never a git
     sweep**, on either path.
 
-    #488 made the `bottom` pane's HEIGHT a function of its content, which means somebody
+    #488 made the table pane's HEIGHT a function of its content, which means somebody
     outside a panel has to know how much content there is: the launcher, before any panel
     exists, and `commands_frame.cmd_resize`, every time the window changes size. Both are
     on paths where cost is felt directly — a launch the operator is waiting on, and a
@@ -407,16 +407,16 @@ def row_count(fid: str) -> int:
     **The listing counts the FRAME's workspace, not the asking process's** (#512).
     `state.workspace_for` is the one rule every frame surface asks — what was chosen inside
     the frame, else what the launcher recorded, else a local resolve — so the pane is sized
-    from the same workspace `slots._bottom` then draws. The two callers make the difference
+    from the same workspace `slots._repos` then draws. The two callers make the difference
     real: the launcher IS the process that resolved it and would agree either way, but
     `cmd_resize` runs as a tmux `run-shell` child, whose environment is the SERVER's and
-    whose cwd and pane id are not the operator's — so it would size `bottom` for whatever
+    whose cwd and pane id are not the operator's — so it would size `repos` for whatever
     workspace it resolved for itself, which on the plane that reported #512 was a
     `default` holding no clones at all.
 
-    Zero for anything that fails, which is the floor `layout.bottom_rows` already
-    handles: a frame whose repo count could not be established gets the one-row strip
-    `bottom` always was, never a taller pane full of nothing.
+    Zero for anything that fails, which is the floor `layout.repos_rows` already
+    handles: a frame whose repo count could not be established gets a one-row pane saying
+    so, never a taller one full of nothing.
     """
     data = cached(fid)
     if data is not None:

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -43,32 +43,39 @@ from .. import util
 
 #: The order slots are dropped in as the terminal shrinks. The side first — a side panel
 #: costs the harness columns, so it goes as soon as space is tight in EITHER dimension,
-#: not only when columns themselves are the short one — then the top, whose row is worth
-#: less than the bottom's alerts and repo table, and which only goes when rows are the
+#: not only when columns themselves are the short one — then `repos`, whose table simply
+#: cannot be drawn in a pane narrower than `statusline._LEFT_W`, then the top, whose row
+#: is worth less than the status strip's alerts and which only goes when rows are the
 #: tight dimension.
 #:
+#: **`bottom` is not here, and it is the one slot that never is.** It is the attention
+#: strip — the one alert and the command that fixes it — which is the whole reason a
+#: frame is worth drawing at all on a terminal too small for anything else.
+#:
 #: **`left` is not here any more, and #488 is why.** It drew repo rows recomposed for a
-#: 22-column pane; `bottom` now draws the same rows as the full-width table the status
+#: 22-column pane; `repos` now draws the same rows as the full-width table the status
 #: line draws, so the sidebar's only remaining job was a lesser copy of its neighbour's.
 #: Retiring it hands those 22 columns back to the harness at every density.
-_DROP_ORDER = ("right", "top", "bottom")
+_DROP_ORDER = ("right", "repos", "top")
 
 #: Rows a horizontal panel occupies, and columns a vertical one does.
 #:
-#: **`bottom`'s entry is a FLOOR now, not its size** (#488). Every other slot is fixed:
-#: `top` says one row's worth of identity, `right` is a column of persona chips. `bottom`
-#: carries the repo table, which is as many rows as there are repos — so its real height
-#: is :func:`bottom_rows`, and this is what it never goes below (and what it is, on a
-#: plane with no repos at all). Callers ask :func:`slot_sizes` rather than indexing this
-#: directly, so nothing has to remember which of the two questions it is asking.
-SLOT_SIZE = {"top": 1, "bottom": 1, "right": 22}
+#: **`repos`' entry is a FLOOR, not its size** (#488, moved off `bottom` by #515). Every
+#: other slot is fixed: `top` says one row's worth of identity, `bottom` is the one-row
+#: attention strip, `right` is a column of persona chips. `repos` carries the table,
+#: which is as many rows as there are repos — so its real height is :func:`repos_rows`,
+#: and this is what it never goes below (and what it is, on a plane with no clones at
+#: all, where the pane says so in one line). Callers ask :func:`slot_sizes` rather than
+#: indexing this directly, so nothing has to remember which of the two questions it is
+#: asking.
+SLOT_SIZE = {"top": 1, "bottom": 1, "repos": 1, "right": 22}
 
 #: Rows the harness keeps whatever the repo table would like. The frame exists to show
 #: the plane's state around an agent session, and a session squeezed into three rows is
 #: not one anybody can read — so the table gives up rows before the harness does.
 #:
 #: Not hypothetical, and this number is what stands between the operator and it: measured
-#: against tmux 3.7c, `resize-pane -t <bottom> -y 40` in a 20-row window left the harness
+#: against tmux 3.7c, `resize-pane -t <the table pane> -y 40` in a 20-row window left the harness
 #: pane **1 row tall**. tmux clamps to what the window has and takes the remainder from
 #: its neighbour without complaint, so an over-large height is not refused — it is
 #: granted, out of the one pane that matters.
@@ -77,7 +84,7 @@ HARNESS_MIN_ROWS = 12
 #: One row per pane border. tmux charges a horizontal split one row for the divider on
 #: top of the pane's own height — measured on 3.7c: a 50-row window split `-l 8` reads
 #: back as a 41-row harness and an 8-row panel, which is 49. Counted explicitly rather
-#: than folded into :data:`HARNESS_MIN_ROWS` so the arithmetic in :func:`bottom_rows`
+#: than folded into :data:`HARNESS_MIN_ROWS` so the arithmetic in :func:`repos_rows`
 #: says what it is doing.
 _BORDER_ROWS = 1
 
@@ -88,54 +95,120 @@ _BORDER_COLS = 1
 
 #: Slots that take COLUMNS off the pane they are split from rather than rows — the `-h`
 #: half of :func:`panel_argvs`' `direction`. Kept as a name rather than an inline
-#: ``== "right"`` because :func:`bottom_cols` and `panel_argvs` are two places that have
+#: ``== "right"`` because :func:`repos_cols` and `panel_argvs` are two places that have
 #: to agree about which splits cost columns, and the next side slot must not have to be
 #: remembered in both.
 _COLUMN_SLOTS = ("right",)
 
+#: The horizontal strips whose height is a CONSTANT, and therefore the rows
+#: :func:`repos_rows` has to subtract before it may spend what is left. `right` is not
+#: here because it costs columns, and `repos` is not here because it is the slot being
+#: sized.
+#:
+#: **`bottom` joined this list in #515 and that is the whole arithmetic change.** It used
+#: to be the variable-height slot itself, so the only fixed strip to subtract was `top`;
+#: it is now the one-row attention strip it was before #488, and the table it used to
+#: carry is `repos`. A `repos_rows` still subtracting `top` alone would hand the table
+#: two rows the status strip and its own border are already using, and tmux grants an
+#: over-large height out of the neighbour rather than refusing it — the harness.
+_FIXED_ROW_SLOTS = ("top", "bottom")
 
-def bottom_cols(slots: list[str] | tuple[str, ...], *, window_cols: int) -> int:
-    """How wide the `bottom` pane actually is, in a *window_cols*-column window whose
+#: The slots whose height is a function of their content rather than a constant — the
+#: ones :func:`slot_sizes` answers with :func:`repos_rows` instead of :data:`SLOT_SIZE`.
+#:
+#: **It is also which pane is the DEPENDENT one when sizes are re-applied**, and that is
+#: not a second meaning bolted on. tmux's `resize-pane -y` moves exactly one boundary, so
+#: in a vertical stack of N panes only N-1 heights can be asserted; assert them all and
+#: the result depends on the order, which is how a re-assertion in split order came out
+#: with the table one row tall and the attention strip six (measured on 3.7c at 200x50:
+#: `top,bottom,repos` left `%3 h=1` and `%2 h=6` — the two sizes swapped panes). The pane
+#: that must be left to take the remainder is the one whose size is already a function of
+#: everything else, which is this one. See `commands_frame._reassert_sizes`.
+VARIABLE_ROW_SLOTS = frozenset({"repos"})
+
+
+def _table_min_cols() -> int:
+    """The narrowest pane the repo table can be drawn in at all — `statusline._LEFT_W`,
+    READ rather than copied.
+
+    `slots._table_cap` answers 0 below this width and `slots._table_lines` refuses
+    outright ("too narrow for the table is NO table, not a cut one"), so a `repos` pane
+    split narrower than this is a bordered rectangle with nothing in it — which reads as
+    "this workspace has no repos" on a plane that has fourteen. :func:`visible_slots`
+    drops the slot instead, and it must drop it at exactly the width the RENDERER stops
+    drawing at: a second copy of the number here would be a guard matching a spelling,
+    and the two would come apart the first time a column width moved.
+
+    Imported inside the call rather than at module scope, the way `frame/slots.py`
+    already reaches for the same module: this file is imported by every launch path and
+    `statusline` pulls in `config`, whose import resolves the plane root.
+    """
+    from .. import statusline as sl
+    return sl._LEFT_W
+
+
+def repos_cols(slots: list[str] | tuple[str, ...], *, window_cols: int) -> int:
+    """How wide the `repos` pane actually is, in a *window_cols*-column window whose
     slots were split in *slots*' order — **not the window's own width** (#500).
 
     `panel_argvs` splits every slot off the HARNESS pane in list order, so a side slot
-    split before `bottom` has already narrowed the pane `bottom` is then carved out of.
-    Measured on tmux 3.7c, window 110x40, `-l 22` for `right` and `-l 7` for `bottom`:
+    split before `repos` has already narrowed the pane `repos` is then carved out of.
+    Measured on tmux 3.7c, window 120x40, `-l 22` for `right` and `-l 6` for the table:
 
-    * ``["top", "bottom", "right"]`` (the shipped order) — `bottom` reads back **110**
-      wide; `right` is split off the harness afterwards and sits beside the harness only.
-    * ``["right", "top", "bottom"]`` and ``["top", "right", "bottom"]`` — `bottom` reads
-      back **87**, which is ``110 - 22 - 1``.
+    * ``["top", "bottom", "repos", "right"]`` (the shipped order) — the table reads back
+      **120** wide; `right` is split off the harness afterwards and sits beside the
+      harness only (`%3 top=32 h=6 w=120`, `%4 top=2 left=98 h=29 w=22`).
+    * ``["right", "top", "bottom", "repos"]`` — the table reads back **97**, which is
+      ``120 - 22 - 1``.
 
     That difference is a promise, not an accident: `instance.frame_of` keeps an
     operator's `[frame] slots` order verbatim and
     `tests/test_frame_config.py::test_the_operators_own_slot_order_is_kept_exactly`
     pins it, precisely because the order IS the geometry. What #500 got wrong was not the
-    order — it was handing `slots.bottom_rows_wanted` the window's width regardless, so a
-    `bottom` that had been inset beside the sidebar was sized for a table its own pane
-    was too narrow to draw. Below `statusline._LEFT_W` (95) the renderer draws no table
-    at all, so a 110-column frame with `right` first got a seven-row pane and one line in
+    order — it was handing `slots.repos_rows_wanted` the window's width regardless, so a
+    table pane that had been inset beside the sidebar was sized for a table its own pane
+    was too narrow to draw. Below :func:`_table_min_cols` the renderer draws no table at
+    all, so a 110-column frame with `right` first got a seven-row pane and one line in
     it, six rows taken off the harness and left blank.
 
-    Order in, order out — this reads *slots* rather than a set, and stops at `bottom`.
-    A slot split AFTER `bottom` costs it nothing (measured above), and killing one gives
-    the columns back (`kill-pane` on `right` widened the same `bottom` from 87 to 110),
+    Order in, order out — this reads *slots* rather than a set, and stops at `repos`.
+    A slot split AFTER `repos` costs it nothing (measured above), and killing one gives
+    the columns back (`kill-pane` on `right` widened the same pane from 87 to 110),
     which is why the list a caller passes has to be the order its panes were actually
     split in: at launch that is the drawable slot list, and for a running frame it is the
     recorded pane map's own order, survivors first and later splits appended.
 
-    With no `bottom` in *slots* this answers the width one WOULD be split to. Nothing
-    asks in that state today — `slot_sizes` only sizes the slots it was given — and an
-    answer that is right the moment the slot appears is better than a zero that is right
-    for nothing.
+    With no `repos` in *slots* this answers the width one WOULD be split to, which is
+    what :func:`visible_slots` asks it before deciding whether the slot survives at all.
     """
     out = window_cols
     for slot in slots:
-        if slot == "bottom":
+        if slot == "repos":
             break
         if slot in _COLUMN_SLOTS:
             out -= SLOT_SIZE[slot] + _BORDER_COLS
     return max(0, out)
+
+
+def repos_fits(order: list[str] | tuple[str, ...], *, window_cols: int) -> bool:
+    """Would a `repos` pane split in *order*, in a *window_cols*-column window, be wide
+    enough to draw a table in at all?
+
+    **One rule, two callers, and the second one is why it is a function.**
+    :func:`visible_slots` asks it at launch, where *order* is the configured slot list.
+    `commands_frame._relayout` asks it for a density change, where *order* is the
+    surviving panes in their recorded split order followed by what is about to be split —
+    which is NOT the level's own list, and which is the whole of #500's round 3. A frame
+    that already has `right` and grows a table gets that table split off a harness pane
+    the sidebar has already narrowed by 23 columns, so the level's list says 110 and the
+    pane is 87.
+
+    Without this shared, both said different things and the disagreement was visible: the
+    launch filter kept `repos` (from the level's order, full width) and the sizer floored
+    it at one row (from the pane's order, too narrow) — a bordered rectangle with nothing
+    in it, which is exactly the "no repos" lie #515 split the pane to avoid.
+    """
+    return repos_cols(order, window_cols=window_cols) >= _table_min_cols()
 
 
 def visible_slots(slots: list[str], cols: int, rows: int,
@@ -146,50 +219,66 @@ def visible_slots(slots: list[str], cols: int, rows: int,
     which is the same choice `statusline.render` makes when it runs out of width. Follows
     `_DROP_ORDER`: `right` is the first to go, on ANY shortage — a terminal that is short
     on rows cannot spare a side panel's own divider any more than a narrow one can spare
-    its columns — then `top`, only when rows specifically are the tight dimension.
+    its columns — then `repos`, and then `top`, only when rows specifically are the tight
+    dimension.
 
-    `bottom` never goes here, and it does not need to: it is the slot that SHRINKS
-    instead (:func:`bottom_rows` floors it at one row, the height it always had), so a
-    terminal too small for a table still gets the alert line the frame is really for.
+    **`repos` goes on a width its own renderer cannot draw in, and that width is read
+    from the renderer** (:func:`_table_min_cols`). This is the drop `bottom` did not need
+    while it carried both things: below `statusline._LEFT_W` the table refuses to draw at
+    all, so the pane kept drawing the attention row above it and the operator saw no
+    difference. Split apart (#515), the same case is a bordered rectangle with nothing in
+    it — a pane that says "no repos" on a plane full of them, which is the false-clean
+    reading the frame refuses everywhere else. The test is the PANE's width, not the
+    window's: a `[frame] slots` naming `right` first insets this pane by 23 columns, so
+    :func:`repos_cols` is asked with the slots that survived the line above.
+
+    `bottom` never goes here, and it is the only slot that never does: it is the one
+    alert and the command that fixes it, which is why a frame is worth drawing on a
+    terminal with room for nothing else.
     """
     keep = list(slots)
     if cols < min_cols or rows < min_rows:
         keep = [s for s in keep if s != "right"]
     if rows < min_rows:
         keep = [s for s in keep if s != "top"]
+    if "repos" in keep and not repos_fits(keep, window_cols=cols):
+        keep = [s for s in keep if s != "repos"]
     if cols < min_cols // 2 or rows < min_rows // 2:
         keep = []
     return [s for s in slots if s in keep]
 
 
-def bottom_rows(*, content_rows: int, window_rows: int,
-                slots: list[str] | tuple[str, ...] = ()) -> int:
-    """How many rows the `bottom` pane gets: what its content wants, floored and capped.
+def repos_rows(*, content_rows: int, window_rows: int,
+               slots: list[str] | tuple[str, ...] = ()) -> int:
+    """How many rows the `repos` pane gets: what its content wants, floored and capped.
 
-    Pure arithmetic, deliberately — this is the whole of #488's "how tall is `bottom`?"
+    Pure arithmetic, deliberately — this is the whole of #488's "how tall is the table?"
     and it is decided here, with no tmux and no filesystem, so both callers that need an
     answer (a launch, and the `window-resized` hook's own recompute) necessarily get the
     same one.
 
-    * **The floor is `SLOT_SIZE["bottom"]`.** A plane with no clones still has an alert
-      row, a todo count and this session's news to draw, which is the row `bottom` always
-      was. Never zero: a zero-row pane is one tmux refuses to split at all.
+    * **The floor is `SLOT_SIZE["repos"]`.** A workspace with no clones still has one
+      line to draw — that it has none, and the command that gets it one
+      (`slots._empty_lines`). Never zero: a zero-row pane is one tmux refuses to split at
+      all.
     * **The cap leaves the harness :data:`HARNESS_MIN_ROWS`.** *window_rows* is the whole
-      window, *slots* is what else is being drawn in it, and every horizontal strip costs
-      its own height plus :data:`_BORDER_ROWS`. `right` costs columns, not rows, so it is
-      not counted here — asking for the whole slot list rather than a pre-computed number
-      is what keeps that decision in one place instead of at each call site.
-    * **Between the two, the content wins.** *content_rows* is what `slots._bottom` would
-      actually fill (`slots.bottom_rows_wanted`), so a two-repo plane gets a three-row
-      strip rather than a fourteen-row one padded with blanks.
+      window, *slots* is what else is being drawn in it, and every horizontal strip in
+      :data:`_FIXED_ROW_SLOTS` costs its own height plus :data:`_BORDER_ROWS`. `right`
+      costs columns, not rows, so it is not counted here — asking for the whole slot list
+      rather than a pre-computed number is what keeps that decision in one place instead
+      of at each call site.
+    * **Between the two, the content wins.** *content_rows* is what `slots._repos` would
+      actually fill (`slots.repos_rows_wanted`), so a two-repo plane gets a two-row strip
+      rather than a fourteen-row one padded with blanks.
 
-    The cap can come out below the floor — a 14-row window has no rows to spare at all —
-    and the floor wins then, because the alternative is a frame with no alert row in
-    exactly the terminal where an alert is most likely to be the reason it is there.
+    The cap can come out below the floor — a 16-row window has no rows to spare at all —
+    and the floor wins then, because `panel_argvs` has to be able to split the pane at
+    all. What protects the harness in that terminal is :func:`visible_slots`, which drops
+    every slot below half the size floors.
     """
-    floor = SLOT_SIZE["bottom"]
+    floor = SLOT_SIZE["repos"]
     other = sum(SLOT_SIZE[s] + _BORDER_ROWS
-                for s in slots if s in ("top",))
+                for s in slots if s in _FIXED_ROW_SLOTS)
     cap = window_rows - other - _BORDER_ROWS - HARNESS_MIN_ROWS
     return max(floor, min(content_rows, cap))
 
@@ -198,11 +287,11 @@ def slot_sizes(slots: list[str], *, window_rows: int, content_rows: int) -> dict
     """Every slot in *slots* mapped to the size it should be given — rows for the
     horizontal strips, columns for the side.
 
-    The one place `bottom`'s variable height and the other slots' fixed sizes are
-    answered together, so a caller never has to know which kind a slot is. `panel_argvs`
-    splits with it, `commands_frame._reassert_sizes` re-applies it, and the
-    `window-resized` recompute calls it again with the window's NEW row count — which is
-    the whole reason it takes *window_rows* rather than closing over a launch-time value.
+    The one place `repos`' variable height and the other slots' fixed sizes are answered
+    together, so a caller never has to know which kind a slot is. `panel_argvs` splits
+    with it, `commands_frame._reassert_sizes` re-applies it, and the `window-resized`
+    recompute calls it again with the window's NEW row count — which is the whole reason
+    it takes *window_rows* rather than closing over a launch-time value.
 
     Unknown slot names are dropped rather than raised on, matching `visible_slots`'
     filter-don't-refuse discipline: `[frame] slots` is committed, untrusted input, and by
@@ -210,12 +299,44 @@ def slot_sizes(slots: list[str], *, window_rows: int, content_rows: int) -> dict
     """
     out: dict[str, int] = {}
     for slot in slots:
-        if slot == "bottom":
-            out[slot] = bottom_rows(content_rows=content_rows,
-                                    window_rows=window_rows, slots=slots)
+        if slot in VARIABLE_ROW_SLOTS:
+            out[slot] = repos_rows(content_rows=content_rows,
+                                   window_rows=window_rows, slots=slots)
         elif slot in SLOT_SIZE:
             out[slot] = SLOT_SIZE[slot]
     return out
+
+
+def harness_rows(sizes: dict[str, int], *, window_rows: int) -> int:
+    """The rows left for the HARNESS pane once every horizontal strip in *sizes* has its
+    own height and its own border — the number `commands_frame._reassert_sizes` asserts
+    on the harness itself after a resize.
+
+    **Why the harness is resized at all, which it never used to be.** tmux redistributes
+    every pane proportionally on a window resize, so the intended sizes have to be
+    re-applied; and `resize-pane -y` moves ONE boundary — the one below the pane, or the
+    one above it when the pane is last in the stack. With two strips (`top` above the
+    harness, `bottom` below it) every `resize-pane` therefore traded with the harness and
+    asserting both was enough. #515 makes three, and the two below the harness trade with
+    EACH OTHER instead: measured on tmux 3.7c at 200x50, asserting `top`, `bottom` and
+    `repos` in split order left the table 1 row and the attention strip 6 — each
+    assertion undoing the last, with the harness never consulted.
+
+    So the harness is told its height explicitly and the variable slot
+    (:data:`VARIABLE_ROW_SLOTS`) is left to take the remainder. Verified against tmux
+    3.7c at 200x50, 200x24, 200x100 and 90x40, with and without the sidebar, and in both
+    orders that put the harness before or after the strip below it: the table lands on
+    exactly `repos_rows`' answer every time.
+
+    *sizes* is :func:`slot_sizes`' map. Slots in :data:`_COLUMN_SLOTS` cost columns, not
+    rows, and are not counted — the same rule :func:`repos_rows` keeps, read from the same
+    constant. Floored at 1: a zero or negative `-y` is a resize tmux refuses, and a
+    refused resize leaves the frame as tmux's own redistribution left it, which is worse
+    than a harness squeezed to one row in a window that has no rows for it anyway.
+    """
+    used = sum(n + _BORDER_ROWS for slot, n in sizes.items()
+               if slot not in _COLUMN_SLOTS)
+    return max(1, window_rows - used)
 
 
 #: What a frame's window runs while charter is still setting it up, before the harness
@@ -503,19 +624,28 @@ def panel_argvs(*, slots: list[str], session: str, socket: str,
     Only `commands_frame._FRAME_IDENTITY` travels, never the whole environment: a `-e` is
     argv, and argv is world-readable. See `commands_frame._frame_identity_env`.
 
-    *sizes* is :func:`slot_sizes`' answer for this window, and it exists because `bottom`
-    is no longer a fixed height (#488). ``None`` falls back to :data:`SLOT_SIZE`, which
-    is `bottom`'s FLOOR — right for a caller that has no window to measure (a test, a
+    *sizes* is :func:`slot_sizes`' answer for this window, and it exists because `repos`
+    is not a fixed height (#488). ``None`` falls back to :data:`SLOT_SIZE`, which is
+    `repos`' FLOOR — right for a caller that has no window to measure (a test, a
     `--probe`), wrong for a launch, which is why both launch paths pass one. Read with a
     per-slot fallback rather than replaced wholesale, so a *sizes* missing an entry
     degrades to the fixed size instead of a `KeyError` inside a launch.
+
+    **`-b` is `top`'s alone, and the rest of the reading order is the split order run
+    backwards.** Every other split is a plain `-v`, which tmux places DIRECTLY below
+    the harness — so a slot split later sits ABOVE one split earlier. Measured on tmux
+    3.7c in a 120x40 window, splitting `top`, `bottom`, `repos`, `right` off the
+    harness in that order: `top` at row 0, harness and `right` at rows 2-30, `repos` at
+    rows 32-37, `bottom` on row 39. That is the frame #515 asks for — identity, the
+    session, the repo table, the attention strip on the terminal's last row — and it is
+    why the shipped `slots` list names `bottom` before `repos` and not after it.
     """
     cmds: list[list[str]] = []
     for slot in slots:
         size = (sizes or SLOT_SIZE).get(slot, SLOT_SIZE[slot])
         # :data:`_COLUMN_SLOTS` rather than a second list of names: which splits take
-        # COLUMNS is exactly what :func:`bottom_cols` has to know to answer how wide
-        # `bottom` ends up, and two copies of that fact are two things to keep in step.
+        # COLUMNS is exactly what :func:`repos_cols` has to know to answer how wide
+        # `repos` ends up, and two copies of that fact are two things to keep in step.
         direction = "-h" if slot in _COLUMN_SLOTS else "-v"
         before = ["-b"] if slot == "top" else []
         cmds.append(_tmux(socket, "split-window", "-t", harness_pane,

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -31,7 +31,7 @@ line out of view and leaves every sibling pane untouched, not the whole frame. `
 clamps the LINE COUNT the way `tui.truncate` already clamps each line's WIDTH.
 
 The measurement itself moved to `slots._height` with #488, beside `slots._width` and for
-the same reason width already lived there: a renderer needs it now. `bottom` is sized to
+the same reason width already lived there: a renderer needs it now. `repos` is sized to
 its content and draws as much of the repo table as its pane holds, choosing which rows to
 spend on through `statusline._pick_rows` — a clamp applied after the fact would cut the
 table at whatever came last, which is the unranked slice that ranking exists to prevent.
@@ -66,7 +66,7 @@ the reason to stderr does not fix that, and the measurement is why (real tmux 3.
 `remain-on-exit on`): tmux writes its own `Pane is dead (status N, <date>)` message by
 moving to the pane's LAST row and issuing a linefeed first, which scrolls the pane up by
 exactly one line — in a six-row pane the first of three stderr lines is lost and the
-rest survive, but `top` is ONE row (`layout.SLOT_SIZE`) and `bottom` is one whenever the
+rest survive, but `top` and `bottom` are ONE row each (`layout.SLOT_SIZE`) and `repos` is
 workspace holds no clones (its own floor, since #488), so that one scrolled line is the
 whole pane and `Pane is dead (status 2)` is provably all that is left. It cost a real debugging session, whose only way through was running the panel's
 argv by hand outside tmux. A pane whose process is still ALIVE keeps what it painted
@@ -112,7 +112,7 @@ TICK = 0.2
 #: when a terminal's real size is unknowable.
 #:
 #: Re-exported from `slots` rather than declared here, because #488 gave a RENDERER a
-#: reason to ask the same question (`bottom` chooses which repo rows to spend its pane
+#: reason to ask the same question (`repos` chooses which repo rows to spend its pane
 #: on, so it has to know how many it has) and two copies of a fallback are two answers
 #: to "how tall is a pane nobody can measure" — one of which would eventually move.
 _DEFAULT_ROWS = slots._DEFAULT_ROWS
@@ -123,7 +123,7 @@ def _rows() -> int:
     with, for exactly the reason this module already asks `slots` for the WIDTH.
 
     It was implemented here first, and correctly, back when height was purely this
-    module's clamp. #488 made it a renderer's question too (`slots._bottom` decides how
+    module's clamp. #488 made it a renderer's question too (`slots._repos` decides how
     many repo rows to draw), and a second `os.get_terminal_size` with its own `OSError`
     fallback beside the first is how the two come to disagree about a pane neither can
     measure. Kept as a named function rather than inlined: `_write` reads better for it,
@@ -163,7 +163,7 @@ def _hold(reason: str, *, once: bool, rc: int) -> int:
     The whole of this module's answer to a panel that cannot run: **returning is the
     bug**. A panel process that exits hands its pane to `remain-on-exit`, and tmux then
     scrolls the pane by exactly one line to write `Pane is dead (status N, <date>)` over
-    it — which in a one-row pane, which `top` always is and `bottom` is on a plane with
+    it — which in a one-row pane, which `top` and `bottom` always are and `repos` is on a
     no clones, is the entire pane (measured against real tmux 3.7c; see the module
     docstring). So the reason is painted and the process
     simply does not leave, which is the only state in which a pane keeps what was
@@ -370,7 +370,7 @@ def run(slot: str, fid: str, *, once: bool = False) -> int:
     **Neither refusal nor a crash exits.** Both end in `_hold`, which paints the reason
     into the pane and stays there, because a panel process that returns hands its pane
     to tmux's own `Pane is dead (status N)` message — which scrolls a one-row `top`/
-    `bottom` pane clean (measured; see the module docstring). The stderr line is kept
+    one-row pane clean (measured; see the module docstring). The stderr line is kept
     beside the paint rather than replaced by it: it is the only trace left when this is
     run by hand for debugging with stdout redirected (`charter panel top --session x >
     /tmp/log`), the case `_DEFAULT_ROWS` already exists for, and inside a real pane the

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -40,12 +40,16 @@ SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 SPINNER_PERIOD = 0.2
 
 #: How many rows the full-height `right` panel draws at `terse`, and how many rows of
-#: repo table `bottom` keeps there. `top` has no equivalent — it is one row at every
-#: density (`layout.SLOT_SIZE`), so what "less" means for it is FIELDS, not rows.
+#: repo table `repos` keeps there. `top` and `bottom` have no equivalent — each is one
+#: row at every density (`layout.SLOT_SIZE`), so what "less" means for them is FIELDS,
+#: not rows.
 #:
-#: `bottom` is BOTH now (#488): at `terse` its attention row keeps one field and its
-#: table keeps this many rows, because a density that buys back rows has to buy them
-#: from the slot that actually has rows to give.
+#: **`repos` is where the rows are, and #515 is why that is one slot rather than two.**
+#: #488 had `bottom` carrying both, so `terse` meant "one field on the attention row AND
+#: this many table rows" — one level name governing two unrelated budgets in one pane.
+#: Split apart, `terse` limits `_bottom` to a single field and limits this pane to this
+#: many rows, and a density that buys back rows still buys them from the slot that
+#: actually has rows to give.
 _TERSE_ROWS = 4
 
 
@@ -105,8 +109,8 @@ def _frame_workspace(fid: str) -> str:
 
     Kept as a named function here rather than inlined at the three call sites, because
     what it means is a `slots` fact: every panel goes through it — `_top` names the
-    workspace, `_bottom` counts its todos and its alerts and draws its repo table — so the
-    things a frame says about "where am I" cannot disagree with each other. That is a
+    workspace, `_bottom` counts its todos and its alerts, `_repos` draws its table — so
+    the things a frame says about "where am I" cannot disagree with each other. That is a
     failure an operator reads immediately: a header saying `default` above a table listing
     another workspace's repos.
     """
@@ -504,8 +508,9 @@ def _unknown_lines(width: int) -> list[str]:
     that appeared while the rows were unknown and vanished the moment they were known
     would read as "the repos went away". That is not enforced HERE, though — the width
     rule for this pane lives in :func:`_table_cap`, which answers 0 below
-    `statusline._LEFT_W`, and `_bottom` already refuses to compose anything on a budget of
-    0. A second copy of the rule in this function would be unreachable through the only
+    `statusline._LEFT_W`, and `_repos` already refuses to compose anything on a budget of
+    0 (and since #515 `layout.visible_slots` does not even split the pane at that width).
+    A second copy of the rule in this function would be unreachable through the only
     caller there is, and a guard no test can turn red is exactly the kind that passes
     because a DIFFERENT guard caught it.
 
@@ -520,8 +525,71 @@ def _unknown_lines(width: int) -> list[str]:
     return [tui.truncate(f"  {sl._DIM}⋯ gathering this workspace's repos…{sl._R}", width)]
 
 
+def _empty_lines(ws: str, width: int) -> list[str]:
+    """What the `repos` pane draws once the gather HAS run and found no clones.
+
+    **A pane of its own cannot be silent about this, and that is what #515 changed.**
+    While the table shared `bottom` with the attention row, a workspace with no clones
+    simply produced no table rows and the pane was the one-line strip it always was —
+    absence said it. Split into its own bordered component, the same silence is an empty
+    rectangle, and an empty rectangle is a claim nobody made: it reads as a table that
+    failed to draw rather than as a workspace with nothing in it.
+
+    So it is said, with the command that changes it — the shape every `statusline._alerts`
+    row already has, because a line that names a problem and not its fix costs a row and
+    settles nothing. *ws* is the FRAME's workspace (`_frame_workspace`), the same one the
+    count was taken from, so the command names the workspace the pane is actually about
+    rather than whatever this process would have resolved for itself (#512).
+
+    Distinct from :func:`_unknown_lines` on purpose: "not gathered yet" and "gathered,
+    nothing there" are two different claims and #512 is the whole cost of drawing them
+    the same. That one is reached when `gather.cached` answers ``None``; this one when it
+    answers a real scan with no rows in it.
+
+    **No `contain.one_line` over *ws*, and that is a decision rather than an omission.**
+    Every rung of `state.workspace_for` that can answer a name checks it against
+    `instance.WORKSPACE_NAME_RE` (`^[A-Za-z0-9][A-Za-z0-9._-]*$`), an alphabet with no
+    newline, no control character and no escape in it — so containment is already true by
+    construction one layer up, and a second copy here would be a guard nothing could ever
+    turn red. `_top` interpolates the same value on the same terms. What is NOT free is
+    the WIDTH: the name is arbitrary length, so the line is measured through
+    `tui.truncate` like every other line in this module.
+    """
+    from .. import statusline as sl
+
+    return [tui.truncate(
+        f"  {sl._DIM}no clones in{sl._R} {ws}{sl._DIM} · charter clone <repo> -w "
+        f"{ws}{sl._R}", width)]
+
+
+def _too_narrow_lines(width: int) -> list[str]:
+    """What the `repos` pane says when it exists but is narrower than its own table.
+
+    **Reachable only by a RESIZE, and that is the whole reason it exists.** At launch
+    `layout.visible_slots` does not split this pane below `layout._table_min_cols()` at
+    all — a bordered rectangle with nothing in it is the "no repos" lie #515 removed. But
+    `cmd_resize` re-sizes panes; it does not create or destroy them, so narrowing a
+    running frame's terminal leaves a `repos` pane that `_table_lines` correctly refuses
+    to draw a cut table into. Before this, that was a blank bordered row: the same lie,
+    reached by dragging instead of by launching.
+
+    So the pane says what it is. One line, the width it needs stated as a number the
+    operator can act on, and read from `statusline._LEFT_W` rather than spelled here for
+    the reason `layout._table_min_cols` gives: the number that stops the table drawing and
+    the number this line quotes must be the same one.
+
+    Bounded through `tui.truncate` like every other line here — this line is drawn at
+    widths below 95 by definition, and `⋯` is East-Asian *Ambiguous*.
+    """
+    from .. import statusline as sl
+
+    return [tui.truncate(
+        f"  {sl._DIM}⋯ too narrow for the repo table — {sl._LEFT_W} columns "
+        f"needed{sl._R}", width)]
+
+
 def _table_cap(fid: str, width: int) -> int:
-    """The most rows of repo table `_bottom` will draw in a *width*-column pane —
+    """The most rows of repo table `_repos` will draw in a *width*-column pane —
     **every reason the renderer draws fewer rows than there is content**, in one place.
 
     Three of them, and until #500 only the first was written down where the LAUNCHER
@@ -529,19 +597,22 @@ def _table_cap(fid: str, width: int) -> int:
 
     * **Too narrow is no table at all.** Below `statusline._LEFT_W` (95)
       :func:`_table_lines` refuses outright rather than trimming a row into a false-clean
-      `charter  main`, and that is not an exotic width: `layout.visible_slots` keeps
-      `bottom` down to `min_cols // 2` (50), so every ordinary 80-column terminal is here.
+      `charter  main`, and that is not an exotic width: every ordinary 80-column terminal
+      is here. Since #515 that answer is also what `layout.visible_slots` reads (through
+      `layout._table_min_cols`) to decide the `repos` pane is not split at all at those
+      widths — one number, two decisions, rather than a renderer that refuses and a
+      launcher that splits a pane for the refusal to sit in.
     * **`terse` keeps :data:`_TERSE_ROWS`.** A density that buys the harness back its
       rows has to buy them from the slot that has rows to give, so `minimal` asks for a
       SHORTER pane, not the same pane with more of it blank.
     * **`statusline._MAX_REPO_LINES` bounds the rest**, the same total-row budget the
       wide table keeps (repo rows plus the `…(+N more)` line, not repo COUNT — see that
       constant's own comment), so a workspace with forty clones gets fourteen rows of
-      table under its attention row rather than forty.
+      table rather than forty.
 
-    **Both sides of "how tall is `bottom`?" call this, and that is the whole point.**
-    :func:`bottom_rows_wanted` asks it to size the pane before it exists;
-    :func:`_bottom` asks it with the pane's own measured width to bound what it draws
+    **Both sides of "how tall is the table pane?" call this, and that is the whole
+    point.** :func:`repos_rows_wanted` asks it to size the pane before it exists;
+    :func:`_repos` asks it with the pane's own measured width to bound what it draws
     into it. A cap applied on one side only is exactly the defect #500 fixes: the sizer
     used to answer from the repo count alone, so an 80-column frame with six repos got a
     seven-row pane to draw one line in, and `minimal` on a wide terminal got an
@@ -565,38 +636,50 @@ def _table_cap(fid: str, width: int) -> int:
     return cap
 
 
-def bottom_rows_wanted(fid: str, *, pane_cols: int) -> int:
-    """How many rows `_bottom` would fill for this frame in a *pane_cols*-column PANE.
+def repos_rows_wanted(fid: str, *, pane_cols: int) -> int:
+    """How many rows `_repos` would fill for this frame in a *pane_cols*-column PANE.
 
-    **One answer to "how tall is `bottom`", read by both sides of the question.** The
-    renderer spends the pane it was given (:func:`_table_lines`' *budget*); the LAUNCHER
-    has to decide how tall to make that pane before any panel exists, and the
+    **One answer to "how tall is the table pane", read by both sides of the question.**
+    The renderer spends the pane it was given (:func:`_table_lines`' *budget*); the
+    LAUNCHER has to decide how tall to make that pane before any panel exists, and the
     `window-resized` recompute has to decide again with the window's new size. If those
     two disagreed, a frame would come up with a pane taller than its content (blank rows
     the harness could have had) or shorter (a table cut off with nothing saying so) —
     and both were shipped by #488, because this asked the repo count and nothing else
     while the renderer also asked the width and the density. Pinned by a test that
-    renders `_bottom` into a pane of exactly this height, at exactly this width and at
+    renders `_repos` into a pane of exactly this height, at exactly this width and at
     every density, and counts the lines that come back.
 
     *pane_cols* is required, and keyword-only so no caller can pass a row count by
-    mistake. A pane narrower than `statusline._LEFT_W` draws no table at all, so it wants
-    the one-row strip `bottom` always was — see :func:`_table_cap`, which is where every
-    reason the renderer draws fewer rows than there is content now lives.
+    mistake. A pane narrower than `statusline._LEFT_W` draws no table at all and is not
+    split at all (`layout.visible_slots`), so the zero this answers there is the honest
+    one rather than a pane sized for nothing — see :func:`_table_cap`, which is where
+    every reason the renderer draws fewer rows than there is content now lives.
 
     **The PANE's columns, not the window's, and the name is the guard.** Round 2 of #500
     called this argument `cols` and every caller handed it the window's width, which is
-    only `bottom`'s width when nothing took columns off it first: with a `[frame]
-    slots` of `["right", "top", "bottom"]` a 110-column window gives an 87-column
-    `bottom` (measured, tmux 3.7c), so a six-repo plane was split seven rows tall for a
-    table the panel then refused to draw. The number is `layout.bottom_cols`' answer, and
-    the rename is what makes the old, wrong call a `TypeError` at the call site rather
-    than a frame with six blank rows in it — the same discipline `window_cols=` already
+    only this pane's width when nothing took columns off it first: with a `[frame] slots`
+    of `["right", "top", "bottom", "repos"]` a 120-column window gives a 97-column table
+    pane (measured, tmux 3.7c), so a six-repo plane was split seven rows tall for a table
+    the panel then refused to draw. The number is `layout.repos_cols`' answer, and the
+    keyword is what makes the old, wrong call a `TypeError` at the call site rather than
+    a frame with six blank rows in it — the same discipline `window_cols=` already
     applies one level up.
 
-    `+ 1` is the attention row — the alert, the spinner, this session's news, the todo
-    count and the hotkey hint — which `_bottom` always draws and which #488 is explicit
-    that the table joins rather than evicts.
+    **The `+ 1` is the pane's own heading, and it is no longer the attention row.** This
+    used to add that row, because `bottom` drew it and the table into one pane; they are
+    two panes now (`bottom` is the one-row strip it was before #488, and
+    `layout.SLOT_SIZE` states its height as the constant it is). What the row buys here
+    is `▪ repos N` — the same heading `_right` gained in #516, from the same
+    `_sidebar_head`, so the frame's two bordered components are labelled the same way and
+    the tree beneath it has something to hang from. Chrome the density does not buy back,
+    exactly as the sidebar's heading is not (`_TERSE_ROWS` bounds the table's ROWS; the
+    label is what the component is).
+
+    Zero is a real answer, and `layout.repos_rows` is what turns it into the one-line
+    pane that says so (`_empty_lines`): a workspace with no clones, or a gather that has
+    not run yet. Those two lines carry no heading — `▪ repos 0` above "no clones in demo"
+    would be the same fact twice in a two-row pane.
 
     `gather.row_count` is what makes this affordable at launch: it answers from the
     frame's cache when there is one and from a plain directory listing when there is not,
@@ -606,7 +689,10 @@ def bottom_rows_wanted(fid: str, *, pane_cols: int) -> int:
     """
     from . import gather
     cap = _table_cap(fid, pane_cols)
-    return 1 + (min(gather.row_count(fid), cap) if cap > 0 else 0)
+    if cap <= 0:
+        return 0
+    rows = gather.row_count(fid)
+    return 1 + min(rows, cap) if rows else 0
 
 
 #: Columns the persona NAME cell is never squeezed below once the badges have a column
@@ -870,7 +956,7 @@ def _right(fid: str) -> str:
     #
     # `> 0` and NOT the two-row floor, which is `_todo_rows`' to keep: this test is only
     # "is there any room at all", asked so a pane with none does not open a cache file it
-    # is about to discard (`bottom_rows_wanted` orders its own two questions the same way,
+    # is about to discard (`repos_rows_wanted` orders its own two questions the same way,
     # and for the same reason). Repeating the floor here would put one rule in two places,
     # where the outer copy silently decides the case and the inner one can be broken
     # without anything noticing — which is exactly what a mutation of the inner guard
@@ -971,7 +1057,22 @@ def _fit_fields(priority: list[tuple[str, str]], width: int,
 
 
 def _bottom(fid: str) -> str:
-    """What still wants attention, and how to act on it.
+    """What still wants attention, and how to act on it — the frame's last row.
+
+    **One row, always, and #515 is what made that true again.** Between #488 and now this
+    pane carried the attention row AND the repo table stacked underneath it with nothing
+    between them, which is exactly what the operator reported: two different kinds of
+    thing sharing a pane, and the eye with nothing to separate them by. The table has its
+    own bordered pane now (:func:`_repos`), and this is the one-row strip it was before —
+    isolated the way `top` is, and sitting on the terminal's LAST row (see
+    `layout.panel_argvs` for the split order that puts it there, measured).
+
+    **Last row rather than first, and it is a property rather than a preference.** The
+    table's height is its content's (`layout.repos_rows`), so whichever of the two sits
+    below the other moves up and down the screen as repos are cloned, go dirty, or drop
+    off. Anchoring the ATTENTION row is worth more than anchoring the table: it is the
+    surface #488 protected from eviction, and an alert you have to go looking for is one
+    you read late. So the table floats and the alert does not.
 
     Only the first alert, deliberately: `_alerts()` already returns its entries in
     priority order, so this picks which one survives rather than leaving it to whichever
@@ -990,16 +1091,15 @@ def _bottom(fid: str) -> str:
     the harness (`_right`'s docstring makes the identical point for `_persona_chips`).
 
     **Four candidate fields on that row, each shown WHOLE or dropped WHOLE — never one
-    assembled string cut once from the right.** The attention row is one row whatever
-    this pane's height is, and its WIDTH is the frame's own, not a narrow side panel's,
-    so ordinarily every field fits comfortably and this never has to choose. But
-    `layout.py`'s own module docstring records a REAL tmux 3.7c resize that transiently
-    starves a pane before the corrective hook snaps it back — not hypothetical, reachable
-    by an ordinary window resize at any moment. A naive single `tui.truncate` over the
-    joined line would risk Task 3's own Critical on perfectly ordinary data: an alert
-    exists specifically to carry the command that fixes it, and slicing into that command
-    mid-word reads as "no problem here" — the exact false-clean failure this plan's
-    Global Constraints call out by name.
+    assembled string cut once from the right.** The attention row is one row and its
+    WIDTH is the frame's own, not a narrow side panel's, so ordinarily every field fits
+    comfortably and this never has to choose. But `layout.py`'s own module docstring
+    records a REAL tmux 3.7c resize that transiently starves a pane before the corrective
+    hook snaps it back — not hypothetical, reachable by an ordinary window resize at any
+    moment. A naive single `tui.truncate` over the joined line would risk Task 3's own
+    Critical on perfectly ordinary data: an alert exists specifically to carry the command
+    that fixes it, and slicing into that command mid-word reads as "no problem here" — the
+    exact false-clean failure this plan's Global Constraints call out by name.
 
     Priority order, highest first: the one alert (`_alerts()`'s own top pick — an
     actionable control-plane problem, carrying its own fix); the in-flight spinner
@@ -1029,42 +1129,12 @@ def _bottom(fid: str) -> str:
     every operator the wrong key, on every repaint, forever. `config.FRAME` is the
     resolved value `commands_frame.conf_text` binds, so there is one source for what the
     panel says and what the frame actually does.
-
-    **Under it, the wide repo table — #488.** The frame suppresses the status line
-    (#386) and until now showed LESS of the plane's repo state than the line it replaced:
-    the only slot drawing repos was a 22-column `left` sidebar recomposing a table
-    designed for 66. `bottom` is the frame's full-width slot, so the table lives here
-    now, at `statusline.py`'s own column widths, and `left` is retired rather than left
-    drawing a lesser copy of its neighbour.
-
-    **The attention row is not evicted by it — it is the first line, always.** The alert
-    and the command that fixes it outrank any repo row; the table gets what is left of
-    the pane after it (`_table_lines`' own *budget*). On a plane with no clones there is
-    no table at all and this is exactly the one-row strip it always was.
-
-    **The pane is measured, not assumed.** :func:`_height` reads this pane's own tty the
-    way :func:`_width` reads its width; :func:`bottom_rows_wanted` is what told the
-    LAUNCHER how tall to make it, and both go through :func:`_table_cap` at the same
-    density and at THIS PANE's width — measured here, predicted there by
-    `layout.bottom_cols`, which is the only reason the launcher's number can match a pane
-    the sidebar has narrowed. So on an untouched frame the two agree exactly and no row
-    is either blank or cut, at every width the frame is drawn at, at every level the
-    density menu offers, and in whatever order the operator's `[frame] slots` puts the
-    edges in. A pane that is shorter anyway — a transient mid-resize
-    size, or a window with no rows to spare — costs the table its lowest-priority rows
-    through `_pick_rows`' ranking, never the attention row.
-
-    **One `gather.read`, and no repo directory touched.** #387 pinned a panel's idle tick
-    at exactly one `stat` and `bottom` is the ONE animated slot (:data:`ANIMATED`), so a
-    table that walked a directory per row would pay that back fourteen times over at five
-    repaints a second. Everything the table draws comes out of the cache; see
-    :func:`_table_row` for the one column that costs (presence) and is therefore absent.
     """
     from .. import config, session as _session, statusline as sl
     from . import state, tmuxctl
-    # The FRAME's workspace (#512), for the todo count and the alerts as much as for the
-    # table: they are three statements about one workspace on one row, and a panel that
-    # resolved its own would count another workspace's todos beside this one's repos.
+    # The FRAME's workspace (#512), for the todo count as much as for the alerts: they
+    # are statements about one workspace on one row, and a panel that resolved its own
+    # would count another workspace's todos beside this one's alerts.
     ws = _frame_workspace(fid)
     todos = sl._todo_count(ws)
     alerts = sl._alerts(ws)
@@ -1103,48 +1173,126 @@ def _bottom(fid: str) -> str:
               "todo": todo_text, "hotkey": hotkey_text}
     parts = [fields[n] for n in ("todo", "alert", "inflight", "news", "hotkey")
              if n in keep]
-    lines = [tui.truncate(" · ".join(parts), w)]
+    return tui.truncate(" · ".join(parts), w)
 
-    # The table gets what is left of the pane below the attention row, bounded by
-    # `_table_cap` — the SAME call `bottom_rows_wanted` made to size this pane, with this
-    # pane's own measured width instead of the window's. Asked for fewer ROWS rather than
-    # sliced afterwards, so what survives at `terse` is still `_pick_rows`' ranked subset
-    # (the repo you are standing in, the ones with something on them) rather than
-    # whichever happened to come first — the same discipline the `terse` chip list in
-    # `_right` keeps.
-    budget = min(_height() - len(lines), _table_cap(fid, w))
-    if budget > 0:
-        from . import gather
-        # `gather.cached`, never `gather.read` (#512). The two differ by exactly one
-        # thing: `read` falls back to a live `scan()` when there is no cache, and a
-        # PANEL is the one caller that must not have that fallback. Two reasons, and
-        # both are rules this module already keeps:
-        #
-        # * **A panel does not sweep.** `_table_lines`' own docstring promises it never
-        #   reaches a repo directory, a `git status` or a `glstate.read_for`; #387 pinned
-        #   an idle tick at one `stat`, and `bottom` is the ONE animated slot, so a paint
-        #   that scans is five cold sweeps a second for as long as anything is in flight.
-        #   `cmd_launch` calls `gather.discard` before it draws, so a fresh frame reached
-        #   that fallback BY DESIGN, on the very repaints an operator is watching.
-        # * **An empty table is not the same claim as an unknown one.** `read`'s fallback
-        #   returns `repos: []` for "the scan found nothing" and for "the scan ran in the
-        #   wrong workspace" alike, and `_table_lines` draws both as no rows at all — a
-        #   pane that says "no repos" on a plane full of them. `None` here keeps the two
-        #   apart, and :func:`_unknown_lines` says which one this is.
-        #
-        # Nothing is left blank waiting: `commands_frame._spawn_gather` kicks a detached
-        # refresh at launch which writes this cache and bumps the version, the same shape
-        # `update.maybe_spawn`/`glstate.maybe_spawn` already use, and every
-        # `posttooluse*` hook refreshes it after that (`notify.plane_changed`).
-        data = gather.cached(fid)
-        lines.extend(_unknown_lines(w) if data is None
-                     else _table_lines(data, w, budget))
-    return "\n".join(lines)
+
+def _repos(fid: str) -> str:
+    """This workspace's repo table, in a bordered pane of its own — #515.
+
+    **The table used to be the bottom half of `_bottom` and that is the defect.** #488
+    put it there because `bottom` was the frame's full-width slot and the 22-column
+    `left` sidebar it replaced could not draw a table at all. What shipped was one pane
+    holding two unrelated things stacked with no rule between them: the attention row,
+    then repo rows running straight on out of it. This is that table given its own pane,
+    which is the only way tmux can draw a rule between the two — and the rule is tmux's,
+    drawn from the five window options `commands_frame._CHROME` pins (#514), never a box
+    a renderer paints for itself.
+
+    **This is #488's actual content, unchanged**: the frame used to show LESS of the
+    plane's repo state than the status line it suppresses (#386), because the only slot
+    drawing repos was a 22-column sidebar whose own docstring conceded that `_NAME_W`
+    (32) and `_BRANCH_W` (34) alone exceed the whole pane. The table is drawn here at the
+    widths it was designed for.
+
+    **It is headed, `▪ repos 6`, from `_sidebar_head` — the same helper `_right` heads
+    its own sections with (#516).** A bordered box of tree rows next to a bordered box
+    whose sections are all labelled reads as an overflow of its neighbour rather than as
+    a component, which is the exact impression #515 exists to remove; and the table's
+    first row is `statusline._TREE_MID` (`├─`), a glyph that means "there is more above
+    me" and had nothing above it once the attention row moved out. One row, and the count
+    is the plane's repo count — a fact the frame did not previously show anywhere.
+
+    **The pane is measured, not assumed.** :func:`_height` reads this pane's own tty the
+    way :func:`_width` reads its width; :func:`repos_rows_wanted` is what told the
+    LAUNCHER how tall to make it, and both go through :func:`_table_cap` at the same
+    density and at THIS PANE's width — measured here, predicted there by
+    `layout.repos_cols`, which is the only reason the launcher's number can match a pane
+    the sidebar has narrowed. So on an untouched frame the two agree exactly and no row
+    is either blank or cut, at every width the frame is drawn at, at every level the
+    density menu offers, and in whatever order the operator's `[frame] slots` puts the
+    edges in. The `- 1` is the heading and nothing else — the attention row is another
+    pane's now, and a budget still reserving a row for THAT would lose the lowest-ranked
+    repo row to nothing.
+
+    A pane that is shorter anyway — a transient mid-resize size, or a window with no rows
+    to spare — costs the table its lowest-priority rows through `_pick_rows`' ranking,
+    and the `…(+N more)` line is reserved out of the budget rather than trimmed off the
+    end (see :func:`_table_lines`), so a starved pane never claims one clean repo is the
+    whole plane.
+
+    **Three states, three different sentences, because they are three different claims.**
+    A gather that has not run yet is `_unknown_lines`; a gather that ran and found
+    nothing is :func:`_empty_lines`; anything else is the table. #512 is the cost of
+    drawing the first two the same, and #515 is the cost of drawing the second one as an
+    empty rectangle — which is what an unmodified `_table_lines` returning `[]` would now
+    be, since this pane no longer has an attention row above it to make its emptiness
+    read as "nothing to add".
+
+    **One `gather.cached`, and no repo directory touched.** #387 pinned a panel's idle
+    tick at exactly one `stat`; this slot is not in :data:`ANIMATED` so it pays even that
+    only on a version bump or a resize, but a table that walked a directory per row would
+    still cost fourteen walks per repaint. Everything the table draws comes out of the
+    cache; see :func:`_table_row` for the one column that costs (presence) and is
+    therefore absent.
+    """
+    w = _width()
+    # `_table_cap` is the SAME call `repos_rows_wanted` made to size this pane, with the
+    # pane's own measured width instead of the window's.
+    cap = _table_cap(fid, w)
+    if cap <= 0:
+        # A pane narrower than `statusline._LEFT_W`. The LAUNCHER does not split one
+        # (`layout.visible_slots`), but `cmd_resize` only re-sizes panes — it neither
+        # creates nor destroys them — so narrowing a running frame's terminal arrives
+        # here with a real pane to fill. Said out loud rather than left blank: see
+        # :func:`_too_narrow_lines`. A renderer must not depend on the launcher's filter
+        # for its own correctness either — `charter panel repos` run by hand into a
+        # narrow terminal reaches exactly here, and an unbounded `_table_lines` would
+        # draw a false-clean `charter  main` into it.
+        return "\n".join(_too_narrow_lines(w))
+    from . import gather
+    # `gather.cached`, never `gather.read` (#512). The two differ by exactly one thing:
+    # `read` falls back to a live `scan()` when there is no cache, and a PANEL is the one
+    # caller that must not have that fallback. Two reasons, and both are rules this
+    # module already keeps:
+    #
+    # * **A panel does not sweep.** `_table_lines`' own docstring promises it never
+    #   reaches a repo directory, a `git status` or a `glstate.read_for`; #387 pinned an
+    #   idle tick at one `stat`, and a paint that scans is a cold sweep every time the
+    #   plane version moves. `cmd_launch` calls `gather.discard` before it draws, so a
+    #   fresh frame reached that fallback BY DESIGN, on the very repaints an operator is
+    #   watching.
+    # * **An empty table is not the same claim as an unknown one.** `read`'s fallback
+    #   returns `repos: []` for "the scan found nothing" and for "the scan ran in the
+    #   wrong workspace" alike, and `_table_lines` draws both as no rows at all — a pane
+    #   that says "no repos" on a plane full of them. `None` here keeps the two apart,
+    #   and :func:`_unknown_lines` says which one this is.
+    #
+    # Nothing is left blank waiting: `commands_frame._spawn_gather` kicks a detached
+    # refresh at launch which writes this cache and bumps the version, the same shape
+    # `update.maybe_spawn`/`glstate.maybe_spawn` already use, and every `posttooluse*`
+    # hook refreshes it after that (`notify.plane_changed`).
+    data = gather.cached(fid)
+    if data is None:
+        return "\n".join(_unknown_lines(w))
+    repos = data.get("repos") or []
+    if not repos:
+        # Gathered, and there is nothing in it. Said out loud rather than left as an
+        # empty bordered rectangle — see :func:`_empty_lines`. No heading: `▪ repos 0`
+        # above "no clones in demo" is the same fact twice in a two-row pane.
+        return "\n".join(_empty_lines(_frame_workspace(fid), w))
+    # The heading takes the first row and the table spends what is left. Asked for fewer
+    # ROWS rather than sliced afterwards, so what survives at `terse` (or in a pane a
+    # resize starved) is still `_pick_rows`' ranked subset — the repo you are standing
+    # in, the ones with something on them — rather than whichever happened to come
+    # first, the same discipline the `terse` chip list in `_right` keeps.
+    budget = min(_height() - 1, cap)
+    return "\n".join([_sidebar_head("repos", len(repos), w),
+                      *(_table_lines(data, w, budget) if budget > 0 else [])])
 
 
 #: Every slot charter can draw. `panel.run` refuses a name that is not in here rather
 #: than painting an empty pane, because an empty pane reads as a broken frame.
-SLOTS = {"top": _top, "bottom": _bottom, "right": _right}
+SLOTS = {"top": _top, "bottom": _bottom, "repos": _repos, "right": _right}
 
 
 #: Which slots draw something that CHANGES ON ITS OWN, with no version bump and no

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -366,13 +366,14 @@ def _table_row(lead: str, name_markup: str, r: dict, width: int,
 
 
 def _table_lines(data: dict, width: int, budget: int) -> list[str]:
-    """The repo table `bottom` draws under its attention row, at most *budget* lines.
+    """The repo table the `repos` pane draws under its heading, at most *budget* lines.
 
     **This is #488's actual answer**: the frame used to show LESS of the plane's repo
     state than the status line it suppresses (#386), because the only slot drawing repos
     was a 22-column sidebar whose own docstring conceded that `_NAME_W` (32) and
-    `_BRANCH_W` (34) alone exceed the whole pane. `bottom` is the frame's full-width
-    slot, so the table goes here and is drawn at the widths it was designed for.
+    `_BRANCH_W` (34) alone exceed the whole pane. The table is drawn at the widths it was
+    designed for — on `bottom` when #488 shipped it, and since #515 in `repos`, a pane of
+    its own whose whole width is the table's.
 
     Reads ONLY *data* — one `gather.read(fid)` in the caller — and never a repo
     directory, a `git status` or a `glstate.read_for` of its own. Every field a row needs
@@ -386,8 +387,11 @@ def _table_lines(data: dict, width: int, budget: int) -> list[str]:
     :class:`_RowKey` — nothing here touches a filesystem, and a `Path` would imply one
     exists to touch.
 
-    *budget* is the pane's real height minus the attention row, measured by
-    :func:`_height` before anything is composed. The budget is spent in priority order —
+    *budget* is the `repos` pane's real height minus its HEADING (`_height() - 1` in
+    :func:`_repos`, floored by :func:`_table_cap`), measured before anything is composed.
+    The row it subtracts is `▪ repos N`, not the attention row — that is another pane's
+    since #515, and a budget still reserving a row for it would cost the table its
+    lowest-ranked repo row for nothing. The budget is spent in priority order —
     repo rows first, then the `…(+N more)` line that admits what was dropped, then piece
     rows — so a short pane loses DETAIL rather than losing a repo. That ordering is
     `statusline._repo_rows`' own (`wt_budget` there), kept because the two tables are
@@ -412,16 +416,18 @@ def _table_lines(data: dict, width: int, budget: int) -> list[str]:
     # `charter  main`. Refusing to draw says "no room to say" where a trimmed row says
     # "nothing to say".
     #
-    # **Ordinary, not exotic — an 80-column terminal lands here.** `[frame] min-cols`
-    # (100) gates `right` and `top` only; `layout.visible_slots` keeps `bottom` all the
-    # way down to `min_cols // 2`, so every frame between 50 and `_LEFT_W - 1` (94)
-    # columns draws the attention row and no table. And the PANE can be narrower than the
-    # window on top of that: the slot order is the geometry, so a `[frame] slots` that
-    # names `right` before `bottom` insets this pane by `right`'s columns and its border
-    # (`layout.bottom_cols`). Which is why :func:`_table_cap` — not this function — is
-    # what the LAUNCHER asks, and why it asks with the width of the PANE rather than of
-    # the window. The attention row above is unaffected either way; it does its own
-    # per-field budgeting (`_fit_fields`).
+    # **Ordinary, not exotic — an 80-column terminal reaches here.** #515 changed WHO
+    # arrives: `layout.visible_slots` now drops `repos` outright below `_LEFT_W`, reading
+    # the width from `layout._table_min_cols` so the launcher's drop and this refusal are
+    # one number, so an 80-column LAUNCH has no `repos` pane at all. What still lands here
+    # is a running frame narrowed by `cmd_resize`, which changes sizes and never which
+    # panes exist, and `charter panel repos` piped into a narrow terminal by hand — and
+    # `_repos` turns this `[]` into :func:`_too_narrow_lines` rather than an empty box.
+    # The PANE can also be narrower than the window: the slot order is the geometry, so a
+    # `[frame] slots` naming `right` before `repos` insets this pane by `right`'s columns
+    # and its border (`layout.repos_cols`). Which is why :func:`_table_cap` — not this
+    # function — is what the LAUNCHER asks, and why it asks with the width of the PANE
+    # rather than of the window.
     if width < sl._LEFT_W:
         return []
 
@@ -546,14 +552,26 @@ def _empty_lines(ws: str, width: int) -> list[str]:
     the same. That one is reached when `gather.cached` answers ``None``; this one when it
     answers a real scan with no rows in it.
 
-    **No `contain.one_line` over *ws*, and that is a decision rather than an omission.**
-    Every rung of `state.workspace_for` that can answer a name checks it against
-    `instance.WORKSPACE_NAME_RE` (`^[A-Za-z0-9][A-Za-z0-9._-]*$`), an alphabet with no
-    newline, no control character and no escape in it — so containment is already true by
-    construction one layer up, and a second copy here would be a guard nothing could ever
-    turn red. `_top` interpolates the same value on the same terms. What is NOT free is
-    the WIDTH: the name is arbitrary length, so the line is measured through
-    `tui.truncate` like every other line in this module.
+    **No `contain.one_line` over *ws*, and the reason is `tui.sanitize`, not the name
+    rungs.** It would be comfortable to say every rung of `state.workspace_for` checks its
+    answer against `instance.WORKSPACE_NAME_RE` (`^[A-Za-z0-9][A-Za-z0-9._-]*$`) — rung 0
+    does, through `valid_name` — but the LAST rung does not: it is `workspace.resolve()`,
+    which hands back `$CHARTER_WORKSPACE` stripped and otherwise untouched. Measured:
+    with `CHARTER_WORKSPACE='ev\\nil\\x1b[31m;rm -rf /'` and no session pointer and no
+    recorded launch workspace, rung 0 rejects it, rungs 1 and 2 have nothing, and rung 3
+    returns that exact string — which arrives here verbatim.
+
+    What contains it is the `tui.truncate` call below, which runs `tui.sanitize` first:
+    the newline is not charter's markup, so it is replaced and the pane still gets ONE
+    line; the SGR is passed through as colour, which costs zero columns and cannot move a
+    cursor. That is the guarantee this module leans on everywhere — a value nobody has
+    thought about yet is contained at the point it is drawn, not by a rung nobody
+    re-checked. `_top` interpolates the same value on the same terms, and has since
+    before #515. Naming the wrong reason is how a guard gets deleted later for being
+    redundant against a property that was never true.
+
+    What is NOT free either way is the WIDTH: the name is arbitrary length, so the line
+    is measured through `tui.truncate` like every other line in this module.
     """
     from .. import statusline as sl
 
@@ -621,8 +639,8 @@ def _table_cap(fid: str, width: int) -> int:
 
     Takes *width* rather than measuring it: the renderer has a pane to measure and the
     launcher has only a window it has not split yet. **Both must be the PANE's width, and
-    that is not always the window's** — `layout.bottom_cols` is where the launcher's side
-    of it is computed, because a `[frame] slots` naming `right` before `bottom` insets
+    that is not always the window's** — `layout.repos_cols` is where the launcher's side
+    of it is computed, because a `[frame] slots` naming `right` before `repos` insets
     this pane by 23 columns (measured on tmux 3.7c: 87 in a 110-column window). Sizing
     from the window's width there is the second half of the same defect, and it is what
     round 2 of #500 shipped.
@@ -1229,11 +1247,16 @@ def _repos(fid: str) -> str:
     read as "nothing to add".
 
     **One `gather.cached`, and no repo directory touched.** #387 pinned a panel's idle
-    tick at exactly one `stat`; this slot is not in :data:`ANIMATED` so it pays even that
-    only on a version bump or a resize, but a table that walked a directory per row would
-    still cost fourteen walks per repaint. Everything the table draws comes out of the
-    cache; see :func:`_table_row` for the one column that costs (presence) and is
-    therefore absent.
+    tick at exactly one `stat` — `panel._tick`'s single `state.version(fid)`, which every
+    slot pays every `panel.TICK` whether it is animated or not, so this pane is a fourth
+    panel process and a fourth such read: the frame's idle cost is up a third on #515, not
+    unchanged. What this slot does not pay is the SECOND one: it is not in
+    :data:`ANIMATED`, so `panel._watch`'s `animates and bool(_running(...))`
+    short-circuits before `_running` is ever called, where `bottom` reads the in-flight
+    record set as well. And neither number is the one that would have mattered — a table
+    that walked a directory per row would cost fourteen walks per repaint. Everything the
+    table draws comes out of the cache; see :func:`_table_row` for the one column that
+    costs (presence) and is therefore absent.
     """
     w = _width()
     # `_table_cap` is the SAME call `repos_rows_wanted` made to size this pane, with the

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -393,7 +393,7 @@ def record_workspace(fid: str, name: str) -> None:
     something else entirely. Measured on the plane that reported #512: three terminal
     pointers naming `harness-wrapper` and one naming `user-reporting`, a `default`
     workspace holding no clones at all, and every panel drawing `default`'s empty repo
-    list beside a `bottom` pane the LAUNCHER had sized for the real workspace's rows.
+    list beside a `repos` pane the LAUNCHER had sized for the real workspace's rows.
 
     The launcher is the one process that knows, so it writes it down — the same argument
     :func:`record_identity` already makes for the rest of a frame's identity, and the same

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -365,13 +365,22 @@ def drift(root: Path) -> list[str]:
 #: The edges a frame may occupy. A slot outside this set is a typo, and a typo must not
 #: reach a tmux argv — so an unknown one is dropped rather than passed through.
 #:
+#: **`repos` joined it in #515.** `bottom` used to carry the attention row and the repo
+#: table in one pane, stacked with no rule between them; the table is its own bordered
+#: component now and `bottom` is the one-row strip it was before #488. The names are what
+#: an operator writes in `[frame] slots`, so this is also the compatibility statement: a
+#: committed `slots = ["top", "bottom", "right"]` is still valid and still launches — it
+#: simply gets no table, because `slots` is the primitive and an explicit list wins
+#: outright (:func:`frame_of`). Anyone who wants the table back adds `repos` to their
+#: list, or deletes the line and takes the default.
+#:
 #: **`left` is gone as of #488**, and that filter is what makes retiring it safe: a
 #: committed `charter.toml` still carrying `slots = ["top", "bottom", "left", "right"]`
 #: — from a plane that upgraded, or from a teammate's checkout — has the dead name
-#: dropped here and gets the other three, rather than a `KeyError` in a launcher or a
+#: dropped here and gets the others, rather than a `KeyError` in a launcher or a
 #: pane split for a slot with no renderer. It drew repo rows recomposed for 22 columns;
-#: `bottom` now draws the same rows at the width the table was designed for.
-FRAME_SLOTS = ("top", "bottom", "right")
+#: `repos` draws the same rows at the width the table was designed for.
+FRAME_SLOTS = ("top", "bottom", "repos", "right")
 
 #: How much frame there is, as a PRESET over :data:`FRAME_SLOTS` — never a second
 #: configuration system sitting beside `slots`.
@@ -390,38 +399,52 @@ FRAME_SLOTS = ("top", "bottom", "right")
 #: :data:`_HOTKEY_RE`), there is no value an operator can write here that is passed
 #: through: it is either one of three constants charter wrote itself, or it is discarded.
 #:
-#: **Every ``slots`` list here is in GEOMETRY order, not reading order — do not sort
-#: them.** `layout.panel_argvs` splits each slot off the harness pane in list order, so a
-#: slot listed after `right` gets only the width it left behind. Measured against tmux
-#: 3.7c in a 200x50 window (#386): `["top", "bottom", "right"]` gives a **200-column**
-#: `bottom`, while `["top", "right", "bottom"]` gives a `bottom` of **177 columns**,
-#: inset beside the side panel. `bottom` carries the one alert, the command that fixes
-#: it, and (since #488) the repo table whose four columns want 95 of them — and
-#: `slots._bottom` drops whole fields when it runs out of width — so they belong to it
-#: rather than to a side panel already truncating its own 22.
+#: **Every ``slots`` list here is in SPLIT order, which is the geometry — not reading
+#: order, and do not sort them.** `layout.panel_argvs` splits each slot off the harness
+#: pane in list order, and two separate things follow from that.
 #:
-#: **#488 re-derived these, it did not patch them.** `bottom` is no longer one row
-#: (`layout.bottom_rows`), so what separates the three levels is no longer only how many
-#: EDGES there are — the two that keep `bottom` differ in how many of its rows the table
-#: is allowed (`slots._TERSE_ROWS` at `terse`), and `full` is now "every edge charter
-#: has" with `left` retired out of it rather than "all four".
+#: *Columns.* A slot listed after `right` gets only the width it left behind. Measured
+#: against tmux 3.7c in a 200x50 window (#386): `["top", "bottom", "right"]` gives a
+#: **200-column** bottom half, while `["top", "right", "bottom"]` gives **177 columns**,
+#: inset beside the side panel. `repos` carries a table whose four columns want 95 of
+#: them and `slots._bottom` drops whole fields when it runs out of width — so the columns
+#: belong to them rather than to a side panel already truncating its own 22.
 #:
-#: **And the PANE is that many rows, not just the table (#500).** `slots._table_cap` is
-#: read by the launcher and the resize hook as well as by the renderer, so `terse` makes
-#: `bottom` genuinely shorter and hands the difference to the harness. As #488 shipped it
-#: only the renderer knew: `minimal` cost the harness exactly the rows `normal` did and
-#: drew fewer of them, which is the opposite of what the level is for.
+#: *Rows.* Every split but `top`'s is a plain `-v`, which tmux places DIRECTLY below the
+#: harness — so a slot split LATER sits ABOVE one split earlier. Measured on tmux 3.7c,
+#: 120x40, splitting `top`, `bottom`, `repos`, `right` off the harness in that order:
+#: `top` on row 0, harness and `right` on rows 2-30, `repos` on rows 32-37, `bottom` on
+#: row 39. Which is why `bottom` is named BEFORE `repos` here and reads AFTER it on
+#: screen. Transpose the two and the frame is the pre-#515 stacking order with a rule
+#: drawn through it.
+#:
+#: **#515 re-derived these, it did not patch them.** #488 made `bottom` variable-height
+#: and the three levels then differed partly by edges and partly by how many rows of one
+#: pane's table were allowed. Now that the table is its own slot the levels differ by
+#: EDGES again, which is what a preset over `slots` can actually express:
+#:
+#: * `minimal` — the two one-row strips, and nothing that costs rows by the repo.
+#: * `normal` — the table as well.
+#: * `full` — the sidebar as well; every edge charter draws.
+#:
+#: **What `minimal` gives back is a whole component, not a shorter one.** As #488/#500
+#: shipped it, `minimal` was `normal` with at most `slots._TERSE_ROWS` of table — which
+#: after #515 would cost the harness a border row it did not cost before, to show four
+#: repo rows. A level whose whole purpose is handing the harness its rows back does not
+#: negotiate over four of them: it drops the component. `slots._TERSE_ROWS` still bounds
+#: the table for anyone who writes `slots` by hand and asks for `minimal` alongside it,
+#: which is the one configuration that can still reach it.
 FRAME_DENSITY = {
-    #: Top and bottom, each saying only the most important thing it has: one field on the
-    #: attention row, and at most `slots._TERSE_ROWS` rows of repo table under it — so the
-    #: pane is that much shorter and the harness keeps the rest. For a terminal where the
-    #: harness's own rows are what you came for.
+    #: The two one-row strips: where you are, and what wants attention — with `_bottom`
+    #: keeping only its single highest-priority field. No repo table and no sidebar, so
+    #: every row and every column the frame is not using is the harness's. For a terminal
+    #: where the harness's own rows are what you came for.
     "minimal": {"slots": ["top", "bottom"], "verbosity": "terse"},
-    #: The same two edges, saying everything they have — the whole repo table, as tall as
-    #: the window can spare it (`layout.HARNESS_MIN_ROWS` is what it may not take).
-    "normal": {"slots": ["top", "bottom"], "verbosity": "normal"},
+    #: Both strips saying everything they have, and the repo table between them — as tall
+    #: as the window can spare it (`layout.HARNESS_MIN_ROWS` is what it may not take).
+    "normal": {"slots": ["top", "bottom", "repos"], "verbosity": "normal"},
     #: Every edge charter draws, and the same order it ships in.
-    "full": {"slots": ["top", "bottom", "right"], "verbosity": "normal"},
+    "full": {"slots": ["top", "bottom", "repos", "right"], "verbosity": "normal"},
 }
 
 #: What a panel falls back to for any level charter does not know — see
@@ -486,22 +509,29 @@ FRAME_FIELDS = {
     #: this was reported: *"only top and bottom single lines added, no left right
     #: sidebar."*
     #:
+    #: **`repos` is on this list as of #515.** `bottom` used to hold the attention row
+    #: and the repo table in one pane with nothing between them; the table is its own
+    #: bordered component now and `bottom` is the one-row strip it was before #488. The
+    #: frame reads identity · session · table · attention, top to bottom.
+    #:
     #: **`left` is not on this list any more, and that is #488 rather than a retreat.**
     #: The sidebar drew repo rows recomposed for 22 columns, which its own docstring
-    #: conceded was less than the status line it replaced. `bottom` is variable-height
-    #: now and draws the FULL table, so the sidebar's only remaining job was a lesser
-    #: copy of its neighbour's, at the cost of 22 columns of harness.
-    #: `layout.visible_slots` still drops `right` first on any shortage against
-    #: `min_cols`/`min_rows`, so a narrow terminal degrades to two strips as before.
+    #: conceded was less than the status line it replaced. `repos` draws the FULL table,
+    #: so the sidebar's only remaining job was a lesser copy of its neighbour's, at the
+    #: cost of 22 columns of harness. `layout.visible_slots` still drops `right` first on
+    #: any shortage against `min_cols`/`min_rows`, so a narrow terminal degrades to the
+    #: strips as before — and drops `repos` too below the width its table needs.
     #:
-    #: **The ORDER is the geometry, not a reading order.** `layout.panel_argvs` splits
-    #: each slot off the harness pane in list order, so a slot listed after `right` gets
-    #: only the width it left behind. Measured against tmux 3.7c in a 200x50 window: this
-    #: order gives a 200-column `bottom`; `["top", "right", "bottom"]` instead gives a
-    #: `bottom` of **177 columns**, inset beside the side panel. `bottom` carries the one
-    #: alert, the command that fixes it, and the repo table — so those columns belong to
-    #: it and not to a side panel already truncating its own 22.
-    "slots": (["top", "bottom", "right"], "slots"),
+    #: **The ORDER is the SPLIT order, which is the geometry, not a reading order.**
+    #: `layout.panel_argvs` splits each slot off the harness pane in list order. A slot
+    #: listed after `right` gets only the width it left behind — measured against tmux
+    #: 3.7c in a 200x50 window, this order gives a 200-column bottom half while
+    #: `["top", "right", "bottom"]` gives **177 columns**, inset beside the side panel.
+    #: And a slot split later sits ABOVE one split earlier, because every split but
+    #: `top`'s is a plain `-v` off the harness: measured on 3.7c at 120x40, this order
+    #: puts `top` on row 0, `repos` on rows 32-37 and `bottom` on row 39. So `bottom` is
+    #: named before `repos` and reads after it.
+    "slots": (["top", "bottom", "repos", "right"], "slots"),
     #: A PRESET over the line above, not a rival to it (see :data:`FRAME_DENSITY`). The
     #: shipped value is the level that expands to EXACTLY the shipped `slots` above —
     #: same edges, same ORDER, and saying as much as a panel has — and that is not a

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -269,37 +269,41 @@ configured for it. A density change goes through the same floors, so choosing `f
 terminal with no room for a side panel gives you the edges that fit rather than a failed
 split.
 
-`bottom` is never dropped by those floors — it **shrinks** instead. Its height is its
-content's: one row per repo (and per worktree, in a single-repo workspace), plus the
-attention row, capped so the harness always keeps at least 12 rows and floored at the one
-row `bottom` has always been. A workspace with no clones gets exactly that one row — and
-so does a frame narrower than the table's own 95 columns, or one at `minimal`, because
-"its content" means *what the panel will actually draw*, not how many clones there are:
-the launcher and the resize hook ask the same function the panel asks, at the same density
-and — the part that is easy to get wrong — at the width of the **pane**, not of the
-window. Those are the same number for the shipped `slots`, where `bottom` spans the whole
-window. They are not the same if you have written a `slots` list that puts `right` before
-`bottom`: the sidebar is split off first, so `bottom` comes out 23 columns narrower, and
-it is that width the pane is sized for. Narrow your terminal below 95 columns and `bottom`
-gives its rows back rather than keeping them blank. The
-cap is recomputed on every terminal resize, not remembered from the launch — tmux does not
+`bottom` is never dropped by those floors, and it is the only slot that never is: it is
+the attention strip — one alert and the command that fixes it — which is the whole reason
+a cramped terminal is worth framing at all. It is one row at every size.
+
+`repos` is the one whose height moves. It is its content's: one row per repo (and per
+worktree, in a single-repo workspace), plus its own `▪ repos N` heading, capped so the
+harness always keeps at least 12 rows. "Its content" means *what the panel will actually
+draw*, not how many clones there are: the launcher and the resize hook ask the same
+function the panel asks, at the same density and — the part that is easy to get wrong — at
+the width of the **pane**, not of the window. Those are the same number for the shipped
+`slots`, where the table spans the whole window. They are not the same if you have written
+a `slots` list that puts `right` before `repos`: the sidebar is split off first, so the
+table comes out 23 columns narrower, and it is that width the pane is sized for. The cap
+is recomputed on every terminal resize, not remembered from the launch — tmux does not
 refuse an over-large pane height, it takes the difference out of the neighbouring pane,
 and the neighbour is your agent session. Recomputing means charter runs for a moment on
 each resize (median 20ms, in the background, so nothing waits on it). During a fast drag
-those runs can finish out of order and leave `bottom` sized for a window you have already
+those runs can finish out of order and leave the table sized for a window you have already
 resized past; it corrects itself the next time you resize, and #501 tracks closing it
 properly.
 
 If the frame ends up narrower than the repo table's own columns (95), the table is not
 drawn rather than drawn with its right-hand columns cut off: a row trimmed past the branch
 loses the CI glyph and the open-change count, and a dirty, failing repo then reads as a
-clean one. That is an ordinary width, not an exotic one — `min-cols` gates `right` and
-`top`, never `bottom` — so an 80-column frame is the attention row and nothing under it,
-and the pane is one row tall to match. A `slots` list naming `right` before `bottom` moves
-that threshold up by the sidebar's 23 columns: such a frame needs 118 columns of terminal
-before the table appears, and between 100 and 117 it is the attention row alone. The
-attention row itself is unaffected — it drops whole fields instead, in priority order.
-(The status line outside a frame still crops instead of refusing; that is #506.)
+clean one. Below that width the `repos` pane is not split at all — an empty bordered box
+says "no repos" to the eye on a plane that has fourteen. That is an ordinary width, not an
+exotic one, so an 80-column frame is the two strips and your session, with the table's
+rows going back to the harness rather than being taken and left blank. A `slots` list
+naming `right` before `repos` moves the threshold up by the sidebar's 23 columns: such a
+frame needs 118 columns of terminal before the table appears. Narrow a frame that is
+*already running* below 95 and the pane cannot be un-split — a resize changes sizes, not
+which panes exist — so it shrinks to one row and says `⋯ too narrow for the repo table —
+95 columns needed` rather than sitting there blank. The attention strip is unaffected
+either way: it drops whole fields instead, in priority order. (The status line outside a
+frame still crops instead of refusing; that is #506.)
 
 If a future `[frame] slots` ever names an edge charter sizes but has no renderer for, that
 slot is skipped rather than drawn as a dead pane — the harness keeps the space — and
@@ -388,17 +392,19 @@ name as the pinned one.
 **The repo table is gathered at launch, in the background.** A launch deletes the cached
 scan first — pids are recycled and a new frame must not adopt a dead one's rows — and a
 detached `charter frame-gather` fills it alongside the frame coming up, then bumps the
-frame so the panels repaint. Until it lands, `bottom` says `⋯ gathering this workspace's
+frame so the panels repaint. Until it lands, `repos` says `⋯ gathering this workspace's
 repos…` rather than drawing an empty table: a workspace with no clones and a workspace not
 yet looked at are different facts, and drawing them the same way is what made a frame read
-as "no repos" on a plane full of them. A panel never gathers on its own — it reads the
-cache or says it has none.
+as "no repos" on a plane full of them. A workspace that really has none says so, with the
+command that changes it: `no clones in <workspace> · charter clone <repo> -w
+<workspace>`. A panel never gathers on its own — it reads the cache or says it has
+none.
 
 ## Configuring it
 
 ```toml
 [frame]
-slots = ["top", "bottom", "right"]
+slots = ["top", "bottom", "repos", "right"]
 density = "full"
 mouse = false
 hotkey = "F2"
@@ -414,9 +420,9 @@ There are three levels:
 
 | level | edges | each panel says |
 |---|---|---|
-| `minimal` | `top` and `bottom` | one field on the attention row, at most four rows of repo table — and a `bottom` pane at most five rows tall (that row plus those four), so the difference goes to your session |
-| `normal` | `top` and `bottom` | everything they have, table as tall as the window can spare |
-| `full` | every edge | everything they have |
+| `minimal` | `top` and `bottom` | the two one-row strips and nothing else — no repo table, no sidebar, so every row and column the frame is not using is your session's; `top` drops the charter version and `bottom` keeps one field |
+| `normal` | `top`, `bottom` and `repos` | both strips saying everything they have, and the repo table between them, as tall as the window can spare |
+| `full` | every edge | the sidebar as well |
 
 `full` is the shipped frame, so writing nothing at all and writing `density = "full"`
 give you the same thing — and that is enforced rather than trusted: charter's own test
@@ -428,19 +434,20 @@ nothing else in charter has to know presets exist — the probe, `doctor`, and t
 floors all read the one resolved list. **An explicit `slots` wins**: `slots` is the
 primitive, and if you wrote a list you meant that list.
 
-`minimal` and `normal` are how you ask for less. Both drop to the two strips; `minimal`
-also makes each panel terser — `top` drops the charter version (the workspace and the
-persona are what it exists to tell you), and `bottom` keeps only its highest-priority
-attention field (an alert if there is one, the spinner if work is running, otherwise the
-todo count, so the row is never blank) and at most four rows of repo table under it. The
-four that survive are the ones worth keeping — the repo you are standing in, and the ones
-with something on them — and the table still says how many it hid. The pane is sized for
-those four rows instead of all of them, which is the point of the level: `minimal` gives
-your session the rows back rather than blanking them. How many rows that is depends on how
-many clones you have — a fourteen-repo workspace gets ten back, an eight-repo one gets
-four, and a workspace with four or fewer gets none, because there was never a fifth row to
-give. `right` shows four persona chips at `minimal` and says how many it hid, and its
-todo list shrinks to four rows the same way.
+`minimal` and `normal` are how you ask for less, and what they give back is a whole
+component rather than a shorter one. `normal` drops the sidebar; `minimal` drops the repo
+table too and leaves the two one-row strips, so a fourteen-repo workspace hands its
+session fifteen rows and a border back rather than four. `minimal` also makes each
+remaining panel terser: `top` drops the charter version (the workspace and the persona are
+what it exists to tell you), and `bottom` keeps only its highest-priority attention field
+— an alert if there is one, the spinner if work is running, otherwise the todo count, so
+the row is never blank.
+
+If you want the table but at `minimal`'s verbosity, write the `slots` list by hand and
+declare the level beside it: an explicit `slots` wins over a preset, and the table then
+keeps its four highest-ranked rows — the repo you are standing in, and the ones with
+something on them — and still says how many it hid. `right` shows four persona chips that
+way too, with its todo list shrunk to four rows the same way.
 
 **The hotkey changes the density of the running frame, and nothing else.** `F2` opens the
 menu, which now lists all three levels with a `•` on the one in effect; choosing one
@@ -463,29 +470,46 @@ cannot make sense of it. That check is not cosmetic: this value is interpolated 
 configuration that `source-file` *executes*, and `charter.toml` is a committed, shared
 file that arrives from someone else's machine.
 
-Every edge is on by default. `top` is a one-line strip — the workspace and the persona on
-the left, the charter version (and the `dev` chip, if you are on that channel) at the
-far right, so identity and build are not read as one sentence; `bottom` is the attention
-row plus the repo table under it, as many rows tall as the plane and the terminal allow
-(see above); `right` is a 22-column sidebar carrying two headed sections — `personas`,
-one row each with the memory, health and in-flight badges lined up in a column of their
-own, and `todos`, this workspace's open todos beneath them. The todo list is what
-`charter ws todo` shows, oldest first, cut to what the pane has room for with a
-`…(+N more)` line saying how many it hid; a workspace with nothing open gets no todo
-section at all rather than a heading over an empty space. The sidebar drops itself on a
-terminal too small for it. The **order** is the order the panes are split in, and therefore the
-geometry: with `bottom` before the sidebar its rows span the whole frame, while listing it
-last leaves it only the width the sidebar did not take — 23 columns fewer, which means a
-118-column terminal before the table is drawn at all. `bottom` is where an alert, the
-command that fixes it, and the repo table all appear, so the shipped order gives it the
-full width.
+Every edge is on by default, and the frame reads top to bottom as **identity · your
+session · the repo table · what wants attention**.
+
+`top` is a one-line strip — the workspace and the persona on the left, the charter version
+(and the `dev` chip, if you are on that channel) at the far right, so identity and build
+are not read as one sentence. `repos` is the repo table in a bordered component of its
+own, headed `▪ repos 6` and as many rows tall as the plane and the terminal allow (see
+above). `bottom` is the attention strip on the terminal's last row — one alert and the
+command that fixes it, the in-flight spinner, this session's news, the todo count and the
+hotkey hint, each shown whole or dropped whole. `right` is a 22-column sidebar carrying
+two headed sections — `personas`, one row each with the memory, health and in-flight
+badges lined up in a column of their own, and `todos`, this workspace's open todos beneath
+them. The todo list is what `charter ws todo` shows, oldest first, cut to what the pane has
+room for with a `…(+N more)` line saying how many it hid; a workspace with nothing open
+gets no todo section at all rather than a heading over an empty space. The sidebar drops
+itself on a terminal too small for it.
+
+**The attention strip is last, and the table floats above it.** The table's height is its
+content's, so whichever of the two sits lower moves up and down the screen as repos are
+cloned or go quiet. Anchoring the alert is worth more than anchoring the table: an alert
+you have to go looking for is one you read late.
+
+**The `slots` order is the order the panes are split in, and therefore the geometry — in
+both directions.** Sideways: a slot listed after `right` gets only the width the sidebar
+left it, 23 columns fewer, which means a 118-column terminal before the table is drawn at
+all. Vertically: every split but `top`'s goes directly below the harness, so a slot listed
+*later* sits *higher* on screen. That is why the shipped list names `bottom` before
+`repos` and the table appears above the strip. If you write the list yourself, keep that
+pair in that order unless you mean to swap them.
 
 **There used to be a `left` sidebar, and it is gone.** It drew repo rows recomposed for 22
 columns — narrower than the name and branch columns of the table it was standing in for,
 so a real branch name was always elided and a dirty, CI-failing repo could render looking
-clean. `bottom` draws that table properly now, and the 22 columns go back to your agent
+clean. `repos` draws that table properly now, and the 22 columns go back to your agent
 session. A `charter.toml` still naming `left` in `slots` is not an error: the name is
-dropped the way any unknown slot is, and you get the rest of your list.
+dropped the way any unknown slot is, and you get the rest of your list. The same rule cuts
+the other way for `repos`, which is a *new* name: a committed `slots = ["top", "bottom",
+"right"]` still launches and simply has no table, because an explicit list is the
+primitive and charter does not add to a list you wrote by hand. Add `repos` to it, or
+delete the line and take the default.
 
 `slots`/`density`/`mouse`/`hotkey` are spelled the same on both sides. `history-limit`,
 `min-cols` and `min-rows` are the three that are not: charter.toml spells them with a

--- a/docs/news/unreleased-the-repo-table-becomes-its-own-panel.md
+++ b/docs/news/unreleased-the-repo-table-becomes-its-own-panel.md
@@ -1,0 +1,110 @@
+---
+version: unreleased
+headline: The repo table becomes its own panel, and the attention row moves to the last line
+---
+
+The bottom of the frame was one pane holding two unrelated things stacked with nothing
+between them — the status one-liner, and then the repo table running straight on out of
+it:
+
+```
+0 todos · ⚠ plane root charter · dirty · work belongs in a workspace clone · ⚡1 running · F2 menu
+├─ charter                    main↓9        ✓ passed
+│  ├─ frame-inside-tmux                     ✓ passed
+│  ├─ guard-all-or-nothing                  ✓ passed
+```
+
+They are two panes now, with a rule between them that tmux draws:
+
+```
+ ⬢ demo*                                                                        charter 0.53.0
+─────────────────────────────────────────────────────────────────────── ──────────────────────
+                                                                       │▪ personas 3
+  (your agent session)                                                 │▸ steward          ✎47
+                                                                       │
+                                                                       │▪ todos 2
+                                                                       │- wire the bottom split
+                                                                       │- look at it
+───────────────────────────────────────────────────────────────────────────────────────────────
+▪ repos 6
+  ├─ api-gateway                       main
+  ├─ billing                           feat/invoices*   ✗ failed   !214
+  ├─ charter                           main*↑9
+  ├─ docs-site                         main             ? passed
+  ├─ scheduler ⑂3                      main
+  └─ web-app                           main↓2
+───────────────────────────────────────────────────────────────────────────────────────────────
+2 todos · ⚠ plane root charter · dirty · ⚡1 running · F2 menu
+```
+
+Top to bottom: identity, your session, the repo table, what wants attention.
+
+**The attention row is last, and that is deliberate.** You asked for the repo list first
+and the `0 todos · …` line after it, and there is a reason beyond the ask: the table's
+height is its content's, so whichever of the two sits lower moves up and down the screen
+as repos are cloned or go quiet. Anchoring the alert to the terminal's last line is worth
+more than anchoring the table. An alert you have to go looking for is one you read late.
+
+**The table is headed now**, `▪ repos 6` — the same heading style the sidebar's sections
+got last release, from the same code, so the frame's two bordered components are labelled
+the same way. It also gives the tree something to hang from: the first row is `├─`, a glyph
+that means *there is more above me*, and once the status line moved out there was nothing.
+
+**A workspace with no clones says so instead of showing you an empty box.** While the
+table shared a pane with the status row, having nothing to table just meant no rows and
+the pane was the one-line strip it always was — absence said it. In a bordered component
+of its own, absence is an empty rectangle, and an empty rectangle reads as a table that
+failed to draw. So it says what it is, with the command that changes it:
+
+```
+  no clones in demo · charter clone <repo> -w demo
+```
+
+That is a different sentence from `⋯ gathering this workspace's repos…`, which is what you
+still get in the second before the launch's background gather lands. Not-looked-at-yet and
+nothing-there are two different facts and drawing them the same way is what once made a
+frame read as "no repos" on a plane full of them.
+
+**Below 95 columns the table is not drawn, and now the pane is not there either.** A
+frame narrower than the table's own columns never drew one — a row trimmed past the branch
+loses the CI glyph and the open-change count, and a dirty, failing repo then reads as
+clean. That used to be invisible, because the pane went on drawing the status row above the
+missing table. On its own it would be a bordered box with nothing in it, so the slot is
+dropped and its rows go back to your session. If you narrow a frame that is *already*
+running, the pane cannot be un-split — a resize changes sizes, not which panes exist — so
+it shrinks to one row and says `⋯ too narrow for the repo table — 95 columns needed`.
+
+**The density levels are re-derived rather than patched.** They differ by edges again,
+which is what a preset over `slots` can honestly express:
+
+| level | edges |
+|---|---|
+| `minimal` | the two one-row strips, and nothing that costs rows by the repo |
+| `normal` | the repo table as well |
+| `full` | the sidebar as well — every edge charter draws |
+
+`minimal` used to be `normal` with at most four rows of table, which after this split would
+have cost your session a border row it did not cost before in order to show four repos. A
+level whose whole purpose is handing rows back does not negotiate over four of them: it
+drops the component. A fourteen-repo workspace now gets fifteen rows and a border back
+rather than four rows. If you want the table at `minimal`'s verbosity, write the `slots`
+list by hand and declare the level beside it — an explicit list wins over a preset.
+
+## What to do
+
+Nothing, if you have never written `[frame] slots` in your `charter.toml`. The default is
+`["top", "bottom", "repos", "right"]` and you get the frame above.
+
+If you *have* written that list, it still launches and it simply has no table — `slots` is
+the primitive, and charter does not add a slot to a list you wrote by hand. Add `repos` to
+it, or delete the line and take the default. Note the order: the list is the order the
+panes are **split** in, and every split but `top`'s goes directly below your session, so a
+slot listed *later* sits *higher* on screen. `bottom` before `repos` is what puts the table
+above the strip.
+
+One thing under the hood, in case you ever wondered why your panes drift after a resize:
+tmux's `resize-pane` moves exactly one boundary, so in a stack of N panes only N-1 heights
+can be asserted. With two strips they always traded with your session and charter never had
+to name it. With three, the two below your session started trading with each other instead
+— measured, at 200x50: the table came back one row tall and the attention strip six. The
+harness pane is told its own height now, and the table takes what is left.

--- a/tests/test_frame_config.py
+++ b/tests/test_frame_config.py
@@ -4,8 +4,8 @@ Defaults are the shipped behaviour, so they are asserted rather than assumed: `m
 off because `set -g mouse on` takes over drag-select, and breaking the operator's copy to
 enable a feature v1 does not ship is a bad trade.
 
-`slots` is every edge charter draws (#386, narrowed to three by #488's retirement of
-`left`), and the reason is the same kind of trade read the other way: inside a frame
+`slots` is every edge charter draws (#386, `left` retired by #488, `repos` added by
+#515), and the reason is the same kind of trade read the other way: inside a frame
 `charter statusline` draws nothing (ADR 0019), so an edge the frame does not fill is
 information nobody sees at all. The order is asserted too, because it is the split order
 and therefore the geometry — see `instance.FRAME_FIELDS`.
@@ -22,7 +22,7 @@ from charter import instance
 class FrameDefaults(unittest.TestCase):
     def test_an_absent_section_yields_the_shipped_defaults(self):
         f = instance.frame_of({})
-        self.assertEqual(f["slots"], ["top", "bottom", "right"])
+        self.assertEqual(f["slots"], ["top", "bottom", "repos", "right"])
         self.assertIs(f["mouse"], False)
         self.assertEqual(f["hotkey"], "F2")
         self.assertEqual(f["history_limit"], 50000)
@@ -33,7 +33,7 @@ class FrameDefaults(unittest.TestCase):
         f = instance.frame_of({"frame": {"mouse": True, "hotkey": "F5"}})
         self.assertIs(f["mouse"], True)
         self.assertEqual(f["hotkey"], "F5")
-        self.assertEqual(f["slots"], ["top", "bottom", "right"])
+        self.assertEqual(f["slots"], ["top", "bottom", "repos", "right"])
 
     def test_an_unknown_slot_is_dropped_rather_than_carried(self):
         """A typo must not reach a tmux argv. Dropping is louder than it looks: the slot
@@ -83,6 +83,9 @@ class FrameDefaults(unittest.TestCase):
         f = instance.frame_of(
             {"frame": {"slots": ["top", "bottom", "left", "right"]}})
         self.assertEqual(f["slots"], ["top", "bottom", "right"])
+        self.assertNotIn("repos", f["slots"],
+                         "an explicit `slots` is the primitive — #515 must not smuggle "
+                         "a slot into a list the operator wrote by hand")
 
     def test_a_malformed_section_falls_back_instead_of_raising(self):
         """`config` is imported by every command including `charter --version`, so a bad
@@ -95,7 +98,7 @@ class FrameDefaults(unittest.TestCase):
         final `isinstance(value, type(default))` type check is deleted: without it, the
         string `"lots"` would be assigned straight into `history_limit`."""
         f = instance.frame_of({"frame": {"slots": "top", "history-limit": "lots"}})
-        self.assertEqual(f["slots"], ["top", "bottom", "right"])
+        self.assertEqual(f["slots"], ["top", "bottom", "repos", "right"])
         self.assertEqual(f["history_limit"], 50000)
 
     def test_a_bool_does_not_satisfy_a_non_bool_default(self):

--- a/tests/test_frame_config.py
+++ b/tests/test_frame_config.py
@@ -13,10 +13,18 @@ and therefore the geometry — see `instance.FRAME_FIELDS`.
 
 from __future__ import annotations
 
+import pathlib
+import tomllib
 import unittest
 from unittest import mock
 
 from charter import instance
+
+#: This repo's own committed `charter.toml` — see
+#: :class:`CharterOwnPlaneDrawsEveryEdgeItShips`. Read off disk rather than through
+#: `config`, which resolves a WORKTREE back to the main tree it was cut from
+#: (`root._plane_of`) and would therefore test the operator's checkout, not this one.
+_COMMITTED = pathlib.Path(__file__).resolve().parents[1] / "charter.toml"
 
 
 class FrameDefaults(unittest.TestCase):
@@ -146,6 +154,40 @@ class FrameDefaults(unittest.TestCase):
         default holds."""
         f = instance.frame_of({"frame": {"history_limit": 999}})
         self.assertEqual(f["history_limit"], 50000)
+
+
+class CharterOwnPlaneDrawsEveryEdgeItShips(unittest.TestCase):
+    """The repo's OWN committed `charter.toml`, read off disk — the one file in this
+    project a slot rename can silently break.
+
+    `slots` is the primitive and an explicit list wins over the default outright, which
+    is the compatibility promise `instance.FRAME_SLOTS` makes to operators. It cuts
+    charter itself too: this repo IS a control plane, and the frame the maintainers run
+    while working on the frame is drawn from this file. A release that adds a slot and
+    leaves this line alone hands every other plane the new edge and takes it away from
+    charter's own, with nothing on screen saying why — which is exactly what #515 did
+    before this test existed. `origin/main` drew the repo table from this file; the first
+    version of the branch that split `repos` out of `bottom` did not.
+
+    Asserted through `instance.frame_of` rather than against the raw TOML list, because
+    the failure is about what charter RESOLVES: a list naming a slot charter no longer
+    has is filtered to nothing here, which reads on screen the same way as a list missing
+    one. And the whole set is required rather than a membership check on today's newest
+    name — the next slot has the same problem and should not need a new test.
+    """
+
+    def test_the_committed_slots_line_names_every_slot_charter_can_draw(self):
+        got = instance.frame_of(tomllib.loads(_COMMITTED.read_text()))["slots"]
+        self.assertEqual(sorted(got), sorted(instance.FRAME_SLOTS), got)
+
+    def test_the_committed_order_is_the_one_the_geometry_wants(self):
+        """The list is the SPLIT order, so it is the geometry (#488/#500): a slot listed
+        later sits higher, and a `repos` listed after `right` is inset by the sidebar's
+        23 columns and needs a 118-column terminal before it draws a table at all. The
+        shipped default is the order charter measured; this file having the same set in a
+        different order would be a frame nobody chose."""
+        got = instance.frame_of(tomllib.loads(_COMMITTED.read_text()))["slots"]
+        self.assertEqual(got, instance.frame_of({})["slots"])
 
 
 class HotkeyIsNotAFreeString(unittest.TestCase):

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -174,19 +174,26 @@ class ShippedDefaultsAgree(unittest.TestCase):
                 common = [s for s in shipped if s in spec["slots"]]
                 self.assertEqual([s for s in spec["slots"] if s in shipped], common)
 
-    def test_minimal_is_the_two_strips_saying_as_little_as_they_can(self):
-        """#387's own words, re-derived by #488. It used to be "one-line top and bottom",
-        and half of that stopped being true: `bottom` is variable-height now, so what
-        makes `minimal` minimal is the VERBOSITY — one field on the attention row and at
-        most `slots._TERSE_ROWS` rows of table under it — not a row count in
-        `SLOT_SIZE`. `top` is still literally one row, and `bottom`'s entry is still the
-        floor it never goes below, so both halves are asserted for what they now mean."""
+    def test_minimal_is_the_two_strips_and_literally_nothing_else(self):
+        """#387's own words, re-derived by #488 and again by #515 — and this time they
+        are literally true again. #488 made `bottom` variable-height, so "one-line top
+        and bottom" stopped being a row count and became a verbosity. #515 gave the table
+        its own slot, so the two strips are one row each once more (`SLOT_SIZE`), and
+        `minimal` is what it says: those two and nothing that costs rows by the repo.
+
+        All three halves asserted — the slot list, the verbosity, and the row counts —
+        because a `minimal` that quietly grew `repos` back would still be terse and still
+        name two strips first, and would cost the harness a whole component's worth of
+        rows plus a border to show four repos."""
         self.assertEqual(instance.FRAME_DENSITY["minimal"]["slots"], ["top", "bottom"])
         self.assertEqual(instance.FRAME_DENSITY["minimal"]["verbosity"], "terse")
+        self.assertNotIn("repos", instance.FRAME_DENSITY["minimal"]["slots"])
         self.assertEqual(layout.SLOT_SIZE["top"], 1)
+        self.assertEqual(layout.SLOT_SIZE["bottom"], 1)
         self.assertEqual(
-            layout.bottom_rows(content_rows=1, window_rows=50, slots=["top", "bottom"]),
-            1, "a plane with nothing to table must still get the one-row strip")
+            layout.slot_sizes(["top", "bottom"], window_rows=50, content_rows=9),
+            {"top": 1, "bottom": 1},
+            "minimal must not have a slot whose height moves with the content")
 
     def test_every_level_expands_to_slots_charter_actually_accepts(self):
         """A level naming a slot outside `FRAME_SLOTS` would be filtered out of an
@@ -373,20 +380,21 @@ class TerseSaysLess(PersonaIso, unittest.TestCase):
             terse = self._render("bottom", "minimal")
         self.assertIn("todo", terse)
 
-    def test_bottoms_table_shows_fewer_repos_and_says_how_many_it_hid(self):
-        """#488 moved the repo table from the retired `left` sidebar to `bottom`, and
-        `terse` had to come with it: `bottom` is the slot with rows to give now, so
-        "less" means fewer of them. Asserted as line COUNTS against the same panel at
-        `normal`, so a renderer that merely broke cannot pass by drawing less of
-        nothing. `+ 1` is the attention row, which is not the table's to spend."""
+    def test_the_tables_pane_shows_fewer_repos_and_says_how_many_it_hid(self):
+        """#488 moved the repo table off the retired `left` sidebar and `terse` came with
+        it; #515 moved it again, into `repos`. The level's meaning is unchanged — it is
+        the slot with rows to give, so "less" means fewer of them — and the arithmetic
+        lost its `+ 1`, because the attention row is another pane's now. Asserted as line
+        COUNTS against the same panel at `normal`, so a renderer that merely broke cannot
+        pass by drawing less of nothing."""
         rows = [{"name": f"repo{i}", "branch": "main", "dirty": False,
                  "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": None,
                  "change": None, "sigil": "", "current": False, "worktree_count": 0}
                 for i in range(9)]
         gather.save(self.fid, {"gathered_at": 0.0, "workspace": "w",
                                "current_repo": None, "repos": rows, "worktrees": []})
-        normal = self._render("bottom", "normal")
-        terse = self._render("bottom", "minimal")
+        normal = self._render("repos", "normal")
+        terse = self._render("repos", "minimal")
         self.assertEqual(len(normal.split("\n")), 1 + 9)
         self.assertEqual(len(terse.split("\n")), 1 + slots._TERSE_ROWS)
         self.assertIn("more", terse, "a panel showing less must say how much less")
@@ -403,7 +411,7 @@ class TerseSaysLess(PersonaIso, unittest.TestCase):
         rows[-1] = dict(rows[-1], name="the-dirty-one", dirty=True, tracked_dirty=True)
         gather.save(self.fid, {"gathered_at": 0.0, "workspace": "w",
                                "current_repo": None, "repos": rows, "worktrees": []})
-        terse = self._render("bottom", "minimal")
+        terse = self._render("repos", "minimal")
         self.assertIn("the-dirty-one", terse)
         # `_pick_rows` re-sorts the CHOSEN set back into cache order, so the two clean
         # repos that share the last rows are still `repo0`/`repo1` — what distinguishes
@@ -426,8 +434,8 @@ class TerseSaysLess(PersonaIso, unittest.TestCase):
                            "behind": 0, "ci": None, "change": None, "sigil": "",
                            "current": False, "worktree_count": 0}
                           for i in range(6)]})
-        normal = self._render("bottom", "normal")
-        terse = self._render("bottom", "minimal")
+        normal = self._render("repos", "normal")
+        terse = self._render("repos", "minimal")
         self.assertIn("piece-5", normal)
         self.assertNotIn("piece-5", terse)
         self.assertIn("solo", terse, "the repo keeps its row whatever its pieces lose")
@@ -818,7 +826,8 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         self.enterContext(mock.patch("charter.frame.tmuxctl.version",
                                      return_value=(3, 7)))
         state.record_harness_pane(self.fid, "%0")
-        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2"})
+        state.record_panes(self.fid,
+                           panels={"top": "%1", "bottom": "%2", "repos": "%5"})
 
     def _run(self, level, fake=None):
         fake = fake or _Tmux()
@@ -849,18 +858,18 @@ class LiveOverride(PersonaIso, unittest.TestCase):
                        if "split-window" in c and "panel" in c]
         self.assertEqual(sorted(split_slots), ["right"])
         self.assertEqual(state.panes(self.fid),
-                         {"top": "%1", "bottom": "%2", "right": "%7"})
+                         {"top": "%1", "bottom": "%2", "repos": "%5", "right": "%7"})
 
-    def _bottom_split_size(self, size):
-        """The `-l` a re-layout hands `split-window` for a `bottom` it has to create.
+    def _repos_split_size(self, size):
+        """The `-l` a re-layout hands `split-window` for a `repos` it has to create.
 
-        A density change can ADD `bottom` — a frame whose panel died and was reaped, or
-        one grown from a level that had none — and that split's own `-l` comes from
-        `layout.slot_sizes`, not from the `_reassert_sizes` that follows it. So it is a
-        second place the window's width has to reach, and the correction after it is
-        `report=False` best-effort rather than a guarantee.
+        A density change can ADD `repos` — `minimal` has none, so every step up from it
+        is this — and that split's own `-l` comes from `layout.slot_sizes`, not from the
+        `_reassert_sizes` that follows it. So it is a second place the window's width has
+        to reach, and the correction after it is `report=False` best-effort rather than a
+        guarantee.
         """
-        state.record_panes(self.fid, panels={"top": "%1"})
+        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2"})
         rows = [{"name": f"repo{i}", "branch": "main", "dirty": False,
                  "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": None,
                  "change": None, "sigil": "", "current": False, "worktree_count": 0}
@@ -870,35 +879,56 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         rc, fake = self._run("normal", _Tmux(size=size))
         self.assertEqual(rc, 0)
         split = next(c for c in fake.calls
-                     if "split-window" in c and "bottom" in c)
+                     if "split-window" in c and "repos" in c)
         return int(split[split.index("-l") + 1])
 
-    def test_a_relayout_splits_bottom_for_the_table_a_wide_window_can_draw(self):
-        self.assertEqual(self._bottom_split_size("200:50"), 1 + 6)
+    def test_a_relayout_splits_the_table_for_what_a_wide_window_can_draw(self):
+        self.assertEqual(self._repos_split_size("200:50"), 1 + 6)
 
-    def test_a_relayout_splits_bottom_for_one_row_on_a_narrow_window(self):
-        """#500's other call site. `_reassert_sizes` runs immediately after and would
-        correct it, but it is `report=False` best-effort against a pane that may already
-        be gone — the split has to ask for the right size in the first place, and a `-l`
-        that over-asks is granted by tmux out of the harness rather than refused."""
-        self.assertEqual(self._bottom_split_size("80:50"), 1)
+    def test_a_narrow_window_does_not_get_a_table_pane_at_all(self):
+        """#500's other call site, and what #515 changed about it. An 80-column frame
+        draws no table, and the pane it used to be given a one-row `-l` for is now not
+        split at all (`layout.visible_slots`) — because a bordered rectangle with nothing
+        in it reads as "no repos" on a plane that has six.
 
-    def test_a_bottom_split_in_beside_a_surviving_sidebar_gets_the_inset_width(self):
+        The control is the wide case in the test above, so a fix that simply stopped
+        splitting `repos` anywhere is red."""
+        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2"})
+        rows = [{"name": f"repo{i}", "branch": "main", "dirty": False,
+                 "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": None,
+                 "change": None, "sigil": "", "current": False, "worktree_count": 0}
+                for i in range(6)]
+        gather.save(self.fid, {"gathered_at": 0.0, "workspace": "w",
+                               "current_repo": None, "repos": rows, "worktrees": []})
+        rc, fake = self._run("normal", _Tmux(size="80:50"))
+        self.assertEqual(rc, 0)
+        self.assertFalse([c for c in fake.calls
+                          if "split-window" in c and "repos" in c], fake.calls)
+
+    def test_a_table_split_in_beside_a_surviving_sidebar_gets_the_inset_width(self):
         """Round 3, and the case that says why the order used here is the PANE order and
-        not *want*'s. A frame launched with `[frame] slots = ["right", "top"]` already
-        has a 22-column sidebar; growing it to `full` splits `bottom` off a harness pane
-        that is therefore already 23 columns narrower than the window — 87 in a
-        110-column window, measured on tmux 3.7c, which draws no table.
+        not *want*'s. A frame launched with `[frame] slots = ["right", "top", "bottom"]`
+        already has a 22-column sidebar; growing it to `full` splits `repos` off a
+        harness pane that is therefore already 23 columns narrower than the window.
 
-        `want` at `full` is `["top", "bottom", "right"]`, whose order says `bottom` comes
-        first and is full width. That is the order a fresh launch would produce, not the
-        order THIS frame's panes are in: `right` is already there and is not re-split.
-        Sizing from `want` here answers 110 and hands back the seven-row pane — so the
-        list handed to `layout.bottom_cols` is the surviving panes in their recorded
-        order followed by what is about to be split, which is what actually happens.
+        `want` at `full` is `["top", "bottom", "repos", "right"]`, whose order says
+        `repos` comes before `right` and is full width. That is the order a fresh launch
+        would produce, not the order THIS frame's panes are in: `right` is already there
+        and is not re-split. So the list handed to `layout.repos_cols` is the surviving
+        panes in their recorded order followed by what is about to be split, which is what
+        actually happens.
+
+        Asserted at a window width the two answers straddle: 130 columns leaves a full
+        table pane 130 wide, and an inset one 107 — both above `statusline._LEFT_W`, so
+        both are split, and the sizes differ only because the inset pane holds fewer of
+        the table's rows... except it does not, since the rows are the same six. The
+        distinguishing case is therefore the width the sidebar pushes BELOW the table's
+        own minimum: at 110 the inset pane is 87 wide and is not split at all, while the
+        un-inset one is 110 and gets its six rows. A sizer reading the window's width
+        would split a seven-row pane there instead — #500's own defect, one slot over.
 
         The control is the same re-layout with no sidebar surviving, so a fix that simply
-        stopped sizing `bottom` for its content is red.
+        stopped splitting `repos` is red.
         """
         rows = [{"name": f"repo{i}", "branch": "main", "dirty": False,
                  "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": None,
@@ -911,20 +941,20 @@ class LiveOverride(PersonaIso, unittest.TestCase):
             state.record_panes(self.fid, panels=panels)
             rc, fake = self._run("full", _Tmux(size="110:50"))
             self.assertEqual(rc, 0)
-            cmd = next(c for c in fake.calls
-                       if "split-window" in c and "bottom" in c)
-            return int(cmd[cmd.index("-l") + 1])
+            cmd = next((c for c in fake.calls
+                        if "split-window" in c and "repos" in c), None)
+            return None if cmd is None else int(cmd[cmd.index("-l") + 1])
 
-        self.assertEqual(_split_l({"right": "%3", "top": "%1"}), 1)
-        self.assertEqual(_split_l({"top": "%1"}), 1 + 6)
+        self.assertIsNone(_split_l({"right": "%3", "top": "%1", "bottom": "%2"}))
+        self.assertEqual(_split_l({"top": "%1", "bottom": "%2"}), 1 + 6)
 
     def test_shrinking_kills_the_panes_it_no_longer_wants(self):
-        state.record_panes(self.fid, panels={"top": "%1", "right": "%3", "bottom": "%2"})
+        state.record_panes(self.fid, panels={"top": "%1", "right": "%3", "bottom": "%2",
+                                             "repos": "%5"})
         rc, fake = self._run("minimal")
         self.assertEqual(rc, 0)
-        killed = [c for c in fake.calls if "kill-pane" in c]
-        self.assertEqual(len(killed), 1, fake.calls)
-        self.assertIn("%3", killed[0])
+        killed = {c[c.index("kill-pane") + 2] for c in fake.calls if "kill-pane" in c}
+        self.assertEqual(killed, {"%3", "%5"}, fake.calls)
         self.assertEqual(state.panes(self.fid), {"top": "%1", "bottom": "%2"})
 
     def test_a_panel_is_disarmed_before_it_is_killed(self):
@@ -966,10 +996,10 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         early return, the hook survives firing `resize-pane -t %1` at dead panes on every
         resize for the life of the window."""
         state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2",
-                                             "right": "%4"})
+                                             "repos": "%5", "right": "%4"})
         rc, fake = self._run("minimal", fake=_Tmux(size="40:8"))
         self.assertEqual(rc, 0)
-        self.assertEqual(len([c for c in fake.calls if "kill-pane" in c]), 3, fake.calls)
+        self.assertEqual(len([c for c in fake.calls if "kill-pane" in c]), 4, fake.calls)
         unset = [c for c in fake.calls if "window-resized" in c and "-u" in c]
         self.assertEqual(len(unset), 1, fake.calls)
         self.assertEqual(state.panes(self.fid), {})
@@ -999,10 +1029,12 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         absent from `keep`, is re-split fresh (`%7`, from the fake), and the bad string
         never reaches disk to be read again by the next keypress."""
         state.record_panes(self.fid,
-                           panels={"top": "%1", "bottom": "%2;kill-server"})
+                           panels={"top": "%1", "repos": "%5",
+                                   "bottom": "%2;kill-server"})
         self._run("normal")
         recorded = state.panes(self.fid)
-        self.assertEqual(recorded, {"top": "%1", "bottom": "%7"}, recorded)
+        self.assertEqual(recorded, {"top": "%1", "repos": "%5", "bottom": "%7"},
+                         recorded)
 
     def test_reassert_sizes_refuses_a_pane_id_of_the_wrong_shape_itself(self):
         """The second half of the same rule, pinned where the builder lives rather than
@@ -1013,13 +1045,16 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         disk and hands it straight here, with no `_relayout` in between.
 
         Called directly, with a hostile id its callers would have filtered, so the
-        assertion cannot be satisfied by somebody else's guard."""
+        assertion cannot be satisfied by somebody else's guard. The HARNESS pane is
+        hostile here too, and for the same reason: `cmd_resize` reads that one off disk as
+        well, and #515 gave this function a `resize-pane -t <harness>` of its own."""
         calls = []
         with mock.patch("charter.frame.tmuxctl.run",
                         side_effect=lambda a, argv, **k: calls.append(list(argv))):
             commands_frame._reassert_sizes(
                 "charter", fid=self.fid,
                 panes={"top": "%1", "bottom": "%2;kill-server"},
+                harness_pane="%0;kill-server",
                 window_cols=200, window_rows=50)
         targets = [c[c.index("-t") + 1] for c in calls if "resize-pane" in c]
         self.assertEqual(targets, ["%1"], calls)
@@ -1287,7 +1322,7 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         self.assertEqual(rc, 0)
         split_slots = sorted(c[c.index("panel") + 1] for c in fake.calls
                              if "split-window" in c and "panel" in c)
-        self.assertEqual(split_slots, ["bottom", "right", "top"], fake.calls)
+        self.assertEqual(split_slots, ["bottom", "repos", "right", "top"], fake.calls)
 
     def test_a_harness_pane_that_is_not_tmuxs_own_shape_is_refused(self):
         """The id comes back off disk, not off `split-window`'s stdout, so it gets the
@@ -1305,11 +1340,11 @@ class ResizeRecomputesForBothDimensions(PersonaIso, unittest.TestCase):
     DENSITY, not from the repo count alone.
 
     This is the surface the operator actually hits, and it is not launch-only: the
-    `window-resized` hook fires on every step of a terminal drag, so a `bottom` sized for
-    a table it can no longer draw is re-asserted continuously for as long as the terminal
-    stays narrow — with the harness pinned at `layout.HARNESS_MIN_ROWS` the whole time
-    (measured on tmux 3.7c: a 26-row, 80-column window with 14 repos gave `bottom` 11
-    rows to draw one line in).
+    `window-resized` hook fires on every step of a terminal drag, so a table pane sized
+    for a table it can no longer draw is re-asserted continuously for as long as the
+    terminal stays narrow — with the harness pinned at `layout.HARNESS_MIN_ROWS` the
+    whole time (measured on tmux 3.7c: a 26-row, 80-column window with 14 repos gave that
+    pane 11 rows to draw one line in).
 
     Driven through `cmd_resize` itself rather than through `_reassert_sizes`, because
     what shipped broken was the call site: it measured the width into `_cols` and threw
@@ -1320,7 +1355,8 @@ class ResizeRecomputesForBothDimensions(PersonaIso, unittest.TestCase):
         super().setUp()
         self.fid = f"rsz-{_a_dead_pid()}"
         state.record_harness_pane(self.fid, "%0")
-        state.record_panes(self.fid, panels={"top": "%1", "bottom": "%2"})
+        state.record_panes(self.fid,
+                           panels={"top": "%1", "bottom": "%2", "repos": "%5"})
         rows = [{"name": f"repo{i}", "branch": "main", "dirty": False,
                  "tracked_dirty": False, "ahead": 0, "behind": 0, "ci": None,
                  "change": None, "sigil": "", "current": False, "worktree_count": 0}
@@ -1328,28 +1364,61 @@ class ResizeRecomputesForBothDimensions(PersonaIso, unittest.TestCase):
         gather.save(self.fid, {"gathered_at": 0.0, "workspace": "w",
                                "current_repo": None, "repos": rows, "worktrees": []})
 
-    def _bottom_height(self, size, *, panels=None):
+    def _heights(self, size, *, panels=None) -> dict[str, int]:
+        """Every `resize-pane -y` `cmd_resize` issues, as ``{pane id: rows}``.
+
+        **The table pane is deliberately absent from this map, and that is the property**
+        (#515). tmux's `resize-pane -y` moves one boundary, so in a stack of N panes only
+        N-1 heights are free; the one left unasserted is `repos`, whose height is already
+        a function of the others, and the HARNESS (`%0`) is asserted instead. So what
+        `cmd_resize` decided about the table is read here as the harness's height — and
+        `tests/test_frame_tmux_integration.py` is where a real tmux confirms the table
+        lands on the rows that leaves it.
+        """
         if panels is not None:
             state.record_panes(self.fid, panels=panels)
         fake = _Tmux(size=size)
         with mock.patch("charter.frame.tmuxctl.run", side_effect=fake):
             rc = commands_frame.cmd_resize(SimpleNamespace(frame=self.fid))
         self.assertEqual(rc, 0)
-        sized = [c for c in fake.calls if "resize-pane" in c and "%2" in c]
-        self.assertEqual(len(sized), 1, fake.calls)
-        return int(sized[0][sized[0].index("-y") + 1])
+        return {c[c.index("-t") + 1]: int(c[c.index("-y") + 1])
+                for c in fake.calls if "resize-pane" in c and "-y" in c}
+
+    def _table_rows(self, size, *, panels=None) -> int:
+        """How many rows `cmd_resize` left the table pane, read back out of the window.
+
+        Not an independent re-derivation: the window's height minus every height
+        `cmd_resize` actually asserted, minus one border row per horizontal pane. That is
+        the same subtraction tmux itself performs when it honours those `-y`s, which is
+        why `test_frame_tmux_integration` can check this number against a real
+        `#{pane_height}` rather than against another copy of charter's arithmetic.
+        """
+        heights = self._heights(size, panels=panels)
+        window_rows = int(size.split(":")[1])
+        # One border row per SPLIT, and the splits are one fewer than the panes in the
+        # stack — which is `len(heights)` named panes plus the table itself.
+        return window_rows - sum(heights.values()) - len(heights)
 
     def test_a_wide_window_keeps_the_table_sized_pane(self):
         """The control. Without it the narrow assertion below would pass against a
         function that always answered one."""
-        self.assertEqual(self._bottom_height("200:50"), 1 + 6)
+        self.assertEqual(self._table_rows("200:50"), 1 + 6)
+
+    def test_the_fixed_strips_are_re_asserted_at_their_own_constant_height(self):
+        """The rest of the map, and the check that #515's arithmetic reached this call
+        site. `bottom` went back to being one row; a `_reassert_sizes` still treating it
+        as the variable slot would hand it the table's height and take those rows out of
+        the harness on every step of a drag. The harness's own `-y` is asserted here too,
+        because before #515 nothing named it at all — with three strips instead of two,
+        the two below the harness trade rows with each other and never with it."""
+        self.assertEqual(self._heights("200:50"), {"%1": 1, "%2": 1, "%0": 38})
 
     def test_narrowing_the_terminal_shrinks_the_pane_back_to_its_one_row(self):
         """The panel draws no table below `statusline._LEFT_W`, so every row past the
         first was blank — and came out of the harness."""
         for cols in (60, 80, statusline._LEFT_W - 1):
             with self.subTest(cols=cols):
-                self.assertEqual(self._bottom_height(f"{cols}:50"), 1)
+                self.assertEqual(self._table_rows(f"{cols}:50"), 1)
 
     def test_the_density_the_operator_chose_is_read_here_too(self):
         """`cmd_density` and `cmd_resize` are different processes minutes apart, so the
@@ -1357,14 +1426,14 @@ class ResizeRecomputesForBothDimensions(PersonaIso, unittest.TestCase):
         being remembered. A `minimal` frame that then gets resized must not be handed the
         `normal` height back."""
         state.record_density(self.fid, "minimal")
-        self.assertEqual(self._bottom_height("200:50"), 1 + slots._TERSE_ROWS)
+        self.assertEqual(self._table_rows("200:50"), 1 + slots._TERSE_ROWS)
         state.record_density(self.fid, "normal")
-        self.assertEqual(self._bottom_height("200:50"), 1 + 6)
+        self.assertEqual(self._table_rows("200:50"), 1 + 6)
 
     def test_a_pane_inset_beside_the_sidebar_is_resized_for_its_own_width(self):
         """Round 3. The window's width is not the PANE's when the frame's `[frame] slots`
-        put `right` before `bottom`: `panel_argvs` splits both off the harness pane in
-        list order, so `bottom` comes off a harness that is already 23 columns narrower —
+        put `right` before `repos`: `panel_argvs` splits both off the harness pane in
+        list order, so the table comes off a harness that is already 23 columns narrower —
         measured on tmux 3.7c, 87 columns in a 110-column window, which is below
         `statusline._LEFT_W` and draws no table at all.
 
@@ -1372,18 +1441,20 @@ class ResizeRecomputesForBothDimensions(PersonaIso, unittest.TestCase):
         defect: it re-applied the over-tall pane on every step of a terminal drag. What it
         does have is the recorded pane map, whose insertion order IS the order those panes
         were split in — `_split_panels` writes it that way and JSON round-trips it — so
-        `layout.bottom_cols` can turn the window's width into the pane's.
+        `layout.repos_cols` can turn the window's width into the pane's.
 
         The control is the same window and the same map with the shipped order, so a fix
-        that stopped sizing `bottom` for its content at all is red rather than green.
+        that stopped sizing the table for its content at all is red rather than green.
         """
         self.assertEqual(
-            self._bottom_height("110:50",
-                                panels={"right": "%3", "top": "%1", "bottom": "%2"}),
+            self._table_rows("110:50",
+                             panels={"right": "%3", "top": "%1", "bottom": "%2",
+                                     "repos": "%5"}),
             1)
         self.assertEqual(
-            self._bottom_height("110:50",
-                                panels={"top": "%1", "bottom": "%2", "right": "%3"}),
+            self._table_rows("110:50",
+                             panels={"top": "%1", "bottom": "%2", "repos": "%5",
+                                     "right": "%3"}),
             1 + 6)
 
 

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -2829,25 +2829,34 @@ class Launch(PersonaIso, unittest.TestCase):
                          "budget and would never be respawned")
 
 
-class BottomIsSplitForWhatItCanDraw(PersonaIso, unittest.TestCase):
-    """#500: the `-l` the launcher hands `split-window` for `bottom` is the number of
-    rows the PANEL will fill, not the number of repos there are.
+class TheTablePaneIsSplitForWhatItCanDraw(PersonaIso, unittest.TestCase):
+    """#500: the `-l` the launcher hands `split-window` for the table pane is the number
+    of rows the PANEL will fill, not the number of repos there are.
 
-    `bottom`'s renderer draws no table below `statusline._LEFT_W` (95) and at most
+    `_repos`' renderer draws no table below `statusline._LEFT_W` (95) and at most
     `slots._TERSE_ROWS` of one at a `terse` density. #488 sized the pane from the repo
     count alone, so both shapes came up with a pane taller than anything that would be
     drawn into it — and `layout.HARNESS_MIN_ROWS` means those rows come straight off the
-    agent session. Asserted at the LAUNCHER rather than at `bottom_rows_wanted`, because
+    agent session. Asserted at the LAUNCHER rather than at `repos_rows_wanted`, because
     the defect was a call site that had the width and did not pass it.
+
+    **The narrow cases assert the pane is not split at all, and that is #515.** While the
+    table shared `bottom` with the attention row, a too-narrow frame still needed that
+    pane and the right answer was a one-row `-l`. Split apart, a one-row table pane at 80
+    columns is a bordered rectangle with nothing in it, so `layout.visible_slots` drops
+    the slot instead — see `tests/test_frame_layout.py` for the boundary itself, and
+    `slots._too_narrow_lines` for the resize case a launch cannot reach.
 
     `gather.row_count` is stubbed so the count is the same on every pass and the only
     thing varying is what the test says varies. What is NOT stubbed is the arithmetic:
-    `_launch_sizes` and `layout.bottom_rows` run for real.
+    `_launch_sizes` and `layout.repos_rows` run for real.
     """
 
-    def _bottom_split_size(self, *, cols, rows=50, repos=6, slots=None):
+    def _table_split_size(self, *, cols, rows=50, repos=6, slots=None):
+        """The `-l` on the `repos` split, or ``None`` when there was no such split."""
         fake = _FakeTmux(exit_code=0,
-                         panel_pane_ids={"top": "%11", "bottom": "%12", "right": "%13"})
+                         panel_pane_ids={"top": "%11", "bottom": "%12", "repos": "%14",
+                                         "right": "%13"})
         with contextlib.ExitStack() as stack:
             stack.enter_context(
                 mock.patch("charter.frame.gather.row_count", return_value=repos))
@@ -2855,28 +2864,27 @@ class BottomIsSplitForWhatItCanDraw(PersonaIso, unittest.TestCase):
                 stack.enter_context(mock.patch.dict(config.FRAME, {"slots": slots}))
             rc = _launch(fake, cols=cols, rows=rows)
         self.assertEqual(rc, 0)
-        split = next(c for c in fake.calls
-                     if "split-window" in c and "bottom" in c)
-        return int(split[split.index("-l") + 1])
+        split = next((c for c in fake.calls
+                      if "split-window" in c and "repos" in c), None)
+        return None if split is None else int(split[split.index("-l") + 1])
 
     def test_a_wide_window_is_split_for_the_whole_table(self):
-        """The control, and it has to hold or the narrow assertion below is vacuous."""
-        self.assertEqual(self._bottom_split_size(cols=200), 1 + 6)
+        """The control, and it has to hold or the narrow assertions below are vacuous."""
+        self.assertEqual(self._table_split_size(cols=200), 1 + 6)
 
-    def test_a_window_too_narrow_for_the_table_is_split_for_one_row(self):
-        """`[frame] min-cols` (100) gates `right` and `top`; `layout.visible_slots` keeps
-        `bottom` down to `min_cols // 2`, so an 80-column terminal draws the attention
-        row and nothing else. It used to be split seven rows tall for it."""
+    def test_a_window_too_narrow_for_the_table_gets_no_table_pane(self):
+        """An 80-column terminal draws no table. It used to be split seven rows tall for
+        one, then one row tall for nothing; now it is not split at all."""
         for cols in (80, statusline._LEFT_W - 1):
             with self.subTest(cols=cols):
-                self.assertEqual(self._bottom_split_size(cols=cols), 1)
+                self.assertIsNone(self._table_split_size(cols=cols))
 
     def test_the_boundary_is_the_tables_own_width(self):
         """Pinned from both sides at `_LEFT_W` itself, so an off-by-one in either
         direction is red rather than absorbed by the two-column gap between the values
         the test above happens to use."""
-        self.assertEqual(self._bottom_split_size(cols=statusline._LEFT_W), 1 + 6)
-        self.assertEqual(self._bottom_split_size(cols=statusline._LEFT_W - 1), 1)
+        self.assertEqual(self._table_split_size(cols=statusline._LEFT_W), 1 + 6)
+        self.assertIsNone(self._table_split_size(cols=statusline._LEFT_W - 1))
 
     def test_a_sidebar_split_first_makes_the_pane_narrower_than_the_window(self):
         """Round 3, and the half two rounds of review passed over: the width that decides
@@ -2884,35 +2892,35 @@ class BottomIsSplitForWhatItCanDraw(PersonaIso, unittest.TestCase):
 
         `instance.frame_of` keeps an operator's `[frame] slots` verbatim and
         `tests/test_frame_config.py::test_the_operators_own_slot_order_is_kept_exactly`
-        calls that a promise, so `["right", "top", "bottom"]` is a frame charter offers.
-        `panel_argvs` splits every slot off the HARNESS pane in list order, so `right`
-        going first leaves `bottom` 23 columns narrower than the window — measured on
-        tmux 3.7c with real `charter panel` processes: window 110x40, the bottom pane
-        reads back **87x7**, and the panel draws ONE line with six rows blank.
+        calls that a promise, so `["right", "top", "bottom", "repos"]` is a frame charter
+        offers. `panel_argvs` splits every slot off the HARNESS pane in list order, so
+        `right` going first leaves the table 23 columns narrower than the window —
+        measured on tmux 3.7c with real `charter panel` processes: window 110x40, the
+        table pane reads back **87** wide, where no table is drawn.
 
         110 is not an arbitrary width. Below `[frame] min-cols` (100) `visible_slots`
-        drops `right` and `bottom` is full width again; at 118 the inset pane is still
+        drops `right` and the table is full width again; at 118 the inset pane is still
         `_LEFT_W` or wider and the table draws. 100..117 is the whole break band, and
         this asserts inside it.
 
         The control below is the same window and the same repo count with the shipped
-        order — without it, a fix that simply stopped sizing `bottom` for its content
-        would pass.
+        order — without it, a fix that simply stopped splitting `repos` would pass.
         """
-        inset = ["right", "top", "bottom"]
-        self.assertEqual(self._bottom_split_size(cols=110, slots=inset), 1)
+        inset = ["right", "top", "bottom", "repos"]
+        self.assertIsNone(self._table_split_size(cols=110, slots=inset))
         self.assertEqual(
-            self._bottom_split_size(cols=110, slots=["top", "bottom", "right"]), 1 + 6)
+            self._table_split_size(cols=110,
+                                   slots=["top", "bottom", "repos", "right"]), 1 + 6)
 
     def test_the_inset_pane_still_gets_its_table_once_the_window_can_spare_it(self):
         """Degradation, not refusal — the fix must not turn "sidebar first" into "never
         a table". At 118 columns the inset pane is 95, which is `_LEFT_W` exactly, and
         the table is drawn and therefore split for. Pinned from both sides of that
         boundary so an off-by-one in the border column is red rather than absorbed."""
-        inset = ["right", "top", "bottom"]
+        inset = ["right", "top", "bottom", "repos"]
         edge = statusline._LEFT_W + layout.SLOT_SIZE["right"] + layout._BORDER_COLS
-        self.assertEqual(self._bottom_split_size(cols=edge, slots=inset), 1 + 6)
-        self.assertEqual(self._bottom_split_size(cols=edge - 1, slots=inset), 1)
+        self.assertEqual(self._table_split_size(cols=edge, slots=inset), 1 + 6)
+        self.assertIsNone(self._table_split_size(cols=edge - 1, slots=inset))
 
 
 class EarlyDeathIsLegible(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_layout.py
+++ b/tests/test_frame_layout.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import sys
 import unittest
+from unittest import mock
 
 from charter import util
 from charter.frame import layout
@@ -96,9 +97,16 @@ class VisibleSlots(unittest.TestCase):
         `statusline._LEFT_W` — the same constant `slots._table_cap` refuses below — so
         the launcher's drop and the renderer's silence can never come apart. A literal
         here would be a guard that matched today's number and stopped matching the
-        renderer's the first time a column width moved."""
+        renderer's the first time a column width moved.
+
+        **`_LEFT_W` is MOVED for the assertion, and that is the whole test.** Asserted
+        against the constant where it stands, this passes just as happily on a
+        `_table_min_cols` whose body is `return 95` — 95 is today's `_LEFT_W`, so the
+        copy and the read are indistinguishable and the mutation survives. Moving the
+        constant separates them: the branch answers 102, a literal answers 95."""
         from charter import statusline
-        self.assertEqual(layout._table_min_cols(), statusline._LEFT_W)
+        with mock.patch.object(statusline, "_LEFT_W", statusline._LEFT_W + 7):
+            self.assertEqual(layout._table_min_cols(), statusline._LEFT_W)
 
     def test_a_tiny_terminal_keeps_nothing(self):
         """Below the floor the harness gets the whole terminal. Degrading to a bare

--- a/tests/test_frame_layout.py
+++ b/tests/test_frame_layout.py
@@ -53,20 +53,52 @@ class VisibleSlots(unittest.TestCase):
             layout.visible_slots(["top", "bottom", "right"], 200, 12, 100, 20),
             ["bottom"])
 
-    def test_the_bottom_is_never_dropped_it_shrinks_instead(self):
-        """#488's own rule, and the reason `bottom` is absent from the two filters above.
-        Every other slot is a fixed size, so the only thing a short window can do with it
-        is drop it; `bottom` is variable-height (`layout.bottom_rows`), so it gives up
-        ROWS and keeps the alert line that is the whole reason a cramped terminal wants a
-        frame at all. Asserted across all three shortages the two filters answer —
-        narrow, short, and neither — so a `bottom` added to either filter is red whichever
-        one it was added to. The last clause (below HALF the floors) is a different rule
-        and still empties the list outright; `test_a_tiny_terminal_keeps_nothing` owns
-        that one."""
+    def test_the_bottom_is_never_dropped_whatever_the_shortage(self):
+        """The reason `bottom` is absent from every filter above. It is the attention
+        strip — one alert and the command that fixes it — which is the whole reason a
+        cramped terminal wants a frame at all, and since #515 it is one fixed row, so
+        there is nothing for a shortage to negotiate over. Asserted across all three
+        shortages the filters answer — narrow, short, and neither — so a `bottom` added
+        to any filter is red whichever one it was added to. The last clause (below HALF
+        the floors) is a different rule and still empties the list outright;
+        `test_a_tiny_terminal_keeps_nothing` owns that one."""
         for cols, rows in ((80, 50), (200, 12), (100, 20)):
             with self.subTest(cols=cols, rows=rows):
                 self.assertIn("bottom", layout.visible_slots(
-                    ["top", "bottom", "right"], cols, rows, 100, 20))
+                    ["top", "bottom", "repos", "right"], cols, rows, 100, 20))
+
+    def test_the_table_goes_when_its_pane_would_be_too_narrow_to_draw_one(self):
+        """#515. `slots._table_cap` answers 0 below `statusline._LEFT_W` and
+        `_table_lines` refuses outright there, so a `repos` pane split at that width is a
+        bordered rectangle with nothing in it — which reads as "this workspace has no
+        repos" on a plane that has fourteen. While the table shared `bottom` with the
+        attention row the same case was invisible: the pane went on drawing the row.
+
+        Asserted at the boundary from both sides, and through the PANE's width rather
+        than the window's: a `[frame] slots` naming `right` first insets this pane by
+        `SLOT_SIZE["right"] + _BORDER_COLS`, so a window wide enough for the table can
+        still leave the pane too narrow for it. That second case is the one a filter
+        reading `cols` directly would get wrong."""
+        from charter import statusline
+        edge = statusline._LEFT_W
+        self.assertIn("repos", layout.visible_slots(
+            ["top", "bottom", "repos"], edge, 50, 100, 20))
+        self.assertNotIn("repos", layout.visible_slots(
+            ["top", "bottom", "repos"], edge - 1, 50, 100, 20))
+        inset = layout.SLOT_SIZE["right"] + layout._BORDER_COLS
+        self.assertIn("repos", layout.visible_slots(
+            ["right", "top", "bottom", "repos"], edge + inset, 50, 100, 20))
+        self.assertNotIn("repos", layout.visible_slots(
+            ["right", "top", "bottom", "repos"], edge + inset - 1, 50, 100, 20))
+
+    def test_the_width_the_table_needs_is_read_from_the_renderer_not_copied(self):
+        """The property, not a spelling. `layout._table_min_cols` reads
+        `statusline._LEFT_W` — the same constant `slots._table_cap` refuses below — so
+        the launcher's drop and the renderer's silence can never come apart. A literal
+        here would be a guard that matched today's number and stopped matching the
+        renderer's the first time a column width moved."""
+        from charter import statusline
+        self.assertEqual(layout._table_min_cols(), statusline._LEFT_W)
 
     def test_a_tiny_terminal_keeps_nothing(self):
         """Below the floor the harness gets the whole terminal. Degrading to a bare
@@ -281,13 +313,15 @@ class PanelGeometry(unittest.TestCase):
         self.assertNotIn("left", layout.SLOT_SIZE)
         self.assertNotIn("left", layout._DROP_ORDER)
         self.assertEqual(
-            layout.slot_sizes(["top", "left", "bottom"], window_rows=50, content_rows=3),
-            {"top": 1, "bottom": 3})
+            layout.slot_sizes(["top", "left", "bottom", "repos"], window_rows=50,
+                              content_rows=3),
+            {"top": 1, "bottom": 1, "repos": 3})
 
 
-class BottomIsSizedToItsContent(unittest.TestCase):
-    """#488: `bottom` is the one variable-height slot, and `bottom_rows` is the whole of
-    how tall it gets. Pure arithmetic, so it is pinned here with no tmux and no cache.
+class ReposIsSizedToItsContent(unittest.TestCase):
+    """#488, moved to `repos` by #515: the one variable-height slot, and `repos_rows` is
+    the whole of how tall it gets. Pure arithmetic, so it is pinned here with no tmux and
+    no cache.
 
     The property is `floor <= rows <= what the window can spare`, and each of the three
     clauses is asserted where the OTHER two cannot be what produced the answer — a single
@@ -300,19 +334,21 @@ class BottomIsSizedToItsContent(unittest.TestCase):
         content itself. Deleting the `min` or the `max` leaves this green — which is why
         the two tests below exist as well."""
         self.assertEqual(
-            layout.bottom_rows(content_rows=4, window_rows=50, slots=["top", "bottom"]),
+            layout.repos_rows(content_rows=4, window_rows=50,
+                              slots=["top", "bottom", "repos"]),
             4)
 
-    def test_it_never_goes_below_the_one_row_it_has_always_been(self):
-        """A plane with no clones has no table, and `slots.bottom_rows_wanted` answers 1
-        — the attention row. Zero would be a pane tmux refuses to split at all, and the
-        alert line is the one thing the frame exists for."""
+    def test_it_never_goes_below_one_row(self):
+        """A plane with no clones has no table, and `slots.repos_rows_wanted` answers 0.
+        Zero would be a pane tmux refuses to split at all, so the floor is one — and the
+        row is spent saying there are no clones and how to get one (`slots._empty_lines`)
+        rather than left blank."""
         for content in (0, 1):
             with self.subTest(content=content):
                 self.assertEqual(
-                    layout.bottom_rows(content_rows=content, window_rows=50,
-                                       slots=["top", "bottom"]),
-                    layout.SLOT_SIZE["bottom"])
+                    layout.repos_rows(content_rows=content, window_rows=50,
+                                      slots=["top", "bottom", "repos"]),
+                    layout.SLOT_SIZE["repos"])
 
     def test_the_harness_keeps_its_floor_however_much_the_table_wants(self):
         """The measured failure this cap exists for (tmux 3.7c): `resize-pane -y 40` in a
@@ -321,32 +357,39 @@ class BottomIsSizedToItsContent(unittest.TestCase):
         a literal height, so the arithmetic is checked rather than restated: whatever
         `bottom` takes, plus the strips and their borders, must leave at least
         `HARNESS_MIN_ROWS`."""
-        slots = ["top", "bottom"]
+        slots = ["top", "bottom", "repos"]
         rows = 20
-        got = layout.bottom_rows(content_rows=99, window_rows=rows, slots=slots)
-        # top(1) + its border(1) + bottom's own border(1)
-        harness = rows - got - layout.SLOT_SIZE["top"] - 2 * layout._BORDER_ROWS
+        got = layout.repos_rows(content_rows=99, window_rows=rows, slots=slots)
+        # top(1) + bottom(1) + a border for each of the three strips
+        harness = (rows - got - layout.SLOT_SIZE["top"] - layout.SLOT_SIZE["bottom"]
+                   - 3 * layout._BORDER_ROWS)
         self.assertGreaterEqual(harness, layout.HARNESS_MIN_ROWS)
         self.assertLess(got, 99, "the cap did not bind at all")
 
-    def test_the_top_strips_own_rows_are_counted_against_the_cap(self):
-        """The cap is what the window can spare, and `top` is part of what it has already
-        spent. A frame drawing `top` must therefore give `bottom` strictly fewer rows
-        than one that is not, at the same window size — the arithmetic that a cap
-        ignoring *slots* would get wrong in exactly the direction that starves the
-        harness."""
-        with_top = layout.bottom_rows(content_rows=99, window_rows=24,
-                                      slots=["top", "bottom"])
-        without = layout.bottom_rows(content_rows=99, window_rows=24, slots=["bottom"])
-        self.assertLess(with_top, without)
+    def test_every_fixed_strips_own_rows_are_counted_against_the_cap(self):
+        """The cap is what the window can spare, and the fixed strips are part of what it
+        has already spent. A frame drawing `top` must therefore give the table strictly
+        fewer rows than one that is not, at the same window size — and so must one
+        drawing `bottom`, which is the row #515 added to the arithmetic. Both are
+        asserted: a `repos_rows` still subtracting `top` alone (the pre-#515 formula)
+        passes the first pair and fails the second."""
+        both = layout.repos_rows(content_rows=99, window_rows=26,
+                                 slots=["top", "bottom", "repos"])
+        no_top = layout.repos_rows(content_rows=99, window_rows=26,
+                                   slots=["bottom", "repos"])
+        no_bottom = layout.repos_rows(content_rows=99, window_rows=26,
+                                      slots=["top", "repos"])
+        self.assertLess(both, no_top)
+        self.assertLess(both, no_bottom)
 
     def test_the_side_column_costs_columns_not_rows(self):
         """`right` is a `-h` split: it takes width from the harness and no rows at all.
         Counting it here would shorten the table for no reason on every wide terminal."""
         self.assertEqual(
-            layout.bottom_rows(content_rows=99, window_rows=50,
-                               slots=["top", "bottom", "right"]),
-            layout.bottom_rows(content_rows=99, window_rows=50, slots=["top", "bottom"]))
+            layout.repos_rows(content_rows=99, window_rows=50,
+                              slots=["top", "bottom", "repos", "right"]),
+            layout.repos_rows(content_rows=99, window_rows=50,
+                              slots=["top", "bottom", "repos"]))
 
     def test_the_floor_wins_over_a_cap_that_has_gone_negative(self):
         """A window with no rows to spare at all. The alternative — returning the cap —
@@ -354,55 +397,56 @@ class BottomIsSizedToItsContent(unittest.TestCase):
         would come up with no bottom pane in exactly the terminal most likely to have an
         alert worth reading."""
         self.assertEqual(
-            layout.bottom_rows(content_rows=9, window_rows=6, slots=["top", "bottom"]),
-            layout.SLOT_SIZE["bottom"])
+            layout.repos_rows(content_rows=9, window_rows=6,
+                              slots=["top", "bottom", "repos"]),
+            layout.SLOT_SIZE["repos"])
 
 
-class BottomsWidthIsWhateverTheSplitOrderLeftIt(unittest.TestCase):
-    """#500, round 3: `layout.bottom_cols` — how wide the `bottom` PANE actually is.
+class TheTablesWidthIsWhateverTheSplitOrderLeftIt(unittest.TestCase):
+    """#500, round 3: `layout.repos_cols` — how wide the `repos` PANE actually is.
 
-    The property, stated once: **a slot that takes columns and is split before `bottom`
-    has already narrowed the pane `bottom` is carved out of.** Not "the window's width",
+    The property, stated once: **a slot that takes columns and is split before `repos`
+    has already narrowed the pane `repos` is carved out of.** Not "the window's width",
     which is what every caller was passing, and not "the width when `slots` happens to be
     the shipped list", which is the coincidence that let it through two rounds of review.
 
     Every number below was measured against real tmux 3.7c on a private socket, window
     110x40, splitting exactly as `panel_argvs` does (`-h -l 22` for `right`, `-v -b -l 1`
-    for `top`, `-v -l 7` for `bottom`, every split targeting the harness pane):
+    for `top`, `-v -l 7` for the table, every split targeting the harness pane):
 
-        ["top", "bottom", "right"]  ->  bottom 110x7   harness 87x30
-        ["right", "top", "bottom"]  ->  bottom  87x7   harness 87x30
-        ["top", "right", "bottom"]  ->  bottom  87x7   harness 87x30
-        ["bottom", "right"]         ->  bottom 110x7   harness 87x32
+        ["top", "repos", "right"]  ->  table 110x7   harness 87x30
+        ["right", "top", "repos"]  ->  table  87x7   harness 87x30
+        ["top", "right", "repos"]  ->  table  87x7   harness 87x30
+        ["repos", "right"]         ->  table 110x7   harness 87x32
 
     and, for the re-layout case, killing `right` on the second of those widened the same
-    `bottom` pane from 87 back to 110, while re-splitting `right` off the harness
-    afterwards left it at 110.
+    table pane from 87 back to 110, while re-splitting `right` off the harness afterwards
+    left it at 110.
     """
 
-    def test_the_shipped_order_leaves_bottom_the_whole_window(self):
-        """The control. `right` is split off the harness AFTER `bottom` and lands beside
-        the harness only, so it costs `bottom` nothing — without this the assertions
+    def test_the_shipped_order_leaves_the_table_the_whole_window(self):
+        """The control. `right` is split off the harness AFTER `repos` and lands beside
+        the harness only, so it costs the table nothing — without this the assertions
         below could be satisfied by subtracting `right` unconditionally."""
         self.assertEqual(
-            layout.bottom_cols(["top", "bottom", "right"], window_cols=110), 110)
+            layout.repos_cols(["top", "bottom", "repos", "right"], window_cols=110), 110)
 
     def test_a_side_slot_split_first_insets_bottom_by_its_columns_and_its_border(self):
         """The defect. `instance.frame_of` keeps an operator's `[frame] slots` order
         verbatim — `tests/test_frame_config.py` calls that a promise — so this is a frame
         charter ships the ability to ask for, not a corner. Both orders that put `right`
-        first are asserted, because "before `bottom`" is the property and "first in the
+        first are asserted, because "before `repos`" is the property and "first in the
         list" is only one spelling of it."""
-        for order in (["right", "top", "bottom"], ["top", "right", "bottom"]):
+        for order in (["right", "top", "repos"], ["top", "right", "repos"]):
             with self.subTest(order=order):
-                self.assertEqual(layout.bottom_cols(order, window_cols=110), 87)
+                self.assertEqual(layout.repos_cols(order, window_cols=110), 87)
 
     def test_the_inset_is_the_slots_own_size_and_not_a_literal(self):
         """87 is `110 - SLOT_SIZE["right"] - _BORDER_COLS`, asserted as that arithmetic
         rather than restated, so a change to the sidebar's width moves this answer
         instead of leaving a stale constant that is right for one release."""
         self.assertEqual(
-            layout.bottom_cols(["right", "bottom"], window_cols=110),
+            layout.repos_cols(["right", "repos"], window_cols=110),
             110 - layout.SLOT_SIZE["right"] - layout._BORDER_COLS)
 
     def test_two_side_slots_before_bottom_are_both_charged(self):
@@ -410,20 +454,21 @@ class BottomsWidthIsWhateverTheSplitOrderLeftIt(unittest.TestCase):
         second side slot exists today; the next one this frame grows is the reason the
         loop subtracts per slot instead of testing for `right`."""
         self.assertEqual(
-            layout.bottom_cols(["right", "right", "bottom"], window_cols=200),
+            layout.repos_cols(["right", "right", "repos"], window_cols=200),
             200 - 2 * (layout.SLOT_SIZE["right"] + layout._BORDER_COLS))
 
     def test_a_horizontal_strip_before_bottom_costs_it_no_columns(self):
         """`top` is a `-v` split: it takes rows off the harness and spans its full width.
         Charging it here would shrink the table on every frame that draws a `top`."""
-        self.assertEqual(layout.bottom_cols(["top", "bottom"], window_cols=110), 110)
+        self.assertEqual(
+            layout.repos_cols(["top", "bottom", "repos"], window_cols=110), 110)
 
     def test_it_never_answers_a_negative_width(self):
         """A terminal narrower than the sidebar. `visible_slots` drops `right` long
         before this, so it is unreachable through the launcher — but the answer feeds a
         `<` against `statusline._LEFT_W`, and a negative there would merely be right by
         accident. Zero says "no columns" and means it."""
-        self.assertEqual(layout.bottom_cols(["right", "bottom"], window_cols=10), 0)
+        self.assertEqual(layout.repos_cols(["right", "repos"], window_cols=10), 0)
 
     def test_which_splits_take_columns_is_one_fact_panel_argvs_shares(self):
         """The two places that must agree: this function decides how much width a slot
@@ -441,7 +486,7 @@ class BottomsWidthIsWhateverTheSplitOrderLeftIt(unittest.TestCase):
                 self.assertEqual(
                     _direction(cmd),
                     "-h" if slot in layout._COLUMN_SLOTS else "-v",
-                    "panel_argvs and bottom_cols disagree about this slot's direction")
+                    "panel_argvs and repos_cols disagree about this slot's direction")
 
 
 class SlotSizesAnswersEverySlotAtOnce(unittest.TestCase):
@@ -451,30 +496,34 @@ class SlotSizesAnswersEverySlotAtOnce(unittest.TestCase):
         self.assertEqual(got["top"], layout.SLOT_SIZE["top"])
         self.assertEqual(got["right"], layout.SLOT_SIZE["right"])
 
-    def test_only_the_bottom_moves_with_the_window(self):
+    def test_only_the_table_moves_with_the_window(self):
         """The one slot whose answer depends on the window it is in — which is why
-        `_reassert_sizes` recomputes on every resize instead of re-applying a constant."""
-        tall = layout.slot_sizes(["top", "bottom", "right"], window_rows=50,
+        `_reassert_sizes` recomputes on every resize instead of re-applying a constant.
+        `bottom` is asserted alongside `top` since #515: it went back to being a fixed
+        row, and a `slot_sizes` that kept treating it as the variable one would still
+        answer plausibly at every window size while starving the harness by a row."""
+        tall = layout.slot_sizes(["top", "bottom", "repos", "right"], window_rows=50,
                                  content_rows=99)
-        short = layout.slot_sizes(["top", "bottom", "right"], window_rows=22,
+        short = layout.slot_sizes(["top", "bottom", "repos", "right"], window_rows=22,
                                   content_rows=99)
         self.assertEqual(tall["top"], short["top"])
+        self.assertEqual(tall["bottom"], short["bottom"])
         self.assertEqual(tall["right"], short["right"])
-        self.assertGreater(tall["bottom"], short["bottom"])
+        self.assertGreater(tall["repos"], short["repos"])
 
     def test_a_size_map_is_what_panel_argvs_splits_with(self):
         """The seam that makes any of this reach tmux: `panel_argvs` takes the map and
         emits it as `-l`. Asserted as the literal string tmux would see, so a map that is
         built correctly and then ignored is red."""
-        sizes = layout.slot_sizes(["bottom"], window_rows=50, content_rows=7)
-        cmd, = layout.panel_argvs(slots=["bottom"], sizes=sizes, **PANELS)
+        sizes = layout.slot_sizes(["repos"], window_rows=50, content_rows=7)
+        cmd, = layout.panel_argvs(slots=["repos"], sizes=sizes, **PANELS)
         self.assertEqual(_size(cmd), "7")
 
     def test_a_missing_entry_degrades_to_the_fixed_size_rather_than_raising(self):
         """`panel_argvs` reads *sizes* with a per-slot fallback. A `KeyError` here would
         be raised from inside a launch, where the whole frame is lost over one slot."""
-        cmd, = layout.panel_argvs(slots=["bottom"], sizes={"top": 4}, **PANELS)
-        self.assertEqual(_size(cmd), str(layout.SLOT_SIZE["bottom"]))
+        cmd, = layout.panel_argvs(slots=["repos"], sizes={"top": 4}, **PANELS)
+        self.assertEqual(_size(cmd), str(layout.SLOT_SIZE["repos"]))
 
 
 class WindowInTheOperatorsServer(unittest.TestCase):

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -880,6 +880,31 @@ class ReposTable(PersonaIso, unittest.TestCase):
         self.assertIn("no clones", tui.strip_ansi(out))
         self.assertIn("charter clone", tui.strip_ansi(out))
 
+    def test_a_workspace_name_the_rungs_never_checked_is_still_one_line(self):
+        """`_empty_lines` interpolates a workspace name with no `contain.one_line` over
+        it, and the reason has to be the true one. It is NOT that every rung of
+        `state.workspace_for` name-checks its answer: rung 0 does (`valid_name`), but the
+        last rung is `workspace.resolve()`, which returns `$CHARTER_WORKSPACE` stripped
+        and otherwise untouched — so a name with a newline in it reaches this renderer
+        verbatim, as this test's first assertion measures.
+
+        What contains it is `tui.truncate`, which runs `tui.sanitize` first: the newline
+        is not charter's markup, so the pane still draws exactly ONE line — the property
+        the whole slot is built on, since a `repos` pane that quietly became three rows
+        tall would push the attention strip off the bottom of the window.
+
+        The hostile value is asserted to have got through as well as to have been
+        contained. Asserting containment alone would pass just as well on a build where a
+        rung DID reject it and the sentence said `default` — a test that proves nothing
+        about the line it is named for."""
+        hostile = "ev\nil\x1b[31m;rm -rf /"
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": hostile}, clear=True):
+            self.assertEqual(state.workspace_for("f-known-empty"), hostile)
+            _seed("f-known-empty")
+            out = self._render("f-known-empty")
+        self.assertEqual(len(out.split("\n")), 1, repr(out))
+        self.assertIn("rm -rf /", tui.strip_ansi(out))
+
     def test_a_frame_whose_repos_are_not_gathered_yet_says_so_rather_than_showing_none(self):
         """#512, at the renderer. `cmd_launch` deletes the cache before it draws anything
         and a detached child fills it a beat later, so there is a real window in which

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -21,7 +21,7 @@ import unittest
 from unittest import mock
 
 from charter import config, instance, statusline, todos, tui, workspace
-from charter.frame import gather, slots, state
+from charter.frame import gather, layout, slots, state
 
 from tests._isolation import PersonaIso
 
@@ -418,7 +418,7 @@ class EveryPanelDrawsTheFramesOwnWorkspace(PersonaIso, unittest.TestCase):
         state.record_workspace("f-1", self.OTHER)
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
             workspace.set_active("chosen-later")
-        self.assertEqual(slots.bottom_rows_wanted("f-1", pane_cols=200), 2)
+        self.assertEqual(slots.repos_rows_wanted("f-1", pane_cols=200), 1 + 1)
 
     def test_the_pane_is_sized_from_the_frames_workspace_too(self):
         """`gather.row_count`'s no-cache path is the third surface that used to resolve
@@ -432,10 +432,10 @@ class EveryPanelDrawsTheFramesOwnWorkspace(PersonaIso, unittest.TestCase):
         `cmd_launch` guarantees by calling `gather.discard`."""
         clone = config.WORKSPACES_DIR / self.OTHER / "arepo"
         (clone / ".git").mkdir(parents=True)
-        self.assertEqual(slots.bottom_rows_wanted("f-1", pane_cols=200), 1,
+        self.assertEqual(slots.repos_rows_wanted("f-1", pane_cols=200), 0,
                          "the fixture already counted a repo before the record existed")
         state.record_workspace("f-1", self.OTHER)
-        self.assertEqual(slots.bottom_rows_wanted("f-1", pane_cols=200), 2)
+        self.assertEqual(slots.repos_rows_wanted("f-1", pane_cols=200), 1 + 1)
 
     def test_a_corrupt_record_falls_back_rather_than_drawing_it(self):
         """`frame_workspace` name-checks on read, so a `workspaces/` escape never reaches
@@ -786,17 +786,17 @@ class FitFields(unittest.TestCase):
                          {"alert", "news"})
 
 
-class BottomTable(PersonaIso, unittest.TestCase):
-    """#488: the repo table `bottom` draws under its attention row.
+class ReposTable(PersonaIso, unittest.TestCase):
+    """#488's repo table, in the bordered pane of its own #515 gave it.
 
     The rows are `statusline.py`'s OWN wide table — same four columns, same declared
     widths, same markers and CI glyphs — composed straight from `gather`'s cache: never a
     `git` call, never `glstate`, and never a repo directory (see `_table_row`'s docstring
     for the one column that costs a filesystem walk per row and is therefore absent).
 
-    Every test here renders through the real `slots.render("bottom", …)` rather than
+    Every test here renders through the real `slots.render("repos", …)` rather than
     calling `_table_lines` directly, because what #488 actually promises is that a
-    PANEL shows this — a helper returning perfect rows that `_bottom` never asks for
+    PANEL shows this — a helper returning perfect rows that `_repos` never asks for
     would satisfy a unit test of the helper and none of the promise.
     """
 
@@ -804,32 +804,81 @@ class BottomTable(PersonaIso, unittest.TestCase):
         with mock.patch("os.get_terminal_size",
                         return_value=os.terminal_size((cols, rows))), \
              mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
-            return slots.render("bottom", fid)
+            return slots.render("repos", fid)
 
     def test_lists_a_repo_from_the_cache(self):
         _seed("f-1", repos=[_row("demo")])
         self.assertIn("demo", self._render())
 
-    def test_the_attention_row_is_still_the_first_line(self):
-        """#488's non-negotiable: the table JOINS the alert, the news, the todo count and
-        the plane-root warning — it does not evict them. Asserted as line 0 specifically,
-        because a table drawn above the row it is meant to sit under would still contain
-        both strings and satisfy a membership check."""
+    def test_the_pane_is_headed_the_way_the_sidebars_sections_are(self):
+        """#515 gave the table a bordered pane; #516 had just given the sidebar's
+        sections headings. An unlabelled box of tree rows beside a labelled one reads as
+        an overflow of its neighbour, which is the impression this issue exists to
+        remove — and the table's first row is `├─`, a glyph that means "there is more
+        above me" and had nothing above it once the attention row moved out.
+
+        Composed through `_sidebar_head`, the same helper `_right` uses, rather than a
+        string of its own: two components labelled two ways is the drift that helper was
+        extracted to stop. The COUNT is asserted separately from the word, because a
+        heading that says `repos` and lies about how many there are is worse than none.
+        """
+        _seed("f-1", repos=[_row("demo"), _row("other")])
+        first = tui.strip_ansi(self._render().split("\n")[0])
+        self.assertEqual(first, tui.strip_ansi(slots._sidebar_head("repos", 2, 200)))
+        self.assertIn("repos", first)
+        self.assertIn("2", first)
+
+    def test_the_two_lines_that_are_not_a_table_carry_no_heading(self):
+        """`▪ repos 0` above "no clones in demo" is the same fact twice in a two-row
+        pane, and above "gathering…" it is a count charter does not have yet. Both of
+        those panes are one line, and the line is the sentence."""
+        self.assertEqual(len(self._render("f-never-gathered").split("\n")), 1)
+        _seed("f-known-empty")
+        empty = self._render("f-known-empty")
+        self.assertEqual(len(empty.split("\n")), 1)
+        self.assertNotIn("repos", tui.strip_ansi(empty))
+
+    def test_the_table_starts_under_the_heading_with_no_attention_row_in_this_pane(self):
+        """#515's non-negotiable, and the inverse of the one #488 needed. The attention
+        row is `bottom`'s own pane now, so this pane is the table and NOTHING else: a
+        renderer that kept composing the row here would put a second copy of the todo
+        count, the alert and the hotkey hint on screen, one pane above the real one.
+
+        Asserted as line 0 specifically — a table drawn under a leftover row would still
+        contain "demo" and satisfy a membership check. The `bottom` renderer is asked in
+        the same test so the pair is pinned together: exactly one of the two panes draws
+        the row, and it is not this one."""
         _seed("f-1", repos=[_row("demo")])
         out = self._render()
-        self.assertIn("todo", tui.strip_ansi(out.split("\n")[0]))
-        self.assertIn("demo", out)
+        self.assertIn("demo", tui.strip_ansi(out.split("\n")[1]))
+        self.assertNotIn("todo", tui.strip_ansi(out))
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((200, 24))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            row = slots.render("bottom", "f-1")
+        self.assertIn("todo", tui.strip_ansi(row))
+        self.assertNotIn("demo", tui.strip_ansi(row))
 
-    def test_a_plane_with_no_repos_is_the_one_row_strip_it_always_was(self):
-        """The floor `layout.bottom_rows` keeps, seen from the renderer's side. The
-        reported "always empty sidebar" of #488 was this case being told the truth —
-        a workspace with 0 clones — so it must stay honest rather than grow furniture.
+    def test_a_plane_with_no_repos_says_so_rather_than_drawing_an_empty_pane(self):
+        """The floor `layout.repos_rows` keeps, seen from the renderer's side — and what
+        #515 changed about it. While this table shared `bottom` with the attention row, a
+        workspace with 0 clones simply produced no table rows and absence said it. In a
+        bordered pane of its own, absence is an empty rectangle, which reads as a table
+        that failed to draw rather than as a workspace with nothing in it.
+
+        So the pane is one row and that row is a sentence — with the command that changes
+        it, the shape every `statusline._alerts` row already has. Both halves asserted:
+        one row (a renderer padding the pane would be red) and the workspace named in it
+        (a renderer that said something generic would not carry the fix).
 
         `_seed` is what makes this the honest case rather than the unknown one below: a
         cache exists and it says zero repos. Delete the seed and this is a DIFFERENT
         claim, which is #512."""
         _seed("f-1")
-        self.assertEqual(len(self._render().split("\n")), 1)
+        out = self._render()
+        self.assertEqual(len(out.split("\n")), 1, out)
+        self.assertIn("no clones", tui.strip_ansi(out))
+        self.assertIn("charter clone", tui.strip_ansi(out))
 
     def test_a_frame_whose_repos_are_not_gathered_yet_says_so_rather_than_showing_none(self):
         """#512, at the renderer. `cmd_launch` deletes the cache before it draws anything
@@ -845,8 +894,9 @@ class BottomTable(PersonaIso, unittest.TestCase):
         _seed("f-known-empty")
         empty = self._render("f-known-empty")
         self.assertIn("gathering", unknown)
-        self.assertEqual(len(unknown.split("\n")), 2)
+        self.assertEqual(len(unknown.split("\n")), 1)
         self.assertNotIn("gathering", empty)
+        self.assertIn("no clones", tui.strip_ansi(empty))
         self.assertEqual(len(empty.split("\n")), 1)
 
     def test_the_gathering_line_goes_the_moment_the_rows_arrive(self):
@@ -859,17 +909,29 @@ class BottomTable(PersonaIso, unittest.TestCase):
         self.assertIn("demo", after)
 
     def test_a_pane_too_narrow_for_the_table_says_nothing_either(self):
-        """`_table_cap` answers 0 below `statusline._LEFT_W` and `bottom` composes nothing
+        """`_table_cap` answers 0 below `statusline._LEFT_W` and `_repos` composes nothing
         on a budget of 0, so a "gathering" line cannot appear where a table never will:
         one that did would show up while the rows were unknown and VANISH once they were
         known — "the repos went away", which is worse than the silence it replaces.
 
         Asserted through the whole renderer at both widths in one test, because what is
-        being pinned is that the two agree: the SAME frame, gathered or not, draws exactly
-        the attention row at 90 columns."""
-        self.assertEqual(len(self._render("f-never-gathered", cols=90).split("\n")), 1)
+        being pinned is that the two agree: the SAME frame, gathered or not, draws the
+        SAME line at 90 columns, and it is not the gathering one.
+
+        And the pane is not even SPLIT at that width by a launch since #515
+        (`layout.visible_slots`), which is asserted here beside the renderer rather than
+        only over in the layout tests: the two together are what stop a blank bordered
+        rectangle appearing. The line the renderer does draw is for the pane a RESIZE
+        leaves behind — `cmd_resize` re-sizes panes and never destroys them."""
+        before = self._render("f-never-gathered", cols=90)
         _seed("f-never-gathered", repos=[_row("demo")])
-        self.assertEqual(len(self._render("f-never-gathered", cols=90).split("\n")), 1)
+        after = self._render("f-never-gathered", cols=90)
+        self.assertEqual(before, after)
+        self.assertNotIn("gathering", before)
+        self.assertIn("too narrow", tui.strip_ansi(before))
+        self.assertEqual(len(before.split("\n")), 1, before)
+        self.assertNotIn("repos", layout.visible_slots(
+            ["top", "bottom", "repos", "right"], 90, 40, 100, 20))
 
     def test_a_repaint_never_runs_a_gather_of_its_own(self):
         """The rule `_table_lines`' own docstring states and #512 found broken: a panel
@@ -1025,8 +1087,8 @@ class BottomTable(PersonaIso, unittest.TestCase):
     def test_the_height_the_launcher_asks_for_is_the_height_the_renderer_fills(self):
         """The seam #488 turns on, over every input that changes either side's answer.
 
-        `slots.bottom_rows_wanted` is what tells `layout.slot_sizes` how tall to split the
-        pane; `_bottom` is what fills it. If the two disagreed, every frame would come up
+        `slots.repos_rows_wanted` is what tells `layout.slot_sizes` how tall to split the
+        pane; `_repos` is what fills it. If the two disagreed, every frame would come up
         either padded with blank rows the harness could have had, or with a table cut off
         and nothing saying so — and neither is visible from either side alone.
 
@@ -1035,14 +1097,18 @@ class BottomTable(PersonaIso, unittest.TestCase):
         a renderer that also read the WIDTH (no table below `statusline._LEFT_W`) and the
         DENSITY (`_TERSE_ROWS` at `terse`), so the seam held only at the one shape the
         original test used — wide, `normal`. Every input either side consults is varied
-        here: repo count across the cap, width across `_LEFT_W` and down to the smallest
-        `layout.visible_slots` still draws `bottom` at, and every level in
-        `instance.FRAME_DENSITY`. The next input to appear — a fourth density, a
-        `bottom`-specific `min-cols` — has to be added to this loop, and until it is, its
-        own dimension is unpinned rather than silently wrong.
+        here: repo count across the cap, width across `_LEFT_W` and down to widths the
+        pane is no longer even split at, and every level in `instance.FRAME_DENSITY`. The
+        next input to appear — a fourth density, a `repos`-specific `min-cols` — has to be
+        added to this loop, and until it is, its own dimension is unpinned rather than
+        silently wrong.
 
         Rendered into a pane of EXACTLY the height the sizer asked for, at EXACTLY the
-        width the sizer was asked about, and counted.
+        width the sizer was asked about, and counted. **`layout.repos_rows` is what turns
+        the sizer's answer into a pane height**, so it is called here rather than the raw
+        want: a 0 (no clones, or a width with no table in it) becomes the one-row pane
+        that says so, and asserting against the raw number would demand a zero-line render
+        the pane could not hold anyway.
         """
         for level in (None, *sorted(instance.FRAME_DENSITY)):
             for n in (0, 1, 4, 9, statusline._MAX_REPO_LINES + 3):
@@ -1052,18 +1118,30 @@ class BottomTable(PersonaIso, unittest.TestCase):
                         _seed(fid, repos=[_row(f"repo{i}") for i in range(n)])
                         if level is not None:
                             state.record_density(fid, level)
-                        want = slots.bottom_rows_wanted(fid, pane_cols=cols)
-                        out = self._render(fid, cols=cols, rows=want)
-                        self.assertEqual(len(out.split("\n")), want, out)
+                        want = slots.repos_rows_wanted(fid, pane_cols=cols)
+                        tall = layout.repos_rows(content_rows=want, window_rows=50,
+                                                 slots=["top", "bottom", "repos"])
+                        out = self._render(fid, cols=cols, rows=tall)
+                        if cols < statusline._LEFT_W:
+                            # Not a pane a LAUNCH splits at all any more
+                            # (`layout.visible_slots`); one a resize leaves behind draws
+                            # the single line saying why, in the single row the floor
+                            # gives it.
+                            self.assertEqual(tall, 1)
+                            self.assertEqual(len(out.split("\n")), 1, out)
+                            self.assertIn("too narrow", tui.strip_ansi(out))
+                            continue
+                        self.assertEqual(len(out.split("\n")), tall, out)
 
     def test_a_frame_too_narrow_for_the_table_is_sized_for_the_row_it_can_draw(self):
         """The width half of the seam, stated as the number the LAUNCHER hands tmux.
 
-        `[frame] min-cols` (100) gates `right` and `top`; `layout.visible_slots` keeps
-        `bottom` down to `min_cols // 2`, so an 80-column terminal draws the attention row
-        and no table at all. Sized from the repo count alone it was given a pane for the
-        table anyway — six repos meant a seven-row pane holding one line, and the other
-        six rows came off the harness.
+        An 80-column terminal cannot draw this table at all. Sized from the repo count
+        alone it was given a pane for the table anyway — six repos meant a seven-row pane
+        holding one line, and the other six rows came off the harness. Since #515 the slot
+        is dropped at those widths instead of sized, and this is the number that says so:
+        zero rows WANTED, which is a different statement from the one-row floor
+        `layout.repos_rows` applies to a pane that does get split.
 
         Asserted against a repo count large enough that the two answers cannot coincide,
         and at `_LEFT_W` itself so the boundary is pinned from both sides rather than
@@ -1071,9 +1149,9 @@ class BottomTable(PersonaIso, unittest.TestCase):
         _seed("narrow", repos=[_row(f"repo{i}") for i in range(6)])
         for cols in (50, 80, statusline._LEFT_W - 1):
             with self.subTest(cols=cols):
-                self.assertEqual(slots.bottom_rows_wanted("narrow", pane_cols=cols), 1)
-        self.assertEqual(slots.bottom_rows_wanted("narrow",
-                                                  pane_cols=statusline._LEFT_W), 1 + 6)
+                self.assertEqual(slots.repos_rows_wanted("narrow", pane_cols=cols), 0)
+        self.assertEqual(slots.repos_rows_wanted("narrow",
+                                                 pane_cols=statusline._LEFT_W), 1 + 6)
 
     def test_a_terse_density_asks_for_a_shorter_pane_not_a_blanker_one(self):
         """`minimal` exists to give the harness its rows back — `instance.FRAME_DENSITY`
@@ -1086,9 +1164,9 @@ class BottomTable(PersonaIso, unittest.TestCase):
         between the two numbers is the one the level is for."""
         _seed("dense", repos=[_row(f"repo{i}") for i in range(10)])
         state.record_density("dense", "normal")
-        wide = slots.bottom_rows_wanted("dense", pane_cols=200)
+        wide = slots.repos_rows_wanted("dense", pane_cols=200)
         state.record_density("dense", "minimal")
-        terse = slots.bottom_rows_wanted("dense", pane_cols=200)
+        terse = slots.repos_rows_wanted("dense", pane_cols=200)
         self.assertEqual(wide, 1 + 10)
         self.assertEqual(terse, 1 + slots._TERSE_ROWS)
         self.assertLess(terse, wide)
@@ -1101,9 +1179,11 @@ class BottomTable(PersonaIso, unittest.TestCase):
         "nothing to say", which is the false-clean failure the plan's Global Constraints
         name. The attention row is unaffected — it budgets its own fields."""
         _seed("f-1", repos=[_row("demo", dirty=True, ci="failed")])
-        out = self._render(cols=statusline._LEFT_W - 1)
-        self.assertEqual(len(out.split("\n")), 1, out)
-        self.assertIn("todo", tui.strip_ansi(out))
+        narrow = tui.strip_ansi(self._render(cols=statusline._LEFT_W - 1))
+        self.assertNotIn("demo", narrow)
+        self.assertIn("too narrow", narrow)
+        self.assertIn(str(statusline._LEFT_W), narrow,
+                      "the line must say how wide the pane has to be")
         # ...and one column wider, it draws.
         self.assertIn("demo", self._render(cols=statusline._LEFT_W))
 
@@ -1212,8 +1292,8 @@ class BottomTable(PersonaIso, unittest.TestCase):
         call is `subprocess.Popen` under `run`. Each of those is the next spelling this
         budget would otherwise miss, so each is counted.
 
-        Measured on this branch: 45 calls for a 2-line repaint and the same 45, in the
-        same order, for a 15-line one."""
+        Measured on this branch: the same calls, in the same order, for a one-row
+        repaint and a fourteen-row one."""
         import builtins
         import io
         import subprocess as _sp
@@ -1244,7 +1324,7 @@ class BottomTable(PersonaIso, unittest.TestCase):
 
         short_lines, short = _count("cost-1", 1)
         tall_lines, tall = _count("cost-many", statusline._MAX_REPO_LINES)
-        self.assertEqual(short_lines, 2)
+        self.assertEqual(short_lines, 1 + 1)
         self.assertEqual(tall_lines, 1 + statusline._MAX_REPO_LINES,
                          "the tall render drew no more rows — this proves nothing")
         self.assertTrue(short, "nothing was counted at all — the budget is vacuous")
@@ -1263,7 +1343,7 @@ class BottomTable(PersonaIso, unittest.TestCase):
         `statusline._LEFT_W` there is no table, so the cache is never reached and the
         test would pass by never running the code it claims to bound.
 
-        **`cached`, not `read` (#512).** `_bottom` stopped calling `gather.read` when a
+        **`cached`, not `read` (#512).** `_repos` stopped calling `gather.read` when a
         panel stopped being allowed to fall back to a live `scan()`, and this test kept
         passing against a mock nothing called any more — the exact "instrumenting one
         function while claiming to bound a property" shape. It is pinned to whichever
@@ -1273,27 +1353,27 @@ class BottomTable(PersonaIso, unittest.TestCase):
              mock.patch("os.get_terminal_size",
                         return_value=os.terminal_size((200, 24))), \
              mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
-            self.assertIn("charter", slots.render("bottom", "f-1"))
+            self.assertIn("charter", slots.render("repos", "f-1"))
 
 
-class BottomRowsWanted(PersonaIso, unittest.TestCase):
-    """`slots.bottom_rows_wanted` — the number the LAUNCHER sizes the pane from."""
+class ReposRowsWanted(PersonaIso, unittest.TestCase):
+    """`slots.repos_rows_wanted` — the number the LAUNCHER sizes the table pane from."""
 
-    def test_a_plane_with_no_repos_wants_exactly_the_attention_row(self):
+    def test_a_plane_with_no_repos_wants_no_table_rows_at_all(self):
         _seed("f-1")
-        self.assertEqual(slots.bottom_rows_wanted("f-1", pane_cols=200), 1)
+        self.assertEqual(slots.repos_rows_wanted("f-1", pane_cols=200), 0)
 
     def test_it_grows_with_the_repos_and_the_pieces_alike(self):
         _seed("f-1", repos=[_row("a"), _row("b")],
               worktrees=[_row("p", repo="a")])
-        self.assertEqual(slots.bottom_rows_wanted("f-1", pane_cols=200), 1 + 3)
+        self.assertEqual(slots.repos_rows_wanted("f-1", pane_cols=200), 1 + 3)
 
     def test_it_is_capped_at_the_wide_tables_own_row_budget(self):
-        """A workspace with forty clones must ask for a fifteen-row strip, not a
-        forty-one-row one — `_MAX_REPO_LINES` is the same total-row budget the wide table
+        """A workspace with forty clones must ask for a fourteen-row pane, not a
+        forty-row one — `_MAX_REPO_LINES` is the same total-row budget the wide table
         keeps, reused rather than invented fresh."""
         _seed("f-1", repos=[_row(f"r{i}") for i in range(40)])
-        self.assertEqual(slots.bottom_rows_wanted("f-1", pane_cols=200),
+        self.assertEqual(slots.repos_rows_wanted("f-1", pane_cols=200),
                          1 + statusline._MAX_REPO_LINES)
 
     def test_the_width_is_required_and_cannot_be_confused_with_the_row_count(self):
@@ -1304,9 +1384,9 @@ class BottomRowsWanted(PersonaIso, unittest.TestCase):
         A missing width is a `TypeError` at the call site, not a default of "wide"."""
         _seed("f-1", repos=[_row("a")])
         with self.assertRaises(TypeError):
-            slots.bottom_rows_wanted("f-1")
+            slots.repos_rows_wanted("f-1")
         with self.assertRaises(TypeError):
-            slots.bottom_rows_wanted("f-1", 200)
+            slots.repos_rows_wanted("f-1", 200)
 
     def test_the_width_asked_for_is_the_panes_and_a_window_width_will_not_fit(self):
         """The rename is the guard, and this is what pins it. Round 2 of #500 spelled this
@@ -1322,13 +1402,13 @@ class BottomRowsWanted(PersonaIso, unittest.TestCase):
         width because the RENDERER measures a pane, and a caller that copies that name up
         here would be naming the thing correctly by luck rather than by contract."""
         import inspect
-        sig = inspect.signature(slots.bottom_rows_wanted)
+        sig = inspect.signature(slots.repos_rows_wanted)
         self.assertEqual([p.name for p in sig.parameters.values()], ["fid", "pane_cols"])
         self.assertEqual(sig.parameters["pane_cols"].kind,
                          inspect.Parameter.KEYWORD_ONLY)
         _seed("f-1", repos=[_row("a")])
         with self.assertRaises(TypeError):
-            slots.bottom_rows_wanted("f-1", cols=200)
+            slots.repos_rows_wanted("f-1", cols=200)
 
     def test_it_never_runs_a_git_sweep(self):
         """It is called on a launch the operator is waiting on, and again on every step
@@ -1338,13 +1418,13 @@ class BottomRowsWanted(PersonaIso, unittest.TestCase):
         _seed("f-1", repos=[_row("a")])
         with mock.patch("charter.frame.gather.scan",
                         side_effect=AssertionError("row_count ran a scan")):
-            self.assertEqual(slots.bottom_rows_wanted("f-1", pane_cols=200), 2)
+            self.assertEqual(slots.repos_rows_wanted("f-1", pane_cols=200), 1 + 1)
 
     def test_a_narrow_frame_does_not_even_ask_how_many_repos_there_are(self):
         """The launch path reaches `gather.row_count` with no cache by design
         (`cmd_launch` calls `gather.discard` first), where it costs a directory listing.
-        Below `statusline._LEFT_W` the answer is one row whatever the count is, so the
-        listing is work with no reader — and `cmd_resize` would pay it again on every
+        Below `statusline._LEFT_W` the answer is no table at all whatever the count is, so
+        the listing is work with no reader — and `cmd_resize` would pay it again on every
         step of a drag that is narrowing the terminal.
 
         `row_count` itself is made to raise, so an implementation that asks and then
@@ -1352,7 +1432,7 @@ class BottomRowsWanted(PersonaIso, unittest.TestCase):
         _seed("f-1", repos=[_row(f"r{i}") for i in range(6)])
         with mock.patch("charter.frame.gather.row_count",
                         side_effect=AssertionError("counted rows it had no room for")):
-            self.assertEqual(slots.bottom_rows_wanted("f-1", pane_cols=80), 1)
+            self.assertEqual(slots.repos_rows_wanted("f-1", pane_cols=80), 0)
 
 
 class RightRenderer(PersonaIso, unittest.TestCase):

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -1245,27 +1245,31 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
                    "-P", "-F", "#{pane_id}", "--", "sleep", "600")
         self.assertEqual(top.returncode, 0, top.stderr)
         top_pane = top.stdout.strip()
-        bot = _tmux("split-window", "-t", harness_pane, "-v", "-l", "6",
+        bot = _tmux("split-window", "-t", harness_pane, "-v", "-l", "1",
                     "-P", "-F", "#{pane_id}", "--", "sleep", "600")
         self.assertEqual(bot.returncode, 0, bot.stderr)
         bottom_pane = bot.stdout.strip()
-        panes = {"top": top_pane, "bottom": bottom_pane}
+        tab = _tmux("split-window", "-t", harness_pane, "-v", "-l", "6",
+                    "-P", "-F", "#{pane_id}", "--", "sleep", "600")
+        self.assertEqual(tab.returncode, 0, tab.stderr)
+        panes = {"top": top_pane, "bottom": bottom_pane, "repos": tab.stdout.strip()}
 
-        # The last size is the one the CAP binds at: at 20 rows the window can spare
-        # only `20 - top(1) - 2 borders - HARNESS_MIN_ROWS` = 5, fewer than the 6 the
-        # content wants — so `bottom` must come out a different number there than at the
-        # other three, and a `bottom_rows` that ignored *window_rows* entirely would
-        # still pass the first three.
-        for cols, rows in ((200, 50), (90, 25), (300, 100), (120, 20)):
+        # The last size is the one the CAP binds at: at 22 rows the window can spare
+        # only `22 - top(1) - bottom(1) - 3 borders - HARNESS_MIN_ROWS` = 5, fewer than
+        # the 6 the content wants — so `repos` must come out a different number there
+        # than at the other three, and a `repos_rows` that ignored *window_rows*
+        # entirely would still pass the first three.
+        for cols, rows in ((200, 50), (90, 25), (300, 100), (120, 22)):
             r = _tmux("resize-window", "-t", "rsz", "-x", str(cols), "-y", str(rows))
             self.assertEqual(r.returncode, 0, r.stderr)
-            with mock.patch("charter.frame.slots.bottom_rows_wanted", return_value=6):
+            with mock.patch("charter.frame.slots.repos_rows_wanted", return_value=6):
                 commands_frame._reassert_sizes(SOCKET, fid=fid, panes=panes,
+                                               harness_pane=harness_pane,
                                                window_cols=cols, window_rows=rows)
-            want = layout.slot_sizes(["top", "bottom"], window_rows=rows,
+            want = layout.slot_sizes(["top", "bottom", "repos"], window_rows=rows,
                                      content_rows=6)
-            if rows == 20:
-                self.assertLess(want["bottom"], 6,
+            if rows == 22:
+                self.assertLess(want["repos"], 6,
                                 "the cap never bound — this loop's last pass is the "
                                 "only one that exercises it")
             for slot, pane in panes.items():
@@ -1280,6 +1284,12 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
                 int(harness), layout.HARNESS_MIN_ROWS,
                 f"the harness kept only {harness} rows at {cols}x{rows} — tmux grants "
                 f"an over-large -y out of the neighbour rather than refusing it")
+            self.assertEqual(
+                int(harness), layout.harness_rows(want, window_rows=rows),
+                f"the harness is {harness} rows at {cols}x{rows}, not the "
+                f"{layout.harness_rows(want, window_rows=rows)} it was told — and it is "
+                f"the pane #515 has to name explicitly, because with three strips the "
+                f"two below it trade rows with each other and never with it")
 
     # -- 5. Session-scoped id delivery for the hotkey menu --------------------------- #
 
@@ -2560,11 +2570,12 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         self.assertTrue(harness_pane, "tmux did not report the harness pane's id")
         self.addCleanup(_kill_pid, self._pane_pid(harness_pane))
 
-        slots = ["top", "bottom", "right"]
-        # `bottom` is content-sized since #488, and the sizer is asked for the size here
-        # rather than left to `SLOT_SIZE`'s floor — a one-row `bottom` would have no room
-        # for the repo table these tests read back, which is the whole point of the slot.
-        # *content_rows* is stated rather than taken from `slots.bottom_rows_wanted`: that
+        slots = ["top", "bottom", "repos", "right"]
+        # `repos` is content-sized since #488 (it was `bottom` until #515 split the
+        # attention row off it), and the sizer is asked for the size here rather than
+        # left to `SLOT_SIZE`'s floor — a one-row table pane would have no room for the
+        # repo rows these tests read back, which is the whole point of the slot.
+        # *content_rows* is stated rather than taken from `slots.repos_rows_wanted`: that
         # helper resolves the workspace from THIS process's environment, and every panel
         # below resolves it from the tmux session's instead, so a mismatch would size the
         # pane for a different plane than the one the panels draw.
@@ -2591,10 +2602,10 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         return harness_pane, panes
 
     def test_every_panel_comes_up_alive_with_real_content_and_the_harness_keeps_focus(self):
-        """Launch composition, proven end to end: a frame with `top`/`bottom`/`right`
-        all configured comes up with every pane alive, each showing real content a
-        broken renderer (or an empty, never-gathered cache) could not have produced, and
-        the harness pane — not the last panel `split-window` happened to draw — holds
+        """Launch composition, proven end to end: a frame with `top`/`bottom`/`repos`/
+        `right` all configured comes up with every pane alive, each showing real content
+        a broken renderer (or an empty, never-gathered cache) could not have produced,
+        and the harness pane — not the last panel `split-window` happened to draw — holds
         keyboard focus once the launch finishes.
 
         **Fix round 1: the repo is made DIRTY before the frame ever launches, not
@@ -2609,10 +2620,13 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         can only come from that sweep actually running and actually landing in
         the cache the table reads back.
 
-        **#488 moved the repo table from `left` to `bottom`**, so the cache-proving
-        assertions moved with it: the same pane now carries the live todo count AND the
-        cached repo row, which is itself worth asserting together — the attention row
-        must survive the table joining it, not be evicted by it.
+        **#488 moved the repo table from `left` to `bottom`, and #515 moved it again to
+        `repos`**, so the cache-proving assertions moved with it. The two are asserted
+        against each other rather than each alone: the table pane carries the cached repo
+        row and NOT the attention row, and the `bottom` pane carries the live todo count
+        and NOT a repo row. Either assertion alone would pass against a renderer that
+        drew both things in both panes, which is what a half-applied split looks like on
+        screen — the operator's report in #515 with a rule drawn through it.
         """
         repo_name = f"cnry{os.getpid() % 10000}"
         branch = f"br{os.getpid() % 10000}a"
@@ -2624,7 +2638,7 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
 
         fid = state.frame_id("four-edge-alive", os.getpid())
         harness_pane, panes = self._spawn_frame(fid)
-        self.assertEqual(set(panes), {"top", "bottom", "right"})
+        self.assertEqual(set(panes), {"top", "bottom", "repos", "right"})
 
         # Poll for real content (`_wait_for`'s own docstring — fix round 1:
         # replaces a fixed `time.sleep(1.5)` that guessed at how long four cold
@@ -2635,7 +2649,8 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         # check below, same as a deliberate wait would have.
         top = self._wait_for(panes["top"], "demo")
         right = self._wait_for(panes["right"], persona_name)
-        bottom = self._wait_for(panes["bottom"], repo_name)
+        table = self._wait_for(panes["repos"], repo_name)
+        bottom = self._wait_for(panes["bottom"], "1 todo")
 
         for slot, pane in panes.items():
             self.assertEqual(self._alive(pane), "0",
@@ -2646,22 +2661,31 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
 
         self.assertIn("demo", top, f"top never showed the real workspace name:\n{top!r}")
 
-        self.assertIn(repo_name, bottom,
-                      f"bottom never showed the real repo:\n{bottom!r}")
-        self.assertIn(branch, bottom,
-                      f"bottom never showed the real branch:\n{bottom!r}")
-        self.assertIn("*", bottom,
-                      f"bottom never showed the dirty marker for a real uncommitted "
-                      f"file — either gather.scan's own git-status sweep never "
-                      f"ran, or nothing carried its result into the cached "
-                      f"row:\n{bottom!r}")
+        self.assertIn(repo_name, table,
+                      f"the table pane never showed the real repo:\n{table!r}")
+        self.assertIn(branch, table,
+                      f"the table pane never showed the real branch:\n{table!r}")
+        self.assertIn("*", table,
+                      f"the table pane never showed the dirty marker for a real "
+                      f"uncommitted file — either gather.scan's own git-status sweep "
+                      f"never ran, or nothing carried its result into the cached "
+                      f"row:\n{table!r}")
 
         self.assertIn(persona_name, right,
                       f"right never showed the real persona:\n{right!r}")
 
         self.assertIn("1 todo", bottom,
-                      f"the attention row was evicted by the table it is supposed to "
-                      f"sit above:\n{bottom!r}")
+                      f"the attention strip never showed the workspace's todo "
+                      f"count:\n{bottom!r}")
+        # #515's own property, and the half a membership check cannot give: the two
+        # things the operator reported as one undivided pane are now in two panes, and
+        # NEITHER draws the other's content. A renderer that split the panes but kept
+        # composing both halves in each would satisfy every assertion above.
+        self.assertNotIn("todo", table,
+                         f"the table pane is still drawing the attention row:\n{table!r}")
+        self.assertNotIn(repo_name, bottom,
+                         f"the attention strip is still drawing the repo "
+                         f"table:\n{bottom!r}")
 
         focus = _tmux("display-message", "-p", "-t", harness_pane,
                       "#{pane_active}").stdout.strip()
@@ -2708,9 +2732,9 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         # The `run-shell` child is a `charter` of its own: it must find THIS plane, not
         # the developer's. `_spawn_frame`'s session already carries `$CHARTER_ROOT` (see
         # `setUp`), and the hook fires in that session's own environment.
-        before = int(_tmux("display-message", "-p", "-t", panes["bottom"],
+        before = int(_tmux("display-message", "-p", "-t", panes["repos"],
                            "#{pane_height}").stdout.strip())
-        self.assertGreater(before, 1, "the fixture never gave bottom a tall pane")
+        self.assertGreater(before, 1, "the fixture never gave the table a tall pane")
 
         r = _tmux("resize-window", "-t", fid, "-x", "160", "-y", "80")
         self.assertEqual(r.returncode, 0, r.stderr)
@@ -2718,16 +2742,26 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         deadline = time.monotonic() + _DEADLINE
         height = before
         while time.monotonic() < deadline:
-            height = int(_tmux("display-message", "-p", "-t", panes["bottom"],
+            height = int(_tmux("display-message", "-p", "-t", panes["repos"],
                                "#{pane_height}").stdout.strip() or before)
             if height < before:
                 break
             time.sleep(0.1)
         self.assertLess(height, before,
-                        f"bottom is {height} rows after the window GREW from 40 to 80 — "
-                        f"tmux's own redistribution only ever stretches on a grow, so "
-                        f"this is what charter's recompute would have had to undo. The "
-                        f"hook never fired, or its child never reached this frame")
+                        f"the table is {height} rows after the window GREW from 40 to "
+                        f"80 — tmux's own redistribution only ever stretches on a grow, "
+                        f"so this is what charter's recompute would have had to undo. "
+                        f"The hook never fired, or its child never reached this frame")
+        # And the two one-row strips really came back to one row. #515 is what makes
+        # this worth asserting here: the recompute now has three horizontal strips to
+        # reconcile and tmux's `resize-pane -y` moves only one boundary, so a recompute
+        # that named the strips and not the harness left two of them trading rows with
+        # each other — the table one row tall and the attention strip six, measured.
+        for slot in ("top", "bottom"):
+            got = _tmux("display-message", "-p", "-t", panes[slot],
+                        "#{pane_height}").stdout.strip()
+            self.assertEqual(got, "1",
+                             f"the {slot} strip is {got} rows after the recompute")
         harness = int(_tmux("display-message", "-p", "-t", harness_pane,
                             "#{pane_height}").stdout.strip())
         self.assertGreaterEqual(harness, layout.HARNESS_MIN_ROWS, harness)
@@ -2738,16 +2772,17 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         leaves open for THIS plan: that test drives `hooks.posttooluse` against
         `bottom` alone, which never touches `gather.py` at all. This drives the
         SAME real hook — never a direct `state.bump` or `gather.refresh` call — and
-        watches `bottom`'s repo table repaint with a NEW branch name that only
+        watches the `repos` pane's table repaint with a NEW branch name that only
         exists because
         `notify.plane_changed` ran `gather.refresh` BEFORE `state.bump` (Task 2's
         own contract, and its own docstring's reason: refresh-then-bump closes the
         window where a poller sees the new version and still reads the stale
         cache). A version bump into a stale or never-refreshed cache would leave
         the table showing the OLD branch forever — this is the one test in the file
-        that would catch that. `bottom` is watched in the same pass, from the SAME
-        single hook call, to pin that one refresh/bump serves every slot that asks,
-        not only the one `PanelIntegration` already covers.
+        that would catch that. `bottom` — a different PANE since #515, drawing the live
+        todo count — is watched in the same pass, from the SAME single hook call, to pin
+        that one refresh/bump serves every slot that asks, not only the one
+        `PanelIntegration` already covers.
 
         **The cache is warmed with one direct `gather.refresh` call before any
         assertion runs — this is load-bearing, not incidental.** Caught by
@@ -2798,9 +2833,10 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
                       f"the primed cache file exists but does not hold the "
                       f"starting branch:\n{cache.read_text()!r}")
 
-        bottom_before = self._wait_for(panes["bottom"], branch_a)
-        self.assertIn(branch_a, bottom_before,
-                      f"the table never showed the starting branch:\n{bottom_before!r}")
+        table_before = self._wait_for(panes["repos"], branch_a)
+        bottom_before = self._wait_for(panes["bottom"], "1 todo")
+        self.assertIn(branch_a, table_before,
+                      f"the table never showed the starting branch:\n{table_before!r}")
         self.assertIn("1 todo", bottom_before,
                       f"bottom never showed the starting todo count:\n{bottom_before!r}")
 
@@ -2840,22 +2876,25 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
         # paint (fix round 1) — waits for the specific new fact each panel is
         # expected to show, rather than a fixed sleep or an undifferentiated
         # "content changed" check.
-        self._wait_for(panes["bottom"], branch_b)
-        # Both new facts land on the SAME pane now, and the two halves of the repaint
-        # arrive together — but poll for the second needle as well rather than assuming
-        # it, so a capture taken between the two is a retry rather than a failure.
+        # The two facts land on two panes since #515, and each is polled for its own
+        # needle — one refresh and one bump have to serve BOTH panels, which is the
+        # property this test is for and which a single-pane assertion can no longer
+        # cover.
+        table_after = self._wait_for(panes["repos"], branch_b)
         bottom_after = self._wait_for(panes["bottom"], "2 todos")
 
-        self.assertNotEqual(bottom_after, bottom_before,
-                            f"bottom never repainted after a real hooks.posttooluse() "
-                            f"call; still showing:\n{bottom_before!r}")
-        self.assertIn(branch_b, bottom_after,
-                      f"bottom repainted but not with the NEW branch:\n{bottom_after!r}")
-        self.assertNotIn(branch_a, bottom_after,
+        self.assertNotEqual(table_after, table_before,
+                            f"the table never repainted after a real "
+                            f"hooks.posttooluse() call; still showing:"
+                            f"\n{table_before!r}")
+        self.assertIn(branch_b, table_after,
+                      f"the table repainted but not with the NEW "
+                      f"branch:\n{table_after!r}")
+        self.assertNotIn(branch_a, table_after,
                          f"the table kept showing the OLD branch after the switch — a "
-                         f"stale cache surviving its own refresh:\n{bottom_after!r}")
+                         f"stale cache surviving its own refresh:\n{table_after!r}")
         self.assertIn("2 todos", bottom_after,
-                      f"the live half of the same pane never repainted:"
+                      f"the live pane never repainted off the same bump:"
                       f"\n{bottom_after!r}")
 
         # Fix round 1: the cache FILE on disk, not only the pane's own capture,
@@ -2873,16 +2912,16 @@ class FourEdgeIntegration(PersonaIso, unittest.TestCase):
                              f"the {slot!r} panel died sometime after repainting")
 
 
-class BottomsWidthIsWhatTmuxActuallyGivesIt(_TmuxServerFixture, PersonaIso):
-    """#500 round 3: `layout.bottom_cols` says how wide the `bottom` pane comes out.
+class TheTablesWidthIsWhatTmuxActuallyGivesIt(_TmuxServerFixture, PersonaIso):
+    """#500 round 3: `layout.repos_cols` says how wide the `repos` pane comes out.
     tmux is the only authority on that, so this asks tmux.
 
     The unit tests in `tests/test_frame_layout.py` pin the arithmetic against a number
     written down by a human who once ran tmux. That is exactly the shape of assertion
     this repo has been burned by — a constant that was right the day it was measured and
     is never re-checked. What is actually being claimed is that a `right` split off the
-    harness pane BEFORE `bottom` costs `bottom` the sidebar's columns plus one border
-    column, and the only thing that can confirm it is `#{pane_width}` off a real server.
+    harness pane BEFORE `repos` costs it the sidebar's columns plus one border column,
+    and the only thing that can confirm it is `#{pane_width}` off a real server.
 
     **The splits are `layout.panel_argvs`' own commands, not hand-retyped ones** — the
     direction (`-h`/`-v`), the `-b`, and the `-l` are the production values, because
@@ -2892,7 +2931,7 @@ class BottomsWidthIsWhatTmuxActuallyGivesIt(_TmuxServerFixture, PersonaIso):
     panels are proven.
     """
 
-    def _bottom_width(self, order: list[str], cols: int) -> int:
+    def _table_width(self, order: list[str], cols: int) -> int:
         session = f"bw{self._pane_counter}"
         self._pane_counter += 1
         r = self._srv("new-session", "-d", "-s", session,
@@ -2914,7 +2953,7 @@ class BottomsWidthIsWhatTmuxActuallyGivesIt(_TmuxServerFixture, PersonaIso):
             pane = p.stdout.strip()
             self.addCleanup(_kill_pid, self._pane_pid_on(pane))
             widths[slot] = pane
-        got = self._srv("display-message", "-p", "-t", widths["bottom"],
+        got = self._srv("display-message", "-p", "-t", widths["repos"],
                         "#{pane_width}").stdout.strip()
         return int(got)
 
@@ -2924,22 +2963,70 @@ class BottomsWidthIsWhatTmuxActuallyGivesIt(_TmuxServerFixture, PersonaIso):
 
     def test_tmux_agrees_with_the_arithmetic_in_both_slot_orders(self):
         """Both orders in one test, because the claim is a DIFFERENCE: the shipped order
-        leaves `bottom` the whole window and an operator's `right`-first order does not.
-        Asserted against `layout.bottom_cols`' own answer rather than against 110 and 87,
+        leaves the table the whole window and an operator's `right`-first order does not.
+        Asserted against `layout.repos_cols`' own answer rather than against 110 and 87,
         so this is tmux checking charter's arithmetic rather than two literals agreeing
         with each other — and the second assertion is what stops "always the window's
         width" from passing.
         """
-        for order in (["top", "bottom", "right"], ["right", "top", "bottom"],
-                      ["top", "right", "bottom"], ["bottom", "right"]):
+        orders = (["top", "bottom", "repos", "right"],
+                  ["right", "top", "bottom", "repos"],
+                  ["top", "right", "bottom", "repos"],
+                  ["repos", "right"])
+        for order in orders:
             with self.subTest(order=order):
-                self.assertEqual(self._bottom_width(order, 110),
-                                 layout.bottom_cols(order, window_cols=110),
-                                 f"tmux disagrees with layout.bottom_cols for {order}")
+                self.assertEqual(self._table_width(order, 110),
+                                 layout.repos_cols(order, window_cols=110),
+                                 f"tmux disagrees with layout.repos_cols for {order}")
         self.assertNotEqual(
-            layout.bottom_cols(["top", "bottom", "right"], window_cols=110),
-            layout.bottom_cols(["right", "top", "bottom"], window_cols=110),
+            layout.repos_cols(orders[0], window_cols=110),
+            layout.repos_cols(orders[1], window_cols=110),
             "the two orders answered the same width — the loop above proved nothing")
+
+    def test_tmux_stacks_the_strips_in_the_order_the_shipped_slots_ask_for(self):
+        """#515's own geometry, asked of tmux rather than reasoned about. Every split but
+        `top`'s is a plain `-v` off the HARNESS pane, which tmux places DIRECTLY below it
+        — so a slot split later sits ABOVE one split earlier, and the shipped list reads
+        backwards on screen for everything under the harness.
+
+        That is not a detail anybody can hold in their head, and getting it wrong ships
+        the pre-#515 stacking order with a rule drawn through it: the status strip
+        squeezed between the session and the table instead of anchored to the terminal's
+        last row. So the panes' own `#{pane_top}` is read back and the reading order
+        asserted: identity, harness, table, attention.
+        """
+        session = f"st{self._pane_counter}"
+        self._pane_counter += 1
+        r = self._srv("new-session", "-d", "-s", session, "-x", "120", "-y", "40",
+                      "-P", "-F", "#{pane_id}", "--", "sleep", "600")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness_pane = r.stdout.strip()
+        self.addCleanup(self._srv, "kill-session", "-t", session)
+
+        order = list(config.FRAME["slots"])
+        sizes = layout.slot_sizes(order, window_rows=40, content_rows=6)
+        panes = {"harness": harness_pane}
+        for slot, cmd in zip(order, layout.panel_argvs(
+                slots=order, session=session, socket=self.SOCKET_NAME,
+                harness_pane=harness_pane, sizes=sizes)):
+            argv = cmd[:cmd.index("--") + 1] + ["sleep", "600"]
+            p = subprocess.run(argv, capture_output=True, text=True, timeout=10)
+            self.assertEqual(p.returncode, 0, f"splitting {slot!r}: {p.stderr}")
+            panes[slot] = p.stdout.strip()
+            self.addCleanup(_kill_pid, self._pane_pid_on(panes[slot]))
+
+        def _top_row(pane):
+            return int(self._srv("display-message", "-p", "-t", pane,
+                                 "#{pane_top}").stdout.strip())
+
+        rows = {name: _top_row(pane) for name, pane in panes.items()}
+        self.assertEqual(
+            [n for n in sorted(rows, key=rows.get) if n != "right"],
+            ["top", "harness", "repos", "bottom"], rows)
+        # And the attention strip really is the window's last row, which is the anchor
+        # #515 chose it for: the table above it grows and shrinks with the repo count
+        # while this one never moves.
+        self.assertEqual(rows["bottom"], 40 - 1, rows)
 
 
 @unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")


### PR DESCRIPTION
Closes #515

`bottom` was one pane holding two unrelated things stacked with nothing between them.
They are two panes now, with a rule tmux draws between them.

## Rendered, on a real tmux 3.7c (200x44, six clones, two todos)

```
 ⬢ demo*                                                                                                         charter 0.53.0
──────────────────────────────────────────────────────────────────────────────────────────────────── ──────────────────────────
                                                                                                    │no personas
  (the agent session — your harness runs here)                                                      │
                                                                                                    │▪ todos 2
                                                                                                    │- look at it
                                                                                                    │- wire the new bottom split
                                                                                                    │
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
▪ repos 6
  ├─ api-gateway                       main
  ├─ billing                           feat/invoices*
  ├─ charter                           main*
  ├─ docs-site                         main
  ├─ scheduler                         main
  └─ web-app                           main
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
2 todos · F2 menu
```

(The rule glyphs above are stitched in from `#{pane_top}`/`#{pane_left}`; tmux draws the
real ones. Pane geometry read back: `%1 0,0 1x200`, `%0 2,0 32x177`, `%4 2,178 32x22`,
`%3 35,0 7x200`, `%2 43,0 1x200`.)

## The order, settled

The issue's two sentences pull in opposite directions — "the repo list first and the
`0 todos · …` line after it", then "i.e. the status strip sits between the harness and the
table". I took the first, and there is a reason beyond the ask: **the table's height is
its content's**, so whichever of the two sits lower moves up and down the screen as repos
are cloned or go quiet. Anchoring the attention row to the terminal's last line is worth
more than anchoring the table — it is the surface #488 protected from eviction, and an
alert you have to go looking for is one you read late. Split into two panes, "must stay
visible when the table is tall" is now true by construction rather than by budgeting.

## What moved

**A new `repos` slot carries the table**; `bottom` goes back to being the one-row
attention strip it was before #488. Every "how tall is it" function moves with the table
rather than staying on the slot that no longer has variable height —
`layout.bottom_rows`/`bottom_cols` → `repos_rows`/`repos_cols`,
`slots.bottom_rows_wanted` → `repos_rows_wanted`, and that function's `+ 1` is re-derived:
it used to be the attention row, and it is now the pane's own `▪ repos N` heading.

**Geometry, measured rather than reasoned.** Every split but `top`'s is a plain `-v` off
the harness, which tmux places DIRECTLY below it — so a slot split *later* sits *higher*.
Splitting `top`, `bottom`, `repos`, `right` in that order at 120x40 gives `top` row 0,
harness rows 2–30, `repos` rows 32–37, `bottom` row 39. That is why the shipped `slots`
names `bottom` before `repos`, and it is pinned by a new integration test that reads
`#{pane_top}` back off a real server.

**Three states the pane could not say before, because absence used to say them.** While
the table shared a pane with the status row, "no clones" meant no rows and the pane was
the one-line strip it always was. On its own, absence is an empty bordered rectangle —
a table that failed to draw. So:

```
  ⋯ gathering this workspace's repos…                    (#512's state, unchanged)
  no clones in demo · charter clone <repo> -w demo       (gathered, and there are none)
  ⋯ too narrow for the repo table — 95 columns needed    (a resize left the pane narrow)
```

At **launch** that third pane is not split at all: `layout.visible_slots` drops `repos`
below `layout._table_min_cols()`, which *reads* `statusline._LEFT_W` rather than copying
it, so the launcher's drop and the renderer's silence cannot come apart. `_relayout`
applies the same rule via `layout.repos_fits`, asked with the order the panes are actually
in rather than the level's — the round-3 half of #500, one slot over.

**Density presets re-derived, not patched.** They differ by EDGES again, which is what a
preset over `slots` can honestly express: `minimal` is the two strips, `normal` adds the
table, `full` adds the sidebar. `minimal` used to be `normal` with at most four table
rows — which after this split would cost the harness a border row it did not cost before,
to show four repos. A level whose whole purpose is handing rows back does not negotiate
over four of them.

**`_reassert_sizes` names the harness pane now, and this one is a real bug the split
exposed.** tmux's `resize-pane -y` moves exactly ONE boundary, so in a stack of N panes
only N-1 heights can be asserted. With two strips they always traded with the harness and
charter never had to name it. With three, the two below the harness trade with *each
other*: measured on 3.7c at 200x50, asserting `top`, `bottom` and `repos` in split order
came back with the table **1** row tall and the attention strip **6** — the two sizes
swapped panes. `layout.harness_rows` is what the harness is told; `layout.VARIABLE_ROW_SLOTS`
is why `repos` is absent from `_RESIZE_FLAG`, so the table is the remainder. Verified
against real tmux at 200x50, 200x24, 200x100 and 90x40, with and without the sidebar.

**The table is headed `▪ repos 6`**, through the same `_sidebar_head` #516 gave the
sidebar's sections. Two bordered components labelled two ways is the drift that helper
was extracted to stop — and the table's first row is `├─`, a glyph meaning "there is more
above me" that had nothing above it once the status row moved out.

**Chrome goes through #514 and nothing else.** No renderer draws a box; the rule between
the two new panes is tmux's, from the five window options `_CHROME` already pins.

## Idle cost

**Corrected in round two — the first version of this section claimed more than the code
does.** `panel._tick` reads `state.version(fid)` once per `TICK` for EVERY slot, animated
or not (`IdleCostsTheSameWhateverTheBottomPaneIsTallEnoughToDraw` pins it at one
filesystem call per panel per tick). #515 takes the frame from three panel processes to
four, so the frame's idle cost rises by one read per tick — **+33%**, not "zero additional
`stat`s".

What is true, and is the half that matters: `repos` is not in `slots.ANIMATED`, so
`panel._watch`'s `animates and bool(_running(...))` short-circuits before `_running` is
ever called, and it never pays the SECOND stat `bottom` pays for the spinner. And neither
number is the one that would have hurt — a table that walked a directory per row would
cost fourteen walks per repaint; everything it draws comes out of one `gather.cached`.
`OnlyTheAnimatedSlotAnimates` renders every slot in the registry, so `repos` joined that
check by declaring itself. `slots._repos`' docstring says this instead of the old claim.

## Compatibility

`repos` is a *new* name, so a committed `slots = ["top", "bottom", "right"]` still
launches and simply has no table — `slots` is the primitive and charter does not add to a
list somebody wrote by hand. The news entry says to add `repos` or delete the line, and a
test pins that #515 does not smuggle the slot into an explicit list.

**And that rule cut this repo, which round two caught before merge.** charter IS a control
plane: its own committed `charter.toml` carried `slots = ["top", "bottom", "right"]`, so
merging the first version of this branch would have taken the repo table off the frame the
maintainers run *while working on the frame* — the plane that reported #515 — with nothing
on screen saying why, while `origin/main` drew it from the same file. Measured under branch
code against the committed file:

```
BEFORE (branch as first pushed)
  [frame] slots      = ['top', 'bottom', 'right']
  drawable at 200x50 = ['top', 'bottom', 'right']
  slot_sizes         = {'top': 1, 'bottom': 1, 'right': 22}
  harness rows       = 46

AFTER
  [frame] slots      = ['top', 'bottom', 'repos', 'right']
  drawable at 200x50 = ['top', 'bottom', 'repos', 'right']
  slot_sizes         = {'top': 1, 'bottom': 1, 'repos': 8, 'right': 22}
  harness rows       = 37
```

The line names `repos` now, its comment is re-derived (it described `bottom` carrying a
table it no longer carries, and quoted the 118-column threshold that belongs to the other
slot order), and `CharterOwnPlaneDrawsEveryEdgeItShips` reads the committed file off disk
so the next slot rename is red rather than silent.

## Verification

- **Suite: 5537 tests, `OK`** — run OUTSIDE a frame, with `CHARTER_SESSION_ID`,
  `CLAUDE_CODE_SESSION_ID`, `TMUX` and `TMUX_PANE` cleared. Rebased onto `origin/main` at
  `bc3fcad` (#533 included).

- **16 mutations, re-run from scratch in round two, no survivors.** Each applied alone,
  run, restored, re-run, `__pycache__` cleared between every step. The run scope is the
  15 `test_frame_*` modules (809 tests) — every mutant died inside it.

  | mutation | round 1 | round 2 (actual) |
  |---|---|---|
  | `visible_slots` keeps `repos` at any width | RED | **RED** (7 failures) |
  | `_table_min_cols` becomes a literal `95` instead of the renderer's number | RED *(wrong)* | **RED** (2 failures) — see below |
  | `repos_rows` forgets `bottom` costs rows (the pre-#515 formula) | RED | **RED** (3) |
  | `repos_cols` stops at `bottom` instead of `repos` | RED | **RED** (1) |
  | `harness_rows` counts the side column's rows too | RED | **RED** (2) |
  | `_reassert_sizes` never names the harness pane | RED | **RED** (9) |
  | the table pane is put back in `_RESIZE_FLAG` (over-determined again) | RED | **RED** (8) |
  | the table pane loses its heading | RED | **RED** (37 + 1 error) |
  | an empty workspace draws an empty pane again | RED | **RED** (3) |
  | a too-narrow pane goes back to being blank | RED | **RED** (62) |
  | `bottom` keeps drawing the table under its row | RED | **RED** (1) |
  | `repos_rows_wanted` forgets the heading row | RED | **RED** (17) |
  | `_relayout` splits a table pane too narrow to draw one | RED | **RED** (1) |
  | the shipped slot order puts `repos` before `bottom` (stacking inverted) | RED | **RED** (13) |
  | `_empty_lines` interpolates the name without `tui.truncate` | *(new)* | **RED** (1) |
  | the `full` density preset drops `repos` | *(new)* | **RED** (11) |
  | `charter.toml` back to `slots = ["top", "bottom", "right"]` | *(new)* | **RED** (2) |

  **One of round one's fourteen was reported wrong, and it was this one.**
  `test_the_width_the_table_needs_is_read_from_the_renderer_not_copied` asserted
  `layout._table_min_cols() == statusline._LEFT_W` against the constant where it stands.
  95 IS today's `_LEFT_W`, so a `_table_min_cols` whose body is `return 95` was
  indistinguishable from one that reads the constant, and the mutant passed the whole
  suite. Re-verified in round two, both directions. The consequence was real rather than
  cosmetic: the launcher's drop and `slots._table_cap`'s refusal come apart the moment
  `_LEFT_W` moves, which is the pane-split-for-a-refusal bug #515 exists to remove. The
  assertion now runs inside `mock.patch.object(statusline, "_LEFT_W", statusline._LEFT_W
  + 7)` — the branch answers 102, the literal answers 95.

  The `_RESIZE_FLAG` row is still worth its sentence: the first pass of this branch kept
  `"repos": "-y"` in that map and skipped the slot in the loop instead, and the mutation
  `"-y"` → `"-x"` **survived** — the entry was unread, and the skip was a second guard for
  a property one guard already had. Both were collapsed into one: `repos` is simply not in
  the map, and putting it back is now red.

## Two docstrings that named the wrong reason

Neither is a behaviour change; both were claims the code does not make.

**`slots._empty_lines`** justified its absent `contain.one_line` with "every rung of
`state.workspace_for` that can answer a name checks it against
`instance.WORKSPACE_NAME_RE`". Rung 0 does. The LAST rung does not — it is
`workspace.resolve()`, which returns `$CHARTER_WORKSPACE` stripped and otherwise
untouched. Measured on the branch:

```
workspace_for -> 'ev\nil\x1b[31m;rm -rf /'
lines: 1
'  \x1b[2mno clones in\x1b[0m ev il\x1b[31m;rm -rf /\x1b[2m · charter clone <repo> -w ev il\x1b[31m;rm -rf /\x1b[0m'
width: [70]
```

The pane is safe and always was, but for the other reason: `tui.truncate` calls
`tui.sanitize`, the newline is not charter's markup, and the line count stays 1. The
docstring is re-derived onto that, and a new test pins both halves — that the hostile name
got through the rungs, AND that the pane is still one line. Asserting containment alone
would pass just as well on a build where a rung DID reject it.

**`slots._table_lines`** still described the pre-#515 layout: "the repo table `bottom`
draws under its attention row", "`bottom` is the frame's full-width slot", and a *budget*
that is "the pane's real height minus the attention row" — it is the height minus the
HEADING, and the attention row is another pane's. `layout.bottom_cols` (renamed
`repos_cols` by this branch) was still named twice, and the comment about 80-column
terminals still stated the rule #515 replaced.

No version bump, no stamping, no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9

