### PR TITLE
A component id is the frame's currency, end to end (Phase 2, Task 1)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -762,11 +762,18 @@ def _add_frame_parsers(sub) -> None:
     _wire(fr, "")
 
     # Internal: one pane of a running frame, spawned by `layout.panel_argvs` — never
-    # typed by an operator. The argv shape here (`panel <slot> --session <fid>`) must
-    # match what that function emits EXACTLY: it is the only thing standing between a
-    # tmux pane and a process that fails at startup, leaving a hole in the frame.
+    # typed by an operator. The argv shape here (`panel <component> --session <fid>`)
+    # must match what that function emits EXACTLY: it is the only thing standing between
+    # a tmux pane and a process that fails at startup, leaving a hole in the frame.
+    #
+    # The word is a component NAME, not a key of `frame.slots.SLOTS`: one of the four
+    # committed slot names, the id of the built-in behind one, or the id of a component
+    # an installed provider supplies. `frame.panel.run` is what resolves it, and it is
+    # the only validation — argparse takes any word, because the value arrives from
+    # charter's own `layout.panel_command` and a second, weaker copy of that resolution
+    # here is the two-answers shape #547 measured.
     pn = sub.add_parser("panel")
-    pn.add_argument("slot")
+    pn.add_argument("slot", metavar="<component>")
     pn.add_argument("--session", dest="session", required=True)
     pn.set_defaults(func=lambda args: frame_panel.run(args.slot, args.session))
 

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -729,7 +729,11 @@ def _panel_died_hook_argv(*, socket: str, panel_pane: str, slot: str,
 
     ``None`` back means charter will not arm this pane, and every value that reaches the
     text is what decides — never where it came from. *panel_pane* must be tmux's own
-    `%<digits>` (`_PANE_ID_RE`), *slot* a key of `frame_slots.SLOTS`, *fid* a
+    `%<digits>` (`_PANE_ID_RE`), *slot* a name `frame_slots.drawable` resolves to a
+    component — one of charter's own under either spelling, or one an installed
+    distribution supplies, and never merely a name SHAPED like one: `top.` is as
+    namespaced-looking as `acme.metrics` and is refused, because the property being
+    checked is "charter can draw this", not "this has a dot in it" — *fid* a
     `state.frame_id` (`_FRAME_ID_RE`), and every word including the interpreter path must
     pass :func:`_action_word_is_safe`. `sys.executable` is the one that is genuinely
     machine-shaped: a path holding a space, `;`, `&`, `(` or `*` was measured to survive
@@ -763,7 +767,7 @@ def _panel_died_hook_argv(*, socket: str, panel_pane: str, slot: str,
     """
     words = util.self_relaunch_argv("frame-respawn", slot, "--pane", panel_pane,
                                     "--frame", fid)
-    if (not _PANE_ID_RE.fullmatch(panel_pane) or slot not in frame_slots.SLOTS
+    if (not _PANE_ID_RE.fullmatch(panel_pane) or not frame_slots.drawable(slot)
             or not _FRAME_ID_RE.fullmatch(fid)
             or not all(_action_word_is_safe(w) for w in words)
             or any(w.split() != [w] for w in words[1:])):
@@ -1195,9 +1199,8 @@ def _drawable_slots(cols: int, rows: int, configured: list[str] | None = None) -
     in the same order, and a slot with no renderer is skipped for the same reason.
 
     `[frame] slots` can accept a slot (`instance.FRAME_SLOTS`, sized by
-    `layout.SLOT_SIZE`) that `frame.slots.SLOTS` — the RENDERER registry — has no
-    renderer for (as `left`/`right` were until Task 3 (#385) gave them one, and as the
-    next slot this frame grows will be on its first day). Left
+    `layout.SLOT_SIZE`) that nothing can draw (as `left`/`right` were until Task 3 (#385)
+    gave them one, and as the next slot this frame grows will be on its first day). Left
     unfiltered, `panel_argvs` would still split a real pane for it; `panel.run`
     correctly refuses or exits 2 (Task 7's own "no empty pane" rule), but with
     `remain-on-exit on` keeping that pane alive, the operator is left with a permanently
@@ -1212,6 +1215,12 @@ def _drawable_slots(cols: int, rows: int, configured: list[str] | None = None) -
     tmux's alternate screen, where nobody reads it (measured; see `frame_ready`'s own
     docstring). `--probe`, `charter frame-probe` and `charter doctor` all name it on
     demand instead, from the same `frame_slots.unimplemented` this filters on.
+
+    **"Has a renderer" is not "is one of charter's four" any more.** A name an installed
+    distribution supplies is drawable too (`frame_slots.drawable`), which is what lets a
+    placed provider survive as far as `panel_argvs` — this filter is where every one of
+    them was dropped before a pane could be split for it. On a machine with no component
+    providers installed the answer is exactly what it always was.
     """
     frame = config.FRAME
     slots = layout.visible_slots(frame["slots"] if configured is None else configured,
@@ -3469,7 +3478,13 @@ def cmd_respawn(args) -> int:
     panel, for nothing being wrong) is avoided rather than reported.
     """
     fid = getattr(args, "frame", None) or os.environ.get("CHARTER_SESSION_ID", "")
-    if not fid or args.slot not in frame_slots.SLOTS:
+    # `frame_slots.drawable`, not a key of `frame_slots.SLOTS`: the panel this is
+    # bringing back may be hosting a component an installed provider supplies, and a
+    # membership test against charter's own four renderers refused every one of them.
+    # It is still a whitelist — the name is interpolated into a `respawn-pane` argv
+    # read back off a tmux hook — and it still admits only names charter can resolve
+    # to a component, never a SHAPE that looks like one.
+    if not fid or not frame_slots.drawable(args.slot):
         return 0
     if not _PANE_ID_RE.fullmatch(args.pane or ""):
         return 0

--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -16,13 +16,20 @@ strips are a fixed height, which one takes what its content needs — from
 what those renderers already do, not a new arrangement. The before/after render at 200x50
 and 80x24 is byte-identical.
 
-**The slot names survive, as a mapping, because they are committed** (:data:`SLOT_OF`).
+**The slot names survive as SHORTHAND, because they are committed** (:data:`SLOT_OF`).
 `[frame] slots = ["top", "bottom", "repos", "right"]` sits in charter.toml on every plane
 that has one, `charter panel top --session …` is the argv `layout.panel_command` emits
-into a tmux pane, and both are compatibility surfaces. So a slot name is what the outside
-world says and a component id is what charter reasons with, with exactly one table
-between them rather than a rename rippling through tmux argv, config files and the
-renderer registry at once.
+into a tmux pane, and both are compatibility surfaces. A component id is the frame's
+currency and a slot name is one of four aliases for a built-in id, resolved by
+:func:`component_id` — one table, rather than a rename rippling through tmux argv, config
+files and the renderer registry at once.
+
+**Which is why a name that is NOT one of those four is a component id, not a typo.** That
+is the whole of Phase 2's Task 1: `charter panel acme.metrics` reaches a component an
+installed provider supplies (:func:`supplies`), because every step between a committed
+`[[frame.component]]` table and a painted pane now resolves a NAME rather than looking one
+up in a table of four. Phase 1 could place a provider and never draw it for exactly the
+opposite reason.
 
 **What each component declares in ``needs`` is what its RENDERER actually reads, which is
 not the same as what the slice names suggest.**
@@ -77,6 +84,46 @@ SLOT_OF = {
 #: the component that draws it. Derived rather than written out, so the two cannot
 #: disagree about a name — the shape `instance.FRAME_DEFAULTS` already uses.
 COMPONENT_OF = {slot: cid for cid, slot in SLOT_OF.items()}
+
+
+def component_id(name):
+    """The component *name* names: a committed slot name resolved, anything else itself.
+
+    **The one direction the two vocabularies are read in**, and the reason `[frame] slots`
+    could be called shorthand rather than a second system. `top` is `identity`'s committed
+    spelling; `acme.metrics` is a provider's id and has no committed spelling, so it is
+    already what it resolves to.
+
+    Unambiguous by inspection and not by luck: no slot name is another component's id
+    (`test_component_registry` asks it of the tables rather than of this sentence), so a
+    name resolves one way whichever vocabulary it was written in.
+
+    Anything that is not text comes back as it went in. This is asked of values that came
+    out of a committed file, and the refusal belongs to whatever validates the value, with
+    the rest of its message — not to a lookup that would raise `TypeError` half a frame
+    away from the line that was wrong.
+    """
+    return COMPONENT_OF.get(name, name) if isinstance(name, str) else name
+
+
+def supplies(cid) -> bool:
+    """Whether an installed distribution supplies the component *cid* — without importing.
+
+    Entry point METADATA only, which is what makes this askable from the places that ask
+    it: `frame/panel.py` before it draws, `frame/slots.py:unimplemented` before a pane is
+    split, and `commands_frame._arm_panel_respawn` before a name reaches tmux config text.
+    None of them may import a stranger's module to find out whether one exists, and the
+    respawn hook in particular must not: it runs while charter is arming a pane, on a name
+    that has been read back off disk.
+
+    A fresh :class:`registry.Providers` per call rather than one cached at module scope.
+    The scan is ~0.2 ms and `importlib.metadata` caches underneath it, so the cache would
+    buy nothing measurable — and it would answer for the ``sys.path`` charter had the
+    first time anything asked, which is wrong for a long-lived process, wrong for a test
+    that installs a distribution, and wrong in the direction that is hard to see: a stale
+    "no such provider" is a pane that never appears.
+    """
+    return Registry().providers.supplies(cid)
 
 
 def _panel(slot: str):

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -126,21 +126,27 @@ def _derive(placed) -> _Derived:
     checks that every one of the five moves together, which is the property the five
     separate tuples never had — they agreed by having been edited in the same commit.
 
-    Keyed by the committed slot name (`builtins.SLOT_OF`) rather than the component id,
-    because that is the vocabulary `[frame] slots`, `charter panel <slot>` and every
-    caller in `commands_frame` already speak. A component with no slot name is a
-    ``KeyError`` here rather than a silently skipped pane: the caller has handed over
-    something that cannot be placed, and answering with a frame missing one panel is the
-    convincing-empty this module refuses everywhere else.
+    Keyed by the name the component is SPELLED with — its committed slot name where it
+    has one (`builtins.SLOT_OF`), and its own id where it does not. The four aliases are
+    what `[frame] slots`, `charter panel top` and every caller in `commands_frame` already
+    say, so they keep answering; a provider's component has no committed spelling and is
+    keyed by the id it was placed under, which is what lets a plane's own arrangement be
+    derived here at all.
+
+    That fallback is the line Phase 1 could not cross: this used to be `SLOT_OF[c.id]`,
+    a `KeyError` by design for any component charter did not write, so the one function
+    every per-slot fact in this module is derived from could not be shown a provider.
     """
-    name = _builtins.SLOT_OF
+    def name(c) -> str:
+        return _builtins.SLOT_OF.get(c.id, c.id)
+
     return _Derived(
-        size={name[c.id]: _cells(c) for c in placed},
-        edge={name[c.id]: c.edge for c in placed},
-        column=tuple(name[c.id] for c in placed if c.edge in _COLUMN_EDGES),
-        fixed_rows=tuple(name[c.id] for c in placed
+        size={name(c): _cells(c) for c in placed},
+        edge={name(c): c.edge for c in placed},
+        column=tuple(name(c) for c in placed if c.edge in _COLUMN_EDGES),
+        fixed_rows=tuple(name(c) for c in placed
                          if c.edge in _ROW_EDGES and isinstance(c.size, Fixed)),
-        variable_rows=frozenset(name[c.id] for c in placed
+        variable_rows=frozenset(name(c) for c in placed
                                 if c.edge in _ROW_EDGES
                                 and not isinstance(c.size, Fixed)),
     )
@@ -191,14 +197,15 @@ _BORDER_ROWS = 1
 #: as an 87-column harness and a 22-column sidebar, which is 109.
 _BORDER_COLS = 1
 
-#: Slots that take COLUMNS off the pane they are split from rather than rows — the `-h`
-#: half of :func:`panel_argvs`' `direction`. Kept as a name rather than an inline
-#: ``== "right"`` because :func:`repos_cols` and `panel_argvs` are two places that have
-#: to agree about which splits cost columns, and the next side slot must not have to be
-#: remembered in both.
+#: Which of the SHIPPED slots take COLUMNS off the pane they are split from rather than
+#: rows — the statement of charter's own frame, derived from each component's declared
+#: edge rather than written out as ``== "right"``.
 #:
-#: Now the component's own `edge` answers it, so the next side slot is not remembered
-#: anywhere: it declares an edge and lands here.
+#: :func:`repos_cols` and :func:`panel_argvs` both have to agree about which splits cost
+#: columns, and they now ask :func:`_edge_of` rather than this tuple — one predicate,
+#: ``edge in _COLUMN_EDGES``, which answers for a component this plane placed as well as
+#: for charter's own. This is that same predicate frozen over the shipped frame, which is
+#: what the geometry test asserts against literals.
 _COLUMN_SLOTS = _SHIPPED.column
 
 #: The horizontal strips whose height is a CONSTANT, and therefore the rows
@@ -216,6 +223,9 @@ _COLUMN_SLOTS = _SHIPPED.column
 #: Both exclusions this comment states are now the components' own declarations: `right`
 #: is out because its edge costs columns, `repos` because its size is `Content()` rather
 #: than `Fixed`. Neither was enforced by anything while this was a written-out tuple.
+#:
+#: Read through :func:`_is_fixed_row`, which is where a component this plane placed gets
+#: the same question answered from its own edge.
 _FIXED_ROW_SLOTS = _SHIPPED.fixed_rows
 
 #: The slots whose height is a function of their content rather than a constant — the
@@ -236,6 +246,97 @@ _FIXED_ROW_SLOTS = _SHIPPED.fixed_rows
 #: its content's and a slot whose height is what is left are the same kind of dependent
 #: pane as far as `resize-pane` is concerned.
 VARIABLE_ROW_SLOTS = _SHIPPED.variable_rows
+
+
+def _key(name):
+    """*name* as the five tables above key it: a built-in id resolved to its alias.
+
+    The tables are keyed by the committed spelling because that spelling is committed, and
+    a component id is the currency — so `identity` and `top` must reach one entry, not
+    two. `builtins.SLOT_OF` is the same one table `_derive` keyed them with, read in the
+    same direction.
+    """
+    return _builtins.SLOT_OF.get(name, name) if isinstance(name, str) else name
+
+
+def _placed_here() -> dict[str, tuple[str, int]]:
+    """name → (edge, cells) for what THIS PLANE places and charter did not write.
+
+    Empty on every plane that spells its frame with `[frame] slots`, which is charter's
+    own and very nearly everyone's — the five tables above are the whole answer there, and
+    this costs a `dict.get` on a mapping that is already resolved.
+
+    **Read from the resolved config rather than passed down through six signatures.**
+    `instance.frame_of` already resolves a plane's `[[frame.component]]` tables into
+    placements carrying an edge and a size policy, and `config.FRAME` already holds them;
+    threading an extra argument through `slot_sizes`, `panel_argvs`, `repos_cols`,
+    `repos_rows` and `harness_rows` would be five more parameters each caller could get
+    wrong and each test could omit — which is how the two answers to "how wide is the
+    table's pane" came apart in #500.
+
+    Imported inside the call, the way :func:`_table_min_cols` reaches for `statusline` and
+    for the same reason: this module is imported by every launch path, and `config`'s
+    import resolves the plane root.
+
+    Only names the shipped tables do not already carry. A plane cannot move charter's own
+    `right` from here — `component_tables` refuses an edge or a size on a built-in that
+    disagrees with its declaration, because `layout` derives the built-in geometry at
+    import and a value read, validated and then ignored is the convincing empty this phase
+    was written against.
+    """
+    from .. import config
+    out: dict[str, tuple[str, int]] = {}
+    for placed in config.FRAME.get("components") or ():
+        name = placed.get("slot")
+        if isinstance(name, str) and name not in SLOT_SIZE:
+            out[name] = (placed["edge"], _policy_cells(placed["size"]))
+    return out
+
+
+def _policy_cells(size) -> int:
+    """A size POLICY as cells, by the one rule :func:`_cells` already states."""
+    return size.n if isinstance(size, Fixed) else 1
+
+
+def _edge_of(name):
+    """Which side of the harness *name* attaches to, or ``None`` for a name nothing placed.
+
+    ``None`` and not a default. Every caller below asks a membership question of the
+    answer (`in _COLUMN_EDGES`, `in _ROW_EDGES`, `in _BEFORE_EDGES`), and a name charter
+    knows nothing about must fall out of all three rather than be assigned a side — which
+    is the same filter-don't-refuse degrade `slot_sizes` has always made one line up.
+    """
+    key = _key(name)
+    if key in SLOT_EDGE:
+        return SLOT_EDGE[key]
+    placed = _placed_here().get(key)
+    return placed[0] if placed else None
+
+
+def _size_of(name):
+    """How many cells *name* is given, or ``None`` for a name nothing placed."""
+    key = _key(name)
+    if key in SLOT_SIZE:
+        return SLOT_SIZE[key]
+    placed = _placed_here().get(key)
+    return placed[1] if placed else None
+
+
+def _is_fixed_row(name) -> bool:
+    """Whether *name* is a horizontal strip whose height :func:`repos_rows` must subtract.
+
+    Two sources, one question, and the branch is which of them knows about *name*.
+    Charter's own components answer from :data:`_FIXED_ROW_SLOTS`, the table `_derive`
+    built from their declared size and edge — so `repos` stays out of it for being
+    `Content()` and `right` for costing columns, exactly as before. A component this plane
+    placed answers from its edge alone, because a committed size is a NUMBER: the config
+    boundary refuses a `[[frame.component]]` table that does not carry one, so there is no
+    third kind for the second branch to be wrong about.
+    """
+    key = _key(name)
+    if key in SLOT_EDGE:
+        return key in _FIXED_ROW_SLOTS
+    return _edge_of(key) in _ROW_EDGES
 
 
 def _table_min_cols() -> int:
@@ -294,10 +395,10 @@ def repos_cols(slots: list[str] | tuple[str, ...], *, window_cols: int) -> int:
     """
     out = window_cols
     for slot in slots:
-        if slot == "repos":
+        if _key(slot) == "repos":
             break
-        if slot in _COLUMN_SLOTS:
-            out -= SLOT_SIZE[slot] + _BORDER_COLS
+        if _edge_of(slot) in _COLUMN_EDGES:
+            out -= _size_of(slot) + _BORDER_COLS
     return max(0, out)
 
 
@@ -388,8 +489,7 @@ def repos_rows(*, content_rows: int, window_rows: int,
     every slot below half the size floors.
     """
     floor = SLOT_SIZE["repos"]
-    other = sum(SLOT_SIZE[s] + _BORDER_ROWS
-                for s in slots if s in _FIXED_ROW_SLOTS)
+    other = sum(_size_of(s) + _BORDER_ROWS for s in slots if _is_fixed_row(s))
     cap = window_rows - other - _BORDER_ROWS - HARNESS_MIN_ROWS
     return max(floor, min(content_rows, cap))
 
@@ -410,11 +510,13 @@ def slot_sizes(slots: list[str], *, window_rows: int, content_rows: int) -> dict
     """
     out: dict[str, int] = {}
     for slot in slots:
-        if slot in VARIABLE_ROW_SLOTS:
+        if _key(slot) in VARIABLE_ROW_SLOTS:
             out[slot] = repos_rows(content_rows=content_rows,
                                    window_rows=window_rows, slots=slots)
-        elif slot in SLOT_SIZE:
-            out[slot] = SLOT_SIZE[slot]
+            continue
+        cells = _size_of(slot)
+        if cells is not None:
+            out[slot] = cells
     return out
 
 
@@ -446,7 +548,7 @@ def harness_rows(sizes: dict[str, int], *, window_rows: int) -> int:
     than a harness squeezed to one row in a window that has no rows for it anyway.
     """
     used = sum(n + _BORDER_ROWS for slot, n in sizes.items()
-               if slot not in _COLUMN_SLOTS)
+               if _edge_of(slot) not in _COLUMN_EDGES)
     return max(1, window_rows - used)
 
 
@@ -665,6 +767,12 @@ def _env_argv(env: dict[str, str] | None) -> list[str]:
 def panel_command(*, slot: str, session: str) -> list[str]:
     """The command one panel pane runs — the part after `split-window`'s own `--`.
 
+    *slot* is a component NAME: one of the four committed slot names, the id of the
+    built-in behind one, or the id of a component an installed provider supplies. It is
+    the argument `frame/panel.py:run` resolves, and the keyword keeps its old spelling
+    because `commands_frame.cmd_respawn` and every test that pins this argv byte for byte
+    already say it.
+
     Split out of :func:`panel_argvs` because a panel is started TWICE by two different
     modules: once by the launcher's `split-window`, and again by
     `commands_frame.cmd_respawn`'s `respawn-pane` after the pane's `pane-died` hook
@@ -753,16 +861,27 @@ def panel_argvs(*, slots: list[str], session: str, socket: str,
     """
     cmds: list[list[str]] = []
     for slot in slots:
-        size = (sizes or SLOT_SIZE).get(slot, SLOT_SIZE[slot])
-        # :data:`_COLUMN_SLOTS` rather than a second list of names: which splits take
-        # COLUMNS is exactly what :func:`repos_cols` has to know to answer how wide
-        # `repos` ends up, and two copies of that fact are two things to keep in step.
-        direction = "-h" if slot in _COLUMN_SLOTS else "-v"
+        size = (sizes or {}).get(slot)
+        if size is None:
+            # `SLOT_SIZE[slot]` is still the last resort, and still a `KeyError` for a
+            # name nothing placed: a caller has asked for a pane charter cannot size, and
+            # splitting one anyway is the permanently-dead rectangle `_drawable_slots`
+            # exists to prevent.
+            size = _size_of(slot)
+            if size is None:
+                size = SLOT_SIZE[slot]
+        # The component's EDGE, not a second list of names: which splits take COLUMNS is
+        # exactly what :func:`repos_cols` has to know to answer how wide `repos` ends up,
+        # and two copies of that fact are two things to keep in step. :data:`_COLUMN_SLOTS`
+        # is that same predicate over the SHIPPED frame; asking the edge is what also
+        # answers it for a component this plane placed.
+        edge = _edge_of(slot)
+        direction = "-h" if edge in _COLUMN_EDGES else "-v"
         # `-b` is the component's EDGE, not the name `top` — see :data:`_BEFORE_EDGES`.
         # A slot charter has no component for keeps the plain `-v`/after placement it had
         # while this was spelled `slot == "top"`, which is the same filter-don't-refuse
         # degrade `slot_sizes` makes one line above.
-        before = ["-b"] if SLOT_EDGE.get(slot) in _BEFORE_EDGES else []
+        before = ["-b"] if edge in _BEFORE_EDGES else []
         cmds.append(_tmux(socket, "split-window", "-t", harness_pane,
                           direction, *before, "-l", str(size),
                           *_env_argv(env),

--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -96,7 +96,7 @@ import signal
 import sys
 import time
 
-from .. import tui
+from .. import contain, tui
 from . import slots, state
 
 #: How often the version file is checked when nothing else has woken this panel. A
@@ -155,6 +155,60 @@ def _paint(slot: str, fid: str) -> None:
     docstring's "Height is this module's job" section.
     """
     _write(slots.render(slot, fid))
+
+
+def _component_painter(reg, cid: str):
+    """A paint function for *cid*, drawn out of *reg* — `_paint`'s shape for a component.
+
+    **The registry is built once and closed over, not rebuilt per tick.** A panel drawing
+    a provider's component repaints on the same clock as any other, and rebuilding would
+    re-scan the installed distributions five times a second for an answer that cannot
+    change inside one process — the kind of cost §4's whole budget argument exists to keep
+    off the repaint path.
+
+    The *name* the loop hands back is ignored: `_watch` carries the name it was started
+    with, and what this draws was decided once, when `run` resolved that name. Taking the
+    argument and not reading it keeps one signature for both painters rather than a second
+    shape for `_tick` to know about.
+    """
+    def paint(_name: str, fid: str) -> None:
+        _write(_component_text(reg, cid, fid))
+    return paint
+
+
+def _component_text(reg, cid: str, fid: str) -> str:
+    """*cid*'s rows for this pane, as the one string `_write` takes.
+
+    ``ctx`` is built from what the component DECLARED (§4e), so a component that declared
+    nothing costs this tick no `gather.read` at all — the idle-cost property survives a
+    renderer charter did not write only if the declaration is what decides, rather than
+    the snapshot being handed over and the declaration describing it afterwards.
+
+    **Never raises**, which is `slots.render`'s promise said again for the other kind of
+    renderer. Everything a stranger's code does wrong is already contained one layer down
+    — `Registry.draw` catches, names the component, escapes what it returned and clips it
+    to the rectangle (§4b properties 1 and 3) — so what is caught here is the ways THIS
+    function can fail: a snapshot that cannot be read, a pane whose size cannot be
+    measured. A panel that stops repainting has already lost the pane, whatever the
+    traceback would have said.
+    """
+    from . import ctx as _ctx, gather
+    try:
+        c = reg.get(cid)
+        snapshot = gather.read(fid) if c.needs else {}
+        drew = reg.draw(cid, _ctx.build(c.needs, width=slots._width(),
+                                        height=_rows(), fid=fid, snapshot=snapshot))
+        return "\n".join(drew)
+    except KeyboardInterrupt:
+        raise
+    except Exception as e:
+        # `contain.one_line` BEFORE the width arithmetic, the order the rest of charter
+        # keeps: *cid* arrived on this process's own command line, an escape sequence in
+        # it is an instruction to the terminal rather than a character, and measuring
+        # first would measure a string that is not what the terminal is about to do.
+        return tui.truncate(
+            f" charter: {contain.one_line(cid)} unavailable ({type(e).__name__})",
+            slots._width())
 
 
 def _hold(reason: str, *, once: bool, rc: int) -> int:
@@ -272,7 +326,7 @@ def _install_sigwinch(resized: dict) -> object:
 
 
 def _tick(resized: dict, seen: str, slot: str, fid: str, *,
-          animating: bool = False) -> str:
+          animating: bool = False, paint=None) -> str:
     """One loop iteration's decision AND its effect — split out of `run` so the
     DECISION (paint now, or wait) can be exercised without also exercising `run`'s
     `while True`/`time.sleep`, which a test cannot call directly without either hanging
@@ -310,16 +364,22 @@ def _tick(resized: dict, seen: str, slot: str, fid: str, *,
     that mean "repaint only on news" — every test in this module that exercises the
     decision directly — keep saying exactly that. `_watch` is what decides it, from
     :func:`_running`.
+
+    *paint* is WHAT to draw, defaulting to :func:`_paint` — charter's own renderer for
+    this slot. A panel hosting a provider's component passes :func:`_component_painter`'s
+    instead. A parameter rather than a branch inside the loop, because the choice is made
+    once, where `run` resolves the name: asking "is this a component?" every tick would
+    put an installed-distribution scan on the repaint path.
     """
     now = state.version(fid)
     if resized["flag"] or now != seen or animating:
         resized["flag"] = False
-        _paint(slot, fid)
+        (paint or _paint)(slot, fid)
         return now
     return seen
 
 
-def _watch(slot: str, fid: str, *, once: bool) -> int:
+def _watch(slot: str, fid: str, *, once: bool, paint=None) -> int:
     """The live loop: paint on every version bump, resize, or spinner frame, until killed.
 
     The third reason is the only one that repeats on its own, and it is bounded twice over
@@ -348,7 +408,7 @@ def _watch(slot: str, fid: str, *, once: bool) -> int:
     try:
         seen = ""
         while True:
-            seen = _tick(resized, seen, slot, fid,
+            seen = _tick(resized, seen, slot, fid, paint=paint,
                          animating=animates and bool(_running(inflight_cache)))
             if once:
                 return 0
@@ -358,14 +418,28 @@ def _watch(slot: str, fid: str, *, once: bool) -> int:
 
 
 def run(slot: str, fid: str, *, once: bool = False) -> int:
-    """Run one panel: refuse an unknown slot, then paint on every version bump or
+    """Run one panel: refuse a name nothing can draw, then paint on every version bump or
     resize until killed (`once=True` — never passed by `charter panel` itself, only by
     tests — paints exactly once and returns).
 
-    Refuses rather than drawing an empty pane for a *slot* not in `slots.SLOTS`: an
-    empty pane reads as a broken frame, and `layout.panel_argvs` can in principle be
-    handed a slot name `slots.py` does not (yet) implement a renderer for (`left`/
-    `right` today — see `layout.SLOT_SIZE`).
+    **`slot` is a component NAME, and this is the link Phase 1 could not build.** A panel
+    process builds no registry and knows no providers, so `charter panel acme.metrics` was
+    `unknown slot` however correctly the config boundary had placed it — which is why
+    `Registry.place` shipped with zero production callers. Three names reach the same
+    component here: a committed slot name (`top`), the id behind it (`identity`), and a
+    provider's own id, resolved through `builtins.component_id` and `slots.drawable`.
+
+    **Charter's own components never fall through to the providers.** A built-in whose
+    renderer is missing from `slots.SLOTS` is refused as it always was, rather than sent
+    off to look for an installed distribution called `sidebar` — a provider must not be
+    able to answer a question about charter's own component by claiming its name.
+
+    Refuses rather than drawing an empty pane for a name nothing can draw: an empty pane
+    reads as a broken frame, and `layout.panel_argvs` can in principle be handed a slot
+    name `slots.py` does not (yet) implement a renderer for (`left`/`right` were, for a
+    release — see `layout.SLOT_SIZE`). An id an installed provider DOES supply is never
+    refused here, even when loading it fails: that is a pane saying which distribution
+    failed and why (§4b property 4), and a refusal would be the silent drop instead.
 
     **Neither refusal nor a crash exits.** Both end in `_hold`, which paints the reason
     into the pane and stays there, because a panel process that returns hands its pane
@@ -380,15 +454,32 @@ def run(slot: str, fid: str, *, once: bool = False) -> int:
     `KeyboardInterrupt` and `SystemExit` are how this process is MEANT to end, and
     swallowing either would hold a pane open against the operator killing it.
     """
-    if slot not in slots.SLOTS:
-        reason = (f"unknown slot {slot!r} "
+    if not slots.drawable(slot):
+        reason = (f"unknown slot {contain.one_line(repr(slot))} "
                   f"(known: {', '.join(sorted(slots.SLOTS))})")
         print(f"charter panel: {reason}", file=sys.stderr)
         return _hold(reason, once=once, rc=2)
 
+    from . import builtins as _builtins
+    cid = _builtins.component_id(slot)
     try:
-        return _watch(slot, fid, once=once)
+        painter = None
+        if cid in _builtins.SLOT_OF:
+            # One of charter's own, under either spelling: `slots.SLOTS` draws it,
+            # exactly as it has since there were four names and nothing else.
+            slot = _builtins.SLOT_OF[cid]
+        else:
+            reg = _builtins.build()
+            # The one production caller `Registry.place` was written for. It does not
+            # propagate a provider's failure: one that cannot be loaded becomes a standin
+            # component holding this pane and drawing the reason, which is what makes a
+            # missing or broken provider a message rather than a hole (§4b). Inside the
+            # `try` all the same — this is a stranger's distribution metadata being read,
+            # and the promise this function makes is that a panel PAINTS why it stopped.
+            reg.place(cid)
+            painter = _component_painter(reg, cid)
+        return _watch(slot, fid, once=once, paint=painter)
     except Exception as e:
-        reason = f"{slot} panel stopped ({type(e).__name__}: {e})"
+        reason = f"{contain.one_line(slot)} panel stopped ({type(e).__name__}: {e})"
         print(f"charter panel: {reason}", file=sys.stderr)
         return _hold(reason, once=once, rc=1)

--- a/charter/frame/registry.py
+++ b/charter/frame/registry.py
@@ -82,14 +82,19 @@ PROVIDER_GROUP = "charter.components"
 #: that has it, with a message in the one pane instead of the frame's geometry shifting
 #: under everything else.
 #:
-#: **No such caller exists yet, and that is deliberate** (§4b property 4, narrowed
-#: 2026-08-26). `instance.component_tables` refuses an arrangement naming a component
-#: charter cannot place, whole, rather than dropping the one placement — because every
-#: step from there to a painted pane still speaks the four committed SLOT NAMES
-#: (`layout._derive`, `layout.panel_command`'s `charter panel <slot>` argv,
-#: `frame/panel.py:run`), so a placement dropped here would be a panel silently absent
-#: with no pane to say why. Phase 2 builds the surface; this is what will be passed
-#: across it.
+#: **The caller is `frame/panel.py:run`, and it does not say** (§4b property 4). A panel
+#: process is handed one component NAME on its own command line and draws it into the pane
+#: tmux already split at the size the launcher already chose, so there is no rectangle left
+#: for it to pass and the pair here is what a standin's message is laid out in.
+#:
+#: The caller that DOES know is `instance.component_tables`, which resolves the committed
+#: `edge` and `size` — and it refuses the whole arrangement when nothing on this machine
+#: supplies the component, because charter cannot split a pane for a rectangle it has no
+#: placement for and a placement dropped there would be a panel silently absent with no
+#: pane to say why (#512, #535). What reaches a standin is therefore the case where the
+#: distribution IS installed and then fails: an import that raises, an API version charter
+#: does not speak, two claimants. Phase 1 had nowhere for that message to appear; the pane
+#: is it.
 STANDIN_EDGE = "bottom"
 #: Capped rather than open: the message is charter's, but the reason inside it quotes a
 #: provider's exception text, and an unbounded panel whose height an installed package
@@ -509,6 +514,12 @@ class Registry:
               size: Any = None) -> Component:
         """Put *cid* on this frame, importing the provider that supplies it if need be.
 
+        **`frame/panel.py:run` is what calls this in production**, once, when a panel
+        process resolves the component name on its own command line. It had none through
+        Phase 1 — every step between a committed table and a painted pane spoke the four
+        committed slot names, so nothing could ever ask for a component charter did not
+        write.
+
         **This never propagates a provider's failure**, and that is the point of it
         (§4b): a committed config naming `acme.metrics` on a machine without it, an
         installed provider that raises on import, a version charter does not speak, two
@@ -529,7 +540,9 @@ class Registry:
 
         Without them a loaded component keeps its own declaration and a standin takes
         :data:`STANDIN_EDGE` and :data:`STANDIN_SIZE` — "the caller did not say" is
-        ``None`` and only ``None``, in both directions.
+        ``None`` and only ``None``, in both directions. That is the shape a PANEL calls
+        this in (`frame/panel.py:run`): the pane is already split at the size the launcher
+        chose, so a panel has no rectangle to pass and asks only for the component.
 
         Already registered — a built-in, or a provider placed twice by a config listing
         it twice — answers what is registered rather than refusing: this asks for *cid*

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -1451,6 +1451,13 @@ ANIMATED = frozenset({"bottom"})
 def unimplemented(configured) -> list[str]:
     """Which of *configured* charter sizes and accepts but has no renderer for.
 
+    **A name, not a key of :data:`SLOTS`.** This is the filter a placed provider had to
+    survive and did not: it asked "is there a renderer in charter's own table", and a
+    component supplied by an installed distribution never is one, so every provider was
+    dropped before `panel_argvs` could split a pane for it. It asks the frame's question
+    now — *can anything draw this* — of which charter's own four renderers are one half
+    and `builtins.supplies` the other. Metadata only; nothing here imports a provider.
+
     Answers empty: every slot `instance.FRAME_SLOTS` accepts and `layout.SLOT_SIZE`
     sizes has a renderer in :data:`SLOTS`. It stayed non-empty for a whole release
     while `left`/`right` were sized but not drawn, and #488 closed the question from
@@ -1465,7 +1472,42 @@ def unimplemented(configured) -> list[str]:
     stays answered here, next to the registry that answers it, rather than
     three times over.
     """
-    return sorted({s for s in configured if s not in SLOTS})
+    return sorted({s for s in configured if not drawable(s)})
+
+
+def drawable(name) -> bool:
+    """Whether `charter panel <name>` has anything to draw — the ONE answer.
+
+    Four callers need it and must agree, which is why it is a function and not four
+    membership tests: :func:`unimplemented` (so a pane is not split for a name nothing can
+    fill), `frame/panel.py:run` (so a panel refuses rather than painting an empty pane),
+    and `commands_frame`'s two respawn guards (so a name charter cannot resolve never
+    reaches tmux config text). Two implementations of one question hide each other's
+    defects (#547), and this question now has a second half — a provider's component —
+    that all four have to see the same way.
+
+    A committed slot name and the component id behind it both answer yes, because they are
+    one component (`builtins.component_id`). A name an installed provider supplies answers
+    yes because its module can draw it. Everything else answers no, and the caller says so
+    where it can be read.
+
+    **A property, never a spelling.** `acme.metrics` is not admitted for having a dot in
+    it: it is admitted because a distribution on this machine declares it in the
+    `charter.components` entry point group. `top.` looks exactly as namespaced and is
+    refused, which is what keeps the respawn hook's guard a guard.
+    """
+    from . import builtins as _builtins
+    if not isinstance(name, str):
+        return False
+    if name in SLOTS:
+        return True
+    cid = _builtins.component_id(name)
+    if cid in _builtins.SLOT_OF:
+        # A built-in whose renderer has been taken out of :data:`SLOTS`. It does not fall
+        # through to the providers: a distribution declaring `sidebar` must not become
+        # the answer to a question about charter's own component.
+        return _builtins.SLOT_OF[cid] in SLOTS
+    return _builtins.supplies(cid)
 
 
 def render(slot: str, fid: str) -> str:

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -793,6 +793,24 @@ def component_tables(section) -> list[dict] | None:
     arrangement before anyone configures one, which is a `Registry.place` with nothing
     passed, not a config boundary reading a package.
 
+    **Present is not the same as usable, and the difference is what a charter command
+    costs.** The ``size`` is checked here rather than left to `Fixed`, because this
+    function runs on the IMPORT path: `config.derive` resolves ``FRAME`` *outside* the
+    try/except that catches a malformed charter.toml, so a `ComponentError` raised out of
+    `Fixed.__post_init__` does not degrade to the default frame — it takes down
+    `import charter.config`, and with it every command on that clone, ``charter
+    --version`` included. `size = 0`, `true`, `-4` and `"12"` each reach that raise if
+    this line does not answer first — `component.cells` refuses all four, ``bool``
+    explicitly, since `isinstance(True, int)` is `True` in Python and `Fixed(True)` would
+    otherwise mean `Fixed(1)`. So the two checks agree on the answer and differ on what it
+    costs: `cells` raises, which is right where a caller can catch it, and this returns
+    ``None``, which is the whole-arrangement degrade the rest of this function makes. That
+    is why ``bool`` is spelled out here as well and not left to the `isinstance(size,
+    int)` beside it. An ``edge`` outside `EDGES` is quieter and no more correct —
+    `layout._edge_of` falls through `_COLUMN_EDGES`/`_ROW_EDGES`/`_BEFORE_EDGES` and
+    `"sideways"` becomes a plain ``-v`` after-split, a pane on an edge nobody asked for.
+    A committed file arrives from someone else's machine; "committed" is not "trusted".
+
     **On a BUILT-IN, ``edge`` and ``size`` are still accepted only where charter can
     honour them, which means only at the component's own declaration.** `layout` derives
     the built-in geometry at import (`layout._derive`), so an ``edge = "top"`` on the repo

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -640,6 +640,13 @@ def frame_of(cfg: dict) -> dict:
     density declared the shipped default holds exactly as it did before.
     """
     out = dict(FRAME_DEFAULTS)
+    # Set before the early return, not only on the way out: a key present on one path and
+    # absent on another is two shapes for one answer, and `layout._placed_here` would then
+    # be reading a `KeyError` on exactly the planes that declare no `[frame]` section at
+    # all. Not in :data:`FRAME_DEFAULTS` because it is not a SETTING — nothing in the
+    # `[frame]` table is spelled `components`, and the generic type check below would read
+    # `[[frame.component]]`'s raw tables straight into it without resolving one.
+    out["components"] = []
     section = cfg.get("frame")
     if not isinstance(section, dict):
         return out
@@ -681,6 +688,13 @@ def frame_of(cfg: dict) -> dict:
     placed = component_tables(section)
     if placed is not None:
         out["slots"] = [p["slot"] for p in placed if p["visible"]]
+    # The arrangement itself, and not only the names it comes down to. `slots` carries
+    # what to split; a placement also carries WHERE and HOW BIG, which for a component
+    # charter did not write is a rectangle nothing else on this machine knows —
+    # `layout._placed_here` is what reads it back. Empty on every plane spelled with
+    # `slots`, which is charter's own: there is no per-plane rectangle to read, and
+    # `layout`'s shipped tables are the whole answer exactly as they were.
+    out["components"] = placed or []
     return out
 
 
@@ -692,31 +706,50 @@ FRAME_COMPONENT_KEY = "component"
 
 #: Every key a ``[[frame.component]]`` table may carry, and the whole of the form.
 #:
-#: * ``use`` — the component id, which is `frame/builtins.py`'s vocabulary and NOT
-#:   ``slots``' one: `identity`, `attention`, `repos`, `sidebar`. The two names for one
-#:   panel exist because `slots` is committed on every plane that has a charter.toml and
-#:   `charter panel <slot>` is a tmux argv (`builtins.SLOT_OF` is the one table between
-#:   them); `use` is the new vocabulary and does not accept the old spelling, so a file
-#:   says which of the two it is written in.
-#: * ``edge`` — which side of the harness it attaches to.
+#: * ``use`` — a component id, which is `frame/builtins.py`'s vocabulary and NOT
+#:   ``slots``' one: charter's own four are `identity`, `attention`, `repos`, `sidebar`,
+#:   and anything else is a component an installed distribution supplies. The two names
+#:   for one built-in panel exist because `slots` is committed on every plane that has a
+#:   charter.toml and `charter panel <slot>` is a tmux argv (`builtins.SLOT_OF` is the one
+#:   table between them); `use` does not accept the old spelling, so a file says which of
+#:   the two it is written in.
+#: * ``edge`` — which side of the harness it attaches to. Optional on one of charter's
+#:   own and REQUIRED on anything else, with ``size``: see :func:`component_tables`.
 #: * ``size`` — how many cells it is given, for a component whose size is `Fixed`.
 #: * ``visible`` — whether it is drawn at all. The one key `slots` could only express by
 #:   deleting a name, which loses the position with it.
 FRAME_COMPONENT_FIELDS = ("use", "edge", "size", "visible")
 
 
-def _placement(reg, cid: str, *, visible: bool = True) -> dict:
+def _placement(cid: str, *, edge: str, size, visible: bool = True) -> dict:
     """One resolved placement: the component, where it sits, how big, and whether drawn.
+
+    **The one place a placement is spelled**, which is why the rectangle is passed in
+    rather than read here: it comes from the component's own declaration for a built-in
+    and from the committed table for a provider, and a second dict literal on the second
+    path is the two-implementations shape that let the test harness keep a worse copy of
+    what runs charter (#547).
 
     ``size`` is the size POLICY (`component.Fixed`/`Content`/`Fill`), not a number.
     Turning a policy into cells is `layout`'s job and it does it in one place
-    (`layout._cells`); a second answer here is the two-implementations shape that let the
-    test harness keep a worse copy of what runs charter (#547).
+    (`layout._policy_cells`).
+
+    ``slot`` is the name this placement TRAVELS under — into `frame_of`'s slot list, into
+    `layout`'s per-name geometry, and into `charter panel <name>`'s argv. A built-in
+    travels under its committed spelling, because that argv and that config key exist on
+    every plane that has a charter.toml; a component charter did not write has no
+    committed spelling and travels under its id, which is the whole of "a component id is
+    the frame's currency".
     """
-    c = reg.get(cid)
     from .frame import builtins as _builtins
-    return {"use": cid, "slot": _builtins.SLOT_OF[cid], "edge": c.edge, "size": c.size,
-            "visible": visible}
+    return {"use": cid, "slot": _builtins.SLOT_OF.get(cid, cid), "edge": edge,
+            "size": size, "visible": visible}
+
+
+def _built_in_placement(reg, cid: str, *, visible: bool = True) -> dict:
+    """:func:`_placement` for one of charter's own, in the rectangle it declares."""
+    c = reg.get(cid)
+    return _placement(cid, edge=c.edge, size=c.size, visible=visible)
 
 
 def component_tables(section) -> list[dict] | None:
@@ -736,38 +769,45 @@ def component_tables(section) -> list[dict] | None:
     the one `slots` describes: the operator sees their arrangement ignored, which is a
     visible, whole-frame difference, rather than one pane's worth of quiet fiction.
 
-    **Task 7 was expected to replace that for the one case it could improve — a component
-    named here with no provider installed getting a MESSAGE in its own pane while the rest
-    of the frame draws — and it does not, deliberately (decided 2026-08-26, §4b property
-    4).** The message has nowhere to appear. `frame.registry.Registry.place` builds the
-    standin and holds the rectangle for it, but every step from here to a painted pane
-    still speaks the four committed SLOT NAMES rather than component ids: this function's
-    own `SLOT_OF` check, :func:`frame_of`'s filter against :data:`FRAME_SLOTS`,
-    `layout._derive`'s `SLOT_OF` keying (a `KeyError` by design for a component with no
-    slot name), `layout.panel_command`'s `charter panel <slot>` argv, and
-    `frame/panel.py`'s refusal of a slot `slots.SLOTS` has no renderer for. Dropping the
-    placement here would therefore be a panel silently absent with no pane to say why —
-    #512 and #535's failure, wearing Task 7's clothes. Refusing whole is the version of
-    the principle charter can actually keep, and the surface that turns the other one on
-    is Phase 2's.
+    **A provider's component is placeable here as of Phase 2, and that is what this
+    function was blocking** (§4b property 4). It used to refuse any ``use`` outside
+    `builtins.SLOT_OF` — charter's own four — because a placement dropped downstream would
+    have been a panel silently absent with no pane to say why: every step from here to a
+    painted pane spoke the four committed slot names. Those steps speak component ids now
+    (`layout._derive`, `layout.panel_argvs`, `frame/slots.py:drawable`,
+    `frame/panel.py:run`), so a component an installed distribution supplies is placed,
+    split for, and drawn — and a provider that then fails to load costs its own pane and
+    says why, which is where §4b's message finally has a surface to live on.
 
-    **``edge`` and ``size`` are accepted only where charter can honour them, which today
-    means only at the component's own declaration.** `layout` derives the whole frame's
-    geometry from those declarations (`layout._derive`), and nothing between here and
-    `split-window` carries a per-plane override yet — so an ``edge = "top"`` on the repo
+    **A provider this machine has no distribution for still refuses the arrangement
+    whole**, and #535 is why that half did not change: charter cannot honour a rectangle
+    for a component it cannot find, and dropping the one table would hand the operator a
+    frame with a panel missing from it.
+
+    **A provider's placement carries its own ``edge`` and ``size``, and both are
+    required.** `config.FRAME` is resolved by every charter command, `charter --version`
+    included, and the only way to ask a provider where it would like to sit is to IMPORT
+    it — so a table that does not say is one charter would have to run a stranger's code
+    to resolve, on every command, before anything was drawn. §4b's own example writes both
+    keys. `default_edge`/`default_size` remain what they are documented as: a sensible
+    arrangement before anyone configures one, which is a `Registry.place` with nothing
+    passed, not a config boundary reading a package.
+
+    **On a BUILT-IN, ``edge`` and ``size`` are still accepted only where charter can
+    honour them, which means only at the component's own declaration.** `layout` derives
+    the built-in geometry at import (`layout._derive`), so an ``edge = "top"`` on the repo
     table would be a value read, validated, stored and then ignored, and the frame would
     draw exactly as if the line were not there. A config key that changes nothing is
-    exactly the convincing empty this phase was written against, so a value charter would
-    not honour refuses the arrangement instead of being quietly absorbed. What the pair IS
-    good for meanwhile is writing the arrangement out in full: `frame_components` answers
-    every `slots` list as tables that resolve back to the same frame, which is what makes
-    the mapping lossless in both directions.
+    exactly the convincing empty this phase was written against. What the pair IS good for
+    meanwhile is writing the arrangement out in full: `frame_components` answers every
+    `slots` list as tables that resolve back to the same frame, which is what makes the
+    mapping lossless in both directions.
     """
     tables = section.get(FRAME_COMPONENT_KEY) if isinstance(section, dict) else None
     if not isinstance(tables, list) or not tables:
         return None
     from .frame import builtins as _builtins
-    from .frame.component import Fixed
+    from .frame.component import EDGES, Fixed
     reg = _builtins.build()
     out: list[dict] = []
     seen: set[str] = set()
@@ -777,22 +817,31 @@ def component_tables(section) -> list[dict] | None:
         if any(k not in FRAME_COMPONENT_FIELDS for k in table):
             return None
         cid = table.get("use")
-        # A component charter cannot place — a typo, a provider this machine has not
-        # installed, or `slots`' vocabulary written into `use` by mistake.
-        if not isinstance(cid, str) or cid not in _builtins.SLOT_OF or cid in seen:
+        if not isinstance(cid, str) or cid in seen:
             return None
         seen.add(cid)
-        c = reg.get(cid)
-        if "edge" in table and table["edge"] != c.edge:
-            return None
-        if "size" in table and not (isinstance(c.size, Fixed)
-                                    and table["size"] == c.size.n
-                                    and not isinstance(table["size"], bool)):
-            return None
         visible = table.get("visible", True)
         if not isinstance(visible, bool):
             return None
-        out.append(_placement(reg, cid, visible=visible))
+        if cid in _builtins.SLOT_OF:
+            c = reg.get(cid)
+            if "edge" in table and table["edge"] != c.edge:
+                return None
+            if "size" in table and not (isinstance(c.size, Fixed)
+                                        and table["size"] == c.size.n
+                                        and not isinstance(table["size"], bool)):
+                return None
+            out.append(_built_in_placement(reg, cid, visible=visible))
+            continue
+        # Not one of charter's own: a component id, which is placeable exactly when an
+        # installed distribution declares it. Asked of entry point METADATA — nothing is
+        # imported here, and a machine without the distribution refuses the arrangement
+        # rather than drawing a frame with a hole where the panel was.
+        edge, size = table.get("edge"), table.get("size")
+        if (not reg.providers.supplies(cid) or edge not in EDGES
+                or not isinstance(size, int) or isinstance(size, bool) or size < 1):
+            return None
+        out.append(_placement(cid, edge=edge, size=Fixed(size), visible=visible))
     return out
 
 
@@ -827,7 +876,7 @@ def frame_components(cfg: dict) -> list[dict]:
         return placed
     from .frame import builtins as _builtins
     reg = _builtins.build()
-    return [_placement(reg, _builtins.COMPONENT_OF[slot])
+    return [_built_in_placement(reg, _builtins.COMPONENT_OF[slot])
             for slot in frame_of(cfg)["slots"]]
 
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -555,22 +555,78 @@ That is the one thing `slots` cannot express. Deleting a name from `slots` loses
 *position* along with it, so turning the panel back on later means remembering where in the
 order it went; `visible = false` keeps the order and turns off the panel.
 
-`edge` and `size` may be written down, and today they may only say what the component
-already declares — `edge = "right"` and `size = 22` on the sidebar, `edge = "top"` on
-identity. Charter derives the whole frame's geometry from those declarations, and nothing
-between `charter.toml` and tmux carries a per-plane override yet, so a value charter cannot
-honour is not quietly accepted and ignored: it takes the arrangement out of play. Writing
-them is still worth it if you like your config explicit — and it is what makes the two
-forms round-trip.
+For one of charter's own four, `edge` and `size` may be written down and may only say what
+the component already declares — `edge = "right"` and `size = 22` on the sidebar, `edge =
+"top"` on identity. Charter derives the built-in geometry from those declarations, and
+nothing between `charter.toml` and tmux carries a per-plane override for them, so a value
+charter cannot honour is not quietly accepted and ignored: it takes the arrangement out of
+play. Writing them is still worth it if you like your config explicit — and it is what
+makes the two forms round-trip.
+
+### A component charter did not write
+
+`use` is a component id, and not every component id is one of charter's four. A Python
+distribution you install can supply one:
+
+```toml
+[project.entry-points."charter.components"]
+"acme.metrics" = "acme_charter.metrics:Component"
+```
+
+With that installed, your arrangement can place it:
+
+```toml
+[[frame.component]]
+use  = "identity"
+
+[[frame.component]]
+use  = "acme.metrics"
+edge = "right"
+size = 12
+
+[[frame.component]]
+use  = "attention"
+```
+
+File order is split order here as everywhere else, so `acme.metrics` is split off before
+the attention strip and the strip is inset beside it.
+
+**`edge` and `size` are required here, and they win.** Required, because the only way to
+ask a package where it would like to sit is to import it — and your config is resolved by
+`charter --version` as much as by `charter frame`, so charter will not run a stranger's
+code to answer a geometry question on every command. And they win, because your
+`charter.toml` is committed and shared: a package's own preference overruling it would mean
+one file drawing two different frames on two machines depending on what happens to be
+installed. Arrangement is committed; execution is local.
+
+**Charter never runs code your config names.** `use` is a *name*, resolved against what is
+installed on this machine. If nothing supplies it, nothing runs and your arrangement is
+refused — which is the whole reason components bind by name rather than by a `command =
+"…"` string.
+
+If the package is installed and then goes wrong — it raises when imported, it speaks a
+component API charter does not, two packages claim the same id, or its `render` throws —
+that costs **its own pane and nothing else**. The pane names the distribution and says what
+happened, and the rest of your frame draws around it.
+
+You can run one by hand, which is what charter itself runs in the pane:
+
+```
+charter panel acme.metrics --session <frame-id>
+```
+
+That takes a component id — or one of the four slot names, which are shorthand for the
+built-in ids, so `charter panel identity` and `charter panel top` draw the same strip.
 
 **An arrangement charter cannot draw is refused whole, and your frame falls back to
 `slots`.** Not one table at a time — dropping just the line charter could not make sense of
 would hand you a frame with a panel silently missing from it, and a missing repo table is a
-plane that looks like it has no clones. So a component charter has never heard of, an edge
-it cannot place, a duplicate, a key that is not one of the four, or a `visible` that is not
-`true`/`false` all mean the same thing: the arrangement is ignored and you get the frame
-your `slots` (or `density`, or the default) describes. You see your whole arrangement not
-take effect, which is something you can act on, rather than one pane's worth of quiet
+plane that looks like it has no clones. So a component charter has never heard of and no
+installed distribution supplies, an edge it cannot place, a duplicate, a key that is not
+one of the four, a provider placed without an `edge` and a `size`, or a `visible` that is
+not `true`/`false` all mean the same thing: the arrangement is ignored and you get the
+frame your `slots` (or `density`, or the default) describes. You see your whole arrangement
+not take effect, which is something you can act on, rather than one pane's worth of quiet
 fiction.
 
 Precedence, most explicit first: `[[frame.component]]`, then an explicit `slots`, then

--- a/docs/news/unreleased-a-component-someone-else-wrote-can-draw-a-pane.md
+++ b/docs/news/unreleased-a-component-someone-else-wrote-can-draw-a-pane.md
@@ -1,0 +1,75 @@
+---
+version: unreleased
+headline: A component someone else wrote can draw a pane
+---
+
+Charter could already find a component an installed package supplies, load it, check its
+API version, refuse two packages claiming one name and stand in for one that failed. What
+it could not do was **draw it**. Every step between a `[[frame.component]]` table and a
+real tmux pane spoke the four committed slot names — `top`, `bottom`, `repos`, `right` —
+so a component with no slot name fell out somewhere between your config and your screen,
+silently, on every path.
+
+Those steps speak a component **id** now. `charter panel <component-id>` is the argv a
+panel pane runs, and a panel process resolves that id itself.
+
+## Placing one
+
+A provider is a Python distribution that declares a component:
+
+```toml
+[project.entry-points."charter.components"]
+"acme.metrics" = "acme_charter.metrics:Component"
+```
+
+Install it, and your `charter.toml` can put it on the frame:
+
+```toml
+[[frame.component]]
+use  = "identity"
+
+[[frame.component]]
+use  = "acme.metrics"
+edge = "right"
+size = 12
+
+[[frame.component]]
+use  = "attention"
+```
+
+File order is split order, as it already was. The pane is split at the edge and size **your
+file** asks for, not the ones the package would prefer — arrangement is committed,
+execution is local, and a committed file has to draw the same frame on every machine.
+
+**`edge` and `size` are required for a component charter did not write.** The only way to
+ask a package where it would like to sit is to import it, and `charter --version` resolves
+your config too; charter will not run a stranger's code to answer a geometry question on
+every command. Charter's own four still take theirs from their own declaration, and still
+refuse a table that disagrees with it.
+
+## When it does not work
+
+**A component no installed distribution supplies refuses the whole arrangement**, exactly
+as an unknown name always did, and the frame falls back to `slots`. Charter cannot place a
+rectangle for a component it cannot find, and dropping just that one table would hand you a
+frame with a panel silently missing from it.
+
+**A provider that is installed and then fails costs its own pane and nothing else.** An
+import that raises, an API version charter does not speak, two distributions claiming one
+id, a `render` that throws — each of those is now a pane naming the distribution and the
+reason, with the rest of the frame drawn around it. That is the surface the standin was
+built for last release and had nowhere to appear on.
+
+## The slot names
+
+`slots = ["top", "bottom", "repos", "right"]` still launches exactly the frame it always
+did, and `charter panel top` is still the argv charter emits for the identity strip. Those
+four names are shorthand for four built-in ids now — `identity`, `attention`, `repos`,
+`sidebar` — and either spelling reaches the same component, so `charter panel identity`
+draws what `charter panel top` draws.
+
+## What to do
+
+Nothing, unless you have a component provider to install. Every `slots` list, every
+`density` level and every `[[frame.component]]` arrangement resolves to exactly the frame
+it resolved to before — same panels, same split order, same widths, same rows.

--- a/docs/superpowers/specs/2026-08-25-agentic-ide-foundation.md
+++ b/docs/superpowers/specs/2026-08-25-agentic-ide-foundation.md
@@ -199,6 +199,29 @@ its symptom is one committed table drawing two different frames on two machines 
 on whether a package happens to be installed. Charter shipped exactly that inversion once
 in `Registry.place` (§4i).
 
+**Where they apply, exactly: `Registry.place` with no rectangle passed, and nowhere else.**
+They are a *runtime* default, read from the loaded component, and the config boundary never
+reads them — so a `[[frame.component]]` table naming a provider must carry **both** `edge`
+and `size`, and one that omits either is refused whole (`instance.component_tables` answers
+`None` and the frame falls back). That is not an oversight to be tidied up later. Filling a
+missing key from the provider's declaration means *importing a stranger's module to answer a
+geometry question*, and `config.FRAME` is resolved at `import charter.config` — on `charter
+--version` as much as on `charter frame`. The choice is between a table that says what it
+wants and a package import on every command, and it is the table.
+
+**The same boundary refuses a rectangle it cannot honour**, not only an absent one: `size`
+must be a whole number of cells of at least 1 — a `bool` is not one, because
+`isinstance(True, int)` is `True` in Python and `Fixed(True)` would otherwise mean
+`Fixed(1)` — and `edge` must be one of the four. `component.cells` already refuses every
+one of those sizes, and the boundary still checks them itself, because the two differ in
+what the refusal *costs*. This is a guard on the **import path**: `derive` resolves `FRAME`
+outside the try/except that catches a malformed charter.toml, so a `ComponentError` from
+`Fixed` does not degrade to the default frame — it takes down every charter command on that
+clone, `charter --version` included. Checked here, the same value is a `None` and the whole
+arrangement falls back to `slots`, which is what every other unusable value in that table
+already does. A committed file arrives from someone else's machine; "committed" is not
+"trusted".
+
 ### Four properties that must survive a stranger's code
 
 These are what make the extension model real rather than a hole:

--- a/tests/test_component_id_is_the_currency.py
+++ b/tests/test_component_id_is_the_currency.py
@@ -43,6 +43,17 @@ is never used; `_derive` is only ever handed charter's own components, which hav
 committed spelling for the fallback to skip; `slot_sizes` is called by one case, on a
 frame with no provider in it. A test that cannot fail is not a pin, and this repo has
 shipped that kind believing it was the other.
+
+**And the paragraph above was itself a claim, not a measurement, the first time it was
+written.** The commit that added those twelve cases said *every* guard this branch adds is
+a line a test goes red without, and left six more of its own standing: `run`'s
+unknown-slot refusal loses its clip and stderr grows from 227 bytes to 5071; `_placed_here`
+— a function this branch added whole — has both halves of its only guard, its read of
+`config.FRAME` and the `_policy_cells` fallback below it survive deletion; and
+`panel_argvs`' last resort emits `-l None` to `split-window` when it is taken out. The
+last four classes here are those six, and the same sweep was run on every one of them
+before this sentence was written rather than after. The lesson is the sweep's scope: it
+has to cover the lines the FIX added, not only the lines the review named.
 """
 
 from __future__ import annotations
@@ -57,7 +68,7 @@ import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from unittest import mock
 
-from charter import commands_frame, config, instance, tui
+from charter import commands_frame, config, contain, instance, tui
 from charter.frame import builtins, component, layout, panel, slots
 
 from tests._isolation import PersonaIso
@@ -794,3 +805,213 @@ class TheProviderNameThatReachesThePaneIsContained(PersonaIso, unittest.TestCase
         self.assertIn("\\x1b", err)
         self.assertNotIn("acme.m panel stopped", painted)
         self.assertIn("\\x1b", painted)
+
+
+class TheNameARefusalRepeatsBackIsClipped(PersonaIso, unittest.TestCase):
+    """`run`'s OTHER containment call — the unknown-slot refusal, on an unreadable name.
+
+    The twin two lines below it is `TheProviderNameThatReachesThePaneIsContained` above,
+    and this line's argument is the same one word for word: **stderr is the surface with
+    no other guard.** The pane copy goes through `_hold`, whose `tui.truncate` bounds it
+    to the pane whatever it is handed; `print(..., file=sys.stderr)` ships exactly what it
+    is given, and `charter panel <name>` is run by hand with stdout redirected often
+    enough that `_DEFAULT_ROWS` exists for it.
+
+    **What `contain.one_line` uniquely adds HERE is the clip, not the escaping.** The
+    value is already inside a `repr()`, and `repr` escapes ESC, newline, tab, the
+    bidirectional overrides and the zero-width joiners on its own — so a hostile name
+    reaches stderr contained either way and a case built on an escape would pass with this
+    call deleted. What `repr` does not do is stop: it repeats the whole name back, and a
+    name is not a value charter chose. `builtins.supplies` reads a stranger's
+    `entry_points.txt`, and a 5000-character entry point name is a legal one.
+
+    Asked at two lengths, because a single length can only show that the line is not one
+    particular size. The property is that the line does not grow with its input at all —
+    which is `DISPLAY_LIMIT`'s own docstring ("a budget a longer input makes longer is not
+    a budget"), asked of the one call site that had no case.
+    """
+
+    #: The whole sentence after the clipped name. Asserted because a clip that ate the
+    #: sentence's own end would leave the operator a name and no list to compare it to,
+    #: which is the confidently-truncated answer rather than the contained one.
+    _TAIL = f"(known: {', '.join(sorted(slots.SLOTS))})"
+
+    def test_the_refusal_does_not_grow_with_the_name_it_refuses(self):
+        lengths = set()
+        for chars in (5_000, 20_000):
+            with self.subTest(chars=chars):
+                rc, painted, err = _painted("acme." + "A" * chars)
+                self.assertEqual(rc, 2, painted)
+                self.assertIn("acme.AAAA", err,
+                              "the refusal stopped naming what it refused")
+                self.assertTrue(err.rstrip("\n").endswith(self._TAIL), err[-80:])
+                self.assertLess(len(err), 2 * contain.DISPLAY_LIMIT,
+                                "a committed value owns the operator's terminal")
+                lengths.add(len(err))
+        self.assertEqual(len(lengths), 1,
+                         f"the line is a function of the name's length: {sorted(lengths)}")
+
+
+class WhatThisPlanePlacedIsReadBackAndCharterOwnIsNot(unittest.TestCase):
+    """`layout._placed_here`, which is how a plane's own rectangle reaches every caller.
+
+    The function is this branch's, and every line of it was unpinned: it is read only by
+    `_edge_of` and `_size_of`, both of which consult the shipped tables FIRST — so for the
+    four names charter writes, what this returns is never looked at, and for every other
+    name charter's own committed frame places nothing at all. Its guards and that ordering
+    were protecting each other: delete either one and the suite stayed green, because the
+    other made it unobservable. **Two lines that hide each other's absence are not a pin,
+    so both are asked here** — that this never offers a built-in, and that `_edge_of` and
+    `_size_of` would not take one if it did.
+
+    `config.FRAME` is patched rather than a plane written to disk because this function
+    reads that mapping and nothing else, and because two of the four cases below are
+    shapes `instance.component_tables` refuses to build — which is the point of asking
+    them: this is the second reader of a value the config boundary already validated, and
+    a reader that raises on a shape it was not expecting is a `TypeError` from inside a
+    lookup, half a frame away from the line that was wrong.
+    """
+
+    #: The four built-ins spelled as `[[frame.component]]` tables — the arrangement a
+    #: plane writes the moment it wants to add a fifth component and has to name the four
+    #: it already had. Resolved through `instance.frame_of` rather than typed out, so the
+    #: rectangles are the ones the config boundary actually produces.
+    def _four_built_ins(self) -> dict:
+        frame = instance.frame_of({"frame": {"component": [
+            {"use": "identity"}, {"use": "attention"},
+            {"use": "repos"}, {"use": "sidebar"}]}})
+        self.assertEqual(frame["slots"], ["top", "bottom", "repos", "right"])
+        self.assertEqual(len(frame["components"]), 4, "the fixture placed nothing")
+        return frame
+
+    def test_a_built_in_a_plane_spelled_out_is_not_read_back_as_a_plane_placement(self):
+        """`Only names the shipped tables do not already carry`, which is the whole of
+        what keeps `layout`'s five tables the single answer for charter's own four. A
+        plane that spells them out is placing four components with edges and sizes, and
+        every one of them would otherwise land in this map beside the table entry it
+        duplicates — two answers to "how wide is `right`", which is #500 exactly.
+        """
+        with mock.patch.dict(config.FRAME, self._four_built_ins()):
+            self.assertEqual(layout._placed_here(), {})
+
+    def test_the_shipped_tables_win_over_a_placement_that_claims_a_built_in(self):
+        """The other half of that pair, and asked with the guard above stubbed out —
+        because with it in place this map can never hold a built-in, so the ordering
+        inside `_edge_of` and `_size_of` is unobservable and a case that did not stub it
+        would pass against either order.
+
+        `instance.component_tables` refuses a `[[frame.component]]` table that moves or
+        resizes one of charter's own, so this arrangement cannot be committed today. That
+        is what makes it the right question to ask here: the refusal is at the config
+        boundary, and this is the line that means `layout` does not depend on it having
+        happened.
+        """
+        moved = {"right": ("bottom", 3), "repos": ("top", 9), "top": ("right", 40)}
+        with mock.patch.object(layout, "_placed_here", return_value=moved):
+            self.assertEqual(layout._edge_of("right"), "right")
+            self.assertEqual(layout._size_of("right"), layout.SLOT_SIZE["right"])
+            self.assertEqual(layout._edge_of("repos"), "bottom")
+            self.assertEqual(layout._size_of("repos"), layout.SLOT_SIZE["repos"])
+            self.assertIs(layout._is_fixed_row("repos"), False)
+            self.assertIs(layout._is_fixed_row("top"), True)
+
+    def test_a_placement_whose_name_is_not_text_costs_only_its_own_entry(self):
+        """A `[[frame.component]]` table's `use` arrives from someone else's machine, and
+        `charter.toml` is TOML — `use = ["sidebar"]` is one keystroke away and a list is
+        not hashable. Without the `isinstance`, the membership test on the next token
+        raises `TypeError` from inside `layout`, and it takes the whole arrangement with
+        it: the provider placed BESIDE the malformed table never reaches the map, so a
+        frame loses a pane it could have drawn over a value it could have skipped.
+
+        The bad tables come first for that reason — under a `_placed_here` with no
+        `isinstance` this raises before the good one is ever read.
+        """
+        components = [{"slot": ["right"], "edge": "right", "size": component.Fixed(9)},
+                      {"slot": None, "edge": "bottom", "size": component.Fixed(2)},
+                      {"slot": 7, "edge": "top", "size": component.Fixed(1)},
+                      {"slot": CID, "edge": "right", "size": component.Fixed(12)}]
+        with mock.patch.dict(config.FRAME, {"components": components}):
+            self.assertEqual(layout._placed_here(), {CID: ("right", 12)})
+            self.assertEqual(layout._edge_of(CID), "right")
+            self.assertEqual(layout._size_of(CID), 12)
+
+    def test_a_frame_mapping_that_carries_no_arrangement_is_an_empty_one(self):
+        """`instance.frame_of` sets `components` on every path — the early return
+        included, which is `TheFrameHasOneShapeWhateverTheConfigSaid` above — so this is
+        the same property stated a second time, at the reader instead of at the writer.
+        It is stated twice on purpose: this is the only one of `config.FRAME`'s keys read
+        with a `.get`, and the reason is that it is the only one that is not a SETTING
+        with a default in `instance.FRAME_DEFAULTS`. A key `frame_of` computes is a key a
+        later `frame_of` can stop computing, and the cost of that here is every `charter
+        frame` command raising `KeyError` on a plane with no `[frame]` section at all.
+        """
+        for frame, label in (({}, "no components key"), ({"components": None}, "None")):
+            with self.subTest(frame=label):
+                with mock.patch.dict(config.FRAME, frame, clear=not frame):
+                    self.assertEqual(layout._placed_here(), {})
+                    self.assertIsNone(layout._edge_of(CID))
+                    self.assertEqual(layout._edge_of("top"), "top")
+
+
+class ASplitIsRefusedRatherThanSizedByANonNumber(unittest.TestCase):
+    """`panel_argvs`' last resort, and what taking it out puts on tmux's command line.
+
+    *sizes* is read with a PER-SLOT fallback so a map missing one entry degrades to the
+    shipped floor instead of raising inside a launch — and the floor is a `dict`, so it is
+    still a `KeyError` for a name nothing placed. The comment on that line calls the
+    alternative "the permanently-dead rectangle `_drawable_slots` exists to prevent", and
+    with the line deleted the alternative is literal: `size` stays `None`, `str(None)` is
+    `"None"`, and `split-window -l None` is what tmux is handed — a launch that has
+    already split some of its panes failing on the argument list of the next one.
+    """
+
+    _PANELS = dict(session="f-1", socket="testsock", harness_pane="%3")
+
+    def test_a_slot_nothing_can_size_stops_the_plan_rather_than_sizing_it_None(self):
+        with self.assertRaises(KeyError):
+            layout.panel_argvs(slots=["top", "nope"], sizes={}, **self._PANELS)
+
+    def test_a_sizes_map_missing_one_entry_still_splits_it_at_the_shipped_floor(self):
+        """The other side of the same two lines: the fallback exists because it fires,
+        and a `KeyError` for `top` would be this function refusing the frame charter
+        itself ships."""
+        [cmd] = layout.panel_argvs(slots=["top"], sizes={}, **self._PANELS)
+        self.assertEqual(cmd[cmd.index("-l") + 1], str(layout.SLOT_SIZE["top"]))
+
+
+class ASizePolicyBecomesCellsByOneRuleStatedOnce(unittest.TestCase):
+    """`_policy_cells` and `_cells` are the same sentence about two spellings of a size.
+
+    `_cells` is handed a COMPONENT and `_policy_cells` a size POLICY, which is why there
+    are two of them: `_placed_here` reads the resolved `[[frame.component]]` table, and a
+    placement carries the policy without the component. What they must never be is two
+    RULES — the number this one returns is the number that reaches `split-window -l` for a
+    component this plane placed, and the number `_cells` returns is the one in
+    `layout.SLOT_SIZE` for the components charter wrote, and a frame in which those two
+    disagree is a stack sized in two different units.
+
+    So they are asked together rather than separately, and across every policy
+    `frame/component.py` defines. Only `Fixed` is reachable through
+    `instance.component_tables` today, which refuses a `[[frame.component]]` table whose
+    `size` is not a number — that is exactly why the non-`Fixed` half needs a case here
+    rather than none: it is the half nothing else on this machine can reach, and without
+    it `_policy_cells` is not the rule `_cells` states but only the first line of it.
+    """
+
+    def test_a_policy_and_a_component_carrying_it_answer_the_same_number(self):
+        for size in (component.Fixed(1), component.Fixed(22), component.Content(),
+                     component.Content(cap=9), component.Fill()):
+            with self.subTest(size=size):
+                whole = component.Component(
+                    id=CID, title="Metrics", edge="right", size=size,
+                    needs=(), events=(), render=lambda ctx: [_DREW])
+                self.assertEqual(layout._policy_cells(size), layout._cells(whole))
+
+    def test_a_pane_whose_height_is_its_content_is_still_worth_one_cell(self):
+        """The floor itself, stated as a number rather than only as an agreement: a
+        `Content` or `Fill` pane has no answer to give before anything has measured it,
+        and `component.cells` refuses a size below one cell because a panel nobody can
+        see is a panel nobody asked for."""
+        for size in (component.Content(), component.Content(cap=9), component.Fill()):
+            with self.subTest(size=size):
+                self.assertEqual(layout._policy_cells(size), 1)

--- a/tests/test_component_id_is_the_currency.py
+++ b/tests/test_component_id_is_the_currency.py
@@ -1,0 +1,410 @@
+"""A component id is what the frame is made of, end to end — config to painted pane.
+
+Phase 1 built the registry, the provider seam and the standin, and then found that none
+of it could reach a pane: `Registry.place` had **zero production callers**, because every
+step between a committed `[[frame.component]]` table and a `split-window` spoke the four
+committed SLOT NAMES instead. A provider could be placed and never drawn, which is the
+one property §4b exists to deliver.
+
+**These cases are the chain, one link each**, and they are written against a real
+installed distribution (`tests.test_component_providers._SitePackages` — a real
+`.dist-info`, a real `entry_points.txt`, a real module on `sys.path`) rather than a
+stubbed `entry_points`, for the reason that file's own docstring gives: a stub proves the
+stub works.
+
+* `instance.component_tables` **places** the provider's component, honouring the
+  committed rectangle (§4i: arrangement is committed, execution is local).
+* `commands_frame._drawable_slots` **keeps** it, where `slots.unimplemented` used to drop
+  every name `frame/slots.py` has no renderer for.
+* `layout` **sizes and splits** it — the `-h`/`-v`, the `-b` and the `-l` come off the
+  component's own edge and the committed size, not off a table of four names.
+* `charter panel <component-id>` **draws** it, in a panel process that builds its own
+  registry. That is the link the coordinator's note calls the hardest, and it is why
+  `panel.run` takes a component NAME now rather than a key of `slots.SLOTS`.
+
+**Nothing here asserts about the machine's own providers.** Every case asks about an id
+its own fixture installed, so a laptop carrying a real charter component provider gives
+the answer CI gives.
+
+**And the committed spelling still resolves to the frame it always did.** `[frame] slots`
+is shorthand for four built-in ids now, and `CharterOwnConfigIsUnchanged` reads charter's
+OWN `charter.toml` off disk and pins the whole resolved arrangement — because a change
+that silently removed the repo table from charter's own plane shipped once (#535) and was
+caught by a reviewer, not by a test.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import pathlib
+import sys
+import tomllib
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from unittest import mock
+
+from charter import commands_frame, config, instance
+from charter.frame import builtins, component, layout, panel, slots
+
+from tests._isolation import PersonaIso
+from tests.test_component_providers import CID, ENTRY, MODULE, _SitePackages, _source
+
+#: charter's own committed file, read off disk rather than through `config` — which
+#: resolves a WORKTREE back to the main tree it was cut from and would therefore test the
+#: operator's checkout instead of this one. Same reason `tests/test_frame_config.py`
+#: reads it this way.
+_COMMITTED = pathlib.Path(__file__).resolve().parents[1] / "charter.toml"
+
+#: What the provider below draws, and a string no built-in renderer could produce.
+_DREW = "metrics 42"
+
+
+def _installed(case, *, render: str = f"lambda ctx: [{_DREW!r}]", head: str = "") -> None:
+    """Put one real provider distribution supplying :data:`CID` on ``sys.path``."""
+    site = _SitePackages(case)
+    site.install("acme-charter", "1.0", {CID: ENTRY},
+                 {MODULE: _source(render=render, head=head)})
+    return site
+
+
+def _painted(name: str, fid: str = "f-1", *, cols: int = 40, rows: int = 6):
+    """`charter panel <name>` for one pass, and what it actually put on the pane.
+
+    The pane's own tty is faked rather than inherited: `slots._width` measures
+    `os.get_terminal_size(sys.stdout.fileno())`, and a captured `StringIO` has no fileno
+    at all — the same fixture `tests/test_frame_panel.py` uses for exactly this.
+    """
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        with mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+             mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, rows))):
+            rc = panel.run(name, fid, once=True)
+    painted = out.getvalue()
+    return rc, painted.split("\x1b[2J", 1)[-1], err.getvalue()
+
+
+class APanelDrawsAProvidersComponent(PersonaIso, unittest.TestCase):
+    """The link Phase 1 could not build: a panel process finding a component from an id.
+
+    A panel builds no registry today and knows no providers — it looks its argument up in
+    `slots.SLOTS`, a dict of four functions charter wrote. So `charter panel acme.metrics`
+    was `unknown slot 'acme.metrics'` however correct everything upstream of it was.
+    """
+
+    def setUp(self):
+        super().setUp()
+        _installed(self)
+
+    def test_charter_panel_draws_an_installed_providers_component(self):
+        """The whole chain's last link, and the task's own failing test."""
+        rc, painted, _err = _painted(CID)
+        self.assertEqual(rc, 0, painted)
+        self.assertIn(_DREW, painted)
+
+    def test_the_provider_is_imported_only_because_a_panel_asked_for_it(self):
+        """§4b's laziness, still true: nothing imports a provider to answer a question
+        about which components exist. The module arrives when the pane does."""
+        self.assertFalse(builtins.supplies("not.installed"))
+        self.assertTrue(builtins.supplies(CID))
+        self.assertNotIn(MODULE, sys.modules,
+                         "asking whether a provider is installed imported it")
+        rc, painted, _err = _painted(CID)
+        self.assertEqual(rc, 0, painted)
+        self.assertIn(MODULE, sys.modules)
+
+    def test_a_component_that_raises_costs_its_own_pane_and_names_itself(self):
+        """§4b property 1, through `panel.run` rather than through `Registry.draw`
+        directly: the pane says which component failed, and the panel does not exit."""
+        _installed(self, render="lambda ctx: 1 / 0")
+        rc, painted, _err = _painted(CID)
+        self.assertEqual(rc, 0, painted)
+        self.assertIn(CID, painted)
+        self.assertIn("ZeroDivisionError", painted)
+
+    def test_a_provider_charter_cannot_load_is_a_pane_that_says_so(self):
+        """§4b property 4. An installed distribution whose module raises on import is
+        the case a standin exists for, and it must reach a PANE — a message with nowhere
+        to appear is the silent drop #512 and #535 both are."""
+        _installed(self, head="raise RuntimeError('provider is broken')")
+        rc, painted, _err = _painted(CID, cols=78)
+        self.assertEqual(rc, 0, painted)
+        self.assertIn("acme-charter", painted)
+        self.assertIn("provider is broken", painted)
+
+    def test_a_bare_name_no_component_answers_to_is_still_refused(self):
+        """The refusal that must survive the widening: `charter panel sideways` is a
+        typo, there is nothing to stand in for, and a pane drawn for it would be the
+        permanently-dead rectangle `_drawable_slots` exists to prevent."""
+        rc, painted, err = _painted("sideways")
+        self.assertNotEqual(rc, 0)
+        self.assertIn("sideways", painted)
+        self.assertIn("sideways", err)
+
+
+class ABuiltInIsReachableByItsComponentIdToo(PersonaIso, unittest.TestCase):
+    """`top` is `identity`'s committed spelling, not a second thing.
+
+    The four slot names stay because they are committed — in `[frame] slots` on every
+    plane that has a charter.toml — but they are shorthand for built-in ids now, and the
+    id is what the frame reasons with. Both spellings must reach the same renderer, or
+    there are two vocabularies rather than one with an alias table.
+    """
+
+    def test_the_component_id_draws_what_the_slot_name_draws(self):
+        for cid, slot in builtins.SLOT_OF.items():
+            with self.subTest(cid=cid):
+                by_id = _painted(cid)
+                by_slot = _painted(slot)
+                self.assertEqual(by_id[0], 0, by_id[1])
+                self.assertEqual(by_id[1], by_slot[1])
+
+    def test_a_built_in_whose_renderer_is_missing_is_refused_by_either_spelling(self):
+        """Charter's own components never reach the provider path, so removing a
+        renderer refuses both spellings rather than sending one of them off to look for
+        an installed distribution called `sidebar`."""
+        with mock.patch.dict(slots.SLOTS):
+            del slots.SLOTS["right"]
+            for name in ("right", "sidebar"):
+                with self.subTest(name=name):
+                    rc, painted, _err = _painted(name)
+                    self.assertNotEqual(rc, 0, painted)
+
+    def test_a_distribution_claiming_a_built_in_id_does_not_answer_for_it(self):
+        """The same refusal with an adversary present, which is the only version of it
+        that is a guard. An installed distribution declaring `sidebar` must not become
+        the answer to a question about charter's OWN component: the panel would take the
+        built-in path anyway and paint `unknown slot right` at rc 0, which is the
+        convincing empty rather than the refusal.
+
+        Asked with the renderer removed because that is the only state in which the two
+        branches disagree — with `slots.SLOTS` whole, `right` is drawable either way and
+        the case would pass against a `drawable` that had no such guard at all.
+        """
+        site = _SitePackages(self)
+        site.install("acme-charter", "1.0", {"sidebar": ENTRY},
+                     {MODULE: _source(cid="sidebar")})
+        self.assertTrue(builtins.supplies("sidebar"))
+        with mock.patch.dict(slots.SLOTS):
+            del slots.SLOTS["right"]
+            for name in ("right", "sidebar"):
+                with self.subTest(name=name):
+                    self.assertFalse(slots.drawable(name))
+                    rc, painted, _err = _painted(name)
+                    self.assertNotEqual(rc, 0, painted)
+
+
+class ConfigPlacesAProvider(unittest.TestCase):
+    """`[[frame.component]]` naming a provider resolves to a placement, rectangle and all.
+
+    Until now `instance.component_tables` refused any `use` outside `builtins.SLOT_OF`,
+    so the arrangement §4b's own example writes could not be expressed at all.
+    """
+
+    def setUp(self):
+        _installed(self)
+        self.cfg = {"frame": {"component": [
+            {"use": "identity"},
+            {"use": "attention"},
+            {"use": CID, "edge": "right", "size": 12},
+        ]}}
+
+    def test_the_provider_is_one_of_the_placements(self):
+        got = instance.frame_components(self.cfg)
+        self.assertEqual([p["use"] for p in got], ["identity", "attention", CID])
+
+    def test_the_committed_rectangle_is_what_is_placed(self):
+        """§4i's own finding, at the config boundary this time: the provider declares
+        `right`/`Fixed(12)` and the table says `right`/`12`, so this case would pass
+        against either. The next one is what tells them apart."""
+        got = instance.frame_components(self.cfg)[-1]
+        self.assertEqual(got["edge"], "right")
+        self.assertEqual(got["size"], component.Fixed(12))
+
+    def test_a_table_that_moves_the_provider_moves_it(self):
+        """The provider's module declares `edge="right", size=Fixed(12)`. A committed
+        table asking for `bottom`/`4` gets `bottom`/`4` — execution does not decide
+        arrangement, which is the inversion §4i measured in `Registry.place`."""
+        cfg = {"frame": {"component": [{"use": CID, "edge": "bottom", "size": 4}]}}
+        got = instance.frame_components(cfg)[-1]
+        self.assertEqual((got["edge"], got["size"]), ("bottom", component.Fixed(4)))
+
+    def test_the_name_that_travels_downstream_is_the_component_id(self):
+        """`frame_of` answers the names `layout` splits panes for. A built-in travels as
+        its committed slot name — `charter panel top` is an argv that exists on every
+        plane — and a provider, which has no committed spelling, travels as its id."""
+        self.assertEqual(instance.frame_of(self.cfg)["slots"],
+                         ["top", "bottom", CID])
+
+    def test_the_rectangle_travels_with_it_and_not_only_the_name(self):
+        """The names alone are what `slots` already carried. A component charter did not
+        write also has an EDGE and a SIZE that nothing else on this machine knows, and
+        `frame_of`'s answer is the only thing `layout._placed_here` gets to read —
+        `config.FRAME` is this function's return value. Dropped here, the provider's pane
+        is split at whatever `SLOT_SIZE` happens to hold, which is a `KeyError`."""
+        got = instance.frame_of(self.cfg)["components"]
+        self.assertEqual([(p["slot"], p["edge"], p["size"]) for p in got],
+                         [("top", "top", component.Fixed(1)),
+                          ("bottom", "bottom", component.Fixed(1)),
+                          (CID, "right", component.Fixed(12))])
+
+    def test_a_provider_no_installed_distribution_supplies_refuses_the_arrangement(self):
+        """Unchanged, and deliberately: charter cannot honour a rectangle for a component
+        it cannot even find, and #535 is why an arrangement is refused WHOLE rather than
+        one table at a time."""
+        cfg = {"frame": {"component": [{"use": "nobody.supplies", "edge": "right",
+                                        "size": 12}]}}
+        self.assertIsNone(instance.component_tables(cfg["frame"]))
+
+    def test_a_provider_placed_without_a_rectangle_refuses_the_arrangement(self):
+        """Charter does not import a stranger's code to answer a geometry question on
+        every command — `config.FRAME` is resolved by `charter --version` too. So a
+        provider's placement carries its own edge and size, or it is not one charter can
+        resolve without running the provider, and the arrangement is refused."""
+        for table in ({"use": CID}, {"use": CID, "edge": "right"},
+                      {"use": CID, "size": 12}):
+            with self.subTest(table=table):
+                self.assertIsNone(
+                    instance.component_tables({"component": [table]}))
+
+
+class TheLauncherSplitsAPaneForIt(unittest.TestCase):
+    """A placed provider survives every filter between config and `split-window`.
+
+    **The frame under test is `instance.frame_of`'s own answer, not one assembled here.**
+    `config.FRAME` is literally that function's return value (`config.py`), so an
+    arrangement built by hand into the shape `layout` wants would be this file
+    manufacturing the condition it claims to observe — and would still pass with
+    `frame_of` dropping the placements on the floor, which is how a provider's pane comes
+    to be split at a size nothing chose.
+    """
+
+    def _frame(self, *tables: dict) -> dict:
+        return instance.frame_of({"frame": {"component": list(tables)}})
+
+    def setUp(self):
+        _installed(self)
+        self.frame = self._frame({"use": "identity"}, {"use": "attention"},
+                                 {"use": CID, "edge": "right", "size": 12})
+        self.assertEqual(self.frame["slots"], ["top", "bottom", CID])
+
+    def test_the_unimplemented_filter_keeps_a_component_a_provider_supplies(self):
+        """`slots.unimplemented` asks "is there a renderer for this", and the answer for
+        a provider's component is not in `slots.SLOTS`. Left as it was, this filter
+        dropped every provider before a pane was ever split for it."""
+        self.assertEqual(slots.unimplemented(["top", CID]), [])
+        self.assertEqual(slots.unimplemented(["top", "made.up"]), ["made.up"])
+
+    def test_it_is_drawable_and_keeps_its_place_in_the_split_order(self):
+        with mock.patch.dict(config.FRAME, self.frame):
+            self.assertEqual(commands_frame._drawable_slots(200, 50),
+                             ["top", "bottom", CID])
+
+    def test_the_split_carries_the_committed_size_and_the_components_own_direction(self):
+        with mock.patch.dict(config.FRAME, self.frame):
+            argvs = layout.panel_argvs(slots=["top", "bottom", CID], session="f-1",
+                                       socket="/sock", harness_pane="%0")
+        cmd = argvs[-1]
+        self.assertIn("-h", cmd, cmd)           # `right` costs columns
+        self.assertNotIn("-b", cmd, cmd)        # and is placed after the harness
+        self.assertEqual(cmd[cmd.index("-l") + 1], "12")
+        self.assertEqual(cmd[-3:], [CID, "--session", "f-1"])
+
+    def test_the_repo_table_is_inset_by_a_provider_split_before_it(self):
+        """#500's arithmetic, which reads a per-slot table of four names. A 12-column
+        component on `right` narrows the pane the table is then carved out of by 12 plus
+        its border — or the table is sized for a pane it does not have."""
+        with mock.patch.dict(config.FRAME, self.frame):
+            self.assertEqual(layout.repos_cols([CID, "repos"], window_cols=200),
+                             200 - 12 - layout._BORDER_COLS)
+
+    def test_a_provider_on_a_row_edge_charges_the_table_its_rows(self):
+        frame = self._frame({"use": CID, "edge": "top", "size": 3})
+        with mock.patch.dict(config.FRAME, frame):
+            got = layout.repos_rows(content_rows=99, window_rows=50,
+                                    slots=[CID, "repos"])
+            self.assertEqual(got, 50 - (3 + layout._BORDER_ROWS)
+                             - layout._BORDER_ROWS - layout.HARNESS_MIN_ROWS)
+
+
+class TheRespawnHookStillOnlyArmsNamesCharterCanDraw(unittest.TestCase):
+    """The guard that widened, and the half of it that must not.
+
+    `_panel_died_hook_argv` interpolates the component name into tmux CONFIG TEXT, which
+    is the `[frame] hotkey` class — a newline there once achieved code execution at
+    launch. So the widening is to names charter can actually resolve to a component,
+    never to a SHAPE: `top.` is namespaced-looking and is refused exactly as it was, and
+    so is `acme.other` on a machine whose only provider supplies `acme.metrics`.
+
+    `tests/test_frame_launcher.py::PanelRespawnHook` pins the other three clauses and
+    pins each so that no OTHER clause could be what refused it; every name here is one
+    bare word that passes `_action_word_is_safe`, for the same reason.
+    """
+
+    def _armed(self, name):
+        """The real builder, with the arguments a launch hands it."""
+        return commands_frame._panel_died_hook_argv(
+            socket="charter", panel_pane="%11", slot=name, fid="demo-1234")
+
+    def test_a_component_an_installed_provider_supplies_is_armed(self):
+        _installed(self)
+        self.assertIsNotNone(self._armed(CID))
+
+    def test_a_name_that_merely_looks_namespaced_is_not(self):
+        _installed(self)
+        for hostile in ("top.", "acme.other", "acme.metrics.x", "middle"):
+            with self.subTest(hostile=hostile):
+                self.assertIsNone(self._armed(hostile))
+
+
+class CharterOwnConfigIsUnchanged(unittest.TestCase):
+    """charter's own committed `charter.toml` resolves to the frame it always drew.
+
+    #535 removed the repo table from charter's own plane and a reviewer caught it, not a
+    test. This reads the file off disk and pins the whole resolved arrangement — the slot
+    list, the component ids behind it, and every rectangle — so a refactor that speaks a
+    new vocabulary has to keep answering in the old one.
+    """
+
+    def setUp(self):
+        self.cfg = tomllib.loads(_COMMITTED.read_text(encoding="utf-8"))
+
+    def test_the_slot_list_is_the_one_that_is_committed(self):
+        self.assertEqual(instance.frame_of(self.cfg)["slots"],
+                         ["top", "bottom", "repos", "right"])
+
+    def test_it_declares_no_arrangement_so_nothing_extra_is_placed(self):
+        """`slots` is the shorthand this plane is written in, so there are no
+        `[[frame.component]]` tables and `layout` has no per-plane rectangle to read."""
+        self.assertIsNone(instance.component_tables(self.cfg.get("frame")))
+        self.assertEqual(instance.frame_of(self.cfg)["components"], [])
+
+    def test_every_placement_is_the_built_in_it_always_was(self):
+        got = instance.frame_components(self.cfg)
+        self.assertEqual([(p["use"], p["slot"], p["edge"], p["visible"]) for p in got],
+                         [("identity", "top", "top", True),
+                          ("attention", "bottom", "bottom", True),
+                          ("repos", "repos", "bottom", True),
+                          ("sidebar", "right", "right", True)])
+
+    def test_the_frame_it_splits_is_byte_for_byte_the_frame_it_split(self):
+        """The whole launch argv, not a summary of it. `slot_sizes` and `panel_argvs`
+        are where a re-keyed table would show up first, and they are asserted against
+        literals rather than against the tables under test."""
+        f = instance.frame_of(self.cfg)
+        with mock.patch.dict(config.FRAME, f):
+            sizes = layout.slot_sizes(f["slots"], window_rows=50, content_rows=6)
+            self.assertEqual(sizes, {"top": 1, "bottom": 1, "repos": 6, "right": 22})
+            argvs = layout.panel_argvs(slots=f["slots"], session="f-1", socket="/sock",
+                                       harness_pane="%0", sizes=sizes)
+        self.assertEqual([a[a.index("split-window") + 1:] for a in argvs], [
+            ["-t", "%0", "-v", "-b", "-l", "1", "-P", "-F", "#{pane_id}", "--",
+             *layout.panel_command(slot="top", session="f-1")],
+            ["-t", "%0", "-v", "-l", "1", "-P", "-F", "#{pane_id}", "--",
+             *layout.panel_command(slot="bottom", session="f-1")],
+            ["-t", "%0", "-v", "-l", "6", "-P", "-F", "#{pane_id}", "--",
+             *layout.panel_command(slot="repos", session="f-1")],
+            ["-t", "%0", "-h", "-l", "22", "-P", "-F", "#{pane_id}", "--",
+             *layout.panel_command(slot="right", session="f-1")],
+        ])

--- a/tests/test_component_id_is_the_currency.py
+++ b/tests/test_component_id_is_the_currency.py
@@ -39,6 +39,7 @@ import io
 import os
 import pathlib
 import sys
+import tempfile
 import tomllib
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -267,6 +268,80 @@ class ConfigPlacesAProvider(unittest.TestCase):
             with self.subTest(table=table):
                 self.assertIsNone(
                     instance.component_tables({"component": [table]}))
+
+    def test_a_rectangle_charter_cannot_honour_refuses_the_arrangement(self):
+        """A key that is PRESENT and unusable, which the absent-key case above never
+        reaches — and the two are separate cases because the consequences are not the
+        same shape.
+
+        A bad ``size`` is the expensive one. ``Fixed.__post_init__`` calls
+        `component.cells`, which refuses `0`, a negative, a `str` and — explicitly —
+        a `bool`, since `isinstance(True, int)` would otherwise make ``size = true``
+        mean ``Fixed(1)``. That raise would come out of `component_tables` →
+        `frame_of` → `config.derive`, and `derive` resolves ``FRAME`` **outside** the
+        try/except that catches a malformed charter.toml. So the whole of
+        `import charter.config` dies, and every command on that clone dies with it —
+        `charter --version` included. `test_a_committed_rectangle_charter_cannot_honour
+        _still_leaves_charter_runnable` below pins that consequence end to end.
+
+        A bad ``edge`` is quieter and still wrong: unvalidated, ``"sideways"`` is placed
+        and travels into `layout._edge_of`, falls out of `_COLUMN_EDGES`/`_ROW_EDGES`/
+        `_BEFORE_EDGES` and silently becomes a plain `-v` after-split — a pane on an
+        edge nobody asked for.
+        """
+        for table in ({"use": CID, "edge": "right", "size": 0},
+                      {"use": CID, "edge": "right", "size": True},
+                      {"use": CID, "edge": "right", "size": -4},
+                      {"use": CID, "edge": "right", "size": "12"},
+                      {"use": CID, "edge": "sideways", "size": 12},
+                      {"use": CID, "edge": "", "size": 12}):
+            with self.subTest(table=table):
+                self.assertIsNone(
+                    instance.component_tables({"component": [table]}))
+
+
+class ABrokenRectangleCostsTheFrameAndNotTheCLI(unittest.TestCase):
+    """The consequence of the guard above, asked of `config.derive` itself.
+
+    `derive` is what runs at `import charter.config`, which is to say on **every**
+    charter command. It wraps `instance.load` in a try/except so a malformed
+    charter.toml degrades instead of raising — but `FRAME` is resolved after that block,
+    not inside it, so anything `frame_of` raises is uncatchable and terminal. A
+    committed `[[frame.component]]` table arrives from someone else's machine (the
+    containment rule in README.md), so "committed" is not "trusted".
+
+    **The good-value case is the control, and it is load-bearing.** Without it, a run
+    where the fixture's distribution was not visible to `derive` would answer the
+    defaults for the reason the mutation is supposed to be caught by — `supplies()`
+    saying no, long before any size is read — and the refusal case would stay green
+    with the guard deleted. It is asked FIRST for the same reason.
+    """
+
+    def setUp(self):
+        _installed(self)
+        self._tmp = tempfile.TemporaryDirectory(prefix="charter-plane-")
+        self.addCleanup(self._tmp.cleanup)
+        self.root = pathlib.Path(self._tmp.name)
+
+    def _derived(self, size: str) -> dict:
+        """``config.derive`` against a plane whose committed table asks for *size*."""
+        (self.root / "charter.toml").write_text(
+            f'schema = 1\n\n[[frame.component]]\nuse = "{CID}"\n'
+            f'edge = "right"\nsize = {size}\n', encoding="utf-8")
+        return config.derive(self.root)["FRAME"]
+
+    def test_a_committed_rectangle_charter_can_honour_is_the_frame_it_derives(self):
+        frame = self._derived("12")
+        self.assertEqual(frame["slots"], [CID])
+        self.assertEqual([(p["slot"], p["edge"], p["size"]) for p in frame["components"]],
+                         [(CID, "right", component.Fixed(12))])
+
+    def test_a_committed_rectangle_charter_cannot_honour_still_leaves_charter_runnable(self):
+        for size in ("0", "true", "-4", '"12"'):
+            with self.subTest(size=size):
+                frame = self._derived(size)      # must not raise: `charter --version`
+                self.assertEqual(frame["slots"], instance.FRAME_DEFAULTS["slots"])
+                self.assertEqual(frame["components"], [])
 
 
 class TheLauncherSplitsAPaneForIt(unittest.TestCase):

--- a/tests/test_component_id_is_the_currency.py
+++ b/tests/test_component_id_is_the_currency.py
@@ -31,6 +31,18 @@ is shorthand for four built-in ids now, and `CharterOwnConfigIsUnchanged` reads 
 OWN `charter.toml` off disk and pins the whole resolved arrangement — because a change
 that silently removed the repo table from charter's own plane shipped once (#535) and was
 caught by a reviewer, not by a test.
+
+**The classes below `CharterOwnConfigIsUnchanged` pin the branch's GUARDS**, one case per
+line that refuses, clamps, contains or falls back. Each was written by deleting the line,
+running the whole suite and watching it stay green — twelve of them did, and every one of
+those twelve is a `if`/fallback/`except` that only fires for a component charter did not
+write, or for a value that is not text. The cases above could not see any of them, and
+the reason is the same one every time: **the payload passed either way.** The three
+drawing cases all draw eleven columns into a forty-column pane, so the pane's real width
+is never used; `_derive` is only ever handed charter's own components, which have a
+committed spelling for the fallback to skip; `slot_sizes` is called by one case, on a
+frame with no provider in it. A test that cannot fail is not a pin, and this repo has
+shipped that kind believing it was the other.
 """
 
 from __future__ import annotations
@@ -45,7 +57,7 @@ import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from unittest import mock
 
-from charter import commands_frame, config, instance
+from charter import commands_frame, config, instance, tui
 from charter.frame import builtins, component, layout, panel, slots
 
 from tests._isolation import PersonaIso
@@ -61,11 +73,12 @@ _COMMITTED = pathlib.Path(__file__).resolve().parents[1] / "charter.toml"
 _DREW = "metrics 42"
 
 
-def _installed(case, *, render: str = f"lambda ctx: [{_DREW!r}]", head: str = "") -> None:
+def _installed(case, *, render: str = f"lambda ctx: [{_DREW!r}]", head: str = "",
+               needs: tuple[str, ...] = ()) -> None:
     """Put one real provider distribution supplying :data:`CID` on ``sys.path``."""
     site = _SitePackages(case)
     site.install("acme-charter", "1.0", {CID: ENTRY},
-                 {MODULE: _source(render=render, head=head)})
+                 {MODULE: _source(render=render, head=head, needs=needs)})
     return site
 
 
@@ -483,3 +496,301 @@ class CharterOwnConfigIsUnchanged(unittest.TestCase):
             ["-t", "%0", "-h", "-l", "22", "-P", "-F", "#{pane_id}", "--",
              *layout.panel_command(slot="right", session="f-1")],
         ])
+
+
+class TheStackIsSizedInTheUnitEachPaneWasDeclaredIn(unittest.TestCase):
+    """`slot_sizes` answers for a component this plane placed, and a pane that costs
+    COLUMNS is charged the harness no ROWS.
+
+    Both halves were correct and neither was pinned, for the same reason: every existing
+    case that calls either function calls it on a frame with no provider in it —
+    `CharterOwnConfigIsUnchanged` reads charter's own committed file, which places four
+    built-ins and nothing else, and the four are already in `layout`'s shipped tables. A
+    per-slot table keyed by four names answers those four correctly whatever it does with
+    a fifth.
+
+    `commands_frame._reassert_sizes` calls both on every window resize and every density
+    relayout, so what is measured here is not a startup path.
+    """
+
+    def setUp(self):
+        _installed(self)
+        self.frame = instance.frame_of({"frame": {"component": [
+            {"use": "identity"}, {"use": "attention"}, {"use": "repos"},
+            {"use": CID, "edge": "right", "size": 12}]}})
+        self.assertEqual(self.frame["slots"], ["top", "bottom", "repos", CID])
+
+    def _sizes(self) -> dict[str, int]:
+        with mock.patch.dict(config.FRAME, self.frame):
+            return layout.slot_sizes(self.frame["slots"], window_rows=50, content_rows=6)
+
+    def test_a_component_this_plane_placed_is_in_the_map_at_its_committed_size(self):
+        """Dropped from the map, the provider is a pane the launcher splits at nothing
+        and `_reassert_sizes` never re-asserts — and every other slot is then sized
+        against a stack one pane short."""
+        self.assertEqual(self._sizes(), {"top": 1, "bottom": 1, "repos": 6, CID: 12})
+
+    def test_the_harness_is_charged_no_rows_for_a_pane_that_costs_columns(self):
+        """The sidebar's 12 are COLUMNS. Charged as rows they come straight off the
+        harness — 39 rows becomes 26 in this 50-row window — and that number is what
+        `resize-pane -y` is given, so the frame is wrong on screen and not only in a
+        dict. Asked twice: against the arithmetic, and against the same map with the
+        provider taken out of it, because a column edge that costs rows is exactly the
+        difference between those two answers.
+        """
+        sizes = self._sizes()
+        with mock.patch.dict(config.FRAME, self.frame):
+            got = layout.harness_rows(sizes, window_rows=50)
+            without = layout.harness_rows(
+                {k: v for k, v in sizes.items() if k != CID}, window_rows=50)
+        rows = sum(sizes[s] + layout._BORDER_ROWS for s in ("top", "bottom", "repos"))
+        self.assertEqual(got, 50 - rows)
+        self.assertEqual(got, without,
+                         "a pane on a column edge changed the harness's row count")
+
+
+class LayoutDerivesEveryFactFromTheComponentItself(unittest.TestCase):
+    """`_derive` is where all five per-slot tables come from, and it must survive being
+    shown a component charter did not write.
+
+    Its own docstring calls the fallback on that line "the line Phase 1 could not cross":
+    it used to be `SLOT_OF[c.id]`, a `KeyError` by design for any id charter has no
+    committed spelling for. The three existing callers in `test_builtin_components.py`
+    all hand it charter's own components, which have one — so the tables they check are
+    built by the branch that was already there.
+    """
+
+    def _metrics(self):
+        return component.Component(id=CID, title="Metrics", edge="right",
+                                   size=component.Fixed(12), needs=(), events=(),
+                                   render=lambda ctx: [_DREW])
+
+    def test_a_component_with_no_committed_spelling_is_keyed_by_its_own_id(self):
+        got = layout._derive([self._metrics()])
+        self.assertEqual(got.size, {CID: 12})
+        self.assertEqual(got.edge, {CID: "right"})
+        self.assertEqual(got.column, (CID,))
+        self.assertEqual(got.fixed_rows, ())
+        self.assertEqual(got.variable_rows, frozenset())
+
+    def test_a_built_in_beside_it_still_answers_to_its_committed_spelling(self):
+        """The other half of the same line: the fallback must not cost `identity` the
+        alias `[frame] slots`, `charter panel top` and every caller in `commands_frame`
+        already spell it with."""
+        got = layout._derive([
+            component.Component(id="identity", title="Identity", edge="top",
+                                size=component.Fixed(1), needs=(), events=(),
+                                render=lambda ctx: ["id"]),
+            self._metrics()])
+        self.assertEqual(got.size, {"top": 1, CID: 12})
+        self.assertEqual(got.column, (CID,))
+        self.assertEqual(got.fixed_rows, ("top",))
+
+
+class TheFrameHasOneShapeWhateverTheConfigSaid(unittest.TestCase):
+    """`frame_of` answers a `components` key on **every** path, the early return
+    included.
+
+    That early return is the path very nearly every plane takes, and its answer is what
+    `layout._placed_here` reads on every command — `config.FRAME` is this function's
+    return value. A key present on one path and absent on another is the
+    two-shapes-for-one-answer the comment on that line exists to prevent, and the early
+    return is the path nothing had ever asked for the key on.
+    """
+
+    def test_a_plane_with_no_usable_frame_section_still_carries_the_key(self):
+        for cfg in ({}, {"frame": "nonsense"}, {"frame": []}, {"other": 1},
+                    {"frame": None}):
+            with self.subTest(cfg=cfg):
+                self.assertEqual(instance.frame_of(cfg)["components"], [])
+
+    def test_it_is_the_same_shape_the_configured_path_answers(self):
+        """Asked of both paths in one case, so "the shapes agree" is the assertion
+        rather than two separate ones that could drift apart."""
+        _installed(self)
+        placed = instance.frame_of(
+            {"frame": {"component": [{"use": CID, "edge": "right", "size": 12}]}})
+        self.assertEqual(sorted(instance.frame_of({})), sorted(placed))
+
+
+class ANameThatIsNotTextIsAnAnswerRatherThanACrash(unittest.TestCase):
+    """Three lookups that resolve a component name, each asked something unhashable.
+
+    Every one of them is reached with a value that came out of a committed file — a
+    `[frame] slots` list, a `[[frame.component]]` table's `use` — and a committed file
+    arrives from someone else's machine (README.md's containment rule). `charter.toml` is
+    TOML, so a list or an inline table under a key that wants a string is one keystroke
+    away and neither is hashable: a `dict.get` on it raises `TypeError` from inside a
+    lookup, half a frame away from the line that was actually wrong, where the refusal
+    belongs beside the rest of that value's validation.
+
+    `slots.drawable` is the expensive one — `commands_frame`'s two respawn guards ask it
+    before a name reaches tmux CONFIG TEXT, so a `TypeError` there is a launch that dies
+    with panes already split.
+    """
+
+    #: Unhashable on purpose. A hashable non-string takes the `dict.get` miss path and
+    #: answers the same with the guard or without it, so it could not tell one from the
+    #: other — it is asked below all the same, because "answers rather than raises" is
+    #: the property and it should hold for both kinds.
+    _UNHASHABLE = (["top"], {"top": 1}, {"top"}, bytearray(b"top"))
+    _HASHABLE = (3, None, b"top", ("top",), True)
+
+    def test_drawable_answers_false(self):
+        for value in self._UNHASHABLE + self._HASHABLE:
+            with self.subTest(value=value):
+                self.assertIs(slots.drawable(value), False)
+
+    def test_component_id_answers_the_value_it_was_given(self):
+        for value in self._UNHASHABLE + self._HASHABLE:
+            with self.subTest(value=value):
+                self.assertIs(builtins.component_id(value), value)
+
+    def test_layouts_key_answers_the_value_it_was_given(self):
+        """`layout._key`'s own contract, and stated as that rather than as a consequence
+        somewhere else: the three lookups reading it (`_edge_of`, `_size_of`,
+        `_is_fixed_row`) each ask a membership question of the result, so an unhashable
+        raises at THEIR line whether or not this one filtered it first. What the guard
+        decides is which of the two `_key` is — a resolve that answers, or a lookup that
+        raises — and `_derive` reads the same `SLOT_OF` in the same direction.
+        """
+        for value in self._UNHASHABLE + self._HASHABLE:
+            with self.subTest(value=value):
+                self.assertIs(layout._key(value), value)
+
+    def test_a_hashable_name_nothing_placed_falls_out_of_every_side(self):
+        """`_edge_of`'s filter-don't-refuse degrade, which is what makes a name charter
+        knows nothing about fall out of `_COLUMN_EDGES`, `_ROW_EDGES` and
+        `_BEFORE_EDGES` alike rather than be assigned a side."""
+        for value in self._HASHABLE:
+            with self.subTest(value=value):
+                self.assertIsNone(layout._edge_of(value))
+                self.assertIsNone(layout._size_of(value))
+                self.assertIs(layout._is_fixed_row(value), False)
+
+
+class APanelPaintsInsideItsOwnRectangle(PersonaIso, unittest.TestCase):
+    """What `_component_text` promises about the pane it paints into, asked with payloads
+    that can tell the promises apart.
+
+    The three drawing cases at the top of this file all draw `metrics 42` — eleven
+    columns into a forty-column pane, short enough that a width of 40, a width of 80 and
+    a width of 1000 all paint the same bytes. So none of them can see the pane's real
+    rectangle being used at all.
+    """
+
+    def test_a_providers_rows_are_clipped_to_THIS_pane_and_not_to_a_constant(self):
+        """§4b property 3 on the one path that actually paints a provider. The width
+        `_component_text` builds the ctx with is what `Registry.draw` clips to, so a
+        constant there is a line that wraps — and a wrapped line in a pane sized to the
+        one row it was supposed to be destroys the frame around it, not only its own
+        pane.
+
+        Two pane widths, one narrower than any plausible constant and one wider, because
+        a single width can only show that the number is not that one number.
+        """
+        _installed(self, render="lambda ctx: ['X' * 200]")
+        for cols in (40, 100):
+            with self.subTest(cols=cols):
+                rc, painted, _err = _painted(CID, cols=cols)
+                self.assertEqual(rc, 0, painted)
+                self.assertEqual([tui.width(line) for line in painted.split("\n")],
+                                 [cols])
+
+    def test_a_component_that_declared_nothing_costs_the_tick_no_snapshot(self):
+        """§4e's idle cost, and the DECLARATION is what decides it. A provider with an
+        empty `needs` is handed an empty ctx, so the plane scan behind `gather.read` is
+        never paid for a pane that could not read it anyway — every tick, on every
+        frame, for as long as the frame is up.
+        """
+        _installed(self)
+        with mock.patch("charter.frame.gather.read") as read:
+            rc, painted, _err = _painted(CID)
+        self.assertEqual(rc, 0, painted)
+        self.assertIn(_DREW, painted)
+        read.assert_not_called()
+
+    def test_a_component_that_declared_a_need_is_handed_the_snapshot(self):
+        """The other side of the same branch, so "never reads" cannot be passing for
+        "never reads for anybody"."""
+        _installed(self, needs=("repos",))
+        with mock.patch("charter.frame.gather.read", return_value={}) as read:
+            rc, painted, _err = _painted(CID)
+        self.assertEqual(rc, 0, painted)
+        self.assertIn(_DREW, painted)
+        read.assert_called_once_with("f-1")
+
+    def test_a_snapshot_that_cannot_be_read_is_a_line_and_not_a_lost_pane(self):
+        """`_component_text`'s own **Never raises**, which is about THIS function's
+        failure modes and not the renderer's — a renderer is already contained one layer
+        down by `Registry.draw`, which is what
+        `test_a_component_that_raises_costs_its_own_pane_and_names_itself` exercises.
+
+        A `gather.read` that fails is transient: the cache directory is on a volume that
+        went away, the scan raced an `rm -rf`. Let out, it reaches `run`'s outer handler,
+        and `run`'s outer handler `_hold`s the pane — permanently, for a failure that
+        would have been over by the next tick.
+        """
+        _installed(self, needs=("repos",))
+        with mock.patch("charter.frame.gather.read",
+                        side_effect=OSError("volume went away")):
+            rc, painted, err = _painted(CID, cols=78)
+        self.assertEqual(rc, 0, painted)
+        self.assertIn(CID, painted)
+        self.assertIn("OSError", painted)
+        self.assertNotIn("panel stopped", err)
+
+    def test_the_failure_line_contains_the_id_before_it_measures_it(self):
+        """The order that line is written in, asked in both directions at once.
+
+        *cid* arrived on this process's own command line. Contained FIRST, an escape in
+        it becomes four visible characters the width arithmetic then budgets for, and the
+        pane names the component that failed. Measured first, `tui.truncate`'s own
+        `sanitize` DELETES the escape instead — and the pane names `acme.m`, a component
+        that does not exist, which is a confidently wrong answer rather than a contained
+        one.
+
+        `_component_text` is asked directly because `run` cannot reach it with such an id
+        — `Registry.place` refuses one that is not `_ID_RE`-shaped before a painter is
+        ever built, which is `TheProviderNameThatReachesThePaneIsContained` below. The
+        containment here is this function's own, on the value this function was handed.
+        """
+        hostile = "acme.\x1b[2Jm"
+        with mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+             mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((40, 6))):
+            line = panel._component_text(builtins.build(), hostile, "f-1")
+        self.assertNotIn("\x1b", line)
+        self.assertIn("\\x1b", line)
+        self.assertNotIn("acme.m", line)
+        self.assertLessEqual(tui.width(line), 40)
+
+
+class TheProviderNameThatReachesThePaneIsContained(PersonaIso, unittest.TestCase):
+    """A component name a stranger's distribution chose, on `run`'s failure path.
+
+    An entry point NAME is not an id charter validated — `builtins.supplies` reads
+    distribution metadata and nothing else, so `acme.\\x1b[2Jm` is supplied, and
+    `slots.drawable` therefore answers True and `run` goes on to place it. `_stand_in` is
+    where it is finally refused, and by then the name is in `run`'s hands and on its way
+    to two surfaces: the pane, and stderr.
+
+    **stderr is the one with no other guard.** The pane's line goes through
+    `tui.truncate`, whose `sanitize` deletes the escape — leaving `acme.m`, a name that
+    is not the one that failed. `print(..., file=sys.stderr)` reaches the operator's
+    terminal exactly as written, and an erase-in-display there is an instruction rather
+    than a character.
+    """
+
+    def test_an_escape_in_a_suppliers_name_reaches_neither_surface_raw(self):
+        hostile = "acme.\x1b[2Jm"
+        site = _SitePackages(self)
+        site.install("hostile-charter", "1.0", {hostile: ENTRY}, {MODULE: _source()})
+        self.assertTrue(slots.drawable(hostile), "the fixture never reached `run`")
+
+        rc, painted, err = _painted(hostile)
+        self.assertEqual(rc, 1, painted)
+        self.assertNotIn("\x1b", err)
+        self.assertIn("\\x1b", err)
+        self.assertNotIn("acme.m panel stopped", painted)
+        self.assertIn("\\x1b", painted)

--- a/tests/test_component_providers.py
+++ b/tests/test_component_providers.py
@@ -62,12 +62,19 @@ _CHARTERS = object()
 
 
 def _source(*, cid: str = CID, api: object = _CHARTERS,
-            render: str = "lambda ctx: ['ok']", head: str = "") -> str:
+            render: str = "lambda ctx: ['ok']", head: str = "",
+            needs: tuple[str, ...] = ()) -> str:
     """A provider module: a version, a factory, and a record of whether it ran.
 
     ``built`` is what makes "refused before the provider built anything" an assertion
     rather than a hope — the module object survives the refusal in ``sys.modules``, so a
     test can ask it afterwards.
+
+    *needs* is the DECLARATION, not a snapshot — §4e's idle cost is decided by it, so a
+    case that wants to watch `gather.read` being made or being skipped needs a component
+    on each side of that branch. A knob here rather than a second module fixture beside
+    this one, for the reason `_SitePackages.install` already gives: two fixtures for one
+    idea drift, and the drift is invisible from either side.
     """
     api = component.API_VERSION if api is _CHARTERS else api
     return textwrap.dedent(f"""\
@@ -82,7 +89,7 @@ def _source(*, cid: str = CID, api: object = _CHARTERS,
             built = True
             return component.Component(
                 id={cid!r}, title="Metrics", edge="right",
-                size=component.Fixed(12), needs=(), events=(),
+                size=component.Fixed(12), needs={needs!r}, events=(),
                 render={render})
         """)
 


### PR DESCRIPTION
Phase 2, Task 1 of the agentic IDE foundation — `docs/superpowers/plans/2026-08-26-phase2-command-surface.md`.

Phase 1 built the component registry, the provider seam, the API-version refusal and the standin, and then found none of it could reach a pane: **`Registry.place` shipped with zero production callers.** Every step between a committed `[[frame.component]]` table and a `split-window` spoke the four committed SLOT NAMES, so a provider could be placed and never drawn.

## The nine sites

| site | was | is |
| --- | --- | --- |
| `instance.component_tables` | `cid not in SLOT_OF` → refuse | places a provider's component, with its committed rectangle |
| `instance.frame_of` | names only | carries the resolved arrangement as `config.FRAME["components"]` |
| `instance._placement` | `SLOT_OF[cid]` | `SLOT_OF.get(cid, cid)` — a provider travels under its id |
| `layout._derive` | `SLOT_OF[c.id]`, a `KeyError` by design | falls back to the component's own id |
| `SLOT_SIZE` / `SLOT_EDGE` as the only geometry | four frozen tables | `_edge_of` / `_size_of` / `_is_fixed_row`, asking the component's declared edge |
| `layout.panel_command`'s argv | `charter panel <slot>` | `charter panel <component>` |
| `cli.py`'s `panel` subparser | `slot` | `<component>`, resolved by `panel.run` and nowhere else |
| `panel.run` | `slot not in slots.SLOTS` | `slots.drawable(name)`, then builds a registry and places the component |
| `slots.SLOTS` | the membership test four callers each did their own way | `slots.drawable`, the one answer all four ask |

The hardest link was the last: a panel process builds no registry and knows no providers. It builds one now, once, at startup, and closes over it — an installed-distribution scan on the repaint path is exactly what §4's budget argument exists to keep off it.

## Behaviour is preserved

`[frame] slots` is unchanged and is now shorthand for four built-in ids, so `charter panel top` and `charter panel identity` draw the same strip.

**5906 tests green, no existing test modified.** `CharterOwnConfigIsUnchanged` reads this repo's own committed `charter.toml` off disk and pins the whole resolved frame down to the launch argv — #535 removed the repo table from charter's own plane and a reviewer caught it, not a test.

Suite run in two environments (ambient cleared; and again with `CHARTER_WORKSPACE` set). Both answered 5906 / OK. Phase 1's pin was 5880; the 26 are this task's.

## The guard is a property, never a spelling

`_panel_died_hook_argv` interpolates the component name into tmux **config text** — the `[frame] hotkey` class, where a newline once achieved code execution at launch. So the widening admits `acme.metrics` because a distribution on this machine declares it in the `charter.components` entry point group, and refuses `top.`, `acme.other` and `acme.metrics.x` for being just as namespaced-looking and supplied by nothing. Metadata only — nothing here imports a provider to find out.

## Mutations run — each RED, each restored to GREEN

1. `panel.run`'s `not slots.drawable(slot)` → `False`. **RED** (5 failures, two of them pre-existing `test_frame_panel` cases).
2. `slots.drawable`'s `_builtins.supplies(cid)` → `"." in cid`. **RED** (4) — the respawn hook armed `acme.other`.
3. `frame_of`'s `out["components"] = placed or []` dropped. **GREEN at first** — a real gap. The launcher cases assembled `config.FRAME` by hand, manufacturing the condition they claimed to observe; `config.FRAME` *is* `frame_of`'s return value. Rewritten to resolve through it. Re-run: **RED** (4).
4. `component_tables`' `reg.providers.supplies(cid)` dropped. **RED** (1).
5. `layout._edge_of`'s `None` → `"bottom"` — "nothing placed it" must have one spelling. **RED** (1, an existing case).
6. `slots.drawable`'s "a built-in never falls through to the providers" branch dropped. **RED** (5), including a new case that installs a distribution claiming `sidebar`.

## Rendered, in a real pty

```
$ charter panel acme.metrics --session demo-1234    # 24x6
|  cpu   38%
|  mem  6.1G
|  p99  84ms

$ charter panel acme.metrics --session demo-1234    # 64x6, provider raises on import
|broken-charter 2.3 supplies acme.metrics, and importing
|acme_metrics raised RuntimeError: acme metrics needs a token.
|Its pane says so; the rest of the frame is drawn

$ charter panel sideways --session demo-1234        # 64x6
| charter: unknown slot 'sideways' (known: bottom, repos, right,…

$ charter panel identity --session demo-1234        # 64x3
| ⬢ default  ◆ steward · ◇ personas forge · reddit · release · s…

$ charter panel top --session demo-1234             # 64x3 — byte-identical
| ⬢ default  ◆ steward · ◇ personas forge · reddit · release · s…
```

No version bump, no stamping, no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
