### PR TITLE
An action does rather than draws, so it starts work and says why it cannot (Phase 2, Task 3)

### DIFF
--- a/charter/frame/action.py
+++ b/charter/frame/action.py
@@ -1,0 +1,259 @@
+"""What an action is, and what one is handed when it runs.
+
+A component *draws*; an action *does* (§4d). That one word is the whole of why this
+module exists beside `component.py` rather than inside it, and why the contract here is
+narrower in the two places where real damage would live.
+
+**Fire-and-report, never blocking** (§4g). :attr:`Action.run` starts work and returns; it
+is not where the work happens. `frame.actions.ActionRegistry.invoke` never waits for it,
+progress surfaces through `inflight`, and the palette closes. A blocking action in a TUI
+is indistinguishable from a hang, and the operator's only recourse would be the escape
+hatch — for something working correctly.
+
+**An action that cannot run right now says why** — it is not omitted. The session lock
+refuses a workspace switch today, and a palette that silently drops the row is worse than
+one that explains: the operator cannot ask about an option they cannot see. That is #512's
+"no repos" drawn over a plane that had them, one surface along. So availability is a pair
+— :attr:`Action.available` and :attr:`Action.reason_unavailable` — and charter asks the
+second one only when the first said no, which is the only arrangement in which the two
+cannot contradict each other on screen.
+
+**What an action may reach is narrower than what a component may read.** ``needs`` exists
+so a renderer's COST is declarable; ``touches`` exists so an action's REACH is. The
+vocabulary is closed, and today it holds no route to a vault value, a forge token or a
+shell. ``vault`` is served as an INVENTORY — which vaults this plane has and what they are
+keyed by, never what is in them — because an action offering to spend a credential needs
+the names to offer, and nothing more to offer them. Spending arrives with the first action
+that spends, and it will go through `charter secret exec`, which already resolves the value
+inside charter's own process, strips every other vault's identity from the child, and
+redacts what comes back. Narrow from day one (§4d): widening costs a line, and un-widening
+after a provider has shipped against it costs everything.
+
+**This is containment, not a sandbox**, on exactly the terms `ctx.py` states for
+components: a provider's module is ordinary Python and can import whatever it likes. What
+the declaration rules out is the accident and the shortcut — the handle that was
+convenient once, sitting on the object where a stranger's code reaches for it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from .. import contain
+from . import ctx as _ctx
+from .component import ID_HINT, names, usable_id
+
+#: The action contract's version, as a single integer, refused at load rather than
+#: negotiated (§4g) — the same mechanism `component.API_VERSION` is, on its own number.
+#:
+#: **Its own number, and a provider declares it under its own name**
+#: (``ACTION_API_VERSION``; see `frame.actions.ActionProviders`). One distribution may
+#: legitimately supply a CI panel and a "rerun failed job" action out of one module — §4d's
+#: own example — and one module attribute cannot mean two contracts whose integers move
+#: independently. Sharing it would mean a component-contract change refusing every action
+#: on the machine for a contract it did not touch, which is a break with no fix a provider
+#: author can apply.
+API_VERSION = 1
+
+#: What an action may declare it reaches. Closed, and it is exactly :data:`SERVES` — a
+#: name accepted here and served empty would be worse than a refusal, for the reason
+#: `component.NEEDS` gives at length: the action would declare it, do nothing, pass its own
+#: tests against an empty fixture, and be indistinguishable from a plane that genuinely has
+#: nothing. ``forge`` and ``shell`` are absent because charter serves neither yet; each
+#: joins the day it can be served, and not before.
+TOUCHES = ("gather", "repos", "todos", "vault")
+
+
+class ActionError(ValueError):
+    """An action that cannot be constructed, registered or started — and why.
+
+    One type for the whole contract, so a caller that degrades rather than propagates —
+    the palette, which turns every one of these into a row that says why — has one thing
+    to catch. Separate from `ComponentError` because the two contracts are separate: a
+    caller catching one must not silently swallow the other's failures.
+    """
+
+
+def _always(ctx) -> bool:
+    """The default availability: yes.
+
+    A default that answered "no" would need a reason, and a default reason is the
+    unfalsifiable row this contract exists to prevent.
+    """
+    return True
+
+
+def _silent(ctx) -> str:
+    """The default reason: none, because the default action is available.
+
+    Never shown: charter asks this only after :attr:`Action.available` said no, and an
+    action that says no has to say why. `frame.actions` finishes the sentence when a
+    provider does not.
+    """
+    return ""
+
+
+@dataclass(frozen=True, kw_only=True)
+class Action:
+    """One thing the command surface can do, and everything charter needs to offer it.
+
+    Keyword-only, for `Component`'s reason: field order is not part of the contract and
+    must not become part of it by accident, because a provider that spelled its action
+    positionally would break the day a field is added, having done nothing wrong.
+
+    Callables rather than methods on a base class, so that an action is a value: a
+    built-in is one expression, a provider's is one expression, and neither inherits
+    anything charter could later change underneath it.
+    """
+
+    #: Held to the component alphabet, by the same function, because it reaches the same
+    #: places: a palette row, a pane title, and — once Task 5 lands per-action keys — a
+    #: tmux ``bind`` line, which is where `[frame] hotkey`'s newline achieved code
+    #: execution at launch.
+    id: str
+    #: Display text. An open alphabet, contained rather than refused — see `component`'s
+    #: docstring for why the pair gets opposite treatments.
+    title: str
+    #: ``run(ctx)`` — starts the work and RETURNS. Whatever it answers, if anything, is
+    #: one line about what it started, shown by the palette; ``None`` is "nothing to say".
+    run: Callable[[Any], Any]
+    #: ``available(ctx) -> bool`` — may this run right now, against this plane, this
+    #: moment. Asked every time the surface is drawn, never cached: the session lock it
+    #: most often reports is held and released by other processes.
+    available: Callable[[Any], bool] = _always
+    #: ``reason_unavailable(ctx) -> str`` — asked ONLY when the line above said no, which
+    #: is what keeps the pair from disagreeing where an operator can see it.
+    reason_unavailable: Callable[[Any], str] = _silent
+    #: What this action reaches, drawn from :data:`TOUCHES`. The ctx is built from it, so
+    #: an action gets what it declared and not one field more.
+    touches: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        # The id first: every message below names the action it is about, and an action
+        # whose id could forge a line would forge those messages too.
+        if not usable_id(self.id):
+            raise ActionError(
+                f"{contain.one_line(repr(self.id))} is not a usable action id — "
+                f"write {ID_HINT}")
+        if not isinstance(self.title, str):
+            raise ActionError(
+                f"action {self.id}: title must be text, not "
+                f"{contain.one_line(repr(self.title))}")
+        for field in ("run", "available", "reason_unavailable"):
+            if not callable(getattr(self, field)):
+                raise ActionError(
+                    f"action {self.id}: {field} must be callable, not "
+                    f"{contain.one_line(repr(getattr(self, field)))}")
+        object.__setattr__(self, "title", contain.one_line(self.title))
+        object.__setattr__(
+            self, "touches",
+            names("touches", f"action {self.id}", self.touches, TOUCHES,
+                  error=ActionError))
+
+
+class VaultInventory:
+    """Which vaults this plane holds and what they are keyed BY — never what is in them.
+
+    **The names are resolved once, when the ctx is built, and the values never are.** An
+    action that declared ``vault`` is offering to do something with a credential — copy
+    one to a file, run a command under one — and to offer that it needs the names to put
+    on a row. It does not need, and does not get, a way to read one.
+
+    :meth:`keys` builds a provider and drops it, deliberately. A cached provider is how a
+    value would arrive here without anybody writing a method for it: the object would
+    simply be holding the file it had read, and everything reachable from a ctx is
+    reachable by the action holding it.
+
+    What this is not: a claim that an action *cannot* read a secret. An action's module is
+    ordinary Python and `charter.secrets` is an import away — the same honesty `ctx.py`
+    states for components. What is claimed, and tested by walking every route out of a
+    real ctx over a real vault, is that **charter hands one over nowhere**: not as a
+    value, not as a provider, not in a closure, not behind a method. An action that reads
+    a vault does it in the open, in code somebody can review, rather than through a
+    convenience charter left on the object.
+    """
+
+    def __init__(self, names: tuple[str, ...]) -> None:
+        self._names = names
+
+    def names(self) -> tuple[str, ...]:
+        """Every vault registered on this plane, alphabetically."""
+        return self._names
+
+    def keys(self, vault: str) -> tuple[str, ...]:
+        """The key NAMES in *vault* — `VaultProvider.keys` is "never the values".
+
+        A vault this plane does not have is a refusal naming it, not an empty tuple: an
+        empty answer is indistinguishable from a vault that holds nothing, and a typo
+        would then read as an empty vault (#512, one surface along).
+        """
+        if vault not in self._names:
+            raise ActionError(
+                f"no vault named {contain.one_line(repr(vault))} on this plane — "
+                f"this action was handed {', '.join(self._names) or 'no vaults'}")
+        from ..secrets import registry as vaultreg
+        return tuple(vaultreg.provider_for(vault).keys())
+
+
+def _vault(snap) -> VaultInventory:
+    """The vault inventory, read once per ctx.
+
+    Deliberately not a slice of the snapshot: vault registration is not plane state the
+    frame gathers on its refresh clock, and putting it there would mean every repaint
+    reading it for components that have no business with it. It is filesystem work, which
+    is exactly why an action has to DECLARE it — the same argument ``needs`` makes for a
+    renderer's cost, applied to an action's reach.
+    """
+    from ..secrets import registry as vaultreg
+    return VaultInventory(tuple(sorted(vaultreg.vaults())))
+
+
+#: How each declared name is served. The three plane slices are `ctx.SERVES`' own
+#: functions, referenced rather than re-written: "what is in ``repos``" must have one
+#: answer, and a second copy would be a second answer the day either moved.
+SERVES = {
+    "gather": _ctx.SERVES["gather"],
+    "repos": _ctx.SERVES["repos"],
+    "todos": _ctx.SERVES["todos"],
+    "vault": _vault,
+}
+
+#: What an action is handed whatever it declared. No width and no height: an action does
+#: not draw, and a rectangle it was handed would be a rectangle it could be tempted to
+#: write into.
+IDENTITY = ("fid",)
+
+
+class ActionCtx(_ctx.Ctx):
+    """What an action may reach: `Ctx`'s semantics over this contract's vocabulary.
+
+    Absent rather than disabled, read-only, and an exactly-assertable attribute set — all
+    inherited, because they are the same property, and two implementations of "what may a
+    stranger's code reach" is the shape #547 is about.
+    """
+
+    _serves = SERVES
+    _geometry = IDENTITY
+    _noun = "action"
+    _declared = "touches"
+
+
+def build(touches, *, fid: str, snapshot: Mapping) -> ActionCtx:
+    """The object *touches* asked for, cut from *snapshot*.
+
+    Built by the registry from the action's OWN declaration, never by whatever is invoking
+    it — so a caller that did not read the declaration cannot hand an action more than it
+    asked for, which is the half of "absent, not disabled" a caller could otherwise undo.
+    """
+    served = names("touches", "this action", touches, tuple(SERVES), error=ActionError)
+    if not isinstance(fid, str):
+        raise ActionError(
+            f"a frame id must be text, not {contain.one_line(repr(fid))}")
+    if not isinstance(snapshot, Mapping):
+        raise ActionError(
+            f"a snapshot must be one mapping of plane state, not "
+            f"{contain.one_line(repr(snapshot))}")
+    fields: dict[str, Any] = {"fid": fid}
+    fields.update({name: SERVES[name](snapshot) for name in served})
+    return ActionCtx(fields)

--- a/charter/frame/action.py
+++ b/charter/frame/action.py
@@ -231,12 +231,18 @@ class ActionCtx(_ctx.Ctx):
     Absent rather than disabled, read-only, and an exactly-assertable attribute set — all
     inherited, because they are the same property, and two implementations of "what may a
     stranger's code reach" is the shape #547 is about.
+
+    **Its vocabulary is declared beside it, not on it.** :data:`SERVES` holds `_vault`,
+    which reads the vault registry and ignores the snapshot it is handed; as a class
+    attribute — even an underscore-prefixed one — it was a live route from the ctx of an
+    action that declared NOTHING to this plane's whole vault inventory, past every test
+    that asserts the attribute set exactly. `frame.ctx.declare` keeps the table off the
+    class; `NoRouteFromAnActionToAVaultValue` walks the class as well as the object.
     """
 
-    _serves = SERVES
-    _geometry = IDENTITY
-    _noun = "action"
-    _declared = "touches"
+
+_ctx.declare(ActionCtx, _ctx.Contract(serves=SERVES, geometry=IDENTITY, noun="action",
+                                      declared="touches"))
 
 
 def build(touches, *, fid: str, snapshot: Mapping) -> ActionCtx:

--- a/charter/frame/actions.py
+++ b/charter/frame/actions.py
@@ -1,0 +1,408 @@
+"""The actions this frame can offer, and starting one without waiting for it.
+
+`registry.py` answers "what is on screen"; this answers "what can be done", and it is the
+same object one contract over: the same entry-point discovery, the same four refusals, the
+same posture that a stranger's code costs its own row and never the session. What differs
+is data — see :class:`ActionProviders`, which sets eight class attributes and inherits
+every refusal rather than repeating one of them. #547 is what a second implementation of
+one question costs, and it was only found because the copy happened to call the original.
+
+**Two properties here are not negotiable.**
+
+*Fire-and-report* (§4g). :meth:`ActionRegistry.invoke` starts the work and answers an
+:class:`Invocation` — a receipt, not a result. It never joins. The action runs on a worker
+thread so that a badly-written one costs its own row rather than the frame's input loop: a
+blocking action in a TUI is indistinguishable from a hang, and the operator's only recourse
+would be the escape hatch, for something working correctly. Progress surfaces through
+`inflight`, which is the frame's existing spinner and not a second clock.
+
+*An unavailable action carries why.* Every registered action is offered, always, and one
+that cannot run right now is offered with the reason on it (:class:`Offer`). Charter
+finishes the sentence when a provider does not — an unavailable row with an empty reason is
+the same defect as a missing row, arriving by a shorter path.
+
+**And this is where a failed provider finally has somewhere to speak.** `registry`'s
+`STANDIN_EDGE` note records that in Phase 1 an arrangement charter could not honour had no
+surface to say so on, so it was refused whole. An action has one: the row itself. A missing
+distribution, a version charter does not speak, two distributions claiming one id — each is
+an offer that is permanently unavailable and says exactly which, and the rest of the
+palette is offered.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import threading
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from .. import contain, inflight
+from . import action, registry
+from .action import Action, ActionError
+from .registry import _because
+
+#: The entry point group an installed distribution declares its actions in (§4d):
+#:
+#: ``[project.entry-points."charter.actions"]`` / ``acme.deploy = "acme_charter:deploy"``
+#:
+#: **Separate from `registry.PROVIDER_GROUP`, not one group with a kind field.** A
+#: component draws and an action does; the contracts have different shapes, different
+#: version integers and different blast radii, and a single group would mean charter
+#: importing a provider's module to find out which of the two it had. Discovery must be
+#: answerable from metadata alone — that is the whole of why an installed-but-unused
+#: provider costs a frame nothing.
+ACTION_GROUP = "charter.actions"
+
+#: How much of a reason charter will carry to a row.
+#:
+#: Larger than `contain.DISPLAY_LIMIT`, which sizes a refusal SENTENCE, because the
+#: reasons that matter most here are the load failures below — and each of those ends by
+#: naming what to do about it. Clipping at a sentence would take the tail, and the tail is
+#: the half the operator can act on. The WIDTH budget is applied where the row is drawn,
+#: by the surface that knows how wide it is; this is a bound on how much a provider's
+#: string may grow, which is a different question and needs its own number.
+REASON_LIMIT = 1024
+
+
+class ActionProviders(registry.Providers):
+    """The action providers installed on this machine, listed without importing one.
+
+    Eight attributes and no methods: everything below is the component loader's, and the
+    contract-specific words are data so that the two cannot drift into giving different
+    answers. What that buys is concrete — the id-collision refusal, the pre-build version
+    check and the "entry point name IS the id" rule hold for actions because they hold at
+    all, not because somebody remembered to write them twice.
+    """
+
+    group = ACTION_GROUP
+    #: **Its own attribute name**, not `API_VERSION`. One module may supply a CI panel and
+    #: a "rerun failed job" action — §4d's own example of why the group is separate — and
+    #: one name cannot carry two contracts whose integers move independently. A module
+    #: declaring only `API_VERSION` has said nothing about this contract, and is refused
+    #: for saying nothing rather than loaded on the other contract's word.
+    version_attr = "ACTION_API_VERSION"
+    speaks = action.API_VERSION
+    kind = Action
+    contract = "action"
+    noun = "frame action"
+    verb = "offering"
+    degrades = "Its row says so; the rest of the palette is offered"
+    too_late = "when you press its key"
+    error = ActionError
+
+
+@dataclasses.dataclass(frozen=True)
+class Offer:
+    """One row of the command surface: what it is, and whether it can run right now.
+
+    A value rather than a live view of the action, because a row is drawn from a moment.
+    Availability is asked once per listing and carried here, so the palette cannot show a
+    row as available and refuse it a line later for a reason it never printed.
+    """
+
+    id: str
+    title: str
+    available: bool
+    #: Empty exactly when :attr:`available`. Never empty when it is not — charter writes
+    #: a sentence when the action would not.
+    reason: str
+
+
+class Invocation:
+    """The receipt :meth:`ActionRegistry.invoke` answers: what was started, and how it went.
+
+    **A receipt, not a result.** :attr:`started` and :attr:`reason` are true the instant
+    invoke returns; :attr:`note`, :attr:`error` and :attr:`ok` are what the work has said
+    SO FAR, and while :attr:`running` they mean "nothing yet" rather than "nothing". A
+    caller that renders this renders the present state of the work, which is the whole
+    point of the surface being non-blocking.
+    """
+
+    def __init__(self, aid: str, *, started: bool, reason: str = "") -> None:
+        self.id = aid
+        #: Whether the work was started. False for an action that refused to be run —
+        #: the reason is on :attr:`reason`, and it is the one the listing would have shown.
+        self.started = started
+        self.reason = reason
+        self._thread: threading.Thread | None = None
+        self._note = ""
+        self._error = ""
+
+    @property
+    def running(self) -> bool:
+        """Whether the action is still inside ``run``."""
+        return self._thread is not None and self._thread.is_alive()
+
+    @property
+    def note(self) -> str:
+        """The one line the action said about what it started, contained. ``""`` so far."""
+        return self._note
+
+    @property
+    def error(self) -> str:
+        """What the action raised, as one line naming the type. ``""`` for none so far."""
+        return self._error
+
+    @property
+    def ok(self) -> bool:
+        """Started, finished, and raised nothing. False while it is still running."""
+        return self.started and not self.running and not self._error
+
+    def join(self, timeout: float | None = None) -> bool:
+        """Wait for the work to finish. **The frame never calls this.**
+
+        It exists for the two callers that are not the frame: a test, which must not tear
+        down a fixture the work is still reading, and a shutdown that wants to know
+        whether anything is still going. Anything DRAWING this asks :attr:`running` — a
+        surface that waited here would be the blocking action this whole contract refuses,
+        wearing the caller's clothes.
+        """
+        if self._thread is None:
+            return True
+        self._thread.join(timeout)
+        return not self._thread.is_alive()
+
+    def _begin(self, a: Action, ctx) -> None:
+        """Put the work on a thread of its own and return.
+
+        Here rather than in :meth:`ActionRegistry.invoke` so that the thread and the
+        fields it writes are owned by one object: a caller that reached in to start it
+        could also reach in to join it, and the whole contract is that nobody joins.
+        """
+        self._thread = threading.Thread(
+            target=self._work, args=(a, ctx), name=f"charter-action-{self.id}",
+            daemon=True)
+        self._thread.start()
+
+    def _work(self, a: Action, ctx) -> None:
+        """The worker thread's whole body: run it, record what it said, clear the record.
+
+        Every exception is recorded rather than raised, `KeyboardInterrupt` included —
+        which is where this deliberately differs from `Registry.draw`, and the difference
+        is the thread. There, re-raising hands the interrupt back to the operator's own
+        main loop; here there is nobody to hand it to, and the default thread excepthook
+        would print a traceback over the frame charter is drawing. So it lands on
+        :attr:`error`, where the surface can say it.
+        """
+        try:
+            note = a.run(ctx)
+            if note is not None:
+                self._note = contain.one_line(str(note), limit=REASON_LIMIT)
+        except BaseException as exc:
+            self._error = _because(exc)
+        finally:
+            inflight.finish(self.id, kind=inflight.ACTION)
+
+
+class ActionRegistry:
+    """The actions this frame knows about, in the order they were registered.
+
+    An instance rather than module state, for `Registry`'s reason: a test, a config
+    boundary, a future second frame each build their own and cannot be affected by what
+    another one registered.
+
+    Registration order is the offer order. It is not geometry — an action has no edge —
+    but it is still charter's to choose rather than the machine's: `Providers.ids` sorts
+    because discovery order is ``sys.path`` order, and a palette that reordered itself
+    when a virtualenv changed would be reporting the wrong thing.
+    """
+
+    def __init__(self) -> None:
+        self._by_id: dict[str, Action] = {}
+        #: id → the position it was registered in. A separate mapping rather than "the
+        #: position in ``self._by_id``", for `Registry._order`'s reason: dicts preserve
+        #: insertion order, so the two agree today and would disagree silently the first
+        #: time anything rebuilt or re-keyed that dict.
+        self._order: dict[str, int] = {}
+        self._next = 1
+        #: id → why it is a standin rather than the action that was asked for, kept after
+        #: the row is drawn so `doctor` can say it in full at a width a row does not have.
+        self._failures: dict[str, str] = {}
+        #: One scan of the installed providers per frame, and it has not happened yet.
+        self.providers = ActionProviders()
+
+    # -- registering ------------------------------------------------------- #
+
+    def register(self, a: Action) -> Action:
+        """Add *a* at the end of the offer order, and answer it.
+
+        Checked before anything is stored, so a refusal leaves the registry exactly as it
+        was: a half-registered action is a row that cannot be run.
+        """
+        if not isinstance(a, Action):
+            raise ActionError(
+                f"{contain.one_line(repr(a))} is not an action — build one with "
+                f"frame.action.Action(...)")
+        if a.id in self._by_id:
+            was = self._by_id[a.id]
+            raise ActionError(
+                f"two actions claim the id {a.id}: {was.title} is registered and "
+                f"{a.title} wants the same id. Neither is offered by charter picking "
+                f"one — rename one of them")
+        self._by_id[a.id] = a
+        self._order[a.id] = self._next
+        self._next += 1
+        return a
+
+    def add(self, aid: str) -> Action:
+        """Offer *aid* on this frame, importing the provider that supplies it if need be.
+
+        **This never propagates a provider's failure** — a committed config naming
+        `acme.deploy` on a machine without it, a provider that raises on import, a version
+        charter does not speak, two distributions claiming one id: each is a ROW saying so,
+        and the rest of the palette is offered. A committed file must never be able to make
+        charter unusable for somebody who has not installed a third-party package.
+
+        Already registered — a built-in, or a config naming one twice — answers what is
+        registered rather than refusing: this asks for *aid* to be offered, where
+        :meth:`register` asks for an action to be added.
+
+        The one thing it raises for is an id that could never name an action at all: there
+        is nothing to stand in for and nothing to write on the row, and that refusal
+        belongs to whatever read the value, beside the rest of its validation.
+        """
+        if isinstance(aid, str) and aid in self._by_id:
+            return self._by_id[aid]
+        try:
+            loaded = self.providers.load(aid)
+        except ActionError as exc:
+            # An id that could never name an action has nothing to stand in for: the
+            # standin below would be refused by `Action` for the same reason, one frame
+            # deeper, where the caller can no longer see which value was unusable.
+            if not action.usable_id(aid):
+                raise
+            return self._stand_in(aid, str(exc))
+        # Outside the `except`, so that a refusal from `register` — the id-collision
+        # rule — is the caller's to see rather than a standin drawn over it.
+        return self.register(loaded)
+
+    def _stand_in(self, aid: str, reason: str) -> Action:
+        """A row that says why *aid* is not the action that was asked for.
+
+        An action, registered like any other, rather than a hole in the palette. Its
+        ``run`` refuses on principle and is unreachable in practice —
+        :meth:`invoke` never runs an unavailable action — because a standin that could be
+        started by a caller taking a different route would be the one thing worse than a
+        missing row: a row that does something nobody can name.
+        """
+        def refuse(ctx):
+            raise ActionError(reason)
+
+        a = self.register(Action(
+            id=aid, title=f"{aid} — unavailable", run=refuse,
+            available=lambda ctx: False, reason_unavailable=lambda ctx: reason))
+        self._failures[aid] = reason
+        return a
+
+    @property
+    def failures(self) -> Mapping[str, str]:
+        """id → why it is a standin, for everything this registry could not load."""
+        return MappingProxyType(dict(self._failures))
+
+    # -- asking ------------------------------------------------------------ #
+
+    def get(self, aid: str) -> Action:
+        """The action registered as *aid*.
+
+        Raises `ActionError` rather than `KeyError`: the id may have come from a committed
+        file naming a provider this machine has not installed, and a caller degrading that
+        way has one type to catch for the whole contract.
+        """
+        try:
+            return self._by_id[aid]
+        except (KeyError, TypeError):
+            raise ActionError(
+                f"no action is registered as {contain.one_line(repr(aid))}") from None
+
+    def all(self) -> tuple[Action, ...]:
+        """Every registered action, in the order it was registered."""
+        return tuple(sorted(self._by_id.values(), key=lambda a: self._order[a.id]))
+
+    def offers(self, *, fid: str, snapshot: Mapping) -> tuple[Offer, ...]:
+        """Every action, as rows, with availability resolved against this moment.
+
+        **Every** action: an unavailable one is a row with its reason, never an omission.
+        The listing is what the operator can see, so what they cannot do has to be visible
+        in it or they cannot find out why.
+        """
+        out = []
+        for a in self.all():
+            available, reason, _ = self._check(a, fid=fid, snapshot=snapshot)
+            out.append(Offer(id=a.id, title=a.title, available=available, reason=reason))
+        return tuple(out)
+
+    def invoke(self, aid: str, *, fid: str, snapshot: Mapping) -> Invocation:
+        """Start *aid* and answer the receipt. **Returns without waiting for it** (§4g).
+
+        Availability is re-asked here rather than trusted from the listing: the plane
+        moves — the session lock is held and released by other processes — and a row drawn
+        a second ago is not a promise. An action that cannot run is not run, and the
+        receipt carries the same reason the row would have.
+
+        The record goes into `inflight` BEFORE the thread starts, so the frame's spinner
+        cannot miss a fast action: a record written from inside the worker could land after
+        the work was already over.
+        """
+        a = self.get(aid)
+        available, reason, ctx = self._check(a, fid=fid, snapshot=snapshot)
+        if not available:
+            return Invocation(aid, started=False, reason=reason)
+        inv = Invocation(aid, started=True)
+        inflight.start(aid, kind=inflight.ACTION)
+        inv._begin(a, ctx)
+        return inv
+
+    # -- availability, in one place -------------------------------------- #
+
+    def _check(self, a: Action, *, fid: str,
+               snapshot: Mapping) -> tuple[bool, str, Any]:
+        """``(available, reason, ctx)`` for *a* against this moment.
+
+        One implementation, asked by both :meth:`offers` and :meth:`invoke`, so the row
+        and the keypress cannot disagree about whether something can run — and one ctx,
+        built once, so an action that declared `vault` costs one registry read rather than
+        one per surface that asks about it.
+
+        A provider's `available` that RAISES answers no, with what it raised: a stranger's
+        code costs its own row, exactly as a renderer that raises costs its own pane. The
+        alternative is an exception out of the listing, which costs the whole palette.
+
+        `KeyboardInterrupt` still travels, as it does through `Registry.draw`: this runs on
+        the frame's own thread, and an interrupt swallowed here is a palette that cannot be
+        stopped while it is being listed.
+        """
+        try:
+            ctx = action.build(a.touches, fid=fid, snapshot=snapshot)
+            available = bool(a.available(ctx))
+        except KeyboardInterrupt:
+            raise
+        except BaseException as exc:
+            return False, self._reason(a, _because(exc)), None
+        if available:
+            return True, "", ctx
+        try:
+            said = a.reason_unavailable(ctx)
+        except KeyboardInterrupt:
+            raise
+        except BaseException as exc:
+            said = _because(exc)
+        return False, self._reason(a, said), ctx
+
+    @staticmethod
+    def _reason(a: Action, said: Any) -> str:
+        """*said* as one row's worth of why, and never nothing.
+
+        Contained BEFORE anything measures or draws it (#472): a reason is a provider's
+        string, or a plane value quoted into one, and a newline in it writes a second row
+        that looks exactly as much like charter's own as the first. `[frame] hotkey` is
+        what a committed value reaching a config line cost once, and a palette row is the
+        same class of place.
+
+        An empty answer is finished by charter rather than passed through. "Unavailable,
+        no reason" is the row this contract exists to prevent, and a provider returning
+        ``""`` produces it just as surely as omitting the row would.
+        """
+        text = contain.one_line(str(said or ""), limit=REASON_LIMIT).strip()
+        return text or (
+            f"{a.id} is unavailable and did not say why — an action that refuses has to "
+            f"name what would make it available")

--- a/charter/frame/actions.py
+++ b/charter/frame/actions.py
@@ -116,14 +116,24 @@ class Invocation:
     SO FAR, and while :attr:`running` they mean "nothing yet" rather than "nothing". A
     caller that renders this renders the present state of the work, which is the whole
     point of the surface being non-blocking.
+
+    **It carries its own in-flight token**, so the record it retires is the record it
+    started. Two invocations of one action are two threads of one process; a `finish`
+    that picked by name and kind would have both of them selecting the identical file,
+    and the loser's record would outlive its work by a day (`inflight.finish`).
     """
 
-    def __init__(self, aid: str, *, started: bool, reason: str = "") -> None:
+    def __init__(self, aid: str, *, started: bool, reason: str = "",
+                 token: str | None = None) -> None:
         self.id = aid
         #: Whether the work was started. False for an action that refused to be run —
         #: the reason is on :attr:`reason`, and it is the one the listing would have shown.
         self.started = started
         self.reason = reason
+        #: What `inflight.start` answered, or ``None`` when it wrote nothing. Never a
+        #: fallback to the name-and-kind search: no record of this invocation's exists,
+        #: so a search would retire a CONCURRENT invocation's — the same leak, inverted.
+        self._token = token
         self._thread: threading.Thread | None = None
         self._note = ""
         self._error = ""
@@ -191,7 +201,8 @@ class Invocation:
         except BaseException as exc:
             self._error = _because(exc)
         finally:
-            inflight.finish(self.id, kind=inflight.ACTION)
+            if self._token is not None:
+                inflight.finish(self.id, kind=inflight.ACTION, token=self._token)
 
 
 class ActionRegistry:
@@ -341,14 +352,15 @@ class ActionRegistry:
 
         The record goes into `inflight` BEFORE the thread starts, so the frame's spinner
         cannot miss a fast action: a record written from inside the worker could land after
-        the work was already over.
+        the work was already over. **Its token goes onto the receipt**, which is the only
+        thing that knows which of several concurrent records is this invocation's.
         """
         a = self.get(aid)
         available, reason, ctx = self._check(a, fid=fid, snapshot=snapshot)
         if not available:
             return Invocation(aid, started=False, reason=reason)
-        inv = Invocation(aid, started=True)
-        inflight.start(aid, kind=inflight.ACTION)
+        inv = Invocation(aid, started=True,
+                         token=inflight.start(aid, kind=inflight.ACTION))
         inv._begin(a, ctx)
         return inv
 

--- a/charter/frame/component.py
+++ b/charter/frame/component.py
@@ -188,22 +188,40 @@ class Fill:
 SIZES = (Fixed, Content, Fill)
 
 
-def names(name: str, owner: str, value: Any, allowed: tuple[str, ...]) -> tuple[str, ...]:
+def usable_id(value: Any) -> bool:
+    """Whether *value* is an id charter will let travel to tmux — see :data:`_ID_RE`.
+
+    Asked rather than re-spelled, because a second copy of this pattern is a second
+    answer to "what may reach a `bind` line", and the two would drift the way ``match``
+    and ``fullmatch`` already did inside this one module. `frame.action` holds an action
+    id to exactly this alphabet for exactly this reason: it reaches a palette row and a
+    key binding from the same class of place a component id does.
+    """
+    return isinstance(value, str) and _ID_RE.fullmatch(value) is not None
+
+
+def names(name: str, owner: str, value: Any, allowed: tuple[str, ...], *,
+          error: type = ComponentError) -> tuple[str, ...]:
     """*value* as a tuple of names drawn from *allowed*, or a refusal naming both.
 
     A bare string is refused rather than accepted, and that is the point of doing this in
     one helper: ``needs = "gather"`` iterates as six one-character needs, so a permissive
     reading would refuse it six times over for the wrong reason, or — worse, with a
     single-character name in play — accept part of it.
+
+    *error* is which contract is being checked. A component's ``needs`` and an action's
+    ``touches`` are the same question asked of two closed vocabularies, and each contract
+    raises its own one type so that a caller degrading rather than propagating still has
+    one thing to catch.
     """
     if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple)):
-        raise ComponentError(
+        raise error(
             f"{owner}: {name} must be a tuple of names, not "
             f"{contain.one_line(repr(value))}")
     out = tuple(value)
     unknown = [v for v in out if v not in allowed]
     if unknown:
-        raise ComponentError(
+        raise error(
             f"{owner}: unknown {name} "
             f"{', '.join(contain.one_line(repr(u)) for u in unknown)} — "
             f"charter serves {', '.join(allowed)}")
@@ -238,7 +256,7 @@ class Component:
     def __post_init__(self) -> None:
         # The id first, because every message below names the component it is about, and
         # a component whose id could forge a line would forge those messages too.
-        if not isinstance(self.id, str) or not _ID_RE.fullmatch(self.id):
+        if not usable_id(self.id):
             raise ComponentError(
                 f"{contain.one_line(repr(self.id))} is not a usable component id — "
                 f"write {ID_HINT}")
@@ -264,7 +282,7 @@ class Component:
                 f"component {self.id}: children must be a tuple of component ids, not "
                 f"{contain.one_line(repr(self.children))}")
         for child in self.children:
-            if not isinstance(child, str) or not _ID_RE.fullmatch(child):
+            if not usable_id(child):
                 raise ComponentError(
                     f"component {self.id}: {contain.one_line(repr(child))} is not a "
                     f"usable component id — write {ID_HINT}")

--- a/charter/frame/ctx.py
+++ b/charter/frame/ctx.py
@@ -76,7 +76,23 @@ class Ctx:
     attribute set *exactly* — and that assertion is the point: a future field is a
     widening of what a stranger's code may reach, and it should cost a test change and
     the conversation that goes with it.
+
+    **The four class attributes below are what a second contract changes.** An action is
+    handed an object with exactly these semantics — absent rather than disabled, read-only,
+    an exact attribute set — over a different vocabulary (`frame.action.ActionCtx`), and
+    writing that twice would be two answers to "what may a stranger's code reach". Each is
+    underscore-prefixed because the exactness assertion reads ``dir()``, and a public class
+    attribute would BE an attribute a component can reach.
     """
+
+    #: name → how that name is cut out of the one snapshot.
+    _serves = SERVES
+    #: The names served whatever was declared.
+    _geometry = GEOMETRY
+    #: What a refusal calls the thing holding this ctx.
+    _noun = "component"
+    #: The field it declares what it is handed in.
+    _declared = "needs"
 
     def __init__(self, fields: Mapping[str, Any]) -> None:
         # Straight into ``__dict__``, because ``__setattr__`` below refuses everything.
@@ -91,14 +107,14 @@ class Ctx:
         guessing which of the two they had made.
         """
         shown = contain.one_line(repr(name))
-        if name in SERVES:
+        if name in self._serves:
             raise AttributeError(
-                f"this component did not declare {name}: add it to the component's "
-                f"needs to be handed it")
+                f"this {self._noun} did not declare {name}: add it to the "
+                f"{self._noun}'s {self._declared} to be handed it")
         raise AttributeError(
-            f"a component ctx has no {shown} — charter serves "
-            f"{', '.join(GEOMETRY)} and the declared needs "
-            f"({', '.join(SERVES)})")
+            f"a {self._noun} ctx has no {shown} — charter serves "
+            f"{', '.join(self._geometry)} and the declared {self._declared} "
+            f"({', '.join(self._serves)})")
 
     def __setattr__(self, name: str, value: Any) -> None:
         """A ctx is what this repaint was handed, not a place to keep state.
@@ -107,11 +123,12 @@ class Ctx:
         be a channel between them that nothing declared and nothing bounds.
         """
         raise AttributeError(
-            f"a component ctx is read-only; {contain.one_line(repr(name))} cannot be set")
+            f"a {self._noun} ctx is read-only; {contain.one_line(repr(name))} cannot "
+            f"be set")
 
     def __delattr__(self, name: str) -> None:
         raise AttributeError(
-            f"a component ctx is read-only; {contain.one_line(repr(name))} cannot be "
+            f"a {self._noun} ctx is read-only; {contain.one_line(repr(name))} cannot be "
             f"removed")
 
 

--- a/charter/frame/ctx.py
+++ b/charter/frame/ctx.py
@@ -29,6 +29,7 @@ discovered in a profile.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any, Mapping
 
@@ -68,6 +69,53 @@ SERVES = {
 GEOMETRY = ("width", "height", "fid")
 
 
+@dataclass(frozen=True)
+class Contract:
+    """One ctx class's vocabulary: what it serves, and what it calls its holder.
+
+    A value rather than four class attributes, because it is looked up as a unit and
+    because a second contract must differ from the first in all four or in none.
+    """
+
+    #: name → how that name is cut out of the one snapshot.
+    serves: Mapping[str, Any]
+    #: The names served whatever was declared.
+    geometry: tuple[str, ...]
+    #: What a refusal calls the thing holding this ctx.
+    noun: str
+    #: The field it declares what it is handed in.
+    declared: str
+
+
+#: class → its :class:`Contract`. **Module state, and that is the whole point** — see
+#: :class:`Ctx`. Nothing reachable from a ctx object reaches this dict: a method's
+#: ``__globals__`` does, but that is this module, and reaching a module is ``import``,
+#: which this contract has never claimed to prevent.
+_CONTRACTS: dict[type, Contract] = {}
+
+
+def declare(cls: type, contract: Contract) -> Contract:
+    """Register *cls*'s vocabulary — the only way a ctx class gets one."""
+    _CONTRACTS[cls] = contract
+    return contract
+
+
+def contract_of(obj) -> Contract:
+    """The contract *obj*'s class was declared with, or its nearest base's.
+
+    The walk up ``__mro__`` is what lets `frame.action.ActionCtx` inherit `Ctx`'s
+    behaviour while declaring its own vocabulary, and a class nobody declared is a
+    charter bug named at the moment it would otherwise answer with somebody else's words.
+    """
+    for cls in type(obj).__mro__:
+        got = _CONTRACTS.get(cls)
+        if got is not None:
+            return got
+    raise TypeError(
+        f"{type(obj).__name__} is a ctx class nobody declared a contract for — "
+        f"call frame.ctx.declare() beside the class")
+
+
 class Ctx:
     """One repaint's worth of what one component may read.
 
@@ -77,22 +125,21 @@ class Ctx:
     widening of what a stranger's code may reach, and it should cost a test change and
     the conversation that goes with it.
 
-    **The four class attributes below are what a second contract changes.** An action is
-    handed an object with exactly these semantics — absent rather than disabled, read-only,
-    an exact attribute set — over a different vocabulary (`frame.action.ActionCtx`), and
-    writing that twice would be two answers to "what may a stranger's code reach". Each is
-    underscore-prefixed because the exactness assertion reads ``dir()``, and a public class
-    attribute would BE an attribute a component can reach.
-    """
+    **A second contract changes the vocabulary, not the semantics.** An action is handed
+    an object with exactly these — absent rather than disabled, read-only, an exact
+    attribute set — over a different vocabulary (`frame.action.ActionCtx`), and writing
+    that twice would be two answers to "what may a stranger's code reach".
 
-    #: name → how that name is cut out of the one snapshot.
-    _serves = SERVES
-    #: The names served whatever was declared.
-    _geometry = GEOMETRY
-    #: What a refusal calls the thing holding this ctx.
-    _noun = "component"
-    #: The field it declares what it is handed in.
-    _declared = "needs"
+    **That vocabulary is not ON this class, and that is a fix rather than a style.** It
+    was four underscore-prefixed class attributes, which looked private and were nothing
+    of the sort: ``type(ctx)._serves["vault"]`` is a callable that reads the vault
+    registry and IGNORES the snapshot handed to it, so an action that declared nothing at
+    all reached the plane's whole vault inventory — the names, and every key name in each
+    — straight off its own ctx's class. Every test that asserts the attribute set exactly
+    filtered names starting with ``_`` and saw nothing wrong. So the table lives in
+    :data:`_CONTRACTS`, keyed by class, and `dir(ctx)`, `vars(ctx)` and every class in
+    ``type(ctx).__mro__`` now carry no callable of charter's at all.
+    """
 
     def __init__(self, fields: Mapping[str, Any]) -> None:
         # Straight into ``__dict__``, because ``__setattr__`` below refuses everything.
@@ -106,15 +153,16 @@ class Ctx:
         all. Answering both with a bare ``AttributeError`` would leave a provider author
         guessing which of the two they had made.
         """
+        c = contract_of(self)
         shown = contain.one_line(repr(name))
-        if name in self._serves:
+        if name in c.serves:
             raise AttributeError(
-                f"this {self._noun} did not declare {name}: add it to the "
-                f"{self._noun}'s {self._declared} to be handed it")
+                f"this {c.noun} did not declare {name}: add it to the "
+                f"{c.noun}'s {c.declared} to be handed it")
         raise AttributeError(
-            f"a {self._noun} ctx has no {shown} — charter serves "
-            f"{', '.join(self._geometry)} and the declared {self._declared} "
-            f"({', '.join(self._serves)})")
+            f"a {c.noun} ctx has no {shown} — charter serves "
+            f"{', '.join(c.geometry)} and the declared {c.declared} "
+            f"({', '.join(c.serves)})")
 
     def __setattr__(self, name: str, value: Any) -> None:
         """A ctx is what this repaint was handed, not a place to keep state.
@@ -123,13 +171,17 @@ class Ctx:
         be a channel between them that nothing declared and nothing bounds.
         """
         raise AttributeError(
-            f"a {self._noun} ctx is read-only; {contain.one_line(repr(name))} cannot "
-            f"be set")
+            f"a {contract_of(self).noun} ctx is read-only; "
+            f"{contain.one_line(repr(name))} cannot be set")
 
     def __delattr__(self, name: str) -> None:
         raise AttributeError(
-            f"a {self._noun} ctx is read-only; {contain.one_line(repr(name))} cannot be "
-            f"removed")
+            f"a {contract_of(self).noun} ctx is read-only; "
+            f"{contain.one_line(repr(name))} cannot be removed")
+
+
+declare(Ctx, Contract(serves=SERVES, geometry=GEOMETRY, noun="component",
+                      declared="needs"))
 
 
 def build(needs, *, width: int, height: int, fid: str, snapshot: Mapping) -> Ctx:

--- a/charter/frame/registry.py
+++ b/charter/frame/registry.py
@@ -219,7 +219,16 @@ def _rectangle(c: Component, *, edge, size) -> Component:
 
 
 class Providers:
-    """The component providers installed on this machine, listed without importing one.
+    """The providers installed on this machine, listed without importing one.
+
+    **Subclassed rather than copied, and that is deliberate.** §4d gives actions their own
+    entry-point group with the same four refusals — a mismatched API version, an id two
+    distributions claim, an import that raises, an entry point answering the wrong kind of
+    thing. Written twice, the two would drift, and the drift is the defect: #547 is what a
+    second implementation of one question costs, and it was only found because the copy
+    happened to call the original. So everything that differs between the two contracts is
+    a class attribute below, and `frame.actions.ActionProviders` sets six of them and
+    inherits every refusal.
 
     **Listed, then imported one at a time, and never the other way round.** The entry
     point NAME is the component id, so charter answers "is `acme.metrics` installed, and
@@ -240,6 +249,34 @@ class Providers:
     cost argument exists to keep off it.
     """
 
+    #: The entry point group this contract's providers declare themselves in.
+    group = PROVIDER_GROUP
+    #: The module attribute charter reads the provider's API version out of. It is
+    #: per-contract rather than shared, because one module may legitimately supply both a
+    #: component and an action, and one attribute cannot mean two contracts whose
+    #: integers move independently — a component change would then refuse every action
+    #: provider on the machine for a contract it did not touch.
+    version_attr = "API_VERSION"
+    #: The integer charter speaks for this contract.
+    speaks = API_VERSION
+    #: What a loaded entry point must be an instance of.
+    kind: type = Component
+    #: The word every refusal calls this contract by.
+    contract = "component"
+    #: What an entry point is expected to name, in a refusal's own words.
+    noun = "frame component"
+    #: What a config does with one of these, for the refusal that says to stop doing it.
+    verb = "placing"
+    #: What the caller does instead of propagating — the clause that tells the operator
+    #: what they still have.
+    degrades = "Its pane says so; the rest of the frame is drawn"
+    #: Where a version charter cannot honour would land if it were hoped through instead
+    #: of refused at load (§4g).
+    too_late = "at render time inside your frame"
+    #: The one type this contract raises, so a caller degrading rather than propagating
+    #: has one thing to catch.
+    error: type = ComponentError
+
     def __init__(self) -> None:
         self._entries: dict[str, tuple] | None = None
 
@@ -247,7 +284,7 @@ class Providers:
         """id → every entry point claiming it. More than one IS the collision (§4h)."""
         if self._entries is None:
             found: dict[str, list] = {}
-            for ep in metadata.entry_points(group=PROVIDER_GROUP):
+            for ep in metadata.entry_points(group=self.group):
                 found.setdefault(ep.name, []).append(ep)
             self._entries = {name: tuple(eps) for name, eps in found.items()}
         return self._entries
@@ -266,8 +303,8 @@ class Providers:
         """Whether anything installed claims *cid* — asked without importing it."""
         return isinstance(cid, str) and cid in self._scan()
 
-    def load(self, cid: str) -> Component:
-        """The component *cid* names, imported now, or a `ComponentError` saying why not.
+    def load(self, cid: str) -> Any:
+        """The thing *cid* names, imported now, or an error saying why not.
 
         Every refusal here is one a caller is expected to DEGRADE rather than propagate —
         `Registry.place` turns each into a pane — so they are written to be read by the
@@ -275,27 +312,28 @@ class Providers:
         """
         shown = contain.one_line(repr(cid))
         if not isinstance(cid, str) or "." not in cid:
-            raise ComponentError(
+            raise self.error(
                 f"nothing on this frame is named {shown}, and no installed provider can "
                 f"be: a provider's id is namespaced by its distribution, like "
-                f"acme.metrics. Charter's own components are registered before any "
+                f"acme.metrics. Charter's own {self.contract}s are registered before any "
                 f"config is read, so a bare name that is not one of them is a typo")
         eps = self._scan().get(cid, ())
         if not eps:
-            raise ComponentError(
-                f"no installed provider supplies the component {contain.one_line(cid)} — "
-                f"install the distribution that declares it in the {PROVIDER_GROUP} "
-                f"entry point group, or stop placing it. The rest of the frame is drawn")
+            raise self.error(
+                f"no installed provider supplies the {self.contract} "
+                f"{contain.one_line(cid)} — "
+                f"install the distribution that declares it in the {self.group} "
+                f"entry point group, or stop {self.verb} it. {self.degrades}")
         if len(eps) > 1:
-            raise ComponentError(
-                f"{len(eps)} installed providers supply the component "
+            raise self.error(
+                f"{len(eps)} installed providers supply the {self.contract} "
                 f"{contain.one_line(cid)}: {', '.join(_where(ep) for ep in eps)}. "
                 f"Charter loads {'NEITHER' if len(eps) == 2 else 'NONE of them'} — "
                 f"picking one by load order would draw a pane whose origin cannot be "
                 f"determined. Uninstall one of them")
         return self._one(eps[0], cid)
 
-    def _one(self, ep, cid: str) -> Component:
+    def _one(self, ep, cid: str) -> Any:
         """The single claimant, imported, version-checked, built and identified."""
         module_name = contain.one_line(str(getattr(ep, "module", "") or ""))
         value = contain.one_line(str(getattr(ep, "value", "") or ""))
@@ -304,28 +342,27 @@ class Providers:
         except KeyboardInterrupt:
             raise
         except BaseException as exc:
-            raise ComponentError(
+            raise self.error(
                 f"{_where(ep)} supplies {contain.one_line(cid)}, and importing "
-                f"{module_name} raised {_because(exc)}. Its pane says so; the rest of "
-                f"the frame is drawn") from None
+                f"{module_name} raised {_because(exc)}. {self.degrades}") from None
 
         # Before the entry point's own attribute is even looked up, let alone called: a
         # version charter cannot honour is refused at LOAD, where the message names a
         # fixable thing, rather than hoped through to render time inside somebody's frame
         # (§4g). There is no shim band and no best-effort mode.
-        speaks = getattr(module, "API_VERSION", None)
+        speaks = getattr(module, self.version_attr, None)
         if isinstance(speaks, bool) or not isinstance(speaks, int):
-            raise ComponentError(
+            raise self.error(
                 f"{_where(ep)} supplies {contain.one_line(cid)} and {module_name} "
-                f"declares API_VERSION = {contain.one_line(repr(speaks))}. Charter "
-                f"speaks component API version {API_VERSION}, as one integer, so this "
-                f"provider is not loaded")
-        if speaks != API_VERSION:
-            raise ComponentError(
-                f"{_where(ep)} supplies {contain.one_line(cid)} for component API "
-                f"version {speaks}, and charter speaks {API_VERSION}. It is not loaded: "
-                f"a contract charter cannot honour fails at render time inside your "
-                f"frame, where you cannot act on it")
+                f"declares {self.version_attr} = {contain.one_line(repr(speaks))}. "
+                f"Charter speaks {self.contract} API version {self.speaks}, as one "
+                f"integer, so this provider is not loaded")
+        if speaks != self.speaks:
+            raise self.error(
+                f"{_where(ep)} supplies {contain.one_line(cid)} for {self.contract} API "
+                f"version {speaks}, and charter speaks {self.speaks}. It is not loaded: "
+                f"a contract charter cannot honour fails {self.too_late}, where you "
+                f"cannot act on it")
 
         obj: Any = module
         try:
@@ -334,7 +371,7 @@ class Providers:
         except KeyboardInterrupt:
             raise
         except BaseException as exc:
-            raise ComponentError(
+            raise self.error(
                 f"{_where(ep)} supplies {contain.one_line(cid)} as {value}, and "
                 f"{module_name} has no such name: {_because(exc)}") from None
 
@@ -342,32 +379,33 @@ class Providers:
         # entry point (`acme_charter.metrics:Component`) reads as an object and a factory
         # is the obvious other spelling — refusing either would refuse a provider author
         # for a choice that changes nothing charter can observe.
-        if not isinstance(obj, Component):
+        if not isinstance(obj, self.kind):
             if not callable(obj):
-                raise ComponentError(
+                raise self.error(
                     f"{_where(ep)} supplies {contain.one_line(cid)} as {value}, which is "
-                    f"{contain.one_line(repr(obj))} — an entry point names a frame "
-                    f"component, or something charter can call with no arguments to get "
-                    f"one")
+                    f"{contain.one_line(repr(obj))} — an entry point names a "
+                    f"{self.noun}, or something charter can call with no arguments to "
+                    f"get one")
             try:
                 obj = obj()
             except KeyboardInterrupt:
                 raise
             except BaseException as exc:
-                raise ComponentError(
+                raise self.error(
                     f"{_where(ep)} supplies {contain.one_line(cid)}, and building it "
                     f"raised {_because(exc)}") from None
-            if not isinstance(obj, Component):
-                raise ComponentError(
+            if not isinstance(obj, self.kind):
+                raise self.error(
                     f"{_where(ep)} supplies {contain.one_line(cid)}, and calling {value} "
-                    f"answered {contain.one_line(repr(obj))} rather than a frame "
-                    f"component")
+                    f"answered {contain.one_line(repr(obj))} rather than a "
+                    f"{self.noun}")
         if obj.id != cid:
-            raise ComponentError(
+            raise self.error(
                 f"{_where(ep)} declares the entry point {contain.one_line(cid)} and "
-                f"answers a component whose id is {contain.one_line(obj.id)}. The entry "
-                f"point name is what a committed charter.toml places and what charter "
-                f"resolves without importing anything, so the two must be one word")
+                f"answers a {self.contract} whose id is {contain.one_line(obj.id)}. The "
+                f"entry point name is what a committed charter.toml places and what "
+                f"charter resolves without importing anything, so the two must be one "
+                f"word")
         return obj
 
 

--- a/charter/inflight.py
+++ b/charter/inflight.py
@@ -224,6 +224,10 @@ def start(agent: str, *, kind: str = DISPATCH) -> str | None:
 
     *kind* is what a reader filters on — :data:`DISPATCH` unless the caller says
     otherwise, which keeps every pre-#420 call site meaning exactly what it meant.
+
+    **The token names exactly one record**, and a caller that can hold onto it should
+    hand it back to :func:`finish` rather than let the name-and-kind search pick — see
+    that function. ``None`` means nothing was written, so there is nothing to retire.
     """
     agent = (agent or "").strip()
     if not agent:
@@ -245,10 +249,21 @@ def start(agent: str, *, kind: str = DISPATCH) -> str | None:
         return None
 
 
-def finish(agent: str, *, kind: str = DISPATCH) -> None:
+def finish(agent: str, *, kind: str = DISPATCH, token: str | None = None) -> None:
     """Clear one in-flight record for *agent* of *kind* — the oldest **still-running**
     one, since a repeat dispatch of the same persona should retire the run that started
     first.
+
+    **A caller holding its own token retires that record and nothing else.** The search
+    below picks a record by name, kind and age, and picking is a race the moment two
+    workers of one agent run in the SAME process: both glob, both filter, both select the
+    identical file, one unlink wins and the loser's record survives — drawn by the frame
+    as ``⏳ 1 running`` for :data:`PRESUMED_DEAD_SECONDS` and then ``⋯ 1 stalled`` until
+    :data:`PRUNE_SECONDS`, a full day after the work ended. Across processes the old
+    dispatch and clone callers cannot do this — a process finishes what it started — but
+    `frame.actions.ActionRegistry.invoke` starts a thread per invocation, so one process
+    now holds several, and the palette makes two of them two keypresses away. *token* is
+    what :func:`start` answered; it names one file, so there is nothing to pick.
 
     "Still running" is the qualification records surviving past the presumed-dead
     threshold made necessary. Oldest-first alone would hand a finishing dispatch the
@@ -265,6 +280,17 @@ def finish(agent: str, *, kind: str = DISPATCH) -> None:
     directions, so a record written by an older charter is still findable and one written
     by this charter is still findable by an older one.
     """
+    if token is not None:
+        # A name and nothing else: a token carrying a separator, ``.`` or ``..`` is not
+        # something this ever wrote, and unlinking what it points at would be a delete
+        # outside the tracker's own directory decided by a caller's string.
+        if not token or Path(token).name != token:
+            return
+        try:
+            (_dir() / f"{token}.json").unlink(missing_ok=True)
+        except OSError:
+            pass
+        return
     agent = (agent or "").strip()
     if not agent:
         return

--- a/charter/inflight.py
+++ b/charter/inflight.py
@@ -74,6 +74,19 @@ CLONE = "clone"
 #: `glstate.maybe_spawn` starts, not the parent that spawned it.
 REFRESH = "gl-refresh"
 
+#: One action of the command surface, started from the palette and still running
+#: (`frame.actions.ActionRegistry.invoke`). Actions are fire-and-report (§4g): invoke
+#: returns having STARTED the work, so this record is the only thing that knows the work
+#: is still going, and the frame's spinner — the one reader that asks for ``kind=None`` —
+#: is what shows it.
+#:
+#: A kind of its own rather than a reuse of :data:`DISPATCH`, for the reason the module
+#: docstring gives about ``clone``: the same records feed the dispatch-overlap nudge, and
+#: an action recorded as a dispatch would make that nudge say *"`switch-workspace` writes
+#: code and `x` are already running"* — wrong, and wrong in the confident, readable way
+#: that is worse than silence. Every reader that must not see one gets that by NOT asking.
+ACTION = "action"
+
 
 def _dir() -> Path:
     from . import config

--- a/tests/test_action_providers.py
+++ b/tests/test_action_providers.py
@@ -1,0 +1,308 @@
+"""The second seam a stranger's code arrives through: `charter.actions`.
+
+§4d gives actions their own entry-point group and a stricter contract than components: "a
+provider that adds a CI panel but cannot add *rerun failed job* is half a plugin", and an
+action *does* rather than draws. The four refusals are the component registry's, which is
+why `ActionProviders` subclasses `Providers` rather than repeating it — and why the cases
+below assert them again from the outside: a shared implementation is only safe while
+something proves both contracts still get the answer.
+
+**Every distribution here is real**, on the same terms as `test_component_providers`:
+`importlib.metadata` is never stubbed, and the fixture that writes a `.dist-info` is that
+file's, imported rather than copied.
+
+**A failed action is a ROW that says why, not a missing row.** That is §4b property 4 for
+the command surface — the surface the component registry was waiting for. A palette that
+silently omits an option is worse than one that explains (#512), and it is worse in a way
+the operator cannot even ask about.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter.frame import action, actions, component
+from tests._isolation import PersonaIso
+from tests.test_component_providers import _SitePackages
+
+AID = "acme.deploy"
+MODULE = "acme_deploy"
+ENTRY = f"{MODULE}:deploy"
+GROUP = "charter.actions"
+
+
+#: "say nothing about the version and let the fixture pick charter's own" — an object
+#: rather than ``None``, because ``None`` is one of the values a case below installs AS the
+#: declared version, and a sentinel that is also a fixture value is a test that quietly
+#: stops testing. `test_component_providers` learned this first and says so at length.
+_CHARTERS = object()
+
+
+def _source(*, aid: str = AID, api: object = _CHARTERS,
+            run: str = "lambda ctx: 'started'",
+            available: str = "lambda ctx: True",
+            reason: str = "lambda ctx: ''", head: str = "") -> str:
+    """A provider module declaring one action, and a record of whether it built it."""
+    api = action.API_VERSION if api is _CHARTERS else api
+    return (
+        "from charter.frame import action\n"
+        f"{head}\n"
+        f"ACTION_API_VERSION = {api!r}\n"
+        "built = False\n"
+        "\n"
+        "\n"
+        "def deploy():\n"
+        "    global built\n"
+        "    built = True\n"
+        "    return action.Action(\n"
+        f"        id={aid!r}, title='Deploy', run={run},\n"
+        f"        available={available}, reason_unavailable={reason})\n"
+    )
+
+
+class TheGroupIsItsOwn(PersonaIso):
+    """§4d: `charter.components` and `charter.actions`, separate. Not one group with a tag."""
+
+    def setUp(self):
+        super().setUp()
+        self.site = _SitePackages(self)
+
+    def test_an_installed_action_provider_is_listed(self):
+        self.site.install("acme-charter", "1.4.0", {AID: ENTRY}, {MODULE: _source()},
+                          group=GROUP)
+        self.assertIn(AID, actions.ActionProviders().ids())
+
+    def test_a_component_provider_is_not_an_action_provider(self):
+        """The whole point of two groups: a component cannot be invoked, and an action
+        cannot be drawn, so an entry point in the wrong group must not be found by the
+        other contract."""
+        self.site.install("acme-charter", "1.4.0", {"acme.metrics": "acme_metrics:m"},
+                          {"acme_metrics": "API_VERSION = 1\nm = None\n"})
+        self.assertNotIn("acme.metrics", actions.ActionProviders().ids())
+
+    def test_an_action_provider_is_not_a_component_provider(self):
+        from charter.frame import registry
+        self.site.install("acme-charter", "1.4.0", {AID: ENTRY}, {MODULE: _source()},
+                          group=GROUP)
+        self.assertNotIn(AID, registry.Providers().ids())
+
+    def test_listing_does_not_import_the_provider(self):
+        self.site.install("boom-charter", "2.0", {"boom.deploy": "boom_deploy:deploy"},
+                          {"boom_deploy": "raise RuntimeError('imported at discovery')\n"},
+                          group=GROUP)
+        providers = actions.ActionProviders()
+        self.assertIn("boom.deploy", providers.ids())
+        self.assertFalse(self.site.imported("boom_deploy"))
+
+    def test_adding_it_imports_it_and_offers_it(self):
+        self.site.install("acme-charter", "1.4.0", {AID: ENTRY}, {MODULE: _source()},
+                          group=GROUP)
+        reg = actions.ActionRegistry()
+        added = reg.add(AID)
+        self.assertTrue(self.site.imported(MODULE))
+        self.assertEqual(added.id, AID)
+        offer = reg.offers(fid="fr-1", snapshot={})[0]
+        self.assertEqual((offer.id, offer.title, offer.available), (AID, "Deploy", True))
+        self.assertEqual(reg.failures, {})
+
+    def test_a_provider_may_name_the_action_itself_rather_than_a_factory(self):
+        self.site.install("acme-charter", "1.4.0", {AID: f"{MODULE}:widget"},
+                          {MODULE: _source() + "\nwidget = deploy()\n"}, group=GROUP)
+        self.assertEqual(actions.ActionRegistry().add(AID).id, AID)
+
+    def test_a_providers_action_actually_runs(self):
+        self.site.install("acme-charter", "1.4.0", {AID: ENTRY},
+                          {MODULE: _source(run="lambda ctx: 'deploying 3 repos'")},
+                          group=GROUP)
+        reg = actions.ActionRegistry()
+        reg.add(AID)
+        inv = reg.invoke(AID, fid="fr-1", snapshot={})
+        self.assertTrue(inv.join(5.0))
+        self.assertEqual(inv.note, "deploying 3 repos")
+        self.assertEqual(inv.error, "")
+
+
+class TheApiVersionIsItsOwnInteger(PersonaIso):
+    """§4g's refusal, on the action contract's own integer.
+
+    Separate from the component one because a single module may legitimately supply both,
+    and one attribute cannot mean two contracts whose versions move independently — a
+    component bump would otherwise refuse every action on the machine for a contract it
+    did not touch.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.site = _SitePackages(self)
+        self.reg = actions.ActionRegistry()
+        self.other = action.API_VERSION + 6
+
+    def _install(self, api):
+        self.site.install("acme-charter", "9.9.9", {AID: ENTRY},
+                          {MODULE: _source(api=api)}, group=GROUP)
+
+    def test_a_provider_speaking_another_version_is_a_row_that_says_so(self):
+        self._install(self.other)
+        self.reg.add(AID)
+        offer = self.reg.offers(fid="fr-1", snapshot={})[0]
+        self.assertFalse(offer.available)
+        self.assertIn("acme-charter 9.9.9", offer.reason)
+        self.assertIn(f"version {self.other}", offer.reason)
+        self.assertIn(f"charter speaks {action.API_VERSION}", offer.reason)
+
+    def test_it_is_refused_before_the_provider_builds_anything(self):
+        self._install(self.other)
+        self.reg.add(AID)
+        import sys
+        self.assertFalse(getattr(sys.modules[MODULE], "built"))
+
+    def test_a_version_that_is_not_one_integer_is_refused(self):
+        """``"1"`` and ``True`` are the two a permissive check lets through: ``True == 1``
+        in Python, so a bare equality would load a provider declaring a boolean."""
+        for api in ("1", 1.0, True, None):
+            with self.subTest(api=api):
+                self._install(api)          # into the one site, replacing what was there
+                reg = actions.ActionRegistry()
+                reg.add(AID)
+                self.assertIn("ACTION_API_VERSION", reg.failures[AID])
+
+    def test_the_component_integer_is_not_the_one_that_is_read(self):
+        """A module declaring only `API_VERSION` has said nothing about this contract."""
+        self.site.install("acme-charter", "9.9.9", {AID: ENTRY},
+                          {MODULE: _source().replace("ACTION_API_VERSION",
+                                                     "API_VERSION")}, group=GROUP)
+        self.reg.add(AID)
+        self.assertIn("ACTION_API_VERSION", self.reg.failures[AID])
+
+
+class TwoProvidersClaimingOneIdLoadNeither(PersonaIso):
+    """§4h, on the action group: a row whose origin cannot be determined is worse."""
+
+    def setUp(self):
+        super().setUp()
+        self.site = _SitePackages(self)
+        self.reg = actions.ActionRegistry()
+        self.site.install("acme-charter", "1.4.0", {AID: ENTRY}, {MODULE: _source()},
+                          group=GROUP)
+        self.site.install("other-charter", "0.2", {AID: "other_deploy:deploy"},
+                          {"other_deploy": _source()}, group=GROUP)
+
+    def test_neither_loads_and_both_are_named(self):
+        self.reg.add(AID)
+        said = self.reg.failures[AID]
+        self.assertIn("acme-charter 1.4.0", said)
+        self.assertIn("other-charter 0.2", said)
+        self.assertIn("NEITHER", said)
+
+    def test_the_rest_of_the_palette_is_offered(self):
+        self.reg.register(action.Action(id="refresh", title="Refresh",
+                                        run=lambda ctx: None))
+        self.reg.add(AID)
+        offered = {o.id: o for o in self.reg.offers(fid="fr-1", snapshot={})}
+        self.assertTrue(offered["refresh"].available)
+        self.assertFalse(offered[AID].available)
+        self.assertIn("acme-charter", offered[AID].reason)
+
+
+class AFailedProviderIsARowNotASilence(PersonaIso):
+    """A missing or broken provider becomes a permanently-unavailable offer WITH the why.
+
+    This is the surface `registry.STANDIN_EDGE`'s note was waiting for: in Phase 1 an
+    arrangement charter could not honour had nowhere to say so, so it was refused whole.
+    An action has somewhere — the row itself.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.site = _SitePackages(self)
+        self.reg = actions.ActionRegistry()
+
+    def _reason(self, aid=AID):
+        self.reg.add(aid)
+        return {o.id: o for o in self.reg.offers(fid="fr-1", snapshot={})}[aid].reason
+
+    def test_a_missing_provider_is_a_row_that_says_it_is_missing(self):
+        said = self._reason()
+        self.assertIn(AID, said)
+        self.assertIn("no installed provider", said)
+        self.assertIn(GROUP, said)
+
+    def test_an_import_that_raises_is_a_row_that_names_it(self):
+        self.site.install("acme-charter", "1.4.0", {AID: ENTRY},
+                          {MODULE: "raise RuntimeError('no such database')\n"},
+                          group=GROUP)
+        said = self._reason()
+        self.assertIn("RuntimeError", said)
+        self.assertIn("no such database", said)
+
+    def test_building_that_raises_is_a_row_that_names_it(self):
+        self.site.install("acme-charter", "1.4.0", {AID: ENTRY},
+                          {MODULE: _source(head="raise_it = 1") .replace(
+                              "    return action.Action(",
+                              "    raise ValueError('bad config')\n    return action.Action(")},
+                          group=GROUP)
+        said = self._reason()
+        self.assertIn("ValueError", said)
+        self.assertIn("bad config", said)
+
+    def test_an_entry_point_answering_a_component_is_refused(self):
+        """The two contracts are not interchangeable, and the refusal says which is wanted."""
+        self.site.install("acme-charter", "1.4.0", {AID: "acme_mixed:thing"},
+                          {"acme_mixed": (
+                              "from charter.frame import component\n"
+                              f"ACTION_API_VERSION = {action.API_VERSION}\n"
+                              "thing = component.Component(\n"
+                              f"    id={AID!r}, title='Metrics', edge='right',\n"
+                              "    size=component.Fixed(12), render=lambda ctx: [])\n")},
+                          group=GROUP)
+        said = self._reason()
+        self.assertIn("frame action", said)
+
+    def test_an_entry_point_name_that_is_not_the_actions_id_is_refused(self):
+        self.site.install("acme-charter", "1.4.0", {AID: ENTRY},
+                          {MODULE: _source(aid="acme.other")}, group=GROUP)
+        said = self._reason()
+        self.assertIn("acme.other", said)
+        self.assertIn(AID, said)
+
+    def test_a_bare_name_no_builtin_claims_says_what_a_provider_id_looks_like(self):
+        said = self._reason("deployy")
+        self.assertIn("namespaced", said)
+
+    def test_a_failed_action_refuses_to_run_rather_than_running_something_else(self):
+        self.reg.add(AID)
+        inv = self.reg.invoke(AID, fid="fr-1", snapshot={})
+        self.assertFalse(inv.started)
+        self.assertIn("no installed provider", inv.reason)
+
+    def test_adding_something_already_registered_answers_what_is_registered(self):
+        first = self.reg.register(action.Action(id="refresh", title="Refresh",
+                                                run=lambda ctx: None))
+        self.assertIs(self.reg.add("refresh"), first)
+
+
+class TheProviderContractIsOneImplementation(unittest.TestCase):
+    """`ActionProviders` mirrors `Providers` by SUBCLASSING it — #547's lesson.
+
+    A copy would drift, and the drift would be a refusal that stopped holding on one of
+    the two contracts with nothing failing. What differs is data, and this asserts that
+    the data is what differs.
+    """
+
+    def test_it_is_the_component_loader_with_this_contracts_answers(self):
+        from charter.frame import registry
+        self.assertTrue(issubclass(actions.ActionProviders, registry.Providers))
+        p = actions.ActionProviders()
+        self.assertEqual(p.group, GROUP)
+        self.assertEqual(p.version_attr, "ACTION_API_VERSION")
+        self.assertEqual(p.speaks, action.API_VERSION)
+        self.assertIs(p.kind, action.Action)
+        self.assertIs(p.error, action.ActionError)
+
+    def test_the_two_groups_are_different_strings(self):
+        from charter.frame import registry
+        self.assertNotEqual(actions.ACTION_GROUP, registry.PROVIDER_GROUP)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_action_registry.py
+++ b/tests/test_action_registry.py
@@ -35,11 +35,14 @@ newline is what a committed value reaching an overlay row costs).
 
 from __future__ import annotations
 
+import itertools
 import threading
 import unittest
 from collections.abc import Mapping
+from typing import Any
+from unittest import mock
 
-from charter import inflight
+from charter import config, inflight
 from charter.frame import action, actions
 from charter.secrets import registry as vaults
 from tests._isolation import PersonaIso
@@ -111,6 +114,108 @@ def _reachable(obj, depth: int = 8) -> list[str]:
             walk(getattr(o, name, None), d - 1)
 
     walk(obj, depth)
+    return out
+
+
+#: Names never followed by :func:`_handed`. ``__globals__`` is a function's defining
+#: MODULE, and reaching a module is ``import`` — which `action.py` says in plain words it
+#: does not prevent. Following it would make every walk below find everything in charter
+#: and assert nothing about what was handed over.
+_NOT_HANDED_OVER = ("__globals__", "__builtins__")
+
+
+def _handed(obj, depth: int = 6) -> list:
+    """Every OBJECT charter handed over with *obj* — its class and that class's bases too.
+
+    `_reachable` walks the instance and collects strings; this walks the type as well and
+    collects objects, because the type is the route the first cut of this contract left
+    wide open. The vocabulary table sat on the ctx class as ``_serves``, so
+    ``type(ctx)._serves["vault"]`` was a callable that reads the vault registry and
+    ignores its argument — reachable from the ctx of an action that declared NOTHING, and
+    invisible to all three assertions about the attribute set, because every one of them
+    filtered names starting with ``_``. A walk that stops at the instance cannot see that;
+    this one has to.
+    """
+    from types import ModuleType
+
+    seen: dict[int, Any] = {}
+
+    def charters(o) -> bool:
+        """Is *o* something charter wrote? Only charter's own classes are opened up
+        attribute by attribute, and only charter's own class dicts are read. `object`
+        and `dict` are shared, immutable and cannot be where charter left a table; going
+        through them costs minutes and finds nothing."""
+        mod = getattr(o if isinstance(o, type) else type(o), "__module__", "") or ""
+        return mod.split(".")[0] == "charter"
+
+    def classes(o):
+        yield from type(o).__mro__
+        if isinstance(o, type):
+            yield from o.__mro__
+
+    def walk(o, d):
+        if d < 0 or o is None or id(o) in seen or isinstance(o, ModuleType):
+            return
+        seen[id(o)] = o
+        if isinstance(o, (str, bytes, bytearray, int, float, bool)):
+            return
+        if isinstance(o, Mapping):
+            for k, v in list(o.items()):
+                walk(k, d - 1)
+                walk(v, d - 1)
+            return
+        if isinstance(o, (list, tuple, set, frozenset)):
+            for item in list(o):
+                walk(item, d - 1)
+            return
+        # `isinstance` rather than truthiness: on a CLASS these names answer the
+        # descriptor rather than a value, and a descriptor is not a route.
+        closure = getattr(o, "__closure__", None)
+        for cell in closure if isinstance(closure, tuple) else ():
+            try:
+                walk(cell.cell_contents, d - 1)
+            except ValueError:          # an empty cell, mid-definition
+                pass
+        for name in ("__self__", "__func__", "__wrapped__", "__dict__", "__defaults__"):
+            walk(getattr(o, name, None), d - 1)
+        for cls in classes(o):
+            if charters(cls):
+                walk(cls, d - 1)
+                walk(dict(vars(cls)), d - 1)
+        if charters(o):
+            for name in dir(o):
+                if name in _NOT_HANDED_OVER:
+                    continue
+                try:
+                    walk(getattr(o, name), d - 1)
+                except Exception:       # an attribute that refuses is not a route
+                    pass
+
+    walk(obj, depth)
+    return list(seen.values())
+
+
+def _inventories(c) -> list:
+    """Every `VaultInventory` an action holding *c* can get out of it, by any route.
+
+    Two halves, like the class docstring's two: what is simply THERE (`_handed`), and
+    what anything found there ANSWERS when called. The argument sets are the ones the
+    escape hatch actually needed — ``_serves["vault"]`` takes a snapshot and ignores it,
+    so ``None`` and ``{}`` are enough to make it hand one over.
+    """
+    out = []
+    for o in _handed(c):
+        if isinstance(o, action.VaultInventory):
+            out.append(o)
+        if not callable(o):
+            continue
+        for args in ((), (None,), ({},)):
+            try:
+                got = o(*args)
+            except Exception:           # a wrong-arity guess is not a finding
+                continue
+            out.extend(x for x in _handed(got, depth=3)
+                       if isinstance(x, action.VaultInventory))
     return out
 
 
@@ -410,6 +515,113 @@ class TheCallerIsNeverBlocked(PersonaIso):
         self.assertNotIn("\n", inv.note)
 
 
+class TwoInvocationsOfOneActionAreTwoRecords(PersonaIso):
+    """Every invocation retires the record IT started, and the palette is why.
+
+    `invoke` puts the work on a thread and returns, so one process can hold several runs
+    of one action at once — which no earlier `inflight` caller ever did: a dispatch, a
+    clone and a `gl-refresh` each finish in the process that started them. `inflight.finish`
+    picks a record by name, kind and age, and two threads picking together pick the SAME
+    file: one unlink wins and the loser's record survives its work by a day, drawn as
+    ``⏳ 1 running`` for the first half hour (`frame/panel.py`, `frame/slots.py`, both
+    reading `kind=None`). Two keypresses in the palette is all it takes.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.reg = actions.ActionRegistry()
+
+    def _records(self) -> list[str]:
+        return sorted(p.stem
+                      for p in (config.STATE_DIR / "dispatch-inflight").glob("*.json"))
+
+    def _first_call_blocks(self, gate, entered):
+        """An action whose FIRST invocation waits and whose second returns at once.
+
+        The ordering is not a hope: the second `invoke` is not made until `entered` says
+        the first is already inside `run`, so which call is which is decided rather than
+        raced. That matters because the property under test is about WHICH record went.
+        """
+        turn = itertools.count()
+
+        def run(ctx):
+            if next(turn) == 0:
+                entered.set()
+                gate.wait(timeout=BLOCKED)
+                return "the slow one"
+            return "the quick one"
+        return run
+
+    def test_an_invocation_retires_its_own_record_and_not_the_one_still_running(self):
+        """The measurement, without a race in the test itself. Picking takes the oldest
+        still-running record, and the second invocation's own record is not it — so a
+        `finish` that picks clears the work that is STILL GOING and leaves the finished
+        one behind, which is the leak with its sign flipped."""
+        gate, entered = threading.Event(), threading.Event()
+        self.addCleanup(gate.set)
+        self.reg.register(_act("twice", run=self._first_call_blocks(gate, entered)))
+
+        slow = self.reg.invoke("twice", fid="fr-1", snapshot=_snapshot())
+        self.assertTrue(entered.wait(SOON), "the first invocation never started")
+        started_first = self._records()
+        self.assertEqual(len(started_first), 1, "the first record was never written")
+
+        quick = self.reg.invoke("twice", fid="fr-1", snapshot=_snapshot())
+        self.assertTrue(quick.join(SOON))
+        self.assertEqual(quick.note, "the quick one")
+        self.assertEqual(self._records(), started_first,
+                         "the finished invocation retired the running one's record")
+
+        gate.set()
+        self.assertTrue(slow.join(SOON))
+        self.assertEqual(self._records(), [], "the running one's record outlived it")
+
+    def test_invocations_that_finish_together_leave_nothing_behind(self):
+        """The shape as an operator meets it: several runs of one action overlapping, all
+        ending at once. Barriers rather than sleeps, so the workers are provably inside
+        `run` when the count is taken and provably leave it together — which is the window
+        a picking `finish` loses records in."""
+        n = 8
+        arrived = threading.Barrier(n + 1, timeout=BLOCKED)
+        release = threading.Barrier(n + 1, timeout=BLOCKED)
+        self.addCleanup(release.abort)
+        self.addCleanup(arrived.abort)
+        self.reg.register(_act("swarm", run=lambda ctx: (arrived.wait(),
+                                                         release.wait())))
+
+        invs = [self.reg.invoke("swarm", fid="fr-1", snapshot=_snapshot())
+                for _ in range(n)]
+        arrived.wait()
+        self.assertEqual(len(self._records()), n, "one record per invocation, in flight")
+        release.wait()
+        for inv in invs:
+            self.assertTrue(inv.join(SOON))
+            self.assertEqual(inv.error, "")
+        self.assertEqual(self._records(), [], "a record outlived the work it described")
+        self.assertEqual(inflight.live(kind=inflight.ACTION), [])
+
+    def test_an_invocation_whose_record_was_never_written_retires_nobody_elses(self):
+        """`inflight.start` answers ``None`` when it wrote nothing — an unwritable state
+        dir, most likely. There is then no record of this invocation to retire, and a
+        fallback to the name-and-kind search would delete a CONCURRENT invocation's: the
+        same leak, arriving from the other direction and on a machine already unwell."""
+        gate, entered = threading.Event(), threading.Event()
+        self.addCleanup(gate.set)
+        self.reg.register(_act("twice", run=self._first_call_blocks(gate, entered)))
+
+        slow = self.reg.invoke("twice", fid="fr-1", snapshot=_snapshot())
+        self.assertTrue(entered.wait(SOON), "the first invocation never started")
+        started_first = self._records()
+
+        with mock.patch.object(inflight, "start", return_value=None):
+            quick = self.reg.invoke("twice", fid="fr-1", snapshot=_snapshot())
+        self.assertTrue(quick.join(SOON))
+        self.assertEqual(self._records(), started_first,
+                         "an invocation that recorded nothing retired somebody else's")
+        gate.set()
+        self.assertTrue(slow.join(SOON))
+
+
 class NoRouteFromAnActionToAVaultValue(PersonaIso):
     """§4d: an action reaching a vault goes THROUGH the guards, never around them.
 
@@ -468,6 +680,38 @@ class NoRouteFromAnActionToAVaultValue(PersonaIso):
         with self.assertRaises(AttributeError) as e:
             c.vault
         self.assertIn("touches", str(e.exception))
+
+    def test_the_walk_finds_an_inventory_when_one_was_declared(self):
+        """The control on the two below: `_handed` really does reach an inventory and
+        recognise it, so a green there is a guard holding rather than a probe that never
+        looked."""
+        self.assertTrue(_inventories(self._ctx(touches=("vault",))))
+
+    def test_an_undeclared_action_cannot_obtain_an_inventory_BY_ANY_ROUTE(self):
+        """The missing half of the test above it. "Absent, not disabled" is a claim about
+        what an action can OBTAIN, and `c.vault` raising is only a claim about one name.
+
+        The first cut of this failed exactly here: the ctx class carried ``_serves``, and
+        ``type(c)._serves["vault"](None)`` answered a live inventory of this plane — every
+        vault name, and every key name in each — to an action whose whole declaration was
+        ``touches=()``. `assertEqual(set(vars(c)), {"fid"})` was true the entire time.
+        """
+        self.assertEqual(_inventories(self._ctx(touches=())), [])
+
+    def test_no_ctx_class_carries_anything_of_charters_beyond_its_behaviour(self):
+        """The same property said the short way, and the one that will still be readable
+        in a year: a ctx class holds dunders and nothing else.
+
+        `Ctx` says "no public methods, deliberately" and three tests assert the attribute
+        set exactly — but all of them read `dir()` and drop names starting with ``_``, so
+        a table parked on the class as ``_serves`` satisfied every one of them. The filter
+        here is the DUNDER, which is behaviour Python owns, rather than the underscore,
+        which is a convention a component author never agreed to.
+        """
+        for cls in type(self._ctx(touches=())).__mro__:
+            carried = {n for n in vars(cls)
+                       if not (n.startswith("__") and n.endswith("__"))}
+            self.assertEqual(carried, set(), f"{cls.__name__} carries {carried}")
 
     def test_the_inventory_keeps_no_provider_between_calls(self):
         """A cached provider is how the value would arrive without anybody writing a

--- a/tests/test_action_registry.py
+++ b/tests/test_action_registry.py
@@ -1,0 +1,530 @@
+"""What an action is, what it is handed, and the two properties that are not negotiable.
+
+An action is the half of the command surface that *does* rather than draws, so the
+contract is stricter than a component's in exactly two ways, and both are pinned here
+against the mutation that would remove them.
+
+**Fire-and-report, never blocking** (§4g). `ActionRegistry.invoke` returns having STARTED
+the work, and `Invocation` is the receipt. `TheCallerIsNeverBlocked` proves that with an
+action that is deliberately still inside `run` when `invoke` returns — the assertion is
+about the receipt reporting the work as running, taken at a moment the action provably
+cannot have finished, rather than about how long anything took. A blocking action in a TUI
+is indistinguishable from a hang, and the operator's only recourse would be the escape
+hatch, for something working correctly.
+
+**An action cannot reach a vault value.** `NoRouteFromAnActionToAVaultValue` installs a
+REAL plain-file vault holding a real value and then goes looking for it two ways, neither
+of which is a spelling check:
+
+1. Everything *reachable* from the ctx charter built — instance dictionaries, containers,
+   closure cells, bound methods' receivers — is collected and searched. A `spend()` that
+   closed over the resolved value, or an inventory that cached its provider, is caught by
+   this without the test knowing either exists.
+2. Every public callable on what charter handed the action is CALLED, with the vault name
+   and the key name it would need, and every answer searched the same way. A `value()`
+   method added tomorrow is caught by this without the test naming it.
+
+Both carry a positive control: the same walk, on the same object, finds the vault's NAME
+and the key's NAME. Without that, a walk that traversed nothing would pass, which is the
+shape where "the guard holds" and "the probe never looked" are the same green.
+
+**An unavailable action carries WHY.** Never omitted from the listing, never listed with
+an empty reason, and contained before it can reach a row (#472, and `[frame] hotkey`'s
+newline is what a committed value reaching an overlay row costs).
+"""
+
+from __future__ import annotations
+
+import threading
+import unittest
+from collections.abc import Mapping
+
+from charter import inflight
+from charter.frame import action, actions
+from charter.secrets import registry as vaults
+from tests._isolation import PersonaIso
+
+#: How long a deliberately-blocked action stays inside `run` before giving up on its own.
+#: Only ever reached when the property under test has been broken — a `join()` where the
+#: implementation should have returned — so it is the bound on how long a RED takes, not
+#: on how long a green does. Finite so that a broken implementation FAILS rather than
+#: hangs: a suite that stops is not a suite that answers.
+BLOCKED = 10.0
+
+#: How long a test waits for a signal it has already caused. Generous, because it bounds a
+#: pass and never a fail.
+SOON = 5.0
+
+SECRET = "s3cr3t-value-no-action-may-see"
+
+
+def _snapshot(**kw):
+    return {"repos": [], "todos": [], **kw}
+
+
+def _act(aid="demo", **kw):
+    """An action with charter's own defaults, for a case that is about one field."""
+    kw.setdefault("title", "Demo")
+    kw.setdefault("run", lambda ctx: None)
+    return action.Action(id=aid, **kw)
+
+
+def _reachable(obj, depth: int = 8) -> list[str]:
+    """Every string reachable from *obj* — through attributes, containers and closures.
+
+    A guard that matches a spelling gets walked past, so this asks the property instead:
+    is the value anywhere in what charter handed over, by any route the handed object
+    could later be asked to follow. Closure cells are walked because a function that
+    resolved a secret once and kept it is the obvious way a "spender" would leak one, and
+    `__self__` because a bound method carries its whole receiver with it.
+    """
+    seen: set[int] = set()
+    out: list[str] = []
+
+    def walk(o, d):
+        if d < 0 or o is None or id(o) in seen:
+            return
+        seen.add(id(o))
+        if isinstance(o, str):
+            out.append(o)
+            return
+        if isinstance(o, (bytes, bytearray)):
+            out.append(bytes(o).decode("utf-8", "replace"))
+            return
+        if isinstance(o, Mapping):
+            for k, v in list(o.items()):
+                walk(k, d - 1)
+                walk(v, d - 1)
+            return
+        if isinstance(o, (list, tuple, set, frozenset)):
+            for item in list(o):
+                walk(item, d - 1)
+            return
+        for cell in getattr(o, "__closure__", None) or ():
+            try:
+                walk(cell.cell_contents, d - 1)
+            except ValueError:          # an empty cell, mid-definition
+                pass
+        for name in ("__self__", "__func__", "__wrapped__", "__dict__"):
+            walk(getattr(o, name, None), d - 1)
+        for name in getattr(type(o), "__slots__", ()) or ():
+            walk(getattr(o, name, None), d - 1)
+
+    walk(obj, depth)
+    return out
+
+
+def _answers(obj, *argsets) -> list:
+    """Every public attribute of *obj*, and every answer it gives to *argsets*.
+
+    Discovered with `dir`, never a literal list of names: the property is "nothing charter
+    hands an action answers a vault value", and a literal list stops testing the day
+    somebody adds a method to the object.
+    """
+    got = []
+    for name in dir(obj):
+        if name.startswith("_"):
+            continue
+        attr = getattr(obj, name)
+        got.append(attr)
+        if callable(attr):
+            for args in argsets:
+                try:
+                    got.append(attr(*args))
+                except Exception as exc:    # a wrong-arity guess is not a finding
+                    got.append(str(exc))
+    return got
+
+
+class TheContract(unittest.TestCase):
+    """An action declares an id, a title, availability with its reason, and what it does."""
+
+    def test_an_action_declares_the_five_things_the_palette_needs(self):
+        a = action.Action(id="clone", title="Clone a repo", run=lambda ctx: "started",
+                          available=lambda ctx: True,
+                          reason_unavailable=lambda ctx: "",
+                          touches=("repos",))
+        self.assertEqual((a.id, a.title, a.touches), ("clone", "Clone a repo", ("repos",)))
+        self.assertTrue(a.available(None))
+        self.assertEqual(a.reason_unavailable(None), "")
+        self.assertEqual(a.run(None), "started")
+
+    def test_an_action_is_available_and_silent_unless_it_says_otherwise(self):
+        """The default is the common case, and it cannot be the ambiguous one."""
+        a = _act()
+        self.assertTrue(a.available(None))
+        self.assertEqual(a.reason_unavailable(None), "")
+
+    def test_an_id_that_could_reach_tmux_is_refused(self):
+        """The same alphabet a component id is held to, and the same reason (#hotkey)."""
+        for bad in ("Clone", "clone repo", "clone\n", "clone;kill-server", "#{x}",
+                    "../clone", "", "a" * 40):
+            with self.subTest(bad=bad):
+                with self.assertRaises(action.ActionError):
+                    _act(bad)
+
+    def test_the_id_alphabet_is_the_component_one_rather_than_a_second_copy(self):
+        """Two spellings of one alphabet is how two guards come to disagree."""
+        from charter.frame import component
+        self.assertTrue(component.usable_id("acme.deploy"))
+        self.assertFalse(component.usable_id("acme.deploy\n"))
+        self.assertEqual(_act("acme.deploy").id, "acme.deploy")
+
+    def test_a_title_is_contained_rather_than_refused(self):
+        """Display text: an open alphabet, closed to anything that can forge a row."""
+        a = _act(title="Deploy\nrm -rf /")
+        self.assertNotIn("\n", a.title)
+        self.assertIn("\\x0a", a.title)
+
+    def test_run_available_and_reason_must_be_callable(self):
+        for field in ("run", "available", "reason_unavailable"):
+            with self.subTest(field=field):
+                with self.assertRaises(action.ActionError) as e:
+                    _act(**{field: "not callable"})
+                self.assertIn(field, str(e.exception))
+
+    def test_an_unknown_touch_is_refused_and_names_what_charter_serves(self):
+        with self.assertRaises(action.ActionError) as e:
+            _act(touches=("gathr",))
+        said = str(e.exception)
+        self.assertIn("gathr", said)
+        for served in action.TOUCHES:
+            self.assertIn(served, said)
+
+    def test_the_declared_vocabulary_is_exactly_what_is_served(self):
+        """A name accepted here and served empty would be worse than a refusal — the
+        action would declare it, do nothing, and be indistinguishable from a plane that
+        genuinely has nothing. `component.NEEDS` is pinned to `ctx.SERVES` for the same
+        reason, and this is that assertion for the other contract."""
+        self.assertEqual(tuple(sorted(action.TOUCHES)), tuple(sorted(action.SERVES)))
+
+
+class WhatAnActionIsHanded(PersonaIso):
+    """Built FROM `touches`: absent, not disabled — the component rule, one contract over."""
+
+    def test_a_ctx_carries_exactly_the_declaration_plus_the_identity(self):
+        c = action.build(("repos",), fid="fr-1", snapshot=_snapshot())
+        expected = {"fid", "repos"}
+        self.assertEqual(set(vars(c)), expected)
+        self.assertEqual({n for n in dir(c) if not n.startswith("_")}, expected)
+
+    def test_an_undeclared_slice_is_absent_and_says_what_to_add(self):
+        c = action.build((), fid="fr-1", snapshot=_snapshot())
+        with self.assertRaises(AttributeError) as e:
+            c.repos
+        self.assertIn("touches", str(e.exception))
+
+    def test_a_name_nothing_serves_is_told_apart_from_one_not_declared(self):
+        c = action.build((), fid="fr-1", snapshot=_snapshot())
+        with self.assertRaises(AttributeError) as e:
+            c.subprocess
+        said = str(e.exception)
+        self.assertIn("subprocess", said)
+        self.assertNotIn("touches to be handed it", said)
+
+    def test_a_ctx_is_read_only(self):
+        c = action.build(("repos",), fid="fr-1", snapshot=_snapshot())
+        with self.assertRaises(AttributeError):
+            c.repos = ()
+        with self.assertRaises(AttributeError):
+            del c.repos
+
+    def test_the_slices_are_the_ones_a_component_gets_rather_than_a_second_reading(self):
+        snap = _snapshot(repos=[{"name": "charter"}])
+        c = action.build(("repos", "todos", "gather"), fid="fr-1", snapshot=snap)
+        self.assertEqual(c.repos, ({"name": "charter"},))
+        self.assertEqual(c.todos, ())
+        self.assertEqual(dict(c.gather), snap)
+
+
+class AnUnavailableActionCarriesWhy(PersonaIso):
+    """§4h and #512's lesson: a row that explains beats a row that is silently absent."""
+
+    def setUp(self):
+        super().setUp()
+        self.reg = actions.ActionRegistry()
+
+    def _offers(self):
+        return {o.id: o for o in self.reg.offers(fid="fr-1", snapshot=_snapshot())}
+
+    def test_an_unavailable_action_is_listed_with_its_reason(self):
+        self.reg.register(_act("switch", title="Switch workspace",
+                               available=lambda ctx: False,
+                               reason_unavailable=lambda ctx: "the session lock holds it"))
+        offer = self._offers()["switch"]
+        self.assertFalse(offer.available)
+        self.assertEqual(offer.title, "Switch workspace")
+        self.assertIn("session lock", offer.reason)
+
+    def test_an_available_action_is_listed_without_one(self):
+        self.reg.register(_act("go"))
+        offer = self._offers()["go"]
+        self.assertTrue(offer.available)
+        self.assertEqual(offer.reason, "")
+
+    def test_an_unavailable_action_that_says_nothing_still_says_something(self):
+        """A provider that returns "" has not made the row honest — charter finishes it."""
+        self.reg.register(_act("mute", available=lambda ctx: False,
+                               reason_unavailable=lambda ctx: "   "))
+        offer = self._offers()["mute"]
+        self.assertFalse(offer.available)
+        self.assertTrue(offer.reason.strip())
+        self.assertIn("mute", offer.reason)
+
+    def test_an_action_whose_availability_raises_is_unavailable_and_names_it(self):
+        def boom(ctx):
+            raise RuntimeError("no plane here")
+        self.reg.register(_act("thrower", available=boom))
+        offer = self._offers()["thrower"]
+        self.assertFalse(offer.available)
+        self.assertIn("RuntimeError", offer.reason)
+        self.assertIn("no plane here", offer.reason)
+
+    def test_an_action_whose_reason_raises_is_still_listed_with_a_reason(self):
+        def boom(ctx):
+            raise ValueError("and the reason broke too")
+        self.reg.register(_act("thrower", available=lambda ctx: False,
+                               reason_unavailable=boom))
+        offer = self._offers()["thrower"]
+        self.assertFalse(offer.available)
+        self.assertIn("ValueError", offer.reason)
+
+    def test_a_hostile_reason_renders_as_one_row(self):
+        """A committed value reaching an overlay row is the `[frame] hotkey` class."""
+        for hostile in ("two\nlines", "para graph", "esc\x1b[2Jape", "car\rriage"):
+            with self.subTest(hostile=hostile):
+                reg = actions.ActionRegistry()
+                reg.register(_act("hostile", available=lambda ctx: False,
+                                  reason_unavailable=lambda ctx, h=hostile: h))
+                reason = reg.offers(fid="f", snapshot=_snapshot())[0].reason
+                self.assertEqual(len(reason.splitlines()), 1)
+                for ch in "\n\r \x1b":
+                    self.assertNotIn(ch, reason)
+
+    def test_each_action_is_asked_with_the_ctx_its_own_touches_declared(self):
+        """The registry builds the ctx, so an action can never be handed more than it
+        declared by a caller that did not read its declaration."""
+        seen = {}
+        self.reg.register(_act("narrow", touches=("todos",),
+                               available=lambda ctx: seen.setdefault("narrow", ctx) or True))
+        self.reg.register(_act("wide", touches=("repos", "todos"),
+                                available=lambda ctx: seen.setdefault("wide", ctx) or True))
+        self.reg.offers(fid="fr-1", snapshot=_snapshot())
+        self.assertEqual(set(vars(seen["narrow"])), {"fid", "todos"})
+        self.assertEqual(set(vars(seen["wide"])), {"fid", "todos", "repos"})
+
+    def test_an_unavailable_action_is_not_run(self):
+        ran = []
+        self.reg.register(_act("locked", run=lambda ctx: ran.append(1),
+                               available=lambda ctx: False,
+                               reason_unavailable=lambda ctx: "the session lock holds it"))
+        inv = self.reg.invoke("locked", fid="fr-1", snapshot=_snapshot())
+        self.assertFalse(inv.started)
+        self.assertIn("session lock", inv.reason)
+        self.assertEqual(ran, [])
+
+    def test_an_unknown_id_is_refused_rather_than_answered_with_a_quiet_nothing(self):
+        with self.assertRaises(actions.ActionError) as e:
+            self.reg.invoke("nope", fid="fr-1", snapshot=_snapshot())
+        self.assertIn("nope", str(e.exception))
+
+
+class TheCallerIsNeverBlocked(PersonaIso):
+    """§4g: an action returns immediately having started work. Progress is `inflight`."""
+
+    def setUp(self):
+        super().setUp()
+        self.reg = actions.ActionRegistry()
+
+    def test_invoke_returns_while_the_action_is_still_inside_run(self):
+        """The receipt reports the work as running at a moment `run` provably cannot have
+        returned: it is blocked on a gate this test has not opened yet."""
+        gate, entered = threading.Event(), threading.Event()
+        self.addCleanup(gate.set)
+
+        def slow(ctx):
+            entered.set()
+            gate.wait(timeout=BLOCKED)
+            return "done"
+
+        self.reg.register(_act("slow", run=slow))
+        inv = self.reg.invoke("slow", fid="fr-1", snapshot=_snapshot())
+        self.assertTrue(entered.wait(SOON), "the action never started")
+        self.assertTrue(inv.started)
+        self.assertTrue(inv.running, "invoke waited for the action to finish")
+        gate.set()
+        self.assertTrue(inv.join(SOON))
+        self.assertFalse(inv.running)
+        self.assertEqual(inv.note, "done")
+
+    def test_work_in_flight_is_visible_while_it_runs_and_gone_after(self):
+        """"Progress surfaces through `inflight`" — the tracker, not a second clock."""
+        gate, entered = threading.Event(), threading.Event()
+        self.addCleanup(gate.set)
+
+        def slow(ctx):
+            entered.set()
+            gate.wait(timeout=BLOCKED)
+
+        self.reg.register(_act("slow", run=slow))
+        inv = self.reg.invoke("slow", fid="fr-1", snapshot=_snapshot())
+        self.assertTrue(entered.wait(SOON))
+        self.assertIn("slow", inflight.live(kind=inflight.ACTION))
+        gate.set()
+        self.assertTrue(inv.join(SOON))
+        self.assertEqual(inflight.live(kind=inflight.ACTION), [])
+
+    def test_an_action_does_not_reach_the_readers_that_did_not_ask_for_it(self):
+        """`inflight`'s own rule: a new kind must not leak into the dispatch nudge."""
+        gate, entered = threading.Event(), threading.Event()
+        self.addCleanup(gate.set)
+        self.reg.register(_act("slow", run=lambda ctx: (entered.set(),
+                                                        gate.wait(timeout=BLOCKED))))
+        inv = self.reg.invoke("slow", fid="fr-1", snapshot=_snapshot())
+        self.assertTrue(entered.wait(SOON))
+        self.assertEqual(inflight.live(), [])
+        gate.set()
+        inv.join(SOON)
+
+    def test_an_action_that_raises_costs_its_own_row_and_names_what_it_raised(self):
+        def boom(ctx):
+            raise ZeroDivisionError("nothing left to divide")
+        self.reg.register(_act("boom", run=boom))
+        inv = self.reg.invoke("boom", fid="fr-1", snapshot=_snapshot())
+        self.assertTrue(inv.join(SOON))
+        self.assertTrue(inv.started)
+        self.assertFalse(inv.ok)
+        self.assertIn("ZeroDivisionError", inv.error)
+        self.assertIn("nothing left to divide", inv.error)
+
+    def test_a_failed_action_clears_its_in_flight_record(self):
+        self.reg.register(_act("boom", run=lambda ctx: 1 / 0))
+        self.assertTrue(self.reg.invoke("boom", fid="f", snapshot=_snapshot()).join(SOON))
+        self.assertEqual(inflight.live(kind=inflight.ACTION), [])
+
+    def test_a_note_a_provider_wrote_is_contained_before_it_can_reach_a_row(self):
+        self.reg.register(_act("noisy", run=lambda ctx: "started\nrm -rf /"))
+        inv = self.reg.invoke("noisy", fid="f", snapshot=_snapshot())
+        self.assertTrue(inv.join(SOON))
+        self.assertEqual(len(inv.note.splitlines()), 1)
+        self.assertNotIn("\n", inv.note)
+
+
+class NoRouteFromAnActionToAVaultValue(PersonaIso):
+    """§4d: an action reaching a vault goes THROUGH the guards, never around them.
+
+    The vault this registers is real and the value in it is real, so every assertion
+    below is about what charter did with an actual secret rather than about what a stub
+    was asked to pretend.
+    """
+
+    def setUp(self):
+        super().setUp()
+        vaults.add_vault("devops", "plain-file",
+                         {"file": str(self.tmp / "devops.json")})
+        vaults.provider_for("devops").set("deploy_token", SECRET)
+        self.reg = actions.ActionRegistry()
+        self.seen = []
+
+    def _ctx(self, touches=("vault",)):
+        self.reg.register(_act("probe", touches=touches,
+                               run=lambda ctx: self.seen.append(ctx)))
+        inv = self.reg.invoke("probe", fid="fr-1", snapshot=_snapshot())
+        self.assertTrue(inv.join(SOON))
+        self.assertEqual(inv.error, "")
+        return self.seen[0]
+
+    def test_the_value_is_really_there_to_be_found(self):
+        """The control on the whole class: this file, read directly, holds the secret."""
+        self.assertEqual(vaults.provider_for("devops").get("deploy_token"), SECRET)
+        self.assertIn(SECRET, (self.tmp / "devops.json").read_text())
+
+    def test_nothing_reachable_from_the_ctx_carries_the_value(self):
+        c = self._ctx()
+        found = _reachable(c)
+        self.assertIn("devops", found, "the walk never reached the vault inventory")
+        self.assertNotIn(SECRET, found)
+        self.assertFalse([s for s in found if SECRET in s])
+
+    def test_nothing_the_vault_object_answers_carries_the_value(self):
+        c = self._ctx()
+        answers = _answers(c.vault, (), ("devops",), ("devops", "deploy_token"))
+        found = [s for a in answers for s in _reachable(a)]
+        self.assertIn("devops", found, "the probe called nothing that answered")
+        self.assertIn("deploy_token", found, "the key names were never reached")
+        self.assertFalse([s for s in found if SECRET in s])
+
+    def test_what_it_does_answer_is_the_names(self):
+        """`touches = ("vault",)` is a real capability and not a no-op: an action can ask
+        WHICH vaults exist and WHAT they are keyed by, which is what an action offering to
+        spend one needs — and is the whole of what charter hands over."""
+        c = self._ctx()
+        self.assertEqual(c.vault.names(), ("devops",))
+        self.assertEqual(c.vault.keys("devops"), ("deploy_token",))
+
+    def test_an_action_that_did_not_declare_vault_has_no_vault_at_all(self):
+        c = self._ctx(touches=())
+        self.assertEqual(set(vars(c)), {"fid"})
+        with self.assertRaises(AttributeError) as e:
+            c.vault
+        self.assertIn("touches", str(e.exception))
+
+    def test_the_inventory_keeps_no_provider_between_calls(self):
+        """A cached provider is how the value would arrive without anybody writing a
+        method for it — the object would simply be holding the file it read."""
+        c = self._ctx()
+        c.vault.keys("devops")
+        self.assertFalse([s for s in _reachable(c.vault) if SECRET in s])
+
+    def test_an_unknown_vault_is_a_refusal_rather_than_an_empty_answer(self):
+        c = self._ctx()
+        with self.assertRaises(Exception) as e:
+            c.vault.keys("no-such-vault")
+        self.assertIn("no-such-vault", str(e.exception))
+
+
+class TheRegistry(PersonaIso):
+    """Registration, order, and the refusals that mirror the component registry's."""
+
+    def setUp(self):
+        super().setUp()
+        self.reg = actions.ActionRegistry()
+
+    def test_actions_are_listed_in_the_order_they_were_registered(self):
+        for aid in ("c", "a", "b"):
+            self.reg.register(_act(aid))
+        self.assertEqual([a.id for a in self.reg.all()], ["c", "a", "b"])
+        self.assertEqual([o.id for o in self.reg.offers(fid="f", snapshot=_snapshot())],
+                         ["c", "a", "b"])
+
+    def test_two_actions_claiming_one_id_refuses_and_names_both(self):
+        self.reg.register(_act("deploy", title="Deploy the plane"))
+        with self.assertRaises(actions.ActionError) as e:
+            self.reg.register(_act("deploy", title="Deploy the docs"))
+        said = str(e.exception)
+        self.assertIn("Deploy the plane", said)
+        self.assertIn("Deploy the docs", said)
+
+    def test_a_collision_leaves_the_registry_as_it_was(self):
+        self.reg.register(_act("deploy", title="Deploy the plane"))
+        with self.assertRaises(actions.ActionError):
+            self.reg.register(_act("deploy", title="Deploy the docs"))
+        self.assertEqual(self.reg.get("deploy").title, "Deploy the plane")
+        self.assertEqual(len(self.reg.all()), 1)
+
+    def test_registering_something_that_is_not_an_action_is_refused(self):
+        with self.assertRaises(actions.ActionError):
+            self.reg.register("deploy")
+
+    def test_an_unknown_id_names_itself(self):
+        with self.assertRaises(actions.ActionError) as e:
+            self.reg.get("ghost")
+        self.assertIn("ghost", str(e.exception))
+
+    def test_the_registries_do_not_share_state(self):
+        self.reg.register(_act("solo"))
+        self.assertEqual(actions.ActionRegistry().all(), ())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_component_ctx.py
+++ b/tests/test_component_ctx.py
@@ -137,6 +137,42 @@ class NoEscapeHatches(unittest.TestCase):
         self.assertEqual(set(ctx.SERVES), set(component.NEEDS))
 
 
+class TheVocabularyIsLookedUpBesideTheClass(unittest.TestCase):
+    """Which contract a ctx answers over is registered beside its class, never ON it.
+
+    The first cut of the second contract (`frame.action.ActionCtx`) put the table on the
+    ctx class as four underscore-prefixed attributes. `type(ctx)._serves["vault"]` is a
+    callable that reads this plane's vault registry and ignores the snapshot handed to
+    it, so an action that declared NOTHING reached the whole inventory straight off its
+    own ctx's class — and every assertion about the attribute set above missed it,
+    because all of them filter names starting with ``_``. `frame.ctx.declare` and
+    :data:`frame.ctx._CONTRACTS` are the fix; `test_action_registry` proves the escape is
+    shut for the capability that touches the filesystem, and these two are the registry's
+    own guards, which nothing else exercises.
+    """
+
+    def test_a_ctx_class_that_declared_nothing_answers_over_its_base_s_contract(self):
+        """The walk up ``__mro__``, and why it is a walk rather than one lookup: `Ctx`'s
+        semantics are taken by subclassing, and a subclass that adds no vocabulary has to
+        speak its base's rather than not speak at all."""
+        class Quiet(ctx.Ctx):
+            pass
+
+        got = ctx.contract_of(Quiet({"fid": "f1"}))
+        self.assertIs(got, ctx.contract_of(_ctx_for()))
+        self.assertEqual(got.noun, "component")
+        self.assertEqual(Quiet({"fid": "f1"}).fid, "f1")
+
+    def test_a_ctx_class_nobody_declared_is_named_rather_than_answered_for(self):
+        """Falling back to `Ctx`'s contract would answer a stranger's class in charter's
+        words — a refusal naming ``needs`` for a thing that has no ``needs`` — and a bare
+        `KeyError` would name a dict instead of the mistake that produced it."""
+        with self.assertRaises(TypeError) as e:
+            ctx.contract_of(object())
+        self.assertIn("object", str(e.exception))
+        self.assertIn("declare", str(e.exception))
+
+
 class SlicesComeFromTheOneSnapshot(unittest.TestCase):
     def test_a_slice_carries_the_snapshot_s_own_content(self):
         c = _ctx_for(needs=("repos", "todos"))

--- a/tests/test_component_providers.py
+++ b/tests/test_component_providers.py
@@ -110,8 +110,14 @@ class _SitePackages:
         importlib.invalidate_caches()
 
     def install(self, dist: str, version: str, entries: dict[str, str],
-                modules: dict[str, str] | None = None) -> None:
+                modules: dict[str, str] | None = None,
+                group: str = "charter.components") -> None:
         """Write one distribution: its metadata, its entry points, its modules.
+
+        *group* is which contract the entry points are declared for. It defaults to
+        components so every case here reads unchanged, and `tests.test_action_providers`
+        passes `charter.actions` — one fixture for "what an installed distribution is",
+        because two would drift and the drift would be invisible from either side.
 
         Installing over a distribution of the same name REPLACES it, module included —
         a second copy left in ``sys.modules`` would serve the previous case's renderer to
@@ -127,7 +133,7 @@ class _SitePackages:
         (info / "METADATA").write_text(
             f"Metadata-Version: 2.1\nName: {dist}\nVersion: {version}\n", encoding="utf-8")
         (info / "entry_points.txt").write_text(
-            "[charter.components]\n" + "".join(f"{k} = {v}\n" for k, v in entries.items()),
+            f"[{group}]\n" + "".join(f"{k} = {v}\n" for k, v in entries.items()),
             encoding="utf-8")
         importlib.invalidate_caches()
 

--- a/tests/test_inflight_dispatch.py
+++ b/tests/test_inflight_dispatch.py
@@ -115,6 +115,70 @@ class InflightStore(unittest.TestCase):
         self.assertEqual(inflight.live(), ["coder"])
 
 
+class ATokenNamesOneRecord(unittest.TestCase):
+    """`finish` can PICK a record or be TOLD one, and picking is a race.
+
+    Name, kind and age is all a caller in another process can offer, and it is enough
+    there: a process finishes what it started, so its own record is the only candidate it
+    can have created. Two workers of one agent inside ONE process is a different shape —
+    both glob, both filter, both select the identical file, one unlink wins, and the
+    loser's record outlives its work by :data:`inflight.PRUNE_SECONDS`, drawn as running
+    for the first half hour of it. `frame.actions.ActionRegistry.invoke` is the first
+    caller of that shape, and `start` has always answered a token naming exactly one file.
+    """
+
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self._orig = config.STATE_DIR
+        config.STATE_DIR = Path(self._td.name)
+        self.addCleanup(self._td.cleanup)
+        self.addCleanup(lambda: setattr(config, "STATE_DIR", self._orig))
+
+    def _stems(self) -> list[str]:
+        return sorted(p.stem
+                      for p in (config.STATE_DIR / "dispatch-inflight").glob("*.json"))
+
+    def test_a_token_retires_the_record_it_names_and_not_the_pick(self):
+        """The whole difference, stated without a thread: the search would take the
+        OLDEST still-running record, and the second invocation's token is not it."""
+        first = inflight.start("coder", kind=inflight.ACTION)
+        second = inflight.start("coder", kind=inflight.ACTION)
+        inflight.finish("coder", kind=inflight.ACTION, token=second)
+        self.assertEqual(self._stems(), [first])
+
+    def test_each_token_retires_its_own_and_two_leave_nothing(self):
+        first = inflight.start("coder", kind=inflight.ACTION)
+        second = inflight.start("coder", kind=inflight.ACTION)
+        inflight.finish("coder", kind=inflight.ACTION, token=second)
+        inflight.finish("coder", kind=inflight.ACTION, token=first)
+        self.assertEqual(self._stems(), [])
+
+    def test_a_token_whose_record_is_already_gone_is_harmless(self):
+        token = inflight.start("coder", kind=inflight.ACTION)
+        inflight.finish("coder", kind=inflight.ACTION, token=token)
+        inflight.finish("coder", kind=inflight.ACTION, token=token)   # must not raise
+        self.assertEqual(self._stems(), [])
+
+    def test_a_token_that_is_not_a_bare_name_deletes_nothing(self):
+        """A token is a file name the tracker wrote. One carrying a separator would make
+        an unlink OUTSIDE the tracker's own directory a caller's string decides — the
+        same reasoning `_safe_name` applies to an agent name, on the other half of the
+        path."""
+        outside = config.STATE_DIR / "evil.json"
+        outside.write_text("{}")
+        kept = inflight.start("coder", kind=inflight.ACTION)
+        inflight.finish("coder", kind=inflight.ACTION, token="../evil")
+        self.assertTrue(outside.exists(), "finish deleted outside its own directory")
+        self.assertEqual(self._stems(), [kept])
+
+    def test_no_token_still_picks_the_way_every_older_caller_expects(self):
+        """The control: dispatch, clone and `gl-refresh` pass no token and must keep the
+        behaviour they have — otherwise this is a change of `finish`, not an addition."""
+        inflight.start("coder")
+        inflight.finish("coder")
+        self.assertEqual(self._stems(), [])
+
+
 class PresumedDead(unittest.TestCase):
     """The record outliving every reasonable expectation is the *most* interesting thing
     this tracker can hold, and deleting it rendered it as nothing at all — "presumed dead"


### PR DESCRIPTION
Task 3 of the Phase 2 command surface: the action registry. `charter.actions` is the
second entry-point group (§4d) — separate from `charter.components`, with its own API
integer refused at load and the same id-collision refusal naming both distributions —
and `frame/actions.py` is what offers them.

## Mirrored by subclassing, not by copying

`registry.Providers` grew nine class attributes naming what a contract calls itself;
`ActionProviders` sets them and inherits every refusal. Two implementations of "is
this provider loadable" would drift, and #547 is what that costs — the copy there was
only caught because it happened to call the original. The same argument applies twice
more: `ActionCtx` inherits `ctx.Ctx`'s absent-not-disabled, read-only,
exactly-assertable semantics over a different vocabulary, and the id alphabet is one
`component.usable_id` both contracts ask rather than two regexes that agree today.

`tests/test_action_providers.py` asserts the four refusals again from the outside,
because a shared implementation is only safe while something proves both contracts
still get the answer.

**One deliberate deviation from "same integer".** The mechanism is the same — one
integer, refused at load, both versions named — but a provider declares it as
`ACTION_API_VERSION`. §4d's own example is one distribution supplying a CI panel and a
"rerun failed job" action, which is one module and one attribute for two contracts
whose integers move independently; sharing the name would mean a component-contract
bump refusing every action on the machine for a contract it did not touch.

## Fire-and-report, never blocking (§4g)

`invoke` answers an `Invocation` — a receipt, not a result — having put the work on a
thread it never joins. Progress surfaces through a new `inflight` kind (`action`),
which the frame's spinner already reads by asking for anything live, and which the
dispatch-overlap nudge does not see because it does not ask.

The property is pinned by an action that is *provably still inside `run`* when
`invoke` returns — it is blocked on a gate the test has not opened — rather than by
timing anything. `Invocation.join` exists for a test and a shutdown and says in its
own docstring that the frame never calls it.

## An unavailable action carries why

Every registered action is offered, always, with `available` / `reason_unavailable`
resolved against this moment by one `_check` that both `offers` and `invoke` ask, so a
row and a keypress cannot disagree. Charter finishes the sentence when a provider
returns nothing — an unavailable row with an empty reason is a missing row arriving by
a shorter path. `available` that raises answers no, with what it raised: a stranger's
code costs its own row, never the palette.

Rendered, with a plane that has no clones, `$CHARTER_WORKSPACE` set, a hostile reason
and one provider this machine does not have installed:

```
  Detach from this frame       
! Switch workspace             $CHARTER_WORKSPACE pins this frame to 'harness-wrapper'
! Refresh forge state          this workspace has no clones yet
! Deploy\u2028rm -rf /         held by\x0athe session lock\x1b[2J
! acme.deploy — unavailable    no installed provider supplies the action acme.deploy — install the distribution that declares it in the charter.actions entry point group, or stop offering it. Its row says so; the rest of the palette is offered
```

(verbatim, so the long row runs off; the reason is ONE row, which is the point — `contain.one_line`
runs before anything measures or draws it, and `[frame] hotkey` is what a committed
value reaching a config line cost once.)

That last row is also §4b property 4 landing: `registry.STANDIN_EDGE`'s note records
that in Phase 1 a component charter could not load had nowhere to say so. An action
has somewhere — the row itself.

## An action cannot reach a vault value

`touches` is `needs` turned from a cost declaration into a reach declaration. What
`vault` serves is an inventory: which vaults this plane has, what they are keyed by,
and no route to what is in them. `forge` and `shell` are **absent from the
vocabulary**, not accepted and served empty — `component.NEEDS` argues at length why a
declarable name nobody can serve is worse than a refusal.

The test that pins it installs a real plain-file vault holding a real value and hunts
for it two ways, neither of them a spelling check:

1. everything *reachable* from the ctx — instance dicts, containers, closure cells,
   bound receivers;
2. everything every public callable on the served object *answers*, discovered with
   `dir` rather than from a list of names.

Both carry a positive control: the same walk finds the vault's name and the key's
name, so a probe that traversed nothing cannot pass as a guard that held. A `value()`
added tomorrow, or a provider cached between calls, fails them without the test naming
either — both were run as mutations and both went RED.

Stated honestly in the code: this is containment, not a sandbox, on exactly the terms
`ctx.py` already states for components. An action's module is ordinary Python and
`charter.secrets` is an import away. The claim is that **charter hands one over
nowhere** — not as a value, not as a provider, not in a closure, not behind a method —
so an action that reads a vault does it in the open, in code somebody can review.
Spending arrives with the first action that spends and will go through `charter secret
exec`, which already resolves inside charter's process, strips every other vault's
identity from the child, and redacts what comes back. Narrow from day one (§4d).

## Mutations run

Each applied, RED, restored, GREEN, with `__pycache__` cleared between:

| mutation | result |
|---|---|
| `invoke` calls `run` inline | RED ×2 — receipt reported nothing running, `inflight` empty |
| `VaultInventory.value()` reaching the provider | RED ×1 — the call probe returned the secret |
| the inventory caches its provider and what it read | RED ×2 — both walks found it |
| charter no longer finishes an empty reason | RED ×1 |
| the reason reaches a row uncontained | RED ×4 — a `\r` split it in two |
| an unavailable action omitted from the listing | RED ×16 |
| `invoke` ignores availability | RED ×2 |
| the id alphabet reduced to `isinstance(str)` | RED ×8 |
| `version_attr` set to the component contract's `API_VERSION` | RED ×12 |
| `SERVES` grows a name `TOUCHES` does not declare | RED ×1 |

## Suite

64 new tests. **5944, OK in both environments** — ambient cleared, and again with
`$CHARTER_WORKSPACE=harness-wrapper` — against Phase 1's pin of 5880, so nothing was
lost. One existing test file changed: `_SitePackages.install` takes a `group=` argument
(defaulting to `charter.components`, so every existing case reads unchanged) rather
than a second fixture for "what an installed distribution is".

No news entry: nothing offers these on screen until the palette (Task 4), and a
release note for a surface nobody can reach would be the convincing empty this phase
keeps removing.
