### PR TITLE
frame: the top bar keeps the persona, and gives the roster back to the sidebar (#530)

### DIFF
--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -118,6 +118,44 @@ def _frame_workspace(fid: str) -> str:
     return state.workspace_for(fid)
 
 
+def _sidebar_live(fid: str) -> bool:
+    """Is the `right` panel on screen in THIS frame, right now?
+
+    Asked so `_top` can stop repeating what the sidebar already says (#530) — and asked
+    LIVE, on every repaint, because the answer moves while the frame runs. #387's density
+    hotkey and `commands_frame.cmd_density` re-lay-out a running frame, and `right` is the
+    first slot `layout.visible_slots` drops on ANY shortage, so a value decided once at
+    launch is wrong the moment the operator presses a key or resizes the window.
+
+    **`state.panes` is the record, and it is the only one that can answer this.** It is
+    written where a frame's shape is actually DECIDED — by `_draw_panels` at launch and
+    again by `cmd_density` after `_relayout` — from the panes tmux really gave back, so a
+    slot whose `split-window` failed is absent from it exactly like a slot the density
+    dropped. The alternatives are all worse in the same direction: `instance
+    .density_slots` is what was *asked for* rather than what is *there*, `[frame] slots`
+    is what the operator configured, and an environment variable is whatever was true at
+    launch — the one thing the docstring above says it must not be. tmux itself cannot be
+    asked either: `list-panes` reports ids and geometry and nothing that says which pane
+    charter meant as `right` (see `state.record_panes`).
+
+    **The cost is one small JSON read on a slot that is not animated.** `top` is not in
+    :data:`ANIMATED`, so it repaints on a version bump, never on `panel.TICK` — and a
+    density change bumps the version precisely so that surviving panels re-read, which is
+    exactly when this answer can have changed. It reads the same directory `_top` already
+    opens four times over (`_frame_workspace`, `verbosity`, `state.harness_session`, the
+    recorded gauge), and nothing on the idle path (`panel._running`, whose one `stat` per
+    tick #387 pinned) goes anywhere near it.
+
+    **False when charter cannot tell**, which covers the corrupt file and the frame
+    launched by a charter that predates `record_panes` alike. That is the safe direction
+    and not merely the convenient one: false means the roster comes BACK to the top bar,
+    which is at worst the duplication this issue is about, while a wrong `True` would take
+    the plane's only roster off a screen that has no sidebar to replace it.
+    """
+    from . import state
+    return "right" in state.panes(fid)
+
+
 def _width() -> int:
     """The pane's own width in columns — measured, never read out of `$COLUMNS`.
 
@@ -211,6 +249,29 @@ def _top(fid: str) -> str:
     that predates the fourth field — answers `[]` and draws nothing, rather than a
     confident `ctx 0%`. Pinned by `tests.test_frame_slots.TopRenderer`.
 
+    **The persona ROSTER is drawn only when the sidebar is not (#530), and the active
+    persona always is.** The operator asked why the top bar lists every persona when the
+    sidebar lists them too, and they were right for the frame they were looking at: since
+    #516 `_right` draws the same names with a heading, memory badges, vault dots, health
+    marks and in-flight badges, in an aligned column — so the top bar's `◇ personas …`
+    said strictly less about exactly the same thing. But it is a CONDITION and not a
+    deletion, because `layout.visible_slots` drops `right` first on any shortage: on a
+    terminal too narrow or too short for a sidebar the top bar is the plane's only roster
+    again, and a `charter statusline` session outside a frame has no sidebar at all
+    (`statusline._persona_line`, this row's other caller, is left exactly as it was).
+
+    `◆ <active>` is on the other side of that line, and stays whatever else is on screen.
+    The roster is a LIST — a thing the sidebar can hold more of, better — while the active
+    persona is IDENTITY: "who am I being" is read here, next to the workspace, which is
+    the question this whole row exists to answer. The sidebar does mark the active one
+    with `▸`, but that is a mark inside a list, not an answer beside a workspace.
+
+    `_sidebar_live` is what decides, per repaint, and its docstring argues the record it
+    reads. What this function must not do is reassemble the roster's words to drop half of
+    them: `statusline._persona_line_parts` hands over the row already split, the same way
+    `PersonaChip` hands `_right` its chips, so nothing here repeats what either surface
+    says and neither can drift from the other.
+
     **At `terse` the version goes, and nothing else does.** `top` answers "where am I and
     who am I being", and of the things on it the charter version is the only one that
     reads the same on every frame on this machine all day — it is a fact about the
@@ -265,7 +326,12 @@ def _top(fid: str) -> str:
     # pointer reads off this slot.
     ws = _frame_workspace(fid)
     pin = "*" if ws == os.environ.get("CHARTER_WORKSPACE", "").strip() else ""
-    persona = statusline._persona_line() or ""
+    # Identity always; the roster only when nothing else on screen is drawing it (#530).
+    # `_persona_line_parts` is what decides which words are which — this row picks its
+    # pieces and never assembles any, for the reason `_right`'s docstring gives about the
+    # chips: a fact recomposed here is a fact free to drift from the surface it copies.
+    line = statusline._persona_line_parts()
+    persona = "" if line is None else line.rendered(roster=not _sidebar_live(fid))
     # Two file reads on a slot that repaints only on a version bump (`top` is not in
     # `ANIMATED`), and nothing is read at all for a frame with no recorded session —
     # which is every frame whose harness is not Claude Code.

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1160,12 +1160,71 @@ def _repo_rows(dirs, active, cur, states, branches, gl, detail_wts=()) -> list[t
     return rows
 
 
+class PersonaLine(NamedTuple):
+    """The persona row, split where a SURFACE can drop half of it.
+
+    :func:`_persona_line` is exactly :meth:`rendered`, so the flat row and a surface that
+    draws only part of it cannot come to disagree about what either one says. That is the
+    whole reason this type exists: `frame/slots.py`'s `_top` must stop drawing the roster
+    when the frame's sidebar is already drawing the same personas with strictly more on
+    them (#530), and the only other way to get that is for `_top` to recompose the row out
+    of `persona.resolve_active`, `persona.vault_of` and `_vault_dot` — precisely the drift
+    `slots._right`'s own docstring says it delegates in order to avoid. Same shape, and
+    same argument, as :class:`PersonaChip` one function down.
+
+    *head* is **identity**: the active persona and the vault it can reach. `slots._right`
+    marks the active one with `▸` in a column of names, but "who am I being" is read on
+    the identity row, so it stays there whatever else is on screen.
+
+    *roster* is the OTHER personas — the half the sidebar redraws with a heading, memory
+    badges, health marks and in-flight badges, and the only half that is ever duplicated.
+
+    *tail* is what trails the roster without belonging to it. Today that is exactly one
+    thing: on the no-active branch, `charter persona use <name>` — the command that gets
+    you a persona, which no other surface says, so it survives the roster being dropped.
+    It is a separate field rather than folded into *head* because it renders AFTER the
+    roster, and the order of the flat row is not this split's to change.
+
+    Every part carries its own leading separator — the same contract :class:`PersonaChip`
+    keeps for its badges — so any subset joined in order needs nothing between the pieces
+    and a caller dropping one is never left holding a dangling ` · `.
+    """
+
+    head: str
+    roster: str
+    tail: str = ""
+
+    def rendered(self, *, roster: bool = True) -> str:
+        """The row as one string, with or without its roster half.
+
+        The join lives here rather than at each surface, so the ORDER of the three parts
+        is written once: a surface decides whether the roster is one of its pieces and
+        never how the pieces go together.
+        """
+        return self.head + (self.roster if roster else "") + self.tail
+
+
 def _persona_line() -> str | None:
     """Footer rows for personas: the *active* (adopted) persona with its vault,
     then a roster of every persona — each is also dispatchable as a sub-agent.
 
     Returns None when no personas are defined, so non-persona projects stay to
     one line.
+
+    Composed from :func:`_persona_line_parts` rather than built alongside it — one
+    builder, two shapes. See :class:`PersonaLine`.
+    """
+    parts = _persona_line_parts()
+    return None if parts is None else parts.rendered()
+
+
+def _persona_line_parts() -> PersonaLine | None:
+    """:func:`_persona_line`, with the row still in the parts it is made of.
+
+    Everything :func:`_persona_line` promises is decided here — both branches, their
+    shared vocabulary, ``None`` for a plane with no personas, and never raising. See
+    :class:`PersonaLine` for where the split falls and why the vault sits on identity's
+    side of it while the `charter persona use` tip sits on neither.
     """
     try:
         from . import persona
@@ -1175,8 +1234,13 @@ def _persona_line() -> str | None:
         names = sorted(names)
         active = persona.resolve_active()
         if not active:
+            # No active persona: the roster is the only list, and the tip is what turns
+            # one of its names into an answer. The tip is the TAIL rather than part of
+            # the roster because it survives the roster being dropped — a sidebar full
+            # of persona names still never says how to adopt one.
             avail = f"{_DIM} · {_R}".join(f"{_DIM}{n}{_R}" for n in names)
-            return f"{_DIM}◆ persona none{_R} · {avail}{_DIM} · charter persona use <name>{_R}"
+            return PersonaLine(f"{_DIM}◆ persona none{_R}", f" · {avail}",
+                               f"{_DIM} · charter persona use <name>{_R}")
         # Active (adopted) persona: name + vault health (the role reads as noise —
         # the name already says it).
         seg = f"{_MAGENTA}◆{_R} {_BOLD}{active}{_R}"
@@ -1195,10 +1259,11 @@ def _persona_line() -> str | None:
         # `personas` is the word `charter persona`, `personas/`, the ADRs and the
         # no-active branch above all already use.
         others = [n for n in names if n != active]
+        roster = ""
         if others:
             chips = f"{_DIM} · {_R}".join(f"{_DIM}{n}{_R}" for n in others)
-            seg += f"{_DIM} · ◇ personas {_R}{chips}"
-        return seg
+            roster = f"{_DIM} · ◇ personas {_R}{chips}"
+        return PersonaLine(seg, roster)
     except Exception:
         return None
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -476,7 +476,10 @@ session · the repo table · what wants attention**.
 
 `top` is a one-line strip — the workspace and the persona on the left, the charter version
 (and the `dev` chip, if you are on that channel) at the far right, so identity and build
-are not read as one sentence. `repos` is the repo table in a bordered component of its
+are not read as one sentence. The persona there is the *active* one, always; the roster of
+every other persona joins it only when `right` is not on screen, since the sidebar draws
+that same list with more on each row. Drop the sidebar — a narrow terminal, or a density
+that does not include it — and the roster comes back to this row. `repos` is the repo table in a bordered component of its
 own, headed `▪ repos 6` and as many rows tall as the plane and the terminal allow (see
 above). `bottom` is the attention strip on the terminal's last row — one alert and the
 command that fixes it, the in-flight spinner, this session's news, the todo count and the

--- a/docs/news/unreleased-the-top-bar-stops-repeating-the-sidebar.md
+++ b/docs/news/unreleased-the-top-bar-stops-repeating-the-sidebar.md
@@ -1,0 +1,52 @@
+---
+version: unreleased
+headline: The frame's top bar stops repeating the roster the sidebar already shows
+---
+
+*"we still have personas in top-bar, why to have it if we already have personas list in
+right sidebar?"*
+
+Right, and only when there IS a right sidebar. Since the sidebar grew headings and a badge
+column, it draws every persona with strictly more on each one — a heading that counts them,
+memory badges, vault dots, health marks, in-flight badges, in an aligned column. The top
+bar drew the same names flat, next to the workspace, and said less about them.
+
+**So the roster leaves the top bar while the sidebar is on screen:**
+
+```
+ ⬢ control-plane  ◆ steward                                    charter 0.53.0
+
+ ▪ personas 5
+ ▸ steward          ✎47
+ ▫ forge            ✎9
+ ▫ reddit           ✎7
+ ▫ release          ✎38
+ ▫ statusline       ✎14
+```
+
+**`◆ steward` stays, and that is the line the change is drawn along.** The roster is a
+*list* — a thing the sidebar can simply hold more of, and better. The active persona is
+*identity*: "who am I being" is read here, beside the workspace, which is the question the
+whole row exists to answer. The sidebar does mark the active one with `▸`, but that is a
+mark inside a list, not an answer next to a workspace.
+
+**And it comes back the moment the sidebar is not there**, which is why this is a condition
+and not a deletion. The frame drops `right` first on any shortage — a terminal below
+`min-cols` or `min-rows` loses the sidebar before it loses anything else — and on that
+terminal the top bar is the plane's only roster again:
+
+```
+ ⬢ control-plane  ◆ steward · ◇ personas forge · reddit · release · s…
+```
+
+Outside a frame, nothing changes at all: a `charter statusline` session has no sidebar to
+be redundant with, and its row reads exactly as it did.
+
+The question is asked **live, on every repaint**, not settled when the frame launched. The
+density hotkey adds and drops the sidebar while the frame is running, so a value decided at
+launch would be wrong the moment you press it — press it twice and the roster leaves and
+returns with the pane it duplicates. Density and this are separate rules: `minimal` still
+drops the charter version and nothing else, and whether that terse row carries a roster is
+decided by the sidebar alone.
+
+Nothing to adopt. Upgrading is the whole of it.

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -16,11 +16,12 @@ from __future__ import annotations
 
 import contextlib
 import os
+import shutil
 import sys
 import unittest
 from unittest import mock
 
-from charter import config, instance, statusline, todos, tui, workspace
+from charter import config, instance, persona, statusline, todos, tui, workspace
 from charter.frame import gather, layout, slots, state
 
 from tests._isolation import PersonaIso
@@ -1812,6 +1813,203 @@ class TheSidebarListsTheWorkspacesTodos(PersonaIso, unittest.TestCase):
         # And the cache really was cold: the rows came from the live fallback, not from
         # a file some earlier assertion had quietly left behind.
         self.assertTrue(scanned.called)
+
+
+class TheTopBarStopsRepeatingTheSidebarsRoster(PersonaIso, unittest.TestCase):
+    """#530: *"we still have personas in top-bar, why to have it if we already have
+    personas list in right sidebar?"*
+
+    Since #516 `_right` draws every persona with a heading, a memory badge, a vault dot, a
+    health mark and an in-flight badge, in an aligned column. `_top` drew the same names
+    flat — strictly less about exactly the same thing — so with a sidebar on screen the
+    roster on the identity row said nothing new.
+
+    **The property is a CONDITION, not a deletion**, and these tests pin both directions,
+    because either one alone is satisfied by a wrong constant: `layout.visible_slots` drops
+    `right` first on ANY shortage, so on a narrow or short terminal the top bar is the
+    plane's only roster, and outside a frame there is no sidebar at all. A test that only
+    asserted the roster's absence would pass a `_top` that never draws one.
+
+    **What must survive either way is `◆ <active>`** — the roster is a list the sidebar
+    can hold better, but the active persona is identity, and "who am I being" is read on
+    this row next to the workspace.
+
+    The panes are recorded through `state.record_panes`, which is where a launch
+    (`commands_frame._draw_panels`) and a live density change (`cmd_density`) both write
+    the frame's real shape — not through a stub of `_sidebar_live`, so what is exercised
+    here is the record an operator's frame actually leaves behind.
+    """
+
+    #: None of these carry the words the assertions look for, so a hit is a label
+    #: charter drew and never the fixture's own name.
+    OTHERS = ("forge", "release")
+
+    def setUp(self):
+        super().setUp()
+        self.make_persona("steward")
+        for n in self.OTHERS:
+            self.make_persona(n)
+        persona.set_active("steward")
+
+    def _top(self, fid, *, cols=200) -> str:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, 3))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return tui.strip_ansi(slots.render("top", fid))
+
+    def _with_sidebar(self, fid="f-wide") -> str:
+        state.record_panes(fid, panels={"top": "%1", "right": "%3", "bottom": "%2"})
+        return self._top(fid)
+
+    def _without_sidebar(self, fid="f-narrow") -> str:
+        state.record_panes(fid, panels={"top": "%1", "bottom": "%2"})
+        return self._top(fid, cols=60)
+
+    def test_the_roster_is_gone_when_the_sidebar_is_drawing_it(self):
+        row = self._with_sidebar()
+        self.assertNotIn("◇ personas", row, row)
+        for n in self.OTHERS:
+            self.assertNotIn(n, row, f"`{n}` is on the top bar and in the sidebar: {row!r}")
+
+    def test_the_active_persona_stays_because_it_is_identity_and_not_a_roster(self):
+        """The half that must never go. The sidebar marks the active persona with `▸`
+        inside a column of names; this row answers "who am I being" beside the workspace,
+        which is a different question and this row's own."""
+        row = self._with_sidebar()
+        self.assertIn("◆ steward", row, row)
+
+    def test_the_roster_comes_back_when_the_sidebar_is_not_on_screen(self):
+        """`visible_slots` drops `right` first on any shortage, so this is the terminal
+        where the top bar is the plane's only roster. Without this the fix above would be
+        a deletion."""
+        row = self._without_sidebar()
+        self.assertIn("◇ personas", row, row)
+        for n in self.OTHERS:
+            self.assertIn(n, row, row)
+
+    def test_a_frame_with_no_recorded_panes_keeps_its_roster(self):
+        """The migration case and the corrupt-file case, which `state.panes` answers the
+        same way. Charter cannot tell, so it draws the roster: at worst that is the
+        duplication this issue is about, where the other direction would take the plane's
+        only roster off a screen with no sidebar to replace it."""
+        self.assertEqual({}, state.panes("f-unrecorded"))
+        self.assertIn("◇ personas", self._top("f-unrecorded"))
+
+    def test_the_answer_is_read_live_rather_than_at_launch(self):
+        """#387's density hotkey adds and drops `right` while the frame runs, so a value
+        decided once is wrong the moment the operator presses a key. Same fid, same
+        process, same renderer — only the record changes in between."""
+        fid = "f-density"
+        state.record_panes(fid, panels={"top": "%1", "bottom": "%2"})
+        self.assertIn("◇ personas", self._top(fid))
+        state.record_panes(fid, panels={"top": "%1", "right": "%3", "bottom": "%2"})
+        self.assertNotIn("◇ personas", self._top(fid))
+        state.record_panes(fid, panels={"top": "%1", "bottom": "%2"})
+        self.assertIn("◇ personas", self._top(fid),
+                      "the sidebar went away and the roster did not come back")
+
+    def test_density_decides_the_version_and_the_sidebar_decides_the_roster(self):
+        """`terse` is the VERSION's business (see `_top`'s docstring), and this must not
+        become a second, silent rule about the persona half. Both terse rows below drop
+        the version; which of them carries a roster is decided by the sidebar and by
+        nothing else.
+
+        Both are reachable. `charter frame-density minimal` expands to `["top", "bottom"]`
+        — no sidebar, so the terse row is the plane's only roster — while an explicit
+        `[frame] slots` naming `right` alongside `density = "minimal"` wins over the
+        preset (`instance.frame_of`), which is the terse frame that does have one.
+        """
+        for fid, panels, roster in (("f-terse-bare", {"top": "%1", "bottom": "%2"}, True),
+                                    ("f-terse-side", {"top": "%1", "right": "%3"}, False)):
+            with self.subTest(fid=fid):
+                state.record_density(fid, "minimal")
+                state.record_panes(fid, panels=panels)
+                self.assertEqual("terse", slots.verbosity(fid))
+                row = self._top(fid)
+                self.assertNotIn("charter 0.", row, "terse kept the version")
+                self.assertIn("◆ steward", row, row)
+                self.assertEqual(roster, "◇ personas" in row, row)
+
+    def test_top_picks_the_parts_rather_than_reassembling_the_row(self):
+        """The shape #516 gave the chips, applied to the row (#530). `_top` chooses which
+        pieces it draws and never what they say — pinned by handing it values nothing in
+        `slots.py` could have produced, and requiring the two it keeps to reach the pane
+        byte-for-byte while the one it drops does not."""
+        parts = statusline.PersonaLine("SENTINEL-HEAD-0xF00D", "SENTINEL-ROSTER-0xBEEF",
+                                       "SENTINEL-TAIL-0xCAFE")
+        with mock.patch("charter.statusline._persona_line_parts", return_value=parts):
+            with_bar = self._with_sidebar()
+            without = self._without_sidebar()
+        self.assertIn("SENTINEL-HEAD-0xF00D", with_bar)
+        self.assertIn("SENTINEL-TAIL-0xCAFE", with_bar)
+        self.assertNotIn("SENTINEL-ROSTER-0xBEEF", with_bar)
+        self.assertIn("SENTINEL-ROSTER-0xBEEF", without)
+
+    def test_a_plane_with_no_personas_draws_no_persona_half_at_all(self):
+        """`_persona_line_parts` answers `None` there, and the row is still a row —
+        the same promise the flat `_persona_line` made by answering `None`."""
+        for n in ("steward", *self.OTHERS):
+            shutil.rmtree(config.PERSONAS_DIR / n)
+        persona.clear_active()
+        row = self._with_sidebar()
+        self.assertIn("⬢", row, row)
+        self.assertNotIn("◆", row, row)
+
+
+class TheStatusLineOutsideAFrameKeepsItsRoster(PersonaIso, unittest.TestCase):
+    """The other caller (#530). `statusline._persona_line` feeds every session that is
+    NOT in a frame, where there is no sidebar and the roster is the only place personas
+    appear — so the split that let `_top` drop half of the row must leave that surface
+    saying exactly what it said before, in exactly the order it said it.
+    """
+
+    def setUp(self):
+        super().setUp()
+        for n in ("steward", "forge", "release"):
+            self.make_persona(n)
+
+    def test_the_flat_line_still_carries_the_whole_roster(self):
+        persona.set_active("steward")
+        line = tui.strip_ansi(statusline._persona_line() or "")
+        self.assertIn("◆ steward", line)
+        self.assertIn("◇ personas", line)
+        self.assertIn("forge", line)
+        self.assertIn("release", line)
+
+    def test_the_flat_line_is_exactly_the_three_parts_in_order(self):
+        """The invariant that keeps the two surfaces from drifting: whatever the parts
+        say, joined head-roster-tail, IS the row the status line prints. Asserted for
+        both branches, because they are two different compositions."""
+        for active in ("steward", None):
+            with self.subTest(active=active):
+                if active:
+                    persona.set_active(active)
+                else:
+                    persona.clear_active()
+                parts = statusline._persona_line_parts()
+                self.assertEqual(parts.head + parts.roster + parts.tail,
+                                 statusline._persona_line())
+
+    def test_no_active_persona_keeps_the_command_that_gets_you_one(self):
+        """The `tail`, and why it is a field of its own rather than part of the roster:
+        a sidebar full of persona names still never says how to adopt one, so the tip
+        survives the roster being dropped while the names do not."""
+        persona.clear_active()
+        parts = statusline._persona_line_parts()
+        self.assertIn("persona none", tui.strip_ansi(parts.head))
+        self.assertIn("charter persona use", tui.strip_ansi(parts.tail))
+        self.assertNotIn("charter persona use", tui.strip_ansi(parts.roster))
+        kept = tui.strip_ansi(parts.rendered(roster=False))
+        self.assertIn("charter persona use", kept)
+        self.assertNotIn("forge", kept, kept)
+
+    def test_the_parts_need_no_separator_between_them(self):
+        """`PersonaChip`'s contract, kept here too: each part carries its own leading
+        separator, so dropping one never leaves a dangling ` · ` at the seam."""
+        persona.clear_active()
+        kept = tui.strip_ansi(statusline._persona_line_parts().rendered(roster=False))
+        self.assertNotIn(" ·  · ", kept, kept)
+        self.assertFalse(kept.rstrip().endswith("·"), kept)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #530.

> *"we still have personas in top-bar, why to have it if we already have personas list in right sidebar?"*

Since #516 `slots._right` draws the same roster with strictly more on every row — a heading that counts them, memory badges, vault dots, health marks, in-flight badges, in an aligned column. `_top` drew the same names flat, next to the workspace, and said less about them.

**The roster leaves `top` while `right` is on screen. `◆ <active>` stays whatever else is.** The roster is a *list*, which the sidebar holds better; the active persona is *identity*, and "who am I being" is read on the identity row beside the workspace. The sidebar marks the active one with `▸`, but that is a mark inside a list, not an answer next to a workspace.

**A condition, not a deletion.** `layout.visible_slots` drops `right` FIRST on any shortage (`cols < min_cols or rows < min_rows`), so below the floor the top bar is the plane's only roster again — and `statusline._persona_line`, this row's other caller for every session *not* in a frame, is left exactly as it was.

## The four states

**1 — wide frame (120x40), sidebar live.** `visible_slots -> ['top', 'bottom', 'repos', 'right']`

```
 ⬢ control-plane  ◆ steward                                             charter 0.53.0
```
```
▪ personas 5
▸ steward
▫ forge
▫ reddit
▫ release
▫ statusline
```

**2 — narrow frame (70x40), `cols < min_cols=100`, sidebar dropped.** `visible_slots -> ['top', 'bottom']`

```
 ⬢ control-plane  ◆ steward · ◇ personas forge · reddit · release · s…
```

**3 — `terse` density.** Both terse rows drop the charter version; which carries a roster is decided by the sidebar and nothing else.

```
# `charter frame-density minimal` -> slots ['top','bottom'], no sidebar
 ⬢ control-plane  ◆ steward · ◇ personas forge · reddit · release · statusline

# `[frame] slots` naming `right` at density = "minimal" — terse WITH a sidebar
 ⬢ control-plane  ◆ steward
```

**4 — outside a frame entirely (`charter statusline`), unchanged.**

```
┌──────────────────────────────────────────────────────────────────────────────────┐
│ ⬢ default · ws 0                                                                 │
│ ◆ steward · ◇ personas forge · reddit · release · statusline    ⬢ charter 0.53.0 │
└──────────────────────────────────────────────────────────────────────────────────┘
```

## The two things that would have bitten

**It is answered live.** `slots._sidebar_live` reads `state.panes(fid)` — the record written where a frame's shape is actually decided (`_draw_panels` at launch, `cmd_density` after `_relayout`), from the panes tmux really gave back. #387's density hotkey adds and drops `right` while the frame runs, so a value captured at launch is wrong the moment the operator presses a key; press it twice and the roster leaves and returns with the pane it duplicates.

Cost: `top` is not in `ANIMATED`, so this is one small JSON read on a slot that repaints on a version bump — and `cmd_density` bumps the version precisely so surviving panels re-read, which is exactly when this answer can have changed. Nothing on the idle path (`panel._running`, whose one `stat` per tick #387 pinned) goes near it. False when charter cannot tell (migration, corrupt file), which is the safe direction: the roster comes back rather than vanishing off a screen with no sidebar to replace it.

**The parts, not a second assembly.** `_persona_line` returned one flat string with both halves already joined, so `_top` could not keep one and drop the other. It gets the treatment `_persona_chips` got in #516: `statusline.PersonaLine` (`head` / `roster` / `tail`) plus `_persona_line_parts`, with `_persona_line` composing exactly `rendered()` over it. `_top` picks its pieces and assembles nothing — the drift `_right`'s docstring rules out. Verified byte-identical output from `_persona_line` on both branches against `origin/main`.

The `charter persona use <name>` tip is the **tail** rather than part of the roster: a sidebar full of persona names still never says how to adopt one, so it survives the roster being dropped while the names do not.

Both branches of `_persona_line` were read whole before changing it (#513's `agents` → `personas` came from exactly that disagreement); `tests/test_frame_vocabulary_is_charters_own.py` still passes untouched.

## Verification

Suite, ambient variables cleared:

```
env -u CHARTER_SESSION_ID -u CLAUDE_CODE_SESSION_ID -u TMUX -u TMUX_PANE \
  python3 -m unittest discover -s tests
Ran 5614 tests in 230.305s
OK
```

**Mutation-tested — ten mutations, every one RED, every restore GREEN**, `__pycache__` cleared before and after each run:

| # | mutation | result |
|---|---|---|
| M1 | `_sidebar_live` pinned `False` (the pre-#530 behaviour) | RED (4 failures) |
| M2 | `_sidebar_live` pinned `True` (a deletion, not a condition) | RED (5) |
| M3 | `_sidebar_live` asks about `repos` instead of `right` | RED (4) |
| M4 | `_sidebar_live` answers `True` on an empty pane map | RED (1) |
| M5 | `_sidebar_live` `lru_cache`d — decided once at launch | RED (1) |
| M6 | `_top` calls `rendered()` regardless | RED (4) |
| M7 | `PersonaLine.rendered` ignores the `roster` flag | RED (5) |
| M8 | `rendered` drops the tail together with the roster | RED (2) |
| M9 | the `charter persona use` tip folded into the roster | RED (1) |
| M10 | the active persona folded into the roster | RED (2) |

New coverage: `TheTopBarStopsRepeatingTheSidebarsRoster` and `TheStatusLineOutsideAFrameKeepsItsRoster` in `tests/test_frame_slots.py` (12 tests). Panes are recorded through the real `state.record_panes` rather than by stubbing `_sidebar_live`, so what is exercised is the record an operator's frame actually leaves behind.

News entry added. No version bump, no stamping, no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNrdmddmvWf1AxLroXwnx9