### PR TITLE
A component may come from a distribution the operator installed, and a broken one costs its pane

### DIFF
--- a/charter/frame/registry.py
+++ b/charter/frame/registry.py
@@ -30,12 +30,306 @@ parents — need to see every component together, and the registry is the only t
 does. All three are refused at registration, naming both offenders, because a tie broken
 at layout time produces a frame that shifts with the data (§4e) and cannot be reproduced
 from the configuration that caused it.
+
+**And this is the seam a stranger's code arrives through.** A committed `charter.toml`
+says which components to place, where and in what order; it never says what code runs
+(§4b). The code comes from a distribution the operator installed, found through
+:data:`PROVIDER_GROUP` — so a cloned repo whose config names `acme.metrics` on a machine
+without it draws a pane saying exactly that, and cannot make anything run. That is the
+whole safety argument for binding by NAME rather than by a `command = "…"` string, which
+would be executable content in a committed file: `[frame] hotkey` and #453 are what that
+costs.
+
+Four rules hold the seam, and each of them is a refusal rather than a best effort:
+
+* **A mismatched API version does not load** (§4g). One integer, named on both sides.
+* **Two providers claiming one id load NEITHER** (§4h), because a pane whose origin
+  cannot be determined is a debugging problem with no entry point.
+* **A provider that raises costs its own pane** — on import, while building, or in
+  ``render`` — and the pane says which component failed and why. A blank pane is the
+  confidently-wrong output the left sidebar was retired for.
+* **Charter contains what a provider returned**, after it returns it. A provider renders
+  committed values — repo names, branches, todo text — and its lines reach a terminal, so
+  escaping and the width budget are applied here rather than trusted to the code that
+  needed containing.
 """
 
 from __future__ import annotations
 
-from .. import contain
-from .component import EDGES, Component, ComponentError, Fill
+import importlib
+from importlib import metadata
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from .. import contain, tui
+from .component import (API_VERSION, EDGES, Component, ComponentError, Content,
+                        Fill)
+
+#: The entry point group an installed distribution declares its components in (§4b):
+#:
+#: ``[project.entry-points."charter.components"]`` / ``acme.metrics = "acme_charter:metrics"``
+#:
+#: `importlib.metadata` is stdlib, so this leaves ``dependencies = []`` untouched, and it
+#: is deliberately not a harness plugin group: the frame is harness-agnostic and a
+#: provider must work under Claude Code, codex and opencode alike, so it binds to charter.
+PROVIDER_GROUP = "charter.components"
+
+#: The edge and size a component charter could not load is stood in for on, when the
+#: caller does not say. A caller that read `[[frame.component]]` DOES know — it passes the
+#: configured pair, so a machine missing one provider draws the same rectangles as a
+#: machine that has it, with a message in the one pane instead of the frame's geometry
+#: shifting under everything else.
+STANDIN_EDGE = "bottom"
+#: Capped rather than open: the message is charter's, but the reason inside it quotes a
+#: provider's exception text, and an unbounded panel whose height an installed package
+#: chooses is a budget the input can grow.
+STANDIN_SIZE = Content(cap=6)
+
+#: How many characters of ONE returned line charter will escape, measure and clip.
+#:
+#: `tui.truncate` bounds a line's VISIBLE WIDTH, and visible width is not a bound on
+#: length: a combining mark measures zero cells, so a line of a million of them fits any
+#: pane and costs the repaint a million characters. `contain.one_line` bounds the
+#: characters, `tui.truncate` bounds the cells, and neither substitutes for the other.
+#:
+#: Larger than `contain.DISPLAY_LIMIT`, which sizes a refusal SENTENCE. This sizes a pane
+#: row, and every invisible in it is replaced by a four-to-six character escape, so a
+#: legitimately full 300-column row of them is still well inside this and only a line
+#: nobody could read is cut.
+LINE_LIMIT = 4096
+
+
+def _where(ep) -> str:
+    """The distribution behind entry point *ep*, named the way a refusal must name it.
+
+    Every refusal below names the PROVIDER and not only the id, because the id came out
+    of a committed file the operator may not have written and the distribution is the
+    thing they can install, uninstall or file a bug against.
+    """
+    dist = getattr(ep, "dist", None)
+    name = getattr(dist, "name", None) or "an unnamed distribution"
+    version = getattr(dist, "version", None)
+    return contain.one_line(f"{name} {version}" if version else str(name))
+
+
+def _because(exc: BaseException) -> str:
+    """A raised thing as one line of a refusal: its type, and what it said.
+
+    The type is kept because a provider's message is frequently empty — ``KeyError('x')``
+    stringifies to ``'x'`` and ``StopIteration`` to nothing at all — and "it failed"
+    without a name is the message that sends the reader to a traceback charter does not
+    have. No traceback: this reaches a pane a few cells wide, and a provider's file paths
+    are not the operator's to read out.
+    """
+    return f"{type(exc).__name__}: {contain.one_line(str(exc))}"
+
+
+def _wrap(text: str, width: int) -> list[str]:
+    """*text* as lines of at most *width* CELLS, split at spaces where it can be.
+
+    Measured with `tui.width`, never `len`: a refusal quoting a component id with a wide
+    character in it would otherwise be laid out a column too long and clipped exactly
+    where the thing it names is.
+
+    A word wider than the pane is cut rather than left to be clipped, because the clip
+    would take the tail with it — and the tail of a refusal is the half that says what to
+    do about it.
+    """
+    if width <= 0:
+        return []
+    out: list[str] = []
+    line = ""
+    for word in text.split(" "):
+        while tui.width(word) > width:
+            head = tui.truncate(word, width, ellipsis="")
+            if not head:                        # one character wider than the pane
+                break
+            if line:
+                out.append(line)
+                line = ""
+            out.append(head)
+            word = word[len(head):]
+        if not line:
+            line = word
+        elif tui.width(line) + 1 + tui.width(word) <= width:
+            line = f"{line} {word}"
+        else:
+            out.append(line)
+            line = word
+    if line:
+        out.append(line)
+    return out
+
+
+def _fit(lines, *, width: int, height: int, escape: bool) -> tuple[str, ...]:
+    """*lines* as at most *height* rows of at most *width* cells each.
+
+    ``escape`` is provenance and not a preference — see :meth:`Registry.draw`.
+
+    `contain.one_line` runs BEFORE the width arithmetic, which is the order the rest of
+    charter uses for the same reason: an escape sequence is a zero-width instruction to
+    the terminal, so measuring first would measure a string that is not what the terminal
+    is about to do, and clipping first would cut an escape in half.
+    """
+    out = []
+    for line in lines[:max(height, 0)]:
+        if escape:
+            line = contain.one_line(line, limit=LINE_LIMIT)
+        out.append(tui.truncate(line, width))
+    return tuple(out)
+
+
+class Providers:
+    """The component providers installed on this machine, listed without importing one.
+
+    **Listed, then imported one at a time, and never the other way round.** The entry
+    point NAME is the component id, so charter answers "is `acme.metrics` installed, and
+    by what" from distribution metadata alone; a provider's module is imported at the
+    moment its component is actually placed and at no other moment. An installed provider
+    the operator has not placed therefore costs a frame nothing — no import, no module,
+    no code of theirs run — which is what makes it safe for a machine to carry several.
+
+    That is also why the entry point name and the component's own id must be the same
+    word, and why :meth:`load` refuses a provider where they differ. The name is what a
+    committed `charter.toml` places and what charter resolves before importing anything;
+    if the loaded component could answer to a different id, a config naming one thing
+    would draw another — and a provider could take over a built-in's name by declaring an
+    entry point that does not mention it.
+
+    One instance per frame, scanning once: entry point discovery walks ``sys.path``, and
+    doing it per component would put a directory walk on the repaint path §4's whole
+    cost argument exists to keep off it.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, tuple] | None = None
+
+    def _scan(self) -> dict[str, tuple]:
+        """id → every entry point claiming it. More than one IS the collision (§4h)."""
+        if self._entries is None:
+            found: dict[str, list] = {}
+            for ep in metadata.entry_points(group=PROVIDER_GROUP):
+                found.setdefault(ep.name, []).append(ep)
+            self._entries = {name: tuple(eps) for name, eps in found.items()}
+        return self._entries
+
+    def ids(self) -> tuple[str, ...]:
+        """Every component id an installed provider claims, alphabetically.
+
+        Sorted rather than in discovery order, because discovery order is ``sys.path``
+        order — a property of the machine, not of the plane — and a menu or a `doctor`
+        line that reordered itself when a virtualenv changed would be reporting the
+        wrong thing. Split order is the registry's, and it comes from placement.
+        """
+        return tuple(sorted(self._scan()))
+
+    def supplies(self, cid: str) -> bool:
+        """Whether anything installed claims *cid* — asked without importing it."""
+        return isinstance(cid, str) and cid in self._scan()
+
+    def load(self, cid: str) -> Component:
+        """The component *cid* names, imported now, or a `ComponentError` saying why not.
+
+        Every refusal here is one a caller is expected to DEGRADE rather than propagate —
+        `Registry.place` turns each into a pane — so they are written to be read by the
+        operator in a few cells, and each one names the distribution.
+        """
+        shown = contain.one_line(repr(cid))
+        if not isinstance(cid, str) or "." not in cid:
+            raise ComponentError(
+                f"nothing on this frame is named {shown}, and no installed provider can "
+                f"be: a provider's id is namespaced by its distribution, like "
+                f"acme.metrics. Charter's own components are registered before any "
+                f"config is read, so a bare name that is not one of them is a typo")
+        eps = self._scan().get(cid, ())
+        if not eps:
+            raise ComponentError(
+                f"no installed provider supplies the component {contain.one_line(cid)} — "
+                f"install the distribution that declares it in the {PROVIDER_GROUP} "
+                f"entry point group, or stop placing it. The rest of the frame is drawn")
+        if len(eps) > 1:
+            raise ComponentError(
+                f"{len(eps)} installed providers supply the component "
+                f"{contain.one_line(cid)}: {', '.join(_where(ep) for ep in eps)}. "
+                f"Charter loads {'NEITHER' if len(eps) == 2 else 'NONE of them'} — "
+                f"picking one by load order would draw a pane whose origin cannot be "
+                f"determined. Uninstall one of them")
+        return self._one(eps[0], cid)
+
+    def _one(self, ep, cid: str) -> Component:
+        """The single claimant, imported, version-checked, built and identified."""
+        module_name = contain.one_line(str(getattr(ep, "module", "") or ""))
+        value = contain.one_line(str(getattr(ep, "value", "") or ""))
+        try:
+            module = importlib.import_module(ep.module)
+        except KeyboardInterrupt:
+            raise
+        except BaseException as exc:
+            raise ComponentError(
+                f"{_where(ep)} supplies {contain.one_line(cid)}, and importing "
+                f"{module_name} raised {_because(exc)}. Its pane says so; the rest of "
+                f"the frame is drawn") from None
+
+        # Before the entry point's own attribute is even looked up, let alone called: a
+        # version charter cannot honour is refused at LOAD, where the message names a
+        # fixable thing, rather than hoped through to render time inside somebody's frame
+        # (§4g). There is no shim band and no best-effort mode.
+        speaks = getattr(module, "API_VERSION", None)
+        if isinstance(speaks, bool) or not isinstance(speaks, int):
+            raise ComponentError(
+                f"{_where(ep)} supplies {contain.one_line(cid)} and {module_name} "
+                f"declares API_VERSION = {contain.one_line(repr(speaks))}. Charter "
+                f"speaks component API version {API_VERSION}, as one integer, so this "
+                f"provider is not loaded")
+        if speaks != API_VERSION:
+            raise ComponentError(
+                f"{_where(ep)} supplies {contain.one_line(cid)} for component API "
+                f"version {speaks}, and charter speaks {API_VERSION}. It is not loaded: "
+                f"a contract charter cannot honour fails at render time inside your "
+                f"frame, where you cannot act on it")
+
+        obj: Any = module
+        try:
+            for part in [p for p in (getattr(ep, "attr", "") or "").split(".") if p]:
+                obj = getattr(obj, part)
+        except KeyboardInterrupt:
+            raise
+        except BaseException as exc:
+            raise ComponentError(
+                f"{_where(ep)} supplies {contain.one_line(cid)} as {value}, and "
+                f"{module_name} has no such name: {_because(exc)}") from None
+
+        # A Component or something that answers one. Both, because the spec's own example
+        # entry point (`acme_charter.metrics:Component`) reads as an object and a factory
+        # is the obvious other spelling — refusing either would refuse a provider author
+        # for a choice that changes nothing charter can observe.
+        if not isinstance(obj, Component):
+            if not callable(obj):
+                raise ComponentError(
+                    f"{_where(ep)} supplies {contain.one_line(cid)} as {value}, which is "
+                    f"{contain.one_line(repr(obj))} — an entry point names a frame "
+                    f"component, or something charter can call with no arguments to get "
+                    f"one")
+            try:
+                obj = obj()
+            except KeyboardInterrupt:
+                raise
+            except BaseException as exc:
+                raise ComponentError(
+                    f"{_where(ep)} supplies {contain.one_line(cid)}, and building it "
+                    f"raised {_because(exc)}") from None
+            if not isinstance(obj, Component):
+                raise ComponentError(
+                    f"{_where(ep)} supplies {contain.one_line(cid)}, and calling {value} "
+                    f"answered {contain.one_line(repr(obj))} rather than a frame "
+                    f"component")
+        if obj.id != cid:
+            raise ComponentError(
+                f"{_where(ep)} declares the entry point {contain.one_line(cid)} and "
+                f"answers a component whose id is {contain.one_line(obj.id)}. The entry "
+                f"point name is what a committed charter.toml places and what charter "
+                f"resolves without importing anything, so the two must be one word")
+        return obj
 
 
 class Registry:
@@ -60,6 +354,16 @@ class Registry:
         #: child id → the composite that draws it. The reason a child leaves
         #: :meth:`on_edge` without leaving the registry.
         self._parent: dict[str, str] = {}
+        #: The ids whose LINES charter did not write — everything that arrived through a
+        #: provider, and every standin, whose text quotes one. See :meth:`draw`.
+        self._foreign: set[str] = set()
+        #: id → why it is a standin rather than the component that was asked for. Kept
+        #: after the pane is drawn, so `doctor` can say it in full at a width a pane does
+        #: not have.
+        self._failures: dict[str, str] = {}
+        #: One scan of the installed providers per frame, and it has not happened yet:
+        #: `Providers` lists nothing until something is placed.
+        self.providers = Providers()
 
     # -- registering ------------------------------------------------------- #
 
@@ -121,6 +425,113 @@ class Registry:
                 f"left of its pane, and {named} " +
                 ("do" if len(fills) > 1 else "does") + ". Size the others Fixed(n) or "
                 f"Content(cap=…)")
+
+    # -- placing what config named ----------------------------------------- #
+
+    def place(self, cid: str, *, edge: str | None = None,
+              size: Any = None) -> Component:
+        """Put *cid* on this frame, importing the provider that supplies it if need be.
+
+        **This never propagates a provider's failure**, and that is the point of it
+        (§4b): a committed config naming `acme.metrics` on a machine without it, an
+        installed provider that raises on import, a version charter does not speak, two
+        distributions claiming one id — each of those is a PANE saying so, and the rest
+        of the frame is drawn. A committed file must never be able to make charter
+        unusable for somebody who has not installed a third-party package.
+
+        *edge* and *size* are the ones config asked for, and they are used for the
+        standin as well, so the rectangles do not move: the frame a machine missing one
+        provider draws is the frame the other machine draws, with a message in that one
+        pane. Without them the standin takes :data:`STANDIN_EDGE` and
+        :data:`STANDIN_SIZE`.
+
+        Already registered — a built-in, or a provider placed twice by a config listing
+        it twice — answers what is registered rather than refusing: this asks for *cid*
+        to be on the frame, where `register` asks for a component to be added.
+
+        The one thing it does raise for is an id that could never name a component at
+        all, because there is nothing to stand in for and nowhere to draw the message:
+        that refusal belongs to whatever read the id, beside the rest of its validation.
+        """
+        if isinstance(cid, str) and cid in self._by_id:
+            return self._by_id[cid]
+        try:
+            c = self.register(self.providers.load(cid))
+        except ComponentError as exc:
+            return self._stand_in(cid, str(exc), edge=edge, size=size)
+        # AFTER the registration that could still have refused it, so a component that
+        # was not placed is not recorded as one whose lines charter contains.
+        self._foreign.add(c.id)
+        return c
+
+    def _stand_in(self, cid: str, reason: str, *, edge, size) -> Component:
+        """A pane that says why *cid* is not the component that was asked for.
+
+        A component, registered like any other, rather than a hole in the frame or a
+        skipped split. A missing panel that nothing anywhere explains is the
+        confidently-wrong output #512 was about: the operator sees a frame that looks
+        deliberate and has no way to find out it is not.
+        """
+        c = self.register(Component(
+            id=cid, title=f"{cid} — not drawn", edge=edge or STANDIN_EDGE,
+            size=size or STANDIN_SIZE, needs=(), events=(),
+            render=lambda ctx: _wrap(reason, ctx.width)))
+        self._failures[cid] = reason
+        self._foreign.add(cid)
+        return c
+
+    @property
+    def failures(self) -> Mapping[str, str]:
+        """id → why it is a standin, for everything this registry could not load."""
+        return MappingProxyType(dict(self._failures))
+
+    # -- drawing ----------------------------------------------------------- #
+
+    def draw(self, cid: str, ctx) -> tuple[str, ...]:
+        """The rows *cid* drew — bounded by its own rectangle, and never raising.
+
+        **A component that raises costs its own pane and never the session** (§4b). Every
+        way a renderer can fail lands here: an exception, a return that is not lines, a
+        line that is not text. The pane then NAMES the component and what it raised,
+        because a pane that goes blank when a component breaks is indistinguishable from
+        one whose plane has nothing to show — and this project has shipped that defect
+        once already (#512).
+
+        `KeyboardInterrupt` is the one thing that still travels: the operator's own
+        interrupt is theirs, and swallowing it would mean a frame that cannot be stopped
+        during a repaint. This is containment, not a sandbox, and nothing here pretends
+        otherwise — a provider's module is ordinary Python.
+
+        **Escaping is decided by who wrote the line, not by the caller.** A provider's
+        rows are escaped: they carry committed plane values — repo names, branch names,
+        todo text — and they reach a terminal, where an escape sequence is an instruction
+        and not a character, so a row of one could move the cursor out of its own
+        rectangle and draw over the pane beside it. Charter's own renderers already
+        contain their committed values at the point they interpolate them and then add
+        charter's own colour markup on top, so escaping their output here would corrupt
+        charter's markup while protecting nothing. The width and the row count are
+        applied to both: the rectangle is the frame's, whoever drew inside it.
+        """
+        c = self.get(cid)
+        try:
+            lines = c.render(ctx)
+            if isinstance(lines, (str, bytes)) or not isinstance(lines, (list, tuple)):
+                raise ComponentError(
+                    f"render must answer a list of lines, not "
+                    f"{contain.one_line(repr(lines))}")
+            for line in lines:
+                if not isinstance(line, str):
+                    raise ComponentError(
+                        f"render answered {contain.one_line(repr(line))}, which is not a "
+                        f"line of text")
+        except KeyboardInterrupt:
+            raise
+        except BaseException as exc:
+            return _fit(_wrap(f"{contain.one_line(cid)} failed to draw — "
+                              f"{_because(exc)}", ctx.width),
+                        width=ctx.width, height=ctx.height, escape=True)
+        return _fit(lines, width=ctx.width, height=ctx.height,
+                    escape=cid in self._foreign)
 
     # -- asking ------------------------------------------------------------ #
 

--- a/charter/frame/registry.py
+++ b/charter/frame/registry.py
@@ -56,6 +56,7 @@ Four rules hold the seam, and each of them is a refusal rather than a best effor
 
 from __future__ import annotations
 
+import dataclasses
 import importlib
 from importlib import metadata
 from types import MappingProxyType
@@ -76,9 +77,19 @@ PROVIDER_GROUP = "charter.components"
 
 #: The edge and size a component charter could not load is stood in for on, when the
 #: caller does not say. A caller that read `[[frame.component]]` DOES know — it passes the
-#: configured pair, so a machine missing one provider draws the same rectangles as a
-#: machine that has it, with a message in the one pane instead of the frame's geometry
-#: shifting under everything else.
+#: configured pair, and :func:`_rectangle` applies it to the loaded component and to the
+#: standin alike, so a machine missing one provider draws the same rectangles as a machine
+#: that has it, with a message in the one pane instead of the frame's geometry shifting
+#: under everything else.
+#:
+#: **No such caller exists yet, and that is deliberate** (§4b property 4, narrowed
+#: 2026-08-26). `instance.component_tables` refuses an arrangement naming a component
+#: charter cannot place, whole, rather than dropping the one placement — because every
+#: step from there to a painted pane still speaks the four committed SLOT NAMES
+#: (`layout._derive`, `layout.panel_command`'s `charter panel <slot>` argv,
+#: `frame/panel.py:run`), so a placement dropped here would be a panel silently absent
+#: with no pane to say why. Phase 2 builds the surface; this is what will be passed
+#: across it.
 STANDIN_EDGE = "bottom"
 #: Capped rather than open: the message is charter's, but the reason inside it quotes a
 #: provider's exception text, and an unbounded panel whose height an installed package
@@ -177,6 +188,34 @@ def _fit(lines, *, width: int, height: int, escape: bool) -> tuple[str, ...]:
             line = contain.one_line(line, limit=LINE_LIMIT)
         out.append(tui.truncate(line, width))
     return tuple(out)
+
+
+def _rectangle(c: Component, *, edge, size) -> Component:
+    """*c* in the rectangle the caller asked for, or in its own where the caller did not.
+
+    **The one place either half of a rectangle is resolved**, and that is the whole
+    point of it being a function rather than two expressions. `Registry.place` has two
+    ways to answer — the component a provider supplied, and the standin drawn when it
+    could not be — and a rectangle resolved separately on each is a rectangle that can
+    differ between them. It did: the loaded component kept its own `edge` and `size` and
+    the configured pair reached only the standin, so one committed `[[frame.component]]`
+    table drew a panel on `right` on a machine with the provider installed and on `top`
+    on a machine without it, with `on_edge` disagreeing to match.
+
+    ``None`` is the only spelling of "the caller did not say". Not falsiness: ``edge =
+    ""`` in a committed file is a value somebody wrote and charter cannot honour, and
+    quietly substituting a default for it is the config key that changes nothing this
+    phase was written against. `Component`'s own validation is what refuses it, here,
+    where the caller can still be told which value was unusable.
+
+    A frozen dataclass replaced rather than mutated, so nothing that already holds *c* —
+    a provider's own module-level singleton, most obviously — sees the frame's
+    arrangement written back into it.
+    """
+    if edge is None and size is None:
+        return c
+    return dataclasses.replace(c, edge=c.edge if edge is None else edge,
+                               size=c.size if size is None else size)
 
 
 class Providers:
@@ -439,24 +478,38 @@ class Registry:
         of the frame is drawn. A committed file must never be able to make charter
         unusable for somebody who has not installed a third-party package.
 
-        *edge* and *size* are the ones config asked for, and they are used for the
-        standin as well, so the rectangles do not move: the frame a machine missing one
-        provider draws is the frame the other machine draws, with a message in that one
-        pane. Without them the standin takes :data:`STANDIN_EDGE` and
-        :data:`STANDIN_SIZE`.
+        *edge* and *size* are the arrangement, **and the arrangement wins** (§4b:
+        *arrangement is committed, execution is local*). They are applied to the
+        component that LOADED exactly as they are to the standin, through one function
+        (:func:`_rectangle`), so the two paths cannot answer differently: the frame a
+        machine missing one provider draws is the frame the other machine draws, with a
+        message in that one pane. The alternative — a provider's own `edge` overruling
+        the committed table — is the same committed file drawing two different frames on
+        two machines, and it inverts the principle the extension model rests on. §4b's
+        `default_edge`/`default_size` are for a sensible arrangement BEFORE anyone
+        configures one; they do not beat one that exists.
+
+        Without them a loaded component keeps its own declaration and a standin takes
+        :data:`STANDIN_EDGE` and :data:`STANDIN_SIZE` — "the caller did not say" is
+        ``None`` and only ``None``, in both directions.
 
         Already registered — a built-in, or a provider placed twice by a config listing
         it twice — answers what is registered rather than refusing: this asks for *cid*
-        to be on the frame, where `register` asks for a component to be added.
+        to be on the frame, where `register` asks for a component to be added. A
+        component keeps the rectangle it went onto the frame in, because `Component` is
+        frozen and a split order already assigned is geometry that has been spent.
 
-        The one thing it does raise for is an id that could never name a component at
-        all, because there is nothing to stand in for and nowhere to draw the message:
-        that refusal belongs to whatever read the id, beside the rest of its validation.
+        The one thing it does raise for is an id, an edge or a size that could never
+        name a component or a rectangle at all: there is nothing to stand in for and
+        nowhere to draw the message, and that refusal belongs to whatever read the value,
+        beside the rest of its validation. It raises the same way whether or not the
+        provider is installed, which is the same symmetry the paragraph above is about.
         """
         if isinstance(cid, str) and cid in self._by_id:
             return self._by_id[cid]
         try:
-            c = self.register(self.providers.load(cid))
+            c = self.register(
+                _rectangle(self.providers.load(cid), edge=edge, size=size))
         except ComponentError as exc:
             return self._stand_in(cid, str(exc), edge=edge, size=size)
         # AFTER the registration that could still have refused it, so a component that
@@ -471,11 +524,16 @@ class Registry:
         skipped split. A missing panel that nothing anywhere explains is the
         confidently-wrong output #512 was about: the operator sees a frame that looks
         deliberate and has no way to find out it is not.
+
+        Built at charter's own defaults and then put through :func:`_rectangle`, the one
+        the loaded component goes through — rather than resolving the pair a second time
+        here. Two spellings of "the caller did not say" is how the two paths came to
+        disagree in the first place.
         """
-        c = self.register(Component(
-            id=cid, title=f"{cid} — not drawn", edge=edge or STANDIN_EDGE,
-            size=size or STANDIN_SIZE, needs=(), events=(),
-            render=lambda ctx: _wrap(reason, ctx.width)))
+        c = self.register(_rectangle(Component(
+            id=cid, title=f"{cid} — not drawn", edge=STANDIN_EDGE,
+            size=STANDIN_SIZE, needs=(), events=(),
+            render=lambda ctx: _wrap(reason, ctx.width)), edge=edge, size=size))
         self._failures[cid] = reason
         self._foreign.add(cid)
         return c

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -736,10 +736,20 @@ def component_tables(section) -> list[dict] | None:
     the one `slots` describes: the operator sees their arrangement ignored, which is a
     visible, whole-frame difference, rather than one pane's worth of quiet fiction.
 
-    Task 7 of this plan replaces that for the one case it can improve: a component named
-    here with no provider installed gets a MESSAGE in its own pane and the rest of the
-    frame draws. That is the same principle with somewhere to say it; until the surface
-    exists, refusing the arrangement is the version of it charter can actually keep.
+    **Task 7 was expected to replace that for the one case it could improve — a component
+    named here with no provider installed getting a MESSAGE in its own pane while the rest
+    of the frame draws — and it does not, deliberately (decided 2026-08-26, §4b property
+    4).** The message has nowhere to appear. `frame.registry.Registry.place` builds the
+    standin and holds the rectangle for it, but every step from here to a painted pane
+    still speaks the four committed SLOT NAMES rather than component ids: this function's
+    own `SLOT_OF` check, :func:`frame_of`'s filter against :data:`FRAME_SLOTS`,
+    `layout._derive`'s `SLOT_OF` keying (a `KeyError` by design for a component with no
+    slot name), `layout.panel_command`'s `charter panel <slot>` argv, and
+    `frame/panel.py`'s refusal of a slot `slots.SLOTS` has no renderer for. Dropping the
+    placement here would therefore be a panel silently absent with no pane to say why —
+    #512 and #535's failure, wearing Task 7's clothes. Refusing whole is the version of
+    the principle charter can actually keep, and the surface that turns the other one on
+    is Phase 2's.
 
     **``edge`` and ``size`` are accepted only where charter can honour them, which today
     means only at the component's own declaration.** `layout` derives the whole frame's

--- a/docs/superpowers/plans/2026-08-26-phase1-component-registry.md
+++ b/docs/superpowers/plans/2026-08-26-phase1-component-registry.md
@@ -190,24 +190,58 @@ def test_a_component_gets_only_what_it_declared(self):
 
 **Files:** Modify `charter/frame/registry.py`; create `tests/test_component_providers.py`
 
-- [ ] **Step 1: write the failing tests** — a provider declaring `API_VERSION` loads; one
+- [x] **Step 1: write the failing tests** — a provider declaring `API_VERSION` loads; one
       declaring a different integer does NOT, and the message names the provider, its version
       and charter's; two providers claiming one id refuse BOTH and name both; a component
       named in config with no provider installed produces a message and the rest of the frame.
-- [ ] **Step 2: run them, confirm they fail.**
-- [ ] **Step 3: implement discovery** via
+      **Narrowed 2026-08-26 — see "Where the message lives" below.** The standin is built; it
+      is not placed *from config*, because there is nowhere yet for it to appear.
+- [x] **Step 2: run them, confirm they fail.**
+- [x] **Step 3: implement discovery** via
       `importlib.metadata.entry_points(group="charter.components")`. **Import lazily** — an
       installed-but-unplaced provider costs nothing.
-- [ ] **Step 4: failure isolation.** A provider that raises on import, or whose `render`
+- [x] **Step 4: failure isolation.** A provider that raises on import, or whose `render`
       raises, costs its own pane and never the session. The pane says which component failed
       and why — a blank pane is the confidently-wrong output the left sidebar was retired for.
-- [ ] **Step 5: contain the output.** A provider's returned lines go through `contain.one_line`
+- [x] **Step 5: contain the output.** A provider's returned lines go through `contain.one_line`
       and `tui.width` applied **by charter**, not trusted to the provider.
-- [ ] **Step 6: run the full suite.**
-- [ ] **Step 7: mutations** — accept a mismatched API version; let one of two colliding ids
+- [x] **Step 6: run the full suite.**
+- [x] **Step 7: mutations** — accept a mismatched API version; let one of two colliding ids
       win; let a raising provider propagate; skip the output containment. Each RED, restored
       GREEN.
-- [ ] **Step 8: commit.**
+- [x] **Step 8: commit.**
+- [x] **Step 9 (review): the arrangement is committed, and `place` was letting the provider
+      overrule it.** `Registry.place` applied the configured `edge`/`size` only to the
+      standin; a provider that loaded kept its own, so one committed table drew two frames on
+      two machines. Fixed in one function both paths call, with the mirror test the absence of
+      which is why it shipped. Recorded in §4i.
+
+#### Where the message lives — Task 7 step 1, narrowed 2026-08-26
+
+Task 6 refuses an arrangement **whole** if it carries anything charter cannot honour, falling
+back to `slots`. Task 7 step 1 as written asks for the opposite for one case: a message and
+the rest of the frame. **The whole-refusal stands, and step 1 is narrowed to match**, because
+the message has nowhere to appear. Every step between a committed table and a painted pane
+still speaks the four committed **slot names**, not component ids:
+
+| where | what stops a provider |
+|---|---|
+| `instance.component_tables` | refuses a `use` outside `builtins.SLOT_OF` |
+| `instance.frame_of` | filters against `FRAME_SLOTS = ("top","bottom","repos","right")` |
+| `instance._placement` | `SLOT_OF[cid]` — `KeyError` for a provider |
+| `layout._derive` | keyed by `SLOT_OF`; a `KeyError` **by design** for a component with no slot name |
+| `layout.SLOT_SIZE` / `SLOT_EDGE` | module constants derived at import from the built-ins |
+| `layout.panel_command` | emits `charter panel <slot>` as tmux argv |
+| `cli.py` `panel` subparser | takes a slot |
+| `frame/panel.py:run` | refuses a slot `slots.SLOTS` has no renderer for |
+| `frame/slots.py` | four renderers; a panel process builds no registry and knows no providers |
+
+`Registry.place` has **zero production callers** today — the only consumer is
+`tests/test_component_providers.py`. So implementing "a message and the rest of the frame"
+now would mean a component dropped from the arrangement with no pane, no argv and no process
+to draw its message in: a silent drop, which is #512's and #535's failure exactly. Refusing
+whole is the version of the principle charter can actually keep. **Placing a provider is
+Phase 2 work**, and that surface is what turns step 1 back on.
 
 ---
 
@@ -218,7 +252,11 @@ def test_a_component_gets_only_what_it_declared(self):
   code path.
 - charter's own components are registered through the **same public seam** a provider uses —
   no private back door.
-- A provider can be installed, placed by config, and drawn — and a broken one costs its pane
-  and nothing else.
+- ~~A provider can be installed, placed by config, and drawn~~ — **moved to Phase 2,
+  2026-08-26.** A provider can be installed, *placed through `Registry.place`*, and drawn,
+  and a broken one costs its pane and nothing else. Placed **by config** it cannot be: the
+  table above is what stands in the way, and every row of it is a surface Phase 2 builds.
+  This criterion was unreachable from Task 7 as scoped and is recorded as such rather than
+  left to be discovered as a surprise.
 - The idle-cost property still holds, verified rather than asserted.
 - Task 1's findings say whether §4c's mouse hypothesis and §4g's popup hypothesis survived.

--- a/docs/superpowers/specs/2026-08-25-agentic-ide-foundation.md
+++ b/docs/superpowers/specs/2026-08-25-agentic-ide-foundation.md
@@ -190,6 +190,15 @@ A component declares its identity and its cost, and renders on request:
 `ctx` hands over what the component is allowed to read. It does **not** hand over a way to
 run a subprocess or reach the network on the repaint path.
 
+**`default_edge` and `default_size` are defaults, and a committed arrangement beats them.**
+The word in that table row is load-bearing: they are for a sensible arrangement *before*
+anyone configures one, and where a `[[frame.component]]` table says an edge or a size, the
+table is what draws. The inverse — a provider's Python overruling a committed file — is
+*execution* deciding *arrangement*, which is the safety principle above run backwards, and
+its symptom is one committed table drawing two different frames on two machines depending
+on whether a package happens to be installed. Charter shipped exactly that inversion once
+in `Registry.place` (§4i).
+
 ### Four properties that must survive a stranger's code
 
 These are what make the extension model real rather than a hole:
@@ -210,10 +219,23 @@ These are what make the extension model real rather than a hole:
    `contain.one_line` and `tui.width` path as a built-in, applied by charter after the
    component returns, not trusted to the component.
 
-4. **A missing provider is a message, not a crash.** `charter.toml` naming `acme.metrics`
-   on a machine without it says so plainly and draws the rest of the frame. A committed
-   config must never make charter unusable for someone who has not installed a third-party
-   package.
+4. **A missing provider is a message, not a crash** — *and the message needs a surface to
+   live on, which Phase 1 does not build.* `charter.toml` naming `acme.metrics` on a
+   machine without it must never make charter unusable for someone who has not installed a
+   third-party package. **Where the message goes, narrowed 2026-08-26:** in Phase 1 it is a
+   standin *component* in the registry (`Registry.place`), holding the rectangle config
+   asked for and drawing the reason — but nothing places it, because every step between a
+   committed table and a painted pane still speaks the four committed **slot names**:
+   `instance.component_tables` refuses a `use` outside `builtins.SLOT_OF`, `frame_of`
+   filters against `FRAME_SLOTS`, `layout._derive` keys off `SLOT_OF` (a `KeyError`, by
+   design, for a component with no slot name), `layout.panel_command` emits
+   `charter panel <slot>` as tmux argv, and `frame/panel.py:run` refuses a slot
+   `slots.SLOTS` has no renderer for. **So until Phase 2 gives the frame a surface that can
+   SAY a component is missing, an arrangement carrying one charter cannot honour is refused
+   whole and the frame falls back to `slots`** — the operator sees their whole arrangement
+   not take effect, which is visible and actionable, rather than one pane quietly absent.
+   A message with nowhere to appear is a silent drop, and a silent drop is #512 and #535.
+   Placing a provider is Phase 2 work, and this property is what it must deliver.
 
 ### What `charter.toml` gets to say
 
@@ -510,6 +532,37 @@ keyboard, and is modal; charter's session-scoped `mouse off` cleanly overrides a
 global `mouse on` with no leak; and **all four `tmuxctl` version floors were confirmed by
 running 3.1c and 3.2**, where before they were justified from CHANGES with a note that no
 binary existed to check.
+
+### A safety principle found running backwards in the code — 2026-08-26
+
+**`Registry.place` ignored the committed `edge` and `size` whenever the provider actually
+loaded**, applying them only to the standin drawn when it did not. Measured, before the fix:
+
+```
+place("acme.metrics", edge="top", size=Fixed(3))
+  package installed  -> edge='right', size=Fixed(12)   (the provider's own declaration)
+  package absent     -> edge='top',   size=Fixed(3)    (what the arrangement asked for)
+```
+
+So one committed `[[frame.component]]` table drew two different frames on two machines, and
+`on_edge('top')` answered `['acme.metrics']` on one and `[]` on the other — and order is
+geometry, so every panel split after it moved too. **This is §4b's own principle inverted:**
+the provider's *code* overruled the *committed arrangement*, which is execution deciding
+arrangement. `default_edge`/`default_size` are for a sensible arrangement before anyone
+configures one; they do not beat one that exists.
+
+**It was unasserted in both directions and 37 tests stayed green with it fixed.** The
+standin half was pinned; the loading half — the half that runs on the machine the provider
+is actually installed on — was pinned nowhere, and `place`'s own docstring asserted the
+opposite of what it did. Fixed by resolving the rectangle in ONE function both paths call,
+with `None` and only `None` meaning "the caller did not say"; the mirror test asserts edge,
+size, split order and `on_edge` for a provider that loads, and asserts the two paths give
+one answer in a single case so neither can be fixed without the other.
+
+**The general lesson, which is the reusable half:** a guard written on the degraded path and
+not on the succeeding one passes every test the degraded path has, and the succeeding path
+is the one operators run. Two code paths that must agree need a test that asks *both in one
+assertion*, not one test each.
 
 ### And a stale number, corrected
 

--- a/tests/test_component_providers.py
+++ b/tests/test_component_providers.py
@@ -24,6 +24,12 @@ closing paragraph, each with a case that fails without the guard:
    `contain.one_line` before the width arithmetic and `tui.width` rather than `len`.
 5. **A missing provider is a message**, in the rectangle config asked for, and the rest of
    the frame is drawn.
+6. **The rectangle config asked for is the one that draws, provider installed or not.**
+   *Arrangement is committed, execution is local* — so a provider's own `edge` and `size`
+   are defaults for before anyone configures one, and they do not beat a table that does.
+   The other five were each pinned on the failing path first; this one shipped inverted
+   because only its failing path was pinned, which is why every case in
+   `TheArrangementIsCommittedAndAProviderDoesNotOverruleIt` asks about both.
 
 **Nothing here reads the machine.** Each case asserts about ids its own fixture installed,
 never about the set of providers this machine happens to carry, so a suite run on a
@@ -362,6 +368,140 @@ class AMissingProviderIsAMessage(unittest.TestCase):
         """A panel that is simply absent is the frame lying about the plane (#512)."""
         self.r.place(CID, edge="right", size=component.Fixed(12))
         self.assertEqual([c.id for c in self.r.on_edge("right")], [CID])
+
+
+class TheArrangementIsCommittedAndAProviderDoesNotOverruleIt(unittest.TestCase):
+    """§4b's principle in the one place a provider's CODE could beat a committed FILE.
+
+    > **Arrangement is committed. Execution is local.**
+
+    §4b gives a provider a `default_edge` and a `default_size` for "a sensible
+    arrangement **before anyone configures one**". Once one is configured, the committed
+    table is what draws. The inverse — the provider's declaration winning — means one
+    `[[frame.component]]` table draws a panel on `right` on the machine with the package
+    installed and on `top` on the machine without it, with `on_edge` disagreeing to
+    match, and order is geometry so every panel split after it moves too.
+
+    **This class exists because that shipped.** `Registry.place` applied the configured
+    pair to the standin and dropped it for the component that loaded, its own docstring
+    asserted the opposite, and the suite was green in both directions: the standin half
+    was pinned (`test_the_standin_keeps_the_rectangle_config_asked_for` above) and the
+    loading half — the half that runs on the machine the provider is actually installed
+    on — was pinned nowhere. So every case below asserts the two paths give ONE answer,
+    and the fixture's provider declares `right`/`Fixed(12)` precisely so that a
+    regression has somewhere different to go.
+    """
+
+    def setUp(self):
+        self.site = _SitePackages(self)
+        self.r = registry.Registry()
+
+    def _install(self):
+        """A provider declaring `right` and twelve columns as its own arrangement."""
+        self.site.install("acme-charter", "1.4.0", {CID: ENTRY}, {MODULE: _source()})
+
+    def test_a_provider_that_loads_takes_the_rectangle_config_asked_for(self):
+        """The mirror of `test_the_standin_keeps_the_rectangle_config_asked_for`.
+
+        Registered rather than merely answered, and the split order asserted with the
+        edge: a component whose rectangle is right and whose split number is wrong is
+        still a frame that moved.
+        """
+        self._install()
+        self.r.register(_builtin("identity", edge="top"))
+        placed = self.r.place(CID, edge="top", size=component.Fixed(3))
+        self.assertEqual(placed.edge, "top")
+        self.assertEqual(placed.size, component.Fixed(3))
+        self.assertEqual(self.r.get(CID).edge, "top")
+        self.assertEqual(self.r.get(CID).size, component.Fixed(3))
+        self.assertEqual([c.id for c in self.r.on_edge("top")], ["identity", CID])
+        self.assertEqual(self.r.on_edge("right"), ())
+        self.assertEqual(self.r.split_order("identity"), 1)
+        self.assertEqual(self.r.split_order(CID), 2)
+        # The arrangement moved and nothing else did: it is still the provider drawing.
+        self.assertEqual(self.r.failures, {})
+        self.assertEqual(self.r.draw(CID, _ctx()), ("ok",))
+
+    def test_the_same_table_draws_the_same_frame_whether_or_not_it_is_installed(self):
+        """One committed table, two machines, and the frame is the same on both.
+
+        The property `place`'s docstring claims, asked of both paths in one case so that
+        neither can be fixed without the other. The two `assertIn`/`assertEqual` on
+        `failures` are what stop this passing on two standins, which is the shape a test
+        of "they agree" fails silently in.
+        """
+        def frame(r):
+            r.register(_builtin("identity", edge="top"))
+            c = r.place(CID, edge="top", size=component.Fixed(3))
+            return (c.edge, c.size, r.split_order(CID),
+                    tuple(x.id for x in r.on_edge("top")),
+                    tuple(x.id for x in r.on_edge("right")))
+
+        absent, present = registry.Registry(), registry.Registry()
+        without = frame(absent)                 # nothing installed yet: a standin
+        self._install()
+        with_it = frame(present)                # the provider itself
+        self.assertIn(CID, absent.failures)
+        self.assertEqual(present.failures, {})
+        self.assertEqual(without, with_it)
+        self.assertEqual(with_it,
+                         ("top", component.Fixed(3), 2, ("identity", CID), ()))
+
+    def test_a_provider_keeps_its_own_rectangle_when_nothing_configured_one(self):
+        """The other half of §4b, and the reason this is not simply "charter decides".
+
+        A `default_edge` is what a provider gets to say, and a `place` that was asked for
+        nothing must leave it alone rather than flattening it to charter's standin
+        defaults — otherwise every provider lands on `bottom` until somebody writes a
+        table, which is a worse default than the one its author chose.
+        """
+        self._install()
+        placed = self.r.place(CID)
+        self.assertEqual((placed.edge, placed.size), ("right", component.Fixed(12)))
+
+    def test_the_half_config_did_not_ask_for_is_left_as_it_was(self):
+        """`edge` and `size` are two questions and a file may answer one of them.
+
+        Both paths, because "the caller did not say" is where the two spellings diverged:
+        the standin resolved it by FALSINESS and the loaded component not at all.
+        """
+        self._install()
+        self.assertEqual(self.r.place(CID, edge="bottom").size, component.Fixed(12))
+        standin = registry.Registry().place("acme.absent", size=component.Fixed(4))
+        self.assertEqual((standin.edge, standin.size),
+                         (registry.STANDIN_EDGE, component.Fixed(4)))
+
+    def test_a_rectangle_charter_could_never_draw_is_refused_either_way(self):
+        """And refused IDENTICALLY, which is the same symmetry the rest of the class is
+        about: a committed value that raises only on the machine without the package is a
+        defect that reproduces on one laptop and nowhere else.
+
+        ``edge = ""`` is in here deliberately. It is falsy, and the standin used to
+        substitute `STANDIN_EDGE` for it silently — a config key read, stored and
+        changing nothing, which is the convincing empty this phase was written against.
+        """
+        self._install()
+        for asked in ({"edge": "sideways"}, {"edge": ""}, {"size": 12},
+                      {"size": "content"}):
+            with self.subTest(asked=asked):
+                with self.assertRaises(component.ComponentError):
+                    registry.Registry().place(CID, **asked)
+                with self.assertRaises(component.ComponentError):
+                    registry.Registry().place("acme.absent", **asked)
+
+    def test_the_providers_own_component_is_not_written_back_to(self):
+        """A frame's arrangement stays in the frame.
+
+        `acme_charter.metrics:Component` — the spec's own example entry point — is a
+        module-level singleton, and a module is imported once per interpreter. Writing
+        this frame's edge into it would hand the next frame that places it an
+        arrangement it never asked for, from a config it may not even have read.
+        """
+        self.site.install("acme-charter", "1.4.0", {CID: f"{MODULE}:widget"},
+                          {MODULE: _source() + "\nwidget = metrics()\n"})
+        self.r.place(CID, edge="top", size=component.Fixed(3))
+        self.assertEqual(sys.modules[MODULE].widget.edge, "right")
+        self.assertEqual(registry.Registry().place(CID).edge, "right")
 
 
 class AProviderThatRaisesCostsItsOwnPane(unittest.TestCase):

--- a/tests/test_component_providers.py
+++ b/tests/test_component_providers.py
@@ -1,0 +1,521 @@
+"""The seam a stranger's code arrives through: discovery, refusal, isolation, containment.
+
+**Every distribution below is real.** `importlib.metadata` is not stubbed anywhere in this
+file — each case writes a real `.dist-info` with a real `entry_points.txt` and a real
+importable module into a directory it puts on ``sys.path``, which is exactly what an
+installed package is as far as `importlib.metadata` is concerned. A stubbed
+`entry_points` would prove the stub works: it would answer with whatever shape the test
+imagined, and the day charter reads `ep.dist.version` or a duplicate name off the real API
+the test would keep passing while the frame refused every provider on the machine.
+
+The four properties §4b says must survive a stranger's code, plus the fifth from its
+closing paragraph, each with a case that fails without the guard:
+
+1. **A mismatched `API_VERSION` does not load**, and the refusal names the provider, the
+   version it speaks and the version charter speaks (§4g). Checked before the provider
+   builds anything, which is asserted rather than assumed.
+2. **An id two providers claim loads NEITHER**, names both, and the rest of the frame is
+   drawn (§4h).
+3. **A provider that raises costs its own pane** — on import, while building, or in
+   ``render`` — and the pane NAMES it. A blank pane is the confidently-wrong output the
+   left sidebar was retired for, and #512's lesson twice over: a convincing empty is worse
+   than a refusal.
+4. **Charter contains what came back**, after the component returned it, with
+   `contain.one_line` before the width arithmetic and `tui.width` rather than `len`.
+5. **A missing provider is a message**, in the rectangle config asked for, and the rest of
+   the frame is drawn.
+
+**Nothing here reads the machine.** Each case asserts about ids its own fixture installed,
+never about the set of providers this machine happens to carry, so a suite run on a
+developer's laptop with a real provider installed gives the answer CI gives.
+"""
+
+from __future__ import annotations
+
+import importlib
+import shutil
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from charter import tui
+from charter.frame import component, ctx, registry
+
+CID = "acme.metrics"
+MODULE = "acme_metrics"
+ENTRY = f"{MODULE}:metrics"
+
+
+#: "say nothing about the version and let the fixture pick charter's own" — an object
+#: rather than ``None``, because ``None`` is one of the values a case below installs AS
+#: the declared version, and a sentinel that is also a fixture value is a test that
+#: quietly stops testing.
+_CHARTERS = object()
+
+
+def _source(*, cid: str = CID, api: object = _CHARTERS,
+            render: str = "lambda ctx: ['ok']", head: str = "") -> str:
+    """A provider module: a version, a factory, and a record of whether it ran.
+
+    ``built`` is what makes "refused before the provider built anything" an assertion
+    rather than a hope — the module object survives the refusal in ``sys.modules``, so a
+    test can ask it afterwards.
+    """
+    api = component.API_VERSION if api is _CHARTERS else api
+    return textwrap.dedent(f"""\
+        from charter.frame import component
+        {head}
+        API_VERSION = {api!r}
+        built = False
+
+
+        def metrics():
+            global built
+            built = True
+            return component.Component(
+                id={cid!r}, title="Metrics", edge="right",
+                size=component.Fixed(12), needs=(), events=(),
+                render={render})
+        """)
+
+
+class _SitePackages:
+    """A directory that is an installed environment, as `importlib.metadata` sees one.
+
+    One directory holding every distribution a case installs, because that is what
+    site-packages is: two providers claiming one entry point name are two `.dist-info`
+    directories side by side, which is the only way to build §4h's collision without
+    inventing a shape for it.
+
+    Cleanups are bound methods of THIS object rather than of the test, so nothing here
+    can be replaced by a subclass defining a method of the same name — the shape that
+    silently dropped a base class's cleanup once already.
+    """
+
+    def __init__(self, case: unittest.TestCase) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="charter-provider-"))
+        self._modules: list[str] = []
+        case.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        case.addCleanup(self._unpath)
+        case.addCleanup(self._forget)
+        sys.path.insert(0, str(self.root))
+        importlib.invalidate_caches()
+
+    def install(self, dist: str, version: str, entries: dict[str, str],
+                modules: dict[str, str] | None = None) -> None:
+        """Write one distribution: its metadata, its entry points, its modules.
+
+        Installing over a distribution of the same name REPLACES it, module included —
+        a second copy left in ``sys.modules`` would serve the previous case's renderer to
+        the next one, and a second `.dist-info` beside it would look to charter exactly
+        like §4h's collision. Both are how a fixture quietly stops testing.
+        """
+        for name, src in (modules or {}).items():
+            (self.root / f"{name}.py").write_text(src, encoding="utf-8")
+            sys.modules.pop(name, None)
+            self._modules.append(name)
+        info = self.root / f"{dist.replace('-', '_')}-{version}.dist-info"
+        info.mkdir(exist_ok=True)
+        (info / "METADATA").write_text(
+            f"Metadata-Version: 2.1\nName: {dist}\nVersion: {version}\n", encoding="utf-8")
+        (info / "entry_points.txt").write_text(
+            "[charter.components]\n" + "".join(f"{k} = {v}\n" for k, v in entries.items()),
+            encoding="utf-8")
+        importlib.invalidate_caches()
+
+    def imported(self, name: str) -> bool:
+        """Whether *name* has actually been imported into this interpreter."""
+        return name in sys.modules
+
+    def _forget(self) -> None:
+        for name in self._modules:
+            sys.modules.pop(name, None)
+
+    def _unpath(self) -> None:
+        while str(self.root) in sys.path:
+            sys.path.remove(str(self.root))
+        importlib.invalidate_caches()
+
+
+def _ctx(width: int = 40, height: int = 8):
+    return ctx.build((), width=width, height=height, fid="fr-1", snapshot={})
+
+
+def _builtin(cid: str = "repos", edge: str = "bottom"):
+    """A component charter registered itself — the rest of the frame, in one object."""
+    return component.Component(id=cid, title=cid.title(), edge=edge,
+                               size=component.Content(), needs=(), events=(),
+                               render=lambda c: [f"{cid} drew"])
+
+
+class DiscoveryIsRealAndLazy(unittest.TestCase):
+    """An installed provider is FOUND from metadata and IMPORTED only when placed."""
+
+    def setUp(self):
+        self.site = _SitePackages(self)
+        self.r = registry.Registry()
+
+    def test_an_installed_provider_is_listed(self):
+        self.site.install("acme-charter", "1.4.0", {CID: ENTRY},
+                          {MODULE: _source()})
+        self.assertIn(CID, registry.Providers().ids())
+
+    def test_listing_does_not_import_the_provider(self):
+        """The whole cost argument: an installed-but-unplaced provider costs nothing.
+
+        The evidence is a module that CANNOT be imported without saying so — listing it
+        would raise here rather than quietly succeed, so this cannot pass by the import
+        happening to be cheap.
+        """
+        self.site.install("boom-charter", "2.0", {"boom.metrics": "boom_metrics:metrics"},
+                          {"boom_metrics": "raise RuntimeError('imported at discovery')\n"})
+        providers = registry.Providers()
+        self.assertIn("boom.metrics", providers.ids())
+        self.assertTrue(providers.supplies("boom.metrics"))
+        self.assertFalse(self.site.imported("boom_metrics"))
+
+    def test_placing_it_imports_it_and_draws_it(self):
+        self.site.install("acme-charter", "1.4.0", {CID: ENTRY},
+                          {MODULE: _source(render="lambda ctx: ['42 open', '3 stale']")})
+        placed = self.r.place(CID)
+        self.assertTrue(self.site.imported(MODULE))
+        self.assertEqual(placed.id, CID)
+        self.assertEqual(self.r.get(CID).title, "Metrics")
+        self.assertEqual([c.id for c in self.r.on_edge("right")], [CID])
+        self.assertEqual(self.r.draw(CID, _ctx()), ("42 open", "3 stale"))
+        self.assertEqual(self.r.failures, {})
+
+    def test_a_provider_may_name_the_component_itself_rather_than_a_factory(self):
+        """`acme_charter.metrics:Component` is the spec's own example spelling."""
+        self.site.install("acme-charter", "1.4.0", {CID: f"{MODULE}:widget"},
+                          {MODULE: _source() + "\nwidget = metrics()\n"})
+        self.assertEqual(self.r.place(CID).id, CID)
+
+    def test_placing_the_same_component_twice_answers_the_one_that_is_placed(self):
+        self.site.install("acme-charter", "1.4.0", {CID: ENTRY}, {MODULE: _source()})
+        first = self.r.place(CID)
+        self.assertIs(self.r.place(CID), first)
+
+
+class TheApiVersionIsRefusedAtLoad(unittest.TestCase):
+    """§4g: one integer, refused at load. Not semver negotiation, not a shim."""
+
+    def setUp(self):
+        self.site = _SitePackages(self)
+        self.r = registry.Registry()
+        self.other = component.API_VERSION + 6
+
+    def _install(self, api):
+        self.site.install("acme-charter", "9.9.9", {CID: ENTRY},
+                          {MODULE: _source(api=api)})
+
+    def test_a_provider_speaking_another_version_does_not_load(self):
+        self._install(self.other)
+        with self.assertRaises(component.ComponentError) as e:
+            registry.Providers().load(CID)
+        said = str(e.exception)
+        self.assertIn("acme-charter 9.9.9", said)
+        self.assertIn(f"version {self.other}", said)
+        self.assertIn(f"charter speaks {component.API_VERSION}", said)
+
+    def test_the_component_it_wanted_to_supply_is_not_on_the_frame(self):
+        """The half that matters: refusing is not enough if it is drawn anyway."""
+        self._install(self.other)
+        self.r.place(CID)
+        self.assertEqual(self.r.get(CID).title, f"{CID} — not drawn")
+        self.assertIn("acme-charter 9.9.9", self.r.failures[CID])
+
+    def test_the_version_is_read_before_the_provider_builds_anything(self):
+        """Refused at LOAD means before its code runs, not after it has built a panel."""
+        self._install(self.other)
+        self.r.place(CID)
+        self.assertFalse(sys.modules[MODULE].built)
+
+    def test_a_provider_declaring_no_version_at_all_does_not_load(self):
+        self.site.install("acme-charter", "9.9.9", {CID: ENTRY},
+                          {MODULE: _source().replace(f"API_VERSION = {component.API_VERSION!r}",
+                                                     "")})
+        with self.assertRaises(component.ComponentError) as e:
+            registry.Providers().load(CID)
+        self.assertIn("API_VERSION", str(e.exception))
+        self.assertIn("acme-charter 9.9.9", str(e.exception))
+
+    def test_a_version_that_is_not_an_integer_does_not_load(self):
+        """``"1"`` and ``True`` are the two a permissive check lets through: ``True ==
+        1`` in Python, so a bare equality would load a provider declaring a boolean."""
+        for api in ("1", True, 1.0, None):
+            with self.subTest(api=api):
+                self._install(api)
+                with self.assertRaises(component.ComponentError) as e:
+                    registry.Providers().load(CID)
+                self.assertIn("API_VERSION", str(e.exception))
+
+
+class OneIdIsClaimedByOneProvider(unittest.TestCase):
+    """§4h: silently picking one means a pane whose origin cannot be determined."""
+
+    def setUp(self):
+        self.site = _SitePackages(self)
+        self.r = registry.Registry()
+        self.site.install("acme-charter", "1.4.0", {CID: ENTRY}, {MODULE: _source()})
+        self.site.install("other-charter", "0.2", {CID: "other_metrics:metrics"},
+                          {"other_metrics": _source()})
+
+    def test_a_collision_loads_neither_and_names_both(self):
+        with self.assertRaises(component.ComponentError) as e:
+            registry.Providers().load(CID)
+        said = str(e.exception)
+        self.assertIn("acme-charter 1.4.0", said)
+        self.assertIn("other-charter 0.2", said)
+        self.assertIn(CID, said)
+
+    def test_neither_provider_is_even_imported(self):
+        """The collision is visible in metadata, so no stranger's code needs to run."""
+        self.r.place(CID)
+        self.assertFalse(self.site.imported(MODULE))
+        self.assertFalse(self.site.imported("other_metrics"))
+
+    def test_the_rest_of_the_frame_is_drawn(self):
+        self.r.register(_builtin())
+        self.r.place(CID)
+        self.assertEqual([c.id for c in self.r.on_edge("bottom")], ["repos", CID])
+        self.assertEqual(self.r.draw("repos", _ctx()), ("repos drew",))
+
+    def test_the_pane_says_which_two(self):
+        self.r.place(CID)
+        drawn = " ".join(self.r.draw(CID, _ctx(width=60)))
+        self.assertIn("acme-charter", drawn)
+        self.assertIn("other-charter", drawn)
+
+
+class TheEntryPointNameIsTheId(unittest.TestCase):
+    """What config places must be what charter can resolve without importing anything."""
+
+    def setUp(self):
+        self.site = _SitePackages(self)
+        self.r = registry.Registry()
+
+    def test_a_provider_answering_a_different_id_does_not_load(self):
+        self.site.install("acme-charter", "1.4.0", {CID: ENTRY},
+                          {MODULE: _source(cid="repos")})
+        with self.assertRaises(component.ComponentError) as e:
+            registry.Providers().load(CID)
+        self.assertIn(CID, str(e.exception))
+        self.assertIn("repos", str(e.exception))
+
+    def test_it_cannot_take_over_a_built_in_that_way(self):
+        """The reason the check exists: a config naming one thing loading another."""
+        self.r.register(_builtin())
+        self.site.install("acme-charter", "1.4.0", {CID: ENTRY},
+                          {MODULE: _source(cid="repos")})
+        self.r.place(CID)
+        self.assertEqual(self.r.draw("repos", _ctx()), ("repos drew",))
+
+    def test_a_bare_id_nothing_registered_is_a_message_not_a_lookup(self):
+        """A typo'd built-in and a provider id spelled without its namespace, at once."""
+        self.r.place("repose")
+        self.assertIn("repose", self.r.failures)
+        self.assertIn("namespaced", self.r.failures["repose"])
+
+    def test_an_id_that_could_never_name_a_component_is_refused(self):
+        with self.assertRaises(component.ComponentError):
+            self.r.place("acme\nmetrics")
+
+
+class AMissingProviderIsAMessage(unittest.TestCase):
+    """§4b: a committed config must never make charter unusable for somebody else."""
+
+    def setUp(self):
+        self.site = _SitePackages(self)          # installed: nothing
+        self.r = registry.Registry()
+
+    def test_the_component_config_named_becomes_a_pane_that_says_so(self):
+        self.r.place(CID)
+        drawn = " ".join(self.r.draw(CID, _ctx(width=70)))
+        self.assertIn(CID, drawn)
+        self.assertIn("no installed provider", drawn)
+
+    def test_the_rest_of_the_frame_is_drawn(self):
+        self.r.register(_builtin())
+        self.r.register(_builtin("identity", edge="top"))
+        self.r.place(CID)
+        self.assertEqual(self.r.draw("repos", _ctx()), ("repos drew",))
+        self.assertEqual(self.r.draw("identity", _ctx()), ("identity drew",))
+
+    def test_the_standin_keeps_the_rectangle_config_asked_for(self):
+        """So a machine missing one provider draws the same frame, minus one pane's text.
+
+        Order is geometry — ``["top","bottom","right"]`` gives a 200-column bottom row and
+        ``["top","right","bottom"]`` gives 177 — so a standin that took a different edge
+        would move every panel registered after it.
+        """
+        self.r.register(_builtin("identity", edge="top"))
+        placed = self.r.place(CID, edge="right", size=component.Fixed(12))
+        self.assertEqual(placed.edge, "right")
+        self.assertEqual(placed.size, component.Fixed(12))
+        self.assertEqual(self.r.split_order("identity"), 1)
+        self.assertEqual(self.r.split_order(CID), 2)
+
+    def test_it_is_a_pane_and_not_a_hole(self):
+        """A panel that is simply absent is the frame lying about the plane (#512)."""
+        self.r.place(CID, edge="right", size=component.Fixed(12))
+        self.assertEqual([c.id for c in self.r.on_edge("right")], [CID])
+
+
+class AProviderThatRaisesCostsItsOwnPane(unittest.TestCase):
+    """§4b property 1, on every path a stranger's code can fail on."""
+
+    def setUp(self):
+        self.site = _SitePackages(self)
+        self.r = registry.Registry()
+        self.r.register(_builtin())
+
+    def _install(self, module_src, entry=ENTRY):
+        self.site.install("acme-charter", "1.4.0", {CID: entry}, {MODULE: module_src})
+
+    def _still_alive(self):
+        self.assertEqual(self.r.draw("repos", _ctx()), ("repos drew",))
+
+    def test_a_module_that_raises_on_import_costs_its_pane(self):
+        self._install("raise RuntimeError('no such database')\n")
+        self.r.place(CID)
+        drawn = " ".join(self.r.draw(CID, _ctx(width=70)))
+        self.assertIn(CID, drawn)
+        self.assertIn("RuntimeError", drawn)
+        self.assertIn("no such database", drawn)
+        self._still_alive()
+
+    def test_a_factory_that_raises_costs_its_pane(self):
+        self._install(f"API_VERSION = {component.API_VERSION!r}\n\n\n"
+                      "def metrics():\n"
+                      "    raise ValueError('bad config')\n")
+        self.r.place(CID)
+        drawn = " ".join(self.r.draw(CID, _ctx(width=70)))
+        self.assertIn("ValueError", drawn)
+        self.assertIn("bad config", drawn)
+        self._still_alive()
+
+    def test_an_entry_point_naming_nothing_costs_its_pane(self):
+        self._install(_source(), entry=f"{MODULE}:absent")
+        self.r.place(CID)
+        self.assertIn("absent", " ".join(self.r.draw(CID, _ctx(width=70))))
+        self._still_alive()
+
+    def test_a_render_that_raises_names_the_component_and_the_failure(self):
+        self._install(_source(render="lambda ctx: 1 / 0"))
+        self.r.place(CID)
+        drawn = " ".join(self.r.draw(CID, _ctx(width=70)))
+        self.assertIn(CID, drawn)
+        self.assertIn("ZeroDivisionError", drawn)
+        self._still_alive()
+
+    def test_a_render_that_raises_never_draws_a_blank_pane(self):
+        """The specific defect: nothing at all, in a frame that looks deliberate."""
+        self._install(_source(render="lambda ctx: 1 / 0"))
+        self.r.place(CID)
+        self.assertNotEqual(self.r.draw(CID, _ctx()), ())
+
+    def test_a_render_that_exits_the_process_costs_its_pane(self):
+        """`SystemExit` is not an `Exception`, and it would take the session with it."""
+        self._install(_source(render="lambda ctx: sys.exit(3)", head="import sys"))
+        self.r.place(CID)
+        self.assertIn("SystemExit", " ".join(self.r.draw(CID, _ctx(width=70))))
+        self._still_alive()
+
+    def test_the_operators_own_interrupt_still_travels(self):
+        """Containment is not a sandbox, and a frame that cannot be stopped is worse."""
+        self._install(_source(render="lambda ctx: (_ for _ in ()).throw(KeyboardInterrupt())"))
+        self.r.place(CID)
+        with self.assertRaises(KeyboardInterrupt):
+            self.r.draw(CID, _ctx())
+
+    def test_a_render_answering_something_that_is_not_lines_costs_its_pane(self):
+        for answer, wanted in (("'one long string'", "one long string"),
+                               ("None", "None"),
+                               ("{'rows': []}", "rows"),
+                               ("[None]", "None"),
+                               ("[b'bytes']", "bytes")):
+            with self.subTest(answer=answer):
+                self._install(_source(render=f"lambda ctx: {answer}"))
+                r = registry.Registry()
+                r.place(CID)
+                drawn = " ".join(r.draw(CID, _ctx(width=70)))
+                self.assertIn(CID, drawn)
+                self.assertIn(wanted, drawn)
+                self._still_alive()
+
+
+class CharterContainsWhatCameBack(unittest.TestCase):
+    """§4b property 3: applied by charter AFTER the component returned, not trusted to it."""
+
+    def setUp(self):
+        self.site = _SitePackages(self)
+        self.r = registry.Registry()
+
+    def _draw(self, render, *, width=20, height=4):
+        self.site.install("acme-charter", "1.4.0", {CID: ENTRY},
+                          {MODULE: _source(render=render)})
+        self.r.place(CID)
+        return self.r.draw(CID, _ctx(width=width, height=height))
+
+    def test_an_escape_sequence_is_shown_rather_than_obeyed(self):
+        """A row of ESC would move the cursor out of its own rectangle and draw over the
+        pane beside it. The component renders committed values — a branch name is one —
+        so this is a value crossing into a format with structure, again.
+
+        **Asserted as the escape being VISIBLE, not merely absent.** `tui.truncate`
+        deletes a non-markup escape on its way past, so "no ESC in the row" is a property
+        a DIFFERENT guard already provides and this test would pass with charter's
+        containment removed entirely — the shape this suite has shipped before. What
+        `contain.one_line` adds is that the row says what was in it, which is the same
+        argument `contain.py` makes for five kinds of "no answer": a defect folded behind
+        a silent deletion is a defect nobody fixes.
+        """
+        rows = self._draw(r"lambda ctx: ['\x1b[2Jwiped']", width=40)
+        self.assertNotIn("\x1b", rows[0])
+        self.assertEqual(rows[0], r"\x1b[2Jwiped")
+
+    def test_a_newline_cannot_forge_a_second_row(self):
+        """Shown as ``\\x0a`` for the same reason: `tui.truncate` alone turns it into a
+        space, and a row silently joined is one nobody knows was two."""
+        rows = self._draw(r"lambda ctx: ['one\ntwo']", width=40)
+        self.assertEqual(rows, (r"one\x0atwo",))
+
+    def test_a_row_is_clipped_to_the_pane_in_CELLS_and_not_in_characters(self):
+        """Width, not length: 20 CJK characters are 40 columns and would overflow the
+        pane by exactly the amount `len` cannot see."""
+        rows = self._draw("lambda ctx: ['世' * 40]", width=20)
+        self.assertLessEqual(tui.width(rows[0]), 20)
+        self.assertLess(len(rows[0]), 20)
+
+    def test_more_rows_than_the_pane_has_are_dropped(self):
+        rows = self._draw("lambda ctx: ['row %d' % i for i in range(100)]", height=4)
+        self.assertEqual(rows, ("row 0", "row 1", "row 2", "row 3"))
+
+    def test_a_pane_with_no_room_draws_nothing(self):
+        self.site.install("acme-charter", "1.4.0", {CID: ENTRY},
+                          {MODULE: _source(render="lambda ctx: ['anything']")})
+        self.r.place(CID)
+        self.assertEqual(self.r.draw(CID, _ctx(width=0, height=0)), ())
+
+    def test_a_row_of_zero_width_characters_is_still_bounded(self):
+        """`tui.truncate` bounds CELLS, and a combining mark is none of them — so a row
+        that measures nothing can still be a megabyte. Both bounds, or neither works."""
+        rows = self._draw("lambda ctx: ['́' * 200000]", width=20)
+        self.assertLessEqual(len(rows[0]), registry.LINE_LIMIT + 1)
+
+    def test_charters_own_markup_survives_its_own_renderer(self):
+        """The other half of the rule, and why escaping is provenance and not a flag.
+
+        Charter's renderers contain their committed values where they interpolate them
+        and add charter's colour on top; escaping their output here would corrupt
+        charter's own markup while protecting nothing.
+        """
+        bold = "\x1b[1m"
+        self.r.register(component.Component(
+            id="identity", title="Identity", edge="top", size=component.Fixed(1),
+            needs=(), events=(), render=lambda c: [f"{bold}charter{tui.RESET}"]))
+        self.assertEqual(self.r.draw("identity", _ctx()),
+                         (f"{bold}charter{tui.RESET}",))


### PR DESCRIPTION
Phase 1, Task 7 of `docs/superpowers/plans/2026-08-26-phase1-component-registry.md`. Sits on
top of #548 (the contract, the registry, `ctx`) and touches only `charter/frame/registry.py`
plus a new test file — no overlap with Tasks 5 and 6.

**Arrangement is committed; execution is local.** A `charter.toml` says which components to
place, where and in what order. It never says what code runs. The code comes from a
distribution the operator installed, declaring an entry point:

```toml
[project.entry-points."charter.components"]
"acme.metrics" = "acme_charter.metrics:component"
```

`importlib.metadata` is stdlib, so `dependencies = []` is untouched. Nothing is placed by
this PR yet — config reaches the registry in Task 6.

## What it draws

Real distributions, written to a real `sys.path` entry, placed and drawn through
`Registry.place` / `Registry.draw`. Discovery lists five ids having imported nothing:

```
installed providers, listed WITHOUT importing any of them:
    acme.dupe, acme.metrics, flaky.board, gauge.load, rude.banner
    imported so far: none

┌─ acme.metrics ───────┐   ┌─ gauge.load ─────────┐
│p50  184ms            │   │gauge-charter 0.9     │
│p99  1.2s             │   │supplies gauge.load   │
│err  0.03%            │   │for component API     │
│repos 2               │   │version 4, and charter│
└──────────────────────┘   │speaks 1. It is not   │
                           │loaded: a contract    │
                           └──────────────────────┘

┌─ acme.dupe ──────────┐   ┌─ acme.absent ────────┐
│2 installed providers │   │no installed provider │
│supply the component  │   │supplies the component│
│acme.dupe:            │   │acme.absent — install │
│acme-charter-fork 3.0,│   │the distribution that │
│other-charter 0.2.    │   │declares it in the    │
│Charter loads NEITHER │   │charter.components    │
└──────────────────────┘   └──────────────────────┘

┌─ flaky.board ──────────────────────────────────────────────┐
│flaky.board failed to draw — ZeroDivisionError: division by │
│zero                                                        │
└────────────────────────────────────────────────────────────┘

┌─ rude.banner ──────────────────────────────────────────────┐
│\x1b[2J\x1b[HOWNED feature/世界-branch-name-that-runs-on    │
└────────────────────────────────────────────────────────────┘

imported after placing: ['acme_metrics', 'flaky_board', 'gauge_load', 'rude_banner']
```

The last line is the point of the first: `acme_dupe_a` and `acme_dupe_b` are absent from it.
The collision is visible in metadata, so neither module is imported to find out. `acme.metrics`
declared `needs = ("repos",)` and its `repos 2` is the `ctx` slice from #548, cut from the one
snapshot. The 22-column refusals run past six rows — `Registry.failures` keeps each reason in
full, at a width a pane does not have, for `doctor` to say later.

`rude.banner` is one row a provider returned: a screen-clear, a cursor home, forty combining
marks and a wide-character branch name. The escapes are **shown**, not obeyed and not silently
deleted.

## The five properties, and the mutation that killed each test

Every mutation below was applied to `charter/frame/registry.py`, run, restored, and re-run
green, with `__pycache__` cleared each time.

| property | mutation applied | result |
|---|---|---|
| a mismatched `API_VERSION` does not load | `if speaks != API_VERSION:` → `if False:` | **RED**, 3 failures |
| an id collision refuses both | `if len(eps) > 1:` → `if False:` | **RED**, 4 failures |
| a raising provider costs its pane | `except BaseException` → `except UnicodeDecodeError` in `draw` | **RED**, 8 errors |
| charter escapes what came back | `if escape:` → `if False:` in `_fit` | **RED**, 3 failures |
| …and clips it | drop the `tui.truncate` call | **RED**, 1 failure |
| …in cells, not characters | `tui.truncate(line, width)` → `line[:width]` | **RED**, 1 failure |
| discovery is lazy | `ep.load()` inside the discovery loop | **RED**, 1 failure + 3 errors |
| a missing provider is a message | `place`'s `except ComponentError` re-raises | **RED**, 14 errors |

## Two defects the tests found in this PR's own work

* **Provider components were never recorded as foreign**, so the containment ran on standins
  and not on the code it exists for. The zero-width-row case caught it.
* **Two containment tests were passing on a different guard.** `tui.truncate` *deletes* a
  stray escape on its way past, so `assertNotIn("\x1b", row)` stayed green with charter's
  containment removed entirely — the shape this suite has shipped before. They now assert the
  escape is *visible* as `\x1b`, which is what charter claims and what `contain.py` argues
  for: a defect folded behind a silent deletion is a defect nobody fixes.

## Decisions taken inside the plan's step, worth a reviewer's eye

* **The entry point name IS the component id, and a provider whose component answers a
  different id is refused, naming both.** The name is what a committed config places and what
  charter resolves *without importing anything*; if the loaded component could answer to
  another id, a config naming one thing would draw another — and a provider could take over a
  built-in by declaring an entry point that never mentions it.
* **A provider id must be namespaced (`dist.name`); charter's own are bare.** So a
  provider-vs-built-in collision cannot exist, and the only collision left is the
  provider-vs-provider one §4h says to refuse. Refusing both there never costs charter its own
  repo table.
* **A missing or refused component becomes a standin pane at the configured edge and size**,
  not a skipped split. Order is geometry — `["top","bottom","right"]` gives a 200-column bottom
  row, `["top","right","bottom"]` gives 177 — so a standin on a different edge would move every
  panel registered after it.
* **Escaping in `draw` is decided by provenance, not by an argument.** Charter's own renderers
  contain their committed values where they interpolate them and add charter's markup on top;
  re-escaping their output would corrupt charter's own colour while protecting nothing. The
  width and row bounds apply to everything — the rectangle is the frame's, whoever drew in it.
* **`SystemExit` is caught, `KeyboardInterrupt` is not.** A provider calling `sys.exit()` in
  `render` would take the session; a frame that cannot be stopped during a repaint is worse
  than one that loses a pane. This is containment, not a sandbox, and the docstring says so.

## Tests

`tests/test_component_providers.py`, 37 cases. **`importlib.metadata` is not stubbed
anywhere** — each case writes a real `.dist-info` with a real `entry_points.txt` and a real
importable module into a directory it puts on `sys.path`, which is what an installed package
is as far as `importlib.metadata` is concerned. A stubbed discovery test proves the stub
works, and would keep passing the day charter reads a duplicate name or `ep.dist.version` off
the real API. No case asserts about the providers this machine happens to carry — only about
ids its own fixture installed — so the answer is the same on a laptop and on CI.

Full suite, run twice:

* ambient charter variables cleared — `Ran 5826 tests`, `OK`
* the same with `CHARTER_WORKSPACE` set to a name no fixture uses — `Ran 5826 tests`, `OK`

(5789 on `origin/main` before this branch, plus the 37 here.)

## No news entry

Nothing an operator can do changes yet: no command, no config key, no frame difference until
`[[frame.component]]` reaches the registry in Task 6. #548 shipped without one for the same
reason. A news entry describing "install a provider and place it" would be untrue until that
lands.

No version bump, no stamping, no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
