### PR TITLE
The plane a charter child works on is the plane its parent resolved (#527, #532)

### DIFF
--- a/charter/glstate.py
+++ b/charter/glstate.py
@@ -202,6 +202,15 @@ def maybe_spawn(dirs, workspace: str | None = None) -> None:
     row it is refreshing is the defect; an environment variable was never what stood
     between them.
     """
+    if not config.HAS_CONTROL_PLANE:
+        # A third brake, and the one that is about WHERE rather than how often. Outside a
+        # plane `config.STATE_DIR` is `<cwd>/.charter`, so a spawn here would scatter
+        # charter's caches into whatever directory the render happened to run in — and the
+        # child, having no plane handed to it (`util.child_env` has none to hand), would go
+        # looking for one of its own. That is how a status line rendered for a throwaway
+        # root came to refresh the operator's live plane (#527): from a linked worktree the
+        # child's walk redirects to the main tree. No plane, no background refresh.
+        return
     now = time.time()
     try:
         state = _read_lock()
@@ -242,7 +251,7 @@ def maybe_spawn(dirs, workspace: str | None = None) -> None:
     try:
         proc = subprocess.Popen(
             cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-            stdin=subprocess.DEVNULL, start_new_session=True, env=os.environ.copy(),
+            stdin=subprocess.DEVNULL, start_new_session=True, env=util.child_env(),
         )
     except Exception:
         # Spawn never happened — don't start the cooldown, so a transient failure

--- a/charter/root.py
+++ b/charter/root.py
@@ -10,6 +10,7 @@ commands simply work.
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from pathlib import Path
 
 #: The file whose presence marks a directory as a control plane.
@@ -28,22 +29,32 @@ def _explain(where: str) -> str:
             f"here, or set ${ENV_VAR} to point at an existing one.")
 
 
-def find_root(start: Path | None = None) -> Path:
+def find_root(start: Path | None = None, env: Mapping[str, str] | None = None) -> Path:
     """The control plane's directory. Raises :class:`ControlPlaneNotFound`.
 
     ``$CHARTER_ROOT`` wins outright when set — and a bad value raises rather than falling
     back to a walk, because silently operating on a *different* control plane than the one
     the user named is worse than failing.
+
+    *env* answers the question for a process that is **not this one**: given THIS
+    environment, standing HERE, which plane would it resolve? Defaults to this process's
+    own, so every existing caller is unchanged. It exists because charter spawns copies of
+    itself (`util.detach_self`, `glstate.maybe_spawn`, `update.maybe_spawn`) and the answer
+    for the child is decided by the environment the parent is about to hand it — which the
+    parent can then check, or correct, *before* the fork. The suite's spawn tripwire
+    (``tests/_planeguard.py``) is the caller that needs it, and asking here rather than
+    re-deriving the walk there is what keeps the two from drifting apart: the walk below is
+    where every subtlety lives (the worktree redirect, the ``workspaces/`` hop outward).
     """
-    env = os.environ.get(ENV_VAR)
-    if env:
-        p = Path(env).expanduser()
+    named = (os.environ if env is None else env).get(ENV_VAR)
+    if named:
+        p = Path(named).expanduser()
         try:
             p = p.resolve()
         except OSError:
-            raise ControlPlaneNotFound(_explain(f"at ${ENV_VAR}={env}")) from None
+            raise ControlPlaneNotFound(_explain(f"at ${ENV_VAR}={named}")) from None
         if not (p / MARKER).is_file():
-            raise ControlPlaneNotFound(_explain(f"at ${ENV_VAR}={env}"))
+            raise ControlPlaneNotFound(_explain(f"at ${ENV_VAR}={named}"))
         return p
 
     cur = (start or Path.cwd()).resolve()

--- a/charter/update.py
+++ b/charter/update.py
@@ -280,6 +280,8 @@ def maybe_spawn() -> None:
     TTL, and a spawn cooldown that also covers *failed* attempts — otherwise an
     offline machine would fork a doomed child on every single render.
     """
+    if not config.HAS_CONTROL_PLANE:
+        return                # see `glstate.maybe_spawn` — no plane, nowhere to cache
     now = time.time()
     lock = _lock_file()
     try:
@@ -299,7 +301,7 @@ def maybe_spawn() -> None:
         subprocess.Popen(
             util.self_relaunch_argv("_version-check"),
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-            stdin=subprocess.DEVNULL, start_new_session=True, env=os.environ.copy(),
+            stdin=subprocess.DEVNULL, start_new_session=True, env=util.child_env(),
         )
     except Exception:
         return

--- a/charter/util.py
+++ b/charter/util.py
@@ -317,6 +317,46 @@ def self_relaunch_argv(*args: str) -> list[str]:
     return [sys.executable, "-P", "-m", "charter", *args]
 
 
+def child_env() -> dict:
+    """This process's environment plus **the plane this process actually resolved**.
+
+    The environment for a charter that charter spawns. Every self-relaunch site used to
+    hand the child a bare ``os.environ.copy()`` and let it work its own plane out by
+    walking up from its own cwd — the same defect `glstate.maybe_spawn` already argues
+    against for the *workspace*: "the status line resolves the workspace for the SESSION …
+    while the child would resolve it for ITSELF, from its own environment and its own
+    directory". The plane is that argument one level up, and it is the bigger half: the
+    workspace decides which rows get refreshed, the plane decides whose ``.charter/`` gets
+    written.
+
+    Measured, from a linked worktree of a charter checkout: a ``gl-refresh`` spawned off
+    the status line landed on the MAIN tree's plane, because `root._plane_of` redirects a
+    worktree to the tree it was cut from and the child had nothing else to go on. A render
+    for one plane refreshed a different one, silently, on every stale render (#527).
+
+    **Only when this process has a plane.** ``$CHARTER_ROOT`` wins outright in
+    `root.find_root`, and a value with no ``charter.toml`` at it RAISES rather than falling
+    back to a walk — so handing a planeless child an empty-handed pointer would be worse
+    than handing it nothing, which is what it gets. Both `maybe_spawn` sites decline to
+    fork at all in that state.
+
+    Overwrites rather than deferring to an inherited ``$CHARTER_ROOT``. When this process
+    was itself resolved from that variable the two agree; when they disagree, `config.ROOT`
+    is the plane whose state this process is actually reading and writing, and the child's
+    job is to agree with its parent rather than with the shell.
+
+    Imports are deferred because `util` sits below `config` and `root` in the import order
+    and must stay there.
+    """
+    from . import config
+    from . import root as _root
+
+    env = os.environ.copy()
+    if config.HAS_CONTROL_PLANE:
+        env[_root.ENV_VAR] = str(config.ROOT)
+    return env
+
+
 def detach_self(args: list[str]) -> bool:
     """Re-run ``charter <args>`` in a process that outlives this one. True if it started.
 
@@ -328,12 +368,15 @@ def detach_self(args: list[str]) -> bool:
 
     Never raises. The caller is a session-start hook, and a plane that cannot spawn a
     background refresh must still open a session.
+
+    The child is handed :func:`child_env`, so ``persona _gc`` collects the plane the hook
+    fired for rather than whichever one its own cwd happens to sit under.
     """
     try:
         subprocess.Popen(
             self_relaunch_argv(*args),
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-            stdin=subprocess.DEVNULL, start_new_session=True, env=os.environ.copy(),
+            stdin=subprocess.DEVNULL, start_new_session=True, env=child_env(),
         )
     except Exception:
         return False

--- a/docs/news/unreleased-a-background-refresh-refreshes-the-plane-that-asked-for-it.md
+++ b/docs/news/unreleased-a-background-refresh-refreshes-the-plane-that-asked-for-it.md
@@ -56,9 +56,15 @@ tests.test_cli_smoke.CliSmokeTest.test_doctor_runs_without_crashing is about to 
 `… -m charter doctor`, and that child would resolve its plane as ~/work/charter …
 ```
 
-It found ten more sites the moment it was armed, including a smoke test whose own docstring
-claimed isolation while running `charter doctor` against the developer's personas,
-workspaces and vault registry.
+It found eight more call sites the moment it was armed. One is a smoke test whose own
+docstring claimed isolation — it set `$CHARTER_HOME`, which covers the per-human directory
+and reads as though it covered the plane — while running `charter doctor` against the
+developer's personas, workspaces and vault registry.
+
+**Two of the eight only fire inside a charter frame**, which is the part worth keeping.
+`$CHARTER_ROOT` wins outright over any walk, and every frame exports it — so two suites
+that isolated their children by `cwd` were correct in a bare shell and wrong in the terminal
+they are actually written in. One of them ran `charter init` against the operator's plane.
 
 `root.find_root` grew an optional `env=` for it, so the guard asks the real resolver instead
 of keeping a private copy of the walk that would drift away from it.

--- a/docs/news/unreleased-a-background-refresh-refreshes-the-plane-that-asked-for-it.md
+++ b/docs/news/unreleased-a-background-refresh-refreshes-the-plane-that-asked-for-it.md
@@ -1,0 +1,67 @@
+---
+version: unreleased
+headline: A background refresh now refreshes the plane that asked for it — and charter's suite stopped running 131 of them against yours
+---
+
+The status line never blocks on the network. When its forge cache or its version cache goes
+stale it forks a detached `charter gl-refresh` / `charter _version-check` and draws the old
+values; the child does the work and rewrites the cache. Session-start hooks do the same for
+`charter persona _gc`.
+
+**The child was never told which plane it was refreshing.** It got a bare copy of the
+environment and worked it out for itself, by walking up from whatever directory it happened
+to inherit. Almost always that is the same plane the parent resolved — and the exception is
+the one that matters, because a linked worktree redirects to the tree it was cut from
+(`root._plane_of`, and rightly so). Render the status line for one plane from inside a
+worktree, and the refresh landed on another.
+
+```
+render:  plane = /tmp/some-plane          (what the status line is drawing)
+child:   plane = ~/work/charter           (what gl-refresh actually refreshed)
+```
+
+`glstate.maybe_spawn` already argues this exact point about the *workspace*: "the status
+line resolves the workspace for the SESSION … while the child would resolve it for ITSELF,
+from its own environment and its own directory". The plane is the same argument one level
+up, and the bigger half — the workspace decides which rows get refreshed, the plane decides
+whose `.charter/` gets written.
+
+**Now the parent hands it over.** `util.child_env` puts the plane this process actually
+resolved on the child's `$CHARTER_ROOT`, and all three spawn sites use it. The child agrees
+with its parent, or there is no child.
+
+**And with no plane, there is no background refresh at all.** Outside a control plane
+`config.STATE_DIR` is `<cwd>/.charter`, so a spawn there scattered charter's caches into
+whatever directory the render happened to run in. Both refreshers now decline to fork.
+
+## What this was found by
+
+charter's own test suite, forking 131 detached charter processes in a single run — every
+one of them against the machine's live control plane, refreshing its forge state and
+rewriting its caches. `tests/_planeguard.py` had said for months that it could not see this:
+
+> **What this cannot see: a subprocess.** … isolating this process does nothing for it.
+
+Six test modules had each remembered the precaution by hand (`update.maybe_spawn = lambda:
+None`, with a comment saying *never fork a network child from the suite*). Twelve had not,
+and one file had remembered it in one case and not in the three beside it.
+
+So the warning is a tripwire now. Before any `Popen` that launches charter, the suite asks
+`root.find_root` **the child's** question — with the child's environment and the child's cwd
+— and refuses, by name, if the answer is your plane:
+
+```
+REFUSED: spawning charter against the real control plane
+tests.test_cli_smoke.CliSmokeTest.test_doctor_runs_without_crashing is about to run
+`… -m charter doctor`, and that child would resolve its plane as ~/work/charter …
+```
+
+It found ten more sites the moment it was armed, including a smoke test whose own docstring
+claimed isolation while running `charter doctor` against the developer's personas,
+workspaces and vault registry.
+
+`root.find_root` grew an optional `env=` for it, so the guard asks the real resolver instead
+of keeping a private copy of the walk that would drift away from it.
+
+This reaches you as a correctness fix in `charter gl-refresh`; the rest only ever mattered
+if you run charter's own test suite. Nothing to adopt — upgrading is the whole of it.

--- a/docs/news/unreleased-a-background-refresh-refreshes-the-plane-that-asked-for-it.md
+++ b/docs/news/unreleased-a-background-refresh-refreshes-the-plane-that-asked-for-it.md
@@ -69,5 +69,36 @@ they are actually written in. One of them ran `charter init` against the operato
 `root.find_root` grew an optional `env=` for it, so the guard asks the real resolver instead
 of keeping a private copy of the walk that would drift away from it.
 
+## And the guard stopped keeping its own copy of "what is a charter"
+
+The tripwire's first two rounds each closed a list of spellings, and each time a new list
+turned up. Measured against a guarded plane, all of these ran, four of them starting a real
+`charter docs` — which regenerates a plane's topology:
+
+```
+["nice", "charter", "docs"]                      ["CHARTER", "docs"]
+["nohup", "charter", "docs"]                     ["/bin/bash", "-lc", "charter docs"]
+["env", "-S", "<python> -c 'from charter import config; print(config.ROOT)'"]
+```
+
+The last one printed the guarded plane.
+
+None of these is exotic. `-lc` is how a login shell is spelled; `CHARTER` is the same binary
+on the filesystems this runs on; `nice` is a wrapper. And charter already knew all three:
+its Bash tool-gate denies `nice cat <vault>`, `CHARTER secret get … --reveal` and `env -S
+'cat <vault>'`, with tests pinning each. The test harness had grown a **second, weaker copy**
+of the same question, and the two had drifted.
+
+So there is one copy now. `tests/_planeguard.py` calls `charter/hooks.py`'s own reader for
+what a wrapper run means — its wrapper table, each wrapper's option arity, `env -S`, the
+case fold, the pre-rename `edm` binary — and adds only the questions production deliberately
+does not ask: a shell's `-c` string, Python source, a script file, and an interpreter
+resolved to what it really is rather than what the symlink is called. A structural test
+fails if the tables drift apart again.
+
+Doing that turned up a real defect in the production guard, filed as #547 rather than
+patched around here: `env -Sfoo=1 cat .charter/vaults/x.json` is currently ALLOWED by the
+Bash tool-gate, because the packed command is split at the wrong `=`.
+
 This reaches you as a correctness fix in `charter gl-refresh`; the rest only ever mattered
 if you run charter's own test suite. Nothing to adopt — upgrading is the whole of it.

--- a/docs/news/unreleased-the-shipped-skills-check-reads-the-index.md
+++ b/docs/news/unreleased-the-shipped-skills-check-reads-the-index.md
@@ -1,0 +1,31 @@
+---
+version: unreleased
+headline: Drafting a skill no longer turns charter's suite red — the shipped-skills check reads the index, not your filesystem
+---
+
+`doctor`'s shadow check knows which skills charter ships, because the CLI installs from a
+wheel that has no `skills/` in it — that directory belongs to the plugin. So the list is a
+constant, `doctor.SHIPPED_SKILLS`, and a test holds it to the truth.
+
+That test enumerated `skills/*/SKILL.md` **on disk**. Draft a skill where skills live and
+the suite went red about a constant being out of sync:
+
+```
+AssertionError: Items in the second set but not the first: 'my-draft'
+```
+
+Neither adding the draft to `SHIPPED_SKILLS` nor deleting the draft is the right answer. The
+same held for a `git stash` that left a directory behind, a half-finished branch's
+leftovers, or a copy someone made to diff against.
+
+**It now asks `git ls-files`** — the seam `test_workflows.py` and (since #529) the plugin
+classification already use, and for the same reason: a denylist of local artefacts is a
+guess at where untracked content lives, and the index is the answer.
+
+**The assertion still runs both ways**, which is the part worth saying out loud. A skill
+committed without updating the constant still fails, on the PR that commits it, which is
+when the decision is due — and a constant naming a skill that no longer exists still fails
+too. Weakening this to a subset check would have made the local-draft symptom go away and
+given the removal half up with it.
+
+This only ever reached you if you run charter's own test suite. Nothing to adopt.

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -142,6 +142,51 @@ class ReportIso(PersonaIso):
         self.consent_home = home
 
 
+def child_plane_env(case, **extra: str) -> tuple[Path, dict]:
+    """A throwaway plane, and the environment that points a CHILD charter at it.
+
+    The way out `tests._planeguard.RealPlaneSpawn` names for a test that genuinely wants
+    to run charter as a subprocess. ``$CHARTER_ROOT`` wins outright in `root.find_root`,
+    so the child resolves THIS plane wherever it is standing — which is the point, because
+    ``python3 -m charter`` normally needs a cwd of the checkout to import the tree under
+    test, and that cwd is exactly what used to resolve the developer's own plane instead.
+
+    A ``charter.toml`` is written, so the child finds a plane rather than raising and
+    falling back to its cwd — the fallback being the hazard, not the fix.
+
+    Returns the plane too, so a case can assert on what the child left in it.
+    """
+    plane = Path(tempfile.mkdtemp(prefix="charter-child-plane-"))
+    case.addCleanup(shutil.rmtree, plane, True)
+    (plane / root.MARKER).write_text("schema = 1\n")
+    return plane, {**os.environ, root.ENV_VAR: str(plane), **extra}
+
+
+def make_plane(case, body: str = "schema = 1\n") -> Path:
+    """Turn a `PersonaIso` case's throwaway root into a REAL control plane, and re-derive.
+
+    `PersonaIso` hands every case a root; it deliberately does not put a ``charter.toml``
+    at it, so `config.HAS_CONTROL_PLANE` is False and every setting derives to its default.
+    That is right for most cases and wrong for any case driving a path charter gates on
+    having a plane at all — `glstate.maybe_spawn` and `update.maybe_spawn` both refuse to
+    fork a background refresh without one, because outside a plane `config.STATE_DIR` is
+    ``<cwd>/.charter`` and there is nowhere legitimate for the child to cache.
+
+    **Re-derives rather than setting the flag by hand.** ``config.HAS_CONTROL_PLANE = True``
+    over a root with no marker is a fixture that tells this process one thing and the
+    child process charter is about to spawn another: the child reads ``$CHARTER_ROOT``,
+    finds no ``charter.toml`` there, and goes looking for a plane of its own. On the
+    machine this was written on that walk landed on the operator's live plane (#527). A
+    plane a test claims to have should be one a subprocess can also find.
+
+    Safe to call after `PersonaIso.setUp`: `config.use` snapshots, and the snapshot the
+    base class already took is the one `restore` puts back.
+    """
+    (case.tmp / root.MARKER).write_text(body)
+    config.use(case.tmp)
+    return case.tmp
+
+
 def isolate_state_dir(case) -> Path:
     """Point ``config.STATE_DIR`` at a throwaway dir for one test case, restoring after.
 

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -1,5 +1,6 @@
-"""Suite-wide tripwires: no test may WRITE into the developer's real ``.charter/``, and
-none may READ a setting off the developer's real ``charter.toml``.
+"""Suite-wide tripwires: no test may WRITE into the developer's real ``.charter/``, none
+may READ a setting off the developer's real ``charter.toml``, and none may SPAWN a charter
+that would resolve it.
 
 `PersonaIso` isolates a test that remembers to derive from it. Nothing made the
 *forgetting* visible, so the same defect kept arriving in a new file: the suite wrote
@@ -56,12 +57,30 @@ everything so a malformed `charter.toml` cannot break import, `root.find_root` s
 instead of failing. `unittest` still records a `BaseException` against the test that raised
 it, so the failure keeps its name.
 
-**What this cannot see: a subprocess.** A `tmux run-shell` hook, or any spawned `charter`,
-resolves its own plane from its own environment, so isolating this process does nothing for
-it — the parent must hand the throwaway plane across the boundary with ``$CHARTER_ROOT`` on
-the child's (or the tmux server's) environment, the way `PanelIntegration` and
-`MenuIntegration` in `test_frame_tmux_integration.py` do. This guard is silent about that
-half by construction, and saying so here is the point: it is not a licence to skip the env.
+**The subprocess half, which this used to say it could not see.** A `tmux run-shell` hook,
+or any spawned `charter`, resolves its own plane from its own environment and its own cwd,
+so isolating THIS process does nothing for it — the parent must hand the throwaway plane
+across the boundary with ``$CHARTER_ROOT`` on the child's (or the tmux server's)
+environment, the way `PanelIntegration` and `MenuIntegration` in
+`test_frame_tmux_integration.py` do. That paragraph stood here as a warning for as long as
+it took someone to measure it, and the measurement (#527) was 131 detached
+``charter _version-check`` / ``charter gl-refresh`` children in one run, every one of them
+carrying no ``$CHARTER_ROOT`` and therefore landing on the operator's live plane —
+refreshing its forge state and rewriting its caches, from a suite that had isolated
+everything it could see.
+
+So the warning is now a tripwire: :class:`RealPlaneSpawn`. Before any `subprocess.Popen`
+that launches charter itself, this asks `root.find_root` **the child's** question — with
+the child's environment and the child's cwd — and refuses if the answer is the real plane.
+Asking `find_root` rather than re-deriving the walk is deliberate: the walk is where the
+subtleties live (a linked worktree redirects to the tree it was cut from, a plane inside a
+plane's ``workspaces/`` hops outward), and a guard with its own private copy of that logic
+is a guard that stops agreeing with the thing it guards.
+
+**Charter's own spawners now hand the plane over** (`util.child_env`), so an isolated case
+satisfies this without knowing it exists. What is left for the tripwire is the case that
+was never covered: a test that spawns charter by hand, and a test that never isolated
+`config.ROOT` in the first place.
 """
 
 from __future__ import annotations
@@ -70,8 +89,10 @@ import builtins
 import io
 import os
 import shutil
+import subprocess
 import sys
 import unittest
+from pathlib import Path
 
 #: The state directory of the plane this test PROCESS resolved at import — before any
 #: `setUp` could repoint `charter.config`, so unavoidably the developer's real one.
@@ -298,6 +319,138 @@ def _guard_reads(config) -> None:
             setattr(config, name, _RefusesToBeRead(name, value))
 
 
+class RealPlaneSpawn(BaseException):
+    """A test spawned a charter that would resolve the developer's own control plane."""
+
+
+def _charter_argv(args) -> list[str] | None:
+    """*args* as a list of strings when it launches charter itself, else ``None``.
+
+    Two spellings, because charter is reached two ways and a guard that knew one would be
+    silent about the other: ``[sys.executable, "-P", "-m", "charter", ...]``
+    (`util.self_relaunch_argv`, which every self-relaunch site goes through) and a bare
+    ``charter`` resolved from ``PATH`` (what `hooks/hooks.json` invokes, and what a test
+    driving the installed CLI would write).
+
+    A ``str`` command line -- ``shell=True`` -- is answered ``None`` rather than parsed. No
+    charter spawn site uses one, and a guard that half-parses shell syntax would refuse the
+    wrong calls while still missing the interesting ones; if such a site ever appears, it
+    should stop using a shell rather than teach this to lex.
+    """
+    if args is None or isinstance(args, (str, bytes)):
+        return None
+    try:
+        parts = [os.fsdecode(a) if isinstance(a, (bytes, os.PathLike)) else str(a)
+                 for a in args]
+    except TypeError:
+        return None
+    if not parts:
+        return None
+    if os.path.basename(parts[0]) == "charter":
+        return parts
+    for i in range(len(parts) - 1):
+        if parts[i] == "-m" and parts[i + 1] == "charter":
+            return parts
+    return None
+
+
+def _explain_spawn(parts: list[str], plane) -> str:
+    return (
+        f"REFUSED: spawning charter against the real control plane\n"
+        f"{_current_test()} is about to run `{' '.join(parts)}`, and that child would "
+        f"resolve its plane as {plane} \u2014 the developer's REAL one. It is a separate "
+        f"process: nothing this suite patches in memory reaches it, so it would refresh "
+        f"that plane's forge state, rewrite its caches, and (for `persona _gc`) collect "
+        f"against it. Two ways out. (1) If the test is not about the spawn, stub it \u2014 "
+        f"`mock.patch.object(charter.update, \"maybe_spawn\", lambda: None)`, or patch "
+        f"`subprocess.Popen` where the code under test looks it up. (2) If the test really "
+        f"wants a child, hand it the throwaway plane as $CHARTER_ROOT: "
+        f"`tests._isolation.child_plane_env(self)` returns exactly that environment, and "
+        f"`PanelIntegration` in `test_frame_tmux_integration.py` does the same by hand. "
+        f"charter's own spawners already do this for you (`util.child_env`), so a case "
+        f"whose `config.ROOT` is isolated never gets here.")
+
+
+def _child_plane(kwargs: dict):
+    """The plane the child described by *kwargs* would resolve -- or ``None`` for none.
+
+    `root.find_root` is asked the child's question directly, with the child's environment
+    (``env=None`` means it inherits ours) and the child's cwd. That is what `find_root`'s
+    ``env`` parameter is for: the alternative is a second copy of the walk living here,
+    quietly disagreeing with the real one the day a worktree rule changes.
+
+    When `find_root` raises, the child is not left with nothing: `find_root_or_cwd` -- what
+    `charter.config` actually calls at import -- falls back to the child's own working
+    directory, unwalked. So does this. A `charter init` in an empty temp directory takes
+    exactly that path, and answering ``None`` there would be the guard waving through the
+    one case the fallback makes dangerous: a bad ``$CHARTER_ROOT`` and a cwd of the
+    checkout.
+    """
+    from charter import root as _root
+
+    env = kwargs.get("env")
+    cwd = kwargs.get("cwd")
+    try:
+        start = Path(os.fsdecode(cwd)) if cwd is not None else Path.cwd()
+    except (TypeError, ValueError, OSError):
+        return None
+    try:
+        return _root.find_root(start, env=os.environ if env is None else env)
+    except _root.ControlPlaneNotFound:
+        try:
+            return start.resolve()        # what `find_root_or_cwd` hands `config`
+        except (OSError, RuntimeError):
+            return None
+    except Exception:
+        return None
+
+
+#: Whether :func:`_guard_spawns` has already wrapped ``Popen.__init__``. Separate from
+#: :data:`_REAL` because `install` gives up early on a machine with no resolvable state
+#: directory, and the spawn tripwire is armed before that point -- it keys off
+#: :data:`_REAL_ROOT`, which `_guard_reads` fills in first.
+_SPAWN_GUARDED = False
+
+
+def _guard_spawns() -> None:
+    """Refuse a charter child that would resolve the real plane. Idempotent.
+
+    Wrapped on ``subprocess.Popen.__init__``, the CLASS, rather than on the
+    ``subprocess.Popen`` module attribute. Two reasons, and both are holes the attribute
+    version would leave open: `subprocess.run`, `check_output` and `check_call` construct
+    the class directly, and so does any module that did ``from subprocess import Popen``.
+
+    The other half of that choice is what makes it correct rather than merely thorough: a
+    test that patches the module attribute -- `test_hooks_need_no_async` and
+    `test_self_relaunch_argv` both do, around real `detach_self` calls -- never reaches the
+    class at all, so it is never refused. That is the right answer, because nothing is
+    spawned. This fires on spawns that really happen, which is the only kind that can touch
+    a plane.
+    """
+    global _SPAWN_GUARDED
+    if _SPAWN_GUARDED:
+        return
+    _SPAWN_GUARDED = True
+    original = subprocess.Popen.__init__
+
+    def __init__(self, args=None, *rest, **kw):
+        parts = _charter_argv(args)
+        if parts is not None and _REAL_ROOT:
+            plane = _child_plane(kw)
+            if plane is not None:
+                try:
+                    here = os.path.abspath(str(plane))
+                except (OSError, TypeError, ValueError):
+                    here = None
+                if here is not None and (here in _REAL_ROOT
+                                         or os.path.realpath(here) in _REAL_ROOT):
+                    raise RealPlaneSpawn(_explain_spawn(parts, plane))
+        return original(self, args, *rest, **kw)
+
+    __init__.__module__ = __name__
+    subprocess.Popen.__init__ = __init__
+
+
 def install() -> None:
     """Wrap every write primitive. Idempotent; called once at `tests` package import."""
     global _REAL
@@ -305,6 +458,7 @@ def install() -> None:
         return
     from charter import config
     _guard_reads(config)
+    _guard_spawns()
     try:
         written = os.path.abspath(str(config.STATE_DIR))
         resolved = os.path.realpath(written)

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -90,6 +90,24 @@ operator's plane as charter", and where a spelling cannot be decided it answers 
 and lets the plane check settle it: a false refusal in a test is loud, named and one line
 from the fix, and a false allow writes to a live machine.
 
+**And the property is asked with production's own reader, not a second copy of it.** The
+round after that one measured the same thing again and found the same answer for a new
+list: ``["nice", "charter", "docs"]``, ``["nohup", …]``, ``["CHARTER", "docs"]``,
+``["/bin/bash", "-lc", "charter docs"]``, ``["env", "-S", "<python> -c 'from charter import
+config; print(config.ROOT)'"]`` — eight forms, none refused, four of them starting a real
+``charter docs``, and the ``env -S`` one printing the guarded plane. Every one of them is
+denied by charter's OWN Bash tool-gate, in `charter/hooks.py`, with tests pinning it
+(`nice cat <vault>`, `CHARTER secret get … --reveal`, `env -S 'cat <vault>'`). The harness
+had grown its own wrapper table, its own `env` option arity and its own case rule, and each
+was weaker than the one production already had.
+
+So `_launcher_argv` calls `hooks._split_env_chdir`, `_COMMAND_WRAPPERS` derives from
+`hooks._WRAPPERS`, and `_CHARTER_WORD` from `hooks._CHARTER_PROGS`. What is left here is
+what production deliberately does not ask — a shell's ``-c`` string, Python source, a script
+file — plus one repair, `_unpack_split_strings`, for a defect in production's `-S` parse
+that reuse would otherwise inherit (#547). `TheHarnessGuardIsNotASecondCopyOfProductions`
+in `test_plane_spawn_guard.py` fails if the two drift apart again.
+
 **Charter's own spawners now hand the plane over** (`util.child_env`), so an isolated case
 satisfies this without knowing it exists. What is left for the tripwire is the case that
 was never covered: a test that spawns charter by hand, and a test that never isolated
@@ -110,6 +128,17 @@ import sys
 import tokenize
 import unittest
 from pathlib import Path
+
+# Production's OWN command reader, not a second copy of it. `charter.hooks` already answers
+# "what program does this command line actually run" for the Bash tool-gate — following
+# wrappers, unpacking `env -S`, folding the program name's case — and every one of those
+# was a hole here while the same input was denied there. See :func:`_launcher_argv`.
+#
+# Imported at module scope, which is safe at exactly this point and not before: `tests`
+# imports `_envguard` and scrubs the ambient charter namespace BEFORE it imports this
+# module, so `charter.config` still resolves its plane with the same environment
+# `install()` would have given it one line later.
+from charter import hooks as _hooks      # noqa: E402
 
 #: The state directory of the plane this test PROCESS resolved at import — before any
 #: `setUp` could repoint `charter.config`, so unavoidably the developer's real one.
@@ -340,9 +369,6 @@ class RealPlaneSpawn(BaseException):
     """A test spawned a charter that would resolve the developer's own control plane."""
 
 
-#: ``NAME=value`` — the shell's environment-assignment prefix, and `env`'s argument form.
-_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*=")
-
 #: An interpreter whose ``-c`` is Python SOURCE and whose first bare argument is a Python
 #: script. `sys.executable`'s own basename is accepted alongside it, because a virtualenv,
 #: a framework build or a `uv`-managed toolchain may spell it something this pattern does
@@ -363,18 +389,50 @@ _SHELL_REDIRECTS = frozenset((">", ">>", "<", "<<", "<<<", ">&", "<&", ">|", "&>
 
 #: Commands whose ARGUMENTS are themselves a command. ``sudo charter doctor`` has ``sudo``
 #: in the command position and charter one word later; a reader that looked only at the
-#: head would call that an argument and allow it. Their argument grammars differ enough
-#: (``timeout 5 charter``, ``xargs -n1 charter``) that following them exactly is not worth
-#: attempting -- the word appearing anywhere after one of these is refused.
-_COMMAND_WRAPPERS = frozenset((
-    "eval", "exec", "command", "builtin", "sudo", "doas", "su", "nohup", "nice", "setsid",
-    "stdbuf", "time", "timeout", "xargs", "watch", "script", "env", "flock", "ionice"))
+#: head would call that an argument and allow it.
+#:
+#: :data:`charter.hooks._WRAPPERS` is the base rather than a list written out again here.
+#: That constant is what charter's own Bash guard follows, and it is the wrapper table with
+#: the argument grammars — :data:`~charter.hooks._WRAPPER_VALUE_FLAGS` and the rest — kept
+#: next to it, which :func:`_launcher_argv` now uses. Restating the class in a second place
+#: is what produced this round's finding: `nice cat <vault>` was denied by production while
+#: ``["nice", "charter", "docs"]`` ran here.
+#:
+#: The additions are the ones production has no reason to carry and this does. `eval` and
+#: `su -c` take a command STRING, which the Bash guard states as a limit it does not follow
+#: (`_split_env_chdir`) and this one refuses instead; `watch`, `script` and `flock` take a
+#: positional of their own before the program, so :func:`_launcher_argv` cannot name the
+#: program past one — and where the program cannot be named, the word appearing ANYWHERE
+#: after the wrapper is what refuses.
+_COMMAND_WRAPPERS = _hooks._WRAPPERS | frozenset((
+    "eval", "su", "watch", "script", "flock"))
 
 #: ``charter`` as a WORD inside a shell command string. ``/`` is allowed BEFORE it, so an
 #: absolute path to the binary (``/usr/local/bin/charter --version``) is a hit, and
 #: forbidden AFTER it, so a path that merely contains the checkout
 #: (``cd ~/IdeaProjects/charter/tests``) is not.
-_CHARTER_WORD = re.compile(r"(?<![\w.-])charter(?![\w.\-/])")
+#:
+#: The names come from :data:`charter.hooks._CHARTER_PROGS`, so ``edm`` — charter's
+#: pre-rename binary, still installed on some machines and still resolving a plane — counts
+#: here for the same reason production keeps it. Case-INSENSITIVE for the reason
+#: `test_the_program_name_is_case_folded_too` already pins in production: on the
+#: filesystems this runs on ``CHARTER`` and ``charter`` are one binary, and a guard that
+#: matches one casing of a name is a guard with a Shift key for a bypass. ``["CHARTER",
+#: "docs"]`` ran against a guarded plane while production denied the same word.
+_CHARTER_WORD = re.compile(
+    r"(?<![\w.-])(?:" + "|".join(re.escape(p) for p in _hooks._CHARTER_PROGS)
+    + r")(?![\w.\-/])", re.IGNORECASE)
+
+#: The name ANYWHERE in a string, by any spelling, boundaries and all. This is the cheap
+#: gate that decides whether a shell string is worth lexing — and it is deliberately looser
+#: than :data:`_CHARTER_WORD`, because a gate that can only cause MISSES must not be the
+#: thing deciding. ``env -Scharter doctor`` glues the name to an option letter, which puts a
+#: word character in front of it and makes the word test say "charter is not named here" —
+#: about a string whose whole content is a charter invocation. The word test still decides
+#: what is a COMMAND once the string is lexed, which is what keeps ``ls -d
+#: <checkout>/charter/sub`` a path rather than a spawn.
+_CHARTER_MENTION = re.compile(
+    "|".join(re.escape(p) for p in _hooks._CHARTER_PROGS), re.IGNORECASE)
 
 #: The names of `subprocess.Popen.__init__`'s positional parameters, in order after *args*.
 #: The guard has to know what the child was told, and a caller may say it either way:
@@ -399,7 +457,89 @@ def _is_python(name: str) -> bool:
 
 
 def _module_is_charter(name: str) -> bool:
-    return name == "charter" or name.startswith("charter.")
+    """``-m <name>``: is that charter? Folded, and including charter's pre-rename package,
+    for the same reason :data:`_CHARTER_WORD` is — production's `_is_charter` reads exactly
+    this argument as ``args[i + 1].lower() in _CHARTER_PROGS``."""
+    low = name.lower()
+    return any(low == p or low.startswith(p + ".") for p in _hooks._CHARTER_PROGS)
+
+
+def _reaches_an_interpreter(rest: list[str]) -> bool:
+    """Could this argv tail be an interpreter being handed something that reaches charter?
+
+    ``-c`` (Python source, or a shell command string), ``-m`` (a module) and a ``.py`` file
+    are the three, and they are the only reason the PROGRAM's identity is ever worth
+    resolving off the filesystem. Cheap, and asked first, so :func:`_program_names` does no
+    `realpath` and no ``PATH`` search for the `git`, `tmux` and `gh` children that make up
+    most of what this suite spawns.
+    """
+    for tok in rest:
+        if not tok.startswith("-"):
+            return tok.endswith(".py")
+        if tok.startswith("--"):
+            continue
+        if any(ch in "cm" for ch in tok[1:]):
+            return True
+    return False
+
+
+def _program_names(prog: str, cwd, env) -> list[str]:
+    """Every basename *prog* could turn out to name, the word itself first.
+
+    An interpreter is not its spelling. ``Popen([<symlink to python3>, "-c", "import
+    charter"])`` ran against a guarded plane because the guard read the LINK's name and
+    stopped; so did ``["./notpython", "-c", …]``. The property is "what program does the
+    child actually exec", and the child answers it with the kernel: a path is resolved
+    (against the CHILD's cwd, since `Popen` chdirs before it execs), a bare name is looked
+    up on the CHILD's ``PATH``, and symlinks are followed to what is really there.
+
+    Best effort, and deliberately additive: the written name stays in the list, so a
+    resolution that fails, points at nothing, or resolves somewhere surprising can only
+    ADD a way to recognise charter, never take one away.
+    """
+    names = [os.path.basename(prog)]
+    try:
+        if os.sep in prog or (os.altsep and os.altsep in prog):
+            where = prog
+            if not os.path.isabs(prog) and cwd is not None:
+                where = os.path.join(os.fsdecode(cwd), prog)
+            names.append(os.path.basename(os.path.realpath(where)))
+        else:
+            path = (env if env is not None else os.environ).get("PATH")
+            found = shutil.which(prog, path=path)
+            if found:
+                names.append(os.path.basename(os.path.realpath(found)))
+    except (AttributeError, OSError, TypeError, ValueError):
+        pass
+    return names
+
+
+def _bundled_option(tok: str, wanted: str, valued: str = "") -> tuple[str, str, int]:
+    """Read one bundled short-option token: ``(letter, attached value, tokens consumed)``.
+
+    Short options bundle, and every reader of one has to walk the LETTERS rather than match
+    the token whole. Both places this file needs that were written separately and only one
+    of them walked: `python -Pmcharter` was caught, while ``bash -lc 'charter docs'`` ran,
+    because the shell branch tested ``tok == "-c"`` and ``tok.startswith("-c")``. ``-lc``,
+    ``-ec``, ``-xc`` and ``-ic`` are ordinary spellings — the first is what a login shell is
+    spelled — and every one of them was a way through.
+
+    *wanted* are the letters that are a way in; *valued* are letters that take a value and
+    are NOT, so the walk stops at one rather than reading its value as more bundled
+    letters. ``letter`` is ``""`` when the token holds neither, and ``consumed`` is ``2``
+    when the option's value is the NEXT argv token rather than glued to this one — which is
+    the caller's to fetch, because ``python -m charter`` and ``python -mcharter`` are the
+    same run.
+    """
+    if not tok.startswith("-") or tok.startswith("--") or tok == "-":
+        return "", "", 1
+    for j, ch in enumerate(tok[1:], start=1):
+        if ch in wanted:
+            attached = tok[j + 1:]
+            return ch, attached, 1 if attached else 2
+        if ch in valued:
+            return "", "", 1 if tok[j + 1:] else 2
+    return "", "", 1
 
 
 def _code_imports_charter(code: str) -> bool:
@@ -489,35 +629,91 @@ def _script_imports_charter(path: str) -> bool:
         return True
 
 
-def _strip_launcher_prefix(parts: list[str]) -> list[str]:
-    """Drop ``VAR=value`` assignments and an `env` wrapper to reach the real command.
+def _unpack_split_strings(parts: list[str]) -> list[str]:
+    """``env -S '<command>'`` with its packed command put back as ordinary tokens.
 
-    ``env -u CHARTER_SESSION_ID python3 -m charter --version`` launches charter; a guard
-    that stopped reading at ``env`` would answer that it does not. Only the option forms
-    `env` itself documents are consumed — anything else ends the walk, because a guard
-    guessing at an unknown option's arity would start skipping the command word itself.
+    Production unpacks this too, and for the reason its own comment gives
+    (:data:`charter.hooks._SPLIT_STRING_FLAGS`): the value IS the command word, so skipping
+    it leaves an empty argv. It reads the ``--split-string=`` spelling BEFORE the glued
+    ``-S…`` one, though, so a packed command that itself contains an ``=`` is split at the
+    wrong one — ``env -Sfoo=1 charter docs`` yields ``1`` as the program and the charter is
+    never seen at all.
+
+    That is not only this guard's problem: measured against `main`'s Bash tool-gate, both
+    ``env -Sfoo=1 charter secret get v k --reveal --force`` and ``env -Sfoo=1 cat
+    .charter/vaults/x.json`` are ALLOWED while the same commands unwrapped are denied.
+    Filed as #547 — this is not the place to change a production guard's decisions. What is
+    repaired here is only the ordering, on the way IN: the flag names are still production's
+    constant, and the result goes straight back to production's splitter, so there is still
+    one reader of what a wrapper run means.
+
+    Only a ``-S`` that an `env` could be taking is unpacked. `ssh -S <control-socket>` is a
+    different flag on a different program, and a guard that unpacked it would be inventing
+    an arity for a program it has not identified — the mistake this function's neighbour
+    was sent back over.
     """
+    out: list[str] = []
+    env_seen = False
     i, n = 0, len(parts)
     while i < n:
         tok = parts[i]
-        if _ASSIGNMENT.match(tok):
+        if env_seen and tok.startswith(_hooks._SPLIT_STRING_FLAGS):
+            if tok.startswith("--") and "=" in tok:
+                packed = tok.split("=", 1)[1]
+            elif not tok.startswith("--") and len(tok) > 2:
+                packed = tok[2:]
+            elif i + 1 < n:
+                packed, i = parts[i + 1], i + 1
+            else:
+                packed = ""
+            try:
+                out.extend(shlex.split(packed))
+            except ValueError:            # will not lex; the words are still the words
+                out.extend(packed.split())
             i += 1
             continue
-        if os.path.basename(tok) != "env":
-            break
+        if os.path.basename(tok).lower() == "env":
+            env_seen = True
+        out.append(tok)
         i += 1
-        while i < n:
-            tok = parts[i]
-            if _ASSIGNMENT.match(tok) or tok in ("-i", "--ignore-environment", "-0",
-                                                 "--null", "-v", "--debug"):
-                i += 1
-            elif tok in ("-u", "--unset", "-C", "--chdir", "-S", "--split-string"):
-                i += 2
-            elif tok.startswith(("--unset=", "--chdir=", "--split-string=")):
-                i += 1
-            else:
-                break
-    return parts[i:]
+    return out
+
+
+def _launcher_argv(parts: list[str]) -> tuple[list[str], list[str]]:
+    """``(the argv the launcher run really reaches, the words consumed getting there)``.
+
+    **Delegated to `charter.hooks._split_env_chdir` rather than re-derived.** That function
+    is production's own answer to "what program does this command line run": it strips
+    ``VAR=value`` assignments, leading redirections, shell keywords and the wrapper run
+    (:data:`~charter.hooks._WRAPPERS`), each wrapper's own options by that wrapper's own
+    arity table, and `timeout`'s bare duration. The version that used to live here read
+    `env` alone, and every gap between the two was a way onto a guarded plane while the
+    same input was denied by production:
+
+    * ``["nice", "charter", "docs"]`` — a wrapper production strips and this did not;
+    * ``["env", "-S", "<python> -c 'from charter import config'"]`` — `-S` was skipped as a
+      value-taking option, which left an EMPTY argv and "no program at all". Production
+      treats its value as TOKENS, and says why at :data:`~charter.hooks._SPLIT_STRING_FLAGS`
+      in the same words the old docstring here used to warn against: *"skipping it would
+      leave an empty argv and the guard would see no program at all — fail-open on the exact
+      input the rest of this table exists to catch."*
+
+    *consumed* is what was dropped on the way, and it is asked separately because the name
+    can be IN it: ``c=charter; eval $c`` puts charter in an assignment and nothing else,
+    and ``env -S`` packs a whole command into one token. Computed as "in *parts* and not in
+    the argv" rather than as a prefix length, because `-S` INSERTS tokens — a word that
+    appears in both is simply checked in the argv instead, where it is checked properly.
+
+    A splitter that raises has decided nothing, so the whole command line becomes
+    *consumed*: the caller then refuses if charter is named anywhere in it, which is the
+    direction it is safe to be wrong in.
+    """
+    try:
+        unpacked = _unpack_split_strings(list(parts))
+        _prog, _env, argv, _chdir, _reads = _hooks._split_env_chdir(unpacked)
+    except Exception:
+        return list(parts), list(parts)
+    return list(argv), [tok for tok in parts if tok not in argv]
 
 
 def _python_launches_charter(rest: list[str]) -> bool:
@@ -527,26 +723,23 @@ def _python_launches_charter(rest: list[str]) -> bool:
     spelled attached (``-mcharter``), separate (``-m charter``) or bundled behind other
     short options (``-Pmcharter``) — all of which CPython accepts, and one of which
     `util.self_relaunch_argv` is a single edit away from producing.
+
+    The bundle is walked by :func:`_bundled_option`, which the SHELL branch of
+    :func:`_cmd_launches_charter` now uses too. It was written twice and walked once, so
+    ``bash -lc 'charter docs'`` ran while ``python -Pmcharter`` was refused.
     """
     i, n = 0, len(rest)
     while i < n:
         tok = rest[i]
         if not tok.startswith("-") or tok == "-":
             return _script_imports_charter(tok)
-        if tok.startswith("--"):
-            i += 1
-            continue
-        skip = 1
-        for j, ch in enumerate(tok[1:], start=1):
-            if ch in "cm":
-                value = tok[j + 1:] or (rest[i + 1] if i + 1 < n else "")
-                return (_code_imports_charter(value) if ch == "c"
-                        else _module_is_charter(value))
-            if ch in "WXQ":               # takes a value, and is no way into charter
-                if not tok[j + 1:]:
-                    skip = 2
-                break
-        i += skip
+        letter, value, consumed = _bundled_option(tok, "cm", valued="WXQ")
+        if letter:
+            if consumed == 2:
+                value = rest[i + 1] if i + 1 < n else ""
+            return (_code_imports_charter(value) if letter == "c"
+                    else _module_is_charter(value))
+        i += consumed
     return False
 
 
@@ -608,10 +801,11 @@ def _shell_segments(command: str) -> list[list[str]]:
     return segments
 
 
-def _shell_launches_charter(command: str, depth: int = 0) -> bool:
+def _shell_launches_charter(command: str, depth: int = 0, cwd=None, env=None) -> bool:
     """Does this shell command STRING run charter?
 
-    The word has to be there at all — that gate is what keeps ``pwd > "$out"`` and the
+    The name has to be there at all — that gate (:data:`_CHARTER_MENTION`, which asks for
+    the name and nothing about its boundaries) is what keeps ``pwd > "$out"`` and the
     frame's tmux fixtures out of the lexer entirely. Once it is there, the only question
     left is whether it is a COMMAND or an ARGUMENT, and both spellings are live in this
     suite. `test_toolgate` asks a real bash to echo its corpus back — ``printf "%s\\x00"
@@ -630,51 +824,76 @@ def _shell_launches_charter(command: str, depth: int = 0) -> bool:
     * a wrapper that takes a command as its arguments — ``sudo``, ``eval``, ``xargs``,
       ``timeout`` — with the word anywhere after it;
     * a string that will not lex, or nesting past the fourth level.
+
+    The per-segment question is :func:`_cmd_launches_charter`'s, in full: the wrapper
+    clause used to be repeated here because that function did not have one, which is how
+    ``["nice", "charter", "docs"]`` — the same wrapper, one layer of quoting less — ran.
     """
-    if not _CHARTER_WORD.search(command):
+    if not _CHARTER_MENTION.search(command):
         return False
     if depth > 3:                         # nesting nobody writes; stop, and refuse
         return True
     for body in _substitution_bodies(command):
-        if _shell_launches_charter(body, depth + 1):
+        if _shell_launches_charter(body, depth + 1, cwd, env):
             return True
     try:
         segments = _shell_segments(command)
     except ValueError:
         return True
     for segment in segments:
-        words = _strip_launcher_prefix(segment)
-        if any(_CHARTER_WORD.search(w) for w in segment[:len(segment) - len(words)]):
-            return True                   # an assignment, or `env`'s own options, name it
-        if not words:
-            continue
-        if "$" in words[0] or "`" in words[0]:
+        if _cmd_launches_charter(segment, depth + 1, cwd, env):
+            return True
+        words, _consumed = _launcher_argv(segment)
+        if words and ("$" in words[0] or "`" in words[0]):
             return True                   # the command word is computed: undecidable
-        if _cmd_launches_charter(words, depth + 1):
-            return True
-        if (os.path.basename(words[0]) in _COMMAND_WRAPPERS
-                and any(_CHARTER_WORD.search(w) for w in words[1:])):
-            return True
     return False
 
 
-def _cmd_launches_charter(parts: list[str], depth: int = 0) -> bool:
-    """Does this argv launch charter — by any spelling that would resolve a plane?"""
-    parts = _strip_launcher_prefix(parts)
+def _cmd_launches_charter(parts: list[str], depth: int = 0, cwd=None, env=None) -> bool:
+    """Does this argv launch charter — by any spelling that would resolve a plane?
+
+    The wrapper run and the assignments in front of the program come off through
+    :func:`_launcher_argv`, which is production's reader; what is left is asked three
+    questions, and each of them is about what the child WILL BE rather than how it is
+    written here:
+
+    * is the program charter — `charter.hooks._is_charter`, case-folded, and by the name
+      the program resolves to as well as the one written down;
+    * is it a Python interpreter being handed source, a module or a script;
+    * is it a shell being handed a command string, by any bundling of ``-c``.
+
+    And one belt-and-braces clause under them: a wrapper whose argument grammar
+    :func:`_launcher_argv` cannot follow past (`eval`, `su -c`, `flock <file>`) with the
+    word anywhere after it. Where a spelling cannot be decided this answers "charter" and
+    lets the plane check settle it.
+    """
+    parts, consumed = _launcher_argv(parts)
+    if any(_CHARTER_WORD.search(w) for w in consumed):
+        return True                       # an assignment, `env -S`'s packed command, …
     if not parts:
         return False
-    head = os.path.basename(parts[0])
-    if head == "charter":
-        return True
     rest = parts[1:]
-    if _is_python(head) and _python_launches_charter(rest):
+    names = _program_names(parts[0], cwd, env) if _reaches_an_interpreter(rest) else [
+        os.path.basename(parts[0])]
+    if any(_hooks._is_charter(name, parts) for name in names):
         return True
-    if head in _SHELL_NAMES:
-        for i, tok in enumerate(rest):
-            if tok == "-c" and i + 1 < len(rest):
-                return _shell_launches_charter(rest[i + 1], depth + 1)
-            if tok.startswith("-c") and len(tok) > 2:
-                return _shell_launches_charter(tok[2:], depth + 1)
+    if any(_is_python(name) for name in names) and _python_launches_charter(rest):
+        return True
+    if any(name.lower() in _SHELL_NAMES for name in names):
+        i = 0
+        while i < len(rest):
+            # `-o`/`-O` are the shell short options that take a value and are no way in;
+            # everything else bundles freely, which is what makes `-lc`, `-ec`, `-xc` and
+            # `-ic` the ordinary spellings they are.
+            letter, value, taken = _bundled_option(rest[i], "c", valued="oO")
+            if letter:
+                if taken == 2:
+                    value = rest[i + 1] if i + 1 < len(rest) else ""
+                return _shell_launches_charter(value, depth + 1, cwd, env)
+            i += taken
+    if (os.path.basename(parts[0]).lower() in _COMMAND_WRAPPERS
+            and any(_CHARTER_WORD.search(w) for w in rest)):
+        return True
     # ``-m charter`` by adjacency, wherever it appears and whatever argv[0] is called.
     # `_is_python` knows the interpreter names this machine has; this catches the one it
     # does not.
@@ -728,8 +947,14 @@ def _charter_argv(args, opts: dict) -> list[str] | None:
     if not parts:
         return None
 
+    # The child's own cwd and environment, which is what decides where a relative
+    # interpreter path lands and which ``PATH`` a bare program name is looked up on. Passed
+    # down rather than left to this process's: `Popen` chdirs before it execs, so
+    # ``["./python3", "-c", "import charter"]`` is a different program depending on `cwd`.
+    cwd, env = opts.get("cwd"), opts.get("env")
+
     executable = _decoded(opts.get("executable")) if opts.get("executable") else None
-    if executable is not None and os.path.basename(executable) == "charter":
+    if executable is not None and _hooks._is_charter(executable, parts):
         return parts
 
     # ``shell=True`` hands args[0] to ``/bin/sh -c`` — as a string, or as the first element
@@ -737,11 +962,11 @@ def _charter_argv(args, opts: dict) -> list[str] | None:
     # STRING, and the previous version answered it ``None``: it declined to parse the one
     # form that carries the whole command.
     if opts.get("shell"):
-        return parts if _shell_launches_charter(parts[0]) else None
+        return parts if _shell_launches_charter(parts[0], 0, cwd, env) else None
     if isinstance(args, (str, bytes)):
         # Without ``shell=True`` a string is one program name and no arguments.
-        return parts if os.path.basename(parts[0]) == "charter" else None
-    return parts if _cmd_launches_charter(parts) else None
+        return parts if _hooks._is_charter(parts[0], parts) else None
+    return parts if _cmd_launches_charter(parts, 0, cwd, env) else None
 
 
 def _explain_spawn(parts: list[str], plane) -> str:

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -758,7 +758,12 @@ def _explain_spawn(parts: list[str], plane) -> str:
         f"`tests._isolation.child_plane_env(self)` returns exactly that environment, and "
         f"`PanelIntegration` in `test_frame_tmux_integration.py` does the same by hand. "
         f"charter's own spawners already do this for you (`util.child_env`), so a case "
-        f"whose `config.ROOT` is isolated never gets here.")
+        f"whose `config.ROOT` is isolated never gets here. One child is the exception to "
+        f"(2), and it is the child that imports the `tests` package: `_envguard` scrubs "
+        f"$CHARTER_ROOT at import of that package, BEFORE `charter.config` loads, so the "
+        f"pointer is gone by the time the plane is resolved and only the child's cwd "
+        f"decides. Give that one a cwd inside a throwaway plane, with $PYTHONPATH carrying "
+        f"the tree — `test_no_test_reads_the_operators_shell` does exactly that.")
 
 
 def _child_plane(opts: dict):

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -77,6 +77,19 @@ subtleties live (a linked worktree redirects to the tree it was cut from, a plan
 plane's ``workspaces/`` hops outward), and a guard with its own private copy of that logic
 is a guard that stops agreeing with the thing it guards.
 
+**By any spelling, because the question is a property and not a pattern.** The first
+version of that tripwire recognised the two argvs charter's own code writes, and measuring
+it against its own ``_REAL_ROOT`` showed what that leaves open: ``[python, "-m", "charter",
+"--version"]`` was refused, while ``[python, "-c", "from charter import config"]``,
+``["/bin/sh", "-c", "<python> -m charter --version"]`` and the same command as a
+``shell=True`` string all RAN, against the operator's live plane. Two of those were already
+in the suite — nine charter-importing ``python -c`` children per run, plus a self-spawning
+chain of them in `test_news_cross_process`, each resolving the operator's plane at import
+and only then calling `config.use`. `_charter_argv` now asks "will this child resolve the
+operator's plane as charter", and where a spelling cannot be decided it answers "charter"
+and lets the plane check settle it: a false refusal in a test is loud, named and one line
+from the fix, and a false allow writes to a live machine.
+
 **Charter's own spawners now hand the plane over** (`util.child_env`), so an isolated case
 satisfies this without knowing it exists. What is left for the tripwire is the case that
 was never covered: a test that spawns charter by hand, and a test that never isolated
@@ -85,12 +98,16 @@ was never covered: a test that spawns charter by hand, and a test that never iso
 
 from __future__ import annotations
 
+import ast
 import builtins
 import io
 import os
+import re
+import shlex
 import shutil
 import subprocess
 import sys
+import tokenize
 import unittest
 from pathlib import Path
 
@@ -323,35 +340,408 @@ class RealPlaneSpawn(BaseException):
     """A test spawned a charter that would resolve the developer's own control plane."""
 
 
-def _charter_argv(args) -> list[str] | None:
+#: ``NAME=value`` — the shell's environment-assignment prefix, and `env`'s argument form.
+_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*=")
+
+#: An interpreter whose ``-c`` is Python SOURCE and whose first bare argument is a Python
+#: script. `sys.executable`'s own basename is accepted alongside it, because a virtualenv,
+#: a framework build or a `uv`-managed toolchain may spell it something this pattern does
+#: not — and `sys.executable` is what every child in this suite is launched with.
+_PYTHON_NAME = re.compile(r"^(?:python|pypy)[0-9.]*t?$")
+
+#: A shell whose ``-c`` is a command STRING, read by :func:`_shell_launches_charter`.
+_SHELL_NAMES = frozenset(("sh", "bash", "zsh", "dash", "ksh", "ash", "mksh", "busybox"))
+
+#: Shell operators that END one command and begin the next, as `shlex` with
+#: ``punctuation_chars=True`` hands them back.
+_SHELL_SEPARATORS = frozenset((";", ";;", "&", "&&", "|", "||", "(", ")", "\n"))
+
+#: Shell operators whose NEXT token is a file, not a command word. Without this
+#: ``>/dev/null charter doctor`` would be read as a command called ``/dev/null``.
+_SHELL_REDIRECTS = frozenset((">", ">>", "<", "<<", "<<<", ">&", "<&", ">|", "&>", "&>>",
+                              "<>"))
+
+#: Commands whose ARGUMENTS are themselves a command. ``sudo charter doctor`` has ``sudo``
+#: in the command position and charter one word later; a reader that looked only at the
+#: head would call that an argument and allow it. Their argument grammars differ enough
+#: (``timeout 5 charter``, ``xargs -n1 charter``) that following them exactly is not worth
+#: attempting -- the word appearing anywhere after one of these is refused.
+_COMMAND_WRAPPERS = frozenset((
+    "eval", "exec", "command", "builtin", "sudo", "doas", "su", "nohup", "nice", "setsid",
+    "stdbuf", "time", "timeout", "xargs", "watch", "script", "env", "flock", "ionice"))
+
+#: ``charter`` as a WORD inside a shell command string. ``/`` is allowed BEFORE it, so an
+#: absolute path to the binary (``/usr/local/bin/charter --version``) is a hit, and
+#: forbidden AFTER it, so a path that merely contains the checkout
+#: (``cd ~/IdeaProjects/charter/tests``) is not.
+_CHARTER_WORD = re.compile(r"(?<![\w.-])charter(?![\w.\-/])")
+
+#: The names of `subprocess.Popen.__init__`'s positional parameters, in order after *args*.
+#: The guard has to know what the child was told, and a caller may say it either way:
+#: ``Popen(argv, cwd=here)`` and ``Popen(argv, -1, None, None, None, None, None, True,
+#: False, here)`` describe the same child. Reading only ``**kw`` answers the second one
+#: "no cwd, no env" and asks `find_root` the wrong question — silently, and in the
+#: direction that allows.
+_POPEN_POSITIONAL = ("bufsize", "executable", "stdin", "stdout", "stderr", "preexec_fn",
+                     "close_fds", "shell", "cwd", "env")
+
+
+def _decoded(value) -> str | None:
+    """*value* as a `str`, or ``None`` when it is not a path-like thing at all."""
+    try:
+        return os.fsdecode(value) if isinstance(value, (bytes, os.PathLike)) else str(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_python(name: str) -> bool:
+    return bool(_PYTHON_NAME.match(name)) or name == os.path.basename(sys.executable)
+
+
+def _module_is_charter(name: str) -> bool:
+    return name == "charter" or name.startswith("charter.")
+
+
+def _code_imports_charter(code: str) -> bool:
+    """Does this Python SOURCE name the ``charter`` module?
+
+    Tokenized rather than pattern-matched, because the two things that have to be told
+    apart are a NAME and a path that happens to contain the word: ``from charter import
+    config`` is a charter child, and ``open('/Users/x/IdeaProjects/charter/canary', 'w')``
+    — which the frame's tmux cases really do spawn — is not. A regex over the raw text
+    cannot see that difference; `tokenize` can, and it is the lexer the child itself will
+    use.
+
+    A STRING whose whole value is ``charter`` (or ``charter.something``) counts too: that
+    is `__import__("charter")` and `importlib.import_module("charter.util")`. A module name
+    assembled at runtime would slip through, and is left to: nothing in this suite writes
+    one, and the alternative — refusing on the bare word — refuses every child whose argv
+    quotes a path inside the checkout.
+
+    **``import tests`` counts as an import of charter**, and only in an import statement.
+    This package's ``__init__`` imports `charter.config` to arm the guards, so a child that
+    imports it resolves a plane without the word ever appearing —
+    `test_no_test_reads_the_operators_shell` spawns exactly that, and it was the last child
+    in the suite still landing on the operator's plane once the ``-c`` shape was closed.
+    Restricting it to an import position is what keeps a local variable called ``tests``
+    from being read as one.
+
+    That child is also the one case where ``$CHARTER_ROOT`` is NOT the way out: `_envguard`
+    scrubs the whole charter namespace at import of this package, *before* `charter.config`
+    loads, so the pointer is gone by the time the plane is resolved and the child's CWD
+    decides. Its fix is a cwd inside a throwaway plane, with ``$PYTHONPATH`` carrying the
+    tree.
+
+    **Source that will not tokenize is refused, not allowed.** It is either a child that
+    cannot run at all — in which case the refusal is loud and one line from the fix — or a
+    lexer disagreement, and a guard that settles its own uncertainty by waving the child
+    through is the failure this one exists to end.
+    """
+    try:
+        importing = False
+        for tok in tokenize.generate_tokens(io.StringIO(code).readline):
+            if tok.type == tokenize.NAME:
+                if tok.string == "charter":
+                    return True
+                if tok.string in ("import", "from"):
+                    importing = True
+                    continue
+                if importing and tok.string == "tests":
+                    return True
+            if tok.type in (tokenize.NEWLINE, tokenize.NL) or (
+                    tok.type == tokenize.OP and tok.string == ";"):
+                importing = False
+            if tok.type == tokenize.STRING:
+                try:
+                    value = ast.literal_eval(tok.string)
+                except (ValueError, SyntaxError, MemoryError, RecursionError):
+                    continue
+                if isinstance(value, str) and _module_is_charter(value):
+                    return True
+    except (tokenize.TokenError, IndentationError, SyntaxError, ValueError):
+        return True
+    return False
+
+
+def _script_imports_charter(path: str) -> bool:
+    """Does the Python FILE at *path* name the charter module?
+
+    ``python <plane>/charter/__main__.py --version`` is charter spelled without ``-m``, and
+    so is a probe written to a temp file that imports the tree under test. Both are asked,
+    in that order, because neither test alone answers both: charter's own ``__main__.py``
+    reaches the CLI through ``from .cli import main`` and never writes the word, so reading
+    it says "not charter" about the entry point itself — while a name test alone would have
+    to decide what ``/tmp/probe.py`` is, and can only guess.
+
+    So: a module of the ``charter`` package, run by path, is charter by its location.
+    Anything else is read, because the file is on disk and reading it is the honest answer.
+    Unreadable, or too large to be a probe, is answered ``True``: both mean this cannot be
+    decided here, and refusal is the direction that is safe to be wrong in.
+    """
+    if os.path.basename(os.path.dirname(path)) == "charter":
+        return True
+    try:
+        if os.path.getsize(path) > 1 << 20:
+            return True
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            return _code_imports_charter(fh.read())
+    except OSError:
+        return True
+
+
+def _strip_launcher_prefix(parts: list[str]) -> list[str]:
+    """Drop ``VAR=value`` assignments and an `env` wrapper to reach the real command.
+
+    ``env -u CHARTER_SESSION_ID python3 -m charter --version`` launches charter; a guard
+    that stopped reading at ``env`` would answer that it does not. Only the option forms
+    `env` itself documents are consumed — anything else ends the walk, because a guard
+    guessing at an unknown option's arity would start skipping the command word itself.
+    """
+    i, n = 0, len(parts)
+    while i < n:
+        tok = parts[i]
+        if _ASSIGNMENT.match(tok):
+            i += 1
+            continue
+        if os.path.basename(tok) != "env":
+            break
+        i += 1
+        while i < n:
+            tok = parts[i]
+            if _ASSIGNMENT.match(tok) or tok in ("-i", "--ignore-environment", "-0",
+                                                 "--null", "-v", "--debug"):
+                i += 1
+            elif tok in ("-u", "--unset", "-C", "--chdir", "-S", "--split-string"):
+                i += 2
+            elif tok.startswith(("--unset=", "--chdir=", "--split-string=")):
+                i += 1
+            else:
+                break
+    return parts[i:]
+
+
+def _python_launches_charter(rest: list[str]) -> bool:
+    """The tail of a Python interpreter's argv: does it reach charter?
+
+    ``-c``, ``-m`` and a bare script path are the three ways in, and each option may be
+    spelled attached (``-mcharter``), separate (``-m charter``) or bundled behind other
+    short options (``-Pmcharter``) — all of which CPython accepts, and one of which
+    `util.self_relaunch_argv` is a single edit away from producing.
+    """
+    i, n = 0, len(rest)
+    while i < n:
+        tok = rest[i]
+        if not tok.startswith("-") or tok == "-":
+            return _script_imports_charter(tok)
+        if tok.startswith("--"):
+            i += 1
+            continue
+        skip = 1
+        for j, ch in enumerate(tok[1:], start=1):
+            if ch in "cm":
+                value = tok[j + 1:] or (rest[i + 1] if i + 1 < n else "")
+                return (_code_imports_charter(value) if ch == "c"
+                        else _module_is_charter(value))
+            if ch in "WXQ":               # takes a value, and is no way into charter
+                if not tok[j + 1:]:
+                    skip = 2
+                break
+        i += skip
+    return False
+
+
+def _substitution_bodies(command: str) -> list[str]:
+    """Every ``$( … )`` and `` ` … ` `` body in *command*, unnested by one level.
+
+    These are the reason a plain command-position reader is not enough, and the omission
+    was not hypothetical: `hooks/hooks.json` — the file this guard's docstring cites as its
+    reason for recognising a bare ``charter`` — spells one of its commands
+    ``out="$(charter doctor 2>&1)" || …``. Every lexer in the world reads that as an
+    ASSIGNMENT and moves on, so the charter invocation inside it is in no command position
+    at all. It is one here, and :func:`_shell_launches_charter` reads it as its own command
+    string.
+
+    An unterminated substitution yields what there is rather than nothing: the string is
+    malformed either way, and the half that can be read is the half that names the command.
+    """
+    bodies: list[str] = []
+    i, n = 0, len(command)
+    while i < n:
+        ch = command[i]
+        if ch == "`":
+            j = command.find("`", i + 1)
+            bodies.append(command[i + 1:] if j < 0 else command[i + 1:j])
+            if j < 0:
+                break
+            i = j + 1
+        elif ch == "$" and command.startswith("$(", i):
+            depth, j = 1, i + 2
+            while j < n and depth:
+                depth += (command[j] == "(") - (command[j] == ")")
+                j += 1
+            bodies.append(command[i + 2:j - 1] if not depth else command[i + 2:])
+            i = j
+        else:
+            i += 1
+    return bodies
+
+
+def _shell_segments(command: str) -> list[list[str]]:
+    """*command* split into the individual commands a shell would run, as word lists.
+
+    Raises `ValueError` when it will not lex — an unbalanced quote — which the caller reads
+    as "undecidable" and refuses.
+    """
+    lex = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lex.whitespace_split = True
+    segments: list[list[str]] = [[]]
+    skip = False
+    for tok in lex:
+        if skip:                          # a redirect's target, not a command word
+            skip = False
+        elif tok in _SHELL_REDIRECTS:
+            skip = True
+        elif tok in _SHELL_SEPARATORS:
+            segments.append([])
+        else:
+            segments[-1].append(tok)
+    return segments
+
+
+def _shell_launches_charter(command: str, depth: int = 0) -> bool:
+    """Does this shell command STRING run charter?
+
+    The word has to be there at all — that gate is what keeps ``pwd > "$out"`` and the
+    frame's tmux fixtures out of the lexer entirely. Once it is there, the only question
+    left is whether it is a COMMAND or an ARGUMENT, and both spellings are live in this
+    suite. `test_toolgate` asks a real bash to echo its corpus back — ``printf "%s\\x00"
+    charter "sec"'ret' list v`` — and never runs charter; ``charter workspace _reconcile
+    >/dev/null 2>&1`` is charter's own hook, and does.
+
+    So the string is segmented into the commands a shell would run, and each is asked the
+    same question as an argv. What cannot be followed is refused rather than allowed, and
+    each of these is a real way to reach charter without ever putting the word in a command
+    position:
+
+    * a command substitution — read as its own command string, one level down;
+    * an assignment whose value names charter — ``cmd=charter; $cmd doctor``;
+    * a command word containing ``$`` or a backtick — the indirection that assignment sets
+      up, and anything else that computes the name;
+    * a wrapper that takes a command as its arguments — ``sudo``, ``eval``, ``xargs``,
+      ``timeout`` — with the word anywhere after it;
+    * a string that will not lex, or nesting past the fourth level.
+    """
+    if not _CHARTER_WORD.search(command):
+        return False
+    if depth > 3:                         # nesting nobody writes; stop, and refuse
+        return True
+    for body in _substitution_bodies(command):
+        if _shell_launches_charter(body, depth + 1):
+            return True
+    try:
+        segments = _shell_segments(command)
+    except ValueError:
+        return True
+    for segment in segments:
+        words = _strip_launcher_prefix(segment)
+        if any(_CHARTER_WORD.search(w) for w in segment[:len(segment) - len(words)]):
+            return True                   # an assignment, or `env`'s own options, name it
+        if not words:
+            continue
+        if "$" in words[0] or "`" in words[0]:
+            return True                   # the command word is computed: undecidable
+        if _cmd_launches_charter(words, depth + 1):
+            return True
+        if (os.path.basename(words[0]) in _COMMAND_WRAPPERS
+                and any(_CHARTER_WORD.search(w) for w in words[1:])):
+            return True
+    return False
+
+
+def _cmd_launches_charter(parts: list[str], depth: int = 0) -> bool:
+    """Does this argv launch charter — by any spelling that would resolve a plane?"""
+    parts = _strip_launcher_prefix(parts)
+    if not parts:
+        return False
+    head = os.path.basename(parts[0])
+    if head == "charter":
+        return True
+    rest = parts[1:]
+    if _is_python(head) and _python_launches_charter(rest):
+        return True
+    if head in _SHELL_NAMES:
+        for i, tok in enumerate(rest):
+            if tok == "-c" and i + 1 < len(rest):
+                return _shell_launches_charter(rest[i + 1], depth + 1)
+            if tok.startswith("-c") and len(tok) > 2:
+                return _shell_launches_charter(tok[2:], depth + 1)
+    # ``-m charter`` by adjacency, wherever it appears and whatever argv[0] is called.
+    # `_is_python` knows the interpreter names this machine has; this catches the one it
+    # does not.
+    return any(parts[i] == "-m" and _module_is_charter(parts[i + 1])
+               for i in range(len(parts) - 1))
+
+
+def _charter_argv(args, opts: dict) -> list[str] | None:
     """*args* as a list of strings when it launches charter itself, else ``None``.
 
-    Two spellings, because charter is reached two ways and a guard that knew one would be
-    silent about the other: ``[sys.executable, "-P", "-m", "charter", ...]``
-    (`util.self_relaunch_argv`, which every self-relaunch site goes through) and a bare
-    ``charter`` resolved from ``PATH`` (what `hooks/hooks.json` invokes, and what a test
-    driving the installed CLI would write).
+    The question is not "is this argv one of the spellings charter's own code uses" — it is
+    **"will this child resolve the operator's plane as charter"**. The difference was
+    measured against the previous version of this function, which asked the first question:
+    ``[python, "-m", "charter", "--version"]`` was refused, while ``[python, "-c", "from
+    charter import config; print(config.ROOT)"]``, ``["/bin/sh", "-c", "<python> -m charter
+    --version"]`` and the same command as a ``shell=True`` string all RAN, against the real
+    plane. The ``-c`` shape was not hypothetical: nine charter-importing ``python -c``
+    children per suite run were being waved through, each resolving the operator's own
+    plane at import before calling `config.use` on the next statement — "a module-level
+    charter import in a child that resolves its own plane" being exactly the shape that
+    produced #527.
 
-    A ``str`` command line -- ``shell=True`` -- is answered ``None`` rather than parsed. No
-    charter spawn site uses one, and a guard that half-parses shell syntax would refuse the
-    wrong calls while still missing the interesting ones; if such a site ever appears, it
-    should stop using a shell rather than teach this to lex.
+    So every spelling that gets there is recognised: a bare ``charter`` from ``PATH``,
+    ``-m charter`` (attached, separate or bundled), ``-c`` source that names the module, a
+    Python script file that imports it, ``executable=``, a shell ``-c`` string, and
+    ``shell=True``. Where a spelling cannot be decided — source that will not tokenize, a
+    script that will not read, any shell string — it is answered "charter" and the plane
+    check decides. A false refusal in a test is loud, named and one line from the fix; a
+    false allow writes to a live machine.
     """
-    if args is None or isinstance(args, (str, bytes)):
+    if args is None:
         return None
-    try:
-        parts = [os.fsdecode(a) if isinstance(a, (bytes, os.PathLike)) else str(a)
-                 for a in args]
-    except TypeError:
-        return None
+    if isinstance(args, os.PathLike):
+        # `Popen` accepts one path-like as the whole command. It is not iterable, so the
+        # sequence branch below would raise `TypeError` and answer "not charter" — which is
+        # the shape of every hole this function has had.
+        args = os.fspath(args)
+    if isinstance(args, (str, bytes)):
+        command = _decoded(args)
+        if command is None:
+            return None
+        parts = [command]
+    else:
+        try:
+            decoded = [_decoded(a) for a in args]
+        except TypeError:
+            return None
+        if any(p is None for p in decoded):
+            return None
+        parts = decoded
     if not parts:
         return None
-    if os.path.basename(parts[0]) == "charter":
+
+    executable = _decoded(opts.get("executable")) if opts.get("executable") else None
+    if executable is not None and os.path.basename(executable) == "charter":
         return parts
-    for i in range(len(parts) - 1):
-        if parts[i] == "-m" and parts[i + 1] == "charter":
-            return parts
-    return None
+
+    # ``shell=True`` hands args[0] to ``/bin/sh -c`` — as a string, or as the first element
+    # of a sequence whose remaining elements become $0, $1... Either way it is a command
+    # STRING, and the previous version answered it ``None``: it declined to parse the one
+    # form that carries the whole command.
+    if opts.get("shell"):
+        return parts if _shell_launches_charter(parts[0]) else None
+    if isinstance(args, (str, bytes)):
+        # Without ``shell=True`` a string is one program name and no arguments.
+        return parts if os.path.basename(parts[0]) == "charter" else None
+    return parts if _cmd_launches_charter(parts) else None
 
 
 def _explain_spawn(parts: list[str], plane) -> str:
@@ -371,8 +761,8 @@ def _explain_spawn(parts: list[str], plane) -> str:
         f"whose `config.ROOT` is isolated never gets here.")
 
 
-def _child_plane(kwargs: dict):
-    """The plane the child described by *kwargs* would resolve -- or ``None`` for none.
+def _child_plane(opts: dict):
+    """The plane the child described by *opts* would resolve -- or ``None`` for none.
 
     `root.find_root` is asked the child's question directly, with the child's environment
     (``env=None`` means it inherits ours) and the child's cwd. That is what `find_root`'s
@@ -385,17 +775,25 @@ def _child_plane(kwargs: dict):
     exactly that path, and answering ``None`` there would be the guard waving through the
     one case the fallback makes dangerous: a bad ``$CHARTER_ROOT`` and a cwd of the
     checkout.
+
+    ``env=None`` is answered with a ``dict`` COPY of `os.environ` rather than the mapping
+    itself, and that is about the other tripwire in this package. `_envguard` refuses an
+    undeclared TARGETED read of ``$CHARTER_ROOT`` and leaves bulk reads alone, so asking
+    `find_root` to ``.get()`` it off the live mapping would raise `AmbientEnvRead` inside
+    the guard — charging every test that spawns `bash` with a read it never made. A copy
+    carries the same values (the ambient ones were scrubbed at install, so it is the same
+    on every machine) and is exactly what the child will inherit.
     """
     from charter import root as _root
 
-    env = kwargs.get("env")
-    cwd = kwargs.get("cwd")
+    env = opts.get("env")
+    cwd = opts.get("cwd")
     try:
         start = Path(os.fsdecode(cwd)) if cwd is not None else Path.cwd()
     except (TypeError, ValueError, OSError):
         return None
     try:
-        return _root.find_root(start, env=os.environ if env is None else env)
+        return _root.find_root(start, env=dict(os.environ) if env is None else env)
     except _root.ControlPlaneNotFound:
         try:
             return start.resolve()        # what `find_root_or_cwd` hands `config`
@@ -434,9 +832,11 @@ def _guard_spawns() -> None:
     original = subprocess.Popen.__init__
 
     def __init__(self, args=None, *rest, **kw):
-        parts = _charter_argv(args)
+        opts = dict(zip(_POPEN_POSITIONAL, rest))
+        opts.update(kw)
+        parts = _charter_argv(args, opts)
         if parts is not None and _REAL_ROOT:
-            plane = _child_plane(kw)
+            plane = _child_plane(opts)
             if plane is not None:
                 try:
                     here = os.path.abspath(str(plane))

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -824,6 +824,15 @@ def _guard_spawns() -> None:
     class at all, so it is never refused. That is the right answer, because nothing is
     spawned. This fires on spawns that really happen, which is the only kind that can touch
     a plane.
+
+    **What it does NOT watch, stated rather than left to be discovered.** `os.execv*`,
+    `os.posix_spawn*`, `os.spawn*` and `os.system` start a process without going anywhere
+    near this class. They are not wrapped, and the reason is not that they are unreachable
+    — it is that nothing reaches CHARTER through them, which is a checkable claim rather
+    than an assumption: `NoCharterEscapesThroughTheExecFamily` in
+    `test_plane_spawn_guard.py` parses every module in `charter/` and `tests/` and fails on
+    a call to one of them that is not the two known non-charter uses. The day a charter
+    spawn is written that way, that case turns red and this docstring is what it points at.
     """
     global _SPAWN_GUARDED
     if _SPAWN_GUARDED:

--- a/tests/test_a_deny_survives_a_broken_channel.py
+++ b/tests/test_a_deny_survives_a_broken_channel.py
@@ -48,7 +48,7 @@ from pathlib import Path
 from unittest import mock
 
 import charter
-from charter import config, hooks
+from charter import config, hooks, root
 from tests._isolation import PersonaIso
 
 #: A payload that MUST be denied, per handler that can deny one.
@@ -89,8 +89,14 @@ class RealPipeCase(PersonaIso):
     and nothing is patched.
     """
 
-    #: `config.use` rather than an env var, because the child must not touch the developer's
-    #: real `.charter/` and this is the same seam `PersonaIso` uses in-process.
+    #: `config.use` is the same seam `PersonaIso` uses in-process — but it is the SECOND
+    #: statement, and the first is ``from charter import config``, which resolves a plane at
+    #: import from the child's own cwd. That cwd is the checkout, so for as long as this
+    #: said "an env var is unnecessary" the child was resolving the developer's real plane
+    #: and only then being repointed. Nothing was harmed, and nothing enforced it —
+    #: "a module-level charter import in a child that resolves its own plane" is the shape
+    #: that produced #527. ``$CHARTER_ROOT`` on the child's environment (below) makes the
+    #: import land where `config.use` is about to point anyway.
     CHILD = ("import sys;"
              "from pathlib import Path;"
              "from charter import config, hooks;"
@@ -102,6 +108,7 @@ class RealPipeCase(PersonaIso):
         super().setUp()
         (self.tmp / "charter.toml").write_text("schema = 1\n")
         self.env = {**os.environ,
+                    root.ENV_VAR: str(self.tmp),
                     "PYTHONPATH": str(Path(charter.__file__).resolve().parent.parent)}
         # Buffering is the subject, so it is not left to the ambient environment: with this
         # set the child's stdout is unbuffered and the bug is invisible again.

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -29,17 +29,33 @@ _CRASH_MARKERS = ("Traceback (most recent call last):", "ModuleNotFoundError", "
 
 
 class CliSmokeTest(unittest.TestCase):
-    """Runs `python3 -m charter ...` as a real subprocess, isolated from the
-    developer's own ~/.charter and the umbrella's own inventory/vaults via a throwaway
-    CHARTER_HOME, so a doctor run here can't read or write real secrets/state."""
+    """Runs `python3 -m charter ...` as a real subprocess, isolated from the developer's
+    own ~/.charter and the umbrella's own inventory/vaults via a throwaway CHARTER_HOME —
+    **and from their control plane**, via a throwaway ``$CHARTER_ROOT``.
+
+    The plane half was missing, and `CHARTER_HOME` reads like it covered it. It did not:
+    the child ran with ``cwd=REPO_ROOT`` and no ``$CHARTER_ROOT``, so it walked up from
+    the checkout and resolved the developer's live plane. ``charter doctor`` then reported
+    on that plane — its personas, its workspaces, its vault registry — from a smoke test
+    that had already declared itself isolated. The suite's spawn tripwire refuses it now
+    (#527); this is the fix it names.
+
+    The cwd stays at the checkout: ``-m`` needs the tree on ``sys.path`` to import the
+    charter under test, and it is ``$CHARTER_ROOT`` — which wins outright in
+    `root.find_root` — that decides the plane.
+    """
 
     def setUp(self) -> None:
         import os
         import tempfile
 
         self.tmp = tempfile.mkdtemp(prefix="charter-smoke-")
+        self.plane = Path(self.tmp) / "plane"
+        self.plane.mkdir()
+        (self.plane / "charter.toml").write_text("schema = 1\n")
         self.env = dict(os.environ)
         self.env["CHARTER_HOME"] = str(Path(self.tmp) / ".charter")
+        self.env["CHARTER_ROOT"] = str(self.plane)
         # Force non-tty color codes off / deterministic output.
         self.env.pop("FORCE_COLOR", None)
 

--- a/tests/test_dev_channel.py
+++ b/tests/test_dev_channel.py
@@ -29,7 +29,7 @@ import unittest
 from unittest import mock
 
 from charter import __version__, channel, config, instance, statusline, update
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, child_plane_env, make_plane
 
 
 @contextlib.contextmanager
@@ -325,10 +325,25 @@ class TheBuildSaysWhatItIs(unittest.TestCase):
 
 class VersionAlwaysPrints(unittest.TestCase):
     def test_the_cli_prints_a_version_line(self):
+        """A REAL child, in a THROWAWAY plane.
+
+        The child is a separate process: nothing this suite patches reaches it, and it
+        resolves its own plane. Run bare, it resolved the developer's — and `--version`
+        prints the build label, which on a dev-channel plane says something different, so
+        this case's outcome depended on the operator's own `charter.toml` in a way
+        `_planeguard`'s `RealPlaneRead` cannot see across a fork (#459, #527).
+
+        `PYTHONPATH` because the cwd is no longer the checkout: `-m` would otherwise have
+        nothing to import.
+        """
         import subprocess
         import sys
+        from pathlib import Path
+
+        plane, env = child_plane_env(
+            self, PYTHONPATH=str(Path(__file__).resolve().parents[1]))
         p = subprocess.run([sys.executable, "-m", "charter", "--version"],
-                           capture_output=True, text=True)
+                           cwd=plane, env=env, capture_output=True, text=True)
         self.assertEqual(p.returncode, 0, p.stderr)
         self.assertIn("charter", p.stdout)
         self.assertIn(__version__, p.stdout)
@@ -501,6 +516,7 @@ class TheBackgroundFetchIsWhereTheNetworkLives(PersonaIso):
 
     def setUp(self):
         super().setUp()
+        make_plane(self)      # `maybe_spawn` refuses to fork without one (#527)
         #: Every URL the code under test asked for. RECORDED rather than merely refused:
         #: `_fetch_head` catches `Exception`, so a stub that raised on an unexpected GET
         #: would have the raise swallowed and the test would pass while the call happened.

--- a/tests/test_docs_show.py
+++ b/tests/test_docs_show.py
@@ -32,6 +32,7 @@ import unittest
 from pathlib import Path
 
 from charter import docsrc
+from tests._isolation import child_plane_env
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DOCS_DIR = REPO_ROOT / "docs"
@@ -107,8 +108,16 @@ class TestDocsCli(unittest.TestCase):
     the part that can silently break an existing caller."""
 
     def _run(self, *args: str) -> subprocess.CompletedProcess:
+        """A real child, pointed at a throwaway plane.
+
+        `cwd=REPO_ROOT` is what `-m` needs to import the tree under test; it is also what
+        used to resolve the developer's own plane, so `charter docs` regenerated that
+        plane's topology from a test that never mentioned it (#527).
+        """
+        _plane, env = child_plane_env(self)
         return subprocess.run([sys.executable, "-m", "charter", "docs", *args],
-                              cwd=REPO_ROOT, capture_output=True, text=True, timeout=60)
+                              cwd=REPO_ROOT, env=env,
+                              capture_output=True, text=True, timeout=60)
 
     def test_show_prints_the_page(self):
         r = self._run("show", "git-policy")
@@ -134,8 +143,7 @@ class TestDocsCli(unittest.TestCase):
         """`charter docs` regenerated the plane's topology long before it grew
         subcommands, and Makefiles in the wild call it that way. Turning it into a
         group that demands a subcommand would break them at a distance."""
-        r = subprocess.run([sys.executable, "-m", "charter", "docs", "--help"],
-                           cwd=REPO_ROOT, capture_output=True, text=True, timeout=60)
+        r = self._run("--help")
         self.assertEqual(r.returncode, 0, r.stderr)
         from charter import cli
 

--- a/tests/test_doctor_shadowed.py
+++ b/tests/test_doctor_shadowed.py
@@ -17,6 +17,7 @@ serves. A naive check flags it as shadowing itself, on the one machine most like
 """
 from __future__ import annotations
 
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -90,15 +91,46 @@ class TestCharterDoesNotShadowItself(unittest.TestCase):
         self.assertEqual(hit, {"skills": [], "docs": []})
 
 
+def tracked_skills(repo: Path = REPO_ROOT) -> set[str]:
+    """Every skill this repository SHIPS — read from the index, not from the disk (#532).
+
+    The question is about the repository: which skills does charter ship, and does
+    `SHIPPED_SKILLS` still name them. `skills/*/SKILL.md` on a working copy is whatever
+    the person running the suite happens to have there, and anyone drafting a skill drafts
+    it where skills live — so an untracked `skills/my-draft/SKILL.md` turned this red with
+    a message about a constant being out of sync, when neither adding the draft to the
+    constant nor deleting the draft is the right answer. Same for a `git stash` that left a
+    directory behind, or a copy someone made to diff against.
+
+    The same seam and the same argument as `test_plugin_freshness.tracked_top_level_
+    directories` (#529) and `test_workflows.tracked`: a denylist of local artefacts is a
+    guess at where untracked content lives, and the index is the answer. The property this
+    test was written for survives intact — a skill added without updating the constant
+    still fails on the PR that COMMITS the skill, which is when the decision is due.
+
+    `check=True` on purpose: if the index cannot be read this test has nothing to say, and
+    an empty set would say it vacuously and green.
+    """
+    out = subprocess.run(
+        ["git", "-C", str(repo), "ls-files", "-z", "--", "skills/*/SKILL.md"],
+        capture_output=True, check=True, text=True)
+    return {p.split("/")[1] for p in out.stdout.split("\0") if p.count("/") == 2}
+
+
 class TestShippedSkillsStayInSync(unittest.TestCase):
     def test_the_constant_matches_the_shipped_directory(self):
         """The CLI ships in a wheel with no `skills/` — that directory belongs to the
         plugin — so the check carries a constant. Adding a skill without updating it would
         leave the new skill shadowable and unreported, which is this check's own failure
-        mode turned inward."""
-        on_disk = {d.name for d in (REPO_ROOT / "skills").iterdir()
-                   if d.is_dir() and (d / "SKILL.md").is_file()}
-        self.assertEqual(set(doctor.SHIPPED_SKILLS), on_disk)
+        mode turned inward.
+
+        **The equality runs both ways on purpose.** `SHIPPED_SKILLS` naming a skill that no
+        longer exists is as much a defect as a skill missing from it, and `doctor`'s shadow
+        check reports on both. Weakening this to a subset assertion to make a local draft
+        stop turning it red would give the removal half away — and a subset assertion here
+        would be nearly true by construction, which is how #529's first attempt went.
+        """
+        self.assertEqual(set(doctor.SHIPPED_SKILLS), tracked_skills())
 
 
 class TestCharterItselfIsExemptHoweverItWasInstalled(PersonaIso):

--- a/tests/test_glstate.py
+++ b/tests/test_glstate.py
@@ -17,10 +17,14 @@ from unittest import mock
 
 from charter import glstate
 
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, make_plane
 
 
 class MaybeSpawnCommandTests(PersonaIso):
+    def setUp(self):
+        super().setUp()
+        make_plane(self)      # `maybe_spawn` refuses to fork without one (#527)
+
     def _dirs(self):
         d = self.tmp / "somerepo"
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_glstate_respawn.py
+++ b/tests/test_glstate_respawn.py
@@ -25,7 +25,7 @@ from unittest import mock
 
 from charter import glstate
 
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, make_plane
 
 
 def _fake_popen(pid):
@@ -48,6 +48,10 @@ def _a_definitely_dead_pid() -> int:
 
 
 class RespawnTests(PersonaIso):
+    def setUp(self):
+        super().setUp()
+        make_plane(self)      # `maybe_spawn` refuses to fork without one (#527)
+
     def _dirs(self):
         d = self.tmp / "somerepo"
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_news_cross_process.py
+++ b/tests/test_news_cross_process.py
@@ -41,8 +41,8 @@ from unittest import mock
 
 import charter
 from charter import (commands, commands_persona, commands_update, doctor, harness,
-                     instance, news)
-from tests._isolation import pin_update_channel
+                     instance, news, root)
+from tests._isolation import child_plane_env, pin_update_channel
 
 #: The `check:` every test here plants, and the handler it stands on. A `check:` may
 #: only name a command `news._PROBEABLE` lists (#317), so the stand-in has to be one
@@ -124,6 +124,7 @@ class CrossProcessReentry(unittest.TestCase):
     """
 
     def setUp(self):
+        self.plane, _ = child_plane_env(self)
         self.dir = Path(tempfile.mkdtemp())
         (self.dir / "0.44.0-loop.md").write_text(
             "---\nversion: 0.44.0\nheadline: h\ncheck: persona lint\nadopt: version\n---\nbody\n")
@@ -144,7 +145,18 @@ class CrossProcessReentry(unittest.TestCase):
         self.assertEqual(len(news.released()), 1)
 
     def _env(self, hop: int) -> dict:
-        return {**os.environ, "PROBE_SRC": SRC, "PROBE_NEWSDIR": str(self.dir),
+        # `HOP` opens with ``from charter import commands_persona, config, news``, and a
+        # charter import resolves a plane from the importing process's own cwd. Every hop
+        # runs from the checkout, so every hop — and each one it spawns in turn — used to
+        # resolve the developer's LIVE plane. `child_plane_env` makes a throwaway one and
+        # ``$CHARTER_ROOT`` points every hop at it instead.
+        #
+        # Read from `os.environ` at CALL time, not from a snapshot taken in `setUp`: the
+        # re-entry marker this whole file is about (`news._ENV`) is set by `_dispatch`
+        # while the probe is running, and it is inherited, not passed. A snapshot predates
+        # it, and the chain would go on hopping with every guard intact.
+        return {**os.environ, root.ENV_VAR: str(self.plane),
+                "PROBE_SRC": SRC, "PROBE_NEWSDIR": str(self.dir),
                 "PROBE_SCRIPT": str(self.script), "PROBE_LOG": str(self.log),
                 "PROBE_HOP": str(hop), "PROBE_CAP": str(HOP_CAP),
                 "PROBE_TIMEOUT": str(HOP_TIMEOUT)}

--- a/tests/test_no_test_reads_the_operators_shell.py
+++ b/tests/test_no_test_reads_the_operators_shell.py
@@ -28,7 +28,7 @@ from unittest import mock
 
 from charter import commands_frame, legacyenv, session, workspace
 from tests import _envguard
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, child_plane_env
 
 
 class WhatIsGuarded(unittest.TestCase):
@@ -243,6 +243,13 @@ class WhatIsScrubbed(unittest.TestCase):
         A child rather than an in-process check because the scrub runs once, at import of
         the `tests` package, and by the time any test executes it has long since happened.
 
+        The child imports that package, which imports `charter.config`, which resolves a
+        plane — so it runs from a THROWAWAY plane with ``$PYTHONPATH`` carrying the tree,
+        rather than from a cwd of the checkout. This was the last child in the suite still
+        resolving the operator's live plane (`_planeguard.RealPlaneSpawn`). ``$CHARTER_ROOT``
+        would not have fixed it: the scrub this case is about removes that pointer *before*
+        charter loads, so for a child that imports this package the cwd is the only lever.
+
         ``$EDM_WORKSPACE`` is planted alongside them because it is the one that got away:
         every other name here was already gone when this case was written, and that one
         walked straight through the property into `charter init`'s stderr (#540). Planting
@@ -257,10 +264,12 @@ class WhatIsScrubbed(unittest.TestCase):
                  "'left': sorted(k for k in os.environ.copy() "
                  "if _envguard._in_namespace(k)),"
                  "'recovered': sorted(_envguard.scrubbed())}))")
+        tree = pathlib.Path(__file__).resolve().parent.parent
+        plane, _ = child_plane_env(self)
         out = subprocess.run(
             [sys.executable, "-c", probe],
-            env={**os.environ.copy(), **planted},
-            cwd=str(pathlib.Path(__file__).resolve().parent.parent),
+            env={**os.environ.copy(), **planted, "PYTHONPATH": str(tree)},
+            cwd=str(plane),
             capture_output=True, text=True, check=True)
         got = json.loads(out.stdout)
         self.assertEqual(got["left"], [],

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -13,8 +13,13 @@ class TestPackaging(unittest.TestCase):
         self.assertRegex(charter.__version__, r"^\d+\.\d+\.\d+")
 
     def test_module_entry_point_runs(self):
+        """A real child, pointed at a throwaway plane. It inherits this process's cwd —
+        the checkout — which is how it used to resolve the developer's own plane (#527).
+        """
+        from tests._isolation import child_plane_env
+        _plane, env = child_plane_env(self)
         p = subprocess.run([sys.executable, "-m", "charter", "--version"],
-                           capture_output=True, text=True)
+                           env=env, capture_output=True, text=True)
         self.assertEqual(p.returncode, 0, p.stderr)
         self.assertIn("charter", p.stdout.lower())
 

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from unittest import mock
 
 from charter import config, root
-from tests import _planeguard
+from tests import _envguard, _planeguard
 
 
 class WhatIsGuarded(unittest.TestCase):
@@ -46,7 +46,14 @@ class WhatIsGuarded(unittest.TestCase):
 
         Recomputed from `root.find_root` rather than read off `config.ROOT`, which any
         `PersonaIso` case may have repointed by the time this runs.
+
+        ``$CHARTER_ROOT`` is declared unset rather than left ambient, which is what
+        `_envguard` asks of any test that depends on it (#519). Saying so is not a
+        formality here: the name was scrubbed at install precisely so this walk starts from
+        the cwd, and a machine that had exported it would otherwise make this assert about
+        the operator's shell.
         """
+        _envguard.unset(root.ENV_VAR)
         self.assertIn(os.path.abspath(str(root.find_root())), _planeguard._REAL_ROOT)
 
 
@@ -62,9 +69,10 @@ class _FakePlane(unittest.TestCase):
         self.addCleanup(shutil.rmtree, self.elsewhere, True)
         (self.elsewhere / root.MARKER).write_text("schema = 1\n")
 
-        # A `charter` that leaves evidence. Named `charter` because that is one of the two
-        # spellings the guard recognises, and it makes the "allowed" case a real spawn of a
-        # real process rather than an assertion about a decision function.
+        # A `charter` that leaves evidence. Named `charter` because that is what the guard
+        # is looking for at the end of every spelling below, and it makes the "allowed"
+        # case a real spawn of a real process rather than an assertion about a decision
+        # function.
         self.marker = self.elsewhere / "the-child-ran"
         self.fake = self.elsewhere / "charter"
         self.fake.write_text(f"#!/bin/sh\necho ran > {self.marker}\n")
@@ -159,6 +167,233 @@ class AnAllowedSpawn(_FakePlane):
         self.assertEqual(out.stdout.strip(), "hi")
 
 
+class EverySpellingThatReachesCharter(_FakePlane):
+    """The question is "will this child resolve the operator's plane as charter", not "is
+    this argv one of the spellings charter's own code uses".
+
+    Round one asked the second question, and the difference was measured against this same
+    ``_REAL_ROOT``: ``[python, "-m", "charter", "--version"]`` was refused, while
+    ``[python, "-c", "from charter import config; print(config.ROOT)"]``, ``["/bin/sh",
+    "-c", "<python> -m charter --version"]`` and the same command as a ``shell=True``
+    string all RAN, against the real plane. Two of those were not hypothetical: nine
+    charter-importing ``python -c`` children per suite run were being waved through, and a
+    third site (`test_news_cross_process`) spawned a chain of them.
+
+    Every case here is a REAL spawn attempt, with a canary the child would leave behind.
+    An `assertRaises` alone would not tell "refused" from "refused after the child had
+    already gone" — the failure mode this file's header names.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.canary = self.elsewhere / "the-child-ran-anyway"
+        self.stranded = {k: v for k, v in os.environ.items() if k != root.ENV_VAR}
+
+    def refuse(self, args, **kw):
+        with self.assertRaises(_planeguard.RealPlaneSpawn) as caught:
+            subprocess.Popen(args, cwd=self.real, env=self.stranded, **kw).wait()
+        self.assertFalse(self.canary.exists(),
+                         "refused after delegating — the child ran anyway")
+        self.assertFalse(self.marker.exists())
+        return str(caught.exception)
+
+    def test_a_python_dash_c_that_imports_charter(self):
+        """The shape that was live in the suite. The write comes FIRST, so a guard that
+        let this through leaves the canary whatever the import then does."""
+        self.refuse([sys.executable, "-c",
+                     f"open({str(self.canary)!r}, 'w').close()\nimport charter"])
+
+    def test_a_dash_c_that_names_the_module_as_a_string(self):
+        """``__import__("charter")`` reaches the same import by a different token."""
+        self.refuse([sys.executable, "-c",
+                     f"open({str(self.canary)!r}, 'w').close()\n__import__('charter')"])
+
+    def test_a_shell_command_string(self):
+        self.refuse(["/bin/sh", "-c", f"{self.fake} --version"])
+
+    def test_the_same_command_with_shell_true(self):
+        self.refuse(f"{self.fake} --version", shell=True)
+
+    def test_a_command_substitution_inside_an_assignment(self):
+        """`hooks/hooks.json`'s own shape — ``out="$(charter doctor 2>&1)" || …``. Every
+        lexer reads that as an assignment, so the invocation is in no command position at
+        all; it is one for `_substitution_bodies`."""
+        self.refuse(["/bin/sh", "-c", f'out="$({self.fake} doctor 2>&1)" || true'])
+
+    def test_a_quoted_command_substitution_that_is_not_an_assignment(self):
+        """The same clause as above with the assignment taken away, and QUOTED — which is
+        what leaves the substitution scan as the only reader of it.
+
+        Unquoted, ``$(…)``'s parentheses are punctuation to `shlex` and the segmenter walks
+        straight into the inner command on its own. Quoted, the whole substitution is one
+        argument to `echo`, in no command position and in no assignment. Two guards that
+        cover each other look like one guard until one of them is taken away.
+        """
+        self.refuse(["/bin/sh", "-c", f'echo "$({self.fake} --version)"'])
+
+    def test_an_assignment_that_names_charter(self):
+        """``c=charter; eval $c``. `eval`'s argument is a variable, so the wrapper clause
+        sees no charter in it and the command word is `eval` rather than something
+        computed: the assignment is the only place the name appears."""
+        self.refuse(["/bin/sh", "-c", f"c={self.fake}; eval $c --version"])
+
+    def test_a_command_word_the_shell_computes(self):
+        """The name reaches the command position through the environment, and the only
+        charter in the string itself is a COMMENT — which `shlex` strips before any reader
+        sees it. What is left is ``$CBIN --version``, and a command word this cannot
+        resolve is refused rather than guessed at."""
+        self.stranded["CBIN"] = str(self.fake)
+        self.refuse(["/bin/sh", "-c", "# this line starts charter\n$CBIN --version"])
+
+    def test_a_wrapper_that_takes_a_command_as_its_arguments(self):
+        """`nice` rather than `sudo`: if this ever stops being refused the fallout is the
+        fake charter running, not a password prompt on a real machine. `nice` also has an
+        argument grammar this deliberately does not follow — the word appearing anywhere
+        after a wrapper is what refuses."""
+        self.refuse(["/bin/sh", "-c", f"nice {self.fake} --version"])
+
+    def test_an_env_wrapper_in_front_of_the_binary(self):
+        """``env -u X <charter>``. The ``-m charter`` adjacency below would answer the
+        other spelling on its own; nothing but reading past `env` answers this one."""
+        self.refuse(["env", "-u", "NOTHING", str(self.fake), "--version"])
+
+    def test_a_dash_c_body_that_will_not_tokenize(self):
+        """Undecidable, and refusal is the direction that is safe to be wrong in.
+
+        No canary here, and deliberately: source that does not compile runs nothing, so an
+        absent canary would be true however this went. The refusal itself is the assertion.
+        """
+        with self.assertRaises(_planeguard.RealPlaneSpawn):
+            subprocess.Popen([sys.executable, "-c", "import ((("],
+                             cwd=self.real, env=self.stranded).wait()
+
+    def test_a_script_that_cannot_be_read(self):
+        """Same rule, the other unreadable input. `python <gone>.py` fails either way; what
+        must not happen is the guard deciding "not charter" because it could not look."""
+        with self.assertRaises(_planeguard.RealPlaneSpawn):
+            subprocess.Popen([sys.executable, str(self.elsewhere / "gone.py")],
+                             cwd=self.real, env=self.stranded).wait()
+
+    def test_a_child_that_imports_the_test_package(self):
+        """``import tests`` arms these guards, which imports `charter.config`, which
+        resolves a plane — with the word never appearing. It was the last child in the
+        suite still landing on the operator's plane.
+
+        And it is the one child ``$CHARTER_ROOT`` cannot rescue: `_envguard` scrubs the
+        charter namespace at import of this package, before `charter.config` loads, so the
+        cwd is what decides. `test_no_test_reads_the_operators_shell` runs from a throwaway
+        plane with ``$PYTHONPATH`` for exactly that reason.
+        """
+        self.refuse([sys.executable, "-c",
+                     f"open({str(self.canary)!r}, 'w').close()\nimport tests"])
+
+    def test_a_shell_string_that_will_not_lex(self):
+        """Undecidable, and refusal is the direction that is safe to be wrong in."""
+        self.refuse(["/bin/sh", "-c", f'{self.fake} "--version'])
+
+    def test_a_module_of_the_charter_package_run_by_path(self):
+        """``python <plane>/charter/__main__.py``. Reading the file would not answer it —
+        charter's real ``__main__.py`` reaches the CLI through ``from .cli import main``
+        and never writes the word — so the package directory in the path is what does."""
+        pkg = self.elsewhere / "tree" / "charter"
+        pkg.mkdir(parents=True)
+        (pkg / "__main__.py").write_text(f"open({str(self.canary)!r}, 'w').close()\n")
+        self.refuse([sys.executable, str(pkg / "__main__.py")])
+
+    def test_a_script_file_that_imports_charter(self):
+        """A probe written to a temp file: nothing in its NAME says charter, and the guard
+        reads it rather than guessing."""
+        probe = self.elsewhere / "probe.py"
+        probe.write_text(f"open({str(self.canary)!r}, 'w').close()\nimport charter\n")
+        self.refuse([sys.executable, str(probe)])
+
+    def test_an_env_wrapper_around_the_dash_m_spelling(self):
+        """The suite's own gate is run as ``env -u CHARTER_SESSION_ID … python3 -m …``."""
+        self.refuse(["env", "-u", "NOTHING", "/bin/false", "-m", "charter", "gl-refresh"])
+
+    def test_the_interpreter_is_named_by_executable_rather_than_argv(self):
+        """``Popen(["x"], executable=".../charter")`` runs charter and says ``x``."""
+        self.refuse(["not-charter", "--version"], executable=str(self.fake))
+
+    def test_a_bare_path_object_as_the_whole_command(self):
+        """`Popen` takes one path-like as the command. A `Path` is not iterable, so a
+        reader that went straight to the sequence branch would get `TypeError` and answer
+        "not charter" — the shape of every hole this recogniser has had."""
+        self.refuse(self.fake)
+
+    def test_cwd_and_env_are_read_when_they_are_passed_positionally(self):
+        """`Popen`'s signature puts ``cwd`` ninth and ``env`` tenth. A guard that read only
+        ``**kw`` would answer "no cwd, no env" here and ask `find_root` about this process
+        instead — silently, and in the direction that allows."""
+        with self.assertRaises(_planeguard.RealPlaneSpawn):
+            subprocess.Popen([str(self.fake)], -1, None, None, None, None, None, True,
+                             False, str(self.real), self.stranded).wait()
+        self.assertFalse(self.marker.exists())
+
+
+class SpellingsThatAreNotASpawn(_FakePlane):
+    """The other half, and the reason the recogniser lexes instead of grepping.
+
+    A guard that refused on the word alone would be conservative in the direction that is
+    safe — and would also refuse `test_toolgate`'s comparison of shlex's parse against a
+    real bash's, whose corpus contains the STRING ``charter "sec"'ret' list v``, and every
+    tmux fixture whose argv quotes a path inside the checkout. Each of these really runs.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.ran = self.elsewhere / "it-ran"
+        self.stranded = {k: v for k, v in os.environ.items() if k != root.ENV_VAR}
+
+    def allow(self, args, **kw):
+        p = subprocess.Popen(args, cwd=self.real, env=self.stranded, **kw)
+        self.assertEqual(p.wait(), 0)
+        self.assertTrue(self.ran.exists(), "the child did not run")
+        return self.ran.read_text()
+
+    def test_charter_as_an_argument_to_another_command(self):
+        """`test_toolgate` runs exactly this: bash, asked to echo a corpus entry back."""
+        self.assertEqual(
+            self.allow(["/bin/sh", "-c", f"printf %s charter > {self.ran}"]), "charter")
+
+    def test_a_path_that_merely_contains_the_word(self):
+        """``cd ~/IdeaProjects/charter/tests`` is not a charter spawn, and the suite is
+        full of children whose argv names a path inside the checkout."""
+        inside = self.elsewhere / "tree" / "charter"
+        inside.mkdir(parents=True)
+        self.assertEqual(
+            self.allow(["/bin/sh", "-c", f"ls -d {inside} > {self.ran}"]).strip(),
+            str(inside))
+
+    def test_a_python_child_whose_only_charter_is_inside_a_string_literal(self):
+        """`tokenize` is what tells a NAME from a path: `test_frame_tmux_integration`
+        spawns ``python -c "open('<checkout>/…', 'w').close()"`` as a hostile-argv fixture,
+        and it has no charter import in it."""
+        path = self.elsewhere / "tree" / "charter" / "canary"
+        path.parent.mkdir(parents=True)
+        self.allow([sys.executable, "-c",
+                    f"open({str(path)!r}, 'w').close()\n"
+                    f"open({str(self.ran)!r}, 'w').write('ok')"])
+        self.assertTrue(path.exists())
+
+    def test_a_wrapped_command_whose_argument_is_a_path_inside_the_checkout(self):
+        """Where the word test's shape earns itself. ``charter`` followed by ``/`` is a
+        directory on the way to something else, not a command — so ``nice ls -d
+        <checkout>/charter/sub`` is a wrapper carrying a PATH, and a regex that stopped one
+        character earlier would refuse it as a wrapper carrying charter."""
+        inside = self.elsewhere / "tree" / "charter" / "sub"
+        inside.mkdir(parents=True)
+        self.assertEqual(
+            self.allow(["/bin/sh", "-c", f"nice ls -d {inside} > {self.ran}"]).strip(),
+            str(inside))
+
+    def test_a_shell_string_with_no_mention_of_charter_is_never_lexed(self):
+        # `.resolve()`, because macOS's ``/tmp`` is a symlink and ``pwd`` reports the
+        # resolved spelling — the same two-spellings problem `_REAL_ROOT` carries.
+        self.assertEqual(self.allow(["/bin/sh", "-c", f'pwd > "{self.ran}"']).strip(),
+                         str(self.real.resolve()))
+
+
 class HowTheChildsPlaneIsResolved(_FakePlane):
     def test_it_asks_find_root_with_the_childs_environment_and_cwd(self):
         """Not with this process's. The whole defect is that the child's answer differs
@@ -179,7 +414,15 @@ class HowTheChildsPlaneIsResolved(_FakePlane):
 
     def test_a_child_with_no_env_of_its_own_is_asked_about_ours(self):
         """``env=None`` means the child inherits this process's environment, so that is
-        the environment its answer depends on."""
+        the environment its answer depends on.
+
+        A COPY of it, not the mapping itself, and the difference is the other tripwire in
+        this package: `_envguard` refuses an undeclared targeted read of ``$CHARTER_ROOT``
+        and leaves bulk reads alone, so handing `find_root` the live `os.environ` would
+        charge every test that spawns a `bash` with a read it never made. The values are
+        the same either way — the ambient ones were scrubbed at install — and a copy is
+        exactly what the child inherits.
+        """
         seen = {}
 
         def spy(start=None, env=None):
@@ -188,7 +431,8 @@ class HowTheChildsPlaneIsResolved(_FakePlane):
 
         with mock.patch.object(root, "find_root", side_effect=spy):
             self.run_fake(cwd=self.elsewhere)
-        self.assertIs(seen["env"], os.environ)
+        self.assertIsNot(seen["env"], os.environ)
+        self.assertEqual(seen["env"], dict(os.environ))
 
     def test_an_unresolvable_child_falls_back_to_its_own_cwd(self):
         """`charter.config` calls `find_root_or_cwd`, which falls back to the working

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -1,0 +1,266 @@
+"""The suite-wide tripwire that refuses to SPAWN a charter against the developer's plane.
+
+The sibling of `test_plane_write_guard.py`, and it follows the same rule: every case here
+installs a THROWAWAY directory as "the real plane" and asserts against that. Pointing a
+case at the operator's actual plane to prove a spawn is refused would, the first time the
+guard regressed, run `gl-refresh` and `persona _gc` against a live machine — which is the
+accident this guard exists to prevent.
+
+**How "it was refused" is told apart from "it silently did nothing".** The fake charter
+below writes a marker file when it runs. A refused case asserts both that
+:class:`RealPlaneSpawn` was raised AND that the marker is absent; the allowed case asserts
+the marker is PRESENT. Without that second half, an absent marker would prove nothing —
+"the child never ran" and "the child ran and could not write" look identical, which is a
+failure mode this repo has shipped before.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import config, root
+from tests import _planeguard
+
+
+class WhatIsGuarded(unittest.TestCase):
+    def test_popen_is_wrapped_on_the_class_at_package_import(self):
+        """The CLASS, not the ``subprocess.Popen`` module attribute.
+
+        `subprocess.run`/`check_output`/`check_call` construct the class directly, and so
+        does anything that did ``from subprocess import Popen``. A wrapper on the module
+        attribute would watch none of them.
+        """
+        self.assertEqual(getattr(subprocess.Popen.__init__, "__module__", None),
+                         "tests._planeguard",
+                         "Popen.__init__ is unwrapped — charter children spawn unseen")
+
+    def test_the_guarded_root_is_this_machines_own_plane(self):
+        """Armed against the plane the test PROCESS resolved, not some later one.
+
+        Recomputed from `root.find_root` rather than read off `config.ROOT`, which any
+        `PersonaIso` case may have repointed by the time this runs.
+        """
+        self.assertIn(os.path.abspath(str(root.find_root())), _planeguard._REAL_ROOT)
+
+
+class _FakePlane(unittest.TestCase):
+    """A throwaway plane installed as "the real plane", plus a fake ``charter`` binary."""
+
+    def setUp(self):
+        self.real = Path(tempfile.mkdtemp(prefix="spawnguard-real-"))
+        self.addCleanup(shutil.rmtree, self.real, True)
+        (self.real / root.MARKER).write_text("schema = 1\n")
+
+        self.elsewhere = Path(tempfile.mkdtemp(prefix="spawnguard-else-"))
+        self.addCleanup(shutil.rmtree, self.elsewhere, True)
+        (self.elsewhere / root.MARKER).write_text("schema = 1\n")
+
+        # A `charter` that leaves evidence. Named `charter` because that is one of the two
+        # spellings the guard recognises, and it makes the "allowed" case a real spawn of a
+        # real process rather than an assertion about a decision function.
+        self.marker = self.elsewhere / "the-child-ran"
+        self.fake = self.elsewhere / "charter"
+        self.fake.write_text(f"#!/bin/sh\necho ran > {self.marker}\n")
+        self.fake.chmod(0o755)
+
+        self.enterContext(mock.patch.object(
+            _planeguard, "_REAL_ROOT",
+            (str(self.real), str(self.real.resolve()))))
+
+    def run_fake(self, **kw):
+        p = subprocess.Popen([str(self.fake)], **kw)
+        p.wait()
+        return p
+
+
+class ARefusedSpawn(_FakePlane):
+    def test_a_charter_child_that_would_walk_onto_the_real_plane_is_refused(self):
+        """No ``$CHARTER_ROOT``, cwd inside the real plane: exactly the 131 detached
+        children #527 measured, which resolved the operator's plane by walking up from
+        wherever the test happened to be running."""
+        with self.assertRaises(_planeguard.RealPlaneSpawn) as caught:
+            self.run_fake(cwd=self.real, env={k: v for k, v in os.environ.items()
+                                              if k != root.ENV_VAR})
+        self.assertFalse(self.marker.exists(),
+                         "refused after delegating — the child ran anyway")
+        self.assertIn("REFUSED", str(caught.exception))
+
+    def test_a_charter_root_pointing_at_the_real_plane_is_refused(self):
+        """Handing the plane across the boundary only helps if it is a DIFFERENT plane."""
+        with self.assertRaises(_planeguard.RealPlaneSpawn):
+            self.run_fake(cwd=self.elsewhere,
+                          env={**os.environ, root.ENV_VAR: str(self.real)})
+        self.assertFalse(self.marker.exists())
+
+    def test_a_dash_m_charter_argv_is_recognised_too(self):
+        """`util.self_relaunch_argv`'s spelling — the one every self-relaunch site uses.
+
+        The interpreter is `/bin/false` so that a guard which failed to refuse would leave
+        a non-zero exit rather than run anything.
+        """
+        with self.assertRaises(_planeguard.RealPlaneSpawn):
+            subprocess.Popen(["/bin/false", "-P", "-m", "charter", "gl-refresh"],
+                             cwd=self.real,
+                             env={k: v for k, v in os.environ.items()
+                                  if k != root.ENV_VAR})
+
+    def test_the_message_names_the_test_and_both_ways_out(self):
+        """A tripwire nobody can act on is a tripwire that gets deleted."""
+        with self.assertRaises(_planeguard.RealPlaneSpawn) as caught:
+            self.run_fake(cwd=self.real, env={k: v for k, v in os.environ.items()
+                                              if k != root.ENV_VAR})
+        msg = str(caught.exception)
+        self.assertIn("ARefusedSpawn.test_the_message_names_the_test_and_both_ways_out",
+                      msg)
+        self.assertIn("CHARTER_ROOT", msg)      # way out (2): hand it a throwaway plane
+        self.assertIn("maybe_spawn", msg)       # way out (1): do not spawn at all
+        self.assertIn(str(self.real), msg)      # which plane it would have landed on
+
+    def test_it_is_a_base_exception_so_charters_own_fallbacks_cannot_eat_it(self):
+        """`glstate.maybe_spawn` and `update.maybe_spawn` both wrap their `Popen` in
+        `except Exception: return`. A tripwire those can catch reports nothing at all."""
+        self.assertTrue(issubclass(_planeguard.RealPlaneSpawn, BaseException))
+        self.assertFalse(issubclass(_planeguard.RealPlaneSpawn, Exception))
+
+
+class AnAllowedSpawn(_FakePlane):
+    def test_a_child_handed_a_throwaway_plane_really_runs(self):
+        """The other half of the evidence: this is what proves an absent marker above
+        means "never ran" rather than "could not write"."""
+        p = self.run_fake(cwd=self.elsewhere,
+                          env={**os.environ, root.ENV_VAR: str(self.elsewhere)})
+        self.assertEqual(p.returncode, 0)
+        self.assertTrue(self.marker.exists())
+
+    def test_a_child_whose_cwd_is_a_throwaway_plane_really_runs(self):
+        """`$CHARTER_ROOT` is not the only isolation that works — a cwd inside another
+        plane resolves that one, and `charter init` in a fresh directory resolves none."""
+        p = self.run_fake(cwd=self.elsewhere,
+                          env={k: v for k, v in os.environ.items()
+                               if k != root.ENV_VAR})
+        self.assertEqual(p.returncode, 0)
+        self.assertTrue(self.marker.exists())
+
+    def test_a_child_that_is_not_charter_is_never_examined(self):
+        """The guard is about charter's own plane resolution. Refusing `git`, `tmux` or
+        `sh` because they happen to run inside the checkout would make the suite
+        unusable — and none of them reads a `charter.toml`."""
+        out = subprocess.run([sys.executable, "-c", "print('hi')"], cwd=self.real,
+                             capture_output=True, text=True,
+                             env={k: v for k, v in os.environ.items()
+                                  if k != root.ENV_VAR})
+        self.assertEqual(out.stdout.strip(), "hi")
+
+
+class HowTheChildsPlaneIsResolved(_FakePlane):
+    def test_it_asks_find_root_with_the_childs_environment_and_cwd(self):
+        """Not with this process's. The whole defect is that the child's answer differs
+        from the parent's, so a guard that asked the parent's question would agree with
+        every spawn it was meant to catch.
+        """
+        seen = {}
+
+        def spy(start=None, env=None):
+            seen["start"], seen["env"] = start, env
+            return self.elsewhere
+
+        with mock.patch.object(root, "find_root", side_effect=spy):
+            self.run_fake(cwd=self.elsewhere,
+                          env={**os.environ, root.ENV_VAR: str(self.elsewhere)})
+        self.assertEqual(Path(seen["start"]), self.elsewhere)
+        self.assertEqual(seen["env"].get(root.ENV_VAR), str(self.elsewhere))
+
+    def test_a_child_with_no_env_of_its_own_is_asked_about_ours(self):
+        """``env=None`` means the child inherits this process's environment, so that is
+        the environment its answer depends on."""
+        seen = {}
+
+        def spy(start=None, env=None):
+            seen["env"] = env
+            return self.elsewhere
+
+        with mock.patch.object(root, "find_root", side_effect=spy):
+            self.run_fake(cwd=self.elsewhere)
+        self.assertIs(seen["env"], os.environ)
+
+    def test_an_unresolvable_child_falls_back_to_its_own_cwd(self):
+        """`charter.config` calls `find_root_or_cwd`, which falls back to the working
+        directory when no plane is found — so a child with a bad `$CHARTER_ROOT` and a cwd
+        of the real plane still lands on it. Answering "no plane, allow" there would be
+        the guard waving through the one case the fallback makes dangerous.
+        """
+        with self.assertRaises(_planeguard.RealPlaneSpawn):
+            self.run_fake(cwd=self.real,
+                          env={**os.environ, root.ENV_VAR: str(self.elsewhere / "gone")})
+        self.assertFalse(self.marker.exists())
+
+
+class WhatCharterHandsItsOwnChildren(unittest.TestCase):
+    """`util.child_env` — the reason an isolated case satisfies the guard without knowing
+    it exists."""
+
+    def setUp(self):
+        self.plane = Path(tempfile.mkdtemp(prefix="spawnguard-plane-"))
+        self.addCleanup(shutil.rmtree, self.plane, True)
+
+    def test_a_child_is_told_the_plane_this_process_resolved(self):
+        from charter import util
+        with mock.patch.object(config, "ROOT", self.plane), \
+                mock.patch.object(config, "HAS_CONTROL_PLANE", True):
+            self.assertEqual(util.child_env()[root.ENV_VAR], str(self.plane))
+
+    def test_an_inherited_pointer_does_not_win_over_the_resolved_plane(self):
+        """`config.ROOT` is the plane this process is actually reading and writing. When
+        the two disagree, the child's job is to agree with its parent, not with a shell
+        variable the parent already declined to follow."""
+        from charter import util
+        with mock.patch.object(config, "ROOT", self.plane), \
+                mock.patch.object(config, "HAS_CONTROL_PLANE", True), \
+                mock.patch.dict(os.environ, {root.ENV_VAR: "/somewhere/else"},
+                                clear=False):
+            self.assertEqual(util.child_env()[root.ENV_VAR], str(self.plane))
+
+    def test_a_planeless_process_hands_nothing(self):
+        """`$CHARTER_ROOT` wins outright in `find_root` and a value with no `charter.toml`
+        at it RAISES rather than falling back — so a pointer to a non-plane is worse than
+        no pointer. The spawners refuse to fork at all in that state; this pins that
+        `child_env` would not have lied to the child either."""
+        from charter import util
+        with mock.patch.object(config, "ROOT", self.plane), \
+                mock.patch.object(config, "HAS_CONTROL_PLANE", False), \
+                mock.patch.dict(os.environ, {}, clear=True):
+            self.assertNotIn(root.ENV_VAR, util.child_env())
+
+
+class NoBackgroundRefreshWithoutAPlane(unittest.TestCase):
+    """Both best-effort refreshers return before forking when there is no plane.
+
+    Not a tidiness rule: outside a plane `config.STATE_DIR` is ``<cwd>/.charter``, so the
+    child would scatter charter's caches into whatever directory the render ran in — and,
+    having been handed no plane, would go looking for one of its own.
+    """
+
+    def test_glstate_does_not_fork(self):
+        from charter import glstate
+        with mock.patch.object(config, "HAS_CONTROL_PLANE", False), \
+                mock.patch.object(glstate.subprocess, "Popen") as popen:
+            glstate.maybe_spawn([Path("/tmp")])
+        popen.assert_not_called()
+
+    def test_update_does_not_fork(self):
+        from charter import update
+        with mock.patch.object(config, "HAS_CONTROL_PLANE", False), \
+                mock.patch.object(update.subprocess, "Popen") as popen:
+            update.maybe_spawn()
+        popen.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -394,6 +394,77 @@ class SpellingsThatAreNotASpawn(_FakePlane):
                          str(self.real.resolve()))
 
 
+class NoCharterEscapesThroughTheExecFamily(unittest.TestCase):
+    """The guard watches `subprocess.Popen.__init__`, and nothing else starts a process.
+
+    `os.execv*`, `os.posix_spawn*`, `os.spawn*` and `os.system` all go around it. Wrapping
+    them too would be the obvious move and the wrong one: `execvp` REPLACES this process,
+    so a wrapper that refused would be refusing something that cannot be a child of the
+    suite at all, and `os.system` is not used here.
+
+    What makes "nothing reaches charter that way" a fact rather than an assumption is this
+    case. Every module in `charter/` and `tests/` is parsed, every call to one of those
+    functions is found, and each has to be one this file has already looked at and written
+    down. A fourth appears the day somebody writes one, named by file and line.
+
+    Parsed rather than grepped, so that ``mock.patch("os.execvp")`` — which
+    `test_frame_launcher` writes fifteen times — is what it is: a string, not a call.
+    """
+
+    #: ``module:function`` → why this one cannot start a charter. Frozen deliberately: the
+    #: point is that a NEW exec is noticed, and a set that grew by itself would notice
+    #: nothing.
+    KNOWN = {
+        "charter/commands_frame.py:execvp":
+            "`bypass` hands this process to the HARNESS (`claude`), and replaces it. The "
+            "thing that runs afterwards is not charter and has no plane to resolve.",
+        "charter/commands_secrets.py:execvpe":
+            "`secret exec` replaces this process with the operator's own command. If they "
+            "type `charter`, the process that becomes charter is the one that was already "
+            "running — a test doing this by accident loses the runner, not a plane.",
+        "tests/test_frame_tmux_integration.py:execvp":
+            "`tmux attach` inside a `pty.fork` child, which `os._exit`s in its `finally`.",
+    }
+
+    _WATCHED = ("execl", "execle", "execlp", "execlpe", "execv", "execve", "execvp",
+                "execvpe", "posix_spawn", "posix_spawnp", "spawnl", "spawnle", "spawnlp",
+                "spawnlpe", "spawnv", "spawnve", "spawnvp", "spawnvpe", "system")
+
+    def test_every_exec_in_the_tree_is_one_that_cannot_become_charter(self):
+        import ast
+
+        tree = Path(__file__).resolve().parent.parent
+        found = {}
+        for path in sorted((*tree.glob("charter/**/*.py"), *tree.glob("tests/**/*.py"))):
+            try:
+                parsed = ast.parse(path.read_text(encoding="utf-8"))
+            except (OSError, SyntaxError):       # not this case's business
+                continue
+            for node in ast.walk(parsed):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                if (isinstance(func, ast.Attribute) and func.attr in self._WATCHED
+                        and isinstance(func.value, ast.Name) and func.value.id == "os"):
+                    key = f"{path.relative_to(tree)}:{func.attr}"
+                    found.setdefault(key, node.lineno)
+
+        unexpected = {k: v for k, v in found.items() if k not in self.KNOWN}
+        self.assertEqual(
+            unexpected, {},
+            f"a process is started by a call `tests._planeguard` does not watch: "
+            f"{unexpected}. `RealPlaneSpawn` wraps `subprocess.Popen.__init__` only, so a "
+            f"charter started this way reaches the operator's plane unseen. Either it "
+            f"cannot become charter — say why, and add it to "
+            f"`NoCharterEscapesThroughTheExecFamily.KNOWN` — or it can, and it should go "
+            f"through `subprocess` instead.")
+
+        gone = set(self.KNOWN) - set(found)
+        self.assertEqual(gone, set(),
+                         f"{gone} is written down here and no longer exists — an "
+                         f"allow-list nobody prunes stops being read")
+
+
 class HowTheChildsPlaneIsResolved(_FakePlane):
     def test_it_asks_find_root_with_the_childs_environment_and_cwd(self):
         """Not with this process's. The whole defect is that the child's answer differs

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -284,8 +284,13 @@ class EverySpellingThatReachesCharter(_FakePlane):
         cwd is what decides. `test_no_test_reads_the_operators_shell` runs from a throwaway
         plane with ``$PYTHONPATH`` for exactly that reason.
         """
-        self.refuse([sys.executable, "-c",
-                     f"open({str(self.canary)!r}, 'w').close()\nimport tests"])
+        msg = self.refuse([sys.executable, "-c",
+                           f"open({str(self.canary)!r}, 'w').close()\nimport tests"])
+        # And the message has to SAY so. A refusal whose stated remedy does not work for
+        # the case it just refused is the shape this round was sent back over: a docstring
+        # pointing at something the code cannot see.
+        self.assertIn("cwd inside a throwaway plane", msg)
+        self.assertIn("PYTHONPATH", msg)
 
     def test_a_shell_string_that_will_not_lex(self):
         """Undecidable, and refusal is the direction that is safe to be wrong in."""

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -17,6 +17,7 @@ failure mode this repo has shipped before.
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -25,7 +26,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from charter import config, root
+from charter import config, hooks, root
 from tests import _envguard, _planeguard
 
 
@@ -55,6 +56,14 @@ class WhatIsGuarded(unittest.TestCase):
         """
         _envguard.unset(root.ENV_VAR)
         self.assertIn(os.path.abspath(str(root.find_root())), _planeguard._REAL_ROOT)
+
+
+#: A program that exists, runs nothing and exits non-zero — the stand-in interpreter for
+#: the ``-m charter`` cases, so that a guard which failed to refuse would leave a failed
+#: exit rather than run something. Looked up rather than written out: there is no
+#: ``/bin/false`` on macOS, so the literal turned a regression in those cases into a
+#: `FileNotFoundError` naming a path instead of a failure naming the guard.
+_FALSE = shutil.which("false") or "/bin/false"
 
 
 class _FakePlane(unittest.TestCase):
@@ -110,11 +119,11 @@ class ARefusedSpawn(_FakePlane):
     def test_a_dash_m_charter_argv_is_recognised_too(self):
         """`util.self_relaunch_argv`'s spelling — the one every self-relaunch site uses.
 
-        The interpreter is `/bin/false` so that a guard which failed to refuse would leave
-        a non-zero exit rather than run anything.
+        The interpreter is :data:`_FALSE` so that a guard which failed to refuse would
+        leave a non-zero exit rather than run anything.
         """
         with self.assertRaises(_planeguard.RealPlaneSpawn):
-            subprocess.Popen(["/bin/false", "-P", "-m", "charter", "gl-refresh"],
+            subprocess.Popen([_FALSE, "-P", "-m", "charter", "gl-refresh"],
                              cwd=self.real,
                              env={k: v for k, v in os.environ.items()
                                   if k != root.ENV_VAR})
@@ -190,12 +199,36 @@ class EverySpellingThatReachesCharter(_FakePlane):
         self.stranded = {k: v for k, v in os.environ.items() if k != root.ENV_VAR}
 
     def refuse(self, args, **kw):
-        with self.assertRaises(_planeguard.RealPlaneSpawn) as caught:
-            subprocess.Popen(args, cwd=self.real, env=self.stranded, **kw).wait()
-        self.assertFalse(self.canary.exists(),
-                         "refused after delegating — the child ran anyway")
-        self.assertFalse(self.marker.exists())
-        return str(caught.exception)
+        """Assert *args* is refused — and stay finite if it is not.
+
+        Two things this does NOT do with an `assertRaises` block, both of them lessons from
+        the suite's own open hangs (#545, #546). It never `wait()`s on a child it did not
+        expect to exist: a regression that lets `watch -n 1 charter` through would otherwise
+        park the whole run forever on a command that by definition never exits. And it hands
+        every child ``/dev/null`` for stdin, so a `su` that reaches a real terminal asks
+        nobody for a password. A guard's own test may not be the thing that makes a red run
+        impossible to get.
+
+        Evidence is cleared FIRST, because several of these run as `subTest`s inside one
+        case and share one setUp: a marker left by an earlier spelling would fail every
+        later one on evidence that is not about it, turning one red case into seven and
+        hiding which spelling actually got through.
+        """
+        for evidence in (self.canary, self.marker):
+            if evidence.exists():
+                evidence.unlink()
+        kw.setdefault("stdin", subprocess.DEVNULL)
+        try:
+            child = subprocess.Popen(args, cwd=self.real, env=self.stranded, **kw)
+        except _planeguard.RealPlaneSpawn as refused:
+            self.assertFalse(self.canary.exists(),
+                             "refused after delegating — the child ran anyway")
+            self.assertFalse(self.marker.exists())
+            return str(refused)
+        child.kill()
+        child.wait()
+        self.fail(f"not refused: {args!r} spawned a charter that would resolve "
+                  f"{self.real} — the guarded plane")
 
     def test_a_python_dash_c_that_imports_charter(self):
         """The shape that was live in the suite. The write comes FIRST, so a guard that
@@ -247,10 +280,196 @@ class EverySpellingThatReachesCharter(_FakePlane):
 
     def test_a_wrapper_that_takes_a_command_as_its_arguments(self):
         """`nice` rather than `sudo`: if this ever stops being refused the fallout is the
-        fake charter running, not a password prompt on a real machine. `nice` also has an
-        argument grammar this deliberately does not follow — the word appearing anywhere
-        after a wrapper is what refuses."""
+        fake charter running, not a password prompt on a real machine.
+
+        The ARGV form is the one that matters and it is `test_a_wrapper_in_an_argv…`
+        below, not this one. This case wrote only the shell-string spelling for a round,
+        and the shell string is the form that already had a wrapper clause — so the plain
+        ``["nice", "charter", "docs"]`` went unexercised and ran.
+        """
         self.refuse(["/bin/sh", "-c", f"nice {self.fake} --version"])
+
+    def test_a_wrapper_in_an_argv_is_followed_to_the_program(self):
+        """The plainest spelling there is, and it RAN: ``["nice", "charter", "docs"]``.
+
+        `_cmd_launches_charter` read `nice` as "a command called nice" and stopped. The
+        wrapper follow existed only inside shell STRINGS, while `_COMMAND_WRAPPERS`' own
+        docstring justified itself with ``sudo charter doctor`` — an argv — and the case
+        above pinned only the string form. A reason that names a shape the code cannot see
+        is the shape this whole round was sent back over.
+
+        Each of these is now answered by `charter.hooks._split_env_chdir`, production's own
+        reader, including each wrapper's own option arity: `nice -n 10`, `timeout`'s bare
+        duration, `xargs -n1`, `stdbuf -o0` glued, and `env -i`, which is the flag a flat
+        "wrappers take a value" table gets wrong.
+        """
+        for argv in (["nice", str(self.fake), "--version"],
+                     ["nice", "-n", "10", str(self.fake), "--version"],
+                     ["nohup", str(self.fake), "--version"],
+                     ["env", "-i", str(self.fake), "--version"],
+                     ["stdbuf", "-o0", str(self.fake), "--version"],
+                     ["timeout", "5", str(self.fake), "--version"],
+                     ["timeout", "--preserve-status", "5", str(self.fake)],
+                     ["xargs", "-n1", str(self.fake)],
+                     ["nice", "-n", "10", "nohup", str(self.fake), "--version"]):
+            with self.subTest(argv=argv):
+                self.refuse(argv)
+
+    def test_a_wrapper_whose_grammar_cannot_be_followed_refuses_on_the_word(self):
+        """`flock <file> <cmd>` and `watch -n1 <cmd>` put a positional of their own in
+        front of the program, so no reader that names "the program" can name charter here.
+
+        These are the reason the wrapper clause survives alongside the production split
+        rather than being replaced by it: where the program cannot be named, the word
+        appearing ANYWHERE after the wrapper is what refuses. `su -c` is here for the same
+        reason `eval` is — its argument is a command STRING, which production's Bash guard
+        states as a limit it does not follow.
+        """
+        for argv in (["flock", str(self.elsewhere / "lock"), str(self.fake), "--version"],
+                     ["watch", "-n", "1", str(self.fake), "--version"],
+                     ["su", "-c", f"{self.fake} --version"]):
+            with self.subTest(argv=argv):
+                self.refuse(argv)
+
+    def test_a_bundled_short_option_reaches_a_shells_command_string(self):
+        """``bash -lc 'charter docs'`` is what a login shell is SPELLED, and it ran.
+
+        `_python_launches_charter` already walked a bundle — that is how ``-Pmcharter`` was
+        caught — while the shell branch matched ``tok == "-c"`` and ``tok.startswith("-c")``
+        and saw none of `-lc`, `-ec`, `-xc`, `-ic`. One walk, `_bundled_option`, now serves
+        both. `-o pipefail` is in here because it is the shell short option that takes a
+        VALUE: a walk that read its value as more bundled letters would be the mirror of
+        the `env -i` mistake production's per-wrapper table exists to avoid.
+        """
+        for argv in (["/bin/bash", "-lc", f"{self.fake} --version"],
+                     ["/bin/sh", "-ec", f"{self.fake} --version"],
+                     ["/bin/sh", "-xc", f"{self.fake} --version"],
+                     ["/bin/sh", "-ic", f"{self.fake} --version"],
+                     ["/bin/sh", f"-c{self.fake} --version"],
+                     ["/bin/bash", "-o", "pipefail", "-c", f"{self.fake} --version"],
+                     ["/bin/bash", "--login", "-c", f"{self.fake} --version"]):
+            with self.subTest(argv=argv):
+                self.refuse(argv)
+
+    def test_env_split_string_is_not_a_way_through(self):
+        """`env -S '<cmd>'` packs a whole command into ONE token, and it printed the
+        guarded plane.
+
+        The old reader skipped `-S` as a value-taking option, which left an EMPTY argv —
+        and an empty argv was answered "not charter". Its own docstring had warned against
+        exactly that (*"a guard guessing at an unknown option's arity would start skipping
+        the command word itself"*) and then committed it on the one flag whose value IS the
+        command word. Production said the same thing and got it right
+        (`hooks._SPLIT_STRING_FLAGS`, pinned by
+        `test_guard_parsing.test_env_split_string_is_not_a_way_through`, whose name this
+        borrows deliberately), and that is the code this now calls.
+        """
+        for argv in (["env", "-S", f"{self.fake} --version"],
+                     ["env", f"-S{self.fake} --version"],
+                     ["env", f"--split-string={self.fake} --version"],
+                     ["env", "-S", f"nice {self.fake} --version"],
+                     ["env", "-S",
+                      f"{sys.executable} -c 'from charter import config; print(config)'"]):
+            with self.subTest(argv=argv):
+                self.refuse(argv)
+
+    def test_a_packed_command_that_itself_contains_an_equals_sign(self):
+        """``env -Sfoo=1 charter docs``, which reusing production's reader let through.
+
+        `hooks._split_env_chdir` reads the ``--split-string=`` spelling before the glued
+        ``-S…`` one, so it splits this at the FIRST ``=`` — the program becomes ``1`` and
+        the charter after it is never looked at. Reuse means inheriting that, so the
+        ORDERING is repaired on the way in (`_unpack_split_strings`) using production's own
+        flag names, and the repaired tokens go back to production's splitter.
+
+        The same input is a live bypass of charter's Bash tool-gate on `main` — measured:
+        ``env -Sfoo=1 cat .charter/vaults/x.json`` and ``env -Sfoo=1 charter secret get v k
+        --reveal --force`` are both ALLOWED there while the unwrapped commands are denied.
+        That is production's to fix (#547); this case is only about the harness not
+        shipping the same hole.
+        """
+        for argv in ([str(self.fake), "docs"],
+                     ["env", f"-Sfoo=1 {self.fake} docs"],
+                     ["env", "-Sfoo=1", str(self.fake), "docs"],
+                     ["env", f"--split-string=foo=1 {self.fake} docs"],
+                     ["/bin/sh", "-c", f"env -Sfoo=1 {self.fake} docs"]):
+            with self.subTest(argv=argv):
+                self.refuse(argv)
+
+    def test_the_name_glued_to_an_option_letter_still_reaches_the_lexer(self):
+        """``env -Scharter --version``, as a shell STRING, and it is the GATE that misses.
+
+        `-S` puts a word character immediately in front of the name, so the word test —
+        which exists to keep ``<checkout>/charter/sub`` from reading as a command — answers
+        "charter is not named here" about a string whose entire content is a charter
+        invocation, and the string is never lexed at all. A gate that can only cause misses
+        must not be the thing deciding: :data:`~tests._planeguard._CHARTER_MENTION` asks
+        for the name and nothing about its boundaries, and the word test still decides what
+        is a command once the lexer has run.
+        """
+        bindir = self.elsewhere / "onpath"
+        bindir.mkdir()
+        shutil.copy(self.fake, bindir / "charter")
+        (bindir / "charter").chmod(0o755)
+        self.stranded["PATH"] = f"{bindir}:{self.stranded.get('PATH', '')}"
+        self.refuse(["/bin/sh", "-c", "env -Scharter --version"])
+
+    def test_the_program_name_is_case_folded_too(self):
+        """``["CHARTER", "docs"]`` ran, against a guarded plane.
+
+        Same class as production's `test_the_program_name_is_case_folded_too`, and the same
+        one-line answer: on the filesystems this runs on `CHARTER` and `charter` are one
+        binary, so a guard that matches one casing has a Shift key for a bypass. The
+        harness guard was the last one in the tree still comparing
+        ``os.path.basename(parts[0]) == "charter"``.
+        """
+        upper = self.elsewhere / "CHARTER"
+        # On a case-INSENSITIVE filesystem this IS `self.fake`, written back unchanged —
+        # which is the whole point of the case: one file, two spellings, one binary.
+        upper.write_text(self.fake.read_text())
+        upper.chmod(0o755)
+        self.refuse([str(upper), "docs"])
+        self.refuse(["/bin/sh", "-c", f"{upper} docs"])
+        self.refuse([_FALSE, "-m", "CHARTER", "gl-refresh"])
+
+    def test_the_pre_rename_binary_is_charter_too(self):
+        """`edm` is charter's former name, and a machine that still has it on `PATH` has a
+        binary that resolves a plane. Production keeps it in `_CHARTER_PROGS` for exactly
+        that reason; this reads the same constant rather than deciding again."""
+        edm = self.elsewhere / "edm"
+        edm.write_text(self.fake.read_text())
+        edm.chmod(0o755)
+        self.refuse([str(edm), "docs"])
+        self.refuse(["nice", str(edm), "docs"])
+
+    def test_an_interpreter_is_what_it_resolves_to_not_what_it_is_called(self):
+        """``Popen([<symlink to python3>, "-c", "import charter"])`` ran.
+
+        The guard read the LINK's name, found neither `python` nor `sys.executable`'s
+        basename in it, and answered "not an interpreter". What the child execs is decided
+        by the kernel, not by the spelling: a path is followed to what is really there, a
+        RELATIVE path against the child's own cwd — `Popen` chdirs before it execs — and a
+        bare name along the child's own ``PATH``.
+        """
+        link = self.elsewhere / "notpython"
+        os.symlink(sys.executable, link)
+        self.refuse([str(link), "-c", "import charter"])
+
+        # relative: it has to live in the plane the child is given, because that is the
+        # directory the name is resolved against.
+        os.symlink(sys.executable, self.real / "notpython")
+        self.refuse(["./notpython", "-c", "import charter"])
+
+    def test_a_bare_name_is_looked_up_on_the_childs_own_path(self):
+        """``Popen(["charter", "--version"], env={"PATH": …})`` — the spelling charter's own
+        hooks use, with nothing but ``PATH`` deciding which binary runs."""
+        bindir = self.elsewhere / "bin"
+        bindir.mkdir()
+        shutil.copy(self.fake, bindir / "charter")
+        (bindir / "charter").chmod(0o755)
+        self.stranded["PATH"] = f"{bindir}:{self.stranded.get('PATH', '')}"
+        self.refuse(["charter", "--version"])
+        self.refuse(["/bin/sh", "-c", f"PATH={bindir}:$PATH charter --version"])
 
     def test_an_env_wrapper_in_front_of_the_binary(self):
         """``env -u X <charter>``. The ``-m charter`` adjacency below would answer the
@@ -314,7 +533,7 @@ class EverySpellingThatReachesCharter(_FakePlane):
 
     def test_an_env_wrapper_around_the_dash_m_spelling(self):
         """The suite's own gate is run as ``env -u CHARTER_SESSION_ID … python3 -m …``."""
-        self.refuse(["env", "-u", "NOTHING", "/bin/false", "-m", "charter", "gl-refresh"])
+        self.refuse(["env", "-u", "NOTHING", _FALSE, "-m", "charter", "gl-refresh"])
 
     def test_the_interpreter_is_named_by_executable_rather_than_argv(self):
         """``Popen(["x"], executable=".../charter")`` runs charter and says ``x``."""
@@ -397,6 +616,106 @@ class SpellingsThatAreNotASpawn(_FakePlane):
         # resolved spelling — the same two-spellings problem `_REAL_ROOT` carries.
         self.assertEqual(self.allow(["/bin/sh", "-c", f'pwd > "{self.ran}"']).strip(),
                          str(self.real.resolve()))
+
+
+class TheHarnessGuardIsNotASecondCopyOfProductions(unittest.TestCase):
+    """The finding this round closed was not "a spelling was missing". It was that the
+    harness guard held its OWN table of wrappers, its OWN `env` option arity and its OWN
+    case rule, and each of them was weaker than the one `charter/hooks.py` already had —
+    against inputs production denies and `tests/test_guard_parsing.py` already pins.
+
+    Measured: ``["nice", "charter", "docs"]``, ``["CHARTER", "docs"]`` and ``["env", "-S",
+    "<python> -c 'from charter import config; print(config.ROOT)'"]`` all ran against a
+    guarded plane, and the last printed it. `nice cat <vault>`, `CHARTER secret get …
+    --reveal` and `env -S 'cat <vault>'` are all denied by production.
+
+    So the cases below are not about a list of commands. They are the join: what production
+    can parse, this parses, because it is the same code. A second copy that starts drifting
+    fails here rather than in someone's plane.
+    """
+
+    def test_the_launcher_split_is_productions_own_reader(self):
+        """Not "behaves like" — IS. If someone reinstates a private walk, this catches it
+        by watching production's function get called."""
+        with mock.patch.object(hooks, "_split_env_chdir",
+                               wraps=hooks._split_env_chdir) as split:
+            _planeguard._launcher_argv(["nice", "charter", "docs"])
+        split.assert_called_once()
+
+    def test_every_wrapper_production_follows_is_followed_here(self):
+        """The whole of `hooks._WRAPPERS`, as an ARGV — the form that was unexercised.
+
+        A decision-function table rather than a spawn table on purpose: `sudo` and `su`
+        would prompt a real machine for a password, and the point being pinned is the
+        JOIN with production's constant, which no amount of spawning would show.
+        """
+        for wrapper in sorted(hooks._WRAPPERS):
+            with self.subTest(wrapper=wrapper):
+                self.assertTrue(
+                    _planeguard._cmd_launches_charter([wrapper, "charter", "docs"]),
+                    f"`{wrapper} charter docs` is a charter spawn to charter's own Bash "
+                    f"guard and not to this one — the two tables have drifted")
+
+    def test_the_wrappers_this_adds_are_the_ones_production_has_no_use_for(self):
+        """An addition is fine; a re-statement is not. Whatever is here beyond production's
+        set has to be a wrapper whose argument grammar cannot be followed to a program —
+        which is why they are refused on the WORD instead."""
+        self.assertLessEqual(hooks._WRAPPERS, _planeguard._COMMAND_WRAPPERS)
+        self.assertEqual(_planeguard._COMMAND_WRAPPERS - hooks._WRAPPERS,
+                         {"eval", "su", "watch", "script", "flock"})
+
+    def test_the_charter_word_is_built_from_productions_names(self):
+        """Including `edm`, charter's pre-rename binary, and folded — the two things
+        `hooks._is_charter` and `_VAULT_PATH_RE` were already folded for."""
+        for name in hooks._CHARTER_PROGS:
+            with self.subTest(name=name):
+                self.assertTrue(_planeguard._CHARTER_WORD.search(f"{name} --version"))
+                self.assertTrue(
+                    _planeguard._CHARTER_WORD.search(f"{name.upper()} --version"))
+        # …and still not a path that merely contains the word, which is the shape the
+        # frame's tmux fixtures spawn by the dozen.
+        self.assertFalse(
+            _planeguard._CHARTER_WORD.search("cd ~/IdeaProjects/charter/tests"))
+
+    #: `test_guard_parsing`'s own wrapper corpus, with `charter` where the vault path was.
+    #: Every one of these is a command charter's Bash guard already names as charter.
+    SAME_CORPUS = ("sudo charter doctor",
+                   "env charter doctor",
+                   "/usr/bin/env charter doctor",
+                   "nice -n 10 charter doctor",
+                   "stdbuf -o0 charter doctor",
+                   "timeout 5 charter doctor",
+                   "timeout -s KILL 5 charter doctor",
+                   "env -i charter doctor",
+                   "env -u PATH charter doctor",
+                   "sudo -u root charter doctor",
+                   "sudo -- charter doctor",
+                   "sudo env charter doctor",
+                   "xargs charter doctor",
+                   "env FOO=bar charter doctor",
+                   "env -S 'charter doctor'",
+                   "env -Scharter doctor",
+                   "env --split-string='charter doctor'",
+                   "CHARTER doctor")
+
+    def test_the_same_corpus_is_charter_to_both_guards(self):
+        """Asked as an ARGV, which is the form that had no wrapper follow at all — a
+        `Popen(["nice", "charter", "docs"])` never becomes a shell string on the way."""
+        for cmd in self.SAME_CORPUS:
+            with self.subTest(cmd=cmd):
+                argv = shlex.split(cmd)
+                self.assertTrue(hooks._is_charter(*hooks._split_env(argv)[::2]),
+                                f"{cmd} is not charter to PRODUCTION — wrong corpus")
+                self.assertTrue(_planeguard._cmd_launches_charter(argv), cmd)
+
+    def test_the_same_corpus_is_charter_inside_a_shell_string(self):
+        """And again one layer of quoting in, where `charter workspace _reconcile` and
+        `out="$(charter doctor 2>&1)"` — charter's own `hooks.json` — actually live."""
+        for cmd in (*self.SAME_CORPUS,
+                    "if true; then charter doctor; fi",
+                    'out="$(charter doctor 2>&1)" || true'):
+            with self.subTest(cmd=cmd):
+                self.assertTrue(_planeguard._shell_launches_charter(cmd), cmd)
 
 
 class NoCharterEscapesThroughTheExecFamily(unittest.TestCase):

--- a/tests/test_self_relaunch_argv.py
+++ b/tests/test_self_relaunch_argv.py
@@ -40,7 +40,7 @@ import charter
 from charter import glstate, planegit, update, util
 from charter import commands_workspace as cw
 
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, make_plane
 
 #: The package directory this test process actually imported, not a path guessed from
 #: `__file__`'s neighbours — whatever `charter` means to the rest of the suite is what
@@ -108,6 +108,10 @@ class GlstateMaybeSpawnUsesIt(PersonaIso):
     path. The quiet one: on any charter checkout this ran the wrong charter on every
     render, indefinitely, until fixed."""
 
+    def setUp(self):
+        super().setUp()
+        make_plane(self)      # `maybe_spawn` refuses to fork without one (#527)
+
     def test_argv_carries_dash_p(self):
         d = self.tmp / "somerepo"
         d.mkdir(parents=True, exist_ok=True)
@@ -128,6 +132,10 @@ class UpdateMaybeSpawnUsesIt(PersonaIso):
     """charter/update.py:185 — `_version-check`, ALSO spawned from the status line's own
     render path. Not one of the five sites #390 originally named; found by grepping the
     tree for every `sys.executable`."""
+
+    def setUp(self):
+        super().setUp()
+        make_plane(self)      # `maybe_spawn` refuses to fork without one (#527)
 
     def test_argv_carries_dash_p(self):
         captured = {}

--- a/tests/test_self_relaunch_shadowing.py
+++ b/tests/test_self_relaunch_shadowing.py
@@ -75,12 +75,21 @@ class WithADecoyCwd(unittest.TestCase):
         (pkg / "__init__.py").write_text(f'__version__ = "{DECOY_VERSION}"\n')
         (pkg / "__main__.py").write_text(_DECOY_MAIN)
 
+        # The decoy dir is also the child's PLANE. `$CHARTER_HOME` below covers the
+        # per-human directory and reads as though it covered this too; it does not, and
+        # the difference only showed up with `$CHARTER_ROOT` in the environment — which
+        # every charter frame exports, so it was invisible everywhere except the terminal
+        # these are written in. With it set, `charter panel top` ran against the
+        # operator's own plane (#527, found by `tests._planeguard.RealPlaneSpawn`).
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+
         self.env = dict(os.environ)
         # Stands in for a real install — see the module docstring for why this is a
         # faithful substitute for `-P`'s own purposes, not a shortcut around them.
         self.env["PYTHONPATH"] = str(REPO_ROOT)
         # Never let a spawned child touch this machine's real ~/.charter.
         self.env["CHARTER_HOME"] = str(self.tmp / ".charter-home")
+        self.env["CHARTER_ROOT"] = str(self.tmp)
 
 
 class TheDecoyGenuinelyShadows(WithADecoyCwd):

--- a/tests/test_statusline_gauge.py
+++ b/tests/test_statusline_gauge.py
@@ -57,6 +57,13 @@ class ContextGaugeCase(unittest.TestCase):
         config.SESSIONS_DIR = self.tmp / "sessions"
         self.addCleanup(lambda: (setattr(config, "SESSIONS_DIR", self._orig),
                                  shutil.rmtree(self.tmp, ignore_errors=True)))
+        # Never fork a network child from the suite. This case renders against the REAL
+        # plane on purpose, so `_brand`'s background version check would be spawned
+        # against it, and `tests._planeguard.RealPlaneSpawn` refuses that outright (#527).
+        # In `setUp` rather than in the one case that first needed it: three of the cases
+        # below call `render`, and the precaution had been remembered in exactly one.
+        from charter import update
+        self.enterContext(mock.patch.object(update, "maybe_spawn", lambda: None))
 
     def test_shows_context_percentage(self):
         self.assertIn("ctx 37%", _plain(statusline._context_gauge(_payload(pct=37.4))))
@@ -122,10 +129,7 @@ class ContextGaugeCase(unittest.TestCase):
         when the chip column is cropped away. Two of them on one line, told apart only
         by a `%`, and neither reads as anything.
         """
-        from charter import inflight, update
-        spawn = update.maybe_spawn          # never fork a network child from the suite
-        update.maybe_spawn = lambda: None
-        self.addCleanup(lambda: setattr(update, "maybe_spawn", spawn))
+        from charter import inflight
         inflight.start("coder")
         out = statusline.render({"session_id": "t", **_payload(pct=42, read=900, write=100)})
         lines = [re.sub(r"\033\[[0-9;]*m", "", l) for l in out.splitlines() if l.strip()]

--- a/tests/test_the_state_directory_is_charters_to_choose.py
+++ b/tests/test_the_state_directory_is_charters_to_choose.py
@@ -148,10 +148,19 @@ class TheCliDecidesIt(unittest.TestCase):
     def child_env() -> dict:
         """The child's environment: this checkout on the path, and every charter variable
         that could redirect the state directory removed, so the plane under test is the
-        temp one and nothing reaches the developer's own."""
+        temp one and nothing reaches the developer's own.
+
+        ``CHARTER_ROOT`` belongs on that list and was missing from it. Isolation here is by
+        ``cwd`` — each case runs the CLI standing inside its own copied plane — and
+        ``$CHARTER_ROOT`` wins outright over that walk (`root.find_root`). Every charter
+        frame exports it, so on the machine most likely to run these, `setUpClass` ran
+        ``charter init`` against the operator's own control plane. It never showed up
+        because nobody ran the suite from inside a frame with the variable set; the suite's
+        spawn tripwire refuses it now (#527), which is how it was found.
+        """
         env = dict(os.environ)
         env["PYTHONPATH"] = str(REPO_ROOT)
-        for var in ("CHARTER_HOME", "CHARTER_PERSONA", "CHARTER_WORKSPACE",
+        for var in ("CHARTER_ROOT", "CHARTER_HOME", "CHARTER_PERSONA", "CHARTER_WORKSPACE",
                     "CHARTER_WORKTREES", "CHARTER_CONFIG_HOME"):
             env.pop(var, None)
         return env

--- a/tests/test_util_run_stdin.py
+++ b/tests/test_util_run_stdin.py
@@ -24,6 +24,7 @@ import unittest
 from pathlib import Path
 
 import charter
+from tests._isolation import child_plane_env
 
 #: So the helper below can `from charter import util` whatever the cwd is.
 _REPO_ROOT = Path(charter.__file__).resolve().parent.parent
@@ -80,11 +81,16 @@ class TheFixtureIsRealBeforeAnythingIsConcludedFromIt(unittest.TestCase):
 
 class AChildNeverInheritsCharterSStdin(unittest.TestCase):
     def _report(self) -> dict:
+        # `_HELPER` opens with ``from charter import util``, and a charter import resolves
+        # a plane from the importing process's own cwd — which here is the checkout, i.e.
+        # the developer's live plane. The helper never writes to it, but nothing said it
+        # could not, and that is the shape #527 was: a module-level charter import in a
+        # child nobody handed a plane. `child_plane_env` hands it one.
+        _, env = child_plane_env(self, PYTHONPATH=str(_REPO_ROOT))
         with _NeverEofStdin() as stdin:
             proc = subprocess.run(
                 [sys.executable, "-c", _HELPER], stdin=stdin,
-                capture_output=True, text=True, timeout=_OUTER_BOUND,
-                env={**os.environ, "PYTHONPATH": str(_REPO_ROOT)},
+                capture_output=True, text=True, timeout=_OUTER_BOUND, env=env,
             )
         # Precondition: the helper ran and reported. An ImportError or a traceback here
         # must be loud, not silently read as "did not block".


### PR DESCRIPTION
Phase 0, group **real-plane-and-filesystem**.

Closes #527
Closes #532

---

## #527 — the issue's measurement was wrong, and the real number is 131

#527 reports **three suite call sites** reaching the real `util.detach_self`. Measured again
at the `subprocess.Popen` seam rather than at `detach_self`, those three spawn **nothing**:
each one has `subprocess.Popen` stubbed for the duration
(`mock.patch.object(util.subprocess, "Popen")`), and a probe that wraps `detach_self` cannot
tell a real fork from a stubbed one. The issue's own instrument could not answer its own
question.

Wrapping `subprocess.Popen.__init__` instead — so only spawns that *actually happen* are
counted — gives the real figure for one full suite run:

```
131 detached charter children, $CHARTER_ROOT unset on every one:
   95  python3 -P -m charter _version-check        (update.maybe_spawn)
   36  python3 -P -m charter gl-refresh --workspace default   (glstate.maybe_spawn)
    0  from util.detach_self  — all four call sites have Popen stubbed
```

With no `$CHARTER_ROOT`, each child walked up from its own cwd. From a linked worktree
`root._plane_of` redirects to the tree it was cut from, so **every one of those 131 resolved
the operator's live plane** — refreshing its forge state and rewriting its caches, from a
suite that had isolated everything it could see.

### The fix is charter's, not the suite's

`util.child_env()` puts the plane this process actually resolved on the child's
`$CHARTER_ROOT`; `detach_self`, `glstate.maybe_spawn` and `update.maybe_spawn` all use it.
`glstate.maybe_spawn` already makes exactly this argument about the *workspace* —

> the status line resolves the workspace for the SESSION … while the child would resolve it
> for ITSELF, from its own environment and its own directory

— and the plane is the same argument one level up, and the bigger half: the workspace
decides which rows get refreshed, the plane decides whose `.charter/` gets written. This is
a real correctness fix in production, independent of the suite.

**And with no plane, neither refresher forks at all.** Outside a control plane
`config.STATE_DIR` is `<cwd>/.charter`, so a spawn there scattered charter's caches into
whatever directory the render happened to run in, and the child — handed nothing — went
looking for a plane of its own.

### The structural half

`tests/_planeguard.py` gains `RealPlaneSpawn`, the tripwire its own docstring said for
months it could not have:

> **What this cannot see: a subprocess.** … isolating this process does nothing for it.

It wraps `Popen.__init__` — the **class**, because `subprocess.run`, `check_output` and
`from subprocess import Popen` all bypass the module attribute — and asks `root.find_root`
**the child's** question, with the child's environment and the child's cwd. A test that
patches the module attribute never reaches it, which is correct: nothing is spawned.

`root.find_root` grew an optional `env=` for that. Re-deriving the walk inside the guard was
the alternative, and the walk is where every subtlety lives (the worktree redirect, the
`workspaces/` hop outward) — a guard with a private copy of that logic stops agreeing with
the thing it guards.

```
REFUSED: spawning charter against the real control plane
tests.test_cli_smoke.CliSmokeTest.test_doctor_runs_without_crashing is about to run
`… -m charter doctor`, and that child would resolve its plane as ~/work/charter — the
developer's REAL one. … Two ways out. (1) If the test is not about the spawn, stub it …
(2) If the test really wants a child, hand it the throwaway plane as $CHARTER_ROOT:
`tests._isolation.child_plane_env(self)` returns exactly that environment …
```

### What it found the moment it was armed

Eight more call sites:

| site | what the child did |
|---|---|
| `test_cli_smoke.CliSmokeTest` | ran `charter doctor` against the developer's personas, workspaces and vault registry — its docstring claimed isolation, because `$CHARTER_HOME` covers the per-human directory and reads as though it covered the plane |
| `test_docs_show.TestDocsCli` | ran `charter docs`, which regenerates a plane's topology |
| `test_packaging`, `test_dev_channel.VersionAlwaysPrints` | `--version` reads the plane's build label, so the assertion depended on the operator's own `[update] channel` — #459's shape, across a fork where `RealPlaneRead` cannot follow |
| `test_statusline_gauge.ContextGaugeCase` | renders against the real plane on purpose; the version-check fork went with it. The file already had the stub — in **one** case, and not in the three beside it |
| `test_the_state_directory_is_charters_to_choose` | ran **`charter init`** against the operator's plane |
| `test_self_relaunch_shadowing.WithADecoyCwd` | ran `charter panel top` against it, five cases over |

**The last two only fire inside a charter frame.** `$CHARTER_ROOT` wins outright over the
cwd walk and every frame exports it, so two suites that isolated their children by `cwd=`
were right in a bare shell and wrong in the terminal they are written in. Neither shows up
in the four required environments, because none of them sets that variable.

Six modules already stubbed the version-check fork by hand, with the same comment twice
over — *"never fork a network child from the suite"*. Twelve did not. That the precaution
existed twelve-and-a-half times over is the argument for the guard, not against it.

## #532 — the shipped-skills check reads the index

`TestShippedSkillsStayInSync` enumerated `skills/*/SKILL.md` **on disk**, so an untracked
draft turned the suite red about a constant being out of sync, with neither adding the draft
nor deleting it being the right answer. It reads `git ls-files` now — the seam #529's fix
and `test_workflows.tracked` already use.

**The equality still runs both ways**, which is the half worth protecting: a skill committed
without updating `SHIPPED_SKILLS` still fails on the PR that commits it, and a constant
naming a skill that no longer exists still fails too. A subset assertion would have made the
symptom go away and given the removal half up with it — #529's own history warns about
exactly that trade.

## Verification

**Zero charter children resolve the real plane.** Re-probed at the `Popen` seam after the
fix: 174 charter children still spawn, every one carrying an explicit `$CHARTER_ROOT` at a
`/var/folders/…` throwaway plane, and `grep` for the real plane returns nothing (was 131).

**#532, both directions, and the symptom.** With an untracked `skills/zz-local-draft/SKILL.md`
present, the old filesystem form is RED and the new index form is GREEN. Dropping a shipped
skill from `SHIPPED_SKILLS` → RED. Adding a name the repo does not ship → RED. Restored →
GREEN.

**Eleven mutations, each applied, run, restored, `__pycache__` cleared:**

| # | mutation | result |
|---|---|---|
| M1 | `glstate.maybe_spawn` hands the child a bare `os.environ` again | **RED** (25 errors) |
| M2 | `update.maybe_spawn` the same | **RED** (13 errors) |
| M3 | `util.child_env` stops naming the plane | **RED** (2 failures, 13 errors) |
| M4 | guard stops recognising a `-m charter` argv | **RED** (1 error) |
| M5 | guard stops recognising a bare `charter` argv0 | **RED** (4 failures, 2 errors) |
| M6 | an unresolvable child is waved through instead of falling back to its cwd | **RED** (1 failure) |
| M7 | guard asks OUR environment instead of the child's | **RED** (2 failures, 1 error) |
| M8 | no-plane brake removed from `glstate.maybe_spawn` | **RED** (1 error) |
| M9 | no-plane brake removed from `update.maybe_spawn` | **RED** (11 errors) |
| M10 | `find_root` ignores the `env` it was handed | **RED** (1 failure, 13 errors) |
| M11 | `SHIPPED_SKILLS` gains/loses a name | **RED** both ways |
| — | restored | **GREEN** |

M4's first attempt deleted two lines and left a `for` loop with no body — an
`IndentationError`, which produced no `OK` and no `FAILED` and would have read as a
survivor. Redone as a one-token change (`"-m"` → `"-mm"`), it is RED. Reporting it because a
mutation whose *harness* broke is the exact thing that gets written up as "no survivors".

### The four environments

Ran in full, `config.ROOT` printed first and confirmed to resolve
`/Users/aharon/IdeaProjects/charter` (the linked-worktree redirect the brief warns about):

| # | environment | this branch | `origin/main` |
|---|---|---|---|
| 1 | ambient cleared, fresh checkout | **OK** (5632) | OK |
| 2 | ambient cleared, a plane that has been used (`.charter/`, `.superpowers/` present) | **OK** (5632) | OK |
| 3 | inside a live frame (`CHARTER_SESSION_ID`, `TMUX`, `TMUX_PANE`) | FAILED (15) | FAILED (15) |
| 4 | `CHARTER_WORKSPACE=anything` | FAILED (8) | FAILED (8) |

**Environments 3 and 4 are byte-identical to `origin/main`** — the failing test names were
diffed, not just the counts, and the diff is empty. They are the ambient-environment cluster
(#519 / #521 / #528), a different phase's group: `test_piece_claim`, `test_session_identity`,
`test_trace`, `test_workspace_lock`, `test_workspace_scope_honesty`,
`test_names_from_files_are_contained`. Nothing here touches them; nothing here makes them
worse.

**A fifth environment, added because it is the one people actually work in:** a live frame
*with `$CHARTER_ROOT` set*, as charter itself sets it. That is what found the last two spawn
sites. Before the fix: 23 failures + **5 errors**. After: 23 failures, **0 errors** — and the
23 are again byte-identical to `origin/main` (the env-3 fifteen, plus eight in
`test_root.TestFindRoot` / `test_nested_plane_named` that an ambient `$CHARTER_ROOT` defeats
because it wins outright over `find_root(start=…)`). Also #528's family.

## Filed, not fixed

#542 — the suite still forks ~90 real `charter _version-check` children per run, each one a
PyPI request. They all land on throwaway planes now, so nothing touches the operator's
state, but a suite that says *"never fork a network child"* in six files does it ninety
times. Filed rather than folded in: the obvious fix (stub both `maybe_spawn`s in
`PersonaIso`) would silently swallow the four modules that call them directly to assert on
argv and cooldown, and `test_glstate_respawn`'s "must not raise" cases would then pass
vacuously — a new member of the class this phase exists to remove.

## Not done here

No version bump, no stamping, no tag.



---

# Round two

Rebased onto `c1f9b95`. Everything above about *"the five environments disagree"* is
superseded: the ambient-environment cluster (#519 / #521 / #528) merged as #540, and the
suite now gives one answer everywhere. The measurements below are on the rebased branch.

## The finding this round answers

The guard recognised **argv spellings**, not the class *"spawn a charter"*. Measured
against its own `_REAL_ROOT`:

| spelling | round one | now |
| --- | --- | --- |
| `[python, "-m", "charter", "--version"]` | REFUSED | REFUSED |
| `[python, "-c", "from charter import config; print(config.ROOT)"]` | **RAN**, on the real plane | REFUSED |
| `["/bin/sh", "-c", "<python> -m charter --version"]` | **RAN**, on the real plane | REFUSED |
| the same command as a `shell=True` string | **RAN**, on the real plane | REFUSED |
| `[python, "<plane>/charter/__main__.py"]` | unexamined | REFUSED |

And `_charter_argv`'s docstring justified its bare-`charter` spelling by naming
`hooks/hooks.json` — where *every* command is a shell command **string**
(`charter workspace _reconcile >/dev/null 2>&1`, `out="$(charter doctor 2>&1)" || …`),
which is precisely the form it declined to parse. The stated reason pointed at a form the
guard could not see. Both of those strings are now read, the second by scanning command
substitutions, since every lexer reads it as an assignment and moves on.

## What was already live

A Popen recorder over the whole suite: **9 charter-importing `python -c` children per run**
(`test_a_deny_survives_a_broken_channel`, `test_util_run_stdin`) whose plane — by the
guard's own `_child_plane` criterion — was the operator's real one, every one waved
through. Plus a third site the recorder found once the recogniser was widened:
`test_news_cross_process` spawns a *chain* of them, each hop starting the next.

They call `config.use()` on the next statement, so nothing was harmed. Nothing enforced it,
and *"a module-level charter import in a child that resolves its own plane"* is the shape
that produced #527.

## The property, not the spellings

`_charter_argv` now asks **"will this child resolve the operator's plane as charter"**:

* a bare `charter` from `PATH`, and `executable=`;
* `-m charter` attached (`-mcharter`), separate, or bundled behind other short options
  (`-Pmcharter`);
* `-c` source that names the module — **tokenized**, so `from charter import config` is a
  charter child and `open('<checkout>/canary', 'w')`, which the frame's tmux fixtures
  really do spawn, is not;
* a script file that imports it (read), and a module of the `charter` package run by path
  (recognised by location — charter's own `__main__.py` reaches the CLI through
  `from .cli import main` and never writes the word);
* `import tests`, which arms these guards and therefore imports `charter.config`;
* a shell `-c` string and `shell=True`, segmented into the commands a shell would run, with
  command substitutions read one level down;
* an `env` wrapper, and a bare path-like as the whole command;
* `Popen`'s positional `cwd` / `env` / `shell`, which `Popen(argv, -1, …, cwd, env)` used to
  hide.

Where a spelling **cannot be decided** — source that will not tokenize, a script that will
not read, a shell string that will not lex, a command word the shell computes (`$c`), a
wrapper whose argument grammar this does not follow (`sudo`, `xargs`, `timeout`) — it is
answered *"charter"* and the plane check decides. A false refusal in a test is loud, named
and one line from the fix; a false allow writes to a live machine.

The other half is that it still **lexes rather than greps**: `test_toolgate` asks a real
bash to echo `charter "sec"'ret' list v` back, and every tmux fixture quotes a path inside
the checkout. `SpellingsThatAreNotASpawn` pins each of those as a real, running child.

## The four sites it found

| site | fix |
| --- | --- |
| `test_a_deny_survives_a_broken_channel` | `$CHARTER_ROOT` — the tmp plane `config.use` was about to point at anyway |
| `test_util_run_stdin` | `child_plane_env` |
| `test_news_cross_process` | `child_plane_env`, read at **call** time so the re-entry marker the file is about still rides along |
| `test_no_test_reads_the_operators_shell` | a cwd inside a throwaway plane — the one child `$CHARTER_ROOT` cannot rescue, because `_envguard` scrubs it *before* `charter.config` loads |

A Popen census over the whole suite now shows **no charter-importing child left on the
operator's plane**. What remains there is `git`, `tmux`, `gh`, `glab` and charter-free
`python -c` probes — none of which reads a `charter.toml`.

## What the guard does not watch, said out loud

`os.execv*`, `os.posix_spawn*`, `os.spawn*` and `os.system` go around
`subprocess.Popen.__init__`. Wrapping them would be refusing something that cannot be a
child of the suite — `execvp` replaces this process. That nothing reaches charter that way
is now a checked fact: `NoCharterEscapesThroughTheExecFamily` parses every module in
`charter/` and `tests/` and fails on any such call that is not one of the three written
down with its reason.

## Mutation testing

22 mutations, each applied, run, restored, `__pycache__` cleared between runs. **All 22
RED, all 22 restored GREEN, no survivors** — every clause listed above, plus the two
directions of the exec-family case (adding an `os.execvp` to `charter/util.py`, and
narrowing the scan to `charter/` alone), and the refusal message's `tests`-package clause.

Two rounds of that were needed. The first pass left **nine survivors**, and each one was a
guard the tests did not actually pin — several because two clauses covered each other and
looked like one. `out="$(charter …)"` is caught by the assignment clause *and* the
substitution scan; an unquoted `$(…)` is split by `shlex`'s own punctuation handling before
either runs. The cases were rewritten until exactly one clause answers each.

## No news entry

This round is entirely test-suite infrastructure. The two entries already on this branch
cover the operator-visible half.


## The gate

`env -u CHARTER_SESSION_ID -u CLAUDE_CODE_SESSION_ID -u TMUX -u TMUX_PANE python3 -m unittest discover -s tests`

```
1 cleared / fresh checkout                Ran 5689 tests in 245.547s … OK
2 cleared / used plane                    Ran 5689 tests in 221.568s … OK
3 inside a live charter frame             Ran 5689 tests in 221.301s … OK
4 CHARTER_WORKSPACE set                   Ran 5689 tests in 227.287s … OK
5 EDM_WORKSPACE set                       Ran 5689 tests in 222.969s … OK

and the sixth this branch added last round, because it is the one people work in:
3b live frame WITH a real $CHARTER_ROOT
   and a real $CHARTER_WORKSPACE          Ran 5689 tests in 221.559s … OK
```

Last round the same six were `OK / OK / 15 failures / 8 / 8 / 23 failures + 5 errors`.
Environment 1 is a `git archive` of this branch's HEAD unpacked into a directory that has
never held a `.charter/`, initialised as its own repo.

**Known and not mine:** `$COLUMNS` (#544). `tui.py:210` reads it, it is outside the charter
namespace, and `COLUMNS=40` fails five tests — two of them in `test_frame_*` modules the
timing branch owns.
