### PR TITLE
Phase 1: the component contract, the registry, and a ctx built from needs

### DIFF
--- a/charter/frame/component.py
+++ b/charter/frame/component.py
@@ -75,7 +75,15 @@ EVENT_KINDS = ("key", "click", "scroll", "focus", "blur", "resize")
 #: a pane rather than a fixable line. Checked here instead, against the one list `ctx`
 #: serves from, for the reason `contain.py`'s docstring gives for one implementation over
 #: four near-misses: two lists for one concept drift, and the drift is the defect.
-NEEDS = ("gather", "repos", "todos", "personas", "changes")
+#:
+#: **These are the slices `gather.scan` actually carries, and no others.** §4f's extended
+#: gather adds personas and changes to the same one snapshot, and each joins this tuple
+#: *when it can be served* — not before. A name accepted here that `ctx` answered with an
+#: empty tuple would be worse than a refusal: a component would declare it, draw nothing,
+#: pass its own tests against an empty fixture, and be indistinguishable from a plane
+#: that genuinely has no personas. `ctx.SERVES` is asked against this tuple by a test, so
+#: the two cannot drift apart in either direction.
+NEEDS = ("gather", "repos", "todos")
 
 #: What a refusal tells a provider author to write instead. One sentence, held in one
 #: place, because it is repeated into every id refusal and a second spelling of it would
@@ -116,19 +124,25 @@ class ComponentError(ValueError):
     """
 
 
-def _positive(name: str, value: Any, *, allow_none: bool = False) -> None:
-    """Refuse *value* unless it is a positive whole number of terminal cells.
+def cells(name: str, value: Any, *, allow_none: bool = False, floor: int = 1) -> None:
+    """Refuse *value* unless it is a whole number of terminal cells, at least *floor*.
 
     ``bool`` is excluded explicitly. ``isinstance(True, int)`` is ``True`` in Python, so
     ``Fixed(True)`` would sail through a plain int check and mean ``Fixed(1)`` — a
     fixture VALUE carrying a meaning nobody wrote, which is a defect this suite has now
     caught in four separate shapes.
+
+    *floor* is 1 for a size policy, because a panel nobody can see is a panel nobody
+    asked for, and 0 for a measured pane in `ctx`, because tmux can genuinely leave a
+    pane with no room at all and a frame draws nothing there rather than refusing. One
+    function with a floor rather than two nearly-identical checks: the ``bool`` trap
+    above is exactly the kind of thing a second copy is written without.
     """
     if allow_none and value is None:
         return
-    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+    if isinstance(value, bool) or not isinstance(value, int) or value < floor:
         raise ComponentError(
-            f"{name} must be a positive whole number of cells, not "
+            f"{name} must be a whole number of cells, at least {floor}, not "
             f"{contain.one_line(repr(value))}")
 
 
@@ -139,7 +153,7 @@ class Fixed:
     n: int
 
     def __post_init__(self) -> None:
-        _positive("a fixed size", self.n)
+        cells("a fixed size", self.n)
 
 
 @dataclass(frozen=True)
@@ -154,7 +168,7 @@ class Content:
     cap: int | None = None
 
     def __post_init__(self) -> None:
-        _positive("a content cap", self.cap, allow_none=True)
+        cells("a content cap", self.cap, allow_none=True)
 
 
 @dataclass(frozen=True)
@@ -174,7 +188,7 @@ class Fill:
 SIZES = (Fixed, Content, Fill)
 
 
-def _tuple(name: str, cid: str, value: Any, allowed: tuple[str, ...]) -> tuple[str, ...]:
+def names(name: str, owner: str, value: Any, allowed: tuple[str, ...]) -> tuple[str, ...]:
     """*value* as a tuple of names drawn from *allowed*, or a refusal naming both.
 
     A bare string is refused rather than accepted, and that is the point of doing this in
@@ -184,13 +198,13 @@ def _tuple(name: str, cid: str, value: Any, allowed: tuple[str, ...]) -> tuple[s
     """
     if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple)):
         raise ComponentError(
-            f"component {cid}: {name} must be a tuple of names, not "
+            f"{owner}: {name} must be a tuple of names, not "
             f"{contain.one_line(repr(value))}")
     out = tuple(value)
     unknown = [v for v in out if v not in allowed]
     if unknown:
         raise ComponentError(
-            f"component {cid}: unknown {name} "
+            f"{owner}: unknown {name} "
             f"{', '.join(contain.one_line(repr(u)) for u in unknown)} — "
             f"charter serves {', '.join(allowed)}")
     return out
@@ -255,7 +269,9 @@ class Component:
                     f"component {self.id}: {contain.one_line(repr(child))} is not a "
                     f"usable component id — write {ID_HINT}")
         object.__setattr__(self, "title", contain.one_line(self.title))
-        object.__setattr__(self, "needs", _tuple("needs", self.id, self.needs, NEEDS))
         object.__setattr__(
-            self, "events", _tuple("events", self.id, self.events, EVENT_KINDS))
+            self, "needs", names("needs", f"component {self.id}", self.needs, NEEDS))
+        object.__setattr__(
+            self, "events",
+            names("events", f"component {self.id}", self.events, EVENT_KINDS))
         object.__setattr__(self, "children", tuple(self.children))

--- a/charter/frame/component.py
+++ b/charter/frame/component.py
@@ -93,6 +93,15 @@ ID_HINT = ("lower-case letters, digits and underscores, starting with a letter, 
 #:
 #: The length bound is per segment and is not decoration: an id is repeated into a pane
 #: title and a menu row, both of which are width-budgeted surfaces.
+#:
+#: **Matched with ``fullmatch``, and the first version of this module used ``match`` and
+#: was wrong.** Python's ``$`` matches at the end of the string *or just before a
+#: trailing newline*, so ``_ID_RE.match("personas\\n")`` succeeds against a pattern that
+#: was written to exclude newlines entirely — an id ending in exactly the character this
+#: whole constant exists to keep away from tmux config text. `frame_of` already reaches
+#: for `fullmatch` on `instance._HOTKEY_RE`, whose pattern carries the same ``^…$``, and
+#: that is why the hotkey guard does not have this hole; it is spelled the same way here
+#: rather than fixed a second way, so the two guards keep one answer between them.
 _ID_RE = re.compile(r"^[a-z][a-z0-9_]{0,31}(?:\.[a-z][a-z0-9_]{0,31})?$")
 
 
@@ -204,11 +213,18 @@ class Component:
     render: Callable[[Any], list[str]]
     needs: tuple[str, ...] = ()
     events: tuple[str, ...] = ()
+    #: The leaf ids this component draws inside its own pane, in the order it draws
+    #: them, or ``()`` for a leaf. Charter never splits a pane (§4d), so this is how N
+    #: things share one — and it is ids rather than components because the rules that
+    #: govern it (one level, exactly one `Fill()`, no child claimed twice) need to see
+    #: every component together, which only the registry does. Their SHAPE is checked
+    #: here; what they refer to is checked at registration.
+    children: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         # The id first, because every message below names the component it is about, and
         # a component whose id could forge a line would forge those messages too.
-        if not isinstance(self.id, str) or not _ID_RE.match(self.id):
+        if not isinstance(self.id, str) or not _ID_RE.fullmatch(self.id):
             raise ComponentError(
                 f"{contain.one_line(repr(self.id))} is not a usable component id — "
                 f"write {ID_HINT}")
@@ -228,7 +244,18 @@ class Component:
             raise ComponentError(
                 f"component {self.id}: render must be callable, not "
                 f"{contain.one_line(repr(self.render))}")
+        if isinstance(self.children, (str, bytes)) or \
+                not isinstance(self.children, (list, tuple)):
+            raise ComponentError(
+                f"component {self.id}: children must be a tuple of component ids, not "
+                f"{contain.one_line(repr(self.children))}")
+        for child in self.children:
+            if not isinstance(child, str) or not _ID_RE.fullmatch(child):
+                raise ComponentError(
+                    f"component {self.id}: {contain.one_line(repr(child))} is not a "
+                    f"usable component id — write {ID_HINT}")
         object.__setattr__(self, "title", contain.one_line(self.title))
         object.__setattr__(self, "needs", _tuple("needs", self.id, self.needs, NEEDS))
         object.__setattr__(
             self, "events", _tuple("events", self.id, self.events, EVENT_KINDS))
+        object.__setattr__(self, "children", tuple(self.children))

--- a/charter/frame/component.py
+++ b/charter/frame/component.py
@@ -1,0 +1,234 @@
+"""What a component is: identity, edge, size policy, declared cost, accepted events.
+
+A slot is a string in a list whose POSITION is secretly geometry. A component is the
+thing that replaces it — a named part of the frame that knows its own edge, how big it
+wants to be, what it reads and which events it accepts (spec §4). Charter's own panels
+consume this seam first, so the extension model has no private back door for them to
+drift through (§4b's sequencing note).
+
+**Everything is checked here, at construction, and nowhere else.** A provider meets this
+module the moment it builds its component, which is before charter has placed it, before
+a pane exists and before anything is on screen. That is the only point at which a
+refusal names a fixable thing rather than appearing inside somebody's frame — the same
+argument §4g makes for refusing a mismatched :data:`API_VERSION` at load rather than
+hoping at render time.
+
+**An id is held to a closed alphabet because it reaches tmux.** `instance._HOTKEY_RE`'s
+docstring records what a committed `[frame] hotkey` did: a newline ended the ``bind``
+line, ``source-file`` returned 0, and a second tmux command ran at launch with no
+keypress. A component id arrives from the same class of place — a committed
+`charter.toml` names it, an installed provider declares it — and travels to a menu row
+and a pane title. So it is a containment boundary rather than a naming convention, and
+:data:`_ID_RE` is deliberately narrower than "whatever Python can hold": an id this
+refuses that a provider wanted costs them a rename, and an id this accepted that tmux
+parses as a command costs the operator the machine.
+
+A title is the other half of that pair and gets the other treatment. Its alphabet is
+open — it is display text, and a provider may legitimately want spaces, punctuation and
+non-ASCII in it — so it is *contained* rather than refused, by the same `contain.one_line`
+every committed display string already goes through, before it can reach a row it might
+otherwise forge a second one of.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from .. import contain
+
+#: The contract's version, as a single integer, refused at load rather than negotiated
+#: (§4g). Charter bumps it when the shape below changes; a provider declaring a different
+#: one does not load, and the refusal names the provider, the version it speaks and the
+#: version charter speaks. There is no shim band and no best-effort mode: loading-and-
+#: hoping means the failure lands at render time inside somebody's frame, where the
+#: person seeing it cannot act on it. It also makes the cost of a change real to charter
+#: — a bump breaks every provider at once, which is the friction that stops the contract
+#: churning.
+API_VERSION = 1
+
+#: The sides of the harness pane a component may attach to. A closed set, checked here,
+#: because the edge decides which tmux split direction the component costs (`layout`'s
+#: `_COLUMN_SLOTS`) and an unknown edge has no answer to that question — it would either
+#: pick one silently or drop the component out of the frame without saying so.
+EDGES = ("top", "bottom", "left", "right")
+
+#: The event kinds a component may declare, closed by §4f. ``focus`` and ``blur`` are the
+#: pair that decision counts as one kind; they are two names here because a component
+#: receives one or the other, never "a focus/blur".
+#:
+#: **``drag`` is absent deliberately and must stay absent.** It is stateful, the hardest
+#: to get right across terminals, and the most likely to fight tmux's own selection —
+#: and the asymmetry is the whole argument: adding it in a later API version costs
+#: nothing, while removing it after a provider has shipped against it costs everything.
+EVENT_KINDS = ("key", "click", "scroll", "focus", "blur", "resize")
+
+#: The slices of the plane snapshot a component may declare in ``needs`` — and therefore
+#: the complete set of names `ctx.build` can answer with. One snapshot, one timestamp
+#: (§4f): everything on screen is from the same moment by construction rather than by
+#: luck, so these are slices of a single scan and not a cache per source.
+#:
+#: **Closed, so that a typo is a refusal rather than a blank pane.** ``ctx`` is built FROM
+#: ``needs``; a component declaring ``"gathr"`` would be handed an object with no such
+#: attribute and would raise on its first repaint, inside the frame, where the message is
+#: a pane rather than a fixable line. Checked here instead, against the one list `ctx`
+#: serves from, for the reason `contain.py`'s docstring gives for one implementation over
+#: four near-misses: two lists for one concept drift, and the drift is the defect.
+NEEDS = ("gather", "repos", "todos", "personas", "changes")
+
+#: What a refusal tells a provider author to write instead. One sentence, held in one
+#: place, because it is repeated into every id refusal and a second spelling of it would
+#: eventually describe a different pattern from the one :data:`_ID_RE` enforces.
+ID_HINT = ("lower-case letters, digits and underscores, starting with a letter, "
+           "optionally namespaced by distribution as `dist.name`")
+
+#: The alphabet an id may be spelled in, and the reason it is this narrow is
+#: :data:`ID_HINT`'s call site rather than taste — see this module's docstring.
+#:
+#: Nothing in ``[a-z0-9_.]`` can end a tmux ``bind`` line, open a quote, start a second
+#: command, introduce a tmux format (``#{...}``), traverse a path (``../``) or carry an
+#: escape sequence. Case is excluded as well, so two ids cannot differ only by a shift
+#: key — a distinction a menu row shows and a reader does not reliably see.
+#:
+#: The length bound is per segment and is not decoration: an id is repeated into a pane
+#: title and a menu row, both of which are width-budgeted surfaces.
+_ID_RE = re.compile(r"^[a-z][a-z0-9_]{0,31}(?:\.[a-z][a-z0-9_]{0,31})?$")
+
+
+class ComponentError(ValueError):
+    """A component that cannot be constructed, placed or composed — and why.
+
+    One type for the whole contract, so a caller that wants to degrade rather than
+    propagate — a config boundary reading `[[frame.component]]`, a discovery pass over
+    installed providers — has one thing to catch. It subclasses ``ValueError`` because
+    every instance of it is a value that failed a check, and because a caller that
+    catches ``ValueError`` around a construction was already right.
+    """
+
+
+def _positive(name: str, value: Any, *, allow_none: bool = False) -> None:
+    """Refuse *value* unless it is a positive whole number of terminal cells.
+
+    ``bool`` is excluded explicitly. ``isinstance(True, int)`` is ``True`` in Python, so
+    ``Fixed(True)`` would sail through a plain int check and mean ``Fixed(1)`` — a
+    fixture VALUE carrying a meaning nobody wrote, which is a defect this suite has now
+    caught in four separate shapes.
+    """
+    if allow_none and value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ComponentError(
+            f"{name} must be a positive whole number of cells, not "
+            f"{contain.one_line(repr(value))}")
+
+
+@dataclass(frozen=True)
+class Fixed:
+    """Exactly *n* cells — rows on a horizontal edge, columns on a vertical one."""
+
+    n: int
+
+    def __post_init__(self) -> None:
+        _positive("a fixed size", self.n)
+
+
+@dataclass(frozen=True)
+class Content:
+    """As tall as its own content, never more than *cap* if one is given.
+
+    The policy `layout.repos_rows` already implements for the repo table, named so the
+    registry can hold it rather than each caller remembering which slot is the variable
+    one.
+    """
+
+    cap: int | None = None
+
+    def __post_init__(self) -> None:
+        _positive("a content cap", self.cap, allow_none=True)
+
+
+@dataclass(frozen=True)
+class Fill:
+    """Whatever the parent has left.
+
+    **Exactly one child of a composite may say this**, and more than one is a
+    registration-time error rather than a runtime tie-break (§4e) — the registry is where
+    that is enforced, because it is the only thing that sees a composite's children
+    together. Ambiguity here produces a layout that shifts with the data, which reads as
+    a bug every single time.
+    """
+
+
+#: The three policies, as one tuple, so the check below cannot fall out of step with the
+#: classes above by being written as three ``isinstance`` arms somebody adds a fourth to.
+SIZES = (Fixed, Content, Fill)
+
+
+def _tuple(name: str, cid: str, value: Any, allowed: tuple[str, ...]) -> tuple[str, ...]:
+    """*value* as a tuple of names drawn from *allowed*, or a refusal naming both.
+
+    A bare string is refused rather than accepted, and that is the point of doing this in
+    one helper: ``needs = "gather"`` iterates as six one-character needs, so a permissive
+    reading would refuse it six times over for the wrong reason, or — worse, with a
+    single-character name in play — accept part of it.
+    """
+    if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple)):
+        raise ComponentError(
+            f"component {cid}: {name} must be a tuple of names, not "
+            f"{contain.one_line(repr(value))}")
+    out = tuple(value)
+    unknown = [v for v in out if v not in allowed]
+    if unknown:
+        raise ComponentError(
+            f"component {cid}: unknown {name} "
+            f"{', '.join(contain.one_line(repr(u)) for u in unknown)} — "
+            f"charter serves {', '.join(allowed)}")
+    return out
+
+
+@dataclass(frozen=True, kw_only=True)
+class Component:
+    """One named part of the frame, and everything charter needs to know to place it.
+
+    Keyword-only on purpose. Field order is not part of the contract and must not become
+    part of it by accident: ``children`` joins this dataclass for composites, and a
+    provider that had spelled its component positionally would break on that addition
+    having done nothing wrong.
+    """
+
+    id: str
+    title: str
+    edge: str
+    size: Fixed | Content | Fill
+    render: Callable[[Any], list[str]]
+    needs: tuple[str, ...] = ()
+    events: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        # The id first, because every message below names the component it is about, and
+        # a component whose id could forge a line would forge those messages too.
+        if not isinstance(self.id, str) or not _ID_RE.match(self.id):
+            raise ComponentError(
+                f"{contain.one_line(repr(self.id))} is not a usable component id — "
+                f"write {ID_HINT}")
+        if not isinstance(self.title, str):
+            raise ComponentError(
+                f"component {self.id}: title must be text, not "
+                f"{contain.one_line(repr(self.title))}")
+        if self.edge not in EDGES:
+            raise ComponentError(
+                f"component {self.id}: {contain.one_line(repr(self.edge))} is not an "
+                f"edge — one of {', '.join(EDGES)}")
+        if not isinstance(self.size, SIZES):
+            raise ComponentError(
+                f"component {self.id}: {contain.one_line(repr(self.size))} is not a size "
+                f"policy — Fixed(n), Content(cap=None) or Fill()")
+        if not callable(self.render):
+            raise ComponentError(
+                f"component {self.id}: render must be callable, not "
+                f"{contain.one_line(repr(self.render))}")
+        object.__setattr__(self, "title", contain.one_line(self.title))
+        object.__setattr__(self, "needs", _tuple("needs", self.id, self.needs, NEEDS))
+        object.__setattr__(
+            self, "events", _tuple("events", self.id, self.events, EVENT_KINDS))

--- a/charter/frame/ctx.py
+++ b/charter/frame/ctx.py
@@ -1,0 +1,144 @@
+"""What a component is handed when it draws: geometry, identity, and its declared slices.
+
+**Constructed FROM ``needs``** (§4e). A component receives an object holding exactly what
+it declared plus the fixed geometry, and asking for anything else raises with the name of
+the thing to add to ``needs``. That is what makes the idle-cost property — one ``stat``
+per panel per tick, which `frame/panel.py` was built around — survive code charter did not
+write: today it is verified by a reviewer reading charter's own renderers, and a reviewer
+cannot read a provider's.
+
+**Absent, not disabled.** A slice that was not declared is not an attribute holding
+``None``, an empty stand-in or a handle that raises when used. It is not there at all. A
+present-but-empty attribute is indistinguishable from a slice that happens to be empty,
+so a component could ship reading nothing and nobody would find out until an operator's
+pane was blank — which is the confidently-wrong output the left sidebar was retired for.
+
+**One snapshot, one timestamp** (§4f). Every slice below comes out of the same scan, so
+"everything on screen is from the same moment" is true by construction rather than by two
+caches happening to agree. A component never gets a way to fetch a fresher one: refreshing
+is the frame's decision, on the frame's clock.
+
+**What this is not.** It is not a sandbox, and nothing here pretends otherwise: a
+provider's module is ordinary Python and can import the standard library like any other.
+What ``ctx`` rules out is the accident and the shortcut — a filesystem handle, a
+subprocess factory or a client sitting on the object because it was convenient once,
+which a renderer then reaches for and whose cost lands on every operator's tick. The
+declaration is what makes that cost visible in review and in config, rather than
+discovered in a profile.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from .. import contain
+from .component import ComponentError, cells, names
+
+
+def _rows(key: str):
+    """A snapshot list served as a tuple — see :data:`SERVES`."""
+    return lambda snap: tuple(snap.get(key) or ())
+
+
+#: How each declared name is cut out of the one snapshot. This mapping IS the vocabulary
+#: `component.NEEDS` names — a test asks each against the other, so a slice cannot be
+#: served without being declarable, or declared without being served.
+#:
+#: **A list arrives as a tuple and a mapping as a read-only view.** One snapshot is
+#: shared by every component in a repaint, so a component that appended to a list, or
+#: cleared it, would be editing what the next one is about to draw. The containment is
+#: SHALLOW and this says so plainly: a repo row inside ``repos`` is still a mutable dict,
+#: and making it otherwise would cost a deep copy per component per tick — which is the
+#: exact budget this module exists to protect. What is bought here is that the SHAPE of
+#: the frame's data cannot be rewritten under another component's feet.
+#:
+#: ``gather`` is the whole scan because that is what today's renderers read — `_bottom`,
+#: `_repos` and `_right` each take `gather.read(fid)` entire. It is a slice like the
+#: others rather than a back door: a component that declared ``todos`` does not get it.
+SERVES = {
+    "gather": lambda snap: MappingProxyType(snap),
+    "repos": _rows("repos"),
+    "todos": _rows("todos"),
+}
+
+#: The keys every component gets whatever it declared: how much room it has, and which
+#: frame it is drawing in. Named once so :func:`build` and the tests that assert the
+#: attribute set exactly are reading the same list.
+GEOMETRY = ("width", "height", "fid")
+
+
+class Ctx:
+    """One repaint's worth of what one component may read.
+
+    No public methods, deliberately. Everything reachable by name on this object is a
+    field that was declared or a piece of geometry, which is what lets a test assert the
+    attribute set *exactly* — and that assertion is the point: a future field is a
+    widening of what a stranger's code may reach, and it should cost a test change and
+    the conversation that goes with it.
+    """
+
+    def __init__(self, fields: Mapping[str, Any]) -> None:
+        # Straight into ``__dict__``, because ``__setattr__`` below refuses everything.
+        self.__dict__.update(fields)
+
+    def __getattr__(self, name: str) -> Any:
+        """Only reached when the attribute is genuinely absent — and it says why.
+
+        Two different mistakes, told apart, because they need different fixes: a slice
+        charter serves that this component did not ask for, and a name nothing serves at
+        all. Answering both with a bare ``AttributeError`` would leave a provider author
+        guessing which of the two they had made.
+        """
+        shown = contain.one_line(repr(name))
+        if name in SERVES:
+            raise AttributeError(
+                f"this component did not declare {name}: add it to the component's "
+                f"needs to be handed it")
+        raise AttributeError(
+            f"a component ctx has no {shown} — charter serves "
+            f"{', '.join(GEOMETRY)} and the declared needs "
+            f"({', '.join(SERVES)})")
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """A ctx is what this repaint was handed, not a place to keep state.
+
+        A composite's parts share a pane and draw one after another; a writable ctx would
+        be a channel between them that nothing declared and nothing bounds.
+        """
+        raise AttributeError(
+            f"a component ctx is read-only; {contain.one_line(repr(name))} cannot be set")
+
+    def __delattr__(self, name: str) -> None:
+        raise AttributeError(
+            f"a component ctx is read-only; {contain.one_line(repr(name))} cannot be "
+            f"removed")
+
+
+def build(needs, *, width: int, height: int, fid: str, snapshot: Mapping) -> Ctx:
+    """The object *needs* asked for, cut from *snapshot* at *width* x *height*.
+
+    Every argument is checked before anything is served, and each refusal is a
+    `ComponentError` — the one type the whole contract raises, so a caller that draws a
+    failed component's message in its own pane rather than losing the session (§4b) has
+    one thing to catch.
+
+    A key the snapshot does not carry is served as its empty value rather than refused:
+    `gather.read` answers ``{}`` for a frame whose cache has not been written yet, and a
+    panel at that moment must draw something. That is a missing *reading*, which is the
+    frame's normal cold state — not a missing *declaration*, which is the mistake the
+    attribute error above exists for.
+    """
+    served = names("needs", "this component", needs, tuple(SERVES))
+    cells("a pane's width", width, floor=0)
+    cells("a pane's height", height, floor=0)
+    if not isinstance(fid, str):
+        raise ComponentError(
+            f"a frame id must be text, not {contain.one_line(repr(fid))}")
+    if not isinstance(snapshot, Mapping):
+        raise ComponentError(
+            f"a snapshot must be one mapping of plane state, not "
+            f"{contain.one_line(repr(snapshot))}")
+    fields = {"width": width, "height": height, "fid": fid}
+    fields.update({name: SERVES[name](snapshot) for name in served})
+    return Ctx(fields)

--- a/charter/frame/registry.py
+++ b/charter/frame/registry.py
@@ -1,0 +1,184 @@
+"""What is on screen, in what order, and which pane owns which component.
+
+One object answers the two questions the frame has always had to answer twice: *which
+components are placed on this edge* and *in what order were they placed*. Today the
+answer is a list of four strings in `instance.FRAME_SLOTS` whose POSITION is the geometry
+— which is why three separate mechanisms grew to change what is on screen (`[frame]
+slots`, `[frame] density`, `cmd_density`'s live re-layout), each with its own idea of what
+a slot is.
+
+**Registration order IS split order, and it is stored rather than derived.**
+`layout.panel_argvs` splits each panel off the harness pane in order, so what a component
+is registered AFTER decides how much room is left for it. Measured against tmux 3.7c in a
+200x50 window (#386): ``["top", "bottom", "right"]`` gives a **200-column** bottom row,
+while ``["top", "right", "bottom"]`` gives **177** — the same three panels, the same
+edges, inset beside the side panel instead of running the full width. The spec's
+200-versus-**154** is the same measurement of the arrangement charter shipped before #488
+retired `left`, where two 22-column sidebars and their borders came off the row instead of
+one. The number moved when a panel was retired; the property did not, and the property is
+what this module stores.
+
+So :meth:`Registry.split_order` answers with the number the registry assigned at
+registration time. Nothing here derives an order from a list position, a sorted mapping or
+an edge grouping — a filtered view (:meth:`Registry.on_edge`) is a filter over that one
+order and never a renumbering of what is left.
+
+**Composition is one level, and it is arbitrated here.** A component owns a pane and
+charter never draws splits inside one (§4d); a composite is how N things share a pane. The
+rules — one level only, exactly one child taking what is left, no child claimed by two
+parents — need to see every component together, and the registry is the only thing that
+does. All three are refused at registration, naming both offenders, because a tie broken
+at layout time produces a frame that shifts with the data (§4e) and cannot be reproduced
+from the configuration that caused it.
+"""
+
+from __future__ import annotations
+
+from .. import contain
+from .component import EDGES, Component, ComponentError, Fill
+
+
+class Registry:
+    """The components this frame knows about, in the order they were registered.
+
+    An instance rather than module state, so a caller — a test, a config boundary
+    resolving one repo's `[[frame.component]]` tables, a future second frame — builds its
+    own and cannot be affected by what another one registered. Module-level mutable state
+    shared behind per-caller objects is the isolation-that-is-a-fiction shape `PersonaIso`
+    exists for, one layer down.
+    """
+
+    def __init__(self) -> None:
+        self._by_id: dict[str, Component] = {}
+        #: id → the split it is, assigned once and never recomputed. A separate mapping
+        #: rather than "the position in ``self._by_id``": dicts preserve insertion order,
+        #: so the two agree today and would silently disagree the first time anything
+        #: rebuilt, filtered or re-keyed that dict — and the disagreement would be a
+        #: geometry change nothing announced.
+        self._order: dict[str, int] = {}
+        self._next = 1
+        #: child id → the composite that draws it. The reason a child leaves
+        #: :meth:`on_edge` without leaving the registry.
+        self._parent: dict[str, str] = {}
+
+    # -- registering ------------------------------------------------------- #
+
+    def register(self, c: Component) -> Component:
+        """Add *c*, at the end of the split order, and answer it.
+
+        Every cross-component rule is checked here, before anything is stored, so a
+        refusal leaves the registry exactly as it was: half a composite is a frame with a
+        pane whose contents nothing owns.
+        """
+        if not isinstance(c, Component):
+            raise ComponentError(
+                f"{contain.one_line(repr(c))} is not a component — build one with "
+                f"frame.component.Component(...)")
+        if c.id in self._by_id:
+            was = self._by_id[c.id]
+            raise ComponentError(
+                f"two components claim the id {c.id}: {was.title} is registered and "
+                f"{c.title} wants the same id. Neither is placed by charter picking "
+                f"one — rename one of them")
+        if c.children:
+            self._check_children(c)
+        self._by_id[c.id] = c
+        self._order[c.id] = self._next
+        self._next += 1
+        for child in c.children:
+            self._parent[child] = c.id
+        return c
+
+    def _check_children(self, c: Component) -> None:
+        """The three composition rules, each raising with both offenders named."""
+        fills, seen = [], set()
+        for cid in c.children:
+            if cid in seen:
+                raise ComponentError(
+                    f"component {c.id} lists {cid} twice — a pane draws each of its "
+                    f"parts once")
+            seen.add(cid)
+            child = self._by_id.get(cid)
+            if child is None:
+                raise ComponentError(
+                    f"component {c.id} is built from {cid}, which is not registered — "
+                    f"register the parts before the composite that draws them")
+            if child.children:
+                raise ComponentError(
+                    f"component {c.id} is built from {cid}, which is itself built from "
+                    f"other components. Composition is one level: a component is a leaf "
+                    f"or a composite of leaves")
+            if cid in self._parent:
+                raise ComponentError(
+                    f"component {c.id} is built from {cid}, which {self._parent[cid]} "
+                    f"already draws — one pane draws it, and two claims have no answer")
+            if isinstance(child.size, Fill):
+                fills.append(cid)
+        if len(fills) != 1:
+            named = ", ".join(fills) if fills else "none of them"
+            raise ComponentError(
+                f"component {c.id} needs exactly one part sized Fill() to take what is "
+                f"left of its pane, and {named} " +
+                ("do" if len(fills) > 1 else "does") + ". Size the others Fixed(n) or "
+                f"Content(cap=…)")
+
+    # -- asking ------------------------------------------------------------ #
+
+    def get(self, cid: str) -> Component:
+        """The component registered as *cid*.
+
+        Raises `ComponentError` rather than `KeyError` when nothing is registered under
+        that id: the id may have come from a committed `charter.toml` naming a provider
+        this machine has not installed, which is a message and not a crash (§4b), and a
+        caller degrading that way has one type to catch for the whole contract.
+        """
+        try:
+            return self._by_id[cid]
+        except (KeyError, TypeError):
+            raise ComponentError(
+                f"no component is registered as {contain.one_line(repr(cid))}") from None
+
+    def all(self) -> tuple[Component, ...]:
+        """Every registered component, composites and their parts alike, in split order.
+
+        A part is still registered — it is drawn by its parent rather than by the frame,
+        which is a placement question and not an existence one. A menu row naming it, and
+        the intra-pane focus §4e gives charter, both need it to be here.
+        """
+        return tuple(sorted(self._by_id.values(), key=lambda c: self._order[c.id]))
+
+    def on_edge(self, edge: str) -> tuple[Component, ...]:
+        """The components PLACED on *edge*, in split order.
+
+        A composite's parts are absent: their parent draws them inside its own pane, and
+        a part that appeared here too would be drawn twice — once in its own pane and
+        once inside its parent's.
+
+        An unrecognised edge is refused rather than answered with ``()``. An empty answer
+        is indistinguishable from "nothing is placed there", so a typo would be a missing
+        panel that nothing anywhere reports.
+        """
+        if edge not in EDGES:
+            raise ComponentError(
+                f"{contain.one_line(repr(edge))} is not an edge — one of "
+                f"{', '.join(EDGES)}")
+        return tuple(c for c in self.all()
+                     if c.edge == edge and c.id not in self._parent)
+
+    def children_of(self, cid: str) -> tuple[Component, ...]:
+        """The parts *cid* draws, in the order it declared them — ``()`` for a leaf.
+
+        Declared order, not split order: these share one pane, and the frame never split
+        it, so the order is the order the composite's own renderer stacks them in.
+        """
+        return tuple(self.get(child) for child in self.get(cid).children)
+
+    def split_order(self, cid: str) -> int:
+        """Which split *cid* is — the number assigned when it was registered.
+
+        Asked rather than inferred. A caller that needs "which split is this" must not
+        have to count positions in a list somebody may have filtered first: `on_edge`
+        already returns such a list, and the numbers it carries are these.
+        """
+        self.get(cid)                       # the refusal that names an unknown id
+        return self._order[cid]

--- a/tests/test_component_contract.py
+++ b/tests/test_component_contract.py
@@ -1,0 +1,238 @@
+"""What a component promises before anything places it or draws it.
+
+The contract is the public seam a third-party provider binds to (spec §4b), and charter's
+own components are its first consumers — so every rule here is enforced at construction,
+where a provider meets it, rather than checked later by whichever call site happens to
+remember.
+
+**The id rules are a containment boundary, not a style preference.** A component id
+reaches a menu row and a tmux pane title, and `instance._HOTKEY_RE` exists because a
+newline in a committed `[frame] hotkey` reached tmux CONFIG TEXT and achieved code
+execution at launch, silently, with no keypress. An id arrives from the same class of
+place — a committed `charter.toml` names it, an installed provider declares it — so it is
+held to the same closed alphabet, and the tests below spend most of their length on the
+values that are refused rather than the one that is accepted.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import unittest
+
+from charter.frame import component
+
+
+def _c(**kw):
+    """A valid component, with *kw* replacing one field at a time.
+
+    Every case below differs from a working component in exactly one way, so a refusal
+    can only be about the field the case names.
+    """
+    base = dict(id="demo", title="Demo", edge="right", size=component.Fixed(3),
+                needs=("gather",), events=(), render=lambda ctx: ["x"])
+    base.update(kw)
+    return component.Component(**base)
+
+
+class TheContract(unittest.TestCase):
+    def test_a_component_declares_what_it_reads(self):
+        c = component.Component(id="demo", title="Demo", edge="right",
+                                size=component.Fixed(3), needs=("gather",),
+                                events=(), render=lambda ctx: ["x"])
+        self.assertEqual(c.needs, ("gather",))
+        self.assertEqual(component.API_VERSION, 1)
+
+    def test_a_component_cannot_be_edited_after_it_is_constructed(self):
+        """Frozen, because every rule here is checked once, at construction.
+
+        A mutable `edge` or `size` would move the whole of this file's enforcement to
+        wherever the field is next read — which is the shape the registry is replacing,
+        where a slot's list position was its geometry and nothing owned the rule.
+        """
+        c = _c()
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            c.edge = "top"
+
+    def test_the_fields_are_keyword_only(self):
+        """Field ORDER is not part of the contract, and must not become part of it.
+
+        Task 3 adds `children`; a provider that had spelled its component positionally
+        would break on that addition, having done nothing wrong.
+        """
+        with self.assertRaises(TypeError):
+            component.Component("demo", "Demo", "right", component.Fixed(3),
+                                (), (), lambda ctx: [])
+
+
+class SizePolicies(unittest.TestCase):
+    """Three policies, and each one validates its own number.
+
+    Children declare, the parent arbitrates (spec §4e) — so a nonsense size is refused
+    where it is written, not resolved as a tie-break while a frame is being laid out.
+    """
+
+    def test_the_three_policies_carry_what_the_spec_says_they_carry(self):
+        self.assertEqual(component.Fixed(3).n, 3)
+        self.assertIsNone(component.Content().cap)
+        self.assertEqual(component.Content(9).cap, 9)
+        self.assertEqual(component.Fill(), component.Fill())
+
+    def test_a_fixed_size_must_be_a_positive_count_of_cells(self):
+        for n in (0, -1, 1.5, "3", None):
+            with self.subTest(n=n), self.assertRaises(component.ComponentError):
+                component.Fixed(n)
+
+    def test_a_bool_is_not_a_size(self):
+        """`Fixed(True)` is `Fixed(1)` to `isinstance(n, int)`, and means nothing.
+
+        The fixture-value class of defect this suite keeps finding: a value that passes
+        the type check while carrying a different meaning entirely.
+        """
+        with self.assertRaises(component.ComponentError):
+            component.Fixed(True)
+
+    def test_a_content_cap_is_absent_or_a_positive_count(self):
+        for cap in (0, -2, 1.5, "9", True):
+            with self.subTest(cap=cap), self.assertRaises(component.ComponentError):
+                component.Content(cap)
+
+    def test_a_size_that_is_not_a_policy_is_refused(self):
+        for size in (3, "content", None, component.Fixed):
+            with self.subTest(size=size), self.assertRaises(component.ComponentError):
+                _c(size=size)
+
+
+class IdIsAContainmentBoundary(unittest.TestCase):
+    def test_a_newline_in_an_id_is_refused(self):
+        """`instance._HOTKEY_RE`'s incident, one surface over.
+
+        The refusal itself is a line of charter's own output naming the offender, so the
+        offender must not be able to write a second line of it either.
+        """
+        with self.assertRaises(component.ComponentError) as e:
+            _c(id="demo\nbind -n F2 run-shell 'touch /tmp/PWNED'")
+        self.assertNotIn("\n", str(e.exception))
+        self.assertIn("PWNED", str(e.exception))       # named, not swallowed
+
+    def test_a_namespaced_provider_id_is_accepted(self):
+        self.assertEqual(_c(id="acme.metrics").id, "acme.metrics")
+
+    def test_a_built_in_id_needs_no_namespace(self):
+        for good in ("repos", "personas", "todos", "attention", "identity", "s1"):
+            with self.subTest(id=good):
+                self.assertEqual(_c(id=good).id, good)
+
+    def test_one_dot_only(self):
+        """Namespaced by distribution (§4h) — one segment, one id, and no more.
+
+        A third level is not a deeper namespace; it is a second syntax nobody decided on.
+        """
+        with self.assertRaises(component.ComponentError):
+            _c(id="acme.metrics.rows")
+
+    def test_everything_outside_the_alphabet_is_refused(self):
+        bad = ["", " ", "Repos", "re pos", "repos;ls", "../repos", "repos/x",
+               "repos\x1b[31m", "acme.", ".metrics", "acme..metrics", "1repos",
+               "repos\r", "repos\t", "repos$(id)", "repos'", 'repos"', "repos#{x}",
+               "repos{}", "repos-x", "repos​", "a" * 65, "_repos", None, 7, b"repos"]
+        for value in bad:
+            with self.subTest(id=value), self.assertRaises(component.ComponentError):
+                _c(id=value)
+
+    def test_the_refusal_says_what_a_usable_id_looks_like(self):
+        """A refusal a provider author cannot act on costs them a bisect."""
+        with self.assertRaises(component.ComponentError) as e:
+            _c(id="Repos")
+        self.assertIn("Repos", str(e.exception))
+        self.assertIn(component.ID_HINT, str(e.exception))
+
+
+class TitleCannotForgeARow(unittest.TestCase):
+    def test_a_newline_in_a_title_is_contained_rather_than_refused(self):
+        """A title is display text with an open alphabet; an id is a name with a closed
+        one. So the title is contained the way every other committed display value is,
+        and what a reader would recognise survives.
+        """
+        c = _c(title="Demo\n  fake  fake")
+        self.assertNotIn("\n", c.title)
+        self.assertIn("\\x0a", c.title)
+        self.assertIn("Demo", c.title)
+
+    def test_a_title_that_is_not_text_is_refused(self):
+        for title in (None, 7, ["Demo"]):
+            with self.subTest(title=title), self.assertRaises(component.ComponentError):
+                _c(title=title)
+
+
+class EdgeIsAClosedSet(unittest.TestCase):
+    def test_the_four_edges_are_accepted(self):
+        for edge in component.EDGES:
+            with self.subTest(edge=edge):
+                self.assertEqual(_c(edge=edge).edge, edge)
+
+    def test_anything_else_is_refused_naming_the_edges(self):
+        for edge in ("middle", "Right", "", None, "right ", "left,right"):
+            with self.subTest(edge=edge), self.assertRaises(component.ComponentError) as e:
+                _c(edge=edge)
+            self.assertIn("bottom", str(e.exception))
+
+
+class NeedsAreTheDeclaredCost(unittest.TestCase):
+    def test_a_slice_nobody_serves_is_refused_at_construction(self):
+        """A typo in `needs` is a component that silently reads nothing.
+
+        `ctx` is built FROM `needs` (§4e), so an unserved name would produce an
+        attribute that is simply absent at render time — a blank pane, which is the
+        confidently-wrong output the left sidebar was retired for.
+        """
+        with self.assertRaises(component.ComponentError) as e:
+            _c(needs=("gathr",))
+        self.assertIn("gathr", str(e.exception))
+        self.assertIn("gather", str(e.exception))      # names what is on offer
+
+    def test_a_bare_string_is_not_a_tuple_of_needs(self):
+        """`needs="gather"` is a sequence of six one-letter needs to anything that
+        iterates it, and every one of them would be refused for the wrong reason."""
+        with self.assertRaises(component.ComponentError) as e:
+            _c(needs="gather")
+        self.assertIn("tuple", str(e.exception))
+
+    def test_a_list_of_needs_becomes_a_tuple(self):
+        self.assertEqual(_c(needs=["gather", "todos"]).needs, ("gather", "todos"))
+
+    def test_declaring_nothing_is_allowed_and_is_the_cheap_case(self):
+        self.assertEqual(_c(needs=()).needs, ())
+
+
+class EventsAreTheClosedFive(unittest.TestCase):
+    def test_every_named_kind_is_accepted(self):
+        self.assertEqual(_c(events=component.EVENT_KINDS).events,
+                         tuple(component.EVENT_KINDS))
+
+    def test_drag_was_deliberately_excluded_and_stays_excluded(self):
+        """§4f: adding `drag` later costs nothing; removing it after a provider has
+        shipped against it costs everything."""
+        with self.assertRaises(component.ComponentError) as e:
+            _c(events=("drag",))
+        self.assertIn("drag", str(e.exception))
+        self.assertIn("scroll", str(e.exception))
+
+    def test_a_bare_string_is_not_a_tuple_of_events(self):
+        with self.assertRaises(component.ComponentError):
+            _c(events="key")
+
+
+class RenderIsCallable(unittest.TestCase):
+    def test_a_renderer_that_cannot_be_called_is_refused(self):
+        for r in (None, "render", ["x"]):
+            with self.subTest(render=r), self.assertRaises(component.ComponentError):
+                _c(render=r)
+
+    def test_the_renderer_is_kept_as_handed_over(self):
+        def rendered(ctx):
+            return ["x"]
+        self.assertIs(_c(render=rendered).render, rendered)
+
+
+if __name__ == "__main__":                                 # pragma: no cover
+    unittest.main()

--- a/tests/test_component_contract.py
+++ b/tests/test_component_contract.py
@@ -114,6 +114,18 @@ class IdIsAContainmentBoundary(unittest.TestCase):
         self.assertNotIn("\n", str(e.exception))
         self.assertIn("PWNED", str(e.exception))       # named, not swallowed
 
+    def test_an_id_ending_in_a_newline_is_refused(self):
+        """Its own case, because it is the one a correct-looking pattern still admits.
+
+        Python's `$` matches at the end of the string OR just before a trailing newline,
+        so `_ID_RE.match("personas\\n")` succeeds against a pattern written to exclude
+        newlines outright. `frame_of` reaches for `fullmatch` on `instance._HOTKEY_RE`
+        for exactly this reason; the id in the middle of a line above is refused by a
+        pattern with the hole still in it, and only this case fails when it is there.
+        """
+        with self.assertRaises(component.ComponentError):
+            _c(id="personas\n")
+
     def test_a_namespaced_provider_id_is_accepted(self):
         self.assertEqual(_c(id="acme.metrics").id, "acme.metrics")
 
@@ -220,6 +232,27 @@ class EventsAreTheClosedFive(unittest.TestCase):
     def test_a_bare_string_is_not_a_tuple_of_events(self):
         with self.assertRaises(component.ComponentError):
             _c(events="key")
+
+
+class ChildrenAreIdsOfTheSameShape(unittest.TestCase):
+    """What a composite's parts LOOK like is this module's rule; what they refer to is
+    the registry's, because only the registry sees every component at once."""
+
+    def test_a_leaf_declares_no_children(self):
+        self.assertEqual(_c().children, ())
+
+    def test_children_are_kept_in_declared_order(self):
+        self.assertEqual(_c(children=["personas", "todos"]).children,
+                         ("personas", "todos"))
+
+    def test_a_child_id_is_held_to_the_same_alphabet_as_an_id(self):
+        for child in ("Personas", "personas\n", "../personas", ""):
+            with self.subTest(child=child), self.assertRaises(component.ComponentError):
+                _c(children=(child,))
+
+    def test_a_bare_string_is_not_a_tuple_of_children(self):
+        with self.assertRaises(component.ComponentError):
+            _c(children="personas")
 
 
 class RenderIsCallable(unittest.TestCase):

--- a/tests/test_component_ctx.py
+++ b/tests/test_component_ctx.py
@@ -1,0 +1,202 @@
+"""A component receives what it declared, and there is nothing else on the object.
+
+This is the decision the whole extension model rests on (§4e): `ctx` is constructed FROM
+`needs`, so the idle-cost property — one `stat` per panel per tick — is enforced by what
+was handed over rather than by a reviewer counting `stat`s in code charter did not write.
+
+**Absent, not disabled.** A component that did not declare a slice does not get an
+attribute holding `None`, an empty stand-in, or a handle that raises when used: the
+attribute is not there, and the `AttributeError` names what to add. A present-but-empty
+attribute is indistinguishable from a slice that happened to be empty, which is how a
+component ships reading nothing and nobody notices until an operator's frame is blank.
+
+The attribute set is asserted exactly, twice over, so a field cannot be added to `ctx`
+without a test change — which is the point: every future field is a widening of what a
+stranger's code may reach, and it should cost a conversation.
+"""
+
+from __future__ import annotations
+
+import types
+import unittest
+
+from charter.frame import component, ctx
+
+
+def _snapshot() -> dict:
+    """A plane scan of the shape `gather.scan` produces — fresh each call.
+
+    Fresh because a shared fixture that any test could edit is a fixture the next test
+    reads instead of its own.
+    """
+    return {"gathered_at": 1755000000.0, "workspace": "plane", "current_repo": "charter",
+            "repos": [{"name": "charter", "dirty": 0}, {"name": "other", "dirty": 2}],
+            "worktrees": [], "todos": [{"title": "one"}, {"title": "two"}],
+            "todo_count": 2}
+
+
+#: "the caller said nothing" as a value of its own, because `None` is one of the
+#: snapshots a test below hands over ON PURPOSE and must reach `build` unchanged.
+_UNSAID = object()
+
+
+def _ctx_for(needs=(), *, width=80, height=10, fid="f1", snapshot=_UNSAID):
+    return ctx.build(needs, width=width, height=height, fid=fid,
+                     snapshot=_snapshot() if snapshot is _UNSAID else snapshot)
+
+
+class OnlyWhatWasDeclared(unittest.TestCase):
+    def test_a_component_gets_only_what_it_declared(self):
+        c = _ctx_for(needs=("gather",), width=80, height=10)
+        self.assertEqual(c.width, 80)
+        self.assertIsNotNone(c.gather)
+        with self.assertRaises(AttributeError):
+            c.todos             # not declared -> not present
+
+    def test_the_attribute_set_is_exactly_the_declaration_plus_the_geometry(self):
+        """Both halves of "exactly": the instance's own fields, and everything a
+        component could reach by name on the object."""
+        c = _ctx_for(needs=("repos", "todos"))
+        expected = {"width", "height", "fid", "repos", "todos"}
+        self.assertEqual(set(vars(c)), expected)
+        self.assertEqual({n for n in dir(c) if not n.startswith("_")}, expected)
+
+    def test_declaring_nothing_leaves_the_geometry_and_nothing_else(self):
+        c = _ctx_for(needs=())
+        self.assertEqual(set(vars(c)), {"width", "height", "fid"})
+
+    def test_the_refusal_names_the_slice_and_where_to_declare_it(self):
+        c = _ctx_for(needs=("gather",))
+        with self.assertRaises(AttributeError) as e:
+            c.repos
+        self.assertIn("repos", str(e.exception))
+        self.assertIn("needs", str(e.exception))
+
+    def test_an_attribute_nobody_serves_at_all_is_refused_the_same_way(self):
+        """A typo reads like a slice that is turned off, and it must not."""
+        c = _ctx_for(needs=("gather",))
+        with self.assertRaises(AttributeError) as e:
+            c.reposs
+        self.assertIn("reposs", str(e.exception))
+
+    def test_a_slice_that_is_not_served_cannot_be_asked_for(self):
+        with self.assertRaises(component.ComponentError) as e:
+            _ctx_for(needs=("filesystem",))
+        self.assertIn("filesystem", str(e.exception))
+
+    def test_two_components_reading_one_snapshot_get_different_objects(self):
+        """The property the mutation "hand over the whole snapshot" breaks."""
+        snap = _snapshot()
+        wide = ctx.build(("gather", "repos"), width=80, height=10, fid="f1",
+                         snapshot=snap)
+        narrow = ctx.build(("todos",), width=80, height=10, fid="f1", snapshot=snap)
+        self.assertEqual(set(vars(narrow)), {"width", "height", "fid", "todos"})
+        self.assertIn("gather", vars(wide))
+
+
+class NoEscapeHatches(unittest.TestCase):
+    """`ctx` hands over data. It hands over no way to *do* anything.
+
+    Not a sandbox, and this file does not pretend it is one: a determined provider can
+    import the standard library like any other Python code. What this rules out is the
+    accident and the shortcut — a handle sitting on `ctx` that a renderer reaches for
+    because it was there, whose cost then lands on every operator's tick.
+    """
+
+    def test_nothing_on_a_ctx_can_be_called(self):
+        c = _ctx_for(needs=tuple(component.NEEDS))
+        for name, value in vars(c).items():
+            with self.subTest(attr=name):
+                self.assertFalse(callable(value))
+                self.assertNotIsInstance(value, types.ModuleType)
+
+    def test_nothing_on_a_ctx_is_a_file_a_socket_or_a_path(self):
+        c = _ctx_for(needs=tuple(component.NEEDS))
+        for name, value in vars(c).items():
+            with self.subTest(attr=name):
+                for hatch in ("fileno", "read", "write", "connect", "open", "joinpath",
+                              "__enter__", "__fspath__"):
+                    self.assertFalse(hasattr(value, hatch), f"{name}.{hatch}")
+
+    def test_a_component_cannot_bolt_a_field_onto_its_own_ctx(self):
+        """One repaint's `ctx` is not a place to keep state, and a composite's parts
+        must not be able to leave each other messages on it."""
+        c = _ctx_for(needs=("gather",))
+        with self.assertRaises(AttributeError):
+            c.subprocess = "sh"
+        with self.assertRaises(AttributeError):
+            del c.width
+
+    def test_the_served_slices_are_the_declared_ones_and_no_others(self):
+        """One vocabulary: what `needs` may name and what `build` can serve are the same
+        list, asked of each other rather than spelled twice.
+
+        Two lists for one concept is the defect `contain.py` and `test_claims.py` were
+        both rewritten for — one of the spellings always ends up missing something.
+        """
+        self.assertEqual(set(ctx.SERVES), set(component.NEEDS))
+
+
+class SlicesComeFromTheOneSnapshot(unittest.TestCase):
+    def test_a_slice_carries_the_snapshot_s_own_content(self):
+        c = _ctx_for(needs=("repos", "todos"))
+        self.assertEqual([r["name"] for r in c.repos], ["charter", "other"])
+        self.assertEqual([t["title"] for t in c.todos], ["one", "two"])
+
+    def test_gather_is_the_whole_scan_because_today_s_renderers_read_it_whole(self):
+        c = _ctx_for(needs=("gather",))
+        self.assertEqual(c.gather["workspace"], "plane")
+        self.assertEqual(c.gather["gathered_at"], 1755000000.0)
+
+    def test_a_list_slice_arrives_as_a_tuple(self):
+        """So a component cannot append to, clear, or reorder the list the next
+        component in the same repaint is about to read."""
+        c = _ctx_for(needs=("repos",))
+        self.assertIsInstance(c.repos, tuple)
+
+    def test_the_whole_scan_cannot_be_rewritten_through_the_ctx(self):
+        c = _ctx_for(needs=("gather",))
+        with self.assertRaises(TypeError):
+            c.gather["workspace"] = "elsewhere"
+
+    def test_an_absent_key_degrades_to_empty_rather_than_raising(self):
+        """`gather.read` answers `{}` for a frame whose cache has not been written yet,
+        and a panel must draw something at that moment rather than fail."""
+        c = _ctx_for(needs=("repos", "todos", "gather"), snapshot={})
+        self.assertEqual(c.repos, ())
+        self.assertEqual(c.todos, ())
+        self.assertEqual(dict(c.gather), {})
+
+    def test_a_snapshot_that_is_not_a_mapping_is_refused(self):
+        for snap in (None, [], "gathered"):
+            with self.subTest(snapshot=snap), self.assertRaises(component.ComponentError):
+                _ctx_for(needs=("gather",), snapshot=snap)
+
+
+class Geometry(unittest.TestCase):
+    def test_width_and_height_are_the_pane_s_own(self):
+        c = _ctx_for(width=22, height=46)
+        self.assertEqual((c.width, c.height), (22, 46))
+
+    def test_the_frame_id_travels_with_the_geometry(self):
+        self.assertEqual(_ctx_for(fid="charter-demo-1234").fid, "charter-demo-1234")
+
+    def test_a_geometry_that_is_not_a_count_of_cells_is_refused(self):
+        for kw in ({"width": -1}, {"height": -1}, {"width": 1.5}, {"height": "10"},
+                   {"width": True}, {"width": None}):
+            with self.subTest(**kw), self.assertRaises(component.ComponentError):
+                _ctx_for(**kw)
+
+    def test_a_frame_id_that_is_not_text_is_refused(self):
+        for fid in (None, 7, ["f1"]):
+            with self.subTest(fid=fid), self.assertRaises(component.ComponentError):
+                _ctx_for(fid=fid)
+
+    def test_a_collapsed_pane_is_zero_and_not_an_error(self):
+        """tmux can leave a pane with no room at all; that is a frame to draw nothing
+        in, not a frame to refuse."""
+        self.assertEqual(_ctx_for(width=0, height=0).width, 0)
+
+
+if __name__ == "__main__":                                 # pragma: no cover
+    unittest.main()

--- a/tests/test_component_registry.py
+++ b/tests/test_component_registry.py
@@ -1,0 +1,230 @@
+"""What is on screen, in what order, and which pane owns which component.
+
+Two properties carry the whole file.
+
+**Order is geometry.** `layout.panel_argvs` splits each panel off the harness pane in
+order, so what a component is placed AFTER decides how much room it gets — measured
+against tmux 3.7c in a 200x50 window (#386). The registry therefore stores the order it
+was given, explicitly, and the tests below assert against an order that is neither
+alphabetical nor grouped by edge, so nothing can pass by deriving it from a list position
+or a sorted dict.
+
+**Composition is one level and arbitrates exactly one `Fill()`** (§4e, §4h). Both are
+registration-time errors naming both offenders, because a tie broken at layout time
+produces a frame that shifts with the data — which reads as a bug every time, and cannot
+be reproduced from the config that caused it.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter.frame import component, registry
+
+
+def _c(cid, **kw):
+    """A leaf component with a valid everything, differing only where a case says so."""
+    base = dict(id=cid, title=cid.title(), edge="right", size=component.Fixed(3),
+                needs=(), events=(), render=lambda ctx: [cid])
+    base.update(kw)
+    return component.Component(**base)
+
+
+class RegistrationOrderIsSplitOrder(unittest.TestCase):
+    def setUp(self):
+        self.r = registry.Registry()
+
+    def test_two_components_on_an_edge_come_back_in_registration_order(self):
+        self.r.register(_c("zulu", edge="bottom"))
+        self.r.register(_c("alpha", edge="bottom"))
+        self.assertEqual([c.id for c in self.r.on_edge("bottom")], ["zulu", "alpha"])
+
+    def test_order_is_neither_alphabetical_nor_grouped_by_edge(self):
+        """The two orders a careless implementation would produce instead.
+
+        `["top", "bottom", "right"]` gives a 200-column bottom row and
+        `["top", "right", "bottom"]` gives 177 — the same three components, the same
+        edges, a different geometry — so an `all()` that sorted or grouped would be
+        returning a different frame while looking correct.
+        """
+        for cid, edge in (("top_bar", "top"), ("side", "right"), ("attention", "bottom")):
+            self.r.register(_c(cid, edge=edge))
+        self.assertEqual([c.id for c in self.r.all()], ["top_bar", "side", "attention"])
+
+    def test_the_order_is_stored_as_a_number_rather_than_a_list_position(self):
+        """Asked of the registry, not read off `all()`.
+
+        A caller that needs "which split is this" — `layout`, and every future
+        re-application of sizes — must be able to ask, rather than infer it from where
+        the component happened to land in a list somebody may later filter.
+        """
+        self.r.register(_c("first", edge="top"))
+        self.r.register(_c("second", edge="bottom"))
+        self.assertLess(self.r.split_order("first"), self.r.split_order("second"))
+
+    def test_a_filtered_view_does_not_renumber_what_is_left(self):
+        """`on_edge` is a filter over one order, not an order of its own."""
+        for cid, edge in (("a_one", "top"), ("b_two", "right"), ("c_three", "right")):
+            self.r.register(_c(cid, edge=edge))
+        self.assertEqual([self.r.split_order(c.id) for c in self.r.on_edge("right")],
+                         [self.r.split_order("b_two"), self.r.split_order("c_three")])
+        self.assertNotEqual(self.r.split_order("b_two"), 0)
+
+
+class OneIdOneComponent(unittest.TestCase):
+    def setUp(self):
+        self.r = registry.Registry()
+
+    def test_a_duplicate_id_is_refused_naming_both(self):
+        """§4h: silently picking one means the frame shows something whose origin cannot
+        be determined, and "which of my two plugins drew this" is a debugging problem
+        with no entry point."""
+        self.r.register(_c("metrics", title="Ours"))
+        with self.assertRaises(component.ComponentError) as e:
+            self.r.register(_c("metrics", title="Theirs"))
+        self.assertIn("metrics", str(e.exception))
+        self.assertIn("Ours", str(e.exception))
+        self.assertIn("Theirs", str(e.exception))
+
+    def test_the_first_registration_survives_the_refusal(self):
+        """A refused second registration must not have half-replaced the first."""
+        self.r.register(_c("metrics", title="Ours", edge="top"))
+        with self.assertRaises(component.ComponentError):
+            self.r.register(_c("metrics", title="Theirs", edge="bottom"))
+        self.assertEqual(self.r.get("metrics").title, "Ours")
+        self.assertEqual([c.id for c in self.r.on_edge("top")], ["metrics"])
+        self.assertEqual(self.r.on_edge("bottom"), ())
+
+    def test_asking_for_a_component_nobody_registered_names_it(self):
+        with self.assertRaises(component.ComponentError) as e:
+            self.r.get("acme.metrics")
+        self.assertIn("acme.metrics", str(e.exception))
+
+    def test_an_unknown_id_cannot_forge_the_refusal_that_names_it(self):
+        with self.assertRaises(component.ComponentError) as e:
+            self.r.get("acme\nmetrics")
+        self.assertNotIn("\n", str(e.exception))
+
+    def test_registering_something_that_is_not_a_component_is_refused(self):
+        for thing in (None, "repos", {"id": "repos"}):
+            with self.subTest(thing=thing), self.assertRaises(component.ComponentError):
+                self.r.register(thing)
+
+
+class EdgesAreAsked(unittest.TestCase):
+    def setUp(self):
+        self.r = registry.Registry()
+
+    def test_an_edge_with_nothing_on_it_is_empty(self):
+        self.assertEqual(self.r.on_edge("left"), ())
+
+    def test_a_misspelled_edge_is_a_refusal_rather_than_an_empty_frame(self):
+        """`on_edge("botom")` answering `()` is a silently missing panel."""
+        with self.assertRaises(component.ComponentError) as e:
+            self.r.on_edge("botom")
+        self.assertIn("botom", str(e.exception))
+
+
+class CompositionIsOneLevel(unittest.TestCase):
+    """A component owns a pane; charter never draws splits inside one (§4d).
+
+    A composite is how N things share a pane, and its children are placed by it rather
+    than by the frame — so they leave `on_edge`, which is what stops the same renderer
+    being drawn twice, once in its own pane and once inside its parent's.
+    """
+
+    def setUp(self):
+        self.r = registry.Registry()
+        self.r.register(_c("personas", size=component.Content(cap=8)))
+        self.r.register(_c("todos", size=component.Fill()))
+
+    def _sidebar(self, **kw):
+        base = dict(id="sidebar", children=("personas", "todos"))
+        base.update(kw)
+        return _c(base.pop("id"), **base)
+
+    def test_a_composite_holds_its_children_in_declared_order(self):
+        self.r.register(self._sidebar())
+        self.assertEqual([c.id for c in self.r.children_of("sidebar")],
+                         ["personas", "todos"])
+
+    def test_a_child_is_no_longer_placed_on_its_own_edge(self):
+        self.r.register(self._sidebar())
+        self.assertEqual([c.id for c in self.r.on_edge("right")], ["sidebar"])
+
+    def test_the_children_are_still_registered_and_reachable(self):
+        """They are hidden from placement, not deleted — `get` still answers, so a menu
+        row and a future per-child focus have something to name."""
+        self.r.register(self._sidebar())
+        self.assertEqual(self.r.get("personas").id, "personas")
+        self.assertIn("personas", [c.id for c in self.r.all()])
+
+    def test_exactly_one_child_fills_what_is_left(self):
+        self.r.register(_c("alerts", size=component.Fill()))
+        with self.assertRaises(component.ComponentError) as e:
+            self.r.register(self._sidebar(children=("personas", "todos", "alerts")))
+        self.assertIn("todos", str(e.exception))
+        self.assertIn("alerts", str(e.exception))
+        self.assertIn("sidebar", str(e.exception))
+
+    def test_a_composite_with_no_filling_child_is_refused_too(self):
+        """Zero is as unarbitrated as two: nothing has been told what the leftover rows
+        of the pane belong to, and the answer would come from whichever renderer happened
+        to run out of content first."""
+        self.r.register(_c("counts", size=component.Fixed(2)))
+        with self.assertRaises(component.ComponentError) as e:
+            self.r.register(self._sidebar(children=("personas", "counts")))
+        self.assertIn("sidebar", str(e.exception))
+        self.assertIn("Fill", str(e.exception))
+
+    def test_a_composite_of_a_composite_is_refused_naming_both(self):
+        """One level (§4h). Arbitrary nesting is the layout engine §4d refused, wearing
+        a different hat."""
+        self.r.register(self._sidebar())
+        self.r.register(_c("filler", size=component.Fill()))
+        with self.assertRaises(component.ComponentError) as e:
+            self.r.register(_c("outer", children=("sidebar", "filler")))
+        self.assertIn("outer", str(e.exception))
+        self.assertIn("sidebar", str(e.exception))
+
+    def test_a_child_nobody_registered_is_refused_naming_it(self):
+        with self.assertRaises(component.ComponentError) as e:
+            self.r.register(self._sidebar(children=("personas", "todoz")))
+        self.assertIn("todoz", str(e.exception))
+
+    def test_a_composite_cannot_contain_itself(self):
+        with self.assertRaises(component.ComponentError):
+            self.r.register(_c("sidebar", children=("sidebar",)))
+
+    def test_a_child_cannot_belong_to_two_composites(self):
+        """Two panes claiming one renderer is a placement with two answers."""
+        self.r.register(self._sidebar())
+        with self.assertRaises(component.ComponentError) as e:
+            self.r.register(_c("other", children=("todos", "personas")))
+        self.assertIn("sidebar", str(e.exception))
+        self.assertIn("other", str(e.exception))
+
+    def test_a_refused_composite_leaves_its_children_placed_as_they_were(self):
+        with self.assertRaises(component.ComponentError):
+            self.r.register(self._sidebar(children=("personas", "todoz")))
+        self.assertEqual([c.id for c in self.r.on_edge("right")], ["personas", "todos"])
+        with self.assertRaises(component.ComponentError):
+            self.r.get("sidebar")
+
+    def test_children_of_a_leaf_is_empty_rather_than_an_error(self):
+        self.assertEqual(self.r.children_of("personas"), ())
+
+
+class Registries(unittest.TestCase):
+    def test_two_registries_do_not_share_state(self):
+        """Every test above builds its own, and a module-level dict shared behind them
+        would make that isolation a fiction — the shape `PersonaIso` exists for, one
+        layer down."""
+        a, b = registry.Registry(), registry.Registry()
+        a.register(_c("repos", edge="bottom"))
+        self.assertEqual(b.all(), ())
+        self.assertEqual([c.id for c in a.all()], ["repos"])
+
+
+if __name__ == "__main__":                                 # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Phase 1, Tasks 2–4 of `docs/superpowers/plans/2026-08-26-phase1-component-registry.md`:
the component contract, the registry, and `ctx` constructed from `needs`.

**This half adds no behaviour.** Nothing registers a built-in and nothing in the frame
changes — this is the thing Task 5 will express today's components in. Three new modules,
three new test files, no existing test touched.

### The component contract (`charter/frame/component.py`)

A frozen, keyword-only dataclass: `id`, `title`, `edge`, `size`, `render`, `needs`,
`events`, `children`. Size policies are `Fixed(n)`, `Content(cap=None)` and `Fill()`, each
validating its own number. Every rule is checked at construction, which is where a
provider meets it — before charter has placed anything, before a pane exists, before
anything is on screen.

An id is held to a closed alphabet because it reaches a menu row and a pane title.
`instance._HOTKEY_RE` is the precedent and the reason: a newline in a committed
`[frame] hotkey` ended the `bind` line, `source-file` returned 0, and a second tmux
command ran at launch with no keypress. A title is the other half of that pair and gets
the other treatment — an open alphabet, so it is contained by `contain.one_line` rather
than refused.

`needs` and `events` are closed sets, so a typo is a refusal here rather than a blank pane
later. `drag` is absent from the event kinds deliberately (§4f).

### The registry (`charter/frame/registry.py`)

**Order is geometry and is stored as a number**, never derived from a list position.
`split_order(id)` is asked; `on_edge` is a filter over that one order rather than a
renumbering of what is left. The docstring carries the measurement — see the note below
about which one.

Composition is arbitrated at registration, because the registry is the only thing that
sees every component at once. Three rules, each naming both offenders: a composite of a
composite (§4h), a composite whose parts do not contain exactly one `Fill()` (§4e), and a
part claimed by two composites. A duplicate id refuses the second registration and names
both titles (§4h). Every check runs before anything is stored, so a refusal leaves the
registry exactly as it was — and a test asserts that.

### `ctx` from `needs` (`charter/frame/ctx.py`)

`build(needs, *, width, height, fid, snapshot)` returns an object holding the geometry,
the frame id and exactly the declared slices. **Absent, not disabled**: an undeclared
slice is not `None`, not an empty stand-in, not a handle that raises — it is not there,
and the `AttributeError` names what to add to `needs`.

The attribute set is asserted exactly, from both `vars()` and `dir()`, so a field cannot
be added without a test change. `Ctx` has no public methods, and two further tests assert
that nothing on a ctx is callable, a module, a file, a socket or a path. The module does
not claim to be a sandbox: a provider's code is ordinary Python. What it rules out is the
accident and the shortcut.

### Two things found on the way

**`_ID_RE` needs `fullmatch`, and the first version of this branch used `match`.** Python's
`$` matches at the end of the string *or just before a trailing newline*, so
`_ID_RE.match("personas\n")` succeeded against a pattern written to exclude newlines
outright — the one character the constant exists to keep away from tmux config text.
`frame_of` already calls `fullmatch` on `instance._HOTKEY_RE`, whose pattern carries the
same `^…$`, which is why the shipped hotkey guard does **not** have this hole. Spelled the
same way here rather than fixed a second way. Found by a test for a composite's child ids,
not by reading the pattern; it has its own test now.

**The plan's 200-versus-154 measurement is from before #488.** The plan asks for that
number in the registry docstring. charter's own committed measurement (`instance.py`,
#386, tmux 3.7c) is **200 versus 177** for the slot set charter ships today; 154 is the
same measurement of the arrangement that had *two* 22-column sidebars, before #488 retired
`left`. The docstring states the current number, then records where 154 came from — the
number moved when a panel was retired, the property did not. Writing 154 as charter's own
claim would contradict the source two files away.

### Verification

Full suite twice, both green, with the ambient charter variables cleared:

* cleared: `Ran 5789 tests` — `OK`
* cleared plus `CHARTER_WORKSPACE=harness-wrapper`: `Ran 5789 tests` — `OK`

5712 on `main` plus 77 new tests. No existing test modified.

Twelve mutations, each applied, run, restored, with `__pycache__` cleared between —
reported with the result the suite actually printed, in the commit messages. Contract: the
id pattern (RED, 29), title containment (RED, 1), the unknown-name check (RED, 2), the
bare-string check (RED, 2), `fullmatch`→`match` (RED, 2). Registry: duplicate ids (RED, 2),
two `Fill()`s (RED, 2), nested composites (RED, 1), order sorted by id (RED, 2), a part
with two parents (RED, 1), parts left on their own edge (RED, 1). Ctx: the whole snapshot
regardless of `needs` (RED, 5), an undeclared field (RED, 3), `__getattr__` answering
`None` (RED, 3), mutable slices (RED, 3), a writable ctx (RED, 1). Each restored: OK.

No version bump, no news entry (nothing here is operator-visible), no tag.
