### PR TITLE
A green tmux run means something: the suite waits for the thing itself, and stops reading a void death as an exit code (#494, #507, #531)

### DIFF
--- a/docs/news/unreleased-a-green-tmux-run-now-means-something.md
+++ b/docs/news/unreleased-a-green-tmux-run-now-means-something.md
@@ -29,6 +29,21 @@ Two tests whose only assertion was that a hostile `#(…)` label creates no cana
 precondition they never had: the label has to be observed on screen first. A menu that never
 rendered used to satisfy them.
 
+One test resisted the whole approach, and it is worth naming because the first fix for it was
+wrong. `-` is not tmux's spelling for "no shortcut" — it is an ordinary key, which is why rows
+past the ninth are keyed with the empty string — and the test that measures this presses `-` on
+a rendered eleven-row menu and requires that nothing ran. Waiting for tmux to repaint proves
+the `-` was *read*; it does not bound the `run-shell` → `charter frame-action` → `subprocess`
+chain whose absence is the whole assertion, and a repaint arrives two orders of magnitude
+sooner than that chain finishes. Swapping the sleep for the repaint made the test pass whether
+or not `-` fired the row — the same defect as the sleep, wearing a fix's clothes. An assertion
+about an absence needs a *bound*, not a readiness signal, so it now gets one from a pacing
+control: the eleventh row's own action, dispatched to the same tmux server only after the
+repaint proves the `-` was consumed. Identical work, started strictly later — so when the
+pacer's canary lands, anything `-` could have started has had longer, and the absence is
+measured. Restoring the constant `-` that this row exists to refuse fails the test again;
+without the pacer it did not.
+
 **A death tmux never had the status of, read as an exit code.** On a loaded tmux 3.4 about one
 pane death in seventeen closes the pane's fd before tmux has the child's status, and never
 gets it — `pane_dead=1`, an empty status, the `pane-died` hook array never run, permanently.

--- a/docs/news/unreleased-a-green-tmux-run-now-means-something.md
+++ b/docs/news/unreleased-a-green-tmux-run-now-means-something.md
@@ -1,0 +1,68 @@
+---
+version: unreleased
+headline: The tmux tests wait for the thing itself instead of sleeping, a dead pane tmux never had a status for stops being read as an exit code, and no test module can hide classes below its `if __name__` trailer any more
+---
+
+Three ways charter's own suite could be green about something it had not measured. None of
+them reaches a plane you run; all three reach anyone who trusts a green run — which, on the
+release workflow, is the one place a wrong call cannot be undone.
+
+**A menu the test only assumed was open.** `MenuClientIntegration` pressed the hotkey on one
+attached terminal, slept 0.8 seconds, and then typed into the other. Under cpu contention the
+menu was not open yet, so the keystroke landed in the pane instead, and the test failed on an
+assertion about charter — about half of runs on a one-cpu tmux 3.4. The negative half was
+worse than flaky: "the other client's key must not select in this menu" is satisfied for free
+by a menu that has not opened, so a late menu made that assertion pass for no reason at all.
+
+There is no format that reports an open menu. All 168 that `display-message -a` names were
+probed against tmux 3.7c with two real terminals attached to one session, before and after a
+`display-menu`: only a byte counter moved, and it moved for the terminal with no menu too.
+But a menu is *drawn*, and these tests own the master fd of the terminal it is drawn on. Each
+attached client now has a reader thread accumulating everything tmux paints on it, and the
+tests wait for the menu's own row to appear there — on the presser's terminal and, asserted
+separately, on nobody else's. The 0.8 s guess is gone from every one of them; the wait
+returns in about 50 ms on an unloaded machine and holds on a loaded one. The other client's
+keystroke is waited on too, by watching the pane's own `cat` echo it — so "it did not select"
+is now about a key that was really delivered and really spent.
+
+Two tests whose only assertion was that a hostile `#(…)` label creates no canary gained a
+precondition they never had: the label has to be observed on screen first. A menu that never
+rendered used to satisfy them.
+
+**A death tmux never had the status of, read as an exit code.** On a loaded tmux 3.4 about one
+pane death in seventeen closes the pane's fd before tmux has the child's status, and never
+gets it — `pane_dead=1`, an empty status, the `pane-died` hook array never run, permanently.
+charter reports an unknown death as `1`. `EarlyDeathIntegration` compares that number against
+`7` and says "a single argument must reach a shell", about a machine where the argument
+reached a shell perfectly well. That is what CI showed: red on two Python versions in one run,
+green on a re-run of identical bytes, and it has already cost a re-run on the publish path.
+
+Those four tests now spend a fresh pane when a trial measured nothing, exactly as the rest of
+the module has since #487 — with the void *asserted* rather than assumed, so a pane tmux
+destroyed, or one it holds a status for but ran no hook for, is a loud failure naming which.
+The probe has to be armed in the server's own config file here, because there is no gate to
+hold this pane open: the whole subject is a command that dies before the frame is drawn.
+Nothing is widened; `7` is still the only value that passes.
+
+**The probe's evidence moved into tmux's own state.** It used to `touch` a file, so "tmux never
+ran the array" and "the marker could not be written" were the same reading — sabotage the
+probe and a real failure became a *skip*. It is now a tmux pane option, set by tmux in the same
+act as running the array, with no shell and no filesystem in between. The mechanism is proved
+usable — written and read back — before anything depends on it, so a tmux that cannot carry the
+evidence says so by name instead of turning every death into a skip.
+
+**And 26 test modules hid classes below their `if __name__` trailer.** `unittest.main()` raises
+`SystemExit`, so everything written after it is dead in the one invocation the trailer exists
+for: `python3 tests/test_doctor_shadowed.py` reported `Ran 8 tests / OK` where
+`python3 -m unittest tests.test_doctor_shadowed` ran 14 — and the six it dropped were the ones
+that exercise the real seam, the eight that survived the pure-function ones. Across the 26,
+154 tests were invisible to a direct run. CI never saw it, because discovery imports a module
+rather than executing it; all 154 do run and do pass there. The gap belonged to whoever was
+debugging one file, which is when a green run is trusted hardest.
+
+The 26 trailers moved to the ends of their files, and a guard now walks the suite and fails on
+the 27th — naming the module, the line, what got hidden and both ways out. All 26 got there the
+same way, by someone appending a class to a finished file and not noticing the trailer above
+the insertion point, so the guard is the point and the sweep is the smaller half.
+
+Nothing to adopt: none of this changes what charter does on your plane.

--- a/tests/test_asks_do_not_hang_bypass_permissions.py
+++ b/tests/test_asks_do_not_hang_bypass_permissions.py
@@ -153,10 +153,6 @@ class TestTheInjectedProseStopsTellingTheAgentToQuiz(InAControlPlane):
             self.assertIn("Scout first", ctx)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestAnUnattendedRunWithNoWorkspaceFailsFast(InAControlPlane):
     """The one block that does NOT get an assume-and-continue rewrite. Every other nudge
     names a preference; this one names a missing input, and guessing it silently claims
@@ -197,3 +193,7 @@ class TestASuppressedAskIsCountedExactlyOnce(ModeCase):
     def test_attended_records_only_the_ask(self):
         self.nudge("default", sid="d")
         self.assertEqual(["dispatch-ask"], self.events("d"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_browser_install.py
+++ b/tests/test_browser_install.py
@@ -79,10 +79,6 @@ class TestBridgeGuidanceSurvives(unittest.TestCase):
         self.assertIn("never read a filled secret back", body)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestTheGeneratorCannotHangOrPromptInvisibly(unittest.TestCase):
     """Two ways the same command stalls with nothing on screen.
 
@@ -210,3 +206,7 @@ class TestTheInstallStatesBothPostures(unittest.TestCase):
         self.assertIn(str(browser.SKILL_DIR), said)
         self.assertIn(str(browser.CONFIG_DIR), said)
         self.assertIn("docs/browser.md", said)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -123,10 +123,6 @@ class CliSmokeTest(unittest.TestCase):
         self._assert_clean(self._run("persona", "secret", "--help"))
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestInitDoesNotPrintOneEnormousLine(unittest.TestCase):
     """The headline is a count; the paths go underneath it.
 
@@ -170,3 +166,7 @@ class TestInitDoesNotPrintOneEnormousLine(unittest.TestCase):
         self.assertEqual(p.returncode, 0, out)
         for expected in ("charter.toml", "personas/", "inventory/", "workspaces/"):
             self.assertIn(expected, out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_docs_show.py
+++ b/tests/test_docs_show.py
@@ -145,10 +145,6 @@ class TestDocsCli(unittest.TestCase):
         self.assertIs(args.func, commands.cmd_docs)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestTheContainmentCheckIsReal(unittest.TestCase):
     """`page.parent` is `root` by construction, so checking it asked a question whose
     answer was always yes. A symlink inside the docs directory pointed anywhere on disk,
@@ -205,3 +201,7 @@ class TestTheCheckoutFallbackIsNotSitePackages(unittest.TestCase):
         docsrc._CHECKOUT = repo / "docs"
         self.assertEqual(docsrc.source(), repo / "docs")
         self.assertEqual(docsrc.read("install"), "# ours\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_doctor_personas.py
+++ b/tests/test_doctor_personas.py
@@ -126,10 +126,6 @@ class MemoryIndexDocstringIsHonest(unittest.TestCase):
         self.assertNotIn("import doctor", src)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class RunTakesATimeoutAndDoctorStreams(unittest.TestCase):
     """A 1Password session needing re-auth stalled the SessionStart preflight for its whole
     20s budget and then printed NOTHING — `cmd_doctor` collected every Result before
@@ -184,3 +180,7 @@ class RunTakesATimeoutAndDoctorStreams(unittest.TestCase):
             res = doctor.check_vaults()
         self.assertEqual(res.status, doctor.WARN)
         self.assertIn("timed out", res.hint)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_doctor_shadowed.py
+++ b/tests/test_doctor_shadowed.py
@@ -101,10 +101,6 @@ class TestShippedSkillsStayInSync(unittest.TestCase):
         self.assertEqual(set(doctor.SHIPPED_SKILLS), on_disk)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestCharterItselfIsExemptHoweverItWasInstalled(PersonaIso):
     """The exemption used to key on `docsrc.source()`, which prefers the PACKAGED copy — so
     it only matched for someone running `python3 -m charter` from the clone. Every
@@ -203,3 +199,7 @@ class TestNoCheckHidesAPythonErrorInAWarning(PersonaIso):
                     break
         self.assertEqual(leaked, [], "a code defect is being reported as 'not checked':\n"
                                      + "\n".join(leaked))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -2324,6 +2324,12 @@ class MenuFormatIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
         Enter must reach the SAME row on the SAME still-open menu. A row with no shortcut
         that the arrow keys could not reach either would be a row that does nothing at
         all — which is the failure the `-` was reached for in the first place.
+
+        The `-` half is the hard one to time, because it asserts an ABSENCE: it needs a
+        bound on how long a row's action takes, not a signal that the key was read. It
+        gets one from a pacing control that runs the same action shape, dispatched later
+        — see the block that builds it for the argument, and for the two ways of getting
+        this wrong that both already shipped here.
         """
         fid = f"menu-fmt-integ4-{os.getpid()}"
         self._new_session(fid)
@@ -2336,29 +2342,65 @@ class MenuFormatIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
         tmp = tempfile.mkdtemp(prefix="charter-integ-fmt4-")
         self.addCleanup(shutil.rmtree, tmp, True)
         canary = os.path.join(tmp, "TENTH_ROW")
+        control = os.path.join(tmp, "PACER")
         # Eleven rows: nine that take the digits, then the two that do not. The canary
         # hangs off the TENTH — the first row past the ninth, and the one that used to be
-        # keyed `-`.
+        # keyed `-`. The ELEVENTH is never selected by this test; its argv exists only so
+        # that the row owns a real `frame-action` id, which the pacing control below
+        # fires directly. See that block for why the two must be the same shape.
         entries = [(f"row {i}", ["true"]) for i in range(11)]
         entries[9] = ("row 9", [sys.executable, "-c",
                                 f"open({canary!r}, 'w').close()"])
+        entries[10] = ("row 10", [sys.executable, "-c",
+                                  f"open({control!r}, 'w').close()"])
         menu.record(fid=fid, entries=entries)
         cmd = menu.menu_argv(fid, SOCKET, client=client)
         self.assertEqual(cmd[10:][1::3][9:], ["", ""], cmd)
         self._drive_menu(fd, cmd, screen=screen, drawn="row 10")
 
-        # `-`, then the FIRST of the nine Downs, then wait for tmux to repaint. The wait
-        # replaces a `time.sleep(0.8)` that assumed `-` had been consumed by then: on a
-        # loaded machine it had not, and the assertion below then passed because the key
-        # was still in flight rather than because it fired nothing. A pty is a FIFO, so
-        # tmux cannot have painted a response to the Down without having already read
-        # past the `-`; there is no new TEXT to wait for, because moving a menu's
-        # selection repaints labels that are already on screen.
+        # `-`, then the FIRST of the nine Downs, then wait for tmux to repaint. A pty is
+        # a FIFO, so tmux cannot have painted a response to the Down without having
+        # already read past the `-`; there is no new TEXT to wait for, because moving a
+        # menu's selection repaints labels that are already on screen.
         mark = screen.drawn_so_far()
         os.write(fd, b"-\x1b[B")
         self.assertTrue(screen.await_more_drawn(mark),
                         "the menu never repainted after a Down, so nothing here shows "
                         "the `-` before it was ever read")
+
+        # **The repaint alone would not license the assertion below, and an earlier
+        # version of this test made exactly that mistake.** It says the `-` has been
+        # READ; the thing being asserted absent is a whole `run-shell` -> `sh` ->
+        # `"$CHARTER_PY" -m charter frame-action a9` -> `subprocess.run` chain, ~0.7 s of
+        # it on this machine, and a repaint arrives 0-50 ms in. Asserting "no canary" at
+        # that point passes whether or not `-` fires the row — the same defect as the
+        # `time.sleep(0.8)` it replaced (#494: a readiness condition standing in for a
+        # settling condition), only quieter, because it looks like a wait.
+        #
+        # So: a PACING CONTROL. The eleventh row's own action string, lifted verbatim out
+        # of the argv `menu_argv` just built and handed straight back to the same tmux
+        # server, differs from the tenth row's by one character — the action id — and so
+        # costs the identical interpreter start, the identical `charter` import and the
+        # identical `subprocess.run`. It is dispatched only AFTER the repaint above
+        # proves tmux consumed the `-`, and tmux is single-threaded: if `-` were bound to
+        # row 10, tmux forked that item's job inside the key event, which it finishes
+        # before it comes back to the command socket to read this one. Same work, started
+        # strictly later — so when the pacer's canary lands, any run the `-` could have
+        # started has had at least as long, and `TENTH_ROW`'s absence is a measurement
+        # rather than a formality. Asserted positively first, so a pacer that never ran
+        # fails loudly instead of licensing the negative for free.
+        actions = cmd[10:][2::3]
+        self.assertTrue(actions[10].startswith("run-shell '")
+                        and actions[10].endswith("'"), actions[10])
+        self.assertEqual(actions[9], actions[10].replace("a10", "a9"), actions)
+        r = _tmux("run-shell", "-t", fid, actions[10][len("run-shell '"):-1])
+        self.assertEqual(r.returncode, 0, r.stderr)
+        deadline = time.monotonic() + _DEADLINE
+        while time.monotonic() < deadline and not os.path.exists(control):
+            time.sleep(0.05)
+        self.assertTrue(os.path.exists(control),
+                        "the pacing control never ran, so nothing below bounds how long "
+                        "a row's action takes and 'no canary' would mean nothing")
         self.assertFalse(os.path.exists(canary),
                          "`-` fired the tenth row — it is a real tmux key, not tmux's "
                          "spelling for 'no shortcut'")

--- a/tests/test_frame_tmux_integration.py
+++ b/tests/test_frame_tmux_integration.py
@@ -37,12 +37,28 @@ did, and a machine that cannot run one says which capability it lacked.
 gets it: `#{pane_dead}` `1`, `#{pane_dead_status}` empty, the pane's `pane-died` array
 never run, permanently. A trial like that measured NOTHING about charter — it is not a
 result to assert on and not a failure to report — and every death-dependent test here now
-detects it with a constant-action probe hook and spends another pane
-(`_TmuxServerFixture._HOOK_TRIALS`, `_arm_array_probe`, `_the_array_never_ran`). The
+detects it with a constant-action probe hook and spends another pane (`_VoidDeaths`:
+`_HOOK_TRIALS`, `_arm_array_probe`, `_the_array_ran`, `_the_array_never_ran`). The
 detector asks whether tmux ran the array, never whether the status came back empty: a
 harness genuinely killed by a signal also has an empty status, and classifying on that
 would make the signal-death test unfailable. Nothing is widened; a machine that produces
 `_HOOK_TRIALS` such deaths in a row skips, naming what it could not measure.
+
+**#507 is the same mechanism reaching a class that had no defence against it**, and #494
+is the last readiness condition this module assumed rather than waited for. The probe's
+evidence now lives in tmux's OWN state rather than in a file it asked a shell to touch
+(`_VoidDeaths._PROBE_OPTION`), `EarlyDeathIntegration` — which reads a dead pane's exit
+STATUS and is exactly what a void destroys — retries a trial that measured nothing like
+everything else here (`_a_measured_death`), and a menu is now WAITED for on the terminal
+it is drawn on rather than slept at (:class:`_Screen`).
+
+**One test here still cannot carry a probe, and says so rather than pretending**:
+`WindowInsideAnOperatorsTmux.test_nothing_of_the_operators_tmux_is_written_by_a_whole_launch`
+reads the code a whole real `cmd_launch` returns, and that pane carries charter's
+production `pane-died` PAIR — `[0]` the write hook, `[1]` `kill-session`. There is no free
+index: `[1]` is where a probe would go and is charter's teardown, and measured against tmux
+3.7c a `[2]` armed beside them never runs at all, because `kill-session` at `[1]` takes the
+server down first. A void death there is still read as an exit code of `1`.
 
 Every test gets its own tmux SESSION (hooks are per-pane, so a shared session would let
 one test's hook leak into another's pane) on the ONE socket this module owns, and every
@@ -56,6 +72,7 @@ from __future__ import annotations
 import os
 import pty
 import re
+import select
 import shutil
 import signal
 import socket
@@ -441,6 +458,140 @@ def _await_dead(pane: str, timeout: float = _DEADLINE) -> int | None:
     return None
 
 
+#: Anything tmux drew that is not TEXT: a CSI/OSC escape sequence, a charset selection,
+#: a single-character escape. Stripped from a copy of a client's screen bytes before the
+#: search in `_Screen.saw`, so a row tmux styled part-way through (the SELECTED row of a
+#: menu carries its own highlight) still reads as the contiguous text it renders as. The
+#: raw bytes are searched first and this is only the fallback — nothing here can hide a
+#: label, it can only reveal one the styling had split.
+_ESCAPES = re.compile(rb"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b\[[0-9;?]*[ -/]*[@-~]"
+                      rb"|\x1b[()][A-Za-z0-9]|\x1b[@-Z\\-_]")
+
+
+class _Screen:
+    """Everything tmux has written to ONE attached client's terminal since it attached.
+
+    **This is the observable #494 needed and could not find in a format.** A tmux menu is
+    a client OVERLAY, not pane content, so `capture-pane` cannot see it and — probed
+    exhaustively against tmux 3.7c with two real ptys on one session, all 168 formats
+    `display-message -a` names, before and after a `display-menu` — not one client, pane,
+    window or session format reports it either. Only `client_written`, a byte counter,
+    moved, and it moved for the client with NO menu too. But the menu is drawn, and these
+    tests own the master fd of the terminal it is drawn on: the menu's own rows arrive on
+    the presser's pty and on nobody else's. Measured: the label appeared on the presser's
+    fd 0.05 s after `display-menu`, and never on the other client's.
+
+    So a test can WAIT for the menu instead of sleeping 0.8 s and hoping — which is the
+    whole of #494, because a keystroke sent before the menu exists is spent on the pane
+    and no later deadline can un-spend it.
+
+    **A THREAD per client, not a drain at the point of asking**, for two reasons. A pty's
+    buffer is finite: with nobody reading, tmux eventually blocks writing to the client,
+    which is a hang the test would read as "the menu never opened". And `saw()` has to be
+    able to answer about output that arrived while the test was looking somewhere else —
+    a single accumulating buffer is what makes the answer independent of when it is asked.
+
+    The reader is stopped and JOINED before `_reap_pty` closes the fd (`_attach_pty`
+    registers this cleanup last, and `addCleanup` is LIFO). Left running, it would sit in
+    a read on a closed fd number that the next `pty.fork` in the same process may well be
+    handed — a thread stealing another client's bytes is exactly the kind of cross-test
+    coincidence this module keeps finding.
+    """
+
+    def __init__(self, fd: int) -> None:
+        self._fd = fd
+        self._buf = bytearray()
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._pump, daemon=True,
+                                        name=f"charter-test-screen-{fd}")
+        self._thread.start()
+
+    def _pump(self) -> None:
+        while not self._stop.is_set():
+            try:
+                ready, _, _ = select.select([self._fd], [], [], 0.05)
+            except (OSError, ValueError):
+                return                    # the fd went away under us — nothing to read
+            if not ready:
+                continue
+            try:
+                chunk = os.read(self._fd, 65536)
+            except OSError:
+                return                    # EIO: the pty's child is gone
+            if not chunk:
+                return
+            with self._lock:
+                self._buf += chunk
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=5)
+
+    def saw(self, needle: str) -> bool:
+        """Has *needle* been drawn on this client's terminal at any point?"""
+        want = needle.encode()
+        with self._lock:
+            raw = bytes(self._buf)
+        return want in raw or want in _ESCAPES.sub(b"", raw)
+
+    def drawn_so_far(self) -> int:
+        """How many bytes tmux has drawn on this client. A MARK, never an assertion."""
+        with self._lock:
+            return len(self._buf)
+
+    def await_more_drawn(self, mark: int, timeout: float = _DEADLINE) -> bool:
+        """Wait until tmux has drawn anything at all on this client past *mark*.
+
+        For the one readiness condition that has no text to wait for: a key that moves a
+        menu's SELECTION repaints rows whose labels are already on screen, so there is no
+        new string to look for — only that tmux painted again. Weaker than
+        :meth:`await_drawn` on its own, and used only where a pty's own FIFO ordering
+        carries the rest of the argument: tmux cannot paint a response to a key without
+        having first read every key written before it.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.drawn_so_far() > mark:
+                return True
+            time.sleep(0.05)
+        return self.drawn_so_far() > mark
+
+    def await_drawn(self, needle: str, timeout: float = _DEADLINE) -> bool:
+        """Wait until *needle* has been drawn on this client, up to *timeout*.
+
+        A POSITIVE wait, so it spends `_DEADLINE` — see that constant. It returns the
+        instant the text is on screen, so the number is what a loaded runner may take and
+        never what a healthy one does; the caller asserts on the answer.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.saw(needle):
+                return True
+            time.sleep(0.05)
+        return self.saw(needle)
+
+
+def _await_pane_changed(session: str, before: str, timeout: float = _DEADLINE) -> str:
+    """Wait until `capture-pane` of *session* differs from *before*, and return it.
+
+    The readiness condition for the NEGATIVE half of #494's two-client tests. "Client B's
+    keystroke must not select in A's menu" says nothing at all unless B's keystroke was
+    really delivered and really spent — a keystroke still in flight satisfies it for free,
+    which is what the fixed sleep it replaces was quietly relying on. A client with no
+    menu open sends its keys to the pane, whose `cat` echoes them, so the pane's own text
+    changing is tmux itself reporting that B's key landed on B's pane. Returns *before*
+    unchanged if it never does, and the caller fails on that.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        now = _tmux("capture-pane", "-p", "-t", session).stdout
+        if now != before:
+            return now
+        time.sleep(0.05)
+    return _tmux("capture-pane", "-p", "-t", session).stdout
+
+
 class _NeedsAttachedClient:
     """`_attach_pty` for the two classes that need a REAL, ATTACHED client, and the
     capability probe that decides whether this machine can give them one.
@@ -451,7 +602,8 @@ class _NeedsAttachedClient:
     rather than asserting anything about a menu nothing drew.
     """
 
-    def _attach_pty(self, session: str, exclude: frozenset = frozenset()) -> tuple[str, int]:
+    def _attach_pty(self, session: str,
+                    exclude: frozenset = frozenset()) -> tuple[str, int, _Screen]:
         """Forks a real `tmux attach -t session` under a pty — the one way to hand
         `display-menu` a client it will actually accept for `-c`/`-t` targeting.
 
@@ -461,10 +613,15 @@ class _NeedsAttachedClient:
 
         Registers the fork's own cleanup (SIGKILL, then reap — see `_reap_pty`) before
         returning the attached client's name (`#{client_name}`, read back from tmux
-        itself once the attachment has had time to register) and the pty's own master fd
+        itself once the attachment has had time to register), the pty's own master fd
         — writing a KEY to the fd (not `tmux send-keys`, confirmed by hand: `send-keys`
         feeds a PANE's own input queue, which an active menu overlay never reads from) is
-        the only way found to actually select a menu item from here.
+        the only way found to actually select a menu item from here — and a :class:`_Screen`
+        watching everything tmux draws on that client, which is what lets a caller wait
+        for a menu rather than sleep and assume one (#494).
+
+        The screen's cleanup is registered AFTER `_reap_pty`'s, so LIFO stops the reader
+        thread FIRST and the fd is never closed out from under it.
         """
         refusals = []
         for term in _TERM_CANDIDATES:
@@ -476,7 +633,9 @@ class _NeedsAttachedClient:
                 raise
             if name:
                 self.addCleanup(_reap_pty, pid, fd)
-                return name, fd
+                screen = _Screen(fd)
+                self.addCleanup(screen.stop)
+                return name, fd, screen
             refusals.append(f"TERM={term}: {_refusal(fd) or '(tmux printed nothing)'}")
             _reap_pty(pid, fd)
         self.skipTest(
@@ -484,8 +643,196 @@ class _NeedsAttachedClient:
             "needs one — tmux refused every terminal type tried: " + " | ".join(refusals))
 
 
+class _VoidDeaths:
+    """Telling a RESULT from a trial that measured nothing — #409, #487, #507.
+
+    On a loaded tmux 3.4 a pane's fd can close before tmux has the child's status, and
+    for some deaths it never gets it: `#{pane_dead}` `1`, `#{pane_dead_status}` EMPTY,
+    the pane's `pane-died` array never run, permanently. A trial like that says nothing
+    about charter — it is not a result to assert on and not a failure to report.
+
+    **A mixin of its own rather than part of `_TmuxServerFixture`, and #507 is why.**
+    `EarlyDeathIntegration` is a plain `unittest.TestCase` that builds its own sessions
+    from `layout.session_argv`, so it inherited none of this — and three of its tests
+    read a dead pane's STATUS, which is precisely what a void destroys.
+    `test_a_lone_argument_reaches_a_shell_not_execvp` failing on two Python versions in
+    one CI run and passing on a re-run of identical bytes is that: `_query_pane_dead_status`
+    answers `commands_frame._UNKNOWN_DEATH_CODE` (1) for a pane tmux holds no status for,
+    and `assertEqual(code, 7)` cannot tell that from a shell that really exited 1.
+
+    Everything here is expressed against `self._srv`, so a class brings its own server.
+    """
+
+    #: Which server this class's tests stand up. `SOCKET` is charter's own; the class
+    #: that is about the tmux charter is a GUEST on overrides it, because a guest server
+    #: charter's own fixture has already configured is not a guest server (`OP_SOCKET`).
+    SOCKET_NAME = SOCKET
+
+    def _srv(self, *args: str, env: dict | None = None) -> subprocess.CompletedProcess:
+        """`tmux` against THIS class's own server — never the module-level `_tmux`, which
+        is `SOCKET` and `SOCKET` only."""
+        return _tmux_on(self.SOCKET_NAME, *args, env=env)
+    #: How many deaths one death-dependent test may spend before it gives up on this
+    #: machine — #409, and #487 for every test in the module rather than two of them.
+    #:
+    #: **Not a retry for flakiness: a retry for a trial that measured nothing.** Measured
+    #: on tmux 3.4 in an Ubuntu 24.04 container pinned to one cpu against twelve spin
+    #: loops, running the real `respawn-pane`/`_pane_state` path 118 times: 111 deaths
+    #: reported `#{pane_dead}` `1` with `#{pane_dead_status}` `33` and ran the pane's
+    #: `pane-died` array; the other 7 reported `1` with an EMPTY status and never ran the
+    #: array — and PERMANENTLY, polling a further 8 seconds never filled either in. tmux
+    #: 3.4's `server_destroy_pane` returns without notifying while `PANE_STATUSREADY` is
+    #: unset, and for those deaths it is never set. A longer deadline is therefore not
+    #: the knob: it would re-ship the same flake with a longer wait attached to it.
+    #:
+    #: What a death like that produces is not a wrong answer, it is NO answer — there is
+    #: nothing for the test to be about — so the trial is spent again on a fresh pane and
+    #: the assertions stay exactly as strict as they were.
+    _HOOK_TRIALS = 3
+
+    #: Where this module's constant-action probe hook goes in a pane's `pane-died` array.
+    #:
+    #: `1` everywhere, whether or not charter armed a `[0]`: tmux runs an array in index
+    #: order, so a probe here cannot fire before charter's own hook, and a SPARSE array
+    #: holding only `[1]` still runs (measured on both tmux 3.4 and 3.7c).
+    #:
+    #: **Which is also where `commands_frame._pane_died_teardown_hook_argv` lands**, so a
+    #: probe must never be armed on a pane carrying the production harness PAIR — it
+    #: would replace the teardown hook and the test would be measuring its own probe.
+    #: No caller here does: `_a_death_the_hook_saw` installs the write hook only, and
+    #: `test_the_write_hook_must_be_installed_before_the_teardown_hook`, which installs
+    #: both, asserts on the array itself and needs no probe.
+    _PROBE_INDEX = 1
+
+    #: The tmux PANE OPTION the probe hook sets, and reads back, as its whole evidence.
+    #:
+    #: **It used to be a FILE, and that is the weakness #495's own attacker flagged and
+    #: #507 folded in here.** The action was `run-shell "touch <marker>"`, so "tmux never
+    #: ran the pane's hook array" and "the marker could not be written" were the same
+    #: reading: anything that made the path unwritable — a full disk, a `_gate_dir` gone,
+    #: a `run-shell` that could not fork — was indistinguishable from a void and got the
+    #: trial spent again. Sabotaging the probe's own action (`touch` -> `true`) turned a
+    #: real failure into a SKIP, which is a suite reporting green about a machine it
+    #: never measured.
+    #:
+    #: A tmux option is set BY TMUX, in the same act as running the array, with no shell,
+    #: no fork and no filesystem in between — so "the array ran" and "a marker got
+    #: written" stop being one question. Measured against tmux 3.7c: a `pane-died` hook
+    #: whose action is `set-option -p @charter-probe ran` sets it on the DYING pane
+    #: (`-p` resolves to the hook's own pane), it survives on a dead-but-kept pane, and
+    #: `show-options -p -v` on a pane that never ran the hook exits 1 with `invalid
+    #: option` and prints nothing — three distinguishable answers where the file had two.
+    _PROBE_OPTION = "@charter-probe"
+
+    #: What the probe hook's action IS. A tmux command, not a shell command line: nothing
+    #: charter builds appears in it, no `#{pane_dead_status}`, no `set-environment` value
+    #: — so the only thing it can ever report is "tmux reached this pane's hook array",
+    #: which on both tmuxes this suite must pass on is the same question as "did tmux
+    #: have the child's status".
+    _PROBE_ACTION = f"set-option -p {_PROBE_OPTION} ran"
+
+    def _the_array_ran(self, pane: str, timeout: float = _DEADLINE) -> bool:
+        """Did tmux run *pane*'s `pane-died` array? Polled, up to *timeout*.
+
+        Reads the option back off tmux itself. An unarmed or unrun pane answers rc 1 and
+        an empty value; a pane whose array ran answers `ran`. Anything else is treated as
+        not-run, and `_the_array_never_ran` is what then refuses to accept that reading
+        unless the pane really is in the one state it is allowed to mean.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            got = self._srv("show-options", "-p", "-v", "-t", pane, self._PROBE_OPTION)
+            if got.returncode == 0 and got.stdout.strip() == "ran":
+                return True
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(0.1)
+
+    def _arm_array_probe(self, pane: str) -> None:
+        """Install the CONSTANT-action `pane-died` probe hook on *pane*. **The one
+        observable that tells a result from a trial that measured nothing.**
+
+        **Call this AFTER whatever hook the test is about, never before.** `set-hook -p
+        -t <pane> pane-died <action>` with no index REPLACES the whole array, so a probe
+        installed first is silently wiped by the very hook it exists to watch — and the
+        trial then looks like a void that also, impossibly, has a status. That is not
+        theoretical: it is what the first version of `_a_hook_delivery` did, and
+        `_the_array_never_ran` is what turned it into three loud failures rather than
+        three silent skips.
+
+        **The option is written and read back HERE, before the hook is armed**, and that
+        round trip is not ceremony. Every caller reads a missing option as "tmux never
+        ran the array" — so a tmux that cannot carry a pane-scoped user option at all, or
+        cannot report one back, would turn every death in this module into a void and
+        every death-dependent test into a skip, on a machine where nothing was wrong. The
+        probe proves it can record and recall before anything depends on it recalling,
+        and says so by name if it cannot.
+
+        **Reading the pane's STATUS instead is a SPELLING, and #487 is the bill for it.**
+        An empty `#{pane_dead_status}` on a dead pane is produced by two different
+        realities, and `commands_frame._pane_state` folds both to the same
+        `_UNKNOWN_DEATH_CODE`. Measured on tmux 3.4 and re-measured on 3.7c: a harness
+        genuinely killed by a signal answers `1:` and the array RUNS (40/40 on 3.4, 15/15
+        on 3.7c); a death tmux never got the status of answers `1:` and the array never
+        runs (7/7 of the voids in `_HOOK_TRIALS`'s 118-trial run). A test that classified
+        on the empty status alone would have to treat a real signal death as a void
+        trial — which is how a suite stops being able to fail.
+        """
+        self.assertEqual(
+            self._srv("set-option", "-p", "-t", pane, self._PROBE_OPTION,
+                      "arming").returncode, 0,
+            f"this tmux will not set the pane option ({self._PROBE_OPTION}) every void "
+            "check in this module reads — a missing option would then mean 'tmux ran no "
+            "hook' everywhere and skip every death-dependent test on a healthy machine")
+        back = self._srv("show-options", "-p", "-v", "-t", pane, self._PROBE_OPTION)
+        self.assertEqual(
+            (back.returncode, back.stdout.strip()), (0, "arming"),
+            f"this tmux set {self._PROBE_OPTION} and would not report it back "
+            f"({back.returncode}, {back.stdout!r}) — see above")
+        self.assertEqual(
+            self._srv("set-option", "-p", "-u", "-t", pane,
+                      self._PROBE_OPTION).returncode, 0)
+        self.assertEqual(
+            self._srv("set-hook", "-p", "-t", pane, f"pane-died[{self._PROBE_INDEX}]",
+                      self._PROBE_ACTION).returncode, 0)
+
+    def _the_array_never_ran(self, pane: str, what: str) -> None:
+        """Assert *pane* is in the ONE state an unset probe option is allowed to mean:
+        dead, with tmux holding no status for it at all.
+
+        The void is asserted here rather than assumed, so the only way a trial can be
+        retried instead of failing is by actually being the measured condition. A pane
+        tmux has DESTROYED (nothing armed `remain-on-exit`, or charter stopped arming it)
+        and a pane tmux has a status for but ran no hook for are both real defects, and
+        both say which one they are instead of being spent as another trial.
+        """
+        dead, _, status = self._srv(
+            "display-message", "-p", "-t", pane,
+            commands_frame._DEAD_FORMAT).stdout.strip().partition(":")
+        self.assertEqual(
+            dead, "1",
+            f"{what}, and tmux does not report the pane dead either (`{dead}:{status}`) "
+            "— the pane was destroyed rather than kept, which is a failure of whatever "
+            "was supposed to arm `remain-on-exit` and NOT the tmux 3.4 window "
+            "`_HOOK_TRIALS` describes")
+        self.assertEqual(
+            status.strip(), "",
+            f"{what}, yet tmux is holding a status ({status.strip()!r}) for it. tmux "
+            "runs a pane's `pane-died` array once it has the child's status, so a status "
+            "with no hook run is charter's hook having been lost, not a trial that "
+            "measured nothing")
+
+    def _no_death_was_delivered(self):
+        self.skipTest(
+            f"none of {self._HOOK_TRIALS} deaths on this machine reached a `pane-died` "
+            "hook at all — tmux never had the child's status when the pane's fd closed "
+            "(measured on tmux 3.4 under load; see `_HOOK_TRIALS`). The capability this "
+            "test measures was not present to measure, and nothing here is widened to "
+            "pass without it.")
+
+
 @unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
-class _TmuxServerFixture:
+class _TmuxServerFixture(_VoidDeaths):
     """One real tmux server per test, and the helpers every class here needs.
 
     A MIXIN rather than a base TestCase, and that is not style. `unittest` collects a
@@ -508,11 +855,6 @@ class _TmuxServerFixture:
     class's own subclass listed `unittest.TestCase` here instead.
     """
 
-    #: Which server this class's tests stand up. `SOCKET` is charter's own; the class
-    #: that is about the tmux charter is a GUEST on overrides it, because a guest server
-    #: charter's own fixture has already configured is not a guest server (`OP_SOCKET`).
-    SOCKET_NAME = SOCKET
-
     #: Whether `_new_pane` arms `remain-on-exit` server-globally, the way
     #: `commands_frame._PLACEHOLDER_CONF` does on charter's own private server.
     #:
@@ -523,11 +865,6 @@ class _TmuxServerFixture:
     #: and cannot see charter failing to set one; measured, by deleting the production
     #: call and watching the test stay green.
     ARMS_REMAIN_ON_EXIT = True
-
-    def _srv(self, *args: str, env: dict | None = None) -> subprocess.CompletedProcess:
-        """`tmux` against THIS class's own server — never the module-level `_tmux`, which
-        is `SOCKET` and `SOCKET` only."""
-        return _tmux_on(self.SOCKET_NAME, *args, env=env)
 
     def setUp(self) -> None:
         # FIRST, and cooperatively: `PersonaIso.setUp` is what repoints `config`, and it
@@ -592,113 +929,6 @@ class _TmuxServerFixture:
         """Open a pane's gate: its program stops waiting and dies the way it was built to."""
         Path(gate).touch()
 
-    # -- Deaths tmux never had the child's status for (#409, #487) -------------------- #
-
-    #: How many deaths one death-dependent test may spend before it gives up on this
-    #: machine — #409, and #487 for every test in the module rather than two of them.
-    #:
-    #: **Not a retry for flakiness: a retry for a trial that measured nothing.** Measured
-    #: on tmux 3.4 in an Ubuntu 24.04 container pinned to one cpu against twelve spin
-    #: loops, running the real `respawn-pane`/`_pane_state` path 118 times: 111 deaths
-    #: reported `#{pane_dead}` `1` with `#{pane_dead_status}` `33` and ran the pane's
-    #: `pane-died` array; the other 7 reported `1` with an EMPTY status and never ran the
-    #: array — and PERMANENTLY, polling a further 8 seconds never filled either in. tmux
-    #: 3.4's `server_destroy_pane` returns without notifying while `PANE_STATUSREADY` is
-    #: unset, and for those deaths it is never set. A longer deadline is therefore not
-    #: the knob: it would re-ship the same flake with a longer wait attached to it.
-    #:
-    #: What a death like that produces is not a wrong answer, it is NO answer — there is
-    #: nothing for the test to be about — so the trial is spent again on a fresh pane and
-    #: the assertions stay exactly as strict as they were.
-    _HOOK_TRIALS = 3
-
-    #: Where this module's constant-action probe hook goes in a pane's `pane-died` array.
-    #:
-    #: `1` everywhere, whether or not charter armed a `[0]`: tmux runs an array in index
-    #: order, so a probe here cannot fire before charter's own hook, and a SPARSE array
-    #: holding only `[1]` still runs (measured on both tmux 3.4 and 3.7c).
-    #:
-    #: **Which is also where `commands_frame._pane_died_teardown_hook_argv` lands**, so a
-    #: probe must never be armed on a pane carrying the production harness PAIR — it
-    #: would replace the teardown hook and the test would be measuring its own probe.
-    #: No caller here does: `_a_death_the_hook_saw` installs the write hook only, and
-    #: `test_the_write_hook_must_be_installed_before_the_teardown_hook`, which installs
-    #: both, asserts on the array itself and needs no probe.
-    _PROBE_INDEX = 1
-
-    def _probe_path(self, pane: str) -> str:
-        """Where `_arm_array_probe`'s marker for *pane* lands. Named separately so a
-        caller can ask about a probe it did not install itself."""
-        return os.path.join(self._gate_dir, f"array-ran-{pane.lstrip('%')}")
-
-    def _arm_array_probe(self, pane: str) -> str:
-        """Install a CONSTANT-action `pane-died` hook on *pane*, and return the path it
-        touches when tmux runs that pane's hook array. **The one observable that tells a
-        result from a trial that measured nothing.**
-
-        **Call this AFTER whatever hook the test is about, never before.** `set-hook -p
-        -t <pane> pane-died <action>` with no index REPLACES the whole array, so a probe
-        installed first is silently wiped by the very hook it exists to watch — and the
-        trial then looks like a void that also, impossibly, has a status. That is not
-        theoretical: it is what the first version of `_a_hook_delivery` did, and
-        `_the_array_never_ran` is what turned it into three loud failures rather than
-        three silent skips.
-
-        The action is `touch <marker>` — no `#{pane_dead_status}`, no `set-environment`
-        value, nothing charter builds — so the only thing its marker can report is "tmux
-        reached this pane's hook array", which on both tmuxes this suite must pass on is
-        the same question as "did tmux have the child's status".
-
-        **Reading the status instead is a SPELLING, and #487 is the bill for it.** An
-        empty `#{pane_dead_status}` on a dead pane is produced by two different
-        realities, and `commands_frame._pane_state` folds both to the same
-        `_UNKNOWN_DEATH_CODE`. Measured on tmux 3.4 and re-measured on 3.7c: a harness
-        genuinely killed by a signal answers `1:` and the array RUNS (40/40 on 3.4, 15/15
-        on 3.7c); a death tmux never got the status of answers `1:` and the array never
-        runs (7/7 of the voids in `_HOOK_TRIALS`'s 118-trial run). A test that classified
-        on the empty status alone would have to treat a real signal death as a void
-        trial — which is how a suite stops being able to fail.
-        """
-        probe = self._probe_path(pane)
-        self.assertEqual(
-            self._srv("set-hook", "-p", "-t", pane, f"pane-died[{self._PROBE_INDEX}]",
-                      f'run-shell "touch {probe}"').returncode, 0)
-        return probe
-
-    def _the_array_never_ran(self, pane: str, what: str) -> None:
-        """Assert *pane* is in the ONE state a missing probe marker is allowed to mean:
-        dead, with tmux holding no status for it at all.
-
-        The void is asserted here rather than assumed, so the only way a trial can be
-        retried instead of failing is by actually being the measured condition. A pane
-        tmux has DESTROYED (nothing armed `remain-on-exit`, or charter stopped arming it)
-        and a pane tmux has a status for but ran no hook for are both real defects, and
-        both say which one they are instead of being spent as another trial.
-        """
-        dead, _, status = self._srv(
-            "display-message", "-p", "-t", pane,
-            commands_frame._DEAD_FORMAT).stdout.strip().partition(":")
-        self.assertEqual(
-            dead, "1",
-            f"{what}, and tmux does not report the pane dead either (`{dead}:{status}`) "
-            "— the pane was destroyed rather than kept, which is a failure of whatever "
-            "was supposed to arm `remain-on-exit` and NOT the tmux 3.4 window "
-            "`_HOOK_TRIALS` describes")
-        self.assertEqual(
-            status.strip(), "",
-            f"{what}, yet tmux is holding a status ({status.strip()!r}) for it. tmux "
-            "runs a pane's `pane-died` array once it has the child's status, so a status "
-            "with no hook run is charter's hook having been lost, not a trial that "
-            "measured nothing")
-
-    def _no_death_was_delivered(self):
-        self.skipTest(
-            f"none of {self._HOOK_TRIALS} deaths on this machine reached a `pane-died` "
-            "hook at all — tmux never had the child's status when the pane's fd closed "
-            "(measured on tmux 3.4 under load; see `_HOOK_TRIALS`). The capability this "
-            "test measures was not present to measure, and nothing here is widened to "
-            "pass without it.")
-
     def _hook_reaches_a_shim(self, *, socket, pane, gate, interpreter_dir,
                              timeout=_DEADLINE, probe=False):
         """Arm *pane*'s respawn hook with a shim as charter's interpreter, open the gate,
@@ -717,9 +947,9 @@ class _TmuxServerFixture:
         *probe* asks for `_arm_array_probe`'s constant-action hook to be armed BESIDE
         charter's own — after it, since an unindexed `set-hook` replaces the array — for
         a caller that intends to tell a void trial from a real one (`_a_hook_delivery`
-        does the telling). Its marker is waited on FIRST, so a void costs one deadline
-        rather than two, and it is the caller, never this method, that decides what a
-        missing marker means.
+        does the telling). Its option is waited on FIRST, so a void costs one deadline
+        rather than two, and it is the caller, never this method, that decides what an
+        unset option means.
         """
         os.makedirs(interpreter_dir, exist_ok=True)
         marker = os.path.join(self._gate_dir, f"argv-{os.path.basename(pane)}")
@@ -732,9 +962,10 @@ class _TmuxServerFixture:
                 socket=socket, panel_pane=pane, slot="top", fid="demo-1")
         self.assertIsNotNone(argv, f"charter refused to arm a hook for {shim!r}")
         self.assertEqual(_run(argv).returncode, 0)
-        armed = self._arm_array_probe(pane) if probe else None
+        if probe:
+            self._arm_array_probe(pane)
         self._release(gate)
-        if armed is not None and not _await_file(armed, timeout):
+        if probe and not self._the_array_ran(pane, timeout):
             return None
         # The shim's own `printf … > marker` creates before it writes, so the readiness
         # condition is TEXT rather than existence — see `_await_text`.
@@ -760,7 +991,7 @@ class _TmuxServerFixture:
         if seen is not None:
             return seen
         self.assertFalse(
-            os.path.exists(self._probe_path(pane)),
+            self._the_array_ran(pane, timeout=0),
             "tmux ran this pane's `pane-died` array — a constant-action probe hook "
             "beside charter's own fired — and charter's own hook delivered no argv at "
             "all. That is charter, not the runner: "
@@ -1053,10 +1284,10 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
         expands to text the program in that pane sets for itself.
 
         Tried up to `_HOOK_TRIALS` times, with the constant-action probe beside the hook
-        under test: `_await_file` timing out here used to be reported as "the hook never
-        reached a shell", which on a loaded tmux 3.4 was true and meant nothing — tmux
-        had run no hook for that pane at all (#487). The probe firing and this file still
-        missing is the case that keeps its failure."""
+        under test: a missing file here used to be reported as "the hook never reached a
+        shell", which on a loaded tmux 3.4 was true and meant nothing — tmux had run no
+        hook for that pane at all (#487). The probe firing and this file still missing is
+        the case that keeps its failure."""
         self._require_pane_died_fires()
         for attempt in range(self._HOOK_TRIALS):
             _, pane, gate = self._new_pane("exit 3")
@@ -1067,9 +1298,9 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
                 _tmux("set-hook", "-p", "-t", pane, "pane-died",
                       f"""run-shell -b 'echo "/opt/py#{{pane_id}}/x" > "{out}"'"""
                       ).returncode, 0)
-            probe = self._arm_array_probe(pane)
+            self._arm_array_probe(pane)
             self._release(gate)
-            if not _await_file(probe):
+            if not self._the_array_ran(pane):
                 self._the_array_never_ran(
                     pane, "tmux never ran this pane's `pane-died` array")
                 continue
@@ -1112,9 +1343,9 @@ class TmuxIntegration(_TmuxServerFixture, PersonaIso):
             socket=SOCKET, session=session, status_path=status_path)).returncode, 0)
         self.assertEqual(_run(commands_frame._pane_died_write_hook_argv(
             socket=SOCKET, harness_pane=pane)).returncode, 0)
-        fired = self._arm_array_probe(pane)
+        self._arm_array_probe(pane)
         self._release(gate)
-        if not _await_file(fired):
+        if not self._the_array_ran(pane):
             self._the_array_never_ran(
                 pane, "tmux never ran this pane's `pane-died` array")
             return None, pane
@@ -1916,9 +2147,11 @@ class MenuFormatIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
         pid = _tmux("display-message", "-p", "-t", fid, "#{pane_pid}").stdout.strip()
         self.addCleanup(_kill_pid, pid)
 
-    def _drive_menu(self, fd: int, cmd: list[str]) -> None:
-        """Bind *cmd* (a real `display-menu` invocation) to a throwaway key and press
-        it through the attached pty — never issue *cmd* directly.
+    def _drive_menu(self, fd: int, cmd: list[str], *, screen: _Screen,
+                    drawn: str) -> None:
+        """Bind *cmd* (a real `display-menu` invocation) to a throwaway key, press it
+        through the attached pty, and WAIT until *drawn* is on that client's screen —
+        never issue *cmd* directly, and never assume the menu opened.
 
         Confirmed by hand, twice, with the identical *cmd*: issued DIRECTLY (via
         `subprocess.run` with a timeout, and separately via `Popen` with none) the menu
@@ -1936,21 +2169,31 @@ class MenuFormatIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
         all. It passed five runs in a row before this was caught — a single, correct
         sequence is what actually works, not a second one "just in case".
 
-        **The sleep below is a readiness condition ASSUMED, and it is the one case #487
-        left open — tracked as #494, not overlooked.** It stands in for "the menu is now
-        open on this client", and under cpu contention it is not: the next keystroke then
-        lands on the pane instead of the menu, and no later deadline can un-spend it.
-        Unlike every other wait in this module it cannot simply be polled, because a menu
-        is a client OVERLAY rather than pane content — `capture-pane` does not see it, and
-        twelve client/pane formats probed against a real attached client before and after
-        `display-menu` came back byte-identical but for the activity timestamp. Finding an
-        observable is the fix; a larger guess is not.
+        **This used to end in `time.sleep(0.8)`, which was a readiness condition ASSUMED
+        — the one case #487 left open, and #494.** The sleep stood in for "the menu is now
+        open on this client", and under cpu contention it was not: the next keystroke then
+        landed on the pane instead of the menu, and no later deadline can un-spend it. No
+        format reports a menu (see :class:`_Screen`, which re-probed all 168 of them), but
+        the menu is DRAWN, and this class owns the master fd of the terminal it is drawn
+        on — so *drawn*, a row of this very menu, arriving on that fd is the condition
+        itself rather than a guess at how long it takes.
+
+        *drawn* is the caller's own label, because only the caller knows what it recorded.
+        Asserting on it also closes a hole the sleep left open in the two tests whose only
+        assertion is that a canary does NOT exist: a menu that never opened at all made
+        those pass for no reason. They now have to show the hostile label really was
+        rendered before "and it did not execute" means anything.
         """
         bind_cmd = ["tmux", "-L", SOCKET, "bind", "-n", "F2"] + cmd[3:]
         r = subprocess.run(bind_cmd, capture_output=True, text=True, timeout=5)
         self.assertEqual(r.returncode, 0, r.stderr)
         os.write(fd, b"\x1bOQ")
-        time.sleep(0.8)
+        self.assertTrue(
+            screen.await_drawn(drawn),
+            f"the menu never drew {drawn!r} on the client that pressed the hotkey, so "
+            "nothing below is about an open menu — a keystroke sent now would be spent "
+            "on the pane, and an assertion that a canary does not exist would pass "
+            "because no menu was ever rendered to execute it")
 
     def _short_canary(self, name: str) -> str:
         """A canary path SHORT enough to survive `record`'s own `_MAX_LABEL` (60 chars)
@@ -1979,13 +2222,17 @@ class MenuFormatIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
     def test_a_shell_job_label_never_executes_when_the_menu_renders(self):
         fid = f"menu-fmt-integ-{os.getpid()}"
         self._new_session(fid)
-        client, fd = self._attach_pty(fid)
+        client, fd, screen = self._attach_pty(fid)
 
         canary = self._short_canary("a")
         hostile_label = f"#(touch {canary})"
 
         menu.record(fid=fid, entries=[(hostile_label, ["true"])])
-        self._drive_menu(fd, menu.menu_argv(fid, SOCKET, client=client))
+        # The label's own basename is what tmux draws once `_safe_label`'s `##` is
+        # collapsed back to one `#` — so waiting for it is waiting for THIS row to be on
+        # screen, which is the precondition "and it still did not execute" needs.
+        self._drive_menu(fd, menu.menu_argv(fid, SOCKET, client=client),
+                         screen=screen, drawn=os.path.basename(canary))
 
         self.assertFalse(os.path.exists(canary),
                          "an unescaped #(...) label executed the instant the menu was "
@@ -1998,13 +2245,14 @@ class MenuFormatIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
         real, rendered menu, not only in `menu_argv`'s own argv-shape unit test."""
         fid = f"menu-fmt-integ2-{os.getpid()}"
         self._new_session(fid)
-        client, fd = self._attach_pty(fid)
+        client, fd, screen = self._attach_pty(fid)
 
         canary = self._short_canary("b")
         hostile_label = f"#{{session_name}} #(touch {canary})"
 
         menu.record(fid=fid, entries=[(hostile_label, ["true"])])
-        self._drive_menu(fd, menu.menu_argv(fid, SOCKET, client=client))
+        self._drive_menu(fd, menu.menu_argv(fid, SOCKET, client=client),
+                         screen=screen, drawn=os.path.basename(canary))
 
         self.assertFalse(os.path.exists(canary),
                          "#{session_name} and #(...) both reach the SAME escape — a "
@@ -2020,7 +2268,7 @@ class MenuFormatIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
         the real id) is what runs, never anything derived from the label."""
         fid = f"menu-fmt-integ3-{os.getpid()}"
         self._new_session(fid)
-        client, fd = self._attach_pty(fid)
+        client, fd, screen = self._attach_pty(fid)
         self.assertEqual(_run(commands_frame._session_id_env_argv(
             socket=SOCKET, session=fid)).returncode, 0)
 
@@ -2044,7 +2292,8 @@ class MenuFormatIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
                               sys.executable).returncode, 0)
         cmd = menu.menu_argv(fid, SOCKET, client=client)
         self.assertIn("$CHARTER_PY", cmd[-1])
-        self._drive_menu(fd, cmd)
+        self._drive_menu(fd, cmd, screen=screen,
+                         drawn=os.path.basename(format_canary))
 
         self.assertFalse(os.path.exists(format_canary),
                          "the hostile label must not have executed merely by being "
@@ -2078,7 +2327,7 @@ class MenuFormatIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
         """
         fid = f"menu-fmt-integ4-{os.getpid()}"
         self._new_session(fid)
-        client, fd = self._attach_pty(fid)
+        client, fd, screen = self._attach_pty(fid)
         self.assertEqual(_run(commands_frame._session_id_env_argv(
             socket=SOCKET, session=fid)).returncode, 0)
         self.assertEqual(_tmux("set-environment", "-t", fid, "CHARTER_PY",
@@ -2096,17 +2345,28 @@ class MenuFormatIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
         menu.record(fid=fid, entries=entries)
         cmd = menu.menu_argv(fid, SOCKET, client=client)
         self.assertEqual(cmd[10:][1::3][9:], ["", ""], cmd)
-        self._drive_menu(fd, cmd)
+        self._drive_menu(fd, cmd, screen=screen, drawn="row 10")
 
-        os.write(fd, b"-")
-        time.sleep(0.8)
+        # `-`, then the FIRST of the nine Downs, then wait for tmux to repaint. The wait
+        # replaces a `time.sleep(0.8)` that assumed `-` had been consumed by then: on a
+        # loaded machine it had not, and the assertion below then passed because the key
+        # was still in flight rather than because it fired nothing. A pty is a FIFO, so
+        # tmux cannot have painted a response to the Down without having already read
+        # past the `-`; there is no new TEXT to wait for, because moving a menu's
+        # selection repaints labels that are already on screen.
+        mark = screen.drawn_so_far()
+        os.write(fd, b"-\x1b[B")
+        self.assertTrue(screen.await_more_drawn(mark),
+                        "the menu never repainted after a Down, so nothing here shows "
+                        "the `-` before it was ever read")
         self.assertFalse(os.path.exists(canary),
                          "`-` fired the tenth row — it is a real tmux key, not tmux's "
                          "spelling for 'no shortcut'")
 
         # Nine Downs from the first row lands on the tenth: the menu opens with row 0
-        # selected, so the count is the index, not the position.
-        os.write(fd, b"\x1b[B" * 9 + b"\r")
+        # selected, so the count is the index, not the position. One of the nine has
+        # already been sent above.
+        os.write(fd, b"\x1b[B" * 8 + b"\r")
         deadline = time.monotonic() + _DEADLINE
         while time.monotonic() < deadline and not os.path.exists(canary):
             time.sleep(0.2)
@@ -2315,11 +2575,75 @@ class MenuClientIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
         self.addCleanup(_cleanup)
         return path
 
+    #: The row every test here records, with the trial's own canary name in it.
+    #:
+    #: The name is not decoration: it is the READINESS CONDITION. A menu is drawn on the
+    #: client it belongs to and on no other, so this text arriving on the presser's own
+    #: pty is "the menu is open, on that client" — observed, where the 0.8 s sleep this
+    #: replaces could only assume it (#494). See :class:`_Screen`.
+    @staticmethod
+    def _row(canary: str) -> str:
+        return f"Detach {os.path.basename(canary)}"
+
+    def _menu_opened_on(self, *, screen: _Screen, other: _Screen, row: str,
+                        who: str) -> None:
+        """Wait until *row* is really drawn on one client's terminal, and on no other.
+
+        Two assertions, and the second is free once the first is possible at all: the
+        row must appear on the presser's terminal, and it must NOT appear on the other
+        client's. That second half used to be reachable only through the canary — "B's
+        keystroke did not select in A's menu" — which is a statement about what did NOT
+        happen. The menu's own rendering says positively whose screen it went to.
+        """
+        self.assertTrue(
+            screen.await_drawn(row),
+            f"no menu carrying {row!r} was ever drawn on {who}'s own terminal, so "
+            "nothing after this line is about an open menu: the next keystroke would be "
+            "spent on the pane, and the assertion that the OTHER client cannot select "
+            "in it would hold for that reason instead of the one it claims")
+        self.assertFalse(
+            other.saw(row),
+            f"{who}'s menu ({row!r}) was drawn on the OTHER client's terminal as well — "
+            "`display-menu -c` did not confine it to the presser, which is the exact "
+            "regression this class exists for")
+
+    def _press_hotkey(self, *, fd: int, screen: _Screen, other: _Screen,
+                      row: str, who: str) -> None:
+        """Press F2 on one client and wait until that client's own menu is really open."""
+        os.write(fd, b"\x1bOQ")
+        self._menu_opened_on(screen=screen, other=other, row=row, who=who)
+
+    def _a_key_the_menu_must_not_take(self, *, fid: str, fd: int, who: str) -> None:
+        """Send `1` from a client that has NO menu open, and wait for it to be spent.
+
+        The negative half of both tests below — "this client's keystream must not select
+        in the other's menu" — is worth nothing while the keystroke is still in flight,
+        which is precisely what the `time.sleep(0.8)` this replaces was relying on. A
+        client with no menu sends its keys to the PANE, whose `/bin/cat` echoes them, so
+        the pane's own text changing is tmux reporting that the key was delivered and
+        spent somewhere that is not a menu.
+        """
+        before = _tmux("capture-pane", "-p", "-t", fid).stdout
+        os.write(fd, b"1")
+        self.assertNotEqual(
+            _await_pane_changed(fid, before), before,
+            f"{who}'s `1` never reached anything — the pane it must fall through to "
+            "never echoed it, so the assertion below would be about a keystroke that "
+            "was never delivered rather than one that was refused")
+
+    def _select(self, fd: int, canary: str, why: str) -> None:
+        """Press the row's own key on the client whose menu is open; the canary follows."""
+        os.write(fd, b"1")
+        deadline = time.monotonic() + _DEADLINE
+        while time.monotonic() < deadline and not os.path.exists(canary):
+            time.sleep(0.2)
+        self.assertTrue(os.path.exists(canary), why)
+
     def test_each_presser_gets_their_own_menu_not_the_others(self):
         fid = f"menu-client-integ-{os.getpid()}"
         self._new_session(fid)
-        clientA, fdA = self._attach_pty(fid)
-        clientB, fdB = self._attach_pty(fid, exclude=frozenset({clientA}))
+        clientA, fdA, screenA = self._attach_pty(fid)
+        clientB, fdB, screenB = self._attach_pty(fid, exclude=frozenset({clientA}))
         self.assertNotEqual(clientA, clientB)
         self.assertEqual(_run(commands_frame._session_id_env_argv(
             socket=SOCKET, session=fid)).returncode, 0)
@@ -2333,44 +2657,33 @@ class MenuClientIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
         # -- A presses: only A's own keystream may select what A's own press opened --
         canary_a = self._short_canary("a")
         menu.record(fid=fid, entries=[
-            ("Detach", [sys.executable, "-c", f"open({canary_a!r}, 'w').close()"]),
+            (self._row(canary_a),
+             [sys.executable, "-c", f"open({canary_a!r}, 'w').close()"]),
         ])
-        # Both sleeps stand in for "the menu is open on that client" — assumed rather
-        # than waited on, the one readiness condition #487 could not convert to a poll.
-        # See `_NeedsAttachedClient._attach_pty`'s sibling `_press_hotkey` and #494.
-        os.write(fdA, b"\x1bOQ")
-        time.sleep(0.8)
-        os.write(fdB, b"1")
-        time.sleep(0.8)
+        self._press_hotkey(fd=fdA, screen=screenA, other=screenB,
+                           row=self._row(canary_a), who="A")
+        self._a_key_the_menu_must_not_take(fid=fid, fd=fdB, who="B")
         self.assertFalse(os.path.exists(canary_a),
                          "client B's own keystream selected an item in the menu A's "
                          "own hotkey opened — the menu did not open specifically on "
                          "A's screen (the exact regression this round fixes)")
-        os.write(fdA, b"1")
-        deadline = time.monotonic() + _DEADLINE
-        while time.monotonic() < deadline and not os.path.exists(canary_a):
-            time.sleep(0.2)
-        self.assertTrue(os.path.exists(canary_a),
-                        "A's own hotkey press must open A's own, selectable menu")
+        self._select(fdA, canary_a,
+                     "A's own hotkey press must open A's own, selectable menu")
 
         # -- Now B presses: the reverse must hold too, not just one direction --
         canary_b = self._short_canary("b")
         menu.record(fid=fid, entries=[
-            ("Detach", [sys.executable, "-c", f"open({canary_b!r}, 'w').close()"]),
+            (self._row(canary_b),
+             [sys.executable, "-c", f"open({canary_b!r}, 'w').close()"]),
         ])
-        os.write(fdB, b"\x1bOQ")
-        time.sleep(0.8)
-        os.write(fdA, b"1")
-        time.sleep(0.8)
+        self._press_hotkey(fd=fdB, screen=screenB, other=screenA,
+                           row=self._row(canary_b), who="B")
+        self._a_key_the_menu_must_not_take(fid=fid, fd=fdA, who="A")
         self.assertFalse(os.path.exists(canary_b),
                          "client A's own keystream selected an item in the menu B's "
                          "own hotkey opened")
-        os.write(fdB, b"1")
-        deadline = time.monotonic() + _DEADLINE
-        while time.monotonic() < deadline and not os.path.exists(canary_b):
-            time.sleep(0.2)
-        self.assertTrue(os.path.exists(canary_b),
-                        "B's own hotkey press must open B's own, selectable menu")
+        self._select(fdB, canary_b,
+                     "B's own hotkey press must open B's own, selectable menu")
 
     def test_a_submenu_opens_on_the_presser_and_its_rows_are_selectable(self):
         """#517's whole mechanism, proved through the real chain rather than asserted
@@ -2395,8 +2708,8 @@ class MenuClientIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
         """
         fid = f"menu-sub-integ-{os.getpid()}"
         self._new_session(fid)
-        clientA, fdA = self._attach_pty(fid)
-        clientB, fdB = self._attach_pty(fid, exclude=frozenset({clientA}))
+        clientA, fdA, screenA = self._attach_pty(fid)
+        clientB, fdB, screenB = self._attach_pty(fid, exclude=frozenset({clientA}))
         self.assertNotEqual(clientA, clientB)
         self.assertEqual(_run(commands_frame._session_id_env_argv(
             socket=SOCKET, session=fid)).returncode, 0)
@@ -2405,30 +2718,37 @@ class MenuClientIntegration(_NeedsAttachedClient, PersonaIso, unittest.TestCase)
         self._install_real_bind(fid)
 
         canary = self._short_canary("sub")
+        # Two DIFFERENT names, so "the top menu is open" and "the submenu is open" are
+        # two different readings off the presser's terminal rather than one. The whole
+        # test turns on the second menu, and a needle both menus matched could not tell
+        # a submenu that never opened from one that did.
+        opener_row = f"workspace: {os.path.basename(canary)} open  ▸"
+        sub_row = f"* demo {os.path.basename(canary)} row"
         menu.record(fid=fid, entries=[
-            menu.Entry("workspace: demo  ▸", opens="workspace"),
-            menu.Entry("* demo",
+            menu.Entry(opener_row, opens="workspace"),
+            menu.Entry(sub_row,
                        (sys.executable, "-c", f"open({canary!r}, 'w').close()"),
                        "workspace"),
         ])
 
-        os.write(fdA, b"\x1bOQ")   # F2 on A -> the top-level menu, on A
-        time.sleep(0.8)
-        os.write(fdA, b"1")        # its only row is the opener -> the submenu, on A
-        time.sleep(1.2)
-        os.write(fdB, b"1")        # B must not be able to select in A's submenu
-        time.sleep(0.8)
+        # F2 on A -> the top-level menu, on A; its only row is the opener, and pressing
+        # it runs a `run-shell` child that opens the SUBMENU. Both openings are waited
+        # for on A's own screen rather than slept through (#494) — and the submenu is the
+        # one that matters, because it is a second `display-menu` targeted by a format
+        # expanded inside the first one's item text, which is exactly what could land on
+        # the wrong client.
+        self._press_hotkey(fd=fdA, screen=screenA, other=screenB, row=opener_row,
+                           who="A")
+        os.write(fdA, b"1")
+        self._menu_opened_on(screen=screenA, other=screenB, row=sub_row, who="A")
+        self._a_key_the_menu_must_not_take(fid=fid, fd=fdB, who="B")
         self.assertFalse(os.path.exists(canary),
                          "client B's keystream selected a row in the SUBMENU that A's "
                          "own press opened — `#{client_name}` inside a menu item's own "
                          "command did not resolve to the client the menu was drawn on")
-        os.write(fdA, b"1")
-        deadline = time.monotonic() + _DEADLINE
-        while time.monotonic() < deadline and not os.path.exists(canary):
-            time.sleep(0.2)
-        self.assertTrue(os.path.exists(canary),
-                        "selecting a submenu opener must open a submenu on the "
-                        "presser's own client, with selectable rows")
+        self._select(fdA, canary,
+                     "selecting a submenu opener must open a submenu on the "
+                     "presser's own client, with selectable rows")
 
 
 def _git(repo: Path, *args: str) -> None:
@@ -3142,7 +3462,7 @@ class TheTablesWidthIsWhatTmuxActuallyGivesIt(_TmuxServerFixture, PersonaIso):
 
 
 @unittest.skipUnless(_HAS_TMUX, "tmux is not installed on this machine")
-class EarlyDeathIntegration(unittest.TestCase):
+class EarlyDeathIntegration(_VoidDeaths, unittest.TestCase):
     """#384: what a command that dies before the frame is drawn actually leaves behind.
 
     `commands_frame.early_death_message`'s whole design rests on facts about TMUX, not
@@ -3197,11 +3517,17 @@ class EarlyDeathIntegration(unittest.TestCase):
         so the second and later sessions in one test would otherwise let their pane
         vanish the instant it died — and a pane that is gone answers nothing, which would
         make every assertion below vacuous rather than red.
+
+        The conf carries ONE line the launcher's own does not: the array probe, armed
+        GLOBALLY — see `_a_measured_death` for what it is for, and why it cannot be armed
+        the way every other class here arms it.
         """
         self._n += 1
         name = f"d{self._n}"
         conf = self._conf_dir / f"{name}.conf"
-        conf.write_text(commands_frame._PLACEHOLDER_CONF)
+        conf.write_text(commands_frame._PLACEHOLDER_CONF
+                        + f"set-hook -g pane-died[{self._PROBE_INDEX}] "
+                          f"'{self._PROBE_ACTION}'\n")
         _tmux("set", "-g", "remain-on-exit", "on")  # no-op (and an error) before the
                                                     # first session; `-f` covers that one
         r = _run(layout.session_argv(session=name, conf=str(conf), socket=SOCKET,
@@ -3211,13 +3537,57 @@ class EarlyDeathIntegration(unittest.TestCase):
         self.assertTrue(pane, "tmux reported no pane id for the new session")
         return pane, _await_dead(pane)
 
+    def _a_measured_death(self, *harness_argv: str) -> tuple[str, int | None]:
+        """`_die`, but only ever returning a death tmux actually had the child's status
+        for — #507.
+
+        **This is #487's mechanism reaching a class that had no defence against it.** On a
+        loaded tmux 3.4 roughly one death in seventeen closes the pane's fd before tmux
+        has the child's status and never gets it: `#{pane_dead}` `1`,
+        `#{pane_dead_status}` EMPTY, the pane's `pane-died` array never run, permanently.
+        `commands_frame._pane_state` folds that empty status to `_UNKNOWN_DEATH_CODE`, so
+        `_die` hands back `1` — and `test_a_lone_argument_reaches_a_shell_not_execvp`
+        compares it with `7` and fails, saying "a single argument must reach a shell"
+        about a machine on which the argument reached a shell perfectly well. That is
+        exactly what CI showed: red on Python 3.11 and 3.13 in one run, green on a re-run
+        of identical bytes, six distinct tests in this module in one day.
+
+        **The probe is armed in the server's own CONFIG FILE, and it has to be.** Every
+        other class here arms `pane-died` on a pane it already holds, after a gate the
+        test opens when it wants the death. There is no gate here: the whole subject is a
+        command that dies BEFORE the frame is drawn, so the pane is often dead before
+        `new-session` has even printed its id, and a hook installed afterwards could never
+        have fired for it. `tmux -f <conf>` is read at server start, before any pane
+        exists — measured against tmux 3.7c: a pane running `exit 7` that dies instantly
+        still sets the option, and the global hook stays armed for the second and later
+        sessions on the same server.
+
+        **A void is asserted, never assumed** (`_the_array_never_ran`): a pane tmux
+        DESTROYED rather than kept, and a pane tmux holds a status for but ran no hook
+        for, are both real defects and both say which one they are. So the only reading
+        that spends another pane is the one that was actually measured — and after
+        `_HOOK_TRIALS` of them the test skips, naming the capability it could not get,
+        rather than asserting on a number tmux never had.
+        """
+        for _ in range(self._HOOK_TRIALS):
+            pane, code = self._die(*harness_argv)
+            if self._the_array_ran(pane):
+                return pane, code
+            self._the_array_never_ran(
+                pane, "tmux never ran this pane's `pane-died` array")
+        self._no_death_was_delivered()
+
     def test_a_lone_argument_reaches_a_shell_not_execvp(self):
         """Half of the contract `charter frame --` is not allowed to narrow. `exit 7` is
         not a program on any machine — it is shell syntax, and it comes back as 7 only if
         tmux ran it through a shell. A `shutil.which(argv[0])` pre-check would refuse
         this text outright (it is not even one word), which is why #384's fix reports
-        after the fact instead of predicting beforehand."""
-        pane, code = self._die("exit 7")
+        after the fact instead of predicting beforehand.
+
+        Through `_a_measured_death`, not `_die`: the number this asserts on is the one a
+        void death does not have (#507). Nothing is widened — `7` is still the only value
+        that passes."""
+        pane, code = self._a_measured_death("exit 7")
         self.assertEqual(code, 7,
                          "a single argument must reach a shell — `charter frame -- "
                          "'ulimit -n; exit 3'` and every other one-liner depend on it")
@@ -3227,8 +3597,13 @@ class EarlyDeathIntegration(unittest.TestCase):
         guess: split into two arguments, the same text is `execvp`'d, so `exit` is looked
         up as a program, is not found, and cannot possibly have run. A word that resolves
         to nothing in THIS form provably never executed — which is the one condition
-        under which `_could_not_have_run` is allowed to speak."""
-        pane, code = self._die("exit", "7")
+        under which `_could_not_have_run` is allowed to speak.
+
+        `_a_measured_death` here for a reason the assertions do not show: this test's
+        `assertNotEqual(code, 7)` would PASS on a void, whose `_UNKNOWN_DEATH_CODE` is
+        `1` — a green that measured nothing at all, which is worse than the red its
+        sibling gets."""
+        pane, code = self._a_measured_death("exit", "7")
         self.assertIsNotNone(code, "the pane should have died at once")
         self.assertNotEqual(code, 7,
                             "`exit 7` must NOT be interpreted by a shell once it is two "
@@ -3247,8 +3622,12 @@ class EarlyDeathIntegration(unittest.TestCase):
 
         No shell's exact phrasing is asserted (`sh`, `dash`, `bash` and `zsh` all differ,
         and tmux uses the machine's own `default-shell`) — only that the missing word
-        itself comes back, which every one of them names."""
-        pane, code = self._die(self.MISSING)
+        itself comes back, which every one of them names.
+
+        `_a_measured_death` for its `code`, which reaches `early_death_message` and is
+        asserted to be non-zero: a void's `_UNKNOWN_DEATH_CODE` is `1`, so that assertion
+        too would pass on a death nothing was learned from (#507)."""
+        pane, code = self._a_measured_death(self.MISSING)
         self.assertIsNotNone(code, "the pane should have died at once")
         self.assertNotEqual(code, 0)
         words = commands_frame._pane_last_words(SOCKET, pane)
@@ -3271,8 +3650,12 @@ class EarlyDeathIntegration(unittest.TestCase):
         either way — it quotes the pane when there is one and answers for itself when
         there is not. What must never differ is that the operator is told which command
         died, which is the whole of #384. The branch-specific wording is pinned where it
-        can be pinned exactly, in `tests/test_frame_launcher.py::EarlyDeathIsLegible`."""
-        pane, code = self._die(self.MISSING, "--flag")
+        can be pinned exactly, in `tests/test_frame_launcher.py::EarlyDeathIsLegible`.
+
+        `_a_measured_death` for the same reason its siblings use it: `assertIn(str(code),
+        msg)` compares the message against whatever number `_pane_state` produced, and on
+        a void that number is `_UNKNOWN_DEATH_CODE` rather than the child's (#507)."""
+        pane, code = self._a_measured_death(self.MISSING, "--flag")
         self.assertIsNotNone(code, "the pane should have died at once")
         self.assertNotEqual(code, 0)
         words = commands_frame._pane_last_words(SOCKET, pane)
@@ -3430,9 +3813,9 @@ class WindowInsideAnOperatorsTmux(_TmuxServerFixture, PersonaIso):
             self.assertEqual(r.returncode, 0, r.stderr)
             self.assertEqual(commands_frame._pane_state(OP_SOCKET_PATH, pane_id),
                              (commands_frame._ALIVE, None))
-            probe = self._arm_array_probe(pane_id)
+            self._arm_array_probe(pane_id)
             self._release(gate)
-            if not _await_file(probe):
+            if not self._the_array_ran(pane_id):
                 self._the_array_never_ran(
                     pane_id, "tmux never ran the harness pane's `pane-died` array")
                 _run(tmuxctl.server_argv(OP_SOCKET_PATH, "kill-window", "-t", window_id))

--- a/tests/test_guard_denials_record_their_shape.py
+++ b/tests/test_guard_denials_record_their_shape.py
@@ -114,10 +114,6 @@ class TestTheHumanReasonIsUnchanged(InAControlPlane):
         self.assertIsNone(hooks._single_credential_reason("git status"))
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestTheCmdFieldLeaksNoValueEither(ShapeCase):
     """`cmd` records the command's first token, which for `VAR=value cmd` is the whole
     assignment — value included. Live traces held `D=/private/tmp/.../demo-plane;` and
@@ -141,3 +137,7 @@ class TestTheCmdFieldLeaksNoValueEither(ShapeCase):
 
     def test_an_ordinary_binary_is_unchanged(self):
         self.assertEqual("git", self.head_of("git clone git@github.com:acme/x.git"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -441,10 +441,6 @@ class TestGuardsAreScopedToAPlane(PersonaIso):
         self.assertEqual(self._decide("charter secret get devops API_TOKEN --reveal"), "deny")
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestLeakGuardInspectsInvocationsNotProse(PersonaIso):
     """Both patterns were substring scans over the whole command line, so a command that
     merely MENTIONED the words was hard-denied with a reason misdescribing what it did.
@@ -493,3 +489,7 @@ class TestAbbreviationsCannotWalkPastTheGuard(unittest.TestCase):
         from charter import cli
         ns = cli.build_parser().parse_args(["secret", "get", "v", "k", "--reveal"])
         self.assertTrue(ns.reveal)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hooks_need_no_async.py
+++ b/tests/test_hooks_need_no_async.py
@@ -78,10 +78,6 @@ class Detaching(unittest.TestCase):
             self.assertFalse(util.detach_self(["gl-refresh"]))
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TheCommandsHonourTheFlag(unittest.TestCase):
     """The manifest passing `--detach` proves nothing on its own.
 
@@ -121,3 +117,7 @@ class TheCommandsHonourTheFlag(unittest.TestCase):
                 mock.patch.object(commands.workspace, "repo_trees", return_value=[]):
             commands.cmd_gl_refresh(SimpleNamespace(detach=False, workspace=None))
         spawn.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_inflight_dispatch.py
+++ b/tests/test_inflight_dispatch.py
@@ -308,10 +308,6 @@ class ManifestWiring(unittest.TestCase):
                          "must match dispatch tools only — never every Bash call")
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class RecordsSayWhatKindOfWorkTheyAre(unittest.TestCase):
     """#420. #387 promised the frame "a spinner while a dispatch, clone or `gl-refresh`
     runs" and shipped dispatches only, because `inflight.start` had exactly one caller.
@@ -561,3 +557,7 @@ class CloneAndRefreshActuallyRecordThemselves(PersonaIso, unittest.TestCase):
         self.assertEqual(rc, 0)
         detach.assert_called_once()
         self.assertEqual(inflight.live_records(kind=None), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -186,10 +186,6 @@ class TestGitignorePresenceCheckIsPrecise(InitIso):
         self.assertEqual(before, after)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestSummaryStaysReadable(InitIso):
     """One line naming every file charter wrote is unreadable once there are three
     harnesses to wire — it reached 254 characters, which is also what made the README's
@@ -228,3 +224,7 @@ class TestSummaryStaysReadable(InitIso):
         # new file, never on a longer way of naming an old one. Past this the README's
         # demo capture stops being legible at GitHub's column width.
         self.assertLess(len(line), 195, f"{len(line)} chars:\n{line}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_no_test_hides_below_the_main_trailer.py
+++ b/tests/test_no_test_hides_below_the_main_trailer.py
@@ -1,0 +1,182 @@
+"""Nothing in a test module may sit BELOW its `if __name__ == "__main__"` trailer (#531).
+
+`unittest.main()` raises `SystemExit`. So in the one invocation the trailer exists for —
+`python3 tests/test_x.py`, the way a developer runs the single file they are debugging —
+every top-level statement written after it is dead: the classes are never defined, their
+tests are never collected, and the run says `OK` about the subset that happened to be
+above the line.
+
+**Twenty-six modules had done it**, and the subset that ran was biased the wrong way. In
+`test_doctor_shadowed.py` the eight tests above the trailer were the pure-function ones
+and the six below were the `PersonaIso` classes that exercise the real seam;
+`python3 tests/test_doctor_shadowed.py` reported `Ran 8 tests / OK` while
+`python3 -m unittest tests.test_doctor_shadowed` ran 14. Across the twenty-six, **154
+tests were invisible to a direct run**.
+
+Nothing was lost in CI — `unittest discover` IMPORTS a module rather than executing it as
+`__main__`, so the trailer never fires there and every class is collected. Measured, not
+assumed: all 154 ran and passed under discovery. The gap opens only for the person
+debugging one file, which is exactly the moment a green run is being trusted hardest, and
+exactly the population #402/#492, #519/#521/#528 and #529 were also all about.
+
+**A guard, not a sweep.** Moving twenty-six trailers is a fix that has to be made a
+twenty-seventh time next month by whoever appends a class to a finished file and does not
+notice the trailer sitting above the insertion point — which is how all twenty-six got
+there, the shape being consistent enough to be diagnostic. This fails on the PR that adds
+the twenty-seventh instead, naming the module, the line, what got hidden, and both ways
+out.
+
+**Anything, not just a class.** The rule is not "no class below the trailer" but "nothing
+below the trailer", because `SystemExit` does not care what the statement is: a helper
+function, a constant, a `mock.patch` teardown all fail the same way, and a rule that named
+classes would wave the next shape through.
+"""
+
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+#: The suite itself — the tree this walks, and the tree it is part of.
+TESTS = Path(__file__).resolve().parent
+
+#: `unittest discover`'s own default pattern, so this guard's idea of "a test module" and
+#: the runner's cannot drift apart. A module the runner collects and this walker skipped
+#: would be a hole exactly the shape of the defect.
+PATTERN = "test*.py"
+
+
+def _trailer(tree: ast.Module) -> ast.If | None:
+    """The module's LAST `if __name__ == ...` block, or `None`.
+
+    The last one rather than the first: a module with two would have the same defect
+    measured from the lower one, and a check anchored on the first would report the
+    statements between them as hidden when they are not.
+
+    Matched on the NAME being compared, not on the string it is compared with — the
+    idiom is spelled `"__main__"` everywhere in this suite today, but `'__main__'`,
+    `!=`, or a comparison against a variable all still run at module-exec time and all
+    still `SystemExit` past whatever follows.
+    """
+    found = None
+    for node in tree.body:
+        if (isinstance(node, ast.If)
+                and isinstance(node.test, ast.Compare)
+                and isinstance(node.test.left, ast.Name)
+                and node.test.left.id == "__name__"):
+            found = node
+    return found
+
+
+def hidden_below_the_trailer(source: str) -> tuple[int, list[tuple[int, str]]]:
+    """What *source* defines after its trailer: `(trailer line, [(line, what), …])`.
+
+    A pure function of the text so the guard below can be shown to FAIL on a module with
+    the defect — see `TheGuardIsNotBlind`. A checker only ever run against a clean tree
+    is a checker nobody has watched work.
+    """
+    tree = ast.parse(source)
+    trailer = _trailer(tree)
+    if trailer is None:
+        return 0, []
+    below = [n for n in tree.body if n.lineno > trailer.lineno]
+    return trailer.lineno, [(n.lineno, getattr(n, "name", type(n).__name__))
+                            for n in below]
+
+
+class NoTestModuleHidesAnythingBelowItsTrailer(unittest.TestCase):
+
+    def test_the_walker_sees_the_whole_suite(self):
+        """The guard's own blind spot, checked first: a walk that found nothing to check
+        would pass forever and say nothing. This suite is over two hundred modules."""
+        modules = sorted(TESTS.glob(PATTERN))
+        self.assertGreater(len(modules), 200,
+                           f"only {len(modules)} test modules found under {TESTS} — the "
+                           f"walk below is checking almost nothing")
+        self.assertIn(Path(__file__).name, [p.name for p in modules],
+                      "the guard does not match its own filename against "
+                      f"{PATTERN!r}, so it cannot be walking what the runner collects")
+
+    def test_nothing_is_defined_after_a_main_trailer(self):
+        for path in sorted(TESTS.glob(PATTERN)):
+            with self.subTest(module=path.name):
+                line, below = hidden_below_the_trailer(path.read_text())
+                self.assertEqual(
+                    below, [],
+                    f"{path.name} defines "
+                    + ", ".join(f"{what!r} (line {at})" for at, what in below)
+                    + f" AFTER the `if __name__` trailer on line {line}. "
+                    "`unittest.main()` raises SystemExit, so `python3 "
+                    f"tests/{path.name}` never defines any of that and reports OK about "
+                    "the tests above the line only (`python3 -m unittest "
+                    f"tests.{path.stem}` runs them all, which is why CI never saw it). "
+                    "Move the trailer to the END of the file, or delete it and run the "
+                    f"module as `python3 -m unittest tests.{path.stem}`.")
+
+
+class TheGuardIsNotBlind(unittest.TestCase):
+    """A guard nobody has watched fail is a guard nobody knows works — the same standard
+    `tests/test_no_test_reads_the_operators_channel.py` holds its own tripwire to."""
+
+    DEFECTIVE = (
+        "import unittest\n"
+        "class Above(unittest.TestCase):\n"
+        "    def test_a(self):\n"
+        "        pass\n"
+        'if __name__ == "__main__":\n'
+        "    unittest.main()\n"
+        "class Below(unittest.TestCase):\n"
+        "    def test_b(self):\n"
+        "        pass\n"
+    )
+
+    def test_a_class_below_the_trailer_is_reported(self):
+        line, below = hidden_below_the_trailer(self.DEFECTIVE)
+        self.assertEqual(line, 5)
+        self.assertEqual(below, [(7, "Below")])
+
+    def test_the_same_module_with_the_trailer_last_is_clean(self):
+        """The control for the control: the fix this guard asks for really does satisfy
+        it, so "move the trailer down" is advice that works rather than advice that
+        merely sounds right."""
+        fixed = self.DEFECTIVE.replace(
+            'if __name__ == "__main__":\n    unittest.main()\n', "")
+        fixed += 'if __name__ == "__main__":\n    unittest.main()\n'
+        self.assertEqual(hidden_below_the_trailer(fixed), (8, []))
+
+    def test_a_helper_below_the_trailer_is_reported_too(self):
+        """Not only classes — `SystemExit` hides a function or a constant just as
+        completely, and the module that hides one is broken in a way that is harder to
+        see, not easier."""
+        source = ('import unittest\n'
+                  'if __name__ == "__main__":\n'
+                  '    unittest.main()\n'
+                  'HELPER = 1\n'
+                  'def helper():\n'
+                  '    return HELPER\n')
+        self.assertEqual(hidden_below_the_trailer(source),
+                         (2, [(4, "Assign"), (5, "helper")]))
+
+    def test_a_module_with_no_trailer_at_all_is_clean(self):
+        """Three modules in this suite carry none. Deleting the trailer is one of the two
+        ways out the failure message offers, so it has to be a way OUT and not a way into
+        a different failure."""
+        self.assertEqual(
+            hidden_below_the_trailer("import unittest\nX = 1\n"), (0, []))
+
+    def test_the_last_trailer_is_the_one_measured(self):
+        """A module with two trailers is defective from the LOWER one. Anchored on the
+        first, this would report the second trailer itself — and everything between them
+        — as hidden, which is a failure message that sends the reader to the wrong line."""
+        source = ('import unittest\n'
+                  'if __name__ == "__main__":\n'
+                  '    unittest.main()\n'
+                  'if __name__ == "__main__":\n'
+                  '    unittest.main()\n'
+                  'X = 1\n')
+        self.assertEqual(hidden_below_the_trailer(source), (4, [(6, "Assign")]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_opencode_shim.py
+++ b/tests/test_opencode_shim.py
@@ -53,10 +53,6 @@ class EnsureShim(unittest.TestCase):
         self.assertIn("input.sessionID", src)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class GuardForwarding(unittest.TestCase):
     """The shim turns an opencode tool call into the hook payload charter already reads.
 
@@ -208,3 +204,7 @@ class MidSessionNudges(unittest.TestCase):
     def test_the_appended_text_is_fenced_so_it_cannot_be_mistaken_for_output(self):
         self.assertIn("charter", self.src.lower())
         self.assertIn("additionalContext", self.src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_persona_agent_forge_wording.py
+++ b/tests/test_persona_agent_forge_wording.py
@@ -84,10 +84,6 @@ class TestGeneratedAgentForgeWordingMatchesDeclaredForges(PersonaIso):
         self.assertIn("gh auth status", text)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class GeneratedAgentBody(unittest.TestCase):
     """What `_render_agent` emits — the reviewer-reported gaps (#7, #8, #9)."""
 
@@ -181,3 +177,7 @@ class DispatchIsolationHint(unittest.TestCase):
                                      "dispatch-isolation": "worktree"}, "# body\n")
         head = body.split("---")[1]
         self.assertNotIn("dispatch-isolation:", head)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_persona_memory_sync.py
+++ b/tests/test_persona_memory_sync.py
@@ -72,10 +72,6 @@ class TestMemorySync(unittest.TestCase):
         self.assertIn("leak", self._pending())     # left uncommitted
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class EveryPlaneCommitOffersTheForgeToken(PersonaIso):
     """charter's headline rule is one credential: each repo's own forge's token over
     HTTPS, never SSH. `commands.commit_push` obeyed it; `cmd_persona_memory_sync` had
@@ -156,3 +152,7 @@ class EveryPlaneCommitOffersTheForgeToken(PersonaIso):
                           f"a push without the forge token: {argv}")
             self.assertFalse([a for a in argv if a.startswith("git@")],
                              f"an SSH remote reached a push: {argv}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_persona_skill_lint.py
+++ b/tests/test_persona_skill_lint.py
@@ -52,10 +52,6 @@ class SkillRefLintCase(unittest.TestCase):
         self.assertEqual(persona._skill_ref_issues("`mattpocock-skills:ask-matt`"), [])
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class UnknownFrontmatterKey(unittest.TestCase):
     """#8: a charter key charter neither reads nor emits reaches nothing.
 
@@ -75,3 +71,7 @@ class UnknownFrontmatterKey(unittest.TestCase):
         """A key in both would mean charter reads it AND emits it — say which."""
         from charter.commands_persona import _AGENT_PASSTHROUGH_KEYS, _CHARTER_OWN_KEYS
         self.assertEqual(set(_AGENT_PASSTHROUGH_KEYS) & set(_CHARTER_OWN_KEYS), set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plane_repo.py
+++ b/tests/test_plane_repo.py
@@ -216,10 +216,6 @@ class TestItNeverReachesDisk(PlaneRepoCase):
         self.assertEqual([r["name"] for r in on_disk], ["web"])
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestCloneToleratesAThinRecord(PlaneRepoCase):
     """`cmd_clone` read `r['default_branch']` directly, so ANY record without it took the
     whole command down with a KeyError rather than cloning. Found by cloning the plane
@@ -236,3 +232,7 @@ class TestCloneToleratesAThinRecord(PlaneRepoCase):
         rec = {"name": "api", "path_with_namespace": "acme/api", "forge": "github",
                "default_branch": "trunk"}
         self.assertIn("trunk", commands._clone_announcement(rec))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plane_root_branch_guard.py
+++ b/tests/test_plane_root_branch_guard.py
@@ -160,10 +160,6 @@ class TestItIsScopedToAPlane(PlaneRootCase):
         self.assertIsNone(_decision(self.run_cmd("git checkout feature")))
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestTheSeparatorIsNotProofOfARestore(PlaneRootCase):
     """`--` separates refs from PATHS, and only what follows it is a path.
 
@@ -198,3 +194,7 @@ class TestTheSeparatorIsNotProofOfARestore(PlaneRootCase):
 
     def test_the_remedy_still_runs_with_a_separator(self):
         self.assertNotEqual(_decision(self.run_cmd("git checkout main --")), "deny")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -282,10 +282,6 @@ class TestVersionSkew(unittest.TestCase):
         self.assertIsNone(hooks.skew_message("not-a-version"))
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestSkewReachesTheUser(unittest.TestCase):
     # `hooks.dispatch` runs REAL handlers, and a handler may write plane state — a trace
     # row, a guard-seen mark. Without redirecting the root those writes land in whatever
@@ -364,3 +360,7 @@ class TestSkewReachesTheUser(unittest.TestCase):
              mock.patch.dict(__import__("os").environ, {"CLAUDE_PLUGIN_ROOT": str(ROOT)}):
             res = doctor.check_plugin_skew()
         self.assertEqual(res.status, doctor.FAIL)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_routing_roster_block.py
+++ b/tests/test_routing_roster_block.py
@@ -174,10 +174,6 @@ class TestItIsMeasured(RosterCase):
         self.assertNotIn("SECRETVALUE", blob)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestItIsReported(RosterCase):
     """The fired-vs-followed pair has to reach a human surface, or measuring it is the
     same write-only gesture the todo store's docstring warns about."""
@@ -228,3 +224,7 @@ class TestDoctorSaysWhenRoutingIsInert(RosterCase):
         (config.ROOT / "charter.toml").write_text("schema = 1\n")
         r = doctor.check_front_door()
         self.assertNotIn("inert", (r.detail + " " + (r.hint or "")).lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_secret_dotenv.py
+++ b/tests/test_secret_dotenv.py
@@ -539,10 +539,6 @@ class DotenvExec(PersonaIso):
                          f"leaked a tmpfile after a non-VaultError exception: {written[0]}")
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class AnEmptySecretIsRefused(PersonaIso):
     """`charter secret set devops API_TOKEN` typed without a value read EOF, stored `""`
     and exited 0. Afterwards `get` says the key is present, `vault list` counts it and
@@ -613,3 +609,7 @@ class AnEmptySecretIsRefused(PersonaIso):
         with mock.patch.object(sys, "stdin", io.StringIO("")):
             self._set()
         self.assertEqual(registry.provider_for("dev").get("API_TOKEN"), "real-token")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_statusline_brand.py
+++ b/tests/test_statusline_brand.py
@@ -192,10 +192,6 @@ class NeverBlocks(unittest.TestCase):
             update.maybe_spawn = orig
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class UpgradeAdviceIsRunnable(unittest.TestCase):
     """Every upgrade command charter prints must actually work.
 
@@ -227,3 +223,7 @@ class UpgradeAdviceIsRunnable(unittest.TestCase):
                     continue
                 with self.subTest(file=rel):
                     self.assertNotIn("uv tool upgrade", line)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_statusline_gauge.py
+++ b/tests/test_statusline_gauge.py
@@ -287,10 +287,6 @@ class RepoRowSigilCase(unittest.TestCase):
         self.assertNotIn("#", line)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class VaultHealthIsCachedOffTheRenderPath(PersonaIso):
     """A `1password` or `reference` vault's `health()` shells out to `op`, and both call
     sites ran it once per persona chip with no cache — on a status line that renders every
@@ -507,3 +503,7 @@ class ThePanelsGaugeReadsTheSameAsTheFooters(unittest.TestCase):
         with mock.patch("charter.statusline._usage_file",
                         side_effect=RuntimeError("boom")):
             self.assertEqual(statusline.recorded_context_gauge("s1"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_todos_command.py
+++ b/tests/test_todos_command.py
@@ -310,10 +310,6 @@ class TestClosingIsWorkspaceScoped(ClosingCase):
         self.assertEqual(len(todos.open_todos("alpha")), 1)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestTheReservedWordsAreEscapable(TodoCommandCase):
     """Issue #59. `done` and `forget` are reserved as closing verbs, so a todo whose text
     is exactly one of them cannot be recorded. Degenerate, but the escape existed all
@@ -336,3 +332,7 @@ class TestTheReservedWordsAreEscapable(TodoCommandCase):
     def test_the_word_inside_a_longer_todo_is_untouched(self):
         rc, _ = self.run_todo(text="done with the migration, write it up")
         self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vault_registration.py
+++ b/tests/test_vault_registration.py
@@ -242,10 +242,6 @@ class SharedAndLocalHalves(PersonaIso):
         self.assertEqual(_stat.S_IMODE(config.VAULTS_REGISTRY.stat().st_mode), 0o600)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class PlaintextMustNotLandInGit(PersonaIso):
     """A plain-file vault holds PLAINTEXT. The default sits under `.charter/`, which
     `charter init` gitignores — but `--file` accepts any path, and a vault pointed at one
@@ -294,3 +290,7 @@ class PlaintextMustNotLandInGit(PersonaIso):
         _sh.rmtree(self.tmp / ".git")
         rc, _ = self._add("anywhere", file=self.tmp / "cfg" / "v.json")
         self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_version_lock.py
+++ b/tests/test_version_lock.py
@@ -204,10 +204,6 @@ class CommitPushTakesGitsArgumentsNotACommandLine(unittest.TestCase):
         self.assertEqual(bad, [], f"commit_push called with a command line, not arguments: {bad}")
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class CommitPushRefusesToClaimSuccessItDidNotHave(PersonaIso):
     """`charter save` printed `✓ Committed : charter save: 0 file(s)` and exited 0 in a
     plane that is not a git repo — which `charter init` in a fresh directory produces, and
@@ -239,3 +235,7 @@ class CommitPushRefusesToClaimSuccessItDidNotHave(PersonaIso):
             rc = commands.commit_push(self.tmp, ["add", "-A"], "m")
         self.assertEqual(rc, 0)
         self.assertIn("Nothing to save", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workspace_lock.py
+++ b/tests/test_workspace_lock.py
@@ -193,10 +193,6 @@ class TestCommandLayer(WorkspaceLockBase):
 from charter import commands_workspace as commands  # noqa: E402
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class UseDoesNotInventAWorkspaceFromATypo(WorkspaceLockBase):
     """`use` validated the name's SHAPE, then created it and took the session lock. So
     `charter workspace use fature-x` made `fature-x`, locked to it, and the correction hit
@@ -250,3 +246,7 @@ class EnsureScaffoldsSoNothingAsksForReinit(WorkspaceLockBase):
     def test_it_has_its_baseline_structure(self):
         workspace.ensure("fresh")
         self.assertTrue((config.WORKSPACES_DIR / "fresh" / "memory").is_dir())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #494
Closes #507
Closes #531

Phase 0, group **timing-and-hygiene**. Three ways a green run meant less than it looked
like. No `charter/` file is touched.

## #494 — a menu that was assumed open

`MenuClientIntegration` pressed the hotkey on one pty and slept 0.8 s before typing on the
other. Under load the menu was not open yet, the keystroke was spent on the pane, and no
later deadline can un-spend it. The negative half was worse: *"the other client's key must
not select in this menu"* is satisfied for free by a menu that never opened.

The issue asked for an observable. There is none in a format — all **168** names
`display-message -a` reports were probed against tmux 3.7c with two real ptys on one
session, before and after a `display-menu`, and only `client_written` (a byte counter)
moved, for the client with **no** menu as well.

But the menu is *drawn*, and these tests own the master fd of the terminal it is drawn on.
`_Screen` gives every attached client a reader thread accumulating everything tmux paints;
the tests wait for the menu's own row to arrive on the presser's terminal, and assert it
arrived on **nobody else's** — which states the class's subject positively for the first
time, instead of only through "a canary did not appear". The other client's keystroke is
waited on too, by watching the pane's own `cat` echo it, so the negative half is about a
key that was really delivered and really spent. Every 0.8 s sleep is gone from
`_drive_menu` and both two-client tests; the wait returns in ~50 ms unloaded and holds on a
loaded machine.

Two `MenuFormatIntegration` tests whose only assertion was "no canary" gained a
precondition they never had: the hostile label has to be observed on screen first. A menu
that never rendered used to satisfy them.

`test_a_row_past_the_ninth…`'s `-` keystroke also stopped being slept at: it is followed by
the first of its own nine Downs and the repaint is waited for, and a pty is a FIFO, so tmux
cannot paint a response to the Down without having read past the `-`.

## #507 — a death tmux never had the status of, read as an exit code

`EarlyDeathIntegration` is a plain `TestCase` that builds its own sessions from
`layout.session_argv`, so it inherited none of #487's void detection — and three of its
tests read a dead pane's **status**, which is exactly what a void destroys.
`_query_pane_dead_status` answers `_UNKNOWN_DEATH_CODE` (`1`) for a pane tmux holds no
status for, and `assertEqual(code, 7)` cannot tell that from a shell that exited 1. That is
the reported failure: red on 3.11 and 3.13 in one run, green on a re-run of identical
bytes.

The issue read this as "a different shape from the void". It is the same mechanism; what
was different is that this class had no defence against it. `_VoidDeaths` is extracted from
`_TmuxServerFixture` so both share one detector, and `_a_measured_death` spends a fresh
pane per void with the void **asserted** (`_the_array_never_ran`) rather than assumed — a
pane tmux destroyed, or one it holds a status for but ran no hook for, is a loud failure
naming which. The probe is armed in the server's own config file here, because there is no
gate to hold this pane open: the whole subject is a command that dies before the frame is
drawn, so it is often dead before `new-session` has printed its id. `tmux -f <conf>` is
read at server start, before any pane exists.

Nothing is widened — `7` is still the only value that passes.

### folded in: the probe's evidence is no longer a file

#495's attacker's point. `_arm_array_probe` used `run-shell "touch <marker>"`, so *"tmux
never ran the array"* and *"the marker could not be written"* were one reading, and
sabotaging the probe turned a real failure into a **skip**. It is now
`set-option -p @charter-probe ran`, read back with `show-options -p -v` — set by tmux, in
the same act as running the array, with no shell, no fork and no filesystem in between.
Measured on 3.7c: `-p` resolves to the dying pane, the value survives on a dead-but-kept
pane, and an unarmed pane answers rc 1 / `invalid option` — three distinguishable answers
where a file had two.

The option is written and read back **at arm time**, before anything depends on it. A tmux
that cannot carry a pane user option would otherwise turn every death in the module into a
void and every death-dependent test into a skip, on a machine where nothing was wrong.

## #531 — 26 modules hid classes below their `if __name__` trailer

`unittest.main()` raises `SystemExit`, so everything after the trailer is dead in the one
invocation the trailer exists for. `python3 tests/test_doctor_shadowed.py` reported
`Ran 8 tests / OK` where `python3 -m unittest tests.test_doctor_shadowed` ran 14 — and the
six it dropped were the `PersonaIso` classes that exercise the real seam. **Across the 26,
154 tests were invisible to a direct run**, measured module by module.

**The coordinator asked whether any had silently never run. None had.** Discovery imports a
module rather than executing it as `__main__`, so CI collected every class; all 154 ran and
passed. The gap belonged to whoever was debugging one file, which is when a green run is
trusted hardest. (Direct-run counts now equal discovery counts for all 26 — spot-checked
after the fix.)

The trailers moved to the ends of their files, and `tests/test_no_test_hides_below_the_main_trailer.py`
walks `tests/` with `unittest discover`'s own pattern and fails on the 27th, naming the
module, the line, what got hidden, and both ways out — the `RealPlaneRead` standard. The
rule is *nothing* below the trailer, not *no class*: `SystemExit` hides a helper or a
constant just as completely.

## Not fixed, named rather than papered over

`WindowInsideAnOperatorsTmux.test_nothing_of_the_operators_tmux_is_written_by_a_whole_launch`
(one of the six flaky tests #507 lists) reads the code a whole real `cmd_launch` returns,
and that pane carries charter's production `pane-died` **pair** — `[0]` the write hook,
`[1]` `kill-session`. There is no free index: `[1]` is where a probe goes and is charter's
teardown, and measured on 3.7c a `[2]` armed beside them never runs at all, because
`kill-session` at `[1]` takes the server down first. A void death there is still read as an
exit code of `1`. Recorded in the module docstring.

## Mutations actually run

Each applied, run, then restored, with `__pycache__` cleared. Results as observed, not as
expected:

| mutation | result |
| --- | --- |
| `cmd_menu` sleeps 2.0 s before drawing — **this branch** | **GREEN** (2 tests, 10.9 s) |
| the same mutation against `origin/main`'s own test file | **RED** — `AssertionError: False is not true : A's own hotkey press must open A's own, selectable menu`, the issue's exact words |
| `cmd_menu` draws on the OTHER attached client | **RED** — `no menu carrying 'Detach chci-…-a' was ever drawn on A's own terminal` |
| `_Screen.saw` always returns True, with the 2 s delay | **RED** — the "not on the other client" half catches a permissive readiness check |
| `menu_argv` drops `-c client` | **GREEN**, and correctly so: `cmd_menu`'s own docstring already records that tmux's default guess was never reproduced failing for one session with several clients — the two-*frame* case is what `-c` fixes. Reported because it did not go red, not hidden. |
| the probe hook's action records nothing (`touch` → a no-op, the attacker's sabotage) | **RED**, 4 failures — `tmux never ran this pane's pane-died array, yet tmux is holding a status ('1') for it`. A failure, **not a skip**. |
| `_PROBE_OPTION` set to a name tmux refuses | **RED** at arm time — `this tmux will not set the pane option … and skip every death-dependent test on a healthy machine` |
| `session_argv` word-splits the harness argv | **RED** — `1 != 7 : a single argument must reach a shell` |
| `test_doctor_shadowed.py`'s trailer put back above its last three classes | **RED** — names all three, both line numbers, and both ways out |
| `hidden_below_the_trailer` stops looking | **RED** — 3 of its own controls |

## Four environments

`config.ROOT` printed before each. Whole suite, `unittest discover -s tests`.

| environment | `ROOT` | result |
| --- | --- | --- |
| 1. fresh checkout, ambient cleared | the fresh tree | `Ran 5621` — **OK** |
| 2. a used plane (`.charter/`, `.superpowers/`), ambient cleared | the operator's | `Ran 5621` — **OK** |
| 3. inside a live charter frame | the operator's | `Ran 5621` — 17 failures |
| 4. `CHARTER_WORKSPACE=anything` | the operator's | `Ran 5621` — 8 failures |

3 and 4 are the ambient-variable leaks this phase's *other* groups own, and both were
attributed rather than assumed:

* **Environment 3**: `origin/main`, stashed into the identical cwd and plane, gives
  **18** — the same 17, **plus**
  `MenuClientIntegration.test_a_submenu_opens_on_the_presser_and_its_rows_are_selectable`.
  That is #494 flaking on this machine, in a live frame, and this branch no longer has it.
  The 17 are #519/#521 — `test_frame_doctor` reading `harness-wrapper-17391` out of the
  developer's terminal, `statusline.main` printing nothing because a frame owns the
  surface, `session.current()` answering from the ambient variable.
* **Environment 4**: `origin/main` gives the same **8**, byte for byte — #528's class,
  `CHARTER_WORKSPACE` leaking into workspace resolution.

So the four answers still differ, and this group is not what makes them differ: with
#519/#521/#528 outstanding, environments 3 and 4 cannot yet agree with 1 and 2. Flagged for
the phase rather than claimed as done here.

Not merged. No version bump, no stamping, no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
