### PR TITLE
The shell the suite was launched from is not a fixture (#519, #521, #528)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,11 +32,18 @@ command.
   refuses any write into the real `.charter/` and fails the test that tried. The same file
   refuses one kind of *read*: a setting your own `charter.toml` declares — today
   `[update] channel` — because a test that reads it is asserting against a fixture written
-  by whoever happens to run the suite. Derive from `tests._isolation.PersonaIso` and
-  neither ever comes up; a case that runs against the real plane on purpose calls
-  `isolate_state_dir(self)` and `pin_update_channel(self)`; a test that spawns a subprocess
-  has to hand it the throwaway plane as `$CHARTER_ROOT`, which no guard in this process can
-  do for you.
+  by whoever happens to run the suite. `tests/_envguard.py` is the third of the same
+  shape, for the third fixture a test can inherit without noticing: **the shell you
+  launched the suite from.** Charter's own variables are removed from the environment
+  before charter is imported, so the answer is identical inside a live frame and on a CI
+  runner; and a test that then *reads* one of the identity variables a session
+  exports — `$CHARTER_SESSION_ID`, `$CHARTER_WORKSPACE`, `$TMUX` and their kin — without
+  saying what it holds is refused by name. Derive from `tests._isolation.PersonaIso` and
+  none of the three ever comes up; a case that runs against the real plane on purpose calls
+  `isolate_state_dir(self)` and `pin_update_channel(self)`; a plain `TestCase` says it is
+  outside a frame with `_envguard.unset_all()`, or states the value it needs with
+  `mock.patch.dict(os.environ, …)`; a test that spawns a subprocess has to hand it the
+  throwaway plane as `$CHARTER_ROOT`, which no guard in this process can do for you.
 - **Comments explain *why*.** The codebase leans hard on this: a comment that restates the
   code earns nothing, one that records the failure a line prevents is worth several
   paragraphs of docs. Read a few modules before writing your first one.
@@ -91,6 +98,14 @@ describing something that only existed on one machine.
 The others: `seq 1 0` counts *down* on BSD and prints nothing on GNU, so a "zero iterations"
 loop silently ran twice on macOS. And `/tmp` is a symlink to `/private/var/...` on macOS, so
 a path comparison that passes locally fails on Linux unless both sides are `.resolve()`d.
+
+The fourth was charter's own environment, and it ran both ways. Inside a live charter
+frame — where anyone working on charter actually runs the suite — sixteen tests failed that
+fail nowhere else, reading `$CHARTER_SESSION_ID`, `$TMUX` and `$TMUX_PANE` out of the
+developer's terminal. And once, more quietly, both sides of an assertion collapsed to an
+ambient `$CHARTER_WORKSPACE` and the test agreed with itself: a mutation that dies with a
+clean environment survived under the pin. `tests/_envguard.py` closes both directions, but
+it only knows about charter's own names; yours is still yours to pin.
 
 **So: a test pins what it depends on.** Anything that changes behaviour and comes from
 outside the test — git config, `$PATH`, locale, the default shell, an env var, the

--- a/charter/config.py
+++ b/charter/config.py
@@ -22,6 +22,7 @@ import sys
 from pathlib import Path
 
 from . import instance as _instance
+from . import legacyenv as _legacyenv
 from . import root as _root
 
 #: Fallbacks used when a control plane declares nothing (or none was found).
@@ -83,23 +84,6 @@ def worktrees_root_for(root: "Path", cfg: dict) -> "Path | None":
         return p.resolve()
     except (OSError, RuntimeError):
         return p       # unresolvable (symlink loop, vanished parent) — still usable
-
-
-_LEGACY_ENV_VARS = (("EDM_HOME", "CHARTER_HOME"), ("EDM_WORKSPACE", "CHARTER_WORKSPACE"),
-                    ("EDM_PERSONA", "CHARTER_PERSONA"))
-
-
-def _warn_legacy_env_vars() -> None:
-    """Print a loud stderr warning for each old `edm`-era env var that's still set —
-    its value is never honored (only the new name is), so silence here would look
-    like state (vaults!) vanished rather than simply needing a renamed env var."""
-    for legacy, new in _LEGACY_ENV_VARS:
-        if os.environ.get(legacy):
-            print(f"charter: ${legacy} is no longer used (charter was renamed from `edm`) — "
-                  f"set ${new} instead. Ignoring ${legacy}.", file=sys.stderr)
-
-
-_warn_legacy_env_vars()
 
 
 def _migrate_state_dir(root: Path) -> Path:
@@ -522,5 +506,15 @@ def restore(previous: dict) -> None:
 
 
 # Bootstrap: locate the plane the same way every command does, and derive from it.
-_warn_legacy_env_vars()
+#
+# The `edm`-era env var names and this warning live in `charter.legacyenv` rather than
+# here, and the move is the point: importing THIS module RESOLVES A PLANE, so a caller that
+# only wants to know charter's former namespace had to pay for one. `tests/_envguard` is
+# that caller and cannot pay — it strips charter's variables from the suite's environment
+# *before* charter is first imported — so it did not ask, and those three names were the
+# only ones that reached the suite (#540). See `legacyenv`'s docstring.
+#
+# Warned ONCE, here. There used to be two calls, one beside the definition and this one, so
+# every charter invocation with a legacy variable exported printed each banner twice.
+_legacyenv.warn()
 globals().update(derive(_root.find_root_or_cwd()))

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -733,7 +733,7 @@ _WALK_FIX = (
 #: `edm` is charter's pre-rename name. Kept because this is a security guard and the cost
 #: of an extra alternative is one string, while the cost of dropping it is a silent
 #: denial that stops happening on a machine where the old binary is still installed.
-#: `config._LEGACY_ENV_VARS` keeps the same posture for the renamed env vars.
+#: `legacyenv.RENAMES` keeps the same posture for the renamed env vars.
 _CHARTER_PROGS = ("charter", "edm")
 
 

--- a/charter/legacyenv.py
+++ b/charter/legacyenv.py
@@ -1,0 +1,57 @@
+"""The `edm`-era environment variables, and the one thing charter still does with them.
+
+charter was renamed from ``edm``. Three variables came with the name, and the old spellings
+are no longer honored — only the new ones are. Silence about a set-but-ignored
+``$EDM_HOME`` would look like state (vaults!) had vanished rather than like a variable
+needing a rename, so each one still exported gets a loud line on stderr.
+
+**Why these three strings are not in `charter.config`, which is where they lived and where
+:func:`warn` is still called from.** Importing `charter.config` RESOLVES A PLANE — that is
+its whole job, and it happens at import — so a caller that only wants to know which names
+charter used to answer to had to pay for a plane it never asked for. `tests/_envguard.py`
+is exactly that caller, and it is the one caller that cannot pay: it removes charter's
+environment from the suite's process *before* `charter.config` is first imported, precisely
+so the plane is not resolved out of the operator's shell, and asking config which names to
+remove would defeat the ordering it exists to protect.
+
+So it did not ask, and these three names were the only charter variables that reached a
+suite which had scrubbed every other one. `charter init` runs in a subprocess there, that
+subprocess inherited ``$EDM_WORKSPACE`` from the developer's shell, :func:`warn` printed a
+133-column banner into its stderr, and two tests failed on a long-time charter developer's
+machine that pass in CI and on a fresh checkout (#540).
+
+A tuple of strings was never what needed a plane. It lives here, in a module that imports
+``os`` and ``sys`` and nothing else, so that anyone may ask — and `tests._envguard` derives
+the names it scrubs from :data:`NAMES` rather than re-spelling them, the same way it asks
+`session._PANE_ID_VARS` instead of copying it out. A fourth rename is covered by the guard
+on the commit that adds it, rather than on the commit that debugs it.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+#: ``(the `edm`-era name, the name that replaced it)``. The value of the old name is never
+#: honored anywhere in charter — this pairing exists so the warning can name the variable
+#: the reader should set instead, which is the whole reason the warning is worth printing.
+RENAMES = (("EDM_HOME", "CHARTER_HOME"),
+           ("EDM_WORKSPACE", "CHARTER_WORKSPACE"),
+           ("EDM_PERSONA", "CHARTER_PERSONA"))
+
+#: Just the old spellings — derived, so the two can never disagree. What
+#: `tests._envguard._scrubbed_names` asks for: charter's own former namespace, which is a
+#: closed historical list rather than a prefix, because charter will not invent a new
+#: ``EDM_*`` variable and a blanket ``EDM_`` prefix would reach past charter's own names
+#: into whatever unrelated tool on the machine happens to share three letters.
+NAMES = tuple(legacy for legacy, _ in RENAMES)
+
+
+def warn() -> None:
+    """Print a loud stderr warning for each old `edm`-era env var that's still set —
+    its value is never honored (only the new name is), so silence here would look
+    like state (vaults!) vanished rather than simply needing a renamed env var."""
+    for legacy, new in RENAMES:
+        if os.environ.get(legacy):
+            print(f"charter: ${legacy} is no longer used (charter was renamed from `edm`) — "
+                  f"set ${new} instead. Ignoring ${legacy}.", file=sys.stderr)

--- a/docs/news/unreleased-the-suite-cannot-read-your-shell.md
+++ b/docs/news/unreleased-the-suite-cannot-read-your-shell.md
@@ -1,0 +1,54 @@
+---
+version: unreleased
+headline: charter's own test suite gives the same answer inside a frame as it does in CI — the shell it was launched from is no longer a fixture
+---
+
+Run charter's suite from inside a live charter frame — which is where anyone working on
+charter actually runs it — and sixteen tests failed that fail nowhere else. Unset four
+variables and the same tree, on the same commit, was green. `$CHARTER_SESSION_ID` held the
+frame's id, `$TMUX` and `$TMUX_PANE` said a tmux was real, and each of those reached a test
+that had never said whether it was inside a frame. A green run meant "green on this
+machine, this minute, in this shell".
+
+**The direction that mattered more was the quiet one.** The same leak had already produced
+a false GREEN: both sides of one assertion collapsed to an ambient `$CHARTER_WORKSPACE`, so
+a mutation that dies with a clean environment survived under the pin. A test that stops
+testing when a variable happens to be set is worse than one that fails, and that one hid a
+real defect through two separate investigations. Behind it sat the measurement: 108 of the
+suite's 168 `patch.dict(os.environ, …)` calls omit `clear=True`, across 38 unrelated files,
+so whatever the developer's shell holds reaches the code under test.
+
+**Fixed as a class, the way the plane guards were.** 0.52.0 refused writes into your real
+`.charter/`; 0.53.0 refused reads of the `[update] channel` your own `charter.toml`
+declares. This is the third of the same shape, for the third fixture a test can inherit
+without noticing:
+
+* Charter's variables are **removed from the suite's environment** before charter is first
+  imported. What is gone cannot leak — not into a bulk `dict(os.environ)`, not into a
+  subprocess that inherits this process, not into any of those 108 call sites. That alone
+  is what makes the answer identical in a frame and on a CI runner.
+* A **targeted read of one of them is refused** while a test runs, unless that test said
+  what it holds. Removal on its own would only silence the red: the test would still be
+  asserting against a value it never chose, and the day its expectation coincides with the
+  ambient one it goes quietly green for the wrong reason. The refusal is what makes the
+  109th instance fail on the pull request that introduces it, on a runner that never had
+  the variable set.
+
+The refusal names the test that made the read, the variable, and both ways out —
+`PersonaIso`, which now declares the whole charter environment unset in one call the way it
+already re-derives every config setting, or stating the value with `patch.dict`. Which
+variables are loud is derived rather than listed: the frame's own identity set, the pane
+variables `charter.session` walks, and the session-id rung below the frame. A variable a
+frame learns to export next is guarded on the commit that teaches it, not on the commit
+that debugs it.
+
+Turning it on found the sixteen and 115 more, in `init`, `doctor`, `statusline`, `root`,
+the workspace lock and the opencode plugin realm — every one of them a test whose answer
+depended on the terminal it ran in. Each now states, once per fixture, that it is outside a
+frame with no session id and no pinned workspace.
+
+The suite now reports the same result in four environments that used to disagree: a fresh
+checkout with the variables cleared, a plane that has been used, inside a live charter
+frame, and with `CHARTER_WORKSPACE` pinned to a name no fixture uses.
+
+None of this reaches you unless you run charter's own test suite. Nothing to adopt.

--- a/docs/news/unreleased-the-suite-cannot-read-your-shell.md
+++ b/docs/news/unreleased-the-suite-cannot-read-your-shell.md
@@ -47,8 +47,25 @@ the workspace lock and the opencode plugin realm — every one of them a test wh
 depended on the terminal it ran in. Each now states, once per fixture, that it is outside a
 frame with no session id and no pinned workspace.
 
-The suite now reports the same result in four environments that used to disagree: a fresh
-checkout with the variables cleared, a plane that has been used, inside a live charter
-frame, and with `CHARTER_WORKSPACE` pinned to a name no fixture uses.
+**And "derived, not listed" had to earn its own words back.** The first version of this
+guard spelled `TMUX` and defended the spelling — the one name with no constant to derive it
+from — while missing three names charter *already keeps in a constant*: `$EDM_HOME`,
+`$EDM_WORKSPACE` and `$EDM_PERSONA`, from before charter was renamed from `edm`. charter
+does not honor their values, but it does warn about them, on stderr, at import — so
+`$EDM_WORKSPACE` exported in a shell put a 133-column banner into the output of every
+`charter` the suite spawned, and two tests failed on the machine of the person most likely
+to still have it exported while passing everywhere else. They are scrubbed now, and asked
+of the same constant the warning is printed from, so a fourth rename is covered on the
+commit that adds it.
 
-None of this reaches you unless you run charter's own test suite. Nothing to adopt.
+Getting there turned up something that *does* reach you: that warning was printed **twice**,
+every time, in every charter invocation with a legacy variable set — two calls at import,
+one beside the definition and one in the bootstrap. It is printed once now.
+
+The suite now reports the same result in five environments that used to disagree: a fresh
+checkout with the variables cleared, a plane that has been used, inside a live charter
+frame, with `CHARTER_WORKSPACE` pinned to a name no fixture uses, and with the pre-rename
+`EDM_WORKSPACE` still exported.
+
+Beyond the doubled warning, none of this reaches you unless you run charter's own test
+suite. Nothing to adopt.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -30,6 +30,19 @@ os.environ["CODEX_HOME"] = os.path.join(_SANDBOX, "codex")
 os.makedirs(os.environ["XDG_CONFIG_HOME"], exist_ok=True)
 os.makedirs(os.environ["CODEX_HOME"], exist_ok=True)
 
+# The third fixture a test can inherit without noticing, after the plane root and these
+# config directories: the SHELL the suite was launched from. `$CHARTER_SESSION_ID`,
+# `$TMUX` and `$CHARTER_WORKSPACE` reach the code under test the same way `$XDG_CONFIG_HOME`
+# did, and cost sixteen false failures inside a live frame plus one false GREEN (#519,
+# #521, #528). This removes them and then refuses an undeclared read of one.
+#
+# ABOVE the `_planeguard` import, which is not cosmetic: `$CHARTER_ROOT` is one of the
+# names scrubbed, and importing `charter.config` is what resolves the plane. Scrub after it
+# and the whole suite is already pointing at whichever plane the operator's shell pinned.
+from . import _envguard      # noqa: E402
+
+_envguard.install()
+
 # The same move for the one directory that CANNOT be redirected away from every test —
 # some tests read the real plane on purpose — but that none of them may write to. See
 # `tests/_planeguard.py`: after this line, a write into the developer's own `.charter/`

--- a/tests/_envguard.py
+++ b/tests/_envguard.py
@@ -35,12 +35,24 @@ under test asks for.
    that never had the variable set in the first place.
 
 **What counts as a charter environment variable is a property, not a list.** It is any
-name in charter's own namespace (``CHARTER_*``, ``CLAUDE*``) plus the terminal-identity
-variables `charter.session` derives a session and a pane from — asked of
-`session._PANE_ID_VARS` and `session._WINDOW_ID_VARS` rather than copied out of them, for
-the same reason `PersonaIso` asks `config.derive` instead of re-listing twenty-five
-settings. A ``CHARTER_`` variable invented next month is guarded the day it is invented,
-and #519's specific four are covered by the property rather than by being spelled.
+name in charter's own namespace (``CHARTER_*``, ``CLAUDE*``), plus the terminal-identity
+variables `charter.session` derives a session and a pane from, plus charter's FORMER
+namespace — each asked of the constant production reads it from (`session._PANE_ID_VARS`,
+`session._WINDOW_ID_VARS`, `legacyenv.NAMES`) rather than copied out of them, for the same
+reason `PersonaIso` asks `config.derive` instead of re-listing twenty-five settings. A
+``CHARTER_`` variable invented next month is guarded the day it is invented, and #519's
+specific four are covered by the property rather than by being spelled.
+
+**The former namespace is here because the first version of this file forgot it, and the
+way it forgot is the argument for the paragraph above.** That version spelled ``TMUX`` and
+justified the spelling — "the one name with no constant to derive it from" — while missing
+three names charter *already keeps in a constant*, and which are exactly the ones a
+long-time charter developer still has exported. ``$EDM_WORKSPACE`` alone made two tests
+fail on that developer's machine and pass in CI: `charter.legacyenv.warn` prints a
+133-column stderr banner for each old name still set, at import of `charter.config`, and so
+in every subprocess this suite spawns (#540). Scrubbed, not refused — charter never honors
+their VALUES, so no test can be asserting the operator's terminal through one; what leaked
+was the banner, and removing the name removes the banner.
 
 **How a test declares.** Three ways, and all three are things tests already do:
 
@@ -107,13 +119,31 @@ def _scrubbed_names() -> frozenset[str]:
     NOT walk, scrubbed anyway because "deliberately not read" is a decision that can change
     and a scrub costs nothing if it is wrong.
 
+    `legacyenv.NAMES` is charter's own former namespace — ``$EDM_HOME``, ``$EDM_WORKSPACE``,
+    ``$EDM_PERSONA``, from before the rename. Outside ``CHARTER_``/``CLAUDE`` by spelling
+    but squarely inside charter by ownership: `legacyenv.warn` runs at import of
+    `charter.config` and prints a 133-column line to stderr for each one still set, which
+    reaches every subprocess this suite spawns. Missing them cost two failures on a
+    developer's machine that CI could not reproduce (#540). Asked of the constant, so a
+    fourth rename is guarded on the commit that adds it —
+    `test_no_test_reads_the_operators_shell.WhatIsGuarded` pins that the asking still
+    happens.
+
+    ``EDM_`` is deliberately NOT a fourth entry in :data:`_PREFIXES`. A prefix is what
+    ``CHARTER_`` earns by being open — a variable nobody has invented yet must not be able
+    to arrive from the operator's shell. charter's ex-namespace is closed in the other
+    direction: no new ``EDM_*`` name will ever be invented, so a prefix would buy nothing
+    forward and would reach sideways into whatever unrelated tool on the machine happens to
+    share three letters.
+
     ``TMUX`` is the one name spelled out, and it has to be: it is tmux's variable, not
     charter's, read in half a dozen places to answer "is this process inside a tmux" with
     no constant to derive it from. Its pane counterpart arrives from `_PANE_ID_VARS`, so
     inventing a constant for one of a pair would buy nothing.
     """
-    from charter import session
-    return frozenset(session._PANE_ID_VARS + session._WINDOW_ID_VARS + ("TMUX",))
+    from charter import legacyenv, session
+    return frozenset(session._PANE_ID_VARS + session._WINDOW_ID_VARS + ("TMUX",)
+                     + legacyenv.NAMES)
 
 
 def _loud_names() -> frozenset[str]:
@@ -305,9 +335,12 @@ def install() -> None:
         return
     _installed = True
 
-    # `charter.session` imports `os` and `re` and nothing else — in particular not
-    # `charter.config` — so asking it for the pane variables here cannot pull the plane
-    # resolution in ahead of the scrub below.
+    # `charter.session` imports `os` and `re`, `charter.legacyenv` imports `os` and `sys`,
+    # and neither imports anything else — in particular not `charter.config` — so asking
+    # them for the pane variables and the pre-rename names here cannot pull the plane
+    # resolution in ahead of the scrub below. `legacyenv` is a separate module for exactly
+    # this reason: those three names used to live in `config`, where nobody could ask for
+    # them without resolving a plane, so this file did not ask and they leaked (#540).
     _SCRUB_NAMES = _scrubbed_names()
 
     for key in [k for k in os.environ if _in_namespace(k)]:

--- a/tests/_envguard.py
+++ b/tests/_envguard.py
@@ -1,0 +1,342 @@
+"""Suite-wide tripwire: no test may read a charter environment variable it did not declare.
+
+`PersonaIso` isolates everything charter derives from the plane ROOT. `_planeguard`
+isolates the state directory and the settings the developer's own ``charter.toml``
+declares. Neither covers the third fixture a test can inherit without noticing: **the
+shell the suite was launched from**.
+
+That fixture is not hypothetical, and it is not stable. Run the suite from inside a live
+charter frame — which is where the operator runs it — and sixteen tests fail that do not
+fail anywhere else (#519, #521): ``$CHARTER_SESSION_ID`` holds the frame's id, ``$TMUX``
+and ``$TMUX_PANE`` say a tmux is real, and each of those reaches a test that never said
+whether it was inside a frame. Run it in CI, where none of them are set, and the same
+tests pass. A suite whose answer depends on the terminal is not a suite; it is a reading
+of the terminal.
+
+**And the failure runs both ways.** On #525 the leak produced a false GREEN: both sides of
+one assertion collapsed to the ambient ``$CHARTER_WORKSPACE``, so a mutation died with a
+clean environment and *survived under the pin* — a test that quietly stopped testing. The
+measurement behind #528 is that 108 of the suite's 168 ``patch.dict(os.environ, …)`` calls
+omit ``clear=True``, across 38 unrelated files, so the survivors reach whatever the code
+under test asks for.
+
+**Two moves, and they close opposite directions.**
+
+1. *The ambient values are removed*, once, before `charter.config` is first imported. What
+   is gone cannot leak — not into a bulk ``dict(os.environ)``, not into a subprocess that
+   inherits this process's environment, not into the 108 call sites that let the rest of
+   the shell through. This is what makes the suite give the same answer inside a frame and
+   outside one, and it takes effect for every test at once rather than 108 times.
+2. *A targeted read of one of those names is REFUSED* while a test is running, unless that
+   test declared what the name holds. Removal alone would only silence the RED: the test
+   would still be asserting against a value it never chose, and the day its expectation
+   coincides with the ambient one it goes quietly green for the wrong reason. Refusal is
+   what makes instance 109 fail on the pull request that introduces it, on a CI runner
+   that never had the variable set in the first place.
+
+**What counts as a charter environment variable is a property, not a list.** It is any
+name in charter's own namespace (``CHARTER_*``, ``CLAUDE*``) plus the terminal-identity
+variables `charter.session` derives a session and a pane from — asked of
+`session._PANE_ID_VARS` and `session._WINDOW_ID_VARS` rather than copied out of them, for
+the same reason `PersonaIso` asks `config.derive` instead of re-listing twenty-five
+settings. A ``CHARTER_`` variable invented next month is guarded the day it is invented,
+and #519's specific four are covered by the property rather than by being spelled.
+
+**How a test declares.** Three ways, and all three are things tests already do:
+
+* Derive from `tests._isolation.PersonaIso`. Its `setUp` calls :func:`unset_all`, which
+  says "this test runs outside a frame, with no session id" — the answer CI would give.
+  One call, for every test that mixes it in.
+* Set the value: ``mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "sess-abc"})``. A
+  name present in the environment is a name the test chose, so it reads normally.
+* Say it is unset: ``clear=True`` on that same call (an emptied environment is a stated
+  one), or :func:`unset` for individual names.
+
+**Scoped to one test, and reset at its boundary.** Declarations live here rather than in
+`os.environ` because `mock.patch.dict` restores by *clearing the whole mapping and
+refilling it*, so a declaration stored as a value would be destroyed by the first
+unrelated `patch.dict` in the same test. `unittest.TestCase.run` is wrapped to arm the
+guard and to save/restore the declaration set around each test — save/restore rather than
+plain reset, because a few tests run an inner `TestCase` inside their own body, and the
+inner run must not disarm the outer one.
+
+**Disarmed outside a test, deliberately.** Module import — `charter.config` resolving a
+root, a test module reading something at collection — happens before any test declared
+anything, and refusing there would be refusing the suite's own boot. The ambient values
+are already gone by then, so those reads are deterministic; it is only the *loudness* that
+waits for a test to be running.
+
+**Raised as a `BaseException`**, for the reason `_planeguard.RealPlaneRead` documents:
+charter is full of ``except Exception`` fallbacks that would turn this tripwire into a
+degraded code path, and `unittest` records a `BaseException` against the test that raised
+it, so the failure keeps its name.
+
+**What this cannot see.** ``os.environb`` shares the same underlying data and bypasses the
+mapping (nothing in charter uses it), and a subprocess resolves its own environment — but
+it inherits this process's, which no longer carries the ambient values, so the two halves
+agree. `setUpModule` and `setUpClass` run outside `TestCase.run` and are unguarded for the
+same reason import is.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from . import _planeguard
+
+
+class AmbientEnvRead(BaseException):
+    """A test read a charter environment variable without declaring what it holds."""
+
+
+#: **Tier one — scrubbed.** Charter's whole namespace, as a PREFIX rather than an
+#: enumeration, because a variable nobody has invented yet must not be able to arrive from
+#: the operator's shell on the day it is invented. ``CLAUDE`` carries no underscore so that
+#: ``CLAUDECODE`` — exported by the harness the operator runs this suite from — is inside
+#: it too. Everything matching this is removed from the environment at install, so it can
+#: neither reach a bulk ``dict(os.environ)`` nor a subprocess that inherits this process.
+_PREFIXES = ("CHARTER_", "CLAUDE")
+
+
+def _scrubbed_names() -> frozenset[str]:
+    """The non-namespaced names scrubbed too, asked of the module that reads them.
+
+    `session._PANE_ID_VARS` is the chain `session.terminal` walks (``TERM_SESSION_ID``,
+    ``TMUX_PANE``, ``STY``, ``SSH_TTY``); `_WINDOW_ID_VARS` is the one it deliberately does
+    NOT walk, scrubbed anyway because "deliberately not read" is a decision that can change
+    and a scrub costs nothing if it is wrong.
+
+    ``TMUX`` is the one name spelled out, and it has to be: it is tmux's variable, not
+    charter's, read in half a dozen places to answer "is this process inside a tmux" with
+    no constant to derive it from. Its pane counterpart arrives from `_PANE_ID_VARS`, so
+    inventing a constant for one of a pair would buy nothing.
+    """
+    from charter import session
+    return frozenset(session._PANE_ID_VARS + session._WINDOW_ID_VARS + ("TMUX",))
+
+
+def _loud_names() -> frozenset[str]:
+    """**Tier two — refused.** The variables that are an IDENTITY the operator's own
+    session exports, as opposed to a path or a knob.
+
+    The distinction is what makes this a guard and not a chore, so it is worth stating
+    precisely. Every name in tier one is scrubbed, so no test's answer can differ between
+    two machines either way. What tier two adds is *loudness*, and loudness is only worth
+    its cost where "unset" is a CLAIM ABOUT THE WORLD the test runs in — am I inside a
+    frame, is this a real tmux, whose session is this, which workspace is pinned over every
+    pointer. A test that reads one of those and finds nothing has asserted something about
+    the operator's terminal without saying so, which is precisely the sixteen failures of
+    #519/#521 and the false green of #528. A test that reads ``$CHARTER_WORKTREES`` and
+    finds nothing has asserted charter's documented default, which is a fixture like any
+    other.
+
+    Derived, not spelled. `commands_frame._FRAME_IDENTITY` already exists to answer exactly
+    "which variables must be THIS session's rather than whichever launcher happened to
+    start the shared tmux server", and its own docstring commits the next such variable to
+    that list — so a variable added there is guarded here on the same commit. The terminal
+    half comes from `session._PANE_ID_VARS`/`_WINDOW_ID_VARS` plus ``TMUX``, and
+    ``CLAUDE_CODE_SESSION_ID`` is `session.current`'s second rung, which
+    `_FRAME_IDENTITY` has no reason to carry because a frame shadows it rather than
+    exporting it.
+
+    Resolved on the first test rather than at install: `charter.commands_frame` pulls in
+    `charter.config`, and the scrub has to happen BEFORE anything resolves a plane.
+    """
+    from charter import commands_frame, session
+    return frozenset(commands_frame._FRAME_IDENTITY
+                     + session._PANE_ID_VARS + session._WINDOW_ID_VARS
+                     + ("TMUX", "CLAUDE_CODE_SESSION_ID"))
+
+
+_SCRUB_NAMES: frozenset[str] = frozenset()
+_LOUD: frozenset[str] = frozenset()
+
+#: Names this test has declared. Reset — saved and restored — around every `TestCase.run`.
+_declared: set[str] = set()
+
+#: Set by :func:`unset_all`: every guarded name is declared unset for this test, except any
+#: the test also puts in the environment (a real value always wins over a blanket unset).
+_all_unset = False
+
+#: Armed only while a test is running. See the module docstring.
+_active = False
+
+_installed = False
+
+
+def _in_namespace(key: str) -> bool:
+    """Tier one: is this a name the scrub removes?"""
+    return key.startswith(_PREFIXES) or key in _SCRUB_NAMES
+
+
+def _explain(key: str) -> str:
+    return (
+        f"REFUSED: read of ${key}\n"
+        f"{_planeguard._current_test()} read ${key} without declaring what it holds. That "
+        f"is an identity the operator's own session exports — inside a charter frame "
+        f"$CHARTER_SESSION_ID is the frame's id, $CHARTER_WORKSPACE outranks every pointer "
+        f"and $TMUX says a tmux is real; in CI all three are unset — so what this test "
+        f"asserts would be a reading of the developer's terminal rather than of a fixture. "
+        f"Sixteen tests failed exactly this way inside a frame (#519, #521), and one went "
+        f"falsely GREEN (#528). Two ways out:\n"
+        f"  - derive the case from `tests._isolation.PersonaIso`, which declares the whole "
+        f"charter environment unset for the test, the way it already re-derives every "
+        f"config setting from a tmp plane; or\n"
+        f"  - state what this test needs: "
+        f"`mock.patch.dict(os.environ, {{\"{key}\": \"...\"}})` for a value, or "
+        f"`tests._envguard.unset(\"{key}\")` (or `clear=True` on that same call) to say it "
+        f"is UNSET.")
+
+
+class _GuardedEnviron(os._Environ):
+    """`os.environ`, with the session-identity variables refusing an undeclared read.
+
+    A subclass of the real thing rather than a wrapper: `os.getenv`, `subprocess`,
+    `tempfile` and `posixpath.expanduser` all look `os.environ` up on the `os` module at
+    call time, so replacing the object is enough, and inheriting means every behaviour not
+    named below — the `putenv`/`unsetenv` syncing that keeps subprocesses honest included —
+    is CPython's own.
+
+    Only *targeted* reads refuse. Iteration, ``len``, ``copy()`` and so ``dict(os.environ)``
+    are untouched, because `mock.patch.dict` snapshots the whole mapping on entry and
+    `commands_frame._frame_env` builds a child environment out of it: a bulk read that
+    exploded would refuse the very calls that isolate a test. Those bulk reads are safe by
+    construction — the ambient values were removed at install, so what they see is the same
+    on every machine.
+    """
+
+    def __getitem__(self, key):
+        if _active and not _all_unset and key in _LOUD and key not in _declared:
+            raise AmbientEnvRead(_explain(key))
+        return super().__getitem__(key)
+
+    def __setitem__(self, key, value):
+        # Setting a name IS declaring it — including when `patch.dict` restores the
+        # mapping it snapshotted, which is why declarations are not stored as values.
+        if _active:
+            _declared.add(key)
+        super().__setitem__(key, value)
+
+    def __delitem__(self, key):
+        if _active:
+            _declared.add(key)
+        super().__delitem__(key)
+
+    def pop(self, key, *default):
+        """``pop`` and ``del`` state that a name is unset; they never refuse.
+
+        `MutableMapping.pop` is written in terms of ``self[key]``, so without this a test
+        clearing a variable it does not want — ``os.environ.pop("TMUX", None)``, the most
+        direct way there is of saying "not inside a tmux" — would be refused for reading
+        the thing it was in the act of removing.
+        """
+        if _active:
+            _declared.add(key)
+        try:
+            value = os._Environ.__getitem__(self, key)
+        except KeyError:
+            if default:
+                return default[0]
+            raise
+        os._Environ.__delitem__(self, key)
+        return value
+
+    def clear(self):
+        """An emptied environment is a stated one: every guarded name is now unset.
+
+        This is the ``clear=True`` that #528 asks 108 call sites to add, and it must count
+        as a declaration or the recommended fix would trip the guard. `mock.patch.dict`
+        calls this on the way out as well, so the declaration outlives the block — which is
+        harmless: what the block restored is the install-time environment, where every
+        guarded name is already absent on every machine.
+        """
+        global _all_unset
+        if _active:
+            _all_unset = True
+        super().clear()
+
+
+def unset(*names: str) -> None:
+    """Declare *names* unset for the rest of this test.
+
+    For the case that has no value to patch in: a test that needs charter to answer "there
+    is no session" or "this is not a tmux" states it here instead of inheriting it.
+    """
+    _declared.update(names)
+
+
+def unset_all() -> None:
+    """Declare the whole charter environment unset for the rest of this test.
+
+    What `PersonaIso.setUp` calls, and the reason a test deriving from it needs no further
+    thought: it runs as if launched from a shell that had never seen charter — which is the
+    environment CI runs in, and the one every assertion in this suite was written against.
+    A name the test then puts in the environment itself still wins.
+    """
+    global _all_unset
+    _all_unset = True
+
+
+def scrubbed() -> dict[str, str]:
+    """What was removed from the environment at install, for a test that wants it back.
+
+    Nothing in the suite needs this today. It exists so that a test which genuinely has to
+    know what the operator's shell held — a doctor check about the real terminal, say — has
+    somewhere honest to get it, instead of the guard being disabled.
+    """
+    return dict(_SCRUBBED)
+
+
+_SCRUBBED: dict[str, str] = {}
+
+
+def install() -> None:
+    """Scrub the ambient values, replace `os.environ`, and arm the guard per test.
+
+    Called once, at import of the `tests` package — and *before* `charter.config` is first
+    imported, which is why `tests/__init__.py` calls it above the `_planeguard` import.
+    ``$CHARTER_ROOT`` is one of the names removed here, and `charter.config` resolves the
+    plane at ITS import: scrub afterwards and the whole suite would already be pointing at
+    whatever plane the operator's shell pinned.
+    """
+    global _SCRUB_NAMES, _installed
+    if _installed:
+        return
+    _installed = True
+
+    # `charter.session` imports `os` and `re` and nothing else — in particular not
+    # `charter.config` — so asking it for the pane variables here cannot pull the plane
+    # resolution in ahead of the scrub below.
+    _SCRUB_NAMES = _scrubbed_names()
+
+    for key in [k for k in os.environ if _in_namespace(k)]:
+        _SCRUBBED[key] = os.environ[key]
+        del os.environ[key]
+
+    base = os.environ
+    os.environ = _GuardedEnviron(base._data, base.encodekey, base.decodekey,
+                                 base.encodevalue, base.decodevalue)
+
+    original_run = unittest.TestCase.run
+
+    def run(self, result=None):
+        """Arm the guard for the duration of one test.
+
+        The declaration set is saved and restored rather than merely cleared: a handful of
+        tests construct a `TestCase` and run it inside their own body to observe what the
+        harness does, and an inner run that reset the set would leave the outer test
+        undeclared for everything after it.
+        """
+        global _declared, _all_unset, _active, _LOUD
+        if not _LOUD:
+            _LOUD = _loud_names()
+        outer, outer_all, outer_active = _declared, _all_unset, _active
+        _declared, _all_unset, _active = set(), False, True
+        try:
+            return original_run(self, result)
+        finally:
+            _declared, _all_unset, _active = outer, outer_all, outer_active
+
+    run.__module__ = __name__
+    unittest.TestCase.run = run

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -21,6 +21,8 @@ from unittest import mock
 
 from charter import config, instance, persona, root
 
+from . import _envguard
+
 #: Snapshotted so a test can still hand-patch one value; `config.DERIVED` is the source
 #: of truth for WHICH values exist, so a setting added to `config.derive` is isolated the
 #: day it is added rather than the day someone remembers this file.
@@ -41,6 +43,15 @@ class PersonaIso(unittest.TestCase):
         self.enterContext(redirect_stdout(io.StringIO()))
         self.enterContext(redirect_stderr(io.StringIO()))
         self.tmp = Path(tempfile.mkdtemp(prefix="edm-test-"))
+
+        # The environment, on the same terms as the plane below: ONE call, and the guard
+        # is the only thing that knows WHICH names charter reads out of the shell. This
+        # says "no session id, not inside a frame, not inside a tmux" — the answer CI
+        # gives, and the one every assertion here was written against. A test that needs
+        # a different answer states it with `patch.dict(os.environ, …)`, which wins.
+        # Without this, `$CHARTER_SESSION_ID` from the operator's own frame reached
+        # sixteen tests and failed them (#519, #521, #528).
+        _envguard.unset_all()
 
         # ONE call. This used to re-implement all twenty-five derivations line for line,
         # and four of them were missing — so the suite wrote fixture data into the

--- a/tests/test_cmd_harness.py
+++ b/tests/test_cmd_harness.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands_harness
+from tests import _envguard
 
 
 def _run(fn, args) -> tuple[int, str]:
@@ -22,6 +23,12 @@ def _run(fn, args) -> tuple[int, str]:
 
 
 class HarnessList(unittest.TestCase):
+    def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
     def test_it_names_every_registered_harness_and_its_ceilings(self):
         rc, text = _run(commands_harness.cmd_harness_list, SimpleNamespace())
         self.assertEqual(rc, 0)

--- a/tests/test_control_plane_schema.py
+++ b/tests/test_control_plane_schema.py
@@ -11,10 +11,16 @@ from contextlib import redirect_stderr
 from pathlib import Path
 
 from charter import doctor, instance
+from tests import _envguard
 
 
 class SchemaIso(unittest.TestCase):
     def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         self.root = Path(tempfile.mkdtemp(prefix="charter-schema-")).resolve()
         (self.root / "charter.toml").write_text(f"schema = {instance.SCHEMA}\n")
 

--- a/tests/test_doctor_forge_visibility.py
+++ b/tests/test_doctor_forge_visibility.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from unittest import mock
 
 from charter import config, doctor
+from tests import _envguard
 from tests._isolation import pin_update_channel
 
 _ENV = {"GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"}
@@ -166,6 +167,11 @@ class TestDoctorChecksDeclaredForgesOnly(unittest.TestCase):
     none are declared (a fresh `charter init`, or a legacy single-forge control plane)."""
 
     def setUp(self):
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         self.root = Path(tempfile.mkdtemp(prefix="edm-doctor-forgecli-"))
         self.addCleanup(lambda: shutil.rmtree(self.root, ignore_errors=True))
         self._orig = (config.CONFIG_ERROR, config.HAS_CONTROL_PLANE, config.ROOT)

--- a/tests/test_doctor_mcp_launchers.py
+++ b/tests/test_doctor_mcp_launchers.py
@@ -30,6 +30,7 @@ import unittest
 from pathlib import Path
 
 from charter import doctor
+from tests import _envguard
 from tests._isolation import PersonaIso, pin_update_channel
 
 
@@ -186,6 +187,11 @@ class TestProjectScopedServersAreChecked(LauncherCase):
 
 class TestItIsWiredIn(unittest.TestCase):
     def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         # `run_all` reaches `check_plugin_freshness`, and so the channel (#459).
         pin_update_channel(self)
 

--- a/tests/test_doctor_personas.py
+++ b/tests/test_doctor_personas.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import unittest
 
 from charter import config, doctor, persona
+from tests import _envguard
 from tests._isolation import PersonaIso, pin_update_channel
 
 
@@ -136,6 +137,11 @@ class RunTakesATimeoutAndDoctorStreams(unittest.TestCase):
     `util.run` entirely just to pass their own timeout literal."""
 
     def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         # The two cases that drive the real `iter_all`/`run_all` reach
         # `check_plugin_freshness`, and so the channel (#459).
         pin_update_channel(self)

--- a/tests/test_frame_config.py
+++ b/tests/test_frame_config.py
@@ -19,6 +19,7 @@ import unittest
 from unittest import mock
 
 from charter import instance
+from tests import _envguard
 
 #: This repo's own committed `charter.toml` — see
 #: :class:`CharterOwnPlaneDrawsEveryEdgeItShips`. Read off disk rather than through
@@ -206,6 +207,11 @@ class HotkeyIsNotAFreeString(unittest.TestCase):
     `slots` is set-filtered here, `mouse` is a bool here, the three numbers are
     int-checked here — this was the fifth input arriving through a fifth door.
     """
+    def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
 
     def test_a_newline_bearing_hotkey_degrades_to_the_default(self):
         """The exploit itself, as an assertion. Fails if `_HOTKEY_RE` is deleted or

--- a/tests/test_frame_doctor.py
+++ b/tests/test_frame_doctor.py
@@ -15,9 +15,16 @@ from unittest import mock
 
 from charter import config, doctor
 from charter.frame import slots
+from tests import _envguard
 
 
 class FrameRow(unittest.TestCase):
+    def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
     def test_a_present_tmux_reports_its_version(self):
         with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)):
             r = doctor.check_frame()

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -41,6 +41,7 @@ from unittest import mock
 from tests._isolation import PersonaIso
 from charter import commands_frame, config, instance, statusline, util
 from charter.frame import gather, layout, menu, slots, state, tmuxctl
+from tests import _envguard
 
 #: The plane this test PROCESS was started in, captured at IMPORT — before any `setUp`
 #: has had a chance to repoint `config`, so it is unavoidably the developer's REAL
@@ -1054,6 +1055,11 @@ class Probe(unittest.TestCase):
     below `tmuxctl.FLOOR` (warn, still runs), not a stricter refusal, is the whole point:
     a probe that refused there would report a frame this same launcher goes on to draw.
     """
+    def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
 
     def test_present_and_at_the_floor_exits_zero(self):
         with mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \

--- a/tests/test_global_shim_is_kept_current.py
+++ b/tests/test_global_shim_is_kept_current.py
@@ -20,10 +20,16 @@ from unittest import mock
 
 from charter import __version__, doctor
 from charter.harness import opencode, registry
+from tests import _envguard
 
 
 class InstallingKeepsItCurrent(unittest.TestCase):
     def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         self.home = Path(tempfile.mkdtemp(prefix="charter-gsr-"))
         self.addCleanup(lambda: shutil.rmtree(self.home, True))
         self.enterContext(mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": str(self.home)}))
@@ -53,6 +59,11 @@ class InstallingKeepsItCurrent(unittest.TestCase):
 
 class DoctorNamesAStalePlugin(unittest.TestCase):
     def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         self.home = Path(tempfile.mkdtemp(prefix="charter-gsr-d-"))
         self.addCleanup(lambda: shutil.rmtree(self.home, True))
         self.enterContext(mock.patch.dict(os.environ,

--- a/tests/test_harness_registry.py
+++ b/tests/test_harness_registry.py
@@ -17,6 +17,7 @@ from unittest import mock
 
 from charter import commands, config
 from charter.harness import base, registry
+from tests import _envguard
 
 
 class Registry(unittest.TestCase):
@@ -41,6 +42,12 @@ class Registry(unittest.TestCase):
 
 
 class InitIsHarnessAgnostic(unittest.TestCase):
+    def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
     def test_a_newly_registered_harness_is_wired_without_touching_init(self):
         """The Codex test. `cmd_init` must not name a harness; it must ask the registry."""
 

--- a/tests/test_hooks_need_no_async.py
+++ b/tests/test_hooks_need_no_async.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from unittest import mock
 
 from charter import util
+from tests import _envguard
 
 MANIFEST = Path(__file__).resolve().parents[1] / "hooks" / "hooks.json"
 
@@ -88,6 +89,11 @@ class TheCommandsHonourTheFlag(unittest.TestCase):
     manifest test still passed, because it only reads JSON. What the hook actually calls
     has to be driven.
     """
+    def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
 
     def _drive(self, module_name: str, func_name: str, argv: list[str]):
         import importlib

--- a/tests/test_inflight_dispatch.py
+++ b/tests/test_inflight_dispatch.py
@@ -30,6 +30,7 @@ from unittest import mock
 
 from charter import config, hooks, inflight, tui
 
+from tests import _envguard
 from tests._isolation import PersonaIso
 
 
@@ -208,6 +209,11 @@ class PresumedDead(unittest.TestCase):
 
 class DispatchNudge(unittest.TestCase):
     def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         self._td = TemporaryDirectory()
         root = Path(self._td.name)
         # `config.use`, not three named attributes. The nudge these cases drive calls

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,10 +12,16 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands, config, instance
+from tests import _envguard
 
 
 class InitIso(unittest.TestCase):
     def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         self.root = Path(tempfile.mkdtemp(prefix="charter-init-")).resolve()
 
     def _init(self, **kw):

--- a/tests/test_init_first_clone.py
+++ b/tests/test_init_first_clone.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from charter import cli, commands, config, gitpolicy, instance, workspace
+from tests import _envguard
 from tests._isolation import PersonaIso
 
 
@@ -322,6 +323,11 @@ class TestThePlaneIsTheSameEitherWay(unittest.TestCase):
     """The acceptance criterion the whole design turns on: being inside a git repo changes
     what init OFFERS, never what it BUILDS. Two identical repo-planes, one accepting and
     one declining, must produce the same control plane."""
+    def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
 
     def _plane(self, accept: bool) -> Path:
         tmp = Path(tempfile.mkdtemp(prefix="charter-either-way-")).resolve()

--- a/tests/test_init_front_door.py
+++ b/tests/test_init_front_door.py
@@ -19,10 +19,16 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands, config, instance
+from tests import _envguard
 
 
 class InitFrontDoorIso(unittest.TestCase):
     def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         self.root = Path(tempfile.mkdtemp(prefix="charter-fd-")).resolve()
 
     def _init(self, **kw):

--- a/tests/test_init_harness_wiring.py
+++ b/tests/test_init_harness_wiring.py
@@ -17,10 +17,16 @@ from unittest import mock
 
 from charter import commands, config
 from charter.harness import opencode
+from tests import _envguard
 
 
 class InitWiresBothHarnesses(unittest.TestCase):
     def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         self.root = Path(tempfile.mkdtemp(prefix="charter-init-h-")).resolve()
         self.addCleanup(lambda: __import__("shutil").rmtree(self.root, True))
         import os

--- a/tests/test_memory_index_health.py
+++ b/tests/test_memory_index_health.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import unittest
 
 from charter import doctor, memstore, persona
+from tests import _envguard
 from tests._isolation import PersonaIso, pin_update_channel
 
 
@@ -88,6 +89,11 @@ class DoctorCheck(unittest.TestCase):
     """
 
     def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         # `run_all` reaches `check_plugin_freshness`, and so the channel (#459).
         pin_update_channel(self)
 

--- a/tests/test_no_test_reads_the_operators_shell.py
+++ b/tests/test_no_test_reads_the_operators_shell.py
@@ -26,7 +26,7 @@ import sys
 import unittest
 from unittest import mock
 
-from charter import commands_frame, session, workspace
+from charter import commands_frame, legacyenv, session, workspace
 from tests import _envguard
 from tests._isolation import PersonaIso
 
@@ -62,6 +62,42 @@ class WhatIsGuarded(unittest.TestCase):
         `_PANE_ID_VARS`; `$TMUX` has no constant to derive it from and is spelled once."""
         self.assertIn("TMUX", _envguard._LOUD)
         self.assertIn("TMUX_PANE", _envguard._LOUD)
+
+    def test_every_name_charter_was_renamed_from_is_scrubbed(self):
+        """charter's OWN former namespace, which the first version of this guard missed.
+
+        It missed them the way lists get missed: ``$EDM_HOME``, ``$EDM_WORKSPACE`` and
+        ``$EDM_PERSONA`` are outside ``CHARTER_``/``CLAUDE`` by spelling, so nothing in the
+        property covered them — while `legacyenv.warn` reads all three at import of
+        `charter.config` and prints a 133-column line to stderr for each one still set, in
+        this process and in every subprocess this suite spawns. ``$EDM_WORKSPACE`` alone
+        made `test_cli_smoke` fail on the width of `charter init`'s output and
+        `test_a_deny_survives_a_broken_channel` fail on an exit status, on the machine of
+        the person most likely to still have it exported, and neither failed in CI (#540).
+
+        Scrubbed but deliberately NOT loud. Tier two is for names where "unset" is a claim
+        about the world the test runs in — whose session is this, is this a real tmux,
+        which workspace outranks every pointer. charter never honors these VALUES at all;
+        what leaked was the banner, not an answer, so removing the name is the whole fix
+        and a refusal would be noise on a read that decides nothing.
+        """
+        for name in legacyenv.NAMES:
+            with self.subTest(variable=name):
+                self.assertTrue(
+                    _envguard._in_namespace(name),
+                    f"${name} is in `charter.legacyenv.RENAMES`, so `legacyenv.warn` "
+                    f"prints a 133-column stderr banner for it at import of "
+                    f"`charter.config` — here and in every subprocess this suite spawns — "
+                    f"whenever the operator has it exported. Unscrubbed, this suite "
+                    f"answers differently on their machine than in CI (#540). Two ways "
+                    f"out:\n"
+                    f"  - derive it: `tests._envguard._scrubbed_names` asks "
+                    f"`legacyenv.NAMES` for exactly this set, so a name that reached "
+                    f"`RENAMES` from somewhere else needs its source asked for there too; "
+                    f"or\n"
+                    f"  - retire it: if charter no longer warns about ${name}, drop its "
+                    f"pair from `legacyenv.RENAMES` — the warning and the scrub are two "
+                    f"halves of one fact and must not disagree.")
 
     def test_every_loud_name_is_also_scrubbed(self):
         """Refusing a read the operator's value could still reach is half a guard: the
@@ -181,12 +217,17 @@ class WhatIsScrubbed(unittest.TestCase):
         """The half `_planeguard` says it cannot see. A spawned `charter` resolves its own
         plane from its own environment, so the scrub has to be a real `unsetenv` and not a
         Python-side illusion — otherwise a subprocess in this suite keys state by the
-        operator's live frame id."""
-        out = subprocess.run(
-            [sys.executable, "-c",
-             "import os;print(' '.join(k for k in os.environ "
-             "if k.startswith(('CHARTER_', 'CLAUDE')) or k in ('TMUX', 'TMUX_PANE')))"],
-            capture_output=True, text=True, check=True).stdout.split()
+        operator's live frame id.
+
+        The child is asked about the whole guarded set rather than a hand-copied corner of
+        it: the probe used to spell four names, and the three it did not spell were
+        precisely the ones that reached `charter init`'s stderr through a subprocess and
+        cost two failures (#540)."""
+        probe = (f"import os;print(' '.join(k for k in os.environ "
+                 f"if k.startswith({_envguard._PREFIXES!r}) "
+                 f"or k in {tuple(sorted(_envguard._SCRUB_NAMES))!r}))")
+        out = subprocess.run([sys.executable, "-c", probe],
+                             capture_output=True, text=True, check=True).stdout.split()
         self.assertEqual(out, [], f"{out} reached a child process")
 
     def test_an_ambient_session_reaching_a_fresh_suite_is_removed_before_charter_loads(self):
@@ -201,9 +242,15 @@ class WhatIsScrubbed(unittest.TestCase):
 
         A child rather than an in-process check because the scrub runs once, at import of
         the `tests` package, and by the time any test executes it has long since happened.
+
+        ``$EDM_WORKSPACE`` is planted alongside them because it is the one that got away:
+        every other name here was already gone when this case was written, and that one
+        walked straight through the property into `charter init`'s stderr (#540). Planting
+        it is what makes this case fail on the tree that had the hole.
         """
         planted = {"CHARTER_SESSION_ID": "ambient-sess", "CHARTER_WORKSPACE": "ambient-ws",
-                   "TMUX": "/tmp/tmux-501/default,1,0", "TMUX_PANE": "%9"}
+                   "TMUX": "/tmp/tmux-501/default,1,0", "TMUX_PANE": "%9",
+                   "EDM_WORKSPACE": "legacy-ws"}
         probe = ("import json, os, tests;"
                  "from tests import _envguard;"
                  "print(json.dumps({"

--- a/tests/test_no_test_reads_the_operators_shell.py
+++ b/tests/test_no_test_reads_the_operators_shell.py
@@ -1,0 +1,327 @@
+"""The third tripwire: the shell the suite was launched from is not a fixture either.
+
+`tests/_planeguard.py` refuses a write into the operator's real `.charter/` (#402) and a
+read of the setting their own `charter.toml` declares (#459). This is the same move for
+what their *shell* declares. Run the suite inside a live charter frame and sixteen tests
+failed that fail nowhere else (#519, #521); on #525 the same leak went the other way and a
+mutation that dies with a clean environment **survived** under an ambient
+``$CHARTER_WORKSPACE`` (#528). One class of defect, both signs.
+
+**Every case here is a control.** A guard nobody has watched fail is a guard nobody knows
+works, so `TheGuardIsNotBlind` makes the refusal happen for real and
+`EveryWayOutOfTheRefusalWorks` exercises each documented escape — because a tripwire with
+no usable exit is deleted by whoever hits it next. `WhatIsScrubbed` pins the other half,
+which is silent by design: the values are gone from this process and from anything it
+spawns, so a bulk `dict(os.environ)` and a subprocess give the same answer on every
+machine without anybody having to declare anything.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+from charter import commands_frame, session, workspace
+from tests import _envguard
+from tests._isolation import PersonaIso
+
+
+class WhatIsGuarded(unittest.TestCase):
+    """The loud set is DERIVED. These cases are what stops it drifting into a spelling."""
+
+    def test_every_variable_a_frame_exports_is_guarded(self):
+        """`_FRAME_IDENTITY` is production's own answer to "which variables must be THIS
+        session's rather than the launcher's", and its docstring commits the next such
+        variable to that list. Asking it is what makes a variable invented next month
+        guarded on the commit that invents it, instead of the commit that debugs it."""
+        for name in commands_frame._FRAME_IDENTITY:
+            with self.subTest(variable=name):
+                self.assertIn(name, _envguard._LOUD)
+
+    def test_every_variable_a_pane_is_identified_by_is_guarded(self):
+        """`session.terminal` walks `_PANE_ID_VARS`; `_WINDOW_ID_VARS` is the chain it
+        deliberately does not walk, guarded anyway because that decision can change."""
+        for name in session._PANE_ID_VARS + session._WINDOW_ID_VARS:
+            with self.subTest(variable=name):
+                self.assertIn(name, _envguard._LOUD)
+
+    def test_the_two_session_id_rungs_below_the_frame_are_guarded(self):
+        """`session.current` falls from `$CHARTER_SESSION_ID` to
+        `$CLAUDE_CODE_SESSION_ID`. A guard that covered only the first would leave the
+        second reachable, which is the rung `test_workspace_lock` actually reads."""
+        self.assertIn("CHARTER_SESSION_ID", _envguard._LOUD)
+        self.assertIn("CLAUDE_CODE_SESSION_ID", _envguard._LOUD)
+
+    def test_tmux_itself_is_guarded_not_only_its_pane(self):
+        """The pair that decides "am I inside a tmux". `$TMUX_PANE` arrives from
+        `_PANE_ID_VARS`; `$TMUX` has no constant to derive it from and is spelled once."""
+        self.assertIn("TMUX", _envguard._LOUD)
+        self.assertIn("TMUX_PANE", _envguard._LOUD)
+
+    def test_every_loud_name_is_also_scrubbed(self):
+        """Refusing a read the operator's value could still reach is half a guard: the
+        loud set has to be a SUBSET of what install removed, or a name could be refused
+        in-process and inherited by a subprocess at the same time."""
+        for name in _envguard._LOUD:
+            with self.subTest(variable=name):
+                self.assertTrue(
+                    _envguard._in_namespace(name),
+                    f"${name} is refused but not scrubbed, so a subprocess would still "
+                    f"see the operator's value")
+
+    def test_the_refusal_is_not_an_exception(self):
+        """`root.find_root` swallows `OSError`, `config.derive` catches everything, and
+        `statusline` wraps whole panels in `except Exception` so a broken plane cannot
+        cost the status line. A tripwire any of those could catch would be reported as
+        "no session" and the test would pass, wrongly."""
+        self.assertTrue(issubclass(_envguard.AmbientEnvRead, BaseException))
+        self.assertFalse(issubclass(_envguard.AmbientEnvRead, Exception))
+
+    def test_the_guard_is_armed_by_wrapping_the_test_runner(self):
+        """Structural, not per-test: `unittest.TestCase.run` is what arms it, so no test
+        can opt out by forgetting a base class — the property `_planeguard` gets from
+        wrapping `open` and this gets from wrapping the one call every test goes through."""
+        self.assertEqual(getattr(unittest.TestCase.run, "__module__", None),
+                         "tests._envguard")
+
+    def test_os_environ_is_the_guarded_mapping(self):
+        """`os.getenv`, `subprocess` and `posixpath.expanduser` all look this up on the
+        `os` module at call time, so replacing the object is what covers every reader."""
+        self.assertIsInstance(os.environ, _envguard._GuardedEnviron)
+
+
+class TheGuardIsNotBlind(unittest.TestCase):
+    """A plain `TestCase` that declares nothing — the state every case below is about."""
+
+    def test_asking_who_this_session_is_gets_refused(self):
+        with self.assertRaises(_envguard.AmbientEnvRead):
+            session.current()
+
+    def test_resolving_a_workspace_gets_refused(self):
+        """`workspace.resolve`'s top rung, and the one that produced #528's false green:
+        both sides of an assertion collapsed to the ambient pin and the test agreed with
+        itself."""
+        with self.assertRaises(_envguard.AmbientEnvRead):
+            workspace.resolve()
+
+    def test_the_message_names_the_test_the_variable_and_both_ways_out(self):
+        """`unittest` puts the test's name in the failure header; the message repeats it
+        so an excerpt quoted into an issue or a CI log still says which test it was — and
+        carries both exits, because a refusal with no remedy gets deleted."""
+        with self.assertRaises(_envguard.AmbientEnvRead) as caught:
+            session.current()
+        message = str(caught.exception)
+        self.assertIn("test_the_message_names_the_test_the_variable_and_both_ways_out",
+                      message)
+        self.assertIn("CHARTER_SESSION_ID", message)
+        self.assertIn("PersonaIso", message)
+        self.assertIn("patch.dict", message)
+        self.assertIn("unset", message)
+
+    def test_every_spelling_of_a_targeted_read_is_closed(self):
+        """`session.current` uses `.get`, but the next reader may not, and
+        `MutableMapping` routes several of these through `__getitem__` only if nothing
+        overrides them. Probed rather than reasoned about."""
+        for label, read in (("[]", lambda: os.environ["CHARTER_SESSION_ID"]),
+                            ("get", lambda: os.environ.get("CHARTER_SESSION_ID")),
+                            ("get w/ default",
+                             lambda: os.environ.get("CHARTER_SESSION_ID", "")),
+                            ("in", lambda: "CHARTER_SESSION_ID" in os.environ),
+                            ("getenv", lambda: os.getenv("CHARTER_SESSION_ID")),
+                            ("setdefault",
+                             lambda: os.environ.setdefault("CHARTER_SESSION_ID", "x"))):
+            with self.subTest(read=label):
+                with self.assertRaises(_envguard.AmbientEnvRead):
+                    read()
+
+    def test_a_refused_setdefault_did_not_set_anything(self):
+        """Refused at the front door, the way `_planeguard` refuses `rmtree` before it
+        scans: a tripwire that raised after the write would leave the variable set for
+        every test that runs after this one."""
+        with self.assertRaises(_envguard.AmbientEnvRead):
+            os.environ.setdefault("CHARTER_SESSION_ID", "tampered")
+        self.assertNotIn("CHARTER_SESSION_ID", os.environ.copy())
+
+    def test_a_variable_outside_the_namespace_reads_normally(self):
+        """The guard is not "the environment is unreadable". `$PATH` still answers, and
+        it has to: `subprocess`, `tempfile` and every `git` call in the suite need it."""
+        self.assertTrue(os.environ["PATH"])
+
+    def test_bulk_reads_are_deliberately_not_refused(self):
+        """`mock.patch.dict` snapshots the whole mapping on entry and
+        `commands_frame._frame_env` builds a child environment out of it. A bulk read that
+        exploded would refuse the very calls that isolate a test. Safe because the values
+        are GONE, which the assertions here are the proof of."""
+        for label, read in (("dict()", lambda: dict(os.environ)),
+                            ("copy", lambda: os.environ.copy()),
+                            ("list", lambda: list(os.environ)),
+                            ("len", lambda: len(os.environ))):
+            with self.subTest(read=label):
+                read()
+        self.assertNotIn("CHARTER_SESSION_ID", dict(os.environ))
+        self.assertNotIn("TMUX", dict(os.environ))
+
+
+class WhatIsScrubbed(unittest.TestCase):
+    """The silent half. Nothing here declares anything, because there is nothing to see."""
+
+    def test_no_charter_variable_survived_into_this_process(self):
+        """Install removes them, so the answer is the same in a frame and in CI — which is
+        what makes the bulk reads above safe and the 108 `patch.dict` calls that omit
+        `clear=True` harmless for the names that mattered (#528)."""
+        leaked = [k for k in os.environ.copy() if _envguard._in_namespace(k)]
+        self.assertEqual(leaked, [], f"{leaked} reached the suite from the shell")
+
+    def test_a_subprocess_does_not_inherit_the_operators_session(self):
+        """The half `_planeguard` says it cannot see. A spawned `charter` resolves its own
+        plane from its own environment, so the scrub has to be a real `unsetenv` and not a
+        Python-side illusion — otherwise a subprocess in this suite keys state by the
+        operator's live frame id."""
+        out = subprocess.run(
+            [sys.executable, "-c",
+             "import os;print(' '.join(k for k in os.environ "
+             "if k.startswith(('CHARTER_', 'CLAUDE')) or k in ('TMUX', 'TMUX_PANE')))"],
+            capture_output=True, text=True, check=True).stdout.split()
+        self.assertEqual(out, [], f"{out} reached a child process")
+
+    def test_an_ambient_session_reaching_a_fresh_suite_is_removed_before_charter_loads(self):
+        """The two cases above cannot fail on a machine that had nothing to leak.
+
+        That is the "probe whose evidence cannot distinguish 'clean' from 'never ran'"
+        shape, and on a CI runner — which exports none of these — it describes both of
+        them exactly. So this one MANUFACTURES the operator's shell in a child process and
+        watches the guard take it apart: a session id, a pinned workspace and a live tmux
+        go in, and what comes back is what the suite could still see. It fails on every
+        machine, including the one where the other two are vacuously true.
+
+        A child rather than an in-process check because the scrub runs once, at import of
+        the `tests` package, and by the time any test executes it has long since happened.
+        """
+        planted = {"CHARTER_SESSION_ID": "ambient-sess", "CHARTER_WORKSPACE": "ambient-ws",
+                   "TMUX": "/tmp/tmux-501/default,1,0", "TMUX_PANE": "%9"}
+        probe = ("import json, os, tests;"
+                 "from tests import _envguard;"
+                 "print(json.dumps({"
+                 "'left': sorted(k for k in os.environ.copy() "
+                 "if _envguard._in_namespace(k)),"
+                 "'recovered': sorted(_envguard.scrubbed())}))")
+        out = subprocess.run(
+            [sys.executable, "-c", probe],
+            env={**os.environ.copy(), **planted},
+            cwd=str(pathlib.Path(__file__).resolve().parent.parent),
+            capture_output=True, text=True, check=True)
+        got = json.loads(out.stdout)
+        self.assertEqual(got["left"], [],
+                         f"{got['left']} survived the scrub into a suite launched from a "
+                         f"live frame")
+        for name in planted:
+            with self.subTest(variable=name):
+                self.assertIn(name, got["recovered"])
+
+    def test_what_was_removed_is_still_available_to_anything_that_needs_it(self):
+        """Scrubbed, not destroyed. A test that genuinely has to know what the operator's
+        shell held has an honest place to get it, so nobody's answer is to disable the
+        guard. Asserted as a shape rather than a value: on a CI runner there is nothing to
+        recover and the dict is empty, which is correct there and must stay green."""
+        self.assertIsInstance(_envguard.scrubbed(), dict)
+        for name in _envguard.scrubbed():
+            with self.subTest(variable=name):
+                self.assertTrue(_envguard._in_namespace(name))
+
+
+class EveryWayOutOfTheRefusalWorks(unittest.TestCase):
+    """The other direction: each documented escape, exercised rather than described."""
+
+    def test_naming_the_variable_unset_makes_the_read_answer(self):
+        _envguard.unset("CHARTER_SESSION_ID", "CLAUDE_CODE_SESSION_ID")
+        self.assertIsNone(session.current())
+
+    def test_declaring_the_whole_environment_unset_makes_the_read_answer(self):
+        _envguard.unset_all()
+        self.assertIsNone(session.current())
+
+    def test_patching_a_value_in_makes_the_read_return_it(self):
+        """Isolation is not "there is never a session" — it is "the session is what the
+        FIXTURE says". A case about being inside a frame writes it and gets it back."""
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "sess-abc"}):
+            self.assertEqual(session.current(), "sess-abc")
+
+    def test_clearing_the_environment_is_itself_a_declaration(self):
+        """`clear=True` is the fix #528 asks 108 call sites to add. If it did not count as
+        a statement, the recommended remedy would trip the guard it was written for."""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(session.current())
+
+    def test_popping_a_variable_says_it_is_unset_without_reading_it(self):
+        """`os.environ.pop("TMUX", None)` is the most direct way there is of saying "not
+        inside a tmux", and `MutableMapping.pop` is written in terms of `self[key]` — so
+        without an override the guard would refuse the thing it was being told."""
+        os.environ.pop("TMUX", None)
+        self.assertNotIn("TMUX", os.environ)
+
+    def test_a_patched_value_survives_an_unrelated_patch_dict_in_the_same_test(self):
+        """`mock.patch.dict` restores by CLEARING the whole mapping and refilling it, which
+        is why a declaration is not stored as a value. If it were, the block below would
+        destroy the one above it and the rest of the test would refuse."""
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "sess-abc"}):
+            with mock.patch.dict(os.environ, {"SOMETHING_ELSE": "1"}):
+                pass
+            self.assertEqual(session.current(), "sess-abc")
+
+
+class IsolationIsTheOtherWayOut(PersonaIso):
+    def test_persona_iso_answers_as_a_shell_that_never_saw_charter(self):
+        self.assertIsNone(session.current())
+
+    def test_a_persona_iso_fixture_can_still_declare_a_session(self):
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "sess-abc"}):
+            self.assertEqual(session.current(), "sess-abc")
+
+
+class TheDeclarationDoesNotOutliveItsTest(unittest.TestCase):
+    """The failure mode a suite-wide flag has, and this one must not.
+
+    `PersonaIso` already carried one of these: a subclass named its cleanup `_restore`, the
+    base's `addCleanup(self._restore)` bound the SUBCLASS's method, and 1186 tests ran
+    afterwards against a leaked plane that looked exactly like a passing run. A declaration
+    that leaked the same way would leave every later test reading the operator's shell
+    while reporting green — the guard silently gone rather than loudly wrong.
+    """
+
+    def test_a_completed_isolated_case_leaves_the_guard_armed(self):
+        case = IsolationIsTheOtherWayOut(
+            "test_persona_iso_answers_as_a_shell_that_never_saw_charter")
+        result = unittest.TestResult()
+        case.run(result)
+        self.assertTrue(result.wasSuccessful(), result.errors or result.failures)
+        with self.assertRaises(_envguard.AmbientEnvRead):
+            session.current()
+
+    def test_a_completed_declaring_case_leaves_the_guard_armed(self):
+        case = EveryWayOutOfTheRefusalWorks(
+            "test_declaring_the_whole_environment_unset_makes_the_read_answer")
+        result = unittest.TestResult()
+        case.run(result)
+        self.assertTrue(result.wasSuccessful(), result.errors or result.failures)
+        with self.assertRaises(_envguard.AmbientEnvRead):
+            session.current()
+
+    def test_this_tests_own_declaration_survives_running_an_inner_case(self):
+        """The save/restore the inner run needs, from the outer side. A plain reset would
+        disarm this test's own statement halfway through, which is the more confusing
+        direction: the failure would land on a line that has nothing to do with the cause.
+        """
+        _envguard.unset_all()
+        case = IsolationIsTheOtherWayOut(
+            "test_persona_iso_answers_as_a_shell_that_never_saw_charter")
+        case.run(unittest.TestResult())
+        self.assertIsNone(session.current())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_opencode_is_installed_once.py
+++ b/tests/test_opencode_is_installed_once.py
@@ -24,10 +24,16 @@ from pathlib import Path
 from unittest import mock
 
 from charter.harness import opencode, registry
+from tests import _envguard
 
 
 class WhereItInstalls(unittest.TestCase):
     def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         self.home = Path(tempfile.mkdtemp(prefix="charter-ocglobal-"))
         self.addCleanup(lambda: shutil.rmtree(self.home, True))
         self.env = mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": str(self.home)})

--- a/tests/test_opencode_plugin_realm.py
+++ b/tests/test_opencode_plugin_realm.py
@@ -43,6 +43,7 @@ from unittest import mock
 
 from charter import __version__, commands, config, doctor, hooks
 from charter.harness import opencode, registry
+from tests import _envguard
 from tests._isolation import PersonaIso, run_hook
 
 _RUNTIME = shutil.which("bun") or shutil.which("node")
@@ -57,6 +58,11 @@ class _Realm(unittest.TestCase):
     """A temp ``$XDG_CONFIG_HOME`` with charter's plugin installed into it."""
 
     def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         self.home = Path(tempfile.mkdtemp(prefix="charter-realm-")).resolve()
         self.addCleanup(lambda: shutil.rmtree(self.home, True))
         self.enterContext(mock.patch.dict(os.environ,

--- a/tests/test_persona_memory_sync.py
+++ b/tests/test_persona_memory_sync.py
@@ -7,6 +7,7 @@ import unittest
 from pathlib import Path
 
 from charter import config, persona, commands_persona
+from tests import _envguard
 from tests._isolation import PersonaIso
 
 _KEYS = ("ROOT", "PERSONAS_DIR", "STATE_DIR", "PERSONA_STATE_DIR", "ACTIVE_PERSONA_FILE")
@@ -24,6 +25,11 @@ class _Args:
 
 class TestMemorySync(unittest.TestCase):
     def setUp(self):
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         self.tmp = Path(tempfile.mkdtemp(prefix="edm-memsync-"))
         _git(self.tmp, "init", "-q")
         _git(self.tmp, "config", "user.email", "t@t")

--- a/tests/test_plane_write_guard.py
+++ b/tests/test_plane_write_guard.py
@@ -20,11 +20,17 @@ from pathlib import Path
 from unittest import mock
 
 from charter import config, root
-from tests import _planeguard
+from tests import _envguard, _planeguard
 
 
 class WhatIsGuarded(unittest.TestCase):
     """The two facts that decide whether the guard is pointed at anything at all."""
+
+    def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
 
     def test_the_guarded_directory_is_this_machines_own_plane_state(self):
         """Installed against the plane the test PROCESS resolved, not some later one.

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -11,6 +11,7 @@ import unittest
 from pathlib import Path
 
 from charter import __version__, hooks
+from tests import _envguard
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -292,6 +293,11 @@ class TestSkewReachesTheUser(unittest.TestCase):
     # through `workspaces/` (0.37.0) is the developer's own control plane. A test must not
     # be able to touch it; `config.use` is the seam the rest of the suite already uses.
     def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         import tempfile
         from charter import config as _config
         self._tmp = tempfile.mkdtemp(prefix="charter-skew-")

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -11,10 +11,16 @@ from pathlib import Path
 from unittest import mock
 
 from charter import root
+from tests import _envguard
 
 
 class RootIso(unittest.TestCase):
     def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         self.tmp = Path(tempfile.mkdtemp(prefix="charter-root-")).resolve()
         self.plane = self.tmp / "my-control-plane"
         (self.plane / "deep" / "nested").mkdir(parents=True)

--- a/tests/test_session_identity.py
+++ b/tests/test_session_identity.py
@@ -16,10 +16,17 @@ import unittest
 from unittest import mock
 
 from charter import config, persona, session, workspace
+from tests import _envguard
 from tests._isolation import PersonaIso
 
 
 class AbsenceIsRepresentable(unittest.TestCase):
+    def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
     def test_current_is_none_when_there_is_no_session(self):
         with mock.patch.dict(os.environ, {}, clear=True):
             self.assertIsNone(session.current())

--- a/tests/test_statusline_crash_guard.py
+++ b/tests/test_statusline_crash_guard.py
@@ -18,10 +18,16 @@ from pathlib import Path
 from unittest import mock
 
 from charter import statusline
+from tests import _envguard
 
 
 class RenderNeverCrashesCase(unittest.TestCase):
     def setUp(self):
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         from charter import config
         self.tmp = Path(tempfile.mkdtemp(prefix="edm-renderguard-"))
         self._orig = config.SESSIONS_DIR

--- a/tests/test_statusline_gauge.py
+++ b/tests/test_statusline_gauge.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from unittest import mock
 
 from charter import config, statusline
+from tests import _envguard
 from tests._isolation import PersonaIso, isolate_state_dir, pin_update_channel
 
 
@@ -35,6 +36,11 @@ def _payload(pct=None, read=None, write=None, usage=True):
 
 class ContextGaugeCase(unittest.TestCase):
     def setUp(self):
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         isolate_state_dir(self)
         # The render path brands the last line, and `_brand` renders the channel chip.
         # This case runs against the real plane on purpose; the chip is not what it is

--- a/tests/test_statusline_session_block.py
+++ b/tests/test_statusline_session_block.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from charter import config, statusline, update
+from tests import _envguard
 from tests._isolation import pin_update_channel
 
 
@@ -82,6 +83,11 @@ class Silence(unittest.TestCase):
 
 class NeverBreaksTheStatusLine(unittest.TestCase):
     def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         # render() reaches _brand() -> update.maybe_spawn(), which forks a real
         # network child. A suite that quietly reaches the internet is not hermetic.
         self._spawn = update.maybe_spawn

--- a/tests/test_statusline_watch.py
+++ b/tests/test_statusline_watch.py
@@ -16,6 +16,7 @@ from contextlib import redirect_stdout
 from unittest import mock
 
 from charter import statusline
+from tests import _envguard
 
 
 class Watch(unittest.TestCase):
@@ -70,6 +71,12 @@ class Watch(unittest.TestCase):
 
 
 class WatchIsReachableFromTheCli(unittest.TestCase):
+    def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
     def test_the_flag_routes_to_the_loop(self):
         with mock.patch.object(statusline, "watch", return_value=0) as w:
             self.assertEqual(statusline.main(["--watch"]), 0)

--- a/tests/test_the_suite_cannot_touch_real_config.py
+++ b/tests/test_the_suite_cannot_touch_real_config.py
@@ -14,9 +14,16 @@ import unittest
 from pathlib import Path
 
 from charter.harness import codex, opencode, registry
+from tests import _envguard
 
 
 class ConfigDirsArePointedSomewhereDisposable(unittest.TestCase):
+    def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
     def test_opencodes_config_dir_is_not_the_developers(self):
         self.assertNotEqual(opencode.global_dir(), Path.home() / ".config" / "opencode")
         self.assertTrue(str(opencode.global_dir()).startswith(tempfile.gettempdir()),

--- a/tests/test_workspace_lock.py
+++ b/tests/test_workspace_lock.py
@@ -21,12 +21,18 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from charter import config, hooks, workspace
+from tests import _envguard
 
 
 class WorkspaceLockBase(unittest.TestCase):
     SID = "sess-lock-test"
 
     def setUp(self) -> None:
+        # Outside a frame, with no session id and no pinned workspace: stated here
+        # rather than inherited from the shell the suite was launched from
+        # (#519, #521, #528).
+        _envguard.unset_all()
+
         self.tmp = Path(tempfile.mkdtemp(prefix="edm-wslock-"))
         # `config.use`, not a hand-picked list. This fixture named five attributes and
         # `set_active` writes through a sixth — `PERSONA_STATE_DIR`, where the trace lives —


### PR DESCRIPTION
A green suite currently means "green on this machine, this minute, in this shell". Run
from inside a live charter frame — which is where the operator actually runs it —
**sixteen tests fail that fail nowhere else** (#519, #521). And the failure runs both
ways: on #525 the same leak produced a **false GREEN**, both sides of an assertion
collapsing to an ambient `$CHARTER_WORKSPACE`, so a mutation that dies with a clean
environment *survived* under the pin — hiding a real defect through two separate
investigations. Behind both: **108 of the suite's 168 `patch.dict(os.environ, …)` calls
omit `clear=True`, across 38 unrelated files** (#528).

## One guard, not 108 edits

`tests/_envguard.py`, modelled on `RealPlaneWrite` (#402) and `RealPlaneRead` (#459).
Two moves, closing opposite directions:

1. **The ambient values are removed**, once, before `charter.config` is first imported.
   What is gone cannot leak — not into a bulk `dict(os.environ)`, not into a subprocess
   that inherits this process, not into any of those 108 call sites. This is what makes
   the suite give the same answer in a frame and in CI, for every test at once.
2. **A targeted read of one of them is refused** while a test runs, unless that test said
   what it holds. Removal alone would only silence the RED — the test would still assert
   against a value it never chose, and would go quietly green the day its expectation
   coincided with the ambient one. The refusal is what makes instance 109 fail on the PR
   that introduces it, on a runner that never had the variable set in the first place.

The refusal is a `BaseException` (charter is full of `except Exception` fallbacks that
would turn a tripwire into a degraded path), and it names the offending test, the
variable, and both ways out — the way `RealPlaneRead` does.

## What is guarded is a property, not a list

* **Scrubbed:** charter's whole namespace as a *prefix* (`CHARTER_*`, `CLAUDE*`), plus
  the terminal-identity variables asked of `session._PANE_ID_VARS` /
  `_WINDOW_ID_VARS`. `TMUX` is the one name spelled out — it is tmux's variable, with no
  constant to derive it from.
* **Refused:** the identities a live session *exports*, derived from
  `commands_frame._FRAME_IDENTITY` (whose own docstring commits the next such variable to
  that list), plus the pane chain and `session.current`'s second rung
  `$CLAUDE_CODE_SESSION_ID`. A `$CHARTER_FOO` a frame learns to export is guarded on the
  commit that teaches it, not the commit that debugs it.

The line between the two tiers is stated in the module and pinned by a test: "unset" is a
**claim about the world** for `$CHARTER_SESSION_ID` (am I inside a frame?) and merely
charter's documented default for `$CHARTER_WORKTREES` — and loudness is only worth its
cost for the first kind. Everything in both tiers is scrubbed either way, so no test's
answer can differ between two machines.

## Structural, not per-test

Armed by wrapping `unittest.TestCase.run`, so no test opts out by forgetting a base class.
The declaration set is **saved and restored** around each run rather than reset, because a
few tests run an inner `TestCase` inside their own body. Declarations live outside
`os.environ` because `mock.patch.dict` restores by clearing the whole mapping and refilling
it — a declaration stored as a value would be destroyed by the first unrelated `patch.dict`
in the same test. `clear=True`, the fix #528 asks 108 sites for, counts as a declaration.

## The fallout, and how small it turned out to be

`PersonaIso.setUp` declares the whole charter environment unset in **one call**, the way it
already re-derives every config setting from a tmp plane — so the 206 files deriving from it
needed nothing. The guard then named **131 tests in 46 classes** that do not derive from it:
`init`, `doctor`, `statusline`, `root`, the workspace lock, the opencode plugin realm. Each
now states, once per fixture, that it is outside a frame with no session id and no pinned
workspace.

## Pinning and controls

`tests/test_no_test_reads_the_operators_shell.py`, in the shape of
`test_no_test_reads_the_operators_channel.py`: every case is a control. The refusal happens
for real; the message names the test and both exits; every documented way out is exercised
(a guard with no usable exit gets deleted by whoever hits it next); a declaration does not
outlive its test, in both directions.

**The scrub is proved by manufacturing an operator's shell in a child process**, not by
observing this one. The two in-process scrub cases cannot fail on a runner that had nothing
to leak — the "evidence that cannot distinguish *clean* from *never ran*" shape this repo
keeps shipping — so a third case plants a session id, a workspace and a live tmux into a
child suite and watches the guard take them apart. It fails on every machine.

## Verification

The four environments that used to disagree, **5644 tests, `OK` in all four**:

| environment | `config.ROOT` | result |
| --- | --- | --- |
| ambient cleared, fresh checkout (no `.charter/`) | the clone | `Ran 5644 … OK` |
| ambient cleared, a used plane (`.charter/`, `.superpowers/`) | `~/IdeaProjects/charter` | `Ran 5644 … OK` |
| inside a live charter frame (`CHARTER_SESSION_ID`, `TMUX`, `TMUX_PANE` set) | `~/IdeaProjects/charter` | `Ran 5644 … OK` |
| `CHARTER_WORKSPACE=anything` | `~/IdeaProjects/charter` | `Ran 5644 … OK` |

(The worktree has its own `charter.toml`, but `root._plane_of` redirects a linked worktree
to its main tree — printed before each run rather than assumed.)

**Mutation testing — 14 mutations, all RED, restored GREEN, `__pycache__` cleared each
time.** M1 the refusal never fires · M2 nothing is scrubbed · M3 the inner run resets
instead of restoring · M4 declarations never reset between tests · M5 `clear()` is not a
declaration · M6 `pop()` falls back to the refusing read · M7 the frame identity is not
derived into the loud set · M8 `TMUX`/`CLAUDE_CODE_SESSION_ID` drop out · M9 the refusal is
a catchable `Exception` · M10 setting a variable is not a declaration · M11 `PersonaIso` no
longer declares · M12 the charter namespace is not scrubbed · M13 `unset_all()` is a no-op ·
M14 `os.environ` is left unwrapped.

Two of those could have been killed by the ambient environment rather than by the tests, so
**M2 and M12 were re-run from a shell with zero charter/tmux variables**: M2 stays RED on
the manufactured-child case alone (`FAILED (failures=1)`), M12 on the
loud-set-is-a-subset-of-scrubbed case. No survivors in either environment.

## Also

News entry (`docs/news/unreleased-the-suite-cannot-read-your-shell.md`) and `CONTRIBUTING.md`,
which now describes the third guard alongside the other two and adds charter's own
environment to *Your machine is not the runner*. No version bump, no stamping, no tag.

Closes #519
Closes #521
Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)
