### PR TITLE
The frame is components, and the config maps onto them (Tasks 5 and 6)

### DIFF
--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -1,0 +1,170 @@
+"""Charter's own panels, expressed as components — the same seam a provider gets.
+
+Four strings in a list is what the frame used to be, and their POSITION was the geometry
+(`instance.FRAME_SLOTS`). This module is where those four names become components that
+declare their own edge, their own size policy and what they read, so that everything
+downstream asks the registry a question instead of remembering an answer.
+
+**Charter's own panels go through the public seam first** (§4b's sequencing note). There
+is no private table of edges beside the one a provider's component will be placed from:
+`layout` derives every one of its per-slot facts — which splits cost columns, which
+strips are a fixed height, which one takes what its content needs — from
+:func:`build`'s registry, and nothing derives them from a list position any more.
+
+**This task changed no output, and that is the point.** Each component wraps the renderer
+`frame/slots.py` already had, unchanged; the six declarations below are a statement of
+what those renderers already do, not a new arrangement. The before/after render at 200x50
+and 80x24 is byte-identical.
+
+**The slot names survive, as a mapping, because they are committed** (:data:`SLOT_OF`).
+`[frame] slots = ["top", "bottom", "repos", "right"]` sits in charter.toml on every plane
+that has one, `charter panel top --session …` is the argv `layout.panel_command` emits
+into a tmux pane, and both are compatibility surfaces. So a slot name is what the outside
+world says and a component id is what charter reasons with, with exactly one table
+between them rather than a rename rippling through tmux argv, config files and the
+renderer registry at once.
+
+**What each component declares in ``needs`` is what its RENDERER actually reads, which is
+not the same as what the slice names suggest.**
+
+* `identity` and `attention` declare nothing. They look like they should read the plane —
+  `_bottom` prints a todo count — but `statusline._todo_count` is a directory glob
+  (`todos.count_open`) and `_alerts` reads charter.toml and the persona roster. Neither
+  goes near `gather`, and a declaration saying otherwise would make the frame's cost
+  budget describe a cost that is not there.
+* `personas` declares nothing either, and the coordinator's note on this is worth keeping:
+  its renderer reads `statusline._persona_chip_cells()` directly. That is a fact about the
+  renderer, not about the contract. Declaring a `personas` slice `ctx` cannot serve would
+  hand a component an empty tuple it could draw nothing from and pass its own tests
+  against — a convincing empty, which is worse than a refusal and is exactly the defect
+  #512 fixed. `component.NEEDS` names the three slices `gather.scan` genuinely carries;
+  personas joins it when it can be served, not before.
+* `repos`, `todos` and `sidebar` declare ``gather`` — the whole scan, not the narrower
+  ``repos``/``todos`` slices — and each for a reason the narrow slice cannot cover.
+  `_repos` reads ``worktrees`` and ``current_repo`` alongside the rows, and it tells
+  ``gather.cached(fid) is None`` ("nothing has scanned yet") apart from an empty scan
+  ("this workspace has no clones"), a distinction the `repos` slice flattens to ``()`` for
+  both. `_todo_rows` reads ``todo_count``, the UNCLIPPED total, which is how the
+  `…(+N more)` line can say how many are hidden; a component built on the `todos` slice
+  alone would report zero hidden todos with no way to know it was wrong.
+
+**Registration order is split order** (`registry.Registry`), so the four placed components
+are registered in the order charter splits their panes off the harness: identity,
+attention, repos, sidebar. The two parts of the sidebar are registered between them,
+because the registry refuses a composite whose parts it has not seen — they take split
+numbers of their own and are never placed, which `Registry.on_edge` is what enforces.
+"""
+
+from __future__ import annotations
+
+from .component import Component, Content, Fill, Fixed
+from .registry import Registry
+
+#: Component id → the `[frame] slots` name it is spelled with in a committed charter.toml
+#: and in `charter panel <slot>`'s argv. The one table between the two vocabularies; see
+#: this module's docstring for why both exist.
+#:
+#: Only PLACED components are here. `personas` and `todos` share the sidebar's pane and
+#: were never slots, so there is nothing for them to be spelled as.
+SLOT_OF = {
+    "identity": "top",
+    "attention": "bottom",
+    "repos": "repos",
+    "sidebar": "right",
+}
+
+#: The reverse, for the direction the config boundary reads in: a committed slot name to
+#: the component that draws it. Derived rather than written out, so the two cannot
+#: disagree about a name — the shape `instance.FRAME_DEFAULTS` already uses.
+COMPONENT_OF = {slot: cid for cid, slot in SLOT_OF.items()}
+
+
+def _panel(slot: str):
+    """The whole-pane renderer for *slot*, adapted to the component contract.
+
+    ``slots.SLOTS`` is read at CALL time rather than captured here, and the tests that
+    replace an entry of it (`mock.patch.dict(slots.SLOTS)`) are why: a renderer captured
+    at registration would go on drawing after the table it came from had been changed,
+    which is the same stale-copy failure `panel_command`'s docstring records for the
+    respawn argv.
+
+    ``split("\\n")`` and never ``splitlines()``. A panel writes the renderer's string out
+    as it is, so the adaptation has to round-trip: ``"\\n".join(s.split("\\n")) == s`` for
+    every string there is, while ``splitlines()`` turns a renderer that answered one empty
+    line into a component that answered no lines at all.
+
+    **The wrapped renderer measures its own pane and ignores ``ctx.width``.** That is
+    today's truth and this says so rather than implying otherwise: `slots._width` asks the
+    pane's own tty because a panel process inherits the LAUNCHING shell's ``$COLUMNS``
+    (`frame/slots.py`'s module docstring measures a 22-column pane reporting 200). The
+    geometry on `ctx` is what a component written against the contract reads; moving
+    charter's own renderers onto it is a later task, and doing it here would have changed
+    output, which this one may not.
+    """
+    def render(ctx) -> list[str]:
+        from . import slots
+        return slots.SLOTS[slot](ctx.fid).split("\n")
+
+    render.__name__ = f"render_{slot}"
+    render.__qualname__ = render.__name__
+    return render
+
+
+def _personas(ctx) -> list[str]:
+    """The sidebar's persona rows — `slots.persona_section` at this pane's size."""
+    from . import slots
+    return slots.persona_section(ctx.width, ctx.height,
+                                 terse=slots.verbosity(ctx.fid) == "terse")
+
+
+def _todos(ctx) -> list[str]:
+    """The sidebar's todo rows, spending the rows the pane gave this part."""
+    from . import slots
+    return slots.todo_section(ctx.fid, ctx.width, ctx.height,
+                              terse=slots.verbosity(ctx.fid) == "terse")
+
+
+def build() -> Registry:
+    """A registry holding charter's six built-in components, in split order.
+
+    A fresh one per call, deliberately — `registry.Registry`'s own docstring argues it:
+    module-level mutable state shared behind per-caller objects is isolation that is a
+    fiction. `layout` asks once at import for the edges and sizes it derives; a config
+    boundary resolving one plane's `[[frame.component]]` tables asks for its own.
+
+    Cheap enough to mean it: six frozen dataclasses and no I/O. The renderers are reached
+    lazily from inside each ``render``, so building a registry imports nothing.
+    """
+    from . import slots
+
+    reg = Registry()
+    reg.register(Component(
+        id="identity", title="identity", edge="top", size=Fixed(1),
+        needs=(), render=_panel("top")))
+    reg.register(Component(
+        id="attention", title="attention", edge="bottom", size=Fixed(1),
+        needs=(), render=_panel("bottom")))
+    # `Content()` with no cap, and `layout.repos_rows` is the cap: the table's height is
+    # what the plane's repos need, bounded by what the harness may not be charged
+    # (`layout.HARNESS_MIN_ROWS`), which is a fact about the WINDOW rather than about the
+    # component. A cap here would be a second, weaker copy of that arithmetic.
+    reg.register(Component(
+        id="repos", title="repos", edge="bottom", size=Content(),
+        needs=("gather",), render=_panel("repos")))
+    # The two parts of the sidebar, registered before the composite that draws them.
+    # `personas` is the `Fill()`: the pane is the persona column everywhere else charter
+    # names it, so it takes what is left and the todos are capped
+    # (`slots._MAX_TODO_LINES`) — `slots._right`'s docstring argues that ordering, and
+    # this is the same decision said in the registry's vocabulary rather than a second
+    # one.
+    reg.register(Component(
+        id="personas", title="personas", edge="right", size=Fill(),
+        needs=(), render=_personas))
+    reg.register(Component(
+        id="todos", title="todos", edge="right", size=Content(cap=slots._MAX_TODO_LINES),
+        needs=("gather",), render=_todos))
+    reg.register(Component(
+        id="sidebar", title="sidebar", edge="right", size=Fixed(22),
+        needs=("gather",), render=_panel("right"),
+        children=("personas", "todos")))
+    return reg

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -38,7 +38,10 @@ creation time (`-P -F '#{pane_id}'`); the caller reads it off stdout and hands i
 
 from __future__ import annotations
 
-from . import tmuxctl
+from typing import NamedTuple
+
+from . import builtins as _builtins, tmuxctl
+from .component import Fixed
 from .. import util
 
 #: The order slots are dropped in as the terminal shrinks. The side first — a side panel
@@ -58,6 +61,93 @@ from .. import util
 #: Retiring it hands those 22 columns back to the harness at every density.
 _DROP_ORDER = ("right", "repos", "top")
 
+#: The frame charter itself draws, as components — `frame/builtins.py`, asked ONCE at
+#: import for the edges and sizes every constant below is derived from.
+#:
+#: **This module used to carry four hand-written tables of per-slot facts** — which slots
+#: cost columns, which are a fixed height, which one is variable, how big each is — and a
+#: fifth spelled inline as ``slot == "top"``. Each was correct and each was a separate
+#: thing to remember, which is what a component's own declaration replaces: the registry
+#: is asked, and nothing here derives a slot's geometry from its position in a list.
+#:
+#: A module-level build is safe because `builtins.build` reads nothing and starts nothing
+#: — six frozen dataclasses whose renderers are reached lazily — and because charter's
+#: own six are fixed. A config boundary placing a plane's `[[frame.component]]` tables
+#: builds its OWN registry (see `instance.frame_components`); it does not edit this one.
+_BUILTIN = _builtins.build()
+
+#: Edges whose split takes COLUMNS off the pane it is carved from, and edges whose split
+#: takes ROWS. The `-h`/`-v` half of :func:`panel_argvs`, said once.
+_COLUMN_EDGES = ("left", "right")
+_ROW_EDGES = ("top", "bottom")
+
+#: The edges tmux has to be told to place BEFORE the harness (`split-window -b`) rather
+#: than after it. Also derived rather than spelled ``slot == "top"``: `left` is retired
+#: (#488) and would belong here the day it came back, and a second answer to "which side
+#: is this on" is what :data:`_COLUMN_EDGES` above already refuses to be.
+_BEFORE_EDGES = ("top", "left")
+
+#: The placed built-ins, in split order — the registry's own order, not this module's
+#: reading of one. `personas` and `todos` are absent: the `sidebar` composite draws them
+#: inside its own pane, so they are registered and never split for, which
+#: `registry.Registry.on_edge` is what enforces.
+_PLACED = tuple(c for c in _BUILTIN.all() if c.id in _builtins.SLOT_OF)
+
+
+def _cells(c) -> int:
+    """How many cells *c* is given when nothing has measured its content yet.
+
+    ``Fixed(n)`` is *n*, and that is the whole of `top`, `bottom` and `right`. A
+    ``Content`` or ``Fill`` slot has no answer to give here — its height is a function of
+    what is in it and of what the window can spare — so it gets the floor every size
+    policy already has (`component.cells` refuses a size below 1 cell: a panel nobody can
+    see is a panel nobody asked for). That floor is not a stand-in for the real number:
+    :func:`repos_rows` is, and :func:`slot_sizes` is what routes a caller to it.
+    """
+    return c.size.n if isinstance(c.size, Fixed) else 1
+
+
+class _Derived(NamedTuple):
+    """The five per-slot facts this module used to keep as five hand-written tables."""
+
+    size: dict[str, int]
+    edge: dict[str, str]
+    column: tuple[str, ...]
+    fixed_rows: tuple[str, ...]
+    variable_rows: frozenset[str]
+
+
+def _derive(placed) -> _Derived:
+    """Read all five off *placed* — the components, in split order, that own a pane.
+
+    One function rather than five comprehensions at module scope, and the reason is that
+    a comprehension at module scope cannot be asked a second question. This can: a test
+    hands it an arrangement whose sidebar is `Content()` or whose table sits on `top` and
+    checks that every one of the five moves together, which is the property the five
+    separate tuples never had — they agreed by having been edited in the same commit.
+
+    Keyed by the committed slot name (`builtins.SLOT_OF`) rather than the component id,
+    because that is the vocabulary `[frame] slots`, `charter panel <slot>` and every
+    caller in `commands_frame` already speak. A component with no slot name is a
+    ``KeyError`` here rather than a silently skipped pane: the caller has handed over
+    something that cannot be placed, and answering with a frame missing one panel is the
+    convincing-empty this module refuses everywhere else.
+    """
+    name = _builtins.SLOT_OF
+    return _Derived(
+        size={name[c.id]: _cells(c) for c in placed},
+        edge={name[c.id]: c.edge for c in placed},
+        column=tuple(name[c.id] for c in placed if c.edge in _COLUMN_EDGES),
+        fixed_rows=tuple(name[c.id] for c in placed
+                         if c.edge in _ROW_EDGES and isinstance(c.size, Fixed)),
+        variable_rows=frozenset(name[c.id] for c in placed
+                                if c.edge in _ROW_EDGES
+                                and not isinstance(c.size, Fixed)),
+    )
+
+
+_SHIPPED = _derive(_PLACED)
+
 #: Rows a horizontal panel occupies, and columns a vertical one does.
 #:
 #: **`repos`' entry is a FLOOR, not its size** (#488, moved off `bottom` by #515). Every
@@ -68,7 +158,15 @@ _DROP_ORDER = ("right", "repos", "top")
 #: all, where the pane says so in one line). Callers ask :func:`slot_sizes` rather than
 #: indexing this directly, so nothing has to remember which of the two questions it is
 #: asking.
-SLOT_SIZE = {"top": 1, "bottom": 1, "repos": 1, "right": 22}
+#:
+#: Derived from each component's declared size (:func:`_cells`) rather than written out,
+#: so `right`'s 22 columns and the floor under the table are stated in one place — the
+#: component — and read here.
+SLOT_SIZE = _SHIPPED.size
+
+#: Which side of the harness each slot is split off, read straight from the component
+#: that draws it. The one fact :func:`panel_argvs` needs that is not a size.
+SLOT_EDGE = _SHIPPED.edge
 
 #: Rows the harness keeps whatever the repo table would like. The frame exists to show
 #: the plane's state around an agent session, and a session squeezed into three rows is
@@ -98,7 +196,10 @@ _BORDER_COLS = 1
 #: ``== "right"`` because :func:`repos_cols` and `panel_argvs` are two places that have
 #: to agree about which splits cost columns, and the next side slot must not have to be
 #: remembered in both.
-_COLUMN_SLOTS = ("right",)
+#:
+#: Now the component's own `edge` answers it, so the next side slot is not remembered
+#: anywhere: it declares an edge and lands here.
+_COLUMN_SLOTS = _SHIPPED.column
 
 #: The horizontal strips whose height is a CONSTANT, and therefore the rows
 #: :func:`repos_rows` has to subtract before it may spend what is left. `right` is not
@@ -111,7 +212,11 @@ _COLUMN_SLOTS = ("right",)
 #: carry is `repos`. A `repos_rows` still subtracting `top` alone would hand the table
 #: two rows the status strip and its own border are already using, and tmux grants an
 #: over-large height out of the neighbour rather than refusing it — the harness.
-_FIXED_ROW_SLOTS = ("top", "bottom")
+#:
+#: Both exclusions this comment states are now the components' own declarations: `right`
+#: is out because its edge costs columns, `repos` because its size is `Content()` rather
+#: than `Fixed`. Neither was enforced by anything while this was a written-out tuple.
+_FIXED_ROW_SLOTS = _SHIPPED.fixed_rows
 
 #: The slots whose height is a function of their content rather than a constant — the
 #: ones :func:`slot_sizes` answers with :func:`repos_rows` instead of :data:`SLOT_SIZE`.
@@ -124,7 +229,13 @@ _FIXED_ROW_SLOTS = ("top", "bottom")
 #: `top,bottom,repos` left `%3 h=1` and `%2 h=6` — the two sizes swapped panes). The pane
 #: that must be left to take the remainder is the one whose size is already a function of
 #: everything else, which is this one. See `commands_frame._reassert_sizes`.
-VARIABLE_ROW_SLOTS = frozenset({"repos"})
+#:
+#: The complement of :data:`_FIXED_ROW_SLOTS` over the horizontal edges, and written as
+#: that rather than as a second list: a slot cannot be in both, or in neither, because
+#: one predicate decides it. `Content` and `Fill` both land here — a slot whose height is
+#: its content's and a slot whose height is what is left are the same kind of dependent
+#: pane as far as `resize-pane` is concerned.
+VARIABLE_ROW_SLOTS = _SHIPPED.variable_rows
 
 
 def _table_min_cols() -> int:
@@ -647,7 +758,11 @@ def panel_argvs(*, slots: list[str], session: str, socket: str,
         # COLUMNS is exactly what :func:`repos_cols` has to know to answer how wide
         # `repos` ends up, and two copies of that fact are two things to keep in step.
         direction = "-h" if slot in _COLUMN_SLOTS else "-v"
-        before = ["-b"] if slot == "top" else []
+        # `-b` is the component's EDGE, not the name `top` — see :data:`_BEFORE_EDGES`.
+        # A slot charter has no component for keeps the plain `-v`/after placement it had
+        # while this was spelled `slot == "top"`, which is the same filter-don't-refuse
+        # degrade `slot_sizes` makes one line above.
+        before = ["-b"] if SLOT_EDGE.get(slot) in _BEFORE_EDGES else []
         cmds.append(_tmux(socket, "split-window", "-t", harness_pane,
                           direction, *before, "-l", str(size),
                           *_env_argv(env),

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -968,6 +968,60 @@ def _todo_rows(data: dict, width: int, budget: int) -> list[str]:
     return rows
 
 
+def persona_section(width: int, height: int, *, terse: bool) -> list[str]:
+    """The sidebar's persona rows: the heading, and every chip a *height*-row pane fits.
+
+    Named because the registry names it — `frame/builtins.py` places this as the
+    `personas` component, one of the two parts of the `sidebar` composite. It is
+    :func:`_right`'s own first half, moved rather than rewritten: `_right` calls it, so
+    there is one implementation of "what the persona column says" and not a component's
+    copy sitting beside the panel's.
+
+    Takes *terse* rather than reading `verbosity(fid)` itself, so the pane that draws BOTH
+    sections asks the frame's density once and hands the same answer to each. Two reads
+    would be two small file reads per repaint where one was enough, and — worse — two
+    chances for the halves of one pane to disagree if the density changed between them.
+
+    A plane with no personas at all says so in one line. It is not an empty column:
+    an empty column is indistinguishable from a pane that failed to draw, which is the
+    reading the frame refuses everywhere else.
+    """
+    from .. import statusline as sl
+    cells = sl._persona_chip_cells()
+    if not cells:
+        return [tui.truncate(f"{sl._DIM}no personas{sl._R}", width)]
+    keep = height - 1                       # the heading takes a row off the list
+    if terse:
+        keep = min(keep, _TERSE_ROWS)
+    cells = _cap_personas(cells, keep)
+    return [_sidebar_head("personas", _persona_total(cells), width),
+            *_persona_rows(cells, width)]
+
+
+def todo_section(fid: str, width: int, budget: int, *, terse: bool) -> list[str]:
+    """This workspace's open todos, in at most *budget* rows — the `todos` component.
+
+    :func:`_right`'s own second half, moved for the reason :func:`persona_section` gives.
+    *budget* is what the pane has left after the personas; the density's own cap
+    (:data:`_TERSE_ROWS` or :data:`_MAX_TODO_LINES`) is applied here rather than by the
+    caller, so a caller that has rows to spare cannot spend more of them on todos than
+    the density allows.
+
+    **The cache is opened only when there is a row to draw it into.** `gather.read` is
+    reached after the budget is known to be positive, never before — a pane with no room
+    must not open a file it is about to discard, which is the same ordering
+    :func:`repos_rows_wanted` keeps and the same reason.
+
+    How SHORT is too short is `_todo_rows`' rule and is asked there once: this decides
+    only whether there is any room at all.
+    """
+    from . import gather
+    budget = min(budget, _TERSE_ROWS if terse else _MAX_TODO_LINES)
+    if budget <= 0:
+        return []
+    return _todo_rows(gather.read(fid), width, budget)
+
+
 def _right(fid: str) -> str:
     """The plane's personas, and this workspace's open todos underneath them.
 
@@ -1017,39 +1071,27 @@ def _right(fid: str) -> str:
     one that is not. How SHORT is too short is `_todo_rows`' own rule and is asked there
     once — this function only decides whether there is any room at all to be worth
     opening the cache for, which is a question about a file read rather than about a row.
-    """
-    from .. import statusline as sl
-    from . import gather
 
+    **The two sections are :func:`persona_section` and :func:`todo_section`**, and this is
+    what composes them into one pane. The registry says the same thing in its own
+    vocabulary — `frame/builtins.py` registers them as the `personas` and `todos` parts of
+    the `sidebar` composite, with `personas` taking what is left (`Fill()`) and the todos
+    capped — and it says it by pointing at these two functions, not by keeping a second
+    copy of them. Charter never splits a pane (§4d); a composite is how two things share
+    one, and this function is that composition for the one composite charter ships.
+    """
     w, h = _width(), _height()
+    # Asked ONCE and handed to both sections: one pane draws them, so one density decides
+    # how much both of them say.
     terse = verbosity(fid) == "terse"
-    cells = sl._persona_chip_cells()
-    if cells:
-        keep = h - 1                        # the heading takes a row off the list
-        if terse:
-            keep = min(keep, _TERSE_ROWS)
-        cells = _cap_personas(cells, keep)
-        lines = [_sidebar_head("personas", _persona_total(cells), w),
-                 *_persona_rows(cells, w)]
-    else:
-        lines = [tui.truncate(f"{sl._DIM}no personas{sl._R}", w)]
+    lines = persona_section(w, h, terse=terse)
 
     # The blank row between the two sections is counted OUT of the todo budget rather
     # than added on top of it, so the section can never be the row that overflows the
     # pane — the same reservation `_table_lines` makes for its own overflow line.
-    #
-    # `> 0` and NOT the two-row floor, which is `_todo_rows`' to keep: this test is only
-    # "is there any room at all", asked so a pane with none does not open a cache file it
-    # is about to discard (`repos_rows_wanted` orders its own two questions the same way,
-    # and for the same reason). Repeating the floor here would put one rule in two places,
-    # where the outer copy silently decides the case and the inner one can be broken
-    # without anything noticing — which is exactly what a mutation of the inner guard
-    # proved while both existed.
-    budget = min(h - len(lines) - 1, _TERSE_ROWS if terse else _MAX_TODO_LINES)
-    if budget > 0:
-        rows = _todo_rows(gather.read(fid), w, budget)
-        if rows:
-            lines.extend(["", *rows])
+    rows = todo_section(fid, w, h - len(lines) - 1, terse=terse)
+    if rows:
+        lines.extend(["", *rows])
     return "\n".join(lines)
 
 

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -678,7 +678,147 @@ def frame_of(cfg: dict) -> dict:
             out[key] = value
     if "density" in section and not took_slots:
         out["slots"] = density_slots(out["density"])
+    placed = component_tables(section)
+    if placed is not None:
+        out["slots"] = [p["slot"] for p in placed if p["visible"]]
     return out
+
+
+#: The TOML key the arrangement is spelled with: ``[[frame.component]]``, an ARRAY of
+#: tables, so file order is split order and the geometry is written down the way it is
+#: read. ``slots`` says the same thing in four words and can say nothing else; this can
+#: name a component charter did not write.
+FRAME_COMPONENT_KEY = "component"
+
+#: Every key a ``[[frame.component]]`` table may carry, and the whole of the form.
+#:
+#: * ``use`` — the component id, which is `frame/builtins.py`'s vocabulary and NOT
+#:   ``slots``' one: `identity`, `attention`, `repos`, `sidebar`. The two names for one
+#:   panel exist because `slots` is committed on every plane that has a charter.toml and
+#:   `charter panel <slot>` is a tmux argv (`builtins.SLOT_OF` is the one table between
+#:   them); `use` is the new vocabulary and does not accept the old spelling, so a file
+#:   says which of the two it is written in.
+#: * ``edge`` — which side of the harness it attaches to.
+#: * ``size`` — how many cells it is given, for a component whose size is `Fixed`.
+#: * ``visible`` — whether it is drawn at all. The one key `slots` could only express by
+#:   deleting a name, which loses the position with it.
+FRAME_COMPONENT_FIELDS = ("use", "edge", "size", "visible")
+
+
+def _placement(reg, cid: str, *, visible: bool = True) -> dict:
+    """One resolved placement: the component, where it sits, how big, and whether drawn.
+
+    ``size`` is the size POLICY (`component.Fixed`/`Content`/`Fill`), not a number.
+    Turning a policy into cells is `layout`'s job and it does it in one place
+    (`layout._cells`); a second answer here is the two-implementations shape that let the
+    test harness keep a worse copy of what runs charter (#547).
+    """
+    c = reg.get(cid)
+    from .frame import builtins as _builtins
+    return {"use": cid, "slot": _builtins.SLOT_OF[cid], "edge": c.edge, "size": c.size,
+            "visible": visible}
+
+
+def component_tables(section) -> list[dict] | None:
+    """The ``[[frame.component]]`` arrangement *section* declares, or ``None``.
+
+    ``None`` means "nothing usable was declared here" — no tables at all, or an
+    arrangement charter cannot draw — and the caller falls back to ``slots``, which falls
+    back to ``density``, which falls back to the shipped default. Every layer of that is
+    a frame charter is certain it can build.
+
+    **An arrangement is refused whole, and #535 is the reason it is not refused one table
+    at a time.** The obvious design — drop the table charter cannot make sense of, keep
+    the rest — hands the operator a frame with a panel silently missing from it, and a
+    missing repo table is a plane that appears to have no clones. That is the exact change
+    #535 shipped, and it was caught by a reviewer rather than by a test. So a single
+    unusable value takes the whole arrangement out of play and the frame charter draws is
+    the one `slots` describes: the operator sees their arrangement ignored, which is a
+    visible, whole-frame difference, rather than one pane's worth of quiet fiction.
+
+    Task 7 of this plan replaces that for the one case it can improve: a component named
+    here with no provider installed gets a MESSAGE in its own pane and the rest of the
+    frame draws. That is the same principle with somewhere to say it; until the surface
+    exists, refusing the arrangement is the version of it charter can actually keep.
+
+    **``edge`` and ``size`` are accepted only where charter can honour them, which today
+    means only at the component's own declaration.** `layout` derives the whole frame's
+    geometry from those declarations (`layout._derive`), and nothing between here and
+    `split-window` carries a per-plane override yet — so an ``edge = "top"`` on the repo
+    table would be a value read, validated, stored and then ignored, and the frame would
+    draw exactly as if the line were not there. A config key that changes nothing is
+    exactly the convincing empty this phase was written against, so a value charter would
+    not honour refuses the arrangement instead of being quietly absorbed. What the pair IS
+    good for meanwhile is writing the arrangement out in full: `frame_components` answers
+    every `slots` list as tables that resolve back to the same frame, which is what makes
+    the mapping lossless in both directions.
+    """
+    tables = section.get(FRAME_COMPONENT_KEY) if isinstance(section, dict) else None
+    if not isinstance(tables, list) or not tables:
+        return None
+    from .frame import builtins as _builtins
+    from .frame.component import Fixed
+    reg = _builtins.build()
+    out: list[dict] = []
+    seen: set[str] = set()
+    for table in tables:
+        if not isinstance(table, dict):
+            return None
+        if any(k not in FRAME_COMPONENT_FIELDS for k in table):
+            return None
+        cid = table.get("use")
+        # A component charter cannot place — a typo, a provider this machine has not
+        # installed, or `slots`' vocabulary written into `use` by mistake.
+        if not isinstance(cid, str) or cid not in _builtins.SLOT_OF or cid in seen:
+            return None
+        seen.add(cid)
+        c = reg.get(cid)
+        if "edge" in table and table["edge"] != c.edge:
+            return None
+        if "size" in table and not (isinstance(c.size, Fixed)
+                                    and table["size"] == c.size.n
+                                    and not isinstance(table["size"], bool)):
+            return None
+        visible = table.get("visible", True)
+        if not isinstance(visible, bool):
+            return None
+        out.append(_placement(reg, cid, visible=visible))
+    return out
+
+
+def frame_components(cfg: dict) -> list[dict]:
+    """The frame *cfg* asks for, as placements in split order — the one resolved answer.
+
+    Three ways of asking for a frame, and this is where they become one thing:
+
+    * ``[[frame.component]]`` is the arrangement written out, and wins when it is usable.
+    * ``slots`` is shorthand for placing built-ins on their own edges in the given split
+      ORDER — which is the geometry, not a reading order. Measured on tmux 3.7c at
+      200x50: ``["top", "bottom", "right"]`` gives a **200-column** bottom row and
+      ``["top", "right", "bottom"]`` gives **177**, inset beside the one sidebar and its
+      border. (The 154 the spec's §4/§4b carry is the pre-#488 arrangement, with two
+      22-column sidebars coming off the row; §4i corrects it.)
+    * ``density`` is a named arrangement — three level names, each expanding to a ``slots``
+      list an operator could have written by hand.
+
+    All three go through :func:`frame_of` for the slot list, so nothing here is a second
+    reading of a committed value: the filtering, the type checks and the density expansion
+    happen once, where they always did.
+
+    **Lossless in both directions.** Every list this answers can be written back out as
+    ``[[frame.component]]`` tables — one per placement, carrying its ``use``, ``edge`` and
+    ``size`` — and :func:`component_tables` resolves those to the same placements again.
+    That round trip is what "the config maps onto the registry" has to mean if `slots` is
+    to be retired later without an operator's committed frame changing under them.
+    """
+    section = cfg.get("frame")
+    placed = component_tables(section)
+    if placed is not None:
+        return placed
+    from .frame import builtins as _builtins
+    reg = _builtins.build()
+    return [_placement(reg, _builtins.COMPONENT_OF[slot])
+            for slot in frame_of(cfg)["slots"]]
 
 
 #: The channels ``[update] channel`` may name, and a CLOSED set — the single most

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -515,6 +515,67 @@ the other way for `repos`, which is a *new* name: a committed `slots = ["top", "
 primitive and charter does not add to a list you wrote by hand. Add `repos` to it, or
 delete the line and take the default.
 
+### Writing the arrangement out
+
+`slots` is shorthand. Each name in it places one of charter's built-in components on the
+edge that component declares, in the split order you wrote. The long form says the same
+thing one table per panel, and file order is split order:
+
+```toml
+[[frame.component]]
+use = "identity"
+
+[[frame.component]]
+use = "attention"
+
+[[frame.component]]
+use = "repos"
+
+[[frame.component]]
+use = "sidebar"
+```
+
+That is exactly the shipped frame — the same panels, the same order, the same geometry as
+`slots = ["top", "bottom", "repos", "right"]`. Note the names: `use` takes a **component
+id**, which is the vocabulary the frame reasons in, and not a `slots` name. The four are
+`identity`, `attention`, `repos` and `sidebar`; the sidebar is one pane drawing two parts,
+`personas` and `todos`, which is why it has one name here and shows two headings on screen.
+Mixing the vocabularies is refused rather than half-understood, so a file says which of the
+two it is written in.
+
+A component can be kept in the arrangement and not drawn:
+
+```toml
+[[frame.component]]
+use = "repos"
+visible = false
+```
+
+That is the one thing `slots` cannot express. Deleting a name from `slots` loses its
+*position* along with it, so turning the panel back on later means remembering where in the
+order it went; `visible = false` keeps the order and turns off the panel.
+
+`edge` and `size` may be written down, and today they may only say what the component
+already declares — `edge = "right"` and `size = 22` on the sidebar, `edge = "top"` on
+identity. Charter derives the whole frame's geometry from those declarations, and nothing
+between `charter.toml` and tmux carries a per-plane override yet, so a value charter cannot
+honour is not quietly accepted and ignored: it takes the arrangement out of play. Writing
+them is still worth it if you like your config explicit — and it is what makes the two
+forms round-trip.
+
+**An arrangement charter cannot draw is refused whole, and your frame falls back to
+`slots`.** Not one table at a time — dropping just the line charter could not make sense of
+would hand you a frame with a panel silently missing from it, and a missing repo table is a
+plane that looks like it has no clones. So a component charter has never heard of, an edge
+it cannot place, a duplicate, a key that is not one of the four, or a `visible` that is not
+`true`/`false` all mean the same thing: the arrangement is ignored and you get the frame
+your `slots` (or `density`, or the default) describes. You see your whole arrangement not
+take effect, which is something you can act on, rather than one pane's worth of quiet
+fiction.
+
+Precedence, most explicit first: `[[frame.component]]`, then an explicit `slots`, then
+`density`, then the shipped default.
+
 `slots`/`density`/`mouse`/`hotkey` are spelled the same on both sides. `history-limit`,
 `min-cols` and `min-rows` are the three that are not: charter.toml spells them with a
 hyphen: the

--- a/docs/news/unreleased-the-frame-is-components-now.md
+++ b/docs/news/unreleased-the-frame-is-components-now.md
@@ -1,0 +1,80 @@
+---
+version: unreleased
+headline: The frame is components now, and you can write its arrangement out
+---
+
+Four strings in a list is what the frame was, and their *position* was the geometry. That
+is still true — `slots = ["top", "bottom", "repos", "right"]` launches exactly the frame it
+always did — but it is shorthand now rather than the whole mechanism. Underneath, each
+panel is a component that declares where it attaches, how big it wants to be, and what it
+reads:
+
+| component | edge | size | what it reads |
+|---|---|---|---|
+| `identity` | top | 1 row | nothing off the plane cache |
+| `attention` | bottom | 1 row | nothing off the plane cache |
+| `repos` | bottom | as tall as its table | the plane scan |
+| `sidebar` | right | 22 columns | the plane scan |
+
+The sidebar is one pane drawing two parts — `personas` and `todos` — which is why it has
+one name and two headings. Charter never splits a pane; a composite is how two things share
+one, and exactly one of them takes what is left over (the personas), so a short pane loses
+the section that is also available as `charter ws todo` rather than the one that is not.
+
+## Writing the arrangement out
+
+`slots` can say four things and no more. The long form can say one panel per table, in file
+order, which is split order:
+
+```toml
+[[frame.component]]
+use = "identity"
+
+[[frame.component]]
+use = "attention"
+
+[[frame.component]]
+use = "repos"
+
+[[frame.component]]
+use = "sidebar"
+```
+
+That resolves to the shipped frame exactly. `use` takes a **component id**, not a `slots`
+name — the four are `identity`, `attention`, `repos`, `sidebar`.
+
+It buys you one thing `slots` cannot express today:
+
+```toml
+[[frame.component]]
+use = "repos"
+visible = false
+```
+
+Deleting a name from `slots` loses its *position* with it, so turning the panel back on
+later means remembering where in the split order it went. `visible = false` keeps the
+order and turns off the panel.
+
+`edge` and `size` may be written down and today may only say what the component already
+declares. Charter derives the whole frame's geometry from those declarations, and nothing
+between `charter.toml` and tmux carries a per-plane override yet — so rather than reading a
+value, validating it, storing it and then drawing as if the line were not there, charter
+refuses it. A config key that changes nothing is worse than one that is not there.
+
+**An arrangement charter cannot draw is refused whole**, and the frame falls back to the
+one `slots` describes. Not one table at a time: dropping just the line charter could not
+make sense of hands you a frame with a panel silently missing, and a missing repo table is
+a plane that looks like it has no clones. Charter has shipped that once and it was caught
+by a person reading a diff, not by a test. So an unknown component, an edge charter cannot
+place, a duplicate, a stray key or a non-boolean `visible` all mean the same thing: your
+whole arrangement does not take effect, which you can see and act on.
+
+Precedence, most explicit first: `[[frame.component]]`, then an explicit `slots`, then
+`density`, then the shipped default.
+
+## What to do
+
+Nothing. Every `slots` list and every `density` level resolves to exactly the frame it drew
+before — same panels, same split order, same widths, same rows — and the panels draw the
+same bytes they drew before, at 200x50 and at 80x24. The long form is there when you want
+it.

--- a/tests/test_builtin_components.py
+++ b/tests/test_builtin_components.py
@@ -1,0 +1,373 @@
+"""Charter's own four panels, expressed as components — and still drawing what they drew.
+
+`frame/builtins.py` is the registry's first consumer and charter's own panels are its
+first content, which is the sequencing §4b asks for: the seam a provider will be placed
+through is the seam charter's own frame is placed through, so there is no private table of
+edges beside the public one.
+
+**The refactor's success condition is that nothing changed**, and these tests are written
+to be able to say so rather than to assume it. The pane the `sidebar` composite draws is
+compared against its two parts composed; each component's render is compared against the
+renderer the slot has always had; and `layout`'s five per-slot tables — which used to be
+five hand-written tuples — are compared against the literal geometry charter ships, not
+against the registry they are now read from. Reading both sides of an assertion out of the
+same constant is the tautology this suite has caught before; the literals are what make
+these assertions able to fail.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import instance
+from charter.frame import builtins, component, ctx as fctx, gather, layout, slots, state
+
+from tests._isolation import PersonaIso
+
+FID = "f-builtin"
+
+
+def _row(name, *, branch="main", current=False, repo=None):
+    """A `gather`-cache-shaped row — the fields `gather._entry` writes."""
+    d = {"name": name, "branch": branch, "dirty": False, "tracked_dirty": False,
+         "ahead": 0, "behind": 0, "ci": None, "change": None, "sigil": "",
+         "current": current, "worktree_count": 0}
+    if repo is not None:
+        d["repo"] = repo
+    return d
+
+
+class Declared(unittest.TestCase):
+    """What the six components say about themselves.
+
+    No plane needed: `builtins.build()` reads nothing and starts nothing, which is the
+    property that lets `layout` ask it at import time.
+    """
+
+    def setUp(self) -> None:
+        self.reg = builtins.build()
+
+    def test_the_registry_holds_the_six_charter_draws_in_split_order(self):
+        """Split order is registration order, and the two parts of the sidebar are
+        registered before the composite that draws them — the registry refuses a
+        composite built from parts it has not seen."""
+        self.assertEqual([c.id for c in self.reg.all()],
+                         ["identity", "attention", "repos", "personas", "todos",
+                          "sidebar"])
+
+    def test_only_the_four_placed_components_are_on_an_edge(self):
+        """`personas` and `todos` are registered and never split for: their parent draws
+        them inside its own pane, and a part that appeared on an edge too would be drawn
+        twice — once in its own pane and once inside the sidebar's."""
+        placed = {edge: [c.id for c in self.reg.on_edge(edge)]
+                  for edge in component.EDGES}
+        self.assertEqual(placed, {"top": ["identity"], "bottom": ["attention", "repos"],
+                                  "left": [], "right": ["sidebar"]})
+
+    def test_the_sidebar_is_the_composite_of_personas_then_todos(self):
+        """In the order the pane stacks them, which is not split order — nothing splits
+        this pane at all (§4d)."""
+        self.assertEqual([c.id for c in self.reg.children_of("sidebar")],
+                         ["personas", "todos"])
+        self.assertEqual([c.id for c in self.reg.children_of("identity")], [])
+
+    def test_each_component_declares_the_edge_and_size_the_frame_draws_it_at(self):
+        """The literal geometry charter ships, asserted as literals.
+
+        `right` is 22 columns and the two strips are one row each; the repo table is
+        `Content()` because its height is the plane's repo count bounded by what the
+        harness may not be charged (`layout.repos_rows`), and a cap written here would be
+        a second, weaker copy of that arithmetic."""
+        got = {c.id: (c.edge, c.size) for c in self.reg.all()}
+        self.assertEqual(got, {
+            "identity": ("top", component.Fixed(1)),
+            "attention": ("bottom", component.Fixed(1)),
+            "repos": ("bottom", component.Content(None)),
+            "personas": ("right", component.Fill()),
+            "todos": ("right", component.Content(slots._MAX_TODO_LINES)),
+            "sidebar": ("right", component.Fixed(22)),
+        })
+
+    def test_exactly_one_part_of_the_sidebar_takes_what_is_left(self):
+        """`personas` is the `Fill()` — the pane is the persona column everywhere else
+        charter names it, so the todos are the section that gives way. The registry
+        refuses a second one at registration, which is what makes this a property of the
+        arrangement rather than of a tie-break at layout time (§4e)."""
+        fills = [c.id for c in self.reg.children_of("sidebar")
+                 if isinstance(c.size, component.Fill)]
+        self.assertEqual(fills, ["personas"])
+
+    def test_every_need_the_built_ins_declare_is_one_ctx_can_actually_serve(self):
+        """A name accepted by `needs` that `ctx` answered with an empty tuple would let a
+        component declare it, draw nothing, and pass its own tests against an empty
+        fixture — indistinguishable from a plane that genuinely has none, which is #512's
+        defect. `component.NEEDS` and `ctx.SERVES` are already asserted against each
+        other; this asserts charter's own components stay inside them."""
+        for c in self.reg.all():
+            with self.subTest(component=c.id):
+                for name in c.needs:
+                    self.assertIn(name, fctx.SERVES)
+
+    def test_a_composite_declares_everything_its_parts_read(self):
+        """The parts draw inside the composite's pane, so whatever they read, the
+        composite's own repaint reads. A composite declaring less than its parts would
+        understate the cost of the pane it owns — which is the one thing `needs` exists to
+        make reviewable."""
+        parts = set()
+        for child in self.reg.children_of("sidebar"):
+            parts |= set(child.needs)
+        self.assertTrue(parts <= set(self.reg.get("sidebar").needs),
+                        f"sidebar declares {self.reg.get('sidebar').needs} but its parts "
+                        f"read {sorted(parts)}")
+
+
+class OneVocabularyForSlotNames(unittest.TestCase):
+    """The slot names and the component ids agree, in both directions.
+
+    Two tables answering "which panels are there" is how the test harness came to keep a
+    worse copy of what runs charter (#547). These pin that `builtins.SLOT_OF`,
+    `slots.SLOTS` and `instance.FRAME_SLOTS` cannot disagree about the set.
+    """
+
+    def test_every_placed_component_names_a_slot_that_has_a_renderer(self):
+        self.assertEqual(sorted(builtins.SLOT_OF.values()), sorted(slots.SLOTS))
+
+    def test_every_slot_config_accepts_is_a_component_charter_can_place(self):
+        self.assertEqual(sorted(builtins.COMPONENT_OF), sorted(instance.FRAME_SLOTS))
+
+    def test_the_two_directions_of_the_mapping_are_one_table(self):
+        """`COMPONENT_OF` is derived from `SLOT_OF`, so a name cannot be added to one and
+        forgotten in the other — asserted rather than trusted, because the derivation is
+        one line and a future edit could write the second table out by hand."""
+        self.assertEqual({slot: cid for cid, slot in builtins.SLOT_OF.items()},
+                         builtins.COMPONENT_OF)
+
+
+class LayoutReadsTheRegistry(unittest.TestCase):
+    """`layout`'s five per-slot tables are now one derivation over the components."""
+
+    def test_the_shipped_frame_is_the_geometry_charter_has_always_drawn(self):
+        """Literals on the right-hand side, deliberately. Reading these back out of the
+        registry would pass against any registry at all, including one that had lost the
+        repo table — which is exactly the change #535 shipped and a reviewer, not a test,
+        caught."""
+        self.assertEqual(layout.SLOT_SIZE,
+                         {"top": 1, "bottom": 1, "repos": 1, "right": 22})
+        self.assertEqual(layout.SLOT_EDGE,
+                         {"top": "top", "bottom": "bottom", "repos": "bottom",
+                          "right": "right"})
+        self.assertEqual(layout._COLUMN_SLOTS, ("right",))
+        self.assertEqual(layout._FIXED_ROW_SLOTS, ("top", "bottom"))
+        self.assertEqual(layout.VARIABLE_ROW_SLOTS, frozenset({"repos"}))
+
+    def test_moving_the_table_to_a_side_edge_moves_every_derived_fact_with_it(self):
+        """One predicate decides all five, so an arrangement that puts the table on the
+        right takes it out of the row tables and into the column one — together. While
+        these were five hand-written tuples they agreed only by having been edited in the
+        same commit."""
+        reg = builtins.build()
+        moved = [c if c.id != "repos" else
+                 component.Component(id="repos", title="repos", edge="right",
+                                     size=c.size, needs=c.needs, render=c.render)
+                 for c in reg.all() if c.id in builtins.SLOT_OF]
+        got = layout._derive(moved)
+        self.assertEqual(got.edge["repos"], "right")
+        self.assertEqual(got.column, ("repos", "right"))
+        self.assertEqual(got.fixed_rows, ("top", "bottom"))
+        self.assertEqual(got.variable_rows, frozenset())
+
+    def test_a_strip_sized_by_its_content_becomes_the_variable_row(self):
+        """The other half of the same predicate: `attention` is the variable row the
+        moment its size stops being `Fixed`, and leaves the fixed table at the same
+        moment. Nothing has to be remembered in two places for that to hold."""
+        reg = builtins.build()
+        changed = [c if c.id != "attention" else
+                   component.Component(id="attention", title="attention", edge="bottom",
+                                       size=component.Content(), needs=c.needs,
+                                       render=c.render)
+                   for c in reg.all() if c.id in builtins.SLOT_OF]
+        got = layout._derive(changed)
+        self.assertEqual(got.fixed_rows, ("top",))
+        self.assertEqual(got.variable_rows, frozenset({"bottom", "repos"}))
+        self.assertEqual(got.size["bottom"], 1)     # the floor a size policy already has
+
+    def test_a_wider_sidebar_is_a_wider_sidebar_everywhere(self):
+        """`SLOT_SIZE["right"]` is what `repos_cols` insets the table pane by, so a size
+        read from one place and not the other is #500's defect. One derivation, one
+        number."""
+        reg = builtins.build()
+        wide = [c if c.id != "sidebar" else
+                component.Component(id="sidebar", title="sidebar", edge="right",
+                                    size=component.Fixed(30), needs=c.needs,
+                                    render=c.render)
+                for c in reg.all() if c.id in builtins.SLOT_OF]
+        self.assertEqual(layout._derive(wide).size["right"], 30)
+
+    def test_the_split_that_goes_before_the_harness_is_the_one_on_a_before_edge(self):
+        """`-b` used to be spelled `slot == "top"`. It is the component's edge now, and
+        `bottom` must not acquire one: a `-b` on the attention strip would put it above
+        the harness, which is the one thing #488 protected it from."""
+        order = ["top", "bottom", "repos", "right"]
+        argvs = layout.panel_argvs(slots=order, session="s", socket="/sock",
+                                   harness_pane="%0")
+        self.assertEqual({slot: ("-b" in argv) for slot, argv in zip(order, argvs)},
+                         {"top": True, "bottom": False, "repos": False, "right": False})
+
+
+class Renders(PersonaIso):
+    """Each component draws exactly the panel its slot has always drawn."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.reg = builtins.build()
+        for p in ("alpha", "bravo"):
+            self.make_persona(p)
+        state.record_workspace(FID, "demo")
+        gather.save(FID, {
+            "gathered_at": 0.0, "workspace": "demo", "current_repo": "charter",
+            "repos": [_row("charter", current=True), _row("atlas")],
+            "worktrees": [],
+            "todos": [{"title": "wire the registry"}, {"title": "measure the frame"}],
+            "todo_count": 5,
+        })
+
+    def _ctx(self, c, *, width=200, height=20):
+        return fctx.build(c.needs, width=width, height=height, fid=FID,
+                          snapshot=gather.read(FID))
+
+    def _pane(self, width, height):
+        return (mock.patch.object(slots, "_width", lambda: width),
+                mock.patch.object(slots, "_height", lambda: height))
+
+    def test_each_component_draws_its_own_slots_panel(self):
+        """Joined back together, byte for byte — and the four outputs are pairwise
+        distinct, which is what makes this able to fail. A wrapper wired to the wrong slot
+        would still satisfy "equals some renderer's output"; it cannot satisfy both."""
+        drawn = {}
+        for cid, slot in builtins.SLOT_OF.items():
+            c = self.reg.get(cid)
+            w, h = self._pane(200, 20)
+            with w, h:
+                drawn[cid] = "\n".join(c.render(self._ctx(c)))
+                self.assertEqual(drawn[cid], slots.SLOTS[slot](FID))
+        self.assertEqual(len(set(drawn.values())), len(drawn),
+                         f"two components drew the same pane: {drawn}")
+
+    def test_a_renderer_that_draws_one_blank_line_still_draws_one(self):
+        """``split("\\n")`` and never ``splitlines()``: a panel writes the string out as
+        it is, so the adaptation has to round-trip. ``splitlines()`` turns a renderer that
+        answered one empty line into a component that answered no lines at all — a pane
+        that is blank because it is empty, told apart from a pane that has nothing to
+        say only by the number of rows it takes."""
+        with mock.patch.dict(slots.SLOTS, {"blank": lambda fid: ""}):
+            render = builtins._panel("blank")
+            c = self.reg.get("identity")
+            self.assertEqual(render(self._ctx(c)), [""])
+        with mock.patch.dict(slots.SLOTS, {"two": lambda fid: "a\n\nb"}):
+            render = builtins._panel("two")
+            c = self.reg.get("identity")
+            self.assertEqual(render(self._ctx(c)), ["a", "", "b"])
+
+    def test_the_sidebars_pane_is_exactly_its_two_parts(self):
+        """The composite draws the parts, it does not keep a second copy of them. This is
+        the whole of the `slots.py` half of this task: `_right` was split into
+        `persona_section` and `todo_section` and then composed back, so a pane that
+        differed from its parts would mean the split changed what the panel says."""
+        w, h = self._pane(22, 20)
+        with w, h:
+            whole = slots.render("right", FID)
+            personas = slots.persona_section(22, 20, terse=False)
+            todos = slots.todo_section(FID, 22, 20 - len(personas) - 1, terse=False)
+        self.assertEqual(whole, "\n".join([*personas, "", *todos]))
+        self.assertTrue(todos, "fixture drew no todos — the composition is untested")
+
+    def test_a_terse_sidebar_spends_fewer_rows_on_todos_than_a_normal_one(self):
+        """The density cap moved out of `_right` and into `todo_section` with this task,
+        and nothing in the suite was holding it: mutating it away (`min(budget,
+        _MAX_TODO_LINES)` regardless of density) left 254 tests green. A guard that moves
+        gets a test at the place it moved to, or the move is where it silently stops
+        working.
+
+        Asserted as the two densities differing, and as the terse count being
+        `slots._TERSE_ROWS`, on a pane with rows to spare — so this is the CAP being
+        applied and not the pane running out."""
+        gather.save(FID, {
+            "gathered_at": 0.0, "workspace": "demo", "current_repo": None,
+            "repos": [], "worktrees": [],
+            "todos": [{"title": f"todo {i}"} for i in range(12)], "todo_count": 12,
+        })
+        with self._pane(22, 30)[0], self._pane(22, 30)[1]:
+            normal = slots.todo_section(FID, 22, 20, terse=False)
+            terse = slots.todo_section(FID, 22, 20, terse=True)
+        self.assertEqual(len(terse), slots._TERSE_ROWS)
+        self.assertEqual(len(normal), slots._MAX_TODO_LINES)
+        self.assertLess(len(terse), len(normal))
+
+    def test_a_component_reads_the_plane_exactly_where_it_said_it_would(self):
+        """`needs` is a claim about what the renderer reads, and this is what checks it.
+
+        Every component is drawn with `gather`'s two readers recording, and the recording
+        must be non-empty for exactly the components that declared ``gather``. A
+        declaration that drifted from its renderer — either way — is red: a component that
+        quietly started reading the plane cache without declaring it, and one that
+        declares a cost it does not pay, are both defects, and only the first is obvious.
+        """
+        declared = {cid for cid in builtins.SLOT_OF
+                    if "gather" in self.reg.get(cid).needs}
+        self.assertTrue(declared and declared != set(builtins.SLOT_OF),
+                        "the fixture must have components on both sides of this")
+        for cid, slot in builtins.SLOT_OF.items():
+            c = self.reg.get(cid)
+            seen: list[str] = []
+            real_read, real_cached = gather.read, gather.cached
+
+            def rec_read(*a, _f=real_read, _s=seen, **k):
+                _s.append("read")
+                return _f(*a, **k)
+
+            def rec_cached(*a, _f=real_cached, _s=seen, **k):
+                _s.append("cached")
+                return _f(*a, **k)
+
+            # Built BEFORE the recorders go on: `ctx.build` reads the snapshot itself,
+            # and a recorder that counted the harness's own read would report every
+            # component as touching the cache.
+            cx = self._ctx(c)
+            w, h = self._pane(200, 20)
+            with w, h, mock.patch.object(gather, "read", rec_read), \
+                    mock.patch.object(gather, "cached", rec_cached):
+                out = c.render(cx)
+            with self.subTest(component=cid):
+                self.assertTrue(out, f"{cid} drew nothing — the reading is untested")
+                self.assertEqual(bool(seen), "gather" in c.needs,
+                                 f"{cid} declares needs={c.needs} and touched "
+                                 f"{seen or 'nothing'}")
+
+    def test_the_sidebars_own_parts_read_where_they_said_they_would(self):
+        """The same check for the two components that are never placed on an edge — they
+        are drawn by their parent, so nothing else would ever exercise their declarations.
+        """
+        for cid in ("personas", "todos"):
+            c = self.reg.get(cid)
+            seen: list[str] = []
+            real_read = gather.read
+
+            def rec_read(*a, _f=real_read, _s=seen, **k):
+                _s.append("read")
+                return _f(*a, **k)
+
+            cx = fctx.build(c.needs, width=22, height=10, fid=FID,
+                            snapshot=gather.read(FID))
+            w, h = self._pane(22, 20)
+            with w, h, mock.patch.object(gather, "read", rec_read):
+                out = c.render(cx)
+            with self.subTest(component=cid):
+                self.assertTrue(out, f"{cid} drew nothing — the reading is untested")
+                self.assertEqual(bool(seen), "gather" in c.needs,
+                                 f"{cid} declares needs={c.needs} and touched "
+                                 f"{seen or 'nothing'}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_component_config.py
+++ b/tests/test_component_config.py
@@ -1,0 +1,284 @@
+"""Three ways of asking for a frame resolve to one arrangement, and none of them moves.
+
+`slots` is shorthand for placing built-ins on their own edges in the given split order;
+`density` is a named arrangement; `[[frame.component]]` is the arrangement written out.
+`instance.frame_components` is where all three become one list of placements, and these
+pin that the two older spellings resolve to exactly the frame they drew before.
+
+**The repo's own committed `charter.toml` is tested by name, not by fixture.** A change
+that silently removed the repo table from charter's own plane has already shipped once
+(#535) and was caught by a reviewer rather than by a test. `TheOperatorsOwnPlane` below is
+that test: it reads the file this repository commits, resolves it, and asserts the table
+is there and at the width its own comment promises.
+"""
+
+from __future__ import annotations
+
+import tomllib
+import unittest
+from pathlib import Path
+
+from charter import instance
+from charter.frame import builtins, layout
+
+#: The repository's own committed `charter.toml` — the plane charter is developed on.
+#: `parents[1]` is the checkout root, the idiom `tests/test_docs_show.py` already uses.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHARTER_TOML = REPO_ROOT / "charter.toml"
+
+
+def _tables(placements) -> list[dict]:
+    """*placements* written back out as `[[frame.component]]` tables would spell them."""
+    out = []
+    for p in placements:
+        table = {"use": p["use"], "edge": p["edge"]}
+        if hasattr(p["size"], "n"):
+            table["size"] = p["size"].n
+        if not p["visible"]:
+            table["visible"] = False
+        out.append(table)
+    return out
+
+
+class SlotsIsShorthandForPlacingBuiltIns(unittest.TestCase):
+    def test_the_shipped_default_places_every_panel_charter_draws(self):
+        """Literals, in split order. Reading the expectation back out of
+        `instance.FRAME_DEFAULTS` would pass against a default that had lost a panel."""
+        got = instance.frame_components({})
+        self.assertEqual([(p["use"], p["edge"], p["visible"]) for p in got],
+                         [("identity", "top", True), ("attention", "bottom", True),
+                          ("repos", "bottom", True), ("sidebar", "right", True)])
+
+    def test_an_operators_slot_order_is_the_split_order_of_the_arrangement(self):
+        """Order is geometry, so it survives the mapping unchanged. `["right", "top"]` is
+        the shortest list that is not already in the shipped list's relative order —
+        `tests/test_frame_config.py` uses it for the same reason."""
+        got = instance.frame_components({"frame": {"slots": ["right", "top"]}})
+        self.assertEqual([p["use"] for p in got], ["sidebar", "identity"])
+
+    def test_a_retired_slot_name_is_dropped_before_it_becomes_a_placement(self):
+        """`left` was retired in #488 and a committed charter.toml outlives an upgrade.
+        The filtering is `frame_of`'s, done once, and the arrangement inherits it rather
+        than reading the committed list a second time."""
+        got = instance.frame_components(
+            {"frame": {"slots": ["top", "bottom", "left", "right"]}})
+        self.assertEqual([p["use"] for p in got],
+                         ["identity", "attention", "sidebar"])
+
+    def test_every_placement_carries_the_edge_and_size_its_component_declares(self):
+        """The arrangement is the registry's answer, not a second table of geometry."""
+        reg = builtins.build()
+        for p in instance.frame_components({}):
+            with self.subTest(component=p["use"]):
+                c = reg.get(p["use"])
+                self.assertEqual((p["edge"], p["size"]), (c.edge, c.size))
+
+
+class DensityIsANamedArrangement(unittest.TestCase):
+    def test_each_shipped_level_resolves_to_the_panels_it_names(self):
+        """Asserted as literals per level, because the point of a preset is that it
+        expands to a frame an operator could have written by hand — and that expansion is
+        what a reader has to be able to check."""
+        want = {
+            "minimal": ["identity", "attention"],
+            "normal": ["identity", "attention", "repos"],
+            "full": ["identity", "attention", "repos", "sidebar"],
+        }
+        self.assertEqual(sorted(want), sorted(instance.FRAME_DENSITY))
+        for level, expect in want.items():
+            with self.subTest(density=level):
+                got = instance.frame_components({"frame": {"density": level}})
+                self.assertEqual([p["use"] for p in got], expect)
+
+    def test_an_explicit_slots_list_still_beats_a_declared_density(self):
+        """`slots` is the primitive and an operator who wrote a list meant that list —
+        `frame_of`'s rule, inherited rather than re-decided here."""
+        got = instance.frame_components(
+            {"frame": {"density": "minimal", "slots": ["top", "repos"]}})
+        self.assertEqual([p["use"] for p in got], ["identity", "repos"])
+
+
+class TheArrangementWrittenOut(unittest.TestCase):
+    def test_file_order_is_split_order(self):
+        cfg = {"frame": {"component": [{"use": "sidebar"}, {"use": "identity"}]}}
+        self.assertEqual(instance.frame_of(cfg)["slots"], ["right", "top"])
+        self.assertEqual([p["use"] for p in instance.frame_components(cfg)],
+                         ["sidebar", "identity"])
+
+    def test_a_component_can_be_kept_in_the_arrangement_and_not_drawn(self):
+        """The one thing `slots` cannot express: deleting a name loses its POSITION with
+        it, so turning a panel back on means remembering where in the order it went."""
+        cfg = {"frame": {"component": [{"use": "identity"}, {"use": "attention"},
+                                       {"use": "repos", "visible": False},
+                                       {"use": "sidebar"}]}}
+        self.assertEqual(instance.frame_of(cfg)["slots"], ["top", "bottom", "right"])
+        got = instance.frame_components(cfg)
+        self.assertEqual([(p["use"], p["visible"]) for p in got],
+                         [("identity", True), ("attention", True),
+                          ("repos", False), ("sidebar", True)])
+
+    def test_an_arrangement_beats_both_slots_and_density(self):
+        cfg = {"frame": {"density": "minimal", "slots": ["top", "bottom", "repos"],
+                         "component": [{"use": "sidebar"}]}}
+        self.assertEqual(instance.frame_of(cfg)["slots"], ["right"])
+
+    def test_every_slots_list_round_trips_through_the_written_out_form(self):
+        """**Lossless in both directions**, which is what makes `slots` retirable later
+        without an operator's committed frame changing under them: resolve a `slots` list
+        to placements, write those placements out as tables, resolve the tables, and get
+        the same placements and the same split order back."""
+        for slots in (["top", "bottom", "repos", "right"], ["right", "top"],
+                      ["top", "bottom"], ["repos"]):
+            with self.subTest(slots=slots):
+                first = instance.frame_components({"frame": {"slots": slots}})
+                cfg = {"frame": {"component": _tables(first)}}
+                self.assertEqual(instance.frame_components(cfg), first)
+                self.assertEqual(instance.frame_of(cfg)["slots"], slots)
+
+
+class AnArrangementCharterCannotDrawIsRefusedWhole(unittest.TestCase):
+    """#535 is why this is refused whole rather than one table at a time.
+
+    Dropping just the table charter cannot make sense of hands the operator a frame with
+    a panel silently missing — and a missing repo table is a plane that appears to have no
+    clones. Every case below asserts the same thing: the frame falls back to the one
+    `slots` describes, and the repo table is still in it.
+    """
+
+    def _fallback(self, tables, *, slots=None):
+        frame = {"component": tables}
+        if slots is not None:
+            frame["slots"] = slots
+        got = instance.frame_of({"frame": frame})["slots"]
+        self.assertEqual(got, slots or list(instance.FRAME_DEFAULTS["slots"]))
+        self.assertIn("repos", got)
+
+    def test_a_component_charter_has_never_heard_of(self):
+        self._fallback([{"use": "identity"}, {"use": "acme.build"}])
+
+    def test_the_old_slot_vocabulary_written_into_use(self):
+        """`use` names a component, not a slot. `top` is a slot name, so a file mixing
+        the two is refused rather than half-understood — `builtins.SLOT_OF` is the one
+        table between the vocabularies and this keeps it the only one."""
+        self._fallback([{"use": "top"}, {"use": "bottom"}])
+
+    def test_an_edge_charter_cannot_place_the_component_at(self):
+        """Charter derives the whole frame's geometry from the components' own
+        declarations and nothing between here and `split-window` carries a per-plane
+        override yet. So an edge charter would not honour refuses the arrangement rather
+        than being read, validated, stored and ignored."""
+        self._fallback([{"use": "repos", "edge": "top"}], slots=["top", "repos"])
+
+    def test_a_size_charter_cannot_give_the_component(self):
+        self._fallback([{"use": "sidebar", "size": 30}])
+
+    def test_a_size_on_a_component_whose_height_is_its_content(self):
+        """`repos` is `Content()`: its height is the plane's repo count bounded by what
+        the harness may not be charged, so there is no number to accept here at all."""
+        self._fallback([{"use": "repos", "size": 4}])
+
+    def test_the_same_component_claimed_twice(self):
+        """One pane draws it, and two claims have no answer — the registry's own rule
+        (`Registry.register`), kept at the config boundary too."""
+        self._fallback([{"use": "repos"}, {"use": "repos"}])
+
+    def test_a_key_the_form_does_not_have(self):
+        """A typo in a key name is a line that does nothing, which is the same class of
+        silence as a value that does nothing."""
+        self._fallback([{"use": "identity", "edges": "top"}])
+
+    def test_a_visible_that_is_not_a_yes_or_no(self):
+        self._fallback([{"use": "identity", "visible": "no"}])
+
+    def test_an_arrangement_that_is_not_an_array_of_tables(self):
+        for junk in ("identity", {"use": "identity"}, [], ["identity"], 3):
+            with self.subTest(junk=junk):
+                got = instance.frame_of({"frame": {"component": junk}})["slots"]
+                self.assertEqual(got, list(instance.FRAME_DEFAULTS["slots"]))
+
+    def test_the_component_keys_a_declared_arrangement_may_carry(self):
+        """Named as a closed set, so a key added to the form has to be added here too."""
+        self.assertEqual(instance.FRAME_COMPONENT_FIELDS,
+                         ("use", "edge", "size", "visible"))
+
+
+class OrderIsGeometry(unittest.TestCase):
+    """The measurement `slots`' order exists to protect, asked of the resolved frame.
+
+    Measured on tmux 3.7c in a 200x50 window: `["top", "bottom", "right"]` gives a
+    **200-column** bottom row, and `["top", "right", "bottom"]` gives **177** — inset
+    beside the one sidebar and its border. (The spec's §4/§4b carry 154, which is the
+    pre-#488 arrangement with two 22-column sidebars coming off the row; §4i corrects it.)
+    """
+
+    def test_the_table_gets_the_whole_window_when_the_sidebar_is_split_after_it(self):
+        slots = instance.frame_of(
+            {"frame": {"slots": ["top", "bottom", "repos", "right"]}})["slots"]
+        self.assertEqual(layout.repos_cols(slots, window_cols=200), 200)
+
+    def test_the_table_is_inset_beside_a_sidebar_split_before_it(self):
+        slots = instance.frame_of(
+            {"frame": {"slots": ["top", "right", "bottom", "repos"]}})["slots"]
+        self.assertEqual(layout.repos_cols(slots, window_cols=200), 177)
+        self.assertEqual(177, 200 - layout.SLOT_SIZE["right"] - layout._BORDER_COLS)
+
+    def test_the_written_out_arrangement_keeps_the_same_two_geometries(self):
+        """The mapping cannot be lossy about the one thing the order decides."""
+        for tables, want in (([{"use": "identity"}, {"use": "attention"},
+                               {"use": "repos"}, {"use": "sidebar"}], 200),
+                             ([{"use": "identity"}, {"use": "sidebar"},
+                               {"use": "attention"}, {"use": "repos"}], 177)):
+            with self.subTest(want=want):
+                slots = instance.frame_of({"frame": {"component": tables}})["slots"]
+                self.assertEqual(layout.repos_cols(slots, window_cols=200), want)
+
+
+class TheOperatorsOwnPlane(unittest.TestCase):
+    """This repository's committed `charter.toml`, resolved — #535's test.
+
+    Reads the file the repo commits rather than a fixture of it, because a fixture is a
+    copy that agrees with the real thing until somebody edits one of them. That is the
+    whole failure mode: the change #535 shipped removed the repo table from charter's own
+    plane and every fixture in the suite went on describing a frame that had one.
+    """
+
+    def setUp(self) -> None:
+        self.assertTrue(CHARTER_TOML.is_file(),
+                        f"{CHARTER_TOML} is missing — this repo IS a control plane")
+        self.cfg = tomllib.loads(CHARTER_TOML.read_text())
+
+    def test_charters_own_plane_still_draws_every_panel_it_draws_today(self):
+        got = instance.frame_components(self.cfg)
+        self.assertEqual([(p["use"], p["edge"], p["visible"]) for p in got],
+                         [("identity", "top", True), ("attention", "bottom", True),
+                          ("repos", "bottom", True), ("sidebar", "right", True)])
+
+    def test_charters_own_plane_still_has_its_repo_table(self):
+        """Said separately from the list above, and on purpose. The assertion that shape
+        changed is one a future edit updates by pasting in whatever it now returns; this
+        one names the panel and cannot be satisfied that way."""
+        drawn = [p["use"] for p in instance.frame_components(self.cfg) if p["visible"]]
+        self.assertIn("repos", drawn)
+
+    def test_the_table_is_split_before_the_sidebar_so_it_gets_the_full_width(self):
+        """charter.toml's own comment promises this: `repos` is split before `right`, so
+        its table gets the full window width and is drawn at 95 columns and up. Listed
+        after the sidebar it would need a 118-column terminal before the table was drawn
+        at all, and below that the slot is dropped and the pane's rows go to the harness
+        (#500)."""
+        slots = instance.frame_of(self.cfg)["slots"]
+        self.assertLess(slots.index("repos"), slots.index("right"))
+        self.assertEqual(layout.repos_cols(slots, window_cols=200), 200)
+
+    def test_the_committed_slot_list_is_the_one_this_charter_can_place(self):
+        """Every name in the committed file resolves to a component. A plane whose
+        charter.toml names something this charter retired would draw fewer panels than
+        its file asks for, which is the upgrade case `instance.FRAME_SLOTS` filters —
+        asserted here against the file that is actually committed."""
+        for slot in self.cfg["frame"]["slots"]:
+            with self.subTest(slot=slot):
+                self.assertIn(slot, builtins.COMPONENT_OF)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Phase 1, second half — Tasks 5 and 6 of
`docs/superpowers/plans/2026-08-26-phase1-component-registry.md`, on top of the
contract/registry/ctx that landed in #548.

## Task 5 — today's components, in the registry

`charter/frame/builtins.py` registers the six: `identity`, `attention`, `repos`, and a
`sidebar` composite of `personas` + `todos`. Each wraps the renderer `frame/slots.py`
already had, unchanged.

`layout` used to carry five hand-written tables of per-slot facts — how big each slot is,
which splits cost columns, which strips are a fixed height, which one is variable, and a
fifth spelled inline as `slot == "top"`. All five are now one `_derive` over the
components' own `edge` and `size`, so they move together instead of agreeing by having
been edited in the same commit.

`_right` is split into `persona_section` and `todo_section` and composed back, so the
composite's two parts are real functions rather than a second copy of what the pane draws.
Same rows, same budget arithmetic, same single `verbosity` read.

### `needs` is what the renderer reads, not what the slice names suggest

- `identity`, `attention`, `personas` declare **nothing**. `_bottom`'s todo count is
  `todos.count_open`, a directory glob; `_alerts` reads charter.toml and the roster;
  `_persona_chip_cells()` reads the plane directly. None of it is a gather slice.
- `personas` in particular does **not** declare a `personas` slice. `ctx` cannot serve one,
  and a name answered with an empty tuple would let a component draw nothing and pass its
  own tests against an empty fixture — the convincing empty #512 removed.
- `repos`, `todos`, `sidebar` declare the whole `gather`, because each reads a key the
  narrow slice drops (`worktrees`, `current_repo`, `todo_count`) or needs
  `cached() is None` told apart from `{}`.

`test_a_component_reads_the_plane_exactly_where_it_said_it_would` checks that
mechanically: every component is drawn with `gather`'s two readers recording, and the
recording must be non-empty for exactly the components that declared `gather`.

### This changes no output

Rendered before and after at **200x50** and **80x24** against the same seeded plane —
every slot at its own pane geometry, plus the split argvs and the resolved sizes.
Byte-identical. At 200x50 (colour stripped for the PR):

```
=== window 200x50 ===
visible slots: ['top', 'bottom', 'repos', 'right']
sizes: {'top': 1, 'bottom': 1, 'repos': 9, 'right': 22}
harness rows: 36
  tmux -S /s split-window -t %0 -v -b -l 1  … charter panel top    --session f-render
  tmux -S /s split-window -t %0 -v    -l 1  … charter panel bottom --session f-render
  tmux -S /s split-window -t %0 -v    -l 9  … charter panel repos  --session f-render
  tmux -S /s split-window -t %0 -h    -l 22 … charter panel right  --session f-render
--- top pane 200x1 ---
 ⬢ demo  ◆ persona none · alpha · bravo · charlie · charter persona use <name>       charter 0.53.0
--- bottom pane 200x1 ---
0 todos · F2 menu
--- repos pane 200x9 ---
▪ repos 6
  ├─ charter                           main*↑2
  ├─ atlas                             feature/x                           ? fail        !42
  ├─ beacon                            main↓3
  ├─ delta                             main
  ├─ echo                              main
  └─ foxtrot                           main
--- right pane 22x36 ---
▪ personas 3
▫ alpha
▫ bravo
▫ charlie

▪ todos 9
- wire the registry
- measure the frame
- write the news entry
  …(+6 more)
=== window 80x24 ===
visible slots: ['top', 'bottom']     # right dropped on width, repos on the table's own floor
```

## Task 6 — the config, mapped losslessly

`instance.frame_components` is the one resolved answer. `slots` is shorthand for placing
built-ins on their own edges in the given split order; `density` is a named arrangement;
`[[frame.component]]` is the arrangement written out, one table per panel, file order being
split order.

`visible = false` is the one thing `slots` cannot express — deleting a name loses its
*position* with it.

`edge` and `size` are accepted only where charter can honour them, which today means only
at the component's own declaration. `layout` derives the frame's geometry from those
declarations and nothing between charter.toml and `split-window` carries a per-plane
override yet, so a value charter would not honour is refused rather than read, validated,
stored and ignored. What the pair is good for meanwhile is the round trip: every `slots`
list resolves to placements that write back out as tables and resolve to the same frame.

**An arrangement charter cannot draw is refused whole**, and the frame falls back to
`slots`. Not one table at a time: dropping the line charter could not parse hands the
operator a frame with a panel silently missing, and a missing repo table is a plane that
looks like it has no clones — #535, caught by a reviewer rather than by a test. Task 7
upgrades the one case it can improve (a component with no provider installed gets a
message in its own pane and the rest of the frame draws).

**The repo's own committed charter.toml is tested by name.** `TheOperatorsOwnPlane` reads
the file this repository commits, resolves it, and asserts the repo table is placed,
visible, and split before the sidebar so it gets the full 200 columns. Replaying #535
(removing `repos` from `FRAME_SLOTS`) turns that class red, including
`test_charters_own_plane_still_has_its_repo_table`.

## Verification

Suite run in two environments, both from a clean `__pycache__`:

| environment | result |
|---|---|
| ambient variables cleared (`CHARTER_SESSION_ID`, `CLAUDE_CODE_SESSION_ID`, `TMUX`, `TMUX_PANE`) | `Ran 5837 tests` — `OK` |
| the same plus `CHARTER_WORKSPACE=demo` | `Ran 5837 tests` — `OK` |

`origin/main` is 5789. **No existing test was modified** — the 48 new ones are all in
`tests/test_builtin_components.py` (21) and `tests/test_component_config.py` (27).

### Mutations run, each RED then restored GREEN

| mutation | result |
|---|---|
| `_panel` uses `splitlines()` instead of `split("\n")` | RED — a renderer drawing one blank line drew none |
| `layout._cells` returns 1 regardless of the declared size | RED, 7 failures across `test_frame_layout` and the new file |
| `_derive`'s `fixed_rows` drops its `isinstance(size, Fixed)` check | RED, 2 failures |
| `-b` on every split rather than on a before-edge | RED, 3 failures |
| `todo_section` drops the terse cap | **GREEN at first** — see below |
| `frame_of` re-orders `slots` into the shipped order | RED, 4 including the 200-vs-177 geometry and the existing order test |
| `component_tables` drops an unusable table instead of refusing the arrangement | RED, 3 failures |
| the resolved arrangement is sorted rather than kept in file order | RED, 4 failures |
| #535 replayed — `repos` removed from `FRAME_SLOTS` | RED, including the operator's-own-plane table test |

The one that came back green is the finding worth reporting: the sidebar's terse todo cap
was **uncovered where it already lived**, so moving it into `todo_section` inherited a
guard nothing was holding. It is covered now
(`test_a_terse_sidebar_spends_fewer_rows_on_todos_than_a_normal_one`), and the same
mutation is RED against it.

### One correction to the plan's own text

The geometry measurement is **200 versus 177**, not 200 versus 154 — `["top","bottom",
"right"]` gives a 200-column bottom row and `["top","right","bottom"]` gives 177, inset
beside one sidebar and its border. 154 is the pre-#488 two-sidebar arrangement. The plan
and §4/§4b carry the stale figure; §4i corrects it, and every number written here and in
the code is the current one.

## Not in this PR

No version bump, no news stamping, no tag. One news entry
(`docs/news/unreleased-the-frame-is-components-now.md`) and the `[[frame.component]]`
section in `docs/frame.md`, since the config form is operator-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
